### PR TITLE
Refactor DAP request handling and optimize bus lookups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,28 @@ panic = "abort"
 [profile.release]
 panic = "abort"
 lto = true
+
+[profile.release.package.firmware-ci-fixture]
+codegen-units = 1
+debug = true
+opt-level = "s"
+
+[profile.release.package.firmware-h563-demo]
+codegen-units = 1
+debug = true
+opt-level = "s"
+
+[profile.release.package.firmware-h563-io-demo]
+codegen-units = 1
+debug = true
+opt-level = "s"
+
+[profile.release.package.firmware-h563-fullchip-demo]
+codegen-units = 1
+debug = true
+opt-level = "s"
+
+[profile.release.package.riscv-ci-fixture]
+codegen-units = 1
+debug = true
+opt-level = "s"

--- a/crates/core/src/peripherals/dwt.rs
+++ b/crates/core/src/peripherals/dwt.rs
@@ -1,0 +1,122 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+use crate::{Peripheral, PeripheralTickResult, SimResult};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+const DWT_CTRL: u64 = 0x00;
+const DWT_CYCCNT: u64 = 0x04;
+
+#[derive(Debug)]
+pub struct Dwt {
+    ctrl: AtomicU32,
+    cyccnt: AtomicU32,
+}
+
+impl Dwt {
+    pub fn new() -> Self {
+        Self {
+            ctrl: AtomicU32::new(0),
+            cyccnt: AtomicU32::new(0),
+        }
+    }
+}
+
+impl Default for Dwt {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Peripheral for Dwt {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let val = match offset & !3 {
+            DWT_CTRL => self.ctrl.load(Ordering::SeqCst),
+            DWT_CYCCNT => self.cyccnt.load(Ordering::SeqCst),
+            _ => 0,
+        };
+
+        let byte_offset = (offset & 3) as u32;
+        Ok(((val >> (byte_offset * 8)) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        // We only support word-aligned writes for simplicity in this MVP,
+        // or we need a read-modify-write buffer.
+        // For DWT, usually 32-bit access is used.
+        // But `write` takes u8.
+        // To properly support byte writes we need either internal state or
+        // we can implement `write_u32` if the trait supported it directly/optimally,
+        // but `Peripheral` trait is byte-oriented.
+        //
+        // However, `Bus` breaks down u32 writes into 4 u8 writes.
+        // We can use a simplified approach: just update the byte in the atomic.
+        // But Atomically updating a single byte in a U32 is tricky without CAS loop.
+        //
+        // Simplification: Load, modify, store.
+
+        let aligned_offset = offset & !3;
+        let byte_shift = (offset & 3) * 8;
+
+        let (atom, _is_cyccnt) = match aligned_offset {
+            DWT_CTRL => (&self.ctrl, false),
+            DWT_CYCCNT => (&self.cyccnt, true),
+            _ => return Ok(()),
+        };
+
+        let mut current = atom.load(Ordering::SeqCst);
+        let mask = 0xFF << byte_shift;
+        current &= !mask;
+        current |= (value as u32) << byte_shift;
+        atom.store(current, Ordering::SeqCst);
+
+        Ok(())
+    }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        // Check CYCCNTENA bit (bit 0) in CTRL
+        let ctrl = self.ctrl.load(Ordering::Relaxed);
+        if (ctrl & 1) != 0 {
+            self.cyccnt.fetch_add(1, Ordering::Relaxed);
+        }
+
+        PeripheralTickResult {
+            irq: false,
+            cycles: 0,
+            dma_requests: Vec::new(),
+            explicit_irqs: Vec::new(),
+        }
+    }
+
+    fn peek(&self, offset: u64) -> Option<u8> {
+        let val = match offset & !3 {
+            DWT_CTRL => self.ctrl.load(Ordering::Relaxed),
+            DWT_CYCCNT => self.cyccnt.load(Ordering::Relaxed),
+            _ => return None,
+        };
+        let byte_offset = (offset & 3) as u32;
+        Some(((val >> (byte_offset * 8)) & 0xFF) as u8)
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::json!({
+            "ctrl": self.ctrl.load(Ordering::Relaxed),
+            "cyccnt": self.cyccnt.load(Ordering::Relaxed),
+        })
+    }
+
+    fn restore(&mut self, state: serde_json::Value) -> SimResult<()> {
+        if let Some(obj) = state.as_object() {
+            if let Some(ctrl) = obj.get("ctrl").and_then(|v| v.as_u64()) {
+                self.ctrl.store(ctrl as u32, Ordering::Relaxed);
+            }
+            if let Some(cyccnt) = obj.get("cyccnt").and_then(|v| v.as_u64()) {
+                self.cyccnt.store(cyccnt as u32, Ordering::Relaxed);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -7,17 +7,12 @@
 use crate::SimResult;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GpioRegisterLayout {
+    #[default]
     Stm32F1,
     Stm32V2,
-}
-
-impl Default for GpioRegisterLayout {
-    fn default() -> Self {
-        Self::Stm32F1
-    }
 }
 
 impl FromStr for GpioRegisterLayout {

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -8,6 +8,7 @@ pub mod adc;
 pub mod afio;
 pub mod declarative;
 pub mod dma;
+pub mod dwt;
 pub mod exti;
 pub mod gpio;
 pub mod i2c;

--- a/crates/core/src/peripherals/rcc.rs
+++ b/crates/core/src/peripherals/rcc.rs
@@ -7,17 +7,12 @@
 use crate::SimResult;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RccRegisterLayout {
+    #[default]
     Stm32F1,
     Stm32V2,
-}
-
-impl Default for RccRegisterLayout {
-    fn default() -> Self {
-        Self::Stm32F1
-    }
 }
 
 impl FromStr for RccRegisterLayout {

--- a/crates/core/src/peripherals/uart.rs
+++ b/crates/core/src/peripherals/uart.rs
@@ -9,17 +9,12 @@ use std::io::{self, Write};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UartRegisterLayout {
+    #[default]
     Stm32F1,
     Stm32V2,
-}
-
-impl Default for UartRegisterLayout {
-    fn default() -> Self {
-        Self::Stm32F1
-    }
 }
 
 impl FromStr for UartRegisterLayout {

--- a/crates/dap/tests/evaluation.rs
+++ b/crates/dap/tests/evaluation.rs
@@ -1,9 +1,6 @@
-use labwired_core::cpu::CortexM;
-use labwired_core::{Bus, Cpu, DebugControl, Machine};
+use labwired_core::{DebugControl, Machine};
 use labwired_dap::server::DapServer;
 use serde_json::json;
-use std::io::{BufRead, BufReader, Write};
-use std::sync::{Arc, Mutex};
 
 #[test]
 fn test_dap_evaluate_register() {

--- a/crates/dap/tests/step_operations.rs
+++ b/crates/dap/tests/step_operations.rs
@@ -2,7 +2,7 @@
 // These tests verify the core stepping behavior that step-out and step-back rely on
 
 use labwired_core::cpu::CortexM;
-use labwired_core::{Bus, Cpu, DebugControl, Machine};
+use labwired_core::{DebugControl, Machine};
 
 /// Helper to create a simple test machine with ARM code in RAM
 fn create_test_machine(code: &[u16]) -> Machine<CortexM> {

--- a/crates/firmware-ci-fixture/Cargo.toml
+++ b/crates/firmware-ci-fixture/Cargo.toml
@@ -18,9 +18,3 @@ name = "firmware-ci-fixture"
 path = "src/main.rs"
 test = false
 bench = false
-
-[profile.release]
-codegen-units = 1
-debug = true
-lto = true
-opt-level = "s"

--- a/crates/firmware-h563-demo/Cargo.toml
+++ b/crates/firmware-h563-demo/Cargo.toml
@@ -17,9 +17,3 @@ name = "firmware-h563-demo"
 path = "src/main.rs"
 test = false
 bench = false
-
-[profile.release]
-codegen-units = 1
-debug = true
-lto = true
-opt-level = "s"

--- a/crates/firmware-h563-fullchip-demo/Cargo.toml
+++ b/crates/firmware-h563-fullchip-demo/Cargo.toml
@@ -17,9 +17,3 @@ name = "firmware-h563-fullchip-demo"
 path = "src/main.rs"
 test = false
 bench = false
-
-[profile.release]
-codegen-units = 1
-debug = true
-lto = true
-opt-level = "s"

--- a/crates/firmware-h563-io-demo/Cargo.toml
+++ b/crates/firmware-h563-io-demo/Cargo.toml
@@ -17,9 +17,3 @@ name = "firmware-h563-io-demo"
 path = "src/main.rs"
 test = false
 bench = false
-
-[profile.release]
-codegen-units = 1
-debug = true
-lto = true
-opt-level = "s"

--- a/crates/riscv-ci-fixture/Cargo.toml
+++ b/crates/riscv-ci-fixture/Cargo.toml
@@ -19,9 +19,3 @@ name = "riscv-ci-fixture"
 path = "src/main.rs"
 test = false
 bench = false
-
-[profile.release]
-codegen-units = 1
-debug = true
-lto = true
-opt-level = "s"


### PR DESCRIPTION
## Summary
- refactor DAP request parsing to typed argument structs with shared validation
- harden error handling paths for malformed requests
- fix profiling tree depth calculation and clamp depth growth
- optimize peripheral lookup with range index + locality hint and add refresh hook
- clean clippy warnings in touched runtime/tests and move firmware release profile overrides to workspace root

## Validation
- cargo fmt
- cargo test -p labwired-core
- cargo test -p labwired-dap
- cargo clippy -p labwired-core -p labwired-dap --all-targets