### PR TITLE
docs: unify documentation hosting and fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > High-performance, declarative firmware simulator for ARM Cortex-M and RISC-V microcontrollers.
 
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://w1ne.github.io/labwired-core/)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://labwired.com/docs/)
 
 ## Highlights
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LabWired Core
-site_url: https://w1ne.github.io/labwired-core/
-repo_url: https://github.com/w1ne/labwired-core
+site_url: https://labwired.com/docs/
+repo_url: https://github.com/w1ne/libwired-core
 repo_name: w1ne/labwired-core
 
 theme:


### PR DESCRIPTION
Unifies documentation hosting at labwired.com/docs/ and fixes broken links in README and mkdocs.yml.