### PR TITLE
docs: use docs.labwired.com subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > High-performance, declarative firmware simulator for ARM Cortex-M and RISC-V microcontrollers.
 
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://w1ne.github.io/labwired-core/)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://labwired.com/docs/index.html)
 
 ## Highlights
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LabWired Core
-site_url: https://w1ne.github.io/labwired-core/
+site_url: https://labwired.com/docs/
 repo_url: https://github.com/w1ne/labwired-core
 repo_name: w1ne/labwired-core
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LabWired Core
-site_url: https://labwired.com/docs/
+site_url: https://docs.labwired.com/
 repo_url: https://github.com/w1ne/labwired-core
 repo_name: w1ne/labwired-core
 


### PR DESCRIPTION
Updates site_url to docs.labwired.com for technical documentation hosting.