### PR TITLE
docs: modern GitHub Actions deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,34 +3,57 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - main
+      - develop
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure Git User
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
 
-      - name: Build and Deploy
-        run: mkdocs gh-deploy --force
+      - name: Build with MkDocs
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > High-performance, declarative firmware simulator for ARM Cortex-M and RISC-V microcontrollers.
 
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://w1ne.github.io/labwired-core/)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://labwired.com/docs/index.html)
 
 ## Highlights
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LabWired Core
-site_url: https://w1ne.github.io/labwired-core/
+site_url: https://labwired.com/docs/
 repo_url: https://github.com/w1ne/labwired-core
 repo_name: w1ne/labwired-core
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: LabWired Core
-site_url: https://labwired.com/docs/
+site_url: https://docs.labwired.com/
 repo_url: https://github.com/w1ne/labwired-core
 repo_name: w1ne/labwired-core
 


### PR DESCRIPTION
Switches from branch-based deployment to modern GitHub Actions artifacts. This keeps the repository root clean.