### PR TITLE
docs: add back-to-website link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ plugins:
   - search
 
 nav:
+  - Main Website: https://labwired.com
   - Home: index.md
   
   - Tutorials:


### PR DESCRIPTION
Adds a direct link back to the main website from the technical documentation site.