### PR TITLE
fix: code integrity and lints

### DIFF
--- a/crates/cli/src/asset_validation.rs
+++ b/crates/cli/src/asset_validation.rs
@@ -30,10 +30,10 @@ pub struct ListChipsArgs {
 
 #[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
+#[allow(dead_code)]
 enum Severity {
     Error,
     Warning,
-    #[allow(dead_code)]
     Info,
 }
 

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -233,37 +233,6 @@ mod tests {
         assert_eq!(gpio.odr, 0xFFFE);
     }
 
-    #[test]
-    fn test_gpio_v2_bsrr_and_brr() {
-        let mut gpio = GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2);
-
-        // BSRR @ 0x18 (set pin 0)
-        gpio.write(0x18, 0x01).unwrap();
-        assert_eq!(gpio.odr & 0x0001, 0x0001);
-
-        // BSRR @ 0x1A (reset pin 1)
-        gpio.write(0x1A, 0x02).unwrap();
-        assert_eq!(gpio.odr & 0x0002, 0x0000);
-
-        // BRR @ 0x28 (reset pin 0)
-        gpio.write(0x28, 0x01).unwrap();
-        assert_eq!(gpio.odr & 0x0001, 0x0000);
-    }
-
-    #[test]
-    fn test_gpio_v2_moder_and_odr() {
-        let mut gpio = GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2);
-
-        // MODER @ 0x00
-        gpio.write(0x00, 0xAA).unwrap();
-        gpio.write(0x01, 0x55).unwrap();
-        assert_eq!(gpio.moder & 0xFFFF, 0x55AA);
-
-        // ODR @ 0x14
-        gpio.write(0x14, 0x34).unwrap();
-        gpio.write(0x15, 0x12).unwrap();
-        assert_eq!(gpio.odr, 0x1234);
-    }
 
     #[test]
     fn test_gpio_v2_moder_and_odr() {

--- a/crates/core/src/system/mod.rs
+++ b/crates/core/src/system/mod.rs
@@ -1,4 +1,4 @@
 pub mod builder;
 pub mod cortex_m;
 pub mod riscv;
-pub mod builder;
+


### PR DESCRIPTION
Fixes clippy warnings and duplicate tests found during migration