### PR TITLE
test: fix demo_blinky regression

### DIFF
--- a/crates/cli/tests/demo_blinky.rs
+++ b/crates/cli/tests/demo_blinky.rs
@@ -43,7 +43,7 @@ fn test_demo_blinky_gpio_toggle() {
     let mut odr_values = Vec::new();
 
     // We want to detect writes to GPIOC_ODR (PC13 is the LED)
-    for _ in 0..500_000 {
+    for _ in 0..10_000_000 {
         machine.step().expect("Execution failed");
 
         // Peek at GPIOC state


### PR DESCRIPTION
Increases test duration to capture LED toggle in release build