### PR TITLE
ci: move core validation workflows into labwired-core

### DIFF
--- a/.github/workflows/core-board-ci-fixture-arm.yml
+++ b/.github/workflows/core-board-ci-fixture-arm.yml
@@ -1,0 +1,59 @@
+name: Core Board Model - CI Fixture ARM
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  ci-fixture-arm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install ARM target
+        run: rustup target add thumbv6m-none-eabi
+
+      - name: Build ARM fixture firmware
+        run: cargo build -p firmware-ci-fixture --release --target thumbv6m-none-eabi
+
+      - name: Run ARM smoke and fault-path checks
+        run: |
+          cargo run -q -p labwired-cli -- test --script examples/ci/uart-ok.yaml --output-dir out/boards/ci-fixture-arm/smoke --no-uart-stdout
+          cargo run -q -p labwired-cli -- test --script examples/ci/dummy-max-uart-bytes.yaml --output-dir out/boards/ci-fixture-arm/max-uart --no-uart-stdout
+          cargo run -q -p labwired-cli -- test --script examples/ci/dummy-no-progress.yaml --output-dir out/boards/ci-fixture-arm/no-progress --no-uart-stdout
+
+      - name: Measure instruction support coverage
+        run: |
+          ./scripts/unsupported_instruction_audit.sh \
+            --firmware target/thumbv6m-none-eabi/release/firmware-ci-fixture \
+            --system configs/systems/ci-fixture-uart1.yaml \
+            --max-steps 5000 \
+            --out-dir out/boards/ci-fixture-arm/unsupported-audit \
+            --fail-on-unsupported
+
+      - name: Publish board metrics summary
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          p = Path("out/boards/ci-fixture-arm/unsupported-audit/metrics.json")
+          m = json.loads(p.read_text())
+          print("### CI Fixture ARM Instruction Support\n")
+          print(f"- Instructions executed: `{m['instructions_executed']}`")
+          print(f"- Unsupported observations: `{m['unsupported_total']}`")
+          print(f"- Instruction support coverage: `{m['instruction_support_percent']}%`")
+          PY
+
+      - name: Upload board artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: board-ci-fixture-arm
+          path: out/boards/ci-fixture-arm/

--- a/.github/workflows/core-board-ci-fixture-riscv.yml
+++ b/.github/workflows/core-board-ci-fixture-riscv.yml
@@ -1,0 +1,56 @@
+name: Core Board Model - CI Fixture RISC-V
+
+on:
+  schedule:
+    - cron: "20 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  ci-fixture-riscv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install RISC-V target
+        run: rustup target add riscv32i-unknown-none-elf
+
+      - name: Build RISC-V fixture firmware
+        run: cargo build -p riscv-ci-fixture --release --target riscv32i-unknown-none-elf
+
+      - name: Run RISC-V smoke checks
+        run: cargo run -q -p labwired-cli -- test --script examples/ci/riscv-uart-ok.yaml --output-dir out/boards/ci-fixture-riscv/smoke --no-uart-stdout
+
+      - name: Measure instruction support coverage
+        run: |
+          ./scripts/unsupported_instruction_audit.sh \
+            --firmware target/riscv32i-unknown-none-elf/release/riscv-ci-fixture \
+            --system configs/systems/ci-fixture-riscv-uart1.yaml \
+            --max-steps 5000 \
+            --out-dir out/boards/ci-fixture-riscv/unsupported-audit \
+            --fail-on-unsupported
+
+      - name: Publish board metrics summary
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          p = Path("out/boards/ci-fixture-riscv/unsupported-audit/metrics.json")
+          m = json.loads(p.read_text())
+          print("### CI Fixture RISC-V Instruction Support\n")
+          print(f"- Instructions executed: `{m['instructions_executed']}`")
+          print(f"- Unsupported observations: `{m['unsupported_total']}`")
+          print(f"- Instruction support coverage: `{m['instruction_support_percent']}%`")
+          PY
+
+      - name: Upload board artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: board-ci-fixture-riscv
+          path: out/boards/ci-fixture-riscv/

--- a/.github/workflows/core-board-nucleo-h563zi.yml
+++ b/.github/workflows/core-board-nucleo-h563zi.yml
@@ -1,0 +1,60 @@
+name: Core Board Model - NUCLEO-H563ZI
+
+on:
+  schedule:
+    - cron: "40 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  nucleo-h563zi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install ARM target
+        run: rustup target add thumbv7m-none-eabi
+
+      - name: Build NUCLEO-H563ZI firmware fixtures
+        run: |
+          cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
+          cargo build -p firmware-h563-fullchip-demo --release --target thumbv7m-none-eabi
+
+      - name: Run NUCLEO-H563ZI smoke checks
+        run: |
+          cargo run -q -p labwired-cli -- test --script examples/nucleo-h563zi/io-smoke.yaml --output-dir out/boards/nucleo-h563zi/io-smoke --no-uart-stdout
+          cargo run -q -p labwired-cli -- test --script examples/nucleo-h563zi/fullchip-smoke.yaml --output-dir out/boards/nucleo-h563zi/fullchip-smoke --no-uart-stdout
+
+      - name: Measure instruction support coverage
+        run: |
+          ./scripts/unsupported_instruction_audit.sh \
+            --firmware target/thumbv7m-none-eabi/release/firmware-h563-io-demo \
+            --system configs/systems/nucleo-h563zi-demo.yaml \
+            --max-steps 20000 \
+            --out-dir out/boards/nucleo-h563zi/unsupported-audit \
+            --fail-on-unsupported
+
+      - name: Publish board metrics summary
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          p = Path("out/boards/nucleo-h563zi/unsupported-audit/metrics.json")
+          m = json.loads(p.read_text())
+          print("### NUCLEO-H563ZI Instruction Support\n")
+          print(f"- Instructions executed: `{m['instructions_executed']}`")
+          print(f"- Unsupported observations: `{m['unsupported_total']}`")
+          print(f"- Instruction support coverage: `{m['instruction_support_percent']}%`")
+          PY
+
+      - name: Upload board artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: board-nucleo-h563zi
+          path: out/boards/nucleo-h563zi/

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1,0 +1,34 @@
+name: Rust Core CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  integrity:
+    name: core-integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run Workspace Tests
+        run: cargo test --workspace

--- a/.github/workflows/core-coverage.yml
+++ b/.github/workflows/core-coverage.yml
@@ -1,0 +1,60 @@
+name: Core Coverage
+
+on:
+  schedule:
+    - cron: "20 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install coverage tooling
+        run: |
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage
+        run: |
+          mkdir -p out/coverage
+          cargo llvm-cov -p labwired-core -p labwired-cli --summary-only --json > out/coverage/llvm-cov.json
+
+      - name: Enforce minimum line coverage
+        run: |
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          threshold = 60.0
+          p = pathlib.Path("out/coverage/llvm-cov.json")
+          data = json.loads(p.read_text())
+          nodes = data.get("data", [])
+          if not nodes:
+              print("No coverage data found", file=sys.stderr)
+              sys.exit(1)
+          totals = nodes[0].get("totals", {})
+          lines = totals.get("lines", {})
+          pct = float(lines.get("percent", 0.0))
+          print(f"Line coverage: {pct:.2f}% (threshold: {threshold:.2f}%)")
+          if pct < threshold:
+              sys.exit(1)
+          pathlib.Path("out/coverage/summary.txt").write_text(
+              f"line_coverage_percent={pct:.2f}\nthreshold={threshold:.2f}\n"
+          )
+          PY
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-coverage
+          path: out/coverage/

--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -1,0 +1,55 @@
+name: Rust Core Nightly
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # 2 AM UTC
+  workflow_dispatch:
+
+jobs:
+  validation:
+    name: Advanced Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install ARM Toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi
+
+      - name: Install ARM and RISC-V targets
+        run: |
+          rustup target add thumbv7m-none-eabi
+          rustup target add thumbv6m-none-eabi
+          rustup target add riscv32i-unknown-none-elf
+
+      - name: Build Firmware Fixtures
+        run: |
+          cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+          cargo build -p firmware-ci-fixture --release --target thumbv6m-none-eabi
+          cargo build -p riscv-ci-fixture --release --target riscv32i-unknown-none-elf
+
+      - name: Unsupported Instruction Audit
+        run: ./scripts/unsupported_instruction_audit.sh --firmware target/thumbv7m-none-eabi/release/demo-blinky --system configs/systems/ci-fixture-uart1.yaml --max-steps 20000 --out-dir out/unsupported-audit/ci-fixture --fail-on-unsupported
+
+      - name: Digital Twin Verification
+        run: ./scripts/digital_twin_verification.sh out/digital-twin-verification
+
+      - name: Trace Drift Assertions
+        run: ./scripts/trace_drift_assert.sh --out-dir out/trace-drift-assert
+
+      - name: Upload Validation Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-validation-artifacts
+          path: |
+            out/unsupported-audit/
+            out/digital-twin-verification/
+            out/trace-drift-assert/

--- a/.github/workflows/core-unsupported-audit.yml
+++ b/.github/workflows/core-unsupported-audit.yml
@@ -1,0 +1,34 @@
+name: Core Unsupported Audit
+
+on:
+  schedule:
+    - cron: "40 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  unsupported-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install ARM target
+        run: rustup target add thumbv7m-none-eabi
+
+      - name: Build audit firmware fixture
+        run: cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+
+      - name: Run unsupported instruction audit
+        run: ./scripts/unsupported_instruction_audit.sh --firmware target/thumbv7m-none-eabi/release/demo-blinky --system configs/systems/ci-fixture-uart1.yaml --max-steps 20000 --out-dir out/unsupported-audit/ci-fixture --fail-on-unsupported
+
+      - name: Upload unsupported audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-unsupported-audit
+          path: out/unsupported-audit/


### PR DESCRIPTION
## Summary
- add core-owned CI workflows directly in `labwired-core`
- keep PR path lean (`core-integrity`)
- move heavy checks to scheduled/manual workflows (coverage, unsupported audit, board-model checks, nightly)

## Workflows added
- `.github/workflows/core-ci.yml`
- `.github/workflows/core-coverage.yml`
- `.github/workflows/core-unsupported-audit.yml`
- `.github/workflows/core-board-ci-fixture-arm.yml`
- `.github/workflows/core-board-ci-fixture-riscv.yml`
- `.github/workflows/core-board-nucleo-h563zi.yml`
- `.github/workflows/core-nightly.yml`
