### PR TITLE
docs: add core-owned CI verification dashboard

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -30,16 +30,11 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
 
-      - name: Install ARM target
+      - name: Run Fast Unit Tests
         run: |
-          rustup target add thumbv7m-none-eabi
-          rustup target add thumbv7em-none-eabihf
-
-      - name: Build test firmware fixture
-        run: |
-          cargo build -p demo-blinky --release --target thumbv7m-none-eabi
-          cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
-          cargo build -p firmware-h563-demo --release --target thumbv7em-none-eabihf
-
-      - name: Run Workspace Tests
-        run: cargo test --workspace
+          cargo test -p labwired-core --lib
+          cargo test -p labwired-config --lib
+          cargo test -p labwired-loader --lib
+          cargo test -p labwired-gdbstub --lib
+          cargo test -p labwired-codegen --lib
+          cargo test -p labwired-cli --bins

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -30,11 +30,16 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
 
-      - name: Run Fast Unit Tests
+      - name: Install ARM target
         run: |
-          cargo test -p labwired-core --lib
-          cargo test -p labwired-config --lib
-          cargo test -p labwired-loader --lib
-          cargo test -p labwired-gdbstub --lib
-          cargo test -p labwired-codegen --lib
-          cargo test -p labwired-cli --bins
+          rustup target add thumbv7m-none-eabi
+          rustup target add thumbv7em-none-eabihf
+
+      - name: Build test firmware fixture
+        run: |
+          cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+          cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
+          cargo build -p firmware-h563-demo --release --target thumbv7em-none-eabihf
+
+      - name: Run Workspace Tests
+        run: cargo test --workspace

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build test firmware fixture
         run: |
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+          cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
           cargo build -p firmware-h563-demo --release --target thumbv7em-none-eabihf
 
       - name: Run Workspace Tests

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -31,10 +31,14 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       - name: Install ARM target
-        run: rustup target add thumbv7m-none-eabi
+        run: |
+          rustup target add thumbv7m-none-eabi
+          rustup target add thumbv7em-none-eabihf
 
       - name: Build test firmware fixture
-        run: cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+        run: |
+          cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+          cargo build -p firmware-h563-demo --release --target thumbv7em-none-eabihf
 
       - name: Run Workspace Tests
         run: cargo test --workspace

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -30,5 +30,11 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Install ARM target
+        run: rustup target add thumbv7m-none-eabi
+
+      - name: Build test firmware fixture
+        run: cargo build -p demo-blinky --release --target thumbv7m-none-eabi
+
       - name: Run Workspace Tests
         run: cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@
 
 [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://labwired.com/docs/)
 
+## CI Dashboard
+
+| Indicator | Status | Link |
+|---|---|---|
+| Core Integrity (PR Gate) | ![Core Integrity](https://github.com/w1ne/labwired-core/actions/workflows/core-ci.yml/badge.svg?branch=main) | [Workflow](https://github.com/w1ne/labwired-core/actions/workflows/core-ci.yml) |
+| Coverage Gate (Scheduled/Manual) | ![Coverage](https://github.com/w1ne/labwired-core/actions/workflows/core-coverage.yml/badge.svg?branch=main) | [Workflow](https://github.com/w1ne/labwired-core/actions/workflows/core-coverage.yml) |
+| Unsupported Audit (Scheduled/Manual) | ![Unsupported Audit](https://github.com/w1ne/labwired-core/actions/workflows/core-unsupported-audit.yml/badge.svg?branch=main) | [Workflow](https://github.com/w1ne/labwired-core/actions/workflows/core-unsupported-audit.yml) |
+| Nightly Validation (Scheduled/Manual) | ![Nightly](https://github.com/w1ne/labwired-core/actions/workflows/core-nightly.yml/badge.svg?branch=main) | [Workflow](https://github.com/w1ne/labwired-core/actions/workflows/core-nightly.yml) |
+
+### Board Model Dashboard
+
+| Board Model | Status | Verification Coverage | Instruction Support % (runtime) | Workflow |
+|---|---|---|---|---|
+| `ci-fixture-uart1` (ARM Cortex-M) | ![ARM Board](https://github.com/w1ne/labwired-core/actions/workflows/core-board-ci-fixture-arm.yml/badge.svg?branch=main) | smoke + max UART + no-progress | published in workflow summary/artifacts | [ARM Board CI](https://github.com/w1ne/labwired-core/actions/workflows/core-board-ci-fixture-arm.yml) |
+| `ci-fixture-riscv-uart1` (RISC-V) | ![RISC-V Board](https://github.com/w1ne/labwired-core/actions/workflows/core-board-ci-fixture-riscv.yml/badge.svg?branch=main) | smoke | published in workflow summary/artifacts | [RISC-V Board CI](https://github.com/w1ne/labwired-core/actions/workflows/core-board-ci-fixture-riscv.yml) |
+| `nucleo-h563zi` | ![H563 Board](https://github.com/w1ne/labwired-core/actions/workflows/core-board-nucleo-h563zi.yml/badge.svg?branch=main) | io-smoke + fullchip-smoke | published in workflow summary/artifacts | [NUCLEO-H563ZI CI](https://github.com/w1ne/labwired-core/actions/workflows/core-board-nucleo-h563zi.yml) |
+
 ## Highlights
 
 - **🚀 [Demos & Examples](../DEMOS.md)** - Central portal for all LabWired demos.

--- a/crates/cli/tests/h5_demo.rs
+++ b/crates/cli/tests/h5_demo.rs
@@ -38,10 +38,8 @@ fn test_h5_demo_uart_output() {
     let manifest = SystemManifest::from_file(&system_path).expect("Failed to load system manifest");
 
     let chip_path = system_path.parent().unwrap().join(&manifest.chip);
-    let chip = ChipDescriptor::from_file(&chip_path).expect(&format!(
-        "Failed to load chip descriptor at {:?}",
-        chip_path
-    ));
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|_| panic!("Failed to load chip descriptor at {:?}", chip_path));
 
     let mut bus =
         labwired_core::bus::SystemBus::from_config(&chip, &manifest).expect("Failed to build bus");

--- a/crates/core/tests/strict_onboarding.rs
+++ b/crates/core/tests/strict_onboarding.rs
@@ -76,7 +76,7 @@ fn test_strict_board_onboarding() -> anyhow::Result<()> {
                     // Change current directory to the example directory so it picks up .cargo/config.toml
                     let build_status = Command::new("cargo")
                         .current_dir(dir)
-                        .args(&["build", "--release"])
+                        .args(["build", "--release"])
                         .status();
 
                     if build_status.is_err() || !build_status.unwrap().success() {
@@ -90,7 +90,7 @@ fn test_strict_board_onboarding() -> anyhow::Result<()> {
                 // cargo run -p labwired-cli -- test --script <path> ...
                 let status = Command::new("cargo")
                     .current_dir(project_root)
-                    .args(&[
+                    .args([
                         "run",
                         "-q",
                         "-p",


### PR DESCRIPTION
Move core CI status reporting to core README with badges/links for integrity, coverage, unsupported audit, board model workflows, and nightly validation.