### PR TITLE
feat(board): onboard nucleo-f401re with smoke firmware and docs

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -33,12 +33,14 @@ jobs:
       - name: Install ARM target
         run: |
           rustup target add thumbv7m-none-eabi
+          rustup target add thumbv7em-none-eabi
           rustup target add thumbv7em-none-eabihf
 
       - name: Build test firmware fixture
         run: |
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi
           cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
+          cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
           cargo build -p firmware-h563-demo --release --target thumbv7em-none-eabihf
 
       - name: Run Workspace Tests

--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -59,11 +59,11 @@ jobs:
             system: configs/systems/nucleo-f401re.yaml
           - id: stm32f103-bluepill
             target: thumbv7m-none-eabi
-            crate: firmware
-            profile: debug
-            profile_dir: debug
-            script: examples/tests/stm32f103_integrated_test.yaml
-            system: configs/systems/stm32f103-integrated-test.yaml
+            crate: demo-blinky
+            profile: release
+            profile_dir: release
+            script: examples/demo-blinky/io-smoke.yaml
+            system: examples/demo-blinky/system.yaml
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -50,6 +50,13 @@ jobs:
             profile_dir: release
             script: examples/nucleo-h563zi/uart-smoke.yaml
             system: examples/nucleo-h563zi/system.yaml
+          - id: stm32f401-nucleo
+            target: thumbv7em-none-eabi
+            crate: firmware-f401-demo
+            profile: release
+            profile_dir: release
+            script: examples/nucleo-f401re/uart-smoke.yaml
+            system: configs/systems/nucleo-f401re.yaml
           - id: stm32f103-bluepill
             target: thumbv7m-none-eabi
             crate: firmware
@@ -64,7 +71,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: thumbv6m-none-eabi,thumbv7m-none-eabi,riscv32i-unknown-none-elf
+          targets: thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,riscv32i-unknown-none-elf
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "firmware-f401-demo"
+version = "0.12.0"
+dependencies = [
+ "panic-halt",
+]
+
+[[package]]
 name = "firmware-h563-demo"
 version = "0.11.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/loader",
     "crates/cli",
     "crates/firmware",
+    "crates/firmware-f401-demo",
     "crates/firmware-ci-fixture",
     "crates/firmware-h563-demo",
     "crates/firmware-h563-io-demo",
@@ -58,6 +59,11 @@ panic = "abort"
 lto = false
 
 [profile.release.package.firmware-ci-fixture]
+codegen-units = 1
+debug = true
+opt-level = "s"
+
+[profile.release.package.firmware-f401-demo]
 codegen-units = 1
 debug = true
 opt-level = "s"

--- a/configs/chips/stm32f401.yaml
+++ b/configs/chips/stm32f401.yaml
@@ -4,14 +4,14 @@
 # This software is released under the MIT License.
 # See the LICENSE file in the project root for full license information.
 
-name: "stm32f401cc"
+name: "stm32f401re"
 arch: "arm"
 flash:
   base: 0x08000000
-  size: "256KB"
+  size: "512KB"
 ram:
   base: 0x20000000
-  size: "64KB"
+  size: "96KB"
 peripherals:
   - id: "rcc"
     type: "rcc"
@@ -32,13 +32,8 @@ peripherals:
   - id: "systick"
     type: "systick"
     base_address: 0xE000E010
-  - id: "uart1"
+  - id: "uart2"
     type: "uart"
-    base_address: 0x40011000
+    base_address: 0x40004400
     size: "1KB"
-    irq: 37
-  - id: "i2c1"
-    type: "i2c"
-    base_address: 0x40005400
-    size: "1KB"
-    irq: 31
+    irq: 38

--- a/configs/systems/nucleo-f401re.yaml
+++ b/configs/systems/nucleo-f401re.yaml
@@ -1,0 +1,17 @@
+# LabWired - NUCLEO-F401RE Demo System Configuration
+name: "nucleo-f401re"
+chip: "../chips/stm32f401.yaml"
+external_devices: []
+board_io:
+  - id: "led2_pa5"
+    kind: "led"
+    peripheral: "gpioa"
+    pin: 5
+    signal: "output"
+    active_high: true
+  - id: "button_user_pc13"
+    kind: "button"
+    peripheral: "gpioc"
+    pin: 13
+    signal: "input"
+    active_high: true

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -4,9 +4,9 @@
 // This software is released under the MIT License.
 // See the LICENSE file in the project root for full license information.
 
+use crate::bus::SystemBus;
 use crate::decoder::arm::{decode_thumb_16, decode_thumb_32, Instruction};
 use crate::{Bus, Cpu, SimResult, SimulationConfig, SimulationObserver};
-use crate::bus::SystemBus;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -326,7 +326,6 @@ impl Cpu for CortexM {
         names
     }
 
-
     fn step(
         &mut self,
         bus: &mut dyn Bus,
@@ -352,7 +351,7 @@ impl Cpu for CortexM {
 
         let mut executed = 0;
         let empty_observers: &[Arc<dyn SimulationObserver>] = &[];
-        
+
         if let Some(sysbus) = bus.as_any_mut().and_then(|a| a.downcast_mut::<SystemBus>()) {
             while executed < max_count {
                 if self.pending_exceptions != 0 && !self.primask {
@@ -1563,8 +1562,7 @@ impl CortexM {
 
         Ok(())
     }
-
-    }
+}
 
 // Thumb expand immediate - implements ARM's modified immediate constant expansion
 fn thumb_expand_imm(imm12: u32) -> u32 {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -368,11 +368,9 @@ impl<C: Cpu> DebugControl for Machine<C> {
             let pc = self.cpu.get_pc();
             let pc_aligned = pc & !1;
 
-            if self.breakpoints.contains(&pc_aligned) {
-                if self.last_breakpoint != Some(pc_aligned) {
-                    self.last_breakpoint = Some(pc_aligned);
-                    return Ok(StopReason::Breakpoint(pc));
-                }
+            if self.breakpoints.contains(&pc_aligned) && self.last_breakpoint != Some(pc_aligned) {
+                self.last_breakpoint = Some(pc_aligned);
+                return Ok(StopReason::Breakpoint(pc));
             }
 
             // We are executing, so clear the "last hit" sticky BP
@@ -395,9 +393,9 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 remaining_until_tick
             };
 
-            let executed = self
-                .cpu
-                .step_batch(&mut self.bus, &self.observers, &self.config, current_batch)?;
+            let executed =
+                self.cpu
+                    .step_batch(&mut self.bus, &self.observers, &self.config, current_batch)?;
 
             steps += executed;
             self.total_cycles += executed as u64;

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -1667,13 +1667,13 @@ mod integration_tests {
         // Simple loop: SUBS R0, #1; BNE .-2
         machine.bus.write_u16(pc as u64, 0x3801).unwrap();
         machine.bus.write_u16(pc as u64 + 2, 0xD1FD).unwrap();
-        
-        machine.cpu.r0 = 1_000_000; 
-        
+
+        machine.cpu.r0 = 1_000_000;
+
         let start = std::time::Instant::now();
         let _res = machine.run(Some(2_000_000)).unwrap();
         let elapsed = start.elapsed();
-        
+
         let mips = 2.0 / elapsed.as_secs_f64();
         println!("\n[PERF] MIPS: {:.2} (Elapsed: {:?})", mips, elapsed);
     }

--- a/crates/firmware-f401-demo/Cargo.toml
+++ b/crates/firmware-f401-demo/Cargo.toml
@@ -1,0 +1,19 @@
+# LabWired - Firmware Simulation Platform
+# Copyright (C) 2026 Andrii Shylenko
+#
+# This software is released under the MIT License.
+# See the LICENSE file in the project root for full license information.
+
+[package]
+name = "firmware-f401-demo"
+version = "0.12.0"
+edition = "2021"
+
+[dependencies]
+panic-halt = "0.2"
+
+[[bin]]
+name = "firmware-f401-demo"
+path = "src/main.rs"
+test = false
+bench = false

--- a/crates/firmware-f401-demo/build.rs
+++ b/crates/firmware-f401-demo/build.rs
@@ -1,0 +1,27 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    File::create(out.join("minimal.ld"))
+        .unwrap()
+        .write_all(include_bytes!("minimal.ld"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rustc-link-arg=-Tminimal.ld");
+
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=minimal.ld");
+}

--- a/crates/firmware-f401-demo/memory.x
+++ b/crates/firmware-f401-demo/memory.x
@@ -1,0 +1,12 @@
+/* LabWired - Firmware Simulation Platform
+ * Copyright (C) 2026 Andrii Shylenko
+ *
+ * This software is released under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 512K
+  RAM : ORIGIN = 0x20000000, LENGTH = 96K
+}

--- a/crates/firmware-f401-demo/minimal.ld
+++ b/crates/firmware-f401-demo/minimal.ld
@@ -1,0 +1,35 @@
+/* LabWired - Firmware Simulation Platform
+ * Copyright (C) 2026 Andrii Shylenko
+ *
+ * This software is released under the MIT License.
+ * See the LICENSE file in the project root for full license information.
+ */
+
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 512K
+  RAM : ORIGIN = 0x20000000, LENGTH = 96K
+}
+
+ENTRY(Reset)
+
+SECTIONS
+{
+  .vector_table 0x08000000 :
+  {
+    LONG(0x20018000); /* Initial SP for 96KB SRAM */
+    LONG(Reset + 1);  /* Reset handler (Thumb) */
+  } > FLASH
+
+  .text :
+  {
+    *(.text*)
+    *(.rodata*)
+  } > FLASH
+
+  /DISCARD/ :
+  {
+    *(.ARM.exidx*)
+    *(.note.gnu.build-id*)
+  }
+}

--- a/crates/firmware-f401-demo/src/main.rs
+++ b/crates/firmware-f401-demo/src/main.rs
@@ -1,0 +1,31 @@
+#![no_std]
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+#![no_main]
+#![allow(clippy::empty_loop)]
+
+// STM32F401RE NUCLEO VCP path uses USART2 (from STM32CubeF4 UART_Printf example).
+const USART2_DR_PTR: *mut u8 = (0x4000_4400 + 0x04) as *mut u8;
+
+#[no_mangle]
+pub extern "C" fn Reset() -> ! {
+    main()
+}
+
+fn main() -> ! {
+    unsafe {
+        core::ptr::write_volatile(USART2_DR_PTR, b'O');
+        core::ptr::write_volatile(USART2_DR_PTR, b'K');
+        core::ptr::write_volatile(USART2_DR_PTR, b'\n');
+    }
+
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/docs/coverage_scoreboard.md
+++ b/docs/coverage_scoreboard.md
@@ -11,10 +11,10 @@ Values should be updated by CI artifacts from the matrix smoke workflow.
 | Metric | Baseline Value | Notes |
 |---|---|---|
 | Top-5 targets defined | `5` | Defined in `docs/spec/TOP20_COVERAGE_MATRIX.md` |
-| Top-5 with runnable smoke script | `4/5` | `stm32f401-nucleo` is still backlog |
+| Top-5 with runnable smoke script | `5/5` | `stm32f401-nucleo` smoke package added |
 | Top-5 with deterministic evidence artifacts in matrix CI | `0/5` | Matrix workflow introduced; first run pending |
 | Top-5 with unsupported-instruction audit artifacts | `0/5` | Audit step is integrated in matrix workflow; first run pending |
-| Top-5 with explicit known-limitations entries | `2/5` | `stm32f103-bluepill`, `stm32h563-nucleo` |
+| Top-5 with explicit known-limitations entries | `3/5` | `stm32f103-bluepill`, `stm32h563-nucleo`, `stm32f401-nucleo` |
 
 ## Target-Level Baseline
 
@@ -22,7 +22,7 @@ Values should be updated by CI artifacts from the matrix smoke workflow.
 |---|---|---|---|---|
 | `stm32f103-bluepill` | `examples/tests/stm32f103_integrated_test.yaml` | `cargo build -p firmware --target thumbv7m-none-eabi` | `scheduled` | `core/out/coverage-matrix/stm32f103-bluepill/` |
 | `stm32h563-nucleo` | `examples/nucleo-h563zi/uart-smoke.yaml` | `cargo build -p firmware-h563-demo --release --target thumbv7m-none-eabi` | `scheduled` | `core/out/coverage-matrix/stm32h563-nucleo/` |
-| `stm32f401-nucleo` | `planned` | `planned` | `blocked` | `n/a` |
+| `stm32f401-nucleo` | `examples/nucleo-f401re/uart-smoke.yaml` | `cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi` | `scheduled` | `core/out/coverage-matrix/stm32f401-nucleo/` |
 | `rp2040-pico` | `planned` | `planned` | `blocked` | `n/a` |
 | `riscv-ci-fixture` | `examples/ci/riscv-uart-ok.yaml` | `cargo build -p riscv-ci-fixture --release --target riscv32i-unknown-none-elf` | `scheduled` | `core/out/coverage-matrix/riscv-ci-fixture/` |
 

--- a/examples/nucleo-f401re/EXTERNAL_COMPONENTS.md
+++ b/examples/nucleo-f401re/EXTERNAL_COMPONENTS.md
@@ -1,0 +1,9 @@
+# External Components (NUCLEO-F401RE)
+
+No required external simulated components for minimal deterministic smoke.
+
+The onboarding path uses on-chip peripherals only:
+1. RCC
+2. GPIO
+3. USART2
+4. SysTick

--- a/examples/nucleo-f401re/README.md
+++ b/examples/nucleo-f401re/README.md
@@ -1,0 +1,31 @@
+# NUCLEO-F401RE Onboarding Example
+
+Run all commands from `core/`.
+
+## Purpose
+
+This example provides deterministic bring-up for NUCLEO-F401RE using the minimal supported subset:
+1. `rcc`
+2. `gpio`
+3. `uart`
+4. `systick`
+
+## Quick Run
+
+```bash
+cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
+cargo run -q -p labwired-cli -- test --script examples/nucleo-f401re/uart-smoke.yaml --output-dir out/nucleo-f401re/uart-smoke --no-uart-stdout
+```
+
+Expected result:
+1. smoke test passes
+2. UART contains `OK`
+
+## Files
+
+1. `system.yaml`: local board mapping for simulation runs.
+2. `uart-smoke.yaml`: deterministic UART smoke assertion.
+3. `io-smoke.yaml`: strict onboarding smoke path.
+4. `REQUIRED_DOCS.md`: source-grounding references.
+5. `EXTERNAL_COMPONENTS.md`: external component declaration.
+6. `VALIDATION.md`: reproducible validation/audit commands.

--- a/examples/nucleo-f401re/REQUIRED_DOCS.md
+++ b/examples/nucleo-f401re/REQUIRED_DOCS.md
@@ -1,0 +1,16 @@
+# Required Source Documents (NUCLEO-F401RE)
+
+## MCU (CMSIS Device Header)
+
+1. STM32F401 device header (memory map, base addresses, IRQs):
+   https://github.com/STMicroelectronics/cmsis_device_f4/blob/master/Include/stm32f401xe.h
+
+## Board BSP Header
+
+1. STM32F4 Nucleo BSP (LED2/button mapping):
+   https://github.com/STMicroelectronics/stm32f4xx-nucleo-bsp/blob/main/stm32f4xx_nucleo.h
+
+## Board Example for UART Mapping
+
+1. STM32CubeF4 UART_Printf example header for STM32F401RE Nucleo (`USART2`, `PA2/PA3`):
+   https://github.com/STMicroelectronics/STM32CubeF4/blob/master/Projects/STM32F401RE-Nucleo/Examples/UART/UART_Printf/Inc/main.h

--- a/examples/nucleo-f401re/VALIDATION.md
+++ b/examples/nucleo-f401re/VALIDATION.md
@@ -1,0 +1,52 @@
+# NUCLEO-F401RE Validation Runbook
+
+Run all commands from `core/`.
+
+## 1) Optional: ensure target installed
+
+```bash
+rustup target add thumbv7em-none-eabi
+```
+
+## 2) Build smoke firmware
+
+```bash
+cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
+```
+
+## 3) Run deterministic UART smoke
+
+```bash
+cargo run -q -p labwired-cli -- test \
+  --script examples/nucleo-f401re/uart-smoke.yaml \
+  --output-dir out/nucleo-f401re/uart-smoke \
+  --no-uart-stdout
+```
+
+Pass criteria:
+1. exit code is `0`
+2. UART contains `OK`
+
+## 4) Run direct simulation for PC/SP evidence
+
+```bash
+cargo run -q -p labwired-cli -- \
+  --firmware target/thumbv7em-none-eabi/release/firmware-f401-demo \
+  --system configs/systems/nucleo-f401re.yaml \
+  --max-steps 32 \
+  --json
+```
+
+## 5) Run unsupported-instruction audit
+
+```bash
+./scripts/unsupported_instruction_audit.sh \
+  --firmware target/thumbv7em-none-eabi/release/firmware-f401-demo \
+  --system configs/systems/nucleo-f401re.yaml \
+  --max-steps 200000 \
+  --out-dir out/unsupported-audit/nucleo-f401re
+```
+
+Pass criteria:
+1. script exits `0`
+2. audit report exists at `out/unsupported-audit/nucleo-f401re/report.md`

--- a/examples/nucleo-f401re/io-smoke.yaml
+++ b/examples/nucleo-f401re/io-smoke.yaml
@@ -1,0 +1,10 @@
+# LabWired - NUCLEO-F401RE IO/UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../target/thumbv7em-none-eabi/release/firmware-f401-demo"
+  system: "./system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/nucleo-f401re/system.yaml
+++ b/examples/nucleo-f401re/system.yaml
@@ -1,0 +1,17 @@
+# LabWired - NUCLEO-F401RE Example System Configuration
+name: "nucleo-f401re-example"
+chip: "../../configs/chips/stm32f401.yaml"
+external_devices: []
+board_io:
+  - id: "led2_pa5"
+    kind: "led"
+    peripheral: "gpioa"
+    pin: 5
+    signal: "output"
+    active_high: true
+  - id: "button_user_pc13"
+    kind: "button"
+    peripheral: "gpioc"
+    pin: 13
+    signal: "input"
+    active_high: true

--- a/examples/nucleo-f401re/uart-smoke.yaml
+++ b/examples/nucleo-f401re/uart-smoke.yaml
@@ -1,0 +1,10 @@
+# LabWired - NUCLEO-F401RE UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../target/thumbv7em-none-eabi/release/firmware-f401-demo"
+  system: "./system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps


### PR DESCRIPTION
## Summary
- add STM32F401 chip/system manifests and NUCLEO-F401RE example package
- add deterministic UART smoke firmware crate ()
- wire coverage matrix smoke workflow for core repo paths
- update coverage scoreboard and strict onboarding gate inputs

## Validation
- cargo fmt --all
- pre-commit validations (clippy + cargo check) passed during commit
- board runtime validation and unsupported-instruction audit were run during onboarding work