### PR TITLE
feat(ci): artifact-driven coverage matrix scoreboard

### DIFF
--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -130,3 +130,38 @@ jobs:
           name: coverage-matrix-${{ matrix.id }}
           path: out/coverage-matrix/${{ matrix.id }}/
           retention-days: 14
+
+  coverage-matrix-scoreboard:
+    name: coverage-matrix-scoreboard
+    runs-on: ubuntu-latest
+    needs: coverage-matrix-smoke
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download matrix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: out/coverage-matrix
+          pattern: coverage-matrix-*
+          merge-multiple: true
+
+      - name: Generate scoreboard
+        run: |
+          python3 scripts/generate_coverage_matrix_scoreboard.py \
+            --matrix-root out/coverage-matrix \
+            --markdown-out out/coverage-matrix/scoreboard.md \
+            --json-out out/coverage-matrix/scoreboard.json
+
+      - name: Publish scoreboard summary
+        run: |
+          cat out/coverage-matrix/scoreboard.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload scoreboard artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-matrix-scoreboard
+          path: |
+            out/coverage-matrix/scoreboard.md
+            out/coverage-matrix/scoreboard.json
+          retention-days: 14

--- a/docs/coverage_scoreboard.md
+++ b/docs/coverage_scoreboard.md
@@ -6,6 +6,15 @@ Scope: Priority-1 Top-5 matrix baseline for deterministic smoke.
 This document is the baseline scoreboard referenced by the Top-20 coverage plan.
 Values should be updated by CI artifacts from the matrix smoke workflow.
 
+## Automated Scoreboard Artifact
+
+The matrix workflow now generates:
+
+- `coverage-matrix-scoreboard/scoreboard.md`
+- `coverage-matrix-scoreboard/scoreboard.json`
+
+These artifacts are published on every matrix run and summarized in GitHub Actions step summary.
+
 ## Baseline Snapshot
 
 | Metric | Baseline Value | Notes |
@@ -29,6 +38,6 @@ Values should be updated by CI artifacts from the matrix smoke workflow.
 ## Update Protocol
 
 1. Matrix CI uploads per-target artifacts under `out/coverage-matrix/<target-id>/`.
-2. Record pass/fail plus stop reason and assertion summary.
-3. Update this file each time top-5 status changes.
+2. Matrix CI aggregates and publishes scoreboard artifacts via `scripts/generate_coverage_matrix_scoreboard.py`.
+3. Update this file when the Top-5 scope, thresholds, or status policy changes.
 4. Do not mark `green` without deterministic re-run evidence.

--- a/scripts/generate_coverage_matrix_scoreboard.py
+++ b/scripts/generate_coverage_matrix_scoreboard.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Generate a coverage-matrix scoreboard from per-target artifacts.
+
+Expected layout:
+  <matrix_root>/<target-id>/result.json
+  <matrix_root>/<target-id>/unsupported-audit/metrics.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix-root",
+        default="out/coverage-matrix",
+        help="Root directory containing per-target matrix outputs.",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        default="out/coverage-matrix/scoreboard.md",
+        help="Path to write markdown scoreboard.",
+    )
+    parser.add_argument(
+        "--json-out",
+        default="out/coverage-matrix/scoreboard.json",
+        help="Path to write machine-readable scoreboard.",
+    )
+    args = parser.parse_args()
+
+    matrix_root = Path(args.matrix_root)
+    if not matrix_root.exists():
+        raise SystemExit(f"matrix root not found: {matrix_root}")
+
+    rows: list[dict[str, Any]] = []
+    for target_dir in sorted(p for p in matrix_root.iterdir() if p.is_dir()):
+        result = _load_json(target_dir / "result.json")
+        metrics = _load_json(target_dir / "unsupported-audit" / "metrics.json")
+
+        status = "missing"
+        stop_reason = "n/a"
+        instructions = 0
+        unsupported = "n/a"
+        support_pct = "n/a"
+
+        if result:
+            status = str(result.get("status", "unknown"))
+            stop_reason = str(result.get("stop_reason", "unknown"))
+            instructions = int(result.get("instructions", 0))
+
+        if metrics:
+            unsupported_val = metrics.get("unsupported_total", 0)
+            support_pct_val = metrics.get("instruction_support_percent", 0)
+            unsupported = str(unsupported_val)
+            support_pct = f"{float(support_pct_val):.2f}%"
+
+        rows.append(
+            {
+                "target_id": target_dir.name,
+                "status": status,
+                "stop_reason": stop_reason,
+                "instructions": instructions,
+                "unsupported_total": unsupported,
+                "instruction_support_percent": support_pct,
+                "artifact_path": str(target_dir),
+            }
+        )
+
+    pass_count = sum(1 for r in rows if r["status"] == "pass")
+    fail_count = sum(1 for r in rows if r["status"] == "fail")
+    missing_count = sum(1 for r in rows if r["status"] not in {"pass", "fail"})
+
+    markdown_lines = [
+        "# Coverage Matrix Scoreboard",
+        "",
+        f"- targets: `{len(rows)}`",
+        f"- pass: `{pass_count}`",
+        f"- fail: `{fail_count}`",
+        f"- missing: `{missing_count}`",
+        "",
+        "| Target | Status | Stop Reason | Instructions | Unsupported | Instruction Support | Artifact |",
+        "|---|---|---|---:|---:|---:|---|",
+    ]
+    for row in rows:
+        markdown_lines.append(
+            "| `{target_id}` | `{status}` | `{stop_reason}` | `{instructions}` | `{unsupported_total}` | `{instruction_support_percent}` | `{artifact_path}` |".format(
+                **row
+            )
+        )
+    markdown_lines.append("")
+
+    markdown_out = Path(args.markdown_out)
+    markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    markdown_out.write_text("\n".join(markdown_lines))
+
+    json_out = Path(args.json_out)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(
+        json.dumps(
+            {
+                "targets": rows,
+                "summary": {
+                    "targets_total": len(rows),
+                    "pass": pass_count,
+                    "fail": fail_count,
+                    "missing": missing_count,
+                },
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add  to aggregate matrix target artifacts
- add matrix post-job to download artifacts, generate scoreboard, publish to workflow summary, and upload scoreboard artifacts
- align  with automated artifact workflow

## Why
This moves gap-coverage tracking from manual markdown updates to executable CI output.