### PR TITLE
ci: add onboarding smoke KPI workflow and scoreboard

### DIFF
--- a/.github/workflows/core-onboarding-smoke.yml
+++ b/.github/workflows/core-onboarding-smoke.yml
@@ -1,0 +1,107 @@
+name: Core Onboarding Smoke
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - "crates/**"
+      - "configs/**"
+      - "examples/**"
+      - "scripts/**"
+      - ".github/workflows/core-onboarding-smoke.yml"
+  workflow_dispatch:
+
+jobs:
+  onboarding-smoke:
+    name: onboarding-${{ matrix.id }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: stm32f401-nucleo
+            crate: firmware-f401-demo
+            target: thumbv7em-none-eabi
+            script: examples/nucleo-f401re/uart-smoke.yaml
+            system: configs/systems/nucleo-f401re.yaml
+          - id: stm32h563-nucleo
+            crate: firmware-h563-demo
+            target: thumbv7m-none-eabi
+            script: examples/nucleo-h563zi/uart-smoke.yaml
+            system: examples/nucleo-h563zi/system.yaml
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7m-none-eabi,thumbv7em-none-eabi
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run onboarding smoke
+        run: |
+          chmod +x scripts/onboarding_smoke.sh
+          scripts/onboarding_smoke.sh \
+            --target-id "${{ matrix.id }}" \
+            --crate "${{ matrix.crate }}" \
+            --target "${{ matrix.target }}" \
+            --script "${{ matrix.script }}" \
+            --system "${{ matrix.system }}" \
+            --out-dir "out/onboarding-smoke/${{ matrix.id }}" \
+            --threshold-seconds 3600
+
+      - name: Publish onboarding summary
+        if: always()
+        run: |
+          cat "out/onboarding-smoke/${{ matrix.id }}/onboarding-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload onboarding artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-smoke-${{ matrix.id }}
+          path: out/onboarding-smoke/${{ matrix.id }}/
+          retention-days: 14
+
+  onboarding-scoreboard:
+    name: onboarding-scoreboard
+    runs-on: ubuntu-latest
+    needs: onboarding-smoke
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download onboarding artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: out/onboarding-smoke
+          pattern: onboarding-smoke-*
+          merge-multiple: false
+
+      - name: Generate onboarding scoreboard
+        run: |
+          python3 scripts/generate_onboarding_scoreboard.py \
+            --metrics-root out/onboarding-smoke \
+            --markdown-out out/onboarding-smoke/onboarding-scoreboard.md \
+            --json-out out/onboarding-smoke/onboarding-scoreboard.json \
+            --soft-threshold-seconds 3600
+
+      - name: Publish scoreboard summary
+        run: |
+          cat out/onboarding-smoke/onboarding-scoreboard.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload scoreboard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-scoreboard
+          path: |
+            out/onboarding-smoke/onboarding-scoreboard.md
+            out/onboarding-smoke/onboarding-scoreboard.json
+          retention-days: 14
+

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -100,3 +100,13 @@ The test runner produces machine-readable outputs for integration with CI report
 - **`uart.log`**: Captured serial output for debugging failures.
 
 Ensure your CI pipeline is configured to archive these artifacts upon failure.
+
+## 5. Onboarding KPI Tracking
+
+For board onboarding competitiveness, `core-onboarding-smoke.yml` runs a deterministic smoke path and emits:
+
+- `onboarding-metrics.json`: elapsed time, failure stage, and first error signature.
+- `onboarding-summary.md`: per-target summary for step output.
+- `onboarding-scoreboard.json` / `onboarding-scoreboard.md`: aggregated run-level view.
+
+This workflow uses a soft threshold (`3600s`) to track time-to-first-smoke without blocking merges.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ For contributors extending the core engine or adding new peripherals:
 - **[Declarative Registers](declarative_registers.md)**: Defining register maps using simple YAML files.
 - **[CI Integration](ci_integration.md)**: How to run LabWired in GitHub Actions or GitLab CI.
 - **[Coverage Scoreboard](coverage_scoreboard.md)**: Top-target smoke coverage and deterministic status tracking.
+- **Onboarding Smoke CI**: `core-onboarding-smoke.yml` publishes time-to-first-smoke metrics and scoreboard artifacts.
 - **[Target Support Rubric](target_support_rubric.md)**: Objective support levels and promotion criteria.
 
 ## 🔍 Debugging

--- a/scripts/generate_onboarding_scoreboard.py
+++ b/scripts/generate_onboarding_scoreboard.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Aggregate onboarding smoke metrics into markdown/json scoreboard artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import median
+
+
+def load_metrics(root: Path) -> list[dict]:
+    metrics: list[dict] = []
+    for path in sorted(root.rglob("onboarding-metrics.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        data["_artifact_path"] = str(path.parent)
+        metrics.append(data)
+    return metrics
+
+
+def build_markdown(metrics: list[dict], threshold_seconds: int) -> str:
+    total = len(metrics)
+    passing = sum(1 for m in metrics if m.get("status") == "pass")
+    failing = total - passing
+    elapsed_values = [int(m.get("elapsed_seconds", 0)) for m in metrics]
+    median_elapsed = int(median(elapsed_values)) if elapsed_values else 0
+    threshold_hits = sum(1 for m in metrics if bool(m.get("threshold_met")))
+
+    lines = [
+        "# Onboarding Smoke Scoreboard",
+        "",
+        f"- targets_total: `{total}`",
+        f"- pass: `{passing}`",
+        f"- fail: `{failing}`",
+        f"- median_elapsed_seconds: `{median_elapsed}`",
+        f"- threshold_seconds: `{threshold_seconds}`",
+        f"- threshold_met: `{threshold_hits}/{total}`",
+        "",
+        "| Target | Status | Elapsed (s) | Threshold Met | Failure Stage | Signature |",
+        "|---|---|---:|---|---|---|",
+    ]
+
+    for m in sorted(metrics, key=lambda row: row.get("target_id", "")):
+        target = m.get("target_id", "unknown")
+        status = m.get("status", "missing")
+        elapsed = m.get("elapsed_seconds", 0)
+        threshold_met = m.get("threshold_met", False)
+        failure_stage = m.get("failure_stage") or "n/a"
+        signature = (m.get("first_error_signature") or "n/a").replace("|", "/")
+        lines.append(
+            f"| `{target}` | `{status}` | `{elapsed}` | `{threshold_met}` | `{failure_stage}` | `{signature}` |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metrics-root", required=True, type=Path)
+    parser.add_argument("--markdown-out", required=True, type=Path)
+    parser.add_argument("--json-out", required=True, type=Path)
+    parser.add_argument("--soft-threshold-seconds", type=int, default=3600)
+    args = parser.parse_args()
+
+    metrics = load_metrics(args.metrics_root)
+    summary = {
+        "targets_total": len(metrics),
+        "pass": sum(1 for m in metrics if m.get("status") == "pass"),
+        "fail": sum(1 for m in metrics if m.get("status") != "pass"),
+        "median_elapsed_seconds": int(median([int(m.get("elapsed_seconds", 0)) for m in metrics]))
+        if metrics
+        else 0,
+        "threshold_seconds": args.soft_threshold_seconds,
+        "threshold_met": sum(1 for m in metrics if bool(m.get("threshold_met"))),
+    }
+    payload = {"summary": summary, "targets": metrics}
+
+    args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_out.write_text(
+        build_markdown(metrics, args.soft_threshold_seconds), encoding="utf-8"
+    )
+    args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/onboarding_smoke.sh
+++ b/scripts/onboarding_smoke.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_ID=""
+CRATE=""
+TARGET=""
+SCRIPT=""
+SYSTEM=""
+OUT_DIR=""
+PROFILE="release"
+THRESHOLD_SECONDS="${ONBOARDING_SOFT_THRESHOLD_SECONDS:-3600}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-id)
+      TARGET_ID="$2"
+      shift 2
+      ;;
+    --crate)
+      CRATE="$2"
+      shift 2
+      ;;
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --script)
+      SCRIPT="$2"
+      shift 2
+      ;;
+    --system)
+      SYSTEM="$2"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    --threshold-seconds)
+      THRESHOLD_SECONDS="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for required in TARGET_ID CRATE TARGET SCRIPT SYSTEM OUT_DIR; do
+  if [[ -z "${!required}" ]]; then
+    echo "Missing required argument: ${required}" >&2
+    exit 2
+  fi
+done
+
+mkdir -p "${OUT_DIR}/logs"
+
+status="pass"
+failure_stage=""
+first_error_signature=""
+
+build_cli_ms=""
+build_firmware_ms=""
+run_smoke_ms=""
+
+stage_start_epoch=0
+run_started_epoch="$(date +%s)"
+run_started_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+capture_signature() {
+  local log_file="$1"
+  awk 'NF {print; exit}' "${log_file}" | tr -d '\r' | sed -E 's/\x1B\[[0-9;]*[mK]//g' | cut -c1-240
+}
+
+run_stage() {
+  local stage="$1"
+  shift
+  local log_file="${OUT_DIR}/logs/${stage}.log"
+  stage_start_epoch="$(date +%s)"
+
+  if "$@" >"${log_file}" 2>&1; then
+    local stage_end_epoch
+    stage_end_epoch="$(date +%s)"
+    local elapsed=$((stage_end_epoch - stage_start_epoch))
+    case "${stage}" in
+      build_cli) build_cli_ms="${elapsed}" ;;
+      build_firmware) build_firmware_ms="${elapsed}" ;;
+      run_smoke) run_smoke_ms="${elapsed}" ;;
+    esac
+    return 0
+  fi
+
+  local stage_end_epoch
+  stage_end_epoch="$(date +%s)"
+  local elapsed=$((stage_end_epoch - stage_start_epoch))
+  case "${stage}" in
+    build_cli) build_cli_ms="${elapsed}" ;;
+    build_firmware) build_firmware_ms="${elapsed}" ;;
+    run_smoke) run_smoke_ms="${elapsed}" ;;
+  esac
+
+  status="fail"
+  failure_stage="${stage}"
+  first_error_signature="$(capture_signature "${log_file}")"
+  if [[ -z "${first_error_signature}" ]]; then
+    first_error_signature="no-log-output"
+  fi
+  return 1
+}
+
+run_smoke_output_dir="${OUT_DIR}/simulation-output"
+mkdir -p "${run_smoke_output_dir}"
+
+if ! run_stage build_cli cargo build -p labwired-cli; then
+  :
+elif [[ "${PROFILE}" == "release" ]]; then
+  if ! run_stage build_firmware cargo build -p "${CRATE}" --release --target "${TARGET}"; then
+    :
+  elif ! run_stage run_smoke cargo run -q -p labwired-cli -- test --script "${SCRIPT}" --output-dir "${run_smoke_output_dir}" --no-uart-stdout; then
+    :
+  fi
+else
+  if ! run_stage build_firmware cargo build -p "${CRATE}" --target "${TARGET}"; then
+    :
+  elif ! run_stage run_smoke cargo run -q -p labwired-cli -- test --script "${SCRIPT}" --output-dir "${run_smoke_output_dir}" --no-uart-stdout; then
+    :
+  fi
+fi
+
+run_finished_epoch="$(date +%s)"
+run_finished_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+elapsed_seconds=$((run_finished_epoch - run_started_epoch))
+threshold_met=false
+if [[ "${elapsed_seconds}" -le "${THRESHOLD_SECONDS}" ]]; then
+  threshold_met=true
+fi
+
+export TARGET_ID CRATE TARGET SCRIPT SYSTEM OUT_DIR PROFILE
+export run_started_iso run_finished_iso elapsed_seconds
+export status failure_stage first_error_signature threshold_met THRESHOLD_SECONDS
+export build_cli_ms build_firmware_ms run_smoke_ms
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+out_dir = Path(os.environ["OUT_DIR"])
+status = os.environ["status"]
+threshold_met = os.environ["threshold_met"].lower() == "true"
+
+def parse_int(name: str):
+    value = os.environ.get(name, "")
+    return int(value) if value.strip() else None
+
+metrics = {
+    "target_id": os.environ["TARGET_ID"],
+    "status": status,
+    "crate": os.environ["CRATE"],
+    "target_triple": os.environ["TARGET"],
+    "script": os.environ["SCRIPT"],
+    "system": os.environ["SYSTEM"],
+    "profile": os.environ["PROFILE"],
+    "started_at_utc": os.environ["run_started_iso"],
+    "finished_at_utc": os.environ["run_finished_iso"],
+    "elapsed_seconds": int(os.environ["elapsed_seconds"]),
+    "failure_stage": os.environ.get("failure_stage", ""),
+    "first_error_signature": os.environ.get("first_error_signature", ""),
+    "threshold_seconds": int(os.environ["THRESHOLD_SECONDS"]),
+    "threshold_met": threshold_met,
+    "stages_seconds": {
+        "build_cli": parse_int("build_cli_ms"),
+        "build_firmware": parse_int("build_firmware_ms"),
+        "run_smoke": parse_int("run_smoke_ms"),
+    },
+}
+
+summary_lines = [
+    f"# Onboarding Smoke: {metrics['target_id']}",
+    "",
+    f"- status: `{metrics['status']}`",
+    f"- elapsed_seconds: `{metrics['elapsed_seconds']}`",
+    f"- threshold_seconds: `{metrics['threshold_seconds']}`",
+    f"- threshold_met: `{metrics['threshold_met']}`",
+    f"- failure_stage: `{metrics['failure_stage'] or 'n/a'}`",
+    f"- first_error_signature: `{metrics['first_error_signature'] or 'n/a'}`",
+]
+
+out_dir.mkdir(parents=True, exist_ok=True)
+(out_dir / "onboarding-metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+(out_dir / "onboarding-summary.md").write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+PY
+
+if [[ "${status}" != "pass" ]]; then
+  echo "Onboarding smoke failed at stage: ${failure_stage}" >&2
+  echo "Signature: ${first_error_signature}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/onboarding_smoke.sh` to run first-pass onboarding smoke and emit metrics
- add `scripts/generate_onboarding_scoreboard.py` to aggregate onboarding artifacts
- add `core-onboarding-smoke.yml` workflow with per-target artifacts and scoreboard job
- document onboarding KPI artifacts in CI docs and docs index

## KPI Outputs
- `onboarding-metrics.json` (elapsed time, failure stage, first-error signature)
- `onboarding-scoreboard.md` / `onboarding-scoreboard.json` (aggregate run summary)