### PR TITLE
ci(core): speed up workflows with shared rust-cache keys

### DIFF
--- a/.github/workflows/core-board-ci-fixture-arm.yml
+++ b/.github/workflows/core-board-ci-fixture-arm.yml
@@ -16,6 +16,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-board-arm
+          workspaces: |
+            . -> target
 
       - name: Install ARM target
         run: rustup target add thumbv6m-none-eabi

--- a/.github/workflows/core-board-ci-fixture-riscv.yml
+++ b/.github/workflows/core-board-ci-fixture-riscv.yml
@@ -16,6 +16,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-board-riscv
+          workspaces: |
+            . -> target
 
       - name: Install RISC-V target
         run: rustup target add riscv32i-unknown-none-elf

--- a/.github/workflows/core-board-nucleo-h563zi.yml
+++ b/.github/workflows/core-board-nucleo-h563zi.yml
@@ -16,6 +16,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-board-h563zi
+          workspaces: |
+            . -> target
 
       - name: Install ARM target
         run: rustup target add thumbv7m-none-eabi

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -25,6 +25,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: core-ci
+          workspaces: |
+            . -> target
 
       - name: Check Formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -75,6 +75,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-coverage-matrix
+          workspaces: |
+            . -> target
 
       - name: Build CLI
         run: cargo build -p labwired-cli

--- a/.github/workflows/core-coverage.yml
+++ b/.github/workflows/core-coverage.yml
@@ -40,6 +40,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: core-coverage
+          workspaces: |
+            . -> target
 
       - name: Cache cargo-llvm-cov
         id: cache-llvm-cov

--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -17,6 +17,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-nightly
+          workspaces: |
+            . -> target
 
       - name: Install ARM Toolchain
         run: |

--- a/.github/workflows/core-onboarding-smoke.yml
+++ b/.github/workflows/core-onboarding-smoke.yml
@@ -42,6 +42,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-onboarding-smoke
+          workspaces: |
+            . -> target
 
       - name: Run onboarding smoke
         run: |
@@ -104,4 +108,3 @@ jobs:
             out/onboarding-smoke/onboarding-scoreboard.md
             out/onboarding-smoke/onboarding-scoreboard.json
           retention-days: 14
-

--- a/.github/workflows/core-unsupported-audit.yml
+++ b/.github/workflows/core-unsupported-audit.yml
@@ -16,6 +16,10 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-unsupported-audit
+          workspaces: |
+            . -> target
 
       - name: Install ARM target
         run: rustup target add thumbv7m-none-eabi


### PR DESCRIPTION
## Summary
- add explicit shared `rust-cache` keys plus workspace scoping in core workflows
- make matrix jobs reuse a common cache namespace instead of per-matrix cold caches
- apply same cache pattern to nightly and board workflows for repeat-run speed

## Workflows updated
- core/.github/workflows/core-ci.yml
- core/.github/workflows/core-coverage.yml
- core/.github/workflows/core-coverage-matrix-smoke.yml
- core/.github/workflows/core-onboarding-smoke.yml
- core/.github/workflows/core-nightly.yml
- core/.github/workflows/core-board-ci-fixture-arm.yml
- core/.github/workflows/core-board-ci-fixture-riscv.yml
- core/.github/workflows/core-board-nucleo-h563zi.yml
- core/.github/workflows/core-unsupported-audit.yml