### PR TITLE
chore: finalize board onboarding documentation

### DIFF
--- a/examples/nucleo-h563zi/EXTERNAL_COMPONENTS.md
+++ b/examples/nucleo-h563zi/EXTERNAL_COMPONENTS.md
@@ -1,0 +1,10 @@
+# External Components (NUCLEO-H563ZI)
+
+No required external simulated components for minimal deterministic smoke test.
+
+The onboarding path uses on-chip peripherals only:
+1. RCC (Reset and Clock Control)
+2. GPIO (General-purpose I/Os)
+3. USART3 (Virtual COM port)
+4. EXTI (Extended Interrupts and Events Controller)
+5. SysTick

--- a/examples/nucleo-h563zi/REQUIRED_DOCS.md
+++ b/examples/nucleo-h563zi/REQUIRED_DOCS.md
@@ -1,0 +1,18 @@
+# Required Source Documents (NUCLEO-H563ZI)
+
+## MCU (CMSIS Device Header)
+
+1. STM32H563 reference manual (RM0481) & datasheet:
+   https://www.st.com/en/microcontrollers-microprocessors/stm32h563zi.html
+2. STM32H563 device header (memory map, base addresses, IRQs):
+   https://github.com/STMicroelectronics/cmsis_device_h5/blob/main/Include/stm32h563xx.h
+
+## Board BSP Header
+
+1. STM32H5xx Nucleo BSP (LED/button mapping):
+   https://github.com/STMicroelectronics/stm32h5xx_nucleo_bsp/blob/main/stm32h5xx_nucleo.h
+
+## Board Example for UART Mapping
+
+1. STM32CubeH5 UART_Printf example header for STM32H563ZI Nucleo (`USART3`, `PD8/PD9`):
+   https://github.com/STMicroelectronics/STM32CubeH5/blob/main/Projects/NUCLEO-H563ZI/Examples/UART/UART_Printf/Inc/main.h

--- a/examples/rp2040-pio/EXTERNAL_COMPONENTS.md
+++ b/examples/rp2040-pio/EXTERNAL_COMPONENTS.md
@@ -1,0 +1,10 @@
+# External Components (RP2040-PIO)
+
+No required external simulated components for the minimal deterministic smoke test.
+
+The onboarding path uses on-chip peripherals only:
+1. SIO (Single-cycle IO / GPIO)
+2. PIO0, PIO1 (Programmable IO)
+3. UART0 (UART)
+4. CLOCKS
+5. RESETS

--- a/examples/rp2040-pio/REQUIRED_DOCS.md
+++ b/examples/rp2040-pio/REQUIRED_DOCS.md
@@ -1,0 +1,15 @@
+# Required Source Documents (RP2040-PIO)
+
+## MCU (RP2040 Datasheet)
+
+1. RP2040 Datasheet (Memory map, base addresses, IRQs):
+   https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf
+
+## Board BSP / SDK Headers
+
+1. Pico C/C++ SDK `hardware_uart` header:
+   https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_uart/include/hardware/uart.h
+2. Pico C/C++ SDK `hardware_pio` header:
+   https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_pio/include/hardware/pio.h
+3. RP2040 `hardware_regs` headers:
+   https://github.com/raspberrypi/pico-sdk/tree/master/src/rp2040/hardware_regs/include/hardware/regs


### PR DESCRIPTION
Adds REQUIRED_DOCS.md and EXTERNAL_COMPONENTS.md for rp2040 and nucleo-h563zi examples to fulfill onboarding Phase 5 requirements.