### PR TITLE
Speed up demo-blinky by 10x for emulator pacing

### DIFF
--- a/examples/demo-blinky/src/main.rs
+++ b/examples/demo-blinky/src/main.rs
@@ -28,7 +28,7 @@ const I2C1_TRISE: *mut u32 = (I2C1_BASE + 0x20) as *mut u32;
 const RCC_APB2ENR_IOPAEN: u32 = 1 << 2;
 const RCC_APB1ENR_I2C1EN: u32 = 1 << 21;
 const GPIO_ODR_ODR5: u32 = 1 << 5;
-const BLINK_DELAY_NOPS: u32 = 2_000_000;
+const BLINK_DELAY_NOPS: u32 = 200_000;
 
 #[entry]
 fn main() -> ! {


### PR DESCRIPTION
## Summary
- Drop `BLINK_DELAY_NOPS` in `examples/demo-blinky/src/main.rs` from `2_000_000` → `200_000`.
- The 2M-NOP busy loop translates to ~16M emulated instructions per blink half-cycle once you add loop overhead and the in-loop TMP102 I²C read. On real STM32F103 silicon @ 8 MHz that's ~250 ms; under `labwired-core` it stretches into multi-second blinks because each NOP is executed instruction-by-instruction by the emulator.
- 200k NOPs gives a visibly snappy LED in the VS Code/Antigravity Command Center HUD without losing the "busy-wait" shape of the demo.

## Context
- Prior commit `32fed0e fix(blinky): increase blink delay so LED toggle is visible` raised this value to make the demo visible on hardware. This PR walks it back for emulator pacing — most users see the demo in the simulator, not on a real Nucleo.
- If real-hardware visibility regresses, `500_000` is a reasonable middle ground.

## Test plan
- [ ] `cargo build --release --target thumbv7m-none-eabi -p demo-blinky`
- [ ] Launch under labwired-core + labwired-vscode (`labwired.demoUi.mode: "on"`), confirm LED toggles at ~1–3 Hz
- [ ] Spot-check `GPIO: Write to GPIOA_ODR: 0x00000020 (LED ON)` log lines still appear in the CLI path