### PR TITLE
feat(i2c): add shm_i2c shared-memory I2C device

### DIFF
--- a/crates/core/src/peripherals/components/i2c_factory.rs
+++ b/crates/core/src/peripherals/components/i2c_factory.rs
@@ -11,6 +11,7 @@
 //! so a yaml typo doesn't silently produce an empty bus.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use crate::peripherals::i2c::I2cDevice;
 
@@ -37,6 +38,24 @@ pub fn build_i2c_device(
                 .unwrap_or(0x76) as u8;
             Some(Box::new(crate::peripherals::components::Bmp280::new(
                 address,
+            )))
+        }
+        "shm_imu" => {
+            let address = config
+                .get("i2c_address")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0x24) as u8;
+            let shm_path = config
+                .get("shm_path")
+                .and_then(|v| v.as_str())
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("/tmp/labwired_proximity_imu"));
+            let size = config
+                .get("size")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(128) as usize;
+            Some(Box::new(crate::peripherals::components::ShmImu::new(
+                address, shm_path, size,
             )))
         }
         _ => None,
@@ -76,5 +95,20 @@ mod tests {
         let cfg = HashMap::new();
         assert!(build_i2c_device("TMP102", &cfg).is_some());
         assert!(build_i2c_device("Tmp102", &cfg).is_some());
+    }
+
+    #[test]
+    fn shm_imu_built_from_config() {
+        let mut cfg = HashMap::new();
+        cfg.insert(
+            "i2c_address".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(0x24)),
+        );
+        cfg.insert(
+            "shm_path".to_string(),
+            serde_yaml::Value::String("/tmp/labwired_proximity_imu".to_string()),
+        );
+        let dev = build_i2c_device("shm_imu", &cfg).expect("shm_imu should build");
+        assert_eq!(dev.address(), 0x24);
     }
 }

--- a/crates/core/src/peripherals/components/i2c_factory.rs
+++ b/crates/core/src/peripherals/components/i2c_factory.rs
@@ -50,10 +50,7 @@ pub fn build_i2c_device(
                 .and_then(|v| v.as_str())
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from("/tmp/labwired_proximity_imu"));
-            let size = config
-                .get("size")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(128) as usize;
+            let size = config.get("size").and_then(|v| v.as_u64()).unwrap_or(128) as usize;
             Some(Box::new(crate::peripherals::components::ShmI2c::new(
                 address, shm_path, size,
             )))

--- a/crates/core/src/peripherals/components/i2c_factory.rs
+++ b/crates/core/src/peripherals/components/i2c_factory.rs
@@ -40,7 +40,7 @@ pub fn build_i2c_device(
                 address,
             )))
         }
-        "shm_imu" => {
+        "shm_i2c" => {
             let address = config
                 .get("i2c_address")
                 .and_then(|v| v.as_u64())
@@ -54,7 +54,7 @@ pub fn build_i2c_device(
                 .get("size")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(128) as usize;
-            Some(Box::new(crate::peripherals::components::ShmImu::new(
+            Some(Box::new(crate::peripherals::components::ShmI2c::new(
                 address, shm_path, size,
             )))
         }
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn shm_imu_built_from_config() {
+    fn shm_i2c_built_from_config() {
         let mut cfg = HashMap::new();
         cfg.insert(
             "i2c_address".to_string(),
@@ -108,7 +108,7 @@ mod tests {
             "shm_path".to_string(),
             serde_yaml::Value::String("/tmp/labwired_proximity_imu".to_string()),
         );
-        let dev = build_i2c_device("shm_imu", &cfg).expect("shm_imu should build");
+        let dev = build_i2c_device("shm_i2c", &cfg).expect("shm_imu should build");
         assert_eq!(dev.address(), 0x24);
     }
 }

--- a/crates/core/src/peripherals/components/mod.rs
+++ b/crates/core/src/peripherals/components/mod.rs
@@ -8,10 +8,10 @@ pub mod aht20;
 pub mod bmp280;
 pub mod i2c_factory;
 pub mod mpu6050;
-pub mod shm_imu;
+pub mod shm_i2c;
 
 pub use aht20::Aht20;
 pub use bmp280::Bmp280;
 pub use i2c_factory::build_i2c_device;
 pub use mpu6050::Mpu6050;
-pub use shm_imu::ShmImu;
+pub use shm_i2c::ShmI2c;

--- a/crates/core/src/peripherals/components/mod.rs
+++ b/crates/core/src/peripherals/components/mod.rs
@@ -8,8 +8,10 @@ pub mod aht20;
 pub mod bmp280;
 pub mod i2c_factory;
 pub mod mpu6050;
+pub mod shm_imu;
 
 pub use aht20::Aht20;
 pub use bmp280::Bmp280;
 pub use i2c_factory::build_i2c_device;
 pub use mpu6050::Mpu6050;
+pub use shm_imu::ShmImu;

--- a/crates/core/src/peripherals/components/shm_i2c.rs
+++ b/crates/core/src/peripherals/components/shm_i2c.rs
@@ -61,6 +61,7 @@ impl ShmI2c {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&self.shm_path)
         else {
             tracing::warn!(path = %self.shm_path.display(), "shm_i2c: failed to open shm file for write");
@@ -108,10 +109,8 @@ mod tests {
 
     #[test]
     fn pointer_read_and_write_round_trip() {
-        let path = std::env::temp_dir().join(format!(
-            "labwired_shm_i2c_test_{}",
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("labwired_shm_i2c_test_{}", std::process::id()));
         std::fs::write(&path, vec![0_u8; 8]).unwrap();
         let mut dev = ShmI2c::new(0x24, path.clone(), 8);
 

--- a/crates/core/src/peripherals/components/shm_i2c.rs
+++ b/crates/core/src/peripherals/components/shm_i2c.rs
@@ -14,9 +14,8 @@ use std::path::PathBuf;
 
 use crate::peripherals::i2c::I2cDevice;
 
-
 #[derive(Debug)]
-pub struct ShmImu {
+pub struct ShmI2c {
     address: u8,
     shm_path: PathBuf,
     size: usize,
@@ -24,7 +23,7 @@ pub struct ShmImu {
     register_address_written: bool,
 }
 
-impl ShmImu {
+impl ShmI2c {
     pub fn new(address: u8, shm_path: PathBuf, size: usize) -> Self {
         Self {
             address,
@@ -40,7 +39,7 @@ impl ShmImu {
             return 0;
         }
         let Ok(mut file) = OpenOptions::new().read(true).open(&self.shm_path) else {
-            tracing::warn!(path = %self.shm_path.display(), "shm_imu: failed to open shm file for read");
+            tracing::warn!(path = %self.shm_path.display(), "shm_i2c: failed to open shm file for read");
             return 0;
         };
         if file.seek(SeekFrom::Start(offset as u64)).is_err() {
@@ -64,7 +63,7 @@ impl ShmImu {
             .create(true)
             .open(&self.shm_path)
         else {
-            tracing::warn!(path = %self.shm_path.display(), "shm_imu: failed to open shm file for write");
+            tracing::warn!(path = %self.shm_path.display(), "shm_i2c: failed to open shm file for write");
             return;
         };
         if file.metadata().map(|m| m.len()).unwrap_or(0) < self.size as u64 {
@@ -77,7 +76,7 @@ impl ShmImu {
     }
 }
 
-impl I2cDevice for ShmImu {
+impl I2cDevice for ShmI2c {
     fn address(&self) -> u8 {
         self.address
     }
@@ -110,11 +109,11 @@ mod tests {
     #[test]
     fn pointer_read_and_write_round_trip() {
         let path = std::env::temp_dir().join(format!(
-            "labwired_shm_imu_test_{}",
+            "labwired_shm_i2c_test_{}",
             std::process::id()
         ));
         std::fs::write(&path, vec![0_u8; 8]).unwrap();
-        let mut dev = ShmImu::new(0x24, path.clone(), 8);
+        let mut dev = ShmI2c::new(0x24, path.clone(), 8);
 
         dev.start();
         dev.write(0x01);

--- a/crates/core/src/peripherals/components/shm_imu.rs
+++ b/crates/core/src/peripherals/components/shm_imu.rs
@@ -1,0 +1,136 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Shared-memory I2C register bridge.
+//!
+//! This small device model is used by Project Phoenix ProximityAgent tests. The
+//! external harness mutates a byte-addressed shared-memory file while firmware
+//! accesses the same bytes through I2C register-pointer transactions.
+
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use crate::peripherals::i2c::I2cDevice;
+
+const DEFAULT_ADDR: u8 = 0x24;
+const DEFAULT_SIZE: usize = 128;
+
+#[derive(Debug)]
+pub struct ShmImu {
+    address: u8,
+    shm_path: PathBuf,
+    size: usize,
+    current_register: u8,
+    register_address_written: bool,
+}
+
+impl ShmImu {
+    pub fn new(address: u8, shm_path: PathBuf, size: usize) -> Self {
+        Self {
+            address,
+            shm_path,
+            size: size.max(1),
+            current_register: 0,
+            register_address_written: false,
+        }
+    }
+
+    pub fn proximity_default(shm_path: PathBuf) -> Self {
+        Self::new(DEFAULT_ADDR, shm_path, DEFAULT_SIZE)
+    }
+
+    fn read_byte(&self, offset: u8) -> u8 {
+        if offset as usize >= self.size {
+            return 0;
+        }
+        let Ok(mut file) = OpenOptions::new().read(true).open(&self.shm_path) else {
+            return 0;
+        };
+        if file.seek(SeekFrom::Start(offset as u64)).is_err() {
+            return 0;
+        }
+        let mut byte = [0_u8; 1];
+        if file.read_exact(&mut byte).is_ok() {
+            byte[0]
+        } else {
+            0
+        }
+    }
+
+    fn write_byte(&self, offset: u8, value: u8) {
+        if offset as usize >= self.size {
+            return;
+        }
+        let Ok(mut file) = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&self.shm_path)
+        else {
+            return;
+        };
+        if file.metadata().map(|m| m.len()).unwrap_or(0) < self.size as u64 {
+            let _ = file.set_len(self.size as u64);
+        }
+        if file.seek(SeekFrom::Start(offset as u64)).is_ok() {
+            let _ = file.write_all(&[value]);
+            let _ = file.flush();
+        }
+    }
+}
+
+impl I2cDevice for ShmImu {
+    fn address(&self) -> u8 {
+        self.address
+    }
+
+    fn read(&mut self) -> u8 {
+        let value = self.read_byte(self.current_register);
+        self.current_register = self.current_register.wrapping_add(1);
+        value
+    }
+
+    fn write(&mut self, data: u8) {
+        if !self.register_address_written {
+            self.current_register = data;
+            self.register_address_written = true;
+        } else {
+            self.write_byte(self.current_register, data);
+            self.current_register = self.current_register.wrapping_add(1);
+        }
+    }
+
+    fn stop(&mut self) {
+        self.register_address_written = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pointer_read_and_write_round_trip() {
+        let path = std::env::temp_dir().join(format!(
+            "labwired_shm_imu_test_{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, vec![0_u8; 8]).unwrap();
+        let mut dev = ShmImu::new(0x24, path.clone(), 8);
+
+        dev.start();
+        dev.write(0x01);
+        dev.write(0x12);
+        dev.write(0x34);
+        dev.stop();
+
+        dev.start();
+        dev.write(0x01);
+        assert_eq!(dev.read(), 0x12);
+        assert_eq!(dev.read(), 0x34);
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/core/src/peripherals/components/shm_imu.rs
+++ b/crates/core/src/peripherals/components/shm_imu.rs
@@ -14,8 +14,6 @@ use std::path::PathBuf;
 
 use crate::peripherals::i2c::I2cDevice;
 
-const DEFAULT_ADDR: u8 = 0x24;
-const DEFAULT_SIZE: usize = 128;
 
 #[derive(Debug)]
 pub struct ShmImu {
@@ -37,15 +35,12 @@ impl ShmImu {
         }
     }
 
-    pub fn proximity_default(shm_path: PathBuf) -> Self {
-        Self::new(DEFAULT_ADDR, shm_path, DEFAULT_SIZE)
-    }
-
     fn read_byte(&self, offset: u8) -> u8 {
         if offset as usize >= self.size {
             return 0;
         }
         let Ok(mut file) = OpenOptions::new().read(true).open(&self.shm_path) else {
+            tracing::warn!(path = %self.shm_path.display(), "shm_imu: failed to open shm file for read");
             return 0;
         };
         if file.seek(SeekFrom::Start(offset as u64)).is_err() {
@@ -69,6 +64,7 @@ impl ShmImu {
             .create(true)
             .open(&self.shm_path)
         else {
+            tracing::warn!(path = %self.shm_path.display(), "shm_imu: failed to open shm file for write");
             return;
         };
         if file.metadata().map(|m| m.len()).unwrap_or(0) < self.size as u64 {


### PR DESCRIPTION
## Summary

Adds a new built-in `I2cDevice` called `shm_i2c` — a shared-memory I2C register bridge. An external test harness mutates a byte-addressed file on disk; firmware accesses the same bytes through normal I2C register-pointer transactions. This is the Path B device model that lets the Proximity HIL loop inject distance samples and receive firmware ACKs without any changes to firmware code.

### What changed

- `crates/core/src/peripherals/components/shm_i2c.rs` — new `I2cDevice` impl
- `crates/core/src/peripherals/components/mod.rs` — exports `ShmI2c`
- `crates/core/src/peripherals/components/i2c_factory.rs` — `"shm_i2c"` factory arm

### YAML usage

```yaml
external_devices:
  - id: "ultrasonic_bridge"
    type: "shm_i2c"
    connection: "i2c1"
    config:
      i2c_address: 0x24
      shm_path: "/tmp/labwired_proximity_imu"
      size: 128
```

### Behavior

- Standard register-pointer semantics: first write after transaction start sets the pointer; subsequent writes/reads step through the file; `stop()` resets pointer state.
- `tracing::warn!` on file-open failure in both `read_byte` and `write_byte`.
- `read_byte` returns 0 if the file does not exist; `write_byte` creates it. The external harness is expected to create the file before simulation starts.
- File I/O per byte — intentional for this proof loop, not intended for high-frequency simulation.

### Validation

- `cargo test -p labwired-core shm_i2c --lib` — pass
- `cargo test -p labwired-core i2c_factory --lib` — 5/5 pass
- End-to-end: 100/100 Proximity HIL samples ACK'd; Tempo trace landed in Grafana Cloud.

### Notes

Happy to rename, restructure, or move behind a feature flag if it doesn't fit the component library direction. Looking forward to seeing the F401 I2C implementation — this device model should compose cleanly with it.