### PR TITLE
fix: wire I2C1 into STM32F401 descriptor

### DIFF
--- a/configs/chips/stm32f401.yaml
+++ b/configs/chips/stm32f401.yaml
@@ -40,3 +40,8 @@ peripherals:
     base_address: 0x40004400
     size: "1KB"
     irq: 38
+  - id: "i2c1"
+    type: "i2c"
+    base_address: 0x40005400
+    size: "1KB"
+    irq: 31

--- a/crates/cli/tests/config_validation.rs
+++ b/crates/cli/tests/config_validation.rs
@@ -69,6 +69,22 @@ fn test_stm32f407_chip_loads() {
     );
 }
 
+#[test]
+fn test_stm32f401_chip_loads_with_i2c1() {
+    let chip_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../configs/chips/stm32f401.yaml");
+
+    let chip = ChipDescriptor::from_file(&chip_path).expect("F401 chip yaml failed to parse");
+
+    assert_eq!(chip.name, "stm32f401re");
+    assert!(
+        chip.peripherals
+            .iter()
+            .any(|p| p.id == "i2c1" && p.base_address == 0x40005400),
+        "F401 must declare i2c1 at 0x40005400"
+    );
+}
+
 /// End-to-end proof that `external_devices` declared in a system manifest
 /// actually attach to the corresponding I²C peripheral at bus-construction
 /// time. Uses the demo-blinky fixture (STM32F103 + TMP102 on i2c1) which


### PR DESCRIPTION
## Summary
- Add I2C1 to the STM32F401 descriptor at the F4-family base address
- Add a config regression test proving F401 declares I2C1

## Validation
- cargo test -p labwired-cli test_stm32f401_chip_loads_with_i2c1 -- --nocapture
- cargo test -p labwired-core i2c -- --nocapture
- cargo test -p labwired-cli --test config_validation -- --nocapture
- cargo run --release -q -p labwired-cli -- test --script examples/nucleo-f401re/uart-smoke.yaml --output-dir /tmp/labwired-f401-i2c-main --no-uart-stdout