### PR TITLE
feat: add STM32F401CDU6 target

### DIFF
--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -49,13 +49,13 @@ jobs:
             profile_dir: release
             script: examples/nucleo-h563zi/uart-smoke.yaml
             system: examples/nucleo-h563zi/system.yaml
-          - id: stm32f401-nucleo
+          - id: stm32f401cdu6
             target: thumbv7em-none-eabi
             crate: firmware-f401-demo
             profile: release
             profile_dir: release
-            script: examples/nucleo-f401re/uart-smoke.yaml
-            system: configs/systems/nucleo-f401re.yaml
+            script: examples/stm32f401cdu6/uart-smoke.yaml
+            system: configs/systems/stm32f401cdu6.yaml
           - id: stm32f103-bluepill
             target: thumbv7m-none-eabi
             crate: demo-blinky
@@ -157,7 +157,7 @@ jobs:
             --json-out out/coverage-matrix/scoreboard.json \
             --required-target stm32f103-bluepill \
             --required-target stm32h563-nucleo \
-            --required-target stm32f401-nucleo \
+            --required-target stm32f401cdu6 \
             --required-target riscv-ci-fixture \
             --required-target demo-blinky-stm32f103 \
             --min-required-pass-rate 0.80
@@ -174,7 +174,7 @@ jobs:
             --json-out /tmp/coverage-matrix-gate.json \
             --required-target stm32f103-bluepill \
             --required-target stm32h563-nucleo \
-            --required-target stm32f401-nucleo \
+            --required-target stm32f401cdu6 \
             --required-target riscv-ci-fixture \
             --required-target demo-blinky-stm32f103 \
             --min-required-pass-rate 0.80

--- a/.github/workflows/core-onboarding-smoke.yml
+++ b/.github/workflows/core-onboarding-smoke.yml
@@ -21,11 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - id: stm32f401-nucleo
+          - id: stm32f401cdu6
             crate: firmware-f401-demo
             target: thumbv7em-none-eabi
-            script: examples/nucleo-f401re/uart-smoke.yaml
-            system: configs/systems/nucleo-f401re.yaml
+            script: examples/stm32f401cdu6/uart-smoke.yaml
+            system: configs/systems/stm32f401cdu6.yaml
           - id: stm32h563-nucleo
             crate: firmware-h563-demo
             target: thumbv7m-none-eabi

--- a/configs/chips/stm32f401cdu6.yaml
+++ b/configs/chips/stm32f401cdu6.yaml
@@ -1,0 +1,47 @@
+# LabWired - STM32F401CDU6 Chip Descriptor
+#
+# Verified on attached hardware via ST-LINK/OpenOCD:
+# - DBGMCU IDCODE: 0x10016433
+# - Flash size: 384 KiB
+
+name: "stm32f401cdu6"
+arch: "arm"
+registers_count: 150
+flash:
+  base: 0x08000000
+  size: "384KB"
+ram:
+  base: 0x20000000
+  size: "96KB"
+peripherals:
+  - id: "rcc"
+    type: "rcc"
+    base_address: 0x40023800
+    size: "1KB"
+    config:
+      profile: "stm32f4"
+  - id: "gpioa"
+    type: "gpio"
+    base_address: 0x40020000
+    size: "1KB"
+  - id: "gpiob"
+    type: "gpio"
+    base_address: 0x40020400
+    size: "1KB"
+  - id: "gpioc"
+    type: "gpio"
+    base_address: 0x40020800
+    size: "1KB"
+  - id: "systick"
+    type: "systick"
+    base_address: 0xE000E010
+  - id: "uart2"
+    type: "uart"
+    base_address: 0x40004400
+    size: "1KB"
+    irq: 38
+  - id: "i2c1"
+    type: "i2c"
+    base_address: 0x40005400
+    size: "1KB"
+    irq: 31

--- a/configs/systems/stm32f401cdu6.yaml
+++ b/configs/systems/stm32f401cdu6.yaml
@@ -1,0 +1,5 @@
+# LabWired - STM32F401CDU6 System Configuration
+name: "stm32f401cdu6"
+chip: "../chips/stm32f401cdu6.yaml"
+external_devices: []
+board_io: []

--- a/crates/cli/tests/config_validation.rs
+++ b/crates/cli/tests/config_validation.rs
@@ -85,6 +85,24 @@ fn test_stm32f401_chip_loads_with_i2c1() {
     );
 }
 
+#[test]
+fn test_stm32f401cdu6_chip_loads_with_i2c1() {
+    let chip_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../configs/chips/stm32f401cdu6.yaml");
+
+    let chip = ChipDescriptor::from_file(&chip_path).expect("F401CDU6 chip yaml failed to parse");
+
+    assert_eq!(chip.name, "stm32f401cdu6");
+    assert_eq!(chip.flash.size, "384KB");
+    assert_eq!(chip.ram.size, "96KB");
+    assert!(
+        chip.peripherals
+            .iter()
+            .any(|p| p.id == "i2c1" && p.base_address == 0x40005400),
+        "F401CDU6 must declare i2c1 at 0x40005400"
+    );
+}
+
 /// End-to-end proof that `external_devices` declared in a system manifest
 /// actually attach to the corresponding I²C peripheral at bus-construction
 /// time. Uses the demo-blinky fixture (STM32F103 + TMP102 on i2c1) which

--- a/docs/coverage_scoreboard.md
+++ b/docs/coverage_scoreboard.md
@@ -30,10 +30,10 @@ Latest validated run:
 | Metric | Baseline Value | Notes |
 |---|---|---|
 | Top-5 targets defined | `5` | Defined in `docs/spec/TOP20_COVERAGE_MATRIX.md` |
-| Top-5 with runnable smoke script | `5/5` | `stm32f401-nucleo` smoke package added |
+| Top-5 with runnable smoke script | `5/5` | `stm32f401cdu6` smoke package added |
 | Top-5 with deterministic evidence artifacts in matrix CI | `5/5` | Published in `coverage-matrix-scoreboard` artifact |
 | Top-5 with unsupported-instruction audit artifacts | `5/5` | Published per-target under matrix artifacts |
-| Top-5 with explicit known-limitations entries | `3/5` | `stm32f103-bluepill`, `stm32h563-nucleo`, `stm32f401-nucleo` |
+| Top-5 with explicit known-limitations entries | `3/5` | `stm32f103-bluepill`, `stm32h563-nucleo`, `stm32f401cdu6` |
 
 ## Target-Level Baseline
 
@@ -41,7 +41,7 @@ Latest validated run:
 |---|---|---|---|---|
 | `stm32f103-bluepill` | `examples/demo-blinky/io-smoke.yaml` | `cargo build -p demo-blinky --release --target thumbv7m-none-eabi` | `passing` | `out/coverage-matrix/coverage-matrix-stm32f103-bluepill/` |
 | `stm32h563-nucleo` | `examples/nucleo-h563zi/uart-smoke.yaml` | `cargo build -p firmware-h563-demo --release --target thumbv7m-none-eabi` | `passing` | `out/coverage-matrix/coverage-matrix-stm32h563-nucleo/` |
-| `stm32f401-nucleo` | `examples/nucleo-f401re/uart-smoke.yaml` | `cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi` | `passing` | `out/coverage-matrix/coverage-matrix-stm32f401-nucleo/` |
+| `stm32f401cdu6` | `examples/stm32f401cdu6/uart-smoke.yaml` | `cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi` | `passing` | `out/coverage-matrix/coverage-matrix-stm32f401cdu6/` |
 | `riscv-ci-fixture` | `examples/ci/riscv-uart-ok.yaml` | `cargo build -p riscv-ci-fixture --release --target riscv32i-unknown-none-elf` | `passing` | `out/coverage-matrix/coverage-matrix-riscv-ci-fixture/` |
 | `demo-blinky-stm32f103` | `examples/demo-blinky/io-smoke.yaml` | `cargo build -p demo-blinky --release --target thumbv7m-none-eabi` | `passing` | `out/coverage-matrix/coverage-matrix-demo-blinky-stm32f103/` |
 

--- a/examples/stm32f401cdu6/system.yaml
+++ b/examples/stm32f401cdu6/system.yaml
@@ -1,0 +1,5 @@
+# LabWired - STM32F401CDU6 Example System
+name: "stm32f401cdu6"
+chip: "../../configs/chips/stm32f401cdu6.yaml"
+external_devices: []
+board_io: []

--- a/examples/stm32f401cdu6/uart-smoke.yaml
+++ b/examples/stm32f401cdu6/uart-smoke.yaml
@@ -1,0 +1,10 @@
+# LabWired - STM32F401CDU6 UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../target/thumbv7em-none-eabi/release/firmware-f401-demo"
+  system: "./system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps


### PR DESCRIPTION
## Summary
- Add a dedicated STM32F401CDU6 chip descriptor matching attached hardware: 384KB flash, 96KB RAM, I2C1 at 0x40005400
- Add STM32F401CDU6 system and UART smoke example
- Point the F401 coverage/onboarding CI target at STM32F401CDU6 instead of the Nucleo-labelled system
- Add config regression coverage for the CDU6 descriptor

## Hardware probe evidence
- lsusb sees ST-LINK/V2: 0483:3748
- OpenOCD detects STM32F4 Cortex-M4 target
- OpenOCD reports flash size = 384 KiB

## Validation
- cargo test -p labwired-cli test_stm32f401cdu6_chip_loads_with_i2c1 -- --nocapture
- cargo test -p labwired-cli --test config_validation -- --nocapture
- cargo test -p labwired-core i2c -- --nocapture
- cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
- cargo run --release -q -p labwired-cli -- test --script examples/stm32f401cdu6/uart-smoke.yaml --output-dir /tmp/labwired-stm32f401cdu6-smoke-2 --no-uart-stdout