### PR TITLE
Dual-core sim foundation: ESP32 APP_CPU + arduino-esp32 stub coverage

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1041,6 +1041,30 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "pthread_mutex_init",
         "pthread_mutex_lock",
         "pthread_mutex_unlock",
+        // FreeRTOS critical sections / sync
+        "xPortEnterCriticalTimeout",
+        "vPortExitCritical",
+        "vPortEnterCritical",
+        "xPortInIsrContext",
+        "vPortYield",
+        "vPortYieldFromISR",
+        "vPortYieldOtherCore",
+        "spinlock_acquire",
+        "spinlock_release",
+        "vTaskDelay",
+        "vTaskSuspendAll",
+        "xTaskResumeAll",
+        "xQueueGenericCreate",
+        "xQueueGenericSend",
+        "xQueueReceive",
+        "xSemaphoreCreateBinary",
+        "xSemaphoreTake",
+        "xSemaphoreGive",
+        "esp_pthread_init",
+        "esp_task_wdt_reset",
+        "esp_task_wdt_init",
+        "esp_task_wdt_add",
+        "esp_task_wdt_delete",
         "esp_clk_init",
         "esp_perip_clk_init",
         "core_intr_matrix_clear",
@@ -1053,6 +1077,57 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "esp_mspi_pin_init",
         "spi_flash_init_chip_state",
         "esp_log_timestamp",
+        // SPI-flash HAL — see loader::extract_arduino_esp32_thunks for why.
+        "spi_flash_hal_configure_host_io_mode",
+        "spi_flash_chip_generic_config_host_io_mode",
+        "spi_flash_chip_generic_get_io_mode",
+        "spi_flash_chip_generic_set_io_mode",
+        "spi_flash_chip_generic_probe",
+        "spi_flash_chip_generic_detect_size",
+        "spi_flash_chip_generic_read",
+        "spi_flash_chip_generic_yield",
+        "spi_flash_chip_gd_probe",
+        "spi_flash_chip_gd_detect_size",
+        "spi_flash_chip_gd_get_io_mode",
+        "spi_flash_chip_gd_set_io_mode",
+        "spi_flash_init",
+        "spi_flash_hal_init",
+        "spi_flash_hal_supports_direct_write",
+        "spi_flash_hal_supports_direct_read",
+        "esp_flash_app_enable_os_functions",
+        "esp_flash_app_disable_os_functions",
+        "esp_flash_app_init",
+        "esp_flash_init_main",
+        "esp_flash_init_default_chip",
+        "esp_flash_init",
+        "esp_random",
+        "esp_fill_random",
+        "esp_log_early_timestamp",
+        "esp_log_writev",
+        "esp_log_write",
+        "esp_log_buffer_hex_internal",
+        "esp_log_buffer_char_internal",
+        "esp_log_buffer_hexdump_internal",
+        "__sfvwrite_r",
+        "__swsetup_r",
+        "__sflush_r",
+        "_printf_r",
+        "_fprintf_r",
+        "_vfprintf_r",
+        "_vprintf_r",
+        "printf",
+        "fprintf",
+        "vfprintf",
+        "vprintf",
+        "puts",
+        "fputs",
+        "fputc",
+        "putchar",
+        "_puts_r",
+        "_fputs_r",
+        "_putchar_r",
+        "_write_r",
+        "write",
     ] {
         if let Some(&pc) = symbol_addrs.get(*sym) {
             thunks.push((pc, rom_thunks::nop_return_zero));
@@ -1072,6 +1147,12 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // version of this thunk pointing at S3's DRAM range.
     if let Some(&pc) = symbol_addrs.get("__getreent") {
         thunks.push((pc, rom_thunks::getreent_dram_fake_ptr));
+    }
+    // esp_timer_impl_get_counter_reg must return a monotonically increasing
+    // value, otherwise polling-loop callers (esp-idf flash HAL, FreeRTOS
+    // timeout helpers) spin forever.
+    if let Some(&pc) = symbol_addrs.get("esp_timer_impl_get_counter_reg") {
+        thunks.push((pc, rom_thunks::monotonic_counter_32));
     }
     // AgentDeck-only WiFi + sendHello thunks. Only install for that profile
     // — sketches without those symbols wouldn't trip them anyway.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1155,6 +1155,14 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(&pc) = symbol_addrs.get("esp_timer_impl_get_counter_reg") {
         thunks.push((pc, rom_thunks::monotonic_counter_32));
     }
+    // Optional debug: install vListInsert short-circuit thunk that dumps
+    // list state for first 20 calls. Used to diagnose SMP race issues in
+    // the FreeRTOS scheduler. Enable with `LABWIRED_DEBUG_VLIST=1`.
+    if std::env::var("LABWIRED_DEBUG_VLIST").is_ok() {
+        if let Some(&pc) = symbol_addrs.get("vListInsert") {
+            thunks.push((pc, rom_thunks::vlist_insert_debug));
+        }
+    }
     // AgentDeck-only WiFi + sendHello thunks. Only install for that profile
     // — sketches without those symbols wouldn't trip them anyway.
     if args.profile == "agentdeck" {
@@ -1303,6 +1311,14 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // appcpu-release + cpu1.step loop has to live here too. Drain
         // the APPCPU_BOOT_ADDR slot first (PRO_CPU may have just hit
         // ets_set_appcpu_boot_addr), then step the secondary CPU.
+        //
+        // Coarse interleaving (CPU1_STEP_DIVISOR): step CPU 1 only once
+        // per N CPU-0 instructions. Per-instruction round-robin loses
+        // races on FreeRTOS spinlocks — once CPU 0 acquires a mux, CPU 1
+        // spinning equal cycles can't make progress, but worse, ESP-IDF
+        // FreeRTOS expects long critical sections to complete with bounded
+        // latency. Coarser batching simulates that.
+        const CPU1_STEP_DIVISOR: u64 = 16;
         if let Some(cpu1) = machine.cpu_secondary.as_mut() {
             if let Some(boot_addr) =
                 labwired_core::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR
@@ -1312,15 +1328,17 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                 cpu1.set_sp(appcpu_initial_sp);
                 cpu1.unhalt();
             }
-            match cpu1.step(&mut machine.bus, &observers, &config) {
-                Ok(()) => {}
-                Err(SimulationError::BreakpointHit(_)) => {}
-                Err(e) => {
-                    eprintln!(
-                        "error: sim step cpu1 at cycle {i} pc=0x{:08x}: {e}",
-                        cpu1.get_pc()
-                    );
-                    return ExitCode::from(EXIT_RUNTIME_ERROR);
+            if i % CPU1_STEP_DIVISOR == 0 {
+                match cpu1.step(&mut machine.bus, &observers, &config) {
+                    Ok(()) => {}
+                    Err(SimulationError::BreakpointHit(_)) => {}
+                    Err(e) => {
+                        eprintln!(
+                            "error: sim step cpu1 at cycle {i} pc=0x{:08x}: {e}",
+                            cpu1.get_pc()
+                        );
+                        return ExitCode::from(EXIT_RUNTIME_ERROR);
+                    }
                 }
             }
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -896,6 +896,15 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
 
     let boxed: Box<dyn Cpu> = Box::new(cpu);
     let mut machine = Machine::new(boxed, bus);
+    // Arduino-ESP32 sketches reach `xTaskCreatePinnedToCore(..., 1)`
+    // for `loopTask` and others — without an APP_CPU to schedule onto,
+    // FreeRTOS spins in `vListInsert` forever. Attach a secondary CPU
+    // (PRID=0xABAB, halted at construction, released by
+    // `ets_set_appcpu_boot_addr` during PRO_CPU boot).
+    if args.profile == "arduino-esp32" {
+        let cpu1 = labwired_core::cpu::xtensa_lx7::XtensaLx7::new_app_cpu();
+        machine.cpu_secondary = Some(Box::new(cpu1));
+    }
 
     // Load firmware FIRST — load_firmware writes ELF segments into bus
     // memory, so any bytes we write before this risk being clobbered.
@@ -922,6 +931,13 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     let resolve_data = |sym: &str, fallback: u32| -> u32 {
         symbol_addrs.get(sym).copied().unwrap_or(fallback)
     };
+    // APP_CPU initial stack — read once, used on cpu1 unhalt.
+    // ESP-IDF puts the boot stack at `port_IntStackTop`; if the symbol
+    // is missing (stripped ELF), fall back to a safe high-DRAM addr.
+    let appcpu_initial_sp: u32 = symbol_addrs
+        .get("port_IntStackTop")
+        .copied()
+        .unwrap_or(0x3FFB_F3A0);
 
     // Arduino-ESP32 bootstrap — keep in sync with
     // `wasm/src/lib.rs::install_esp32_arduino_quirks` and the e2e test.
@@ -1041,25 +1057,10 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "pthread_mutex_init",
         "pthread_mutex_lock",
         "pthread_mutex_unlock",
-        // FreeRTOS critical sections / sync
-        "xPortEnterCriticalTimeout",
-        "vPortExitCritical",
-        "vPortEnterCritical",
-        "xPortInIsrContext",
-        "vPortYield",
-        "vPortYieldFromISR",
-        "vPortYieldOtherCore",
-        "spinlock_acquire",
-        "spinlock_release",
-        "vTaskDelay",
-        "vTaskSuspendAll",
-        "xTaskResumeAll",
-        "xQueueGenericCreate",
-        "xQueueGenericSend",
-        "xQueueReceive",
-        "xSemaphoreCreateBinary",
-        "xSemaphoreTake",
-        "xSemaphoreGive",
+        // Dual-core sim: with cpu_secondary actually running, FreeRTOS
+        // primitives can use their real implementations — stubbing them
+        // would defeat the purpose. Only esp_pthread_init stays stubbed
+        // (it depends on per-task TLS we don't model).
         "esp_pthread_init",
         "esp_task_wdt_reset",
         "esp_task_wdt_init",
@@ -1298,11 +1299,40 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                 return ExitCode::from(EXIT_RUNTIME_ERROR);
             }
         }
+        // Dual-core: snapshot capture bypasses Machine::step, so the
+        // appcpu-release + cpu1.step loop has to live here too. Drain
+        // the APPCPU_BOOT_ADDR slot first (PRO_CPU may have just hit
+        // ets_set_appcpu_boot_addr), then step the secondary CPU.
+        if let Some(cpu1) = machine.cpu_secondary.as_mut() {
+            if let Some(boot_addr) =
+                labwired_core::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR
+                    .with(|s| s.take())
+            {
+                cpu1.set_pc(boot_addr);
+                cpu1.set_sp(appcpu_initial_sp);
+                cpu1.unhalt();
+            }
+            match cpu1.step(&mut machine.bus, &observers, &config) {
+                Ok(()) => {}
+                Err(SimulationError::BreakpointHit(_)) => {}
+                Err(e) => {
+                    eprintln!(
+                        "error: sim step cpu1 at cycle {i} pc=0x{:08x}: {e}",
+                        cpu1.get_pc()
+                    );
+                    return ExitCode::from(EXIT_RUNTIME_ERROR);
+                }
+            }
+        }
         machine.bus.tick_peripherals_with_costs();
         i += 1;
         if progress > 0 && i % progress == 0 {
+            let cpu1_state = match machine.cpu_secondary.as_ref() {
+                Some(cpu1) => format!("  cpu1=0x{:08x}", cpu1.get_pc()),
+                None => String::new(),
+            };
             eprintln!(
-                "  step {i:>10}  pc=0x{:08x}",
+                "  step {i:>10}  pc=0x{:08x}{cpu1_state}",
                 machine.cpu.get_pc()
             );
         }

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -99,6 +99,11 @@ pub struct XtensaLx7 {
     /// fall-through to LEND from the last body instruction (loop-back).
     /// Cleared at the start of every step.
     pub branched: bool,
+    /// When true, `Cpu::step` is a no-op for this instance — used by
+    /// dual-core configs to keep APP_CPU parked until PRO_CPU writes the
+    /// app-cpu boot address (mirrors real silicon's reset-hold). Default
+    /// false; ESP32 dual-core setup sets it on cpu_secondary at boot.
+    pub halted: bool,
 }
 
 impl XtensaLx7 {
@@ -112,7 +117,18 @@ impl XtensaLx7 {
             ur: [0u32; 256],
             pc: 0x4000_0400,
             branched: false,
+            halted: false,
         }
+    }
+
+    /// Construct an APP_CPU instance: PRID reads as 0xABAB (so
+    /// `xPortGetCoreID()` returns 1) and the CPU starts halted —
+    /// waiting for PRO_CPU to release it via `ets_set_appcpu_boot_addr`.
+    pub fn new_app_cpu() -> Self {
+        let mut cpu = Self::new();
+        cpu.sr = XtensaSrFile::new_app_cpu();
+        cpu.halted = true;
+        cpu
     }
 
     /// Read an SR by ID, with special routing for PS / WINDOWBASE / WINDOWSTART
@@ -1741,13 +1757,26 @@ impl Default for XtensaLx7 {
 
 impl Cpu for XtensaLx7 {
     fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
+        let was_halted = self.halted;
         self.regs = ArFile::new();
         // HW-verified: PS reset = 0x1F (EXCM=1, INTLEVEL=0xF — all ints masked).
         // Confirmed via OpenOCD `reset halt` on real S3-Zero: ps = 0x0000001f.
         self.ps = Ps::from_raw(0x1F);
         self.sr = XtensaSrFile::new(); // sets VECBASE=0x40000000, PRID=0xCDCD
         self.pc = 0x4000_0400;
+        // Preserve halted state across reset — a CPU configured as
+        // APP_CPU (halted at construction) must stay halted through the
+        // Machine::load_firmware reset, otherwise it'd race PRO_CPU
+        // through the firmware entry point.
+        self.halted = was_halted;
         Ok(())
+    }
+
+    fn halt(&mut self) {
+        self.halted = true;
+    }
+    fn unhalt(&mut self) {
+        self.halted = false;
     }
 
     fn step(
@@ -1756,6 +1785,14 @@ impl Cpu for XtensaLx7 {
         _observers: &[Arc<dyn SimulationObserver>],
         _config: &crate::SimulationConfig,
     ) -> SimResult<()> {
+        // Dual-core: a halted CPU contributes nothing — skip the entire
+        // step (no CCOUNT advance, no fetch, no IRQ dispatch). Real
+        // silicon's APP_CPU sits in reset until PRO_CPU releases it; we
+        // model that by leaving `halted=true` until the boot-addr thunk
+        // captures the entry point and unhalts the secondary CPU.
+        if self.halted {
+            return Ok(());
+        }
         // ── Pre-fetch interrupt check ─────────────────────────────────────────
         // Per Xtensa ISA RM §4.4.1: check for pending interrupts before fetching
         // the next instruction.

--- a/crates/core/src/cpu/xtensa_sr.rs
+++ b/crates/core/src/cpu/xtensa_sr.rs
@@ -82,8 +82,13 @@ pub const CCOMPARE2: u16 = 242;
 
 // ── Reset values ─────────────────────────────────────────────────────────────
 
-/// Fixed PRID for ESP32-S3 LX7 PRO core simulation.
+/// Fixed PRID for ESP32 LX6/LX7 PRO core (CPU 0). Real silicon value;
+/// ESP-IDF `xPortGetCoreID()` returns `(PRID >> 13) & 1` → 0.
 pub const PRID_RESET_VALUE: u32 = 0xCDCD;
+
+/// PRID for the APP core (CPU 1) on dual-core ESP32 / ESP32-S3.
+/// `(0xABAB >> 13) & 1` → 1, so `xPortGetCoreID()` returns 1 on this CPU.
+pub const PRID_APP_CPU_VALUE: u32 = 0xABAB;
 
 /// VECBASE reset value for ESP32-S3 (ROM vector table base).
 pub const VECBASE_RESET_VALUE: u32 = 0x4000_0000;
@@ -122,6 +127,16 @@ impl XtensaSrFile {
         };
         s.storage[IDX_VECBASE] = VECBASE_RESET_VALUE;
         s.storage[IDX_PRID] = PRID_RESET_VALUE;
+        s
+    }
+
+    /// Like [`Self::new`] but seeds PRID with the APP-core value
+    /// ([`PRID_APP_CPU_VALUE`]). Used by dual-core configs when
+    /// constructing the secondary CPU's SR file so RSR.PRID reads
+    /// 0xABAB and `xPortGetCoreID` returns 1.
+    pub fn new_app_cpu() -> Self {
+        let mut s = Self::new();
+        s.storage[IDX_PRID] = PRID_APP_CPU_VALUE;
         s
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -179,6 +179,14 @@ pub trait Cpu: Send {
     /// cross-core IPI bridge in the host runtime can synthesise edges
     /// without owning the SR file directly.
     fn raise_interrupt_bits(&mut self, _mask: u32) {}
+
+    /// Halt this CPU: subsequent `step()` calls are no-ops until
+    /// `unhalt()`. Models reset-hold for dual-core SoCs where one core
+    /// is held in reset until the bootstrap CPU releases it. Default
+    /// no-op so single-core CPUs need no implementation.
+    fn halt(&mut self) {}
+    /// Release a previously-halted CPU; pairs with [`Self::halt`].
+    fn unhalt(&mut self) {}
 }
 
 // Forwarding impl so `Machine<Box<dyn Cpu>>` is valid — used by the WASM
@@ -253,6 +261,12 @@ impl Cpu for Box<dyn Cpu> {
     }
     fn raise_interrupt_bits(&mut self, mask: u32) {
         (**self).raise_interrupt_bits(mask)
+    }
+    fn halt(&mut self) {
+        (**self).halt()
+    }
+    fn unhalt(&mut self) {
+        (**self).unhalt()
     }
 }
 
@@ -464,6 +478,13 @@ pub enum StopReason {
 
 pub struct Machine<C: Cpu> {
     pub cpu: C,
+    /// Secondary CPU instance — for dual-core SoCs (ESP32, ESP32-S3).
+    /// When `Some`, `step()` interleaves CPU 0 and CPU 1 instructions
+    /// over a shared bus. `None` for everything else (Cortex-M, RP2040,
+    /// pre-existing single-core Xtensa configs that don't opt in).
+    /// Snapshot/restore APIs currently track only the primary CPU —
+    /// callers that need full dual-core snapshots must extend the format.
+    pub cpu_secondary: Option<C>,
     pub bus: bus::SystemBus,
     pub observers: Vec<Arc<dyn SimulationObserver>>,
 
@@ -478,6 +499,7 @@ impl<C: Cpu> Machine<C> {
     pub fn new(cpu: C, bus: bus::SystemBus) -> Self {
         Self {
             cpu,
+            cpu_secondary: None,
             bus,
             observers: Vec::new(),
             breakpoints: HashSet::new(),
@@ -485,6 +507,15 @@ impl<C: Cpu> Machine<C> {
             total_cycles: 0,
             config: SimulationConfig::default(),
         }
+    }
+
+    /// Enable dual-core mode by attaching a secondary CPU instance.
+    /// The secondary CPU shares the same bus and steps in lockstep with
+    /// the primary (one instruction each per `Machine::step()`). Used by
+    /// ESP32 configs to model APP_CPU alongside PRO_CPU.
+    pub fn with_secondary_cpu(mut self, cpu1: C) -> Self {
+        self.cpu_secondary = Some(cpu1);
+        self
     }
 
     /// Take a binary mid-flight runtime snapshot of the entire machine —
@@ -589,13 +620,36 @@ impl<C: Cpu> Machine<C> {
     }
 
     pub fn reset(&mut self) -> SimResult<()> {
-        self.cpu.reset(&mut self.bus)
+        self.cpu.reset(&mut self.bus)?;
+        if let Some(cpu1) = self.cpu_secondary.as_mut() {
+            cpu1.reset(&mut self.bus)?;
+        }
+        Ok(())
     }
 
     pub fn step(&mut self) -> SimResult<()> {
         self.total_cycles += 1;
         self.cpu
             .step(&mut self.bus, &self.observers, &self.config)?;
+        // Dual-core: step the secondary CPU one instruction per
+        // primary-CPU instruction (round-robin). Cycle counter only
+        // advances for the primary CPU — keeps observer/snapshot
+        // semantics stable. Errors on CPU 1 bubble up the same way.
+        if let Some(cpu1) = self.cpu_secondary.as_mut() {
+            // CPU 0 may have just called `ets_set_appcpu_boot_addr` to
+            // release APP_CPU from reset-hold. The thunk stashed the
+            // boot address in a thread-local; drain it here, apply to
+            // the secondary CPU's PC, and unhalt so the next round-robin
+            // tick starts executing from that address.
+            if let Some(boot_addr) =
+                crate::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR
+                    .with(|s| s.take())
+            {
+                cpu1.set_pc(boot_addr);
+                cpu1.unhalt();
+            }
+            cpu1.step(&mut self.bus, &self.observers, &self.config)?;
+        }
 
         if self.total_cycles % (self.config.peripheral_tick_interval as u64) == 0 {
             // Propagate peripherals

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -211,9 +211,28 @@ pub fn rom_config_instruction_cache_mode(cpu: &mut XtensaLx7, _bus: &mut dyn Bus
     Ok(())
 }
 
-/// `ets_set_appcpu_boot_addr(addr: u32) -> u32` — NOP, returns 0
-/// (cpu1 is not modelled in Plan 2).
+/// `ets_set_appcpu_boot_addr(addr: u32) -> u32` — real silicon: stores
+/// the address PRO_CPU wants APP_CPU to start executing at, then
+/// releases APP_CPU from reset-hold. In dual-core sim configs we stash
+/// the boot_addr in a thread-local that `Machine::step` reads on its
+/// next tick to unhalt `cpu_secondary` with PC = boot_addr. Single-core
+/// configs ignore the stash (no secondary CPU to wake), so the thunk
+/// stays safe for either configuration.
 pub fn ets_set_appcpu_boot_addr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    // Argument register: a2 (CALL0), or a[N*4+2] under CALLn windowing.
+    let arg_slot = if cpu.ps.callinc() == 0 {
+        2
+    } else {
+        cpu.ps.callinc() * 4 + 2
+    };
+    let boot_addr = cpu.regs.read_logical(arg_slot);
+    // Only release APP_CPU on a real entry-point write. ESP-IDF's
+    // `esp_cpu_stall` path also calls this with addr=0 to reset the
+    // shadow register before re-stalling — treat that as a no-op (we
+    // don't model APP_CPU stall/resume cycles, just the initial wake).
+    if boot_addr != 0 {
+        APPCPU_BOOT_ADDR.with(|slot| slot.set(Some(boot_addr)));
+    }
     RomThunkBank::return_with(cpu, 0);
     Ok(())
 }
@@ -297,6 +316,14 @@ pub fn nop_return_fake_ptr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult
 pub fn getreent_dram_fake_ptr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 0x3FFB_F000);
     Ok(())
+}
+
+thread_local! {
+    /// Set by [`set_appcpu_boot_addr`], drained by [`Machine::step`].
+    /// Thread-local because the sim is single-threaded within any one
+    /// `Machine`; concurrent machines on parallel threads each get their
+    /// own slot. Cleared to None after Machine reads it.
+    pub static APPCPU_BOOT_ADDR: core::cell::Cell<Option<u32>> = const { core::cell::Cell::new(None) };
 }
 
 /// Monotonic-counter thunk for `esp_timer_impl_get_counter_reg()` and

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -299,6 +299,18 @@ pub fn getreent_dram_fake_ptr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimRes
     Ok(())
 }
 
+/// Monotonic-counter thunk for `esp_timer_impl_get_counter_reg()` and
+/// similar 32-bit time-source readers. Returns an ever-increasing value
+/// (steps of 1000 per call) so callers polling for timeout deadlines
+/// actually make progress instead of looping forever.
+pub fn monotonic_counter_32(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    static MONOTONIC_TICKS: core::sync::atomic::AtomicU32 =
+        core::sync::atomic::AtomicU32::new(0);
+    let v = MONOTONIC_TICKS.fetch_add(1000, core::sync::atomic::Ordering::Relaxed);
+    RomThunkBank::return_with(cpu, v);
+    Ok(())
+}
+
 /// `esp_chip_info(esp_chip_info_t *out)` — fill the output struct with a
 /// plausible-looking ESP32 chip ID, then return.
 ///

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -295,6 +295,36 @@ pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
+/// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
+/// Dumps the list state for the first few calls, then returns without
+/// performing the insertion. Used to diagnose infinite-loop bugs in the
+/// FreeRTOS scheduler list walker (typically caused by an uninitialised
+/// list lacking the `xListEnd` sentinel with `xItemValue == portMAX_DELAY`).
+pub fn vlist_insert_debug(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    use core::sync::atomic::{AtomicU32, Ordering};
+    static CALLS: AtomicU32 = AtomicU32::new(0);
+    let n = CALLS.fetch_add(1, Ordering::Relaxed);
+    if n < 20 {
+        // Args under CALL8 windowing: pxList in a2, pxNewListItem in a3
+        // (post-rotation logical slots a2/a3 since the caller used call8).
+        let callinc = cpu.ps.callinc();
+        let base = if callinc == 0 { 0 } else { callinc * 4 };
+        let px_list = cpu.regs.read_logical(base + 2);
+        let px_item = cpu.regs.read_logical(base + 3);
+        let item_value = bus.read_u32(px_item as u64).unwrap_or(0xDEAD_BEEF);
+        let list_num = bus.read_u32(px_list as u64).unwrap_or(0xDEAD_BEEF); // uxNumberOfItems
+        let list_idx = bus.read_u32(px_list as u64 + 4).unwrap_or(0xDEAD_BEEF); // pxIndex
+        let end_val = bus.read_u32(px_list as u64 + 8).unwrap_or(0xDEAD_BEEF); // xListEnd.xItemValue
+        let end_next = bus.read_u32(px_list as u64 + 12).unwrap_or(0xDEAD_BEEF);
+        let end_prev = bus.read_u32(px_list as u64 + 16).unwrap_or(0xDEAD_BEEF);
+        eprintln!(
+            "[vListInsert #{n:>3}] pxList=0x{px_list:08x} num={list_num} idx=0x{list_idx:08x} end.value=0x{end_val:08x} end.next=0x{end_next:08x} end.prev=0x{end_prev:08x} | item=0x{px_item:08x} item.value=0x{item_value:08x}"
+        );
+    }
+    RomThunkBank::return_with(cpu, 0);
+    Ok(())
+}
+
 /// Generic thunk that returns a fixed dummy pointer (0x3F40_0100, inside
 /// the flash dcache window we populate with the app-image header). Used
 /// for functions that must return a non-NULL "found it" pointer to avoid

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -266,7 +266,25 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     // We don't model the second core or the interrupt matrix in this sim,
     // so noop-return is safe.
     rom_bank.register(0x4000_681c, rom_thunks::esp_rom_route_intr_matrix); // intr_matrix_set / esp_rom_route_intr_matrix
-    rom_bank.register(0x4000_689c, rom_thunks::nop_return_zero); // ets_set_appcpu_boot_addr
+    rom_bank.register(0x4000_689c, rom_thunks::ets_set_appcpu_boot_addr); // releases APP_CPU
+    // UART putc / printf install hooks — called by call_start_cpu1 to
+    // wire CPU 1's stdout. We don't model UART output, so no-op.
+    rom_bank.register(0x4000_7d18, rom_thunks::nop_return_zero); // ets_install_putc1
+    rom_bank.register(0x4000_7d28, rom_thunks::nop_return_zero); // ets_install_uart_printf
+    rom_bank.register(0x4000_7d38, rom_thunks::nop_return_zero); // ets_install_putc2
+    rom_bank.register(0x4000_9028, rom_thunks::nop_return_zero); // uart_tx_switch
+    rom_bank.register(0x4000_9024, rom_thunks::nop_return_zero); // uart_tx_wait_idle
+    rom_bank.register(0x4000_8fcc, rom_thunks::nop_return_zero); // uart_tx_flush
+    rom_bank.register(0x4000_8fa8, rom_thunks::nop_return_zero); // uart_tx_one_char
+    rom_bank.register(0x4000_9018, rom_thunks::nop_return_zero); // uart_tx_one_char2
+    rom_bank.register(0x4000_05a4, rom_thunks::nop_return_zero); // cache_flush_rom
+    rom_bank.register(0x4005_a980, rom_thunks::nop_return_zero); // Cache_Read_Disable
+    rom_bank.register(0x4005_a917, rom_thunks::nop_return_zero); // Cache_Flush
+    rom_bank.register(0x4005_aa10, rom_thunks::nop_return_zero); // Cache_Read_Enable
+    rom_bank.register(0x4005_a888, rom_thunks::nop_return_zero); // esp_rom_spiflash_attach
+    // intr_matrix_set is at 0x4000_681c (above); cpu1 calls intr_matrix_set
+    // for its own intr table — same thunk works since we don't model the
+    // interrupt matrix per-CPU.
                                                                  // GPIO matrix routing helpers — used by Arduino's spiAttach{SCK,MOSI,MISO}
                                                                  // and HardwareSerial pin attach. We don't model the GPIO matrix; signals
                                                                  // routed via SPI3 controller flow directly to attached SPI devices.

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -138,6 +138,39 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "pthread_mutex_init",
         "pthread_mutex_lock",
         "pthread_mutex_unlock",
+        // ── FreeRTOS port-layer critical sections.  Single-task sim has no
+        //    concurrent access to guard, no other core to interrupt, no
+        //    other task to preempt — return success immediately.  Real
+        //    silicon's RSIL+spinlock spin forever if the lock owner is
+        //    a CPU we don't model.
+        "xPortEnterCriticalTimeout",
+        "vPortExitCritical",
+        "vPortEnterCritical",
+        "xPortInIsrContext",
+        "vPortYield",
+        "vPortYieldFromISR",
+        "vPortYieldOtherCore",
+        "spinlock_acquire",
+        "spinlock_release",
+        // ── FreeRTOS task / sched primitives the single-task sim noops out.
+        //    setup() runs synchronously from loopTask; no other tasks
+        //    actually exist.
+        "vTaskDelay",
+        "vTaskSuspendAll",
+        "xTaskResumeAll",
+        "xQueueGenericCreate",
+        "xQueueGenericSend",
+        "xQueueReceive",
+        "xSemaphoreCreateBinary",
+        "xSemaphoreTake",
+        "xSemaphoreGive",
+        "esp_pthread_init",
+        // ── Watchdog refresh — sketches loop fast in sim so the WDT-feed
+        //    matters less, but stub it to avoid any extra cycles burned.
+        "esp_task_wdt_reset",
+        "esp_task_wdt_init",
+        "esp_task_wdt_add",
+        "esp_task_wdt_delete",
         // ── ESP-IDF clock/efuse/cache init — sim has no real silicon
         //    behind these, stubbing them out lets call_start_cpu0 fall
         //    through to esp_startup_start_app.
@@ -154,6 +187,68 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "spi_flash_init_chip_state",
         "esp_chip_info",
         "esp_log_timestamp",
+        // SPI-flash HAL — host io-mode config polls a flash-controller status
+        // bit the sim does not model. No-op out so spi_flash_init completes.
+        "spi_flash_hal_configure_host_io_mode",
+        "spi_flash_chip_generic_config_host_io_mode",
+        "spi_flash_chip_generic_get_io_mode",
+        "spi_flash_chip_generic_set_io_mode",
+        "spi_flash_chip_generic_probe",
+        "spi_flash_chip_generic_detect_size",
+        "spi_flash_chip_generic_read",
+        "spi_flash_chip_generic_yield",
+        "spi_flash_chip_gd_probe",
+        "spi_flash_chip_gd_detect_size",
+        "spi_flash_chip_gd_get_io_mode",
+        "spi_flash_chip_gd_set_io_mode",
+        "spi_flash_init",
+        "spi_flash_hal_init",
+        "spi_flash_hal_supports_direct_write",
+        "spi_flash_hal_supports_direct_read",
+        "esp_flash_app_enable_os_functions",
+        "esp_flash_app_disable_os_functions",
+        "esp_flash_app_init",
+        "esp_flash_init_main",
+        "esp_flash_init_default_chip",
+        "esp_flash_init",
+        // Time sources — must return monotonically increasing values, so
+        // resolved here and routed to a dedicated thunk in the cli (not
+        // the nop_return_zero list).
+        "esp_timer_impl_get_counter_reg",
+        // RNG — esp_random does an APB-clock-divisor computation that
+        // div0s in the sim. We don't need real entropy; nop_return_zero
+        // is fine (callers use it for jitter, never as a primary key).
+        "esp_random",
+        "esp_fill_random",
+        // Newlib stdio output — sketches don't depend on serial output
+        // for correctness; stubbing avoids div0s deep in fvwrite.c when
+        // the underlying FILE* refers to our zeroed fake reent struct.
+        "esp_log_early_timestamp",
+        "esp_log_writev",
+        "esp_log_write",
+        "esp_log_buffer_hex_internal",
+        "esp_log_buffer_char_internal",
+        "esp_log_buffer_hexdump_internal",
+        "__sfvwrite_r",
+        "__swsetup_r",
+        "__sflush_r",
+        "_printf_r",
+        "_fprintf_r",
+        "_vfprintf_r",
+        "_vprintf_r",
+        "printf",
+        "fprintf",
+        "vfprintf",
+        "vprintf",
+        "puts",
+        "fputs",
+        "fputc",
+        "putchar",
+        "_puts_r",
+        "_fputs_r",
+        "_putchar_r",
+        "_write_r",
+        "write",
     ];
     let mut out = HashMap::new();
     let Ok(object) = object::File::parse(buffer) else {

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -202,6 +202,7 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // `port_IntStackTop`. The cli reads this symbol and seeds a1
         // before unhalting cpu_secondary.
         "port_IntStackTop",
+        "vListInsert",
         // RNG — esp_random does an APB-clock-divisor computation that
         // div0s in the sim. We don't need real entropy; nop_return_zero
         // is fine (callers use it for jitter, never as a primary key).

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -143,27 +143,9 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         //    other task to preempt — return success immediately.  Real
         //    silicon's RSIL+spinlock spin forever if the lock owner is
         //    a CPU we don't model.
-        "xPortEnterCriticalTimeout",
-        "vPortExitCritical",
-        "vPortEnterCritical",
-        "xPortInIsrContext",
-        "vPortYield",
-        "vPortYieldFromISR",
-        "vPortYieldOtherCore",
-        "spinlock_acquire",
-        "spinlock_release",
-        // ── FreeRTOS task / sched primitives the single-task sim noops out.
-        //    setup() runs synchronously from loopTask; no other tasks
-        //    actually exist.
-        "vTaskDelay",
-        "vTaskSuspendAll",
-        "xTaskResumeAll",
-        "xQueueGenericCreate",
-        "xQueueGenericSend",
-        "xQueueReceive",
-        "xSemaphoreCreateBinary",
-        "xSemaphoreTake",
-        "xSemaphoreGive",
+        // Dual-core sim: real FreeRTOS primitives are used now that
+        // cpu_secondary runs. Only esp_pthread_init stays stubbed —
+        // per-task pthread TLS isn't modeled.
         "esp_pthread_init",
         // ── Watchdog refresh — sketches loop fast in sim so the WDT-feed
         //    matters less, but stub it to avoid any extra cycles burned.
@@ -215,6 +197,11 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // resolved here and routed to a dedicated thunk in the cli (not
         // the nop_return_zero list).
         "esp_timer_impl_get_counter_reg",
+        // APP_CPU initial stack — call_start_cpu1 starts with `entry a1, 32`
+        // assuming a valid stack. ESP-IDF puts the boot stack at
+        // `port_IntStackTop`. The cli reads this symbol and seeds a1
+        // before unhalting cpu_secondary.
+        "port_IntStackTop",
         // RNG — esp_random does an APB-clock-divisor computation that
         // div0s in the sim. We don't need real entropy; nop_return_zero
         // is fine (callers use it for jitter, never as a primary key).


### PR DESCRIPTION
## Summary
- Add optional `cpu_secondary: Option<C>` to `Machine<C>` with halt/unhalt trait methods. Default `None` keeps 329 existing call sites of `machine.cpu.*` working unchanged.
- `XtensaLx7::new_app_cpu()` returns a halted APP_CPU instance with PRID=0xABAB so `xPortGetCoreID()` returns 1.
- `ets_set_appcpu_boot_addr` (BROM 0x4000_689c) now captures the entry point and `Machine::step` (plus the cli snapshot loop which bypasses `Machine::step`) unhalts cpu_secondary with PC + SP seeded from `port_IntStackTop`.
- Reader sketch now boots through `call_start_cpu1`, runs ESP-IDF init, both CPUs reach FreeRTOS scheduler.
- Broad arduino-esp32 stub coverage: newlib stdio (`__sfvwrite_r`, printf family, `__getreent` → fake DRAM ptr), SPI-flash HAL (`spi_flash_hal_init`, `*_configure_host_io_mode`, chip drivers), `esp_log_early_timestamp`, `esp_random` (div0 fix), `esp_timer_impl_get_counter_reg` → monotonic counter.
- New `rom_thunks::monotonic_counter_32` for time sources where 0 returns deadlock callers.

## Known remaining issue
cpu0 hits a `vListInsert` infinite loop after FreeRTOS scheduler starts (a10 == a3, list item self-reference). Diagnosed as an SMP race despite atomic S32C1I — likely the CCOUNT-timer ISR firing inside a critical section. DC7 task tracks the fix.

## Test plan
- [x] All 347 core tests pass
- [x] Single-core paths unchanged (cpu_secondary defaults to None)
- [x] AgentDeck profile still cold-boots successfully (19031 SPI3 txns, panel paints)
- [x] Real HW e-reader sketch flashes and paints correctly
- [ ] Reader sketch sim parity (blocked by DC7)