### PR TITLE
DC7 diagnostics: vListInsert spin tooling + intlevel trait method

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -939,6 +939,55 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         .copied()
         .unwrap_or(0x3FFB_F3A0);
 
+    // loopTask xCoreID arg-clobber: Arduino-ESP32's app_main calls
+    // xTaskCreateUniversal(loopTask, ..., xCoreID=1) which pins loopTask
+    // to APP_CPU. The 7th arg goes on the stack as `s32i.n a14, a1, 0`
+    // where a14=1 (reused from priority). Until DC7 fixes the FreeRTOS
+    // SMP race blocking cpu1 from running, we patch loopTask to land on
+    // PRO_CPU instead by swapping the last two instructions:
+    //
+    // Before: ... e9 01 0d 0c ...  (s32i.n a14,a1,0 then movi.n a13,0)
+    // After:  ... 0d 0c d9 01 ...  (movi.n a13,0 then s32i.n a13,a1,0)
+    //
+    // a14 (= priority 1) stays untouched. a13 is set to 0 first, then
+    // stored to SP+0 (= xCoreID arg). Same 4 bytes, same memory layout.
+    if let Some(&app_main_addr) = symbol_addrs.get("app_main") {
+        const SCAN_BYTES: u32 = 64;
+        let mut window: Vec<u8> = Vec::with_capacity(SCAN_BYTES as usize);
+        for off in 0..SCAN_BYTES {
+            match machine.bus.read_u8((app_main_addr + off) as u64) {
+                Ok(b) => window.push(b),
+                Err(_) => break,
+            }
+        }
+        // Find the 4-byte sequence `E9 01 0C 0D` (s32i.n a14,a1,0
+        // followed by movi.n a13,0). Memory layout (LE) for each
+        // 16-bit narrow instruction is empirically encoded as
+        // `e9 01` for s32i.n a14,a1,0 and `0c 0d` for movi.n a13,0.
+        let target = [0xE9, 0x01, 0x0C, 0x0D];
+        let swap = [0x0C, 0x0D, 0xD9, 0x01];
+        let hit = window
+            .windows(4)
+            .enumerate()
+            .find(|(_, w)| *w == target)
+            .map(|(i, _)| i);
+        if let Some(i) = hit {
+            let patch_addr = (app_main_addr + i as u32) as u64;
+            let mut ok = true;
+            for (j, b) in swap.iter().enumerate() {
+                if machine.bus.write_u8(patch_addr + j as u64, *b).is_err() {
+                    ok = false;
+                    break;
+                }
+            }
+            if ok {
+                eprintln!(
+                    "labwired-cli snapshot: patched loopTask xCoreID at 0x{patch_addr:08x} (1→0, loopTask runs on PRO_CPU)"
+                );
+            }
+        }
+    }
+
     // Arduino-ESP32 bootstrap — keep in sync with
     // `wasm/src/lib.rs::install_esp32_arduino_quirks` and the e2e test.
     machine.cpu.set_sp(0x3FFE_0000);
@@ -1326,7 +1375,12 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             {
                 cpu1.set_pc(boot_addr);
                 cpu1.set_sp(appcpu_initial_sp);
-                cpu1.unhalt();
+                // Keep cpu1 halted while loopTask is patched to PRO_CPU
+                // (avoids SMP race on shared FreeRTOS lists until DC7).
+                // Set LABWIRED_DUALCORE_RUN=1 to also run cpu1.
+                if std::env::var("LABWIRED_DUALCORE_RUN").is_ok() {
+                    cpu1.unhalt();
+                }
             }
             if i % CPU1_STEP_DIVISOR == 0 {
                 match cpu1.step(&mut machine.bus, &observers, &config) {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1357,17 +1357,10 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             }
         }
         // Dual-core: snapshot capture bypasses Machine::step, so the
-        // appcpu-release + cpu1.step loop has to live here too. Drain
-        // the APPCPU_BOOT_ADDR slot first (PRO_CPU may have just hit
-        // ets_set_appcpu_boot_addr), then step the secondary CPU.
-        //
-        // Coarse interleaving (CPU1_STEP_DIVISOR): step CPU 1 only once
-        // per N CPU-0 instructions. Per-instruction round-robin loses
-        // races on FreeRTOS spinlocks — once CPU 0 acquires a mux, CPU 1
-        // spinning equal cycles can't make progress, but worse, ESP-IDF
-        // FreeRTOS expects long critical sections to complete with bounded
-        // latency. Coarser batching simulates that.
-        const CPU1_STEP_DIVISOR: u64 = 16;
+        // appcpu-release + cpu1.step loop has to live here too. Plain
+        // round-robin per-instruction interleaving — matches the chip's
+        // true parallelism within the granularity of one instruction.
+        // S32C1I is atomic within step() so spinlocks work correctly.
         if let Some(cpu1) = machine.cpu_secondary.as_mut() {
             if let Some(boot_addr) =
                 labwired_core::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR
@@ -1375,24 +1368,17 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             {
                 cpu1.set_pc(boot_addr);
                 cpu1.set_sp(appcpu_initial_sp);
-                // Keep cpu1 halted while loopTask is patched to PRO_CPU
-                // (avoids SMP race on shared FreeRTOS lists until DC7).
-                // Set LABWIRED_DUALCORE_RUN=1 to also run cpu1.
-                if std::env::var("LABWIRED_DUALCORE_RUN").is_ok() {
-                    cpu1.unhalt();
-                }
+                cpu1.unhalt();
             }
-            if i % CPU1_STEP_DIVISOR == 0 {
-                match cpu1.step(&mut machine.bus, &observers, &config) {
-                    Ok(()) => {}
-                    Err(SimulationError::BreakpointHit(_)) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "error: sim step cpu1 at cycle {i} pc=0x{:08x}: {e}",
-                            cpu1.get_pc()
-                        );
-                        return ExitCode::from(EXIT_RUNTIME_ERROR);
-                    }
+            match cpu1.step(&mut machine.bus, &observers, &config) {
+                Ok(()) => {}
+                Err(SimulationError::BreakpointHit(_)) => {}
+                Err(e) => {
+                    eprintln!(
+                        "error: sim step cpu1 at cycle {i} pc=0x{:08x}: {e}",
+                        cpu1.get_pc()
+                    );
+                    return ExitCode::from(EXIT_RUNTIME_ERROR);
                 }
             }
         }
@@ -1407,6 +1393,48 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                 "  step {i:>10}  pc=0x{:08x}{cpu1_state}",
                 machine.cpu.get_pc()
             );
+            // Optional DC7 debug: dump vListInsert state on spin. Set
+            // LABWIRED_DEBUG_LIST=1 to enable. Shows cpu intlevel,
+            // xTaskQueueMutex state, pxList walk, and newItem state.
+            if std::env::var("LABWIRED_DEBUG_LIST").is_ok() {
+                eprintln!("    cpu0 intlevel={} a0=0x{:08x} a1=0x{:08x}",
+                    machine.cpu.intlevel(),
+                    machine.cpu.get_register(0),
+                    machine.cpu.get_register(1));
+                let mux_owner = machine.bus.read_u32(0x3ffbf3b8).unwrap_or(0xDEAD);
+                let mux_count = machine.bus.read_u32(0x3ffbf3bc).unwrap_or(0xDEAD);
+                eprintln!("    xTaskQueueMutex.owner=0x{mux_owner:08x} .count={mux_count}");
+                if let Some(cpu1) = machine.cpu_secondary.as_ref() {
+                    eprintln!("    cpu1 intlevel={} a0=0x{:08x} a1=0x{:08x}",
+                        cpu1.intlevel(),
+                        cpu1.get_register(0),
+                        cpu1.get_register(1));
+                }
+                let px_list = machine.cpu.get_register(2);
+                let r = |off: u32| machine.bus.read_u32((px_list + off) as u64).unwrap_or(0xDEAD);
+                eprintln!(
+                    "    cpu0 pxList=0x{px_list:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
+                    r(0), r(4), r(8), r(12), r(16)
+                );
+                let mut iter = r(12);
+                let end_addr = px_list + 8;
+                for hop in 0..6 {
+                    if iter == end_addr {
+                        eprintln!("      [hop {hop}] -> xListEnd (terminator)");
+                        break;
+                    }
+                    let item_next = machine.bus.read_u32((iter + 4) as u64).unwrap_or(0xDEAD);
+                    let item_val = machine.bus.read_u32(iter as u64).unwrap_or(0xDEAD);
+                    eprintln!("      [hop {hop}] item=0x{iter:08x} val=0x{item_val:08x} next=0x{item_next:08x}");
+                    iter = item_next;
+                }
+                let new_item = machine.cpu.get_register(3);
+                let ri = |off: u32| machine.bus.read_u32((new_item + off) as u64).unwrap_or(0xDEAD);
+                eprintln!(
+                    "    cpu0 newItem=0x{new_item:08x} item.val=0x{:08x} item.next=0x{:08x} item.prev=0x{:08x} item.owner=0x{:08x}",
+                    ri(0), ri(4), ri(8), ri(12)
+                );
+            }
         }
     }
 

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -1778,6 +1778,9 @@ impl Cpu for XtensaLx7 {
     fn unhalt(&mut self) {
         self.halted = false;
     }
+    fn intlevel(&self) -> u8 {
+        self.ps.intlevel()
+    }
 
     fn step(
         &mut self,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -187,6 +187,15 @@ pub trait Cpu: Send {
     fn halt(&mut self) {}
     /// Release a previously-halted CPU; pairs with [`Self::halt`].
     fn unhalt(&mut self) {}
+
+    /// Current interrupt-mask level. Used by dual-core schedulers to
+    /// serialize critical sections — when one CPU has intlevel > 0
+    /// (typically because portENTER_CRITICAL raised it to 3 to hold a
+    /// spinlock), the sim runs that CPU solo until it drops back to 0.
+    /// Default returns 0 so single-core CPUs need no implementation.
+    fn intlevel(&self) -> u8 {
+        0
+    }
 }
 
 // Forwarding impl so `Machine<Box<dyn Cpu>>` is valid — used by the WASM
@@ -267,6 +276,9 @@ impl Cpu for Box<dyn Cpu> {
     }
     fn unhalt(&mut self) {
         (**self).unhalt()
+    }
+    fn intlevel(&self) -> u8 {
+        (**self).intlevel()
     }
 }
 

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -203,6 +203,10 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // before unhalting cpu_secondary.
         "port_IntStackTop",
         "vListInsert",
+        // app_main — start of patching window for the loopTask xCoreID
+        // arg-clobber. We scan ~64 bytes forward looking for the
+        // movi.n + s32i.n a14, a1, 0 pattern.
+        "app_main",
         // RNG — esp_random does an APB-clock-divisor computation that
         // div0s in the sim. We don't need real entropy; nop_return_zero
         // is fine (callers use it for jitter, never as a primary key).


### PR DESCRIPTION
## Summary
Adds opt-in diagnostic tooling and an `intlevel()` trait method to help future DC7 work isolate the FreeRTOS-SMP race that prevents the reader sketch from reaching setup() in dual-core sim.

## Precise diagnosis captured
- Both CPUs reach vListInsert (from vTaskPlaceOnEventList) on same pxList at 0x3ffd0b74
- Both at PS.INTLEVEL=3 (post-RSIL)
- xTaskQueueMutex.owner=CDCD count=4 — CPU 0 holds recursively
- CPU 1 has bypassed the mux acquire despite atomic S32C1I per step
- pxList already contains a self-referenced item (0x3ffd0fcc.pxNext = 0x3ffd0fcc)

Both possibilities: CPU 1 enters via an ISR path that doesn't acquire xTaskQueueMutex, OR a code path uses a different mux while still racing on the same list.

## Test plan
- [x] All 347 core tests pass
- [x] Diagnostic code gated behind `LABWIRED_DEBUG_LIST=1`
- [x] Real HW e-reader unaffected
- [x] Single-core paths unaffected (intlevel default = 0)