### PR TITLE
sim: portYIELD + timer tick + abort-halt — fix IPC-task spin (DC7)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1071,16 +1071,26 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     } else if args.profile == "agentdeck" {
         thunks.push((0x400e_2280, rom_thunks::nop_return_zero));
     }
-    // ESP-IDF clock/efuse/cache/dport bring-up — the sim has no silicon
-    // behind these so we stub them to return-0. Only installed when the
-    // symbol is present in the ELF (Arduino-ESP32 profile).
+    // Real-silicon noreturn functions — abort_halt prints diagnostics and
+    // halts the CPU instead of returning. Without this, stubbing them as
+    // nop_return_zero creates tight `assert → return → re-check → assert`
+    // loops in xQueueGenericSend's parameter-validation path.
     for sym in &[
         "panic_abort",
-        "__assert_func",   // newlib: catches double-fault on assert during reent init
+        "__assert_func",
         "abort",
         "__assert",
         "__cxa_pure_virtual",
         "__cxa_throw",
+    ] {
+        if let Some(&pc) = symbol_addrs.get(*sym) {
+            thunks.push((pc, rom_thunks::abort_halt));
+        }
+    }
+    // ESP-IDF clock/efuse/cache/dport bring-up — the sim has no silicon
+    // behind these so we stub them to return-0. Only installed when the
+    // symbol is present in the ELF (Arduino-ESP32 profile).
+    for sym in &[
         // newlib stdio init — sketch doesn't use stdio on render path
         "__sinit",
         "__sfp",
@@ -1158,6 +1168,19 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",
         "esp_log_buffer_hexdump_internal",
+        // log mutex (esp_log_impl_lock/unlock) — sim doesn't model the log
+        // mutex queue, and the real impl calls xQueueGenericSend on an
+        // uninitialized queue, tripping a NULL-pcHead assertion.
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
+        // FreeRTOS recursive mutexes used by newlib stdio locks — same
+        // null-queue assertion problem. Stub since sim is effectively
+        // single-threaded on the panel-render path.
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
         "__sfvwrite_r",
         "__swsetup_r",
         "__sflush_r",
@@ -1203,6 +1226,12 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // timeout helpers) spin forever.
     if let Some(&pc) = symbol_addrs.get("esp_timer_impl_get_counter_reg") {
         thunks.push((pc, rom_thunks::monotonic_counter_32));
+    }
+    // esp_clk_cpu_freq() — FreeRTOS divides CPU freq by tick rate to set
+    // _xt_tick_divisor; without a meaningful value, divisor is 0 and the
+    // timer ISR re-fires every CCOUNT cycle, pinning CPU 0 in the tick hook.
+    if let Some(&pc) = symbol_addrs.get("esp_clk_cpu_freq") {
+        thunks.push((pc, rom_thunks::esp_clk_cpu_freq_240mhz));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in
@@ -1421,6 +1450,14 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                     "    cpu0 pxList=0x{px_list:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
                     r(0), r(4), r(8), r(12), r(16)
                 );
+                if let Some(cpu1) = machine.cpu_secondary.as_ref() {
+                    let px_list1 = cpu1.get_register(2);
+                    let r1 = |off: u32| machine.bus.read_u32((px_list1 + off) as u64).unwrap_or(0xDEAD);
+                    eprintln!(
+                        "    cpu1 pxList=0x{px_list1:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
+                        r1(0), r1(4), r1(8), r1(12), r1(16)
+                    );
+                }
                 let mut iter = r(12);
                 let end_addr = px_list + 8;
                 for hop in 0..6 {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1328,29 +1328,6 @@ impl SystemBus {
     }
 
     pub fn write_u32(&mut self, addr: u64, value: u32) -> SimResult<()> {
-        // Debug: catch FreeRTOS list-item self-reference (item.pxNext = &item).
-        // ListItem_t layout has pxNext at offset 4; writing item-pointer P to
-        // address P+4 means item references itself. Gated by env var so the
-        // check is zero-cost in normal runs.
-        if std::env::var_os("LABWIRED_TRACE_LIST_CORRUPTION").is_some() {
-            if (addr as u32).wrapping_sub(value) == 4
-                && value >= 0x3FF8_0000
-                && value < 0x4000_0000
-            {
-                eprintln!(
-                    "[bus-watch] self-ref write: addr=0x{:08x} value=0x{:08x}",
-                    addr as u32, value
-                );
-            }
-            // Also trace any write near the suspected corrupted item region
-            if let Ok(target) = std::env::var("LABWIRED_WATCH_ADDR") {
-                if let Some(t) = target.strip_prefix("0x").and_then(|h| u32::from_str_radix(h, 16).ok()) {
-                    if (addr as u32) >= t && (addr as u32) < t + 16 {
-                        eprintln!("[bus-watch] write addr=0x{:08x} value=0x{:08x}", addr as u32, value);
-                    }
-                }
-            }
-        }
         if self.config.optimized_bus_access && self.ram.write_u32(addr, value) {
             return Ok(());
         }

--- a/crates/core/src/cpu/xtensa_sr.rs
+++ b/crates/core/src/cpu/xtensa_sr.rs
@@ -64,7 +64,8 @@ pub const EXCSAVE5: u16 = 213;
 pub const EXCSAVE6: u16 = 214;
 pub const EXCSAVE7: u16 = 215;
 pub const CPENABLE: u16 = 224; // 0xE0
-pub const INTERRUPT: u16 = 226; // 0xE2 (read-only from SW)
+pub const INTERRUPT: u16 = 226; // 0xE2 (RSR: read INTERRUPT)
+pub const INTSET: u16 = 226; // 0xE2 (WSR: sets bits in INTERRUPT — same SR id as INTERRUPT, ISA-distinguished by RSR vs WSR direction)
 pub const INTCLEAR: u16 = 227; // 0xE3 (write-clears INTERRUPT bits)
 pub const INTENABLE: u16 = 228; // 0xE4
 pub const PS: u16 = 230; // 0xE6
@@ -155,7 +156,10 @@ impl XtensaSrFile {
     ///
     /// Special dispatch:
     /// - `INTCLEAR (227)`: clears bits in `INTERRUPT` — `interrupt &= !v`.
-    /// - `INTERRUPT (226)`: direct SW writes ignored (hardware-latched).
+    /// - `INTSET (226)`: sets bits in `INTERRUPT` — `interrupt |= v`. INTSET
+    ///   and INTERRUPT share SR id 226 in the Xtensa LX ISA; RSR reads the
+    ///   pending-IRQ status, WSR (this path) is the software-trigger entry
+    ///   point used by FreeRTOS `portYIELD()` (BIT(7) → SOFTWARE0).
     /// - `PRID (235)`: writes ignored (read-only).
     /// - `SAR (3)`: masked to 6 bits per Xtensa LX ISA.
     pub fn write(&mut self, sr_id: u16, v: u32) {
@@ -169,8 +173,12 @@ impl XtensaSrFile {
                 self.storage[IDX_INTERRUPT] &= !v;
             }
             IDX_INTERRUPT => {
-                // Direct SW writes to INTERRUPT are ignored (hardware-latched)
-                tracing::trace!("WSR: direct write to INTERRUPT (id=226) ignored");
+                // WSR.INTSET (shares SR id 226 with INTERRUPT): set bits in
+                // INTERRUPT. This is the SW-IRQ trigger path that FreeRTOS
+                // `portYIELD()` rides on — without it, scheduler yields are
+                // silently dropped and tasks calling xQueueReceive on empty
+                // queues spin without ever blocking, corrupting wait lists.
+                self.storage[IDX_INTERRUPT] |= v;
             }
             IDX_PRID => {
                 // PRID is read-only hardware register
@@ -182,6 +190,28 @@ impl XtensaSrFile {
             }
             idx => {
                 self.storage[idx] = v;
+                // Xtensa CCOMPARE0 semantics: writing CCOMPARE0 acknowledges
+                // the previous timer-0 interrupt (clears bit 6 in INTERRUPT)
+                // AND, if the new value is already <= CCOUNT, immediately
+                // raises bit 6 again so the next tick fires on the cycle the
+                // comparator is met.
+                //
+                // Without the acknowledge half of this, the bit stays high
+                // after the ISR returns and dispatches again, causing a
+                // tight ISR re-entry loop.
+                //
+                // Without the raise half, FreeRTOS's `_frxt_tick_timer_init`
+                // sets CCOMPARE0 = CCOUNT + divisor at scheduler-start time
+                // — but our CCOUNT has already overrun (bump-allocator-backed
+                // boot is slower than the divisor), so the firmware never
+                // gets a tick, never yields, and IPC tasks spin in
+                // xQueueReceive corrupting wait lists.
+                if idx == 240 /* CCOMPARE0 */ {
+                    self.storage[IDX_INTERRUPT] &= !(1 << 6);
+                    if v != 0 && self.storage[IDX_CCOUNT] >= v {
+                        self.storage[IDX_INTERRUPT] |= 1 << 6;
+                    }
+                }
             }
         }
     }

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -295,6 +295,35 @@ pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
+/// Thunk for `__assert_func` / `panic_abort` / `abort` — functions that
+/// real-silicon C convention treats as `noreturn`. Stubbing them as
+/// nop_return_zero would silently return into the caller, which on the
+/// FreeRTOS xQueue assertion paths produces a tight loop:
+/// `assert → return → check failed cond → jump back to assert`.
+///
+/// Instead, halt the calling CPU and print the assertion arguments so the
+/// operator sees what blew up.  The caller never re-runs, so the loop
+/// breaks.  The OTHER CPU (if dual-core) keeps running.
+pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    use core::sync::atomic::{AtomicU32, Ordering};
+    static FIRST_PRINT: AtomicU32 = AtomicU32::new(0);
+    if FIRST_PRINT.fetch_add(1, Ordering::Relaxed) < 5 {
+        let n = cpu.ps.callinc() * 4;
+        let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;
+        eprintln!(
+            "[abort_halt] core={core_id} pc=0x{:08x} a0=0x{:08x} a10=0x{:08x} a11=0x{:08x} a12=0x{:08x} a13=0x{:08x}",
+            cpu.pc,
+            cpu.regs.read_logical(0),
+            cpu.regs.read_logical(n + 2),
+            cpu.regs.read_logical(n + 3),
+            cpu.regs.read_logical(n + 4),
+            cpu.regs.read_logical(n + 5)
+        );
+    }
+    cpu.halted = true;
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the
@@ -681,6 +710,17 @@ pub fn esp_idf_heap_caps_realloc(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> Sim
 /// `ets_get_cpu_frequency() -> u32` — returns 240 (MHz).
 pub fn rom_cpu_freq_240mhz(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 240);
+    Ok(())
+}
+
+/// `esp_clk_cpu_freq() -> u32` — returns 240_000_000 (Hz).
+///
+/// FreeRTOS's `_frxt_tick_timer_init` uses this to compute
+/// `_xt_tick_divisor = cpu_freq / configTICK_RATE_HZ`. Without it (or with
+/// the stubbed esp_clk_init returning 0), the divisor is 0 and the timer
+/// ISR can never advance CCOMPARE0 — every CCOUNT cycle re-fires the tick.
+pub fn esp_clk_cpu_freq_240mhz(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    RomThunkBank::return_with(cpu, 240_000_000);
     Ok(())
 }
 

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -74,6 +74,15 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "__retarget_lock_close_recursive",
         "__retarget_lock_acquire_recursive",
         "__retarget_lock_release_recursive",
+        // Newlib-stdio-driven mutex API. Real silicon backs these via
+        // FreeRTOS recursive mutexes whose handles live in (uninitialised
+        // in our sim) static memory; calling the real impl asserts on
+        // pcHead != NULL. Stub to no-op since the sim is effectively
+        // single-threaded on the render path.
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr
@@ -158,6 +167,7 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         //    through to esp_startup_start_app.
         "esp_clk_init",
         "esp_perip_clk_init",
+        "esp_clk_cpu_freq",
         "core_intr_matrix_clear",
         "esp_efuse_check_errors",
         "esp_dport_access_stall_other_cpu_start",
@@ -217,6 +227,9 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // the underlying FILE* refers to our zeroed fake reent struct.
         "esp_log_early_timestamp",
         "esp_log_writev",
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
         "esp_log_write",
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",


### PR DESCRIPTION
## Summary
- Implement `WSR.INTSET` (id 226) — was treated as ignored direct-INTERRUPT write, dropping every `portYIELD()` silently
- CCOMPARE0 ack-and-rearm on write — fixes the timer tick when firmware sets the comparator below the current CCOUNT (bump-allocator boot overruns the divisor)
- New `esp_clk_cpu_freq` thunk returning 240 MHz — without it `_xt_tick_divisor` is 0 and the tick ISR re-fires every cycle
- New `abort_halt` thunk for `__assert_func` / `abort` / `panic_abort` — these are no-return on real silicon; stubbing as nop turned `xQueueGenericSend`'s NULL-queue assertion into a tight retry loop
- Stub `xQueueGiveMutexRecursive` / `xQueueTakeMutexRecursive` / `esp_log_impl_*` — newlib stdio locks and the log mutex back onto recursive mutexes whose handles are never initialised in the bump-allocator world
- Drop the dead inherent `SystemBus::write_u32/write_u16` watchpoint from #93 — it never fired because the CPU dispatches through the `Bus` trait impl, not the inherent method

## Background
DC7 was diagnosed as an SMP race in vListInsert. The actual mechanism: an IPC task (single-core, on PRO_CPU) calls `xQueueReceive` on an empty queue, `vTaskPlaceOnEventList` adds it to the wait list, exits the critical section — and then re-enters because the yield was silently dropped. The wait list ends up containing the same item twice; the walker walks into the item itself, and the second insertion writes `item.pxNext = item` (self-reference). Subsequent inserts spin forever in the walker.

With portYIELD now working, timer ticks firing on schedule, and assertions actually halting instead of looping, the spin pattern is broken. The next visible blocker is unrelated firmware-init details (display library init paths) hitting fresh real assertions, which now produce clean halts with diagnostics rather than infinite loops.

## Test plan
- [x] `cargo test --workspace --release --tests` — 913 tests pass
- [x] Reader sketch sim with these fixes: PC progresses out of the vListInsert spin into setup() and onward (then halts at a downstream firmware assertion with a clear diagnostic)
- [ ] AgentDeck snapshot path still works end-to-end in the playground (untested in this PR — please verify before deploying)