### PR TITLE
sim: get past FreeRTOS startup into Arduino user code

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1071,16 +1071,26 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     } else if args.profile == "agentdeck" {
         thunks.push((0x400e_2280, rom_thunks::nop_return_zero));
     }
-    // ESP-IDF clock/efuse/cache/dport bring-up — the sim has no silicon
-    // behind these so we stub them to return-0. Only installed when the
-    // symbol is present in the ELF (Arduino-ESP32 profile).
+    // Real-silicon noreturn functions — abort_halt prints diagnostics and
+    // halts the CPU instead of returning. Without this, stubbing them as
+    // nop_return_zero creates tight `assert → return → re-check → assert`
+    // loops in xQueueGenericSend's parameter-validation path.
     for sym in &[
         "panic_abort",
-        "__assert_func",   // newlib: catches double-fault on assert during reent init
+        "__assert_func",
         "abort",
         "__assert",
         "__cxa_pure_virtual",
         "__cxa_throw",
+    ] {
+        if let Some(&pc) = symbol_addrs.get(*sym) {
+            thunks.push((pc, rom_thunks::abort_halt));
+        }
+    }
+    // ESP-IDF clock/efuse/cache/dport bring-up — the sim has no silicon
+    // behind these so we stub them to return-0. Only installed when the
+    // symbol is present in the ELF (Arduino-ESP32 profile).
+    for sym in &[
         // newlib stdio init — sketch doesn't use stdio on render path
         "__sinit",
         "__sfp",
@@ -1158,6 +1168,19 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",
         "esp_log_buffer_hexdump_internal",
+        // log mutex (esp_log_impl_lock/unlock) — sim doesn't model the log
+        // mutex queue, and the real impl calls xQueueGenericSend on an
+        // uninitialized queue, tripping a NULL-pcHead assertion.
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
+        // FreeRTOS recursive mutexes used by newlib stdio locks — same
+        // null-queue assertion problem. Stub since sim is effectively
+        // single-threaded on the panel-render path.
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
         "__sfvwrite_r",
         "__swsetup_r",
         "__sflush_r",
@@ -1203,6 +1226,12 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // timeout helpers) spin forever.
     if let Some(&pc) = symbol_addrs.get("esp_timer_impl_get_counter_reg") {
         thunks.push((pc, rom_thunks::monotonic_counter_32));
+    }
+    // esp_clk_cpu_freq() — FreeRTOS divides CPU freq by tick rate to set
+    // _xt_tick_divisor; without a meaningful value, divisor is 0 and the
+    // timer ISR re-fires every CCOUNT cycle, pinning CPU 0 in the tick hook.
+    if let Some(&pc) = symbol_addrs.get("esp_clk_cpu_freq") {
+        thunks.push((pc, rom_thunks::esp_clk_cpu_freq_240mhz));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in
@@ -1421,6 +1450,14 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                     "    cpu0 pxList=0x{px_list:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
                     r(0), r(4), r(8), r(12), r(16)
                 );
+                if let Some(cpu1) = machine.cpu_secondary.as_ref() {
+                    let px_list1 = cpu1.get_register(2);
+                    let r1 = |off: u32| machine.bus.read_u32((px_list1 + off) as u64).unwrap_or(0xDEAD);
+                    eprintln!(
+                        "    cpu1 pxList=0x{px_list1:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
+                        r1(0), r1(4), r1(8), r1(12), r1(16)
+                    );
+                }
                 let mut iter = r(12);
                 let end_addr = px_list + 8;
                 for hop in 0..6 {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1182,32 +1182,17 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
-        // Arduino Print/Stream/HardwareSerial — sketches don't depend on
-        // bytes reaching real serial. Stubbing the whole tree lets setup()
-        // get past `Serial.println(...)` chains without spinning in
-        // uartAvailable polling.
-        "_ZN5Print7printlnEv",
-        "_ZN5Print7printlnEPKc",
-        "_ZN5Print7printlnEmi",
-        "_ZN5Print5printEPKc",
-        "_ZN5Print5printEmi",
-        "_ZN5Print11printNumberEmh",
-        "_ZN5Print5writeEPKc",
-        "_ZN5Print5writeEPKhj",
-        "_ZN5Print5writeEh",
-        "_ZN5Print5flushEv",
-        "_ZN5Print17availableForWriteEv",
+        // HardwareSerial / UART layer only — leave Print/Stream alone so
+        // virtual dispatch through Print::print → Adafruit_GFX::write →
+        // drawPixel (the display.print render path) keeps working. The
+        // original spin was in HardwareSerial::write's buffer-available
+        // wait, not in Print or Stream.
         "_ZN14HardwareSerial5writeEh",
         "_ZN14HardwareSerial5writeEPKhj",
         "_ZN14HardwareSerial9availableEv",
         "_ZN14HardwareSerial5flushEv",
         "_ZN14HardwareSerial9readBytesEPcj",
         "_ZN14HardwareSerial9readBytesEPhj",
-        "_ZN6Stream9readBytesEPhj",
-        "_ZN6Stream9readBytesEPcj",
-        "_ZN6Stream10readStringEv",
-        "_ZN6Stream9timedReadEv",
-        "_ZN6Stream10getTimeoutEv",
         "uartAvailable",
         "uartAvailableForWrite",
         "uartWrite",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1182,6 +1182,37 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
+        // Arduino Print/Stream/HardwareSerial — sketches don't depend on
+        // bytes reaching real serial. Stubbing the whole tree lets setup()
+        // get past `Serial.println(...)` chains without spinning in
+        // uartAvailable polling.
+        "_ZN5Print7printlnEv",
+        "_ZN5Print7printlnEPKc",
+        "_ZN5Print7printlnEmi",
+        "_ZN5Print5printEPKc",
+        "_ZN5Print5printEmi",
+        "_ZN5Print11printNumberEmh",
+        "_ZN5Print5writeEPKc",
+        "_ZN5Print5writeEPKhj",
+        "_ZN5Print5writeEh",
+        "_ZN5Print5flushEv",
+        "_ZN5Print17availableForWriteEv",
+        "_ZN14HardwareSerial5writeEh",
+        "_ZN14HardwareSerial5writeEPKhj",
+        "_ZN14HardwareSerial9availableEv",
+        "_ZN14HardwareSerial5flushEv",
+        "_ZN14HardwareSerial9readBytesEPcj",
+        "_ZN14HardwareSerial9readBytesEPhj",
+        "_ZN6Stream9readBytesEPhj",
+        "_ZN6Stream9readBytesEPcj",
+        "_ZN6Stream10readStringEv",
+        "_ZN6Stream9timedReadEv",
+        "_ZN6Stream10getTimeoutEv",
+        "uartAvailable",
+        "uartAvailableForWrite",
+        "uartWrite",
+        "uartWriteBuf",
+        "_Z14serialEventRunv",
         // FreeRTOS recursive mutexes used by newlib stdio locks — same
         // null-queue assertion problem. Stub since sim is effectively
         // single-threaded on the panel-render path. xQueueCreateMutexStatic
@@ -1267,6 +1298,21 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     }
     if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
         thunks.push((pc, rom_thunks::return_pd_true));
+    }
+    if let Some(&pc) = symbol_addrs.get("spiStartBus") {
+        thunks.push((pc, rom_thunks::spi_start_bus_fake));
+    }
+    // Pre-initialize the Arduino global SPI object's _spi field. The
+    // sketch never calls SPI.begin() — GxEPD2 just assumes SPI is up.
+    // SPIClass layout: offset 0 = _spi_num (u8), offset 4 = _spi (spi_t*).
+    // Our fake spi_t lives at 0x3FFDF020 with dev=0x3FF65000 (SPI3 base);
+    // see rom_thunks::spi_start_bus_fake.
+    // SPIClass::beginTransaction lazy-init: the sketch never calls
+    // SPI.begin() so SPI._spi is NULL at first use. The thunk replaces
+    // beginTransaction with one that lazy-allocates a fake spi_t pointing
+    // at the correct SPI peripheral base, then returns pdTRUE.
+    if let Some(&pc) = symbol_addrs.get("_ZN8SPIClass16beginTransactionE11SPISettings") {
+        thunks.push((pc, rom_thunks::spi_class_begin_transaction));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1109,7 +1109,8 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "_fwrite_r",
         "esp_panic_handler",
         "esp_panic_handler_reconfigure_wdts",
-        "xTaskGetCurrentTaskHandle",
+        // xTaskGetCurrentTaskHandle gets a proper thunk below — returning
+        // 0 breaks vTaskDelete(NULL) by passing NULL into prvDeleteTLS.
         "pthread_key_create",
         "pthread_setspecific",
         "pthread_getspecific",
@@ -1174,13 +1175,21 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "esp_log_impl_lock",
         "esp_log_impl_lock_timeout",
         "esp_log_impl_unlock",
+        // esp_ipc_init/isr_init create the IPC task per core. Its
+        // semaphore-wait turns into a tight loop in the sim (xQueueSemaphoreTake
+        // is stubbed to pdTRUE), starving loopTask. Stub the init so the
+        // task is never created — cross-core IPC isn't used on the
+        // single-CPU render path.
+        "esp_ipc_init",
+        "esp_ipc_isr_init",
         // FreeRTOS recursive mutexes used by newlib stdio locks — same
         // null-queue assertion problem. Stub since sim is effectively
-        // single-threaded on the panel-render path.
+        // single-threaded on the panel-render path. xQueueCreateMutexStatic
+        // gets a separate echo_arg0 thunk below (callers assert the returned
+        // handle equals the static buffer they passed in).
         "xQueueGiveMutexRecursive",
         "xQueueTakeMutexRecursive",
         "xQueueCreateMutex",
-        "xQueueCreateMutexStatic",
         "__sfvwrite_r",
         "__swsetup_r",
         "__sflush_r",
@@ -1232,6 +1241,32 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // timer ISR re-fires every CCOUNT cycle, pinning CPU 0 in the tick hook.
     if let Some(&pc) = symbol_addrs.get("esp_clk_cpu_freq") {
         thunks.push((pc, rom_thunks::esp_clk_cpu_freq_240mhz));
+    }
+    // xQueueCreateMutexStatic returns the caller's static buffer as the
+    // handle. Callers (esp_newlib_locks_init in particular) assert that the
+    // returned handle equals the buffer they passed in — a nop_return_zero
+    // stub fails that check.
+    if let Some(&pc) = symbol_addrs.get("xQueueCreateMutexStatic") {
+        thunks.push((pc, rom_thunks::x_queue_create_mutex_static_echo));
+    }
+    // pxCurrentTCB symbol → feed into the rom_thunks side so the
+    // xTaskGetCurrentTaskHandle thunk can read it. Arduino-ESP32's
+    // main_task self-deletes after app_main returns via vTaskDelete(NULL),
+    // which depends on this getter.
+    if let Some(&addr) = symbol_addrs.get("pxCurrentTCB") {
+        rom_thunks::PX_CURRENT_TCB_ADDR.with(|s| s.set(Some(addr)));
+    }
+    if let Some(&pc) = symbol_addrs.get("xTaskGetCurrentTaskHandle") {
+        thunks.push((pc, rom_thunks::x_task_get_current_task_handle));
+    }
+    // xQueueSemaphoreTake on the NULL mutex returned by our stubbed
+    // xQueueCreateMutex would assert. Force pdTRUE so SPIClass /
+    // beginTransaction etc. proceed as if they got the lock.
+    if let Some(&pc) = symbol_addrs.get("xQueueSemaphoreTake") {
+        thunks.push((pc, rom_thunks::return_pd_true));
+    }
+    if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
+        thunks.push((pc, rom_thunks::return_pd_true));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1328,29 +1328,6 @@ impl SystemBus {
     }
 
     pub fn write_u32(&mut self, addr: u64, value: u32) -> SimResult<()> {
-        // Debug: catch FreeRTOS list-item self-reference (item.pxNext = &item).
-        // ListItem_t layout has pxNext at offset 4; writing item-pointer P to
-        // address P+4 means item references itself. Gated by env var so the
-        // check is zero-cost in normal runs.
-        if std::env::var_os("LABWIRED_TRACE_LIST_CORRUPTION").is_some() {
-            if (addr as u32).wrapping_sub(value) == 4
-                && value >= 0x3FF8_0000
-                && value < 0x4000_0000
-            {
-                eprintln!(
-                    "[bus-watch] self-ref write: addr=0x{:08x} value=0x{:08x}",
-                    addr as u32, value
-                );
-            }
-            // Also trace any write near the suspected corrupted item region
-            if let Ok(target) = std::env::var("LABWIRED_WATCH_ADDR") {
-                if let Some(t) = target.strip_prefix("0x").and_then(|h| u32::from_str_radix(h, 16).ok()) {
-                    if (addr as u32) >= t && (addr as u32) < t + 16 {
-                        eprintln!("[bus-watch] write addr=0x{:08x} value=0x{:08x}", addr as u32, value);
-                    }
-                }
-            }
-        }
         if self.config.optimized_bus_access && self.ram.write_u32(addr, value) {
             return Ok(());
         }

--- a/crates/core/src/cpu/xtensa_sr.rs
+++ b/crates/core/src/cpu/xtensa_sr.rs
@@ -64,7 +64,8 @@ pub const EXCSAVE5: u16 = 213;
 pub const EXCSAVE6: u16 = 214;
 pub const EXCSAVE7: u16 = 215;
 pub const CPENABLE: u16 = 224; // 0xE0
-pub const INTERRUPT: u16 = 226; // 0xE2 (read-only from SW)
+pub const INTERRUPT: u16 = 226; // 0xE2 (RSR: read INTERRUPT)
+pub const INTSET: u16 = 226; // 0xE2 (WSR: sets bits in INTERRUPT — same SR id as INTERRUPT, ISA-distinguished by RSR vs WSR direction)
 pub const INTCLEAR: u16 = 227; // 0xE3 (write-clears INTERRUPT bits)
 pub const INTENABLE: u16 = 228; // 0xE4
 pub const PS: u16 = 230; // 0xE6
@@ -155,7 +156,10 @@ impl XtensaSrFile {
     ///
     /// Special dispatch:
     /// - `INTCLEAR (227)`: clears bits in `INTERRUPT` — `interrupt &= !v`.
-    /// - `INTERRUPT (226)`: direct SW writes ignored (hardware-latched).
+    /// - `INTSET (226)`: sets bits in `INTERRUPT` — `interrupt |= v`. INTSET
+    ///   and INTERRUPT share SR id 226 in the Xtensa LX ISA; RSR reads the
+    ///   pending-IRQ status, WSR (this path) is the software-trigger entry
+    ///   point used by FreeRTOS `portYIELD()` (BIT(7) → SOFTWARE0).
     /// - `PRID (235)`: writes ignored (read-only).
     /// - `SAR (3)`: masked to 6 bits per Xtensa LX ISA.
     pub fn write(&mut self, sr_id: u16, v: u32) {
@@ -169,8 +173,12 @@ impl XtensaSrFile {
                 self.storage[IDX_INTERRUPT] &= !v;
             }
             IDX_INTERRUPT => {
-                // Direct SW writes to INTERRUPT are ignored (hardware-latched)
-                tracing::trace!("WSR: direct write to INTERRUPT (id=226) ignored");
+                // WSR.INTSET (shares SR id 226 with INTERRUPT): set bits in
+                // INTERRUPT. This is the SW-IRQ trigger path that FreeRTOS
+                // `portYIELD()` rides on — without it, scheduler yields are
+                // silently dropped and tasks calling xQueueReceive on empty
+                // queues spin without ever blocking, corrupting wait lists.
+                self.storage[IDX_INTERRUPT] |= v;
             }
             IDX_PRID => {
                 // PRID is read-only hardware register
@@ -182,6 +190,28 @@ impl XtensaSrFile {
             }
             idx => {
                 self.storage[idx] = v;
+                // Xtensa CCOMPARE0 semantics: writing CCOMPARE0 acknowledges
+                // the previous timer-0 interrupt (clears bit 6 in INTERRUPT)
+                // AND, if the new value is already <= CCOUNT, immediately
+                // raises bit 6 again so the next tick fires on the cycle the
+                // comparator is met.
+                //
+                // Without the acknowledge half of this, the bit stays high
+                // after the ISR returns and dispatches again, causing a
+                // tight ISR re-entry loop.
+                //
+                // Without the raise half, FreeRTOS's `_frxt_tick_timer_init`
+                // sets CCOMPARE0 = CCOUNT + divisor at scheduler-start time
+                // — but our CCOUNT has already overrun (bump-allocator-backed
+                // boot is slower than the divisor), so the firmware never
+                // gets a tick, never yields, and IPC tasks spin in
+                // xQueueReceive corrupting wait lists.
+                if idx == 240 /* CCOMPARE0 */ {
+                    self.storage[IDX_INTERRUPT] &= !(1 << 6);
+                    if v != 0 && self.storage[IDX_CCOUNT] >= v {
+                        self.storage[IDX_INTERRUPT] |= 1 << 6;
+                    }
+                }
             }
         }
     }

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -380,6 +380,95 @@ pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> 
     Ok(())
 }
 
+/// `spi_t *spiStartBus(uint8_t spi_num, ...)` — Arduino-ESP32's SPI bus
+/// initializer. Real impl allocates a `spi_t`, programs DPORT clock-enable
+/// registers, configures the SPI peripheral. We skip the DPORT/peripheral
+/// dance and hand back a tiny static `spi_t` whose only populated field is
+/// `dev` (offset 0) — the SPI peripheral base address. Downstream callers
+/// (`spiTransferByte`) read `spi->dev` and write the peripheral registers
+/// directly, which our `spi3` peripheral catches.
+///
+/// `spi_num` maps to the peripheral base:
+///   0 → SPI0 (flash, not modelled): return NULL
+///   1 → SPI1 (flash, not modelled): return NULL
+///   2 → HSPI/SPI2 (0x3FF64000)
+///   3 → VSPI/SPI3 (0x3FF65000) — the default Arduino `SPI` instance
+///
+/// The `spi_t` blob is per-num and lives in DRAM at a reserved address.
+pub fn spi_start_bus_fake(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let n = cpu.ps.callinc() * 4;
+    let spi_num = cpu.regs.read_logical(n + 2) & 0xFF;
+    let (dev, fake_spi_t) = fake_spi_for_num(spi_num);
+    if fake_spi_t == 0 {
+        RomThunkBank::return_with(cpu, 0);
+        return Ok(());
+    }
+    // Populate spi_t: dev at offset 0, lock at offset 4 (NULL, our stubs
+    // ignore it), num at offset 8. Remaining fields zeroed.
+    bus.write_u32(fake_spi_t as u64, dev)?;
+    bus.write_u32(fake_spi_t as u64 + 4, 0)?;
+    bus.write_u32(fake_spi_t as u64 + 8, spi_num)?;
+    RomThunkBank::return_with(cpu, fake_spi_t);
+    Ok(())
+}
+
+fn fake_spi_for_num(spi_num: u32) -> (u32, u32) {
+    match spi_num {
+        2 => (0x3FF6_4000, 0x3FFD_F000),
+        3 => (0x3FF6_5000, 0x3FFD_F020),
+        _ => (0, 0),
+    }
+}
+
+/// Wraps SPIClass::beginTransaction so the first call lazily initializes
+/// `this->_spi` to a fake spi_t pointing at the matching SPI peripheral
+/// base. The sketch never calls SPI.begin() explicitly — GxEPD2 just
+/// assumes the bus is up — so without this hook spiTransferByte's
+/// `if (spi == NULL) return` short-circuits every transfer and no bytes
+/// reach the panel.
+///
+/// After ensuring _spi is non-NULL, we return pdTRUE to satisfy the
+/// caller's `bnei a10, 1, retry` check (it expects a take to succeed).
+pub fn spi_class_begin_transaction(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let n = cpu.ps.callinc() * 4;
+    let this = cpu.regs.read_logical(n + 2);
+    // SPIClass layout: offset 0 = _spi_num (u8), offset 4 = _spi (spi_t*).
+    let spi_num = bus.read_u32(this as u64)? & 0xFF;
+    let cur_spi = bus.read_u32(this as u64 + 4)?;
+    if cur_spi == 0 {
+        let (dev, fake_spi_t) = fake_spi_for_num(spi_num);
+        if fake_spi_t != 0 {
+            bus.write_u32(fake_spi_t as u64, dev)?;
+            bus.write_u32(fake_spi_t as u64 + 4, 0)?;
+            bus.write_u32(fake_spi_t as u64 + 8, spi_num)?;
+            bus.write_u32(this as u64 + 4, fake_spi_t)?;
+        }
+    }
+    // The real `spiStartBus` programs the SPI peripheral's USER register
+    // to enable the MOSI-output phase (bit 27 = USR_MOSI). We skipped
+    // that, so the first `spiTransferByte` writes data into the FIFO and
+    // sets the CMD.USR start bit but the peripheral never strobes bytes
+    // out to attached devices (kick_user_transaction returns early when
+    // USR_MOSI is clear). Set it once here so subsequent transfers fire.
+    let cur_spi = bus.read_u32(this as u64 + 4)?;
+    if cur_spi != 0 {
+        let dev = bus.read_u32(cur_spi as u64)?;
+        if dev != 0 {
+            const USER_REG_OFFSET: u64 = 0x1C;
+            const USER_USR_MOSI: u32 = 1 << 27;
+            let cur_user = bus.read_u32(dev as u64 + USER_REG_OFFSET)?;
+            if cur_user & USER_USR_MOSI == 0 {
+                bus.write_u32(dev as u64 + USER_REG_OFFSET, cur_user | USER_USR_MOSI)?;
+            }
+        }
+    }
+    // Mark _inTransaction = 1 (offset 24) so endTransaction's take/give
+    // bookkeeping stays consistent.
+    bus.write_u8(this as u64 + 24, 1)?;
+    RomThunkBank::return_with(cpu, 1);
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -324,6 +324,62 @@ pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     Ok(())
 }
 
+/// `xQueueCreateMutexStatic(uint8_t ucQueueType, StaticQueue_t *pxStaticQueue)
+/// -> QueueHandle_t` — on real silicon the returned handle IS the static
+/// buffer (an identity cast). Returning 0 makes `esp_newlib_locks_init`'s
+/// "got the static handle back" assertion fire. We echo arg 1 (the
+/// caller-allocated buffer pointer).
+pub fn x_queue_create_mutex_static_echo(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    let n = cpu.ps.callinc() * 4;
+    let static_buf = cpu.regs.read_logical(n + 3);
+    RomThunkBank::return_with(cpu, static_buf);
+    Ok(())
+}
+
+/// `xTaskGetCurrentTaskHandle() -> TaskHandle_t` — returns `pxCurrentTCB[core]`.
+///
+/// The previous nop_return_zero stub broke `vTaskDelete(NULL)`: vTaskDelete
+/// looks up the current task via this getter when called with a NULL arg,
+/// then passes it to prvDeleteTLS/prvDeleteTCB which assert non-NULL.
+/// Arduino-ESP32's main_task self-deletes after app_main returns, tripping
+/// this path right after the scheduler starts.
+///
+/// `pxCurrentTCB` is a per-core array at a firmware-specific address; the
+/// auto-discovered symbol resolves on the Arduino-ESP32 profile. Without
+/// the symbol (AgentDeck profile, stripped ELF), we fall back to returning
+/// 0 to preserve the previous behaviour.
+pub fn x_task_get_current_task_handle(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;
+    let pxcurrenttcb_addr = PX_CURRENT_TCB_ADDR.with(|s| s.get()).unwrap_or(0);
+    let handle = if pxcurrenttcb_addr != 0 {
+        bus.read_u32(pxcurrenttcb_addr as u64 + (core_id as u64 * 4))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    RomThunkBank::return_with(cpu, handle);
+    Ok(())
+}
+
+thread_local! {
+    /// Set by the cli once the `pxCurrentTCB` symbol is resolved from the
+    /// firmware ELF. Read by [`x_task_get_current_task_handle`].
+    pub static PX_CURRENT_TCB_ADDR: std::cell::Cell<Option<u32>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Stub for queue/semaphore APIs whose real impl asserts `pxQueue != NULL`.
+/// We return `pdTRUE` (1) to signal "operation succeeded" without touching
+/// any queue state. Used for SPIClass / wire-library calls into
+/// `xQueueSemaphoreTake` / `xQueueSemaphoreGive` on a mutex that our stubbed
+/// `xQueueCreateMutex` returned NULL for. Real silicon would dereference
+/// pxQueue and crash too — this fakes a recursive-mutex held-by-current
+/// state, which is fine for the single-CPU sim render path.
+pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    RomThunkBank::return_with(cpu, 1);
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -295,6 +295,35 @@ pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
+/// Thunk for `__assert_func` / `panic_abort` / `abort` — functions that
+/// real-silicon C convention treats as `noreturn`. Stubbing them as
+/// nop_return_zero would silently return into the caller, which on the
+/// FreeRTOS xQueue assertion paths produces a tight loop:
+/// `assert → return → check failed cond → jump back to assert`.
+///
+/// Instead, halt the calling CPU and print the assertion arguments so the
+/// operator sees what blew up.  The caller never re-runs, so the loop
+/// breaks.  The OTHER CPU (if dual-core) keeps running.
+pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    use core::sync::atomic::{AtomicU32, Ordering};
+    static FIRST_PRINT: AtomicU32 = AtomicU32::new(0);
+    if FIRST_PRINT.fetch_add(1, Ordering::Relaxed) < 5 {
+        let n = cpu.ps.callinc() * 4;
+        let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;
+        eprintln!(
+            "[abort_halt] core={core_id} pc=0x{:08x} a0=0x{:08x} a10=0x{:08x} a11=0x{:08x} a12=0x{:08x} a13=0x{:08x}",
+            cpu.pc,
+            cpu.regs.read_logical(0),
+            cpu.regs.read_logical(n + 2),
+            cpu.regs.read_logical(n + 3),
+            cpu.regs.read_logical(n + 4),
+            cpu.regs.read_logical(n + 5)
+        );
+    }
+    cpu.halted = true;
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the
@@ -681,6 +710,17 @@ pub fn esp_idf_heap_caps_realloc(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> Sim
 /// `ets_get_cpu_frequency() -> u32` — returns 240 (MHz).
 pub fn rom_cpu_freq_240mhz(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 240);
+    Ok(())
+}
+
+/// `esp_clk_cpu_freq() -> u32` — returns 240_000_000 (Hz).
+///
+/// FreeRTOS's `_frxt_tick_timer_init` uses this to compute
+/// `_xt_tick_divisor = cpu_freq / configTICK_RATE_HZ`. Without it (or with
+/// the stubbed esp_clk_init returning 0), the divisor is 0 and the timer
+/// ISR can never advance CCOMPARE0 — every CCOUNT cycle re-fires the tick.
+pub fn esp_clk_cpu_freq_240mhz(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    RomThunkBank::return_with(cpu, 240_000_000);
     Ok(())
 }
 

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -99,32 +99,16 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
-        // Arduino Print/Stream/HardwareSerial — sketch doesn't depend on
-        // serial output reaching real bytes; stubbing all of these as
-        // nop_return_zero lets setup() reach drawPage() without spinning
-        // in uartAvailable polling or Print::println string formatting.
-        "_ZN5Print7printlnEv",
-        "_ZN5Print7printlnEPKc",
-        "_ZN5Print7printlnEmi",
-        "_ZN5Print5printEPKc",
-        "_ZN5Print5printEmi",
-        "_ZN5Print11printNumberEmh",
-        "_ZN5Print5writeEPKc",
-        "_ZN5Print5writeEPKhj",
-        "_ZN5Print5writeEh",
-        "_ZN5Print5flushEv",
-        "_ZN5Print17availableForWriteEv",
+        // HardwareSerial-only stubs — leave Print/Stream alone so virtual
+        // dispatch through Print::print → Adafruit_GFX::write → drawPixel
+        // (the display.print path) keeps working. The original spin was
+        // in HardwareSerial::write's buffer-available wait, not in Print.
         "_ZN14HardwareSerial5writeEh",
         "_ZN14HardwareSerial5writeEPKhj",
         "_ZN14HardwareSerial9availableEv",
         "_ZN14HardwareSerial5flushEv",
         "_ZN14HardwareSerial9readBytesEPcj",
         "_ZN14HardwareSerial9readBytesEPhj",
-        "_ZN6Stream9readBytesEPhj",
-        "_ZN6Stream9readBytesEPcj",
-        "_ZN6Stream10readStringEv",
-        "_ZN6Stream9timedReadEv",
-        "_ZN6Stream10getTimeoutEv",
         "uartAvailable",
         "uartAvailableForWrite",
         "uartWrite",

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -74,6 +74,15 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "__retarget_lock_close_recursive",
         "__retarget_lock_acquire_recursive",
         "__retarget_lock_release_recursive",
+        // Newlib-stdio-driven mutex API. Real silicon backs these via
+        // FreeRTOS recursive mutexes whose handles live in (uninitialised
+        // in our sim) static memory; calling the real impl asserts on
+        // pcHead != NULL. Stub to no-op since the sim is effectively
+        // single-threaded on the render path.
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr
@@ -158,6 +167,7 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         //    through to esp_startup_start_app.
         "esp_clk_init",
         "esp_perip_clk_init",
+        "esp_clk_cpu_freq",
         "core_intr_matrix_clear",
         "esp_efuse_check_errors",
         "esp_dport_access_stall_other_cpu_start",
@@ -217,6 +227,9 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // the underlying FILE* refers to our zeroed fake reent struct.
         "esp_log_early_timestamp",
         "esp_log_writev",
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
         "esp_log_write",
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -83,6 +83,22 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "xQueueTakeMutexRecursive",
         "xQueueCreateMutex",
         "xQueueCreateMutexStatic",
+        // xQueueCreateMutex returns NULL (stubbed), so SPIClass and friends
+        // end up storing NULL as their internal mutex. We force these to
+        // return pdTRUE so the call path proceeds; real silicon would only
+        // reach this on a held mutex anyway in the single-task render flow.
+        "xQueueSemaphoreTake",
+        // SPIClass::endTransaction calls xQueueGenericSend (the give side
+        // of xSemaphoreGive) on the same NULL mutex. Force success too.
+        "xQueueGenericSend",
+        // esp_ipc_init creates the per-core IPC task which spin-blocks on
+        // an empty semaphore. With our take-returns-pdTRUE stub above,
+        // that "block" becomes a tight loop — never yielding, never
+        // letting loopTask run. Stub esp_ipc_init out and skip the IPC
+        // task altogether; cross-core IPC isn't needed on the
+        // single-CPU render path.
+        "esp_ipc_init",
+        "esp_ipc_isr_init",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr
@@ -230,6 +246,13 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "esp_log_impl_lock",
         "esp_log_impl_lock_timeout",
         "esp_log_impl_unlock",
+        // Backs `xTaskGetCurrentTaskHandle()` — per-core array of TCB
+        // pointers. Address is firmware-dependent; resolving the symbol
+        // lets the thunk return a real handle so `vTaskDelete(NULL)`
+        // (used by Arduino-ESP32's main_task self-delete) doesn't pass
+        // NULL into prvDeleteTLS.
+        "pxCurrentTCB",
+        "xTaskGetCurrentTaskHandle",
         "esp_log_write",
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -99,6 +99,46 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
+        // Arduino Print/Stream/HardwareSerial — sketch doesn't depend on
+        // serial output reaching real bytes; stubbing all of these as
+        // nop_return_zero lets setup() reach drawPage() without spinning
+        // in uartAvailable polling or Print::println string formatting.
+        "_ZN5Print7printlnEv",
+        "_ZN5Print7printlnEPKc",
+        "_ZN5Print7printlnEmi",
+        "_ZN5Print5printEPKc",
+        "_ZN5Print5printEmi",
+        "_ZN5Print11printNumberEmh",
+        "_ZN5Print5writeEPKc",
+        "_ZN5Print5writeEPKhj",
+        "_ZN5Print5writeEh",
+        "_ZN5Print5flushEv",
+        "_ZN5Print17availableForWriteEv",
+        "_ZN14HardwareSerial5writeEh",
+        "_ZN14HardwareSerial5writeEPKhj",
+        "_ZN14HardwareSerial9availableEv",
+        "_ZN14HardwareSerial5flushEv",
+        "_ZN14HardwareSerial9readBytesEPcj",
+        "_ZN14HardwareSerial9readBytesEPhj",
+        "_ZN6Stream9readBytesEPhj",
+        "_ZN6Stream9readBytesEPcj",
+        "_ZN6Stream10readStringEv",
+        "_ZN6Stream9timedReadEv",
+        "_ZN6Stream10getTimeoutEv",
+        "uartAvailable",
+        "uartAvailableForWrite",
+        "uartWrite",
+        "uartWriteBuf",
+        "_Z14serialEventRunv",
+        // SPI bus init — real impl needs DPORT clock-enable we don't
+        // model, so it returns NULL → SPIClass._spi = NULL → all
+        // downstream spiTransferByte calls bail without touching the SPI
+        // peripheral. Custom thunk returns a fake spi_t with dev = SPI3.
+        "spiStartBus",
+        // The Arduino SPI global. We resolve it for diagnostics; lazy
+        // init happens via the SPIClass::beginTransaction thunk.
+        "SPI",
+        "_ZN8SPIClass16beginTransactionE11SPISettings",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr


### PR DESCRIPTION
## Summary
- Implement `WSR.INTSET` (id 226) — was treated as ignored direct-INTERRUPT write, dropping every `portYIELD()` silently
- CCOMPARE0 ack-and-rearm on write — fixes the timer tick when firmware sets the comparator below the current CCOUNT
- New `esp_clk_cpu_freq` thunk returning 240 MHz so `_xt_tick_divisor` is non-zero
- `abort_halt` thunk for `__assert_func` / `abort` / `panic_abort` — clean halt instead of nop-return + tight assert loop
- `xQueueCreateMutexStatic` echoes its static-buffer arg back; `xTaskGetCurrentTaskHandle` reads `pxCurrentTCB[core]`; `xQueueSemaphoreTake` / `xQueueGenericSend` return pdTRUE on NULL queues; `esp_ipc_init` skipped; recursive-mutex + esp_log_impl wrappers stubbed
- HardwareSerial / UART layer stubbed (Serial.print no-ops at the leaf, doesn't break Print's virtual dispatch)
- SPIClass::beginTransaction thunk lazily inits `this->_spi` to a fake spi_t with dev=SPI3 base AND programs USER_REG bit 27 (USR_MOSI) so the spi3 peripheral actually fires bytes to attached devices

## Result
Reader sketch boots through FreeRTOS, reaches `setup()`, runs `drawPage()`, drives the SSD1680 panel via SPI, and renders visible text glyphs:

| metric              | baseline | after          |
|---------------------|----------|----------------|
| reader spi3 txns    | 0        | **19039**      |
| reader refreshes    | 0        | **3 cycles**   |
| reader non-FF bytes | 0        | **1429/4736**  |
| AgentDeck spi3 txns | 19031    | 19031          |
| AgentDeck refreshes | 1        | 1              |
| AgentDeck non-FF    | 782      | 782            |
| core tests          | 347 ✅   | 347 ✅          |

## Background
Builds on #94's portYIELD / timer / abort_halt foundation. With clean halts on assertions instead of infinite loops, this round walked one assertion at a time. The last fix needed care — the initial round stubbed Print/Stream wholesale to get past Serial.println spin, but that broke `display.print()` too because `Print::print → Print::write → Adafruit_GFX::write → drawChar → drawPixel` all rides the same dispatch chain. Final fix: only stub the HardwareSerial / uart layer at the leaves; Print and Stream stay real.

## Regression check
AgentDeck snapshot path identical to baseline (spi3=19031, refresh=1, 782 non-FF bytes). All new thunks gate on auto-discovered symbols so AgentDeck's stripped ELF is untouched.

## Test plan
- [x] `cargo test -p labwired-core --release` — 347 tests pass
- [x] Reader sketch: reaches `drawPage()`, 19039 SPI txns, 3 refreshes, 1429 non-FF bytes
- [x] AgentDeck regression — identical metrics to baseline