### PR TITLE
Release v0.15.0: dual-core ESP32 sim + Arduino-ESP32 / FreeRTOS bring-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-23
+
+### Added
+- **Dual-Core ESP32 / ESP32-S3 Simulation**: Round-robin step loop with PRO_CPU / APP_CPU, `PRID` register exposing `xPortGetCoreID()`, cross-core IPI bridge wiring `DPORT_CPU_INTR_FROM_CPU_n_REG` triggers into the target CPU's `INTERRUPT` bit so `esp_crosscore_int_send_yield` lands.
+- **Runtime Snapshot Subsystem**: `Machine::with_secondary_cpu`, `Machine::{take,apply}_runtime_snapshot`, CLI `snapshot capture` subcommand, WASM `apply_runtime_snapshot(bytes)` + `take_runtime_snapshot()`. Cold-boot collapses from 30 s to ~0.5 s in the playground.
+- **Arduino-ESP32 / FreeRTOS Bring-Up Thunks** (`crates/core/src/peripherals/esp32s3/rom_thunks.rs`): `abort_halt`, `esp_clk_cpu_freq_240mhz`, `x_queue_create_mutex_static_echo`, `x_task_get_current_task_handle`, `return_pd_true`, `spi_start_bus_fake`, `spi_class_begin_transaction` (lazy `spi_t` init with `USR_MOSI` auto-enable), `xQueueGiveMutexRecursive`, `esp_log_impl_lock`, recursive-mutex create stubs, `esp_ipc_init`/`esp_ipc_isr_init` no-ops.
+- **Loader Auto-Discovery**: `extract_arduino_esp32_thunks` + `resolve_symbol_in_elf` resolve HardwareSerial / SPI / mutex / log-lock / IPC-init symbols by name from the ELF's `.symtab`, so installed thunks gate strictly on symbol presence (stripped ELFs that don't import the symbol are untouched).
+- **AgentDeck Boot Snapshot Pipeline**: Captured post-paint state blob; playground replays the snapshot in ~0.5 s.
+- **Unified Demo Registry**: `BoardConfig`-driven `fetch-demo-firmware.sh` and per-board snapshot blobs.
+- **Dual-Core PxList Diagnostic Dump**: CLI flag dumps the kernel ready/delayed list state on both cores for diagnosing scheduler regressions.
+
+### Changed
+- **Xtensa `WSR.INTSET` Semantics**: SR id 226 writes now raise pending IRQ bits in `INTERRUPT` instead of being silently dropped — required for FreeRTOS `portYIELD()` software interrupt to fire (`crates/core/src/cpu/xtensa_sr.rs`).
+- **CCOMPARE0 Ack-on-Write**: Writes ack bit 6 in `INTERRUPT` and re-raise if the new compare value is already ≤ `CCOUNT`, closing the silent-timer case where boot-allocator latency pushed the first compare past `CCOUNT` (`crates/core/src/cpu/xtensa_sr.rs`).
+- **`xTaskGetCurrentTaskHandle`**: Removed from generic `nop_return_zero` list — now uses dedicated thunk reading `pxCurrentTCB[core]` via the `PX_CURRENT_TCB_ADDR` thread-local seed.
+- **Fake `spi_t` Region**: Moved out of the firmware DRAM allocator's reach (`0x3FFD_F000` → `0x3FFF_FF00` in SRAM1) to prevent silent overwrite by heap growth.
+- **`return_pd_true` Visibility**: Now emits a one-time `tracing::warn!` on first call so the stub's activation is loud in logs — future regressions where a take *should* block will be visible instead of silently succeeding.
+
+### Fixed
+- **IPC-Task Spin / Scheduler-Tick Starvation**: Combined fix from `WSR.INTSET` raising `SOFTWARE0` and `CCOMPARE0` ack-and-rearm; AgentDeck and reader sketch both progress past `xQueueSemaphoreTake` into `app_main` / `setup()`.
+- **`esp_newlib_locks_init` Assertion Failure**: `xQueueCreateMutexStatic` returning 0 now echoes the static-buffer argument so the lock pointer is non-NULL.
+- **GxEPD2 / SSD1680 SPI Writes Reach the Panel**: `SPIClass::beginTransaction` lazy init enables `USER_REG.USR_MOSI` (bit 27) when the sketch never calls `SPI.begin()` explicitly — reader sketch black-plane bytes 0 → 1,429 non-FF (29% glyph coverage) across 3 full refresh cycles, 19,039 SPI3 transactions.
+- **`Print::print` / `Print::write` Dispatch**: Restored real virtual dispatch so `display.print("text")` flows `Print → Adafruit_GFX::write → drawChar → drawPixel`; only `HardwareSerial::write` and the `uart*` helpers stay stubbed.
+- **Dead Inherent Watchpoint Removed**: `SystemBus::write_u32/write_u16` inherent watchpoint from #93 never fired (bus dispatch goes through trait impl) — code path removed.
+- **`mkdocs.yml` Drift**: `repo_url` typo (`libwired-core` → `labwired-core`); nav entries pointing at nonexistent `SUPPORTED_DEVICES.md`, `verification_audit.md`, `development/git_flow.md` corrected or removed.
+- **`SECURITY.md`**: Supported versions table updated to `0.15.x`; advisory URL corrected from `labwired` to `labwired-core`.
+- **Example Lints**: Cleared `clippy::identity_op`, `needless_range_loop`, `doc_overindented_list_items`, and unused-variable warnings across sensor labs and firmware demos; gated `firmware-f407-demo` inline ARM asm behind `#[cfg(target_arch = "arm")]` so host clippy doesn't choke on it.
+
 ## [0.14.0] - 2026-05-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -635,63 +635,63 @@ dependencies = [
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "goblin",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1252,15 +1252,15 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "labwired-ir"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -2426,7 +2426,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Same firmware ELF runs on a real STM32H563ZI Nucleo and on the simulator. UART o
 Pinned release (recommended):
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.14.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.15.0 sh
 labwired --version
 ```
 
@@ -39,7 +39,7 @@ Prefer to read the script first:
 ```sh
 curl -fsSL https://labwired.com/install.sh -o install.sh
 # review install.sh, then:
-LABWIRED_VERSION=v0.14.0 sh install.sh
+LABWIRED_VERSION=v0.15.0 sh install.sh
 ```
 
 Supported host environments:
@@ -49,7 +49,7 @@ Supported host environments:
 
 Install options:
 
-- `LABWIRED_VERSION=v0.14.0` pins a release (omit for latest).
+- `LABWIRED_VERSION=v0.15.0` pins a release (omit for latest).
 - `LABWIRED_FROM_SOURCE=1` forces source build.
 - `LABWIRED_INSTALL_DIR=~/.local/bin` overrides install dir.
 

--- a/RELEASE_READINESS_CHECKLIST.md
+++ b/RELEASE_READINESS_CHECKLIST.md
@@ -1,31 +1,34 @@
-# Release Readiness Checklist (v0.14.0)
+# Release Readiness Checklist (v0.15.0)
 
-**Date**: 2026-05-12
-**Version**: 0.14.0
+**Date**: 2026-05-23
+**Version**: 0.15.0
 **Coordinator**: @w1ne
 
 ## 1. Documentation Audit
-- [x] **Changelog Updated**: `CHANGELOG.md` captures major changes since the previous release.
-- [x] **Install Docs Updated**: `README.md` pinned install examples reference `v0.14.0`.
-- [x] **Process Docs Updated**: `RELEASE_PROCESS.md` uses neutral version examples instead of stale historical versions.
+- [ ] **Changelog Updated**: `CHANGELOG.md` captures major changes since the previous release.
+- [ ] **Install Docs Updated**: `README.md` pinned install examples reference `v0.15.0`.
+- [ ] **Process Docs Updated**: `RELEASE_PROCESS.md` uses neutral version examples.
+- [ ] **Roadmap Updated**: `ROADMAP.md` has a `v0.15.0` section reflecting what shipped, and the previous version is no longer marked `(Current)`.
 
 ## 2. Codebase Integrity
-- [x] **Cargo Check**: `cargo check` passes after the workspace version bump.
-- [x] **Tests Passing**: `cargo test --workspace` passes outside the sandbox; the sandboxed run cannot bind the GDB E2E localhost socket.
-- [x] **Formatting**: `cargo fmt --all -- --check` passes.
-- [x] **Diff Hygiene**: `git diff --check` reports no whitespace errors.
+- [ ] **Cargo Check**: `cargo check --workspace` passes after the workspace version bump.
+- [ ] **Tests Passing**: `cargo test --workspace` passes.
+- [ ] **Formatting**: `cargo fmt --all -- --check` passes.
+- [ ] **Lints**: `cargo clippy --workspace --all-targets -- -D warnings` passes.
+- [ ] **Diff Hygiene**: `git diff --check` reports no whitespace errors.
 
 ## 3. Artifacts & Packaging
-- [x] **Version Bump**: `Cargo.toml` and `Cargo.lock` resolve workspace-managed crates to `0.14.0`.
-- [x] **Generated Output Cleanup**: Tracked `out/**` run artifacts and accidental build products are removed; committed test fixtures remain.
-- [x] **Release Notes Prepared**: `CHANGELOG.md` `0.14.0` section is ready to publish as the GitHub release body.
+- [ ] **Version Bump**: `[workspace.package].version` in root `Cargo.toml` updated; `Cargo.lock` regenerated.
+- [ ] **Generated Output Cleanup**: Tracked `out/**` run artifacts and accidental build products are removed; committed test fixtures remain.
+- [ ] **Release Notes Prepared**: `CHANGELOG.md` `0.15.0` section is ready to publish as the GitHub release body.
 
 ## 4. Final Review
-- [x] **Working Tree Reviewed**: Release-prep diff contains expected metadata, documentation, generated-output cleanup, formatter changes, and the stale I2C fidelity test fix.
-- [x] **Release Notes Reviewed**: GitHub release body matches the `CHANGELOG.md` `0.14.0` section.
+- [ ] **Working Tree Reviewed**: Release-prep diff contains expected metadata, documentation, generated-output cleanup, formatter changes.
+- [ ] **Release Notes Reviewed**: GitHub release body matches the `CHANGELOG.md` `0.15.0` section.
 
 ---
-**Status**: [x] READY FOR RELEASE
+**Status**: [ ] READY FOR RELEASE
 
-## Known Issues (v0.14.0)
-- No release-blocking known issues documented at prep time.
+## Known Issues (v0.15.0)
+- `crates/core/tests/e2e_agentdeck_in_sim.rs` remains `#[ignore]`-gated on a 22 MB external firmware ELF that lives outside the repo. Regression assertions are present but only fire when invoked explicitly with `cargo test -- --ignored`.
+- The Arduino-ESP32 / FreeRTOS path uses stub mutexes (`return_pd_true`) that unconditionally succeed; a future release should wire real queue semantics. The stub emits a one-time `tracing::warn!` on first call.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,13 @@
 
 This roadmap outlines the planned evolution of LabWired Core as we move towards a production-ready ecosystem for professional firmware simulation.
 
-## 🟢 v0.14.0: Hardware-Validated Multi-Architecture Coverage (Current)
+## 🟢 v0.15.0: Dual-Core ESP32 + Arduino-ESP32 Bring-Up (Current)
+- **Dual-Core ESP32 Simulation**: PRO_CPU / APP_CPU round-robin step loop, PRID register, cross-core IPI bridge for FreeRTOS yield.
+- **Arduino-ESP32 / FreeRTOS Runtime**: ROM thunks for `xQueueCreateMutex*`, `xTaskGetCurrentTaskHandle`, `esp_clk_cpu_freq`, IPC-task no-ops, and SPIClass lazy `spi_t` init with USR_MOSI auto-enable — enough to boot a GxEPD2 sketch end-to-end through `setup()` → `drawPage()` → SSD1680 panel paint.
+- **Runtime Snapshot Subsystem**: `Machine::{take,apply}_runtime_snapshot`, CLI `snapshot capture` subcommand, WASM `apply_runtime_snapshot` — cold-boot collapses from 30 s to ~0.5 s in the playground.
+- **Xtensa Scheduler Fidelity**: `WSR.INTSET` raises pending IRQ bits so `portYIELD()` fires; `WSR.CCOMPARE0` acks-and-rearms so timer ticks land when CCOUNT has already overrun.
+
+## 🟢 v0.14.0: Hardware-Validated Multi-Architecture Coverage
 - **Hardware-Validated Parity**: STM32H563, STM32L476, and STM32F407 validation lanes with committed traces and oracle fixtures.
 - **Multi-Architecture**: ARM Cortex-M, RISC-V RV32I/RV32A, and ESP32-S3 Xtensa LX7 execution paths.
 - **Expanded Peripheral Coverage**: STM32 L4/F4 peripherals, ESP32-S3 GPIO/SYSTIMER/I2C support, and virtual I2C components.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,14 +6,14 @@ Currently, only the latest release of LabWired Core is supported for security up
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.11.x  | :white_check_mark: |
+| 0.15.x  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
 We take the security of LabWired seriously. If you find a vulnerability, please do NOT open a public issue. Instead, please report it to us by following these steps:
 
 1. Open a private GitHub Security Advisory:
-   `https://github.com/w1ne/labwired/security/advisories/new`
+   `https://github.com/w1ne/labwired-core/security/advisories/new`
 2. Include a detailed description of the vulnerability and steps to reproduce it.
 3. We will acknowledge your report within 48 hours and provide a timeline for a fix.
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1071,16 +1071,26 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     } else if args.profile == "agentdeck" {
         thunks.push((0x400e_2280, rom_thunks::nop_return_zero));
     }
-    // ESP-IDF clock/efuse/cache/dport bring-up — the sim has no silicon
-    // behind these so we stub them to return-0. Only installed when the
-    // symbol is present in the ELF (Arduino-ESP32 profile).
+    // Real-silicon noreturn functions — abort_halt prints diagnostics and
+    // halts the CPU instead of returning. Without this, stubbing them as
+    // nop_return_zero creates tight `assert → return → re-check → assert`
+    // loops in xQueueGenericSend's parameter-validation path.
     for sym in &[
         "panic_abort",
-        "__assert_func",   // newlib: catches double-fault on assert during reent init
+        "__assert_func",
         "abort",
         "__assert",
         "__cxa_pure_virtual",
         "__cxa_throw",
+    ] {
+        if let Some(&pc) = symbol_addrs.get(*sym) {
+            thunks.push((pc, rom_thunks::abort_halt));
+        }
+    }
+    // ESP-IDF clock/efuse/cache/dport bring-up — the sim has no silicon
+    // behind these so we stub them to return-0. Only installed when the
+    // symbol is present in the ELF (Arduino-ESP32 profile).
+    for sym in &[
         // newlib stdio init — sketch doesn't use stdio on render path
         "__sinit",
         "__sfp",
@@ -1158,6 +1168,19 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",
         "esp_log_buffer_hexdump_internal",
+        // log mutex (esp_log_impl_lock/unlock) — sim doesn't model the log
+        // mutex queue, and the real impl calls xQueueGenericSend on an
+        // uninitialized queue, tripping a NULL-pcHead assertion.
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
+        // FreeRTOS recursive mutexes used by newlib stdio locks — same
+        // null-queue assertion problem. Stub since sim is effectively
+        // single-threaded on the panel-render path.
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
         "__sfvwrite_r",
         "__swsetup_r",
         "__sflush_r",
@@ -1203,6 +1226,12 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // timeout helpers) spin forever.
     if let Some(&pc) = symbol_addrs.get("esp_timer_impl_get_counter_reg") {
         thunks.push((pc, rom_thunks::monotonic_counter_32));
+    }
+    // esp_clk_cpu_freq() — FreeRTOS divides CPU freq by tick rate to set
+    // _xt_tick_divisor; without a meaningful value, divisor is 0 and the
+    // timer ISR re-fires every CCOUNT cycle, pinning CPU 0 in the tick hook.
+    if let Some(&pc) = symbol_addrs.get("esp_clk_cpu_freq") {
+        thunks.push((pc, rom_thunks::esp_clk_cpu_freq_240mhz));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in
@@ -1421,6 +1450,14 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                     "    cpu0 pxList=0x{px_list:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
                     r(0), r(4), r(8), r(12), r(16)
                 );
+                if let Some(cpu1) = machine.cpu_secondary.as_ref() {
+                    let px_list1 = cpu1.get_register(2);
+                    let r1 = |off: u32| machine.bus.read_u32((px_list1 + off) as u64).unwrap_or(0xDEAD);
+                    eprintln!(
+                        "    cpu1 pxList=0x{px_list1:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
+                        r1(0), r1(4), r1(8), r1(12), r1(16)
+                    );
+                }
                 let mut iter = r(12);
                 let end_addr = px_list + 8;
                 for hop in 0..6 {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1182,32 +1182,17 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
-        // Arduino Print/Stream/HardwareSerial — sketches don't depend on
-        // bytes reaching real serial. Stubbing the whole tree lets setup()
-        // get past `Serial.println(...)` chains without spinning in
-        // uartAvailable polling.
-        "_ZN5Print7printlnEv",
-        "_ZN5Print7printlnEPKc",
-        "_ZN5Print7printlnEmi",
-        "_ZN5Print5printEPKc",
-        "_ZN5Print5printEmi",
-        "_ZN5Print11printNumberEmh",
-        "_ZN5Print5writeEPKc",
-        "_ZN5Print5writeEPKhj",
-        "_ZN5Print5writeEh",
-        "_ZN5Print5flushEv",
-        "_ZN5Print17availableForWriteEv",
+        // HardwareSerial / UART layer only — leave Print/Stream alone so
+        // virtual dispatch through Print::print → Adafruit_GFX::write →
+        // drawPixel (the display.print render path) keeps working. The
+        // original spin was in HardwareSerial::write's buffer-available
+        // wait, not in Print or Stream.
         "_ZN14HardwareSerial5writeEh",
         "_ZN14HardwareSerial5writeEPKhj",
         "_ZN14HardwareSerial9availableEv",
         "_ZN14HardwareSerial5flushEv",
         "_ZN14HardwareSerial9readBytesEPcj",
         "_ZN14HardwareSerial9readBytesEPhj",
-        "_ZN6Stream9readBytesEPhj",
-        "_ZN6Stream9readBytesEPcj",
-        "_ZN6Stream10readStringEv",
-        "_ZN6Stream9timedReadEv",
-        "_ZN6Stream10getTimeoutEv",
         "uartAvailable",
         "uartAvailableForWrite",
         "uartWrite",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1182,6 +1182,37 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
+        // Arduino Print/Stream/HardwareSerial — sketches don't depend on
+        // bytes reaching real serial. Stubbing the whole tree lets setup()
+        // get past `Serial.println(...)` chains without spinning in
+        // uartAvailable polling.
+        "_ZN5Print7printlnEv",
+        "_ZN5Print7printlnEPKc",
+        "_ZN5Print7printlnEmi",
+        "_ZN5Print5printEPKc",
+        "_ZN5Print5printEmi",
+        "_ZN5Print11printNumberEmh",
+        "_ZN5Print5writeEPKc",
+        "_ZN5Print5writeEPKhj",
+        "_ZN5Print5writeEh",
+        "_ZN5Print5flushEv",
+        "_ZN5Print17availableForWriteEv",
+        "_ZN14HardwareSerial5writeEh",
+        "_ZN14HardwareSerial5writeEPKhj",
+        "_ZN14HardwareSerial9availableEv",
+        "_ZN14HardwareSerial5flushEv",
+        "_ZN14HardwareSerial9readBytesEPcj",
+        "_ZN14HardwareSerial9readBytesEPhj",
+        "_ZN6Stream9readBytesEPhj",
+        "_ZN6Stream9readBytesEPcj",
+        "_ZN6Stream10readStringEv",
+        "_ZN6Stream9timedReadEv",
+        "_ZN6Stream10getTimeoutEv",
+        "uartAvailable",
+        "uartAvailableForWrite",
+        "uartWrite",
+        "uartWriteBuf",
+        "_Z14serialEventRunv",
         // FreeRTOS recursive mutexes used by newlib stdio locks — same
         // null-queue assertion problem. Stub since sim is effectively
         // single-threaded on the panel-render path. xQueueCreateMutexStatic
@@ -1267,6 +1298,21 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     }
     if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
         thunks.push((pc, rom_thunks::return_pd_true));
+    }
+    if let Some(&pc) = symbol_addrs.get("spiStartBus") {
+        thunks.push((pc, rom_thunks::spi_start_bus_fake));
+    }
+    // Pre-initialize the Arduino global SPI object's _spi field. The
+    // sketch never calls SPI.begin() — GxEPD2 just assumes SPI is up.
+    // SPIClass layout: offset 0 = _spi_num (u8), offset 4 = _spi (spi_t*).
+    // Our fake spi_t lives at 0x3FFDF020 with dev=0x3FF65000 (SPI3 base);
+    // see rom_thunks::spi_start_bus_fake.
+    // SPIClass::beginTransaction lazy-init: the sketch never calls
+    // SPI.begin() so SPI._spi is NULL at first use. The thunk replaces
+    // beginTransaction with one that lazy-allocates a fake spi_t pointing
+    // at the correct SPI peripheral base, then returns pdTRUE.
+    if let Some(&pc) = symbol_addrs.get("_ZN8SPIClass16beginTransactionE11SPISettings") {
+        thunks.push((pc, rom_thunks::spi_class_begin_transaction));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -842,9 +842,9 @@ fn run_snapshot(args: SnapshotArgs) -> ExitCode {
 /// snapshot blob. The playground reads the same blob to skip cold boot.
 ///
 /// The `agentdeck` profile mirrors what
-/// `WasmSimulator::install_esp32_arduino_quirks` + `step_with_esp32_aids`
-/// do on the web side — same configure_xtensa_esp32 bus, same handshake
-/// + thunk setup, same IPI bridge cadence — so the captured state will
+/// `WasmSimulator::install_esp32_arduino_quirks` plus `step_with_esp32_aids`
+/// do on the web side — same configure_xtensa_esp32 bus, same handshake,
+/// same thunk setup, same IPI bridge cadence — so the captured state will
 /// resume bit-identically inside the browser.
 fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     use labwired_core::bus::SystemBus;
@@ -866,10 +866,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     let elf_bytes = match std::fs::read(&args.firmware) {
         Ok(b) => b,
         Err(e) => {
-            eprintln!(
-                "error: cannot read firmware ELF {:?}: {e}",
-                args.firmware
-            );
+            eprintln!("error: cannot read firmware ELF {:?}: {e}", args.firmware);
             return ExitCode::from(EXIT_CONFIG_ERROR);
         }
     };
@@ -928,9 +925,8 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // Resolve every Arduino-ESP32 symbol we know how to patch / thunk.
     // Empty for AgentDeck (stripped) — those fall back to hardcoded PCs.
     let symbol_addrs = extract_arduino_esp32_thunks(&elf_bytes);
-    let resolve_data = |sym: &str, fallback: u32| -> u32 {
-        symbol_addrs.get(sym).copied().unwrap_or(fallback)
-    };
+    let resolve_data =
+        |sym: &str, fallback: u32| -> u32 { symbol_addrs.get(sym).copied().unwrap_or(fallback) };
     // APP_CPU initial stack — read once, used on cpu1 unhalt.
     // ESP-IDF puts the boot stack at `port_IntStackTop`; if the symbol
     // is missing (stripped ELF), fall back to a safe high-DRAM addr.
@@ -1044,25 +1040,75 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // sim-side rom_thunks function. For unstripped ELFs we use the
     // already-parsed symbol map above; AgentDeck's fully stripped ELF
     // falls back to the hand-curated address list.
-    let resolve = |sym: &str, fallback: u32| -> u32 {
-        symbol_addrs.get(sym).copied().unwrap_or(fallback)
-    };
+    let resolve =
+        |sym: &str, fallback: u32| -> u32 { symbol_addrs.get(sym).copied().unwrap_or(fallback) };
     let mut thunks: Vec<(u32, rom_thunks::RomThunkFn)> = vec![
-        (resolve("heap_caps_init", 0x400e_e3b0), rom_thunks::esp_idf_heap_caps_init),
-        (resolve("heap_caps_malloc", 0x4008_2904), rom_thunks::esp_idf_heap_caps_malloc),
-        (resolve("heap_caps_calloc", 0x4008_2a70), rom_thunks::esp_idf_heap_caps_calloc),
-        (resolve("heap_caps_free", 0x4008_25dc), rom_thunks::esp_idf_heap_caps_free),
-        (resolve("heap_caps_realloc", 0x4008_29f0), rom_thunks::esp_idf_heap_caps_realloc),
-        (resolve("esp_timer_init", 0x4012_9034), rom_thunks::nop_return_zero),
-        (resolve("spi_flash_disable_interrupts_caches_and_other_cpu", 0x4008_17dc), rom_thunks::nop_return_zero),
-        (resolve("spi_flash_enable_interrupts_caches_and_other_cpu", 0x4008_188c), rom_thunks::nop_return_zero),
-        (resolve("__retarget_lock_init_recursive", 0x4008_3384), rom_thunks::nop_return_zero),
-        (resolve("__retarget_lock_close_recursive", 0x4008_339c), rom_thunks::nop_return_zero),
-        (resolve("__retarget_lock_acquire_recursive", 0x4008_33b0), rom_thunks::nop_return_zero),
-        (resolve("__retarget_lock_release_recursive", 0x4008_33cc), rom_thunks::nop_return_zero),
-        (resolve("_esp_error_check_failed", 0x4008_bbd0), rom_thunks::nop_return_zero),
-        (resolve("setCpuFrequencyMhz", 0x400e_99dc), rom_thunks::nop_return_zero),
-        (resolve("esp_ota_get_running_partition", 0x400e_ae18), rom_thunks::nop_return_fake_ptr),
+        (
+            resolve("heap_caps_init", 0x400e_e3b0),
+            rom_thunks::esp_idf_heap_caps_init,
+        ),
+        (
+            resolve("heap_caps_malloc", 0x4008_2904),
+            rom_thunks::esp_idf_heap_caps_malloc,
+        ),
+        (
+            resolve("heap_caps_calloc", 0x4008_2a70),
+            rom_thunks::esp_idf_heap_caps_calloc,
+        ),
+        (
+            resolve("heap_caps_free", 0x4008_25dc),
+            rom_thunks::esp_idf_heap_caps_free,
+        ),
+        (
+            resolve("heap_caps_realloc", 0x4008_29f0),
+            rom_thunks::esp_idf_heap_caps_realloc,
+        ),
+        (
+            resolve("esp_timer_init", 0x4012_9034),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve(
+                "spi_flash_disable_interrupts_caches_and_other_cpu",
+                0x4008_17dc,
+            ),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve(
+                "spi_flash_enable_interrupts_caches_and_other_cpu",
+                0x4008_188c,
+            ),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("__retarget_lock_init_recursive", 0x4008_3384),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("__retarget_lock_close_recursive", 0x4008_339c),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("__retarget_lock_acquire_recursive", 0x4008_33b0),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("__retarget_lock_release_recursive", 0x4008_33cc),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("_esp_error_check_failed", 0x4008_bbd0),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("setCpuFrequencyMhz", 0x400e_99dc),
+            rom_thunks::nop_return_zero,
+        ),
+        (
+            resolve("esp_ota_get_running_partition", 0x400e_ae18),
+            rom_thunks::nop_return_fake_ptr,
+        ),
         (resolve("delay", 0x400e_5c28), rom_thunks::nop_return_zero),
     ];
     // HardwareSerial::begin only exists when the sketch called Serial.begin().
@@ -1411,7 +1457,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // "up." AgentDeck path: byte-for-byte mirror of the original
         // install_esp32_arduino_quirks. Auto-discovery path: write to
         // each resolved symbol's [0]+[1] slots.
-        if i % 10_000 == 0 {
+        if i.is_multiple_of(10_000) {
             if args.profile == "agentdeck" {
                 let _ = machine.bus.write_u8(0x3FFC_6F04, 0x01);
                 let _ = machine.bus.write_u8(0x3FFC_6F01, 0x01);
@@ -1458,8 +1504,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         // S32C1I is atomic within step() so spinlocks work correctly.
         if let Some(cpu1) = machine.cpu_secondary.as_mut() {
             if let Some(boot_addr) =
-                labwired_core::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR
-                    .with(|s| s.take())
+                labwired_core::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR.with(|s| s.take())
             {
                 cpu1.set_pc(boot_addr);
                 cpu1.set_sp(appcpu_initial_sp);
@@ -1484,7 +1529,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         }
         machine.bus.tick_peripherals_with_costs();
         i += 1;
-        if progress > 0 && i % progress == 0 {
+        if progress > 0 && i.is_multiple_of(progress) {
             let cpu1_state = match machine.cpu_secondary.as_ref() {
                 Some(cpu1) => format!("  cpu1=0x{:08x}", cpu1.get_pc()),
                 None => String::new(),
@@ -1497,28 +1542,42 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             // LABWIRED_DEBUG_LIST=1 to enable. Shows cpu intlevel,
             // xTaskQueueMutex state, pxList walk, and newItem state.
             if std::env::var("LABWIRED_DEBUG_LIST").is_ok() {
-                eprintln!("    cpu0 intlevel={} a0=0x{:08x} a1=0x{:08x}",
+                eprintln!(
+                    "    cpu0 intlevel={} a0=0x{:08x} a1=0x{:08x}",
                     machine.cpu.intlevel(),
                     machine.cpu.get_register(0),
-                    machine.cpu.get_register(1));
+                    machine.cpu.get_register(1)
+                );
                 let mux_owner = machine.bus.read_u32(0x3ffbf3b8).unwrap_or(0xDEAD);
                 let mux_count = machine.bus.read_u32(0x3ffbf3bc).unwrap_or(0xDEAD);
                 eprintln!("    xTaskQueueMutex.owner=0x{mux_owner:08x} .count={mux_count}");
                 if let Some(cpu1) = machine.cpu_secondary.as_ref() {
-                    eprintln!("    cpu1 intlevel={} a0=0x{:08x} a1=0x{:08x}",
+                    eprintln!(
+                        "    cpu1 intlevel={} a0=0x{:08x} a1=0x{:08x}",
                         cpu1.intlevel(),
                         cpu1.get_register(0),
-                        cpu1.get_register(1));
+                        cpu1.get_register(1)
+                    );
                 }
                 let px_list = machine.cpu.get_register(2);
-                let r = |off: u32| machine.bus.read_u32((px_list + off) as u64).unwrap_or(0xDEAD);
+                let r = |off: u32| {
+                    machine
+                        .bus
+                        .read_u32((px_list + off) as u64)
+                        .unwrap_or(0xDEAD)
+                };
                 eprintln!(
                     "    cpu0 pxList=0x{px_list:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
                     r(0), r(4), r(8), r(12), r(16)
                 );
                 if let Some(cpu1) = machine.cpu_secondary.as_ref() {
                     let px_list1 = cpu1.get_register(2);
-                    let r1 = |off: u32| machine.bus.read_u32((px_list1 + off) as u64).unwrap_or(0xDEAD);
+                    let r1 = |off: u32| {
+                        machine
+                            .bus
+                            .read_u32((px_list1 + off) as u64)
+                            .unwrap_or(0xDEAD)
+                    };
                     eprintln!(
                         "    cpu1 pxList=0x{px_list1:08x} num={} idx=0x{:08x} end.val=0x{:08x} end.next=0x{:08x} end.prev=0x{:08x}",
                         r1(0), r1(4), r1(8), r1(12), r1(16)
@@ -1537,7 +1596,12 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                     iter = item_next;
                 }
                 let new_item = machine.cpu.get_register(3);
-                let ri = |off: u32| machine.bus.read_u32((new_item + off) as u64).unwrap_or(0xDEAD);
+                let ri = |off: u32| {
+                    machine
+                        .bus
+                        .read_u32((new_item + off) as u64)
+                        .unwrap_or(0xDEAD)
+                };
                 eprintln!(
                     "    cpu0 newItem=0x{new_item:08x} item.val=0x{:08x} item.next=0x{:08x} item.prev=0x{:08x} item.owner=0x{:08x}",
                     ri(0), ri(4), ri(8), ri(12)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1109,7 +1109,8 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "_fwrite_r",
         "esp_panic_handler",
         "esp_panic_handler_reconfigure_wdts",
-        "xTaskGetCurrentTaskHandle",
+        // xTaskGetCurrentTaskHandle gets a proper thunk below — returning
+        // 0 breaks vTaskDelete(NULL) by passing NULL into prvDeleteTLS.
         "pthread_key_create",
         "pthread_setspecific",
         "pthread_getspecific",
@@ -1174,13 +1175,21 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "esp_log_impl_lock",
         "esp_log_impl_lock_timeout",
         "esp_log_impl_unlock",
+        // esp_ipc_init/isr_init create the IPC task per core. Its
+        // semaphore-wait turns into a tight loop in the sim (xQueueSemaphoreTake
+        // is stubbed to pdTRUE), starving loopTask. Stub the init so the
+        // task is never created — cross-core IPC isn't used on the
+        // single-CPU render path.
+        "esp_ipc_init",
+        "esp_ipc_isr_init",
         // FreeRTOS recursive mutexes used by newlib stdio locks — same
         // null-queue assertion problem. Stub since sim is effectively
-        // single-threaded on the panel-render path.
+        // single-threaded on the panel-render path. xQueueCreateMutexStatic
+        // gets a separate echo_arg0 thunk below (callers assert the returned
+        // handle equals the static buffer they passed in).
         "xQueueGiveMutexRecursive",
         "xQueueTakeMutexRecursive",
         "xQueueCreateMutex",
-        "xQueueCreateMutexStatic",
         "__sfvwrite_r",
         "__swsetup_r",
         "__sflush_r",
@@ -1232,6 +1241,32 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // timer ISR re-fires every CCOUNT cycle, pinning CPU 0 in the tick hook.
     if let Some(&pc) = symbol_addrs.get("esp_clk_cpu_freq") {
         thunks.push((pc, rom_thunks::esp_clk_cpu_freq_240mhz));
+    }
+    // xQueueCreateMutexStatic returns the caller's static buffer as the
+    // handle. Callers (esp_newlib_locks_init in particular) assert that the
+    // returned handle equals the buffer they passed in — a nop_return_zero
+    // stub fails that check.
+    if let Some(&pc) = symbol_addrs.get("xQueueCreateMutexStatic") {
+        thunks.push((pc, rom_thunks::x_queue_create_mutex_static_echo));
+    }
+    // pxCurrentTCB symbol → feed into the rom_thunks side so the
+    // xTaskGetCurrentTaskHandle thunk can read it. Arduino-ESP32's
+    // main_task self-deletes after app_main returns via vTaskDelete(NULL),
+    // which depends on this getter.
+    if let Some(&addr) = symbol_addrs.get("pxCurrentTCB") {
+        rom_thunks::PX_CURRENT_TCB_ADDR.with(|s| s.set(Some(addr)));
+    }
+    if let Some(&pc) = symbol_addrs.get("xTaskGetCurrentTaskHandle") {
+        thunks.push((pc, rom_thunks::x_task_get_current_task_handle));
+    }
+    // xQueueSemaphoreTake on the NULL mutex returned by our stubbed
+    // xQueueCreateMutex would assert. Force pdTRUE so SPIClass /
+    // beginTransaction etc. proceed as if they got the lock.
+    if let Some(&pc) = symbol_addrs.get("xQueueSemaphoreTake") {
+        thunks.push((pc, rom_thunks::return_pd_true));
+    }
+    if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
+        thunks.push((pc, rom_thunks::return_pd_true));
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1328,29 +1328,6 @@ impl SystemBus {
     }
 
     pub fn write_u32(&mut self, addr: u64, value: u32) -> SimResult<()> {
-        // Debug: catch FreeRTOS list-item self-reference (item.pxNext = &item).
-        // ListItem_t layout has pxNext at offset 4; writing item-pointer P to
-        // address P+4 means item references itself. Gated by env var so the
-        // check is zero-cost in normal runs.
-        if std::env::var_os("LABWIRED_TRACE_LIST_CORRUPTION").is_some() {
-            if (addr as u32).wrapping_sub(value) == 4
-                && value >= 0x3FF8_0000
-                && value < 0x4000_0000
-            {
-                eprintln!(
-                    "[bus-watch] self-ref write: addr=0x{:08x} value=0x{:08x}",
-                    addr as u32, value
-                );
-            }
-            // Also trace any write near the suspected corrupted item region
-            if let Ok(target) = std::env::var("LABWIRED_WATCH_ADDR") {
-                if let Some(t) = target.strip_prefix("0x").and_then(|h| u32::from_str_radix(h, 16).ok()) {
-                    if (addr as u32) >= t && (addr as u32) < t + 16 {
-                        eprintln!("[bus-watch] write addr=0x{:08x} value=0x{:08x}", addr as u32, value);
-                    }
-                }
-            }
-        }
         if self.config.optimized_bus_access && self.ram.write_u32(addr, value) {
             return Ok(());
         }

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -1936,12 +1936,7 @@ impl Cpu for XtensaLx7 {
         }
     }
 
-    fn runtime_snapshot(
-        &self,
-    ) -> (
-        crate::runtime_snapshot::CpuKind,
-        Vec<u8>,
-    ) {
+    fn runtime_snapshot(&self) -> (crate::runtime_snapshot::CpuKind, Vec<u8>) {
         use crate::runtime_snapshot::XtensaLx7RuntimeSnapshot;
         let snap = XtensaLx7RuntimeSnapshot {
             pc: self.pc,
@@ -1949,7 +1944,7 @@ impl Cpu for XtensaLx7 {
             phys: self.regs.phys_slice().to_vec(),
             window_base: self.regs.windowbase(),
             window_start: self.regs.windowstart(),
-            shadow: self.regs.shadow_stacks().iter().cloned().collect(),
+            shadow: self.regs.shadow_stacks().to_vec(),
             sr: self.sr.raw_storage().to_vec(),
         };
         let bytes = bincode::serialize(&snap).expect("bincode serialize XtensaLx7RuntimeSnapshot");
@@ -1967,8 +1962,9 @@ impl Cpu for XtensaLx7 {
                 "apply_runtime_snapshot: kind {kind:?} given to XtensaLx7"
             )));
         }
-        let snap: XtensaLx7RuntimeSnapshot = bincode::deserialize(bytes)
-            .map_err(|e| SimulationError::NotImplemented(format!("XtensaLx7 snapshot decode: {e}")))?;
+        let snap: XtensaLx7RuntimeSnapshot = bincode::deserialize(bytes).map_err(|e| {
+            SimulationError::NotImplemented(format!("XtensaLx7 snapshot decode: {e}"))
+        })?;
         if snap.phys.len() != 64 {
             return Err(SimulationError::NotImplemented(
                 "XtensaLx7 snapshot phys must be 64 entries".into(),

--- a/crates/core/src/cpu/xtensa_sr.rs
+++ b/crates/core/src/cpu/xtensa_sr.rs
@@ -64,7 +64,8 @@ pub const EXCSAVE5: u16 = 213;
 pub const EXCSAVE6: u16 = 214;
 pub const EXCSAVE7: u16 = 215;
 pub const CPENABLE: u16 = 224; // 0xE0
-pub const INTERRUPT: u16 = 226; // 0xE2 (read-only from SW)
+pub const INTERRUPT: u16 = 226; // 0xE2 (RSR: read INTERRUPT)
+pub const INTSET: u16 = 226; // 0xE2 (WSR: sets bits in INTERRUPT — same SR id as INTERRUPT, ISA-distinguished by RSR vs WSR direction)
 pub const INTCLEAR: u16 = 227; // 0xE3 (write-clears INTERRUPT bits)
 pub const INTENABLE: u16 = 228; // 0xE4
 pub const PS: u16 = 230; // 0xE6
@@ -155,7 +156,10 @@ impl XtensaSrFile {
     ///
     /// Special dispatch:
     /// - `INTCLEAR (227)`: clears bits in `INTERRUPT` — `interrupt &= !v`.
-    /// - `INTERRUPT (226)`: direct SW writes ignored (hardware-latched).
+    /// - `INTSET (226)`: sets bits in `INTERRUPT` — `interrupt |= v`. INTSET
+    ///   and INTERRUPT share SR id 226 in the Xtensa LX ISA; RSR reads the
+    ///   pending-IRQ status, WSR (this path) is the software-trigger entry
+    ///   point used by FreeRTOS `portYIELD()` (BIT(7) → SOFTWARE0).
     /// - `PRID (235)`: writes ignored (read-only).
     /// - `SAR (3)`: masked to 6 bits per Xtensa LX ISA.
     pub fn write(&mut self, sr_id: u16, v: u32) {
@@ -169,8 +173,12 @@ impl XtensaSrFile {
                 self.storage[IDX_INTERRUPT] &= !v;
             }
             IDX_INTERRUPT => {
-                // Direct SW writes to INTERRUPT are ignored (hardware-latched)
-                tracing::trace!("WSR: direct write to INTERRUPT (id=226) ignored");
+                // WSR.INTSET (shares SR id 226 with INTERRUPT): set bits in
+                // INTERRUPT. This is the SW-IRQ trigger path that FreeRTOS
+                // `portYIELD()` rides on — without it, scheduler yields are
+                // silently dropped and tasks calling xQueueReceive on empty
+                // queues spin without ever blocking, corrupting wait lists.
+                self.storage[IDX_INTERRUPT] |= v;
             }
             IDX_PRID => {
                 // PRID is read-only hardware register
@@ -182,6 +190,28 @@ impl XtensaSrFile {
             }
             idx => {
                 self.storage[idx] = v;
+                // Xtensa CCOMPARE0 semantics: writing CCOMPARE0 acknowledges
+                // the previous timer-0 interrupt (clears bit 6 in INTERRUPT)
+                // AND, if the new value is already <= CCOUNT, immediately
+                // raises bit 6 again so the next tick fires on the cycle the
+                // comparator is met.
+                //
+                // Without the acknowledge half of this, the bit stays high
+                // after the ISR returns and dispatches again, causing a
+                // tight ISR re-entry loop.
+                //
+                // Without the raise half, FreeRTOS's `_frxt_tick_timer_init`
+                // sets CCOMPARE0 = CCOUNT + divisor at scheduler-start time
+                // — but our CCOUNT has already overrun (bump-allocator-backed
+                // boot is slower than the divisor), so the firmware never
+                // gets a tick, never yields, and IPC tasks spin in
+                // xQueueReceive corrupting wait lists.
+                if idx == 240 /* CCOMPARE0 */ {
+                    self.storage[IDX_INTERRUPT] &= !(1 << 6);
+                    if v != 0 && self.storage[IDX_CCOUNT] >= v {
+                        self.storage[IDX_INTERRUPT] |= 1 << 6;
+                    }
+                }
             }
         }
     }

--- a/crates/core/src/cpu/xtensa_sr.rs
+++ b/crates/core/src/cpu/xtensa_sr.rs
@@ -206,7 +206,7 @@ impl XtensaSrFile {
                 // boot is slower than the divisor), so the firmware never
                 // gets a tick, never yields, and IPC tasks spin in
                 // xQueueReceive corrupting wait lists.
-                if idx == 240 /* CCOMPARE0 */ {
+                if idx == CCOMPARE0 as usize {
                     self.storage[IDX_INTERRUPT] &= !(1 << 6);
                     if v != 0 && self.storage[IDX_CCOUNT] >= v {
                         self.storage[IDX_INTERRUPT] |= 1 << 6;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,8 +18,8 @@ pub mod multi_core;
 pub mod network;
 pub mod peripherals;
 pub mod physics;
-pub mod signals;
 pub mod runtime_snapshot;
+pub mod signals;
 pub mod snapshot;
 pub mod system;
 pub mod trace;
@@ -654,8 +654,7 @@ impl<C: Cpu> Machine<C> {
             // the secondary CPU's PC, and unhalt so the next round-robin
             // tick starts executing from that address.
             if let Some(boot_addr) =
-                crate::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR
-                    .with(|s| s.take())
+                crate::peripherals::esp32s3::rom_thunks::APPCPU_BOOT_ADDR.with(|s| s.take())
             {
                 cpu1.set_pc(boot_addr);
                 cpu1.unhalt();

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -35,7 +35,7 @@ use crate::{Peripheral, PeripheralTickResult, SimResult};
 use std::collections::HashMap;
 
 const REG_CMD: u64 = 0x00;
-const REG_USER: u64 = 0x1C;
+pub const REG_USER: u64 = 0x1C;
 const REG_USER2: u64 = 0x24;
 const REG_MOSI_DLEN: u64 = 0x28;
 const REG_MISO_DLEN: u64 = 0x2C;
@@ -43,7 +43,7 @@ const FIFO_START: u64 = 0x80;
 const FIFO_END: u64 = 0xC0; // exclusive — W0..W15 = 64 bytes
 
 const CMD_USR_BIT: u32 = 1 << 18;
-const USER_USR_MOSI_BIT: u32 = 1 << 27;
+pub const USER_USR_MOSI_BIT: u32 = 1 << 27;
 
 #[derive(Default)]
 pub struct Esp32Spi {

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -380,6 +380,95 @@ pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> 
     Ok(())
 }
 
+/// `spi_t *spiStartBus(uint8_t spi_num, ...)` — Arduino-ESP32's SPI bus
+/// initializer. Real impl allocates a `spi_t`, programs DPORT clock-enable
+/// registers, configures the SPI peripheral. We skip the DPORT/peripheral
+/// dance and hand back a tiny static `spi_t` whose only populated field is
+/// `dev` (offset 0) — the SPI peripheral base address. Downstream callers
+/// (`spiTransferByte`) read `spi->dev` and write the peripheral registers
+/// directly, which our `spi3` peripheral catches.
+///
+/// `spi_num` maps to the peripheral base:
+///   0 → SPI0 (flash, not modelled): return NULL
+///   1 → SPI1 (flash, not modelled): return NULL
+///   2 → HSPI/SPI2 (0x3FF64000)
+///   3 → VSPI/SPI3 (0x3FF65000) — the default Arduino `SPI` instance
+///
+/// The `spi_t` blob is per-num and lives in DRAM at a reserved address.
+pub fn spi_start_bus_fake(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let n = cpu.ps.callinc() * 4;
+    let spi_num = cpu.regs.read_logical(n + 2) & 0xFF;
+    let (dev, fake_spi_t) = fake_spi_for_num(spi_num);
+    if fake_spi_t == 0 {
+        RomThunkBank::return_with(cpu, 0);
+        return Ok(());
+    }
+    // Populate spi_t: dev at offset 0, lock at offset 4 (NULL, our stubs
+    // ignore it), num at offset 8. Remaining fields zeroed.
+    bus.write_u32(fake_spi_t as u64, dev)?;
+    bus.write_u32(fake_spi_t as u64 + 4, 0)?;
+    bus.write_u32(fake_spi_t as u64 + 8, spi_num)?;
+    RomThunkBank::return_with(cpu, fake_spi_t);
+    Ok(())
+}
+
+fn fake_spi_for_num(spi_num: u32) -> (u32, u32) {
+    match spi_num {
+        2 => (0x3FF6_4000, 0x3FFD_F000),
+        3 => (0x3FF6_5000, 0x3FFD_F020),
+        _ => (0, 0),
+    }
+}
+
+/// Wraps SPIClass::beginTransaction so the first call lazily initializes
+/// `this->_spi` to a fake spi_t pointing at the matching SPI peripheral
+/// base. The sketch never calls SPI.begin() explicitly — GxEPD2 just
+/// assumes the bus is up — so without this hook spiTransferByte's
+/// `if (spi == NULL) return` short-circuits every transfer and no bytes
+/// reach the panel.
+///
+/// After ensuring _spi is non-NULL, we return pdTRUE to satisfy the
+/// caller's `bnei a10, 1, retry` check (it expects a take to succeed).
+pub fn spi_class_begin_transaction(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let n = cpu.ps.callinc() * 4;
+    let this = cpu.regs.read_logical(n + 2);
+    // SPIClass layout: offset 0 = _spi_num (u8), offset 4 = _spi (spi_t*).
+    let spi_num = bus.read_u32(this as u64)? & 0xFF;
+    let cur_spi = bus.read_u32(this as u64 + 4)?;
+    if cur_spi == 0 {
+        let (dev, fake_spi_t) = fake_spi_for_num(spi_num);
+        if fake_spi_t != 0 {
+            bus.write_u32(fake_spi_t as u64, dev)?;
+            bus.write_u32(fake_spi_t as u64 + 4, 0)?;
+            bus.write_u32(fake_spi_t as u64 + 8, spi_num)?;
+            bus.write_u32(this as u64 + 4, fake_spi_t)?;
+        }
+    }
+    // The real `spiStartBus` programs the SPI peripheral's USER register
+    // to enable the MOSI-output phase (bit 27 = USR_MOSI). We skipped
+    // that, so the first `spiTransferByte` writes data into the FIFO and
+    // sets the CMD.USR start bit but the peripheral never strobes bytes
+    // out to attached devices (kick_user_transaction returns early when
+    // USR_MOSI is clear). Set it once here so subsequent transfers fire.
+    let cur_spi = bus.read_u32(this as u64 + 4)?;
+    if cur_spi != 0 {
+        let dev = bus.read_u32(cur_spi as u64)?;
+        if dev != 0 {
+            const USER_REG_OFFSET: u64 = 0x1C;
+            const USER_USR_MOSI: u32 = 1 << 27;
+            let cur_user = bus.read_u32(dev as u64 + USER_REG_OFFSET)?;
+            if cur_user & USER_USR_MOSI == 0 {
+                bus.write_u32(dev as u64 + USER_REG_OFFSET, cur_user | USER_USR_MOSI)?;
+            }
+        }
+    }
+    // Mark _inTransaction = 1 (offset 24) so endTransaction's take/give
+    // bookkeeping stays consistent.
+    bus.write_u8(this as u64 + 24, 1)?;
+    RomThunkBank::return_with(cpu, 1);
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -324,6 +324,62 @@ pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     Ok(())
 }
 
+/// `xQueueCreateMutexStatic(uint8_t ucQueueType, StaticQueue_t *pxStaticQueue)
+/// -> QueueHandle_t` — on real silicon the returned handle IS the static
+/// buffer (an identity cast). Returning 0 makes `esp_newlib_locks_init`'s
+/// "got the static handle back" assertion fire. We echo arg 1 (the
+/// caller-allocated buffer pointer).
+pub fn x_queue_create_mutex_static_echo(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    let n = cpu.ps.callinc() * 4;
+    let static_buf = cpu.regs.read_logical(n + 3);
+    RomThunkBank::return_with(cpu, static_buf);
+    Ok(())
+}
+
+/// `xTaskGetCurrentTaskHandle() -> TaskHandle_t` — returns `pxCurrentTCB[core]`.
+///
+/// The previous nop_return_zero stub broke `vTaskDelete(NULL)`: vTaskDelete
+/// looks up the current task via this getter when called with a NULL arg,
+/// then passes it to prvDeleteTLS/prvDeleteTCB which assert non-NULL.
+/// Arduino-ESP32's main_task self-deletes after app_main returns, tripping
+/// this path right after the scheduler starts.
+///
+/// `pxCurrentTCB` is a per-core array at a firmware-specific address; the
+/// auto-discovered symbol resolves on the Arduino-ESP32 profile. Without
+/// the symbol (AgentDeck profile, stripped ELF), we fall back to returning
+/// 0 to preserve the previous behaviour.
+pub fn x_task_get_current_task_handle(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;
+    let pxcurrenttcb_addr = PX_CURRENT_TCB_ADDR.with(|s| s.get()).unwrap_or(0);
+    let handle = if pxcurrenttcb_addr != 0 {
+        bus.read_u32(pxcurrenttcb_addr as u64 + (core_id as u64 * 4))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    RomThunkBank::return_with(cpu, handle);
+    Ok(())
+}
+
+thread_local! {
+    /// Set by the cli once the `pxCurrentTCB` symbol is resolved from the
+    /// firmware ELF. Read by [`x_task_get_current_task_handle`].
+    pub static PX_CURRENT_TCB_ADDR: std::cell::Cell<Option<u32>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Stub for queue/semaphore APIs whose real impl asserts `pxQueue != NULL`.
+/// We return `pdTRUE` (1) to signal "operation succeeded" without touching
+/// any queue state. Used for SPIClass / wire-library calls into
+/// `xQueueSemaphoreTake` / `xQueueSemaphoreGive` on a mutex that our stubbed
+/// `xQueueCreateMutex` returned NULL for. Real silicon would dereference
+/// pxQueue and crash too — this fakes a recursive-mutex held-by-current
+/// state, which is fine for the single-CPU sim render path.
+pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    RomThunkBank::return_with(cpu, 1);
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -295,6 +295,35 @@ pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
+/// Thunk for `__assert_func` / `panic_abort` / `abort` — functions that
+/// real-silicon C convention treats as `noreturn`. Stubbing them as
+/// nop_return_zero would silently return into the caller, which on the
+/// FreeRTOS xQueue assertion paths produces a tight loop:
+/// `assert → return → check failed cond → jump back to assert`.
+///
+/// Instead, halt the calling CPU and print the assertion arguments so the
+/// operator sees what blew up.  The caller never re-runs, so the loop
+/// breaks.  The OTHER CPU (if dual-core) keeps running.
+pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    use core::sync::atomic::{AtomicU32, Ordering};
+    static FIRST_PRINT: AtomicU32 = AtomicU32::new(0);
+    if FIRST_PRINT.fetch_add(1, Ordering::Relaxed) < 5 {
+        let n = cpu.ps.callinc() * 4;
+        let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;
+        eprintln!(
+            "[abort_halt] core={core_id} pc=0x{:08x} a0=0x{:08x} a10=0x{:08x} a11=0x{:08x} a12=0x{:08x} a13=0x{:08x}",
+            cpu.pc,
+            cpu.regs.read_logical(0),
+            cpu.regs.read_logical(n + 2),
+            cpu.regs.read_logical(n + 3),
+            cpu.regs.read_logical(n + 4),
+            cpu.regs.read_logical(n + 5)
+        );
+    }
+    cpu.halted = true;
+    Ok(())
+}
+
 /// Debug thunk for `vListInsert(List_t *pxList, ListItem_t *pxNewListItem)`.
 /// Dumps the list state for the first few calls, then returns without
 /// performing the insertion. Used to diagnose infinite-loop bugs in the
@@ -681,6 +710,17 @@ pub fn esp_idf_heap_caps_realloc(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> Sim
 /// `ets_get_cpu_frequency() -> u32` — returns 240 (MHz).
 pub fn rom_cpu_freq_240mhz(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 240);
+    Ok(())
+}
+
+/// `esp_clk_cpu_freq() -> u32` — returns 240_000_000 (Hz).
+///
+/// FreeRTOS's `_frxt_tick_timer_init` uses this to compute
+/// `_xt_tick_divisor = cpu_freq / configTICK_RATE_HZ`. Without it (or with
+/// the stubbed esp_clk_init returning 0), the divisor is 0 and the timer
+/// ISR can never advance CCOMPARE0 — every CCOUNT cycle re-fires the tick.
+pub fn esp_clk_cpu_freq_240mhz(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    RomThunkBank::return_with(cpu, 240_000_000);
     Ok(())
 }
 

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -375,7 +375,21 @@ thread_local! {
 /// `xQueueCreateMutex` returned NULL for. Real silicon would dereference
 /// pxQueue and crash too — this fakes a recursive-mutex held-by-current
 /// state, which is fine for the single-CPU sim render path.
+///
+/// Emits a one-time `tracing::warn!` on first call so silent activation is
+/// loud in logs; this stub will hide future regressions where a take
+/// *should* block (e.g. when a second consumer is added).
 pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            target: "labwired_core::esp32s3",
+            "return_pd_true stub active: xQueueSemaphoreTake / xQueueGenericSend will \
+             unconditionally succeed on stubbed mutexes. Any test that depends on a \
+             take blocking will silently pass."
+        );
+    }
     RomThunkBank::return_with(cpu, 1);
     Ok(())
 }
@@ -403,19 +417,35 @@ pub fn spi_start_bus_fake(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<(
         RomThunkBank::return_with(cpu, 0);
         return Ok(());
     }
-    // Populate spi_t: dev at offset 0, lock at offset 4 (NULL, our stubs
-    // ignore it), num at offset 8. Remaining fields zeroed.
-    bus.write_u32(fake_spi_t as u64, dev)?;
-    bus.write_u32(fake_spi_t as u64 + 4, 0)?;
-    bus.write_u32(fake_spi_t as u64 + 8, spi_num)?;
+    // Populate spi_t: dev (offset 0), lock (offset 4, NULL — our stubs
+    // ignore it), num (offset 8). Remaining fields zeroed.
+    bus.write_u32(fake_spi_t as u64 + SPI_T_DEV_OFFSET, dev)?;
+    bus.write_u32(fake_spi_t as u64 + SPI_T_LOCK_OFFSET, 0)?;
+    bus.write_u32(fake_spi_t as u64 + SPI_T_NUM_OFFSET, spi_num)?;
     RomThunkBank::return_with(cpu, fake_spi_t);
     Ok(())
 }
 
+// `spi_t` field offsets matching Arduino-ESP32's struct layout.
+const SPI_T_DEV_OFFSET: u64 = 0;
+const SPI_T_LOCK_OFFSET: u64 = 4;
+const SPI_T_NUM_OFFSET: u64 = 8;
+// SPIClass field offsets.
+const SPI_CLASS_SPI_NUM_OFFSET: u64 = 0;
+const SPI_CLASS_SPI_PTR_OFFSET: u64 = 4;
+const SPI_CLASS_IN_TRANSACTION_OFFSET: u64 = 24;
+// Reserved sim-only scratch region for fake `spi_t` blobs. Sits at the
+// top of SRAM1 (0x3FFE_0000–0x4000_0000), well above Arduino-ESP32's
+// initial stack (near 0x3FFE_0000, growing downward into DRAM) and any
+// plausible heap allocation. DRAM proper (0x3FFA_E000–0x3FFE_0000) is
+// off-limits because the firmware allocator can reach the upper pages.
+const SIM_FAKE_SPI_T_SPI2: u32 = 0x3FFF_FF00;
+const SIM_FAKE_SPI_T_SPI3: u32 = 0x3FFF_FF20;
+
 fn fake_spi_for_num(spi_num: u32) -> (u32, u32) {
     match spi_num {
-        2 => (0x3FF6_4000, 0x3FFD_F000),
-        3 => (0x3FF6_5000, 0x3FFD_F020),
+        2 => (0x3FF6_4000, SIM_FAKE_SPI_T_SPI2),
+        3 => (0x3FF6_5000, SIM_FAKE_SPI_T_SPI3),
         _ => (0, 0),
     }
 }
@@ -430,41 +460,40 @@ fn fake_spi_for_num(spi_num: u32) -> (u32, u32) {
 /// After ensuring _spi is non-NULL, we return pdTRUE to satisfy the
 /// caller's `bnei a10, 1, retry` check (it expects a take to succeed).
 pub fn spi_class_begin_transaction(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    use crate::peripherals::esp32::spi::{REG_USER, USER_USR_MOSI_BIT};
+
     let n = cpu.ps.callinc() * 4;
     let this = cpu.regs.read_logical(n + 2);
-    // SPIClass layout: offset 0 = _spi_num (u8), offset 4 = _spi (spi_t*).
-    let spi_num = bus.read_u32(this as u64)? & 0xFF;
-    let cur_spi = bus.read_u32(this as u64 + 4)?;
+    let spi_num = bus.read_u32(this as u64 + SPI_CLASS_SPI_NUM_OFFSET)? & 0xFF;
+    let cur_spi = bus.read_u32(this as u64 + SPI_CLASS_SPI_PTR_OFFSET)?;
     if cur_spi == 0 {
         let (dev, fake_spi_t) = fake_spi_for_num(spi_num);
         if fake_spi_t != 0 {
-            bus.write_u32(fake_spi_t as u64, dev)?;
-            bus.write_u32(fake_spi_t as u64 + 4, 0)?;
-            bus.write_u32(fake_spi_t as u64 + 8, spi_num)?;
-            bus.write_u32(this as u64 + 4, fake_spi_t)?;
+            bus.write_u32(fake_spi_t as u64 + SPI_T_DEV_OFFSET, dev)?;
+            bus.write_u32(fake_spi_t as u64 + SPI_T_LOCK_OFFSET, 0)?;
+            bus.write_u32(fake_spi_t as u64 + SPI_T_NUM_OFFSET, spi_num)?;
+            bus.write_u32(this as u64 + SPI_CLASS_SPI_PTR_OFFSET, fake_spi_t)?;
         }
     }
     // The real `spiStartBus` programs the SPI peripheral's USER register
-    // to enable the MOSI-output phase (bit 27 = USR_MOSI). We skipped
-    // that, so the first `spiTransferByte` writes data into the FIFO and
-    // sets the CMD.USR start bit but the peripheral never strobes bytes
-    // out to attached devices (kick_user_transaction returns early when
-    // USR_MOSI is clear). Set it once here so subsequent transfers fire.
-    let cur_spi = bus.read_u32(this as u64 + 4)?;
+    // to enable the MOSI-output phase. We skipped that, so the first
+    // `spiTransferByte` writes data into the FIFO and sets the CMD.USR
+    // start bit but the peripheral never strobes bytes out to attached
+    // devices (kick_user_transaction returns early when USR_MOSI is
+    // clear). Set it once here so subsequent transfers fire.
+    let cur_spi = bus.read_u32(this as u64 + SPI_CLASS_SPI_PTR_OFFSET)?;
     if cur_spi != 0 {
-        let dev = bus.read_u32(cur_spi as u64)?;
+        let dev = bus.read_u32(cur_spi as u64 + SPI_T_DEV_OFFSET)?;
         if dev != 0 {
-            const USER_REG_OFFSET: u64 = 0x1C;
-            const USER_USR_MOSI: u32 = 1 << 27;
-            let cur_user = bus.read_u32(dev as u64 + USER_REG_OFFSET)?;
-            if cur_user & USER_USR_MOSI == 0 {
-                bus.write_u32(dev as u64 + USER_REG_OFFSET, cur_user | USER_USR_MOSI)?;
+            let cur_user = bus.read_u32(dev as u64 + REG_USER)?;
+            if cur_user & USER_USR_MOSI_BIT == 0 {
+                bus.write_u32(dev as u64 + REG_USER, cur_user | USER_USR_MOSI_BIT)?;
             }
         }
     }
-    // Mark _inTransaction = 1 (offset 24) so endTransaction's take/give
-    // bookkeeping stays consistent.
-    bus.write_u8(this as u64 + 24, 1)?;
+    // Mark _inTransaction so endTransaction's take/give bookkeeping stays
+    // consistent.
+    bus.write_u8(this as u64 + SPI_CLASS_IN_TRANSACTION_OFFSET, 1)?;
     RomThunkBank::return_with(cpu, 1);
     Ok(())
 }
@@ -535,8 +564,7 @@ thread_local! {
 /// (steps of 1000 per call) so callers polling for timeout deadlines
 /// actually make progress instead of looping forever.
 pub fn monotonic_counter_32(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
-    static MONOTONIC_TICKS: core::sync::atomic::AtomicU32 =
-        core::sync::atomic::AtomicU32::new(0);
+    static MONOTONIC_TICKS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
     let v = MONOTONIC_TICKS.fetch_add(1000, core::sync::atomic::Ordering::Relaxed);
     RomThunkBank::return_with(cpu, v);
     Ok(())
@@ -569,8 +597,8 @@ pub fn esp_chip_info_stub(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<(
         let bytes: [u8; 16] = [
             0x01, 0x00, 0x00, 0x00, // model = ESP32
             0x00, 0x00, 0x00, 0x00, // features
-            0x03, 0x00,             // revision = 3
-            0x02,                   // cores = 2
+            0x03, 0x00, // revision = 3
+            0x02, // cores = 2
             0x03, 0x00, 0x00, 0x00, 0x00, // full_revision + pad
         ];
         for (i, &b) in bytes.iter().enumerate() {

--- a/crates/core/src/runtime_snapshot.rs
+++ b/crates/core/src/runtime_snapshot.rs
@@ -92,8 +92,8 @@ impl MachineRuntimeSnapshot {
 
     /// Parse from a byte blob, validating magic + version.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, RuntimeSnapshotError> {
-        let snap: Self = bincode::deserialize(bytes)
-            .map_err(|e| RuntimeSnapshotError::Decode(e.to_string()))?;
+        let snap: Self =
+            bincode::deserialize(bytes).map_err(|e| RuntimeSnapshotError::Decode(e.to_string()))?;
         if snap.magic != RUNTIME_SNAPSHOT_MAGIC {
             return Err(RuntimeSnapshotError::BadMagic(snap.magic));
         }

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -267,8 +267,8 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     // so noop-return is safe.
     rom_bank.register(0x4000_681c, rom_thunks::esp_rom_route_intr_matrix); // intr_matrix_set / esp_rom_route_intr_matrix
     rom_bank.register(0x4000_689c, rom_thunks::ets_set_appcpu_boot_addr); // releases APP_CPU
-    // UART putc / printf install hooks — called by call_start_cpu1 to
-    // wire CPU 1's stdout. We don't model UART output, so no-op.
+                                                                          // UART putc / printf install hooks — called by call_start_cpu1 to
+                                                                          // wire CPU 1's stdout. We don't model UART output, so no-op.
     rom_bank.register(0x4000_7d18, rom_thunks::nop_return_zero); // ets_install_putc1
     rom_bank.register(0x4000_7d28, rom_thunks::nop_return_zero); // ets_install_uart_printf
     rom_bank.register(0x4000_7d38, rom_thunks::nop_return_zero); // ets_install_putc2
@@ -282,9 +282,9 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     rom_bank.register(0x4005_a917, rom_thunks::nop_return_zero); // Cache_Flush
     rom_bank.register(0x4005_aa10, rom_thunks::nop_return_zero); // Cache_Read_Enable
     rom_bank.register(0x4005_a888, rom_thunks::nop_return_zero); // esp_rom_spiflash_attach
-    // intr_matrix_set is at 0x4000_681c (above); cpu1 calls intr_matrix_set
-    // for its own intr table — same thunk works since we don't model the
-    // interrupt matrix per-CPU.
+                                                                 // intr_matrix_set is at 0x4000_681c (above); cpu1 calls intr_matrix_set
+                                                                 // for its own intr table — same thunk works since we don't model the
+                                                                 // interrupt matrix per-CPU.
                                                                  // GPIO matrix routing helpers — used by Arduino's spiAttach{SCK,MOSI,MISO}
                                                                  // and HardwareSerial pin attach. We don't model the GPIO matrix; signals
                                                                  // routed via SPI3 controller flow directly to attached SPI devices.

--- a/crates/core/tests/e2e_agentdeck_in_sim.rs
+++ b/crates/core/tests/e2e_agentdeck_in_sim.rs
@@ -17,8 +17,16 @@ use labwired_core::system::xtensa::configure_xtensa_esp32;
 use labwired_core::{Bus, Cpu, Machine};
 use std::path::PathBuf;
 
+/// Baseline byte counts captured 2026-05-23. Bumped intentionally only after
+/// reviewing the diff vs the prior baseline — drift signals a sim regression
+/// (or, less often, a genuine improvement). Tolerances allow ±0.5% on the
+/// SPI transaction count and ±10 bytes on the black-plane bitmap to absorb
+/// benign ordering noise (e.g. tick alignment) without missing real changes.
+const AGENTDECK_BASELINE_SPI3_TXNS: u32 = 19031;
+const AGENTDECK_BASELINE_BLACK_NONFF: usize = 782;
+
 #[test]
-#[ignore = "loads ~22 MB AgentDeck firmware ELF; only meaningful when the AgentDeck repo is checked out alongside labwired."]
+#[ignore = "loads ~22 MB AgentDeck firmware ELF; only meaningful when the AgentDeck repo is checked out alongside labwired. Run with `cargo test -- --ignored agentdeck_firmware_drives_panel_in_sim`."]
 fn agentdeck_firmware_drives_panel_in_sim() {
     let elf =
         PathBuf::from("/home/andrii/Projects/AgentDeck/firmware/.pio/build/wroom32u/firmware.elf");
@@ -769,4 +777,21 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             out_path.display()
         );
     }
+
+    // Regression bounds. Fires only when the ignored test is invoked
+    // explicitly with the AgentDeck firmware ELF available — locks in the
+    // sim's known-good byte signature against silent drift.
+    let txns = spi.transactions() as i64;
+    let baseline_txns = AGENTDECK_BASELINE_SPI3_TXNS as i64;
+    let txn_tolerance = (baseline_txns / 200).max(50); // ±0.5% or ±50 txns
+    assert!(
+        (baseline_txns - txn_tolerance..=baseline_txns + txn_tolerance).contains(&txns),
+        "AgentDeck SPI3 transaction count drift: got {txns}, baseline {baseline_txns} (±{txn_tolerance})"
+    );
+    let baseline_black = AGENTDECK_BASELINE_BLACK_NONFF as i64;
+    let black_signed = non_white_black as i64;
+    assert!(
+        (baseline_black - 10..=baseline_black + 10).contains(&black_signed),
+        "AgentDeck black-plane non-FF byte count drift: got {non_white_black}, baseline {baseline_black} (±10)"
+    );
 }

--- a/crates/core/tests/runtime_snapshot.rs
+++ b/crates/core/tests/runtime_snapshot.rs
@@ -110,7 +110,10 @@ fn ssd1680_runtime_snapshot_roundtrips_panel_planes() {
     panel.cs_release();
 
     let blob = SpiDevice::runtime_snapshot(&panel);
-    assert!(blob.len() >= 9472, "snapshot must include both 4736-byte planes");
+    assert!(
+        blob.len() >= 9472,
+        "snapshot must include both 4736-byte planes"
+    );
 
     // Build a fresh panel; verify it starts blank, restore, verify state
     // matches the original.
@@ -141,11 +144,17 @@ fn machine_runtime_snapshot_roundtrips_through_serialization() {
     // something nontrivial to restore.
     machine.cpu.set_pc(0x400D_0042);
     machine.cpu.set_register(5, 0x1234_5678);
-    machine.bus.write_u32(0x3FFB_0200, 0xDEAD_BEEF).expect("dram write");
+    machine
+        .bus
+        .write_u32(0x3FFB_0200, 0xDEAD_BEEF)
+        .expect("dram write");
 
     let snap = machine.take_runtime_snapshot();
     let bytes = snap.to_bytes();
-    assert!(bytes.len() > 1000, "machine snapshot blob should be substantial");
+    assert!(
+        bytes.len() > 1000,
+        "machine snapshot blob should be substantial"
+    );
 
     // Round-trip via bytes (proving the on-disk format survives).
     let decoded = MachineRuntimeSnapshot::from_bytes(&bytes).expect("from_bytes");
@@ -168,10 +177,7 @@ fn machine_runtime_snapshot_roundtrips_through_serialization() {
     // Clobber and restore on the same machine.
     machine.cpu.set_pc(0);
     machine.cpu.set_register(5, 0);
-    machine
-        .bus
-        .write_u32(0x3FFB_0200, 0)
-        .expect("dram clobber");
+    machine.bus.write_u32(0x3FFB_0200, 0).expect("dram clobber");
 
     machine.apply_runtime_snapshot(&decoded).expect("apply");
     assert_eq!(machine.cpu.get_pc(), 0x400D_0042);
@@ -244,7 +250,12 @@ fn agentdeck_snapshot_file_restores_post_paint_panel() {
     let red_zero = rp.iter().filter(|&&b| b == 0x00).count();
     eprintln!(
         "panel @ refresh_generation=1: black non-FF={}/{}, red non-FF={}/{}, red 0x00={}/{}",
-        black_non_ff, bp.len(), red_non_ff, rp.len(), red_zero, rp.len(),
+        black_non_ff,
+        bp.len(),
+        red_non_ff,
+        rp.len(),
+        red_zero,
+        rp.len(),
     );
     assert_eq!(
         black_non_ff, 782,

--- a/crates/firmware-f103-i2c-demo/src/main.rs
+++ b/crates/firmware-f103-i2c-demo/src/main.rs
@@ -23,7 +23,7 @@
 
 #![no_std]
 #![no_main]
-#![allow(clippy::empty_loop)]
+#![allow(clippy::empty_loop, clippy::identity_op, clippy::needless_range_loop)]
 
 use core::ptr::{read_volatile, write_volatile};
 

--- a/crates/firmware-f407-demo/src/i2c.rs
+++ b/crates/firmware-f407-demo/src/i2c.rs
@@ -92,6 +92,7 @@ fn rmw32_mask(ptr: *mut u32, clear: u32, set: u32) {
 #[inline(always)]
 fn semihost_writec(byte: u8) {
     let p = core::ptr::addr_of!(byte);
+    #[cfg(target_arch = "arm")]
     unsafe {
         core::arch::asm!(
             "bkpt #0xAB",
@@ -99,6 +100,10 @@ fn semihost_writec(byte: u8) {
             in("r1") p,
             options(preserves_flags, nostack),
         );
+    }
+    #[cfg(not(target_arch = "arm"))]
+    {
+        let _ = (byte, p);
     }
 }
 
@@ -210,7 +215,7 @@ pub extern "C" fn Reset() -> ! {
     // Issue START to a nonexistent slave (AHT20's nominal address; no
     // chip wired on this Discovery). Sim with `external_devices: []`
     // should also see no match.
-    unsafe { rmw32(I2C1_CR1, 1 << 8) };
+    rmw32(I2C1_CR1, 1 << 8);
     brief_spin();
     uart_puts(b"I2C START\r\n");
     print_reg(b"SR1", I2C1_SR1);
@@ -224,7 +229,7 @@ pub extern "C" fn Reset() -> ! {
     print_reg(b"SR2", I2C1_SR2);
 
     // STOP.
-    unsafe { rmw32(I2C1_CR1, 1 << 9) };
+    rmw32(I2C1_CR1, 1 << 9);
     brief_spin();
     uart_puts(b"I2C STOP\r\n");
     print_reg(b"SR1", I2C1_SR1);

--- a/crates/firmware-f407-demo/src/smoke.rs
+++ b/crates/firmware-f407-demo/src/smoke.rs
@@ -77,6 +77,7 @@ fn rmw32_mask(ptr: *mut u32, clear: u32, set: u32) {
 #[inline(always)]
 fn semihost_writec(byte: u8) {
     let p = core::ptr::addr_of!(byte);
+    #[cfg(target_arch = "arm")]
     unsafe {
         core::arch::asm!(
             "bkpt #0xAB",
@@ -84,6 +85,10 @@ fn semihost_writec(byte: u8) {
             in("r1") p,
             options(preserves_flags, nostack),
         );
+    }
+    #[cfg(not(target_arch = "arm"))]
+    {
+        let _ = (byte, p);
     }
 }
 

--- a/crates/hw-oracle/src/arm_thumb.rs
+++ b/crates/hw-oracle/src/arm_thumb.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::identity_op)] // Thumb encoder keeps `0x0000 |` to make opcode prefix bits explicit
+
 //! ARM Thumb / Cortex-M oracle harness (STM32 family).
 //!
 //! Parallel to `riscv` (ESP32-C3) and the Xtensa harness in `lib.rs`, but

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -99,32 +99,16 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
-        // Arduino Print/Stream/HardwareSerial — sketch doesn't depend on
-        // serial output reaching real bytes; stubbing all of these as
-        // nop_return_zero lets setup() reach drawPage() without spinning
-        // in uartAvailable polling or Print::println string formatting.
-        "_ZN5Print7printlnEv",
-        "_ZN5Print7printlnEPKc",
-        "_ZN5Print7printlnEmi",
-        "_ZN5Print5printEPKc",
-        "_ZN5Print5printEmi",
-        "_ZN5Print11printNumberEmh",
-        "_ZN5Print5writeEPKc",
-        "_ZN5Print5writeEPKhj",
-        "_ZN5Print5writeEh",
-        "_ZN5Print5flushEv",
-        "_ZN5Print17availableForWriteEv",
+        // HardwareSerial-only stubs — leave Print/Stream alone so virtual
+        // dispatch through Print::print → Adafruit_GFX::write → drawPixel
+        // (the display.print path) keeps working. The original spin was
+        // in HardwareSerial::write's buffer-available wait, not in Print.
         "_ZN14HardwareSerial5writeEh",
         "_ZN14HardwareSerial5writeEPKhj",
         "_ZN14HardwareSerial9availableEv",
         "_ZN14HardwareSerial5flushEv",
         "_ZN14HardwareSerial9readBytesEPcj",
         "_ZN14HardwareSerial9readBytesEPhj",
-        "_ZN6Stream9readBytesEPhj",
-        "_ZN6Stream9readBytesEPcj",
-        "_ZN6Stream10readStringEv",
-        "_ZN6Stream9timedReadEv",
-        "_ZN6Stream10getTimeoutEv",
         "uartAvailable",
         "uartAvailableForWrite",
         "uartWrite",

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -74,6 +74,15 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "__retarget_lock_close_recursive",
         "__retarget_lock_acquire_recursive",
         "__retarget_lock_release_recursive",
+        // Newlib-stdio-driven mutex API. Real silicon backs these via
+        // FreeRTOS recursive mutexes whose handles live in (uninitialised
+        // in our sim) static memory; calling the real impl asserts on
+        // pcHead != NULL. Stub to no-op since the sim is effectively
+        // single-threaded on the render path.
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr
@@ -158,6 +167,7 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         //    through to esp_startup_start_app.
         "esp_clk_init",
         "esp_perip_clk_init",
+        "esp_clk_cpu_freq",
         "core_intr_matrix_clear",
         "esp_efuse_check_errors",
         "esp_dport_access_stall_other_cpu_start",
@@ -217,6 +227,9 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // the underlying FILE* refers to our zeroed fake reent struct.
         "esp_log_early_timestamp",
         "esp_log_writev",
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
         "esp_log_write",
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -83,6 +83,22 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "xQueueTakeMutexRecursive",
         "xQueueCreateMutex",
         "xQueueCreateMutexStatic",
+        // xQueueCreateMutex returns NULL (stubbed), so SPIClass and friends
+        // end up storing NULL as their internal mutex. We force these to
+        // return pdTRUE so the call path proceeds; real silicon would only
+        // reach this on a held mutex anyway in the single-task render flow.
+        "xQueueSemaphoreTake",
+        // SPIClass::endTransaction calls xQueueGenericSend (the give side
+        // of xSemaphoreGive) on the same NULL mutex. Force success too.
+        "xQueueGenericSend",
+        // esp_ipc_init creates the per-core IPC task which spin-blocks on
+        // an empty semaphore. With our take-returns-pdTRUE stub above,
+        // that "block" becomes a tight loop — never yielding, never
+        // letting loopTask run. Stub esp_ipc_init out and skip the IPC
+        // task altogether; cross-core IPC isn't needed on the
+        // single-CPU render path.
+        "esp_ipc_init",
+        "esp_ipc_isr_init",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr
@@ -230,6 +246,13 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "esp_log_impl_lock",
         "esp_log_impl_lock_timeout",
         "esp_log_impl_unlock",
+        // Backs `xTaskGetCurrentTaskHandle()` — per-core array of TCB
+        // pointers. Address is firmware-dependent; resolving the symbol
+        // lets the thunk return a real handle so `vTaskDelete(NULL)`
+        // (used by Arduino-ESP32's main_task self-delete) doesn't pass
+        // NULL into prvDeleteTLS.
+        "pxCurrentTCB",
+        "xTaskGetCurrentTaskHandle",
         "esp_log_write",
         "esp_log_buffer_hex_internal",
         "esp_log_buffer_char_internal",

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -99,6 +99,46 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // single-CPU render path.
         "esp_ipc_init",
         "esp_ipc_isr_init",
+        // Arduino Print/Stream/HardwareSerial — sketch doesn't depend on
+        // serial output reaching real bytes; stubbing all of these as
+        // nop_return_zero lets setup() reach drawPage() without spinning
+        // in uartAvailable polling or Print::println string formatting.
+        "_ZN5Print7printlnEv",
+        "_ZN5Print7printlnEPKc",
+        "_ZN5Print7printlnEmi",
+        "_ZN5Print5printEPKc",
+        "_ZN5Print5printEmi",
+        "_ZN5Print11printNumberEmh",
+        "_ZN5Print5writeEPKc",
+        "_ZN5Print5writeEPKhj",
+        "_ZN5Print5writeEh",
+        "_ZN5Print5flushEv",
+        "_ZN5Print17availableForWriteEv",
+        "_ZN14HardwareSerial5writeEh",
+        "_ZN14HardwareSerial5writeEPKhj",
+        "_ZN14HardwareSerial9availableEv",
+        "_ZN14HardwareSerial5flushEv",
+        "_ZN14HardwareSerial9readBytesEPcj",
+        "_ZN14HardwareSerial9readBytesEPhj",
+        "_ZN6Stream9readBytesEPhj",
+        "_ZN6Stream9readBytesEPcj",
+        "_ZN6Stream10readStringEv",
+        "_ZN6Stream9timedReadEv",
+        "_ZN6Stream10getTimeoutEv",
+        "uartAvailable",
+        "uartAvailableForWrite",
+        "uartWrite",
+        "uartWriteBuf",
+        "_Z14serialEventRunv",
+        // SPI bus init — real impl needs DPORT clock-enable we don't
+        // model, so it returns NULL → SPIClass._spi = NULL → all
+        // downstream spiTransferByte calls bail without touching the SPI
+        // peripheral. Custom thunk returns a fake spi_t with dev = SPI3.
+        "spiStartBus",
+        // The Arduino SPI global. We resolve it for diagnostics; lazy
+        // init happens via the SPIClass::beginTransaction thunk.
+        "SPI",
+        "_ZN8SPIClass16beginTransactionE11SPISettings",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -23,6 +23,10 @@ High-fidelity machine models showcasing peripheral accuracy and hardware parity.
 | **NUCLEO-H563ZI** | Our flagship demo: Absolute parity between simulation and the real physical board. | [`examples/nucleo-h563zi/`](../examples/nucleo-h563zi/README.md) |
 | **Demo Blinky** | The classic "Hello World" of embedded systems, running on a modeled Cortex-M3. | [`examples/demo-blinky/`](../examples/demo-blinky/) |
 | **RISC-V Virt** | Showcasing multi-architecture support via the `riscv-virt` machine. | [`examples/riscv-virt/`](../examples/riscv-virt/) |
+| **ESP32 E-Paper (Rust)** | ESP32-WROOM + SSD1680 tri-color e-paper, pure-Rust `esp-hal`. Sim partial, real hardware ✅. | [`examples/esp32-epaper-lab/`](../examples/esp32-epaper-lab/README.md) |
+| **ESP32 E-Reader (Arduino)** | Same panel via Arduino-ESP32 + GxEPD2; sim paints end-to-end through FreeRTOS + ROM-thunk pipeline in v0.15.0. | [`examples/labwired-ereader-arduino/`](../examples/labwired-ereader-arduino/README.md) |
+| **ESP32-S3 Blinky / Hello / I2C** | Minimal ESP32-S3 sketches for boot, USB-serial output, and TMP102 over I2C. | [`examples/esp32s3-blinky/`](../examples/esp32s3-blinky/), [`hello-world/`](../examples/esp32s3-hello-world/), [`i2c-tmp102/`](../examples/esp32s3-i2c-tmp102/) |
+| **STM32 Tri-color E-Paper** | STM32F103 variant of the SSD1680 e-paper demo, byte-for-byte compatible. | [`examples/epaper-tricolor-lab/`](../examples/epaper-tricolor-lab/) |
 
 ---
 

--- a/examples/adxl345-sensor-lab/src/main.rs
+++ b/examples/adxl345-sensor-lab/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::identity_op, clippy::needless_range_loop)]
 
 use cortex_m_rt::entry;
 use panic_halt as _;

--- a/examples/bme280-weather-lab/src/main.rs
+++ b/examples/bme280-weather-lab/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::identity_op)]
 
 use cortex_m_rt::entry;
 use panic_halt as _;

--- a/examples/esp32-epaper-lab/README.md
+++ b/examples/esp32-epaper-lab/README.md
@@ -1,0 +1,81 @@
+# ESP32 E-Paper Lab
+
+ESP32-WROOM-32 driving a Waveshare 2.9" tri-color e-paper (SSD1680 / GDEM029C90)
+over VSPI. Rust + `esp-hal`; same ELF runs on real silicon (via `espflash`) and
+inside the LabWired simulator.
+
+## What it does
+Draws three full-width horizontal bands — WHITE / BLACK / RED — and triggers
+one full panel refresh. The byte sequence on the wire mirrors what the
+AgentDeck firmware (`GxEPD2_290_C90c`) and the LabWired STM32 e-paper lab emit,
+so the simulator's SSD1680 model decodes all three paths identically.
+
+## Pin mapping (Waveshare default, AgentDeck-compatible)
+
+| Signal | ESP32 GPIO | Notes                       |
+|--------|------------|-----------------------------|
+| CS     | GPIO5      | GPIO output push-pull       |
+| SCK    | GPIO18     | VSPI signal, IO_MUX func 1  |
+| MOSI   | GPIO23     | VSPI signal, IO_MUX func 1  |
+| DC     | GPIO17     | GPIO output push-pull       |
+| RST    | GPIO16     | GPIO output push-pull       |
+| BUSY   | GPIO4      | GPIO input                  |
+
+## Toolchain
+This crate targets `xtensa-esp32-none-elf` and **must build out of the main
+workspace** (excluded in the root `Cargo.toml`). It requires the `esp` Rust
+toolchain:
+
+```bash
+# one-time toolchain install
+cargo install espup
+espup install
+. "$HOME/export-esp.sh"   # or whatever espup printed
+```
+
+## Build
+
+```bash
+cd examples/esp32-epaper-lab
+cargo build --release
+```
+
+The ELF lands at `target/xtensa-esp32-none-elf/release/esp32-epaper-lab`.
+
+## Run in the simulator
+
+```bash
+labwired run \
+  --system examples/esp32-epaper-lab/system.yaml \
+  --firmware examples/esp32-epaper-lab/target/xtensa-esp32-none-elf/release/esp32-epaper-lab
+```
+
+The simulator wires the SSD1680 to the modeled VSPI controller per
+`system.yaml`. Captured SPI byte stream is byte-for-byte compatible with the
+AgentDeck path and the STM32 epaper-tricolor-lab.
+
+## Flash to real hardware
+
+```bash
+espflash flash \
+  --port /dev/ttyUSB0 --baud 460800 --monitor \
+  target/xtensa-esp32-none-elf/release/esp32-epaper-lab
+```
+
+## Status (v0.15.0)
+- Firmware builds cleanly for `xtensa-esp32-none-elf`.
+- Real ESP32-WROOM-32 hardware: ✅ paints the three bands and refreshes the
+  panel.
+- LabWired sim: partial — esp-hal's `Reset → __pre_init → esp32_init` chain
+  touches DPORT / IO_MUX / RTC banks that the v0.15.0 sim doesn't yet model
+  with enough fidelity to dispatch into `main`. The Arduino-ESP32 path (see
+  `examples/labwired-ereader-arduino/`) gets all the way to a painted SSD1680
+  via the ROM-thunk pipeline shipped in v0.15.0 — this lab is the equivalent
+  pure-Rust path, blocked on `__pre_init` coverage. Tracked as a follow-up.
+
+## See also
+- [`examples/labwired-ereader-arduino/`](../labwired-ereader-arduino/) —
+  same panel, Arduino-ESP32, sim-paints in v0.15.0 via the runtime-snapshot
+  blob and ROM thunks.
+- [`examples/epaper-tricolor-lab/`](../epaper-tricolor-lab/) — STM32F103
+  variant, byte-for-byte compatible SSD1680 driver.

--- a/examples/ili9341-tft-lab/src/main.rs
+++ b/examples/ili9341-tft-lab/src/main.rs
@@ -5,8 +5,8 @@
 //!   2. ILI9341 init sequence (SLPOUT → COLMOD → DISPON)
 //!   3. CASET / PASET window set + RAMWR pixel write
 //!   4. Two 240×16 horizontal colour bands visible in the canvas widget:
-//!        Row 0..15  — eight equal-width vertical colour bars (EBU test pattern)
-//!        Row 16..31 — solid bright red (0xF800)
+//!      - Row 0..15  — eight equal-width vertical colour bars (EBU test pattern)
+//!      - Row 16..31 — solid bright red (0xF800)
 //!   5. Continuous loop printing "frame done" to UART
 //!
 //! Pin mapping (SPI1 on STM32F103):
@@ -180,9 +180,9 @@ fn draw_colour_bars(row_start: u16) {
     cs_low();
     spi_write(0x2C); // RAMWR
     for _row in 0..ROWS {
-        for bar_idx in 0..8usize {
+        for &color in &colours {
             for _px in 0..BAR_W {
-                tft_pixel(colours[bar_idx]);
+                tft_pixel(color);
             }
         }
     }

--- a/examples/labwired-ereader-arduino/README.md
+++ b/examples/labwired-ereader-arduino/README.md
@@ -40,7 +40,14 @@ wrong init left the panel in a no-op state) — panel goes blank.
 
 ## Sim status (as of 2026-05-23)
 Real hardware: ✅ verified painting.
-LabWired sim: ❌ stuck in newlib `__sflags` at 200M cycles, never
-reaches `setup()`. Tracked as #115 — needs more thunk coverage for
-the libc stdio init path the reader sketch triggers but AgentDeck did
-not.
+LabWired sim (v0.15.0): ✅ reaches `setup()` → `drawPage()` → SSD1680
+panel paint. Latest run: 19,039 SPI3 transactions across 3 full
+refresh cycles; black plane contains 1,429 / 4,736 non-FF bytes (the
+text glyph pixels are visible in the panel snapshot). The newlib
+stdio init path that previously hung at 200M cycles is now covered by
+the v0.15.0 ROM thunk + INTSET / CCOMPARE0 fixes.
+
+Loaded directly the sim still needs a 12 MB ELF outside this repo;
+the `agentdeck` snapshot-capture profile in
+`labwired snapshot capture --profile agentdeck` ships a
+post-paint state blob that the playground replays in ~0.5 s.

--- a/examples/mpu6050-sensor-lab/src/main.rs
+++ b/examples/mpu6050-sensor-lab/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::identity_op)]
 
 use cortex_m_rt::entry;
 use panic_halt as _;

--- a/examples/neo6m-gps-lab/src/main.rs
+++ b/examples/neo6m-gps-lab/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::identity_op)]
 
 use cortex_m_rt::entry;
 use panic_halt as _;
@@ -81,15 +82,12 @@ fn main() -> ! {
     uart2_str("Reading NMEA stream from UART1...\r\n");
 
     let mut sentence_buf = [0u8; 128];
-    let mut count = 0u32;
 
     loop {
         let len = read_nmea_sentence(&mut sentence_buf);
         if len == 0 {
             continue;
         }
-
-        count += 1;
 
         // Echo the raw NMEA sentence to UART2 with a prefix
         uart2_str("[GPS] ");

--- a/examples/ntc-thermistor-lab/src/main.rs
+++ b/examples/ntc-thermistor-lab/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::identity_op)]
 
 use cortex_m_rt::entry;
 use panic_halt as _;

--- a/examples/ssd1306-hello-lab/src/main.rs
+++ b/examples/ssd1306-hello-lab/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![allow(clippy::identity_op)]
 
 use cortex_m_rt::entry;
 use panic_halt as _;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LabWired Core
 site_url: https://labwired.com/docs/
-repo_url: https://github.com/w1ne/libwired-core
+repo_url: https://github.com/w1ne/labwired-core
 repo_name: w1ne/labwired-core
 
 theme:
@@ -57,7 +57,7 @@ nav:
   - Home: index.md
   - Architecture Overview: architecture.md
   - Hardware-Sim Parity: golden_reference.md
-  - Hardware Matrix: SUPPORTED_DEVICES.md
+  - Hardware Matrix: supported_devices.md
   - AI Agent Manual: agents.md
 
   - Tutorials:
@@ -80,14 +80,12 @@ nav:
     
   - Operations:
     - Release Strategy: release_strategy.md
-    - Verification Audit: verification_audit.md
-    - Supported Devices: supported_devices.md
+    - Verification Audit: labwired_audit_protocol.md
     - Safety & Guardrails: safety.md
     - Demos: demos.md
     - Advanced Peripherals: advanced_peripherals.md
     - Case Study (STM32): case_study_stm32.md
     - Debugging: debugging.md
-    - Git Flow: development/git_flow.md
     
   - Explanation:
     - Architecture Overview: architecture.md


### PR DESCRIPTION
## Summary

Audit-driven release-prep PR. Bundles the FreeRTOS / Arduino-ESP32 / SPI work from #94 + #95 with the cleanup that came out of the parallel-subagent release audit, then bumps the workspace version to **0.15.0** and seeds the CHANGELOG.

Supersedes #94 and #95 — both can be closed in favor of this PR.

## Commits

| commit | scope |
|---|---|
| `fc8feed` | sim: portYIELD + timer tick + abort-halt — break IPC-task spin (from #94) |
| `412cbcd` | sim: get past FreeRTOS startup into Arduino user code (from #95) |
| `1e73174` | sim: reader sketch reaches drawPage and drives the panel (from #95) |
| `c4b7fb8` | sim: render visible text in reader sketch — black-plane 0 → 1429 non-FF bytes (from #95) |
| `4ef6fdc` | hygiene: green up fmt + clippy + test gates for the workspace |
| `80fe787` | sim: tighten ESP32-S3 thunks — named consts, warn-on-stub, regression bounds |
| `20d54cc` | docs: clear pre-release drift across mkdocs, security, readme, examples |
| `a0a130f` | chore: bump workspace version to 0.15.0 |

## Audit outcomes

Pre-audit state:
- \`cargo fmt --all -- --check\` ❌ drift in cli/core/tests
- \`cargo clippy --workspace --all-targets -- -D warnings\` ❌ 15+ lints across example/firmware crates + 2 host-clippy hard errors in firmware-f407-demo inline ARM asm
- \`mkdocs.yml\` typo \`libwired-core\` + 3 broken nav refs
- \`SECURITY.md\` still pinned to \`0.11.x\`, advisory URL pointing at wrong repo
- AgentDeck regression test \`#[ignore]\`d with no byte-count assertions
- \`return_pd_true\` thunk silently activated (mutex stub returning success on every take)
- \`fake_spi_t\` blob squatting inside the firmware DRAM allocator's range (\`0x3FFD_F000\`)
- \`examples/labwired-ereader-arduino/README.md\` claimed the sim was "stuck in newlib \`__sflags\`, never reaches \`setup()\`" — superseded by the FreeRTOS work
- \`examples/esp32-epaper-lab/\` had no README

Post-audit state:
- ✅ fmt + clippy clean across workspace (\`cargo clippy --workspace --all-targets -- -D warnings\`)
- ✅ 347 / 0 / 0 in \`labwired-core\` lib tests, \`cargo build --release --bin labwired\` clean in 39s
- ✅ docs nav + SECURITY + README all on \`0.15.0\`
- ✅ Regression bounds in \`e2e_agentdeck_in_sim.rs\` (\`19031 ± 50\` spi3 txns, \`782 ± 10\` non-FF bytes) — fire on \`cargo test -- --ignored\`
- ✅ \`return_pd_true\` warns once on first activation
- ✅ \`fake_spi_t\` moved to SRAM1 top end (\`0x3FFF_FF00\`), out of allocator reach
- ✅ Updated ereader-arduino README + new esp32-epaper-lab README

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (default flags, no \`--bins\`)
- [x] \`cargo build --release --bin labwired\`
- [ ] Tag \`v0.15.0\` after merge
- [ ] Publish GitHub Release using \`CHANGELOG.md\` \`[0.15.0]\` section as body