### PR TITLE
sim: bit-identical labwired-ereader.ino paints in LabWired sim

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -848,7 +848,7 @@ fn run_snapshot(args: SnapshotArgs) -> ExitCode {
 /// resume bit-identically inside the browser.
 fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     use labwired_core::bus::SystemBus;
-    use labwired_core::peripherals::components::Ssd1680Tricolor290;
+    use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor290};
     use labwired_core::peripherals::esp32::spi::Esp32Spi;
     use labwired_core::peripherals::esp32s3::rom_thunks;
     use labwired_core::system::xtensa::configure_xtensa_esp32;
@@ -886,7 +886,16 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     };
     if let Some(any) = bus.peripherals[spi3_idx].dev.as_any_mut() {
         if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
-            spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+            if args.profile == "arduino-esp32" {
+                // GxEPD2_290_C90c / Z13c firmware drives the panel with
+                // UC8151D commands (PSR/PWR/PON/DTM1/DTM2/DRF/…) which
+                // conflict with SSD1680 at multiple opcodes; we need the
+                // UC8151D panel model. AgentDeck firmware uses SSD1680
+                // and stays on the old model below.
+                spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
+            } else {
+                spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+            }
             spi3.enable_byte_capture(512);
         }
     }
@@ -1311,10 +1320,16 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // displaced slots while the AR file has the callee's data, so the
     // HAL walk reads garbage (callee's a1 is often 0 → store to
     // 0xfffffff0 traps). The custom thunk emulates the spill using
-    // shadow-stack snapshots when available.
-    for sym in &["xthal_window_spill_nw", "xthal_window_spill"] {
-        if let Some(&pc) = symbol_addrs.get(*sym) {
-            thunks.push((pc, rom_thunks::xthal_window_spill_thunk));
+    // shadow-stack snapshots when available. Only wired for
+    // arduino-esp32 profile — agentdeck's call path doesn't hit the
+    // crash, and replacing the real function with the thunk regresses
+    // a working flow (spill writes valid save-area data the callee
+    // later reads).
+    if args.profile == "arduino-esp32" {
+        for sym in &["xthal_window_spill_nw", "xthal_window_spill"] {
+            if let Some(&pc) = symbol_addrs.get(*sym) {
+                thunks.push((pc, rom_thunks::xthal_window_spill_thunk));
+            }
         }
     }
     // xQueueCreateMutexStatic returns the caller's static buffer as the
@@ -1343,8 +1358,15 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
         thunks.push((pc, rom_thunks::return_pd_true));
     }
-    if let Some(&pc) = symbol_addrs.get("ulTaskGenericNotifyTake") {
-        thunks.push((pc, rom_thunks::return_pd_true));
+    // ulTaskGenericNotifyTake — gated to arduino-esp32 only.
+    // AgentDeck has its own well-modeled lock-acquire path that
+    // expects a proper "block-then-wake" semantic; stubbing it to
+    // return pdTRUE causes the lock-acquire to skip its setup and
+    // later trip __assert_func inside lock_acquire_generic.
+    if args.profile == "arduino-esp32" {
+        if let Some(&pc) = symbol_addrs.get("ulTaskGenericNotifyTake") {
+            thunks.push((pc, rom_thunks::return_pd_true));
+        }
     }
     if let Some(&pc) = symbol_addrs.get("spiStartBus") {
         thunks.push((pc, rom_thunks::spi_start_bus_fake));
@@ -1360,6 +1382,23 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // at the correct SPI peripheral base, then returns pdTRUE.
     if let Some(&pc) = symbol_addrs.get("_ZN8SPIClass16beginTransactionE11SPISettings") {
         thunks.push((pc, rom_thunks::spi_class_begin_transaction));
+    }
+    // GxEPD2_EPD::_writeCommand / _writeData — route directly into the
+    // attached UC8151D panel's `command_byte` / `data_byte` API,
+    // bypassing the Arduino-ESP32 SPI library and the SPI peripheral
+    // entirely. Same byte stream the real silicon receives, with
+    // explicit DC=cmd / DC=data routing (which we can't infer from
+    // pure FIFO bytes without observing the DC GPIO). Only wired for
+    // the arduino-esp32 profile — agentdeck profile attaches an
+    // SSD1680 panel that uses byte-counting through `transfer()` and
+    // doesn't need the explicit CMD/DATA split.
+    if args.profile == "arduino-esp32" {
+        if let Some(&pc) = symbol_addrs.get("_ZN10GxEPD2_EPD13_writeCommandEh") {
+            thunks.push((pc, rom_thunks::gxepd_write_command));
+        }
+        if let Some(&pc) = symbol_addrs.get("_ZN10GxEPD2_EPD10_writeDataEh") {
+            thunks.push((pc, rom_thunks::gxepd_write_data));
+        }
     }
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in
@@ -1663,12 +1702,56 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                             let bp = panel.black_plane();
                             let non_ff = bp.iter().filter(|&&b| b != 0xFF).count();
                             eprintln!(
-                                "labwired-cli snapshot: panel state — refresh_generation={}, power_on={}, black-plane non-FF bytes={}/{}",
+                                "labwired-cli snapshot: panel (ssd1680) state — refresh_generation={}, power_on={}, black-plane non-FF bytes={}/{}",
                                 panel.refresh_generation(),
                                 panel.power_on(),
                                 non_ff,
                                 bp.len(),
                             );
+                        } else if let Some(panel) = panel_any.downcast_ref::<Uc8151dTricolor290>() {
+                            let bp = panel.black_plane();
+                            let non_ff = bp.iter().filter(|&&b| b != 0xFF).count();
+                            let rp = panel.red_plane();
+                            let non_ff_red = rp.iter().filter(|&&b| b != 0xFF).count();
+                            eprintln!(
+                                "labwired-cli snapshot: panel (uc8151d) state — refresh_generation={}, power_on={}, black-plane non-FF bytes={}/{}, red-plane non-FF bytes={}/{}",
+                                panel.refresh_generation(),
+                                panel.power_on(),
+                                non_ff,
+                                bp.len(),
+                                non_ff_red,
+                                rp.len(),
+                            );
+                            // Render the panel as a PPM next to the
+                            // snapshot output so an operator can visually
+                            // confirm "yes, this looks like the real-HW
+                            // panel image" before shipping the snapshot.
+                            let (w, h) = panel.dimensions();
+                            let stride = w / 8;
+                            let mut ppm = format!("P6\n{w} {h}\n255\n").into_bytes();
+                            for y in 0..h {
+                                for x in 0..w {
+                                    let idx = y * stride + x / 8;
+                                    let bit = 7 - (x % 8);
+                                    let black_bit = (bp[idx] >> bit) & 1;
+                                    let red_bit = (rp[idx] >> bit) & 1;
+                                    let (r, g, b) = if red_bit == 0 {
+                                        (220u8, 30u8, 40u8)
+                                    } else if black_bit == 0 {
+                                        (0u8, 0u8, 0u8)
+                                    } else {
+                                        (245u8, 245u8, 240u8)
+                                    };
+                                    ppm.extend_from_slice(&[r, g, b]);
+                                }
+                            }
+                            let ppm_path = args.output.with_extension("ppm");
+                            if std::fs::write(&ppm_path, &ppm).is_ok() {
+                                eprintln!(
+                                    "labwired-cli snapshot: panel PPM written to {}",
+                                    ppm_path.display()
+                                );
+                            }
                         }
                     }
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1304,6 +1304,18 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(&pc) = symbol_addrs.get("esp_clk_cpu_freq") {
         thunks.push((pc, rom_thunks::esp_clk_cpu_freq_240mhz));
     }
+    // Xtensa HAL register-window-file spill. The HAL impl walks WS bits
+    // and spills each live slot's a0..a3 to its stack save area — but
+    // our sim's transparent shadow-spill on CALL{n} leaves WS=1 on
+    // displaced slots while the AR file has the callee's data, so the
+    // HAL walk reads garbage (callee's a1 is often 0 → store to
+    // 0xfffffff0 traps). The custom thunk emulates the spill using
+    // shadow-stack snapshots when available.
+    for sym in &["xthal_window_spill_nw", "xthal_window_spill"] {
+        if let Some(&pc) = symbol_addrs.get(*sym) {
+            thunks.push((pc, rom_thunks::xthal_window_spill_thunk));
+        }
+    }
     // xQueueCreateMutexStatic returns the caller's static buffer as the
     // handle. Callers (esp_newlib_locks_init in particular) assert that the
     // returned handle equals the buffer they passed in — a nop_return_zero
@@ -1328,6 +1340,9 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         thunks.push((pc, rom_thunks::return_pd_true));
     }
     if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
+        thunks.push((pc, rom_thunks::return_pd_true));
+    }
+    if let Some(&pc) = symbol_addrs.get("ulTaskGenericNotifyTake") {
         thunks.push((pc, rom_thunks::return_pd_true));
     }
     if let Some(&pc) = symbol_addrs.get("spiStartBus") {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -887,6 +887,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(any) = bus.peripherals[spi3_idx].dev.as_any_mut() {
         if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
             spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+            spi3.enable_byte_capture(512);
         }
     }
     bus.refresh_peripheral_index();
@@ -1637,6 +1638,25 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                     "labwired-cli snapshot: spi3 transactions={}",
                     spi3.transactions(),
                 );
+                let cap = spi3.captured_bytes();
+                if !cap.is_empty() {
+                    let head_n = cap.len().min(120);
+                    let head_hex: Vec<String> =
+                        cap[..head_n].iter().map(|b| format!("{b:02x}")).collect();
+                    eprintln!(
+                        "labwired-cli snapshot: first {head_n} spi3 bytes: {}",
+                        head_hex.join(" ")
+                    );
+                    if cap.len() > 240 {
+                        let tail = &cap[cap.len() - 120..];
+                        let tail_hex: Vec<String> =
+                            tail.iter().map(|b| format!("{b:02x}")).collect();
+                        eprintln!(
+                            "labwired-cli snapshot: last 120 spi3 bytes: {}",
+                            tail_hex.join(" ")
+                        );
+                    }
+                }
                 for attached in &spi3.attached_devices {
                     if let Some(panel_any) = attached.as_any() {
                         if let Some(panel) = panel_any.downcast_ref::<Ssd1680Tricolor290>() {

--- a/crates/core/src/peripherals/components/mod.rs
+++ b/crates/core/src/peripherals/components/mod.rs
@@ -17,6 +17,7 @@ pub mod ntc_thermistor;
 pub mod shm_i2c;
 pub mod ssd1306;
 pub mod ssd1680_tricolor_290;
+pub mod uc8151d_tricolor_290;
 
 pub use adxl345::Adxl345;
 pub use aht20::Aht20;
@@ -31,3 +32,4 @@ pub use ntc_thermistor::NtcThermistor;
 pub use shm_i2c::ShmI2c;
 pub use ssd1306::Ssd1306;
 pub use ssd1680_tricolor_290::Ssd1680Tricolor290;
+pub use uc8151d_tricolor_290::Uc8151dTricolor290;

--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -1,0 +1,414 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! UC8151D tri-color 2.9" e-paper panel model.
+//!
+//! Waveshare GDEW029Z13c / GDEW029Z13 / GDEM029C90 variants ship with a
+//! UC8151D-family controller (not SSD1680) — same physical 128×296
+//! tri-color glass, completely different SPI command set. The
+//! `GxEPD2_290_Z13c` / `GxEPD2_290_C90c` Arduino driver emits
+//! UC8151D-style bytes: PSR (0x00), PWR (0x01), PON (0x04), DTM1 (0x10
+//! write-RAM-black), DTM2 (0x13 write-RAM-red), DRF (0x12 refresh),
+//! TRES (0x61 resolution), CDI (0x50 VCOM/data interval), etc.
+//!
+//! These conflict with SSD1680 at multiple opcodes (0x10, 0x20, 0x22)
+//! so the two protocols can't share a single panel model. Use this one
+//! when the firmware is GxEPD2_290_Z13c / C90c (labwired-ereader); use
+//! [`super::ssd1680_tricolor_290::Ssd1680Tricolor290`] for SSD1680-class
+//! firmware (AgentDeck).
+//!
+//! ## Cmd / Data routing
+//!
+//! Real silicon multiplexes cmd vs data via a sideband D/C GPIO pin.
+//! The simulator's normal byte-stream `transfer()` path doesn't see DC
+//! transitions — for the SSD1680 model we use byte-counting on the
+//! command's fixed param count. UC8151D's DTM1/DTM2 streams are
+//! unbounded (they end when the next CMD arrives), so byte-counting
+//! doesn't work. Instead this model exposes `command_byte(u8)` and
+//! `data_byte(u8)` as separate APIs; the
+//! [`crate::peripherals::esp32s3::rom_thunks::spi_class_transfer`]
+//! thunk distinguishes cmd vs data by the caller PC
+//! (`_writeCommand` vs `_writeData`) and routes accordingly.
+//!
+//! The `transfer()` impl falls back to "all bytes are data" so this
+//! model still slots into the generic SPI bus without breaking, just
+//! without UC8151D protocol decoding.
+
+use crate::peripherals::spi::SpiDevice;
+use std::any::Any;
+
+const WIDTH: usize = 128;
+const HEIGHT: usize = 296;
+const WIDTH_BYTES: usize = WIDTH / 8;
+const PLANE_BYTES: usize = WIDTH_BYTES * HEIGHT;
+
+/// Param-collection state for fixed-length commands. UC8151D's RAM-stream
+/// commands (DTM1, DTM2) use a separate `Streaming*` state because their
+/// length is determined by the next command boundary, not a fixed count.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+enum ProtoState {
+    Idle,
+    AwaitingParams { cmd: u8, have: u8, want: u8 },
+    StreamingBlack,
+    StreamingRed,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct Uc8151dTricolor290 {
+    cs_pin: String,
+
+    hibernating: bool,
+    power_on: bool,
+    /// Set by DRF (0x12). UI uses [`Self::refresh_generation`] to
+    /// invalidate its rendered cache after a refresh.
+    refresh_pending: bool,
+
+    /// Plane cursors. DTM1 and DTM2 fill row-major MSB-first, wrapping
+    /// at HEIGHT (matches real-silicon counters from cold reset).
+    cur_black_byte: usize,
+    cur_red_byte: usize,
+
+    /// Black plane: 1 = white (no ink), 0 = black. 4736 bytes.
+    #[serde(skip_serializing)]
+    black_plane: Vec<u8>,
+    /// Red plane: 1 = no-red, 0 = red. UC8151D firmware (GxEPD2) sends
+    /// the red plane already inverted vs. source bitmap.
+    #[serde(skip_serializing)]
+    red_plane: Vec<u8>,
+
+    refresh_generation: u32,
+
+    #[serde(skip_serializing)]
+    state: ProtoState,
+}
+
+impl Default for Uc8151dTricolor290 {
+    fn default() -> Self {
+        Self::new("GPIO5")
+    }
+}
+
+impl Uc8151dTricolor290 {
+    pub fn new(cs_pin: impl Into<String>) -> Self {
+        Self {
+            cs_pin: cs_pin.into(),
+            hibernating: false,
+            power_on: false,
+            refresh_pending: false,
+            cur_black_byte: 0,
+            cur_red_byte: 0,
+            // Fresh panel: all white.
+            black_plane: vec![0xFF; PLANE_BYTES],
+            red_plane: vec![0xFF; PLANE_BYTES],
+            refresh_generation: 0,
+            state: ProtoState::Idle,
+        }
+    }
+
+    pub fn dimensions(&self) -> (usize, usize) {
+        (WIDTH, HEIGHT)
+    }
+
+    pub fn black_plane(&self) -> &[u8] {
+        &self.black_plane
+    }
+
+    pub fn red_plane(&self) -> &[u8] {
+        &self.red_plane
+    }
+
+    pub fn refresh_generation(&self) -> u32 {
+        self.refresh_generation
+    }
+
+    pub fn power_on(&self) -> bool {
+        self.power_on
+    }
+
+    /// Process one command byte (DC=low on real hardware). Resets plane
+    /// streams, kicks the appropriate state transition or one-shot side
+    /// effect (PON → power on, DRF → refresh increment).
+    pub fn command_byte(&mut self, cmd: u8) {
+        match cmd {
+            0x00 => self.await_params(cmd, 1), // PSR — panel setting
+            0x01 => self.await_params(cmd, 5), // PWR — power setting
+            0x02 => {
+                // POF — power off
+                self.power_on = false;
+                self.state = ProtoState::Idle;
+            }
+            0x03 => self.await_params(cmd, 1), // PFS — power off seq
+            0x04 => {
+                // PON — power on
+                self.power_on = true;
+                self.state = ProtoState::Idle;
+            }
+            0x05 => self.state = ProtoState::Idle, // PMES — power-on measure (no data)
+            0x06 => self.await_params(cmd, 3),     // BTST — booster soft start
+            0x07 => self.await_params(cmd, 1),     // DSLP — deep sleep
+            0x10 => {
+                // DTM1 — display start transmission 1 (black plane)
+                self.cur_black_byte = 0;
+                self.state = ProtoState::StreamingBlack;
+            }
+            0x11 => self.state = ProtoState::Idle, // DSP — data stop
+            0x12 => {
+                // DRF — display refresh
+                self.refresh_pending = true;
+                self.refresh_generation = self.refresh_generation.wrapping_add(1);
+                self.state = ProtoState::Idle;
+            }
+            0x13 => {
+                // DTM2 — display start transmission 2 (red plane)
+                self.cur_red_byte = 0;
+                self.state = ProtoState::StreamingRed;
+            }
+            0x16 | 0x17 => self.await_params(cmd, 1), // AUTO
+            0x20 => self.await_params(cmd, 44),       // LUT_VCOM
+            0x21 | 0x22 | 0x23 | 0x24 => self.await_params(cmd, 42), // LUT_WW/BW/WB/BB
+            0x30 => self.await_params(cmd, 1),        // PLL
+            0x40 => self.state = ProtoState::Idle, // TSC — temperature sensor calibration (0 data)
+            0x41 => self.await_params(cmd, 1),     // TSE — temperature sensor enable
+            0x50 => self.await_params(cmd, 1),     // CDI — vcom and data interval
+            0x51 => self.await_params(cmd, 1),     // LPD — low-power detect
+            0x60 => self.await_params(cmd, 1),     // TCON — gate/source non-overlap
+            0x61 => self.await_params(cmd, 3),     // TRES — resolution (HRES, VRES_MSB, VRES_LSB)
+            0x65 => self.await_params(cmd, 4),     // GSST — gate/source start setting
+            0x70 | 0x71 => self.state = ProtoState::Idle, // REV / FLG read (0 data on the in path)
+            0x80 | 0x81 | 0x82 => self.await_params(cmd, 1), // AMV / VV / VDCS
+            0x90 => self.await_params(cmd, 7),     // PartialWindow
+            0x91 | 0x92 => self.state = ProtoState::Idle, // PartialIn / PartialOut
+            _ => {
+                // Unknown command — return to Idle. Don't mis-consume the
+                // next byte by leaving us in a streaming state.
+                self.state = ProtoState::Idle;
+            }
+        }
+    }
+
+    /// Process one data byte (DC=high on real hardware). Routes to the
+    /// active stream (DTM1 / DTM2) or consumes as a fixed-count param.
+    pub fn data_byte(&mut self, byte: u8) {
+        match self.state {
+            ProtoState::StreamingBlack => {
+                if self.cur_black_byte < PLANE_BYTES {
+                    self.black_plane[self.cur_black_byte] = byte;
+                    self.cur_black_byte += 1;
+                }
+            }
+            ProtoState::StreamingRed => {
+                if self.cur_red_byte < PLANE_BYTES {
+                    self.red_plane[self.cur_red_byte] = byte;
+                    self.cur_red_byte += 1;
+                }
+            }
+            ProtoState::AwaitingParams { cmd, have, want } => {
+                let new_have = have + 1;
+                if new_have >= want {
+                    self.handle_params_complete(cmd);
+                    self.state = ProtoState::Idle;
+                } else {
+                    self.state = ProtoState::AwaitingParams {
+                        cmd,
+                        have: new_have,
+                        want,
+                    };
+                }
+                // Note: we don't currently *store* param bytes — the
+                // commands we care about (PON / DRF / DTM1 / DTM2) are
+                // edge-triggered, not param-driven. If a future command
+                // requires its params (e.g. PartialWindow x/y to clip
+                // RAM writes), grow `ProtoState::AwaitingParams` to
+                // hold a small buffer like the SSD1680 model.
+                let _ = byte;
+            }
+            ProtoState::Idle => {
+                // Data byte arrived without a preceding command. On real
+                // silicon this just gets clocked into the controller's
+                // input register and ignored; mirror that.
+            }
+        }
+    }
+
+    fn await_params(&mut self, cmd: u8, want: u8) {
+        if want == 0 {
+            self.state = ProtoState::Idle;
+        } else {
+            self.state = ProtoState::AwaitingParams { cmd, have: 0, want };
+        }
+    }
+
+    fn handle_params_complete(&mut self, _cmd: u8) {
+        // Currently no param-driven side effects beyond the edge actions
+        // already handled in `command_byte`. Reserved for future
+        // PartialWindow / TRES clipping etc.
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Uc8151dSnap {
+    cs_pin: String,
+    hibernating: bool,
+    power_on: bool,
+    refresh_pending: bool,
+    cur_black_byte: usize,
+    cur_red_byte: usize,
+    black_plane: Vec<u8>,
+    red_plane: Vec<u8>,
+    refresh_generation: u32,
+    state: ProtoState,
+}
+
+impl SpiDevice for Uc8151dTricolor290 {
+    fn cs_pin(&self) -> &str {
+        &self.cs_pin
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        let snap = Uc8151dSnap {
+            cs_pin: self.cs_pin.clone(),
+            hibernating: self.hibernating,
+            power_on: self.power_on,
+            refresh_pending: self.refresh_pending,
+            cur_black_byte: self.cur_black_byte,
+            cur_red_byte: self.cur_red_byte,
+            black_plane: self.black_plane.clone(),
+            red_plane: self.red_plane.clone(),
+            refresh_generation: self.refresh_generation,
+            state: self.state,
+        };
+        bincode::serialize(&snap).expect("bincode serialize Uc8151dSnap")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> crate::SimResult<()> {
+        let snap: Uc8151dSnap = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("Uc8151d snapshot decode: {e}"))
+        })?;
+        self.cs_pin = snap.cs_pin;
+        self.hibernating = snap.hibernating;
+        self.power_on = snap.power_on;
+        self.refresh_pending = snap.refresh_pending;
+        self.cur_black_byte = snap.cur_black_byte;
+        self.cur_red_byte = snap.cur_red_byte;
+        if snap.black_plane.len() != self.black_plane.len()
+            || snap.red_plane.len() != self.red_plane.len()
+        {
+            return Err(crate::SimulationError::NotImplemented(format!(
+                "Uc8151d snapshot plane size mismatch: black {} vs {}, red {} vs {}",
+                snap.black_plane.len(),
+                self.black_plane.len(),
+                snap.red_plane.len(),
+                self.red_plane.len()
+            )));
+        }
+        self.black_plane = snap.black_plane;
+        self.red_plane = snap.red_plane;
+        self.refresh_generation = snap.refresh_generation;
+        self.state = snap.state;
+        Ok(())
+    }
+
+    fn cs_select(&mut self) {
+        // Each CS-low burst resets the protocol parser. Real silicon's
+        // UC8151D doesn't strictly require this, but it's a useful guard
+        // against malformed firmware that interrupts a stream mid-byte.
+        self.state = ProtoState::Idle;
+    }
+
+    fn cs_release(&mut self) {
+        // Preserve state — a DTM1/DTM2 stream may span the entire CS-low
+        // window and we don't want CS-high to discard the framebuffer.
+    }
+
+    fn transfer(&mut self, mosi: u8) -> u8 {
+        // Fallback path for callers that don't go through the
+        // `spi_class_transfer` thunk. Treat the byte as data (we can't
+        // distinguish cmd vs data without DC pin visibility). This makes
+        // the panel mostly useless for true byte-stream input, but at
+        // least keeps the SPI bus broadcaster happy.
+        self.data_byte(mosi);
+        0
+    }
+
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Replay the bytes captured from the labwired-ereader sketch's
+    /// `display.init() + drawPage()` and assert the panel reaches
+    /// `power_on=true` and `refresh_generation > 0`.
+    #[test]
+    fn ereader_init_powers_panel_on() {
+        let mut p = Uc8151dTricolor290::new("GPIO5");
+        // PSR(0x8F) — panel setting
+        p.command_byte(0x00);
+        p.data_byte(0x8F);
+        // TRES(0x80=128, 0x01_28=296)
+        p.command_byte(0x61);
+        p.data_byte(0x80);
+        p.data_byte(0x01);
+        p.data_byte(0x28);
+        // CDI(0x77)
+        p.command_byte(0x50);
+        p.data_byte(0x77);
+        // PON
+        p.command_byte(0x04);
+        assert!(p.power_on(), "PON should set power_on=true");
+        // DRF
+        p.command_byte(0x12);
+        assert_eq!(
+            p.refresh_generation(),
+            1,
+            "DRF should increment refresh_generation"
+        );
+    }
+
+    #[test]
+    fn dtm1_fills_black_plane() {
+        let mut p = Uc8151dTricolor290::new("GPIO5");
+        p.command_byte(0x10); // DTM1 — start black RAM write
+                              // Send a recognizable pattern.
+        for i in 0..256u32 {
+            p.data_byte((i & 0xFF) as u8);
+        }
+        assert_eq!(p.black_plane()[0], 0x00);
+        assert_eq!(p.black_plane()[255], 0xFF);
+        // Stream should still be live; rest of plane untouched.
+        assert_eq!(
+            p.black_plane()[256],
+            0xFF,
+            "untouched bytes stay at 0xFF reset"
+        );
+    }
+
+    #[test]
+    fn next_command_ends_dtm_stream() {
+        let mut p = Uc8151dTricolor290::new("GPIO5");
+        p.command_byte(0x10);
+        p.data_byte(0xAA);
+        p.command_byte(0x13); // DTM2 — should end DTM1 stream
+        p.data_byte(0x55);
+        assert_eq!(p.black_plane()[0], 0xAA);
+        assert_eq!(p.red_plane()[0], 0x55);
+    }
+
+    #[test]
+    fn unknown_command_returns_to_idle() {
+        let mut p = Uc8151dTricolor290::new("GPIO5");
+        p.command_byte(0xFE); // unrecognized
+        p.command_byte(0x04); // PON should still work after
+        assert!(p.power_on());
+    }
+}

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -100,6 +100,16 @@ impl Esp32Spi {
         &self.captured_bytes
     }
 
+    /// Append one byte to the capture buffer. Intended for ROM thunks
+    /// that bypass the FIFO/CMD.USR path (e.g. GxEPD2 `_writeCommand` /
+    /// `_writeData` thunks) but still want bytes visible to diagnostic
+    /// dumps.
+    pub fn push_captured_byte(&mut self, byte: u8) {
+        if self.record_enabled {
+            self.captured_bytes.push(byte);
+        }
+    }
+
     pub fn transactions(&self) -> u64 {
         self.transactions
     }

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -295,6 +295,145 @@ pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
+/// Thunk for `GxEPD2_EPD::_writeCommand(uint8_t)`.
+///
+/// Reaches directly into the [`Uc8151dTricolor290`] panel attached to
+/// `spi3` and calls `command_byte(byte)`. This bypasses the full
+/// firmware-side path through the Arduino-ESP32 SPI library, which on
+/// our sim's incomplete `_spi` struct produces wrong MOSI_DLEN values
+/// that mangle the SSD1680/UC8151D protocol stream. Routing CMD vs
+/// DATA at the GxEPD2 entry point is the cleanest place to inject DC
+/// state — real silicon uses the DC GPIO pin; we use the calling
+/// function identity.
+pub fn gxepd_write_command(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let callinc = cpu.ps.callinc();
+    let n = callinc * 4;
+    let byte = (cpu.regs.read_logical(n + 3) & 0xFF) as u8;
+    if let Some(bus_any) = bus.as_any_mut() {
+        if let Some(sys_bus) = bus_any.downcast_mut::<crate::bus::SystemBus>() {
+            if let Some(spi3_idx) = sys_bus.find_peripheral_index_by_name("spi3") {
+                if let Some(any) = sys_bus.peripherals[spi3_idx].dev.as_any_mut() {
+                    if let Some(spi3) =
+                        any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>()
+                    {
+                        for attached in &mut spi3.attached_devices {
+                            if let Some(panel_any) = attached.as_any_mut() {
+                                if let Some(panel) = panel_any.downcast_mut::<
+                                    crate::peripherals::components::Uc8151dTricolor290,
+                                >() {
+                                    panel.command_byte(byte);
+                                }
+                            }
+                        }
+                        // Record the byte in capture for diagnostics.
+                        spi3.push_captured_byte(byte);
+                    }
+                }
+            }
+        }
+    }
+    RomThunkBank::return_with(cpu, 0);
+    Ok(())
+}
+
+/// Thunk for `GxEPD2_EPD::_writeData(uint8_t)`. See
+/// [`gxepd_write_command`] for context — same routing, but invokes
+/// `panel.data_byte(byte)` for the DC=high path.
+pub fn gxepd_write_data(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let callinc = cpu.ps.callinc();
+    let n = callinc * 4;
+    let byte = (cpu.regs.read_logical(n + 3) & 0xFF) as u8;
+    if let Some(bus_any) = bus.as_any_mut() {
+        if let Some(sys_bus) = bus_any.downcast_mut::<crate::bus::SystemBus>() {
+            if let Some(spi3_idx) = sys_bus.find_peripheral_index_by_name("spi3") {
+                if let Some(any) = sys_bus.peripherals[spi3_idx].dev.as_any_mut() {
+                    if let Some(spi3) =
+                        any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>()
+                    {
+                        for attached in &mut spi3.attached_devices {
+                            if let Some(panel_any) = attached.as_any_mut() {
+                                if let Some(panel) = panel_any.downcast_mut::<
+                                    crate::peripherals::components::Uc8151dTricolor290,
+                                >() {
+                                    panel.data_byte(byte);
+                                }
+                            }
+                        }
+                        spi3.push_captured_byte(byte);
+                    }
+                }
+            }
+        }
+    }
+    RomThunkBank::return_with(cpu, 0);
+    Ok(())
+}
+
+/// Thunk for `SPIClass::transfer(uint8_t)` (and the underlying
+/// `spiTransferByteNL` / `spiTransferByte`).
+///
+/// In real Arduino-ESP32 the call chain is:
+///   `SPIClass::transfer(byte)` →
+///   `spiTransferByteNL(spi, byte)` →
+///   writes `MOSI_DLEN = 7`, writes byte to W0, sets `CMD.USR = 1`,
+///   spins on `CMD.USR`, reads back W0 as the received byte.
+///
+/// In sim, the firmware's `_spi` struct is populated by our
+/// [`spi_class_begin_transaction`] thunk but doesn't carry every field
+/// the real library expects (`_spi->lock`, `_spi->cur_freq`, …). When
+/// `spiTransferByteNL` reads from `_spi->dev` and finds a fake-but-
+/// well-aligned peripheral base address, it computes a `MOSI_DLEN`
+/// value from data we never populated and the resulting bytes-on-the-
+/// wire don't match what the panel expects (`01 28 50 77 04` instead
+/// of `01 27 01 00` for `DRIVER_OUTPUT_CONTROL`).
+///
+/// Cleanest fix: intercept at `SPIClass::transfer(byte)` and write the
+/// byte directly to the right `Esp32Spi` peripheral's registers using
+/// the bus. We use the same offsets the real library would (MOSI_DLEN
+/// = 7, W0 = byte, CMD.USR = 1) — our peripheral then drains the byte
+/// to the attached SSD1680 model exactly as if the firmware's driver
+/// had done it correctly.
+///
+/// Argument convention: a2 = `this` (`SPIClass*`), a3 = byte (low 8
+/// bits). The thunk reads `_spi` (at `this+4`) → `dev` (at `_spi+0`)
+/// to find the peripheral base, defaulting to SPI3 (0x3FF6_5000) when
+/// the firmware hasn't populated `_spi` yet (some code paths reach
+/// `transfer` before `beginTransaction`).
+///
+/// Returns 0 (the SSD1680 protocol is write-only on the panel-render
+/// path; GxEPD2 ignores the byte read back from `SPI.transfer`).
+pub fn spi_class_transfer(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    use crate::peripherals::esp32::spi::{REG_USER, USER_USR_MOSI_BIT};
+    const REG_CMD: u64 = 0x00;
+    const REG_MOSI_DLEN: u64 = 0x28;
+    const FIFO_W0: u64 = 0x80;
+    const CMD_USR_BIT: u32 = 1 << 18;
+
+    let callinc = cpu.ps.callinc();
+    let n = callinc * 4;
+    let this = cpu.regs.read_logical(n + 2);
+    let byte = (cpu.regs.read_logical(n + 3) & 0xFF) as u32;
+
+    // Resolve SPI peripheral base. Prefer firmware's `_spi->dev` when
+    // populated; fall back to SPI3 (the bus our SSD1680 model is
+    // attached to) when `_spi` is NULL or unmapped.
+    let spi_t_ptr = bus.read_u32(this as u64 + 4).unwrap_or(0);
+    let dev_base = if spi_t_ptr != 0 {
+        bus.read_u32(spi_t_ptr as u64).unwrap_or(0x3FF6_5000)
+    } else {
+        0x3FF6_5000
+    };
+    let dev = dev_base as u64;
+
+    bus.write_u32(dev + REG_MOSI_DLEN, 7)?; // 8 bits = 1 byte
+    bus.write_u32(dev + FIFO_W0, byte)?;
+    bus.write_u32(dev + REG_USER, USER_USR_MOSI_BIT)?;
+    bus.write_u32(dev + REG_CMD, CMD_USR_BIT)?; // kick — peripheral drains synchronously
+
+    RomThunkBank::return_with(cpu, 0);
+    Ok(())
+}
+
 /// Custom thunk for `xthal_window_spill_nw` / `xthal_window_spill`.
 ///
 /// The Xtensa HAL routine walks the AR file and for each live AR slot
@@ -349,7 +488,13 @@ pub fn xthal_window_spill_thunk(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimRe
         let _ = bus.write_u32(sp - 8, a2);
         let _ = bus.write_u32(sp - 4, a3);
     }
-    // Plain RET.N: PC ← a0. We bypass PS.CALLINC routing entirely.
+    // Plain RET.N: PC ← a0. The function's actual terminal instruction
+    // is `ret.n` (0x0d 0xf0) regardless of how it was entered, so
+    // emulating that directly is correct for both the `_nw` (CALL0)
+    // entry and the wrapper (CALL{n} which does its own ENTRY). We
+    // bypass PS.CALLINC routing because some firmware code paths reach
+    // the spill via `j` (jump), leaving CALLINC stale from an
+    // unrelated outer frame.
     cpu.pc = cpu.regs.read_logical(0);
     Ok(())
 }

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -295,6 +295,65 @@ pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
+/// Custom thunk for `xthal_window_spill_nw` / `xthal_window_spill`.
+///
+/// The Xtensa HAL routine walks the AR file and for each live AR slot
+/// (WS[slot]=1) writes the slot's a0..a3 to its stack save area at
+/// *(slot.a1 - 16 .. slot.a1 - 4). The sim's transparent shadow-spill on
+/// `CALL{n}` saves displaced slot values to a per-WB shadow stack but
+/// leaves the WS bit set — so when the firmware-side spill walks WS, it
+/// sees the displaced slot as live and reads CALLEE's a0..a3 / a1 from
+/// the physical AR file (which the callee has likely clobbered with its
+/// own locals; in particular slot.a1 is often 0, making the spill store
+/// to `0 - 16 = 0xfffffff0` and trap).
+///
+/// This thunk does the spill semantically using the sim's knowledge:
+/// for each WS=1 slot, if a shadow snapshot exists for that slot the
+/// pre-displacement [a0, a1, a2, a3] is used; otherwise the physical AR
+/// values. If `a1` is 0 we skip (no save area to write to — happens for
+/// the top-of-stack initial frame).
+///
+/// Returns via plain RET.N semantics (PC ← a0), matching the function's
+/// terminal `0x0d 0xf0`. We ignore PS.CALLINC because some firmware code
+/// paths reach this routine via `j` (jump) rather than CALL{n}, leaving
+/// CALLINC stale from an unrelated outer frame.
+pub fn xthal_window_spill_thunk(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
+    let ws = cpu.regs.windowstart();
+    let shadows = cpu.regs.shadow_stacks().clone();
+    for slot in 0..16u8 {
+        if (ws >> slot) & 1 == 0 {
+            continue;
+        }
+        let base = (slot as usize) * 4;
+        let (a0, a1, a2, a3) = if let Some(snap) = shadows[slot as usize].last() {
+            (snap[0], snap[1], snap[2], snap[3])
+        } else {
+            (
+                cpu.regs.physical(base),
+                cpu.regs.physical(base + 1),
+                cpu.regs.physical(base + 2),
+                cpu.regs.physical(base + 3),
+            )
+        };
+        // Only spill when a1 looks like a plausible ESP32 stack pointer
+        // — DRAM/IRAM/SRAM data view (0x3FF8_0000..0x4000_0000). Skipping
+        // bogus slots is safer than letting bus.write_u32 underflow into
+        // the address-space wrap (which trips RamPeripheral's debug
+        // index-bounds panic before its u64-add-overflow check fires).
+        if !(0x3FF8_0000..0x4000_0000).contains(&a1) || a1 < 16 {
+            continue;
+        }
+        let sp = a1 as u64;
+        let _ = bus.write_u32(sp - 16, a0);
+        let _ = bus.write_u32(sp - 12, a1);
+        let _ = bus.write_u32(sp - 8, a2);
+        let _ = bus.write_u32(sp - 4, a3);
+    }
+    // Plain RET.N: PC ← a0. We bypass PS.CALLINC routing entirely.
+    cpu.pc = cpu.regs.read_logical(0);
+    Ok(())
+}
+
 /// Thunk for `__assert_func` / `panic_abort` / `abort` — functions that
 /// real-silicon C convention treats as `noreturn`. Stubbing them as
 /// nop_return_zero would silently return into the caller, which on the

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -129,6 +129,18 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // init happens via the SPIClass::beginTransaction thunk.
         "SPI",
         "_ZN8SPIClass16beginTransactionE11SPISettings",
+        // GxEPD2_EPD::_writeCommand / _writeData — intercepted at the
+        // top of the Arduino driver so DC=cmd vs DC=data routing is
+        // explicit (the real silicon uses a sideband GPIO pin we don't
+        // observe in the SPI peripheral model). The thunks write the
+        // byte straight into the attached UC8151D panel's
+        // `command_byte` / `data_byte` API, bypassing the
+        // Arduino-ESP32 SPI library (whose `_spi` struct fields aren't
+        // fully populated without a real `SPI.begin()` call) and the
+        // Esp32Spi FIFO routing. Same byte stream the real panel
+        // receives, byte-for-byte.
+        "_ZN10GxEPD2_EPD13_writeCommandEh",
+        "_ZN10GxEPD2_EPD10_writeDataEh",
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -88,6 +88,12 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // return pdTRUE so the call path proceeds; real silicon would only
         // reach this on a held mutex anyway in the single-task render flow.
         "xQueueSemaphoreTake",
+        // Arduino-ESP32's loopTask wraps `ulTaskGenericNotifyTake(pdTRUE,
+        // portMAX_DELAY)` around setup()/loop() to coordinate with the
+        // wdt-feed timer. In single-task sim there's nobody to notify it,
+        // so the take blocks forever. Stub to return non-zero so
+        // setup()/loop() actually run.
+        "ulTaskGenericNotifyTake",
         // SPIClass::endTransaction calls xQueueGenericSend (the give side
         // of xSemaphoreGive) on the same NULL mutex. Force success too.
         "xQueueGenericSend",
@@ -252,6 +258,17 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         // `port_IntStackTop`. The cli reads this symbol and seeds a1
         // before unhalting cpu_secondary.
         "port_IntStackTop",
+        // Xtensa HAL register-window-file spill. Called explicitly by
+        // setjmp / exception unwinding / GxEPD2 internals. The "_nw"
+        // variant uses a non-standard CALL0 ABI (a0 = return address) and
+        // walks the AR file storing each slot's a0..a3 to *(slot.sp - 16)
+        // ... -4. If any live slot has sp = 0 (e.g. a freshly-pushed
+        // shadow frame the firmware hasn't yet primed), the store
+        // dereferences 0 - 16 = 0xfffffff0 and traps. The sim already does
+        // shadow-spill on CALL{n}, so the explicit HAL spill is redundant
+        // for the panel-render path — stub to a return-zero no-op.
+        "xthal_window_spill_nw",
+        "xthal_window_spill",
         "vListInsert",
         // app_main — start of patching window for the loopTask xCoreID
         // arg-clobber. We scan ~64 bytes forward looking for the


### PR DESCRIPTION
## Summary

Closes the bit-identical loop for Arduino-ESP32 \`GxEPD2_290_C90c\` /
\`Z13c\` firmware. Same \`.elf\` that espflash'es to a Waveshare 2.9"
tri-color WROOM now paints the \"LabWired Reader\" page inside the
LabWired simulator — \`refresh_generation=1\`, \`power_on=true\`,
\`black-plane non-FF bytes=1429/4736\` (≈30% glyph coverage),
\`red-plane non-FF bytes=71/4736\`.

## Root cause chain

1. **\`xthal_window_spill_nw\` crash** at cycle 721,049. Sim's transparent
   shadow-spill on \`CALL{n}\` leaves \`WindowStart[displaced]=1\` while
   the AR file holds the callee's data. Firmware-side spill walks WS,
   reads garbage \`a1\`, stores to \`a1 - 16 = 0xfffffff0\`, traps.
   Fixed via custom \`xthal_window_spill_thunk\` that does the spill
   semantically using the sim's shadow-stack snapshots.

2. **Wrong panel controller.** Firmware emits UC8151D-family bytes,
   not SSD1680 (opcodes \`0x00 PSR\`, \`0x04 PON\`, \`0x10 DTM1\`,
   \`0x12 DRF\`, \`0x13 DTM2\`, etc. — these conflict with SSD1680 at
   \`0x10\`, \`0x20\`, \`0x22\`). Added a parallel \`Uc8151dTricolor290\`
   panel model.

3. **Cmd-vs-data routing.** UC8151D's DTM1/DTM2 RAM streams end on the
   next CMD (no fixed length), so byte-counting doesn't work — need
   the DC pin. Sim doesn't observe DC. Thunked
   \`GxEPD2_EPD::_writeCommand\` / \`_writeData\` at the Arduino driver
   entry points where the distinction is unambiguous; thunks call
   \`panel.command_byte()\` / \`panel.data_byte()\` directly.

4. **loopTask wedge.** Stubbed \`ulTaskGenericNotifyTake\` to return
   non-zero so \`setup()/loop()\` actually run.

All new thunks are gated to \`arduino-esp32\` profile — agentdeck e2e
test still passes with the documented baseline (19031 spi3 txns,
782 non-FF bytes).

## Test plan
- [x] \`cargo test -p labwired-core --lib\` → 351/0/0
- [x] \`cargo test e2e_agentdeck_in_sim -- --ignored\` → passes
- [x] \`labwired snapshot capture --profile arduino-esp32 -f labwired-ereader-stripped.elf\` → panel paints, PPM written
- [ ] Visual verification of panel PPM matches real-WROOM content
- [ ] Playground bump + wasm rebuild (separate PR in labwired monorepo)