### PR TITLE
scrub: third-party product references + correct H563 determinism scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Runtime Snapshot Subsystem**: `Machine::with_secondary_cpu`, `Machine::{take,apply}_runtime_snapshot`, CLI `snapshot capture` subcommand, WASM `apply_runtime_snapshot(bytes)` + `take_runtime_snapshot()`. Cold-boot collapses from 30 s to ~0.5 s in the playground.
 - **Arduino-ESP32 / FreeRTOS Bring-Up Thunks** (`crates/core/src/peripherals/esp32s3/rom_thunks.rs`): `abort_halt`, `esp_clk_cpu_freq_240mhz`, `x_queue_create_mutex_static_echo`, `x_task_get_current_task_handle`, `return_pd_true`, `spi_start_bus_fake`, `spi_class_begin_transaction` (lazy `spi_t` init with `USR_MOSI` auto-enable), `xQueueGiveMutexRecursive`, `esp_log_impl_lock`, recursive-mutex create stubs, `esp_ipc_init`/`esp_ipc_isr_init` no-ops.
 - **Loader Auto-Discovery**: `extract_arduino_esp32_thunks` + `resolve_symbol_in_elf` resolve HardwareSerial / SPI / mutex / log-lock / IPC-init symbols by name from the ELF's `.symtab`, so installed thunks gate strictly on symbol presence (stripped ELFs that don't import the symbol are untouched).
-- **AgentDeck Boot Snapshot Pipeline**: Captured post-paint state blob; playground replays the snapshot in ~0.5 s.
+- **Boot Snapshot Pipeline**: Capture a post-paint state blob from any heavy ESP32 firmware via `labwired snapshot capture` and replay it in the playground in ~0.5 s.
 - **Unified Demo Registry**: `BoardConfig`-driven `fetch-demo-firmware.sh` and per-board snapshot blobs.
 - **Dual-Core PxList Diagnostic Dump**: CLI flag dumps the kernel ready/delayed list state on both cores for diagnosing scheduler regressions.
 
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`return_pd_true` Visibility**: Now emits a one-time `tracing::warn!` on first call so the stub's activation is loud in logs — future regressions where a take *should* block will be visible instead of silently succeeding.
 
 ### Fixed
-- **IPC-Task Spin / Scheduler-Tick Starvation**: Combined fix from `WSR.INTSET` raising `SOFTWARE0` and `CCOMPARE0` ack-and-rearm; AgentDeck and reader sketch both progress past `xQueueSemaphoreTake` into `app_main` / `setup()`.
+- **IPC-Task Spin / Scheduler-Tick Starvation**: Combined fix from `WSR.INTSET` raising `SOFTWARE0` and `CCOMPARE0` ack-and-rearm; Arduino-ESP32 firmware now progresses past `xQueueSemaphoreTake` into `app_main` / `setup()`.
 - **`esp_newlib_locks_init` Assertion Failure**: `xQueueCreateMutexStatic` returning 0 now echoes the static-buffer argument so the lock pointer is non-NULL.
-- **GxEPD2 / SSD1680 SPI Writes Reach the Panel**: `SPIClass::beginTransaction` lazy init enables `USER_REG.USR_MOSI` (bit 27) when the sketch never calls `SPI.begin()` explicitly — reader sketch black-plane bytes 0 → 1,429 non-FF (29% glyph coverage) across 3 full refresh cycles, 19,039 SPI3 transactions.
+- **GxEPD2 / SSD1680 SPI Writes Reach the Panel**: `SPIClass::beginTransaction` lazy init enables `USER_REG.USR_MOSI` (bit 27) when the sketch never calls `SPI.begin()` explicitly; combined with the GxEPD2 cmd/data thunks and the UC8151D panel model, an Arduino-ESP32 GxEPD2 sketch now paints the tri-color e-paper panel in sim.
 - **`Print::print` / `Print::write` Dispatch**: Restored real virtual dispatch so `display.print("text")` flows `Print → Adafruit_GFX::write → drawChar → drawPixel`; only `HardwareSerial::write` and the `uart*` helpers stay stubbed.
 - **Dead Inherent Watchpoint Removed**: `SystemBus::write_u32/write_u16` inherent watchpoint from #93 never fired (bus dispatch goes through trait impl) — code path removed.
 - **`mkdocs.yml` Drift**: `repo_url` typo (`libwired-core` → `labwired-core`); nav entries pointing at nonexistent `SUPPORTED_DEVICES.md`, `verification_audit.md`, `development/git_flow.md` corrected or removed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LabWired Core
 
-Deterministic firmware simulator for ARM Cortex-M and RISC-V — with hardware-validated parity.
+Deterministic firmware simulator for ARM Cortex-M, RISC-V, and Xtensa (ESP32 / ESP32-S3) — the same ELF runs on hardware and in the simulator.
 
 [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://labwired.com/docs/)
 
@@ -8,14 +8,14 @@ Deterministic firmware simulator for ARM Cortex-M and RISC-V — with hardware-v
 
 Most firmware simulators let you boot a binary and stop there. LabWired goes further:
 
-- **Hardware-validated parity.** A real NUCLEO-H563ZI board is captured step-by-step via OpenOCD+GDB and diffed against the simulator running the same ELF. The committed report — [`determinism_report_h563.json`](examples/nucleo-h563zi/golden-reference/determinism_report_h563.json) — records `status: PASS` over 50 compared steps. The full pipeline is documented in [`docs/golden_reference.md`](docs/golden_reference.md).
+- **Hardware-validated reset + UART parity.** A real NUCLEO-H563ZI board is captured via OpenOCD+GDB and diffed against the simulator running the same firmware ELF. The committed report — [`determinism_report_h563.json`](examples/nucleo-h563zi/golden-reference/determinism_report_h563.json) — documents the verified scope (post-reset architectural alignment + UART byte parity over the smoke run) and explicitly notes what isn't verified (step-by-step PC sequence past reset — OpenOCD's sampling can't resolve every executed instruction on real silicon). For deeper byte-parity evidence under continuous execution, see the NUCLEO-L476RG survival traces (`firmware-l476-demo/`).
 - **Deterministic by construction.** Same firmware → same trace, byte-for-byte, across runs and machines. Trace SHA-256 hashes are CI-gated.
 - **Production-grade debug.** GDB Remote Serial Protocol stub *and* a native VS Code Debug Adapter Protocol server — breakpoints, register inspect, expression evaluation, all without hardware.
 - **Configurable fidelity.** Cycle-accurate when correctness matters; high-MIPS host execution when iteration speed matters. See [`docs/architecture.md`](docs/architecture.md) for the perf gates.
 
 ## Featured demo: NUCLEO-H563ZI
 
-Same firmware ELF runs on a real STM32H563ZI Nucleo and on the simulator. UART output matches. Instruction PCs match. The proof is committed alongside the firmware that produced it: [`examples/nucleo-h563zi/`](examples/nucleo-h563zi/).
+Same firmware ELF runs on a real STM32H563ZI Nucleo and on the simulator. UART output matches. Reset-state architectural alignment verified. The captured artifacts (HW trace, sim trace, sim run result, UART log, determinism report) are committed alongside the firmware that produced them: [`examples/nucleo-h563zi/`](examples/nucleo-h563zi/).
 
 ## What this repo owns
 

--- a/configs/systems/esp32-wroom-epaper.yaml
+++ b/configs/systems/esp32-wroom-epaper.yaml
@@ -1,6 +1,7 @@
-# AgentDeck production hardware reference manifest.
+# ESP32-WROOM-32 + Waveshare 2.9" tri-color e-paper system manifest.
 #
-# Pin map matches `firmware/src/pins.h` on the physical AgentDeck device:
+# Standard Arduino-ESP32 SPI3 / VSPI wiring used by the GxEPD2 reference
+# constructors:
 #   BUSY = GPIO4
 #   RST  = GPIO16
 #   DC   = GPIO17
@@ -10,7 +11,7 @@
 #
 # Kept in sync with `examples/esp32-epaper-lab/system.yaml` manually — bump
 # both when the wiring ever needs to change.
-name: "agentdeck"
+name: "esp32-wroom-epaper"
 chip: "../chips/esp32.yaml"
 external_devices:
   - id: "epaper"

--- a/configs/systems/nucleo-f103rb-epaper.yaml
+++ b/configs/systems/nucleo-f103rb-epaper.yaml
@@ -6,7 +6,7 @@
 #
 # NUCLEO-F103RB + Waveshare 2.9" tri-color e-paper (SSD1680 / GDEM029C90).
 #
-# Wiring assumed (matches AgentDeck schematic ported to F103 Arduino headers):
+# Wiring assumed (matches the reference firmware schematic ported to F103 Arduino headers):
 #   SPI1.SCK  -> PA5  (D13)  -> CLK
 #   SPI1.MOSI -> PA7  (D11)  -> DIN
 #   GPIO      -> PA4  (D10)  -> CS

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -857,7 +857,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
 
     if args.profile != "agentdeck" && args.profile != "arduino-esp32" {
         eprintln!(
-            "error: unknown profile '{p}' — supported: 'agentdeck' (AgentDeck firmware, hardcoded thunk PCs), 'arduino-esp32' (any Arduino-ESP32 ELF with symbols intact, auto-discovers thunk PCs)",
+            "error: unknown profile '{p}' — supported: 'agentdeck' (preset-PC profile — hardcoded thunk addresses for a specific firmware build), 'arduino-esp32' (any Arduino-ESP32 ELF with symbols intact, auto-discovers thunk PCs)",
             p = args.profile
         );
         return ExitCode::from(EXIT_CONFIG_ERROR);
@@ -876,7 +876,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     let cpu = configure_xtensa_esp32(&mut bus);
 
     // Attach an SSD1680 2.9" tri-color panel to spi3, cs=GPIO5 — the
-    // AgentDeck wiring. Identical to `e2e_agentdeck_in_sim`.
+    // the reference firmware wiring. Identical to `e2e_external_arduino_esp32_in_sim`.
     let spi3_idx = match bus.find_peripheral_index_by_name("spi3") {
         Some(i) => i,
         None => {
@@ -890,7 +890,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                 // GxEPD2_290_C90c / Z13c firmware drives the panel with
                 // UC8151D commands (PSR/PWR/PON/DTM1/DTM2/DRF/…) which
                 // conflict with SSD1680 at multiple opcodes; we need the
-                // UC8151D panel model. AgentDeck firmware uses SSD1680
+                // UC8151D panel model. Arduino-ESP32 reference firmware uses SSD1680
                 // and stays on the old model below.
                 spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
             } else {
@@ -933,7 +933,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     machine.cpu.set_pc(program_image.entry_point as u32);
 
     // Resolve every Arduino-ESP32 symbol we know how to patch / thunk.
-    // Empty for AgentDeck (stripped) — those fall back to hardcoded PCs.
+    // Empty for the reference firmware (stripped) — those fall back to hardcoded PCs.
     let symbol_addrs = extract_arduino_esp32_thunks(&elf_bytes);
     let resolve_data =
         |sym: &str, fallback: u32| -> u32 { symbol_addrs.get(sym).copied().unwrap_or(fallback) };
@@ -999,7 +999,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     machine.cpu.set_sp(0x3FFE_0000);
     // Handshake-byte pre-paint. Two paths:
     //   * `agentdeck` profile — use the exact byte addresses the original
-    //     install_esp32_arduino_quirks wrote, byte-for-byte. AgentDeck's
+    //     install_esp32_arduino_quirks wrote, byte-for-byte. the reference firmware's
     //     ELF is stripped, so symbol auto-discovery returns nothing.
     //   * `arduino-esp32` profile — resolve s_resume_cores / s_cpu_up /
     //     s_cpu_inited / s_system_inited / s_other_cpu_startup_done from
@@ -1048,7 +1048,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
 
     // Build the thunk address list. Each entry maps a flash PC to a
     // sim-side rom_thunks function. For unstripped ELFs we use the
-    // already-parsed symbol map above; AgentDeck's fully stripped ELF
+    // already-parsed symbol map above; the reference firmware's fully stripped ELF
     // falls back to the hand-curated address list.
     let resolve =
         |sym: &str, fallback: u32| -> u32 { symbol_addrs.get(sym).copied().unwrap_or(fallback) };
@@ -1359,7 +1359,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         thunks.push((pc, rom_thunks::return_pd_true));
     }
     // ulTaskGenericNotifyTake — gated to arduino-esp32 only.
-    // AgentDeck has its own well-modeled lock-acquire path that
+    // the reference firmware has its own well-modeled lock-acquire path that
     // expects a proper "block-then-wake" semantic; stubbing it to
     // return pdTRUE causes the lock-acquire to skip its setup and
     // later trip __assert_func inside lock_acquire_generic.
@@ -1408,7 +1408,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             thunks.push((pc, rom_thunks::vlist_insert_debug));
         }
     }
-    // AgentDeck-only WiFi + sendHello thunks. Only install for that profile
+    // the reference firmware-only WiFi + sendHello thunks. Only install for that profile
     // — sketches without those symbols wouldn't trip them anyway.
     if args.profile == "agentdeck" {
         thunks.extend_from_slice(&[
@@ -1509,7 +1509,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         }
         // Re-stamp the dual-core handshake bytes every 10k cycles so
         // start_other_core / do_other_cpu_settings keep seeing them as
-        // "up." AgentDeck path: byte-for-byte mirror of the original
+        // "up." preset-PC path: byte-for-byte mirror of the original
         // install_esp32_arduino_quirks. Auto-discovery path: write to
         // each resolved symbol's [0]+[1] slots.
         if i.is_multiple_of(10_000) {

--- a/crates/core/src/decoder/xtensa_narrow.rs
+++ b/crates/core/src/decoder/xtensa_narrow.rs
@@ -122,7 +122,7 @@ pub fn decode_narrow(halfword: u16) -> Instruction {
 /// for the specific MOVI.N test inputs in its HW-oracle comments. Real
 /// firmware uses BEQZ.N encodings (e.g. 0x079c) where bits[11:8]=0x7
 /// gives `s & 0x8 == 0`, mis-routing it to MOVI.N. Discovered when
-/// AgentDeck firmware's memset jumped to a wrong offset.
+/// Arduino-ESP32 reference firmware's memset jumped to a wrong offset.
 fn decode_narrow_c(hw: u16, r: u8, _s: u8, t: u8) -> Instruction {
     // Field naming note: the narrow extractor uses LOCAL field names that
     // DON'T match the wide decoder's positions. In this file:

--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -18,7 +18,7 @@
 //! so the two protocols can't share a single panel model. Use this one
 //! when the firmware is GxEPD2_290_Z13c / C90c (labwired-ereader); use
 //! [`super::ssd1680_tricolor_290::Ssd1680Tricolor290`] for SSD1680-class
-//! firmware (AgentDeck).
+//! firmware (the reference firmware).
 //!
 //! ## Cmd / Data routing
 //!

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -550,7 +550,7 @@ pub fn x_queue_create_mutex_static_echo(cpu: &mut XtensaLx7, _bus: &mut dyn Bus)
 ///
 /// `pxCurrentTCB` is a per-core array at a firmware-specific address; the
 /// auto-discovered symbol resolves on the Arduino-ESP32 profile. Without
-/// the symbol (AgentDeck profile, stripped ELF), we fall back to returning
+/// the symbol (preset-PC profile, stripped ELF), we fall back to returning
 /// 0 to preserve the previous behaviour.
 pub fn x_task_get_current_task_handle(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -235,7 +235,7 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     rom_bank.register(0x4000_9edc, rom_thunks::nop_return_zero); // esp_rom_gpio_connect_in_signal
     rom_bank.register(0x4000_9fdc, rom_thunks::nop_return_zero); // esp_rom_gpio_pad_select_gpio
                                                                  // MMU / cache setup helpers — discovered iteratively while booting
-                                                                 // the AgentDeck Arduino-ESP32 binary in sim. All no-ops because the
+                                                                 // the the reference firmware Arduino-ESP32 binary in sim. All no-ops because the
                                                                  // sim's flash XIP peripheral is a flat RamPeripheral, no MMU model.
     rom_bank.register(0x4000_95a4, rom_thunks::nop_return_zero); // mmu_init
                                                                  // libgcc helpers — Arduino-ESP32 links against ROM copies for

--- a/crates/core/tests/e2e_esp32_epaper.rs
+++ b/crates/core/tests/e2e_esp32_epaper.rs
@@ -7,7 +7,7 @@
 // verify the SSD1680 panel received the expected three-band pattern.
 //
 // This is the side-by-side fidelity check that justifies "same ELF on
-// chip and in sim" for the AgentDeck-style ESP32 + tri-color e-paper
+// chip and in sim" for the Arduino-ESP32-style ESP32 + tri-color e-paper
 // hardware target.
 
 use labwired_core::bus::SystemBus;

--- a/crates/core/tests/e2e_external_arduino_esp32_in_sim.rs
+++ b/crates/core/tests/e2e_external_arduino_esp32_in_sim.rs
@@ -2,13 +2,14 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 //
-// Stress test: load the AgentDeck firmware ELF (Arduino-ESP32 + GxEPD2)
-// into our ESP32-classic sim and see how far it gets.
+// Stress test: load an external Arduino-ESP32 + GxEPD2 firmware ELF into
+// our ESP32-classic sim and assert that the SSD1680 panel model receives
+// the expected byte stream and refresh sequence.
 //
-// AgentDeck is real production firmware that the user verified paints the
-// physical e-paper panel. Same wiring, same chip — so if our sim's ESP32
-// emulation is complete enough, the panel-state assertion at the end
-// should see the SSD1680 receive a non-zero refresh.
+// The ELF path is taken from the LABWIRED_EXTERNAL_ARDUINO_ESP32_ELF env
+// var; if the var isn't set or the file isn't readable the test reports
+// "skipped" rather than failing — this test only runs when the operator
+// has built a reference firmware locally and pointed the var at it.
 
 use labwired_core::bus::SystemBus;
 use labwired_core::peripherals::components::Ssd1680Tricolor290;
@@ -22,16 +23,20 @@ use std::path::PathBuf;
 /// (or, less often, a genuine improvement). Tolerances allow ±0.5% on the
 /// SPI transaction count and ±10 bytes on the black-plane bitmap to absorb
 /// benign ordering noise (e.g. tick alignment) without missing real changes.
-const AGENTDECK_BASELINE_SPI3_TXNS: u32 = 19031;
-const AGENTDECK_BASELINE_BLACK_NONFF: usize = 782;
+const EXTERNAL_BASELINE_SPI3_TXNS: u32 = 19031;
+const EXTERNAL_BASELINE_BLACK_NONFF: usize = 782;
 
 #[test]
-#[ignore = "loads ~22 MB AgentDeck firmware ELF; only meaningful when the AgentDeck repo is checked out alongside labwired. Run with `cargo test -- --ignored agentdeck_firmware_drives_panel_in_sim`."]
-fn agentdeck_firmware_drives_panel_in_sim() {
-    let elf =
-        PathBuf::from("/home/andrii/Projects/AgentDeck/firmware/.pio/build/wroom32u/firmware.elf");
+#[ignore = "loads a large external Arduino-ESP32 firmware ELF; only runs when LABWIRED_EXTERNAL_ARDUINO_ESP32_ELF is set. Run with `cargo test -- --ignored external_arduino_esp32_firmware_drives_panel_in_sim`."]
+fn external_arduino_esp32_firmware_drives_panel_in_sim() {
+    let elf = std::env::var("LABWIRED_EXTERNAL_ARDUINO_ESP32_ELF")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp/external-arduino-esp32.elf"));
     if !elf.exists() {
-        eprintln!("[skip] AgentDeck firmware ELF unavailable at {elf:?}");
+        eprintln!(
+            "[skip] external Arduino-ESP32 firmware ELF unavailable at {elf:?}; \
+             set LABWIRED_EXTERNAL_ARDUINO_ESP32_ELF to a valid ELF path to enable"
+        );
         return;
     }
 
@@ -233,7 +238,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
     //   magic=0xE9, segment_count=1, spi_mode=0, spi_speed_size=0,
     //   entry_addr=<elf entry>, wp_pin=0xEE, spi_pin_drv=[0,0,0],
     //   chip_id=0 (ESP32), min_chip_rev=0, reserved=[0;8], hash_appended=0
-    let entry = 0x40081bf0_u32; // matches AgentDeck ELF entry
+    let entry = 0x40081bf0_u32; // matches the external Arduino-ESP32 ELF entry
     let header: [u8; 24] = [
         0xE9,
         0x01,
@@ -367,7 +372,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                         COUNTS[idx] += 1;
                         let c = COUNTS[idx];
                         if c <= 3 || c.is_multiple_of(100) {
-                            eprintln!("[agentdeck-sim] {name} #{c} @step {step_count}");
+                            eprintln!("[arduino-esp32-sim] {name} #{c} @step {step_count}");
                         }
                     }
                 }
@@ -470,7 +475,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                         let a1 = machine.cpu.get_register(1);
                         let a2 = machine.cpu.get_register(2);
                         let a3 = machine.cpu.get_register(3);
-                        eprintln!("[agentdeck-sim] {label} @step {step_count} a0=0x{a0:08x} a1=0x{a1:08x} a2=0x{a2:08x} a3=0x{a3:08x}");
+                        eprintln!("[arduino-esp32-sim] {label} @step {step_count} a0=0x{a0:08x} a1=0x{a1:08x} a2=0x{a2:08x} a3=0x{a3:08x}");
                         if pc == 0x40083aac || pc == 0x4008d260 {
                             // At _xt_user_exit entry or _frxt_dispatch start — peek
                             // at the full saved frame.
@@ -482,7 +487,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                                         machine.bus.read_u32(sp as u64 + off).unwrap_or(0xDEADBEEF);
                                     row.push_str(&format!("[+{off}]={v:#010x} "));
                                 }
-                                eprintln!("[agentdeck-sim]   frame@{sp:#x}: {row}");
+                                eprintln!("[arduino-esp32-sim]   frame@{sp:#x}: {row}");
                             }
                         }
                     }
@@ -496,12 +501,12 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             // a10 = return of soc_get_available_memory_regions (count)
             // a6 = same (mov.n a6, a10)
             let count = machine.cpu.get_register(10);
-            eprintln!("[agentdeck-sim] soc_get_available_memory_regions returned count={count} (step {step_count})");
+            eprintln!("[arduino-esp32-sim] soc_get_available_memory_regions returned count={count} (step {step_count})");
         }
         // Trace the spin-loop at 0x400ed12d once to learn where a7 points.
         if machine.cpu.get_pc() == 0x400ed12d && step_count > 1_000_000 && step_count < 1_000_100 {
             eprintln!(
-                "[agentdeck-sim] spin@400ed12d: a7=0x{:08x} a6=0x{:08x} sp=0x{:08x}",
+                "[arduino-esp32-sim] spin@400ed12d: a7=0x{:08x} a6=0x{:08x} sp=0x{:08x}",
                 machine.cpu.get_register(7),
                 machine.cpu.get_register(6),
                 machine.cpu.get_register(1),
@@ -516,7 +521,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             let features = machine.bus.read_u32(sp as u64 + 28).unwrap_or(0);
             let revision = machine.bus.read_u16(sp as u64 + 32).unwrap_or(0);
             eprintln!(
-                "[agentdeck-sim] esp_chip_info returned: model={model} features=0x{features:08x} revision={revision} cores={cores}"
+                "[arduino-esp32-sim] esp_chip_info returned: model={model} features=0x{features:08x} revision={revision} cores={cores}"
             );
         }
         // Trap on abort() entry — dump the 8 PCs immediately before it
@@ -524,7 +529,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
         if machine.cpu.get_pc() == 0x40091f60 {
             let caller_a0 = machine.cpu.get_register(0);
             eprintln!(
-                "[agentdeck-sim] abort() entry at step {step_count}. caller_a0=0x{caller_a0:08x}"
+                "[arduino-esp32-sim] abort() entry at step {step_count}. caller_a0=0x{caller_a0:08x}"
             );
             eprintln!("  last 8 PCs leading here:");
             for i in 0..8 {
@@ -546,7 +551,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             };
             let msg_addr = machine.cpu.get_register(2);
             let msg = read_string(msg_addr, &machine.bus);
-            eprintln!("[agentdeck-sim] esp_system_abort: \"{msg}\" (step {step_count})");
+            eprintln!("[arduino-esp32-sim] esp_system_abort: \"{msg}\" (step {step_count})");
         }
         if machine.cpu.get_pc() == 0x40091fe4 {
             // Inside the caller's window, args are a10..a13.
@@ -564,7 +569,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             };
             // Also dump caller PC and the 8 PCs before this __assert_func entry.
             let caller_a0 = machine.cpu.get_register(0);
-            eprintln!("[agentdeck-sim] __assert_func entry caller_a0=0x{caller_a0:08x}");
+            eprintln!("[arduino-esp32-sim] __assert_func entry caller_a0=0x{caller_a0:08x}");
             eprintln!("  last 8 PCs leading here:");
             for i in 0..8 {
                 let off = ((trail_idx + 64) - 1 - i) % 64;
@@ -577,7 +582,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             let f = read_string(f_addr, &machine.bus);
             let n = read_string(fn_addr, &machine.bus);
             let e = read_string(expr_addr, &machine.bus);
-            eprintln!("[agentdeck-sim] __assert_func: file=\"{f}\" line={line} fn=\"{n}\" expr=\"{e}\" (step {step_count})");
+            eprintln!("[arduino-esp32-sim] __assert_func: file=\"{f}\" line={line} fn=\"{n}\" expr=\"{e}\" (step {step_count})");
         }
         // Cross-core IPI snoop. Sample DPORT mapping + trigger regs each step
         // and synthesize the matching INTERRUPT edge when a trigger fires.
@@ -596,7 +601,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                 if v != 0 && bit < 32 && from_cpu_bit0 != Some(bit) {
                     let prev = from_cpu_bit0;
                     from_cpu_bit0 = Some(bit);
-                    eprintln!("[agentdeck-sim] FROM_CPU_INTR0 mapped to CPU int bit {bit} (was {prev:?}) @step {step_count}");
+                    eprintln!("[arduino-esp32-sim] FROM_CPU_INTR0 mapped to CPU int bit {bit} (was {prev:?}) @step {step_count}");
                 }
             }
             if let Ok(v) = machine.bus.read_u32(0x3FF0_0168) {
@@ -604,7 +609,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                 if v != 0 && bit < 32 && from_cpu_bit1 != Some(bit) {
                     let prev = from_cpu_bit1;
                     from_cpu_bit1 = Some(bit);
-                    eprintln!("[agentdeck-sim] FROM_CPU_INTR1 mapped to CPU int bit {bit} (was {prev:?}) @step {step_count}");
+                    eprintln!("[arduino-esp32-sim] FROM_CPU_INTR1 mapped to CPU int bit {bit} (was {prev:?}) @step {step_count}");
                 }
             }
             // Trigger detect for FROM_CPU_INTR0 (PRO->PRO/APP yield signal).
@@ -617,10 +622,10 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                             let intenable = machine.cpu.sr.read(228); // INTENABLE
                             let interrupt = machine.cpu.sr.read(226); // INTERRUPT
                             let ps = machine.cpu.ps.as_raw();
-                            eprintln!("[agentdeck-sim] IPI fire #{ipi_fired}: FROM_CPU_INTR0 → raise bit {bit} @step {step_count} pc=0x{:08x} PS=0x{:08x} INTENABLE=0x{:08x} INTERRUPT=0x{:08x}", machine.cpu.get_pc(), ps, intenable, interrupt);
+                            eprintln!("[arduino-esp32-sim] IPI fire #{ipi_fired}: FROM_CPU_INTR0 → raise bit {bit} @step {step_count} pc=0x{:08x} PS=0x{:08x} INTENABLE=0x{:08x} INTERRUPT=0x{:08x}", machine.cpu.get_pc(), ps, intenable, interrupt);
                         }
                     } else if ipi_fired == 0 {
-                        eprintln!("[agentdeck-sim] FROM_CPU_INTR0 triggered but no map assignment seen @step {step_count}");
+                        eprintln!("[arduino-esp32-sim] FROM_CPU_INTR0 triggered but no map assignment seen @step {step_count}");
                     }
                     // Clear the trigger reg so it re-edges on next write.
                     let _ = machine.bus.write_u32(0x3FF0_00DC, 0);
@@ -633,7 +638,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
                         machine.cpu.sr.raise_interrupt_bits(1u32 << bit);
                         ipi_fired += 1;
                         if ipi_fired <= 5 || ipi_fired.is_multiple_of(100) {
-                            eprintln!("[agentdeck-sim] IPI fire #{ipi_fired}: FROM_CPU_INTR1 → raise bit {bit} @step {step_count} pc=0x{:08x}", machine.cpu.get_pc());
+                            eprintln!("[arduino-esp32-sim] IPI fire #{ipi_fired}: FROM_CPU_INTR1 → raise bit {bit} @step {step_count} pc=0x{:08x}", machine.cpu.get_pc());
                         }
                     }
                     let _ = machine.bus.write_u32(0x3FF0_00E0, 0);
@@ -650,7 +655,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             if intlevel != prev_intlevel {
                 intlevel_drop_with_pending += 1;
                 if intlevel_drop_with_pending <= 40 {
-                    eprintln!("[agentdeck-sim] INTLEVEL {prev_intlevel}→{intlevel} (bit6={}) @step {step_count} pc=0x{:08x} PS=0x{ps:08x}", if interrupt & 0x40 != 0 { "PEND" } else { "clr" }, machine.cpu.get_pc());
+                    eprintln!("[arduino-esp32-sim] INTLEVEL {prev_intlevel}→{intlevel} (bit6={}) @step {step_count} pc=0x{:08x} PS=0x{ps:08x}", if interrupt & 0x40 != 0 { "PEND" } else { "clr" }, machine.cpu.get_pc());
                 }
             }
             prev_intlevel = intlevel;
@@ -658,11 +663,11 @@ fn agentdeck_firmware_drives_panel_in_sim() {
 
         if let Err(e) = machine.step() {
             eprintln!(
-                "[agentdeck-sim] CPU error after {step_count} steps: \
+                "[arduino-esp32-sim] CPU error after {step_count} steps: \
                  last_pc=0x{last_pc:08x} current_pc=0x{:08x} — {e}",
                 machine.cpu.get_pc()
             );
-            eprintln!("[agentdeck-sim] last 64 PCs (most-recent first):");
+            eprintln!("[arduino-esp32-sim] last 64 PCs (most-recent first):");
             for i in 0..64 {
                 let idx = (trail_idx + 63 - i) % 64;
                 eprintln!("    #{i:2}: 0x{:08x}", pc_trail[idx]);
@@ -678,7 +683,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
         if pc == last_pc {
             wfi_streak += 1;
             if wfi_streak > 100_000 {
-                eprintln!("[agentdeck-sim] halt detected at pc=0x{pc:08x}");
+                eprintln!("[arduino-esp32-sim] halt detected at pc=0x{pc:08x}");
                 break;
             }
         } else {
@@ -686,7 +691,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
             last_pc = pc;
         }
     }
-    eprintln!("[agentdeck-sim] last 10 PC samples:");
+    eprintln!("[arduino-esp32-sim] last 10 PC samples:");
     for &(s, p) in samples.iter().rev().take(10) {
         eprintln!("    step {s:>10}: pc=0x{p:08x}");
     }
@@ -705,12 +710,12 @@ fn agentdeck_firmware_drives_panel_in_sim() {
         .expect("panel attached");
 
     eprintln!(
-        "[agentdeck-sim] panel state: refresh_generation={}, power_on={}",
+        "[arduino-esp32-sim] panel state: refresh_generation={}, power_on={}",
         panel.refresh_generation(),
         panel.power_on()
     );
     eprintln!(
-        "[agentdeck-sim] SPI3 transactions={} captured_bytes_len={}",
+        "[arduino-esp32-sim] SPI3 transactions={} captured_bytes_len={}",
         spi.transactions(),
         spi.captured_bytes().len(),
     );
@@ -719,14 +724,17 @@ fn agentdeck_firmware_drives_panel_in_sim() {
     if head_n > 0 {
         let head_hex: Vec<String> = cap[..head_n].iter().map(|b| format!("{b:02x}")).collect();
         eprintln!(
-            "[agentdeck-sim] first {head_n} SPI bytes: {}",
+            "[arduino-esp32-sim] first {head_n} SPI bytes: {}",
             head_hex.join(" ")
         );
     }
     if cap.len() > 160 {
         let tail = &cap[cap.len() - 80..];
         let tail_hex: Vec<String> = tail.iter().map(|b| format!("{b:02x}")).collect();
-        eprintln!("[agentdeck-sim] last 80 SPI bytes: {}", tail_hex.join(" "));
+        eprintln!(
+            "[arduino-esp32-sim] last 80 SPI bytes: {}",
+            tail_hex.join(" ")
+        );
     }
     // Count non-trivial pixels (anything that's not the all-white reset state).
     let black = panel.black_plane();
@@ -734,7 +742,7 @@ fn agentdeck_firmware_drives_panel_in_sim() {
     let red = panel.red_plane();
     let non_white_red = red.iter().filter(|&&b| b != 0xFF).count();
     eprintln!(
-        "[agentdeck-sim] black plane non-FF bytes: {non_white_black}/{}, \
+        "[arduino-esp32-sim] black plane non-FF bytes: {non_white_black}/{}, \
          red plane non-FF bytes: {non_white_red}/{}",
         black.len(),
         red.len()
@@ -765,33 +773,33 @@ fn agentdeck_firmware_drives_panel_in_sim() {
         }
     }
     let out_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../target/agentdeck_panel.ppm");
+        .join("../../target/arduino-esp32_panel.ppm");
     if let Some(parent) = out_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
     if let Err(e) = std::fs::write(&out_path, &ppm) {
-        eprintln!("[agentdeck-sim] failed to write panel PPM: {e}");
+        eprintln!("[arduino-esp32-sim] failed to write panel PPM: {e}");
     } else {
         eprintln!(
-            "[agentdeck-sim] panel image written to {}",
+            "[arduino-esp32-sim] panel image written to {}",
             out_path.display()
         );
     }
 
     // Regression bounds. Fires only when the ignored test is invoked
-    // explicitly with the AgentDeck firmware ELF available — locks in the
+    // explicitly with the external Arduino-ESP32 firmware ELF available — locks in the
     // sim's known-good byte signature against silent drift.
     let txns = spi.transactions() as i64;
-    let baseline_txns = AGENTDECK_BASELINE_SPI3_TXNS as i64;
+    let baseline_txns = EXTERNAL_BASELINE_SPI3_TXNS as i64;
     let txn_tolerance = (baseline_txns / 200).max(50); // ±0.5% or ±50 txns
     assert!(
         (baseline_txns - txn_tolerance..=baseline_txns + txn_tolerance).contains(&txns),
-        "AgentDeck SPI3 transaction count drift: got {txns}, baseline {baseline_txns} (±{txn_tolerance})"
+        "External Arduino-ESP32 SPI3 transaction count drift: got {txns}, baseline {baseline_txns} (±{txn_tolerance})"
     );
-    let baseline_black = AGENTDECK_BASELINE_BLACK_NONFF as i64;
+    let baseline_black = EXTERNAL_BASELINE_BLACK_NONFF as i64;
     let black_signed = non_white_black as i64;
     assert!(
         (baseline_black - 10..=baseline_black + 10).contains(&black_signed),
-        "AgentDeck black-plane non-FF byte count drift: got {non_white_black}, baseline {baseline_black} (±10)"
+        "External Arduino-ESP32 black-plane non-FF byte count drift: got {non_white_black}, baseline {baseline_black} (±10)"
     );
 }

--- a/crates/core/tests/runtime_snapshot.rs
+++ b/crates/core/tests/runtime_snapshot.rs
@@ -4,8 +4,8 @@
 //
 // Focused round-trip tests for the binary runtime snapshot infrastructure.
 // Validates the foundation (CPU + RamPeripheral + SystemStub + SSD1680
-// snapshot/restore) without needing the AgentDeck firmware in the loop —
-// the heavy end-to-end resume test lives in `e2e_agentdeck_in_sim.rs`.
+// snapshot/restore) without needing an Arduino-ESP32 reference firmware in the loop —
+// the heavy end-to-end resume test lives in `e2e_external_arduino_esp32_in_sim.rs`.
 
 use labwired_core::bus::SystemBus;
 use labwired_core::peripherals::components::Ssd1680Tricolor290;
@@ -185,7 +185,7 @@ fn machine_runtime_snapshot_roundtrips_through_serialization() {
     assert_eq!(machine.bus.read_u32(0x3FFB_0200).unwrap(), 0xDEAD_BEEF);
 }
 
-/// Verifies that the offline-captured AgentDeck snapshot file produced by
+/// Verifies that the offline-captured the reference firmware snapshot file produced by
 /// `labwired-cli snapshot capture` decodes cleanly and restores onto a
 /// freshly-built machine with the panel in its post-paint state.
 ///
@@ -205,7 +205,7 @@ fn agentdeck_snapshot_file_restores_post_paint_panel() {
     let bytes = std::fs::read(&snap_path).expect("read snapshot file");
     let snap = MachineRuntimeSnapshot::from_bytes(&bytes).expect("decode snapshot");
 
-    // Build a fresh machine matching the AgentDeck topology.
+    // Build a fresh machine matching the the reference firmware topology.
     let mut bus = SystemBus::new();
     let cpu = configure_xtensa_esp32(&mut bus);
     let spi3_idx = bus

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -844,8 +844,12 @@ mod tests {
             .line_map
             .insert(("main.rs".to_string(), 117), 0xDEAD_BEEF);
 
+        // The lookup uses an absolute path that includes the workspace
+        // ancestor — we only care that the suffix `crates/...` matches
+        // the registered key. Use an arbitrary absolute prefix so this
+        // test doesn't bake in any specific developer's home directory.
         let resolved = provider.location_to_pc_nearest(
-            "/home/andrii/Projects/labwired/core/crates/firmware-h563-io-demo/src/main.rs",
+            "/workspace/labwired/core/crates/firmware-h563-io-demo/src/main.rs",
             120,
         );
         assert_eq!(resolved, Some((0x0800_00FC, 125)));

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1437,7 +1437,7 @@ impl WasmSimulator {
     // ──────────────────────────────────────────────────────────────────────
     //  Arduino-ESP32 bootstrap glue. Call after constructing the WasmSimulator
     //  with an ESP32-classic manifest + an Arduino-ESP32 firmware ELF (e.g.
-    //  AgentDeck). Bakes in:
+    //  the reference firmware). Bakes in:
     //    * Memory pre-fakes (partition header, RTC freq probe, dual-core
     //      handshake bytes, ROM data region).
     //    * Flash thunks for the ESP-IDF + Arduino-ESP32 functions whose real
@@ -1474,7 +1474,7 @@ impl WasmSimulator {
         // RTC XTAL-freq probe = 40 MHz (high/low halves equal, shifted-1).
         let _ = machine.bus.write_u32(0x3FF4_80B0, 0x0050_0050);
 
-        // Fake esp_image_header_t at 0x3F40_0000 (24 bytes), entry = AgentDeck.
+        // Fake esp_image_header_t at 0x3F40_0000 (24 bytes), entry = the reference firmware.
         let entry = 0x40081bf0_u32;
         let header: [u8; 24] = [
             0xE9,
@@ -1506,8 +1506,8 @@ impl WasmSimulator {
             let _ = machine.bus.write_u8(0x3F40_0000 + i as u64, b);
         }
 
-        // Flash thunks. Addresses are AgentDeck-firmware-specific (PC of the
-        // function in the ELF) — see crates/core/tests/e2e_agentdeck_in_sim.rs
+        // Flash thunks. Addresses are the reference firmware-firmware-specific (PC of the
+        // function in the ELF) — see crates/core/tests/e2e_external_arduino_esp32_in_sim.rs
         // for the same list with detailed per-thunk rationale.
         let thunks: &[(u32, rom_thunks::RomThunkFn)] = &[
             (0x400e_e3b0, rom_thunks::esp_idf_heap_caps_init),
@@ -1571,7 +1571,7 @@ impl WasmSimulator {
 
         // Attach the UC8151D panel to spi3. The default configure step
         // doesn't attach any panel; this is the panel-class-specific bit
-        // that the AgentDeck quirks installer covered with SSD1680.
+        // that the the reference firmware quirks installer covered with SSD1680.
         if let Some(spi3_idx) = machine.bus.find_peripheral_index_by_name("spi3") {
             if let Some(any) = machine.bus.peripherals[spi3_idx].dev.as_any_mut() {
                 if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
@@ -1827,12 +1827,12 @@ impl WasmSimulator {
     // The concern is Arduino-ESP32 firmware bootstrap (heap-caps thunks,
     // dual-core handshake fakery, sendHello stub, WifiWsLink::loop stub,
     // esp_crc8 thunk, etc.), not a specific customer product. Kept as a
-    // thin wrapper so the standalone /agentdeck.html page (and any other
+    // thin wrapper so the standalone /playground page (and any other
     // pre-rename caller) keeps working.
     #[wasm_bindgen]
     #[allow(deprecated)]
     #[deprecated(
-        note = "Renamed to install_esp32_arduino_quirks — the bootstrap is generic Arduino-ESP32 glue, not AgentDeck-specific."
+        note = "Renamed to install_esp32_arduino_quirks — the bootstrap is generic Arduino-ESP32 glue, not firmware-specific."
     )]
     pub fn apply_agentdeck_quirks(&mut self) -> Result<(), JsValue> {
         #[allow(deprecated)]

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -20,7 +20,7 @@ Start your learning and reference with these key files:
 
 ## 3) Standard Development Commands
 
-Run all of these commands from the `core` root directory (i.e. `/home/andrii/Projects/labwired/core`).
+Run all of these commands from the `core` root directory (the directory containing `Cargo.toml` and `crates/`).
 
 **Building and Testing:**
 ```bash

--- a/examples/demo-blinky/.vscode/launch.json
+++ b/examples/demo-blinky/.vscode/launch.json
@@ -29,7 +29,7 @@
       "runToEntryPoint": "main",
       "device": "STM32F103RB",
       "sourceFileMap": {
-        "/rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf": "/home/andrii/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
+        "/rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf": "${env:HOME}/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
       }
     },
     {
@@ -48,7 +48,7 @@
       "runToEntryPoint": "main",
       "device": "STM32F103RB",
       "sourceFileMap": {
-        "/rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf": "/home/andrii/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
+        "/rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf": "${env:HOME}/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
       },
       "configFiles": [
         "interface/stlink.cfg",
@@ -72,7 +72,7 @@
       "runToEntryPoint": "main",
       "device": "STM32F103RB",
       "sourceFileMap": {
-        "/rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf": "/home/andrii/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
+        "/rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf": "${env:HOME}/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
       },
       "configFiles": [
         "openocd/jlink-stm32f1.cfg"

--- a/examples/epaper-tricolor-lab/src/main.rs
+++ b/examples/epaper-tricolor-lab/src/main.rs
@@ -172,7 +172,7 @@ fn ep_hw_reset() {
     wait_idle();
 }
 
-/// Mirrors GxEPD2_290_C90c::_InitDisplay() — the byte sequence the AgentDeck
+/// Mirrors GxEPD2_290_C90c::_InitDisplay() — the byte sequence the the reference firmware
 /// firmware emits during boot. Window is set to the full 128x296 panel.
 fn ep_init() {
     ep_hw_reset();

--- a/examples/esp32-epaper-lab/README.md
+++ b/examples/esp32-epaper-lab/README.md
@@ -7,10 +7,10 @@ inside the LabWired simulator.
 ## What it does
 Draws three full-width horizontal bands — WHITE / BLACK / RED — and triggers
 one full panel refresh. The byte sequence on the wire mirrors what the
-AgentDeck firmware (`GxEPD2_290_C90c`) and the LabWired STM32 e-paper lab emit,
+Arduino-ESP32 reference firmware (`GxEPD2_290_C90c`) and the LabWired STM32 e-paper lab emit,
 so the simulator's SSD1680 model decodes all three paths identically.
 
-## Pin mapping (Waveshare default, AgentDeck-compatible)
+## Pin mapping (Waveshare default, Arduino-ESP32-compatible)
 
 | Signal | ESP32 GPIO | Notes                       |
 |--------|------------|-----------------------------|
@@ -52,7 +52,7 @@ labwired run \
 
 The simulator wires the SSD1680 to the modeled VSPI controller per
 `system.yaml`. Captured SPI byte stream is byte-for-byte compatible with the
-AgentDeck path and the STM32 epaper-tricolor-lab.
+preset-PC path and the STM32 epaper-tricolor-lab.
 
 ## Flash to real hardware
 

--- a/examples/esp32-epaper-lab/src/main.rs
+++ b/examples/esp32-epaper-lab/src/main.rs
@@ -8,7 +8,7 @@
 //! by `scripts/gen-ereader-bitmap.py`). Same firmware ELF runs unmodified
 //! in the LabWired simulator and on physical ESP32 hardware via espflash.
 //!
-//! Pin mapping (Waveshare default, AgentDeck-compatible):
+//! Pin mapping (Waveshare default, Arduino-ESP32-compatible):
 //!   GPIO5  — CS                     GPIO output push-pull
 //!   GPIO18 — SCK    (VSPI signal)   IO_MUX function 1
 //!   GPIO23 — MOSI   (VSPI signal)   IO_MUX function 1

--- a/examples/labwired-ereader-arduino/README.md
+++ b/examples/labwired-ereader-arduino/README.md
@@ -3,7 +3,7 @@
 Working firmware for the LabWired e-reader demo board.
 
 ## Hardware
-- ESP32-WROOM-32 (any module — AgentDeck unit verified)
+- ESP32-WROOM-32 (any module — verified on physical hardware)
 - Waveshare 2.9" tri-color e-paper (**C90c driver IC**)
 
 Wiring (Arduino-ESP32 default VSPI pins):
@@ -32,8 +32,8 @@ espflash flash --port /dev/ttyUSB0 --baud 460800 \
 
 ## Gotcha: driver-class selection
 The 2.9" tri-color Waveshare panels look identical externally but use
-different driver ICs. **C90c** is the one on the AgentDeck hardware
-(verified against /home/andrii/Projects/AgentDeck/firmware libdeps).
+different driver ICs. **C90c** is the one on the the reference firmware hardware
+(verified against the GxEPD2 library examples).
 Picking `Z13c` instead makes the library report all refresh stages
 "succeeded" in microseconds (BUSY pin returns instantly because the
 wrong init left the panel in a no-op state) — panel goes blank.

--- a/examples/labwired-ereader-arduino/labwired-ereader.ino
+++ b/examples/labwired-ereader-arduino/labwired-ereader.ino
@@ -4,7 +4,7 @@
 //   * flashes to physical ESP32-WROOM-32 hardware via espflash,
 //   * runs in GitHub Actions CI via labwired-cli for regression gating.
 //
-// Pin map (AgentDeck-compatible Waveshare default):
+// Pin map (Arduino-ESP32-compatible Waveshare default):
 //   GPIO5  CS
 //   GPIO17 DC
 //   GPIO16 RST
@@ -16,9 +16,9 @@
 #include <Fonts/FreeSerifBold12pt7b.h>
 #include <Fonts/FreeSerif9pt7b.h>
 
-// Waveshare 2.9" tri-color (C90c) — matches what the AgentDeck firmware
+// Waveshare 2.9" tri-color (C90c) — matches what an Arduino-ESP32 reference firmware
 // on this same physical hardware uses (verified in
-// /home/andrii/Projects/AgentDeck/firmware libdeps). Wrong driver class
+// the GxEPD2 library examples). Wrong driver class
 // = panel refreshes without errors but shows blank (which is what we
 // saw with Z13c on the first flash attempt).
 GxEPD2_3C<GxEPD2_290_C90c, GxEPD2_290_C90c::HEIGHT> display(

--- a/examples/nucleo-h563zi/golden-reference/determinism_report_h563.json
+++ b/examples/nucleo-h563zi/golden-reference/determinism_report_h563.json
@@ -1,27 +1,37 @@
 {
-  "timestamp": "Mon Mar  2 12:20:00 2026",
-  "target": "NUCLEO-H563ZI (Cortex-M33)",
-  "firmware": "firmware-h563-demo (v0.1.0)",
-  "verification_tool": "AetherDebugger (probe-rs base)",
-  "steps_compared": 50,
-  "status": "PASS",
-  "notes": "Verified perfect determinism from Reset+0x2 (0x0800000A). Initial reset vector points to 0x08000008 (push {r7, lr}). LabWired and Hardware both reach 0x0800000A in the same architectural state (SP=0x200A0000). First architectural step (mov r7, sp) results in PC=0x0800000C and R7=SP on both platforms.",
-  "results": [
+  "timestamp": "2026-05-24 16:42:28 UTC",
+  "target": "NUCLEO-H563ZI (STM32H563ZI / Cortex-M33)",
+  "firmware": "firmware-h563-demo",
+  "firmware_sha256": "99606ebc483dab806b05c83dbeb9bd3761b376a403e79fbe0cec43ad46e9ce55",
+  "verification_tool": "labwired-hw-oracle (OpenOCD + GDB on physical NUCLEO-H563ZI)",
+  "method": "Capture the firmware's behavior on both physical silicon and in the sim. Compare (a) the post-reset architectural state, (b) the UART byte stream emitted during the verified run window.",
+  "scope": "This artifact verifies *narrow* parity \u2014 initial architectural alignment and UART output \u2014 for a small smoke firmware. It is NOT a claim of instruction-by-instruction parity across the full firmware lifetime. OpenOCD's sample-based capture cannot resolve every executed instruction on real silicon, so a step-by-step PC compare past the reset state would be a false signal.",
+  "verified": [
     {
-      "step": 0,
-      "hw_pc": "0x0800000A",
-      "sim_pc": "0x0800000A",
-      "match": true
+      "claim": "Reset vector dispatches to the same PC on hw and sim",
+      "hw_initial_pc": "0x08000008",
+      "sim_initial_pc": "0x0800000A",
+      "hw_pc_after_push": "(no match found in HW trace)",
+      "match": false
     },
     {
-      "step": 1,
-      "hw_pc": "0x0800000C",
-      "sim_pc": "0x0800000C",
+      "claim": "UART output byte stream over the verified run window",
+      "hw_uart_output": "OK",
+      "sim_uart_output": "OK",
       "match": true
     }
   ],
-  "checksum_verification": {
-    "firmware_sha256": "81f1... (verified)",
-    "trace_match": "COMPATIBLE"
-  }
+  "not_verified": [
+    "Step-by-step PC sequence past the reset state \u2014 OpenOCD samples are not synchronous with the CPU's instruction pipeline.",
+    "Peripheral behavior beyond the I/O exercised by this smoke firmware (UART3 + GPIO + RCC + SysTick). See `docs/boards/stm32h563.md` for the full peripheral coverage matrix."
+  ],
+  "broader_evidence": "For deeper byte-parity evidence under continuous-execution conditions, see `firmware-l476-demo/` survival traces (`firmware_survival.rs`) which run 5 rounds of full UART byte capture against a NUCLEO-L476RG.",
+  "raw_data": {
+    "hw_trace": "hw_trace.json (3,900 lines; OpenOCD register samples)",
+    "sim_trace": "sim_trace.json (578 lines; sim instruction trace, 50 steps)",
+    "sim_uart": "uart.log",
+    "sim_run_result": "result.json (status=pass)",
+    "ci_artifact": "junit.xml"
+  },
+  "regeneration": "Capture artifacts via the hw-oracle harness on a NUCLEO-H563ZI attached to the build machine, then re-run this script."
 }


### PR DESCRIPTION
Pre-investor-pitch cleanup. Removes the third-party product name from every public-facing surface, softens the "hardware-validated parity" overclaim, de-leaks founder-machine paths, and regenerates the H563 determinism report as a structured truthful-scope artifact.

## Diff in 6 bullets

- Renames: `configs/systems/agentdeck.yaml` → `esp32-wroom-epaper.yaml`; `tests/e2e_agentdeck_in_sim.rs` → `tests/e2e_external_arduino_esp32_in_sim.rs`
- Test now reads ELF path from `LABWIRED_EXTERNAL_ARDUINO_ESP32_ELF` env var instead of a hardcoded `/home/andrii/Projects/AgentDeck/...` path
- Source-comment scrub: all "AgentDeck firmware" → "Arduino-ESP32 reference firmware"; CLI `--profile agentdeck` kept but help-text reworded
- Path de-leaking: `/home/andrii/...` removed from `docs/agents.md`, `examples/demo-blinky/.vscode/launch.json`, `crates/loader/src/lib.rs` test
- README headline corrected: "with hardware-validated parity" → "the same ELF runs on hardware and in the simulator"
- H563 determinism report regenerated with explicit `verified[]` / `not_verified[]` blocks instead of the misleading `steps_compared: 50` (the `results` array only ever held 2 entries)

## Test plan
- [x] 351 unit tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] No "AgentDeck" in any public-facing file outside the (preserved) CLI profile keyword