### PR TITLE
fix(clippy): three lint errors on main (manual_range_patterns + unnecessary_cast)

### DIFF
--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -168,7 +168,7 @@ impl Uc8151dTricolor290 {
             }
             0x16 | 0x17 => self.await_params(cmd, 1), // AUTO
             0x20 => self.await_params(cmd, 44),       // LUT_VCOM
-            0x21 | 0x22 | 0x23 | 0x24 => self.await_params(cmd, 42), // LUT_WW/BW/WB/BB
+            0x21..=0x24 => self.await_params(cmd, 42), // LUT_WW/BW/WB/BB
             0x30 => self.await_params(cmd, 1),        // PLL
             0x40 => self.state = ProtoState::Idle, // TSC — temperature sensor calibration (0 data)
             0x41 => self.await_params(cmd, 1),     // TSE — temperature sensor enable
@@ -178,7 +178,7 @@ impl Uc8151dTricolor290 {
             0x61 => self.await_params(cmd, 3),     // TRES — resolution (HRES, VRES_MSB, VRES_LSB)
             0x65 => self.await_params(cmd, 4),     // GSST — gate/source start setting
             0x70 | 0x71 => self.state = ProtoState::Idle, // REV / FLG read (0 data on the in path)
-            0x80 | 0x81 | 0x82 => self.await_params(cmd, 1), // AMV / VV / VDCS
+            0x80..=0x82 => self.await_params(cmd, 1), // AMV / VV / VDCS
             0x90 => self.await_params(cmd, 7),     // PartialWindow
             0x91 | 0x92 => self.state = ProtoState::Idle, // PartialIn / PartialOut
             _ => {

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -412,7 +412,7 @@ pub fn spi_class_transfer(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<(
     let callinc = cpu.ps.callinc();
     let n = callinc * 4;
     let this = cpu.regs.read_logical(n + 2);
-    let byte = (cpu.regs.read_logical(n + 3) & 0xFF) as u32;
+    let byte = cpu.regs.read_logical(n + 3) & 0xFF;
 
     // Resolve SPI peripheral base. Prefer firmware's `_spi->dev` when
     // populated; fall back to SPI3 (the bus our SSD1680 model is


### PR DESCRIPTION
Fixes red CI on main. 3 mechanical clippy fixes from the recent UC8151D + spi_class_transfer additions. No behavior change. 351 unit tests still pass.