### PR TITLE
feat(xtensa): implement ILL/ILL.N exec arm (Phase 1.5)

### DIFF
--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -1589,6 +1589,25 @@ impl XtensaLx7 {
                 self.pc = self.pc.wrapping_add(len);
             }
 
+            // ILL / ILL.N — illegal instruction (intentional trap).
+            //
+            // Xtensa ISA RM §3.5.7 "ILL.N" and §3.5.6 "ILL": these encodings
+            // are defined to raise an IllegalInstructionCause exception
+            // (EXCCAUSE=0, vector = VECBASE+0x300). They're emitted by the
+            // toolchain as "should never reach here" safety nets — most
+            // commonly the `memw; ill.n` sequence that follows a write to a
+            // RTC_CNTL reset register, where on real silicon the chip resets
+            // before the ILL.N is fetched. Without this arm, the simulator's
+            // executor falls through to NotImplemented and reports
+            // "exec: Ill", which masks the fact that the firmware reached
+            // the trap deliberately.
+            //
+            // Encoding (HW-oracle verified, see decoder/xtensa_narrow.rs):
+            //   ILL.N  → 16-bit `6d f0` (op0=0xD, r=0xF, t-field=6, s=0)
+            //   ILL    → 24-bit `00 00 00` (routed via Unknown today; same
+            //             EXCCAUSE=0 semantics, so leaving the alias).
+            Ill => return self.raise_general_exception(0),
+
             // Unknown opcode: raise IllegalInstruction (EXCCAUSE=0).
             //
             // Xtensa LX7 ISA RM §5.2: executing an instruction not defined in the

--- a/crates/core/tests/brom_boot_smoke.rs
+++ b/crates/core/tests/brom_boot_smoke.rs
@@ -115,24 +115,61 @@ fn esp32_brom_loads_and_executes() {
     // garbage (= probable peripheral-state bug).
     let start_pc = machine.cpu.get_pc();
     eprintln!("[BROM] starting execution at PC=0x{:08x}", start_pc);
-    let mut step_err = None;
+    // Tolerate Xtensa general exceptions (ExceptionRaised): the simulator
+    // already mutates PC → VECBASE+0x300 on exception entry, so the next
+    // step() lands in the kernel exception vector. Real silicon delivers
+    // ILL.N / unimplemented-opcode traps to the same vector, and the BROM
+    // hands them off to `panic_helper`/`reset`. Stop only when the same PC
+    // repeats too many times (handler is stuck spinning) or when we hit a
+    // NotImplemented / bus error (genuine simulator gap).
+    let mut step_err: Option<(usize, String)> = None;
+    let mut last_pc = machine.cpu.get_pc();
+    let mut same_pc_streak = 0usize;
     for i in 0..50_000 {
-        if let Err(e) = machine.step() {
-            step_err = Some((i, e));
-            break;
+        match machine.step() {
+            Ok(()) => {
+                let pc = machine.cpu.get_pc();
+                if pc == last_pc {
+                    same_pc_streak += 1;
+                    if same_pc_streak > 64 {
+                        step_err = Some((i, format!("PC stuck at 0x{:08x}", pc)));
+                        break;
+                    }
+                } else {
+                    same_pc_streak = 0;
+                    last_pc = pc;
+                }
+            }
+            Err(labwired_core::SimulationError::ExceptionRaised { cause, pc }) => {
+                // Soft exception: log + continue. The CPU has already
+                // re-pointed PC at the kernel exception vector.
+                eprintln!(
+                    "[BROM] EXCCAUSE={} raised at cycle {}, faulting PC=0x{:08x} (handler at 0x{:08x})",
+                    cause,
+                    i,
+                    pc,
+                    machine.cpu.get_pc()
+                );
+                last_pc = machine.cpu.get_pc();
+                same_pc_streak = 0;
+            }
+            Err(e) => {
+                step_err = Some((i, format!("{}", e)));
+                break;
+            }
         }
     }
     let final_pc = machine.cpu.get_pc();
     match step_err {
         Some((cycle, err)) => {
             eprintln!(
-                "[BROM] CPU exception at cycle {}, PC=0x{:08x}: {}",
+                "[BROM] simulator stalled at cycle {}, PC=0x{:08x}: {}",
                 cycle, final_pc, err
             );
         }
         None => {
             eprintln!(
-                "[BROM] 50000 steps completed without exception, final PC=0x{:08x}",
+                "[BROM] 50000 steps completed without fatal error, final PC=0x{:08x}",
                 final_pc
             );
         }

--- a/crates/core/tests/xtensa_exec.rs
+++ b/crates/core/tests/xtensa_exec.rs
@@ -5457,3 +5457,47 @@ fn test_exec_break_n_halts_with_pc() {
     // PC must not have advanced (exception halts before advance).
     assert_eq!(cpu.get_pc(), TEST_PC, "PC must not advance on BREAK.N");
 }
+
+/// G5: ILL.N (narrow illegal-instruction trap) raises EXCCAUSE=0 and re-vectors
+/// the PC to the kernel exception vector (VECBASE + 0x300).
+///
+/// Per Xtensa ISA RM §3.5.7 the ILL.N opcode is defined to raise
+/// IllegalInstructionCause (EXCCAUSE=0). It is emitted by GCC/clang as the
+/// trailing "should never reach here" trap after sequences that must reset or
+/// halt the core (e.g. the `memw; ill.n` pair that follows a write to
+/// RTC_CNTL_OPTIONS0 in the ESP32 BROM `_rtc_trigger_sw_system_reset`).
+///
+/// HW-oracle (xtensa-esp32s3-elf-as + objdump):
+///   ill.n → 0xf06d (16-bit; write_narrow emits bytes 6d f0).
+///
+/// Regression for labwired-core#105: before this arm existed, the executor
+/// reported "not implemented: exec: Ill" and the BROM smoke test stalled at
+/// PC=0x4000fdd3.
+#[test]
+fn test_exec_ill_n_raises_exccause_0() {
+    let mut cpu = XtensaLx7::new();
+    let mut bus = SystemBus::new();
+    cpu.reset(&mut bus).unwrap();
+    cpu.set_pc(TEST_PC);
+
+    // ILL.N (0xf06d): r=0xF, t-field=6, s=0.
+    write_narrow(&mut bus, TEST_PC as u64, 0xf06d);
+
+    let err = cpu
+        .step(&mut bus, &[], &labwired_core::SimulationConfig::default())
+        .unwrap_err();
+    match err {
+        SimulationError::ExceptionRaised { cause, pc } => {
+            assert_eq!(cause, 0, "ILL.N must raise EXCCAUSE=0");
+            assert_eq!(pc, TEST_PC, "EPC1 must point at the faulting ILL.N");
+        }
+        other => panic!("expected ExceptionRaised{{cause:0,..}}, got {:?}", other),
+    }
+    // Handler PC = VECBASE + 0x300. Reset value of VECBASE is 0x40000000.
+    let expected_handler = cpu.sr.read(VECBASE_ID).wrapping_add(0x300);
+    assert_eq!(
+        cpu.get_pc(),
+        expected_handler,
+        "PC must re-vector to kernel exception vector"
+    );
+}


### PR DESCRIPTION
## Summary
Phase 1.5 follow-up to [#106](https://github.com/w1ne/labwired-core/pull/106). The BROM smoke test was stalling at PC 0x4000fdd3 (bytes \`6d f0 01\`). The decoder *was* identifying these as ILL.N (Xtensa narrow 'illegal instruction' opcode, ISA RM §3.5.7) — the executor just had no arm for \`Instruction::Ill\`, so it fell through to \"not implemented: exec: Ill\".

Adds the executor arm: \`Ill =&gt; raise_general_exception(0)\` — raises EXCCAUSE=0 (IllegalInstructionCause), sets EPC1, sets PS.EXCM, re-vectors PC to VECBASE+0x300. Same behavior as the existing \`Unknown(_)\` arm. Matches real silicon.

## Test
- New regression test \`test_exec_ill_n_raises_exccause_0\` in \`crates/core/tests/xtensa_exec.rs\`
- \`brom_boot_smoke\` updated to tolerate \`ExceptionRaised\` (continue stepping; CPU state is self-consistent post-exception) + added a same-PC streak detector so deliberate halt loops terminate cleanly

## New blocker
BROM now traps cleanly at the ILL.N, is delivered to the kernel exception vector at 0x40000300, and stalls one step later because \`.KernelExceptionVector.text\` is \`BREAK 1,0; J -3\` — the deliberate \"crashed forever\" halt. We reach it because \`_rtc_trigger_sw_system_reset\` was invoked but RTC_CNTL isn't modeled yet, so the SW reset doesn't actually reset the core.

This is **exactly what Phase 2 (RTC_CNTL on #TBD, opening next) fixes**. Once that merges, the BROM should skip past the SW-reset path entirely.

## Test plan
- [x] cargo test --lib clean
- [x] cargo test --test brom_boot_smoke -- --nocapture (loops to halt vector, terminates cleanly)
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt --check clean