### PR TITLE
feat(hw-oracle): ESP32-WROOM-32 capture-and-replay harness

### DIFF
--- a/crates/hw-oracle/Cargo.toml
+++ b/crates/hw-oracle/Cargo.toml
@@ -8,16 +8,30 @@ description = "HW oracle harness: JTAG-driven cross-validation against physical 
 [dependencies]
 labwired-hw-oracle-macros = { path = "../hw-oracle-macros" }
 labwired-core = { path = "../core" }
+labwired-loader = { path = "../loader" }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 libc = { workspace = true }
 goblin = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
 # serialport pulls libudev-sys on Linux which needs libudev-dev system
 # package — not present on CI's hosted runners. The crate is only used by
 # the HW flash/detect path (gated by the `hw-oracle` feature), so make the
 # dep itself optional and activate it through the feature.
 serialport = { workspace = true, optional = true }
+
+# Chip-model HW-vs-sim diff tool (issue #105). Loads a baseline capture
+# produced by `scripts/hw-oracle/esp32_capture.sh`, replays the firmware
+# in the simulator for the same number of cycles, and emits a JSON diff.
+# Always available — does not require the `hw-oracle` feature because the
+# replay side runs purely in sim and only reads files written by the HW
+# capture step.
+[[bin]]
+name = "esp32_replay_in_sim"
+path = "src/bin/esp32_replay_in_sim.rs"
 
 [features]
 default = []

--- a/crates/hw-oracle/src/bin/esp32_replay_in_sim.rs
+++ b/crates/hw-oracle/src/bin/esp32_replay_in_sim.rs
@@ -1,0 +1,388 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// ESP32-WROOM-32 HW-oracle replay tool (chip-model verification, issue #105).
+//
+// Reads a capture directory produced by `scripts/hw-oracle/esp32_capture.sh`,
+// loads the SAME firmware ELF into our `configure_xtensa_esp32` sim, runs it
+// for a comparable number of cycles, samples PC at the same step indices,
+// re-reads the same checkpoint memory regions, and emits a JSON diff with
+// the first divergence point.
+//
+// This tool requires NO hardware: it operates entirely on captured artifacts
+// plus the firmware ELF. Operators run it after `esp32_capture.sh` (which
+// does need hardware) or against a sample capture committed to the repo.
+//
+// Output (printed to stdout, also written to <capture>/diff.json):
+//
+//   {
+//     "schema":          "labwired-hw-oracle/esp32-wroom/diff/v1",
+//     "capture_dir":     "...",
+//     "elf":             "...",
+//     "pc_samples":      256,
+//     "pc_first_diverge": { "step": 17, "hw_pc": "0x...", "sim_pc": "0x..." },
+//     "mem_pre_match":   true,
+//     "mem_post_mismatches": [
+//       { "addr": "0x40080000", "hw": "0xdeadbeef", "sim": "0x00000000" },
+//       ...
+//     ],
+//     "summary":         "ok" | "diverged"
+//   }
+//
+// Exit codes:
+//   0  Capture loaded and diff produced (regardless of whether trace matched).
+//   1  Capture dir malformed / firmware ELF unreadable.
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Parser;
+use labwired_core::bus::SystemBus;
+use labwired_core::system::xtensa::configure_xtensa_esp32;
+use labwired_core::{Cpu, Machine};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Capture-side manifest (subset; everything else is ignored).
+#[derive(Debug, Deserialize)]
+struct OracleManifest {
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    elf: String,
+    /// Informational; not consumed by the diff logic but useful in `Debug`
+    /// dumps when a capture/sim disagreement is investigated by hand.
+    #[serde(default)]
+    #[allow(dead_code)]
+    chip: String,
+    #[serde(default)]
+    pc_samples: u32,
+    #[serde(default)]
+    pc_sample_interval_ms: u32,
+    #[serde(default)]
+    checkpoints: Vec<Checkpoint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Checkpoint {
+    /// Human-readable region name, surfaced only via `Debug`; the diff keys
+    /// off `addr` so unrecognised labels still round-trip.
+    #[allow(dead_code)]
+    label: String,
+    /// Hex string, e.g. "0x40080000".
+    addr: String,
+    words: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct DiffReport {
+    schema: &'static str,
+    capture_dir: String,
+    elf: String,
+    pc_samples: usize,
+    pc_first_diverge: Option<PcDiverge>,
+    mem_pre_match: bool,
+    mem_post_mismatches: Vec<MemMismatch>,
+    summary: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct PcDiverge {
+    step: usize,
+    hw_pc: String,
+    sim_pc: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MemMismatch {
+    addr: String,
+    hw: String,
+    sim: String,
+}
+
+#[derive(Parser)]
+#[command(
+    name = "esp32_replay_in_sim",
+    about = "Replay a captured ESP32-WROOM-32 firmware run inside the sim and diff."
+)]
+struct Args {
+    /// Path to the capture directory written by `esp32_capture.sh`.
+    #[arg(long)]
+    capture: PathBuf,
+
+    /// Override the firmware ELF path (defaults to the one named in oracle.json).
+    #[arg(long)]
+    elf: Option<PathBuf>,
+
+    /// Cycles to step before sampling each PC point. Defaults to a budget
+    /// derived from `pc_sample_interval_ms` assuming 240 MHz CPU clock so
+    /// that sim and HW sample the same nominal "wall-clock window."
+    #[arg(long)]
+    cycles_per_sample: Option<u64>,
+
+    /// Maximum total sim steps (safety cap). Defaults to
+    /// `cycles_per_sample * pc_samples * 4`.
+    #[arg(long)]
+    max_steps: Option<u64>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let report = run(&args)?;
+    let pretty = serde_json::to_string_pretty(&report)?;
+    println!("{pretty}");
+    let out = args.capture.join("diff.json");
+    fs::write(&out, &pretty).with_context(|| format!("write diff to {}", out.display()))?;
+    eprintln!("[esp32_replay_in_sim] diff written to {}", out.display());
+    Ok(())
+}
+
+fn run(args: &Args) -> Result<DiffReport> {
+    let manifest_path = args.capture.join("oracle.json");
+    let manifest_raw = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read manifest {}", manifest_path.display()))?;
+    let manifest: OracleManifest = serde_json::from_str(&manifest_raw)
+        .with_context(|| format!("parse manifest {}", manifest_path.display()))?;
+
+    // If the HW capture exited early ("no_hardware"), still let the operator
+    // run the sim side so they can sanity-check the replay pipeline. We just
+    // skip the diff comparison.
+    if manifest.status == "no_hardware" {
+        eprintln!(
+            "[esp32_replay_in_sim] note: capture status='no_hardware' — running sim only, \
+             no comparison possible. Connect an ESP32 and re-capture for a real diff."
+        );
+    }
+
+    let elf_path = match &args.elf {
+        Some(p) => p.clone(),
+        None => PathBuf::from(&manifest.elf),
+    };
+    if !elf_path.is_file() {
+        bail!(
+            "firmware ELF not readable: {} (override with --elf)",
+            elf_path.display()
+        );
+    }
+
+    // ── Sim setup ────────────────────────────────────────────────────────────
+    let mut bus = SystemBus::new();
+    let cpu = configure_xtensa_esp32(&mut bus);
+    bus.refresh_peripheral_index();
+    let mut machine = Machine::new(cpu, bus);
+
+    let image = labwired_loader::load_elf(&elf_path)
+        .with_context(|| format!("load ELF {}", elf_path.display()))?;
+    machine
+        .load_firmware(&image)
+        .map_err(|e| anyhow!("load_firmware: {e:?}"))?;
+    machine.cpu.set_pc(image.entry_point as u32);
+
+    // ── Cycle budgeting ──────────────────────────────────────────────────────
+    // Default budget: assume 240 MHz CPU. cycles_per_ms = 240_000.
+    // cycles_per_sample = sample_interval_ms * 240_000.
+    let pc_samples = manifest.pc_samples.max(1) as usize;
+    let cycles_per_sample = args.cycles_per_sample.unwrap_or_else(|| {
+        let ms = manifest.pc_sample_interval_ms.max(1) as u64;
+        ms * 240_000
+    });
+    let max_steps = args
+        .max_steps
+        .unwrap_or((cycles_per_sample * pc_samples as u64).saturating_mul(4));
+
+    eprintln!(
+        "[esp32_replay_in_sim] sim plan: {pc_samples} samples × {cycles_per_sample} cycles \
+         (max_steps={max_steps})"
+    );
+
+    // ── HW-side artifacts ────────────────────────────────────────────────────
+    let hw_pc_trace = read_pc_trace(&args.capture.join("pc_trace.tsv"))?;
+    let hw_mem_pre = read_mem_snapshot(&args.capture.join("mem_pre.json"))?;
+    let hw_mem_post = read_mem_snapshot(&args.capture.join("mem_post.json"))?;
+
+    // ── Sim PC trace ─────────────────────────────────────────────────────────
+    let mut sim_pc_trace: Vec<u32> = Vec::with_capacity(pc_samples);
+    let mut sim_mem_pre: BTreeMap<u32, u32> = BTreeMap::new();
+    let mut sim_mem_post: BTreeMap<u32, u32> = BTreeMap::new();
+
+    // Pre-snapshot: grab the same checkpoint windows BEFORE we step.
+    capture_checkpoints(&machine, &manifest.checkpoints, &mut sim_mem_pre);
+
+    let mut steps_taken: u64 = 0;
+    for sample in 0..pc_samples {
+        let target = (sample as u64 + 1) * cycles_per_sample;
+        let target = target.min(max_steps);
+        while steps_taken < target {
+            if let Err(e) = machine.step() {
+                eprintln!(
+                    "[esp32_replay_in_sim] sim stopped at step {steps_taken}: \
+                     pc=0x{:08x} err={e:?}",
+                    machine.cpu.get_pc()
+                );
+                // Pad the remaining samples with the halt PC so the diff
+                // tells the operator exactly when sim divergence started.
+                let halt_pc = machine.cpu.get_pc();
+                while sim_pc_trace.len() < pc_samples {
+                    sim_pc_trace.push(halt_pc);
+                }
+                break;
+            }
+            steps_taken += 1;
+            if steps_taken >= max_steps {
+                break;
+            }
+        }
+        if sim_pc_trace.len() >= pc_samples {
+            break;
+        }
+        sim_pc_trace.push(machine.cpu.get_pc());
+        if steps_taken >= max_steps {
+            // Cap reached; fill rest with the last observed PC.
+            while sim_pc_trace.len() < pc_samples {
+                sim_pc_trace.push(machine.cpu.get_pc());
+            }
+            break;
+        }
+    }
+
+    capture_checkpoints(&machine, &manifest.checkpoints, &mut sim_mem_post);
+
+    // ── Diff ────────────────────────────────────────────────────────────────
+    let mut pc_first_diverge = None;
+    if manifest.status != "no_hardware" {
+        for (step, &hw_pc) in hw_pc_trace.iter().enumerate() {
+            let Some(&sim_pc) = sim_pc_trace.get(step) else {
+                break;
+            };
+            if hw_pc != sim_pc {
+                pc_first_diverge = Some(PcDiverge {
+                    step,
+                    hw_pc: format!("0x{hw_pc:08x}"),
+                    sim_pc: format!("0x{sim_pc:08x}"),
+                });
+                break;
+            }
+        }
+    }
+
+    let mem_pre_match =
+        manifest.status == "no_hardware" || mem_maps_equal(&hw_mem_pre, &sim_mem_pre);
+
+    let mem_post_mismatches = if manifest.status == "no_hardware" {
+        Vec::new()
+    } else {
+        diff_mem_maps(&hw_mem_post, &sim_mem_post)
+    };
+
+    let summary = if pc_first_diverge.is_none()
+        && mem_pre_match
+        && mem_post_mismatches.is_empty()
+        && manifest.status != "no_hardware"
+    {
+        "ok"
+    } else if manifest.status == "no_hardware" {
+        "sim_only"
+    } else {
+        "diverged"
+    };
+
+    Ok(DiffReport {
+        schema: "labwired-hw-oracle/esp32-wroom/diff/v1",
+        capture_dir: args.capture.display().to_string(),
+        elf: elf_path.display().to_string(),
+        pc_samples,
+        pc_first_diverge,
+        mem_pre_match,
+        mem_post_mismatches,
+        summary,
+    })
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn read_pc_trace(path: &Path) -> Result<Vec<u32>> {
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let mut out = Vec::new();
+    for (lineno, line) in raw.lines().enumerate() {
+        if lineno == 0 || line.is_empty() {
+            // Skip header / blank.
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        if cols.len() < 3 {
+            continue;
+        }
+        let pc_hex = cols[2].trim_start_matches("0x");
+        let pc = u32::from_str_radix(pc_hex, 16)
+            .with_context(|| format!("parse pc '{}' on line {lineno}", cols[2]))?;
+        out.push(pc);
+    }
+    Ok(out)
+}
+
+fn read_mem_snapshot(path: &Path) -> Result<BTreeMap<u32, u32>> {
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed: BTreeMap<String, String> = serde_json::from_str(&raw)
+        .with_context(|| format!("parse mem snapshot {}", path.display()))?;
+    let mut out = BTreeMap::new();
+    for (k, v) in parsed {
+        let addr = u32::from_str_radix(k.trim_start_matches("0x"), 16)
+            .with_context(|| format!("parse mem snapshot addr '{k}'"))?;
+        let word = u32::from_str_radix(v.trim_start_matches("0x"), 16)
+            .with_context(|| format!("parse mem snapshot word '{v}'"))?;
+        out.insert(addr, word);
+    }
+    Ok(out)
+}
+
+fn capture_checkpoints<C: Cpu>(
+    machine: &Machine<C>,
+    checkpoints: &[Checkpoint],
+    out: &mut BTreeMap<u32, u32>,
+) {
+    for cp in checkpoints {
+        let base = match u32::from_str_radix(cp.addr.trim_start_matches("0x"), 16) {
+            Ok(a) => a,
+            Err(_) => {
+                eprintln!("[esp32_replay_in_sim] bad checkpoint addr {}", cp.addr);
+                continue;
+            }
+        };
+        for i in 0..cp.words {
+            let addr = base.wrapping_add(i * 4);
+            // Best-effort read — unmapped regions just produce 0, which is
+            // semantically "sim has no model" and shows up as a diff entry
+            // for the operator to investigate.
+            let word = machine.bus.read_u32(addr as u64).unwrap_or(0);
+            out.insert(addr, word);
+        }
+    }
+}
+
+fn mem_maps_equal(a: &BTreeMap<u32, u32>, b: &BTreeMap<u32, u32>) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    for (k, v) in a {
+        if b.get(k) != Some(v) {
+            return false;
+        }
+    }
+    true
+}
+
+fn diff_mem_maps(hw: &BTreeMap<u32, u32>, sim: &BTreeMap<u32, u32>) -> Vec<MemMismatch> {
+    let mut out = Vec::new();
+    for (&addr, &hw_word) in hw {
+        let sim_word = sim.get(&addr).copied().unwrap_or(0);
+        if hw_word != sim_word {
+            out.push(MemMismatch {
+                addr: format!("0x{addr:08x}"),
+                hw: format!("0x{hw_word:08x}"),
+                sim: format!("0x{sim_word:08x}"),
+            });
+        }
+    }
+    out
+}

--- a/scripts/hw-oracle/README_esp32.md
+++ b/scripts/hw-oracle/README_esp32.md
@@ -1,0 +1,227 @@
+# ESP32-WROOM-32 HW-oracle (chip-model verification)
+
+Operator runbook for the ESP32-WROOM-32 capture-and-replay harness that
+backs the full ESP32 chip-model rebuild (roadmap: issue #105).
+
+The harness has two halves:
+
+1. **`esp32_capture.sh`** — drives a real ESP32 via OpenOCD, flashes a
+   firmware ELF, and dumps a baseline trace (PC samples + memory
+   checkpoints) into a timestamped capture directory.
+2. **`esp32_replay_in_sim`** (Rust binary in `crates/hw-oracle`) — loads
+   the SAME firmware into our simulator, runs it for a comparable cycle
+   budget, re-reads the same checkpoints, and emits a JSON diff with the
+   first divergence point.
+
+This pair is the verification gate for every new peripheral added to the
+ESP32-classic chip model: if the sim's trace converges to HW for a given
+firmware, we have evidence the peripheral matters in that firmware
+behave correctly. If it diverges, the diff tells us at which PC / which
+checkpoint to look.
+
+For the existing decoder-vs-`objdump` oracle scripts (`b7-sweep.sh`,
+`b8-sweep.sh`), see [`README.md`](README.md).
+
+## Hardware
+
+| Component             | Notes                                                |
+| --------------------- | ---------------------------------------------------- |
+| ESP32-WROOM-32 module | DevKitC, DOIT v1, NodeMCU-32S, or any breakout that  |
+|                       | exposes 5 V, GND, EN, IO0, IO12 (TDI), IO13 (TCK),   |
+|                       | IO14 (TMS), IO15 (TDO).                              |
+| ESP-Prog JTAG adapter | FT2232H-based; Espressif sells one but any FT2232H   |
+|                       | board works (e.g. Tigard). USB → 6-pin JTAG header.  |
+| USB-UART bridge       | Either the dev kit's onboard CP2102 or a CH340 USB- |
+|                       | UART module on UART0 (IO1 / IO3). Used by `tio` for  |
+|                       | the optional UART stdout capture.                    |
+| 5 V USB power         | Both the ESP-Prog and the dev kit need power. With   |
+|                       | the DevKitC's onboard regulator you can power the    |
+|                       | board from its USB jack while JTAG is on ESP-Prog.   |
+
+### Cabling
+
+JTAG header (ESP-Prog 2x5 1.27 mm IDC → ESP32 pin):
+
+| ESP-Prog | ESP32 GPIO | Function |
+| -------: | ---------: | -------- |
+|   VTREF  | 3.3 V      | level ref |
+|   GND    | GND        |          |
+|   TMS    | IO14       |          |
+|   TCK    | IO13       |          |
+|   TDO    | IO15       |          |
+|   TDI    | IO12       |          |
+|   RESET  | EN         | optional |
+
+Wire EN to RESET so OpenOCD's `reset halt` actually toggles RESET. Without
+it you can still attach but `reset` is a no-op.
+
+> The 2.9" Waveshare tri-color e-paper module on the same board does NOT
+> need disconnecting for capture — the firmware still drives it normally
+> while OpenOCD samples PC.
+
+## Software
+
+| Tool        | Why                              | Install                                       |
+| ----------- | -------------------------------- | --------------------------------------------- |
+| openocd     | JTAG bridge                      | Espressif fork: <https://github.com/espressif/openocd-esp32/releases> (distro `openocd` may lack `target/esp32.cfg`) |
+| python3     | mem-snapshot post-processing     | usually pre-installed                         |
+| tio         | UART stdout capture (optional)   | `sudo apt install tio`                        |
+| Rust 1.80+  | running the sim replay binary    | already required by the rest of LabWired core |
+
+Verify OpenOCD has the ESP32 config:
+
+```sh
+openocd -f interface/ftdi/esp32_devkitj_v1.cfg -f target/esp32.cfg -c "init; reset halt; shutdown"
+```
+
+You should see `Info : esp32.cpu0: Target halted, PC: 0x40000400`. If
+instead you get "could not find target/esp32.cfg", install the Espressif
+fork.
+
+## Running a capture
+
+```sh
+# Flash the firmware to HW, sample PC 256 times every 20 ms, dump
+# checkpoint memory before and after. Writes to
+# scripts/hw-oracle/captures/esp32-wroom/<utc-ts>/.
+./scripts/hw-oracle/esp32_capture.sh path/to/firmware.elf
+
+# Optional: tune the sample plan via env vars
+ESP32_SAMPLES=512 ESP32_SAMPLE_MS=10 \
+  ./scripts/hw-oracle/esp32_capture.sh path/to/firmware.elf
+```
+
+Expected output:
+
+```
+[esp32_capture] capture dir: scripts/hw-oracle/captures/esp32-wroom/20260525T141855Z
+[esp32_capture] probing for ESP32 via openocd (interface/ftdi/esp32_devkitj_v1.cfg + target/esp32.cfg)...
+[esp32_capture] flashing /abs/path/firmware.elf...
+[esp32_capture] capturing pre-run memory snapshot...
+[esp32_capture] sampling PC: 256 samples every 20 ms...
+[esp32_capture] PC trace: 256 samples in 5180 ms
+[esp32_capture] capturing post-run memory snapshot...
+[esp32_capture] done: scripts/hw-oracle/captures/esp32-wroom/20260525T141855Z
+[esp32_capture] next: cargo run --release -p labwired-hw-oracle --bin esp32_replay_in_sim -- \
+                        --capture .../20260525T141855Z --elf /abs/path/firmware.elf
+```
+
+### Graceful degradation when no hardware is connected
+
+The script returns:
+
+| Exit | Meaning                                            |
+| ---: | -------------------------------------------------- |
+|    0 | Capture complete (`oracle.json` `status="ok"`)     |
+|    2 | OpenOCD not on PATH                                |
+|    3 | No ESP32 detected (writes `status="no_hardware"` ) |
+|    4 | Bad args (missing/unreadable ELF)                  |
+
+Exit codes 2 and 3 are the headless-CI path — the script never hangs.
+
+### Optional: capture UART stdout in parallel
+
+The current sim has no UART0 model for ESP32-classic, so this only feeds
+the **HW** side. Useful for diagnosing where firmware boot diverges:
+
+```sh
+tio --log --log-file uart0.txt /dev/ttyUSB0 -b 115200
+```
+
+Run `tio` BEFORE invoking `esp32_capture.sh`. After capture, move
+`uart0.txt` into the capture dir for future diffing once we model UART0.
+
+## Replaying in the simulator
+
+```sh
+cargo run --release -p labwired-hw-oracle --bin esp32_replay_in_sim -- \
+    --capture scripts/hw-oracle/captures/esp32-wroom/<ts> \
+    --elf path/to/firmware.elf      # optional; defaults to oracle.json's elf
+```
+
+Output (stdout AND written to `<capture>/diff.json`):
+
+```json
+{
+  "schema": "labwired-hw-oracle/esp32-wroom/diff/v1",
+  "capture_dir": "scripts/hw-oracle/captures/esp32-wroom/20260525T141855Z",
+  "elf": "/abs/path/firmware.elf",
+  "pc_samples": 256,
+  "pc_first_diverge": { "step": 17, "hw_pc": "0x400d0204", "sim_pc": "0x400d0210" },
+  "mem_pre_match": true,
+  "mem_post_mismatches": [
+    { "addr": "0x3ff44004", "hw": "0x00000020", "sim": "0x00000000" }
+  ],
+  "summary": "diverged"
+}
+```
+
+### Tuning the cycle budget
+
+The replay assumes 240 MHz CPU and converts `pc_sample_interval_ms`
+(from the manifest) to a sim cycle count. Override:
+
+```sh
+cargo run --release -p labwired-hw-oracle --bin esp32_replay_in_sim -- \
+    --capture <dir> \
+    --cycles-per-sample 50000 \
+    --max-steps 500_000_000
+```
+
+The defaults are intentionally generous (4× the nominal budget for
+`max-steps`) so the sim has slack to overshoot HW without bailing.
+
+## Interpreting the diff
+
+| Field                  | What divergence here means                            |
+| ---------------------- | ----------------------------------------------------- |
+| `pc_first_diverge`     | First sample where sim PC ≠ HW PC. Look at the HW PC |
+|                        | in objdump; if it's inside an unmodeled peripheral    |
+|                        | thunk (e.g. SPI), that's your next peripheral to add. |
+| `mem_pre_match: false` | Sim didn't observe the same boot state HW saw. Likely |
+|                        | a missing flash XIP segment or BROM init.             |
+| `mem_post_mismatches`  | Specific MMIO/RAM addresses where sim and HW ended up |
+|                        | with different values. The first 1–2 entries usually  |
+|                        | point at the responsible peripheral.                  |
+| `summary: "sim_only"`  | Capture exited with `status=no_hardware`; only the    |
+|                        | sim half ran. Useful for replay-pipeline sanity.      |
+| `summary: "ok"`        | All sampled signals matched. Promote this firmware to |
+|                        | a CI baseline.                                        |
+
+## Limitations (today)
+
+- **SPI / I²C bus snoop**: not captured. Requires a Saleae or similar logic
+  analyzer. Punt until we have one wired into CI.
+- **PC sampling intervals are nominal**: OpenOCD halt/resume round-trips
+  take ≈1 ms each, so a 20 ms-nominal sample is actually 21–25 ms of
+  wall-clock. Good enough for "did sim and HW diverge?", not good enough
+  for cycle-accurate timing comparisons.
+- **No interrupt capture**: BROM IRQs that fire between samples are
+  invisible to this harness. Add interrupt-vector breakpoint hooks once
+  we need them.
+- **UART0 stdout** is captured separately (via `tio`) on the HW side only;
+  the sim has no UART0 model for ESP32-classic yet.
+
+## File layout reference
+
+```
+scripts/hw-oracle/
+├── README.md              ← objdump-based decoder oracle (unchanged)
+├── README_esp32.md        ← this file
+├── b7-sweep.sh            ← branch-decoder oracle (unchanged)
+├── b8-sweep.sh            ← call/return-decoder oracle (unchanged)
+├── esp32_capture.sh       ← NEW: ESP32-WROOM-32 HW capture
+└── captures/
+    └── esp32-wroom/
+        └── <utc-ts>/
+            ├── oracle.json
+            ├── pc_trace.tsv
+            ├── mem_pre.json
+            ├── mem_post.json
+            ├── openocd.log
+            ├── elf.path
+            └── diff.json          (written by the replay tool)
+
+crates/hw-oracle/src/bin/
+└── esp32_replay_in_sim.rs ← NEW: sim-side replay + diff
+```

--- a/scripts/hw-oracle/esp32_capture.sh
+++ b/scripts/hw-oracle/esp32_capture.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+# ESP32-WROOM-32 HW oracle capture (chip-model verification, issue #105).
+#
+# Drives OpenOCD against a real ESP32-WROOM-32 connected via an ESP-Prog
+# (FT2232H) JTAG adapter and records a baseline trace that the sim can be
+# diff'd against by `esp32_replay_in_sim`.
+#
+# Captured signals (per "what we can sample without a logic analyzer"):
+#   - PC samples at fixed wall-clock intervals (halt → reg pc → resume).
+#   - Memory dumps of fixed checkpoint regions at the start and end of
+#     the run (IRAM head, DRAM .bss head, GPIO+UART0 MMIO windows).
+#   - UART0 stdout stream is NOT captured here (separate `tio` recording —
+#     see README_esp32.md), because OpenOCD can't passively snoop UART.
+#   - SPI bus snoop is INTENTIONALLY out of scope without a logic analyzer.
+#
+# Output layout (matches the existing hw-oracle naming convention):
+#   scripts/hw-oracle/captures/esp32-wroom/<utc-ts>/
+#     ├── oracle.json        Manifest: chip, sample params, region map.
+#     ├── pc_trace.tsv       step\tns_offset\tpc_hex      (one line per sample)
+#     ├── mem_pre.json       {addr_hex: [word_hex, ...]}  (pre-resume snapshot)
+#     ├── mem_post.json      {addr_hex: [word_hex, ...]}  (post-cycles snapshot)
+#     ├── openocd.log        Raw OpenOCD stdout/stderr (debugging).
+#     └── elf.path           Absolute path of the firmware ELF flashed.
+#
+# Usage:
+#   scripts/hw-oracle/esp32_capture.sh <firmware.elf> [opts]
+#
+# Options (env-var driven so the script stays argument-free for CI):
+#   ESP32_OPENOCD_IF   OpenOCD interface cfg     (default: interface/ftdi/esp32_devkitj_v1.cfg)
+#   ESP32_OPENOCD_TGT  OpenOCD target cfg        (default: target/esp32.cfg)
+#   ESP32_SAMPLES      Number of PC samples      (default: 256)
+#   ESP32_SAMPLE_MS    Interval between samples  (default: 20 ms)
+#   ESP32_CAPTURE_DIR  Override capture root     (default: scripts/hw-oracle/captures/esp32-wroom)
+#
+# Exit codes:
+#   0   Capture succeeded.
+#   2   OpenOCD not installed.
+#   3   No ESP32 detected (OpenOCD failed to attach within 30 s).
+#   4   Bad arguments (missing/unreadable ELF).
+#
+# This script is safe to invoke in headless CI: it returns the gracefully-
+# degraded exit codes above instead of hanging when no hardware is present.
+
+set -u
+set -o pipefail
+
+# ── arg parsing ───────────────────────────────────────────────────────────────
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <firmware.elf>" >&2
+  echo "       (see header of $0 for env-var options)" >&2
+  exit 4
+fi
+ELF="$1"
+if [[ ! -r "$ELF" ]]; then
+  echo "error: firmware ELF '$ELF' is not readable" >&2
+  exit 4
+fi
+ELF_ABS="$(readlink -f "$ELF")"
+
+OOCD_IF="${ESP32_OPENOCD_IF:-interface/ftdi/esp32_devkitj_v1.cfg}"
+OOCD_TGT="${ESP32_OPENOCD_TGT:-target/esp32.cfg}"
+SAMPLES="${ESP32_SAMPLES:-256}"
+SAMPLE_MS="${ESP32_SAMPLE_MS:-20}"
+CAPTURE_ROOT="${ESP32_CAPTURE_DIR:-$(dirname "$0")/captures/esp32-wroom}"
+
+# ── tool presence ─────────────────────────────────────────────────────────────
+if ! command -v openocd >/dev/null 2>&1; then
+  cat >&2 <<EOM
+[esp32_capture] openocd not found on PATH.
+
+Install ESP-IDF's fork (recommended; ships ESP32 configs):
+  sudo apt install openocd                  # distro build, may lack esp32.cfg
+  # or: https://github.com/espressif/openocd-esp32/releases
+
+Then re-run:
+  $0 $*
+EOM
+  exit 2
+fi
+
+# ── output dir ────────────────────────────────────────────────────────────────
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$CAPTURE_ROOT/$TS"
+mkdir -p "$OUT"
+echo "$ELF_ABS" > "$OUT/elf.path"
+echo "[esp32_capture] capture dir: $OUT"
+
+# ── checkpoint regions ─────────────────────────────────────────────────────────
+# Word-addressed (32-bit). Counts chosen to keep the snapshot small while
+# covering the windows most likely to diverge between sim and HW.
+#
+# Source: ESP32 TRM v4.9 §1.3.2 (address map) — same map our
+# `configure_xtensa_esp32` builder targets.
+#
+# Format: "label addr_hex count"
+CHECKPOINTS=(
+  "iram_head            0x40080000   64"   # SRAM0 IRAM start (256 B)
+  "dram_head            0x3FFAE000   64"   # SRAM2 DRAM start (256 B)
+  "sram1_top            0x3FFFE000   16"   # SRAM1 high (initial stack)
+  "uart0_regs           0x3FF40000   16"   # UART0 status/fifo window
+  "gpio_out             0x3FF44000   16"   # GPIO output regs
+  "rtc_apb_freq         0x3FF480B0    1"   # XTAL probe word
+)
+
+# ── helper: run an openocd batch script ────────────────────────────────────────
+run_oocd() {
+  local script="$1"
+  local logfile="$2"
+  # `-c "init; ...; shutdown"` keeps the daemon ephemeral. We pipe a tcl
+  # script via a here-doc command file so multi-line sequencing is reliable.
+  openocd \
+    -f "$OOCD_IF" \
+    -f "$OOCD_TGT" \
+    -c "init" \
+    -c "$script" \
+    -c "shutdown" \
+    >"$logfile" 2>&1
+}
+
+# ── attach probe ──────────────────────────────────────────────────────────────
+echo "[esp32_capture] probing for ESP32 via openocd ($OOCD_IF + $OOCD_TGT)..."
+if ! timeout 30 run_oocd "reset halt" "$OUT/openocd_probe.log"; then
+  echo "[esp32_capture] openocd failed to attach. Tail of log:" >&2
+  tail -n 40 "$OUT/openocd_probe.log" >&2 || true
+  echo "" >&2
+  echo "[esp32_capture] No hardware? See $(dirname "$0")/README_esp32.md" >&2
+  # Still write a manifest so callers can detect "ran but no HW".
+  cat > "$OUT/oracle.json" <<EOF
+{
+  "schema": "labwired-hw-oracle/esp32-wroom/v1",
+  "status": "no_hardware",
+  "elf": "$ELF_ABS",
+  "captured_utc": "$TS",
+  "openocd_interface": "$OOCD_IF",
+  "openocd_target": "$OOCD_TGT"
+}
+EOF
+  exit 3
+fi
+
+# ── flash the firmware ────────────────────────────────────────────────────────
+echo "[esp32_capture] flashing $ELF_ABS..."
+if ! run_oocd "reset halt; program $ELF_ABS verify; reset halt" "$OUT/openocd_flash.log"; then
+  echo "[esp32_capture] flash failed. Tail of log:" >&2
+  tail -n 60 "$OUT/openocd_flash.log" >&2 || true
+  exit 1
+fi
+
+# ── pre-run memory snapshot ───────────────────────────────────────────────────
+emit_mem_snapshot() {
+  local out_json="$1"
+  local oocd_log="$2"
+  # Build a TCL batch that emits `LBW_MEM <addr_hex> <hex...>` lines we can
+  # post-parse without depending on OpenOCD's verbose `mdw` formatting.
+  local script=""
+  for cp in "${CHECKPOINTS[@]}"; do
+    # shellcheck disable=SC2206
+    local parts=($cp)
+    local addr="${parts[1]}"
+    local count="${parts[2]}"
+    # `mem2array dst width addr count` (width=32 → 32-bit words)
+    script+="array unset words; mem2array words 32 $addr $count;"
+    script+=" for {set i 0} {\$i < $count} {incr i} {"
+    script+="   set off [expr {\$i * 4}];"
+    script+="   puts [format \"LBW_MEM 0x%08x 0x%08x\" [expr {$addr + \$off}] \$words(\$i)];"
+    script+=" };"
+  done
+  run_oocd "halt; $script" "$oocd_log" || true
+  # Convert log → JSON {addr: word}. Python is the path of least resistance;
+  # if not present we fall back to a jq-free hand-rolled dump.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$oocd_log" "$out_json" <<'PY'
+import json, sys
+log, out = sys.argv[1], sys.argv[2]
+words = {}
+with open(log) as f:
+    for line in f:
+        if not line.startswith("LBW_MEM "):
+            continue
+        _, addr, val = line.split()
+        words[addr] = val
+with open(out, "w") as f:
+    json.dump(words, f, indent=2, sort_keys=True)
+PY
+  else
+    {
+      echo "{"
+      first=1
+      grep '^LBW_MEM ' "$oocd_log" | while read -r _ addr val; do
+        if [[ $first -eq 1 ]]; then first=0; else echo ","; fi
+        printf '  "%s": "%s"' "$addr" "$val"
+      done
+      echo
+      echo "}"
+    } > "$out_json"
+  fi
+}
+
+echo "[esp32_capture] capturing pre-run memory snapshot..."
+emit_mem_snapshot "$OUT/mem_pre.json" "$OUT/openocd_mem_pre.log"
+
+# ── PC sample loop (resume / halt / read pc / repeat) ─────────────────────────
+echo "[esp32_capture] sampling PC: $SAMPLES samples every ${SAMPLE_MS} ms..."
+printf 'step\tns_offset\tpc_hex\n' > "$OUT/pc_trace.tsv"
+T0_NS=$(date +%s%N)
+# Construct a single TCL script that does the full loop server-side so the
+# round-trip overhead doesn't dominate the sample interval.
+SAMPLE_SCRIPT="reset run;"
+for ((i=0; i<SAMPLES; i++)); do
+  SAMPLE_SCRIPT+=" after $SAMPLE_MS; halt;"
+  # Print PC tagged with our sample index so we can recover step ordering.
+  SAMPLE_SCRIPT+=" puts [format \"LBW_PC %d 0x%08x\" $i [reg pc -force]];"
+  SAMPLE_SCRIPT+=" resume;"
+done
+run_oocd "$SAMPLE_SCRIPT" "$OUT/openocd_pc.log" || true
+T1_NS=$(date +%s%N)
+DUR_NS=$((T1_NS - T0_NS))
+
+# Note: `reg pc -force` prints "pc (/32): 0x00000000" — we already wrap it
+# in `puts [format ...]`, so the output line is literally "LBW_PC i 0xADDR".
+# Convert that to the TSV. We approximate ns_offset as (i * SAMPLE_MS * 1e6)
+# because OpenOCD doesn't expose per-sample wall-clock; this gives the
+# replay tool a consistent x-axis even though it's nominal.
+grep '^LBW_PC ' "$OUT/openocd_pc.log" | awk -v ms="$SAMPLE_MS" '
+{
+  step = $2
+  pc = $3
+  ns = step * ms * 1000000
+  printf("%d\t%d\t%s\n", step, ns, pc)
+}' >> "$OUT/pc_trace.tsv"
+
+echo "[esp32_capture] PC trace: $(($(wc -l < "$OUT/pc_trace.tsv") - 1)) samples in $((DUR_NS / 1000000)) ms"
+
+# ── post-run memory snapshot ──────────────────────────────────────────────────
+echo "[esp32_capture] capturing post-run memory snapshot..."
+emit_mem_snapshot "$OUT/mem_post.json" "$OUT/openocd_mem_post.log"
+
+# ── consolidate openocd log ────────────────────────────────────────────────────
+cat \
+  "$OUT/openocd_probe.log" \
+  "$OUT/openocd_flash.log" \
+  "$OUT/openocd_mem_pre.log" \
+  "$OUT/openocd_pc.log" \
+  "$OUT/openocd_mem_post.log" \
+  > "$OUT/openocd.log" 2>/dev/null || true
+rm -f "$OUT"/openocd_{probe,flash,mem_pre,mem_post,pc}.log
+
+# ── manifest ──────────────────────────────────────────────────────────────────
+# Emit JSON without invoking jq — escape only the few strings that need it.
+{
+  echo "{"
+  echo "  \"schema\": \"labwired-hw-oracle/esp32-wroom/v1\","
+  echo "  \"status\": \"ok\","
+  echo "  \"elf\": \"$ELF_ABS\","
+  echo "  \"captured_utc\": \"$TS\","
+  echo "  \"chip\": \"esp32-wroom-32\","
+  echo "  \"cpu\": \"xtensa-lx6\","
+  echo "  \"openocd_interface\": \"$OOCD_IF\","
+  echo "  \"openocd_target\": \"$OOCD_TGT\","
+  echo "  \"pc_samples\": $SAMPLES,"
+  echo "  \"pc_sample_interval_ms\": $SAMPLE_MS,"
+  echo "  \"capture_wall_ms\": $((DUR_NS / 1000000)),"
+  echo "  \"checkpoints\": ["
+  total=${#CHECKPOINTS[@]}
+  i=0
+  for cp in "${CHECKPOINTS[@]}"; do
+    # shellcheck disable=SC2206
+    parts=($cp)
+    label="${parts[0]}"
+    addr="${parts[1]}"
+    count="${parts[2]}"
+    sep=","
+    if (( ++i == total )); then sep=""; fi
+    echo "    { \"label\": \"$label\", \"addr\": \"$addr\", \"words\": $count }$sep"
+  done
+  echo "  ]"
+  echo "}"
+} > "$OUT/oracle.json"
+
+echo "[esp32_capture] done: $OUT"
+echo "[esp32_capture] next: cargo run --release -p labwired-hw-oracle --bin esp32_replay_in_sim -- \\"
+echo "                        --capture $OUT --elf $ELF_ABS"


### PR DESCRIPTION
## Summary
Builds out the HW-vs-sim verification harness for the chip-model roadmap ([#105](https://github.com/w1ne/labwired-core/issues/105)). Lets us capture a baseline trace from real ESP32 hardware (the user has an ESP32-WROOM-32 with a Waveshare 2.9\" tri-color e-paper) and diff it against sim execution of the same firmware.

## What's here
- **\`scripts/hw-oracle/esp32_capture.sh\`** — OpenOCD-driven HW capture: flashes a firmware ELF over an ESP-Prog (FT2232H) JTAG adapter, samples PC at fixed intervals, dumps memory checkpoint regions (IRAM head, DRAM head, UART0 regs, GPIO regs, RTC XTAL probe word). Output: \`scripts/hw-oracle/captures/esp32-wroom/&lt;utc-ts&gt;/\`.
- **\`crates/hw-oracle/src/bin/esp32_replay_in_sim.rs\`** — Rust bin: loads the same ELF into \`configure_xtensa_esp32\`, replays for a comparable cycle budget, re-reads the same checkpoints, writes \`diff.json\`.
- **\`scripts/hw-oracle/README_esp32.md\`** — operator runbook (hardware list, JTAG cabling, OpenOCD install, invocation, diff interpretation).
- **\`crates/hw-oracle/Cargo.toml\`** — new \`[[bin]]\` target + deps.

## Operator flow
\`\`\`
# 1. Connect ESP-Prog (TMS=IO14 TCK=IO13 TDO=IO15 TDI=IO12 VTREF=3V3 EN→RESET)
./scripts/hw-oracle/esp32_capture.sh firmware.elf
# 2. Replay in sim + diff
cargo run --release -p labwired-hw-oracle --bin esp32_replay_in_sim -- --capture &lt;ts-dir&gt;
\`\`\`

## Signal
JSON \`{ schema, pc_first_diverge: {step, hw_pc, sim_pc}, mem_pre_match, mem_post_mismatches[], summary: \"ok\"|\"diverged\"|\"sim_only\" }\`. Drives the chip-model work: each first-divergence PC tells us which peripheral to model next.

## Graceful headless
Capture script exits 2 if openocd missing, 3 if no ESP32 attaches within 30 s, never hangs. Replay bin handles \`no_hardware\` captures and labels result \`sim_only\`.

## Test plan
- [x] cargo build --release passes
- [x] cargo clippy -p labwired-hw-oracle --all-targets -- -D warnings clean
- [ ] Real HW: operator runs capture against an ESP32-WROOM-32 with a known firmware, verifies diff matches expected sim behavior