### PR TITLE
feat(esp32/rtc_cntl): RTC controller peripheral (Phase 2b)

### DIFF
--- a/crates/core/src/peripherals/esp32/mod.rs
+++ b/crates/core/src/peripherals/esp32/mod.rs
@@ -15,4 +15,5 @@
 //!   - GPIOs 0..39 (S3: 0..48 with USB-Serial-JTAG hardware)
 
 pub mod gpio;
+pub mod rtc_cntl;
 pub mod spi;

--- a/crates/core/src/peripherals/esp32/rtc_cntl.rs
+++ b/crates/core/src/peripherals/esp32/rtc_cntl.rs
@@ -1,0 +1,388 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! RTC Controller (RTC_CNTL) peripheral for ESP32-classic.
+//!
+//! Per ESP32 TRM v5.0 §13. The RTC_CNTL block sits at base `0x3FF4_8000`
+//! and carries the reset-cause registers, RTC slow-clock counter,
+//! deep-sleep wake state, analog config registers, and the four
+//! general-purpose retention scratch words (`STORE0..3`) that survive
+//! deep sleep.
+//!
+//! ## Why this peripheral exists
+//!
+//! ESP32 BROM and ESP-IDF startup read this block heavily during init:
+//!
+//!   * `rtc_get_reset_reason(cpu)` decodes the per-core reset cause from
+//!     `RESET_STATE` (offset 0x34). We seed POWERON_RESET (=1) for both
+//!     cores so a first-boot probe gets a coherent answer.
+//!   * `rtc_time_get()` (and friends) snapshots the 48-bit RTC slow-counter
+//!     into `TIME0` (low 32) / `TIME1` (high 16) by writing the TIME_UPDATE
+//!     trigger at offset 0x0C. We expose the live counter on every read of
+//!     TIME0/TIME1 so callers see a monotonic value.
+//!   * Arduino-ESP32's frequency detect reads `RTC_APB_FREQ_REG` at
+//!     offset 0xB0; the 40 MHz encoding is `0x0050_0050` (low and high
+//!     halves equal, shifted left by 1). Pre-seeded at construction.
+//!   * `STORE0..3` (offsets 0x4C..0x58) are retention RAM scratch words.
+//!     Plain read/write round-trip — no side effects modeled.
+//!
+//! Analog config registers (`ANA_CONF` at 0x30, `DIG_PWC` at 0x8C,
+//! `BIAS_CONF` at 0x80) and other power-domain knobs read-as-zero
+//! unless previously written, and accept any write.
+
+use crate::{Peripheral, PeripheralTickResult, SimResult};
+use std::collections::HashMap;
+
+// ── Register offsets (per ESP32 TRM v5.0 §13.5 and ESP-IDF
+// `soc/esp32/include/soc/rtc_cntl_reg.h`) ─────────────────────────────────
+
+/// RTC_CNTL_OPTIONS0_REG — bit 31 = sw_sys_rst trigger; bits[1:0] = sw_stall_*.
+pub const RTC_CNTL_OPTIONS0_OFFSET: u64 = 0x00;
+/// RTC_CNTL_TIME_UPDATE_REG — bit 31 = TIME_UPDATE (write 1 to snapshot).
+pub const RTC_CNTL_TIME_UPDATE_OFFSET: u64 = 0x0C;
+/// RTC_CNTL_TIME0_REG — low 32 bits of the 48-bit slow-counter snapshot.
+pub const RTC_CNTL_TIME0_OFFSET: u64 = 0x10;
+/// RTC_CNTL_TIME1_REG — high 16 bits (bits[15:0]) of slow-counter snapshot.
+pub const RTC_CNTL_TIME1_OFFSET: u64 = 0x14;
+/// RTC_CNTL_RESET_STATE_REG — bits[3:0]=PRO_CPU cause, bits[7:4]=APP_CPU cause.
+pub const RTC_CNTL_RESET_STATE_OFFSET: u64 = 0x34;
+/// RTC_CNTL_STORE0_REG..STORE3_REG — 4 retention scratch words.
+pub const RTC_CNTL_STORE0_OFFSET: u64 = 0x4C;
+pub const RTC_CNTL_STORE1_OFFSET: u64 = 0x50;
+pub const RTC_CNTL_STORE2_OFFSET: u64 = 0x54;
+pub const RTC_CNTL_STORE3_OFFSET: u64 = 0x58;
+/// RTC_APB_FREQ_REG — APB frequency encoding probed at boot. Arduino-ESP32
+/// expects `0x0050_0050` for a 40 MHz XTAL (both halves equal, low-then-high).
+pub const RTC_APB_FREQ_OFFSET: u64 = 0xB0;
+/// 40 MHz XTAL encoding the Arduino-ESP32 boot reads back.
+pub const RTC_APB_FREQ_40MHZ: u32 = 0x0050_0050;
+
+// Reset cause field width per CPU (3 bits in classic ESP32; we mask to 4
+// bits to leave room for the ESP32-S series extension without changing
+// shape). Bit packing in `RESET_STATE`:
+//   bits[3:0]  = PROCPU_RESET_CAUSE
+//   bits[7:4]  = APPCPU_RESET_CAUSE
+const RESET_CAUSE_PROCPU_SHIFT: u32 = 0;
+const RESET_CAUSE_APPCPU_SHIFT: u32 = 4;
+const RESET_CAUSE_MASK: u32 = 0xF;
+
+/// Reset-cause enum values (ESP-IDF `esp_rom_rtc_get_reset_reason`).
+pub const POWERON_RESET: u32 = 1;
+#[allow(dead_code)]
+pub const SW_RESET: u32 = 3;
+
+/// RTC Controller peripheral.
+///
+/// Word-granular sparse storage (HashMap) keeps the model compact —
+/// most of the 0x200-byte address window is unused on a first-boot
+/// probe. Side-effect logic lives in `write`; reads of TIME0/TIME1
+/// pull from the live `slow_counter` so back-to-back queries observe
+/// monotonic progress without firmware needing to trigger TIME_UPDATE.
+#[derive(Debug)]
+pub struct RtcCntl {
+    /// Base MMIO address (for debugging / logs only — not used in
+    /// offset math since the bus already dispatches by offset).
+    base: u32,
+    /// Backing word store. Indexed by 4-byte-aligned offset.
+    regs: HashMap<u32, u32>,
+    /// RTC slow-clock counter (48-bit on real silicon; we use u64 for
+    /// arithmetic ease — only low 48 bits surface through TIME0/TIME1).
+    slow_counter: u64,
+}
+
+impl Default for RtcCntl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RtcCntl {
+    /// Canonical MMIO base address on ESP32-classic.
+    pub const BASE: u32 = 0x3FF4_8000;
+
+    /// Construct a freshly-powered RTC_CNTL block.
+    ///
+    /// Seeds:
+    ///   * `RESET_STATE` = POWERON_RESET for both PRO_CPU and APP_CPU.
+    ///   * `RTC_APB_FREQ_REG` = 40 MHz encoding (0x0050_0050).
+    ///   * `slow_counter` = 0.
+    pub fn new() -> Self {
+        let mut regs = HashMap::new();
+        let reset_state = (POWERON_RESET << RESET_CAUSE_PROCPU_SHIFT)
+            | (POWERON_RESET << RESET_CAUSE_APPCPU_SHIFT);
+        regs.insert(RTC_CNTL_RESET_STATE_OFFSET as u32, reset_state);
+        regs.insert(RTC_APB_FREQ_OFFSET as u32, RTC_APB_FREQ_40MHZ);
+        Self {
+            base: Self::BASE,
+            regs,
+            slow_counter: 0,
+        }
+    }
+
+    /// Base MMIO address (informational).
+    pub fn base(&self) -> u32 {
+        self.base
+    }
+
+    /// Set the per-core reset cause. Used by reset-injection tests.
+    pub fn set_reset_cause(&mut self, procpu: u32, appcpu: u32) {
+        let v = ((procpu & RESET_CAUSE_MASK) << RESET_CAUSE_PROCPU_SHIFT)
+            | ((appcpu & RESET_CAUSE_MASK) << RESET_CAUSE_APPCPU_SHIFT);
+        self.regs.insert(RTC_CNTL_RESET_STATE_OFFSET as u32, v);
+    }
+
+    /// Read the live slow-counter value (tests use this to verify tick()
+    /// progression without going through MMIO).
+    pub fn slow_counter(&self) -> u64 {
+        self.slow_counter
+    }
+
+    fn read_word(&self, word_off: u32) -> u32 {
+        // TIME0/TIME1 always reflect the live counter (every read snapshots,
+        // matching the conservative interpretation — firmware that ignores
+        // TIME_UPDATE still gets a monotonic value).
+        match u64::from(word_off) {
+            RTC_CNTL_TIME0_OFFSET => (self.slow_counter & 0xFFFF_FFFF) as u32,
+            RTC_CNTL_TIME1_OFFSET => ((self.slow_counter >> 32) & 0xFFFF) as u32,
+            _ => self.regs.get(&word_off).copied().unwrap_or(0),
+        }
+    }
+
+    fn write_word(&mut self, word_off: u32, value: u32) {
+        // TIME_UPDATE handshake: bit 31 set → snapshot the live counter
+        // into TIME0/TIME1 entries and clear the trigger immediately
+        // (real silicon takes ~3 RTC cycles; we model it as instant).
+        if u64::from(word_off) == RTC_CNTL_TIME_UPDATE_OFFSET && (value & (1 << 31)) != 0 {
+            let snap = self.slow_counter;
+            self.regs
+                .insert(RTC_CNTL_TIME0_OFFSET as u32, (snap & 0xFFFF_FFFF) as u32);
+            self.regs
+                .insert(RTC_CNTL_TIME1_OFFSET as u32, ((snap >> 32) & 0xFFFF) as u32);
+            // Clear TIME_UPDATE trigger (write back without bit 31).
+            self.regs.insert(word_off, value & !(1u32 << 31));
+            return;
+        }
+        self.regs.insert(word_off, value);
+    }
+}
+
+impl Peripheral for RtcCntl {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word_off = (offset & !3) as u32;
+        let byte_off = (offset & 3) * 8;
+        let word = self.read_word(word_off);
+        Ok(((word >> byte_off) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let word_off = (offset & !3) as u32;
+        let byte_off = (offset & 3) * 8;
+        // Read-modify-write on the existing word (or 0 if unwritten).
+        let mut word = self.regs.get(&word_off).copied().unwrap_or(0);
+        word &= !(0xFFu32 << byte_off);
+        word |= (value as u32) << byte_off;
+        self.write_word(word_off, word);
+        Ok(())
+    }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        // Advance the slow-counter by 1 per tick. Real silicon ticks at
+        // ~150 kHz; we don't simulate sub-cycle precision — firmware
+        // that needs wall-clock timing uses Systimer instead.
+        self.slow_counter = self.slow_counter.wrapping_add(1);
+        PeripheralTickResult::default()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Snap {
+            regs: Vec<(u32, u32)>,
+            slow_counter: u64,
+        }
+        let snap = Snap {
+            regs: self.regs.iter().map(|(k, v)| (*k, *v)).collect(),
+            slow_counter: self.slow_counter,
+        };
+        bincode::serialize(&snap).expect("bincode serialize RtcCntl")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Snap {
+            regs: Vec<(u32, u32)>,
+            slow_counter: u64,
+        }
+        let snap: Snap = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("RtcCntl snapshot decode: {e}"))
+        })?;
+        self.regs = snap.regs.into_iter().collect();
+        self.slow_counter = snap.slow_counter;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_u32_at(p: &RtcCntl, offset: u64) -> u32 {
+        let mut v = 0u32;
+        for i in 0..4u64 {
+            v |= (p.read(offset + i).unwrap() as u32) << (i * 8);
+        }
+        v
+    }
+
+    fn write_u32_at(p: &mut RtcCntl, offset: u64, value: u32) {
+        for i in 0..4u64 {
+            p.write(offset + i, ((value >> (i * 8)) & 0xFF) as u8)
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn new_reports_poweron_reset_for_both_cores() {
+        let p = RtcCntl::new();
+        let v = read_u32_at(&p, RTC_CNTL_RESET_STATE_OFFSET);
+        let procpu = (v >> RESET_CAUSE_PROCPU_SHIFT) & RESET_CAUSE_MASK;
+        let appcpu = (v >> RESET_CAUSE_APPCPU_SHIFT) & RESET_CAUSE_MASK;
+        assert_eq!(procpu, POWERON_RESET, "PRO_CPU reset cause");
+        assert_eq!(appcpu, POWERON_RESET, "APP_CPU reset cause");
+    }
+
+    #[test]
+    fn rtc_apb_freq_reads_40mhz_encoding_before_any_write() {
+        let p = RtcCntl::new();
+        assert_eq!(
+            read_u32_at(&p, RTC_APB_FREQ_OFFSET),
+            RTC_APB_FREQ_40MHZ,
+            "RTC_APB_FREQ_REG must read back the 40 MHz encoding (0x0050_0050) \
+             at construction so Arduino-ESP32's XTAL probe sees a sane value \
+             without needing a wasm-layer fake-write."
+        );
+    }
+
+    #[test]
+    fn store0_round_trips_a_value() {
+        let mut p = RtcCntl::new();
+        write_u32_at(&mut p, RTC_CNTL_STORE0_OFFSET, 0xDEAD_BEEF);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_STORE0_OFFSET), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn all_store_words_round_trip_independently() {
+        // Sanity: writing STORE0 doesn't bleed into STORE1..3.
+        let mut p = RtcCntl::new();
+        write_u32_at(&mut p, RTC_CNTL_STORE0_OFFSET, 0x1111_1111);
+        write_u32_at(&mut p, RTC_CNTL_STORE1_OFFSET, 0x2222_2222);
+        write_u32_at(&mut p, RTC_CNTL_STORE2_OFFSET, 0x3333_3333);
+        write_u32_at(&mut p, RTC_CNTL_STORE3_OFFSET, 0x4444_4444);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_STORE0_OFFSET), 0x1111_1111);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_STORE1_OFFSET), 0x2222_2222);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_STORE2_OFFSET), 0x3333_3333);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_STORE3_OFFSET), 0x4444_4444);
+    }
+
+    #[test]
+    fn tick_advances_slow_counter() {
+        let mut p = RtcCntl::new();
+        assert_eq!(p.slow_counter(), 0);
+        p.tick();
+        p.tick();
+        p.tick();
+        assert_eq!(p.slow_counter(), 3);
+    }
+
+    #[test]
+    fn time0_reads_reflect_live_slow_counter() {
+        let mut p = RtcCntl::new();
+        for _ in 0..5 {
+            p.tick();
+        }
+        assert_eq!(read_u32_at(&p, RTC_CNTL_TIME0_OFFSET), 5);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_TIME1_OFFSET), 0);
+    }
+
+    #[test]
+    fn time_update_handshake_clears_trigger_bit() {
+        let mut p = RtcCntl::new();
+        p.tick();
+        p.tick();
+        write_u32_at(&mut p, RTC_CNTL_TIME_UPDATE_OFFSET, 1 << 31);
+        let trig = read_u32_at(&p, RTC_CNTL_TIME_UPDATE_OFFSET);
+        assert_eq!(trig & (1 << 31), 0, "TIME_UPDATE bit must auto-clear");
+    }
+
+    #[test]
+    fn ana_conf_dig_pwc_bias_conf_writes_accepted_round_trip() {
+        // Power-domain control words have no modeled side effects in this
+        // peripheral — they round-trip like regular storage. Reads before
+        // any write return 0.
+        let mut p = RtcCntl::new();
+        assert_eq!(read_u32_at(&p, 0x30), 0, "ANA_CONF unwritten reads 0");
+        assert_eq!(read_u32_at(&p, 0x80), 0, "BIAS_CONF unwritten reads 0");
+        assert_eq!(read_u32_at(&p, 0x8C), 0, "DIG_PWC unwritten reads 0");
+        write_u32_at(&mut p, 0x30, 0xAAAA_5555);
+        write_u32_at(&mut p, 0x80, 0xCAFE_F00D);
+        write_u32_at(&mut p, 0x8C, 0x1234_5678);
+        assert_eq!(read_u32_at(&p, 0x30), 0xAAAA_5555);
+        assert_eq!(read_u32_at(&p, 0x80), 0xCAFE_F00D);
+        assert_eq!(read_u32_at(&p, 0x8C), 0x1234_5678);
+    }
+
+    #[test]
+    fn options0_round_trips() {
+        // OPTIONS0 has the sw_sys_rst trigger; we don't model the reset
+        // (no firmware in scope writes it for real), but the write must
+        // round-trip so probe-then-readback sequences see the value.
+        let mut p = RtcCntl::new();
+        write_u32_at(&mut p, RTC_CNTL_OPTIONS0_OFFSET, 0x8000_0001);
+        assert_eq!(read_u32_at(&p, RTC_CNTL_OPTIONS0_OFFSET), 0x8000_0001);
+    }
+
+    #[test]
+    fn set_reset_cause_changes_reset_state_word() {
+        let mut p = RtcCntl::new();
+        p.set_reset_cause(SW_RESET, POWERON_RESET);
+        let v = read_u32_at(&p, RTC_CNTL_RESET_STATE_OFFSET);
+        assert_eq!((v >> RESET_CAUSE_PROCPU_SHIFT) & RESET_CAUSE_MASK, SW_RESET);
+        assert_eq!(
+            (v >> RESET_CAUSE_APPCPU_SHIFT) & RESET_CAUSE_MASK,
+            POWERON_RESET
+        );
+    }
+
+    #[test]
+    fn runtime_snapshot_round_trip_preserves_state() {
+        let mut p = RtcCntl::new();
+        write_u32_at(&mut p, RTC_CNTL_STORE0_OFFSET, 0xC0FF_EE00);
+        for _ in 0..7 {
+            p.tick();
+        }
+        let snap = p.runtime_snapshot();
+
+        let mut restored = RtcCntl::new();
+        restored.restore_runtime_snapshot(&snap).unwrap();
+        assert_eq!(restored.slow_counter(), 7);
+        assert_eq!(read_u32_at(&restored, RTC_CNTL_STORE0_OFFSET), 0xC0FF_EE00);
+        assert_eq!(
+            read_u32_at(&restored, RTC_APB_FREQ_OFFSET),
+            RTC_APB_FREQ_40MHZ
+        );
+    }
+
+    #[test]
+    fn base_is_esp32_classic_canonical_address() {
+        let p = RtcCntl::new();
+        assert_eq!(p.base(), 0x3FF4_8000);
+    }
+}

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -212,7 +212,8 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
                                                                  // clock-tree changes so return the post-init default of 240 MHz.
     rom_bank.register(0x4000_855c, rom_thunks::rom_cpu_freq_240mhz);
     // ets_get_detected_xtal_freq() — returns XTAL freq in MHz. Return
-    // 40 (matches the RTC_APB_FREQ_REG fake we pre-write in the test).
+    // 40 (matches the RTC_APB_FREQ_REG 0x0050_0050 encoding the RtcCntl
+    // peripheral seeds at construction).
     rom_bank.register(0x4000_8588, rom_thunks::rom_xtal_freq_40mhz);
     // ets_printf — formats and writes to UART. Reuse the S3 thunk.
     rom_bank.register(0x4000_7d54, rom_thunks::ets_printf);
@@ -386,16 +387,23 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
         Box::new(crate::peripherals::esp32s3::system_stub::SystemStub::new()),
     );
 
-    // RTC_CNTL (TRM §31). esp_hal::init touches WDTCONFIG / WDTWPROTECT
-    // registers here to disable the RTC watchdog. The S3 RtcCntlStub
-    // round-trips writes and seeds PLL_LOCK as locked — same model fits
-    // ESP32-classic since the firmware only reads back what it wrote.
+    // RTC_CNTL (TRM §13). Real ESP32-classic peripheral — seeds POWERON_RESET
+    // for both cores at construction, pre-loads RTC_APB_FREQ_REG with the
+    // 40 MHz encoding (0x0050_0050) so Arduino-ESP32's XTAL probe finds a
+    // sane value without needing a wasm-layer fake-write, and exposes the
+    // monotonic slow-counter via TIME0/TIME1 reads. STORE0..3 round-trip
+    // as retention scratch words; ANA_CONF / DIG_PWC / BIAS_CONF accept
+    // any value (no analog domain modeled).
+    //
+    // Size 0x200 covers the documented register window 0x3FF4_8000..0x3FF4_80FC
+    // plus the OPTIONS alias range up to 0x3FF4_8200. RTC_IO at 0x3FF4_8400
+    // is registered separately by the catch-all stub block below.
     bus.add_peripheral(
         "rtc_cntl",
         0x3FF4_8000,
-        0x1000,
+        0x200,
         None,
-        Box::new(crate::peripherals::esp32s3::system_stub::RtcCntlStub::new()),
+        Box::new(crate::peripherals::esp32::rtc_cntl::RtcCntl::new()),
     );
 
     // TIMG0 / TIMG1 — TimgStub auto-asserts RTC_CALI_RDY (bit 15 of

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1580,8 +1580,9 @@ impl WasmSimulator {
         let _ = machine.bus.write_u8(0x3FFC_6FFE, 0x01); // s_system_inited[1]
         let _ = machine.bus.write_u8(0x3FFC_7190, 0x01); // s_other_cpu_startup_done
 
-        // RTC XTAL-freq probe = 40 MHz (high/low halves equal, shifted-1).
-        let _ = machine.bus.write_u32(0x3FF4_80B0, 0x0050_0050);
+        // RTC_APB_FREQ_REG (0x3FF4_80B0) is now pre-seeded with the 40 MHz
+        // encoding (0x0050_0050) by the RtcCntl peripheral at construction —
+        // no quirk write needed here.
 
         // Fake esp_image_header_t at 0x3F40_0000 (24 bytes), entry = the reference firmware.
         let entry = 0x40081bf0_u32;
@@ -1692,8 +1693,9 @@ impl WasmSimulator {
         // Seed SP — call_start_cpu0 expects BROM to have placed SP near
         // top of DRAM. We skip BROM.
         machine.cpu.set_sp(0x3FFE_0000);
-        // RTC XTAL-freq probe = 40 MHz.
-        let _ = machine.bus.write_u32(0x3FF4_80B0, 0x0050_0050);
+        // RTC_APB_FREQ_REG (0x3FF4_80B0) now comes pre-seeded with the 40 MHz
+        // encoding (0x0050_0050) from the RtcCntl peripheral — no quirk
+        // write needed.
 
         let symbol_addrs = labwired_loader::extract_arduino_esp32_thunks(elf_bytes);
 


### PR DESCRIPTION
## Summary
Phase 2b of the chip-model roadmap ([#105](https://github.com/w1ne/labwired-core/issues/105)). Adds the ESP32 RTC controller peripheral so BROM's \`rtc_init\` and ESP-IDF's reset-cause/RTC-counter reads return real values instead of garbage/zero.

## Coverage
Register set (offsets from base 0x3FF4_8000):
- OPTIONS0 (0x00) — round-trip
- TIME_UPDATE (0x0C) — bit-31 trigger auto-clears, snapshots \`slow_counter\` into TIME0/TIME1
- TIME0/TIME1 (0x10/0x14) — read live \`slow_counter\` low/high
- RESET_STATE (0x34) — seeded POWERON_RESET (1) for both 4-bit core fields
- STORE0..STORE3 (0x4C/0x50/0x54/0x58) — retention scratch round-trip
- RTC_APB_FREQ_REG (0xB0) — pre-seeded 0x0050_0050 (40 MHz XTAL encoded as freq_mhz&lt;&lt;1 in both halves)
- ANA_CONF / BIAS_CONF / DIG_PWC / any other in-range offset — round-trip

\`tick()\` advances \`slow_counter\` by 1. Includes \`runtime_snapshot\`/\`restore_runtime_snapshot\` for resume parity.

Wired in \`configure_xtensa_esp32\` at 0x3FF4_8000 size 0x200, replacing \`RtcCntlStub\`.

## Removed
- Both \`bus.write_u32(0x3FF4_80B0, 0x0050_0050)\` fakes in \`crates/wasm/src/lib.rs\` (the autodiscover quirks installer and the legacy AgentDeck installer). With \`RtcCntl\` seeding the value at construction, the fake-writes are redundant.

## Test
- 12 new \`rtc_cntl::tests::*\` pass
- \`cargo test --lib -p labwired-core\`: 363/363 pass
- \`cargo clippy --all-targets -- -D warnings\`: clean (including labwired-wasm)
- \`cargo fmt --all\`: applied

## Follow-up (not in this PR)
CLI (\`crates/cli/src/main.rs:1047\`) and e2e test (\`crates/core/tests/e2e_external_arduino_esp32_in_sim.rs:87\`) still contain the same fake-write. They're now harmless no-ops (writing the value the peripheral already provides) but should be cleaned up in a hygiene pass.