### PR TITLE
test(core): e2e labwired-ereader Arduino-ESP32 paint smoke (+RTC TIME_VALID fix)

### DIFF
--- a/crates/core/src/peripherals/esp32/rtc_cntl.rs
+++ b/crates/core/src/peripherals/esp32/rtc_cntl.rs
@@ -194,10 +194,8 @@ impl RtcCntl {
             self.regs
                 .insert(RTC_CNTL_TIME1_OFFSET as u32, ((snap >> 32) & 0xFFFF) as u32);
             // Clear TIME_UPDATE trigger and set TIME_VALID (bit 30) ACK.
-            self.regs.insert(
-                word_off,
-                (value & !(1u32 << 31)) | RTC_CNTL_TIME_VALID_BIT,
-            );
+            self.regs
+                .insert(word_off, (value & !(1u32 << 31)) | RTC_CNTL_TIME_VALID_BIT);
             return;
         }
         // SW_SYS_RST: latch the request and clear the trigger bit in

--- a/crates/core/src/peripherals/esp32/rtc_cntl.rs
+++ b/crates/core/src/peripherals/esp32/rtc_cntl.rs
@@ -40,8 +40,15 @@ use std::collections::HashMap;
 
 /// RTC_CNTL_OPTIONS0_REG — bit 31 = sw_sys_rst trigger; bits[1:0] = sw_stall_*.
 pub const RTC_CNTL_OPTIONS0_OFFSET: u64 = 0x00;
-/// RTC_CNTL_TIME_UPDATE_REG — bit 31 = TIME_UPDATE (write 1 to snapshot).
+/// RTC_CNTL_TIME_UPDATE_REG — bit 31 = TIME_UPDATE (write 1 to snapshot),
+/// bit 30 = TIME_VALID (RO, set by hardware once the snapshot has landed).
 pub const RTC_CNTL_TIME_UPDATE_OFFSET: u64 = 0x0C;
+/// RTC_CNTL_TIME_VALID — read-only ACK bit (bit 30). ESP-IDF's
+/// `rtc_time_get` writes TIME_UPDATE (bit 31), then polls TIME_VALID
+/// (bit 30) before reading TIME0/TIME1. We set this synchronously when
+/// bit 31 is written so the poll exits immediately (real silicon takes
+/// ~3 RTC slow-clock cycles; we model it as instant).
+pub const RTC_CNTL_TIME_VALID_BIT: u32 = 1 << 30;
 /// RTC_CNTL_TIME0_REG — low 32 bits of the 48-bit slow-counter snapshot.
 pub const RTC_CNTL_TIME0_OFFSET: u64 = 0x10;
 /// RTC_CNTL_TIME1_REG — high 16 bits (bits[15:0]) of slow-counter snapshot.
@@ -176,16 +183,21 @@ impl RtcCntl {
 
     fn write_word(&mut self, word_off: u32, value: u32) {
         // TIME_UPDATE handshake: bit 31 set → snapshot the live counter
-        // into TIME0/TIME1 entries and clear the trigger immediately
-        // (real silicon takes ~3 RTC cycles; we model it as instant).
+        // into TIME0/TIME1 entries, clear the trigger, and set the
+        // TIME_VALID ACK bit so the firmware's `bbci a8, 30, loop`
+        // poll exits. Real silicon takes ~3 RTC slow-clock cycles; we
+        // model it as instant.
         if u64::from(word_off) == RTC_CNTL_TIME_UPDATE_OFFSET && (value & (1 << 31)) != 0 {
             let snap = self.slow_counter;
             self.regs
                 .insert(RTC_CNTL_TIME0_OFFSET as u32, (snap & 0xFFFF_FFFF) as u32);
             self.regs
                 .insert(RTC_CNTL_TIME1_OFFSET as u32, ((snap >> 32) & 0xFFFF) as u32);
-            // Clear TIME_UPDATE trigger (write back without bit 31).
-            self.regs.insert(word_off, value & !(1u32 << 31));
+            // Clear TIME_UPDATE trigger and set TIME_VALID (bit 30) ACK.
+            self.regs.insert(
+                word_off,
+                (value & !(1u32 << 31)) | RTC_CNTL_TIME_VALID_BIT,
+            );
             return;
         }
         // SW_SYS_RST: latch the request and clear the trigger bit in
@@ -363,6 +375,28 @@ mod tests {
         write_u32_at(&mut p, RTC_CNTL_TIME_UPDATE_OFFSET, 1 << 31);
         let trig = read_u32_at(&p, RTC_CNTL_TIME_UPDATE_OFFSET);
         assert_eq!(trig & (1 << 31), 0, "TIME_UPDATE bit must auto-clear");
+    }
+
+    #[test]
+    fn time_update_handshake_sets_time_valid_ack() {
+        // ESP-IDF's `rtc_time_get` (esp_hw_support/port/esp32/rtc_time.c)
+        // writes TIME_UPDATE (bit 31) then polls TIME_VALID (bit 30):
+        //
+        //   WRITE_PERI_REG(RTC_CNTL_TIME_UPDATE_REG, RTC_CNTL_TIME_UPDATE);
+        //   while (GET_PERI_REG_MASK(RTC_CNTL_TIME_UPDATE_REG,
+        //                            RTC_CNTL_TIME_VALID) == 0) {
+        //       esp_rom_delay_us(1);
+        //   }
+        //
+        // Without the ACK the loop runs forever — exactly the stall the
+        // labwired-ereader e2e test hit before this fix.
+        let mut p = RtcCntl::new();
+        write_u32_at(&mut p, RTC_CNTL_TIME_UPDATE_OFFSET, 1 << 31);
+        let v = read_u32_at(&p, RTC_CNTL_TIME_UPDATE_OFFSET);
+        assert!(
+            v & RTC_CNTL_TIME_VALID_BIT != 0,
+            "TIME_VALID (bit 30) must be set after TIME_UPDATE write"
+        );
     }
 
     #[test]

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -157,16 +157,19 @@ fn labwired_ereader_runs_to_panel_paint() {
     // Build the thunk list — by-symbol lookups; missing symbols are
     // silently skipped (the sketch doesn't pull in that path).
     let mut thunks: Vec<(u32, rom_thunks::RomThunkFn)> = Vec::new();
-    let push_named = |list: &mut Vec<(u32, rom_thunks::RomThunkFn)>,
-                      sym: &str,
-                      f: rom_thunks::RomThunkFn| {
-        if let Some(&pc) = symbol_addrs.get(sym) {
-            list.push((pc, f));
-        }
-    };
+    let push_named =
+        |list: &mut Vec<(u32, rom_thunks::RomThunkFn)>, sym: &str, f: rom_thunks::RomThunkFn| {
+            if let Some(&pc) = symbol_addrs.get(sym) {
+                list.push((pc, f));
+            }
+        };
 
     // Heap caps suite (bump allocator).
-    push_named(&mut thunks, "heap_caps_init", rom_thunks::esp_idf_heap_caps_init);
+    push_named(
+        &mut thunks,
+        "heap_caps_init",
+        rom_thunks::esp_idf_heap_caps_init,
+    );
     push_named(
         &mut thunks,
         "heap_caps_malloc",
@@ -177,7 +180,11 @@ fn labwired_ereader_runs_to_panel_paint() {
         "heap_caps_calloc",
         rom_thunks::esp_idf_heap_caps_calloc,
     );
-    push_named(&mut thunks, "heap_caps_free", rom_thunks::esp_idf_heap_caps_free);
+    push_named(
+        &mut thunks,
+        "heap_caps_free",
+        rom_thunks::esp_idf_heap_caps_free,
+    );
     push_named(
         &mut thunks,
         "heap_caps_realloc",
@@ -316,7 +323,11 @@ fn labwired_ereader_runs_to_panel_paint() {
 
     // Custom-return thunks.
     push_named(&mut thunks, "esp_chip_info", rom_thunks::esp_chip_info_stub);
-    push_named(&mut thunks, "__getreent", rom_thunks::getreent_dram_fake_ptr);
+    push_named(
+        &mut thunks,
+        "__getreent",
+        rom_thunks::getreent_dram_fake_ptr,
+    );
     push_named(
         &mut thunks,
         "esp_timer_impl_get_counter_reg",

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -1,0 +1,535 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// End-to-end smoke test for the `labwired-ereader` Arduino-ESP32 sketch.
+//
+// Goal: load the ereader's stock ELF (built with PlatformIO) into our
+// ESP32-classic sim, mirror the wasm playground's
+// `install_arduino_esp32_quirks` install path **minimally** by resolving
+// every thunk address from the ELF's symbol table (so the test isn't
+// pinned to one firmware build), and step long enough to either see the
+// UC8151D panel get a `refresh()` or stall.
+//
+// This is the native-Rust counterpart to the wasm playground path —
+// same panel attach, same SP seed, same handshake bytes, same ROM
+// thunks, same IPI bridge, same step budget. If this test paints,
+// the firmware paints in the playground too.
+//
+// Heavy and slow (~200M cycles in the worst case), so `#[ignore]`d by
+// default. Run with:
+//
+//     cargo test -p labwired-core --test e2e_labwired_ereader \
+//         -- --ignored --nocapture
+//
+// Skips quietly with `[skip]` when the ELF isn't present — the test only
+// fires when a recently-built ereader image is at
+// `/tmp/labwired-ereader/build/labwired-ereader.ino.elf`, or wherever
+// `LABWIRED_EREADER_ELF` points.
+
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::components::Uc8151dTricolor290;
+use labwired_core::peripherals::esp32::spi::Esp32Spi;
+use labwired_core::peripherals::esp32s3::rom_thunks;
+use labwired_core::system::xtensa::configure_xtensa_esp32;
+use labwired_core::{Bus, Cpu, Machine};
+use std::path::PathBuf;
+
+const DEFAULT_ELF: &str = "/tmp/labwired-ereader/build/labwired-ereader.ino.elf";
+
+#[test]
+#[ignore = "loads the 12MB labwired-ereader Arduino-ESP32 ELF and runs up to 200M cycles. \
+            Run with: cargo test -p labwired-core --test e2e_labwired_ereader -- --ignored --nocapture"]
+fn labwired_ereader_runs_to_panel_paint() {
+    let elf_path = std::env::var("LABWIRED_EREADER_ELF")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_ELF));
+    if !elf_path.exists() {
+        eprintln!(
+            "[skip] labwired-ereader ELF not found at {elf_path:?}; \
+             build labwired-ereader and/or set LABWIRED_EREADER_ELF to enable"
+        );
+        return;
+    }
+
+    let elf_bytes = std::fs::read(&elf_path).expect("read ELF");
+    let image = labwired_loader::load_elf(&elf_path).expect("parse ELF");
+
+    // ── 1. Bring up an ESP32-classic and attach the UC8151D tri-color
+    //       panel to spi3 (same as install_arduino_esp32_quirks). The
+    //       default configure step doesn't attach a panel.
+    let mut bus = SystemBus::new();
+    let cpu = configure_xtensa_esp32(&mut bus);
+
+    let spi3_idx = bus
+        .find_peripheral_index_by_name("spi3")
+        .expect("spi3 registered by configure_xtensa_esp32");
+    {
+        let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
+        let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
+        spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
+    }
+    bus.refresh_peripheral_index();
+
+    let mut machine = Machine::new(cpu, bus);
+    machine.load_firmware(&image).expect("load firmware");
+    machine.cpu.set_pc(image.entry_point as u32);
+
+    // ── 2. SP seed — real silicon's BROM places SP near the top of
+    //       DRAM before jumping to call_start_cpu0; we skip BROM in the
+    //       sim so seed it ourselves.
+    machine.cpu.set_sp(0x3FFE_0000);
+
+    // ── 3. Symbol-driven thunk install. Resolves addresses from the
+    //       ereader ELF and installs only the thunks for symbols
+    //       actually present — silently skips missing ones. Identical
+    //       in spirit to the wasm playground's install_arduino_esp32_quirks.
+    let mut symbol_addrs = labwired_loader::extract_arduino_esp32_thunks(&elf_bytes);
+    // Symbols that aren't in the loader's KNOWN list but we need for
+    // this firmware. Resolved directly so we don't have to round-trip
+    // through the loader for one-off additions.
+    for sym in &[
+        "_ZN14HardwareSerial5beginEmjaabmh",
+        "_get_effective_baudrate",
+    ] {
+        if let Some(addr) = labwired_loader::resolve_symbol_in_elf(&elf_bytes, sym) {
+            symbol_addrs.insert(*sym, addr);
+        }
+    }
+    eprintln!(
+        "[ereader-sim] resolved {} Arduino-ESP32 thunk symbols from ELF",
+        symbol_addrs.len()
+    );
+
+    // Dual-core handshake bytes (pre-write to 0x01 + record for the
+    // keep-alive loop below so .bss zero-init can't wipe them).
+    let mut handshake_bytes: Vec<u32> = Vec::new();
+    for sym in &[
+        "s_resume_cores",
+        "s_cpu_up",
+        "s_cpu_inited",
+        "s_system_inited",
+    ] {
+        if let Some(&addr) = symbol_addrs.get(*sym) {
+            let _ = machine.bus.write_u8(addr as u64, 0x01);
+            let _ = machine.bus.write_u8(addr as u64 + 1, 0x01);
+            handshake_bytes.push(addr);
+            handshake_bytes.push(addr + 1);
+        }
+    }
+    if let Some(&addr) = symbol_addrs.get("s_other_cpu_startup_done") {
+        let _ = machine.bus.write_u8(addr as u64, 0x01);
+        handshake_bytes.push(addr);
+    }
+
+    // loopTask xCoreID patch — scan first 64 bytes of app_main for the
+    // `movi.n a8, 1; mov.n a9, a13` immediate pattern that pins
+    // loopTask to APP_CPU and rewrite it to PRO_CPU (we're single-CPU).
+    if let Some(&app_main_addr) = symbol_addrs.get("app_main") {
+        const SCAN_BYTES: u32 = 64;
+        let mut window = Vec::with_capacity(SCAN_BYTES as usize);
+        for off in 0..SCAN_BYTES {
+            match machine.bus.read_u8((app_main_addr + off) as u64) {
+                Ok(b) => window.push(b),
+                Err(_) => break,
+            }
+        }
+        let target = [0xE9_u8, 0x01, 0x0C, 0x0D];
+        let swap = [0x0C_u8, 0x0D, 0xD9, 0x01];
+        if let Some((i, _)) = window.windows(4).enumerate().find(|(_, w)| *w == target) {
+            let patch_addr = (app_main_addr + i as u32) as u64;
+            for (j, b) in swap.iter().enumerate() {
+                let _ = machine.bus.write_u8(patch_addr + j as u64, *b);
+            }
+            eprintln!(
+                "[ereader-sim] patched loopTask xCoreID in app_main @0x{:08x}",
+                patch_addr as u32
+            );
+        }
+    }
+
+    // pxCurrentTCB pointer seed for xTaskGetCurrentTaskHandle thunk.
+    if let Some(&addr) = symbol_addrs.get("pxCurrentTCB") {
+        rom_thunks::PX_CURRENT_TCB_ADDR.with(|s| s.set(Some(addr)));
+        eprintln!("[ereader-sim] pxCurrentTCB @0x{addr:08x}");
+    }
+
+    // Build the thunk list — by-symbol lookups; missing symbols are
+    // silently skipped (the sketch doesn't pull in that path).
+    let mut thunks: Vec<(u32, rom_thunks::RomThunkFn)> = Vec::new();
+    let push_named = |list: &mut Vec<(u32, rom_thunks::RomThunkFn)>,
+                      sym: &str,
+                      f: rom_thunks::RomThunkFn| {
+        if let Some(&pc) = symbol_addrs.get(sym) {
+            list.push((pc, f));
+        }
+    };
+
+    // Heap caps suite (bump allocator).
+    push_named(&mut thunks, "heap_caps_init", rom_thunks::esp_idf_heap_caps_init);
+    push_named(
+        &mut thunks,
+        "heap_caps_malloc",
+        rom_thunks::esp_idf_heap_caps_malloc,
+    );
+    push_named(
+        &mut thunks,
+        "heap_caps_calloc",
+        rom_thunks::esp_idf_heap_caps_calloc,
+    );
+    push_named(&mut thunks, "heap_caps_free", rom_thunks::esp_idf_heap_caps_free);
+    push_named(
+        &mut thunks,
+        "heap_caps_realloc",
+        rom_thunks::esp_idf_heap_caps_realloc,
+    );
+
+    // No-op stubs for ESP-IDF / Arduino-ESP32 init paths we don't model.
+    for sym in &[
+        "esp_timer_init",
+        "spi_flash_disable_interrupts_caches_and_other_cpu",
+        "spi_flash_enable_interrupts_caches_and_other_cpu",
+        "__retarget_lock_init_recursive",
+        "__retarget_lock_close_recursive",
+        "__retarget_lock_acquire_recursive",
+        "__retarget_lock_release_recursive",
+        "_esp_error_check_failed",
+        "setCpuFrequencyMhz",
+        "delay",
+        "xQueueGiveMutexRecursive",
+        "xQueueTakeMutexRecursive",
+        "esp_ipc_init",
+        "esp_ipc_isr_init",
+        "esp_log_impl_lock",
+        "esp_log_impl_lock_timeout",
+        "esp_log_impl_unlock",
+        "esp_panic_handler",
+        "esp_panic_handler_reconfigure_wdts",
+        "pthread_key_create",
+        "pthread_setspecific",
+        "pthread_getspecific",
+        "pthread_mutex_init",
+        "pthread_mutex_lock",
+        "pthread_mutex_unlock",
+        "_lock_acquire",
+        "_lock_acquire_recursive",
+        "_lock_release",
+        "_lock_release_recursive",
+        "_lock_init",
+        "_lock_init_recursive",
+        "_lock_close",
+        "_lock_close_recursive",
+        "_lock_try_acquire",
+        "_lock_try_acquire_recursive",
+        "esp_pthread_init",
+        "esp_task_wdt_reset",
+        "esp_task_wdt_init",
+        "esp_task_wdt_add",
+        "esp_task_wdt_delete",
+        "esp_clk_init",
+        "esp_perip_clk_init",
+        "core_intr_matrix_clear",
+        "esp_flash_init",
+        "esp_flash_init_default_chip",
+        "esp_flash_init_main",
+        "esp_flash_app_init",
+        "esp_flash_app_enable_os_functions",
+        "esp_flash_app_disable_protect",
+        "esp_flash_app_disable_os_functions",
+        "esp_flash_read_chip_id",
+        "esp_flash_chip_driver_initialized",
+        "do_core_init",
+        "do_secondary_init",
+        // NOTE: `esp_startup_start_app` is INTENTIONALLY NOT STUBBED.
+        // The real impl calls `vTaskStartScheduler()` which never returns
+        // — control goes off to the first task. Stubbing it makes start_cpu0
+        // fall into the `j .` safety-net loop at the bottom of start_cpu0.
+        "esp_partition_main_flash_region_safe",
+        "spi_flash_init",
+        "spi_flash_init_chip_state",
+        "esp_efuse_check_errors",
+        "esp_dport_access_stall_other_cpu_start",
+        "esp_dport_access_stall_other_cpu_end",
+        "esp_cpu_unstall",
+        "bootloader_flash_update_id",
+        "bootloader_init_mem",
+        "esp_mspi_pin_init",
+        "esp_log_timestamp",
+        "esp_log_early_timestamp",
+        "esp_log_writev",
+        "esp_random",
+        "esp_fill_random",
+        // HardwareSerial::begin chain hits `_get_effective_baudrate` →
+        // `quou a10, a8, a10` with divisor=0 because getApbFrequency()
+        // returns 0 in the sim → divide-by-zero exception. Stub the
+        // whole begin so the UART init never runs (the sim has no UART
+        // model the firmware can observe anyway).
+        "_ZN14HardwareSerial5beginEmjaabmh",
+        // Belt-and-braces: stub the leaf too, in case anything outside
+        // begin reaches it.
+        "_get_effective_baudrate",
+        "_ZN14HardwareSerial5writeEh",
+        "_ZN14HardwareSerial5writeEPKhj",
+        "_ZN14HardwareSerial9availableEv",
+        "_ZN14HardwareSerial5flushEv",
+        "_ZN14HardwareSerial9readBytesEPcj",
+        "_ZN14HardwareSerial9readBytesEPhj",
+        "uartAvailable",
+        "uartAvailableForWrite",
+        "uartWrite",
+        "uartWriteBuf",
+        "_Z14serialEventRunv",
+        "vListInsert",
+    ] {
+        push_named(&mut thunks, sym, rom_thunks::nop_return_zero);
+    }
+
+    // Non-NULL fake handle returns for FreeRTOS object creation.
+    for sym in &[
+        "xQueueCreateMutex",
+        "xQueueCreateMutexStatic",
+        "xQueueGenericCreate",
+        "xSemaphoreCreateMutex",
+        "xSemaphoreCreateBinary",
+        "xSemaphoreCreateCounting",
+        "xQueueCreateCountingSemaphore",
+        "xEventGroupCreate",
+    ] {
+        push_named(&mut thunks, sym, rom_thunks::nop_return_fake_ptr);
+    }
+
+    // SPI-flash lock stubs (real impl asserts on uninitialised mutex).
+    for sym in &[
+        "spi_flash_init_lock",
+        "spi_flash_op_lock",
+        "spi_flash_op_unlock",
+    ] {
+        push_named(&mut thunks, sym, rom_thunks::nop_return_zero);
+    }
+
+    // esp_ota_get_running_partition → fake non-NULL ptr so assertions pass.
+    push_named(
+        &mut thunks,
+        "esp_ota_get_running_partition",
+        rom_thunks::nop_return_fake_ptr,
+    );
+
+    // Custom-return thunks.
+    push_named(&mut thunks, "esp_chip_info", rom_thunks::esp_chip_info_stub);
+    push_named(&mut thunks, "__getreent", rom_thunks::getreent_dram_fake_ptr);
+    push_named(
+        &mut thunks,
+        "esp_timer_impl_get_counter_reg",
+        rom_thunks::monotonic_counter_32,
+    );
+    push_named(
+        &mut thunks,
+        "esp_clk_cpu_freq",
+        rom_thunks::esp_clk_cpu_freq_240mhz,
+    );
+    push_named(
+        &mut thunks,
+        "xQueueCreateMutexStatic",
+        rom_thunks::x_queue_create_mutex_static_echo,
+    );
+    push_named(
+        &mut thunks,
+        "xTaskGetCurrentTaskHandle",
+        rom_thunks::x_task_get_current_task_handle,
+    );
+    push_named(
+        &mut thunks,
+        "xQueueSemaphoreTake",
+        rom_thunks::return_pd_true,
+    );
+    push_named(&mut thunks, "xQueueGenericSend", rom_thunks::return_pd_true);
+    push_named(
+        &mut thunks,
+        "ulTaskGenericNotifyTake",
+        rom_thunks::return_pd_true,
+    );
+    push_named(&mut thunks, "spiStartBus", rom_thunks::spi_start_bus_fake);
+    push_named(
+        &mut thunks,
+        "_ZN8SPIClass16beginTransactionE11SPISettings",
+        rom_thunks::spi_class_begin_transaction,
+    );
+
+    // GxEPD2 cmd/data → straight into the attached UC8151D panel.
+    push_named(
+        &mut thunks,
+        "_ZN10GxEPD2_EPD13_writeCommandEh",
+        rom_thunks::gxepd_write_command,
+    );
+    push_named(
+        &mut thunks,
+        "_ZN10GxEPD2_EPD10_writeDataEh",
+        rom_thunks::gxepd_write_data,
+    );
+
+    // xthal_window_spill — semantic spill via shadow stack.
+    for sym in &["xthal_window_spill_nw", "xthal_window_spill"] {
+        push_named(&mut thunks, sym, rom_thunks::xthal_window_spill_thunk);
+    }
+
+    // Real-silicon noreturn — halt the CPU rather than letting assert →
+    // return turn into a tight loop.
+    for sym in &[
+        "panic_abort",
+        "__assert_func",
+        "abort",
+        "__assert",
+        "__cxa_pure_virtual",
+        "__cxa_throw",
+    ] {
+        push_named(&mut thunks, sym, rom_thunks::abort_halt);
+    }
+
+    let installed = thunks.len();
+    for (pc, f) in thunks {
+        machine
+            .bus
+            .install_flash_thunk(pc, f)
+            .unwrap_or_else(|e| panic!("install thunk @{pc:#x}: {e}"));
+    }
+    eprintln!("[ereader-sim] installed {installed} flash thunks");
+
+    // ── 4. Step loop. Mirrors step_with_esp32_aids: handshake keep-alive
+    //       every 10k cycles, plus the cross-core IPI bridge sampling
+    //       DPORT FROM_CPU_n mapping + trigger registers and synthesising
+    //       the matching CPU interrupt edge.
+    const MAX_STEPS: u64 = 200_000_000;
+    const SAMPLE_EVERY: u64 = 1_000_000;
+    let mut step_count = 0u64;
+    let mut last_pc = machine.cpu.get_pc();
+    let mut same_pc_streak = 0u64;
+    let mut samples: Vec<(u64, u32)> = Vec::new();
+    let mut last_distinct: std::collections::VecDeque<u32> =
+        std::collections::VecDeque::with_capacity(64);
+
+    // IPI bridge state.
+    let mut from_cpu_bit0: Option<u8> = None;
+    let mut from_cpu_bit1: Option<u8> = None;
+
+    let mut step_err: Option<String> = None;
+    let mut stalled = false;
+
+    for _ in 0..MAX_STEPS {
+        step_count += 1;
+
+        // Handshake keep-alive: re-write 0x01 to every recorded byte
+        // every 10k cycles so .bss zero-init can't wipe them.
+        if step_count.is_multiple_of(10_000) {
+            for &addr in &handshake_bytes {
+                let _ = machine.bus.write_u8(addr as u64, 0x01);
+            }
+        }
+
+        // IPI bridge. DPORT_PRO_CPU_INTR_FROM_CPU_n_MAP_REG @ 0x3FF0_0164/_0168
+        // captures the bit assignment, and writes to CPU_INTR_FROM_CPU_n
+        // @ 0x3FF0_00DC/_00E0 trigger that bit on PRO_CPU.
+        if let Ok(v) = machine.bus.read_u32(0x3FF0_0164) {
+            let bit = (v & 0x1F) as u8;
+            if v != 0 && bit < 32 {
+                from_cpu_bit0 = Some(bit);
+            }
+        }
+        if let Ok(v) = machine.bus.read_u32(0x3FF0_0168) {
+            let bit = (v & 0x1F) as u8;
+            if v != 0 && bit < 32 {
+                from_cpu_bit1 = Some(bit);
+            }
+        }
+        if let Ok(v0) = machine.bus.read_u32(0x3FF0_00DC) {
+            if v0 != 0 {
+                if let Some(bit) = from_cpu_bit0 {
+                    machine.cpu.raise_interrupt_bits(1u32 << bit);
+                }
+                let _ = machine.bus.write_u32(0x3FF0_00DC, 0);
+            }
+        }
+        if let Ok(v1) = machine.bus.read_u32(0x3FF0_00E0) {
+            if v1 != 0 {
+                if let Some(bit) = from_cpu_bit1 {
+                    machine.cpu.raise_interrupt_bits(1u32 << bit);
+                }
+                let _ = machine.bus.write_u32(0x3FF0_00E0, 0);
+            }
+        }
+
+        if let Err(e) = machine.step() {
+            step_err = Some(format!("{e}"));
+            break;
+        }
+        let pc = machine.cpu.get_pc();
+        if pc == last_pc {
+            same_pc_streak += 1;
+            // 1M same-PC streak = definitely stalled (spin-wait that
+            // we're not feeding correctly, or HALT loop).
+            if same_pc_streak > 1_000_000 {
+                stalled = true;
+                break;
+            }
+        } else {
+            same_pc_streak = 0;
+            last_pc = pc;
+            last_distinct.push_back(pc);
+            if last_distinct.len() > 64 {
+                last_distinct.pop_front();
+            }
+        }
+        if step_count.is_multiple_of(SAMPLE_EVERY) {
+            samples.push((step_count, pc));
+        }
+    }
+
+    // ── 5. Report.
+    let final_pc = machine.cpu.get_pc();
+
+    // Pull the panel back out and read its state.
+    let spi3_idx = machine.bus.find_peripheral_index_by_name("spi3").unwrap();
+    let any = machine.bus.peripherals[spi3_idx].dev.as_any().unwrap();
+    let spi = any.downcast_ref::<Esp32Spi>().unwrap();
+    let panel = spi
+        .attached_devices
+        .iter()
+        .find_map(|d| {
+            d.as_any()
+                .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
+        })
+        .expect("panel attached");
+    let refresh_gen = panel.refresh_generation();
+    let power_on = panel.power_on();
+    let txns = spi.transactions();
+
+    eprintln!("[ereader-sim] ── final state ─────────────────────────────────");
+    eprintln!("[ereader-sim] cycles executed:    {step_count}");
+    eprintln!("[ereader-sim] final PC:           0x{final_pc:08x}");
+    eprintln!("[ereader-sim] same-PC streak:     {same_pc_streak}");
+    eprintln!("[ereader-sim] panel refresh_gen:  {refresh_gen}");
+    eprintln!("[ereader-sim] panel power_on:     {power_on}");
+    eprintln!("[ereader-sim] SPI3 transactions:  {txns}");
+    if let Some(e) = &step_err {
+        eprintln!("[ereader-sim] cpu step error:    {e}");
+    }
+    if stalled {
+        eprintln!(
+            "[ereader-sim] STALLED at PC=0x{final_pc:08x} (same PC for {same_pc_streak} cycles)"
+        );
+        eprintln!("[ereader-sim] last 64 distinct PCs (oldest → newest):");
+        for p in last_distinct.iter() {
+            eprintln!("    0x{p:08x}");
+        }
+    }
+    eprintln!("[ereader-sim] last 10 PC samples:");
+    for &(s, p) in samples.iter().rev().take(10) {
+        eprintln!("    step {s:>10}: pc=0x{p:08x}");
+    }
+
+    // ── 6. Verdict. Painting = at least one refresh().
+    assert!(
+        refresh_gen >= 1,
+        "labwired-ereader did not reach a panel refresh in {step_count} cycles \
+         (final PC=0x{final_pc:08x}, refresh_gen={refresh_gen}, stalled={stalled})"
+    );
+}


### PR DESCRIPTION
## Summary

End-to-end test that proves the stock **labwired-ereader** Arduino-ESP32 sketch runs through to a panel paint in the simulator — and the two simulator gaps that had to be closed to make it happen.

The test loads the PlatformIO ELF (`/tmp/labwired-ereader/build/labwired-ereader.ino.elf`, configurable via `LABWIRED_EREADER_ELF`), mirrors the wasm playground's `install_arduino_esp32_quirks` path minimally (panel attach, SP seed, handshake bytes, symbol-resolved ROM thunks, loopTask xCoreID patch, `pxCurrentTCB` seed), and steps with the cross-core IPI bridge + handshake keep-alive active.

**Result: `refresh_generation = 2` in ~200M sim cycles.** Boots all the way through `call_start_cpu0` → ESP-IDF init → `vTaskStartScheduler` → `loopTask` → setup() → loop() → GxEPD2 render.

Two real fixes (kept inline to keep the test diff self-contained):

1. **RTC_CNTL `TIME_VALID` ACK bit.** `rtc_time_get` writes `TIME_UPDATE` (bit 31) and busy-waits on `TIME_VALID` (bit 30) before reading `TIME0/TIME1`. The peripheral snapshotted the counter and cleared the trigger but never set the ACK bit — the firmware spun forever in `rtc_time_get` calling `esp_rom_delay_us(1)`. Now sets `TIME_VALID` synchronously alongside the snapshot. New unit test `time_update_handshake_sets_time_valid_ack` locks it in.
2. **`HardwareSerial::begin` → `_get_effective_baudrate` divide-by-zero.** The leaf does `quou a10, a8, a10` with the divisor coming from `getApbFrequency()` — which returns 0 in the sim. Stubbed via the test's thunk install (no peripheral change), matching the existing reference Arduino-ESP32 e2e test's mitigation.

The test is `#[ignore]`d (12 MB ELF, ~4 minutes wall time in release). Skips quietly with `[skip]` when the ELF isn't present, so CI is a no-op until somebody points the env var at a fresh build.

## Test plan

- [x] `cargo test -p labwired-core --lib peripherals::esp32::rtc_cntl` — 16/16 pass (incl. new TIME_VALID ACK test)
- [x] `cargo test --release -p labwired-core --test e2e_labwired_ereader -- --ignored --nocapture` — passes; `refresh_generation=2`
- [x] Default `cargo test -p labwired-core` skips the new test (it's `#[ignore]`d), no behavior change on CI

## How to run locally

```bash
cargo test --release -p labwired-core --test e2e_labwired_ereader -- --ignored --nocapture
```

Or with a custom ELF path:

```bash
LABWIRED_EREADER_ELF=/path/to/labwired-ereader.ino.elf \
  cargo test --release -p labwired-core --test e2e_labwired_ereader -- --ignored --nocapture
```