### PR TITLE
fix(wasm): replace, don't stack, panel attaches in install_arduino_esp32_quirks

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1687,12 +1687,16 @@ impl WasmSimulator {
             .as_mut()
             .ok_or_else(|| JsValue::from_str("no machine"))?;
 
-        // Attach the UC8151D panel to spi3. The default configure step
-        // doesn't attach any panel; this is the panel-class-specific bit
-        // that the the reference firmware quirks installer covered with SSD1680.
+        // Attach the UC8151D panel to spi3. Replace any pre-attached
+        // device (the system YAML may have wired an SSD1680 placeholder
+        // from when the ereader board's panel class was misidentified —
+        // GxEPD2's ereader actually drives UC8151D, and a stale SSD1680
+        // confuses both runtime decoding and snapshot restore (the spi3
+        // blob layout depends on attached-device count + types)).
         if let Some(spi3_idx) = machine.bus.find_peripheral_index_by_name("spi3") {
             if let Some(any) = machine.bus.peripherals[spi3_idx].dev.as_any_mut() {
                 if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
+                    spi3.attached_devices.clear();
                     spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
                 }
             }


### PR DESCRIPTION
Snapshot restore in the playground was failing with:
```
snapshot apply: not implemented: Ssd1680 snapshot decode: Invalid size 1333065489701666816
```
…falling back to ~30 s cold boot.

Root cause: the ereader system YAML wires an SSD1680 to spi3 (legacy panel-class label), then `install_arduino_esp32_quirks` attached a UC8151D on top. spi3 ended up with two devices in `attached_devices`. The CLI snapshot capture attached only one (UC8151D), so the snapshot's spi3 blob has 1-device layout while the playground's spi3 had 2-device layout — bincode tried to decode UC8151D bytes as an SSD1680 and got garbage.

Fix: clear attached_devices before attaching UC8151D so both paths have a single-UC8151D spi3.