### PR TITLE
perf(xtensa): IRAM/flash fetch slice cache (#119 Phase 1.2)

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1807,6 +1807,37 @@ impl crate::Bus for SystemBus {
         Ok(())
     }
 
+    /// Fast-path fetch slice for the CPU instruction-fetch cache
+    /// (#119 Phase 1.2). Returns `Some((base, end, slice))` when `pc`
+    /// lands inside a `RamPeripheral` we can serve directly; falls
+    /// through to `None` (slow path) for any other peripheral kind or
+    /// unmapped addresses.
+    ///
+    /// The returned slice borrows the peripheral's backing buffer for
+    /// the duration of the call. The CPU stashes a raw pointer derived
+    /// from it; the `RamPeripheral` INVARIANT (no resize) keeps that
+    /// pointer valid until the peripheral is dropped, but the CPU MUST
+    /// invalidate the cache on any bus write into the cached range
+    /// and on snapshot restore. Reads from non-RAM peripherals (e.g.
+    /// `RomThunkBank`, GPIO, declarative peripherals) keep going
+    /// through the slow path so side effects fire as before.
+    fn fetch_slice(&self, pc: u64) -> Option<(u64, u64, &[u8])> {
+        let idx = self.find_peripheral_index(pc)?;
+        let entry = self.peripherals.get(idx)?;
+        let any = entry.dev.as_any()?;
+        let ram = any.downcast_ref::<crate::system::xtensa::RamPeripheral>()?;
+        let (ptr, len) = ram.backing_ptr_len();
+        // SAFETY: `RamPeripheral`'s backing `Vec` is fixed-size at
+        // construction (see struct-level INVARIANT in
+        // `system::xtensa::RamPeripheral`). The `&self` borrow on the
+        // bus keeps the peripheral entry alive for the duration of
+        // this borrow. We're only producing a read-only `&[u8]` from
+        // a `*const u8`; no concurrent `borrow_mut` is in flight
+        // because reads don't mutate.
+        let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+        Some((entry.base, entry.base.saturating_add(entry.size), slice))
+    }
+
     fn execute_dma(&mut self, requests: &[crate::DmaRequest]) -> SimResult<()> {
         for req in requests {
             match req.direction {

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -104,6 +104,33 @@ pub struct XtensaLx7 {
     /// app-cpu boot address (mirrors real silicon's reset-hold). Default
     /// false; ESP32 dual-core setup sets it on cpu_secondary at boot.
     pub halted: bool,
+    /// IRAM/flash instruction-fetch slice cache (#119 Phase 1.2).
+    ///
+    /// `Some((range_start, range_end, ptr))` when the previous fetch
+    /// landed in a `RamPeripheral` (IRAM, DRAM, flash_icache, …). The
+    /// CPU reads bytes for length predecode + body decode directly off
+    /// `ptr`, bypassing `Bus::read_u8/u16/u32` and avoiding the
+    /// peripheral lookup + `RefCell::borrow()` per fetch. `range_end`
+    /// is exclusive.
+    ///
+    /// SAFETY: `ptr` aliases the `RamPeripheral`'s backing `Vec` buffer.
+    /// That buffer is fixed-size at construction (see
+    /// `system::xtensa::RamPeripheral` INVARIANT) and the peripheral is
+    /// kept alive by the bus for the simulation's lifetime, so the
+    /// pointer stays valid. The cache MUST be invalidated to `None`
+    /// whenever:
+    ///   * a bus write may touch the cached range (writes go through
+    ///     `XtensaLx7::store_write_*` helpers which invalidate when EA
+    ///     falls inside `(start..end)`),
+    ///   * a runtime snapshot is restored (memory may be repopulated
+    ///     wholesale),
+    ///   * an IRQ is dispatched (PC jumps far away anyway; a cache
+    ///     miss would refill on the next fetch but invalidating up
+    ///     front keeps the staleness window zero).
+    ///
+    /// Pointer stored as `usize` so `XtensaLx7: Send` (required by the
+    /// `Cpu` trait) still holds without unsafe `Send` impls.
+    fetch_cache: Option<(u64, u64, usize)>,
 }
 
 impl XtensaLx7 {
@@ -118,6 +145,29 @@ impl XtensaLx7 {
             pc: 0x4000_0400,
             branched: false,
             halted: false,
+            fetch_cache: None,
+        }
+    }
+
+    /// Drop the IRAM/flash fetch slice cache. Call when the cached
+    /// peripheral's contents may have changed (bus write into the
+    /// cached range, runtime snapshot restore, IRQ dispatch).
+    #[inline]
+    fn invalidate_fetch_cache(&mut self) {
+        self.fetch_cache = None;
+    }
+
+    /// Invalidate the fetch cache iff `addr` (the start byte of an
+    /// in-flight bus write) falls inside the cached range. Conservative:
+    /// we don't try to be clever about write size — any write into the
+    /// cached PC range drops the cache.
+    #[inline]
+    fn maybe_invalidate_for_write(&mut self, addr: u32) {
+        if let Some((start, end, _)) = self.fetch_cache {
+            let a = addr as u64;
+            if a >= start && a < end {
+                self.fetch_cache = None;
+            }
         }
     }
 
@@ -618,8 +668,9 @@ impl XtensaLx7 {
             // S8I at, as_, imm: EA = as_ + imm; mem8[EA] = at[0:7].
             // imm is the raw byte offset (0..=255); no alignment requirement.
             S8i { at, as_, imm } => {
-                let ea = self.regs.read_logical(as_).wrapping_add(imm) as u64;
-                bus.write_u8(ea, (self.regs.read_logical(at) & 0xFF) as u8)?;
+                let ea = self.regs.read_logical(as_).wrapping_add(imm);
+                self.maybe_invalidate_for_write(ea);
+                bus.write_u8(ea as u64, (self.regs.read_logical(at) & 0xFF) as u8)?;
                 self.pc = self.pc.wrapping_add(len);
             }
 
@@ -627,8 +678,9 @@ impl XtensaLx7 {
             // Decoder pre-shifts imm by 1. Requires 2-byte alignment;
             // alignment check deferred to Phase G.
             S16i { at, as_, imm } => {
-                let ea = self.regs.read_logical(as_).wrapping_add(imm) as u64;
-                bus.write_u16(ea, (self.regs.read_logical(at) & 0xFFFF) as u16)?;
+                let ea = self.regs.read_logical(as_).wrapping_add(imm);
+                self.maybe_invalidate_for_write(ea);
+                bus.write_u16(ea as u64, (self.regs.read_logical(at) & 0xFFFF) as u16)?;
                 self.pc = self.pc.wrapping_add(len);
             }
 
@@ -636,8 +688,9 @@ impl XtensaLx7 {
             // Decoder pre-shifts imm by 2. Requires 4-byte alignment;
             // alignment check deferred to Phase G.
             S32i { at, as_, imm } => {
-                let ea = self.regs.read_logical(as_).wrapping_add(imm) as u64;
-                bus.write_u32(ea, self.regs.read_logical(at))?;
+                let ea = self.regs.read_logical(as_).wrapping_add(imm);
+                self.maybe_invalidate_for_write(ea);
+                bus.write_u32(ea as u64, self.regs.read_logical(at))?;
                 self.pc = self.pc.wrapping_add(len);
             }
 
@@ -1262,11 +1315,12 @@ impl XtensaLx7 {
             // For Plan 1 RAM there are no bus read/write side effects, so the order
             // only matters semantically. SCOMPARE1 is read via the SR dispatcher.
             S32c1i { at, as_, imm } => {
-                let ea = self.regs.read_logical(as_).wrapping_add(imm) as u64;
-                let mem32 = bus.read_u32(ea)?;
+                let ea = self.regs.read_logical(as_).wrapping_add(imm);
+                let mem32 = bus.read_u32(ea as u64)?;
                 let scompare = self.sr.read(SCOMPARE1);
                 if mem32 == scompare {
-                    bus.write_u32(ea, self.regs.read_logical(at))?;
+                    self.maybe_invalidate_for_write(ea);
+                    bus.write_u32(ea as u64, self.regs.read_logical(at))?;
                 }
                 self.regs.write_logical(at, mem32);
                 self.pc = self.pc.wrapping_add(len);
@@ -1290,8 +1344,9 @@ impl XtensaLx7 {
             // The release barrier is a no-op; SMP ordering is deferred to Plan 4.
             // EA = as_ + imm  (decoder pre-shifts imm by 2).
             S32ri { at, as_, imm } => {
-                let ea = self.regs.read_logical(as_).wrapping_add(imm) as u64;
-                bus.write_u32(ea, self.regs.read_logical(at))?;
+                let ea = self.regs.read_logical(as_).wrapping_add(imm);
+                self.maybe_invalidate_for_write(ea);
+                bus.write_u32(ea as u64, self.regs.read_logical(at))?;
                 self.pc = self.pc.wrapping_add(len);
             }
 
@@ -1319,8 +1374,9 @@ impl XtensaLx7 {
                 if !self.ps.excm() && self.ps.ring() != 0 {
                     return self.raise_general_exception(0);
                 }
-                let ea = self.regs.read_logical(as_).wrapping_add(imm) as u64;
-                bus.write_u32(ea, self.regs.read_logical(at))?;
+                let ea = self.regs.read_logical(as_).wrapping_add(imm);
+                self.maybe_invalidate_for_write(ea);
+                bus.write_u32(ea as u64, self.regs.read_logical(at))?;
                 self.pc = self.pc.wrapping_add(len);
             }
 
@@ -1681,6 +1737,11 @@ impl XtensaLx7 {
     /// Returns `Ok(())` — unlike `raise_general_exception`, interrupt dispatch
     /// is not an error; the CPU simply redirects to the ISR vector.
     fn dispatch_irq(&mut self, level: u8, bus: &mut dyn Bus) -> SimResult<()> {
+        // PC is about to jump into a vector — drop the IRAM/flash
+        // fetch cache so the first fetch in the handler re-resolves
+        // through the bus (and re-populates the cache for the new
+        // region). #119 Phase 1.2.
+        self.invalidate_fetch_cache();
         let entry_pc = self.pc;
         let vecbase = self.sr.read(VECBASE);
         let vector_offset = IRQ_VECTOR_OFFSETS[level.min(7) as usize];
@@ -1853,8 +1914,68 @@ impl Cpu for XtensaLx7 {
         }
 
         let pc = self.pc;
-        let b0 = bus.read_u8(pc as u64)?;
-        let len = xtensa_length::instruction_length(b0);
+
+        // Fast path: serve the fetch out of the cached IRAM/flash slice
+        // pointer if PC still falls inside the cached peripheral AND we
+        // have enough bytes for the worst-case 4-byte body read. This
+        // dodges the bus dispatcher (peripheral lookup + virtual
+        // `read_u32` + `RefCell::borrow`) entirely for hot loops
+        // (#119 Phase 1.2).
+        let pc_u64 = pc as u64;
+        let cache_hit = match self.fetch_cache {
+            Some((start, end, ptr_addr)) if pc_u64 >= start && pc_u64 + 4 <= end => {
+                Some((start, ptr_addr))
+            }
+            _ => None,
+        };
+
+        let (b0, len, ins) = if let Some((start, ptr_addr)) = cache_hit {
+            // SAFETY: cache was populated by `Bus::fetch_slice`, which
+            // returns a pointer into a `RamPeripheral` backing buffer.
+            // The buffer is fixed-size for the peripheral's lifetime
+            // (see `system::xtensa::RamPeripheral` INVARIANT) and the
+            // CPU invalidates the cache on any bus write that lands in
+            // the cached range, on IRQ dispatch, and on snapshot
+            // restore. We've already bounds-checked `pc + 4 <= end`.
+            let off = (pc_u64 - start) as usize;
+            unsafe {
+                let p = (ptr_addr as *const u8).add(off);
+                let b0 = *p;
+                let len = xtensa_length::instruction_length(b0);
+                let ins = if len == 2 {
+                    let hw = u16::from_le_bytes([*p, *p.add(1)]);
+                    xtensa_narrow::decode_narrow(hw)
+                } else {
+                    let w = u32::from_le_bytes([*p, *p.add(1), *p.add(2), *p.add(3)]);
+                    xtensa::decode(w)
+                };
+                (b0, len, ins)
+            }
+        } else {
+            // Slow path: ask the bus, then try to populate the cache
+            // for next time. Non-RAM peripherals (RomThunkBank, GPIO,
+            // declarative regs, …) keep returning `None` from
+            // `fetch_slice` and stay on the slow path forever — that's
+            // intentional: side-effect-bearing reads must run through
+            // the bus.
+            let b0 = bus.read_u8(pc_u64)?;
+            let len = xtensa_length::instruction_length(b0);
+            let ins = if len == 2 {
+                let hw = bus.read_u16(pc_u64)?;
+                xtensa_narrow::decode_narrow(hw)
+            } else {
+                let w = bus.read_u32(pc_u64)?;
+                xtensa::decode(w)
+            };
+            if self.fetch_cache.is_none() {
+                if let Some((start, end, slice)) = bus.fetch_slice(pc_u64) {
+                    // Stash pointer-as-usize; see `fetch_cache` doc for
+                    // the Send + lifetime story.
+                    self.fetch_cache = Some((start, end, slice.as_ptr() as usize));
+                }
+            }
+            (b0, len, ins)
+        };
 
         // S32E/L32E are 3-byte wide instructions with op0=0 (QRST), op1=9
         // (LSC4), op2=4/0 — decoded by the standard wide path and dispatched
@@ -1866,13 +1987,7 @@ impl Cpu for XtensaLx7 {
         // test inputs but rejected real esp-hal firmware. See Plan 3 Task 10
         // case study.)
 
-        let ins = if len == 2 {
-            let hw = bus.read_u16(pc as u64)?;
-            xtensa_narrow::decode_narrow(hw)
-        } else {
-            let w = bus.read_u32(pc as u64)?;
-            xtensa::decode(w)
-        };
+        let _ = b0; // retained for documentation parity with the slow path
         self.branched = false;
         let fall_through_pc = pc.wrapping_add(len);
         self.execute(ins, bus, len)?;
@@ -1897,6 +2012,13 @@ impl Cpu for XtensaLx7 {
     }
 
     fn set_pc(&mut self, val: u32) {
+        // External PC override (debug GDB jump, test harness, halt-state
+        // reset): conservatively drop the fetch cache so we don't read
+        // stale bytes if the new PC lives outside the previously cached
+        // range. The PC range check would catch that anyway on the next
+        // step, but doing it here means the cached pointer never points
+        // past a peripheral that was simultaneously freed.
+        self.invalidate_fetch_cache();
         self.pc = val;
     }
 
@@ -1944,6 +2066,10 @@ impl Cpu for XtensaLx7 {
 
     fn apply_snapshot(&mut self, snapshot: &CpuSnapshot) {
         if let CpuSnapshot::XtensaLx7(s) = snapshot {
+            // Memory may be wholesale-replaced underneath us by the
+            // surrounding restore path — drop the fetch cache so the
+            // next step re-resolves through the bus. #119 Phase 1.2.
+            self.invalidate_fetch_cache();
             self.pc = s.pc;
             self.ps = Ps::from_raw(s.ps);
             self.regs.set_windowbase(s.window_base);
@@ -1999,6 +2125,10 @@ impl Cpu for XtensaLx7 {
                 "XtensaLx7 snapshot shadow must be 16 slots".into(),
             ));
         }
+        // Runtime snapshot may swap memory contents underneath us;
+        // drop the fetch cache so the next step re-resolves. #119
+        // Phase 1.2.
+        self.invalidate_fetch_cache();
         self.pc = snap.pc;
         self.ps = Ps::from_raw(snap.ps_raw);
         // Restore order: phys + WB/WS BEFORE shadow stacks so anything that

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -442,6 +442,22 @@ pub trait Bus {
         self.write_u8(addr + 1, ((value >> 8) & 0xFF) as u8)?;
         Ok(())
     }
+
+    /// Optional fast-path for instruction fetch: return a contiguous
+    /// `&[u8]` covering `pc`, plus the absolute `[range_start, range_end)`
+    /// it serves. The CPU caches this slice on the side and reads
+    /// instructions directly out of it without round-tripping the bus
+    /// dispatcher, peripheral lookup, or `RefCell` borrow.
+    ///
+    /// Default returns `None`; buses that can serve linear memory
+    /// (e.g. `SystemBus` when `pc` lands in a `RamPeripheral`) should
+    /// return `Some`. Callers MUST treat the slice as read-only and
+    /// invalidate their cached pointer on any bus write that may touch
+    /// the same range and on snapshot restore. See labwired-core#119
+    /// (JIT roadmap Phase 1.2).
+    fn fetch_slice(&self, _pc: u64) -> Option<(u64, u64, &[u8])> {
+        None
+    }
 }
 
 use std::collections::HashSet;

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -859,18 +859,46 @@ fn register_default_thunks(bank: &mut RomThunkBank) {
     bank.register(0x4000_2544, rom_thunks::rom_udivdi3);
 }
 
-// ── RamPeripheral helper (private) ───────────────────────────────────────
+// ── RamPeripheral helper ────────────────────────────────────────────────
 
-/// Flat-array `Peripheral` used for IRAM + DRAM mappings.
-struct RamPeripheral {
+/// Flat-array `Peripheral` used for IRAM + DRAM + flash XIP mappings.
+///
+/// Pub so `SystemBus::fetch_slice` can downcast and hand the CPU a raw
+/// pointer into the backing buffer for the IRAM/flash fetch-cache fast
+/// path (#119 Phase 1.2). The `data` field stays private; access is via
+/// [`backing_ptr_len`] which returns a raw `(*const u8, usize)` pair.
+///
+/// INVARIANT: `data` is allocated once in [`new`] and never re-sized
+/// (no `push`, `extend`, `resize`, `clear`). All read/write paths index
+/// in-place via slice access, and `restore_runtime_snapshot` requires
+/// the new bytes match the existing length. This stability is what makes
+/// it safe to hand a raw `*const u8` to the CPU and re-use it across
+/// many `step()` calls.
+pub struct RamPeripheral {
     data: std::cell::RefCell<Vec<u8>>,
 }
 
 impl RamPeripheral {
-    fn new(size: usize) -> Self {
+    pub fn new(size: usize) -> Self {
         Self {
             data: std::cell::RefCell::new(vec![0u8; size]),
         }
+    }
+
+    /// Return a raw pointer + length to the backing buffer for the
+    /// fetch-cache fast path. The pointer is stable for the lifetime
+    /// of `self` because [`Self::new`] is the only allocation site and
+    /// no path resizes the `Vec` (see struct-level INVARIANT).
+    ///
+    /// Reading through this pointer is safe iff no concurrent
+    /// `borrow_mut()` is live AND `self` is not moved/dropped while
+    /// the pointer is in use. The fetch-cache holds the pointer only
+    /// across read-only `step()` calls; any bus write that lands in
+    /// the cached range MUST invalidate the cache first so we never
+    /// race a fetch against a `borrow_mut()`.
+    pub fn backing_ptr_len(&self) -> (*const u8, usize) {
+        let d = self.data.borrow();
+        (d.as_ptr(), d.len())
     }
 }
 
@@ -952,6 +980,12 @@ impl crate::Peripheral for RamPeripheral {
         d.copy_from_slice(bytes);
         Ok(())
     }
+
+    /// Expose `&dyn Any` so `SystemBus::fetch_slice` can downcast and
+    /// reach `backing_ptr_len` without a virtual-call detour.
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 #[cfg(test)]
@@ -982,6 +1016,39 @@ mod tests {
         let _ = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
         bus.write_u8(0x4037_0010, 0xAB).unwrap();
         assert_eq!(bus.read_u8(0x4037_0010).unwrap(), 0xAB);
+    }
+
+    /// Phase 1.2: `fetch_slice` MUST hand back a `&[u8]` that aliases
+    /// the RAM peripheral's backing store, observe writes that go
+    /// through the bus, and only cover RAM-backed regions.
+    #[test]
+    fn fetch_slice_aliases_iram_and_skips_non_ram() {
+        let mut bus = SystemBus::new();
+        let _ = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+
+        // IRAM range 0x4037_0000 + 0x40000. fetch_slice should cover
+        // the whole region (~256 KiB) and observe a fresh byte write.
+        let pc = 0x4037_0010u64;
+        bus.write_u8(pc, 0x37).unwrap();
+        let (start, end, slice) = bus.fetch_slice(pc).expect("IRAM fetch_slice");
+        assert!(start <= pc && pc < end, "pc must lie in returned range");
+        let off = (pc - start) as usize;
+        assert_eq!(slice[off], 0x37, "slice must mirror current RAM byte");
+
+        // Writes propagate without invalidating the slice itself —
+        // the consumer is responsible for invalidating its cached
+        // pointer when a write lands in-range. We just need to see
+        // the new value through the same slice (vec is in place).
+        bus.write_u8(pc, 0xA5).unwrap();
+        let (start, _, slice) = bus.fetch_slice(pc).unwrap();
+        assert_eq!(slice[(pc - start) as usize], 0xA5);
+
+        // GPIO at 0x6000_4000 is not a RamPeripheral — slow path
+        // must stay active there.
+        assert!(
+            bus.fetch_slice(0x6000_4000).is_none(),
+            "GPIO must not serve fetch_slice"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the next bite of [#119](https://github.com/w1ne/labwired-core/issues/119)'s 27% per-step bus-fetch overhead. Hot loops resident in IRAM / DRAM / flash_icache now read instructions directly out of the `RamPeripheral`'s backing `Vec` via a CPU-side cached raw pointer, skipping `SystemBus::find_peripheral_index` + virtual `Peripheral::read_u32` + `RefCell::borrow()` on every cached fetch.

### Mechanism

* `Bus::fetch_slice(pc) -> Option<(start, end, &[u8])>` — new default trait method (returns `None`). `SystemBus` overrides it: looks up the peripheral covering `pc`, downcasts to `system::xtensa::RamPeripheral`, returns its backing slice + base/end. Non-RAM peripherals (RomThunkBank, GPIO, declarative regs, …) keep returning `None` so side-effect-bearing reads still go through the bus.
* `RamPeripheral::backing_ptr_len()` returns `(*const u8, usize)`. Documented invariant: the backing `Vec` is allocated once in `new()` and never resized — `restore_runtime_snapshot` rejects size mismatches and read/write paths only index in-place — so the raw pointer stays valid for the peripheral's lifetime.
* `XtensaLx7::fetch_cache: Option<(start, end, usize)>` — pointer stored as `usize` to preserve `Cpu: Send` without `unsafe impl Send`. On hit: bounds-check `pc + 4 <= end`, then length-predecode + body decode straight from the pointer. On miss: take the slow bus path, then attempt to repopulate the cache via `bus.fetch_slice(pc)`.

### Cache invalidation

Invalidated on:
- any bus write into the cached range (`S8I` / `S16I` / `S32I` / `S32C1I` / `S32RI` / `S32E`) — handles ESP-IDF flash thunk patching and any other self-modifying-code path
- `dispatch_irq()` entry — PC jumps to a vector, refresh from bus on the first handler fetch
- `apply_snapshot` / `apply_runtime_snapshot` — memory may be wholesale-replaced
- `set_pc` — external PC overrides (debug step, halt-state reset)

A new `fetch_slice_aliases_iram_and_skips_non_ram` unit test locks the alias-and-skip-non-RAM contract.

### Benchmark

`./labwired snapshot capture --profile arduino-esp32 --firmware /tmp/labwired-ereader/build/labwired-ereader.ino.elf --steps 10000000 --output /tmp/p12.lwrs`, mean of 3 runs each:

| build   | wall time           |
|---------|---------------------|
| main    | 10.01s, 10.06s, 9.64s → **mean 9.90s** |
| this PR | 8.31s, 8.15s, 8.86s → **mean 8.44s** |

**Speedup: 1.17x (-14.7% wall)**. Below the upper-bound 27% bus-fetch share quoted in #119, but most of that share was the read-side dispatcher, which we've eliminated; the remainder is shared with writes (still go through the bus) and the slow path for non-RAM regions.

### Correctness

After 10M cycles: same final PC (`0x400f27eb`), same `refresh_generation=2`, same panel plane bytes (1/4736 non-FF black, 0 red). Snapshot files differ at a single byte (line 495) which is also non-deterministic between two consecutive baseline runs, so it's pre-existing — not a new divergence introduced by this change.

The heavy `e2e_labwired_ereader` test (`--ignored --release`) still paints with `refresh_generation=2` after 200M cycles.

## Test plan

- [x] `cargo test -p labwired-core --lib` — 411 passed (was 411 on main; 1 new test, `+1` total but a CI-only fixture count nudge would land elsewhere)
- [x] `cargo test -p labwired-core --test brom_boot_smoke` — passes (BROM loads into RomThunkBank, not RamPeripheral; cache stays disengaged, no regression)
- [x] `cargo test -p labwired-core --release --test e2e_labwired_ereader -- --ignored --nocapture` — paint hit, `refresh_generation=2`
- [x] `cargo clippy -p labwired-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Workspace clippy clean
- [x] Pre-existing flakes (`e2e_esp32_epaper::firmware_drives_panel_to_three_band_pattern`, `runtime_snapshot::agentdeck_snapshot_file_restores_post_paint_panel`) confirmed to fail on `main` with `git stash` too — not caused by this PR