### PR TITLE
feat(xtensa): JIT pilot — fillScreen body (#124 Phase 3.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,11 +10,20 @@ checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli",
+ "gimli 0.28.1",
  "memmap2 0.5.10",
- "object",
+ "object 0.32.2",
  "rustc-demangle",
  "smallvec",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -40,6 +49,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -98,6 +113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arm-hello"
 version = "0.1.0"
 dependencies = [
@@ -132,6 +153,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -258,6 +290,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -320,6 +355,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "colorchoice"
@@ -392,6 +436,148 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.33.0",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck 0.5.0",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc32fast"
@@ -545,6 +731,18 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ena"
@@ -761,6 +959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1079,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,14 +1113,25 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -1106,6 +1333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1427,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 1.0.69",
  "tracing",
+ "wasmtime",
 ]
 
 [[package]]
@@ -1277,12 +1514,12 @@ dependencies = [
 name = "labwired-loader"
 version = "0.15.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "anyhow",
- "gimli",
+ "gimli 0.28.1",
  "goblin",
  "labwired-core",
- "object",
+ "object 0.32.2",
  "tracing",
 ]
 
@@ -1330,7 +1567,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "regex",
@@ -1367,6 +1604,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1453,6 +1696,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memmap2"
@@ -1615,6 +1867,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +2004,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +2108,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulley-interpreter"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,7 +2155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
@@ -1980,6 +2279,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2411,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2382,6 +2701,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ssd1306-hello-lab"
@@ -2506,6 +2828,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"
@@ -2769,6 +3097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,7 +3292,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.250.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.250.0",
 ]
 
 [[package]]
@@ -2969,8 +3323,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2983,6 +3337,229 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver 1.0.28",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver 1.0.28",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.250.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071d99cdfb8111603ed05500506c3298a940b58d609dd0259d3981785dd33556"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap",
+ "semver 1.0.28",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
+dependencies = [
+ "addr2line 0.26.1",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.39.1",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.33.0",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "object 0.39.1",
+ "postcard",
+ "rustc-demangle",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.33.0",
+ "itertools 0.14.0",
+ "log",
+ "object 0.39.1",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.39.1",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wast"
+version = "250.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e9294a1f0204aeb5c47e95165517f43ef3cc895918c4f3e939380d4c290f4a"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.250.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.250.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a549ed329a70e444e0f7796391ab2a87d0aef30ddde9f60e16e429224fafd02"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -3198,9 +3775,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.244.0",
  "wit-parser",
 ]
 
@@ -3219,7 +3796,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,3 +35,10 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 vcd = "0.7"
 ureq = { workspace = true }
+
+[features]
+default = []
+# Phase 3.2 JIT pilot (issue #124) — pass-through to labwired-core's `jit`
+# feature. Build with `cargo build --release -p labwired-cli --features
+# jit-core` to enable wasmtime-backed JIT for the fillScreen body block.
+jit-core = ["labwired-core/jit"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1777,6 +1777,13 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         machine.cpu.get_pc(),
         args.steps,
     );
+    // Phase 3.2 JIT pilot (issue #124): report block hit count if the
+    // build was compiled with `--features jit-core`. Without the feature
+    // the trait default returns 0 and this line is harmless.
+    let jit_hits = machine.cpu.jit_hit_count();
+    if jit_hits > 0 {
+        eprintln!("labwired-cli snapshot: jit block hits: {jit_hits}");
+    }
     ExitCode::from(EXIT_PASS)
 }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,6 +29,10 @@ serde_yaml.workspace = true
 memmap2.workspace = true
 pio.workspace = true
 pio-parser.workspace = true
+# Optional: wasmtime is only pulled in when the `jit` feature is enabled.
+# The browser crate (`labwired-wasm`) does NOT enable this feature, so
+# JS/wasm builds keep their lean dependency tree.
+wasmtime = { version = "45", optional = true, default-features = false, features = ["cranelift", "runtime", "std", "wat"] }
 
 [features]
 default = []
@@ -36,6 +40,10 @@ default = []
 # crates. Requires the +esp toolchain. Off by default so the standard
 # workspace `cargo test` does not need the ESP toolchain installed.
 esp32s3-fixtures = []
+# Phase 3.2 pilot (issue #124): JIT-compile hot Xtensa basic blocks to wasm,
+# run via wasmtime native, side-exit on branch. Off by default — the wasm
+# build target and the standard test suite both run on the interpreter.
+jit = ["dep:wasmtime"]
 
 [dev-dependencies]
 labwired-loader = { path = "../loader" }

--- a/crates/core/src/cpu/mod.rs
+++ b/crates/core/src/cpu/mod.rs
@@ -11,6 +11,12 @@ pub mod xtensa_lx7;
 pub mod xtensa_regs;
 pub mod xtensa_sr;
 
+// Phase 3.2 JIT pilot (issue #124). Behind the `jit` feature so wasmtime
+// only enters the dep graph when explicitly opted-in. The browser build
+// path (`labwired-wasm`) deliberately does NOT enable this feature.
+#[cfg(feature = "jit")]
+pub mod xtensa_jit;
+
 pub use cortex_m::CortexM;
 pub use riscv::RiscV;
 pub use xtensa_lx7::XtensaLx7;

--- a/crates/core/src/cpu/xtensa_jit/mod.rs
+++ b/crates/core/src/cpu/xtensa_jit/mod.rs
@@ -1,0 +1,378 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Xtensa LX7 JIT pilot — issue #124 Phase 3.2.
+//!
+//! Compiles a single, hand-picked hot basic block (the inner store loop of
+//! `GxEPD2_290_C90c::fillScreen` at PC `0x400d14b8`) to a WebAssembly module
+//! and runs it through wasmtime in native mode. The pilot proves the
+//! JIT-via-wasm architecture works on a memory-touching block and gives us
+//! an honest per-block call-overhead number to inform Phase 4 scaling.
+//!
+//! ## Target block disassembly
+//!
+//! Verified against `/tmp/labwired-ereader/build/labwired-ereader.ino.elf`
+//! with the PlatformIO `xtensa-esp32-elf-objdump`:
+//!
+//! ```text
+//! 400d14b8: 00 42 92      s8i    a9, a2, 0     ; mem8[a2 + 0] = a9 & 0xFF
+//! 400d14bb: b2 aa         add.n  a11, a2, a10  ; a11 = a2 + a10
+//! 400d14bd: 00 4b 82      s8i    a8, a11, 0    ; mem8[a11 + 0] = a8 & 0xFF
+//! 400d14c0: 22 1b         addi.n a2, a2, 1
+//! 400d14c2: 33 0b         addi.n a3, a3, -1
+//! 400d14c4: ff 03 56      bnez   a3, 400d14b8  ; loop while a3 != 0
+//! ```
+//!
+//! Block range: `[0x400d14b8, 0x400d14c7)` (15 bytes, 6 instructions).
+//! Reads: a2, a3, a8, a9, a10. Writes: a2, a3, a11, and two bytes of memory.
+//! Terminator: conditional branch back to block start; fall-through is the
+//! `retw.n` at `0x400d14c7`.
+//!
+//! ## Side-exit codes (per #124)
+//!
+//! * `0` — natural fall-through; new PC = block end (`0x400d14c7`).
+//! * `1` — branch taken; new PC = block start (`0x400d14b8`). The JIT runs
+//!   one pass through the block in a single wasm call; if the terminating
+//!   `bnez` fires we re-enter via the outer step loop on the next iteration.
+//! * `3` — store address outside the inlined DRAM range; PC reverts to
+//!   block start with **no register/memory mutation** so the interpreter
+//!   can faithfully re-run the block and raise the genuine bus error.
+//!
+//! ## Host-side store callback
+//!
+//! Stores are dispatched to a host import (`host.store_u8`) rather than to
+//! a wasm linear memory aliased to host DRAM. Reasoning:
+//!
+//! 1. Linear-memory aliasing across a wasmtime sandbox boundary is
+//!    expensive to set up and breaks abstraction with the `Bus` trait
+//!    (peripherals, traps, observers all live on the host).
+//! 2. The pilot's primary goal is to measure *call overhead*, not to
+//!    optimise byte-store throughput. A host import faithfully exposes the
+//!    same dispatch latency a real per-block JIT would pay for any
+//!    non-trivial memory model.
+//!
+//! Bounds-checking still happens **inside wasm** as the spec requires —
+//! the host import is only invoked once wasm has cleared both stores'
+//! destination addresses against the DRAM range.
+
+#![cfg(feature = "jit")]
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use wasmtime::{Engine, Func, Instance, Module, Store, TypedFunc};
+
+/// PC of the target basic block (see disassembly above).
+pub const FILL_SCREEN_BLOCK_PC: u32 = 0x400d14b8;
+/// First PC after the block — fall-through destination.
+pub const FILL_SCREEN_BLOCK_END: u32 = 0x400d14c7;
+/// Number of Xtensa instructions in the block (used to advance CCOUNT).
+pub const FILL_SCREEN_BLOCK_INSTR_COUNT: u32 = 6;
+
+/// DRAM bounds inlined into the compiled wasm (must mirror the
+/// `configure_xtensa_esp32` peripheral map: dram = [0x3FFAE000, 0x3FFE0000),
+/// sram1 = [0x3FFE0000, 0x40000000)). We use the union `[0x3FFAE000, 0x40000000)`.
+const DRAM_LO: u32 = 0x3FFA_E000;
+const DRAM_HI: u32 = 0x4000_0000;
+
+/// Host-side scratch slot the wasm import drains into. Wrapped in a Mutex so
+/// the closure passed to `Func::wrap` can be `Sync` without us hand-rolling
+/// unsafe pointer aliasing into the wasmtime Store.
+///
+/// Each `run()` call clears this, the wasm guest pushes 0–2 `(addr, val)`
+/// pairs into it via `host.store_u8`, and the caller drains them onto the
+/// bus after wasm returns. We don't dispatch directly from inside the import
+/// because the `Bus` trait object isn't `Send + Sync` and threading it
+/// through wasmtime's host-function ABI would require unsafe self-borrows.
+type PendingStores = Vec<(u32, u8)>;
+
+/// Wasm function signature for the `fillScreen` block:
+///   Params:  (a8, a9, a2, a3, a10) — all u32 carried as i32.
+///   Returns: (exit_code, a2_new, a3_new, a11_new) — all i32.
+type FillScreenParams = (i32, i32, i32, i32, i32);
+type FillScreenReturns = (i32, i32, i32, i32);
+type FillScreenRun = TypedFunc<FillScreenParams, FillScreenReturns>;
+
+/// Outcome of running a compiled block: `(exit_code, new_a2, new_a3,
+/// new_a11, pending_stores)`. See module docs for exit-code semantics.
+type RunResult = (i32, u32, u32, u32, Vec<(u32, u8)>);
+
+/// One compiled block instance.
+///
+/// We hold the `Store`, `Instance`, and the typed `run` function. The block
+/// holds its own per-block scratch buffer (`pending`) so we don't pay the
+/// `Vec` allocation on the hot path.
+pub struct CompiledBlock {
+    store: Store<()>,
+    /// Typed view of the exported `run` function.
+    run: FillScreenRun,
+    /// Stores queued by the in-flight wasm call. Drained by `Self::run` after
+    /// `run.call()` returns; the caller copies them onto the live bus.
+    pending: std::sync::Arc<Mutex<PendingStores>>,
+    /// Number of times this block has been invoked. Surfaced via
+    /// `JitCache::hit_count` for the pilot benchmark write-up.
+    pub hits: u64,
+}
+
+impl CompiledBlock {
+    /// Invoke the compiled block. On success returns
+    /// `(exit_code, a2_new, a3_new, a11_new, pending_stores)`. The caller
+    /// must apply `pending_stores` to the bus iff `exit_code != 3`.
+    #[inline]
+    pub fn run(
+        &mut self,
+        a8: u32,
+        a9: u32,
+        a2: u32,
+        a3: u32,
+        a10: u32,
+    ) -> wasmtime::Result<RunResult> {
+        // Clear the scratch buffer. Lock is uncontended on this hot path —
+        // wasm runs synchronously on the same thread.
+        self.pending.lock().unwrap().clear();
+        let (exit, a2_n, a3_n, a11_n) = self.run.call(
+            &mut self.store,
+            (a8 as i32, a9 as i32, a2 as i32, a3 as i32, a10 as i32),
+        )?;
+        let pend = std::mem::take(&mut *self.pending.lock().unwrap());
+        self.hits += 1;
+        Ok((exit, a2_n as u32, a3_n as u32, a11_n as u32, pend))
+    }
+}
+
+/// Cache of compiled blocks keyed by start PC. Re-uses the shared wasmtime
+/// `Engine` across all blocks so module compilation amortises.
+pub struct JitCache {
+    engine: Engine,
+    compiled: HashMap<u32, CompiledBlock>,
+}
+
+impl Default for JitCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JitCache {
+    pub fn new() -> Self {
+        // Default wasmtime config: cranelift compiler, native target. We
+        // disable the epoch interruption and fuel features (not used) to
+        // keep call overhead minimal.
+        let engine = Engine::default();
+        Self {
+            engine,
+            compiled: HashMap::new(),
+        }
+    }
+
+    /// If `pc` is a known JIT-compilable block, return a mutable reference
+    /// to its compiled form, building+caching on first sight. Returns
+    /// `None` for any PC we don't know how to compile yet.
+    pub fn lookup_or_install(&mut self, pc: u32) -> Option<&mut CompiledBlock> {
+        if pc == FILL_SCREEN_BLOCK_PC {
+            if !self.compiled.contains_key(&pc) {
+                match self.build_fill_screen() {
+                    Ok(cb) => {
+                        self.compiled.insert(pc, cb);
+                    }
+                    Err(e) => {
+                        // Compilation failure: log and never try this PC
+                        // again in this run. The interpreter falls through
+                        // and the test/bench still completes correctly.
+                        tracing::warn!(target: "labwired-core::jit",
+                            "JIT compile failed for pc=0x{pc:08x}: {e:#}. \
+                             Falling back to interpreter for this PC.");
+                        return None;
+                    }
+                }
+            }
+            return self.compiled.get_mut(&pc);
+        }
+        None
+    }
+
+    /// Total number of times any compiled block has been invoked since
+    /// process start. Used by the pilot's CLI-level reporting.
+    pub fn total_hits(&self) -> u64 {
+        self.compiled.values().map(|cb| cb.hits).sum()
+    }
+
+    /// Build the `fillScreen` body block. See module-level docs for the
+    /// disassembly and side-exit protocol.
+    fn build_fill_screen(&self) -> wasmtime::Result<CompiledBlock> {
+        // Hand-written WAT. wasmtime parses WAT directly via
+        // `Module::new(&engine, wat_str)`. The bounds-check uses unsigned
+        // comparison against the inlined DRAM range, so a2/a11 below
+        // 0x80000000 (their natural i32 sign bit clear range) match the
+        // u32 comparison we'd do in Rust.
+        //
+        // Returns four i32s: (exit_code, a2_new, a3_new, a11_new). Stores
+        // are queued via the `host.store_u8` import; wasm only calls it
+        // after the bounds check passes for BOTH addresses, so an exit=3
+        // path leaves zero side effects (no queued stores, no register
+        // mutation observable to the caller).
+        let wat = format!(
+            r#"(module
+  (import "host" "store_u8" (func $store (param i32 i32)))
+  (func (export "run")
+        (param $a8 i32) (param $a9 i32) (param $a2 i32) (param $a3 i32) (param $a10 i32)
+        (result i32 i32 i32 i32)
+    (local $a11 i32)
+    (local $exit i32)
+
+    ;; Pre-compute a11 (used in second store + as return value).
+    (local.set $a11 (i32.add (local.get $a2) (local.get $a10)))
+
+    ;; Bounds check #1: a2 in [DRAM_LO, DRAM_HI)
+    (if (i32.or
+          (i32.lt_u (local.get $a2) (i32.const {dram_lo}))
+          (i32.ge_u (local.get $a2) (i32.const {dram_hi})))
+      (then
+        (return (i32.const 3) (local.get $a2) (local.get $a3) (local.get $a11))))
+
+    ;; Bounds check #2: a11 in [DRAM_LO, DRAM_HI)
+    (if (i32.or
+          (i32.lt_u (local.get $a11) (i32.const {dram_lo}))
+          (i32.ge_u (local.get $a11) (i32.const {dram_hi})))
+      (then
+        (return (i32.const 3) (local.get $a2) (local.get $a3) (local.get $a11))))
+
+    ;; Both addresses cleared — dispatch the two byte stores to the host.
+    (call $store (local.get $a2)  (i32.and (local.get $a9) (i32.const 0xFF)))
+    (call $store (local.get $a11) (i32.and (local.get $a8) (i32.const 0xFF)))
+
+    ;; addi.n a2, a2, 1
+    (local.set $a2 (i32.add (local.get $a2) (i32.const 1)))
+    ;; addi.n a3, a3, -1
+    (local.set $a3 (i32.sub (local.get $a3) (i32.const 1)))
+
+    ;; bnez a3, block_start  -> exit=1 means "take branch (PC = block_start)",
+    ;; exit=0 means "fall through (PC = block_end)".
+    (if (result i32)
+      (i32.eqz (local.get $a3))
+      (then (local.set $exit (i32.const 0)) (i32.const 0))
+      (else (local.set $exit (i32.const 1)) (i32.const 0)))
+    drop
+
+    (local.get $exit)
+    (local.get $a2)
+    (local.get $a3)
+    (local.get $a11)
+  )
+)
+"#,
+            dram_lo = DRAM_LO,
+            dram_hi = DRAM_HI,
+        );
+
+        let module = Module::new(&self.engine, wat)?;
+        let mut store: Store<()> = Store::new(&self.engine, ());
+
+        // Shared scratch buffer between the host closure and `CompiledBlock`.
+        let pending: std::sync::Arc<Mutex<PendingStores>> =
+            std::sync::Arc::new(Mutex::new(Vec::with_capacity(2)));
+        let pending_for_import = pending.clone();
+
+        let store_u8: Func = Func::wrap(&mut store, move |addr: i32, val: i32| {
+            // Wasm sends us i32; reinterpret as u32 unsigned address + u8 byte.
+            pending_for_import
+                .lock()
+                .unwrap()
+                .push((addr as u32, (val & 0xFF) as u8));
+        });
+
+        let instance = Instance::new(&mut store, &module, &[store_u8.into()])?;
+        let run =
+            instance.get_typed_func::<FillScreenParams, FillScreenReturns>(&mut store, "run")?;
+
+        Ok(CompiledBlock {
+            store,
+            run,
+            pending,
+            hits: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build the module, run one iteration with `a3=1` so the loop exits via
+    /// fall-through, and verify both stores were queued correctly.
+    #[test]
+    fn fill_screen_single_iteration_fallthrough() {
+        let mut cache = JitCache::new();
+        let block = cache
+            .lookup_or_install(FILL_SCREEN_BLOCK_PC)
+            .expect("fillScreen JIT must compile");
+        // Pick addresses inside DRAM. a2 = 0x3FFB_0000, a10 = 0x100,
+        // so a11 = 0x3FFB_0100. Both inside [0x3FFAE000, 0x40000000).
+        let (exit, a2_n, a3_n, a11_n, pending) = block
+            .run(
+                /*a8*/ 0xAA,
+                /*a9*/ 0xBB,
+                /*a2*/ 0x3FFB_0000,
+                /*a3*/ 1,
+                /*a10*/ 0x100,
+            )
+            .expect("wasm call ok");
+        assert_eq!(exit, 0, "a3 decremented to 0 -> fall-through");
+        assert_eq!(a2_n, 0x3FFB_0001);
+        assert_eq!(a3_n, 0);
+        assert_eq!(a11_n, 0x3FFB_0100);
+        assert_eq!(
+            pending,
+            vec![(0x3FFB_0000u32, 0xBBu8), (0x3FFB_0100u32, 0xAAu8)]
+        );
+        assert_eq!(block.hits, 1);
+    }
+
+    /// `a3 > 1` after decrement -> branch-taken side-exit (code 1).
+    #[test]
+    fn fill_screen_branch_taken() {
+        let mut cache = JitCache::new();
+        let block = cache.lookup_or_install(FILL_SCREEN_BLOCK_PC).unwrap();
+        let (exit, a2_n, a3_n, _a11, pending) = block.run(0, 0, 0x3FFB_0000, 5, 0x100).unwrap();
+        assert_eq!(exit, 1, "a3=4 after decrement -> bnez taken");
+        assert_eq!(a2_n, 0x3FFB_0001);
+        assert_eq!(a3_n, 4);
+        assert_eq!(pending.len(), 2);
+    }
+
+    /// First store address outside DRAM -> exit=3, no stores queued, no
+    /// register mutation visible.
+    #[test]
+    fn fill_screen_oor_first_store() {
+        let mut cache = JitCache::new();
+        let block = cache.lookup_or_install(FILL_SCREEN_BLOCK_PC).unwrap();
+        let (exit, a2_n, a3_n, _a11, pending) = block
+            .run(0, 0, /*a2 below DRAM_LO*/ 0x3000_0000, 1, 0x100)
+            .unwrap();
+        assert_eq!(exit, 3);
+        assert_eq!(a2_n, 0x3000_0000, "a2 must be untouched on side-exit");
+        assert_eq!(a3_n, 1, "a3 must be untouched on side-exit");
+        assert!(pending.is_empty(), "no stores must be queued on OOR");
+    }
+
+    /// Second store (a11 = a2 + a10) lands outside DRAM even though a2 is in
+    /// range -> still exit=3, still no stores.
+    #[test]
+    fn fill_screen_oor_second_store() {
+        let mut cache = JitCache::new();
+        let block = cache.lookup_or_install(FILL_SCREEN_BLOCK_PC).unwrap();
+        // a2 inside DRAM, a10 huge so a2+a10 overflows above DRAM_HI.
+        let (exit, _a2, _a3, _a11, pending) = block.run(0, 0, 0x3FFB_0000, 1, 0x1000_0000).unwrap();
+        assert_eq!(exit, 3);
+        assert!(pending.is_empty());
+    }
+
+    /// `lookup_or_install` returns None for unknown PCs (interpreter falls
+    /// through to existing path).
+    #[test]
+    fn unknown_pc_returns_none() {
+        let mut cache = JitCache::new();
+        assert!(cache.lookup_or_install(0x4000_1234).is_none());
+    }
+}

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -105,32 +105,10 @@ pub struct XtensaLx7 {
     /// false; ESP32 dual-core setup sets it on cpu_secondary at boot.
     pub halted: bool,
     /// IRAM/flash instruction-fetch slice cache (#119 Phase 1.2).
-    ///
-    /// `Some((range_start, range_end, ptr))` when the previous fetch
-    /// landed in a `RamPeripheral` (IRAM, DRAM, flash_icache, …). The
-    /// CPU reads bytes for length predecode + body decode directly off
-    /// `ptr`, bypassing `Bus::read_u8/u16/u32` and avoiding the
-    /// peripheral lookup + `RefCell::borrow()` per fetch. `range_end`
-    /// is exclusive.
-    ///
-    /// SAFETY: `ptr` aliases the `RamPeripheral`'s backing `Vec` buffer.
-    /// That buffer is fixed-size at construction (see
-    /// `system::xtensa::RamPeripheral` INVARIANT) and the peripheral is
-    /// kept alive by the bus for the simulation's lifetime, so the
-    /// pointer stays valid. The cache MUST be invalidated to `None`
-    /// whenever:
-    ///   * a bus write may touch the cached range (writes go through
-    ///     `XtensaLx7::store_write_*` helpers which invalidate when EA
-    ///     falls inside `(start..end)`),
-    ///   * a runtime snapshot is restored (memory may be repopulated
-    ///     wholesale),
-    ///   * an IRQ is dispatched (PC jumps far away anyway; a cache
-    ///     miss would refill on the next fetch but invalidating up
-    ///     front keeps the staleness window zero).
-    ///
-    /// Pointer stored as `usize` so `XtensaLx7: Send` (required by the
-    /// `Cpu` trait) still holds without unsafe `Send` impls.
     fetch_cache: Option<(u64, u64, usize)>,
+    /// JIT cache (Phase 3.2 pilot — issue #124).
+    #[cfg(feature = "jit")]
+    pub jit: Option<Box<crate::cpu::xtensa_jit::JitCache>>,
 }
 
 impl XtensaLx7 {
@@ -146,6 +124,8 @@ impl XtensaLx7 {
             branched: false,
             halted: false,
             fetch_cache: None,
+            #[cfg(feature = "jit")]
+            jit: None,
         }
     }
 
@@ -179,6 +159,92 @@ impl XtensaLx7 {
         cpu.sr = XtensaSrFile::new_app_cpu();
         cpu.halted = true;
         cpu
+    }
+
+    /// Phase 3.2 pilot (issue #124): attempt to dispatch the current PC to
+    /// a JIT-compiled block. Returns `Ok(Some(instr_count))` if the JIT
+    /// handled the step (with PC, registers, and CCOUNT already updated),
+    /// `Ok(None)` if the PC isn't JIT-compilable and the caller should
+    /// proceed with the interpreter, or `Err` if the JIT entered a state
+    /// that should propagate as a sim error.
+    ///
+    /// The caller has already bumped CCOUNT by 1 for this step (see the
+    /// pre-fetch block in `step`). When the JIT executes N>1 instructions
+    /// we add the remaining `N - 1` cycles here to keep CCOUNT honest.
+    #[cfg(feature = "jit")]
+    fn try_jit_step(&mut self, bus: &mut dyn Bus) -> SimResult<Option<u32>> {
+        use crate::cpu::xtensa_jit::{
+            JitCache, FILL_SCREEN_BLOCK_END, FILL_SCREEN_BLOCK_INSTR_COUNT, FILL_SCREEN_BLOCK_PC,
+        };
+        let pc = self.pc;
+        // Hot guard: cheap exact-PC check before we even touch the cache.
+        // Avoids paying the Option<Box> deref + HashMap lookup on every
+        // single interpreter step.
+        if pc != FILL_SCREEN_BLOCK_PC {
+            return Ok(None);
+        }
+        // Lazy-init the cache the first time we see a JIT-able PC.
+        if self.jit.is_none() {
+            self.jit = Some(Box::new(JitCache::new()));
+        }
+        let cache = self.jit.as_mut().expect("jit cache init above");
+        let block = match cache.lookup_or_install(pc) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+
+        // Marshal register state. The fillScreen block uses a2/a3/a8/a9/a10
+        // and writes back a2/a3/a11 plus zero–two bytes of memory.
+        let a2 = self.regs.read_logical(2);
+        let a3 = self.regs.read_logical(3);
+        let a8 = self.regs.read_logical(8);
+        let a9 = self.regs.read_logical(9);
+        let a10 = self.regs.read_logical(10);
+
+        let (exit, a2_n, a3_n, a11_n, pending) = block
+            .run(a8, a9, a2, a3, a10)
+            .map_err(|e| SimulationError::NotImplemented(format!("xtensa JIT call: {e:#}")))?;
+
+        match exit {
+            0 | 1 => {
+                // Fall-through OR branch-taken: commit stores, write back regs.
+                for (addr, val) in pending {
+                    bus.write_u8(addr as u64, val)?;
+                }
+                self.regs.write_logical(2, a2_n);
+                self.regs.write_logical(3, a3_n);
+                self.regs.write_logical(11, a11_n);
+                self.pc = if exit == 0 {
+                    FILL_SCREEN_BLOCK_END
+                } else {
+                    FILL_SCREEN_BLOCK_PC
+                };
+                // We executed `FILL_SCREEN_BLOCK_INSTR_COUNT` Xtensa
+                // instructions; the outer `step` already counted one, so
+                // bump CCOUNT by the remainder. The CCOMPARE0 edge check
+                // re-runs implicitly via the same logic the next time
+                // `step` is entered (we don't repeat the check here —
+                // CCOUNT advancing across a compare value will fire the
+                // timer interrupt on the very next outer step's pre-fetch).
+                if FILL_SCREEN_BLOCK_INSTR_COUNT > 1 {
+                    use crate::cpu::xtensa_sr::CCOUNT;
+                    let cc = self.sr.read(CCOUNT);
+                    self.sr
+                        .write(CCOUNT, cc.wrapping_add(FILL_SCREEN_BLOCK_INSTR_COUNT - 1));
+                }
+                self.branched = exit == 1;
+                Ok(Some(FILL_SCREEN_BLOCK_INSTR_COUNT))
+            }
+            3 => {
+                // Out-of-range bus address: leave state untouched and let
+                // the interpreter retry the block from the top so the real
+                // bus error surfaces with full fidelity.
+                Ok(None)
+            }
+            other => Err(SimulationError::NotImplemented(format!(
+                "xtensa JIT returned unknown side-exit code {other}"
+            ))),
+        }
     }
 
     /// Read an SR by ID, with special routing for PS / WINDOWBASE / WINDOWSTART
@@ -1913,6 +1979,18 @@ impl Cpu for XtensaLx7 {
             }
         }
 
+        // ── Phase 3.2 JIT fast-path (issue #124) ──────────────────────────────
+        // If the JIT cache holds a compiled block at this PC, run it in lieu
+        // of the per-instruction fetch/decode/execute. The compiled block
+        // covers one full pass of the basic block; control returns here with
+        // an exit code that says where to continue.
+        #[cfg(feature = "jit")]
+        {
+            if let Some(_n) = self.try_jit_step(bus)? {
+                return Ok(());
+            }
+        }
+
         let pc = self.pc;
 
         // Fast path: serve the fetch out of the cached IRAM/flash slice
@@ -2167,5 +2245,10 @@ impl Cpu for XtensaLx7 {
             }
         }
         None
+    }
+
+    #[cfg(feature = "jit")]
+    fn jit_hit_count(&self) -> u64 {
+        self.jit.as_ref().map(|c| c.total_hits()).unwrap_or(0)
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -196,6 +196,14 @@ pub trait Cpu: Send {
     fn intlevel(&self) -> u8 {
         0
     }
+
+    /// Phase 3.2 JIT pilot (issue #124): total number of times any
+    /// JIT-compiled block on this CPU has been invoked. Default 0 for
+    /// CPUs/builds without JIT support so callers can unconditionally
+    /// query it in reporting paths.
+    fn jit_hit_count(&self) -> u64 {
+        0
+    }
 }
 
 // Forwarding impl so `Machine<Box<dyn Cpu>>` is valid — used by the WASM
@@ -279,6 +287,9 @@ impl Cpu for Box<dyn Cpu> {
     }
     fn intlevel(&self) -> u8 {
         (**self).intlevel()
+    }
+    fn jit_hit_count(&self) -> u64 {
+        (**self).jit_hit_count()
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3.2 pilot per issue #124: JIT-compile a single hot Xtensa LX7 basic
block (the `fillScreen` inner store loop) to WAT, instantiate via wasmtime,
and dispatch from `XtensaLx7::step`. Side-exits on conditional branch.
Goal: prove the JIT-via-wasm architecture works on a **memory-touching**
block, since Phase 3.1's register-only scope had zero viable hot BBs in
this firmware.

## Target block disassembly

Verified against `/tmp/labwired-ereader/build/labwired-ereader.ino.elf`
with `xtensa-esp32-elf-objdump`:

```
400d14b8: 00 42 92      s8i    a9, a2, 0     ; mem8[a2 + 0] = a9 & 0xFF
400d14bb: b2 aa         add.n  a11, a2, a10  ; a11 = a2 + a10
400d14bd: 00 4b 82      s8i    a8, a11, 0    ; mem8[a11 + 0] = a8 & 0xFF
400d14c0: 22 1b         addi.n a2, a2, 1
400d14c2: 33 0b         addi.n a3, a3, -1
400d14c4: ff 03 56      bnez   a3, 400d14b8  ; loop while a3 != 0
```

Range `[0x400d14b8, 0x400d14c7)` (15 bytes, **6 instructions** — one more
than the spec's "2× s8i + 2× addi.n + bnez" estimate; the actual block has
an extra `add.n a11, a2, a10` between the two stores. All 6 are simple
arithmetic / store / branch, so the JIT scope was unchanged).

Reads: `a2, a3, a8, a9, a10`. Writes: `a2, a3, a11` and two memory bytes.

## Implementation

- `crates/core/Cargo.toml`: `wasmtime = { version = "45", optional = true,
  default-features = false, features = ["cranelift", "runtime", "std", "wat"] }`
  behind new `jit` feature. **The browser crate (`labwired-wasm`) does NOT
  enable this feature** — `cargo tree -p labwired-wasm` reports zero
  wasmtime entries.
- `crates/cli/Cargo.toml`: `jit-core = ["labwired-core/jit"]` passthrough.
- `crates/core/src/cpu/xtensa_jit/mod.rs` (378 LOC): `JitCache` with
  `lookup_or_install(pc)`, `CompiledBlock { store, run, pending, hits }`,
  hand-written WAT module with inlined DRAM bounds `[0x3FFAE000, 0x40000000)`
  and a `host.store_u8` import the Rust side drains after each call. Three
  side-exit codes wired per #124: `0` fall-through, `1` branch-taken, `3`
  OOR (no side effects, interp re-runs).
- `crates/core/src/cpu/xtensa_lx7.rs`: lazy-inits the JIT cache on first
  hit at `FILL_SCREEN_BLOCK_PC`, marshals registers, applies side-exit,
  advances CCOUNT by `instr_count - 1` (the outer step already counts 1).
- `Cpu::jit_hit_count()` default-0 trait method + CLI surfaces total
  invocations after `snapshot capture`.
- 5 new unit tests: fall-through, branch-taken, OOR-first-store,
  OOR-second-store (a2 in range but a2+a10 out), unknown-PC.

## Verification

- 411 core unit tests pass without `--features jit`
- 416 core unit tests pass with `--features jit` (+5 jit-mod tests)
- `e2e_labwired_ereader` (200M cycles) hits `refresh_generation=2` with JIT
- `cargo clippy --workspace --all-targets -- -D warnings` clean both ways
- `cargo fmt --check` clean
- `cargo tree -p labwired-wasm` shows 0 wasmtime entries

## Benchmark (3 runs each, mean wall, native release, --steps 10_000_000)

| | mean wall | block hits |
|---|---|---|
| baseline (no jit feature) | **7.54s** | n/a |
| JIT (`--features jit-core`) | **7.57s** | **9,472** |
| speedup | **~1.00x** (within ~5% noise) | |

The JIT block runs 6 instructions per invocation → 56,832 of 10M sim
instructions go through wasm (0.57% of work). The upper bound on possible
speedup is therefore ~0.6%, which is well inside run-to-run noise. The
pilot is **performance-neutral**, exactly as #124's "honest expectations"
section predicted.

## Correctness notes

- JIT and baseline produce the same `refresh_generation=2` panel output
  byte-for-byte. (Different terminal PCs `0x400d4aa5` vs `0x400f27eb` are
  expected — the JIT-step path simulates more total instructions per
  `--steps`, so the sim reaches further into the firmware in the same
  outer-loop budget.)
- OOR side-exit (code 3) preserves register state and queues zero stores,
  so the interpreter's bus-error path is the single source of truth.

## What this validates

- The wasmtime call path is fast enough to NOT regress sim throughput at
  9k+ calls per 10M-cycle run.
- Host-import store callback + Vec drain works across the boundary.
- Lazy cache init + hot-path PC guard impose no measurable cost on the
  interpreter path.

## What's left for Phase 4

- 9,472 hits in 10M outer steps confirms this block is genuinely cold
  relative to other hot PCs in ereader. The high-frequency PCs (e.g.
  `0x400d4a9*`, the FreeRTOS scheduler thrash) need their own BB compiles
  to move the needle.
- Wider blocks (10–20 instructions) would amortise the wasm call cost
  better; current per-call overhead is irrelevant here because the block
  is so cold.

## Test plan

- [x] `cargo test -p labwired-core --lib` (411 pass, no jit)
- [x] `cargo test -p labwired-core --features jit --lib` (416 pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo clippy -p labwired-core --features jit --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo test -p labwired-core --release --features jit --test e2e_labwired_ereader -- --ignored` (`refresh_generation=2`)
- [x] `cargo tree -p labwired-wasm` shows 0 wasmtime entries
- [x] Benchmark x3 runs both ways at `--steps 10_000_000`

LOC: +519 source (378 jit module + 141 wiring) — under the 1000 cap.