### PR TITLE
feat(xtensa): JIT CALL8 windowed-call emit (#124 Phase 3.6.2)

### DIFF
--- a/crates/core/src/cpu/xtensa_jit/mod.rs
+++ b/crates/core/src/cpu/xtensa_jit/mod.rs
@@ -58,6 +58,13 @@
 
 #![cfg(feature = "jit")]
 
+mod windowed_call;
+
+pub use windowed_call::{
+    WindowedCallBlock, WindowedCallResult, EXIT_TAKEN as WINDOWED_EXIT_TAKEN, EXIT_WINDOWED_REFUSE,
+    LOOPV_CALL8_INSTR_COUNT, LOOPV_CALL8_NEXT_PC, LOOPV_CALL8_PC, LOOPV_CALL8_TARGET,
+};
+
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -146,6 +153,14 @@ impl CompiledBlock {
 pub struct JitCache {
     engine: Engine,
     compiled: HashMap<u32, CompiledBlock>,
+    /// Phase 3.6.2: windowed CALL8 block for `_Z4loopv` (PC 0x400d4a99).
+    /// Boxed + lazy so we don't pay wasmtime instantiation cost on every
+    /// `JitCache::new()` (e.g. dual-core configs build two CPUs).
+    pub loopv_call8: Option<Box<WindowedCallBlock>>,
+    /// Phase 3.6.2 instrumentation: track how often the windowed-call
+    /// JIT refused (exit code 5) so the lockstep + bench reports can
+    /// quantify how many CALL8s actually went through the wasm path.
+    pub windowed_refusals: u64,
 }
 
 impl Default for JitCache {
@@ -163,6 +178,8 @@ impl JitCache {
         Self {
             engine,
             compiled: HashMap::new(),
+            loopv_call8: None,
+            windowed_refusals: 0,
         }
     }
 
@@ -192,10 +209,34 @@ impl JitCache {
         None
     }
 
+    /// Lazily compile + return the LOOPV CALL8 block. Returns `None` if
+    /// wasm compilation fails (extremely unlikely — the template is fixed
+    /// and validated at unit-test time, so a runtime failure here points
+    /// at a wasmtime regression rather than a usage bug).
+    pub fn lookup_or_install_windowed(&mut self, pc: u32) -> Option<&mut WindowedCallBlock> {
+        if pc != LOOPV_CALL8_PC {
+            return None;
+        }
+        if self.loopv_call8.is_none() {
+            match WindowedCallBlock::build_loopv(&self.engine) {
+                Ok(b) => self.loopv_call8 = Some(Box::new(b)),
+                Err(e) => {
+                    tracing::warn!(target: "labwired-core::jit",
+                        "windowed CALL8 JIT compile failed for pc=0x{pc:08x}: {e:#}. \
+                         Falling back to interpreter for this PC.");
+                    return None;
+                }
+            }
+        }
+        self.loopv_call8.as_deref_mut()
+    }
+
     /// Total number of times any compiled block has been invoked since
     /// process start. Used by the pilot's CLI-level reporting.
     pub fn total_hits(&self) -> u64 {
-        self.compiled.values().map(|cb| cb.hits).sum()
+        let fillscreen_hits: u64 = self.compiled.values().map(|cb| cb.hits).sum();
+        let windowed_hits = self.loopv_call8.as_ref().map(|b| b.hits).unwrap_or(0);
+        fillscreen_hits + windowed_hits
     }
 
     /// Build the `fillScreen` body block. See module-level docs for the

--- a/crates/core/src/cpu/xtensa_jit/windowed_call.rs
+++ b/crates/core/src/cpu/xtensa_jit/windowed_call.rs
@@ -1,0 +1,287 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Xtensa LX7 JIT — windowed CALL8 emit (Phase 3.6.2 / issue #124).
+//!
+//! # Windowed-register one-pager (per Xtensa LX ISA RM §§4.7, 8)
+//!
+//! The Xtensa LX has a 64-entry physical register file (`AR[0..63]`) viewed
+//! through a 16-entry logical window (`a0..a15`). The mapping is:
+//!
+//! ```text
+//! logical aN = AR[(WindowBase * 4 + N) & 0x3F]
+//! ```
+//!
+//! `WindowBase` is a 4-bit pointer (0..=15). `WindowStart` is a 16-bit
+//! bitmask: each bit `WS[k]` is set iff a live frame occupies the slot of
+//! AR registers starting at `AR[k*4]`. At reset WB=0 and WS=0b1 (the
+//! initial frame at slot 0 is live).
+//!
+//! ## CALL8 (the instruction at 0x400d4a99 we're JIT-ing)
+//!
+//! ISA §8 CALL{n} encodes one of three windowed calls. CALL8 in particular:
+//!
+//! 1. `ret_pc = ((PC + 3) & 0x3FFFFFFF) | (2 << 30)` — the low 30 bits are
+//!    the byte address of the *next* instruction; the top 2 bits encode
+//!    `CALLINC = N/4 = 2` so a future RETW knows how far to rotate WB
+//!    backwards.
+//! 2. `target = ((PC + 4) & ~3) + sign_extend(offset)*4` — a PC-relative
+//!    word offset from the *aligned* address of the next instruction.
+//! 3. Write `ret_pc` into the caller's logical `a{N} = a8`. This physical
+//!    register **becomes the callee's `a0`** once ENTRY rotates WB.
+//! 4. `PS.CALLINC := 2`. **Critically, CALL{n} does NOT rotate WindowBase
+//!    and does NOT touch WindowStart.** Those happen on the matching
+//!    `ENTRY` instruction at the callee's entry point.
+//! 5. `PC := target`.
+//!
+//! The naive "JIT must update WindowBase += 2 and set WindowStart bit"
+//! reading of the spec is **incorrect for CALL** — that's ENTRY's job.
+//! Doing it on CALL would diverge from the LX7 interpreter and break
+//! lockstep instantly. We match the interpreter exactly: set CALLINC,
+//! write the return address into the OLD frame's a8, jump.
+//!
+//! ## Sim-level shadow spill
+//!
+//! Real silicon raises WindowOverflow when ENTRY lands in an already-live
+//! slot, and the OF8/OF12 vector handlers spill the displaced frame to a
+//! save-area on the stack. Our sim's [`spill_shadow_on_call`] runs at
+//! CALL time and pushes the displaced frame's 4 ARs to a per-WB Vec; the
+//! matching RETW pops. This is invisible to firmware (the save chain is
+//! never read by guest code) but it MUST execute on every CALL or RETW
+//! will pop the wrong frame and corrupt registers later.
+//!
+//! Because the spill walks the AR file, touches per-slot Vecs, and is
+//! conditional on WindowStart bits, replicating it inside wasm would
+//! require either:
+//!   * exposing the full AR file as a wasm-visible buffer (large surface
+//!     area, breaks `Bus` abstraction), or
+//!   * calling a host import once per slot check (8+ wasmtime crossings
+//!     per CALL8, killing any speedup).
+//!
+//! The pragmatic choice: **the JIT's wasm body computes only the cheap,
+//! purely-functional parts (constants, exit code) and the Rust host
+//! applies the architectural side-effects via the existing interpreter
+//! helpers (`spill_shadow_on_call`, `write_logical`, `set_callinc`).**
+//! Lockstep validates the result against a pure-interpreter trace
+//! byte-for-byte.
+//!
+//! ## Why this still wins (or at least, why it's worth measuring)
+//!
+//! The interpreter pays per-instruction overhead for: PC fetch, length
+//! predecode, body decode, match-arm dispatch, generic-instruction
+//! housekeeping (CCOUNT, branched-flag clear, IRQ check). The JIT
+//! collapses that to a single wasmtime call + a known side-effect
+//! sequence. For a single-instruction block this almost certainly does
+//! NOT win on its own (call overhead dwarfs the savings), and the spec
+//! is honest about this. The payoff for Phase 3.6 comes from chained
+//! windowed flows we'll add in later sub-phases — this file is the
+//! *correctness foundation* that lets those land safely.
+
+#![cfg(feature = "jit")]
+
+use wasmtime::{Engine, Instance, Module, Store, TypedFunc};
+
+/// PC of the dominant CALL8 in the ereader firmware (per Phase 3.0
+/// dispatch counter data: ~92% of all dispatches land here).
+///
+/// Disassembly: `400d4a99: 1d d4 e5  call8  400f27e8 <_Z4loopv>`.
+pub const LOOPV_CALL8_PC: u32 = 0x400d_4a99;
+
+/// CALL8 target (constant offset from PC encoded in the instruction).
+pub const LOOPV_CALL8_TARGET: u32 = 0x400f_27e8;
+
+/// First PC after the CALL8 — used only when constructing the encoded
+/// return address (`bits[29:0]`).
+pub const LOOPV_CALL8_NEXT_PC: u32 = 0x400d_4a9c;
+
+/// Number of Xtensa instructions the JIT'd block covers. The CALL8 is
+/// one instruction; CCOUNT accounting in `try_jit_step` skips the bump
+/// if this is 1 (the outer step already counted it).
+pub const LOOPV_CALL8_INSTR_COUNT: u32 = 1;
+
+/// Side-exit code: branch taken (caller sets PC = target and continues).
+pub const EXIT_TAKEN: i32 = 1;
+/// Side-exit code: window overflow / refusal to JIT. Caller falls back
+/// to the interpreter for this step. Defined by the Phase 3 roadmap.
+pub const EXIT_WINDOWED_REFUSE: i32 = 5;
+
+/// Result of a windowed-CALL8 JIT invocation.
+///
+/// * `exit_code` — `EXIT_TAKEN` for a normal CALL, `EXIT_WINDOWED_REFUSE`
+///   to refuse and let the interpreter handle the step.
+/// * `ret_pc_encoded` — the value to write into logical a8 (already with
+///   `CALLINC << 30` baked in).
+/// * `target_pc` — the new PC.
+/// * `callinc` — value for `PS.CALLINC` (2 for CALL8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowedCallResult {
+    pub exit_code: i32,
+    pub ret_pc_encoded: u32,
+    pub target_pc: u32,
+    pub callinc: u8,
+}
+
+/// Wasm function signature for the CALL8 block.
+///
+/// Inputs:
+///   * `pc` — the current PC (so we can detect a stale cache key if the
+///     PC drifts; the wasm code asserts it matches the constant).
+///   * `windowstart` — current WindowStart bitmask (16 bits in low half
+///     of an i32).
+///   * `windowbase` — current WindowBase (0..15) in low 4 bits.
+///
+/// Outputs: `(exit_code, ret_pc_encoded, target_pc, callinc)` all i32.
+pub type WindowedCallParams = (i32, i32, i32);
+pub type WindowedCallReturns = (i32, i32, i32, i32);
+pub type WindowedCallFn = TypedFunc<WindowedCallParams, WindowedCallReturns>;
+
+/// Compiled CALL8 block.
+pub struct WindowedCallBlock {
+    store: Store<()>,
+    run: WindowedCallFn,
+    pub hits: u64,
+}
+
+impl WindowedCallBlock {
+    /// Build the CALL8 block for [`LOOPV_CALL8_PC`].
+    pub fn build_loopv(engine: &Engine) -> wasmtime::Result<Self> {
+        // Hand-written WAT.
+        //
+        // The wasm body computes:
+        //   * The encoded return address: `(NEXT_PC & 0x3FFF_FFFF) | (CALLINC << 30)`.
+        //     This is a compile-time constant for the LOOPV block; we still
+        //     emit the arithmetic so the same template will work for other
+        //     CALL8 PCs in future sub-phases.
+        //   * The target PC (constant).
+        //   * The CALLINC value (constant: 2 for CALL8).
+        //
+        // Window-overflow refusal protocol: if BOTH bits `WS[wb_new]` and
+        // `WS[wb_new+1]` are set after the CALLINC=2 rotation, return
+        // EXIT_WINDOWED_REFUSE so the interpreter can handle it. This is
+        // overly conservative (the interpreter handles overflow itself via
+        // the shadow-spill mechanism), but it keeps the JIT semantically
+        // safe even if the shadow-spill assumptions ever change.
+        //
+        // Actually, since our interp's sim-level spill always succeeds
+        // (never raises WindowOverflow), we never need to refuse — but the
+        // exit code path is wired so the JIT can opt out later if we ever
+        // re-enable the hardware overflow vector.
+        let next_pc = LOOPV_CALL8_NEXT_PC;
+        let target = LOOPV_CALL8_TARGET;
+        let ret_pc_const = (next_pc & 0x3FFF_FFFF) | (2u32 << 30);
+
+        let wat = format!(
+            r#"(module
+  (func (export "run")
+        (param $pc i32) (param $windowstart i32) (param $windowbase i32)
+        (result i32 i32 i32 i32)
+    (local $wb_new i32)
+
+    ;; Stale-PC guard. If the caller dispatched us at the wrong PC the
+    ;; cache key is stale — refuse and let interp handle the step.
+    (if (i32.ne (local.get $pc) (i32.const {pc_const}))
+      (then
+        (return (i32.const {refuse}) (i32.const 0) (i32.const 0) (i32.const 0))))
+
+    ;; Compute wb_new = (windowbase + callinc) & 0x0F  (callinc=2)
+    (local.set $wb_new
+      (i32.and (i32.add (local.get $windowbase) (i32.const 2)) (i32.const 0x0F)))
+
+    ;; OPTIONAL refusal: if WindowStart bit at wb_new+1 is set, the next
+    ;; ENTRY in the callee would step into a still-live frame and need
+    ;; the shadow-spill helper. We DO NOT refuse on that condition here
+    ;; because the interpreter's spill_shadow_on_call handles it
+    ;; transparently — refusing would change observable timing and make
+    ;; the JIT useless on every other call. Kept as a no-op block to
+    ;; document the decision.
+    (drop (local.get $wb_new))
+    (drop (local.get $windowstart))
+
+    ;; Return the constants. The host applies spill_shadow_on_call(2),
+    ;; writes ret_pc into logical a8, sets PS.CALLINC=2, sets PC=target.
+    (i32.const {taken})        ;; exit_code
+    (i32.const {ret_pc_const}) ;; ret_pc_encoded
+    (i32.const {target})       ;; target_pc
+    (i32.const 2)              ;; callinc
+  )
+)
+"#,
+            pc_const = LOOPV_CALL8_PC as i32,
+            refuse = EXIT_WINDOWED_REFUSE,
+            taken = EXIT_TAKEN,
+            ret_pc_const = ret_pc_const as i32,
+            target = target as i32,
+        );
+
+        let module = Module::new(engine, wat)?;
+        let mut store: Store<()> = Store::new(engine, ());
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let run = instance
+            .get_typed_func::<WindowedCallParams, WindowedCallReturns>(&mut store, "run")?;
+        Ok(Self {
+            store,
+            run,
+            hits: 0,
+        })
+    }
+
+    /// Invoke the compiled CALL8 block.
+    #[inline]
+    pub fn run(
+        &mut self,
+        pc: u32,
+        windowstart: u16,
+        windowbase: u8,
+    ) -> wasmtime::Result<WindowedCallResult> {
+        let (exit, ret_pc, target, callinc) = self.run.call(
+            &mut self.store,
+            (pc as i32, windowstart as i32, windowbase as i32),
+        )?;
+        self.hits += 1;
+        Ok(WindowedCallResult {
+            exit_code: exit,
+            ret_pc_encoded: ret_pc as u32,
+            target_pc: target as u32,
+            callinc: (callinc & 0xFF) as u8,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopv_call8_returns_constants() {
+        let engine = Engine::default();
+        let mut block = WindowedCallBlock::build_loopv(&engine).expect("compile");
+        let res = block.run(LOOPV_CALL8_PC, 0x0001, 0).expect("run");
+        assert_eq!(res.exit_code, EXIT_TAKEN);
+        assert_eq!(res.target_pc, LOOPV_CALL8_TARGET);
+        assert_eq!(res.callinc, 2);
+        // Encoded ret_pc: (0x400d4a9c & 0x3FFF_FFFF) | (2 << 30) = 0x800d4a9c
+        assert_eq!(res.ret_pc_encoded, 0x800d_4a9c);
+        assert_eq!(block.hits, 1);
+    }
+
+    #[test]
+    fn stale_pc_returns_refuse() {
+        let engine = Engine::default();
+        let mut block = WindowedCallBlock::build_loopv(&engine).expect("compile");
+        let res = block.run(0x4000_0000, 0x0001, 0).expect("run");
+        assert_eq!(res.exit_code, EXIT_WINDOWED_REFUSE);
+    }
+
+    #[test]
+    fn multiple_hits_match() {
+        let engine = Engine::default();
+        let mut block = WindowedCallBlock::build_loopv(&engine).expect("compile");
+        let r1 = block.run(LOOPV_CALL8_PC, 0x0001, 0).expect("run");
+        let r2 = block.run(LOOPV_CALL8_PC, 0xFFFF, 7).expect("run");
+        let r3 = block.run(LOOPV_CALL8_PC, 0x0042, 15).expect("run");
+        assert_eq!(r1, r2);
+        assert_eq!(r2, r3);
+        assert_eq!(block.hits, 3);
+    }
+}

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -175,11 +175,15 @@ impl XtensaLx7 {
     fn try_jit_step(&mut self, bus: &mut dyn Bus) -> SimResult<Option<u32>> {
         use crate::cpu::xtensa_jit::{
             JitCache, FILL_SCREEN_BLOCK_END, FILL_SCREEN_BLOCK_INSTR_COUNT, FILL_SCREEN_BLOCK_PC,
+            LOOPV_CALL8_PC,
         };
         let pc = self.pc;
-        // Hot guard: cheap exact-PC check before we even touch the cache.
-        // Avoids paying the Option<Box> deref + HashMap lookup on every
-        // single interpreter step.
+        // Hot guard: cheap exact-PC check for any of the JIT'd PCs before
+        // we even touch the cache. Avoids paying the Option<Box> deref +
+        // HashMap lookup on every single interpreter step.
+        if pc == LOOPV_CALL8_PC {
+            return self.try_jit_windowed_call(bus);
+        }
         if pc != FILL_SCREEN_BLOCK_PC {
             return Ok(None);
         }
@@ -243,6 +247,80 @@ impl XtensaLx7 {
             }
             other => Err(SimulationError::NotImplemented(format!(
                 "xtensa JIT returned unknown side-exit code {other}"
+            ))),
+        }
+    }
+
+    /// Phase 3.6.2 (issue #124): JIT'd windowed CALL8 dispatch for the
+    /// `_Z4loopv` call at PC 0x400d4a99 — the dominant hot block (~92%
+    /// of all dispatches per Phase 3.0 data).
+    ///
+    /// # Semantics (must match the [`xtensa::Instruction::Call8`] arm
+    /// of [`Self::execute`] byte-for-byte)
+    ///
+    /// 1. `ret_pc = ((PC + 3) & 0x3FFFFFFF) | (CALLINC << 30)`  (CALLINC=2)
+    /// 2. `target = ((PC + 4) & ~3) + offset`
+    /// 3. `spill_shadow_on_call(2)` — preserve caller's a0..a7 across the
+    ///    upcoming window rotation, and conditionally shadow-save the
+    ///    callee's a0..a3 slot if it's already live.
+    /// 4. `write_logical(8, ret_pc)` — store return address in caller's a8
+    ///    (becomes callee's a0 after ENTRY's rotation).
+    /// 5. `PS.CALLINC := 2`
+    /// 6. `PC := target`
+    ///
+    /// Steps 1+2+6 are computed inside the wasm module (all constants for
+    /// the LOOPV PC) and returned as `(ret_pc_encoded, target_pc, callinc)`.
+    /// Steps 3+4+5 happen here on the Rust side — replicating them inside
+    /// wasm would require exposing the full 64-entry AR file plus per-slot
+    /// shadow stacks to the wasm sandbox, with no perf upside.
+    ///
+    /// Returns:
+    /// * `Ok(Some(1))` — JIT handled the step (one Xtensa instr executed,
+    ///   matching the outer step's already-incremented CCOUNT).
+    /// * `Ok(None)` — JIT refused (window-overflow guard or PC drift);
+    ///   caller proceeds to interpreter.
+    /// * `Err` — wasmtime error or unknown exit code.
+    #[cfg(feature = "jit")]
+    fn try_jit_windowed_call(&mut self, _bus: &mut dyn Bus) -> SimResult<Option<u32>> {
+        use crate::cpu::xtensa_jit::{
+            JitCache, EXIT_WINDOWED_REFUSE, LOOPV_CALL8_INSTR_COUNT, WINDOWED_EXIT_TAKEN,
+        };
+        let pc = self.pc;
+        if self.jit.is_none() {
+            self.jit = Some(Box::new(JitCache::new()));
+        }
+        let cache = self.jit.as_mut().expect("jit cache init above");
+        let block = match cache.lookup_or_install_windowed(pc) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+
+        let result = block
+            .run(pc, self.regs.windowstart(), self.regs.windowbase())
+            .map_err(|e| {
+                SimulationError::NotImplemented(format!("xtensa JIT windowed call: {e:#}"))
+            })?;
+
+        match result.exit_code {
+            x if x == WINDOWED_EXIT_TAKEN => {
+                // Apply the architectural side-effects in the same order
+                // as the Call8 interpreter arm.
+                self.spill_shadow_on_call(result.callinc);
+                self.regs.write_logical(8, result.ret_pc_encoded);
+                self.ps.set_callinc(result.callinc);
+                self.pc = result.target_pc;
+                self.branched = true;
+                // CCOUNT: one Xtensa instr executed; outer step already
+                // bumped CCOUNT by 1, so no further adjustment needed.
+                debug_assert_eq!(LOOPV_CALL8_INSTR_COUNT, 1);
+                Ok(Some(LOOPV_CALL8_INSTR_COUNT))
+            }
+            x if x == EXIT_WINDOWED_REFUSE => {
+                cache.windowed_refusals += 1;
+                Ok(None)
+            }
+            other => Err(SimulationError::NotImplemented(format!(
+                "xtensa windowed-call JIT returned unknown side-exit code {other}"
             ))),
         }
     }

--- a/crates/core/tests/jit_lockstep.rs
+++ b/crates/core/tests/jit_lockstep.rs
@@ -134,3 +134,36 @@ fn lockstep_detects_register_corruption_on_real_firmware() {
     assert_eq!(err.jit.ar[4], 0xDEAD_BEEF);
     assert_ne!(err.interp.ar[4], 0xDEAD_BEEF);
 }
+
+/// Phase 3.6.2 (#124): long-run lockstep on the JIT'd windowed CALL8 at
+/// 0x400d4a99. 500_000 steps is enough for the firmware to reach the
+/// loopTask scheduler tick and dispatch through the JIT'd CALL8 many
+/// times. A divergence here means the windowed-call emit code disagrees
+/// with the LX7 interpreter on register-file or PS state at SOME step.
+///
+/// The test is `#[ignore]`d like the others — runs locally and in CI
+/// when the ereader ELF is available.
+#[test]
+#[ignore = "needs labwired-ereader ELF; run with: \
+            cargo test -p labwired-core --release --features jit \
+            --test jit_lockstep lockstep_windowed_call_long_run -- --ignored --nocapture"]
+fn lockstep_windowed_call_long_run() {
+    let Some(elf_path) = ereader_elf_path() else {
+        eprintln!("[skip] labwired-ereader ELF missing; set LABWIRED_EREADER_ELF to enable");
+        return;
+    };
+    eprintln!("[lockstep] long-run windowed-call check, ELF: {elf_path:?}");
+
+    let factory = || build_ereader_machine(&elf_path);
+    let runner = LockstepRunner::new(factory, 500_000);
+    match runner.run_and_compare() {
+        Ok(report) => {
+            eprintln!(
+                "[lockstep] OK windowed-call: {} steps compared, final pc=0x{:08x}",
+                report.steps_compared,
+                report.interp_final.map(|s| s.pc).unwrap_or(0),
+            );
+        }
+        Err(div) => panic!("windowed-call JIT diverged:\n\n{div}"),
+    }
+}


### PR DESCRIPTION
Builds on #126 (Phase 3.2 pilot) and #127 (lockstep harness). Emits wasm for CALL8 at the dominant hot block (PC 0x400d4a99, _Z4loopv tail-call from loopTask).

## What's correct

500k steps byte-identical against the interpreter via the lockstep harness from #127. The naive 'rotate WindowBase on CALL' reading of the spec was wrong (that's ENTRY's job); the JIT matches LX7 exactly. New test `lockstep_windowed_call_long_run` locks this in.

## What's not (yet) fast

A/B 10M-cycle ereader snapshot, native release, n=3:
- Baseline median: 7.42s
- JIT median: 7.91s
- **Δ: ~6% slower** — wasmtime call overhead exceeds savings on a single-instruction block

This is correctness foundation, not a speedup. The roadmap (#124) was explicit that 3.6.2 alone can't win; payoff arrives in 3.6.3+ once RETW/ENTRY/MOVSP and larger windowed BBs land to amortise the call cost.

## Test gate

411 tests pass with AND without `--features jit`. brom_smoke passes. ereader e2e still paints (refresh_generation=2). Clippy + fmt clean.