### PR TITLE
feat(wasm): browser-side JIT prototype, hot block 0x400829cc (#124 Phase 4 — first iteration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "wasmtime",
+ "wat",
 ]
 
 [[package]]
@@ -1544,6 +1545,7 @@ dependencies = [
  "cortex-m",
  "gdbstub",
  "gdbstub_arch",
+ "js-sys",
  "labwired-config",
  "labwired-core",
  "labwired-gdbstub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1121,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1427,6 +1449,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 1.0.69",
  "tracing",
+ "wasmparser 0.220.1",
  "wasmtime",
  "wat",
 ]
@@ -3327,6 +3350,20 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.220.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d07b6a3b550fefa1a914b6d54fc175dd11c3392da11eee604e6ffc759805d25"
+dependencies = [
+ "ahash",
+ "bitflags 2.11.1",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver 1.0.28",
+ "serde",
 ]
 
 [[package]]

--- a/configs/chips/nrf52840.yaml
+++ b/configs/chips/nrf52840.yaml
@@ -13,3 +13,21 @@ peripherals:
     size: "4KB"
     config:
       profile: "nrf52"
+  - id: "spi0"
+    type: "spi"
+    base_address: 0x40003000
+    size: "4KB"
+    config:
+      profile: "nrf52"
+  - id: "gpio0"
+    type: "gpio"
+    base_address: 0x50000000
+    size: "4KB"
+    config:
+      profile: "nrf52"
+  - id: "gpio1"
+    type: "gpio"
+    base_address: 0x50001000
+    size: "4KB"
+    config:
+      profile: "nrf52"

--- a/configs/systems/seeed-xiao-nrf52840-sense.yaml
+++ b/configs/systems/seeed-xiao-nrf52840-sense.yaml
@@ -1,0 +1,28 @@
+name: "seeed-xiao-nrf52840-sense"
+chip: "../chips/nrf52840.yaml"
+external_devices: []
+board_io:
+  - id: "led_red"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 26
+    signal: "output"
+    active_high: false
+  - id: "led_green"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 30
+    signal: "output"
+    active_high: false
+  - id: "led_blue"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 6
+    signal: "output"
+    active_high: false
+  - id: "spi0_bus"
+    kind: "spi_device"
+    peripheral: "spi0"
+    pin: 5
+    signal: "output"
+    active_high: false

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,6 +10,15 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+# build.rs compiles the JIT hot-block WAT into wasm bytes at compile time
+# so both the native (wasmtime) and browser (`js_sys::WebAssembly`) backends
+# consume identical bytes. See `crates/core/build.rs` and
+# `cpu/xtensa_jit/wasm_bytes.rs` (#124 Phase 4 browser-side JIT prototype).
+build = "build.rs"
+
+[build-dependencies]
+# Used solely by build.rs to pre-compile the hot-block WAT into wasm bytes.
+wat = "1.0"
 
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -56,3 +56,7 @@ jit = ["dep:wasmtime"]
 
 [dev-dependencies]
 labwired-loader = { path = "../loader" }
+# Used by the wasm_emit tests to validate that hand-rolled binary modules
+# parse cleanly per the Wasm Core Spec. Test-only — keeps the production
+# dependency surface unchanged.
+wasmparser = "0.220"

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -25,13 +25,10 @@ fn main() {
     println!("cargo:rerun-if-changed={WAT_SRC}");
     println!("cargo:rerun-if-changed=build.rs");
 
-    let wat_text = fs::read_to_string(WAT_SRC)
-        .unwrap_or_else(|e| panic!("read {WAT_SRC}: {e}"));
-    let bytes = wat::parse_str(&wat_text)
-        .unwrap_or_else(|e| panic!("parse {WAT_SRC} as WAT: {e}"));
+    let wat_text = fs::read_to_string(WAT_SRC).unwrap_or_else(|e| panic!("read {WAT_SRC}: {e}"));
+    let bytes = wat::parse_str(&wat_text).unwrap_or_else(|e| panic!("parse {WAT_SRC} as WAT: {e}"));
 
     let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR must be set by cargo");
     let dest = PathBuf::from(out_dir).join("xtensa_jit_hot_bb.wasm");
-    fs::write(&dest, &bytes)
-        .unwrap_or_else(|e| panic!("write {}: {e}", dest.display()));
+    fs::write(&dest, &bytes).unwrap_or_else(|e| panic!("write {}: {e}", dest.display()));
 }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,0 +1,37 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// #124 Phase 4: pre-compile the Xtensa JIT hot-block WAT into wasm bytes
+// at crate build time. Both backends (native wasmtime + browser
+// `js_sys::WebAssembly`) consume the identical byte stream so emit logic
+// stays runtime-agnostic.
+//
+// The WAT source lives in `src/cpu/xtensa_jit/hot_bb.wat`. This script:
+//   1. Reads the WAT text.
+//   2. Parses it with the `wat` crate (build-dep only — keeps it out of
+//      the browser bundle's runtime deps).
+//   3. Writes the resulting binary module to
+//      `$OUT_DIR/xtensa_jit_hot_bb.wasm`, which `wasm_bytes.rs` pulls in
+//      via `include_bytes!`.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+const WAT_SRC: &str = "src/cpu/xtensa_jit/hot_bb.wat";
+
+fn main() {
+    println!("cargo:rerun-if-changed={WAT_SRC}");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let wat_text = fs::read_to_string(WAT_SRC)
+        .unwrap_or_else(|e| panic!("read {WAT_SRC}: {e}"));
+    let bytes = wat::parse_str(&wat_text)
+        .unwrap_or_else(|e| panic!("parse {WAT_SRC} as WAT: {e}"));
+
+    let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR must be set by cargo");
+    let dest = PathBuf::from(out_dir).join("xtensa_jit_hot_bb.wasm");
+    fs::write(&dest, &bytes)
+        .unwrap_or_else(|e| panic!("write {}: {e}", dest.display()));
+}

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -824,7 +824,15 @@ impl SystemBus {
                     }
                     Box::new(i2c)
                 }
-                "spi" | "stm32spi" => Box::new(crate::peripherals::spi::Spi::new()),
+                "spi" | "stm32spi" => {
+                    let layout: crate::peripherals::spi::SpiRegisterLayout =
+                        if p_cfg.r#type.contains("nrf") {
+                            crate::peripherals::spi::SpiRegisterLayout::Nrf52Spim
+                        } else {
+                            Self::parse_profile_or_default(p_cfg, "SPI")?
+                        };
+                    Box::new(crate::peripherals::spi::Spi::new_with_layout(layout))
+                }
                 "pwr" => Box::new(crate::peripherals::pwr::Pwr::new()),
                 "flash" | "flash_iface" => Box::new(crate::peripherals::flash::Flash::new()),
                 "rng" => Box::new(crate::peripherals::rng::Rng::new()),

--- a/crates/core/src/cpu/mod.rs
+++ b/crates/core/src/cpu/mod.rs
@@ -17,6 +17,12 @@ pub mod xtensa_sr;
 #[cfg(feature = "jit")]
 pub mod xtensa_jit;
 
+// Phase 4 (#124): pre-compiled wasm bytes + architectural constants for
+// the hot BB, shared between native and browser JIT backends. Always
+// compiled (no feature gate) so the browser crate can use them without
+// pulling in wasmtime.
+pub mod xtensa_jit_bytes;
+
 pub use cortex_m::CortexM;
 pub use riscv::RiscV;
 pub use xtensa_lx7::XtensaLx7;

--- a/crates/core/src/cpu/mod.rs
+++ b/crates/core/src/cpu/mod.rs
@@ -11,10 +11,13 @@ pub mod xtensa_lx7;
 pub mod xtensa_regs;
 pub mod xtensa_sr;
 
-// Phase 3.2 JIT pilot (issue #124). Behind the `jit` feature so wasmtime
-// only enters the dep graph when explicitly opted-in. The browser build
-// path (`labwired-wasm`) deliberately does NOT enable this feature.
-#[cfg(feature = "jit")]
+// Phase 3.2 JIT pilot (issue #124). The wasmtime-backed adapters inside
+// this module are themselves `#[cfg(feature = "jit")]`-gated (see
+// `xtensa_jit::bb_multi` / `xtensa_jit::windowed_call`) so the browser
+// build path (`labwired-wasm`) — which deliberately does NOT enable
+// `jit` — still gets access to the runtime-agnostic `emit_core`
+// submodule. Phase 4.1 lifted the gate from the module declaration so
+// the walker + emit core are visible without a wasmtime dep.
 pub mod xtensa_jit;
 
 // Phase 4 (#124): pre-compiled wasm bytes + architectural constants for

--- a/crates/core/src/cpu/xtensa_jit/bb_multi.rs
+++ b/crates/core/src/cpu/xtensa_jit/bb_multi.rs
@@ -87,25 +87,16 @@ use wasmtime::{Engine, Func, Instance, Module, Store, TypedFunc};
 use crate::decoder::xtensa::{self, Instruction};
 use crate::decoder::{xtensa_length, xtensa_narrow};
 
-// ── Side-exit codes ───────────────────────────────────────────────────
-
-/// Block ran cleanly to terminator. Caller commits regs + advances PC.
-pub const EXIT_FALL_THROUGH: i32 = 0;
-/// Host L8UI import hit a bus error; caller MUST fall back to interpreter
-/// and re-execute the block from the top.
-pub const EXIT_HOST_BUS_ERROR: i32 = 5;
-
-// ── Phase 3.6.3 target BB ─────────────────────────────────────────────
-
-/// PC of the dominant hot multi-instruction BB (call_start_cpu0 delay loop).
-pub const HOT_BB_PC: u32 = 0x400829cc;
-/// First PC after the JITed range; the interpreter resumes here at `callx8`.
-pub const HOT_BB_END: u32 = 0x400829e4;
-/// Number of Xtensa instructions executed by the JIT body.
-pub const HOT_BB_INSTR_COUNT: u32 = 8;
-/// L32R literal address read by the block: `((0x400829e1 + 3) & ~3) + sext_offset`.
-/// Resolved at compile time from the ELF; matches what the interpreter computes.
-pub const HOT_BB_L32R_ADDR: u32 = 0x4008_0534;
+// ── Side-exit codes + BB constants ─────────────────────────────────────
+//
+// Re-exported from `cpu::xtensa_jit_bytes` (which is always compiled,
+// even without `--features jit`) so the browser-side prototype can use
+// the same values without dragging wasmtime into its dep graph
+// (#124 Phase 4).
+pub use crate::cpu::xtensa_jit_bytes::{
+    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_L32R_ADDR,
+    HOT_BB_PC, HOT_BB_WASM,
+};
 
 // ── Wasm function signature ───────────────────────────────────────────
 
@@ -281,79 +272,23 @@ fn is_supported(ins: &Instruction) -> bool {
     )
 }
 
-// ── WAT emit for the target block ─────────────────────────────────────
-
-/// Emit the WAT body for the 0x400829cc block. This is hand-written for
-/// the specific opcode sequence; future Phase 3.6.4 work will generalise
-/// `emit_op_wat` to walk an arbitrary `DecodedOp` slice.
-///
-/// The wasm module exports `run(a3: i32, a5: i32, l32r_val: i32) ->
-/// (exit_code, a2, a6, a8, a10)`. It calls `host.read_u8(addr)` twice
-/// for the L8UI ops. If either returns -1, exit code is HOST_BUS_ERROR.
-fn emit_hot_bb_wat() -> String {
-    format!(
-        r#"(module
-  (import "host" "read_u8" (func $read_u8 (param i32) (result i32)))
-  (func (export "run")
-        (param $a3 i32) (param $a5 i32) (param $l32r i32)
-        (result i32 i32 i32 i32 i32)
-    (local $a2 i32)
-    (local $a6 i32)
-    (local $a8 i32)
-    (local $a10 i32)
-    (local $tmp i32)
-
-    ;; 1. or a10, a5, a5  -> a10 = a5
-    (local.set $a10 (local.get $a5))
-
-    ;; 2. memw — barrier, semantic no-op in sim
-
-    ;; 3. l8ui a6, a3, 0  -> a6 = read_u8(a3 + 0)
-    (local.set $tmp (call $read_u8 (local.get $a3)))
-    (if (i32.lt_s (local.get $tmp) (i32.const 0))
-      (then
-        (return (i32.const {bus_err}) (i32.const 0) (i32.const 0) (i32.const 0) (i32.const 0))))
-    (local.set $a6 (i32.and (local.get $tmp) (i32.const 0xFF)))
-
-    ;; 4. memw — barrier
-
-    ;; 5. l8ui a2, a3, 1  -> a2 = read_u8(a3 + 1)
-    (local.set $tmp (call $read_u8 (i32.add (local.get $a3) (i32.const 1))))
-    (if (i32.lt_s (local.get $tmp) (i32.const 0))
-      (then
-        (return (i32.const {bus_err}) (i32.const 0) (i32.const 0) (i32.const 0) (i32.const 0))))
-    (local.set $a2 (i32.and (local.get $tmp) (i32.const 0xFF)))
-
-    ;; 6. extui a2, a2, 0, 8  -> a2 = (a2 >> 0) & ((1<<8) - 1) = a2 & 0xFF
-    ;;    (already byte after l8ui, but emit for correctness)
-    (local.set $a2 (i32.and (local.get $a2) (i32.const 0xFF)))
-
-    ;; 7. and a2, a2, a6  -> a2 &= a6
-    (local.set $a2 (i32.and (local.get $a2) (local.get $a6)))
-
-    ;; 8. l32r a8, 0x40080534  -> a8 = pre-resolved literal
-    (local.set $a8 (local.get $l32r))
-
-    ;; Exit clean: callx8 a8 is the terminator, interpreter handles it.
-    (i32.const {ok})
-    (local.get $a2)
-    (local.get $a6)
-    (local.get $a8)
-    (local.get $a10)
-  )
-)
-"#,
-        ok = EXIT_FALL_THROUGH,
-        bus_err = EXIT_HOST_BUS_ERROR,
-    )
-}
+// ── Emit: runtime-agnostic byte stream ────────────────────────────────
+//
+// The hot-block wasm body is owned by `hot_bb.wat` and pre-compiled into
+// `xtensa_jit_bytes::HOT_BB_WASM` at crate build time. The native
+// (wasmtime) and browser (`js_sys::WebAssembly`) backends consume that
+// identical byte stream — that's the entire emit/runtime decoupling.
+//
+// `Module::new(engine, bytes)` accepts a `&[u8]` (binary modules) as well
+// as WAT text; passing bytes here exercises the same code path the
+// browser will take, so any encoder-side regression breaks the native
+// tests too.
 
 impl MultiOpBlock {
     /// Build the hot BB module + instance. Failure path bubbles wasmtime
     /// errors; caller logs + falls back to interpreter.
     pub fn build_hot_bb(engine: &Engine) -> wasmtime::Result<Self> {
-        let wat = emit_hot_bb_wat();
-        let module = Module::new(engine, wat)?;
+        let module = Module::new(engine, HOT_BB_WASM)?;
         let mut store: Store<()> = Store::new(engine, ());
 
         let pending_loads: std::sync::Arc<Mutex<Vec<u32>>> =

--- a/crates/core/src/cpu/xtensa_jit/bb_multi.rs
+++ b/crates/core/src/cpu/xtensa_jit/bb_multi.rs
@@ -76,6 +76,7 @@ use super::emit_core::{self, BlockShape, EmittedBlock, PsBits, SideExitReason};
 pub use crate::cpu::xtensa_jit_bytes::{
     EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
     HOT_BB_L32R_ADDR, HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT,
+    LOOPTASK_TAIL_END, LOOPTASK_TAIL_INSTR_COUNT, LOOPTASK_TAIL_PC,
 };
 
 // Re-export the walker types from emit_core for back-compat with the
@@ -147,6 +148,18 @@ pub struct LoopTaskPrefixResult {
     pub next_pc: u32,
     pub l8ui_at_value: u32,
     pub beqz_target_pc: u32,
+}
+
+/// Result of running a [`BlockShape::LoopTaskTail`] block (Phase 4.4).
+///
+/// Fields mirror the emit-core wasm signature `() -> (exit_code,
+/// next_pc, l32r_at_value)`. The dispatcher writes `l32r_at_value` into
+/// the AR named by [`BlockShape::LoopTaskTail::l32r_at`] and sets
+/// `cpu.pc = next_pc`.
+pub struct LoopTaskTailResult {
+    pub exit_code: i32,
+    pub next_pc: u32,
+    pub l32r_at_value: u32,
 }
 
 impl MultiOpBlock {
@@ -250,6 +263,75 @@ impl MultiOpBlock {
         Self::build_from_emitted(engine, emitted)
     }
 
+    /// Build the loopTask tail block (`L32R → BEQZ` at
+    /// [`LOOPTASK_TAIL_PC`]). Synthesizes the canonical 0x400d4a9c byte
+    /// stream the ereader firmware exposes (matching the disasm in
+    /// `xtensa_jit_bytes`) so the cache builder doesn't need a live
+    /// `Bus`. The shape recognizer constant-folds both the L32R literal
+    /// and the BEQZ direction, so the resulting wasm body is a fixed
+    /// return tuple.
+    pub fn build_looptask_tail(engine: &Engine) -> wasmtime::Result<Self> {
+        // Canonical bytes: L32R a8, &serialEventRun ; BEQZ a8, loopTask_top.
+        // The L32R pc_rel_byte_offset is computed from the real
+        // disassembly (imm16 = 0xFEED → ea = ((PC+3) & ~3) + (-72) ≈ ...).
+        // We synthesize the slice with a literal pool at PC-32 that holds
+        // `serialEventRun = NULL` so the recognizer constant-folds BEQZ
+        // as statically-taken (the steady-state ereader case).
+        //
+        // imm16 encoding for L32R: pc_rel_byte_offset = (imm16 -
+        // 0x10000) * 4 (since bit 15 is set for backward refs). For
+        // pc_rel_byte_offset = -32 → imm16 = 0xFFF8. L32R word layout:
+        // imm16<<8 | at<<4 | opcode → 0xFFF8<<8 | 8<<4 | 0x1 = 0xFFF881.
+        // Little-endian bytes: [0x81, 0xF8, 0xFF].
+        //
+        // BEQZ a8, +offset: target = LOOPTASK_PC (back to the prefix
+        // start, which sits at LOOPTASK_TAIL_PC - 15). The decoder bakes
+        // +4 into its stored offset, so the offset we carry is
+        // target - after_l32r_pc = LOOPTASK_PC - (LOOPTASK_TAIL_PC + 3) =
+        // -18. The encoded imm12 satisfies signext(imm12)+4 == -18 →
+        // imm12 = -22 = 0xFEA. BEQZ word layout: imm12<<12 | as_<<8 |
+        // 0x16 = 0xFEA816. Little-endian bytes: [0x16, 0xA8, 0xFE].
+        let mut bus_slice: Vec<u8> = Vec::new();
+        // Literal pool at PC-32: 4 bytes of zero (= NULL pointer, the
+        // steady-state value of `serialEventRun`).
+        const LITERAL_POOL_VALUE: u32 = 0;
+        for _ in 0..32 {
+            bus_slice.push(0);
+        }
+        // Overwrite the 4 bytes at offset 0 with the literal pool value
+        // (still all zero here — kept explicit for symmetry with the
+        // prefix builder).
+        for (i, b) in LITERAL_POOL_VALUE.to_le_bytes().iter().enumerate() {
+            bus_slice[i] = *b;
+        }
+        // Instructions at LOOPTASK_TAIL_PC.
+        bus_slice.extend_from_slice(&[
+            0x81, 0xF8, 0xFF, // L32R a8, ... (pc_rel_byte_offset = -32 → EA = TAIL_PC - 32)
+            0x16, 0xA8, 0xFE, // BEQZ a8, LOOPTASK_PC
+            0x65, 0x3C, 0xFE, // CALL8 (terminator, never executed by JIT body)
+            0x06, 0xF9, 0xFF, // J (terminator, never executed by JIT body)
+        ]);
+        // slice_base_pc: pc_to_offset(LOOPTASK_TAIL_PC - 32) == 0.
+        let slice_base_pc = LOOPTASK_TAIL_PC.wrapping_sub(32);
+
+        let emitted = emit_core::walk_and_emit(
+            &bus_slice,
+            LOOPTASK_TAIL_PC,
+            |pc| {
+                let off = pc.wrapping_sub(slice_base_pc) as usize;
+                if off < bus_slice.len() {
+                    Some(off)
+                } else {
+                    None
+                }
+            },
+            PsBits::default(),
+        )
+        .map_err(|e| wasmtime::Error::msg(format!("emit_core walk_and_emit: {e}")))?;
+
+        Self::build_from_emitted(engine, emitted)
+    }
+
     /// Compile + instantiate a wasmtime block from a pre-emitted byte
     /// stream. Phase 4.2's browser adapter has a structurally
     /// identical entry point on its side; both consume `EmittedBlock`
@@ -265,24 +347,32 @@ impl MultiOpBlock {
         let scratch: std::sync::Arc<Mutex<ScratchSlot>> =
             std::sync::Arc::new(Mutex::new(ScratchSlot::default()));
 
-        let pending_for_import = pending_loads.clone();
-        let scratch_for_import = scratch.clone();
+        // host.read_u8 is only wired for shapes that perform L8UI in the
+        // wasm body. The Phase 4.4 [`BlockShape::LoopTaskTail`] returns a
+        // pre-baked constant tuple — no imports needed.
+        let needs_read_u8 = !matches!(emitted.shape, BlockShape::LoopTaskTail { .. });
 
-        // host.read_u8(addr): the host had already pre-staged byte values
-        // into `pending_loads` (one per L8UI in BB order). The import
-        // pops the next value and returns it. If `pending_loads` is empty
-        // when called, we report a bus error so wasm bails cleanly.
-        let read_u8: Func = Func::wrap(&mut store, move |_addr: i32| -> i32 {
-            let mut p = pending_for_import.lock().unwrap();
-            if p.is_empty() {
-                scratch_for_import.lock().unwrap().bus_error = true;
-                return -1;
-            }
-            let v = p.remove(0);
-            v as i32
-        });
-
-        let instance = Instance::new(&mut store, &module, &[read_u8.into()])?;
+        let instance = if needs_read_u8 {
+            let pending_for_import = pending_loads.clone();
+            let scratch_for_import = scratch.clone();
+            // host.read_u8(addr): the host had already pre-staged byte
+            // values into `pending_loads` (one per L8UI in BB order). The
+            // import pops the next value and returns it. If
+            // `pending_loads` is empty when called, we report a bus error
+            // so wasm bails cleanly.
+            let read_u8: Func = Func::wrap(&mut store, move |_addr: i32| -> i32 {
+                let mut p = pending_for_import.lock().unwrap();
+                if p.is_empty() {
+                    scratch_for_import.lock().unwrap().bus_error = true;
+                    return -1;
+                }
+                let v = p.remove(0);
+                v as i32
+            });
+            Instance::new(&mut store, &module, &[read_u8.into()])?
+        } else {
+            Instance::new(&mut store, &module, &[])?
+        };
         let run = instance.get_func(&mut store, "run").ok_or_else(|| {
             wasmtime::Error::msg("emit-core wasm module missing required `run` export")
         })?;
@@ -381,6 +471,28 @@ impl MultiOpBlock {
         })
     }
 
+    /// Invoke a [`BlockShape::LoopTaskTail`] block. Signature: `() ->
+    /// (exit, next_pc, l32r_at_value)`. The caller commits
+    /// `l32r_at_value` into the AR named by the shape descriptor's
+    /// `l32r_at` and advances PC to `next_pc`.
+    #[inline]
+    pub fn run_looptask_tail(&mut self) -> wasmtime::Result<LoopTaskTailResult> {
+        debug_assert!(matches!(
+            self.emitted.shape,
+            BlockShape::LoopTaskTail { .. }
+        ));
+        use wasmtime::Val;
+        let params: [Val; 0] = [];
+        let mut results = [Val::I32(0); 3];
+        self.run.call(&mut self.store, &params, &mut results)?;
+        self.hits += 1;
+        Ok(LoopTaskTailResult {
+            exit_code: results[0].i32().unwrap_or(0),
+            next_pc: results[1].i32().unwrap_or(0) as u32,
+            l32r_at_value: results[2].i32().unwrap_or(0) as u32,
+        })
+    }
+
     /// Classify a wire `exit_code` into the runtime-agnostic
     /// [`SideExitReason`] vocabulary. Useful for tests + Phase 4.2
     /// side-exit handling.
@@ -472,6 +584,7 @@ mod tests {
                 l8ui_at,
                 l8ui_base_at,
                 l32r_literal_value: _,
+                beqz_target_pc: _,
             } => {
                 // Per the canonical bytes pinned in `build_looptask_prefix`:
                 // L32R writes a2, L8UI writes a3, L8UI base = a2.
@@ -705,7 +818,132 @@ mod tests {
             lt.shape()
         );
 
+        // LOOPTASK_TAIL_PC installs and reports LoopTaskTail (Phase 4.4).
+        let tail = cache
+            .lookup_or_install_multi_op(LOOPTASK_TAIL_PC)
+            .expect("loopTask tail installs");
+        assert!(
+            matches!(tail.shape(), BlockShape::LoopTaskTail { .. }),
+            "loopTask tail must be LoopTaskTail-shaped, got {:?}",
+            tail.shape()
+        );
+
         // An unknown PC still refuses (cache stays narrow).
         assert!(cache.lookup_or_install_multi_op(0xDEAD_BEEF).is_none());
+    }
+
+    // ── Phase 4.4 loopTask tail dispatch tests ───────────────────────
+    //
+    // The tail block (`L32R → BEQZ` at LOOPTASK_TAIL_PC) is the
+    // counterpart to the prefix block. Both halves of the BEQZ are
+    // statically resolved at walk_and_emit time against the live bus's
+    // literal pool, so the wasm body is a constant return tuple. These
+    // tests exercise the dispatcher end-to-end through `Cpu::step` so
+    // we catch any divergence between the JIT path and the pure-interp
+    // path on either branch direction.
+
+    /// Layout a memory image for the loopTask tail block. The L32R
+    /// loads from a literal pool at PC-32; `literal` is the value
+    /// stored there (controls whether BEQZ is statically taken).
+    #[cfg(test)]
+    fn populate_looptask_tail_image(bus: &mut DispatcherTestBus, literal: u32) {
+        // Literal pool at PC-32 (matches the synthesized fixture in
+        // `build_looptask_tail`).
+        bus.write_word_le(LOOPTASK_TAIL_PC.wrapping_sub(32), literal);
+        let instrs: &[u8] = &[
+            0x81, 0xF8, 0xFF, // L32R a8, ... (EA = PC - 32)
+            0x16, 0xA8, 0xFE, // BEQZ a8, LOOPTASK_PC
+            0x65, 0x3C, 0xFE, // CALL8 (terminator; not exercised)
+            0x06, 0xF9, 0xFF, // J (terminator; not exercised)
+        ];
+        for (i, b) in instrs.iter().enumerate() {
+            bus.write_byte(LOOPTASK_TAIL_PC + i as u32, *b);
+        }
+    }
+
+    /// Run the loopTask tail at `LOOPTASK_TAIL_PC` through either the
+    /// JIT or the pure interpreter until PC leaves the tail range,
+    /// then return `(pc, a8)`. The JIT executes the whole tail in one
+    /// step; the interpreter needs two.
+    #[cfg(test)]
+    fn run_looptask_tail_once(jit_enabled: bool, literal: u32) -> (u32, u32) {
+        use crate::cpu::XtensaLx7;
+        use crate::Cpu;
+        let observers: Vec<std::sync::Arc<dyn crate::SimulationObserver>> = Vec::new();
+        let config = crate::SimulationConfig::default();
+
+        let mut cpu = XtensaLx7::new();
+        cpu.jit_enabled = jit_enabled;
+        cpu.pc = LOOPTASK_TAIL_PC;
+        cpu.ps = crate::cpu::xtensa_regs::Ps::from_raw(0);
+
+        let mut bus = DispatcherTestBus::new();
+        populate_looptask_tail_image(&mut bus, literal);
+
+        // Step until PC leaves the tail range. Cap at 8 to bound a
+        // runaway: interp needs 2, JIT needs 1. When BEQZ takes we
+        // land at LOOPTASK_PC (outside the tail range — loop top).
+        for _ in 0..8 {
+            let pc = cpu.pc;
+            if pc < LOOPTASK_TAIL_PC || pc >= LOOPTASK_TAIL_END {
+                break;
+            }
+            cpu.step(&mut bus, &observers, &config).expect("step ok");
+        }
+        (cpu.pc, cpu.regs.read_logical(8))
+    }
+
+    /// Lockstep: BEQZ-taken path (literal == 0). JIT and interp must
+    /// agree on post-state PC + a8. PC must land at LOOPTASK_PC.
+    #[test]
+    fn looptask_tail_jit_matches_interp_branch_taken() {
+        let (jit_pc, jit_a8) = run_looptask_tail_once(true, 0);
+        let (int_pc, int_a8) = run_looptask_tail_once(false, 0);
+        assert_eq!(jit_pc, int_pc, "PC mismatch jit={jit_pc:#x} int={int_pc:#x}");
+        assert_eq!(jit_a8, int_a8, "a8 mismatch jit={jit_a8:#x} int={int_a8:#x}");
+        assert_eq!(jit_pc, LOOPTASK_PC, "BEQZ taken should land at loopTask top");
+        assert_eq!(jit_a8, 0, "L32R wrote the literal (0)");
+    }
+
+    /// Lockstep: BEQZ-not-taken path (literal != 0). JIT and interp
+    /// must agree on post-state PC + a8. PC must land at
+    /// LOOPTASK_TAIL_END (fall-through to CALL8 serialEventRun).
+    #[test]
+    fn looptask_tail_jit_matches_interp_branch_not_taken() {
+        let literal = 0x400d_2e68u32; // canonical ereader: &_Z14serialEventRunv
+        let (jit_pc, jit_a8) = run_looptask_tail_once(true, literal);
+        let (int_pc, int_a8) = run_looptask_tail_once(false, literal);
+        assert_eq!(jit_pc, int_pc, "PC mismatch jit={jit_pc:#x} int={int_pc:#x}");
+        assert_eq!(jit_a8, int_a8, "a8 mismatch jit={jit_a8:#x} int={int_a8:#x}");
+        assert_eq!(jit_pc, LOOPTASK_TAIL_END);
+        assert_eq!(jit_a8, literal);
+    }
+
+    /// `build_looptask_tail` produces a block tagged with the right
+    /// shape and dispatching it through `run_looptask_tail` yields a
+    /// statically-resolved 3-tuple matching the BEQZ direction.
+    #[test]
+    fn looptask_tail_dispatches_constant_tuple() {
+        let engine = Engine::default();
+        let mut block = MultiOpBlock::build_looptask_tail(&engine).expect("compile");
+        // Canonical synthesized fixture has literal == 0 → BEQZ taken.
+        match block.shape() {
+            BlockShape::LoopTaskTail {
+                l32r_at,
+                l32r_literal_value,
+                statically_taken,
+                ..
+            } => {
+                assert_eq!(l32r_at, 8, "loopTask tail L32R writes a8");
+                assert_eq!(l32r_literal_value, 0);
+                assert!(statically_taken);
+            }
+            other => panic!("expected LoopTaskTail, got {other:?}"),
+        }
+        let res = block.run_looptask_tail().expect("run");
+        assert_eq!(res.exit_code, EXIT_BRANCH_TAKEN);
+        assert_eq!(res.next_pc, LOOPTASK_PC);
+        assert_eq!(res.l32r_at_value, 0);
+        assert_eq!(block.hits, 1);
     }
 }

--- a/crates/core/src/cpu/xtensa_jit/bb_multi.rs
+++ b/crates/core/src/cpu/xtensa_jit/bb_multi.rs
@@ -2,16 +2,19 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! Xtensa LX7 JIT — multi-op basic-block emit (Phase 3.6.3 / issue #124).
+//! Xtensa LX7 JIT — multi-op basic-block wasmtime adapter (#124 Phase 3.6.3
+//! / Phase 4.1 refactor).
 //!
-//! Phase 3.6.2 (#128) shipped a one-instruction CALL8 JIT and measured
-//! ~6% **slower** vs baseline interpreter — proof that wasmtime call
-//! overhead (~200ns/call) dwarfs the savings of replacing a single
-//! interpreter dispatch (~50ns).
-//!
-//! This module is the fix: JIT-compile a **whole basic block** (5-10+
-//! instructions) per wasm module, so one wasmtime call amortises N
-//! interpreter dispatches.
+//! Phase 3.6.3 introduced the multi-op hot-block JIT. Phase 4.1 split that
+//! work into two halves:
+//!   * [`super::emit_core`] owns the runtime-agnostic walker + the bytes
+//!     `walk_and_emit` produces. No wasmtime imports.
+//!   * This module is a thin wasmtime adapter — it consumes the bytes,
+//!     hands them to `wasmtime::Module::new`, wires up the `host.read_u8`
+//!     import, and dispatches `Func::call`. The browser stub in
+//!     `labwired-wasm::jit_browser` is the equivalent JS-side adapter
+//!     and will share the exact same byte stream once Phase 4.2 fills it
+//!     in.
 //!
 //! ## Target block (BB profile, 10M-step ereader run)
 //!
@@ -54,38 +57,15 @@
 //!
 //! ## Side-exit codes
 //!
-//! * `0` — block executed cleanly to the terminator; caller commits
-//!   regs (a2, a6, a8, a10) and sets PC = block-end (0x400829e4) so the
-//!   interpreter picks up at the callx8.
-//! * `5` — `read_u8` import returned a host bus error (signalled by
-//!   pushing an error marker into the pending list). Caller falls back
-//!   to interpreter for the whole block — no register or memory state
-//!   visible from wasm has been committed.
-//!
-//! ## Why this should win when 3.6.2 didn't
-//!
-//! Per Phase 3.0 measurement:
-//!   - Interpreter dispatch: ~50ns/instruction
-//!   - Wasmtime call: ~200ns
-//!
-//! For an 8-instr BB:
-//!   - Interpreter: 8 × 50ns = **400ns/pass**
-//!   - JIT: 200ns (wasm call) + 2 × ~100ns (host imports for L8UI) +
-//!     ~50ns (pure arithmetic in JITed code) = **~450ns/pass**
-//!
-//! That's roughly break-even per pass. But 908k hits means **even a
-//! 5% per-call improvement** compounds into ~270ms on a ~5s benchmark.
-//! And this block is the canary: if it doesn't speed up, no longer
-//! block on this firmware will, and we'll need a different approach
-//! (e.g. inlining the bus read).
+//! Wire codes are in [`crate::cpu::xtensa_jit_bytes`]; the higher-level
+//! reason vocabulary lives in [`super::emit_core::SideExitReason`].
 
 #![cfg(feature = "jit")]
 
 use std::sync::Mutex;
 use wasmtime::{Engine, Func, Instance, Module, Store, TypedFunc};
 
-use crate::decoder::xtensa::{self, Instruction};
-use crate::decoder::{xtensa_length, xtensa_narrow};
+use super::emit_core::{self, EmittedBlock, PsBits, SideExitReason};
 
 // ── Side-exit codes + BB constants ─────────────────────────────────────
 //
@@ -95,8 +75,13 @@ use crate::decoder::{xtensa_length, xtensa_narrow};
 // (#124 Phase 4).
 pub use crate::cpu::xtensa_jit_bytes::{
     EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_L32R_ADDR,
-    HOT_BB_PC, HOT_BB_WASM,
+    HOT_BB_PC,
 };
+
+// Re-export the walker types from emit_core for back-compat with the
+// existing public API (tests + xtensa_lx7.rs reach for these via
+// `xtensa_jit::{walk_bb, DecodedOp}`).
+pub use super::emit_core::{walk_bb, DecodedOp};
 
 // ── Wasm function signature ───────────────────────────────────────────
 
@@ -106,11 +91,14 @@ type BbParams = (i32, i32, i32);
 type BbReturns = (i32, i32, i32, i32, i32);
 type BbRun = TypedFunc<BbParams, BbReturns>;
 
-/// Per-call scratch slots for host imports. The L8UI import pushes
-/// `Ok(u8)` or `Err(())` here; the wasm caller consumes them in order.
+/// Per-call scratch slot. The L8UI import pushes a bus-error flag here
+/// if it's called with the pending queue empty.
 #[derive(Default)]
 struct ScratchSlot {
-    /// Byte values read from `host.read_u8`, in call order.
+    /// Byte values read from `host.read_u8`, in call order. Currently
+    /// unused — kept for symmetry with the browser-side queue and so
+    /// future debug instrumentation can record load order.
+    #[allow(dead_code, reason = "reserved for Phase 4.2 trace instrumentation")]
     bytes: Vec<u8>,
     /// True iff any L8UI import hit a host bus error.
     bus_error: bool,
@@ -124,6 +112,11 @@ pub struct MultiOpBlock {
     /// L8UI host-import call sequence, populated by the caller before
     /// the wasm call. The wasm body indexes into this by position.
     pending_loads: std::sync::Arc<Mutex<Vec<u32>>>,
+    /// The emit-core output we built this block from. Held so callers
+    /// can interrogate `length_in_instrs`, `end_pc`, and the side-exit
+    /// reason map without a separate registry. Phase 4.2 will read
+    /// these for variable-length blocks.
+    pub emitted: EmittedBlock,
 }
 
 pub struct MultiOpResult {
@@ -134,161 +127,65 @@ pub struct MultiOpResult {
     pub a10: u32,
 }
 
-// ── Decoded-op intermediate form ──────────────────────────────────────
-
-/// One decoded Xtensa op + its byte length. Used by the BB walker.
-#[derive(Debug, Clone)]
-pub struct DecodedOp {
-    pub pc: u32,
-    pub len: u32,
-    pub ins: Instruction,
-}
-
-/// Walk forward from `start_pc`, decoding instructions out of `text`
-/// (a flat slice mapping PC → byte). Stops when:
-///   * a terminator (any control transfer) is reached — terminator is
-///     **excluded** from the returned vec.
-///   * an unsupported opcode is hit — returns `None` (refuse the whole BB).
-///   * `max_ops` instructions have been collected — returns what we have.
-///
-/// `pc_to_offset` converts a PC to an index into `text`; returns `None`
-/// if the PC is outside `text`.
-pub fn walk_bb<F>(
-    start_pc: u32,
-    mut pc_to_offset: F,
-    text: &[u8],
-    max_ops: usize,
-) -> Option<Vec<DecodedOp>>
-where
-    F: FnMut(u32) -> Option<usize>,
-{
-    let mut ops = Vec::with_capacity(max_ops);
-    let mut pc = start_pc;
-    while ops.len() < max_ops {
-        let off = pc_to_offset(pc)?;
-        if off >= text.len() {
-            return None;
-        }
-        let b0 = text[off];
-        let len: u32 = xtensa_length::instruction_length(b0);
-        // Verify the full instruction fits inside `text`.
-        if off + (len as usize) > text.len() {
-            return None;
-        }
-        let ins = if len == 2 {
-            let hw = u16::from_le_bytes([text[off], text[off + 1]]);
-            xtensa_narrow::decode_narrow(hw)
-        } else if len == 3 {
-            let w = u32::from_le_bytes([text[off], text[off + 1], text[off + 2], 0]);
-            xtensa::decode(w)
-        } else {
-            return None;
-        };
-        if is_terminator(&ins) {
-            return Some(ops);
-        }
-        if !is_supported(&ins) {
-            return None;
-        }
-        ops.push(DecodedOp { pc, len, ins });
-        pc = pc.wrapping_add(len);
-    }
-    Some(ops)
-}
-
-/// Is this opcode a basic-block terminator (control transfer)?
-fn is_terminator(ins: &Instruction) -> bool {
-    use Instruction::*;
-    matches!(
-        ins,
-        Call0 { .. }
-            | Call4 { .. }
-            | Call8 { .. }
-            | Call12 { .. }
-            | Callx0 { .. }
-            | Callx4 { .. }
-            | Callx8 { .. }
-            | Callx12 { .. }
-            | Ret
-            | Retw
-            | Jx { .. }
-            | Beq { .. }
-            | Bne { .. }
-            | Blt { .. }
-            | Bge { .. }
-            | Bltu { .. }
-            | Bgeu { .. }
-            | Beqz { .. }
-            | Bnez { .. }
-            | Bltz { .. }
-            | Bgez { .. }
-            | Beqi { .. }
-            | Bnei { .. }
-            | Blti { .. }
-            | Bgei { .. }
-            | Bltui { .. }
-            | Bgeui { .. }
-            | Bany { .. }
-            | Ball { .. }
-            | Bnone { .. }
-            | Bnall { .. }
-            | Bbc { .. }
-            | Bbs { .. }
-            | Bbci { .. }
-            | Bbsi { .. }
-            | Entry { .. }
-            | Rfe
-            | Rfde
-            | Rfi { .. }
-            | Rfwo
-            | Rfwu
-            | Ill
-    )
-}
-
-/// Is this opcode in the Phase 3.6.3 supported set?
-///
-/// Keep this list narrow: any new opcode here needs corresponding emit
-/// code in [`emit_wat_for_block`]. Adding more is a Phase 3.6.4+ task.
-fn is_supported(ins: &Instruction) -> bool {
-    use Instruction::*;
-    matches!(
-        ins,
-        // Pure arithmetic / bitwise
-        Add { .. }
-            | Sub { .. }
-            | And { .. }
-            | Or { .. }
-            | Xor { .. }
-            | Addi { .. }
-            | Movi { .. }
-            | Extui { .. }
-            // Loads
-            | L8ui { .. }
-            | L32r { .. }
-            // Barriers — semantic no-ops in sim
-            | Memw
-            | Nop
-    )
-}
-
-// ── Emit: runtime-agnostic byte stream ────────────────────────────────
-//
-// The hot-block wasm body is owned by `hot_bb.wat` and pre-compiled into
-// `xtensa_jit_bytes::HOT_BB_WASM` at crate build time. The native
-// (wasmtime) and browser (`js_sys::WebAssembly`) backends consume that
-// identical byte stream — that's the entire emit/runtime decoupling.
-//
-// `Module::new(engine, bytes)` accepts a `&[u8]` (binary modules) as well
-// as WAT text; passing bytes here exercises the same code path the
-// browser will take, so any encoder-side regression breaks the native
-// tests too.
-
 impl MultiOpBlock {
-    /// Build the hot BB module + instance. Failure path bubbles wasmtime
-    /// errors; caller logs + falls back to interpreter.
+    /// Build the hot BB module + instance. Walks the BB via
+    /// [`emit_core::walk_and_emit`] to fetch the bytes, then hands them
+    /// to wasmtime. Failure path bubbles wasmtime errors; the caller
+    /// logs and falls back to interpreter.
+    ///
+    /// The walker is supplied with the pre-baked [`HOT_BB_WASM`] bytes
+    /// indirectly via [`emit_core::walk_and_emit`] which currently
+    /// recognises only the canonical hot-BB shape. We synthesise an
+    /// in-memory bus slice from the canonical disassembly (so the
+    /// emit-core call path is exercised end-to-end) — this matches the
+    /// `bb_multi` invariants and re-uses the build-time-baked wasm
+    /// bytes byte-for-byte.
     pub fn build_hot_bb(engine: &Engine) -> wasmtime::Result<Self> {
-        let module = Module::new(engine, HOT_BB_WASM)?;
+        // Canonical disassembly bytes for the 8-instruction hot block.
+        // Encoded little-endian byte-stream: each 3-byte group is the
+        // reverse of the wide-instruction word value objdump prints.
+        // E.g. `20a550 or a10, a5, a5` decodes to word=0x00_20_a5_50 and
+        // sits in memory as bytes 0x50, 0xa5, 0x20. Pinning the canonical
+        // byte stream here lets the emit-core path validate end-to-end
+        // without round-tripping through the Bus trait at JIT-cache
+        // build time. The `xtensa_lx7::try_jit_multi_op` path uses the
+        // real bus and is covered by the lockstep harness.
+        const HOT_BB_BYTES: &[u8] = &[
+            0x50, 0xa5, 0x20, // or    a10, a5, a5    (word 0x20a550)
+            0xc0, 0x20, 0x00, // memw                  (word 0x0020c0)
+            0x62, 0x03, 0x00, // l8ui  a6,  a3, 0      (word 0x000362)
+            0xc0, 0x20, 0x00, // memw                  (word 0x0020c0)
+            0x22, 0x03, 0x01, // l8ui  a2,  a3, 1      (word 0x010322)
+            0x20, 0x20, 0x74, // extui a2,  a2, 0, 8   (word 0x742020)
+            0x60, 0x22, 0x10, // and   a2,  a2, a6     (word 0x102260)
+            0x81, 0xd4, 0xf6, // l32r  a8,  0x40080534 (word 0xf6d481)
+            0xe0, 0x08, 0x00, // callx8 a8 — terminator (word 0x0008e0)
+        ];
+
+        let emitted = emit_core::walk_and_emit(
+            HOT_BB_BYTES,
+            HOT_BB_PC,
+            |pc| {
+                let off = pc.wrapping_sub(HOT_BB_PC) as usize;
+                if off < HOT_BB_BYTES.len() {
+                    Some(off)
+                } else {
+                    None
+                }
+            },
+            PsBits::default(),
+        )
+        .map_err(|e| wasmtime::Error::msg(format!("emit_core walk_and_emit: {e}")))?;
+
+        Self::build_from_emitted(engine, emitted)
+    }
+
+    /// Compile + instantiate a wasmtime block from a pre-emitted byte
+    /// stream. Phase 4.2's browser adapter will have a structurally
+    /// identical entry point on its side; both consume `EmittedBlock`
+    /// verbatim.
+    pub fn build_from_emitted(engine: &Engine, emitted: EmittedBlock) -> wasmtime::Result<Self> {
+        let module = Module::new(engine, &emitted.wasm_bytes)?;
         let mut store: Store<()> = Store::new(engine, ());
 
         let pending_loads: std::sync::Arc<Mutex<Vec<u32>>> =
@@ -306,8 +203,6 @@ impl MultiOpBlock {
         let read_u8: Func = Func::wrap(&mut store, move |_addr: i32| -> i32 {
             let mut p = pending_for_import.lock().unwrap();
             if p.is_empty() {
-                // No pre-staged value → host signals "couldn't satisfy
-                // this load". Pushed into scratch so caller knows.
                 scratch_for_import.lock().unwrap().bus_error = true;
                 return -1;
             }
@@ -323,6 +218,7 @@ impl MultiOpBlock {
             scratch,
             hits: 0,
             pending_loads,
+            emitted,
         })
     }
 
@@ -354,36 +250,18 @@ impl MultiOpBlock {
             a10: a10 as u32,
         })
     }
+
+    /// Classify a wire `exit_code` into the runtime-agnostic
+    /// [`SideExitReason`] vocabulary. Useful for tests + Phase 4.2
+    /// side-exit handling.
+    pub fn classify_exit(&self, exit_code: i32) -> Option<SideExitReason> {
+        self.emitted.reason_for(exit_code)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Sanity: walker stops at a terminator.
-    #[test]
-    fn walker_stops_at_terminator() {
-        // Build a 4-byte fake "text" containing one ADDI followed by a RET.N.
-        // ADDI a3, a4, 5 — 3 bytes wide form: tricky to hand-encode; use
-        // a real ELF byte pattern instead. We'll use NOP.N (2 bytes 0x3d 0xf0)
-        // for the supported op and RET.N (2 bytes 0x0d 0xf0) for terminator.
-        let text: Vec<u8> = vec![0x3d, 0xf0, 0x3d, 0xf0, 0x0d, 0xf0];
-        let ops = walk_bb(0, |pc| Some(pc as usize), &text, 16).unwrap();
-        assert_eq!(ops.len(), 2, "should collect 2 NOP.Ns then stop at RET.N");
-        for op in &ops {
-            assert!(matches!(op.ins, Instruction::Nop));
-        }
-    }
-
-    /// Walker refuses unsupported opcodes.
-    #[test]
-    fn walker_refuses_unsupported() {
-        // SSL — supported by neither the walker's allowlist nor the LX7
-        // execute arm we care about. Bytes for `ssl a3`: 0x40, 0x13, 0x40.
-        let text: Vec<u8> = vec![0x40, 0x13, 0x40, 0x00, 0x00, 0x00];
-        let ops = walk_bb(0, |pc| Some(pc as usize), &text, 16);
-        assert!(ops.is_none(), "must refuse unsupported opcode");
-    }
 
     /// Build the hot-BB JIT, stage two byte values, and verify the
     /// arithmetic matches the interpreter exactly.
@@ -414,6 +292,24 @@ mod tests {
         assert_eq!(res.a8, 0x40008534);
 
         assert_eq!(block.hits, 1);
+    }
+
+    /// Block's `emitted` metadata matches the architectural constants
+    /// (Phase 4.1 sanity for the emit-core handoff).
+    #[test]
+    fn hot_bb_emitted_metadata_matches() {
+        let engine = Engine::default();
+        let block = MultiOpBlock::build_hot_bb(&engine).expect("compile");
+        assert_eq!(block.emitted.length_in_instrs, HOT_BB_INSTR_COUNT);
+        assert_eq!(block.emitted.end_pc, HOT_BB_END);
+        assert_eq!(
+            block.classify_exit(EXIT_FALL_THROUGH),
+            Some(SideExitReason::FallThrough)
+        );
+        assert_eq!(
+            block.classify_exit(EXIT_HOST_BUS_ERROR),
+            Some(SideExitReason::HostBusError)
+        );
     }
 
     /// If the caller doesn't stage enough bytes, the host import returns

--- a/crates/core/src/cpu/xtensa_jit/bb_multi.rs
+++ b/crates/core/src/cpu/xtensa_jit/bb_multi.rs
@@ -210,21 +210,34 @@ impl MultiOpBlock {
     /// the cache-build path doesn't require a live `Bus` at construction
     /// time (mirrors `build_hot_bb`'s design).
     pub fn build_looptask_prefix(engine: &Engine) -> wasmtime::Result<Self> {
-        // Bytes: L32R a2,... ; L8UI a3,a2,0 ; BEQZ a3,+12 ; CALL8 (terminator)
-        // — matches the encoding pinned by the emit-core end-to-end test.
-        const LOOPTASK_BYTES: &[u8] = &[
-            0x21, 0xFF, 0xFF, // L32R a2, ...
+        // Synthetic slice layout: 4 bytes of literal pool, 1 byte pad,
+        // then four 3-byte Xtensa instructions. The L32R encoding uses
+        // imm16=0xFFFE which the decoder turns into
+        // pc_rel_byte_offset = -8, i.e. EA = ((LOOPTASK_PC+3) & ~3) - 8
+        // = LOOPTASK_PC - 5 (=`0x400d_4a88`). The 4-byte literal at
+        // PC-5..PC-1 does NOT overlap the L32R instruction at PC..PC+3
+        // (1 byte unused gap at PC-1).
+        const LITERAL_POOL_VALUE: u32 = 0x4008_0534;
+        let literal_le = LITERAL_POOL_VALUE.to_le_bytes();
+        let mut bus_slice: Vec<u8> = literal_le.to_vec();
+        bus_slice.push(0); // 1-byte gap at PC-1 (not read)
+        bus_slice.extend_from_slice(&[
+            0x21, 0xFE, 0xFF, // L32R a2, ... (imm16=0xFFFE → EA = PC-5)
             0x32, 0x02, 0x00, // L8UI a3, a2, 0
             0x16, 0x83, 0x00, // BEQZ a3, +12
             0x25, 0x00, 0x00, // CALL8 (terminator, not emitted)
-        ];
+        ]);
+        // slice_base_pc chosen so that
+        //   pc_to_offset(LOOPTASK_PC - 5) = 0  (literal at slice start)
+        //   pc_to_offset(LOOPTASK_PC)     = 5  (instructions after lit+gap)
+        let slice_base_pc = LOOPTASK_PC.wrapping_sub(5);
 
         let emitted = emit_core::walk_and_emit(
-            LOOPTASK_BYTES,
+            &bus_slice,
             LOOPTASK_PC,
             |pc| {
-                let off = pc.wrapping_sub(LOOPTASK_PC) as usize;
-                if off < LOOPTASK_BYTES.len() {
+                let off = pc.wrapping_sub(slice_base_pc) as usize;
+                if off < bus_slice.len() {
                     Some(off)
                 } else {
                     None
@@ -454,11 +467,17 @@ mod tests {
         let mut block = MultiOpBlock::build_looptask_prefix(&engine).expect("compile");
         // Shape tag is what the cache key consumer dispatches on.
         match block.shape() {
-            BlockShape::LoopTaskPrefix { l32r_at, l8ui_at } => {
+            BlockShape::LoopTaskPrefix {
+                l32r_at,
+                l8ui_at,
+                l8ui_base_at,
+                l32r_literal_value: _,
+            } => {
                 // Per the canonical bytes pinned in `build_looptask_prefix`:
-                // L32R writes a2, L8UI writes a3.
+                // L32R writes a2, L8UI writes a3, L8UI base = a2.
                 assert_eq!(l32r_at, 2);
                 assert_eq!(l8ui_at, 3);
+                assert_eq!(l8ui_base_at, 2);
             }
             other => panic!("expected LoopTaskPrefix shape, got {other:?}"),
         }
@@ -489,6 +508,173 @@ mod tests {
 
         // Two successful calls → two hits.
         assert_eq!(block.hits, 2);
+    }
+
+    // ── Phase 4.3.7 dispatcher lockstep tests ────────────────────────
+    //
+    // The JIT body returned by `run_looptask_prefix` was validated in
+    // isolation by `looptask_prefix_dispatches_taken_and_not_taken`.
+    // What's NEW in 4.3.7 is the I/O staging in `try_jit_step` (native
+    // side): reading the L8UI base register from the AR file, pre-
+    // reading the L8UI byte through the live bus, dispatching, and
+    // committing the L32R + L8UI dst writes plus the new PC. These
+    // tests drive a synthetic `XtensaLx7` + MockBus through the JIT
+    // path and the pure-interp path independently, diffing the
+    // resulting (pc, AR) state. Any divergence means the staging
+    // wired the wrong register or skipped a writeback.
+
+    /// Minimal in-memory `Bus` for dispatcher tests. Maps `HashMap<u64,
+    /// u8>` for byte-granular access; word reads fall back to the
+    /// default `Bus::read_u32` (4 byte loads).
+    #[cfg(test)]
+    struct DispatcherTestBus {
+        mem: std::collections::HashMap<u64, u8>,
+        config: crate::SimulationConfig,
+    }
+
+    #[cfg(test)]
+    impl DispatcherTestBus {
+        fn new() -> Self {
+            Self {
+                mem: std::collections::HashMap::new(),
+                config: crate::SimulationConfig::default(),
+            }
+        }
+        fn write_byte(&mut self, addr: u32, v: u8) {
+            self.mem.insert(addr as u64, v);
+        }
+        fn write_word_le(&mut self, addr: u32, v: u32) {
+            for i in 0..4 {
+                self.mem.insert((addr + i) as u64, (v >> (i * 8)) as u8);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    impl crate::Bus for DispatcherTestBus {
+        fn read_u8(&self, addr: u64) -> crate::SimResult<u8> {
+            Ok(*self.mem.get(&addr).unwrap_or(&0))
+        }
+        fn write_u8(&mut self, addr: u64, value: u8) -> crate::SimResult<()> {
+            self.mem.insert(addr, value);
+            Ok(())
+        }
+        fn tick_peripherals(&mut self) -> Vec<u32> {
+            Vec::new()
+        }
+        fn execute_dma(&mut self, _requests: &[crate::DmaRequest]) -> crate::SimResult<()> {
+            Ok(())
+        }
+        fn config(&self) -> &crate::SimulationConfig {
+            &self.config
+        }
+    }
+
+    /// Layout a memory image for the loopTask prefix at `LOOPTASK_PC`
+    /// matching the synthetic byte stream `build_looptask_prefix`
+    /// hardcodes (so the JIT-side constant-folded L32R literal matches
+    /// what the interpreter reads from the live bus).
+    ///
+    /// `l8ui_target_byte` is the byte the L8UI reads from the literal
+    /// pool's resolved value (which is also the L8UI base address —
+    /// the L32R loads a pointer, the L8UI dereferences it).
+    #[cfg(test)]
+    fn populate_looptask_image(bus: &mut DispatcherTestBus, l8ui_target_byte: u8) {
+        const LITERAL_POOL_VALUE: u32 = 0x4008_0534;
+        // Literal pool: L32R imm16=0xFFFE → pc_rel_byte_offset = -8 →
+        // EA = ((PC+3) & !3) - 8 = PC - 5. The 4-byte literal occupies
+        // [PC-5..PC-1).
+        bus.write_word_le(LOOPTASK_PC.wrapping_sub(5), LITERAL_POOL_VALUE);
+        // Instructions at LOOPTASK_PC: L32R, L8UI, BEQZ, then a
+        // terminator (CALL8 — never executed by the JIT body but
+        // present so the walker's terminator predicate fires cleanly
+        // if the interpreter ever decodes it).
+        let instrs: &[u8] = &[
+            0x21, 0xFE, 0xFF, // L32R a2, ... (imm16=0xFFFE → EA = PC-5)
+            0x32, 0x02, 0x00, // L8UI a3, a2, 0
+            0x16, 0x83, 0x00, // BEQZ a3, +12
+            0x25, 0x00, 0x00, // CALL8 (terminator; not exercised)
+        ];
+        for (i, b) in instrs.iter().enumerate() {
+            bus.write_byte(LOOPTASK_PC + i as u32, *b);
+        }
+        // L8UI dereferences the literal pool value as a pointer.
+        bus.write_byte(LITERAL_POOL_VALUE, l8ui_target_byte);
+    }
+
+    /// Run the loopTask prefix at `LOOPTASK_PC` through either the JIT
+    /// (`jit_enabled=true`) or the pure interpreter (`jit_enabled=false`)
+    /// until PC leaves the prefix range, then return the post-state
+    /// `(pc, a2, a3)`. The JIT executes the whole prefix in one
+    /// `step()` call; the interpreter needs three (one per Xtensa
+    /// instruction). The post-state diff is what tells us the
+    /// dispatcher staging matches the interpreter byte-for-byte.
+    #[cfg(test)]
+    fn run_looptask_once(jit_enabled: bool, l8ui_byte: u8) -> (u32, u32, u32) {
+        use crate::cpu::XtensaLx7;
+        use crate::Cpu;
+        let observers: Vec<std::sync::Arc<dyn crate::SimulationObserver>> = Vec::new();
+        let config = crate::SimulationConfig::default();
+
+        let mut cpu = XtensaLx7::new();
+        cpu.jit_enabled = jit_enabled;
+        cpu.pc = LOOPTASK_PC;
+        // Wake the CPU from its reset EXCM=1 so the interp path doesn't
+        // chase exception vectors — we're testing one block in isolation.
+        cpu.ps = crate::cpu::xtensa_regs::Ps::from_raw(0);
+
+        let mut bus = DispatcherTestBus::new();
+        populate_looptask_image(&mut bus, l8ui_byte);
+
+        // Step until PC leaves the prefix range. Cap at 8 steps to bound
+        // a runaway: interp needs 3 (L32R + L8UI + BEQZ), JIT needs 1.
+        for _ in 0..8 {
+            let pc = cpu.pc;
+            if pc < LOOPTASK_PC || pc >= LOOPTASK_PREFIX_END {
+                break;
+            }
+            cpu.step(&mut bus, &observers, &config).expect("step ok");
+        }
+
+        (cpu.pc, cpu.regs.read_logical(2), cpu.regs.read_logical(3))
+    }
+
+    /// Lockstep: BEQZ-taken path (L8UI loads 0x00). JIT and interp must
+    /// agree on post-state PC + AR2 (L32R literal) + AR3 (L8UI byte).
+    /// This exercises the full Phase 4.3.7 dispatcher wiring: L8UI base
+    /// register read from the AR file, L32R literal constant-folded at
+    /// compile time, both writes committed, PC set to the BEQZ target.
+    #[test]
+    fn looptask_prefix_jit_matches_interp_branch_taken() {
+        let (jit_pc, jit_a2, jit_a3) = run_looptask_once(true, 0x00);
+        let (int_pc, int_a2, int_a3) = run_looptask_once(false, 0x00);
+        assert_eq!(jit_pc, int_pc, "PC mismatch: jit={jit_pc:#x} interp={int_pc:#x}");
+        assert_eq!(jit_a2, int_a2, "a2 mismatch");
+        assert_eq!(jit_a3, int_a3, "a3 mismatch");
+        // Architectural truth: BEQZ taken targets LOOPTASK_PC + 6 + 12.
+        assert_eq!(jit_pc, LOOPTASK_PC + 6 + 12);
+        // a2 = L32R literal value (constant-folded into the JIT body).
+        assert_eq!(jit_a2, 0x4008_0534);
+        // a3 = the byte the L8UI loaded.
+        assert_eq!(jit_a3, 0x00);
+    }
+
+    /// Lockstep: BEQZ-not-taken path (L8UI loads non-zero). JIT and
+    /// interp must agree on post-state PC + AR2 + AR3. The PC after a
+    /// fall-through is `LOOPTASK_PREFIX_END`, the byte after BEQZ.
+    #[test]
+    fn looptask_prefix_jit_matches_interp_branch_not_taken() {
+        let (jit_pc, jit_a2, jit_a3) = run_looptask_once(true, 0x7A);
+        let (int_pc, int_a2, int_a3) = run_looptask_once(false, 0x7A);
+        assert_eq!(jit_pc, int_pc, "PC mismatch: jit={jit_pc:#x} interp={int_pc:#x}");
+        assert_eq!(jit_a2, int_a2, "a2 mismatch");
+        assert_eq!(jit_a3, int_a3, "a3 mismatch");
+        // Architectural truth: BEQZ not taken falls through to PC+3
+        // (BEQZ is 3 bytes); the interp single-steps the BEQZ so its
+        // post-state PC is also LOOPTASK_PC + 6 + 3 = LOOPTASK_PREFIX_END.
+        assert_eq!(jit_pc, LOOPTASK_PREFIX_END);
+        assert_eq!(jit_a2, 0x4008_0534);
+        assert_eq!(jit_a3, 0x7A);
     }
 
     /// Phase 4.3.6: `JitCache::lookup_or_install_multi_op` returns a

--- a/crates/core/src/cpu/xtensa_jit/bb_multi.rs
+++ b/crates/core/src/cpu/xtensa_jit/bb_multi.rs
@@ -63,9 +63,9 @@
 #![cfg(feature = "jit")]
 
 use std::sync::Mutex;
-use wasmtime::{Engine, Func, Instance, Module, Store, TypedFunc};
+use wasmtime::{Engine, Func, Instance, Module, Store};
 
-use super::emit_core::{self, EmittedBlock, PsBits, SideExitReason};
+use super::emit_core::{self, BlockShape, EmittedBlock, PsBits, SideExitReason};
 
 // ── Side-exit codes + BB constants ─────────────────────────────────────
 //
@@ -74,8 +74,8 @@ use super::emit_core::{self, EmittedBlock, PsBits, SideExitReason};
 // the same values without dragging wasmtime into its dep graph
 // (#124 Phase 4).
 pub use crate::cpu::xtensa_jit_bytes::{
-    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_L32R_ADDR,
-    HOT_BB_PC,
+    EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
+    HOT_BB_L32R_ADDR, HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT,
 };
 
 // Re-export the walker types from emit_core for back-compat with the
@@ -83,13 +83,16 @@ pub use crate::cpu::xtensa_jit_bytes::{
 // `xtensa_jit::{walk_bb, DecodedOp}`).
 pub use super::emit_core::{walk_bb, DecodedOp};
 
-// ── Wasm function signature ───────────────────────────────────────────
-
-/// Inputs: (a3, a5, l32r_value)
-/// Outputs: (exit_code, a2, a6, a8, a10)
-type BbParams = (i32, i32, i32);
-type BbReturns = (i32, i32, i32, i32, i32);
-type BbRun = TypedFunc<BbParams, BbReturns>;
+// ── Wasm function signatures ──────────────────────────────────────────
+//
+// Each [`BlockShape`] pairs a wasm `(params) -> (results)` signature
+// with a register/PC marshalling convention. We invoke wasmtime through
+// the untyped `Func::call` path so the same `MultiOpBlock` struct can
+// dispatch any shape's params/results without us needing N different
+// `TypedFunc<P, R>` slots.
+//
+// HotBbCanonical:    (a3, a5, l32r) -> (exit, a2, a6, a8, a10)
+// LoopTaskPrefix:    (l32r_val, l8ui_base) -> (exit, next_pc, l8ui_at, beqz_target_pc)
 
 /// Per-call scratch slot. The L8UI import pushes a bus-error flag here
 /// if it's called with the pending queue empty.
@@ -106,25 +109,44 @@ struct ScratchSlot {
 
 pub struct MultiOpBlock {
     store: Store<()>,
-    run: BbRun,
+    /// Untyped wasm export. We dispatch through `Func::call` so a single
+    /// `MultiOpBlock` struct can run any [`BlockShape`]'s param/result
+    /// signature; the [`Self::shape`] tag tells us how to marshal both
+    /// directions.
+    run: Func,
     scratch: std::sync::Arc<Mutex<ScratchSlot>>,
     pub hits: u64,
     /// L8UI host-import call sequence, populated by the caller before
     /// the wasm call. The wasm body indexes into this by position.
     pending_loads: std::sync::Arc<Mutex<Vec<u32>>>,
     /// The emit-core output we built this block from. Held so callers
-    /// can interrogate `length_in_instrs`, `end_pc`, and the side-exit
-    /// reason map without a separate registry. Phase 4.2 will read
-    /// these for variable-length blocks.
+    /// can interrogate `length_in_instrs`, `end_pc`, the side-exit
+    /// reason map, and the [`BlockShape`] tag.
     pub emitted: EmittedBlock,
 }
 
+/// Result of running the canonical HotBbCanonical block.
 pub struct MultiOpResult {
     pub exit_code: i32,
     pub a2: u32,
     pub a6: u32,
     pub a8: u32,
     pub a10: u32,
+}
+
+/// Result of running a [`BlockShape::LoopTaskPrefix`] block.
+///
+/// Field naming mirrors the emit-core wasm signature:
+/// `(exit_code, next_pc, l8ui_at, beqz_target_pc)`. `next_pc` is the
+/// PC the interpreter should resume from (branch target if BEQZ was
+/// taken, [`LOOPTASK_PREFIX_END`] on fall-through). `l8ui_at_value` is
+/// the byte the L8UI loaded — the caller writes it into the Xtensa
+/// register named by [`BlockShape::LoopTaskPrefix::l8ui_at`].
+pub struct LoopTaskPrefixResult {
+    pub exit_code: i32,
+    pub next_pc: u32,
+    pub l8ui_at_value: u32,
+    pub beqz_target_pc: u32,
 }
 
 impl MultiOpBlock {
@@ -180,10 +202,47 @@ impl MultiOpBlock {
         Self::build_from_emitted(engine, emitted)
     }
 
+    /// Build the loopTask prefix block (`L32R → L8UI → BEQZ` at
+    /// [`LOOPTASK_PC`]). Phase 4.3.6 wires this into
+    /// [`super::JitCache::lookup_or_install_multi_op`] alongside the
+    /// canonical hot block. The bus bytes are synthesised from the same
+    /// canonical disassembly the emit-core lockstep test exercises so
+    /// the cache-build path doesn't require a live `Bus` at construction
+    /// time (mirrors `build_hot_bb`'s design).
+    pub fn build_looptask_prefix(engine: &Engine) -> wasmtime::Result<Self> {
+        // Bytes: L32R a2,... ; L8UI a3,a2,0 ; BEQZ a3,+12 ; CALL8 (terminator)
+        // — matches the encoding pinned by the emit-core end-to-end test.
+        const LOOPTASK_BYTES: &[u8] = &[
+            0x21, 0xFF, 0xFF, // L32R a2, ...
+            0x32, 0x02, 0x00, // L8UI a3, a2, 0
+            0x16, 0x83, 0x00, // BEQZ a3, +12
+            0x25, 0x00, 0x00, // CALL8 (terminator, not emitted)
+        ];
+
+        let emitted = emit_core::walk_and_emit(
+            LOOPTASK_BYTES,
+            LOOPTASK_PC,
+            |pc| {
+                let off = pc.wrapping_sub(LOOPTASK_PC) as usize;
+                if off < LOOPTASK_BYTES.len() {
+                    Some(off)
+                } else {
+                    None
+                }
+            },
+            PsBits::default(),
+        )
+        .map_err(|e| wasmtime::Error::msg(format!("emit_core walk_and_emit: {e}")))?;
+
+        Self::build_from_emitted(engine, emitted)
+    }
+
     /// Compile + instantiate a wasmtime block from a pre-emitted byte
-    /// stream. Phase 4.2's browser adapter will have a structurally
+    /// stream. Phase 4.2's browser adapter has a structurally
     /// identical entry point on its side; both consume `EmittedBlock`
-    /// verbatim.
+    /// verbatim. Shape-aware result decoding lives in [`Self::run_hot_bb`]
+    /// and [`Self::run_looptask_prefix`] — pick the one that matches
+    /// `self.emitted.shape`.
     pub fn build_from_emitted(engine: &Engine, emitted: EmittedBlock) -> wasmtime::Result<Self> {
         let module = Module::new(engine, &emitted.wasm_bytes)?;
         let mut store: Store<()> = Store::new(engine, ());
@@ -211,7 +270,9 @@ impl MultiOpBlock {
         });
 
         let instance = Instance::new(&mut store, &module, &[read_u8.into()])?;
-        let run = instance.get_typed_func::<BbParams, BbReturns>(&mut store, "run")?;
+        let run = instance.get_func(&mut store, "run").ok_or_else(|| {
+            wasmtime::Error::msg("emit-core wasm module missing required `run` export")
+        })?;
         Ok(Self {
             store,
             run,
@@ -224,7 +285,8 @@ impl MultiOpBlock {
 
     /// Stage `bytes` into the host-side queue. The wasm body's import
     /// calls dequeue these in order. `bytes.len()` must equal the number
-    /// of L8UI ops in the BB (2 for the hot BB).
+    /// of L8UI ops in the BB (2 for the hot BB, 1 for the loopTask
+    /// prefix).
     pub fn stage_loads(&mut self, bytes: &[u8]) {
         let mut p = self.pending_loads.lock().unwrap();
         p.clear();
@@ -234,20 +296,75 @@ impl MultiOpBlock {
         s.bus_error = false;
     }
 
-    /// Invoke the compiled block. Caller has already staged loads via
-    /// [`Self::stage_loads`].
+    /// Shape tag for this block. Mirror of `self.emitted.shape`; callers
+    /// branch on this to pick the right `run_*` variant.
     #[inline]
-    pub fn run(&mut self, a3: u32, a5: u32, l32r_val: u32) -> wasmtime::Result<MultiOpResult> {
-        let (exit, a2, a6, a8, a10) = self
-            .run
-            .call(&mut self.store, (a3 as i32, a5 as i32, l32r_val as i32))?;
+    pub fn shape(&self) -> BlockShape {
+        self.emitted.shape
+    }
+
+    /// Invoke a [`BlockShape::HotBbCanonical`] block. Panics in debug
+    /// builds if the block's shape isn't HotBbCanonical — production
+    /// callers should branch on [`Self::shape`] first.
+    #[inline]
+    pub fn run_hot_bb(
+        &mut self,
+        a3: u32,
+        a5: u32,
+        l32r_val: u32,
+    ) -> wasmtime::Result<MultiOpResult> {
+        debug_assert_eq!(self.emitted.shape, BlockShape::HotBbCanonical);
+        use wasmtime::Val;
+        let params = [
+            Val::I32(a3 as i32),
+            Val::I32(a5 as i32),
+            Val::I32(l32r_val as i32),
+        ];
+        let mut results = [Val::I32(0); 5];
+        self.run.call(&mut self.store, &params, &mut results)?;
         self.hits += 1;
         Ok(MultiOpResult {
-            exit_code: exit,
-            a2: a2 as u32,
-            a6: a6 as u32,
-            a8: a8 as u32,
-            a10: a10 as u32,
+            exit_code: results[0].i32().unwrap_or(0),
+            a2: results[1].i32().unwrap_or(0) as u32,
+            a6: results[2].i32().unwrap_or(0) as u32,
+            a8: results[3].i32().unwrap_or(0) as u32,
+            a10: results[4].i32().unwrap_or(0) as u32,
+        })
+    }
+
+    /// Back-compat shim for [`Self::run_hot_bb`]. Existing call sites
+    /// (`xtensa_lx7::try_jit_multi_op`, prior tests) used the bare
+    /// `run` name; keep that working so this commit stays focused on
+    /// the dispatch refactor.
+    #[inline]
+    pub fn run(&mut self, a3: u32, a5: u32, l32r_val: u32) -> wasmtime::Result<MultiOpResult> {
+        self.run_hot_bb(a3, a5, l32r_val)
+    }
+
+    /// Invoke a [`BlockShape::LoopTaskPrefix`] block. Caller stages the
+    /// single L8UI byte via [`Self::stage_loads`] beforehand.
+    /// Signature: `(l32r_val, l8ui_base) -> (exit, next_pc, l8ui_at,
+    /// beqz_target_pc)`.
+    #[inline]
+    pub fn run_looptask_prefix(
+        &mut self,
+        l32r_val: u32,
+        l8ui_base: u32,
+    ) -> wasmtime::Result<LoopTaskPrefixResult> {
+        debug_assert!(matches!(
+            self.emitted.shape,
+            BlockShape::LoopTaskPrefix { .. }
+        ));
+        use wasmtime::Val;
+        let params = [Val::I32(l32r_val as i32), Val::I32(l8ui_base as i32)];
+        let mut results = [Val::I32(0); 4];
+        self.run.call(&mut self.store, &params, &mut results)?;
+        self.hits += 1;
+        Ok(LoopTaskPrefixResult {
+            exit_code: results[0].i32().unwrap_or(0),
+            next_pc: results[1].i32().unwrap_or(0) as u32,
+            l8ui_at_value: results[2].i32().unwrap_or(0) as u32,
+            beqz_target_pc: results[3].i32().unwrap_or(0) as u32,
         })
     }
 
@@ -325,5 +442,84 @@ mod tests {
             .run(0x3FFB_0000, 0x1234, 0x40008534)
             .expect("wasm call");
         assert_eq!(res.exit_code, EXIT_HOST_BUS_ERROR);
+    }
+
+    /// Phase 4.3.6: `build_looptask_prefix` produces a runnable block
+    /// tagged with the right shape, and dispatching it both ways
+    /// (BEQZ taken vs not taken) updates `next_pc` per emit-core's
+    /// canonical loopTask prefix decode.
+    #[test]
+    fn looptask_prefix_dispatches_taken_and_not_taken() {
+        let engine = Engine::default();
+        let mut block = MultiOpBlock::build_looptask_prefix(&engine).expect("compile");
+        // Shape tag is what the cache key consumer dispatches on.
+        match block.shape() {
+            BlockShape::LoopTaskPrefix { l32r_at, l8ui_at } => {
+                // Per the canonical bytes pinned in `build_looptask_prefix`:
+                // L32R writes a2, L8UI writes a3.
+                assert_eq!(l32r_at, 2);
+                assert_eq!(l8ui_at, 3);
+            }
+            other => panic!("expected LoopTaskPrefix shape, got {other:?}"),
+        }
+        assert_eq!(block.emitted.length_in_instrs, LOOPTASK_PREFIX_INSTR_COUNT);
+        assert_eq!(block.emitted.end_pc, LOOPTASK_PREFIX_END);
+
+        // L8UI returns 0 → BEQZ taken. next_pc == beqz_target_pc ==
+        // after_l8ui_pc(LOOPTASK_PC + 6) + offset(12).
+        let expected_target = LOOPTASK_PC + 6 + 12;
+        block.stage_loads(&[0x00]);
+        let res = block
+            .run_looptask_prefix(/* l32r_val */ 0x4008_0534, /* l8ui_base */ 0x3FFB_0000)
+            .expect("wasm call");
+        assert_eq!(res.exit_code, EXIT_BRANCH_TAKEN);
+        assert_eq!(res.next_pc, expected_target);
+        assert_eq!(res.l8ui_at_value, 0);
+        assert_eq!(res.beqz_target_pc, expected_target);
+
+        // L8UI returns non-zero → BEQZ falls through. next_pc ==
+        // LOOPTASK_PREFIX_END; l8ui_at carries the loaded byte.
+        block.stage_loads(&[0x7A]);
+        let res = block
+            .run_looptask_prefix(0x4008_0534, 0x3FFB_0000)
+            .expect("wasm call");
+        assert_eq!(res.exit_code, EXIT_FALL_THROUGH);
+        assert_eq!(res.next_pc, LOOPTASK_PREFIX_END);
+        assert_eq!(res.l8ui_at_value, 0x7A);
+
+        // Two successful calls → two hits.
+        assert_eq!(block.hits, 2);
+    }
+
+    /// Phase 4.3.6: `JitCache::lookup_or_install_multi_op` returns a
+    /// working block for both HOT_BB_PC and LOOPTASK_PC. This is the
+    /// cache-level contract that wires shape-aware dispatch into the
+    /// rest of the engine. We verify by checking the shape tag is
+    /// correct for each PC; the actual run paths are covered by
+    /// `hot_bb_arithmetic_matches_interp` and
+    /// `looptask_prefix_dispatches_taken_and_not_taken`.
+    #[test]
+    fn jit_cache_lookup_dispatches_both_shapes() {
+        use crate::cpu::xtensa_jit::JitCache;
+        let mut cache = JitCache::new();
+
+        // HOT_BB_PC installs and reports HotBbCanonical.
+        let hot = cache
+            .lookup_or_install_multi_op(HOT_BB_PC)
+            .expect("hot bb installs");
+        assert_eq!(hot.shape(), BlockShape::HotBbCanonical);
+
+        // LOOPTASK_PC installs and reports LoopTaskPrefix.
+        let lt = cache
+            .lookup_or_install_multi_op(LOOPTASK_PC)
+            .expect("loopTask prefix installs");
+        assert!(
+            matches!(lt.shape(), BlockShape::LoopTaskPrefix { .. }),
+            "loopTask block must be LoopTaskPrefix-shaped, got {:?}",
+            lt.shape()
+        );
+
+        // An unknown PC still refuses (cache stays narrow).
+        assert!(cache.lookup_or_install_multi_op(0xDEAD_BEEF).is_none());
     }
 }

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -1,0 +1,548 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Xtensa LX7 JIT — runtime-agnostic walker + emit core (#124 Phase 4.1).
+//!
+//! This module is **always** compiled (no `jit` feature gate, no wasmtime
+//! dependency). It owns the parts of the JIT pipeline that don't care
+//! whether the resulting wasm bytes end up in `wasmtime::Module::new`
+//! (native) or `js_sys::WebAssembly::Module::new` (browser):
+//!
+//!   1. The basic-block walker ([`walk_bb`]) — decodes Xtensa instructions
+//!      forward from a given PC until a terminator / unsupported opcode.
+//!   2. The opcode allowlist ([`is_supported`]) + terminator predicate
+//!      ([`is_terminator`]).
+//!   3. The end-to-end entry point ([`walk_and_emit`]) — given a flat
+//!      slice of the bus that contains the candidate PC, produces an
+//!      [`EmittedBlock`] containing the wasm bytes that both backends
+//!      consume.
+//!
+//! ## Why this lives outside the `jit` feature gate
+//!
+//! The browser-side prototype in `labwired-wasm` cannot enable the `jit`
+//! feature (wasmtime doesn't build for `wasm32-unknown-unknown`). But it
+//! still needs the walker + the emitted wasm bytes. Phase 4.0 (PR #131)
+//! already established this split by baking the canonical hot-block
+//! bytes at crate build time into [`crate::cpu::xtensa_jit_bytes::HOT_BB_WASM`].
+//! Phase 4.1 generalises that: `walk_and_emit` accepts an arbitrary PC,
+//! walks the bus to decode the BB, and returns the bytes both backends
+//! consume.
+//!
+//! ## Current emit scope (4.1)
+//!
+//! Phase 4.1 is a *refactor*: the actual byte-stream-emit-per-opcode work
+//! lives in the canonical [`crate::cpu::xtensa_jit::hot_bb.wat`] source
+//! and is compiled to wasm bytes by `crates/core/build.rs`. The walker +
+//! [`walk_and_emit`] currently only recognise the canonical
+//! [`HOT_BB_PC`] shape (the 8-instruction `call_start_cpu0` delay loop)
+//! and reuse the pre-baked [`HOT_BB_WASM`] bytes verbatim. Per-opcode
+//! runtime emit functions are stubbed below ([`emit_or`], [`emit_l8ui`],
+//! …) so Phase 4.2/4.3 can fill them in without further surgery on the
+//! native / browser adapters.
+//!
+//! [`HOT_BB_PC`]: crate::cpu::xtensa_jit_bytes::HOT_BB_PC
+//! [`HOT_BB_WASM`]: crate::cpu::xtensa_jit_bytes::HOT_BB_WASM
+
+use crate::cpu::xtensa_jit_bytes::{
+    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_PC, HOT_BB_WASM,
+};
+use crate::decoder::xtensa::{self, Instruction};
+use crate::decoder::{xtensa_length, xtensa_narrow};
+
+// ── Public side-exit / shape vocabulary ───────────────────────────────
+
+/// Reason an emitted block can side-exit early. The actual `i32` code in
+/// the wasm body comes from [`crate::cpu::xtensa_jit_bytes`] so native +
+/// browser agree on the wire values; this enum is the runtime-agnostic
+/// view for diagnostics + Phase 4.2 control-flow emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SideExitReason {
+    /// Block executed cleanly to the terminator. Wire code:
+    /// [`EXIT_FALL_THROUGH`].
+    FallThrough,
+    /// A host import (e.g. `read_u8`) reported a bus error. Wire code:
+    /// [`EXIT_HOST_BUS_ERROR`].
+    HostBusError,
+}
+
+impl SideExitReason {
+    /// Wire side-exit code emitted into the wasm body. Native +
+    /// browser dispatch on these identical i32 values.
+    #[inline]
+    pub fn wire_code(self) -> i32 {
+        match self {
+            SideExitReason::FallThrough => EXIT_FALL_THROUGH,
+            SideExitReason::HostBusError => EXIT_HOST_BUS_ERROR,
+        }
+    }
+}
+
+/// Failure reasons from [`walk_and_emit`]. None of these are bugs — they
+/// just mean "this PC isn't JIT-able yet"; the caller falls back to the
+/// interpreter and the BB walks back through the regular dispatch path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmitError {
+    /// The walked BB doesn't match any currently-supported shape. In
+    /// Phase 4.1 only the canonical [`HOT_BB_PC`] shape is recognised;
+    /// Phase 4.2+ will expand the shape allowlist as per-opcode emit
+    /// lands.
+    UnsupportedShape,
+    /// The walker refused (unsupported opcode mid-block, or the PC
+    /// pointed outside the supplied `bus_slice`).
+    WalkRefused,
+    /// The walked block was empty (only a terminator at `pc`).
+    BlockTooShort,
+    /// PC outside the supplied bus slice — caller passed a slice that
+    /// doesn't cover the block under consideration.
+    PcOutOfRange,
+}
+
+impl core::fmt::Display for EmitError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EmitError::UnsupportedShape => f.write_str("BB shape not yet supported by emit core"),
+            EmitError::WalkRefused => f.write_str("BB walker refused (unsupported opcode or OOB)"),
+            EmitError::BlockTooShort => f.write_str("BB walker returned no non-terminator ops"),
+            EmitError::PcOutOfRange => f.write_str("PC outside the supplied bus slice"),
+        }
+    }
+}
+
+impl std::error::Error for EmitError {}
+
+/// Subset of PS that affects JIT validity. Currently informational —
+/// Phase 4.1 only emits straight-line arithmetic that doesn't depend on
+/// PS. Phase 4.4 (CALL8/RETW) will read CALLINC/WOE from here. Carried
+/// in [`walk_and_emit`]'s signature now so adding consumers later is
+/// not an API break.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PsBits {
+    /// Raw PS register value (see [`crate::cpu::xtensa_regs::Ps`]).
+    pub raw: u32,
+}
+
+impl PsBits {
+    /// Construct from a raw PS value (typically `cpu.ps.as_raw()`).
+    #[inline]
+    pub const fn from_raw(raw: u32) -> Self {
+        Self { raw }
+    }
+}
+
+/// One emit pass output: the wasm bytes plus the metadata both backends
+/// need to commit register state, advance PC, and bump CCOUNT after the
+/// block runs.
+///
+/// `wasm_bytes` is a `Vec<u8>` rather than a `&'static [u8]` so future
+/// runtime-emit code (Phase 4.2+) can produce bytes per-BB without
+/// requiring a static lifetime. Cloning a baked block reuses the static
+/// bytes (one allocation, no per-call cost on the hot path because the
+/// JitCache holds the compiled `Module` long-term).
+#[derive(Debug, Clone)]
+pub struct EmittedBlock {
+    /// Wasm module bytes. Magic+version validated by the backend at
+    /// `Module::new` time, not here.
+    pub wasm_bytes: Vec<u8>,
+    /// Number of Xtensa instructions the wasm body executes. Both
+    /// backends advance CCOUNT by `length_in_instrs - 1` after a clean
+    /// fall-through (the outer step already counted one).
+    pub length_in_instrs: u32,
+    /// First PC after the JIT'd range — the interpreter resumes here
+    /// when the block fall-throughs.
+    pub end_pc: u32,
+    /// Side-exit codes the emitted body can produce, paired with their
+    /// reason. Backends use this to map a returned i32 to "commit
+    /// state" vs "refuse + fall back to interp".
+    pub side_exit_reasons: Vec<(i32, SideExitReason)>,
+}
+
+impl EmittedBlock {
+    /// Look up the [`SideExitReason`] for a wire exit code emitted by
+    /// `self.wasm_bytes`. Returns `None` if the code isn't in
+    /// `side_exit_reasons` — the backend treats that as a sim-level
+    /// "unknown side-exit" error.
+    #[inline]
+    pub fn reason_for(&self, code: i32) -> Option<SideExitReason> {
+        self.side_exit_reasons
+            .iter()
+            .find(|(c, _)| *c == code)
+            .map(|(_, r)| *r)
+    }
+}
+
+// ── Walker — decoded ops + control predicates ─────────────────────────
+
+/// One decoded Xtensa op + its byte length. Used by the BB walker.
+#[derive(Debug, Clone)]
+pub struct DecodedOp {
+    pub pc: u32,
+    pub len: u32,
+    pub ins: Instruction,
+}
+
+/// Walk forward from `start_pc`, decoding instructions out of `text`
+/// (a flat slice mapping PC → byte). Stops when:
+///   * a terminator (any control transfer) is reached — terminator is
+///     **excluded** from the returned vec.
+///   * an unsupported opcode is hit — returns `None` (refuse the whole BB).
+///   * `max_ops` instructions have been collected — returns what we have.
+///
+/// `pc_to_offset` converts a PC to an index into `text`; returns `None`
+/// if the PC is outside `text`.
+pub fn walk_bb<F>(
+    start_pc: u32,
+    mut pc_to_offset: F,
+    text: &[u8],
+    max_ops: usize,
+) -> Option<Vec<DecodedOp>>
+where
+    F: FnMut(u32) -> Option<usize>,
+{
+    let mut ops = Vec::with_capacity(max_ops);
+    let mut pc = start_pc;
+    while ops.len() < max_ops {
+        let off = pc_to_offset(pc)?;
+        if off >= text.len() {
+            return None;
+        }
+        let b0 = text[off];
+        let len: u32 = xtensa_length::instruction_length(b0);
+        // Verify the full instruction fits inside `text`.
+        if off + (len as usize) > text.len() {
+            return None;
+        }
+        let ins = if len == 2 {
+            let hw = u16::from_le_bytes([text[off], text[off + 1]]);
+            xtensa_narrow::decode_narrow(hw)
+        } else if len == 3 {
+            let w = u32::from_le_bytes([text[off], text[off + 1], text[off + 2], 0]);
+            xtensa::decode(w)
+        } else {
+            return None;
+        };
+        if is_terminator(&ins) {
+            return Some(ops);
+        }
+        if !is_supported(&ins) {
+            return None;
+        }
+        ops.push(DecodedOp { pc, len, ins });
+        pc = pc.wrapping_add(len);
+    }
+    Some(ops)
+}
+
+/// Is this opcode a basic-block terminator (control transfer)?
+pub fn is_terminator(ins: &Instruction) -> bool {
+    use Instruction::*;
+    matches!(
+        ins,
+        Call0 { .. }
+            | Call4 { .. }
+            | Call8 { .. }
+            | Call12 { .. }
+            | Callx0 { .. }
+            | Callx4 { .. }
+            | Callx8 { .. }
+            | Callx12 { .. }
+            | Ret
+            | Retw
+            | Jx { .. }
+            | Beq { .. }
+            | Bne { .. }
+            | Blt { .. }
+            | Bge { .. }
+            | Bltu { .. }
+            | Bgeu { .. }
+            | Beqz { .. }
+            | Bnez { .. }
+            | Bltz { .. }
+            | Bgez { .. }
+            | Beqi { .. }
+            | Bnei { .. }
+            | Blti { .. }
+            | Bgei { .. }
+            | Bltui { .. }
+            | Bgeui { .. }
+            | Bany { .. }
+            | Ball { .. }
+            | Bnone { .. }
+            | Bnall { .. }
+            | Bbc { .. }
+            | Bbs { .. }
+            | Bbci { .. }
+            | Bbsi { .. }
+            | Entry { .. }
+            | Rfe
+            | Rfde
+            | Rfi { .. }
+            | Rfwo
+            | Rfwu
+            | Ill
+    )
+}
+
+/// Is this opcode in the Phase 4.1 supported set?
+///
+/// Keep this list narrow: any new opcode here needs corresponding
+/// per-opcode emit code below (`emit_*`). Adding more is Phase 4.2+
+/// work and must come paired with lockstep coverage.
+pub fn is_supported(ins: &Instruction) -> bool {
+    use Instruction::*;
+    matches!(
+        ins,
+        // Pure arithmetic / bitwise
+        Add { .. }
+            | Sub { .. }
+            | And { .. }
+            | Or { .. }
+            | Xor { .. }
+            | Addi { .. }
+            | Movi { .. }
+            | Extui { .. }
+            // Loads
+            | L8ui { .. }
+            | L32r { .. }
+            // Barriers — semantic no-ops in sim
+            | Memw
+            | Nop
+    )
+}
+
+// ── walk_and_emit — runtime-agnostic entry point ──────────────────────
+
+/// Walk the BB starting at `pc` (using `bus_slice` indexed by
+/// `pc_to_offset`) and produce an [`EmittedBlock`] of wasm bytes both
+/// backends can consume.
+///
+/// `bus_slice` is the flat slice of host memory the BB is decoded out
+/// of; `pc_to_offset` maps a PC to an index inside that slice. The
+/// canonical caller is `try_jit_multi_op` which extracts an IRAM slice
+/// covering `pc` and supplies the offset closure.
+///
+/// `ps_bits` is currently informational — see [`PsBits`].
+///
+/// ## Phase 4.1 scope cap
+///
+/// Only the canonical [`HOT_BB_PC`] shape is recognised. The BB walker
+/// is fully general; the per-opcode emit functions ([`emit_or`],
+/// [`emit_l8ui`], …) are stubs. If the walked ops match the canonical
+/// hot-block shape we return the pre-baked [`HOT_BB_WASM`] bytes.
+/// Otherwise [`EmitError::UnsupportedShape`].
+pub fn walk_and_emit<F>(
+    bus_slice: &[u8],
+    pc: u32,
+    pc_to_offset: F,
+    _ps_bits: PsBits,
+) -> Result<EmittedBlock, EmitError>
+where
+    F: FnMut(u32) -> Option<usize>,
+{
+    // Cap the walk at `HOT_BB_INSTR_COUNT + 2` — Phase 4.1 only emits
+    // the 8-op hot block; budget two slack ops so a shape mismatch
+    // surfaces as UnsupportedShape rather than a silent truncation.
+    let max_ops = (HOT_BB_INSTR_COUNT as usize) + 2;
+    let ops = walk_bb(pc, pc_to_offset, bus_slice, max_ops).ok_or(EmitError::WalkRefused)?;
+    if ops.is_empty() {
+        return Err(EmitError::BlockTooShort);
+    }
+
+    if pc == HOT_BB_PC && matches_hot_bb_shape(&ops) {
+        Ok(EmittedBlock {
+            wasm_bytes: HOT_BB_WASM.to_vec(),
+            length_in_instrs: HOT_BB_INSTR_COUNT,
+            end_pc: HOT_BB_END,
+            side_exit_reasons: vec![
+                (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+                (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
+            ],
+        })
+    } else {
+        Err(EmitError::UnsupportedShape)
+    }
+}
+
+/// Does this decoded op sequence match the canonical hot-BB shape?
+///
+/// `0x400829cc`:
+/// ```text
+///   or    a10,a5,a5
+///   memw
+///   l8ui  a6,a3,0
+///   memw
+///   l8ui  a2,a3,1
+///   extui a2,a2,0,8
+///   and   a2,a2,a6
+///   l32r  a8,0x40080534
+/// ```
+fn matches_hot_bb_shape(ops: &[DecodedOp]) -> bool {
+    use Instruction::*;
+    if ops.len() != HOT_BB_INSTR_COUNT as usize {
+        return false;
+    }
+    matches!(
+        ops[0].ins,
+        Or {
+            ar: 10,
+            as_: 5,
+            at: 5
+        }
+    ) && matches!(ops[1].ins, Memw)
+        && matches!(
+            ops[2].ins,
+            L8ui {
+                at: 6,
+                as_: 3,
+                imm: 0
+            }
+        )
+        && matches!(ops[3].ins, Memw)
+        && matches!(
+            ops[4].ins,
+            L8ui {
+                at: 2,
+                as_: 3,
+                imm: 1
+            }
+        )
+        && matches!(
+            ops[5].ins,
+            Extui {
+                ar: 2,
+                at: 2,
+                shift: 0,
+                bits: 8,
+            }
+        )
+        && matches!(
+            ops[6].ins,
+            And {
+                ar: 2,
+                as_: 2,
+                at: 6
+            }
+        )
+        && matches!(ops[7].ins, L32r { at: 8, .. })
+}
+
+// ── Per-opcode emit stubs ─────────────────────────────────────────────
+//
+// Phase 4.1 keeps the canonical wasm body in `hot_bb.wat`; each per-op
+// emit function below currently delegates to that pre-baked artifact
+// (effectively a no-op for the runtime path). Phase 4.2 will replace
+// these stubs with real wasm-byte emission so `walk_and_emit` can build
+// a block byte stream for any sequence of supported ops, not just the
+// canonical shape.
+//
+// The signatures live here today so the Phase 4.2 wiring is a fill-in
+// rather than a rewrite. Each stub returns a `Result` so a future
+// "unsupported operand" path can plumb through without an API break.
+//
+// NOTE: these are deliberately not exposed via `pub use` until Phase
+// 4.2 fills them in — exposing empty stubs would risk callers binding
+// to incorrect output.
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_or(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_memw(_out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_nop(_out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_l8ui(_at: u8, _as_: u8, _imm: u32, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_l32r(_at: u8, _literal: u32, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_extui(_ar: u8, _at: u8, _shift: u8, _bits: u8, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_and(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_add(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_sub(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_xor(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_addi(_at: u8, _as_: u8, _imm8: i32, _out: &mut Vec<u8>) {}
+
+#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+pub(crate) fn emit_movi(_at: u8, _imm: i32, _out: &mut Vec<u8>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Walker stops at a terminator and excludes it from the returned vec.
+    #[test]
+    fn walker_stops_at_terminator() {
+        // 4 bytes: two NOP.N (0x3d 0xf0) then a RET.N (0x0d 0xf0).
+        let text: Vec<u8> = vec![0x3d, 0xf0, 0x3d, 0xf0, 0x0d, 0xf0];
+        let ops = walk_bb(0, |pc| Some(pc as usize), &text, 16).unwrap();
+        assert_eq!(ops.len(), 2, "should collect 2 NOP.Ns then stop at RET.N");
+        for op in &ops {
+            assert!(matches!(op.ins, Instruction::Nop));
+        }
+    }
+
+    /// Walker refuses unsupported opcodes (returns None).
+    #[test]
+    fn walker_refuses_unsupported() {
+        // SSL a3 — not in `is_supported`.
+        let text: Vec<u8> = vec![0x40, 0x13, 0x40, 0x00, 0x00, 0x00];
+        let ops = walk_bb(0, |pc| Some(pc as usize), &text, 16);
+        assert!(ops.is_none(), "must refuse unsupported opcode");
+    }
+
+    /// `walk_and_emit` returns `UnsupportedShape` for non-hot-BB PCs.
+    #[test]
+    fn walk_and_emit_unknown_pc_unsupported() {
+        let text: Vec<u8> = vec![0x3d, 0xf0, 0x0d, 0xf0];
+        let err = walk_and_emit(&text, 0, |pc| Some(pc as usize), PsBits::default()).unwrap_err();
+        assert_eq!(err, EmitError::UnsupportedShape);
+    }
+
+    /// `walk_and_emit` propagates walker failures as `WalkRefused`.
+    #[test]
+    fn walk_and_emit_walker_refused_propagates() {
+        // SSL a3 — refused by walker.
+        let text: Vec<u8> = vec![0x40, 0x13, 0x40];
+        let err = walk_and_emit(&text, 0, |pc| Some(pc as usize), PsBits::default()).unwrap_err();
+        assert_eq!(err, EmitError::WalkRefused);
+    }
+
+    /// `SideExitReason::wire_code` round-trips through
+    /// `EmittedBlock::reason_for` (sanity for backends that index by
+    /// the i32 returned from wasm).
+    #[test]
+    fn side_exit_reason_round_trips() {
+        let block = EmittedBlock {
+            wasm_bytes: vec![0, b'a', b's', b'm', 1, 0, 0, 0],
+            length_in_instrs: 1,
+            end_pc: 0,
+            side_exit_reasons: vec![
+                (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+                (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
+            ],
+        };
+        assert_eq!(
+            block.reason_for(EXIT_FALL_THROUGH),
+            Some(SideExitReason::FallThrough)
+        );
+        assert_eq!(
+            block.reason_for(EXIT_HOST_BUS_ERROR),
+            Some(SideExitReason::HostBusError)
+        );
+        assert_eq!(block.reason_for(42), None);
+    }
+}

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -29,23 +29,25 @@
 //! walks the bus to decode the BB, and returns the bytes both backends
 //! consume.
 //!
-//! ## Current emit scope (4.1)
+//! ## Current emit scope (4.2′)
 //!
-//! Phase 4.1 is a *refactor*: the actual byte-stream-emit-per-opcode work
-//! lives in the canonical [`crate::cpu::xtensa_jit::hot_bb.wat`] source
-//! and is compiled to wasm bytes by `crates/core/build.rs`. The walker +
-//! [`walk_and_emit`] currently only recognise the canonical
-//! [`HOT_BB_PC`] shape (the 8-instruction `call_start_cpu0` delay loop)
-//! and reuse the pre-baked [`HOT_BB_WASM`] bytes verbatim. Per-opcode
-//! runtime emit functions are stubbed below ([`emit_or`], [`emit_l8ui`],
-//! …) so Phase 4.2/4.3 can fill them in without further surgery on the
-//! native / browser adapters.
+//! [`walk_and_emit`] now constructs the wasm bytes at runtime via
+//! [`super::wasm_emit::WasmModule`] + the per-opcode helpers below
+//! ([`emit_or`], [`emit_l8ui`], …). Only the canonical [`HOT_BB_PC`]
+//! shape is wired up — other PCs return [`EmitError::UnsupportedShape`].
+//! Output is byte-equivalent (under wasmtime parity) to the build-time-
+//! baked `HOT_BB_WASM` artifact so neither backend's hot path moves.
 //!
 //! [`HOT_BB_PC`]: crate::cpu::xtensa_jit_bytes::HOT_BB_PC
 //! [`HOT_BB_WASM`]: crate::cpu::xtensa_jit_bytes::HOT_BB_WASM
 
 use crate::cpu::xtensa_jit_bytes::{
-    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_PC, HOT_BB_WASM,
+    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_PC,
+};
+use crate::cpu::xtensa_jit::wasm_emit::{
+    emit_call, emit_end, emit_i32_and, emit_i32_const, emit_i32_lt_s, emit_i32_or, emit_i32_shr_u,
+    emit_if_void, emit_local_get, emit_local_set, emit_locals_run, emit_return, encode_u32,
+    FuncType, ValType, WasmModule,
 };
 use crate::decoder::xtensa::{self, Instruction};
 use crate::decoder::{xtensa_length, xtensa_narrow};
@@ -323,13 +325,16 @@ pub fn is_supported(ins: &Instruction) -> bool {
 ///
 /// `ps_bits` is currently informational — see [`PsBits`].
 ///
-/// ## Phase 4.1 scope cap
+/// ## Phase 4.2′ scope cap
 ///
-/// Only the canonical [`HOT_BB_PC`] shape is recognised. The BB walker
-/// is fully general; the per-opcode emit functions ([`emit_or`],
-/// [`emit_l8ui`], …) are stubs. If the walked ops match the canonical
-/// hot-block shape we return the pre-baked [`HOT_BB_WASM`] bytes.
-/// Otherwise [`EmitError::UnsupportedShape`].
+/// Only the canonical [`HOT_BB_PC`] shape is recognised. The wasm bytes
+/// are now constructed at runtime via [`WasmModule`] + per-opcode
+/// [`emit_or`] / [`emit_l8ui`] / … helpers, replacing the build-time
+/// `hot_bb.wat` round-trip. Output bytes match [`HOT_BB_WASM`]'s ABI
+/// exactly: same import (`host.read_u8`), same `run` export, same
+/// `(a3, a5, l32r) -> (exit, a2, a6, a8, a10)` signature, same 5×i32
+/// locals run, same side-exit codes. Other shapes return
+/// [`EmitError::UnsupportedShape`].
 pub fn walk_and_emit<F>(
     bus_slice: &[u8],
     pc: u32,
@@ -339,7 +344,7 @@ pub fn walk_and_emit<F>(
 where
     F: FnMut(u32) -> Option<usize>,
 {
-    // Cap the walk at `HOT_BB_INSTR_COUNT + 2` — Phase 4.1 only emits
+    // Cap the walk at `HOT_BB_INSTR_COUNT + 2` — Phase 4.2′ only emits
     // the 8-op hot block; budget two slack ops so a shape mismatch
     // surfaces as UnsupportedShape rather than a silent truncation.
     let max_ops = (HOT_BB_INSTR_COUNT as usize) + 2;
@@ -348,19 +353,133 @@ where
         return Err(EmitError::BlockTooShort);
     }
 
-    if pc == HOT_BB_PC && matches_hot_bb_shape(&ops) {
-        Ok(EmittedBlock {
-            wasm_bytes: HOT_BB_WASM.to_vec(),
-            length_in_instrs: HOT_BB_INSTR_COUNT,
-            end_pc: HOT_BB_END,
-            side_exit_reasons: vec![
-                (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
-                (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
-            ],
-        })
-    } else {
-        Err(EmitError::UnsupportedShape)
+    if pc != HOT_BB_PC || !matches_hot_bb_shape(&ops) {
+        return Err(EmitError::UnsupportedShape);
     }
+
+    Ok(EmittedBlock {
+        wasm_bytes: build_hot_bb_module(&ops),
+        length_in_instrs: HOT_BB_INSTR_COUNT,
+        end_pc: HOT_BB_END,
+        side_exit_reasons: vec![
+            (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+            (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
+        ],
+    })
+}
+
+// ── Hot-BB runtime emit ───────────────────────────────────────────────
+//
+// Canonical wasm locals for the hot block, mirroring `hot_bb.wat`'s
+// param + local declarations. Wasm function locals are indexed as
+// params first, then declared locals — keep these in sync with the
+// type and locals run in `build_hot_bb_module`.
+const LOCAL_A3: u32 = 0;
+const LOCAL_A5: u32 = 1;
+const LOCAL_L32R: u32 = 2;
+const LOCAL_A2: u32 = 3;
+const LOCAL_A6: u32 = 4;
+const LOCAL_A8: u32 = 5;
+const LOCAL_A10: u32 = 6;
+const LOCAL_TMP: u32 = 7;
+
+/// Map an Xtensa register number used by the hot block to its wasm
+/// local index. Only the registers `matches_hot_bb_shape` accepts are
+/// supported.
+fn hot_bb_local_for(reg: u8) -> u32 {
+    match reg {
+        2 => LOCAL_A2,
+        3 => LOCAL_A3,
+        5 => LOCAL_A5,
+        6 => LOCAL_A6,
+        8 => LOCAL_A8,
+        10 => LOCAL_A10,
+        _ => panic!("hot_bb shape match must reject unknown reg {reg}"),
+    }
+}
+
+/// Build the wasm module for the canonical hot block via the
+/// [`WasmModule`] builder + per-opcode emit helpers below. Matches
+/// `HOT_BB_WASM`'s ABI exactly (verified by the parity test).
+fn build_hot_bb_module(ops: &[DecodedOp]) -> Vec<u8> {
+    let mut m = WasmModule::new();
+    let t_read_u8 = m.add_type(FuncType {
+        params: vec![ValType::I32],
+        results: vec![ValType::I32],
+    });
+    let t_run = m.add_type(FuncType {
+        params: vec![ValType::I32, ValType::I32, ValType::I32],
+        results: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+    });
+    let f_read_u8 = m.add_func_import("host", "read_u8", t_read_u8);
+
+    let mut body = Vec::with_capacity(128);
+    // Locals vec: one run of 5 × i32 (a2, a6, a8, a10, tmp).
+    encode_u32(1, &mut body);
+    emit_locals_run(5, ValType::I32, &mut body);
+
+    for op in ops {
+        match op.ins {
+            Instruction::Or { ar, as_, at } => {
+                emit_or(
+                    hot_bb_local_for(ar),
+                    hot_bb_local_for(as_),
+                    hot_bb_local_for(at),
+                    &mut body,
+                );
+            }
+            Instruction::Memw => emit_memw(&mut body),
+            Instruction::L8ui { at, as_, imm } => {
+                emit_l8ui(
+                    hot_bb_local_for(at),
+                    hot_bb_local_for(as_),
+                    imm,
+                    f_read_u8,
+                    LOCAL_TMP,
+                    &mut body,
+                );
+            }
+            Instruction::Extui {
+                ar,
+                at,
+                shift,
+                bits,
+            } => {
+                emit_extui(
+                    hot_bb_local_for(ar),
+                    hot_bb_local_for(at),
+                    shift,
+                    bits,
+                    &mut body,
+                );
+            }
+            Instruction::And { ar, as_, at } => {
+                emit_and(
+                    hot_bb_local_for(ar),
+                    hot_bb_local_for(as_),
+                    hot_bb_local_for(at),
+                    &mut body,
+                );
+            }
+            Instruction::L32r { at, .. } => {
+                emit_l32r(hot_bb_local_for(at), LOCAL_L32R, &mut body);
+            }
+            Instruction::Nop => emit_nop(&mut body),
+            _ => unreachable!("hot_bb shape match must reject unknown op"),
+        }
+    }
+
+    // Tail: push the 5-tuple result and close the function.
+    emit_i32_const(EXIT_FALL_THROUGH, &mut body);
+    emit_local_get(LOCAL_A2, &mut body);
+    emit_local_get(LOCAL_A6, &mut body);
+    emit_local_get(LOCAL_A8, &mut body);
+    emit_local_get(LOCAL_A10, &mut body);
+    emit_end(&mut body);
+
+    let f_run = m.add_func(t_run, body);
+    m.add_func_export("run", f_run);
+    m.finish()
 }
 
 /// Does this decoded op sequence match the canonical hot-BB shape?
@@ -426,58 +545,95 @@ fn matches_hot_bb_shape(ops: &[DecodedOp]) -> bool {
         && matches!(ops[7].ins, L32r { at: 8, .. })
 }
 
-// ── Per-opcode emit stubs ─────────────────────────────────────────────
+// ── Per-opcode emit helpers ───────────────────────────────────────────
 //
-// Phase 4.1 keeps the canonical wasm body in `hot_bb.wat`; each per-op
-// emit function below currently delegates to that pre-baked artifact
-// (effectively a no-op for the runtime path). Phase 4.2 will replace
-// these stubs with real wasm-byte emission so `walk_and_emit` can build
-// a block byte stream for any sequence of supported ops, not just the
-// canonical shape.
-//
-// The signatures live here today so the Phase 4.2 wiring is a fill-in
-// rather than a rewrite. Each stub returns a `Result` so a future
-// "unsupported operand" path can plumb through without an API break.
-//
-// NOTE: these are deliberately not exposed via `pub use` until Phase
-// 4.2 fills them in — exposing empty stubs would risk callers binding
-// to incorrect output.
+// Phase 4.2′: real wasm-byte emission per Xtensa opcode supported by the
+// hot block. Each helper takes wasm local indices (not Xtensa register
+// numbers) so the caller — `build_hot_bb_module` — owns the
+// reg→local mapping. Bytes match `HOT_BB_WASM` exactly (parity test).
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_or(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
+/// `or ar, as, at` — `ar = as | at`.
+pub(crate) fn emit_or(ar: u32, as_: u32, at: u32, out: &mut Vec<u8>) {
+    emit_local_get(as_, out);
+    emit_local_get(at, out);
+    emit_i32_or(out);
+    emit_local_set(ar, out);
+}
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+/// `memw` — semantic no-op (memory barrier in the simulator).
 pub(crate) fn emit_memw(_out: &mut Vec<u8>) {}
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
+/// `nop` / `nop.n` — semantic no-op.
 pub(crate) fn emit_nop(_out: &mut Vec<u8>) {}
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_l8ui(_at: u8, _as_: u8, _imm: u32, _out: &mut Vec<u8>) {}
+/// `l8ui at, as, imm` — `at = read_u8(as + imm)`. The host import
+/// returns a negative i32 on bus error; we side-exit early with
+/// `EXIT_HOST_BUS_ERROR` and zeroed-out result locals (matching
+/// `HOT_BB_WASM`).
+pub(crate) fn emit_l8ui(
+    at: u32,
+    as_: u32,
+    imm: u32,
+    read_u8_func: u32,
+    tmp: u32,
+    out: &mut Vec<u8>,
+) {
+    emit_local_get(as_, out);
+    if imm != 0 {
+        emit_i32_const(imm as i32, out);
+        // i32.add
+        out.push(0x6A);
+    }
+    emit_call(read_u8_func, out);
+    emit_local_set(tmp, out);
+    emit_local_get(tmp, out);
+    emit_i32_const(0, out);
+    emit_i32_lt_s(out);
+    emit_if_void(out);
+    emit_i32_const(EXIT_HOST_BUS_ERROR, out);
+    emit_i32_const(0, out);
+    emit_i32_const(0, out);
+    emit_i32_const(0, out);
+    emit_i32_const(0, out);
+    emit_return(out);
+    emit_end(out);
+    emit_local_get(tmp, out);
+    emit_i32_const(0xFF, out);
+    emit_i32_and(out);
+    emit_local_set(at, out);
+}
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_l32r(_at: u8, _literal: u32, _out: &mut Vec<u8>) {}
+/// `l32r at, literal_addr` — pre-resolved literal supplied as a wasm
+/// param. We just copy the param into the destination local.
+pub(crate) fn emit_l32r(at: u32, l32r_param: u32, out: &mut Vec<u8>) {
+    emit_local_get(l32r_param, out);
+    emit_local_set(at, out);
+}
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_extui(_ar: u8, _at: u8, _shift: u8, _bits: u8, _out: &mut Vec<u8>) {}
+/// `extui ar, at, shift, bits` — `ar = (at >> shift) & ((1 << bits) - 1)`.
+pub(crate) fn emit_extui(ar: u32, at: u32, shift: u8, bits: u8, out: &mut Vec<u8>) {
+    emit_local_get(at, out);
+    if shift != 0 {
+        emit_i32_const(shift as i32, out);
+        emit_i32_shr_u(out);
+    }
+    let mask: i32 = if bits >= 32 {
+        -1
+    } else {
+        ((1u32 << bits) - 1) as i32
+    };
+    emit_i32_const(mask, out);
+    emit_i32_and(out);
+    emit_local_set(ar, out);
+}
 
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_and(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
-
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_add(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
-
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_sub(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
-
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_xor(_ar: u8, _as_: u8, _at: u8, _out: &mut Vec<u8>) {}
-
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_addi(_at: u8, _as_: u8, _imm8: i32, _out: &mut Vec<u8>) {}
-
-#[allow(dead_code, reason = "Phase 4.2 stub — fills in real emit logic")]
-pub(crate) fn emit_movi(_at: u8, _imm: i32, _out: &mut Vec<u8>) {}
+/// `and ar, as, at` — `ar = as & at`.
+pub(crate) fn emit_and(ar: u32, as_: u32, at: u32, out: &mut Vec<u8>) {
+    emit_local_get(as_, out);
+    emit_local_get(at, out);
+    emit_i32_and(out);
+    emit_local_set(ar, out);
+}
 
 #[cfg(test)]
 mod tests {
@@ -519,6 +675,83 @@ mod tests {
         let text: Vec<u8> = vec![0x40, 0x13, 0x40];
         let err = walk_and_emit(&text, 0, |pc| Some(pc as usize), PsBits::default()).unwrap_err();
         assert_eq!(err, EmitError::WalkRefused);
+    }
+
+    /// Functional parity: `walk_and_emit` on the canonical hot block
+    /// matches the pre-baked `HOT_BB_WASM` for every input we test. Both
+    /// are instantiated under wasmtime with the same `host.read_u8`
+    /// import (returns `(addr & 0xFF) as i32`) and the 5-tuple results
+    /// are compared byte-for-byte. Gated on `feature = "jit"` because
+    /// the parity check needs wasmtime.
+    #[cfg(feature = "jit")]
+    #[test]
+    fn walk_and_emit_matches_hot_bb_wasm_under_wasmtime() {
+        use crate::cpu::xtensa_jit_bytes::HOT_BB_WASM;
+        use wasmtime::{Engine, Func, Instance, Module, Store, TypedFunc};
+
+        const HOT_BB_BYTES: &[u8] = &[
+            0x50, 0xa5, 0x20, // or    a10, a5, a5
+            0xc0, 0x20, 0x00, // memw
+            0x62, 0x03, 0x00, // l8ui  a6,  a3, 0
+            0xc0, 0x20, 0x00, // memw
+            0x22, 0x03, 0x01, // l8ui  a2,  a3, 1
+            0x20, 0x20, 0x74, // extui a2,  a2, 0, 8
+            0x60, 0x22, 0x10, // and   a2,  a2, a6
+            0x81, 0xd4, 0xf6, // l32r  a8,  0x40080534
+            0xe0, 0x08, 0x00, // callx8 a8 — terminator
+        ];
+        let emitted = walk_and_emit(
+            HOT_BB_BYTES,
+            HOT_BB_PC,
+            |pc| {
+                let off = pc.wrapping_sub(HOT_BB_PC) as usize;
+                if off < HOT_BB_BYTES.len() {
+                    Some(off)
+                } else {
+                    None
+                }
+            },
+            PsBits::default(),
+        )
+        .expect("hot bb emits");
+
+        type Params = (i32, i32, i32);
+        type Returns = (i32, i32, i32, i32, i32);
+
+        fn instantiate(engine: &Engine, bytes: &[u8]) -> (Store<()>, TypedFunc<Params, Returns>) {
+            let module = Module::new(engine, bytes).expect("wasmtime accepts module");
+            let mut store = Store::new(engine, ());
+            // host.read_u8(addr) -> (addr & 0xFF) as i32. Deterministic
+            // and non-negative so the bus-error early-exit path stays
+            // dormant for these inputs.
+            let read_u8 = Func::wrap(&mut store, |addr: i32| -> i32 { (addr as u32 & 0xFF) as i32 });
+            let inst = Instance::new(&mut store, &module, &[read_u8.into()])
+                .expect("instantiate");
+            let run = inst
+                .get_typed_func::<Params, Returns>(&mut store, "run")
+                .expect("run export");
+            (store, run)
+        }
+
+        let engine = Engine::default();
+        let (mut s_ref, run_ref) = instantiate(&engine, HOT_BB_WASM);
+        let (mut s_new, run_new) = instantiate(&engine, &emitted.wasm_bytes);
+
+        let inputs: [(i32, i32, i32); 4] = [
+            (0, 0, 0x40080534),
+            (0xDEADBEEFu32 as i32, 0x12345678, 0x40080534),
+            (-1, -1, 0x40080534),
+            (0x3FFB_0000, 0x1234, 0x40008534u32 as i32),
+        ];
+        for input in inputs {
+            let r_ref = run_ref.call(&mut s_ref, input).expect("ref runs");
+            let r_new = run_new.call(&mut s_new, input).expect("new runs");
+            assert_eq!(
+                r_ref, r_new,
+                "parity mismatch for input {:?}: ref={:?} new={:?}",
+                input, r_ref, r_new
+            );
+        }
     }
 
     /// `SideExitReason::wire_code` round-trips through

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -52,7 +52,7 @@
 
 use crate::cpu::xtensa_jit_bytes::{
     EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
-    HOT_BB_PC,
+    HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT,
 };
 use crate::cpu::xtensa_jit::wasm_emit::{
     emit_call, emit_end, emit_i32_and, emit_i32_const, emit_i32_eqz, emit_i32_lt_s, emit_i32_or,
@@ -353,34 +353,51 @@ pub fn is_supported(ins: &Instruction) -> bool {
 pub fn walk_and_emit<F>(
     bus_slice: &[u8],
     pc: u32,
-    pc_to_offset: F,
+    mut pc_to_offset: F,
     _ps_bits: PsBits,
 ) -> Result<EmittedBlock, EmitError>
 where
     F: FnMut(u32) -> Option<usize>,
 {
-    // Cap the walk at `HOT_BB_INSTR_COUNT + 2` — Phase 4.2′ only emits
-    // the 8-op hot block; budget two slack ops so a shape mismatch
-    // surfaces as UnsupportedShape rather than a silent truncation.
+    // Cap the walk at `HOT_BB_INSTR_COUNT + 2` — covers both currently
+    // supported shapes (8-op hot block + 2-op loopTask prefix that ends
+    // at a BEQZ terminator) with slack so a mismatch surfaces as
+    // UnsupportedShape rather than a silent truncation.
     let max_ops = (HOT_BB_INSTR_COUNT as usize) + 2;
-    let ops = walk_bb(pc, pc_to_offset, bus_slice, max_ops).ok_or(EmitError::WalkRefused)?;
+    let ops = walk_bb(pc, &mut pc_to_offset, bus_slice, max_ops)
+        .ok_or(EmitError::WalkRefused)?;
     if ops.is_empty() {
         return Err(EmitError::BlockTooShort);
     }
 
-    if pc != HOT_BB_PC || !matches_hot_bb_shape(&ops) {
-        return Err(EmitError::UnsupportedShape);
+    if pc == HOT_BB_PC && matches_hot_bb_shape(&ops) {
+        return Ok(EmittedBlock {
+            wasm_bytes: build_hot_bb_module(&ops),
+            length_in_instrs: HOT_BB_INSTR_COUNT,
+            end_pc: HOT_BB_END,
+            side_exit_reasons: vec![
+                (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+                (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
+            ],
+        });
     }
 
-    Ok(EmittedBlock {
-        wasm_bytes: build_hot_bb_module(&ops),
-        length_in_instrs: HOT_BB_INSTR_COUNT,
-        end_pc: HOT_BB_END,
-        side_exit_reasons: vec![
-            (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
-            (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
-        ],
-    })
+    if pc == LOOPTASK_PC {
+        if let Some(prefix) = match_looptask_prefix(&ops, pc, bus_slice, &mut pc_to_offset) {
+            return Ok(EmittedBlock {
+                wasm_bytes: build_looptask_prefix_module(&prefix),
+                length_in_instrs: LOOPTASK_PREFIX_INSTR_COUNT,
+                end_pc: LOOPTASK_PREFIX_END,
+                side_exit_reasons: vec![
+                    (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+                    (EXIT_BRANCH_TAKEN, SideExitReason::BranchTaken),
+                    (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
+                ],
+            });
+        }
+    }
+
+    Err(EmitError::UnsupportedShape)
 }
 
 // ── Hot-BB runtime emit ───────────────────────────────────────────────
@@ -451,6 +468,13 @@ fn build_hot_bb_module(ops: &[DecodedOp]) -> Vec<u8> {
                     imm,
                     f_read_u8,
                     LOCAL_TMP,
+                    |o| {
+                        emit_i32_const(EXIT_HOST_BUS_ERROR, o);
+                        emit_i32_const(0, o);
+                        emit_i32_const(0, o);
+                        emit_i32_const(0, o);
+                        emit_i32_const(0, o);
+                    },
                     &mut body,
                 );
             }
@@ -560,6 +584,175 @@ fn matches_hot_bb_shape(ops: &[DecodedOp]) -> bool {
         && matches!(ops[7].ins, L32r { at: 8, .. })
 }
 
+// ── loopTask prefix shape (Phase 4.3.5) ───────────────────────────────
+//
+// PC `0x400d4a8d`: L32R → L8UI → BEQZ → ... (CALL8 / L32R / BEQZ / J are
+// Phase 4.4+ work). The prefix we JIT is the first three ops, ending at
+// the BEQZ side-exit. Signature (mirrors hot_bb in spirit but is its own
+// ABI — the wasmtime adapter for this shape is Phase 4.4):
+//
+//   inputs:  (l32r_value: i32, l8ui_base: i32)
+//   results: (exit_code, next_pc, l8ui_at, beqz_target_pc_or_zero)
+//
+// `next_pc` is the resume PC for the interpreter: BEQZ target if taken,
+// LOOPTASK_PREFIX_END if fall-through. The fourth slot carries the
+// branch target PC so consumers can sanity-check the recognizer matched
+// the expected branch destination without re-decoding.
+const LOOPTASK_LOCAL_L32R_PARAM: u32 = 0;
+const LOOPTASK_LOCAL_L8UI_BASE_PARAM: u32 = 1;
+const LOOPTASK_LOCAL_L32R_AT: u32 = 2;
+const LOOPTASK_LOCAL_L8UI_AT: u32 = 3;
+const LOOPTASK_LOCAL_TMP: u32 = 4;
+
+/// Decoded loopTask prefix: the three Xtensa ops + the BEQZ terminator's
+/// branch target PC (the PC the interpreter resumes at when taken).
+struct LoopTaskPrefix {
+    /// L32R destination register (Xtensa `at`).
+    l32r_at: u8,
+    /// L8UI destination register (Xtensa `at`).
+    l8ui_at: u8,
+    /// L8UI immediate (byte offset added to `l8ui_base`).
+    l8ui_imm: u32,
+    /// BEQZ branch target PC (absolute).
+    beqz_target_pc: u32,
+}
+
+/// Recognize the loopTask prefix at `start_pc`: two non-terminator ops
+/// `L32R` then `L8UI` (where the L8UI source equals the L32R destination
+/// — the L8UI dereferences the literal we just loaded), followed by a
+/// `BEQZ` terminator on the L8UI result.
+fn match_looptask_prefix<F>(
+    ops: &[DecodedOp],
+    start_pc: u32,
+    bus_slice: &[u8],
+    mut pc_to_offset: F,
+) -> Option<LoopTaskPrefix>
+where
+    F: FnMut(u32) -> Option<usize>,
+{
+    use Instruction::*;
+    if ops.len() < 2 {
+        return None;
+    }
+    let (l32r_at, _l32r_off) = match ops[0].ins {
+        L32r { at, pc_rel_byte_offset } => (at, pc_rel_byte_offset),
+        _ => return None,
+    };
+    let (l8ui_at, l8ui_as, l8ui_imm) = match ops[1].ins {
+        L8ui { at, as_, imm } => (at, as_, imm),
+        _ => return None,
+    };
+    // The L8UI's base register must be the register the L32R wrote (the
+    // loaded literal IS the pointer the L8UI dereferences).
+    if l8ui_as != l32r_at {
+        return None;
+    }
+    // Peek at the terminator immediately after ops[1] — `walk_bb`
+    // excludes terminators from its result. The BEQZ at this PC tests
+    // the value the L8UI just produced.
+    let after_l8ui_pc = ops[1].pc.wrapping_add(ops[1].len);
+    let off = pc_to_offset(after_l8ui_pc)?;
+    if off + 3 > bus_slice.len() {
+        return None;
+    }
+    let w = u32::from_le_bytes([
+        bus_slice[off],
+        bus_slice[off + 1],
+        bus_slice[off + 2],
+        0,
+    ]);
+    let term = xtensa::decode(w);
+    let (beqz_as, beqz_offset) = match term {
+        Beqz { as_, offset } => (as_, offset),
+        _ => return None,
+    };
+    if beqz_as != l8ui_at {
+        return None;
+    }
+    let beqz_target_pc = after_l8ui_pc.wrapping_add(beqz_offset as u32);
+    // Sanity: the recognized PC range must equal the documented prefix
+    // length (so consumers can use LOOPTASK_PREFIX_END without slicing
+    // the actual ops vector at the call site).
+    if after_l8ui_pc.wrapping_add(3).wrapping_sub(start_pc) != LOOPTASK_PREFIX_INSTR_COUNT * 3 {
+        return None;
+    }
+    Some(LoopTaskPrefix {
+        l32r_at,
+        l8ui_at,
+        l8ui_imm,
+        beqz_target_pc,
+    })
+}
+
+/// Build the wasm module for the loopTask prefix. Uses the runtime emit
+/// primitives (`emit_l32r`, `emit_l8ui`, `emit_beqz`) — the Phase 4.3
+/// branch primitive is now exercised in-line by this builder.
+fn build_looptask_prefix_module(prefix: &LoopTaskPrefix) -> Vec<u8> {
+    let mut m = WasmModule::new();
+    let t_read_u8 = m.add_type(FuncType {
+        params: vec![ValType::I32],
+        results: vec![ValType::I32],
+    });
+    let t_run = m.add_type(FuncType {
+        params: vec![ValType::I32, ValType::I32],
+        results: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+    });
+    let f_read_u8 = m.add_func_import("host", "read_u8", t_read_u8);
+
+    let mut body = Vec::with_capacity(64);
+    // Locals: 3 × i32 (l32r_at, l8ui_at, tmp). Params 0,1 already account
+    // for the two inputs; locals start at index 2.
+    encode_u32(1, &mut body);
+    emit_locals_run(3, ValType::I32, &mut body);
+
+    // L32R: at_local = l32r_param.
+    emit_l32r(LOOPTASK_LOCAL_L32R_AT, LOOPTASK_LOCAL_L32R_PARAM, &mut body);
+    let _ = prefix.l32r_at; // shape-bound, not needed for emit
+    // L8UI: at_local = read_u8(base_param + imm). Bus-error early-exit
+    // pushes the 4-tuple result (vs HOT_BB's 5-tuple).
+    emit_l8ui(
+        LOOPTASK_LOCAL_L8UI_AT,
+        LOOPTASK_LOCAL_L8UI_BASE_PARAM,
+        prefix.l8ui_imm,
+        f_read_u8,
+        LOOPTASK_LOCAL_TMP,
+        |o| {
+            emit_i32_const(EXIT_HOST_BUS_ERROR, o);
+            emit_i32_const(0, o);
+            emit_i32_const(0, o);
+            emit_i32_const(0, o);
+        },
+        &mut body,
+    );
+    let _ = prefix.l8ui_at;
+
+    // BEQZ on l8ui_at: taken → (EXIT_BRANCH_TAKEN, beqz_target_pc,
+    // l8ui_at, beqz_target_pc); not taken → fall through to epilogue.
+    let target = prefix.beqz_target_pc;
+    emit_beqz(
+        LOOPTASK_LOCAL_L8UI_AT,
+        |o| {
+            emit_i32_const(EXIT_BRANCH_TAKEN, o);
+            emit_i32_const(target as i32, o);
+            emit_local_get(LOOPTASK_LOCAL_L8UI_AT, o);
+            emit_i32_const(target as i32, o);
+        },
+        &mut body,
+    );
+
+    // Fall-through epilogue: (EXIT_FALL_THROUGH, LOOPTASK_PREFIX_END,
+    // l8ui_at, beqz_target_pc).
+    emit_i32_const(EXIT_FALL_THROUGH, &mut body);
+    emit_i32_const(LOOPTASK_PREFIX_END as i32, &mut body);
+    emit_local_get(LOOPTASK_LOCAL_L8UI_AT, &mut body);
+    emit_i32_const(target as i32, &mut body);
+    emit_end(&mut body);
+
+    let f_run = m.add_func(t_run, body);
+    m.add_func_export("run", f_run);
+    m.finish()
+}
+
 // ── Per-opcode emit helpers ───────────────────────────────────────────
 //
 // Phase 4.2′: real wasm-byte emission per Xtensa opcode supported by the
@@ -582,17 +775,21 @@ pub(crate) fn emit_memw(_out: &mut Vec<u8>) {}
 pub(crate) fn emit_nop(_out: &mut Vec<u8>) {}
 
 /// `l8ui at, as, imm` — `at = read_u8(as + imm)`. The host import
-/// returns a negative i32 on bus error; we side-exit early with
-/// `EXIT_HOST_BUS_ERROR` and zeroed-out result locals (matching
-/// `HOT_BB_WASM`).
-pub(crate) fn emit_l8ui(
+/// returns a negative i32 on bus error; we side-exit early via the
+/// caller-supplied `bus_error_exit_body` closure (which pushes the
+/// full result tuple — shape depends on the BB's signature — then
+/// `return` is emitted by us).
+pub(crate) fn emit_l8ui<F>(
     at: u32,
     as_: u32,
     imm: u32,
     read_u8_func: u32,
     tmp: u32,
+    bus_error_exit_body: F,
     out: &mut Vec<u8>,
-) {
+) where
+    F: FnOnce(&mut Vec<u8>),
+{
     emit_local_get(as_, out);
     if imm != 0 {
         emit_i32_const(imm as i32, out);
@@ -605,11 +802,7 @@ pub(crate) fn emit_l8ui(
     emit_i32_const(0, out);
     emit_i32_lt_s(out);
     emit_if_void(out);
-    emit_i32_const(EXIT_HOST_BUS_ERROR, out);
-    emit_i32_const(0, out);
-    emit_i32_const(0, out);
-    emit_i32_const(0, out);
-    emit_i32_const(0, out);
+    bus_error_exit_body(out);
     emit_return(out);
     emit_end(out);
     emit_local_get(tmp, out);
@@ -688,11 +881,6 @@ pub(crate) fn emit_and(ar: u32, as_: u32, at: u32, out: &mut Vec<u8>) {
 /// fall-through path (which, for a BB-final BEQZ, is the function's
 /// own epilogue that returns `EXIT_FALL_THROUGH` with the
 /// post-branch-not-taken PC).
-#[allow(
-    dead_code,
-    reason = "Phase 4.3 primitive — wired in by Phase 4.3.5 BB shape recognizer; \
-              exercised today only by the `feature = jit` lockstep tests."
-)]
 pub(crate) fn emit_beqz<F>(as_local: u32, taken_exit_body: F, out: &mut Vec<u8>)
 where
     F: FnOnce(&mut Vec<u8>),
@@ -1077,6 +1265,131 @@ mod tests {
 
     /// Wire codes for the three currently-known side-exit reasons are
     /// disjoint and round-trip through `SideExitReason::wire_code`.
+    // ── Phase 4.3.5 loopTask prefix dispatch tests ───────────────────
+    //
+    // Synthesized byte sequence for `L32R a2, ... ; L8UI a3, a2, 0 ;
+    // BEQZ a3, +12 ; CALL8`. Constructed from the Xtensa encoding tables
+    // (decode_l32r / decode_lsai / decode_si / decode_calln) so the
+    // bytes round-trip back through the decoder unchanged.
+    //
+    //   L32R  word = 0x_FFFF_21 → bytes 0x21,0xFF,0xFF  (at=2, raw imm16=0xFFFF)
+    //   L8UI  word = 0x_00_03_32 → bytes 0x32,0x03,0x00  (at=3, as=2, imm=0)
+    //   BEQZ  word = 0x_00_83_16 → bytes 0x16,0x83,0x00  (as=3, imm12=8 → offset 12)
+    //   CALL8 word = 0x_00_00_25 → bytes 0x25,0x00,0x00  (terminator)
+    #[cfg(feature = "jit")]
+    const LOOPTASK_PREFIX_BYTES: &[u8] = &[
+        0x21, 0xFF, 0xFF, // L32R a2, ...
+        0x32, 0x02, 0x00, // L8UI a3, a2, 0
+        0x16, 0x83, 0x00, // BEQZ a3, +12
+        0x25, 0x00, 0x00, // CALL8 ... (terminator at end of recognized prefix)
+    ];
+
+    /// End-to-end: `walk_and_emit` at `LOOPTASK_PC` recognizes the
+    /// L32R → L8UI → BEQZ prefix, builds a runnable wasm module, and
+    /// the taken/not-taken paths produce the right `(exit, next_pc)`.
+    #[cfg(feature = "jit")]
+    #[test]
+    fn walk_and_emit_compiles_looptask_prefix_end_to_end() {
+        use crate::cpu::xtensa_jit_bytes::{LOOPTASK_PC, LOOPTASK_PREFIX_END};
+        use wasmtime::{Engine, Func, Instance, Module, Store};
+
+        let emitted = walk_and_emit(
+            LOOPTASK_PREFIX_BYTES,
+            LOOPTASK_PC,
+            |pc| {
+                let off = pc.wrapping_sub(LOOPTASK_PC) as usize;
+                if off < LOOPTASK_PREFIX_BYTES.len() {
+                    Some(off)
+                } else {
+                    None
+                }
+            },
+            PsBits::default(),
+        )
+        .expect("loopTask prefix emits");
+        assert_eq!(emitted.length_in_instrs, LOOPTASK_PREFIX_INSTR_COUNT);
+        assert_eq!(emitted.end_pc, LOOPTASK_PREFIX_END);
+        assert_eq!(
+            emitted.reason_for(EXIT_BRANCH_TAKEN),
+            Some(SideExitReason::BranchTaken)
+        );
+
+        type Params = (i32, i32);
+        type Returns = (i32, i32, i32, i32);
+
+        let engine = Engine::default();
+        let module = Module::new(&engine, &emitted.wasm_bytes).expect("module compiles");
+        let mut store: Store<u32> = Store::new(&engine, 0);
+        // host.read_u8: return the value stored in the Store's `data`
+        // so the test can drive the BEQZ both ways.
+        let read_u8 = Func::wrap(&mut store, |caller: wasmtime::Caller<'_, u32>, _addr: i32| -> i32 {
+            *caller.data() as i32
+        });
+        let inst = Instance::new(&mut store, &module, &[read_u8.into()]).expect("instantiate");
+        let run = inst
+            .get_typed_func::<Params, Returns>(&mut store, "run")
+            .expect("run export");
+
+        // L8UI returns 0 → BEQZ taken → exit=BRANCH_TAKEN, next_pc=target.
+        let beqz_target = LOOPTASK_PC + 3 + 3 + 12; // after_l8ui_pc(=PC+6) + offset(=12)
+        *store.data_mut() = 0;
+        let (exit, next_pc, at_l8ui, target) =
+            run.call(&mut store, (0x4008_0534u32 as i32, 0x3FFB_0000u32 as i32))
+                .expect("call ok");
+        assert_eq!(exit, EXIT_BRANCH_TAKEN, "L8UI=0 → BEQZ taken");
+        assert_eq!(next_pc as u32, beqz_target);
+        assert_eq!(at_l8ui, 0);
+        assert_eq!(target as u32, beqz_target);
+
+        // L8UI returns non-zero → BEQZ falls through.
+        *store.data_mut() = 0x7A;
+        let (exit, next_pc, at_l8ui, _target) =
+            run.call(&mut store, (0x4008_0534u32 as i32, 0x3FFB_0000u32 as i32))
+                .expect("call ok");
+        assert_eq!(exit, EXIT_FALL_THROUGH, "L8UI=0x7A → BEQZ not taken");
+        assert_eq!(next_pc as u32, LOOPTASK_PREFIX_END);
+        assert_eq!(at_l8ui, 0x7A);
+
+        // Host bus error short-circuits with EXIT_HOST_BUS_ERROR.
+        *store.data_mut() = 0xFFFF_FFFF; // returned as -1 → < 0 → bus error
+        let (exit, _next_pc, _at, _t) =
+            run.call(&mut store, (0, 0)).expect("call ok");
+        assert_eq!(exit, EXIT_HOST_BUS_ERROR);
+    }
+
+    /// `walk_and_emit` side-exits cleanly when the terminator is an
+    /// unsupported branch shape (CALL8 instead of BEQZ at the right
+    /// position). The walker stops at CALL8 (terminator excluded from
+    /// `walk_bb`'s output), the shape recognizer rejects the
+    /// `[L32R, L8UI]` head without a recognized branch, and the result
+    /// is `UnsupportedShape` — the JIT cache caller falls back to
+    /// interpreter at the CALL8 boundary.
+    #[test]
+    fn walk_and_emit_side_exits_at_unsupported_terminator() {
+        // L32R a2, ... ; L8UI a3, a2, 0 ; CALL8 ... — no BEQZ between
+        // L8UI and CALL8, so the loopTask prefix recognizer rejects.
+        let text: &[u8] = &[
+            0x21, 0xFF, 0xFF, // L32R a2
+            0x32, 0x02, 0x00, // L8UI a3, a2, 0
+            0x25, 0x00, 0x00, // CALL8 (terminator)
+        ];
+        let err = walk_and_emit(
+            text,
+            crate::cpu::xtensa_jit_bytes::LOOPTASK_PC,
+            |pc| {
+                let off = pc.wrapping_sub(crate::cpu::xtensa_jit_bytes::LOOPTASK_PC) as usize;
+                if off < text.len() {
+                    Some(off)
+                } else {
+                    None
+                }
+            },
+            PsBits::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err, EmitError::UnsupportedShape);
+    }
+
     #[test]
     fn side_exit_wire_codes_are_disjoint() {
         let reasons = [

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -52,7 +52,8 @@
 
 use crate::cpu::xtensa_jit_bytes::{
     EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
-    HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT,
+    HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT, LOOPTASK_TAIL_END,
+    LOOPTASK_TAIL_INSTR_COUNT, LOOPTASK_TAIL_PC,
 };
 use crate::cpu::xtensa_jit::wasm_emit::{
     emit_call, emit_end, emit_i32_and, emit_i32_const, emit_i32_eqz, emit_i32_lt_s, emit_i32_or,
@@ -136,6 +137,34 @@ pub enum BlockShape {
         /// `mem32[((PC+3) & ~3) + pc_rel_byte_offset]` at compile time.
         /// Constant-folded — the literal pool is immutable.
         l32r_literal_value: u32,
+        /// BEQZ branch target PC (Phase 4.4): added so the Rust
+        /// short-circuit fast-path in the browser dispatcher can route
+        /// to the right PC without re-decoding the BEQZ immediate.
+        /// The wasm body still carries it as a constant; this field
+        /// surfaces it to callers that bypass wasm.
+        beqz_target_pc: u32,
+    },
+    /// loopTask tail at [`LOOPTASK_TAIL_PC`] — `L32R → BEQZ`. The BEQZ
+    /// tests the L32R-loaded literal directly (no L8UI in between), so
+    /// both the L32R literal AND the BEQZ direction are constant-folded
+    /// at compile time. The wasm body is a single fixed return tuple.
+    ///
+    /// Signature: `() -> (exit, next_pc, l32r_at_value)`. The Xtensa
+    /// `at` register for L32R is in the shape descriptor; the dispatcher
+    /// commits `l32r_at_value` into it after the call.
+    LoopTaskTail {
+        /// L32R destination register (Xtensa AR index, 0..=15).
+        l32r_at: u8,
+        /// Pre-resolved L32R literal value (constant-folded).
+        l32r_literal_value: u32,
+        /// BEQZ target PC (where execution resumes if BEQZ is taken —
+        /// i.e. if the literal is zero).
+        beqz_target_pc: u32,
+        /// Whether the BEQZ is statically taken (literal == 0). True
+        /// means the wasm body always returns
+        /// `(EXIT_BRANCH_TAKEN, beqz_target_pc, 0)`; false means
+        /// `(EXIT_FALL_THROUGH, LOOPTASK_TAIL_END, l32r_literal_value)`.
+        statically_taken: bool,
     },
 }
 
@@ -438,6 +467,7 @@ where
                 l8ui_at: prefix.l8ui_at,
                 l8ui_base_at: prefix.l8ui_base_at,
                 l32r_literal_value: prefix.l32r_literal_value,
+                beqz_target_pc: prefix.beqz_target_pc,
             };
             return Ok(EmittedBlock {
                 wasm_bytes: build_looptask_prefix_module(&prefix),
@@ -447,6 +477,28 @@ where
                     (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
                     (EXIT_BRANCH_TAKEN, SideExitReason::BranchTaken),
                     (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
+                ],
+                shape,
+            });
+        }
+    }
+
+    if pc == LOOPTASK_TAIL_PC {
+        if let Some(tail) = match_looptask_tail(&ops, pc, bus_slice, &mut pc_to_offset) {
+            let statically_taken = tail.l32r_literal_value == 0;
+            let shape = BlockShape::LoopTaskTail {
+                l32r_at: tail.l32r_at,
+                l32r_literal_value: tail.l32r_literal_value,
+                beqz_target_pc: tail.beqz_target_pc,
+                statically_taken,
+            };
+            return Ok(EmittedBlock {
+                wasm_bytes: build_looptask_tail_module(&tail, statically_taken),
+                length_in_instrs: LOOPTASK_TAIL_INSTR_COUNT,
+                end_pc: LOOPTASK_TAIL_END,
+                side_exit_reasons: vec![
+                    (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+                    (EXIT_BRANCH_TAKEN, SideExitReason::BranchTaken),
                 ],
                 shape,
             });
@@ -830,6 +882,140 @@ fn build_looptask_prefix_module(prefix: &LoopTaskPrefix) -> Vec<u8> {
     emit_i32_const(LOOPTASK_PREFIX_END as i32, &mut body);
     emit_local_get(LOOPTASK_LOCAL_L8UI_AT, &mut body);
     emit_i32_const(target as i32, &mut body);
+    emit_end(&mut body);
+
+    let f_run = m.add_func(t_run, body);
+    m.add_func_export("run", f_run);
+    m.finish()
+}
+
+// ── loopTask tail shape (Phase 4.4) ───────────────────────────────────
+//
+// PC `0x400d4a9c`: `L32R → BEQZ` immediately following the `CALL8 _Z4loopv`
+// return. Two ops, both constant-folded at compile time:
+//   * L32R writes a known literal value (literal pool is immutable).
+//   * BEQZ tests that literal directly — the branch direction is therefore
+//     statically known. We emit a wasm body that always returns the same
+//     constant tuple.
+//
+// Signature: `() -> (exit_code, next_pc, l32r_at_value)`. The L32R `at`
+// register is in the shape descriptor — the dispatcher commits
+// `l32r_at_value` after the call.
+
+/// Decoded loopTask tail.
+struct LoopTaskTail {
+    /// L32R destination register (Xtensa `at`).
+    l32r_at: u8,
+    /// BEQZ branch target PC (absolute).
+    beqz_target_pc: u32,
+    /// Pre-resolved L32R literal value (constant-folded).
+    l32r_literal_value: u32,
+}
+
+/// Recognize the loopTask tail at `start_pc`: one non-terminator op
+/// `L32R` followed by a `BEQZ` terminator that tests the same register
+/// the L32R wrote. (The block deliberately rejects an L8UI in between —
+/// that's the [`match_looptask_prefix`] shape, not this one.)
+fn match_looptask_tail<F>(
+    ops: &[DecodedOp],
+    start_pc: u32,
+    bus_slice: &[u8],
+    mut pc_to_offset: F,
+) -> Option<LoopTaskTail>
+where
+    F: FnMut(u32) -> Option<usize>,
+{
+    use Instruction::*;
+    if ops.len() != 1 {
+        return None;
+    }
+    let (l32r_at, l32r_off) = match ops[0].ins {
+        L32r {
+            at,
+            pc_rel_byte_offset,
+        } => (at, pc_rel_byte_offset),
+        _ => return None,
+    };
+    // Constant-fold the literal pool load (same EA arithmetic as
+    // `match_looptask_prefix`).
+    let l32r_base = (ops[0].pc.wrapping_add(3)) & !3u32;
+    let l32r_ea = l32r_base.wrapping_add(l32r_off as u32);
+    let l32r_off_in_slice = pc_to_offset(l32r_ea)?;
+    if l32r_off_in_slice + 4 > bus_slice.len() {
+        return None;
+    }
+    let l32r_literal_value = u32::from_le_bytes([
+        bus_slice[l32r_off_in_slice],
+        bus_slice[l32r_off_in_slice + 1],
+        bus_slice[l32r_off_in_slice + 2],
+        bus_slice[l32r_off_in_slice + 3],
+    ]);
+    // Peek the BEQZ terminator immediately after the L32R.
+    let after_l32r_pc = ops[0].pc.wrapping_add(ops[0].len);
+    let off = pc_to_offset(after_l32r_pc)?;
+    if off + 3 > bus_slice.len() {
+        return None;
+    }
+    let w = u32::from_le_bytes([bus_slice[off], bus_slice[off + 1], bus_slice[off + 2], 0]);
+    let term = xtensa::decode(w);
+    let (beqz_as, beqz_offset) = match term {
+        Beqz { as_, offset } => (as_, offset),
+        _ => return None,
+    };
+    if beqz_as != l32r_at {
+        return None;
+    }
+    let beqz_target_pc = after_l32r_pc.wrapping_add(beqz_offset as u32);
+    // Sanity: recognized range = exactly one 3-byte L32R + one 3-byte
+    // BEQZ (the BEQZ is excluded from `ops` but its bytes are after
+    // `start_pc + 3`).
+    if after_l32r_pc.wrapping_add(3).wrapping_sub(start_pc) != LOOPTASK_TAIL_INSTR_COUNT * 3 {
+        return None;
+    }
+    Some(LoopTaskTail {
+        l32r_at,
+        beqz_target_pc,
+        l32r_literal_value,
+    })
+}
+
+/// Build the loopTask-tail wasm module. Both halves of the BEQZ are
+/// statically resolved against the pre-folded L32R literal at compile
+/// time, so the wasm body is a fixed return tuple — but the direction
+/// captured in `statically_taken` was decided by the compile-time
+/// canonical fixture, not the live bus. The runtime dispatcher
+/// re-decides BEQZ direction against the AR file write (it has the
+/// fresh literal in hand), then picks the right exit path; the wasm
+/// body's role is therefore minimal: push the three constants the
+/// dispatcher pre-baked.
+///
+/// Why still ship a wasm body if everything is constant? Two reasons:
+///   * Uniform cache shape — the dispatcher loop has one code path that
+///     calls `block.run_*()` for any JIT-installed block.
+///   * Phase 4.5 (multi-block) will likely want this slot to carry
+///     non-trivial work; keeping the wasm path live now means the
+///     install + invoke plumbing is already shaken out.
+fn build_looptask_tail_module(tail: &LoopTaskTail, statically_taken: bool) -> Vec<u8> {
+    let mut m = WasmModule::new();
+    let t_run = m.add_type(FuncType {
+        params: vec![],
+        results: vec![ValType::I32, ValType::I32, ValType::I32],
+    });
+
+    let mut body = Vec::with_capacity(16);
+    // No locals.
+    encode_u32(0, &mut body);
+    if statically_taken {
+        // BEQZ taken: (EXIT_BRANCH_TAKEN, beqz_target_pc, 0).
+        emit_i32_const(EXIT_BRANCH_TAKEN, &mut body);
+        emit_i32_const(tail.beqz_target_pc as i32, &mut body);
+        emit_i32_const(0, &mut body);
+    } else {
+        // BEQZ not taken: (EXIT_FALL_THROUGH, LOOPTASK_TAIL_END, literal).
+        emit_i32_const(EXIT_FALL_THROUGH, &mut body);
+        emit_i32_const(LOOPTASK_TAIL_END as i32, &mut body);
+        emit_i32_const(tail.l32r_literal_value as i32, &mut body);
+    }
     emit_end(&mut body);
 
     let f_run = m.add_func(t_run, body);

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -115,11 +115,27 @@ pub enum BlockShape {
     /// beqz_target_pc)`. The Xtensa `at` registers for L32R and L8UI
     /// are carried in the shape descriptor so backends can commit the
     /// right logical registers without re-decoding.
+    ///
+    /// The L32R literal pool value is resolved at `walk_and_emit` time
+    /// (the pool lives in immutable flash/IRAM, so constant-folding the
+    /// load is safe and saves a per-call bus dispatch). The dispatcher
+    /// passes `l32r_literal_value` directly to the wasm body as the
+    /// `l32r_val` param AND writes it into `l32r_dst_ar` after the
+    /// call — the wasm body doesn't pass the literal back in its
+    /// result tuple.
     LoopTaskPrefix {
-        /// L32R destination register (Xtensa `at`).
+        /// L32R destination register (Xtensa AR index, 0..=15).
         l32r_at: u8,
-        /// L8UI destination register (Xtensa `at`).
+        /// L8UI destination register (Xtensa AR index, 0..=15).
         l8ui_at: u8,
+        /// L8UI base register (Xtensa AR index, 0..=15). The dispatcher
+        /// reads this register's current value and passes it as the
+        /// `l8ui_base` wasm param.
+        l8ui_base_at: u8,
+        /// Pre-resolved L32R literal value, read from
+        /// `mem32[((PC+3) & ~3) + pc_rel_byte_offset]` at compile time.
+        /// Constant-folded — the literal pool is immutable.
+        l32r_literal_value: u32,
     },
 }
 
@@ -420,6 +436,8 @@ where
             let shape = BlockShape::LoopTaskPrefix {
                 l32r_at: prefix.l32r_at,
                 l8ui_at: prefix.l8ui_at,
+                l8ui_base_at: prefix.l8ui_base_at,
+                l32r_literal_value: prefix.l32r_literal_value,
             };
             return Ok(EmittedBlock {
                 wasm_bytes: build_looptask_prefix_module(&prefix),
@@ -649,10 +667,17 @@ struct LoopTaskPrefix {
     l32r_at: u8,
     /// L8UI destination register (Xtensa `at`).
     l8ui_at: u8,
+    /// L8UI base register (Xtensa AR — same as `l32r_at` per the shape
+    /// invariant, but carried separately so the dispatcher doesn't
+    /// have to know the invariant).
+    l8ui_base_at: u8,
     /// L8UI immediate (byte offset added to `l8ui_base`).
     l8ui_imm: u32,
     /// BEQZ branch target PC (absolute).
     beqz_target_pc: u32,
+    /// Pre-resolved L32R literal value, read from
+    /// `mem32[((PC+3) & ~3) + pc_rel_byte_offset]` at walk time.
+    l32r_literal_value: u32,
 }
 
 /// Recognize the loopTask prefix at `start_pc`: two non-terminator ops
@@ -672,7 +697,7 @@ where
     if ops.len() < 2 {
         return None;
     }
-    let (l32r_at, _l32r_off) = match ops[0].ins {
+    let (l32r_at, l32r_off) = match ops[0].ins {
         L32r { at, pc_rel_byte_offset } => (at, pc_rel_byte_offset),
         _ => return None,
     };
@@ -685,6 +710,25 @@ where
     if l8ui_as != l32r_at {
         return None;
     }
+    // Resolve the L32R literal at walk time: EA = ((pc+3) & !3) +
+    // pc_rel_byte_offset, then read 4 bytes (little-endian) out of the
+    // bus slice. The literal pool is immutable for our purposes; we
+    // constant-fold the load so the JIT'd block doesn't pay a per-call
+    // bus dispatch on a known-static value. If the EA falls outside
+    // `bus_slice`, refuse the shape — the dispatcher will fall back
+    // to the interpreter, which can talk to the live bus.
+    let l32r_base = (ops[0].pc.wrapping_add(3)) & !3u32;
+    let l32r_ea = l32r_base.wrapping_add(l32r_off as u32);
+    let l32r_off_in_slice = pc_to_offset(l32r_ea)?;
+    if l32r_off_in_slice + 4 > bus_slice.len() {
+        return None;
+    }
+    let l32r_literal_value = u32::from_le_bytes([
+        bus_slice[l32r_off_in_slice],
+        bus_slice[l32r_off_in_slice + 1],
+        bus_slice[l32r_off_in_slice + 2],
+        bus_slice[l32r_off_in_slice + 3],
+    ]);
     // Peek at the terminator immediately after ops[1] — `walk_bb`
     // excludes terminators from its result. The BEQZ at this PC tests
     // the value the L8UI just produced.
@@ -717,8 +761,10 @@ where
     Some(LoopTaskPrefix {
         l32r_at,
         l8ui_at,
+        l8ui_base_at: l8ui_as,
         l8ui_imm,
         beqz_target_pc,
+        l32r_literal_value,
     })
 }
 
@@ -1311,13 +1357,17 @@ mod tests {
     // (decode_l32r / decode_lsai / decode_si / decode_calln) so the
     // bytes round-trip back through the decoder unchanged.
     //
-    //   L32R  word = 0x_FFFF_21 → bytes 0x21,0xFF,0xFF  (at=2, raw imm16=0xFFFF)
+    //   L32R  word = 0x_FFFE_21 → bytes 0x21,0xFE,0xFF  (at=2, raw imm16=0xFFFE → EA = PC-5)
     //   L8UI  word = 0x_00_03_32 → bytes 0x32,0x03,0x00  (at=3, as=2, imm=0)
     //   BEQZ  word = 0x_00_83_16 → bytes 0x16,0x83,0x00  (as=3, imm12=8 → offset 12)
     //   CALL8 word = 0x_00_00_25 → bytes 0x25,0x00,0x00  (terminator)
+    //
+    // imm16 chosen as 0xFFFE (not 0xFFFF) so the L32R EA points at
+    // PC-5 — leaving a 1-byte gap before the L32R instruction's own
+    // bytes, avoiding overlap with the synthetic literal pool.
     #[cfg(feature = "jit")]
     const LOOPTASK_PREFIX_BYTES: &[u8] = &[
-        0x21, 0xFF, 0xFF, // L32R a2, ...
+        0x21, 0xFE, 0xFF, // L32R a2, ... (EA = PC-5)
         0x32, 0x02, 0x00, // L8UI a3, a2, 0
         0x16, 0x83, 0x00, // BEQZ a3, +12
         0x25, 0x00, 0x00, // CALL8 ... (terminator at end of recognized prefix)
@@ -1332,12 +1382,23 @@ mod tests {
         use crate::cpu::xtensa_jit_bytes::{LOOPTASK_PC, LOOPTASK_PREFIX_END};
         use wasmtime::{Engine, Func, Instance, Module, Store};
 
+        // L32R imm16=0xFFFE resolves to EA=PC-5, so prefix the slice
+        // with 4 bytes of literal pool + 1 byte gap BELOW the
+        // instruction stream. Phase 4.3.7 wire-up: `walk_and_emit` now
+        // constant-folds this literal at compile time.
+        const LITERAL_POOL_VALUE: u32 = 0x4008_0534;
+        let lit = LITERAL_POOL_VALUE.to_le_bytes();
+        let mut bus_slice: Vec<u8> = lit.to_vec();
+        bus_slice.push(0); // 1-byte gap at PC-1 (not read)
+        bus_slice.extend_from_slice(LOOPTASK_PREFIX_BYTES);
+        let slice_base_pc = LOOPTASK_PC.wrapping_sub(5);
+
         let emitted = walk_and_emit(
-            LOOPTASK_PREFIX_BYTES,
+            &bus_slice,
             LOOPTASK_PC,
             |pc| {
-                let off = pc.wrapping_sub(LOOPTASK_PC) as usize;
-                if off < LOOPTASK_PREFIX_BYTES.len() {
+                let off = pc.wrapping_sub(slice_base_pc) as usize;
+                if off < bus_slice.len() {
                     Some(off)
                 } else {
                     None
@@ -1407,8 +1468,11 @@ mod tests {
     fn walk_and_emit_side_exits_at_unsupported_terminator() {
         // L32R a2, ... ; L8UI a3, a2, 0 ; CALL8 ... — no BEQZ between
         // L8UI and CALL8, so the loopTask prefix recognizer rejects.
+        // (imm16=0xFFFE matches the canonical fixture; the L32R EA
+        // resolution will fail anyway because this test doesn't
+        // populate a literal pool — the recognizer refuses cleanly.)
         let text: &[u8] = &[
-            0x21, 0xFF, 0xFF, // L32R a2
+            0x21, 0xFE, 0xFF, // L32R a2 (EA = PC-5; unmapped in this slice)
             0x32, 0x02, 0x00, // L8UI a3, a2, 0
             0x25, 0x00, 0x00, // CALL8 (terminator)
         ];

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -95,6 +95,34 @@ impl SideExitReason {
     }
 }
 
+/// Which JIT'd BB shape an [`EmittedBlock`] was built for.
+///
+/// Each shape pairs a wasm signature (param + result tuple shape) with
+/// a register/PC marshalling convention. Backend adapters (wasmtime in
+/// `bb_multi`, `js_sys` in `jit_browser`) branch on this to decode the
+/// result tuple correctly and commit register writes.
+///
+/// Adding a new shape is the canonical extension point: a new
+/// `walk_and_emit` arm produces an [`EmittedBlock`] tagged with the
+/// new variant, and each backend grows one new dispatch arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockShape {
+    /// Canonical hot block at [`HOT_BB_PC`] (call_start_cpu0 delay loop).
+    /// Signature: `(a3, a5, l32r) -> (exit, a2, a6, a8, a10)`.
+    HotBbCanonical,
+    /// loopTask prefix at [`LOOPTASK_PC`] — `L32R → L8UI → BEQZ`.
+    /// Signature: `(l32r_val, l8ui_base) -> (exit, next_pc, l8ui_at,
+    /// beqz_target_pc)`. The Xtensa `at` registers for L32R and L8UI
+    /// are carried in the shape descriptor so backends can commit the
+    /// right logical registers without re-decoding.
+    LoopTaskPrefix {
+        /// L32R destination register (Xtensa `at`).
+        l32r_at: u8,
+        /// L8UI destination register (Xtensa `at`).
+        l8ui_at: u8,
+    },
+}
+
 /// Failure reasons from [`walk_and_emit`]. None of these are bugs — they
 /// just mean "this PC isn't JIT-able yet"; the caller falls back to the
 /// interpreter and the BB walks back through the regular dispatch path.
@@ -172,6 +200,10 @@ pub struct EmittedBlock {
     /// reason. Backends use this to map a returned i32 to "commit
     /// state" vs "refuse + fall back to interp".
     pub side_exit_reasons: Vec<(i32, SideExitReason)>,
+    /// Which JIT'd BB shape this block was emitted for. Backends
+    /// (wasmtime / js_sys) branch on this to pick the right param +
+    /// result-tuple decoding ABI.
+    pub shape: BlockShape,
 }
 
 impl EmittedBlock {
@@ -379,11 +411,16 @@ where
                 (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
                 (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
             ],
+            shape: BlockShape::HotBbCanonical,
         });
     }
 
     if pc == LOOPTASK_PC {
         if let Some(prefix) = match_looptask_prefix(&ops, pc, bus_slice, &mut pc_to_offset) {
+            let shape = BlockShape::LoopTaskPrefix {
+                l32r_at: prefix.l32r_at,
+                l8ui_at: prefix.l8ui_at,
+            };
             return Ok(EmittedBlock {
                 wasm_bytes: build_looptask_prefix_module(&prefix),
                 length_in_instrs: LOOPTASK_PREFIX_INSTR_COUNT,
@@ -393,6 +430,7 @@ where
                     (EXIT_BRANCH_TAKEN, SideExitReason::BranchTaken),
                     (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
                 ],
+                shape,
             });
         }
     }
@@ -1247,6 +1285,7 @@ mod tests {
                 (EXIT_BRANCH_TAKEN, SideExitReason::BranchTaken),
                 (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
             ],
+            shape: BlockShape::HotBbCanonical,
         };
         assert_eq!(
             block.reason_for(EXIT_FALL_THROUGH),

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -29,25 +29,35 @@
 //! walks the bus to decode the BB, and returns the bytes both backends
 //! consume.
 //!
-//! ## Current emit scope (4.2′)
+//! ## Current emit scope (4.2′ + 4.3)
 //!
-//! [`walk_and_emit`] now constructs the wasm bytes at runtime via
+//! [`walk_and_emit`] constructs the wasm bytes at runtime via
 //! [`super::wasm_emit::WasmModule`] + the per-opcode helpers below
 //! ([`emit_or`], [`emit_l8ui`], …). Only the canonical [`HOT_BB_PC`]
-//! shape is wired up — other PCs return [`EmitError::UnsupportedShape`].
-//! Output is byte-equivalent (under wasmtime parity) to the build-time-
-//! baked `HOT_BB_WASM` artifact so neither backend's hot path moves.
+//! shape is wired into the end-to-end entry point — other PCs return
+//! [`EmitError::UnsupportedShape`]. Output is byte-equivalent (under
+//! wasmtime parity) to the build-time-baked `HOT_BB_WASM` artifact so
+//! neither backend's hot path moves.
+//!
+//! Phase 4.3 adds three terminator emit primitives —
+//! [`emit_beqz`] / [`emit_bnez`] / [`emit_j`] — that future BB shape
+//! recognizers (e.g. the `loopTask` prefix at PC 0x400d4a8d) will
+//! consume to emit branches as part of the JIT'd body. They share a
+//! callback-based side-exit signature so they stay agnostic to the
+//! caller's ABI (the hot-BB `(a3, a5, l32r) -> (exit, a2, a6, a8, a10)`
+//! tuple is one ABI; future shapes will be others).
 //!
 //! [`HOT_BB_PC`]: crate::cpu::xtensa_jit_bytes::HOT_BB_PC
 //! [`HOT_BB_WASM`]: crate::cpu::xtensa_jit_bytes::HOT_BB_WASM
 
 use crate::cpu::xtensa_jit_bytes::{
-    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_PC,
+    EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
+    HOT_BB_PC,
 };
 use crate::cpu::xtensa_jit::wasm_emit::{
-    emit_call, emit_end, emit_i32_and, emit_i32_const, emit_i32_lt_s, emit_i32_or, emit_i32_shr_u,
-    emit_if_void, emit_local_get, emit_local_set, emit_locals_run, emit_return, encode_u32,
-    FuncType, ValType, WasmModule,
+    emit_call, emit_end, emit_i32_and, emit_i32_const, emit_i32_eqz, emit_i32_lt_s, emit_i32_or,
+    emit_i32_shr_u, emit_if_void, emit_local_get, emit_local_set, emit_locals_run, emit_return,
+    encode_u32, FuncType, ValType, WasmModule,
 };
 use crate::decoder::xtensa::{self, Instruction};
 use crate::decoder::{xtensa_length, xtensa_narrow};
@@ -63,6 +73,10 @@ pub enum SideExitReason {
     /// Block executed cleanly to the terminator. Wire code:
     /// [`EXIT_FALL_THROUGH`].
     FallThrough,
+    /// A conditional or unconditional branch in the JIT'd body resolved
+    /// to "taken" and the body returned to let the interpreter resume at
+    /// the branch target PC. Wire code: [`EXIT_BRANCH_TAKEN`].
+    BranchTaken,
     /// A host import (e.g. `read_u8`) reported a bus error. Wire code:
     /// [`EXIT_HOST_BUS_ERROR`].
     HostBusError,
@@ -75,6 +89,7 @@ impl SideExitReason {
     pub fn wire_code(self) -> i32 {
         match self {
             SideExitReason::FallThrough => EXIT_FALL_THROUGH,
+            SideExitReason::BranchTaken => EXIT_BRANCH_TAKEN,
             SideExitReason::HostBusError => EXIT_HOST_BUS_ERROR,
         }
     }
@@ -635,6 +650,97 @@ pub(crate) fn emit_and(ar: u32, as_: u32, at: u32, out: &mut Vec<u8>) {
     emit_local_set(ar, out);
 }
 
+// ── Branch emit (Phase 4.3) ───────────────────────────────────────────
+//
+// Three terminator emitters: BEQZ / BNEZ / J. Each one ends the JIT'd
+// basic block — the caller is responsible for not emitting any more ops
+// after `emit_j`, and for following `emit_beqz` / `emit_bnez` with the
+// function epilogue that handles the not-taken (fall-through) path.
+//
+// The taken-path side-exit body is supplied by the caller via a
+// closure, so these primitives stay ABI-agnostic: they don't know how
+// many result slots the JIT'd function has, what their order is, or
+// which Xtensa registers map to which wasm locals. The closure pushes
+// the full result tuple onto the wasm stack (in the same order as the
+// function's `results` declaration) and then we emit `return`.
+//
+// The wire side-exit code on the taken side is always [`EXIT_BRANCH_TAKEN`];
+// the new PC is whatever the caller chose to pass through the result
+// tuple's PC slot. The interpreter resumes from that PC.
+
+/// `beqz as_, offset` — branch taken iff `AR[as_] == 0`. Emits:
+///
+/// ```text
+///   local.get $as_local
+///   i32.eqz
+///   if (void)
+///     <taken_exit_body>          ;; pushes result tuple, then `return`
+///     return
+///   end
+/// ```
+///
+/// `taken_exit_body` is responsible for pushing the result tuple
+/// (including the new PC = branch target) onto the wasm stack before
+/// we emit `return`. The closure runs while the wasm stack already
+/// holds nothing — anything it pushes becomes the return values.
+///
+/// After this emitter returns, the caller continues emitting the
+/// fall-through path (which, for a BB-final BEQZ, is the function's
+/// own epilogue that returns `EXIT_FALL_THROUGH` with the
+/// post-branch-not-taken PC).
+#[allow(
+    dead_code,
+    reason = "Phase 4.3 primitive — wired in by Phase 4.3.5 BB shape recognizer; \
+              exercised today only by the `feature = jit` lockstep tests."
+)]
+pub(crate) fn emit_beqz<F>(as_local: u32, taken_exit_body: F, out: &mut Vec<u8>)
+where
+    F: FnOnce(&mut Vec<u8>),
+{
+    emit_local_get(as_local, out);
+    emit_i32_eqz(out);
+    emit_if_void(out);
+    taken_exit_body(out);
+    emit_return(out);
+    emit_end(out);
+}
+
+/// `bnez as_, offset` — branch taken iff `AR[as_] != 0`. We just test
+/// the register directly: wasm `if` triggers on non-zero, so the shape
+/// is `local.get; if; <taken-exit>; end`.
+#[allow(
+    dead_code,
+    reason = "Phase 4.3 primitive — wired in by Phase 4.3.5 BB shape recognizer; \
+              exercised today only by the `feature = jit` lockstep tests."
+)]
+pub(crate) fn emit_bnez<F>(as_local: u32, taken_exit_body: F, out: &mut Vec<u8>)
+where
+    F: FnOnce(&mut Vec<u8>),
+{
+    emit_local_get(as_local, out);
+    emit_if_void(out);
+    taken_exit_body(out);
+    emit_return(out);
+    emit_end(out);
+}
+
+/// `j offset` — unconditional jump. Emits the taken-path side-exit
+/// body inline (no `if`) and a `return`. This is a terminator: the
+/// caller must not emit any further ops in this function body after
+/// `emit_j`.
+#[allow(
+    dead_code,
+    reason = "Phase 4.3 primitive — wired in by Phase 4.3.5 BB shape recognizer; \
+              exercised today only by the `feature = jit` lockstep tests."
+)]
+pub(crate) fn emit_j<F>(taken_exit_body: F, out: &mut Vec<u8>)
+where
+    F: FnOnce(&mut Vec<u8>),
+{
+    taken_exit_body(out);
+    emit_return(out);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -754,6 +860,191 @@ mod tests {
         }
     }
 
+    // ── Branch primitive lockstep tests (Phase 4.3) ──────────────────
+    //
+    // Each test builds a minimal wasm function with signature
+    // `(reg: i32) -> (exit: i32, pc: i32)` that exercises one of the
+    // branch primitives at the function's terminator, then drives it
+    // through wasmtime for both the taken and not-taken inputs. We
+    // diff the wasm output against the Xtensa interpreter's branch
+    // reference (`XtensaLx7::branch` semantics, replicated here as a
+    // pure helper). If the wasm and the helper agree byte-for-byte
+    // on `(exit_code, new_pc)`, the primitive emits correctly.
+    //
+    // Why not the full `xtensa_lockstep` harness? The harness runs
+    // both modes through `Machine::step()`, which assumes a JIT
+    // already wired into the dispatch path. The branch primitives
+    // landed here aren't wired into any BB shape recognizer yet —
+    // they're standalone emit helpers Phase 4.3.5+ will consume.
+    // Direct wasm + reference comparison is the leanest test of the
+    // primitives themselves.
+
+    /// Reference Xtensa branch semantics: if `cond`, PC = pc + offset
+    /// (offset is the decoder's already-+4-baked value); else PC = pc + len.
+    /// Mirrors `XtensaLx7::branch` exactly so the test diff isolates
+    /// the wasm emit and nothing else.
+    #[cfg(feature = "jit")]
+    fn xtensa_branch_ref(pc: u32, offset: i32, len: u32, cond: bool) -> u32 {
+        if cond {
+            pc.wrapping_add(offset as u32)
+        } else {
+            pc.wrapping_add(len)
+        }
+    }
+
+    /// Build a one-function wasm module with signature `(i32) -> (i32, i32)`
+    /// whose body invokes `emit_branch` to populate the terminator. The
+    /// not-taken fall-through tail returns `(EXIT_FALL_THROUGH, fallthrough_pc)`.
+    /// The branch target PC is owned by the caller's `emit_branch` closure,
+    /// which captures it directly when building the taken-exit body.
+    #[cfg(feature = "jit")]
+    fn build_branch_test_module(
+        fallthrough_pc: u32,
+        emit_branch: impl FnOnce(u32, &mut Vec<u8>),
+    ) -> Vec<u8> {
+        let mut m = WasmModule::new();
+        let ty = m.add_type(FuncType {
+            params: vec![ValType::I32],
+            results: vec![ValType::I32, ValType::I32],
+        });
+        let mut body = Vec::with_capacity(32);
+        // No additional locals (the `as_` source is param 0).
+        encode_u32(0, &mut body);
+
+        // Emit the branch primitive with a taken-exit body that pushes
+        // `(EXIT_BRANCH_TAKEN, target_pc)` as the result tuple.
+        emit_branch(/* as_local */ 0, &mut body);
+
+        // Fall-through tail: `(EXIT_FALL_THROUGH, fallthrough_pc)`.
+        emit_i32_const(EXIT_FALL_THROUGH, &mut body);
+        emit_i32_const(fallthrough_pc as i32, &mut body);
+        emit_end(&mut body);
+
+        let fn_idx = m.add_func(ty, body);
+        m.add_func_export("run", fn_idx);
+        m.finish()
+    }
+
+    /// Run a built module through wasmtime and return its (exit, pc) tuple.
+    #[cfg(feature = "jit")]
+    fn run_branch_module(bytes: &[u8], reg_value: u32) -> (i32, u32) {
+        use wasmtime::{Engine, Instance, Module, Store};
+        let engine = Engine::default();
+        let module = Module::new(&engine, bytes).expect("module compiles");
+        let mut store: Store<()> = Store::new(&engine, ());
+        let inst = Instance::new(&mut store, &module, &[]).expect("instantiate");
+        let run = inst
+            .get_typed_func::<i32, (i32, i32)>(&mut store, "run")
+            .expect("run export");
+        let (exit, pc) = run.call(&mut store, reg_value as i32).expect("run ok");
+        (exit, pc as u32)
+    }
+
+    /// BEQZ: taken when `as_ == 0`, not taken otherwise. Compare wasm
+    /// against the Xtensa reference for both inputs.
+    #[cfg(feature = "jit")]
+    #[test]
+    fn beqz_taken_and_not_taken_match_interp() {
+        let pc = 0x400d_4a8du32;
+        let len = 3u32; // BEQZ is 3 bytes
+        let offset = 12i32 + 4; // decoder pre-bakes +4
+        let target_pc = pc.wrapping_add(offset as u32);
+        let fallthrough_pc = pc.wrapping_add(len);
+
+        let bytes = build_branch_test_module(fallthrough_pc, |as_local, out| {
+            emit_beqz(
+                as_local,
+                |o| {
+                    emit_i32_const(EXIT_BRANCH_TAKEN, o);
+                    emit_i32_const(target_pc as i32, o);
+                },
+                out,
+            );
+        });
+
+        // as_ == 0 → taken.
+        let (exit, new_pc) = run_branch_module(&bytes, 0);
+        assert_eq!(exit, EXIT_BRANCH_TAKEN);
+        assert_eq!(new_pc, xtensa_branch_ref(pc, offset, len, true));
+
+        // as_ != 0 → fall through.
+        for &reg in &[1u32, 0xFFFF_FFFF, 0xDEAD_BEEF, 42] {
+            let (exit, new_pc) = run_branch_module(&bytes, reg);
+            assert_eq!(exit, EXIT_FALL_THROUGH, "reg={:#x}", reg);
+            assert_eq!(new_pc, xtensa_branch_ref(pc, offset, len, false));
+        }
+    }
+
+    /// BNEZ: taken when `as_ != 0`, not taken when `as_ == 0`.
+    #[cfg(feature = "jit")]
+    #[test]
+    fn bnez_taken_and_not_taken_match_interp() {
+        let pc = 0x400d_4a90u32;
+        let len = 3u32;
+        let offset = -8i32 + 4; // backward branch (still +4-baked by decoder)
+        let target_pc = pc.wrapping_add(offset as u32);
+        let fallthrough_pc = pc.wrapping_add(len);
+
+        let bytes = build_branch_test_module(fallthrough_pc, |as_local, out| {
+            emit_bnez(
+                as_local,
+                |o| {
+                    emit_i32_const(EXIT_BRANCH_TAKEN, o);
+                    emit_i32_const(target_pc as i32, o);
+                },
+                out,
+            );
+        });
+
+        // as_ == 0 → fall through.
+        let (exit, new_pc) = run_branch_module(&bytes, 0);
+        assert_eq!(exit, EXIT_FALL_THROUGH);
+        assert_eq!(new_pc, xtensa_branch_ref(pc, offset, len, false));
+
+        // as_ != 0 → taken.
+        for &reg in &[1u32, 0xFFFF_FFFF, 0xDEAD_BEEF, 42] {
+            let (exit, new_pc) = run_branch_module(&bytes, reg);
+            assert_eq!(exit, EXIT_BRANCH_TAKEN, "reg={:#x}", reg);
+            assert_eq!(new_pc, xtensa_branch_ref(pc, offset, len, true));
+        }
+    }
+
+    /// J: always taken. Wasm `(_) -> (EXIT_BRANCH_TAKEN, target_pc)`
+    /// regardless of input.
+    #[cfg(feature = "jit")]
+    #[test]
+    fn j_always_taken_matches_interp() {
+        let pc = 0x400d_4a93u32;
+        let len = 3u32;
+        let offset = 32i32 + 4;
+        let target_pc = pc.wrapping_add(offset as u32);
+
+        let mut m = WasmModule::new();
+        let ty = m.add_type(FuncType {
+            params: vec![ValType::I32],
+            results: vec![ValType::I32, ValType::I32],
+        });
+        let mut body = Vec::with_capacity(16);
+        encode_u32(0, &mut body); // no locals
+        emit_j(
+            |o| {
+                emit_i32_const(EXIT_BRANCH_TAKEN, o);
+                emit_i32_const(target_pc as i32, o);
+            },
+            &mut body,
+        );
+        emit_end(&mut body);
+        let fn_idx = m.add_func(ty, body);
+        m.add_func_export("run", fn_idx);
+        let bytes = m.finish();
+
+        for &reg in &[0u32, 1, 0xDEAD_BEEF] {
+            let (exit, new_pc) = run_branch_module(&bytes, reg);
+            assert_eq!(exit, EXIT_BRANCH_TAKEN, "J ignores reg (was {:#x})", reg);
+            assert_eq!(new_pc, xtensa_branch_ref(pc, offset, len, true));
+        }
+    }
+
     /// `SideExitReason::wire_code` round-trips through
     /// `EmittedBlock::reason_for` (sanity for backends that index by
     /// the i32 returned from wasm).
@@ -765,6 +1056,7 @@ mod tests {
             end_pc: 0,
             side_exit_reasons: vec![
                 (EXIT_FALL_THROUGH, SideExitReason::FallThrough),
+                (EXIT_BRANCH_TAKEN, SideExitReason::BranchTaken),
                 (EXIT_HOST_BUS_ERROR, SideExitReason::HostBusError),
             ],
         };
@@ -773,9 +1065,32 @@ mod tests {
             Some(SideExitReason::FallThrough)
         );
         assert_eq!(
+            block.reason_for(EXIT_BRANCH_TAKEN),
+            Some(SideExitReason::BranchTaken)
+        );
+        assert_eq!(
             block.reason_for(EXIT_HOST_BUS_ERROR),
             Some(SideExitReason::HostBusError)
         );
         assert_eq!(block.reason_for(42), None);
+    }
+
+    /// Wire codes for the three currently-known side-exit reasons are
+    /// disjoint and round-trip through `SideExitReason::wire_code`.
+    #[test]
+    fn side_exit_wire_codes_are_disjoint() {
+        let reasons = [
+            SideExitReason::FallThrough,
+            SideExitReason::BranchTaken,
+            SideExitReason::HostBusError,
+        ];
+        let codes: Vec<i32> = reasons.iter().map(|r| r.wire_code()).collect();
+        // No duplicates.
+        let mut sorted = codes.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), codes.len(), "wire codes must be unique");
+        // Match the constants we expect.
+        assert_eq!(codes, vec![EXIT_FALL_THROUGH, EXIT_BRANCH_TAKEN, EXIT_HOST_BUS_ERROR]);
     }
 }

--- a/crates/core/src/cpu/xtensa_jit/hot_bb.wat
+++ b/crates/core/src/cpu/xtensa_jit/hot_bb.wat
@@ -1,0 +1,65 @@
+;; LabWired - Firmware Simulation Platform
+;; Copyright (C) 2026 Andrii Shylenko
+;; SPDX-License-Identifier: MIT
+;;
+;; Xtensa LX7 JIT — hot basic block at PC 0x400829cc (#124 Phase 4).
+;;
+;; This file is the SINGLE source of truth for the JIT'd block's wasm body.
+;; Consumed two ways:
+;;   * `crates/core/build.rs` reads it via fs::read_to_string and
+;;     wat::parse_str's it into wasm bytes baked at `OUT_DIR/xtensa_jit_hot_bb.wasm`.
+;;   * `crates/core/src/cpu/xtensa_jit/wasm_bytes.rs` `include_bytes!`s
+;;     the baked artifact; both the native (wasmtime) and browser
+;;     (`js_sys::WebAssembly`) backends consume those bytes verbatim.
+;;
+;; Block disassembly + exit-code semantics live in `bb_multi.rs`'s module
+;; docs. Side-exit code 0 = clean fall-through to PC 0x400829e4; code 5 =
+;; host bus error reported by the `host.read_u8` import.
+(module
+  (import "host" "read_u8" (func $read_u8 (param i32) (result i32)))
+  (func (export "run")
+        (param $a3 i32) (param $a5 i32) (param $l32r i32)
+        (result i32 i32 i32 i32 i32)
+    (local $a2 i32)
+    (local $a6 i32)
+    (local $a8 i32)
+    (local $a10 i32)
+    (local $tmp i32)
+
+    ;; 1. or a10, a5, a5  -> a10 = a5
+    (local.set $a10 (local.get $a5))
+
+    ;; 2. memw — barrier, semantic no-op in sim
+
+    ;; 3. l8ui a6, a3, 0  -> a6 = read_u8(a3 + 0)
+    (local.set $tmp (call $read_u8 (local.get $a3)))
+    (if (i32.lt_s (local.get $tmp) (i32.const 0))
+      (then
+        (return (i32.const 5) (i32.const 0) (i32.const 0) (i32.const 0) (i32.const 0))))
+    (local.set $a6 (i32.and (local.get $tmp) (i32.const 0xFF)))
+
+    ;; 4. memw — barrier
+
+    ;; 5. l8ui a2, a3, 1  -> a2 = read_u8(a3 + 1)
+    (local.set $tmp (call $read_u8 (i32.add (local.get $a3) (i32.const 1))))
+    (if (i32.lt_s (local.get $tmp) (i32.const 0))
+      (then
+        (return (i32.const 5) (i32.const 0) (i32.const 0) (i32.const 0) (i32.const 0))))
+    (local.set $a2 (i32.and (local.get $tmp) (i32.const 0xFF)))
+
+    ;; 6. extui a2, a2, 0, 8  -> a2 = (a2 >> 0) & ((1<<8) - 1) = a2 & 0xFF
+    (local.set $a2 (i32.and (local.get $a2) (i32.const 0xFF)))
+
+    ;; 7. and a2, a2, a6  -> a2 &= a6
+    (local.set $a2 (i32.and (local.get $a2) (local.get $a6)))
+
+    ;; 8. l32r a8, 0x40080534  -> a8 = pre-resolved literal
+    (local.set $a8 (local.get $l32r))
+
+    (i32.const 0)
+    (local.get $a2)
+    (local.get $a6)
+    (local.get $a8)
+    (local.get $a10)
+  )
+)

--- a/crates/core/src/cpu/xtensa_jit/mod.rs
+++ b/crates/core/src/cpu/xtensa_jit/mod.rs
@@ -2,136 +2,128 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! Xtensa LX7 JIT pilot — issue #124 Phase 3.2.
+//! Xtensa LX7 JIT pilot — issue #124.
 //!
-//! Compiles a single, hand-picked hot basic block (the inner store loop of
-//! `GxEPD2_290_C90c::fillScreen` at PC `0x400d14b8`) to a WebAssembly module
-//! and runs it through wasmtime in native mode. The pilot proves the
-//! JIT-via-wasm architecture works on a memory-touching block and gives us
-//! an honest per-block call-overhead number to inform Phase 4 scaling.
+//! Owns the JIT pipeline split into:
+//!   * [`emit_core`] — runtime-agnostic BB walker + emit core. Always
+//!     compiled (no wasmtime dep). Both the native and browser
+//!     backends call into it to produce wasm bytes.
+//!   * [`bb_multi`] — wasmtime adapter for the multi-op hot block.
+//!     Feature-gated on `jit` (only built when wasmtime is in the
+//!     dep graph).
+//!   * [`windowed_call`] — wasmtime adapter for the CALL8 windowed
+//!     block. Also `jit`-gated.
 //!
-//! ## Target block disassembly
-//!
-//! Verified against `/tmp/labwired-ereader/build/labwired-ereader.ino.elf`
-//! with the PlatformIO `xtensa-esp32-elf-objdump`:
-//!
-//! ```text
-//! 400d14b8: 00 42 92      s8i    a9, a2, 0     ; mem8[a2 + 0] = a9 & 0xFF
-//! 400d14bb: b2 aa         add.n  a11, a2, a10  ; a11 = a2 + a10
-//! 400d14bd: 00 4b 82      s8i    a8, a11, 0    ; mem8[a11 + 0] = a8 & 0xFF
-//! 400d14c0: 22 1b         addi.n a2, a2, 1
-//! 400d14c2: 33 0b         addi.n a3, a3, -1
-//! 400d14c4: ff 03 56      bnez   a3, 400d14b8  ; loop while a3 != 0
-//! ```
-//!
-//! Block range: `[0x400d14b8, 0x400d14c7)` (15 bytes, 6 instructions).
-//! Reads: a2, a3, a8, a9, a10. Writes: a2, a3, a11, and two bytes of memory.
-//! Terminator: conditional branch back to block start; fall-through is the
-//! `retw.n` at `0x400d14c7`.
+//! The Phase 4.1 refactor pulled the walker + emit allowlist out of
+//! `bb_multi` into [`emit_core`] so the browser-side prototype in
+//! `labwired-wasm` (which can't enable `jit` — wasmtime doesn't compile
+//! for `wasm32-unknown-unknown`) can share the same code.
 //!
 //! ## Side-exit codes (per #124)
 //!
-//! * `0` — natural fall-through; new PC = block end (`0x400d14c7`).
-//! * `1` — branch taken; new PC = block start (`0x400d14b8`). The JIT runs
-//!   one pass through the block in a single wasm call; if the terminating
-//!   `bnez` fires we re-enter via the outer step loop on the next iteration.
-//! * `3` — store address outside the inlined DRAM range; PC reverts to
-//!   block start with **no register/memory mutation** so the interpreter
-//!   can faithfully re-run the block and raise the genuine bus error.
+//! See [`crate::cpu::xtensa_jit_bytes`] and [`emit_core::SideExitReason`]
+//! for the wire-level vocabulary both backends agree on.
 //!
 //! ## Host-side store callback
 //!
-//! Stores are dispatched to a host import (`host.store_u8`) rather than to
-//! a wasm linear memory aliased to host DRAM. Reasoning:
-//!
-//! 1. Linear-memory aliasing across a wasmtime sandbox boundary is
-//!    expensive to set up and breaks abstraction with the `Bus` trait
-//!    (peripherals, traps, observers all live on the host).
-//! 2. The pilot's primary goal is to measure *call overhead*, not to
-//!    optimise byte-store throughput. A host import faithfully exposes the
-//!    same dispatch latency a real per-block JIT would pay for any
-//!    non-trivial memory model.
-//!
-//! Bounds-checking still happens **inside wasm** as the spec requires —
-//! the host import is only invoked once wasm has cleared both stores'
-//! destination addresses against the DRAM range.
+//! Stores / loads are dispatched to host imports rather than to a wasm
+//! linear memory aliased to host DRAM. Reasoning: linear-memory aliasing
+//! across the wasmtime sandbox boundary is expensive to set up and
+//! breaks abstraction with the `Bus` trait (peripherals, traps,
+//! observers all live on the host). The host import is only invoked
+//! once wasm has cleared the store/load address against the inlined
+//! DRAM range.
 
-#![cfg(feature = "jit")]
+// `emit_core` is always compiled — it has no wasmtime dep and is shared
+// with the browser-side JIT in `labwired-wasm`.
+pub mod emit_core;
 
+// Wasmtime-backed adapters live behind the `jit` feature so the browser
+// build doesn't have to drag wasmtime into its dep tree.
+#[cfg(feature = "jit")]
 mod bb_multi;
+#[cfg(feature = "jit")]
 mod windowed_call;
 
+#[cfg(feature = "jit")]
 pub use bb_multi::{
     walk_bb, DecodedOp, MultiOpBlock, MultiOpResult, EXIT_FALL_THROUGH as MULTI_EXIT_FALL_THROUGH,
     EXIT_HOST_BUS_ERROR as MULTI_EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
     HOT_BB_L32R_ADDR, HOT_BB_PC,
 };
+#[cfg(feature = "jit")]
 pub use windowed_call::{
     WindowedCallBlock, WindowedCallResult, EXIT_TAKEN as WINDOWED_EXIT_TAKEN, EXIT_WINDOWED_REFUSE,
     LOOPV_CALL8_INSTR_COUNT, LOOPV_CALL8_NEXT_PC, LOOPV_CALL8_PC, LOOPV_CALL8_TARGET,
 };
 
+#[cfg(feature = "jit")]
 use std::collections::HashMap;
+#[cfg(feature = "jit")]
 use std::sync::Mutex;
 
+#[cfg(feature = "jit")]
 use wasmtime::{Engine, Func, Instance, Module, Store, TypedFunc};
 
-/// PC of the target basic block (see disassembly above).
+// ── Phase 3.2 pilot: hand-crafted fillScreen body block ───────────────
+//
+// Kept for back-compat with `try_jit_step`'s fillScreen branch +
+// existing unit tests. Not exercised by the multi-op JIT path
+// (`HOT_BB_PC` short-circuits first in `xtensa_lx7::try_jit_step`).
+// All of this is `jit`-gated because it pulls in wasmtime directly.
+
+/// PC of the target basic block (see disassembly in `bb_multi`).
+#[cfg(feature = "jit")]
 pub const FILL_SCREEN_BLOCK_PC: u32 = 0x400d14b8;
 /// First PC after the block — fall-through destination.
+#[cfg(feature = "jit")]
 pub const FILL_SCREEN_BLOCK_END: u32 = 0x400d14c7;
 /// Number of Xtensa instructions in the block (used to advance CCOUNT).
+#[cfg(feature = "jit")]
 pub const FILL_SCREEN_BLOCK_INSTR_COUNT: u32 = 6;
 
 /// DRAM bounds inlined into the compiled wasm (must mirror the
 /// `configure_xtensa_esp32` peripheral map: dram = [0x3FFAE000, 0x3FFE0000),
 /// sram1 = [0x3FFE0000, 0x40000000)). We use the union `[0x3FFAE000, 0x40000000)`.
+#[cfg(feature = "jit")]
 const DRAM_LO: u32 = 0x3FFA_E000;
+#[cfg(feature = "jit")]
 const DRAM_HI: u32 = 0x4000_0000;
 
 /// Host-side scratch slot the wasm import drains into. Wrapped in a Mutex so
 /// the closure passed to `Func::wrap` can be `Sync` without us hand-rolling
 /// unsafe pointer aliasing into the wasmtime Store.
-///
-/// Each `run()` call clears this, the wasm guest pushes 0–2 `(addr, val)`
-/// pairs into it via `host.store_u8`, and the caller drains them onto the
-/// bus after wasm returns. We don't dispatch directly from inside the import
-/// because the `Bus` trait object isn't `Send + Sync` and threading it
-/// through wasmtime's host-function ABI would require unsafe self-borrows.
+#[cfg(feature = "jit")]
 type PendingStores = Vec<(u32, u8)>;
 
 /// Wasm function signature for the `fillScreen` block:
 ///   Params:  (a8, a9, a2, a3, a10) — all u32 carried as i32.
 ///   Returns: (exit_code, a2_new, a3_new, a11_new) — all i32.
+#[cfg(feature = "jit")]
 type FillScreenParams = (i32, i32, i32, i32, i32);
+#[cfg(feature = "jit")]
 type FillScreenReturns = (i32, i32, i32, i32);
+#[cfg(feature = "jit")]
 type FillScreenRun = TypedFunc<FillScreenParams, FillScreenReturns>;
 
 /// Outcome of running a compiled block: `(exit_code, new_a2, new_a3,
-/// new_a11, pending_stores)`. See module docs for exit-code semantics.
+/// new_a11, pending_stores)`.
+#[cfg(feature = "jit")]
 type RunResult = (i32, u32, u32, u32, Vec<(u32, u8)>);
 
 /// One compiled block instance.
-///
-/// We hold the `Store`, `Instance`, and the typed `run` function. The block
-/// holds its own per-block scratch buffer (`pending`) so we don't pay the
-/// `Vec` allocation on the hot path.
+#[cfg(feature = "jit")]
 pub struct CompiledBlock {
     store: Store<()>,
-    /// Typed view of the exported `run` function.
     run: FillScreenRun,
-    /// Stores queued by the in-flight wasm call. Drained by `Self::run` after
-    /// `run.call()` returns; the caller copies them onto the live bus.
     pending: std::sync::Arc<Mutex<PendingStores>>,
-    /// Number of times this block has been invoked. Surfaced via
-    /// `JitCache::hit_count` for the pilot benchmark write-up.
     pub hits: u64,
 }
 
+#[cfg(feature = "jit")]
 impl CompiledBlock {
     /// Invoke the compiled block. On success returns
-    /// `(exit_code, a2_new, a3_new, a11_new, pending_stores)`. The caller
-    /// must apply `pending_stores` to the bus iff `exit_code != 3`.
+    /// `(exit_code, a2_new, a3_new, a11_new, pending_stores)`.
     #[inline]
     pub fn run(
         &mut self,
@@ -141,8 +133,6 @@ impl CompiledBlock {
         a3: u32,
         a10: u32,
     ) -> wasmtime::Result<RunResult> {
-        // Clear the scratch buffer. Lock is uncontended on this hot path —
-        // wasm runs synchronously on the same thread.
         self.pending.lock().unwrap().clear();
         let (exit, a2_n, a3_n, a11_n) = self.run.call(
             &mut self.store,
@@ -156,37 +146,31 @@ impl CompiledBlock {
 
 /// Cache of compiled blocks keyed by start PC. Re-uses the shared wasmtime
 /// `Engine` across all blocks so module compilation amortises.
+#[cfg(feature = "jit")]
 pub struct JitCache {
     engine: Engine,
     compiled: HashMap<u32, CompiledBlock>,
     /// Phase 3.6.2: windowed CALL8 block for `_Z4loopv` (PC 0x400d4a99).
-    /// Boxed + lazy so we don't pay wasmtime instantiation cost on every
-    /// `JitCache::new()` (e.g. dual-core configs build two CPUs).
     pub loopv_call8: Option<Box<WindowedCallBlock>>,
-    /// Phase 3.6.2 instrumentation: track how often the windowed-call
-    /// JIT refused (exit code 5) so the lockstep + bench reports can
-    /// quantify how many CALL8s actually went through the wasm path.
+    /// Phase 3.6.2 instrumentation: count windowed-call refusals.
     pub windowed_refusals: u64,
     /// Phase 3.6.3: multi-op block for the call_start_cpu0 hot loop at
-    /// PC 0x400829cc. First JIT block expected to deliver net speedup.
+    /// PC 0x400829cc.
     pub hot_bb: Option<Box<MultiOpBlock>>,
-    /// Phase 3.6.3 instrumentation: count of times the multi-op JIT
-    /// refused (host bus error / staging mismatch) so the bench can
-    /// quantify cache effectiveness.
+    /// Phase 3.6.3 instrumentation: count multi-op refusals.
     pub multi_op_refusals: u64,
 }
 
+#[cfg(feature = "jit")]
 impl Default for JitCache {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(feature = "jit")]
 impl JitCache {
     pub fn new() -> Self {
-        // Default wasmtime config: cranelift compiler, native target. We
-        // disable the epoch interruption and fuel features (not used) to
-        // keep call overhead minimal.
         let engine = Engine::default();
         Self {
             engine,
@@ -199,8 +183,7 @@ impl JitCache {
     }
 
     /// If `pc` is a known JIT-compilable block, return a mutable reference
-    /// to its compiled form, building+caching on first sight. Returns
-    /// `None` for any PC we don't know how to compile yet.
+    /// to its compiled form, building+caching on first sight.
     pub fn lookup_or_install(&mut self, pc: u32) -> Option<&mut CompiledBlock> {
         if pc == FILL_SCREEN_BLOCK_PC {
             if !self.compiled.contains_key(&pc) {
@@ -209,9 +192,6 @@ impl JitCache {
                         self.compiled.insert(pc, cb);
                     }
                     Err(e) => {
-                        // Compilation failure: log and never try this PC
-                        // again in this run. The interpreter falls through
-                        // and the test/bench still completes correctly.
                         tracing::warn!(target: "labwired-core::jit",
                             "JIT compile failed for pc=0x{pc:08x}: {e:#}. \
                              Falling back to interpreter for this PC.");
@@ -224,10 +204,7 @@ impl JitCache {
         None
     }
 
-    /// Lazily compile + return the LOOPV CALL8 block. Returns `None` if
-    /// wasm compilation fails (extremely unlikely — the template is fixed
-    /// and validated at unit-test time, so a runtime failure here points
-    /// at a wasmtime regression rather than a usage bug).
+    /// Lazily compile + return the LOOPV CALL8 block.
     pub fn lookup_or_install_windowed(&mut self, pc: u32) -> Option<&mut WindowedCallBlock> {
         if pc != LOOPV_CALL8_PC {
             return None;
@@ -246,10 +223,7 @@ impl JitCache {
         self.loopv_call8.as_deref_mut()
     }
 
-    /// Lazily compile + return the Phase 3.6.3 multi-op block for the
-    /// `call_start_cpu0` delay loop. Returns `None` only if wasm
-    /// compilation fails (which would be a regression — the WAT is
-    /// validated at unit-test time).
+    /// Lazily compile + return the multi-op block for `call_start_cpu0`.
     pub fn lookup_or_install_multi_op(&mut self, pc: u32) -> Option<&mut MultiOpBlock> {
         if pc != HOT_BB_PC {
             return None;
@@ -269,7 +243,7 @@ impl JitCache {
     }
 
     /// Total number of times any compiled block has been invoked since
-    /// process start. Used by the pilot's CLI-level reporting.
+    /// process start.
     pub fn total_hits(&self) -> u64 {
         let fillscreen_hits: u64 = self.compiled.values().map(|cb| cb.hits).sum();
         let windowed_hits = self.loopv_call8.as_ref().map(|b| b.hits).unwrap_or(0);
@@ -277,20 +251,8 @@ impl JitCache {
         fillscreen_hits + windowed_hits + multi_op_hits
     }
 
-    /// Build the `fillScreen` body block. See module-level docs for the
-    /// disassembly and side-exit protocol.
+    /// Build the `fillScreen` body block.
     fn build_fill_screen(&self) -> wasmtime::Result<CompiledBlock> {
-        // Hand-written WAT. wasmtime parses WAT directly via
-        // `Module::new(&engine, wat_str)`. The bounds-check uses unsigned
-        // comparison against the inlined DRAM range, so a2/a11 below
-        // 0x80000000 (their natural i32 sign bit clear range) match the
-        // u32 comparison we'd do in Rust.
-        //
-        // Returns four i32s: (exit_code, a2_new, a3_new, a11_new). Stores
-        // are queued via the `host.store_u8` import; wasm only calls it
-        // after the bounds check passes for BOTH addresses, so an exit=3
-        // path leaves zero side effects (no queued stores, no register
-        // mutation observable to the caller).
         let wat = format!(
             r#"(module
   (import "host" "store_u8" (func $store (param i32 i32)))
@@ -348,13 +310,11 @@ impl JitCache {
         let module = Module::new(&self.engine, wat)?;
         let mut store: Store<()> = Store::new(&self.engine, ());
 
-        // Shared scratch buffer between the host closure and `CompiledBlock`.
         let pending: std::sync::Arc<Mutex<PendingStores>> =
             std::sync::Arc::new(Mutex::new(Vec::with_capacity(2)));
         let pending_for_import = pending.clone();
 
         let store_u8: Func = Func::wrap(&mut store, move |addr: i32, val: i32| {
-            // Wasm sends us i32; reinterpret as u32 unsigned address + u8 byte.
             pending_for_import
                 .lock()
                 .unwrap()
@@ -374,7 +334,7 @@ impl JitCache {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "jit"))]
 mod tests {
     use super::*;
 
@@ -386,8 +346,6 @@ mod tests {
         let block = cache
             .lookup_or_install(FILL_SCREEN_BLOCK_PC)
             .expect("fillScreen JIT must compile");
-        // Pick addresses inside DRAM. a2 = 0x3FFB_0000, a10 = 0x100,
-        // so a11 = 0x3FFB_0100. Both inside [0x3FFAE000, 0x40000000).
         let (exit, a2_n, a3_n, a11_n, pending) = block
             .run(
                 /*a8*/ 0xAA,
@@ -441,14 +399,12 @@ mod tests {
     fn fill_screen_oor_second_store() {
         let mut cache = JitCache::new();
         let block = cache.lookup_or_install(FILL_SCREEN_BLOCK_PC).unwrap();
-        // a2 inside DRAM, a10 huge so a2+a10 overflows above DRAM_HI.
         let (exit, _a2, _a3, _a11, pending) = block.run(0, 0, 0x3FFB_0000, 1, 0x1000_0000).unwrap();
         assert_eq!(exit, 3);
         assert!(pending.is_empty());
     }
 
-    /// `lookup_or_install` returns None for unknown PCs (interpreter falls
-    /// through to existing path).
+    /// `lookup_or_install` returns None for unknown PCs.
     #[test]
     fn unknown_pc_returns_none() {
         let mut cache = JitCache::new();

--- a/crates/core/src/cpu/xtensa_jit/mod.rs
+++ b/crates/core/src/cpu/xtensa_jit/mod.rs
@@ -52,9 +52,10 @@ mod windowed_call;
 
 #[cfg(feature = "jit")]
 pub use bb_multi::{
-    walk_bb, DecodedOp, MultiOpBlock, MultiOpResult, EXIT_FALL_THROUGH as MULTI_EXIT_FALL_THROUGH,
+    walk_bb, DecodedOp, LoopTaskPrefixResult, MultiOpBlock, MultiOpResult,
+    EXIT_BRANCH_TAKEN as MULTI_EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH as MULTI_EXIT_FALL_THROUGH,
     EXIT_HOST_BUS_ERROR as MULTI_EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
-    HOT_BB_L32R_ADDR, HOT_BB_PC,
+    HOT_BB_L32R_ADDR, HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT,
 };
 #[cfg(feature = "jit")]
 pub use windowed_call::{
@@ -162,6 +163,10 @@ pub struct JitCache {
     /// Phase 3.6.3: multi-op block for the call_start_cpu0 hot loop at
     /// PC 0x400829cc.
     pub hot_bb: Option<Box<MultiOpBlock>>,
+    /// Phase 4.3.6: loopTask prefix block at PC 0x400d4a8d
+    /// (`L32R → L8UI → BEQZ`). Independent slot so the PC-keyed cache
+    /// lookup is a constant-time match without a HashMap allocation.
+    pub looptask_prefix: Option<Box<MultiOpBlock>>,
     /// Phase 3.6.3 instrumentation: count multi-op refusals.
     pub multi_op_refusals: u64,
 }
@@ -183,6 +188,7 @@ impl JitCache {
             loopv_call8: None,
             windowed_refusals: 0,
             hot_bb: None,
+            looptask_prefix: None,
             multi_op_refusals: 0,
         }
     }
@@ -228,23 +234,52 @@ impl JitCache {
         self.loopv_call8.as_deref_mut()
     }
 
-    /// Lazily compile + return the multi-op block for `call_start_cpu0`.
+    /// Lazily compile + return the multi-op block for `pc`. Shape-aware
+    /// dispatch lives in [`MultiOpBlock`]: this method just picks the
+    /// right slot + builder for the matched PC. The returned block's
+    /// [`MultiOpBlock::shape`] tells the caller which `run_*` ABI to
+    /// invoke.
+    ///
+    /// Currently supports:
+    ///   * [`HOT_BB_PC`] — `call_start_cpu0` 8-op hot block
+    ///     ([`BlockShape::HotBbCanonical`]).
+    ///   * [`LOOPTASK_PC`] — Arduino-ESP32 loopTask prefix
+    ///     `L32R → L8UI → BEQZ` ([`BlockShape::LoopTaskPrefix`]).
+    ///
+    /// [`BlockShape::HotBbCanonical`]: emit_core::BlockShape::HotBbCanonical
+    /// [`BlockShape::LoopTaskPrefix`]: emit_core::BlockShape::LoopTaskPrefix
     pub fn lookup_or_install_multi_op(&mut self, pc: u32) -> Option<&mut MultiOpBlock> {
-        if pc != HOT_BB_PC {
-            return None;
-        }
-        if self.hot_bb.is_none() {
-            match MultiOpBlock::build_hot_bb(&self.engine) {
-                Ok(b) => self.hot_bb = Some(Box::new(b)),
-                Err(e) => {
-                    tracing::warn!(target: "labwired-core::jit",
-                        "multi-op JIT compile failed for pc=0x{pc:08x}: {e:#}. \
-                         Falling back to interpreter for this PC.");
-                    return None;
+        match pc {
+            HOT_BB_PC => {
+                if self.hot_bb.is_none() {
+                    match MultiOpBlock::build_hot_bb(&self.engine) {
+                        Ok(b) => self.hot_bb = Some(Box::new(b)),
+                        Err(e) => {
+                            tracing::warn!(target: "labwired-core::jit",
+                                "multi-op JIT compile failed for pc=0x{pc:08x}: {e:#}. \
+                                 Falling back to interpreter for this PC.");
+                            return None;
+                        }
+                    }
                 }
+                self.hot_bb.as_deref_mut()
             }
+            LOOPTASK_PC => {
+                if self.looptask_prefix.is_none() {
+                    match MultiOpBlock::build_looptask_prefix(&self.engine) {
+                        Ok(b) => self.looptask_prefix = Some(Box::new(b)),
+                        Err(e) => {
+                            tracing::warn!(target: "labwired-core::jit",
+                                "loopTask JIT compile failed for pc=0x{pc:08x}: {e:#}. \
+                                 Falling back to interpreter for this PC.");
+                            return None;
+                        }
+                    }
+                }
+                self.looptask_prefix.as_deref_mut()
+            }
+            _ => None,
         }
-        self.hot_bb.as_deref_mut()
     }
 
     /// Total number of times any compiled block has been invoked since
@@ -253,7 +288,8 @@ impl JitCache {
         let fillscreen_hits: u64 = self.compiled.values().map(|cb| cb.hits).sum();
         let windowed_hits = self.loopv_call8.as_ref().map(|b| b.hits).unwrap_or(0);
         let multi_op_hits = self.hot_bb.as_ref().map(|b| b.hits).unwrap_or(0);
-        fillscreen_hits + windowed_hits + multi_op_hits
+        let looptask_hits = self.looptask_prefix.as_ref().map(|b| b.hits).unwrap_or(0);
+        fillscreen_hits + windowed_hits + multi_op_hits + looptask_hits
     }
 
     /// Build the `fillScreen` body block.

--- a/crates/core/src/cpu/xtensa_jit/mod.rs
+++ b/crates/core/src/cpu/xtensa_jit/mod.rs
@@ -38,6 +38,11 @@
 // with the browser-side JIT in `labwired-wasm`.
 pub mod emit_core;
 
+// `wasm_emit` — hand-rolled wasm binary encoder. The Phase 4.2′ rewrite
+// replaces the hardcoded build-time WAT path with runtime byte
+// emission so every block can be JIT'd, not just the single shape.
+pub mod wasm_emit;
+
 // Wasmtime-backed adapters live behind the `jit` feature so the browser
 // build doesn't have to drag wasmtime into its dep tree.
 #[cfg(feature = "jit")]

--- a/crates/core/src/cpu/xtensa_jit/mod.rs
+++ b/crates/core/src/cpu/xtensa_jit/mod.rs
@@ -52,10 +52,11 @@ mod windowed_call;
 
 #[cfg(feature = "jit")]
 pub use bb_multi::{
-    walk_bb, DecodedOp, LoopTaskPrefixResult, MultiOpBlock, MultiOpResult,
+    walk_bb, DecodedOp, LoopTaskPrefixResult, LoopTaskTailResult, MultiOpBlock, MultiOpResult,
     EXIT_BRANCH_TAKEN as MULTI_EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH as MULTI_EXIT_FALL_THROUGH,
     EXIT_HOST_BUS_ERROR as MULTI_EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT,
     HOT_BB_L32R_ADDR, HOT_BB_PC, LOOPTASK_PC, LOOPTASK_PREFIX_END, LOOPTASK_PREFIX_INSTR_COUNT,
+    LOOPTASK_TAIL_END, LOOPTASK_TAIL_INSTR_COUNT, LOOPTASK_TAIL_PC,
 };
 #[cfg(feature = "jit")]
 pub use windowed_call::{
@@ -167,6 +168,9 @@ pub struct JitCache {
     /// (`L32R → L8UI → BEQZ`). Independent slot so the PC-keyed cache
     /// lookup is a constant-time match without a HashMap allocation.
     pub looptask_prefix: Option<Box<MultiOpBlock>>,
+    /// Phase 4.4: loopTask tail block at PC 0x400d4a9c
+    /// (`L32R → BEQZ`). Independent slot for the same reason.
+    pub looptask_tail: Option<Box<MultiOpBlock>>,
     /// Phase 3.6.3 instrumentation: count multi-op refusals.
     pub multi_op_refusals: u64,
 }
@@ -189,6 +193,7 @@ impl JitCache {
             windowed_refusals: 0,
             hot_bb: None,
             looptask_prefix: None,
+            looptask_tail: None,
             multi_op_refusals: 0,
         }
     }
@@ -278,6 +283,20 @@ impl JitCache {
                 }
                 self.looptask_prefix.as_deref_mut()
             }
+            LOOPTASK_TAIL_PC => {
+                if self.looptask_tail.is_none() {
+                    match MultiOpBlock::build_looptask_tail(&self.engine) {
+                        Ok(b) => self.looptask_tail = Some(Box::new(b)),
+                        Err(e) => {
+                            tracing::warn!(target: "labwired-core::jit",
+                                "loopTask tail JIT compile failed for pc=0x{pc:08x}: {e:#}. \
+                                 Falling back to interpreter for this PC.");
+                            return None;
+                        }
+                    }
+                }
+                self.looptask_tail.as_deref_mut()
+            }
             _ => None,
         }
     }
@@ -289,7 +308,8 @@ impl JitCache {
         let windowed_hits = self.loopv_call8.as_ref().map(|b| b.hits).unwrap_or(0);
         let multi_op_hits = self.hot_bb.as_ref().map(|b| b.hits).unwrap_or(0);
         let looptask_hits = self.looptask_prefix.as_ref().map(|b| b.hits).unwrap_or(0);
-        fillscreen_hits + windowed_hits + multi_op_hits + looptask_hits
+        let tail_hits = self.looptask_tail.as_ref().map(|b| b.hits).unwrap_or(0);
+        fillscreen_hits + windowed_hits + multi_op_hits + looptask_hits + tail_hits
     }
 
     /// Build the `fillScreen` body block.

--- a/crates/core/src/cpu/xtensa_jit/wasm_emit.rs
+++ b/crates/core/src/cpu/xtensa_jit/wasm_emit.rs
@@ -1,0 +1,298 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Hand-rolled wasm binary encoder for the universal browser JIT.
+//!
+//! Replaces the build-time `wat`-baked single-block path with runtime
+//! byte emission. Implements only the subset of the wasm binary format
+//! the JIT actually needs: type / import / function / export / code
+//! sections + LEB128 immediates. No tables, globals, element, data,
+//! memory, or start sections — JIT'd blocks don't use any of those.
+//!
+//! Reference: WebAssembly Core Specification §5 (Binary Format).
+
+/// Append a value as unsigned LEB128.
+pub fn encode_u32(mut value: u32, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+/// Append a value as signed LEB128.
+pub fn encode_s32(mut value: i32, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value as u8) & 0x7F;
+        // Arithmetic shift right preserves sign.
+        value >>= 7;
+        // Termination: value has stabilized at 0 or -1 AND the sign bit of the
+        // emitted byte matches.
+        let sign_bit = byte & 0x40;
+        if (value == 0 && sign_bit == 0) || (value == -1 && sign_bit != 0) {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+// ── Wasm value types (subset we use) ──────────────────────────────────────────
+
+/// Wasm value type encoding.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ValType {
+    I32 = 0x7F,
+    I64 = 0x7E,
+}
+
+impl ValType {
+    fn byte(self) -> u8 {
+        self as u8
+    }
+}
+
+/// A wasm function type: parameter types and result types.
+#[derive(Clone, Debug)]
+pub struct FuncType {
+    pub params: Vec<ValType>,
+    pub results: Vec<ValType>,
+}
+
+// ── Module builder ────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct WasmModule {
+    types: Vec<FuncType>,
+    /// (module, name, type_idx) for each function import.
+    imports: Vec<(String, String, u32)>,
+    /// type_idx per defined function (excluding imports).
+    func_type_idx: Vec<u32>,
+    /// (name, func_idx_global) for each exported function.
+    exports: Vec<(String, u32)>,
+    /// Raw code body per defined function: just the body bytes (locals
+    /// + instructions), without the size prefix or the end marker — the
+    /// `finish_code_section` adds those.
+    codes: Vec<Vec<u8>>,
+}
+
+impl WasmModule {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare a function type; returns its index.
+    pub fn add_type(&mut self, ty: FuncType) -> u32 {
+        let idx = self.types.len() as u32;
+        self.types.push(ty);
+        idx
+    }
+
+    /// Declare a function import; returns its global function index.
+    /// Function imports are indexed before defined functions.
+    pub fn add_func_import(&mut self, module: &str, name: &str, type_idx: u32) -> u32 {
+        let idx = self.imports.len() as u32;
+        self.imports
+            .push((module.to_string(), name.to_string(), type_idx));
+        idx
+    }
+
+    /// Declare a defined function with body bytes; returns its global
+    /// function index. Body bytes must be the function body (without
+    /// locals-count or end byte — those are appended here).
+    pub fn add_func(&mut self, type_idx: u32, body: Vec<u8>) -> u32 {
+        let idx = (self.imports.len() + self.func_type_idx.len()) as u32;
+        self.func_type_idx.push(type_idx);
+        self.codes.push(body);
+        idx
+    }
+
+    /// Export a function by global index.
+    pub fn add_func_export(&mut self, name: &str, func_idx: u32) {
+        self.exports.push((name.to_string(), func_idx));
+    }
+
+    /// Finalize: emit the binary module bytes.
+    pub fn finish(self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(64);
+        // Magic + version.
+        out.extend_from_slice(b"\0asm");
+        out.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+        // Sections in spec order. Each section is `id, size-leb, contents`.
+        if !self.types.is_empty() {
+            push_section(&mut out, 1, |s| {
+                encode_u32(self.types.len() as u32, s);
+                for ty in &self.types {
+                    s.push(0x60); // func type tag
+                    encode_u32(ty.params.len() as u32, s);
+                    for p in &ty.params {
+                        s.push(p.byte());
+                    }
+                    encode_u32(ty.results.len() as u32, s);
+                    for r in &ty.results {
+                        s.push(r.byte());
+                    }
+                }
+            });
+        }
+        if !self.imports.is_empty() {
+            push_section(&mut out, 2, |s| {
+                encode_u32(self.imports.len() as u32, s);
+                for (mod_name, name, ty_idx) in &self.imports {
+                    encode_u32(mod_name.len() as u32, s);
+                    s.extend_from_slice(mod_name.as_bytes());
+                    encode_u32(name.len() as u32, s);
+                    s.extend_from_slice(name.as_bytes());
+                    s.push(0x00); // import kind = func
+                    encode_u32(*ty_idx, s);
+                }
+            });
+        }
+        if !self.func_type_idx.is_empty() {
+            push_section(&mut out, 3, |s| {
+                encode_u32(self.func_type_idx.len() as u32, s);
+                for ty_idx in &self.func_type_idx {
+                    encode_u32(*ty_idx, s);
+                }
+            });
+        }
+        if !self.exports.is_empty() {
+            push_section(&mut out, 7, |s| {
+                encode_u32(self.exports.len() as u32, s);
+                for (name, fn_idx) in &self.exports {
+                    encode_u32(name.len() as u32, s);
+                    s.extend_from_slice(name.as_bytes());
+                    s.push(0x00); // export kind = func
+                    encode_u32(*fn_idx, s);
+                }
+            });
+        }
+        if !self.codes.is_empty() {
+            push_section(&mut out, 10, |s| {
+                encode_u32(self.codes.len() as u32, s);
+                for body in &self.codes {
+                    // Body = locals-vec + instructions + end. We require
+                    // the caller to have included locals + end already if
+                    // it wanted them — the body is taken verbatim, then
+                    // size-prefixed.
+                    encode_u32(body.len() as u32, s);
+                    s.extend_from_slice(body);
+                }
+            });
+        }
+        out
+    }
+}
+
+/// Emit one section: id byte, then size-prefixed contents.
+fn push_section(out: &mut Vec<u8>, id: u8, build: impl FnOnce(&mut Vec<u8>)) {
+    let mut section = Vec::with_capacity(32);
+    build(&mut section);
+    out.push(id);
+    encode_u32(section.len() as u32, out);
+    out.extend_from_slice(&section);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enc_u(v: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        encode_u32(v, &mut out);
+        out
+    }
+
+    fn enc_s(v: i32) -> Vec<u8> {
+        let mut out = Vec::new();
+        encode_s32(v, &mut out);
+        out
+    }
+
+    #[test]
+    fn leb128_u32_known_values() {
+        // Reference cases from Wasm spec + GitHub gists.
+        assert_eq!(enc_u(0), vec![0x00]);
+        assert_eq!(enc_u(1), vec![0x01]);
+        assert_eq!(enc_u(127), vec![0x7F]);
+        assert_eq!(enc_u(128), vec![0x80, 0x01]);
+        assert_eq!(enc_u(16383), vec![0xFF, 0x7F]);
+        assert_eq!(enc_u(16384), vec![0x80, 0x80, 0x01]);
+        assert_eq!(enc_u(624485), vec![0xE5, 0x8E, 0x26]);
+        assert_eq!(enc_u(u32::MAX), vec![0xFF, 0xFF, 0xFF, 0xFF, 0x0F]);
+    }
+
+    #[test]
+    fn leb128_s32_known_values() {
+        assert_eq!(enc_s(0), vec![0x00]);
+        assert_eq!(enc_s(1), vec![0x01]);
+        assert_eq!(enc_s(-1), vec![0x7F]);
+        assert_eq!(enc_s(63), vec![0x3F]);
+        assert_eq!(enc_s(-64), vec![0x40]);
+        assert_eq!(enc_s(64), vec![0xC0, 0x00]);
+        assert_eq!(enc_s(-65), vec![0xBF, 0x7F]);
+        assert_eq!(enc_s(-12345), vec![0xC7, 0x9F, 0x7F]);
+    }
+
+    #[test]
+    fn empty_module_starts_with_magic() {
+        let bytes = WasmModule::new().finish();
+        assert_eq!(&bytes[0..8], b"\0asm\x01\0\0\0");
+        // Empty module = just magic + version, no sections.
+        assert_eq!(bytes.len(), 8);
+    }
+
+    #[test]
+    fn small_module_with_one_export_is_well_formed() {
+        // (module
+        //   (type (func (result i32)))
+        //   (func (export "answer") (result i32) i32.const 42)
+        // )
+        let mut m = WasmModule::new();
+        let ty = m.add_type(FuncType {
+            params: vec![],
+            results: vec![ValType::I32],
+        });
+        let mut body = Vec::new();
+        // locals = 0
+        encode_u32(0, &mut body);
+        // i32.const 42 ; end
+        body.push(0x41);
+        encode_s32(42, &mut body);
+        body.push(0x0B); // end
+        let fn_idx = m.add_func(ty, body);
+        m.add_func_export("answer", fn_idx);
+        let bytes = m.finish();
+        // Sanity-check the structure: magic + type section (1) +
+        // function section (3) + export section (7) + code section (10).
+        assert_eq!(&bytes[0..8], b"\0asm\x01\0\0\0");
+        // Walk section IDs after the header.
+        let mut p = 8;
+        let mut section_ids = Vec::new();
+        while p < bytes.len() {
+            let id = bytes[p];
+            section_ids.push(id);
+            p += 1;
+            // Decode size LEB128.
+            let mut size = 0u32;
+            let mut shift = 0;
+            loop {
+                let b = bytes[p];
+                p += 1;
+                size |= ((b & 0x7F) as u32) << shift;
+                if b & 0x80 == 0 {
+                    break;
+                }
+                shift += 7;
+            }
+            p += size as usize;
+        }
+        assert_eq!(section_ids, vec![1, 3, 7, 10]);
+        assert_eq!(p, bytes.len());
+    }
+}

--- a/crates/core/src/cpu/xtensa_jit/wasm_emit.rs
+++ b/crates/core/src/cpu/xtensa_jit/wasm_emit.rs
@@ -198,6 +198,146 @@ fn push_section(out: &mut Vec<u8>, id: u8, build: impl FnOnce(&mut Vec<u8>)) {
     out.extend_from_slice(&section);
 }
 
+// ── Instruction byte emitters (Wasm Core Spec §5.4) ───────────────────────────
+//
+// Each helper appends the opcode byte (and any LEB-encoded immediates) to
+// `out`. Numeric and parametric ops are single-byte; variable / control /
+// call ops carry an unsigned (or, for blocktype, signed) LEB128 immediate.
+
+/// `local.get x` — push the value of local `x`.
+pub fn emit_local_get(idx: u32, out: &mut Vec<u8>) {
+    out.push(0x20);
+    encode_u32(idx, out);
+}
+
+/// `local.set x` — pop and store into local `x`.
+pub fn emit_local_set(idx: u32, out: &mut Vec<u8>) {
+    out.push(0x21);
+    encode_u32(idx, out);
+}
+
+/// `local.tee x` — store top-of-stack into local `x` without popping.
+pub fn emit_local_tee(idx: u32, out: &mut Vec<u8>) {
+    out.push(0x22);
+    encode_u32(idx, out);
+}
+
+/// `i32.const N` — push a 32-bit signed immediate (LEB128-encoded).
+pub fn emit_i32_const(value: i32, out: &mut Vec<u8>) {
+    out.push(0x41);
+    encode_s32(value, out);
+}
+
+/// `i32.add` — pop two i32s, push their sum.
+pub fn emit_i32_add(out: &mut Vec<u8>) {
+    out.push(0x6A);
+}
+
+/// `i32.sub` — pop b then a, push a - b.
+pub fn emit_i32_sub(out: &mut Vec<u8>) {
+    out.push(0x6B);
+}
+
+/// `i32.and` — bitwise AND.
+pub fn emit_i32_and(out: &mut Vec<u8>) {
+    out.push(0x71);
+}
+
+/// `i32.or` — bitwise OR.
+pub fn emit_i32_or(out: &mut Vec<u8>) {
+    out.push(0x72);
+}
+
+/// `i32.xor` — bitwise XOR.
+pub fn emit_i32_xor(out: &mut Vec<u8>) {
+    out.push(0x73);
+}
+
+/// `i32.shl` — logical shift left.
+pub fn emit_i32_shl(out: &mut Vec<u8>) {
+    out.push(0x74);
+}
+
+/// `i32.shr_s` — arithmetic (signed) shift right.
+pub fn emit_i32_shr_s(out: &mut Vec<u8>) {
+    out.push(0x75);
+}
+
+/// `i32.shr_u` — logical (unsigned) shift right.
+pub fn emit_i32_shr_u(out: &mut Vec<u8>) {
+    out.push(0x76);
+}
+
+/// `i32.eqz` — push 1 if top-of-stack is zero, else 0.
+pub fn emit_i32_eqz(out: &mut Vec<u8>) {
+    out.push(0x45);
+}
+
+/// `i32.eq` — push 1 if a == b, else 0.
+pub fn emit_i32_eq(out: &mut Vec<u8>) {
+    out.push(0x46);
+}
+
+/// `i32.lt_s` — signed less-than comparison.
+pub fn emit_i32_lt_s(out: &mut Vec<u8>) {
+    out.push(0x48);
+}
+
+/// `call x` — invoke function index `x`.
+pub fn emit_call(func_idx: u32, out: &mut Vec<u8>) {
+    out.push(0x10);
+    encode_u32(func_idx, out);
+}
+
+/// `return` — return from the current function.
+pub fn emit_return(out: &mut Vec<u8>) {
+    out.push(0x0F);
+}
+
+/// `drop` — pop and discard top-of-stack.
+pub fn emit_drop(out: &mut Vec<u8>) {
+    out.push(0x1A);
+}
+
+/// `end` — end of a block / function body.
+pub fn emit_end(out: &mut Vec<u8>) {
+    out.push(0x0B);
+}
+
+/// `else` — start the else-branch of an `if`.
+pub fn emit_else(out: &mut Vec<u8>) {
+    out.push(0x05);
+}
+
+/// `if blocktype` where blocktype = type index (signed-LEB-encoded per §5.3.2).
+///
+/// Used for multi-value `if` blocks (e.g. the JIT's return-on-error path
+/// produces 5 × i32). Per the Wasm Core Spec, blocktype carries an `s33`
+/// when it refers to a type index — small positive indices encode
+/// identically to unsigned LEB, but indices ≥ 64 differ (signed LEB inserts
+/// a zero continuation byte to keep the sign bit clear). We delegate to
+/// `encode_s32`; this is valid for indices up to `i32::MAX`, which is more
+/// than enough for any JIT'd module.
+pub fn emit_if_type(type_idx: u32, out: &mut Vec<u8>) {
+    out.push(0x04);
+    encode_s32(type_idx as i32, out);
+}
+
+/// `if (result <none>)` — single-byte blocktype 0x40 means empty type.
+pub fn emit_if_void(out: &mut Vec<u8>) {
+    out.push(0x04);
+    out.push(0x40);
+}
+
+/// Emit one `(count, valtype)` run for the locals declaration vector of a
+/// code section body. Wasm encodes a function's locals as a vec of runs;
+/// callers that need multiple distinct types should call this once per run
+/// (and prefix the whole vector with its run-count via `encode_u32`).
+pub fn emit_locals_run(count: u32, ty: ValType, out: &mut Vec<u8>) {
+    encode_u32(count, out);
+    out.push(ty.byte());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,6 +387,147 @@ mod tests {
         assert_eq!(bytes.len(), 8);
     }
 
+    // ── Instruction emitter tests ────────────────────────────────────────────
+    //
+    // One test per helper, asserting the exact byte sequence per Wasm Core
+    // Spec §5.4. Helper to make these short:
+    fn emit<F: FnOnce(&mut Vec<u8>)>(f: F) -> Vec<u8> {
+        let mut v = Vec::new();
+        f(&mut v);
+        v
+    }
+
+    #[test]
+    fn op_local_get() {
+        assert_eq!(emit(|o| emit_local_get(0, o)), vec![0x20, 0x00]);
+        // Multi-byte LEB for the immediate.
+        assert_eq!(emit(|o| emit_local_get(128, o)), vec![0x20, 0x80, 0x01]);
+    }
+
+    #[test]
+    fn op_local_set() {
+        assert_eq!(emit(|o| emit_local_set(5, o)), vec![0x21, 0x05]);
+    }
+
+    #[test]
+    fn op_local_tee() {
+        assert_eq!(emit(|o| emit_local_tee(5, o)), vec![0x22, 0x05]);
+    }
+
+    #[test]
+    fn op_i32_const() {
+        assert_eq!(emit(|o| emit_i32_const(0, o)), vec![0x41, 0x00]);
+        assert_eq!(emit(|o| emit_i32_const(-1, o)), vec![0x41, 0x7F]);
+        assert_eq!(emit(|o| emit_i32_const(255, o)), vec![0x41, 0xFF, 0x01]);
+        assert_eq!(
+            emit(|o| emit_i32_const(-12345, o)),
+            vec![0x41, 0xC7, 0x9F, 0x7F]
+        );
+    }
+
+    #[test]
+    fn op_i32_add() {
+        assert_eq!(emit(emit_i32_add), vec![0x6A]);
+    }
+
+    #[test]
+    fn op_i32_sub() {
+        assert_eq!(emit(emit_i32_sub), vec![0x6B]);
+    }
+
+    #[test]
+    fn op_i32_and() {
+        assert_eq!(emit(emit_i32_and), vec![0x71]);
+    }
+
+    #[test]
+    fn op_i32_or() {
+        assert_eq!(emit(emit_i32_or), vec![0x72]);
+    }
+
+    #[test]
+    fn op_i32_xor() {
+        assert_eq!(emit(emit_i32_xor), vec![0x73]);
+    }
+
+    #[test]
+    fn op_i32_shl() {
+        assert_eq!(emit(emit_i32_shl), vec![0x74]);
+    }
+
+    #[test]
+    fn op_i32_shr_s() {
+        assert_eq!(emit(emit_i32_shr_s), vec![0x75]);
+    }
+
+    #[test]
+    fn op_i32_shr_u() {
+        assert_eq!(emit(emit_i32_shr_u), vec![0x76]);
+    }
+
+    #[test]
+    fn op_i32_eqz() {
+        assert_eq!(emit(emit_i32_eqz), vec![0x45]);
+    }
+
+    #[test]
+    fn op_i32_eq() {
+        assert_eq!(emit(emit_i32_eq), vec![0x46]);
+    }
+
+    #[test]
+    fn op_i32_lt_s() {
+        assert_eq!(emit(emit_i32_lt_s), vec![0x48]);
+    }
+
+    #[test]
+    fn op_call() {
+        assert_eq!(emit(|o| emit_call(7, o)), vec![0x10, 0x07]);
+    }
+
+    #[test]
+    fn op_return() {
+        assert_eq!(emit(emit_return), vec![0x0F]);
+    }
+
+    #[test]
+    fn op_drop() {
+        assert_eq!(emit(emit_drop), vec![0x1A]);
+    }
+
+    #[test]
+    fn op_end() {
+        assert_eq!(emit(emit_end), vec![0x0B]);
+    }
+
+    #[test]
+    fn op_else() {
+        assert_eq!(emit(emit_else), vec![0x05]);
+    }
+
+    #[test]
+    fn op_if_void() {
+        assert_eq!(emit(emit_if_void), vec![0x04, 0x40]);
+    }
+
+    #[test]
+    fn op_if_type() {
+        // Small positive type idx encodes to a single LEB byte (matches
+        // unsigned-LEB for values < 64).
+        assert_eq!(emit(|o| emit_if_type(3, o)), vec![0x04, 0x03]);
+        // For values ≥ 64 the signed LEB encoding inserts a continuation
+        // so the sign bit of the final byte stays clear. 128 → 0x80 0x01.
+        assert_eq!(emit(|o| emit_if_type(128, o)), vec![0x04, 0x80, 0x01]);
+    }
+
+    #[test]
+    fn op_locals_run() {
+        assert_eq!(
+            emit(|o| emit_locals_run(3, ValType::I32, o)),
+            vec![0x03, 0x7F]
+        );
+    }
+
     #[test]
     fn small_module_with_one_export_is_well_formed() {
         // (module
@@ -294,5 +575,60 @@ mod tests {
         }
         assert_eq!(section_ids, vec![1, 3, 7, 10]);
         assert_eq!(p, bytes.len());
+    }
+
+    /// End-to-end: build `and_mask(a, b) = a & b; return` using both the
+    /// `WasmModule` builder AND the new instruction emitters, then assert
+    /// the magic + section IDs and validate with `wasmparser`.
+    #[test]
+    fn end_to_end_and_mask_module_parses() {
+        let mut m = WasmModule::new();
+        let ty = m.add_type(FuncType {
+            params: vec![ValType::I32, ValType::I32],
+            results: vec![ValType::I32],
+        });
+        let mut body = Vec::new();
+        encode_u32(0, &mut body); // no extra locals beyond params
+        emit_local_get(0, &mut body);
+        emit_local_get(1, &mut body);
+        emit_i32_and(&mut body);
+        emit_return(&mut body);
+        emit_end(&mut body);
+        let fn_idx = m.add_func(ty, body);
+        m.add_func_export("and_mask", fn_idx);
+        let bytes = m.finish();
+
+        // Magic header.
+        assert_eq!(&bytes[0..8], b"\0asm\x01\0\0\0");
+
+        // Walk via wasmparser: collect section IDs and prove every payload
+        // (including operators in the code body) parses cleanly.
+        use wasmparser::{Parser, Payload};
+        let mut section_ids = Vec::new();
+        let mut saw_code = false;
+        let mut saw_export = false;
+        for payload in Parser::new(0).parse_all(&bytes) {
+            match payload.expect("wasmparser must parse our bytes") {
+                Payload::TypeSection(_) => section_ids.push(1),
+                Payload::FunctionSection(_) => section_ids.push(3),
+                Payload::ExportSection(r) => {
+                    section_ids.push(7);
+                    for ex in r {
+                        assert_eq!(ex.expect("export decodes").name, "and_mask");
+                    }
+                    saw_export = true;
+                }
+                Payload::CodeSectionStart { .. } => section_ids.push(10),
+                Payload::CodeSectionEntry(body) => {
+                    for op in body.get_operators_reader().expect("ops reader") {
+                        op.expect("each op decodes");
+                    }
+                    saw_code = true;
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(section_ids, vec![1, 3, 7, 10]);
+        assert!(saw_code && saw_export);
     }
 }

--- a/crates/core/src/cpu/xtensa_jit_bytes.rs
+++ b/crates/core/src/cpu/xtensa_jit_bytes.rs
@@ -44,6 +44,29 @@ pub const LOOPTASK_PREFIX_INSTR_COUNT: u32 = 3;
 /// taken; the interpreter resumes from here.
 pub const LOOPTASK_PREFIX_END: u32 = LOOPTASK_PC + 9;
 
+/// PC of the loopTask **tail** block (Phase 4.4): the `L32R → BEQZ` pair
+/// at `_Z8loopTaskPv + 0x18`, immediately following the `CALL8 _Z4loopv`
+/// return. Decoded as:
+/// ```text
+///   400d4a9c: l32r  a8, &serialEventRun
+///   400d4a9f: beqz  a8, 400d4a8d        ; loop back to loopTask top
+///   400d4aa2: call8 serialEventRun       ; terminator (interp)
+///   400d4aa5: j     400d4a8d             ; terminator (interp)
+/// ```
+/// The JIT covers the L32R + BEQZ pair (BEQZ is the terminator). In
+/// steady-state polling (`serialEventRun == NULL`, the default at boot)
+/// BEQZ is taken every iteration and the dispatcher loops straight back
+/// to [`LOOPTASK_PC`], avoiding both `CALL8 serialEventRun` and the
+/// unconditional `J`. When the literal is non-zero the JIT falls through
+/// to `0x400d4aa2` (the CALL8) and the interpreter handles the rest.
+pub const LOOPTASK_TAIL_PC: u32 = 0x400d_4a9c;
+/// Number of Xtensa instructions in the loopTask tail block. L32R + BEQZ.
+pub const LOOPTASK_TAIL_INSTR_COUNT: u32 = 2;
+/// First PC after the loopTask tail block — fall-through resume PC when
+/// BEQZ is not taken (i.e. `serialEventRun != NULL`). The interpreter
+/// resumes at the `CALL8 serialEventRun`.
+pub const LOOPTASK_TAIL_END: u32 = LOOPTASK_TAIL_PC + 6;
+
 /// Side-exit: block executed cleanly to the terminator.
 pub const EXIT_FALL_THROUGH: i32 = 0;
 /// Side-exit: a conditional or unconditional branch terminated the BB

--- a/crates/core/src/cpu/xtensa_jit_bytes.rs
+++ b/crates/core/src/cpu/xtensa_jit_bytes.rs
@@ -39,8 +39,7 @@ pub const EXIT_HOST_BUS_ERROR: i32 = 5;
 /// Hot-block wasm module bytes, pre-compiled at crate build time. Backends
 /// instantiate via either `wasmtime::Module::new` (native) or
 /// `js_sys::WebAssembly::Module::new` (browser) with these exact bytes.
-pub const HOT_BB_WASM: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/xtensa_jit_hot_bb.wasm"));
+pub const HOT_BB_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/xtensa_jit_hot_bb.wasm"));
 
 #[cfg(test)]
 mod tests {
@@ -51,7 +50,11 @@ mod tests {
     /// or otherwise malformed.
     #[test]
     fn baked_wasm_has_magic_header() {
-        assert!(HOT_BB_WASM.len() > 32, "hot_bb.wasm suspiciously small: {} bytes", HOT_BB_WASM.len());
+        assert!(
+            HOT_BB_WASM.len() > 32,
+            "hot_bb.wasm suspiciously small: {} bytes",
+            HOT_BB_WASM.len()
+        );
         // \0asm magic
         assert_eq!(&HOT_BB_WASM[0..4], b"\0asm");
         // wasm version 1
@@ -63,8 +66,10 @@ mod tests {
     #[cfg(feature = "jit")]
     #[test]
     fn constants_agree_with_jit_module() {
-        use crate::cpu::xtensa_jit::{HOT_BB_END as JIT_END, HOT_BB_INSTR_COUNT as JIT_N,
-            HOT_BB_L32R_ADDR as JIT_L32R, HOT_BB_PC as JIT_PC};
+        use crate::cpu::xtensa_jit::{
+            HOT_BB_END as JIT_END, HOT_BB_INSTR_COUNT as JIT_N, HOT_BB_L32R_ADDR as JIT_L32R,
+            HOT_BB_PC as JIT_PC,
+        };
         assert_eq!(HOT_BB_PC, JIT_PC);
         assert_eq!(HOT_BB_END, JIT_END);
         assert_eq!(HOT_BB_INSTR_COUNT, JIT_N);

--- a/crates/core/src/cpu/xtensa_jit_bytes.rs
+++ b/crates/core/src/cpu/xtensa_jit_bytes.rs
@@ -1,0 +1,73 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Xtensa JIT runtime-agnostic emit artifacts (#124 Phase 4).
+//!
+//! This module is **always** compiled — independent of the `jit` feature.
+//! Reason: the browser-side JIT prototype lives in `labwired-wasm`, which
+//! doesn't (and can't) enable `jit` (wasmtime doesn't build for
+//! wasm32-unknown-unknown). But it still needs the compiled wasm bytes +
+//! the architectural constants (block PC bounds, instruction count, L32R
+//! literal address). So we keep emit output here, outside the JIT feature
+//! gate, while the runtime backends — wasmtime native vs `js_sys` in the
+//! browser — stay gated to their respective build configurations.
+//!
+//! The wasm bytes are pre-compiled at crate build time by `build.rs` from
+//! the canonical WAT source at `src/cpu/xtensa_jit/hot_bb.wat`. Both
+//! backends consume bit-identical bytes; emit decoupling is exactly that
+//! shared byte stream.
+
+/// PC of the JITed hot multi-instruction BB (`call_start_cpu0` delay loop).
+/// Mirrors `xtensa_jit::bb_multi::HOT_BB_PC`; duplicated here so the
+/// browser path can reference it without requiring the `jit` feature.
+pub const HOT_BB_PC: u32 = 0x400829cc;
+/// First PC after the JITed range; the interpreter resumes here at
+/// `callx8`.  Mirrors `xtensa_jit::bb_multi::HOT_BB_END`.
+pub const HOT_BB_END: u32 = 0x400829e4;
+/// Number of Xtensa instructions executed by the JITed body.
+pub const HOT_BB_INSTR_COUNT: u32 = 8;
+/// L32R literal address read by the block. Mirrors
+/// `xtensa_jit::bb_multi::HOT_BB_L32R_ADDR`.
+pub const HOT_BB_L32R_ADDR: u32 = 0x4008_0534;
+
+/// Side-exit: block executed cleanly to the terminator.
+pub const EXIT_FALL_THROUGH: i32 = 0;
+/// Side-exit: host `read_u8` import signalled a bus error.
+pub const EXIT_HOST_BUS_ERROR: i32 = 5;
+
+/// Hot-block wasm module bytes, pre-compiled at crate build time. Backends
+/// instantiate via either `wasmtime::Module::new` (native) or
+/// `js_sys::WebAssembly::Module::new` (browser) with these exact bytes.
+pub const HOT_BB_WASM: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/xtensa_jit_hot_bb.wasm"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke: the baked artifact looks like a wasm module (magic + version).
+    /// Catches build.rs regressions that would leave the OUT_DIR file empty
+    /// or otherwise malformed.
+    #[test]
+    fn baked_wasm_has_magic_header() {
+        assert!(HOT_BB_WASM.len() > 32, "hot_bb.wasm suspiciously small: {} bytes", HOT_BB_WASM.len());
+        // \0asm magic
+        assert_eq!(&HOT_BB_WASM[0..4], b"\0asm");
+        // wasm version 1
+        assert_eq!(&HOT_BB_WASM[4..8], &[0x01, 0x00, 0x00, 0x00]);
+    }
+
+    /// Constants must match the JIT module's view of the block (so the
+    /// browser can reference them without pulling in the `jit` feature).
+    #[cfg(feature = "jit")]
+    #[test]
+    fn constants_agree_with_jit_module() {
+        use crate::cpu::xtensa_jit::{HOT_BB_END as JIT_END, HOT_BB_INSTR_COUNT as JIT_N,
+            HOT_BB_L32R_ADDR as JIT_L32R, HOT_BB_PC as JIT_PC};
+        assert_eq!(HOT_BB_PC, JIT_PC);
+        assert_eq!(HOT_BB_END, JIT_END);
+        assert_eq!(HOT_BB_INSTR_COUNT, JIT_N);
+        assert_eq!(HOT_BB_L32R_ADDR, JIT_L32R);
+    }
+}

--- a/crates/core/src/cpu/xtensa_jit_bytes.rs
+++ b/crates/core/src/cpu/xtensa_jit_bytes.rs
@@ -33,6 +33,11 @@ pub const HOT_BB_L32R_ADDR: u32 = 0x4008_0534;
 
 /// Side-exit: block executed cleanly to the terminator.
 pub const EXIT_FALL_THROUGH: i32 = 0;
+/// Side-exit: a conditional or unconditional branch terminated the BB
+/// with the taken path. The wasm body has populated the result tuple's
+/// PC slot with the branch target; the interpreter resumes execution
+/// from there. Wire code consumed by both backends (Phase 4.3, #124).
+pub const EXIT_BRANCH_TAKEN: i32 = 1;
 /// Side-exit: host `read_u8` import signalled a bus error.
 pub const EXIT_HOST_BUS_ERROR: i32 = 5;
 

--- a/crates/core/src/cpu/xtensa_jit_bytes.rs
+++ b/crates/core/src/cpu/xtensa_jit_bytes.rs
@@ -31,6 +31,19 @@ pub const HOT_BB_INSTR_COUNT: u32 = 8;
 /// `xtensa_jit::bb_multi::HOT_BB_L32R_ADDR`.
 pub const HOT_BB_L32R_ADDR: u32 = 0x4008_0534;
 
+/// PC of the actually-hottest steady-state block: `loopTask` polling loop
+/// (Arduino-ESP32 main scheduler). Decoded as
+/// `L32R → L8UI → BEQZ → CALL8 → L32R → BEQZ → J`. Phase 4.3.5 JIT-compiles
+/// the **prefix** (L32R → L8UI → BEQZ), ending at the first BEQZ side-exit.
+/// Full coverage needs CALL8/RETW (Phase 4.4).
+pub const LOOPTASK_PC: u32 = 0x400d_4a8d;
+/// Number of Xtensa instructions in the loopTask prefix (L32R, L8UI, BEQZ).
+pub const LOOPTASK_PREFIX_INSTR_COUNT: u32 = 3;
+/// First PC after the loopTask prefix — `LOOPTASK_PC + 3 + 3 + 3` (three
+/// 3-byte instructions). Used as the fall-through PC when the BEQZ is not
+/// taken; the interpreter resumes from here.
+pub const LOOPTASK_PREFIX_END: u32 = LOOPTASK_PC + 9;
+
 /// Side-exit: block executed cleanly to the terminator.
 pub const EXIT_FALL_THROUGH: i32 = 0;
 /// Side-exit: a conditional or unconditional branch terminated the BB

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -2080,6 +2080,10 @@ impl Default for XtensaLx7 {
 }
 
 impl Cpu for XtensaLx7 {
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
     fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
         let was_halted = self.halted;
         self.regs = ArFile::new();

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -183,7 +183,7 @@ impl XtensaLx7 {
     fn try_jit_step(&mut self, bus: &mut dyn Bus) -> SimResult<Option<u32>> {
         use crate::cpu::xtensa_jit::{
             JitCache, FILL_SCREEN_BLOCK_END, FILL_SCREEN_BLOCK_INSTR_COUNT, FILL_SCREEN_BLOCK_PC,
-            HOT_BB_PC, LOOPTASK_PC, LOOPV_CALL8_PC,
+            HOT_BB_PC, LOOPTASK_PC, LOOPTASK_TAIL_PC, LOOPV_CALL8_PC,
         };
         let pc = self.pc;
         // Hot guard: cheap exact-PC check for any of the JIT'd PCs before
@@ -197,6 +197,9 @@ impl XtensaLx7 {
         }
         if pc == LOOPTASK_PC {
             return self.try_jit_looptask_prefix(bus);
+        }
+        if pc == LOOPTASK_TAIL_PC {
+            return self.try_jit_looptask_tail(bus);
         }
         if pc != FILL_SCREEN_BLOCK_PC {
             return Ok(None);
@@ -466,6 +469,7 @@ impl XtensaLx7 {
                 l8ui_at,
                 l8ui_base_at,
                 l32r_literal_value,
+                beqz_target_pc: _,
             } => (l32r_at, l8ui_at, l8ui_base_at, l32r_literal_value),
             other => {
                 return Err(SimulationError::NotImplemented(format!(
@@ -543,6 +547,93 @@ impl XtensaLx7 {
                 "xtensa loopTask JIT returned unknown side-exit code {other}"
             ))),
         }
+    }
+
+    /// Phase 4.4 (issue #124): JIT dispatch for the loopTask **tail**
+    /// (`L32R → BEQZ`) at PC 0x400d4a9c, immediately following the
+    /// `CALL8 _Z4loopv` return. Two Xtensa instructions, both
+    /// constant-folded by the recognizer (literal value + BEQZ
+    /// direction). The wasm body is a fixed return tuple; the
+    /// dispatcher commits the L32R write + advances PC.
+    ///
+    /// Together with [`Self::try_jit_looptask_prefix`] this absorbs the
+    /// first 3 + last 2 instructions of the 7-instruction loopTask
+    /// body, leaving the two `CALL8`s (and the conditional `J`) to the
+    /// interpreter.
+    #[cfg(feature = "jit")]
+    fn try_jit_looptask_tail(&mut self, bus: &mut dyn Bus) -> SimResult<Option<u32>> {
+        use crate::cpu::xtensa_jit::emit_core::BlockShape;
+        use crate::cpu::xtensa_jit::{
+            JitCache, LOOPTASK_TAIL_END, LOOPTASK_TAIL_INSTR_COUNT, MULTI_EXIT_BRANCH_TAKEN,
+            MULTI_EXIT_FALL_THROUGH,
+        };
+        let pc = self.pc;
+        if self.jit.is_none() {
+            self.jit = Some(Box::new(JitCache::new()));
+        }
+        let cache = self.jit.as_mut().expect("jit cache init above");
+        let block = match cache.lookup_or_install_multi_op(pc) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+        let (l32r_dst_ar, beqz_target_pc) = match block.shape() {
+            BlockShape::LoopTaskTail {
+                l32r_at,
+                beqz_target_pc,
+                ..
+            } => (l32r_at, beqz_target_pc),
+            other => {
+                return Err(SimulationError::NotImplemented(format!(
+                    "loopTask tail JIT at pc=0x{pc:08x} installed with wrong shape {other:?}"
+                )));
+            }
+        };
+        // We still run the wasm body for hit-counter parity with the
+        // browser path, but the result tuple's bias toward the
+        // canonical-fixture literal is overridden below by a live-bus
+        // L32R re-read. (The native install path uses a synthesised
+        // fixture — same pattern as `build_looptask_prefix` — so the
+        // baked literal can disagree with the live bus.)
+        let _ = block
+            .run_looptask_tail()
+            .map_err(|e| SimulationError::NotImplemented(format!("xtensa loopTask tail JIT: {e:#}")))?;
+
+        // Resolve the L32R literal against the live bus. The L32R EA
+        // formula is `((pc + 3) & ~3) + pc_rel_byte_offset`; for the
+        // synthesised fixture pc_rel_byte_offset = -32, but for the
+        // real ereader at PC=0x400d4a9c it's also a known constant
+        // captured by the canonical disassembly. Re-decoding here keeps
+        // the JIT robust against canonical-fixture drift.
+        let l32r_pc = pc;
+        let aligned = (l32r_pc.wrapping_add(3)) & !3u32;
+        // For the real ereader at PC=0x400d4a9c, the L32R word
+        // `0xedfe81` decodes to imm16 = 0xfeed → pc_rel_byte_offset
+        // = (0xfeed - 0x10000) * 4 = -76. Decode dynamically from the
+        // bus so the JIT is right for any literal-pool layout.
+        let instr_word = bus.read_u32(l32r_pc as u64)?;
+        // L32R bits 8..23 hold imm16; the low byte is the opcode/at.
+        let imm16 = ((instr_word >> 8) & 0xFFFF) as i32;
+        let pc_rel_byte_offset = (imm16 - 0x10000) * 4; // bit15 always set for valid L32R
+        let literal_ea = aligned.wrapping_add(pc_rel_byte_offset as u32);
+        let l32r_literal = bus.read_u32(literal_ea as u64)?;
+
+        self.regs.write_logical(l32r_dst_ar, l32r_literal);
+        let taken = l32r_literal == 0;
+        let (next_pc, branched, exit_code) = if taken {
+            (beqz_target_pc, true, MULTI_EXIT_BRANCH_TAKEN)
+        } else {
+            (LOOPTASK_TAIL_END, false, MULTI_EXIT_FALL_THROUGH)
+        };
+        self.pc = next_pc;
+        if LOOPTASK_TAIL_INSTR_COUNT > 1 {
+            use crate::cpu::xtensa_sr::CCOUNT;
+            let cc = self.sr.read(CCOUNT);
+            self.sr
+                .write(CCOUNT, cc.wrapping_add(LOOPTASK_TAIL_INSTR_COUNT - 1));
+        }
+        self.branched = branched;
+        let _ = exit_code; // for symmetry with the prefix dispatcher
+        Ok(Some(LOOPTASK_TAIL_INSTR_COUNT))
     }
 
     /// Read an SR by ID, with special routing for PS / WINDOWBASE / WINDOWSTART

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -183,7 +183,7 @@ impl XtensaLx7 {
     fn try_jit_step(&mut self, bus: &mut dyn Bus) -> SimResult<Option<u32>> {
         use crate::cpu::xtensa_jit::{
             JitCache, FILL_SCREEN_BLOCK_END, FILL_SCREEN_BLOCK_INSTR_COUNT, FILL_SCREEN_BLOCK_PC,
-            HOT_BB_PC, LOOPV_CALL8_PC,
+            HOT_BB_PC, LOOPTASK_PC, LOOPV_CALL8_PC,
         };
         let pc = self.pc;
         // Hot guard: cheap exact-PC check for any of the JIT'd PCs before
@@ -194,6 +194,9 @@ impl XtensaLx7 {
         }
         if pc == HOT_BB_PC {
             return self.try_jit_multi_op(bus);
+        }
+        if pc == LOOPTASK_PC {
+            return self.try_jit_looptask_prefix(bus);
         }
         if pc != FILL_SCREEN_BLOCK_PC {
             return Ok(None);
@@ -421,6 +424,123 @@ impl XtensaLx7 {
             }
             other => Err(SimulationError::NotImplemented(format!(
                 "xtensa multi-op JIT returned unknown side-exit code {other}"
+            ))),
+        }
+    }
+
+    /// Phase 4.3.7 (issue #124): JIT dispatch for the loopTask prefix
+    /// (`L32R → L8UI → BEQZ`) at PC 0x400d4a8d.
+    ///
+    /// Marshals the input state (`l8ui_base` AR register), invokes the
+    /// pre-compiled wasm block, and commits the result back to the CPU
+    /// register file:
+    ///   * Always writes `l32r_literal_value` into the L32R dst AR (the
+    ///     wasm body doesn't carry the literal through its result
+    ///     tuple — it's constant-folded at compile time).
+    ///   * On BRANCH_TAKEN / FALL_THROUGH: writes the L8UI byte into the
+    ///     L8UI dst AR and advances PC to the appropriate target.
+    ///   * On HOST_BUS_ERROR: refuses (returns Ok(None)) so the
+    ///     interpreter can raise the fault with full bus context.
+    ///
+    /// CCOUNT: bumps by `LOOPTASK_PREFIX_INSTR_COUNT - 1` on success
+    /// (the outer step already counted one).
+    #[cfg(feature = "jit")]
+    fn try_jit_looptask_prefix(&mut self, bus: &mut dyn Bus) -> SimResult<Option<u32>> {
+        use crate::cpu::xtensa_jit::emit_core::BlockShape;
+        use crate::cpu::xtensa_jit::{
+            JitCache, LOOPTASK_PREFIX_INSTR_COUNT, MULTI_EXIT_BRANCH_TAKEN,
+            MULTI_EXIT_FALL_THROUGH, MULTI_EXIT_HOST_BUS_ERROR,
+        };
+        let pc = self.pc;
+        if self.jit.is_none() {
+            self.jit = Some(Box::new(JitCache::new()));
+        }
+        let cache = self.jit.as_mut().expect("jit cache init above");
+        let block = match cache.lookup_or_install_multi_op(pc) {
+            Some(b) => b,
+            None => return Ok(None),
+        };
+        let (l32r_dst_ar, l8ui_dst_ar, l8ui_base_ar, l32r_literal_value) = match block.shape() {
+            BlockShape::LoopTaskPrefix {
+                l32r_at,
+                l8ui_at,
+                l8ui_base_at,
+                l32r_literal_value,
+            } => (l32r_at, l8ui_at, l8ui_base_at, l32r_literal_value),
+            other => {
+                return Err(SimulationError::NotImplemented(format!(
+                    "loopTask JIT at pc=0x{pc:08x} installed with wrong shape {other:?}"
+                )));
+            }
+        };
+
+        // Pre-read the single L8UI byte through the live bus so a real
+        // bus error surfaces via the interpreter retry path. The L8UI
+        // base register IS the L32R destination (shape invariant
+        // `l8ui_base_at == l32r_at` — the L8UI dereferences the literal
+        // the L32R just loaded). The L32R hasn't executed yet at this
+        // point, so we use the resolved literal value as the base
+        // rather than reading the stale AR file slot.
+        debug_assert_eq!(l8ui_base_ar, l32r_dst_ar);
+        let l8ui_base = l32r_literal_value;
+        let b0 = match bus.read_u8(l8ui_base as u64) {
+            Ok(v) => v,
+            Err(_) => return Ok(None),
+        };
+        block.stage_loads(&[b0]);
+        let result = block.run_looptask_prefix(l32r_literal_value, l8ui_base).map_err(|e| {
+            SimulationError::NotImplemented(format!("xtensa loopTask JIT: {e:#}"))
+        })?;
+
+        // The L32R literal write happens unconditionally on every
+        // path the wasm body returns through (matches interp semantics:
+        // L32R runs before the BEQZ).
+        self.regs.write_logical(l32r_dst_ar, l32r_literal_value);
+
+        match result.exit_code {
+            x if x == MULTI_EXIT_BRANCH_TAKEN => {
+                self.regs.write_logical(l8ui_dst_ar, result.l8ui_at_value);
+                self.pc = result.beqz_target_pc;
+                if LOOPTASK_PREFIX_INSTR_COUNT > 1 {
+                    use crate::cpu::xtensa_sr::CCOUNT;
+                    let cc = self.sr.read(CCOUNT);
+                    self.sr
+                        .write(CCOUNT, cc.wrapping_add(LOOPTASK_PREFIX_INSTR_COUNT - 1));
+                }
+                self.branched = true;
+                Ok(Some(LOOPTASK_PREFIX_INSTR_COUNT))
+            }
+            x if x == MULTI_EXIT_FALL_THROUGH => {
+                self.regs.write_logical(l8ui_dst_ar, result.l8ui_at_value);
+                self.pc = result.next_pc;
+                if LOOPTASK_PREFIX_INSTR_COUNT > 1 {
+                    use crate::cpu::xtensa_sr::CCOUNT;
+                    let cc = self.sr.read(CCOUNT);
+                    self.sr
+                        .write(CCOUNT, cc.wrapping_add(LOOPTASK_PREFIX_INSTR_COUNT - 1));
+                }
+                self.branched = false;
+                Ok(Some(LOOPTASK_PREFIX_INSTR_COUNT))
+            }
+            x if x == MULTI_EXIT_HOST_BUS_ERROR => {
+                // Roll back the L32R write so the interpreter retry
+                // produces the same architectural state as if the JIT
+                // never ran. AR file has no "undo"; we re-read the
+                // pre-call value, but the easiest correct path is to
+                // leave the JIT-side write in place — the interpreter
+                // will replay the L32R as its first op and produce an
+                // identical write, then attempt the L8UI which will
+                // raise the real bus fault. Documented behaviour:
+                // post-refusal architectural state may have the L32R
+                // dst pre-populated, which is benign because the
+                // interpreter overwrites it.
+                if let Some(c) = self.jit.as_mut() {
+                    c.multi_op_refusals += 1;
+                }
+                Ok(None)
+            }
+            other => Err(SimulationError::NotImplemented(format!(
+                "xtensa loopTask JIT returned unknown side-exit code {other}"
             ))),
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -221,6 +221,15 @@ impl Cpu for Box<dyn Cpu> {
     fn reset(&mut self, bus: &mut dyn Bus) -> SimResult<()> {
         (**self).reset(bus)
     }
+    /// Forward the concrete-type escape hatch through the Box.
+    /// Without this, `Machine<Box<dyn Cpu>>::cpu.as_any_mut()` would
+    /// hit the default impl on the trait (which returns `None`),
+    /// silently disabling every downcast — including the browser JIT
+    /// dispatcher in `labwired-wasm`. Reported during #124 Phase 4.2
+    /// bench validation.
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        (**self).as_any_mut()
+    }
     fn step(
         &mut self,
         bus: &mut dyn Bus,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -118,6 +118,14 @@ pub trait SimulationObserver: std::fmt::Debug + Send + Sync {
 /// Trait representing a CPU architecture
 pub trait Cpu: Send {
     fn reset(&mut self, bus: &mut dyn Bus) -> SimResult<()>;
+    /// Downcast escape hatch for runtime fast-paths that need the
+    /// concrete CPU type (e.g. the browser-side JIT prototype in
+    /// `labwired-wasm` reaches into `XtensaLx7` for direct register
+    /// access). Default returns `None`, matching the rest of the trait
+    /// surface: only the CPUs that opt in are reachable this way.
+    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
+        None
+    }
     fn step(
         &mut self,
         bus: &mut dyn Bus,

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -13,6 +13,7 @@ pub enum GpioRegisterLayout {
     #[default]
     Stm32F1,
     Stm32V2,
+    Nrf52,
 }
 
 impl FromStr for GpioRegisterLayout {
@@ -23,8 +24,9 @@ impl FromStr for GpioRegisterLayout {
         match v.as_str() {
             "stm32f1" | "f1" | "legacy" => Ok(Self::Stm32F1),
             "stm32v2" | "v2" | "modern" | "stm32-modern" | "h5" | "stm32h5" => Ok(Self::Stm32V2),
+            "nrf52" | "nordic" => Ok(Self::Nrf52),
             _ => Err(format!(
-                "unsupported GPIO register layout '{}'; supported: stm32f1, stm32v2",
+                "unsupported GPIO register layout '{}'; supported: stm32f1, stm32v2, nrf52",
                 value
             )),
         }
@@ -46,6 +48,8 @@ pub struct GpioPort {
     lckr: u32,    // 0x18: configuration lock register
     afrl: u32,    // 0x20: alternate function low register (STM32v2)
     afrh: u32,    // 0x24: alternate function high register (STM32v2)
+    dir: u32,     // 0x514: direction register (nRF52)
+    pin_cnf: [u32; 32],
 }
 
 impl GpioPort {
@@ -94,6 +98,16 @@ impl GpioPort {
                 0x1C => self.lckr,
                 0x20 => self.afrl,
                 0x24 => self.afrh,
+                _ => 0,
+            },
+            GpioRegisterLayout::Nrf52 => match offset {
+                0x504 => self.odr,
+                0x510 => self.idr,
+                0x514 => self.dir,
+                0x700..=0x77C if offset % 4 == 0 => {
+                    let idx = ((offset - 0x700) / 4) as usize;
+                    self.pin_cnf[idx]
+                }
                 _ => 0,
             },
         }
@@ -146,6 +160,20 @@ impl GpioPort {
                 }
                 _ => {}
             },
+            GpioRegisterLayout::Nrf52 => match offset {
+                0x504 => self.odr = value,
+                0x508 => self.odr |= value,
+                0x50C => self.odr &= !value,
+                0x510 => self.idr = value,
+                0x514 => self.dir = value,
+                0x518 => self.dir |= value,
+                0x51C => self.dir &= !value,
+                0x700..=0x77C if offset % 4 == 0 => {
+                    let idx = ((offset - 0x700) / 4) as usize;
+                    self.pin_cnf[idx] = value;
+                }
+                _ => {}
+            },
         }
     }
 
@@ -154,6 +182,7 @@ impl GpioPort {
         match self.layout {
             GpioRegisterLayout::Stm32F1 => 0x10,
             GpioRegisterLayout::Stm32V2 => 0x18,
+            GpioRegisterLayout::Nrf52 => 0x508,
         }
     }
 
@@ -162,6 +191,7 @@ impl GpioPort {
         match self.layout {
             GpioRegisterLayout::Stm32F1 => 0x14,
             GpioRegisterLayout::Stm32V2 => 0x28,
+            GpioRegisterLayout::Nrf52 => 0x50C,
         }
     }
 }

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -6,6 +6,7 @@
 
 use crate::SimResult;
 use std::any::Any;
+use std::str::FromStr;
 
 /// Trait implemented by simulated SPI devices (peripherals attached to an SPI bus).
 ///
@@ -41,9 +42,34 @@ pub trait SpiDevice: Send {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpiRegisterLayout {
+    #[default]
+    Stm32,
+    Nrf52Spim,
+}
+
+impl FromStr for SpiRegisterLayout {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let v = value.trim().to_ascii_lowercase();
+        match v.as_str() {
+            "stm32" | "stm32f1" | "stm32v2" => Ok(Self::Stm32),
+            "nrf52" | "nrf52_spim" | "nrf_spim" | "nordic" => Ok(Self::Nrf52Spim),
+            _ => Err(format!(
+                "unsupported SPI register layout '{}'; supported: stm32, nrf52",
+                value
+            )),
+        }
+    }
+}
+
 /// STM32F1 compatible SPI peripheral
 #[derive(Default, serde::Serialize)]
 pub struct Spi {
+    layout: SpiRegisterLayout,
     cr1: u16,
     cr2: u16,
     sr: u16,
@@ -66,6 +92,21 @@ pub struct Spi {
     /// MISO data — RXNE stays clear, DR reads as 0).
     loopback: bool,
 
+    nrf_events_end: u32,
+    nrf_events_stopped: u32,
+    nrf_enable: u32,
+    nrf_psel_sck: u32,
+    nrf_psel_mosi: u32,
+    nrf_psel_miso: u32,
+    nrf_frequency: u32,
+    nrf_config: u32,
+    nrf_rxd_ptr: u32,
+    nrf_rxd_maxcnt: u32,
+    nrf_rxd_amount: u32,
+    nrf_txd_ptr: u32,
+    nrf_txd_maxcnt: u32,
+    nrf_txd_amount: u32,
+
     #[serde(skip)]
     pub attached_devices: Vec<Box<dyn SpiDevice>>,
 }
@@ -73,6 +114,7 @@ pub struct Spi {
 impl core::fmt::Debug for Spi {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Spi")
+            .field("layout", &self.layout)
             .field("cr1", &self.cr1)
             .field("sr", &self.sr)
             .field("transfer_in_progress", &self.transfer_in_progress)
@@ -84,7 +126,12 @@ impl core::fmt::Debug for Spi {
 
 impl Spi {
     pub fn new() -> Self {
+        Self::new_with_layout(SpiRegisterLayout::Stm32)
+    }
+
+    pub fn new_with_layout(layout: SpiRegisterLayout) -> Self {
         Self {
+            layout,
             // Reset values verified against real STM32L476RG silicon via
             // SWD register dump on a NUCLEO-L476RG:
             //   CR1 = 0x0000  CR2 = 0x0700  SR = 0x0002  DR = 0x0000
@@ -112,6 +159,9 @@ impl Spi {
     }
 
     fn read_reg(&self, offset: u64) -> u16 {
+        if matches!(self.layout, SpiRegisterLayout::Nrf52Spim) {
+            return self.read_nrf_reg(offset) as u16;
+        }
         match offset {
             0x00 => self.cr1,
             0x04 => self.cr2,
@@ -131,6 +181,10 @@ impl Spi {
     }
 
     fn write_reg(&mut self, offset: u64, value: u16) {
+        if matches!(self.layout, SpiRegisterLayout::Nrf52Spim) {
+            self.write_nrf_reg(offset, value as u32);
+            return;
+        }
         match offset {
             0x00 => {
                 self.cr1 = value;
@@ -172,12 +226,64 @@ impl Spi {
             _ => {}
         }
     }
+
+    fn read_nrf_reg(&self, offset: u64) -> u32 {
+        match offset {
+            0x104 => self.nrf_events_stopped,
+            0x118 => self.nrf_events_end,
+            0x500 => self.nrf_enable,
+            0x508 => self.nrf_psel_sck,
+            0x50C => self.nrf_psel_mosi,
+            0x510 => self.nrf_psel_miso,
+            0x524 => self.nrf_frequency,
+            0x534 => self.nrf_rxd_ptr,
+            0x538 => self.nrf_rxd_maxcnt,
+            0x53C => self.nrf_rxd_amount,
+            0x544 => self.nrf_txd_ptr,
+            0x548 => self.nrf_txd_maxcnt,
+            0x54C => self.nrf_txd_amount,
+            0x554 => self.nrf_config,
+            _ => 0,
+        }
+    }
+
+    fn write_nrf_reg(&mut self, offset: u64, value: u32) {
+        match offset {
+            0x010 if value != 0 => {
+                self.nrf_events_end = 1;
+                self.nrf_txd_amount = self.nrf_txd_maxcnt;
+                self.nrf_rxd_amount = self.nrf_rxd_maxcnt;
+            }
+            0x014 if value != 0 => {
+                self.nrf_events_stopped = 1;
+            }
+            0x104 => self.nrf_events_stopped = value,
+            0x118 => self.nrf_events_end = value,
+            0x500 => self.nrf_enable = value,
+            0x508 => self.nrf_psel_sck = value,
+            0x50C => self.nrf_psel_mosi = value,
+            0x510 => self.nrf_psel_miso = value,
+            0x524 => self.nrf_frequency = value,
+            0x534 => self.nrf_rxd_ptr = value,
+            0x538 => self.nrf_rxd_maxcnt = value,
+            0x53C => self.nrf_rxd_amount = value,
+            0x544 => self.nrf_txd_ptr = value,
+            0x548 => self.nrf_txd_maxcnt = value,
+            0x54C => self.nrf_txd_amount = value,
+            0x554 => self.nrf_config = value,
+            _ => {}
+        }
+    }
 }
 
 impl crate::Peripheral for Spi {
     fn read(&self, offset: u64) -> SimResult<u8> {
         let reg_offset = offset & !3;
         let byte_offset = (offset % 4) as u32;
+        if matches!(self.layout, SpiRegisterLayout::Nrf52Spim) {
+            let reg_val = self.read_nrf_reg(reg_offset);
+            return Ok(((reg_val >> (byte_offset * 8)) & 0xFF) as u8);
+        }
         // Widen to u32 before the shift: SPI registers are u16 but byte
         // accesses at offsets 2 and 3 read the upper byte of the next
         // halfword. The CI release profile has overflow checks on, so
@@ -192,6 +298,15 @@ impl crate::Peripheral for Spi {
         let reg_offset = offset & !3;
         let byte_offset = (offset % 4) as u32;
 
+        if matches!(self.layout, SpiRegisterLayout::Nrf52Spim) {
+            let mut reg_val = self.read_nrf_reg(reg_offset);
+            let mask: u32 = 0xFF << (byte_offset * 8);
+            reg_val &= !mask;
+            reg_val |= (value as u32) << (byte_offset * 8);
+            self.write_nrf_reg(reg_offset, reg_val);
+            return Ok(());
+        }
+
         // Same widen-then-shift dance as read() to avoid u16 shift overflow.
         // Writes to bytes 2..3 are naturally discarded because the final
         // `write_reg(reg_offset, reg_val as u16)` truncates back to u16.
@@ -205,6 +320,11 @@ impl crate::Peripheral for Spi {
     }
 
     fn write_u16(&mut self, offset: u64, value: u16) -> SimResult<()> {
+        if matches!(self.layout, SpiRegisterLayout::Nrf52Spim) {
+            self.write(offset, (value & 0xFF) as u8)?;
+            self.write(offset + 1, ((value >> 8) & 0xFF) as u8)?;
+            return Ok(());
+        }
         // SPI DR (offset 0x0C) MUST be atomic — a Thumb `strh` from firmware
         // is one bus access, kicking off a single SPI transfer. The default
         // trait impl byte-splits, which would start two transfers back-to-back

--- a/crates/core/src/tests/nrf52.rs
+++ b/crates/core/src/tests/nrf52.rs
@@ -58,3 +58,74 @@ fn test_nrf52_full_smoke() {
         "UART0 TXD should contain 'K' (75)"
     );
 }
+
+#[test]
+fn xiao_nrf52840_sense_manifest_builds_with_uart_gpio_spi() {
+    let mut chip_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    chip_path.push("../../configs/chips/nrf52840.yaml");
+
+    let mut system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    system_path.push("../../configs/systems/seeed-xiao-nrf52840-sense.yaml");
+
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|_| panic!("Failed to load chip config at {:?}", chip_path));
+    let mut manifest = SystemManifest::from_file(&system_path)
+        .unwrap_or_else(|_| panic!("Failed to load system manifest at {:?}", system_path));
+
+    let anchored_chip = system_path.parent().unwrap().join(&manifest.chip);
+    manifest.chip = anchored_chip.to_str().unwrap().to_string();
+
+    let bus = SystemBus::from_config(&chip, &manifest).expect("Failed to build XIAO bus");
+    let names: Vec<&str> = bus.peripherals.iter().map(|p| p.name.as_str()).collect();
+
+    assert!(names.contains(&"uart0"), "uart0 missing: {names:?}");
+    assert!(names.contains(&"gpio0"), "gpio0 missing: {names:?}");
+    assert!(names.contains(&"gpio1"), "gpio1 missing: {names:?}");
+    assert!(names.contains(&"spi0"), "spi0 missing: {names:?}");
+}
+
+#[test]
+fn xiao_nrf52840_gpio_task_registers_drive_led_pins() {
+    let mut chip_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    chip_path.push("../../configs/chips/nrf52840.yaml");
+
+    let mut system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    system_path.push("../../configs/systems/seeed-xiao-nrf52840-sense.yaml");
+
+    let chip = ChipDescriptor::from_file(&chip_path).unwrap();
+    let mut manifest = SystemManifest::from_file(&system_path).unwrap();
+    let anchored_chip = system_path.parent().unwrap().join(&manifest.chip);
+    manifest.chip = anchored_chip.to_str().unwrap().to_string();
+
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("Failed to build XIAO bus");
+
+    bus.write_u32(0x5000_0508, 1 << 26).unwrap();
+    assert_eq!(bus.read_u32(0x5000_0504).unwrap() & (1 << 26), 1 << 26);
+
+    bus.write_u32(0x5000_050C, 1 << 26).unwrap();
+    assert_eq!(bus.read_u32(0x5000_0504).unwrap() & (1 << 26), 0);
+}
+
+#[test]
+fn xiao_nrf52840_spim0_start_sets_end_event_and_amount() {
+    let mut chip_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    chip_path.push("../../configs/chips/nrf52840.yaml");
+
+    let mut system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    system_path.push("../../configs/systems/seeed-xiao-nrf52840-sense.yaml");
+
+    let chip = ChipDescriptor::from_file(&chip_path).unwrap();
+    let mut manifest = SystemManifest::from_file(&system_path).unwrap();
+    let anchored_chip = system_path.parent().unwrap().join(&manifest.chip);
+    manifest.chip = anchored_chip.to_str().unwrap().to_string();
+
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("Failed to build XIAO bus");
+
+    bus.write_u32(0x4000_3500, 7).unwrap();
+    bus.write_u32(0x4000_3544, 0x2000_0000).unwrap();
+    bus.write_u32(0x4000_3548, 4).unwrap();
+    bus.write_u32(0x4000_3010, 1).unwrap();
+
+    assert_eq!(bus.read_u32(0x4000_3118).unwrap(), 1);
+    assert_eq!(bus.read_u32(0x4000_354C).unwrap(), 4);
+}

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -84,18 +84,7 @@ fn labwired_ereader_runs_to_panel_paint() {
     //       ereader ELF and installs only the thunks for symbols
     //       actually present — silently skips missing ones. Identical
     //       in spirit to the wasm playground's install_arduino_esp32_quirks.
-    let mut symbol_addrs = labwired_loader::extract_arduino_esp32_thunks(&elf_bytes);
-    // Symbols that aren't in the loader's KNOWN list but we need for
-    // this firmware. Resolved directly so we don't have to round-trip
-    // through the loader for one-off additions.
-    for sym in &[
-        "_ZN14HardwareSerial5beginEmjaabmh",
-        "_get_effective_baudrate",
-    ] {
-        if let Some(addr) = labwired_loader::resolve_symbol_in_elf(&elf_bytes, sym) {
-            symbol_addrs.insert(*sym, addr);
-        }
-    }
+    let symbol_addrs = labwired_loader::extract_arduino_esp32_thunks(&elf_bytes);
     eprintln!(
         "[ereader-sim] resolved {} Arduino-ESP32 thunk symbols from ELF",
         symbol_addrs.len()

--- a/crates/firmware-nrf52840-demo/src/main.rs
+++ b/crates/firmware-nrf52840-demo/src/main.rs
@@ -9,23 +9,40 @@ const UART0_BASE: u32 = 0x40002000;
 const UART0_ENABLE: *mut u32 = (UART0_BASE + 0x500) as *mut u32;
 const UART0_TXD: *mut u32 = (UART0_BASE + 0x51C) as *mut u32;
 
-// Mock LED for demonstration
-const MOCK_LED_REG: *mut u32 = 0x50000000 as *mut u32;
+const GPIO0_BASE: u32 = 0x50000000;
+const GPIO0_OUTSET: *mut u32 = (GPIO0_BASE + 0x508) as *mut u32;
+const GPIO0_OUTCLR: *mut u32 = (GPIO0_BASE + 0x50C) as *mut u32;
+const GPIO0_DIRSET: *mut u32 = (GPIO0_BASE + 0x518) as *mut u32;
+const LED_RED: u32 = 1 << 26;
+const LED_GREEN: u32 = 1 << 30;
+const LED_BLUE: u32 = 1 << 6;
+
+const SPIM0_BASE: u32 = 0x40003000;
+const SPIM0_TASKS_START: *mut u32 = (SPIM0_BASE + 0x010) as *mut u32;
+const SPIM0_ENABLE: *mut u32 = (SPIM0_BASE + 0x500) as *mut u32;
+const SPIM0_PSEL_SCK: *mut u32 = (SPIM0_BASE + 0x508) as *mut u32;
+const SPIM0_PSEL_MOSI: *mut u32 = (SPIM0_BASE + 0x50C) as *mut u32;
+const SPIM0_PSEL_MISO: *mut u32 = (SPIM0_BASE + 0x510) as *mut u32;
+const SPIM0_FREQUENCY: *mut u32 = (SPIM0_BASE + 0x524) as *mut u32;
+const SPIM0_TXD_PTR: *mut u32 = (SPIM0_BASE + 0x544) as *mut u32;
+const SPIM0_TXD_MAXCNT: *mut u32 = (SPIM0_BASE + 0x548) as *mut u32;
+
+static SPI_SMOKE_BYTES: [u8; 4] = [0x9A, 0xBC, 0xDE, 0xF0];
 
 #[entry]
 fn main() -> ! {
-    let mut led_state = 0u32;
-
     unsafe {
         // Enable UART (value 4 = ENABLE)
         core::ptr::write_volatile(UART0_ENABLE, 4);
+        configure_gpio();
+        configure_spim0();
     }
 
     loop {
-        // "Blink" the mocked LED by toggling the register
-        led_state ^= 1;
         unsafe {
-            core::ptr::write_volatile(MOCK_LED_REG, led_state);
+            core::ptr::write_volatile(GPIO0_OUTCLR, LED_RED);
+            core::ptr::write_volatile(GPIO0_OUTSET, LED_GREEN | LED_BLUE);
+            core::ptr::write_volatile(SPIM0_TASKS_START, 1);
         }
 
         // Write a message to UART
@@ -36,6 +53,23 @@ fn main() -> ! {
             cortex_m::asm::nop();
         }
     }
+}
+
+unsafe fn configure_gpio() {
+    let leds = LED_RED | LED_GREEN | LED_BLUE;
+    core::ptr::write_volatile(GPIO0_DIRSET, leds);
+    core::ptr::write_volatile(GPIO0_OUTSET, leds);
+}
+
+unsafe fn configure_spim0() {
+    // XIAO SPI pins: D8/SCK=P1.13, D10/MOSI=P1.15, D9/MISO=P1.14.
+    core::ptr::write_volatile(SPIM0_PSEL_SCK, 32 + 13);
+    core::ptr::write_volatile(SPIM0_PSEL_MOSI, 32 + 15);
+    core::ptr::write_volatile(SPIM0_PSEL_MISO, 32 + 14);
+    core::ptr::write_volatile(SPIM0_FREQUENCY, 0x0200_0000);
+    core::ptr::write_volatile(SPIM0_TXD_PTR, SPI_SMOKE_BYTES.as_ptr() as u32);
+    core::ptr::write_volatile(SPIM0_TXD_MAXCNT, SPI_SMOKE_BYTES.len() as u32);
+    core::ptr::write_volatile(SPIM0_ENABLE, 7);
 }
 
 fn print_uart(s: &str) {

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -135,6 +135,16 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "_ZN14HardwareSerial5flushEv",
         "_ZN14HardwareSerial9readBytesEPcj",
         "_ZN14HardwareSerial9readBytesEPhj",
+        // HardwareSerial::begin(unsigned long, unsigned int, signed char,
+        // signed char, bool, unsigned long, unsigned char) — Arduino-ESP32's
+        // serial init walks through `_get_effective_baudrate`, which divides
+        // by `getApbFrequency()`. Our sim doesn't drive that register, so
+        // the division is by zero. Skip the whole begin() rather than emulate
+        // the baud calculation; we don't model UART output anyway. The
+        // demangled placeholder above (`HardwareSerial::begin(...)`) never
+        // matched object's mangled symbol name; the mangled form here does.
+        "_ZN14HardwareSerial5beginEmjaabmh",
+        "_get_effective_baudrate",
         "uartAvailable",
         "uartAvailableForWrite",
         "uartWrite",
@@ -164,7 +174,9 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "_esp_error_check_failed",
         "setCpuFrequencyMhz",
         "esp_ota_get_running_partition", // fake non-null ptr
-        "HardwareSerial::begin(unsigned long, unsigned int, signed char, signed char, bool, unsigned long, unsigned char)",
+        // NB: HardwareSerial::begin lives above as its mangled symbol
+        // (_ZN14HardwareSerial5beginEmjaabmh) since object/goblin return
+        // mangled names from the symbol table.
         "delay",
         // ── Dual-core handshake bytes (in .bss). ────────────────────────────
         // `call_start_cpu0` busy-waits until various handshake bytes
@@ -215,8 +227,8 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         //    All stubbed to no-op or fake-ptr; consumers that don't actually
         //    use the returned data (which is most setup() / loop() code on
         //    the sketch's render path) get to keep running.
-        "__getreent",            // returns a DRAM pointer (zeroed reent struct)
-        "esp_panic_handler",     // we don't want to enter the panic path at all
+        "__getreent",        // returns a DRAM pointer (zeroed reent struct)
+        "esp_panic_handler", // we don't want to enter the panic path at all
         "esp_panic_handler_reconfigure_wdts",
         "xTaskGetCurrentTaskHandle",
         "pthread_key_create",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -10,6 +10,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2.92"
+# #124 Phase 4: js-sys exposes `js_sys::WebAssembly::{Module, Instance}` used
+# by the browser-side JIT prototype in `src/jit_browser.rs`. Already a
+# transitive dep of `serde-wasm-bindgen`; pinning it here makes the direct
+# usage visible at the dep boundary.
+js-sys = "0.3"
 labwired-core = { path = "../core" }
 labwired-config = { path = "../config" }
 labwired-loader = { path = "../loader" }

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -1,0 +1,359 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Browser-side Xtensa JIT prototype (#124 Phase 4).
+//!
+//! ## Why this exists
+//!
+//! The native JIT in `labwired-core::cpu::xtensa_jit` runs hot Xtensa
+//! basic blocks as WebAssembly modules via wasmtime. Wasmtime doesn't
+//! compile for `wasm32-unknown-unknown`, so the deployed browser sim
+//! has been paying full interpreter cost for every instruction —
+//! including the dominant 0x400829cc hot block (~82% of ereader work).
+//!
+//! This module is the browser counterpart: it takes the **same wasm
+//! bytes** the native JIT consumes (baked at compile time by
+//! `crates/core/build.rs`), instantiates them through
+//! `js_sys::WebAssembly::{Module, Instance}`, and exposes a Rust API
+//! that calls the resulting module on the hot path.
+//!
+//! ## Decoupling
+//!
+//! Emit is fully decoupled from runtime:
+//!   1. `crates/core/src/cpu/xtensa_jit/hot_bb.wat` — single source of
+//!      truth for the JIT body.
+//!   2. `crates/core/build.rs` — compiles WAT → wasm bytes at crate
+//!      build time. Build-deps only; doesn't leak into the runtime
+//!      dependency tree.
+//!   3. `labwired_core::cpu::xtensa_jit_bytes::HOT_BB_WASM` — bytes
+//!      accessible from any crate, with or without `--features jit`.
+//!   4. Native (wasmtime) backend uses `Module::new(engine, HOT_BB_WASM)`.
+//!   5. Browser (this module) uses
+//!      `js_sys::WebAssembly::Module::new(Uint8Array(HOT_BB_WASM))`.
+//!
+//! ## Host import surface
+//!
+//! The JITed block imports `host.read_u8(addr: i32) -> i32`. The host
+//! returns `-1` to signal a bus error; the wasm body then returns
+//! exit code `5` (EXIT_HOST_BUS_ERROR) and the caller falls back to
+//! the interpreter. To match the native backend's "pre-staged byte
+//! queue" model, the browser path stages a small Vec on the host side
+//! and dequeues from a JS closure each time the import is invoked.
+//!
+//! ## Scope cap (#124 Phase 4)
+//!
+//! * One block JIT'd (0x400829cc — the dominant 82%-of-work hot BB).
+//! * No BB walker, no cache management, no peripheral dispatch from
+//!   inside wasm. This is a prototype to measure whether the
+//!   browser-wasm-inside-browser-wasm architecture pays off; if it
+//!   does, generalising is a Phase 4.1+ follow-up.
+
+use js_sys::{Array, Function, Object, Reflect, Uint8Array, WebAssembly};
+use labwired_core::cpu::xtensa_jit_bytes::{
+    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_L32R_ADDR,
+    HOT_BB_PC, HOT_BB_WASM,
+};
+use labwired_core::cpu::xtensa_sr::CCOUNT;
+use labwired_core::cpu::XtensaLx7;
+use labwired_core::Bus;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+/// Result of running the hot-block wasm body in the browser.
+pub struct BrowserMultiOpResult {
+    pub exit_code: i32,
+    pub a2: u32,
+    pub a6: u32,
+    pub a8: u32,
+    pub a10: u32,
+}
+
+/// Browser-side handle for the JITed hot block. Holds the compiled
+/// `WebAssembly.Module`, the instantiated `Instance`, a long-lived JS
+/// closure for the `host.read_u8` import, and the shared host-side
+/// byte queue.
+///
+/// Lifetimes: the closure is reachable from JS as long as this struct is
+/// alive (the JS-side import refers back into it). Drop order matters:
+/// we drop the `_keepalive` field last so the JS engine can never call
+/// a stale closure. Rust drops fields top-to-bottom; we order them so
+/// that the closure outlives the instance.
+pub struct BrowserHotBbJit {
+    /// Cached `run` export. Calling this dispatches into wasm.
+    run: Function,
+    /// Host-side queue of pre-staged byte values, dequeued by the JS
+    /// shim each time wasm invokes `host.read_u8`. RefCell + Rc because
+    /// (a) the closure needs a long-lived clone and (b) the queue is
+    /// mutated both from `stage_loads` and from inside the closure.
+    pending: Rc<RefCell<Vec<u8>>>,
+    /// Number of times `run` has been invoked. Surfaced for the
+    /// `bench_jit` benchmark.
+    pub hits: u64,
+    /// Keep the closure alive for the lifetime of the instance.
+    /// Dropping this severs the JS-side import — must outlive any
+    /// possible call into `run`.
+    _read_u8_closure: Closure<dyn FnMut(i32) -> i32>,
+    /// `Instance` is kept alive to root the imports' lifetimes. Held
+    /// after `run` (which references it through JS) so drop order is
+    /// safe.
+    _instance: WebAssembly::Instance,
+}
+
+impl BrowserHotBbJit {
+    /// Compile + instantiate the hot-block module. Failure modes:
+    ///   * `WebAssembly.Module(buffer)` rejects the bytes — extremely
+    ///     unlikely given the bytes pass wasmtime validation already.
+    ///   * `WebAssembly.Instance(module, imports)` errors — usually a
+    ///     mismatch in the import object shape; the construction here
+    ///     is exhaustively typed so this should not happen in practice.
+    ///   * `instance.exports.run` is not a Function — shouldn't happen
+    ///     for a module that declares an exported function named `run`,
+    ///     but we surface it as JsValue rather than panicking.
+    pub fn compile() -> Result<Self, JsValue> {
+        // 1. Wrap the static wasm bytes in a `Uint8Array` view. We
+        //    `copy_from` to avoid handing the engine a backing buffer
+        //    that we still hold (the Rust slice is `'static` so it's
+        //    not unsafe to share, but copy is cheap and removes a
+        //    subtle lifetime concern).
+        let buf = Uint8Array::new_with_length(HOT_BB_WASM.len() as u32);
+        buf.copy_from(HOT_BB_WASM);
+
+        // 2. Compile. `Module::new` accepts `&JsValue` so we pass the
+        //    typed-array up-casted.
+        let module = WebAssembly::Module::new(&buf.into())
+            .map_err(|e| JsValue::from_str(&format!("WebAssembly.Module: {e:?}")))?;
+
+        // 3. Build the host-side byte queue and the JS closure that
+        //    dequeues from it. The closure captures an `Rc<RefCell<…>>`
+        //    so the queue is reachable from both Rust (`stage_loads`)
+        //    and JS (each invocation of `host.read_u8`).
+        let pending: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::with_capacity(2)));
+        let pending_for_closure = pending.clone();
+        let read_u8_closure = Closure::<dyn FnMut(i32) -> i32>::new(move |_addr: i32| -> i32 {
+            // Wasm passes the address but we don't need it — the host
+            // pre-staged the bytes in BB order. If the queue is empty
+            // we report a bus error; the wasm body returns exit=5.
+            let mut q = pending_for_closure.borrow_mut();
+            if q.is_empty() {
+                return -1;
+            }
+            q.remove(0) as i32
+        });
+
+        // 4. Build the imports object: { host: { read_u8: closure } }.
+        let host_obj = Object::new();
+        Reflect::set(
+            &host_obj,
+            &JsValue::from_str("read_u8"),
+            read_u8_closure.as_ref().unchecked_ref(),
+        )
+        .map_err(|e| JsValue::from_str(&format!("set host.read_u8: {e:?}")))?;
+
+        let imports = Object::new();
+        Reflect::set(&imports, &JsValue::from_str("host"), &host_obj)
+            .map_err(|e| JsValue::from_str(&format!("set imports.host: {e:?}")))?;
+
+        // 5. Instantiate.
+        let instance = WebAssembly::Instance::new(&module, &imports)
+            .map_err(|e| JsValue::from_str(&format!("WebAssembly.Instance: {e:?}")))?;
+
+        // 6. Pluck `run` out of the exports. `exports` is a frozen JS
+        //    object; `Reflect::get` returns the function value.
+        let exports = instance.exports();
+        let run_val = Reflect::get(&exports, &JsValue::from_str("run"))
+            .map_err(|e| JsValue::from_str(&format!("get exports.run: {e:?}")))?;
+        let run: Function = run_val
+            .dyn_into::<Function>()
+            .map_err(|_| JsValue::from_str("exports.run is not a Function"))?;
+
+        Ok(Self {
+            run,
+            pending,
+            hits: 0,
+            _read_u8_closure: read_u8_closure,
+            _instance: instance,
+        })
+    }
+
+    /// Stage the byte values the wasm body's L8UI ops will receive.
+    /// `bytes.len()` must equal the BB's L8UI count (2 for the hot BB).
+    pub fn stage_loads(&self, bytes: &[u8]) {
+        let mut q = self.pending.borrow_mut();
+        q.clear();
+        q.extend_from_slice(bytes);
+    }
+
+    /// Invoke the hot block. Returns the 5-tuple `(exit, a2, a6, a8, a10)`
+    /// produced by the wasm body, decoded back to Rust types.
+    ///
+    /// JS-side, `run(...)` returns a JS Array because wasm multi-value
+    /// returns map to arrays in the WebAssembly JavaScript API. We
+    /// pluck five `i32`s back out via `Reflect::get` + `as_f64()` —
+    /// JS numbers cleanly hold any i32 round-trip.
+    pub fn run(&mut self, a3: u32, a5: u32, l32r_val: u32) -> Result<BrowserMultiOpResult, JsValue> {
+        let result = self.run.call3(
+            &JsValue::NULL,
+            &JsValue::from_f64(a3 as i32 as f64),
+            &JsValue::from_f64(a5 as i32 as f64),
+            &JsValue::from_f64(l32r_val as i32 as f64),
+        )?;
+        let arr: Array = result
+            .dyn_into::<Array>()
+            .map_err(|_| JsValue::from_str("wasm.run return is not an Array"))?;
+        if arr.length() != 5 {
+            return Err(JsValue::from_str(&format!(
+                "wasm.run returned {} values; expected 5",
+                arr.length()
+            )));
+        }
+        let g = |i: u32| -> i32 {
+            arr.get(i)
+                .as_f64()
+                .map(|f| f as i64 as i32)
+                .unwrap_or(0)
+        };
+        self.hits += 1;
+        Ok(BrowserMultiOpResult {
+            exit_code: g(0),
+            a2: g(1) as u32,
+            a6: g(2) as u32,
+            a8: g(3) as u32,
+            a10: g(4) as u32,
+        })
+    }
+}
+
+/// Lazily-built process-wide JIT cache for the browser. Mirrors the
+/// `JitCache` shape on the native side but holds only the hot BB —
+/// scope cap for the prototype (#124 Phase 4).
+///
+/// We keep this thread-local because:
+///   * The browser sim is single-threaded (wasm32 main thread).
+///   * `js_sys` types are not `Send`, ruling out global statics.
+pub struct BrowserJitCache {
+    pub hot_bb: Option<BrowserHotBbJit>,
+    pub refusals: u64,
+}
+
+impl Default for BrowserJitCache {
+    fn default() -> Self {
+        Self {
+            hot_bb: None,
+            refusals: 0,
+        }
+    }
+}
+
+impl BrowserJitCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Lazily compile + return the hot block. Returns `None` only if
+    /// JS-side compilation/instantiation failed; the caller logs and
+    /// proceeds with the interpreter.
+    pub fn lookup_or_install(&mut self) -> Option<&mut BrowserHotBbJit> {
+        if self.hot_bb.is_none() {
+            match BrowserHotBbJit::compile() {
+                Ok(b) => self.hot_bb = Some(b),
+                Err(e) => {
+                    web_sys_console_warn(&format!(
+                        "labwired-wasm: browser JIT compile failed: {e:?}. Falling back to interpreter."
+                    ));
+                    return None;
+                }
+            }
+        }
+        self.hot_bb.as_mut()
+    }
+}
+
+/// Attempt to dispatch the current PC into the browser JIT. Returns
+/// `true` if the JIT handled the step (caller does NOT call
+/// `Cpu::step` for this iteration); `false` otherwise.
+///
+/// The semantics mirror `XtensaLx7::try_jit_multi_op` in the native
+/// path:
+///   * Pre-read both L8UI bytes through the live bus. If either bus
+///     read errors, refuse the JIT.
+///   * Pre-resolve the L32R literal.
+///   * Stage the bytes, invoke wasm.
+///   * Commit registers + advance PC + bump CCOUNT iff exit=0.
+///
+/// We don't run the IRQ / pre-fetch path here — those happen on the
+/// regular interpreter step. The JIT is a fast-path for the hot BB
+/// only; the caller's loop falls back to the normal step path for
+/// every other PC.
+pub fn try_browser_jit_step(
+    cpu: &mut XtensaLx7,
+    bus: &mut dyn Bus,
+    cache: &mut BrowserJitCache,
+) -> bool {
+    if cpu.pc != HOT_BB_PC {
+        return false;
+    }
+    // Pre-read both L8UI bytes through the live bus.
+    let a3 = cpu.regs.read_logical(3);
+    let a5 = cpu.regs.read_logical(5);
+    let b0 = match bus.read_u8(a3 as u64) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let b1 = match bus.read_u8((a3.wrapping_add(1)) as u64) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let l32r_val = match bus.read_u32(HOT_BB_L32R_ADDR as u64) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let block = match cache.lookup_or_install() {
+        Some(b) => b,
+        None => return false,
+    };
+    block.stage_loads(&[b0, b1]);
+    let res = match block.run(a3, a5, l32r_val) {
+        Ok(r) => r,
+        Err(_) => {
+            cache.refusals += 1;
+            return false;
+        }
+    };
+    match res.exit_code {
+        x if x == EXIT_FALL_THROUGH => {
+            cpu.regs.write_logical(10, res.a10);
+            cpu.regs.write_logical(6, res.a6);
+            cpu.regs.write_logical(2, res.a2);
+            cpu.regs.write_logical(8, res.a8);
+            cpu.pc = HOT_BB_END;
+            // CCOUNT honesty: the interpreter would have advanced
+            // CCOUNT by HOT_BB_INSTR_COUNT (one per instruction). We
+            // mirror that here so the timer interrupt + CCOMPARE0
+            // edge logic still fires correctly.
+            let cc = cpu.sr.read(CCOUNT);
+            cpu.sr.write(CCOUNT, cc.wrapping_add(HOT_BB_INSTR_COUNT));
+            cpu.branched = false;
+            true
+        }
+        x if x == EXIT_HOST_BUS_ERROR => {
+            cache.refusals += 1;
+            false
+        }
+        _ => {
+            cache.refusals += 1;
+            false
+        }
+    }
+}
+
+/// Console warn shim — avoids pulling in `web-sys` just for `console`.
+/// `console.warn` is universally available; we go through wasm-bindgen
+/// js_namespace = console directly.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn web_sys_console_warn(s: &str);
+}

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -50,6 +50,7 @@
 //!   does, generalising is a Phase 4.1+ follow-up.
 
 use js_sys::{Array, Function, Object, Reflect, Uint8Array, WebAssembly};
+use labwired_core::cpu::xtensa_jit::emit_core::{self, EmitError, EmittedBlock, PsBits};
 use labwired_core::cpu::xtensa_jit_bytes::{
     EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_L32R_ADDR,
     HOT_BB_PC, HOT_BB_WASM,
@@ -233,18 +234,10 @@ impl BrowserHotBbJit {
 /// We keep this thread-local because:
 ///   * The browser sim is single-threaded (wasm32 main thread).
 ///   * `js_sys` types are not `Send`, ruling out global statics.
+#[derive(Default)]
 pub struct BrowserJitCache {
     pub hot_bb: Option<BrowserHotBbJit>,
     pub refusals: u64,
-}
-
-impl Default for BrowserJitCache {
-    fn default() -> Self {
-        Self {
-            hot_bb: None,
-            refusals: 0,
-        }
-    }
 }
 
 impl BrowserJitCache {
@@ -346,6 +339,116 @@ pub fn try_browser_jit_step(
             cache.refusals += 1;
             false
         }
+    }
+}
+
+// ── Phase 4.1 universal install surface (stub) ────────────────────────
+//
+// The path above (`BrowserHotBbJit::compile` / `try_browser_jit_step`)
+// hand-wires the canonical hot block via the pre-baked
+// [`HOT_BB_WASM`] constant. Phase 4.1 introduces a runtime-agnostic
+// emit core in `labwired_core::cpu::xtensa_jit::emit_core`; this stub
+// is the browser-side adapter that Phase 4.2 will flesh out to drive
+// arbitrary blocks through the same surface as the wasmtime path.
+//
+// The native adapter (`bb_multi::MultiOpBlock::build_from_emitted`)
+// already accepts an [`EmittedBlock`] and instantiates it through
+// wasmtime. Phase 4.2 will mirror that here by:
+//   1. Walking the bus from `cpu.pc` via `emit_core::walk_and_emit`.
+//   2. Handing the resulting bytes to `WebAssembly::Module::new` and
+//      installing the host import surface (read_u8 today; load/store
+//      pair + control-flow exits in 4.3/4.4).
+//   3. Caching by `(pc, ps_bits)` per the universal-JIT plan.
+//
+// Today the stub returns `Err(NotYetImplemented)` so callers can
+// already type-check the integration without us pretending the
+// browser runtime is wired.
+
+/// Phase 4.2-and-later install error surface. Mirrors the native
+/// `wasmtime::Error` boundary but stays runtime-agnostic; the browser
+/// path can grow JS-specific variants as Phase 4.2 lands.
+#[allow(
+    dead_code,
+    reason = "Phase 4.1 stub: Phase 4.2 will wire callers (install + cache key)"
+)]
+#[derive(Debug)]
+pub enum BrowserInstallError {
+    /// The emit-core walker refused the PC (unsupported opcode shape,
+    /// PC outside the bus slice, etc).
+    Emit(EmitError),
+    /// Phase 4.2 is not implemented yet. Returned by
+    /// [`BrowserJitCache::install_from_emitted`] so callers can wire
+    /// the integration today and have it light up once Phase 4.2
+    /// replaces this branch with actual `WebAssembly::Module::new`
+    /// instantiation.
+    NotYetImplemented,
+}
+
+impl core::fmt::Display for BrowserInstallError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            BrowserInstallError::Emit(e) => write!(f, "emit_core: {e}"),
+            BrowserInstallError::NotYetImplemented => {
+                f.write_str("browser-side install is not yet implemented (Phase 4.2 stub)")
+            }
+        }
+    }
+}
+
+impl From<EmitError> for BrowserInstallError {
+    fn from(e: EmitError) -> Self {
+        BrowserInstallError::Emit(e)
+    }
+}
+
+impl BrowserJitCache {
+    /// Walk the BB at `pc` via [`emit_core::walk_and_emit`] and (when
+    /// Phase 4.2 lands) instantiate the resulting bytes through
+    /// `js_sys::WebAssembly`. Today this returns
+    /// [`BrowserInstallError::NotYetImplemented`] on the success path
+    /// so callers can already wire the integration end-to-end.
+    ///
+    /// The signature mirrors `bb_multi::MultiOpBlock::build_from_emitted`
+    /// on the native side: both accept the bytes emit-core produced and
+    /// instantiate them via their respective runtime. That's the entire
+    /// emit/runtime decoupling, made explicit in the type system.
+    #[allow(
+        dead_code,
+        reason = "Phase 4.1 stub: Phase 4.2 wires the browser install path"
+    )]
+    pub fn install_from_emitted(
+        &mut self,
+        _emitted: &EmittedBlock,
+    ) -> Result<(), BrowserInstallError> {
+        // Phase 4.2 fills in:
+        //   let buf = Uint8Array::new_with_length(_emitted.wasm_bytes.len() as u32);
+        //   buf.copy_from(&_emitted.wasm_bytes);
+        //   let module = WebAssembly::Module::new(&buf.into())?;
+        //   ... install host imports built from _emitted.side_exit_reasons ...
+        //   let instance = WebAssembly::Instance::new(&module, &imports)?;
+        //   self.hot_bb = Some(BrowserHotBbJit { ... });
+        Err(BrowserInstallError::NotYetImplemented)
+    }
+
+    /// Walk + install for the given PC. Threads through emit_core so
+    /// the API surface is symmetric with the native adapter. Returns
+    /// `Ok(())` once Phase 4.2 wires up the browser runtime; today
+    /// always errors with [`BrowserInstallError::NotYetImplemented`]
+    /// after a successful walk, or [`BrowserInstallError::Emit`] when
+    /// the walker refuses.
+    #[allow(
+        dead_code,
+        reason = "Phase 4.1 stub: Phase 4.2 will drive this from try_browser_jit_step"
+    )]
+    pub fn walk_and_install(
+        &mut self,
+        bus_slice: &[u8],
+        pc: u32,
+        pc_to_offset: impl FnMut(u32) -> Option<usize>,
+        ps_bits: PsBits,
+    ) -> Result<(), BrowserInstallError> {
+        let emitted = emit_core::walk_and_emit(bus_slice, pc, pc_to_offset, ps_bits)?;
+        self.install_from_emitted(&emitted)
     }
 }
 

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -193,7 +193,12 @@ impl BrowserHotBbJit {
     /// returns map to arrays in the WebAssembly JavaScript API. We
     /// pluck five `i32`s back out via `Reflect::get` + `as_f64()` —
     /// JS numbers cleanly hold any i32 round-trip.
-    pub fn run(&mut self, a3: u32, a5: u32, l32r_val: u32) -> Result<BrowserMultiOpResult, JsValue> {
+    pub fn run(
+        &mut self,
+        a3: u32,
+        a5: u32,
+        l32r_val: u32,
+    ) -> Result<BrowserMultiOpResult, JsValue> {
         let result = self.run.call3(
             &JsValue::NULL,
             &JsValue::from_f64(a3 as i32 as f64),
@@ -209,12 +214,7 @@ impl BrowserHotBbJit {
                 arr.length()
             )));
         }
-        let g = |i: u32| -> i32 {
-            arr.get(i)
-                .as_f64()
-                .map(|f| f as i64 as i32)
-                .unwrap_or(0)
-        };
+        let g = |i: u32| -> i32 { arr.get(i).as_f64().map(|f| f as i64 as i32).unwrap_or(0) };
         self.hits += 1;
         Ok(BrowserMultiOpResult {
             exit_code: g(0),

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -65,7 +65,7 @@ use labwired_core::cpu::xtensa_jit::emit_core::{
 };
 use labwired_core::cpu::xtensa_jit_bytes::{
     EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_L32R_ADDR, HOT_BB_PC,
-    LOOPTASK_PREFIX_INSTR_COUNT,
+    LOOPTASK_PREFIX_INSTR_COUNT, LOOPTASK_TAIL_END, LOOPTASK_TAIL_INSTR_COUNT,
 };
 use labwired_core::cpu::xtensa_sr::CCOUNT;
 use labwired_core::cpu::XtensaLx7;
@@ -94,6 +94,18 @@ pub struct BrowserLoopTaskPrefixResult {
     pub next_pc: u32,
     pub l8ui_at_value: u32,
     pub beqz_target_pc: u32,
+}
+
+/// Result of running a [`BlockShape::LoopTaskTail`] block (Phase 4.4).
+///
+/// Field naming mirrors the emit-core wasm signature `() -> (exit_code,
+/// next_pc, l32r_at_value)`. The browser dispatcher writes
+/// `l32r_at_value` into the AR named by the shape descriptor's
+/// `l32r_at` and sets `cpu.pc = next_pc`.
+pub struct BrowserLoopTaskTailResult {
+    pub exit_code: i32,
+    pub next_pc: u32,
+    pub l32r_at_value: u32,
 }
 
 /// One installed block: the compiled `WebAssembly.Module`, its
@@ -163,6 +175,12 @@ impl BrowserCompiledBlock {
         //    from it. The closure captures the queue via `Rc` so both
         //    Rust (`stage_loads`) and JS (each `host.read_u8` call) can
         //    reach it.
+        //
+        // The Phase 4.4 [`BlockShape::LoopTaskTail`] module is constant
+        // (no imports). We still build the closure (cheap; the empty
+        // queue path returns -1 and the wasm body never calls it) so
+        // every block ships with the same scaffolding.
+        let needs_read_u8 = !matches!(emitted.shape, BlockShape::LoopTaskTail { .. });
         let pending: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::with_capacity(4)));
         let pending_for_closure = pending.clone();
         let read_u8_closure = Closure::<dyn FnMut(i32) -> i32>::new(move |_addr: i32| -> i32 {
@@ -176,10 +194,17 @@ impl BrowserCompiledBlock {
             q.remove(0) as i32
         });
 
-        // 4. Build imports + instantiate.
-        let imports = build_imports(&read_u8_closure)?;
-        let instance = WebAssembly::Instance::new(&module, &imports)
-            .map_err(|e| JsValue::from_str(&format!("WebAssembly.Instance: {e:?}")))?;
+        // 4. Build imports + instantiate. Tail blocks have no imports;
+        //    pass an empty object so the wasm validator is happy.
+        let instance = if needs_read_u8 {
+            let imports = build_imports(&read_u8_closure)?;
+            WebAssembly::Instance::new(&module, &imports)
+                .map_err(|e| JsValue::from_str(&format!("WebAssembly.Instance: {e:?}")))?
+        } else {
+            let empty = Object::new();
+            WebAssembly::Instance::new(&module, &empty)
+                .map_err(|e| JsValue::from_str(&format!("WebAssembly.Instance: {e:?}")))?
+        };
 
         // 5. Pluck the `run` export. emit-core always exports `run`;
         //    if that changes, this is the one place to update.
@@ -289,6 +314,26 @@ impl BrowserCompiledBlock {
         })
     }
 
+    /// Invoke a [`BlockShape::LoopTaskTail`] block. Returns
+    /// `(exit, next_pc, l32r_at_value)`. No staged loads — the body is
+    /// constant-folded at compile time. Mirrors
+    /// `bb_multi::MultiOpBlock::run_looptask_tail`.
+    pub fn run_looptask_tail(&mut self) -> Result<BrowserLoopTaskTailResult, JsValue> {
+        debug_assert!(matches!(
+            self.emitted.shape,
+            BlockShape::LoopTaskTail { .. }
+        ));
+        let result = self.run.call0(&JsValue::NULL)?;
+        let arr = decode_result_array(result, 3)?;
+        let g = |i: u32| -> i32 { arr.get(i).as_f64().map(|f| f as i64 as i32).unwrap_or(0) };
+        self.hits += 1;
+        Ok(BrowserLoopTaskTailResult {
+            exit_code: g(0),
+            next_pc: g(1) as u32,
+            l32r_at_value: g(2) as u32,
+        })
+    }
+
     /// Expose the block's emit-core metadata. Used by the dispatcher
     /// to advance PC and bump CCOUNT after a clean fall-through.
     pub fn emitted(&self) -> &EmittedBlock {
@@ -365,6 +410,10 @@ pub struct BrowserJitCache {
     /// Total hits across all compiled blocks. Tracked as a running
     /// total so `WasmSimulator::jit_hits()` is O(1).
     total_hits: u64,
+    /// Phase 4.4 instrumentation: per-PC hit counters. Surfaced via
+    /// [`Self::hits_per_pc`] so the bench harness can validate that
+    /// each installed shape is actually firing.
+    pub hits_by_pc: HashMap<u32, u64>,
 }
 
 impl BrowserJitCache {
@@ -437,6 +486,11 @@ impl BrowserJitCache {
     fn bump_hit(&mut self) {
         self.total_hits = self.total_hits.saturating_add(1);
     }
+
+    /// Bump the per-PC hit counter (Phase 4.4 diagnostics).
+    fn bump_hit_pc(&mut self, pc: u32) {
+        *self.hits_by_pc.entry(pc).or_insert(0) += 1;
+    }
 }
 
 /// Failure surface for [`BrowserJitCache::install_from_emitted`].
@@ -500,6 +554,89 @@ pub fn try_browser_jit_step(
     // why it matters perf-wise.
     if cache.refused.contains(&(pc, ps_bits.raw)) {
         return false;
+    }
+
+    // Phase 4.4 short-circuit: for shapes whose wasm body is dominated
+    // by constants (so the wasm call overhead exceeds the work it
+    // does), execute the equivalent logic in Rust and skip the
+    // WebAssembly.Function.call_N round-trip entirely. This is the
+    // single biggest perf lever for short blocks — Phase 4.6.1 showed
+    // a 7% regression even with the prefix-only setup; Phase 4.4
+    // empirical data (see /tmp/jit_bench_phase44.txt) showed a ~14%
+    // delta between the wasm-call and pure-Rust dispatch paths for
+    // the tail block alone.
+    if let Some(installed) = cache.get_mut(pc, ps_bits) {
+        match installed.emitted().shape {
+            BlockShape::LoopTaskTail {
+                l32r_at,
+                l32r_literal_value,
+                beqz_target_pc,
+                statically_taken,
+            } => {
+                cpu.regs.write_logical(l32r_at, l32r_literal_value);
+                if statically_taken {
+                    cpu.pc = beqz_target_pc;
+                    cpu.branched = true;
+                } else {
+                    cpu.pc = LOOPTASK_TAIL_END;
+                    cpu.branched = false;
+                }
+                if LOOPTASK_TAIL_INSTR_COUNT > 1 {
+                    let cc = cpu.sr.read(CCOUNT);
+                    cpu.sr
+                        .write(CCOUNT, cc.wrapping_add(LOOPTASK_TAIL_INSTR_COUNT - 1));
+                }
+                installed.hits += 1;
+                cache.bump_hit();
+                cache.bump_hit_pc(pc);
+                return true;
+            }
+            BlockShape::LoopTaskPrefix {
+                l32r_at,
+                l8ui_at,
+                l8ui_base_at,
+                l32r_literal_value,
+                beqz_target_pc,
+            } => {
+                // Same idea as above for the prefix. The wasm body
+                // here would: write L32R, call host.read_u8(literal),
+                // branch on the result. We do the same in Rust: the
+                // L8UI base is the L32R literal (shape invariant
+                // l8ui_base_at == l32r_at), the byte is read through
+                // the live bus, and the BEQZ direction tested
+                // directly. A bus error refuses cleanly.
+                debug_assert_eq!(l8ui_base_at, l32r_at);
+                let l8ui_base = l32r_literal_value;
+                let b0 = match bus.read_u8(l8ui_base as u64) {
+                    Ok(v) => v,
+                    Err(_) => return false,
+                };
+                cpu.regs.write_logical(l32r_at, l32r_literal_value);
+                cpu.regs.write_logical(l8ui_at, b0 as u32);
+                if b0 == 0 {
+                    // BEQZ taken: skip wdt_reset, land at CALL8 loopv
+                    // (target carried in the shape descriptor — for
+                    // the real ereader at PC 0x400d4a8d this is
+                    // 0x400d4a99; the canonical fixture differs).
+                    cpu.pc = beqz_target_pc;
+                    cpu.branched = true;
+                } else {
+                    // BEQZ not taken: fall through to wdt_reset CALL8.
+                    cpu.pc = labwired_core::cpu::xtensa_jit_bytes::LOOPTASK_PREFIX_END;
+                    cpu.branched = false;
+                }
+                if LOOPTASK_PREFIX_INSTR_COUNT > 1 {
+                    let cc = cpu.sr.read(CCOUNT);
+                    cpu.sr
+                        .write(CCOUNT, cc.wrapping_add(LOOPTASK_PREFIX_INSTR_COUNT - 1));
+                }
+                installed.hits += 1;
+                cache.bump_hit();
+                cache.bump_hit_pc(pc);
+                return true;
+            }
+            _ => {}
+        }
     }
 
     // Fast path: block already installed under (pc, ps_bits). Skip
@@ -647,6 +784,7 @@ pub fn try_browser_jit_step(
                     }
                     cpu.branched = false;
                     cache.bump_hit();
+                    cache.bump_hit_pc(pc);
                     true
                 }
                 x if x == EXIT_HOST_BUS_ERROR => {
@@ -664,6 +802,7 @@ pub fn try_browser_jit_step(
             l8ui_at,
             l8ui_base_at,
             l32r_literal_value,
+            beqz_target_pc: _,
         } => {
             // Stage inputs per the shape descriptor. The L8UI base
             // register IS the L32R destination (shape invariant
@@ -710,6 +849,7 @@ pub fn try_browser_jit_step(
                     }
                     cpu.branched = true;
                     cache.bump_hit();
+                    cache.bump_hit_pc(pc);
                     true
                 }
                 x if x == EXIT_FALL_THROUGH => {
@@ -722,11 +862,68 @@ pub fn try_browser_jit_step(
                     }
                     cpu.branched = false;
                     cache.bump_hit();
+                    cache.bump_hit_pc(pc);
                     true
                 }
                 x if x == EXIT_HOST_BUS_ERROR => {
                     cache.refusals = cache.refusals.saturating_add(1);
                     false
+                }
+                _ => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    false
+                }
+            }
+        }
+        BlockShape::LoopTaskTail {
+            l32r_at,
+            l32r_literal_value: _,
+            beqz_target_pc: _,
+            statically_taken: _,
+        } => {
+            // No staged inputs and no host imports for this shape — the
+            // wasm body returns a pre-baked constant tuple decided at
+            // walk_and_emit time from the live bus's literal pool.
+            let block = match cache.get_mut(pc, ps_bits) {
+                Some(b) => b,
+                None => return false,
+            };
+            let res = match block.run_looptask_tail() {
+                Ok(r) => r,
+                Err(_) => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    return false;
+                }
+            };
+
+            // L32R writes unconditionally (matches interp: L32R runs
+            // before the BEQZ test).
+            cpu.regs.write_logical(l32r_at, res.l32r_at_value);
+
+            match res.exit_code {
+                x if x == EXIT_BRANCH_TAKEN => {
+                    cpu.pc = res.next_pc;
+                    if LOOPTASK_TAIL_INSTR_COUNT > 1 {
+                        let cc = cpu.sr.read(CCOUNT);
+                        cpu.sr
+                            .write(CCOUNT, cc.wrapping_add(LOOPTASK_TAIL_INSTR_COUNT - 1));
+                    }
+                    cpu.branched = true;
+                    cache.bump_hit();
+                    cache.bump_hit_pc(pc);
+                    true
+                }
+                x if x == EXIT_FALL_THROUGH => {
+                    cpu.pc = res.next_pc;
+                    if LOOPTASK_TAIL_INSTR_COUNT > 1 {
+                        let cc = cpu.sr.read(CCOUNT);
+                        cpu.sr
+                            .write(CCOUNT, cc.wrapping_add(LOOPTASK_TAIL_INSTR_COUNT - 1));
+                    }
+                    cpu.branched = false;
+                    cache.bump_hit();
+                    cache.bump_hit_pc(pc);
+                    true
                 }
                 _ => {
                     cache.refusals = cache.refusals.saturating_add(1);

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -60,7 +60,9 @@
 //!      counted one).
 
 use js_sys::{Array, Function, Object, Reflect, Uint8Array, WebAssembly};
-use labwired_core::cpu::xtensa_jit::emit_core::{self, EmitError, EmittedBlock, PsBits};
+use labwired_core::cpu::xtensa_jit::emit_core::{
+    self, BlockShape, EmitError, EmittedBlock, PsBits,
+};
 use labwired_core::cpu::xtensa_jit_bytes::{
     EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_L32R_ADDR, HOT_BB_PC,
 };
@@ -81,6 +83,22 @@ pub struct BrowserMultiOpResult {
     pub a6: u32,
     pub a8: u32,
     pub a10: u32,
+}
+
+/// Result of running a [`BlockShape::LoopTaskPrefix`] block. Mirrors
+/// the native `bb_multi::LoopTaskPrefixResult`. Constructed by
+/// [`BrowserCompiledBlock::run_looptask_prefix`]; consumed once the
+/// dispatcher grows L32R-literal + L8UI-base staging (next chunk).
+#[allow(
+    dead_code,
+    reason = "Phase 4.3.6 shape-aware result type; consumed by Phase 4.4+ dispatcher \
+              once loopTask staging lands"
+)]
+pub struct BrowserLoopTaskPrefixResult {
+    pub exit_code: i32,
+    pub next_pc: u32,
+    pub l8ui_at_value: u32,
+    pub beqz_target_pc: u32,
 }
 
 /// One installed block: the compiled `WebAssembly.Module`, its
@@ -197,33 +215,26 @@ impl BrowserCompiledBlock {
         q.extend_from_slice(bytes);
     }
 
-    /// Invoke the block. Returns the 5-tuple `(exit, a2, a6, a8, a10)`
-    /// produced by the wasm body.
+    /// Invoke a [`BlockShape::HotBbCanonical`] block. Returns the
+    /// 5-tuple `(exit, a2, a6, a8, a10)` produced by the wasm body.
     ///
     /// JS-side, multi-value wasm returns become Arrays. We pluck five
     /// `i32`s out via `Array::get` + `as_f64` — JS numbers round-trip
     /// every i32 cleanly.
-    pub fn run(
+    pub fn run_hot_bb(
         &mut self,
         a3: u32,
         a5: u32,
         l32r_val: u32,
     ) -> Result<BrowserMultiOpResult, JsValue> {
+        debug_assert_eq!(self.emitted.shape, BlockShape::HotBbCanonical);
         let result = self.run.call3(
             &JsValue::NULL,
             &JsValue::from_f64(a3 as i32 as f64),
             &JsValue::from_f64(a5 as i32 as f64),
             &JsValue::from_f64(l32r_val as i32 as f64),
         )?;
-        let arr: Array = result
-            .dyn_into::<Array>()
-            .map_err(|_| JsValue::from_str("wasm.run return is not an Array"))?;
-        if arr.length() != 5 {
-            return Err(JsValue::from_str(&format!(
-                "wasm.run returned {} values; expected 5",
-                arr.length()
-            )));
-        }
+        let arr = decode_result_array(result, 5)?;
         let g = |i: u32| -> i32 { arr.get(i).as_f64().map(|f| f as i64 as i32).unwrap_or(0) };
         self.hits += 1;
         Ok(BrowserMultiOpResult {
@@ -235,11 +246,83 @@ impl BrowserCompiledBlock {
         })
     }
 
+    /// Back-compat shim for [`Self::run_hot_bb`]. Existing browser
+    /// dispatcher call sites used the bare `run` name; preserved so
+    /// this commit stays focused on shape-aware dispatch.
+    #[allow(
+        dead_code,
+        reason = "Back-compat shim; dispatcher now calls run_hot_bb directly"
+    )]
+    pub fn run(
+        &mut self,
+        a3: u32,
+        a5: u32,
+        l32r_val: u32,
+    ) -> Result<BrowserMultiOpResult, JsValue> {
+        self.run_hot_bb(a3, a5, l32r_val)
+    }
+
+    /// Invoke a [`BlockShape::LoopTaskPrefix`] block. Returns
+    /// `(exit, next_pc, l8ui_at_value, beqz_target_pc)`. Caller stages
+    /// the single L8UI byte via [`Self::stage_loads`] beforehand.
+    ///
+    /// Mirrors `bb_multi::MultiOpBlock::run_looptask_prefix`. The
+    /// browser dispatcher currently refuses LoopTaskPrefix blocks at
+    /// run time (it doesn't yet drive the staging — see
+    /// [`try_browser_jit_step`]); this method is the wired execution
+    /// path that lights up once Phase 4.4 grows the dispatcher.
+    #[allow(
+        dead_code,
+        reason = "Phase 4.3.6 shape-aware run path; consumed by Phase 4.4+ dispatcher \
+                  once loopTask staging lands"
+    )]
+    pub fn run_looptask_prefix(
+        &mut self,
+        l32r_val: u32,
+        l8ui_base: u32,
+    ) -> Result<BrowserLoopTaskPrefixResult, JsValue> {
+        debug_assert!(matches!(
+            self.emitted.shape,
+            BlockShape::LoopTaskPrefix { .. }
+        ));
+        let result = self.run.call2(
+            &JsValue::NULL,
+            &JsValue::from_f64(l32r_val as i32 as f64),
+            &JsValue::from_f64(l8ui_base as i32 as f64),
+        )?;
+        let arr = decode_result_array(result, 4)?;
+        let g = |i: u32| -> i32 { arr.get(i).as_f64().map(|f| f as i64 as i32).unwrap_or(0) };
+        self.hits += 1;
+        Ok(BrowserLoopTaskPrefixResult {
+            exit_code: g(0),
+            next_pc: g(1) as u32,
+            l8ui_at_value: g(2) as u32,
+            beqz_target_pc: g(3) as u32,
+        })
+    }
+
     /// Expose the block's emit-core metadata. Used by the dispatcher
     /// to advance PC and bump CCOUNT after a clean fall-through.
     pub fn emitted(&self) -> &EmittedBlock {
         &self.emitted
     }
+}
+
+/// Decode a multi-value wasm return into a JS Array of the expected
+/// arity. Shared by `run_hot_bb` and `run_looptask_prefix` so each
+/// shape's decoding stays a one-liner.
+fn decode_result_array(result: JsValue, expected: u32) -> Result<Array, JsValue> {
+    let arr: Array = result
+        .dyn_into::<Array>()
+        .map_err(|_| JsValue::from_str("wasm.run return is not an Array"))?;
+    if arr.length() != expected {
+        return Err(JsValue::from_str(&format!(
+            "wasm.run returned {} values; expected {}",
+            arr.length(),
+            expected
+        )));
+    }
+    Ok(arr)
 }
 
 /// Build the JS `imports` object the wasm module expects. Today the
@@ -509,72 +592,91 @@ pub fn try_browser_jit_step(
         }
     }
 
-    // Pre-read host-input values. Today's emit (the canonical hot BB)
-    // needs two L8UI bytes from [a3, a3+1] and the L32R literal at
-    // HOT_BB_L32R_ADDR. Phase 4.3+ will need a more general staging
-    // model — at that point the EmittedBlock will carry a manifest of
-    // required inputs.
-    let a3 = cpu.regs.read_logical(3);
-    let a5 = cpu.regs.read_logical(5);
-    let b0 = match bus.read_u8(a3 as u64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    let b1 = match bus.read_u8((a3.wrapping_add(1)) as u64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    // L32R address is currently hardcoded for the hot block. Phase 4.3
-    // will move this into EmittedBlock alongside the rest of the input
-    // staging manifest.
-    let l32r_addr = if pc == HOT_BB_PC { HOT_BB_L32R_ADDR } else { 0 };
-    let l32r_val = match bus.read_u32(l32r_addr as u64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
-    let block = match cache.get_mut(pc, ps_bits) {
-        Some(b) => b,
+    // Shape-aware dispatch. Today the browser drives the
+    // HotBbCanonical shape end-to-end. LoopTaskPrefix blocks are
+    // recognized by emit-core and installed in the cache, but the
+    // dispatcher refuses them at run-time because the staging logic
+    // (which L32R literal address, which register to use as the L8UI
+    // base) isn't wired here yet — that's the next browser-side
+    // chunk. Refusing cleanly keeps the dispatch path correct
+    // (interpreter handles the PC) while making the shape-aware
+    // dispatch contract explicit.
+    let block_shape = match cache.get_mut(pc, ps_bits) {
+        Some(b) => b.emitted().shape,
         None => return false,
     };
-    let end_pc = block.emitted().end_pc;
-    let length_in_instrs = block.emitted().length_in_instrs;
 
-    block.stage_loads(&[b0, b1]);
-    let res = match block.run(a3, a5, l32r_val) {
-        Ok(r) => r,
-        Err(_) => {
-            cache.refusals = cache.refusals.saturating_add(1);
-            return false;
-        }
-    };
+    match block_shape {
+        BlockShape::HotBbCanonical => {
+            // Pre-read host-input values for the canonical hot BB:
+            // two L8UI bytes from [a3, a3+1] and the L32R literal at
+            // HOT_BB_L32R_ADDR.
+            let a3 = cpu.regs.read_logical(3);
+            let a5 = cpu.regs.read_logical(5);
+            let b0 = match bus.read_u8(a3 as u64) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+            let b1 = match bus.read_u8((a3.wrapping_add(1)) as u64) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+            let l32r_addr = if pc == HOT_BB_PC { HOT_BB_L32R_ADDR } else { 0 };
+            let l32r_val = match bus.read_u32(l32r_addr as u64) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
 
-    match res.exit_code {
-        x if x == EXIT_FALL_THROUGH => {
-            cpu.regs.write_logical(10, res.a10);
-            cpu.regs.write_logical(6, res.a6);
-            cpu.regs.write_logical(2, res.a2);
-            cpu.regs.write_logical(8, res.a8);
-            cpu.pc = end_pc;
-            // CCOUNT honesty: the interpreter would have advanced
-            // CCOUNT by length_in_instrs - 1 (one per instruction; the
-            // outer step counts one more on its own). Mirror the
-            // native `try_jit_multi_op` path. If a future emit ever
-            // produces a 0-length block, the saturating_sub keeps the
-            // arithmetic sane.
-            if length_in_instrs > 1 {
-                let cc = cpu.sr.read(CCOUNT);
-                cpu.sr.write(CCOUNT, cc.wrapping_add(length_in_instrs - 1));
+            let block = match cache.get_mut(pc, ps_bits) {
+                Some(b) => b,
+                None => return false,
+            };
+            let end_pc = block.emitted().end_pc;
+            let length_in_instrs = block.emitted().length_in_instrs;
+
+            block.stage_loads(&[b0, b1]);
+            let res = match block.run_hot_bb(a3, a5, l32r_val) {
+                Ok(r) => r,
+                Err(_) => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    return false;
+                }
+            };
+
+            match res.exit_code {
+                x if x == EXIT_FALL_THROUGH => {
+                    cpu.regs.write_logical(10, res.a10);
+                    cpu.regs.write_logical(6, res.a6);
+                    cpu.regs.write_logical(2, res.a2);
+                    cpu.regs.write_logical(8, res.a8);
+                    cpu.pc = end_pc;
+                    // CCOUNT honesty: the interpreter would have advanced
+                    // CCOUNT by length_in_instrs - 1 (one per instruction;
+                    // the outer step counts one more on its own).
+                    if length_in_instrs > 1 {
+                        let cc = cpu.sr.read(CCOUNT);
+                        cpu.sr.write(CCOUNT, cc.wrapping_add(length_in_instrs - 1));
+                    }
+                    cpu.branched = false;
+                    cache.bump_hit();
+                    true
+                }
+                x if x == EXIT_HOST_BUS_ERROR => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    false
+                }
+                _ => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    false
+                }
             }
-            cpu.branched = false;
-            cache.bump_hit();
-            true
         }
-        x if x == EXIT_HOST_BUS_ERROR => {
-            cache.refusals = cache.refusals.saturating_add(1);
-            false
-        }
-        _ => {
+        BlockShape::LoopTaskPrefix { .. } => {
+            // Block was emitted + installed (good — the cache contract
+            // works for both shapes). End-to-end dispatch needs new
+            // staging: the L32R literal address comes from decoding the
+            // L32R instruction itself, and the L8UI base register is
+            // shape-dependent. That staging layer is the next chunk.
             cache.refusals = cache.refusals.saturating_add(1);
             false
         }

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -64,7 +64,8 @@ use labwired_core::cpu::xtensa_jit::emit_core::{
     self, BlockShape, EmitError, EmittedBlock, PsBits,
 };
 use labwired_core::cpu::xtensa_jit_bytes::{
-    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_L32R_ADDR, HOT_BB_PC,
+    EXIT_BRANCH_TAKEN, EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_L32R_ADDR, HOT_BB_PC,
+    LOOPTASK_PREFIX_INSTR_COUNT,
 };
 use labwired_core::cpu::xtensa_sr::CCOUNT;
 use labwired_core::cpu::XtensaLx7;
@@ -86,14 +87,8 @@ pub struct BrowserMultiOpResult {
 }
 
 /// Result of running a [`BlockShape::LoopTaskPrefix`] block. Mirrors
-/// the native `bb_multi::LoopTaskPrefixResult`. Constructed by
-/// [`BrowserCompiledBlock::run_looptask_prefix`]; consumed once the
-/// dispatcher grows L32R-literal + L8UI-base staging (next chunk).
-#[allow(
-    dead_code,
-    reason = "Phase 4.3.6 shape-aware result type; consumed by Phase 4.4+ dispatcher \
-              once loopTask staging lands"
-)]
+/// the native `bb_multi::LoopTaskPrefixResult`. Consumed by the
+/// browser dispatcher in [`try_browser_jit_step`] (Phase 4.3.7).
 pub struct BrowserLoopTaskPrefixResult {
     pub exit_code: i32,
     pub next_pc: u32,
@@ -267,15 +262,8 @@ impl BrowserCompiledBlock {
     /// the single L8UI byte via [`Self::stage_loads`] beforehand.
     ///
     /// Mirrors `bb_multi::MultiOpBlock::run_looptask_prefix`. The
-    /// browser dispatcher currently refuses LoopTaskPrefix blocks at
-    /// run time (it doesn't yet drive the staging — see
-    /// [`try_browser_jit_step`]); this method is the wired execution
-    /// path that lights up once Phase 4.4 grows the dispatcher.
-    #[allow(
-        dead_code,
-        reason = "Phase 4.3.6 shape-aware run path; consumed by Phase 4.4+ dispatcher \
-                  once loopTask staging lands"
-    )]
+    /// browser dispatcher in [`try_browser_jit_step`] drives this
+    /// for LoopTaskPrefix-shaped blocks (Phase 4.3.7).
     pub fn run_looptask_prefix(
         &mut self,
         l32r_val: u32,
@@ -671,14 +659,80 @@ pub fn try_browser_jit_step(
                 }
             }
         }
-        BlockShape::LoopTaskPrefix { .. } => {
-            // Block was emitted + installed (good — the cache contract
-            // works for both shapes). End-to-end dispatch needs new
-            // staging: the L32R literal address comes from decoding the
-            // L32R instruction itself, and the L8UI base register is
-            // shape-dependent. That staging layer is the next chunk.
-            cache.refusals = cache.refusals.saturating_add(1);
-            false
+        BlockShape::LoopTaskPrefix {
+            l32r_at,
+            l8ui_at,
+            l8ui_base_at,
+            l32r_literal_value,
+        } => {
+            // Stage inputs per the shape descriptor. The L8UI base
+            // register IS the L32R destination (shape invariant
+            // `l8ui_base_at == l32r_at` — the L8UI dereferences the
+            // literal the L32R just loaded). The L32R hasn't executed
+            // yet, so we use the constant-folded literal value as the
+            // L8UI base rather than reading the stale AR slot. The
+            // single L8UI byte is pre-read through the live bus so a
+            // real bus error surfaces via the interpreter retry path
+            // (mirrors `try_jit_looptask_prefix` on the native side).
+            debug_assert_eq!(l8ui_base_at, l32r_at);
+            let l8ui_base = l32r_literal_value;
+            let b0 = match bus.read_u8(l8ui_base as u64) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+
+            let block = match cache.get_mut(pc, ps_bits) {
+                Some(b) => b,
+                None => return false,
+            };
+            block.stage_loads(&[b0]);
+            let res = match block.run_looptask_prefix(l32r_literal_value, l8ui_base) {
+                Ok(r) => r,
+                Err(_) => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    return false;
+                }
+            };
+
+            // L32R literal write happens unconditionally on every
+            // successful path (matches interp semantics — L32R runs
+            // before the BEQZ test).
+            cpu.regs.write_logical(l32r_at, l32r_literal_value);
+
+            match res.exit_code {
+                x if x == EXIT_BRANCH_TAKEN => {
+                    cpu.regs.write_logical(l8ui_at, res.l8ui_at_value);
+                    cpu.pc = res.beqz_target_pc;
+                    if LOOPTASK_PREFIX_INSTR_COUNT > 1 {
+                        let cc = cpu.sr.read(CCOUNT);
+                        cpu.sr
+                            .write(CCOUNT, cc.wrapping_add(LOOPTASK_PREFIX_INSTR_COUNT - 1));
+                    }
+                    cpu.branched = true;
+                    cache.bump_hit();
+                    true
+                }
+                x if x == EXIT_FALL_THROUGH => {
+                    cpu.regs.write_logical(l8ui_at, res.l8ui_at_value);
+                    cpu.pc = res.next_pc;
+                    if LOOPTASK_PREFIX_INSTR_COUNT > 1 {
+                        let cc = cpu.sr.read(CCOUNT);
+                        cpu.sr
+                            .write(CCOUNT, cc.wrapping_add(LOOPTASK_PREFIX_INSTR_COUNT - 1));
+                    }
+                    cpu.branched = false;
+                    cache.bump_hit();
+                    true
+                }
+                x if x == EXIT_HOST_BUS_ERROR => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    false
+                }
+                _ => {
+                    cache.refusals = cache.refusals.saturating_add(1);
+                    false
+                }
+            }
         }
     }
 }

--- a/crates/wasm/src/jit_browser.rs
+++ b/crates/wasm/src/jit_browser.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! Browser-side Xtensa JIT prototype (#124 Phase 4).
+//! Browser-side Xtensa JIT (#124 Phase 4).
 //!
 //! ## Why this exists
 //!
@@ -12,58 +12,69 @@
 //! has been paying full interpreter cost for every instruction —
 //! including the dominant 0x400829cc hot block (~82% of ereader work).
 //!
-//! This module is the browser counterpart: it takes the **same wasm
-//! bytes** the native JIT consumes (baked at compile time by
-//! `crates/core/build.rs`), instantiates them through
-//! `js_sys::WebAssembly::{Module, Instance}`, and exposes a Rust API
-//! that calls the resulting module on the hot path.
+//! Phase 4.1 split the JIT pipeline into a runtime-agnostic emit core
+//! ([`emit_core::walk_and_emit`]) plus per-runtime adapters. Phase 4.2
+//! (this module) is the browser adapter: it consumes [`EmittedBlock`]
+//! from emit-core, hands the bytes to `js_sys::WebAssembly::{Module,
+//! Instance}`, wires up the `host.read_u8` import as a wasm-bindgen
+//! `Closure`, and dispatches into wasm via `Function::call3`.
 //!
-//! ## Decoupling
+//! ## Cache
 //!
-//! Emit is fully decoupled from runtime:
-//!   1. `crates/core/src/cpu/xtensa_jit/hot_bb.wat` — single source of
-//!      truth for the JIT body.
-//!   2. `crates/core/build.rs` — compiles WAT → wasm bytes at crate
-//!      build time. Build-deps only; doesn't leak into the runtime
-//!      dependency tree.
-//!   3. `labwired_core::cpu::xtensa_jit_bytes::HOT_BB_WASM` — bytes
-//!      accessible from any crate, with or without `--features jit`.
-//!   4. Native (wasmtime) backend uses `Module::new(engine, HOT_BB_WASM)`.
-//!   5. Browser (this module) uses
-//!      `js_sys::WebAssembly::Module::new(Uint8Array(HOT_BB_WASM))`.
+//! Compiled blocks are keyed by `(pc, ps_bits)` in a [`HashMap`] so
+//! re-entry after the first compile is just a HashMap lookup + a wasm
+//! call. The native side's `JitCache` keys by `pc` only (PsBits isn't
+//! consulted at the supported-opcode set today); we key by the pair
+//! anyway so when Phase 4.4 starts emitting PS-dependent code
+//! (CALL{n}/RETW need CALLINC) the cache is already correct.
 //!
-//! ## Host import surface
+//! ## Host import surface (Phase 4.2 scope)
 //!
-//! The JITed block imports `host.read_u8(addr: i32) -> i32`. The host
-//! returns `-1` to signal a bus error; the wasm body then returns
-//! exit code `5` (EXIT_HOST_BUS_ERROR) and the caller falls back to
-//! the interpreter. To match the native backend's "pre-staged byte
-//! queue" model, the browser path stages a small Vec on the host side
-//! and dequeues from a JS closure each time the import is invoked.
+//! The emit-core today produces a single import: `host.read_u8(i32) ->
+//! i32`. Backend behaviour: the host pre-stages the L8UI bytes via
+//! [`BrowserCompiledBlock::stage_loads`], the closure dequeues from
+//! that shared [`Rc<RefCell<Vec<u8>>>`]. If the queue is empty the
+//! closure returns `-1` and the wasm body exits with
+//! [`EXIT_HOST_BUS_ERROR`]; the dispatcher treats that as a refusal.
 //!
-//! ## Scope cap (#124 Phase 4)
+//! Phase 4.3 will add `host.read_u32` / `host.write_u32` /
+//! `host.branch_target` imports as variable-length-block emit lands;
+//! [`build_imports`] is structured so wiring more imports is
+//! additive.
 //!
-//! * One block JIT'd (0x400829cc — the dominant 82%-of-work hot BB).
-//! * No BB walker, no cache management, no peripheral dispatch from
-//!   inside wasm. This is a prototype to measure whether the
-//!   browser-wasm-inside-browser-wasm architecture pays off; if it
-//!   does, generalising is a Phase 4.1+ follow-up.
+//! ## Dispatch path
+//!
+//! [`try_browser_jit_step`] is the entry point. Given the current CPU,
+//! the bus, and the cache:
+//!   1. Read PS bits (today informational, see [`PsBits`]).
+//!   2. Look up `(pc, ps_bits)` in the cache.
+//!   3. On miss: ask the bus for an IRAM slice covering `pc` via
+//!      [`Bus::fetch_slice`] (#119 Phase 1.2), run
+//!      [`emit_core::walk_and_emit`] over it, install the resulting
+//!      block into the cache.
+//!   4. Pre-resolve any host-input values the block needs (today: two
+//!      L8UI bytes + one L32R literal).
+//!   5. Call `run(a3, a5, l32r_val)`, marshal the return tuple back
+//!      into the CPU register file, advance PC to [`EmittedBlock::end_pc`],
+//!      bump CCOUNT by `length_in_instrs - 1` (the outer step already
+//!      counted one).
 
 use js_sys::{Array, Function, Object, Reflect, Uint8Array, WebAssembly};
 use labwired_core::cpu::xtensa_jit::emit_core::{self, EmitError, EmittedBlock, PsBits};
 use labwired_core::cpu::xtensa_jit_bytes::{
-    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_END, HOT_BB_INSTR_COUNT, HOT_BB_L32R_ADDR,
-    HOT_BB_PC, HOT_BB_WASM,
+    EXIT_FALL_THROUGH, EXIT_HOST_BUS_ERROR, HOT_BB_L32R_ADDR, HOT_BB_PC,
 };
 use labwired_core::cpu::xtensa_sr::CCOUNT;
 use labwired_core::cpu::XtensaLx7;
 use labwired_core::Bus;
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-/// Result of running the hot-block wasm body in the browser.
+/// Result of running an emitted block in the browser. Mirrors the
+/// native `bb_multi::MultiOpResult` 5-tuple.
 pub struct BrowserMultiOpResult {
     pub exit_code: i32,
     pub a2: u32,
@@ -72,71 +83,79 @@ pub struct BrowserMultiOpResult {
     pub a10: u32,
 }
 
-/// Browser-side handle for the JITed hot block. Holds the compiled
-/// `WebAssembly.Module`, the instantiated `Instance`, a long-lived JS
-/// closure for the `host.read_u8` import, and the shared host-side
-/// byte queue.
+/// One installed block: the compiled `WebAssembly.Module`, its
+/// `Instance`, the cached `run` export, and the host-side load queue
+/// the `host.read_u8` import dequeues from.
 ///
-/// Lifetimes: the closure is reachable from JS as long as this struct is
-/// alive (the JS-side import refers back into it). Drop order matters:
-/// we drop the `_keepalive` field last so the JS engine can never call
-/// a stale closure. Rust drops fields top-to-bottom; we order them so
-/// that the closure outlives the instance.
-pub struct BrowserHotBbJit {
-    /// Cached `run` export. Calling this dispatches into wasm.
+/// Drop order: Rust drops fields top-to-bottom. We list the closure
+/// AFTER `run` and `_instance` so the JS-reachable import is still
+/// alive whenever `run` could conceivably be called. Once we stop
+/// invoking `run` (by dropping the whole struct), the closure can be
+/// torn down safely.
+pub struct BrowserCompiledBlock {
+    /// Exported `run` function — the wasm body of the emitted block.
+    /// Cached as a `Function` so dispatch is a direct `call3` with no
+    /// `Reflect::get` per invocation.
     run: Function,
-    /// Host-side queue of pre-staged byte values, dequeued by the JS
-    /// shim each time wasm invokes `host.read_u8`. RefCell + Rc because
-    /// (a) the closure needs a long-lived clone and (b) the queue is
-    /// mutated both from `stage_loads` and from inside the closure.
+    /// Host-side queue of pre-staged byte values. The closure dequeues
+    /// from this each time wasm invokes `host.read_u8`. RefCell+Rc
+    /// because (a) the closure holds a long-lived clone, (b)
+    /// `stage_loads` mutates it from outside the closure.
     pending: Rc<RefCell<Vec<u8>>>,
-    /// Number of times `run` has been invoked. Surfaced for the
-    /// `bench_jit` benchmark.
+    /// emit-core's view of the block — kept for `length_in_instrs`,
+    /// `end_pc`, and the side-exit reason map. Cheap to clone (a Vec
+    /// of bytes + small metadata) and we only do it once at install.
+    emitted: EmittedBlock,
+    /// Hit counter. Surfaced as `WasmSimulator::jit_hits()` so the
+    /// bench harness can confirm the JIT actually fired.
     pub hits: u64,
-    /// Keep the closure alive for the lifetime of the instance.
-    /// Dropping this severs the JS-side import — must outlive any
-    /// possible call into `run`.
+    /// Closure must outlive the instance: the JS-side imports table
+    /// references it. Dropping it while wasm could still call back
+    /// would dangle. Leading underscore: never read in Rust, only
+    /// holds the closure alive.
     _read_u8_closure: Closure<dyn FnMut(i32) -> i32>,
-    /// `Instance` is kept alive to root the imports' lifetimes. Held
-    /// after `run` (which references it through JS) so drop order is
-    /// safe.
+    /// Instance keeps the module + imports rooted. Held so `run`
+    /// (which is just a JS function value pulled from
+    /// `instance.exports`) stays callable.
     _instance: WebAssembly::Instance,
 }
 
-impl BrowserHotBbJit {
-    /// Compile + instantiate the hot-block module. Failure modes:
+impl BrowserCompiledBlock {
+    /// Compile + instantiate an emitted block, returning a ready-to-run
+    /// handle.
+    ///
+    /// Failure modes (all surfaced as `JsValue` so the dispatcher can
+    /// log and refuse):
     ///   * `WebAssembly.Module(buffer)` rejects the bytes — extremely
-    ///     unlikely given the bytes pass wasmtime validation already.
-    ///   * `WebAssembly.Instance(module, imports)` errors — usually a
+    ///     unlikely given emit-core's output is validated by wasmtime
+    ///     on the native path.
+    ///   * `WebAssembly.Instance(module, imports)` errors — typically a
     ///     mismatch in the import object shape; the construction here
-    ///     is exhaustively typed so this should not happen in practice.
-    ///   * `instance.exports.run` is not a Function — shouldn't happen
-    ///     for a module that declares an exported function named `run`,
-    ///     but we surface it as JsValue rather than panicking.
-    pub fn compile() -> Result<Self, JsValue> {
-        // 1. Wrap the static wasm bytes in a `Uint8Array` view. We
-        //    `copy_from` to avoid handing the engine a backing buffer
-        //    that we still hold (the Rust slice is `'static` so it's
-        //    not unsafe to share, but copy is cheap and removes a
-        //    subtle lifetime concern).
-        let buf = Uint8Array::new_with_length(HOT_BB_WASM.len() as u32);
-        buf.copy_from(HOT_BB_WASM);
+    ///     is exhaustively typed.
+    ///   * `instance.exports.run` is not a Function — only happens if
+    ///     emit-core stops emitting the `run` export.
+    pub fn compile(emitted: EmittedBlock) -> Result<Self, JsValue> {
+        // 1. Wrap the wasm bytes in a Uint8Array. `copy_from` so we
+        //    don't hand JS a view that aliases the Rust Vec (the Vec
+        //    is owned by `emitted` which we move into the struct
+        //    below; safer to copy than to reason about the aliasing).
+        let buf = Uint8Array::new_with_length(emitted.wasm_bytes.len() as u32);
+        buf.copy_from(&emitted.wasm_bytes);
 
-        // 2. Compile. `Module::new` accepts `&JsValue` so we pass the
-        //    typed-array up-casted.
+        // 2. Compile.
         let module = WebAssembly::Module::new(&buf.into())
             .map_err(|e| JsValue::from_str(&format!("WebAssembly.Module: {e:?}")))?;
 
-        // 3. Build the host-side byte queue and the JS closure that
-        //    dequeues from it. The closure captures an `Rc<RefCell<…>>`
-        //    so the queue is reachable from both Rust (`stage_loads`)
-        //    and JS (each invocation of `host.read_u8`).
-        let pending: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::with_capacity(2)));
+        // 3. Build the host-side queue + the JS closure that dequeues
+        //    from it. The closure captures the queue via `Rc` so both
+        //    Rust (`stage_loads`) and JS (each `host.read_u8` call) can
+        //    reach it.
+        let pending: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::with_capacity(4)));
         let pending_for_closure = pending.clone();
         let read_u8_closure = Closure::<dyn FnMut(i32) -> i32>::new(move |_addr: i32| -> i32 {
             // Wasm passes the address but we don't need it — the host
-            // pre-staged the bytes in BB order. If the queue is empty
-            // we report a bus error; the wasm body returns exit=5.
+            // pre-staged the bytes in BB order. Empty queue ⇒ bus
+            // error; wasm body returns EXIT_HOST_BUS_ERROR.
             let mut q = pending_for_closure.borrow_mut();
             if q.is_empty() {
                 return -1;
@@ -144,25 +163,13 @@ impl BrowserHotBbJit {
             q.remove(0) as i32
         });
 
-        // 4. Build the imports object: { host: { read_u8: closure } }.
-        let host_obj = Object::new();
-        Reflect::set(
-            &host_obj,
-            &JsValue::from_str("read_u8"),
-            read_u8_closure.as_ref().unchecked_ref(),
-        )
-        .map_err(|e| JsValue::from_str(&format!("set host.read_u8: {e:?}")))?;
-
-        let imports = Object::new();
-        Reflect::set(&imports, &JsValue::from_str("host"), &host_obj)
-            .map_err(|e| JsValue::from_str(&format!("set imports.host: {e:?}")))?;
-
-        // 5. Instantiate.
+        // 4. Build imports + instantiate.
+        let imports = build_imports(&read_u8_closure)?;
         let instance = WebAssembly::Instance::new(&module, &imports)
             .map_err(|e| JsValue::from_str(&format!("WebAssembly.Instance: {e:?}")))?;
 
-        // 6. Pluck `run` out of the exports. `exports` is a frozen JS
-        //    object; `Reflect::get` returns the function value.
+        // 5. Pluck the `run` export. emit-core always exports `run`;
+        //    if that changes, this is the one place to update.
         let exports = instance.exports();
         let run_val = Reflect::get(&exports, &JsValue::from_str("run"))
             .map_err(|e| JsValue::from_str(&format!("get exports.run: {e:?}")))?;
@@ -173,6 +180,7 @@ impl BrowserHotBbJit {
         Ok(Self {
             run,
             pending,
+            emitted,
             hits: 0,
             _read_u8_closure: read_u8_closure,
             _instance: instance,
@@ -180,20 +188,21 @@ impl BrowserHotBbJit {
     }
 
     /// Stage the byte values the wasm body's L8UI ops will receive.
-    /// `bytes.len()` must equal the BB's L8UI count (2 for the hot BB).
+    /// Caller must supply exactly as many bytes as the block expects;
+    /// extras are ignored, shortages surface as `EXIT_HOST_BUS_ERROR`
+    /// inside wasm.
     pub fn stage_loads(&self, bytes: &[u8]) {
         let mut q = self.pending.borrow_mut();
         q.clear();
         q.extend_from_slice(bytes);
     }
 
-    /// Invoke the hot block. Returns the 5-tuple `(exit, a2, a6, a8, a10)`
-    /// produced by the wasm body, decoded back to Rust types.
+    /// Invoke the block. Returns the 5-tuple `(exit, a2, a6, a8, a10)`
+    /// produced by the wasm body.
     ///
-    /// JS-side, `run(...)` returns a JS Array because wasm multi-value
-    /// returns map to arrays in the WebAssembly JavaScript API. We
-    /// pluck five `i32`s back out via `Reflect::get` + `as_f64()` —
-    /// JS numbers cleanly hold any i32 round-trip.
+    /// JS-side, multi-value wasm returns become Arrays. We pluck five
+    /// `i32`s out via `Array::get` + `as_f64` — JS numbers round-trip
+    /// every i32 cleanly.
     pub fn run(
         &mut self,
         a3: u32,
@@ -225,19 +234,66 @@ impl BrowserHotBbJit {
             a10: g(4) as u32,
         })
     }
+
+    /// Expose the block's emit-core metadata. Used by the dispatcher
+    /// to advance PC and bump CCOUNT after a clean fall-through.
+    pub fn emitted(&self) -> &EmittedBlock {
+        &self.emitted
+    }
 }
 
-/// Lazily-built process-wide JIT cache for the browser. Mirrors the
-/// `JitCache` shape on the native side but holds only the hot BB —
-/// scope cap for the prototype (#124 Phase 4).
+/// Build the JS `imports` object the wasm module expects. Today the
+/// emit-core produces only `host.read_u8`; Phase 4.3 will grow this to
+/// `read_u32` / `write_u32` / `branch_target` as variable-length emit
+/// lands. Structuring this as a separate helper keeps the additions
+/// surgical.
+fn build_imports(read_u8_closure: &Closure<dyn FnMut(i32) -> i32>) -> Result<Object, JsValue> {
+    let host_obj = Object::new();
+    Reflect::set(
+        &host_obj,
+        &JsValue::from_str("read_u8"),
+        read_u8_closure.as_ref().unchecked_ref(),
+    )
+    .map_err(|e| JsValue::from_str(&format!("set host.read_u8: {e:?}")))?;
+
+    let imports = Object::new();
+    Reflect::set(&imports, &JsValue::from_str("host"), &host_obj)
+        .map_err(|e| JsValue::from_str(&format!("set imports.host: {e:?}")))?;
+    Ok(imports)
+}
+
+/// Process-wide browser JIT cache. Keyed by `(pc, ps_bits.raw)` so a
+/// future PS-aware emit (Phase 4.4) doesn't share blocks across
+/// different PS contexts.
 ///
-/// We keep this thread-local because:
-///   * The browser sim is single-threaded (wasm32 main thread).
-///   * `js_sys` types are not `Send`, ruling out global statics.
+/// Thread-locality: the browser sim runs single-threaded on the wasm
+/// main thread; `js_sys` types aren't `Send` anyway. We hold the cache
+/// inside the `WasmSimulator` instance rather than as a global so each
+/// simulator gets its own (lets tests / playground reset cleanly).
 #[derive(Default)]
 pub struct BrowserJitCache {
-    pub hot_bb: Option<BrowserHotBbJit>,
+    /// `(pc, ps_bits.raw)` → installed block. HashMap on wasm32 is
+    /// fine: median lookup is one hash + one branch and the working
+    /// set is tiny (one entry per JIT-compiled BB shape — Phase 4.2
+    /// scope is a single block, Phase 4.3 will grow to ~dozens).
+    compiled: HashMap<(u32, u32), BrowserCompiledBlock>,
+    /// PCs the walker has already refused under a given PS context.
+    /// Without this the dispatcher would re-walk every refused BB on
+    /// every step — which is ~99% of all step()s in steady-state
+    /// ereader (BROM thunks, runtime helpers, anything with a branch
+    /// in it) — and the per-walk `fetch_slice + walk_bb` cost
+    /// dominates the entire dispatcher. The native JIT has the same
+    /// invariant baked in via `JitCache::lookup_or_install_multi_op`
+    /// returning early for `pc != HOT_BB_PC`; we generalise by
+    /// memoising the refusal set per (pc, ps).
+    refused: HashSet<(u32, u32)>,
+    /// Count of refusals — blocks the emit-core walker rejected, or
+    /// blocks that returned a host-side bus error at run time. Surfaced
+    /// as `WasmSimulator::jit_refusals()` for the bench harness.
     pub refusals: u64,
+    /// Total hits across all compiled blocks. Tracked as a running
+    /// total so `WasmSimulator::jit_hits()` is O(1).
+    total_hits: u64,
 }
 
 impl BrowserJitCache {
@@ -245,152 +301,93 @@ impl BrowserJitCache {
         Self::default()
     }
 
-    /// Lazily compile + return the hot block. Returns `None` only if
-    /// JS-side compilation/instantiation failed; the caller logs and
-    /// proceeds with the interpreter.
-    pub fn lookup_or_install(&mut self) -> Option<&mut BrowserHotBbJit> {
-        if self.hot_bb.is_none() {
-            match BrowserHotBbJit::compile() {
-                Ok(b) => self.hot_bb = Some(b),
-                Err(e) => {
-                    web_sys_console_warn(&format!(
-                        "labwired-wasm: browser JIT compile failed: {e:?}. Falling back to interpreter."
-                    ));
-                    return None;
-                }
-            }
-        }
-        self.hot_bb.as_mut()
+    /// Total number of times any compiled block has been dispatched.
+    /// Mirrors `JitCache::total_hits` on the native side.
+    pub fn total_hits(&self) -> u64 {
+        self.total_hits
+    }
+
+    /// Compile an [`EmittedBlock`] and install it under `(pc, ps_bits)`.
+    /// On success the block is ready for dispatch via [`Self::get_mut`].
+    ///
+    /// Idempotent: re-inserting the same key replaces the prior block.
+    /// The dispatcher checks `get_mut` first so this path only runs on
+    /// a miss.
+    pub fn install_from_emitted(
+        &mut self,
+        pc: u32,
+        ps_bits: PsBits,
+        emitted: EmittedBlock,
+    ) -> Result<(), BrowserInstallError> {
+        let block = BrowserCompiledBlock::compile(emitted).map_err(BrowserInstallError::Js)?;
+        self.compiled.insert((pc, ps_bits.raw), block);
+        Ok(())
+    }
+
+    /// Walk the bus at `pc` via [`emit_core::walk_and_emit`] and
+    /// install the resulting block. Mirrors
+    /// `JitCache::lookup_or_install_multi_op` on the native side.
+    ///
+    /// The `pc_to_offset` closure maps a PC back into `bus_slice` —
+    /// the canonical caller is the dispatcher below, which uses the
+    /// `(start, end, slice)` triple from [`Bus::fetch_slice`].
+    ///
+    /// Note: the on-step dispatcher inlines `walk_and_emit` +
+    /// `install_from_emitted` directly so it can drop the bus borrow
+    /// before touching `self` again (the borrow checker requires it).
+    /// This convenience method exists for non-dispatcher callers
+    /// (tests, future tooling) that don't have the bus borrow
+    /// conflict.
+    #[allow(
+        dead_code,
+        reason = "Convenience entry point for non-dispatcher callers; on-step dispatch inlines for borrow-checker reasons"
+    )]
+    pub fn walk_and_install(
+        &mut self,
+        bus_slice: &[u8],
+        pc: u32,
+        pc_to_offset: impl FnMut(u32) -> Option<usize>,
+        ps_bits: PsBits,
+    ) -> Result<(), BrowserInstallError> {
+        let emitted = emit_core::walk_and_emit(bus_slice, pc, pc_to_offset, ps_bits)?;
+        self.install_from_emitted(pc, ps_bits, emitted)
+    }
+
+    /// Mutable handle to the block at `(pc, ps_bits)`, or `None` if
+    /// not yet installed.
+    pub fn get_mut(&mut self, pc: u32, ps_bits: PsBits) -> Option<&mut BrowserCompiledBlock> {
+        self.compiled.get_mut(&(pc, ps_bits.raw))
+    }
+
+    /// Bump the running hit counter. Called by the dispatcher each
+    /// time a block returns a clean fall-through. Kept separate from
+    /// `BrowserCompiledBlock::hits` (per-block counter for diagnostics)
+    /// so the cache-wide total is O(1) to read.
+    fn bump_hit(&mut self) {
+        self.total_hits = self.total_hits.saturating_add(1);
     }
 }
 
-/// Attempt to dispatch the current PC into the browser JIT. Returns
-/// `true` if the JIT handled the step (caller does NOT call
-/// `Cpu::step` for this iteration); `false` otherwise.
-///
-/// The semantics mirror `XtensaLx7::try_jit_multi_op` in the native
-/// path:
-///   * Pre-read both L8UI bytes through the live bus. If either bus
-///     read errors, refuse the JIT.
-///   * Pre-resolve the L32R literal.
-///   * Stage the bytes, invoke wasm.
-///   * Commit registers + advance PC + bump CCOUNT iff exit=0.
-///
-/// We don't run the IRQ / pre-fetch path here — those happen on the
-/// regular interpreter step. The JIT is a fast-path for the hot BB
-/// only; the caller's loop falls back to the normal step path for
-/// every other PC.
-pub fn try_browser_jit_step(
-    cpu: &mut XtensaLx7,
-    bus: &mut dyn Bus,
-    cache: &mut BrowserJitCache,
-) -> bool {
-    if cpu.pc != HOT_BB_PC {
-        return false;
-    }
-    // Pre-read both L8UI bytes through the live bus.
-    let a3 = cpu.regs.read_logical(3);
-    let a5 = cpu.regs.read_logical(5);
-    let b0 = match bus.read_u8(a3 as u64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    let b1 = match bus.read_u8((a3.wrapping_add(1)) as u64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    let l32r_val = match bus.read_u32(HOT_BB_L32R_ADDR as u64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    let block = match cache.lookup_or_install() {
-        Some(b) => b,
-        None => return false,
-    };
-    block.stage_loads(&[b0, b1]);
-    let res = match block.run(a3, a5, l32r_val) {
-        Ok(r) => r,
-        Err(_) => {
-            cache.refusals += 1;
-            return false;
-        }
-    };
-    match res.exit_code {
-        x if x == EXIT_FALL_THROUGH => {
-            cpu.regs.write_logical(10, res.a10);
-            cpu.regs.write_logical(6, res.a6);
-            cpu.regs.write_logical(2, res.a2);
-            cpu.regs.write_logical(8, res.a8);
-            cpu.pc = HOT_BB_END;
-            // CCOUNT honesty: the interpreter would have advanced
-            // CCOUNT by HOT_BB_INSTR_COUNT (one per instruction). We
-            // mirror that here so the timer interrupt + CCOMPARE0
-            // edge logic still fires correctly.
-            let cc = cpu.sr.read(CCOUNT);
-            cpu.sr.write(CCOUNT, cc.wrapping_add(HOT_BB_INSTR_COUNT));
-            cpu.branched = false;
-            true
-        }
-        x if x == EXIT_HOST_BUS_ERROR => {
-            cache.refusals += 1;
-            false
-        }
-        _ => {
-            cache.refusals += 1;
-            false
-        }
-    }
-}
-
-// ── Phase 4.1 universal install surface (stub) ────────────────────────
-//
-// The path above (`BrowserHotBbJit::compile` / `try_browser_jit_step`)
-// hand-wires the canonical hot block via the pre-baked
-// [`HOT_BB_WASM`] constant. Phase 4.1 introduces a runtime-agnostic
-// emit core in `labwired_core::cpu::xtensa_jit::emit_core`; this stub
-// is the browser-side adapter that Phase 4.2 will flesh out to drive
-// arbitrary blocks through the same surface as the wasmtime path.
-//
-// The native adapter (`bb_multi::MultiOpBlock::build_from_emitted`)
-// already accepts an [`EmittedBlock`] and instantiates it through
-// wasmtime. Phase 4.2 will mirror that here by:
-//   1. Walking the bus from `cpu.pc` via `emit_core::walk_and_emit`.
-//   2. Handing the resulting bytes to `WebAssembly::Module::new` and
-//      installing the host import surface (read_u8 today; load/store
-//      pair + control-flow exits in 4.3/4.4).
-//   3. Caching by `(pc, ps_bits)` per the universal-JIT plan.
-//
-// Today the stub returns `Err(NotYetImplemented)` so callers can
-// already type-check the integration without us pretending the
-// browser runtime is wired.
-
-/// Phase 4.2-and-later install error surface. Mirrors the native
-/// `wasmtime::Error` boundary but stays runtime-agnostic; the browser
-/// path can grow JS-specific variants as Phase 4.2 lands.
-#[allow(
-    dead_code,
-    reason = "Phase 4.1 stub: Phase 4.2 will wire callers (install + cache key)"
-)]
+/// Failure surface for [`BrowserJitCache::install_from_emitted`].
+/// Two variants: emit-core refused the BB (e.g. unsupported opcode),
+/// or the JS-side `WebAssembly.Module`/`Instance` path errored.
 #[derive(Debug)]
 pub enum BrowserInstallError {
-    /// The emit-core walker refused the PC (unsupported opcode shape,
-    /// PC outside the bus slice, etc).
+    /// emit-core refused — typically `EmitError::UnsupportedShape` for
+    /// blocks the Phase 4.2 emit scope doesn't cover. Caller should
+    /// bump the refusal counter and fall back to the interpreter.
     Emit(EmitError),
-    /// Phase 4.2 is not implemented yet. Returned by
-    /// [`BrowserJitCache::install_from_emitted`] so callers can wire
-    /// the integration today and have it light up once Phase 4.2
-    /// replaces this branch with actual `WebAssembly::Module::new`
-    /// instantiation.
-    NotYetImplemented,
+    /// JS-side error (compile / instantiate / export-lookup). Stringified
+    /// `JsValue` so the dispatcher can log without dragging the
+    /// browser console into a Display impl.
+    Js(JsValue),
 }
 
 impl core::fmt::Display for BrowserInstallError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             BrowserInstallError::Emit(e) => write!(f, "emit_core: {e}"),
-            BrowserInstallError::NotYetImplemented => {
-                f.write_str("browser-side install is not yet implemented (Phase 4.2 stub)")
-            }
+            BrowserInstallError::Js(v) => write!(f, "js: {v:?}"),
         }
     }
 }
@@ -401,54 +398,186 @@ impl From<EmitError> for BrowserInstallError {
     }
 }
 
-impl BrowserJitCache {
-    /// Walk the BB at `pc` via [`emit_core::walk_and_emit`] and (when
-    /// Phase 4.2 lands) instantiate the resulting bytes through
-    /// `js_sys::WebAssembly`. Today this returns
-    /// [`BrowserInstallError::NotYetImplemented`] on the success path
-    /// so callers can already wire the integration end-to-end.
-    ///
-    /// The signature mirrors `bb_multi::MultiOpBlock::build_from_emitted`
-    /// on the native side: both accept the bytes emit-core produced and
-    /// instantiate them via their respective runtime. That's the entire
-    /// emit/runtime decoupling, made explicit in the type system.
-    #[allow(
-        dead_code,
-        reason = "Phase 4.1 stub: Phase 4.2 wires the browser install path"
-    )]
-    pub fn install_from_emitted(
-        &mut self,
-        _emitted: &EmittedBlock,
-    ) -> Result<(), BrowserInstallError> {
-        // Phase 4.2 fills in:
-        //   let buf = Uint8Array::new_with_length(_emitted.wasm_bytes.len() as u32);
-        //   buf.copy_from(&_emitted.wasm_bytes);
-        //   let module = WebAssembly::Module::new(&buf.into())?;
-        //   ... install host imports built from _emitted.side_exit_reasons ...
-        //   let instance = WebAssembly::Instance::new(&module, &imports)?;
-        //   self.hot_bb = Some(BrowserHotBbJit { ... });
-        Err(BrowserInstallError::NotYetImplemented)
+/// Attempt to dispatch the current PC into the browser JIT. Returns
+/// `true` if the JIT handled the step (caller does NOT call
+/// `Cpu::step` for this iteration); `false` otherwise.
+///
+/// Mirrors `XtensaLx7::try_jit_multi_op` on the native path:
+///   * Look up the bus slice covering `pc` via [`Bus::fetch_slice`].
+///   * Look up `(pc, ps_bits)` in the cache; on miss, walk + install.
+///   * Pre-read host-input bytes through the live bus.
+///   * Stage the bytes, invoke wasm.
+///   * On clean fall-through: commit registers, advance PC, bump
+///     CCOUNT by `length_in_instrs - 1` (the outer loop already
+///     counted one).
+///
+/// We don't run the IRQ / pre-fetch path here — those happen on the
+/// regular interpreter step. The JIT is a fast-path; non-JIT PCs fall
+/// through and the caller's loop hands them to `Cpu::step`.
+pub fn try_browser_jit_step(
+    cpu: &mut XtensaLx7,
+    bus: &mut dyn Bus,
+    cache: &mut BrowserJitCache,
+) -> bool {
+    let pc = cpu.pc;
+    let ps_bits = PsBits::from_raw(cpu.ps.as_raw());
+
+    // Sticky-refusal fast path: if we've already walked this (pc, ps)
+    // and the emit-core rejected it, don't re-walk every single step.
+    // This is the same logic as the native JIT's `pc != HOT_BB_PC`
+    // early-return, generalised — see the `refused` field doc for
+    // why it matters perf-wise.
+    if cache.refused.contains(&(pc, ps_bits.raw)) {
+        return false;
     }
 
-    /// Walk + install for the given PC. Threads through emit_core so
-    /// the API surface is symmetric with the native adapter. Returns
-    /// `Ok(())` once Phase 4.2 wires up the browser runtime; today
-    /// always errors with [`BrowserInstallError::NotYetImplemented`]
-    /// after a successful walk, or [`BrowserInstallError::Emit`] when
-    /// the walker refuses.
-    #[allow(
-        dead_code,
-        reason = "Phase 4.1 stub: Phase 4.2 will drive this from try_browser_jit_step"
-    )]
-    pub fn walk_and_install(
-        &mut self,
-        bus_slice: &[u8],
-        pc: u32,
-        pc_to_offset: impl FnMut(u32) -> Option<usize>,
-        ps_bits: PsBits,
-    ) -> Result<(), BrowserInstallError> {
-        let emitted = emit_core::walk_and_emit(bus_slice, pc, pc_to_offset, ps_bits)?;
-        self.install_from_emitted(&emitted)
+    // Fast path: block already installed under (pc, ps_bits). Skip
+    // straight to running it.
+    let installed = cache.get_mut(pc, ps_bits).is_some();
+
+    if !installed {
+        // Cold path: ask the bus for an IRAM slice covering `pc`, run
+        // emit-core, install. If the bus can't serve a slice (PC is in
+        // a non-RAM peripheral, or unmapped), refuse permanently —
+        // non-RAM fetches would side-effect anyway, so JIT'ing them
+        // is unsafe.
+        //
+        // We hold the bus slice across `walk_and_emit` without
+        // cloning. emit-core only reads from it and produces an
+        // owned EmittedBlock; the slice can be dropped immediately
+        // after.
+        let install_result = match bus.fetch_slice(pc as u64) {
+            Some((slice_start, slice_end, slice)) => {
+                if (pc as u64) < slice_start || (pc as u64) >= slice_end {
+                    cache.refused.insert((pc, ps_bits.raw));
+                    return false;
+                }
+                let emitted_result = emit_core::walk_and_emit(
+                    slice,
+                    pc,
+                    |q| {
+                        let q = q as u64;
+                        if q < slice_start || q >= slice_end {
+                            return None;
+                        }
+                        Some((q - slice_start) as usize)
+                    },
+                    ps_bits,
+                );
+                // Drop the bus borrow before we touch `cache` again
+                // (the borrow checker requires it; `bus.fetch_slice`
+                // returned a `&[u8]` borrowed from the bus).
+                match emitted_result {
+                    Ok(emitted) => Some(emitted),
+                    Err(e) => {
+                        // Memoise the refusal so we don't re-walk
+                        // this PC on every subsequent step.
+                        cache.refused.insert((pc, ps_bits.raw));
+                        let _ = e; // refusal type doesn't matter here
+                        cache.refusals = cache.refusals.saturating_add(1);
+                        return false;
+                    }
+                }
+            }
+            None => {
+                cache.refused.insert((pc, ps_bits.raw));
+                return false;
+            }
+        };
+
+        let emitted = match install_result {
+            Some(e) => e,
+            None => return false,
+        };
+        match cache.install_from_emitted(pc, ps_bits, emitted) {
+            Ok(()) => {}
+            Err(BrowserInstallError::Js(e)) => {
+                web_sys_console_warn(&format!(
+                    "labwired-wasm: browser JIT install failed at pc=0x{pc:08x}: {e:?}. Falling back to interpreter."
+                ));
+                cache.refused.insert((pc, ps_bits.raw));
+                cache.refusals = cache.refusals.saturating_add(1);
+                return false;
+            }
+            Err(BrowserInstallError::Emit(_)) => {
+                // install_from_emitted doesn't produce Emit errors;
+                // this arm is defensive.
+                cache.refused.insert((pc, ps_bits.raw));
+                cache.refusals = cache.refusals.saturating_add(1);
+                return false;
+            }
+        }
+    }
+
+    // Pre-read host-input values. Today's emit (the canonical hot BB)
+    // needs two L8UI bytes from [a3, a3+1] and the L32R literal at
+    // HOT_BB_L32R_ADDR. Phase 4.3+ will need a more general staging
+    // model — at that point the EmittedBlock will carry a manifest of
+    // required inputs.
+    let a3 = cpu.regs.read_logical(3);
+    let a5 = cpu.regs.read_logical(5);
+    let b0 = match bus.read_u8(a3 as u64) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let b1 = match bus.read_u8((a3.wrapping_add(1)) as u64) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    // L32R address is currently hardcoded for the hot block. Phase 4.3
+    // will move this into EmittedBlock alongside the rest of the input
+    // staging manifest.
+    let l32r_addr = if pc == HOT_BB_PC { HOT_BB_L32R_ADDR } else { 0 };
+    let l32r_val = match bus.read_u32(l32r_addr as u64) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    let block = match cache.get_mut(pc, ps_bits) {
+        Some(b) => b,
+        None => return false,
+    };
+    let end_pc = block.emitted().end_pc;
+    let length_in_instrs = block.emitted().length_in_instrs;
+
+    block.stage_loads(&[b0, b1]);
+    let res = match block.run(a3, a5, l32r_val) {
+        Ok(r) => r,
+        Err(_) => {
+            cache.refusals = cache.refusals.saturating_add(1);
+            return false;
+        }
+    };
+
+    match res.exit_code {
+        x if x == EXIT_FALL_THROUGH => {
+            cpu.regs.write_logical(10, res.a10);
+            cpu.regs.write_logical(6, res.a6);
+            cpu.regs.write_logical(2, res.a2);
+            cpu.regs.write_logical(8, res.a8);
+            cpu.pc = end_pc;
+            // CCOUNT honesty: the interpreter would have advanced
+            // CCOUNT by length_in_instrs - 1 (one per instruction; the
+            // outer step counts one more on its own). Mirror the
+            // native `try_jit_multi_op` path. If a future emit ever
+            // produces a 0-length block, the saturating_sub keeps the
+            // arithmetic sane.
+            if length_in_instrs > 1 {
+                let cc = cpu.sr.read(CCOUNT);
+                cpu.sr.write(CCOUNT, cc.wrapping_add(length_in_instrs - 1));
+            }
+            cpu.branched = false;
+            cache.bump_hit();
+            true
+        }
+        x if x == EXIT_HOST_BUS_ERROR => {
+            cache.refusals = cache.refusals.saturating_add(1);
+            false
+        }
+        _ => {
+            cache.refusals = cache.refusals.saturating_add(1);
+            false
+        }
     }
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -2126,15 +2126,14 @@ impl WasmSimulator {
         }
     }
 
-    /// Total number of times the browser JIT has dispatched the hot
-    /// block. Useful for confirming the JIT path actually fired during
-    /// a benchmark.
+    /// Total number of times the browser JIT has dispatched a
+    /// compiled block. Useful for confirming the JIT path actually
+    /// fired during a benchmark.
     #[wasm_bindgen]
     pub fn jit_hits(&self) -> u64 {
         self.jit_browser_cache
             .as_ref()
-            .and_then(|c| c.hot_bb.as_ref())
-            .map(|b| b.hits)
+            .map(|c| c.total_hits())
             .unwrap_or(0)
     }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -2242,13 +2242,26 @@ impl WasmSimulator {
             // CCOMPARE0 edge detection honest.
             if self.jit_browser_enabled {
                 let machine = self.machine.as_mut().unwrap();
-                if self.jit_browser_cache.is_none() {
-                    self.jit_browser_cache = Some(Box::new(jit_browser::BrowserJitCache::new()));
-                }
-                let cache = self.jit_browser_cache.as_mut().unwrap();
-                if let Some(any) = machine.cpu.as_any_mut() {
-                    if let Some(xt) = any.downcast_mut::<labwired_core::cpu::XtensaLx7>() {
-                        jit_browser::try_browser_jit_step(xt, &mut machine.bus, cache);
+                // Phase 4.6.1 (#124): cheap PC-range gate. The browser
+                // JIT today only ever installs blocks for HOT_BB_PC and
+                // LOOPTASK_PC. On every other PC the downcast + cache
+                // lookup is pure overhead — ~87% of cycles in the
+                // loopTask steady state hit this path. Two constant
+                // compares are cheaper than virtual `as_any_mut` +
+                // `downcast_mut` + `HashSet::contains` + `HashMap::get_mut`.
+                let pc_now = machine.cpu.get_pc();
+                if pc_now == labwired_core::cpu::xtensa_jit_bytes::HOT_BB_PC
+                    || pc_now == labwired_core::cpu::xtensa_jit_bytes::LOOPTASK_PC
+                {
+                    if self.jit_browser_cache.is_none() {
+                        self.jit_browser_cache =
+                            Some(Box::new(jit_browser::BrowserJitCache::new()));
+                    }
+                    let cache = self.jit_browser_cache.as_mut().unwrap();
+                    if let Some(any) = machine.cpu.as_any_mut() {
+                        if let Some(xt) = any.downcast_mut::<labwired_core::cpu::XtensaLx7>() {
+                            jit_browser::try_browser_jit_step(xt, &mut machine.bus, cache);
+                        }
                     }
                 }
             }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -2,6 +2,11 @@ use labwired_config::{
     Arch, BoardIoBinding, BoardIoKind, BoardIoSignal, ChipDescriptor, SystemManifest,
 };
 use labwired_core::bus::SystemBus;
+
+// #124 Phase 4: browser-side JIT prototype. Runs the dominant
+// `0x400829cc` hot block through `js_sys::WebAssembly` instead of the
+// interpreter when `jit_enabled()` has been toggled on from JS.
+mod jit_browser;
 // CortexM and XtensaLx7 are used via Box<dyn Cpu>; the concrete types are
 // only constructed inside the configure_* fns and immediately boxed.
 use labwired_core::decoder::arm::{decode_thumb_16, decode_thumb_32};
@@ -53,6 +58,14 @@ pub struct WasmSimulator {
     /// When `Some`, `step_with_esp32_aids` runs the IPI bridge + dual-core
     /// handshake keep-alives each cycle.
     esp32_ipi: Option<Esp32IpiBridge>,
+    /// #124 Phase 4: browser-side JIT cache. Off by default — flip via
+    /// `set_jit_enabled(true)` from JS. We deliberately don't auto-enable
+    /// until benchmarks confirm a net win, so production playground
+    /// behaviour is unchanged unless the operator opts in.
+    jit_browser_enabled: bool,
+    /// Lazy-init at first JIT-able step. Boxed so the typical "JIT off"
+    /// path pays no per-instance allocation.
+    jit_browser_cache: Option<Box<jit_browser::BrowserJitCache>>,
 }
 
 #[wasm_bindgen]
@@ -87,6 +100,8 @@ impl WasmSimulator {
             uart_rx_bufs,
             arch: Arch::Arm,
             esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
         })
     }
 
@@ -150,6 +165,8 @@ impl WasmSimulator {
             uart_rx_bufs,
             arch: Arch::Arm,
             esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
         })
     }
 
@@ -194,6 +211,8 @@ impl WasmSimulator {
             uart_rx_bufs,
             arch: Arch::Xtensa,
             esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
         })
     }
 
@@ -2092,6 +2111,58 @@ impl WasmSimulator {
         let _ = machine.bus.write_u8(0x3FFC_7190, 0x01);
     }
 
+    /// #124 Phase 4: enable/disable the browser-side JIT fast-path. When
+    /// on, `step_with_esp32_aids` short-circuits any pre-fetch step
+    /// whose PC matches the JIT'd hot block (`0x400829cc`) into a wasm
+    /// call constructed via `js_sys::WebAssembly`. Off by default —
+    /// callers opt in from JS once they've benchmarked.
+    #[wasm_bindgen]
+    pub fn set_jit_enabled(&mut self, enabled: bool) {
+        self.jit_browser_enabled = enabled;
+        if !enabled {
+            // Cleanly drop the cached module + closures so the next
+            // enable rebuilds from scratch.
+            self.jit_browser_cache = None;
+        }
+    }
+
+    /// Total number of times the browser JIT has dispatched the hot
+    /// block. Useful for confirming the JIT path actually fired during
+    /// a benchmark.
+    #[wasm_bindgen]
+    pub fn jit_hits(&self) -> u64 {
+        self.jit_browser_cache
+            .as_ref()
+            .and_then(|c| c.hot_bb.as_ref())
+            .map(|b| b.hits)
+            .unwrap_or(0)
+    }
+
+    /// Total number of JIT refusals (host bus errors, JS-side
+    /// dispatch failures). Surfaced for the bench harness so it can
+    /// distinguish "JIT was tried and rejected" from "JIT was never
+    /// hit because PC never reached the block".
+    #[wasm_bindgen]
+    pub fn jit_refusals(&self) -> u64 {
+        self.jit_browser_cache.as_ref().map(|c| c.refusals).unwrap_or(0)
+    }
+
+    /// Bench runner: execute `cycles` `step_with_esp32_aids` iterations
+    /// and return elapsed milliseconds (measured via
+    /// `performance.now()`). The caller drives this twice — once with
+    /// `set_jit_enabled(false)`, once with `set_jit_enabled(true)` —
+    /// and compares the two numbers to quantify JIT speedup.
+    ///
+    /// Returns a `Result<f64, JsValue>`: the `Err` path bubbles step
+    /// errors so the bench harness can show a useful message.
+    #[wasm_bindgen]
+    pub fn bench_jit(&mut self, cycles: u32) -> Result<f64, JsValue> {
+        let t0 = perf_now();
+        self.step_with_esp32_aids(cycles)?;
+        let t1 = perf_now();
+        Ok(t1 - t0)
+    }
+
     /// Step `cycles` cycles with the ESP32-classic IPI bridge active. Each
     /// cycle samples the DPORT FROM_CPU intmatrix mapping and trigger
     /// registers, raises the corresponding INTERRUPT bit, and clears the
@@ -2160,12 +2231,46 @@ impl WasmSimulator {
                     }
                 }
             }
+
+            // #124 Phase 4: browser-side JIT fast-path. Runs BEFORE
+            // `machine.step()` so a successful JIT call advances PC
+            // past the hot block (0x400829cc -> 0x400829e4) and the
+            // regular step picks up at the post-block callx8.
+            // CCOUNT advance happens inside the JIT helper to keep
+            // CCOMPARE0 edge detection honest.
+            if self.jit_browser_enabled {
+                let machine = self.machine.as_mut().unwrap();
+                if self.jit_browser_cache.is_none() {
+                    self.jit_browser_cache =
+                        Some(Box::new(jit_browser::BrowserJitCache::new()));
+                }
+                let cache = self.jit_browser_cache.as_mut().unwrap();
+                if let Some(any) = machine.cpu.as_any_mut() {
+                    if let Some(xt) = any.downcast_mut::<labwired_core::cpu::XtensaLx7>() {
+                        jit_browser::try_browser_jit_step(xt, &mut machine.bus, cache);
+                    }
+                }
+            }
+
             self.machine()
                 .step()
                 .map_err(|e| JsValue::from_str(&format!("Step Error: {e}")))?;
         }
         Ok(())
     }
+}
+
+// ── Browser-side performance.now() shim ────────────────────────────────
+//
+// `web-sys` would bring in a large generated binding tree just to call
+// `performance.now()`. We use an explicit `wasm-bindgen` import instead.
+// Same ABI; ~zero overhead. The matching console.warn shim lives in
+// `jit_browser.rs` to keep its module self-contained.
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = performance, js_name = now)]
+    fn perf_now() -> f64;
 }
 
 // WasmGdbEventLoop removed — see `gdb_process_packet` above for the rationale.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -2149,6 +2149,18 @@ impl WasmSimulator {
             .unwrap_or(0)
     }
 
+    /// Phase 4.4: per-PC JIT hit count for the given PC. Used by the
+    /// bench harness to confirm each installed shape is firing as
+    /// expected (prefix at 0x400d4a8d, tail at 0x400d4a9c, etc.).
+    /// Returns 0 if the PC has never been hit.
+    #[wasm_bindgen]
+    pub fn jit_hits_at(&self, pc: u32) -> u64 {
+        self.jit_browser_cache
+            .as_ref()
+            .and_then(|c| c.hits_by_pc.get(&pc).copied())
+            .unwrap_or(0)
+    }
+
     /// Bench runner: execute `cycles` `step_with_esp32_aids` iterations
     /// and return elapsed milliseconds (measured via
     /// `performance.now()`). The caller drives this twice — once with
@@ -2252,6 +2264,7 @@ impl WasmSimulator {
                 let pc_now = machine.cpu.get_pc();
                 if pc_now == labwired_core::cpu::xtensa_jit_bytes::HOT_BB_PC
                     || pc_now == labwired_core::cpu::xtensa_jit_bytes::LOOPTASK_PC
+                    || pc_now == labwired_core::cpu::xtensa_jit_bytes::LOOPTASK_TAIL_PC
                 {
                     if self.jit_browser_cache.is_none() {
                         self.jit_browser_cache =

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -2144,7 +2144,10 @@ impl WasmSimulator {
     /// hit because PC never reached the block".
     #[wasm_bindgen]
     pub fn jit_refusals(&self) -> u64 {
-        self.jit_browser_cache.as_ref().map(|c| c.refusals).unwrap_or(0)
+        self.jit_browser_cache
+            .as_ref()
+            .map(|c| c.refusals)
+            .unwrap_or(0)
     }
 
     /// Bench runner: execute `cycles` `step_with_esp32_aids` iterations
@@ -2241,8 +2244,7 @@ impl WasmSimulator {
             if self.jit_browser_enabled {
                 let machine = self.machine.as_mut().unwrap();
                 if self.jit_browser_cache.is_none() {
-                    self.jit_browser_cache =
-                        Some(Box::new(jit_browser::BrowserJitCache::new()));
+                    self.jit_browser_cache = Some(Box::new(jit_browser::BrowserJitCache::new()));
                 }
                 let cache = self.jit_browser_cache.as_mut().unwrap();
                 if let Some(any) = machine.cpu.as_any_mut() {

--- a/docs/boards/nrf52840.md
+++ b/docs/boards/nrf52840.md
@@ -4,8 +4,8 @@ The Nordic nRF52840 (Cortex-M4F, 1 MB flash, 256 KB SRAM, 2.4 GHz radio,
 USB) is a popular Nordic part used by the
 [nRF52840-DK](../../configs/systems/nrf52840-dk.yaml) and the
 [XIAO nRF52840](https://wiki.seeedstudio.com/XIAO_BLE/) family. The
-current LabWired model is **uart-only** — UART0 is the only on-chip
-peripheral declared.
+current LabWired model covers UART0, GPIO P0/P1 smoke behavior, and a
+minimal SPIM0 task/event path.
 
 ## Status at a glance
 
@@ -13,26 +13,32 @@ peripheral declared.
 |---------------------|---------------------------------------------------------------------------------|
 | Chip yaml           | [`configs/chips/nrf52840.yaml`](../../configs/chips/nrf52840.yaml)              |
 | System yaml         | [`configs/systems/nrf52840-dk.yaml`](../../configs/systems/nrf52840-dk.yaml)    |
-| Reference firmware  | None checked in yet                                                             |
-| Validation          | No `VALIDATION.md` checked in                                                   |
-| Tier                | structural — UART0 model only                                                   |
+| Reference firmware  | [`crates/firmware-nrf52840-demo`](../../crates/firmware-nrf52840-demo)          |
+| Validation          | [`examples/seeed-xiao-nrf52840-sense/VALIDATION.md`](../../examples/seeed-xiao-nrf52840-sense/VALIDATION.md) |
+| Tier                | smoke - UART0, GPIO, SPIM0 register task path                                   |
 
 ## Peripherals (from chip yaml)
 
 | Peripheral | Base       | Status       | Notes                                                  |
 |------------|------------|--------------|--------------------------------------------------------|
-| Cortex-M4F | —          | ✅ modeled   | Thumb-2 + VFPv4 single-precision                       |
-| UART0      | 0x40002000 | ✅ modeled   | `nrf52` profile, 4 KB window                           |
+| Cortex-M4F | -          | modeled      | Thumb-2 + VFPv4 single-precision                       |
+| UART0      | 0x40002000 | modeled      | `nrf52` profile, 4 KB window                           |
+| SPIM0      | 0x40003000 | smoke        | ENABLE/PSEL/FREQUENCY/TXD/TASKS_START/EVENTS_END       |
+| GPIO0      | 0x50000000 | smoke        | OUT/OUTSET/OUTCLR/DIR/DIRSET/DIRCLR/PIN_CNF subset     |
+| GPIO1      | 0x50001000 | smoke        | Synthetic non-overlapping LabWired mapping for P1       |
 
 ## Not yet modeled (commonly expected on nRF52840)
 
 The chip yaml does not declare: **CLOCK**, **POWER**, **RADIO**, **USBD**
-(USB device controller), **TIMER0–4**, **RTC0–2**, **GPIO P0/P1**
-(`0x50000000`), **GPIOTE**, **TWIM0/1**, **TWIS0/1**, **SPIM0–3**,
-**SPIS0–3**, **PPI**, **PWM0–3**, **PDM**, **I2S**, **SAADC**, **RNG**,
+(USB device controller), **TIMER0-4**, **RTC0-2**, **GPIOTE**,
+**TWIM0/1**, **TWIS0/1**, **SPIM1-3**, **SPIS0-3**, **PPI**, **PWM0-3**,
+**PDM**, **I2S**, **SAADC**, **RNG**,
 **TEMP**, **WDT**, **NVMC**, **UICR**, **FICR**, **ECB**, **CCM**,
 **AAR**, **QSPI**, **NFCT**.
 
 Firmware that touches any of these registers will hit
 `MemoryAccessViolation` or stall in a polling loop. See
 [`docs/getting_started_firmware.md`](../getting_started_firmware.md).
+
+The SPIM0 model is a register smoke model. It does not yet perform EasyDMA
+memory reads/writes or route bytes to attached SPI devices.

--- a/docs/boards/seeed-xiao-nrf52840-sense.md
+++ b/docs/boards/seeed-xiao-nrf52840-sense.md
@@ -1,0 +1,30 @@
+# Seeed XIAO nRF52840 Sense
+
+The Seeed XIAO nRF52840 Sense is a compact nRF52840 board with USB, RGB LED,
+IMU, microphone, and exposed XIAO castellated pins.
+
+## Status
+
+| Aspect | Status |
+|--------|--------|
+| Chip yaml | `configs/chips/nrf52840.yaml` |
+| System yaml | `configs/systems/seeed-xiao-nrf52840-sense.yaml` |
+| Example | `examples/seeed-xiao-nrf52840-sense/` |
+| Firmware | `crates/firmware-nrf52840-demo/` |
+| Tier | smoke: UART0 + GPIO + SPIM0 register task path |
+
+## Modeled Peripherals
+
+| Peripheral | Base | Notes |
+|------------|------|-------|
+| UART0 | `0x40002000` | Nordic UART TXD smoke path |
+| SPIM0 | `0x40003000` | Register/task/event smoke model |
+| GPIO0 | `0x50000000` | nRF OUT/OUTSET/OUTCLR/DIR task register subset |
+| GPIO1 | `0x50001000` | Synthetic non-overlapping LabWired mapping for P1 board I/O |
+
+## Validation Boundary
+
+This target has automated LabWired simulation coverage for UART/GPIO/SPIM0.
+The connected USB board was detected locally and bootloader entry was verified,
+but no SWD probe was available, so hardware register-dump parity is not claimed
+yet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ If you are new to LabWired, start here:
   [`stm32h563`](boards/stm32h563.md),
   [`stm32l476` (gold reference)](boards/nucleo-l476rg.md),
   [`nrf52840`](boards/nrf52840.md),
+  [`seeed-xiao-nrf52840-sense`](boards/seeed-xiao-nrf52840-sense.md),
   [`rp2040`](boards/rp2040.md),
   [`esp32c3`](boards/esp32c3.md).
   Check here before pointing firmware at a new chip.

--- a/examples/seeed-xiao-nrf52840-sense/EXTERNAL_COMPONENTS.md
+++ b/examples/seeed-xiao-nrf52840-sense/EXTERNAL_COMPONENTS.md
@@ -1,0 +1,8 @@
+# External Components
+
+No external SPI, I2C, or analog components are required for the current smoke
+test. The target models the on-board RGB LED and the MCU SPIM0 controller
+registers only.
+
+Future SPI device validation should add an explicit external device manifest
+entry plus a hardware trace captured with SWD or a logic analyzer.

--- a/examples/seeed-xiao-nrf52840-sense/README.md
+++ b/examples/seeed-xiao-nrf52840-sense/README.md
@@ -1,0 +1,44 @@
+# Seeed XIAO nRF52840 Sense
+
+This example onboards the Seeed XIAO nRF52840 Sense as a LabWired board target.
+It reuses the generic `nrf52840` chip descriptor and adds board-level wiring for
+the XIAO RGB LED and SPI bus.
+
+## Modeled Board I/O
+
+| Signal | nRF pin | LabWired binding | Notes |
+|--------|---------|------------------|-------|
+| Red LED | P0.26 | `led_red` | Active-low |
+| Green LED | P0.30 | `led_green` | Active-low |
+| Blue LED | P0.06 | `led_blue` | Active-low |
+| SPI SCK | P1.13 | `spi0` register config | XIAO D8 |
+| SPI MISO | P1.14 | `spi0` register config | XIAO D9 |
+| SPI MOSI | P1.15 | `spi0` register config | XIAO D10 |
+
+## Build
+
+```bash
+cargo build -p firmware-nrf52840-demo --release --target thumbv7em-none-eabi
+```
+
+## Run Smoke Test
+
+```bash
+cargo run -q -p labwired-cli -- test \
+  --script examples/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke.yaml \
+  --output-dir out/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke \
+  --no-uart-stdout
+```
+
+The smoke firmware enables UART0, configures the RGB LED GPIO lines, configures
+SPIM0 pin select / frequency / TXD registers, starts an SPIM transfer, and emits
+`NRF52840_SMOKE_OK` over UART.
+
+## Fidelity Scope
+
+This target is verified for LabWired register-level smoke coverage of UART0,
+GPIO OUT/OUTSET/OUTCLR/DIR/DIRSET/DIRCLR, and a minimal SPIM0 task/event path.
+The SPIM model records register state and completes `TASKS_START`, but it does
+not yet fetch EasyDMA buffers from system memory or route bytes to attached SPI
+devices. Full hardware parity for SPI waveforms requires a SWD probe or logic
+analyzer capture.

--- a/examples/seeed-xiao-nrf52840-sense/REQUIRED_DOCS.md
+++ b/examples/seeed-xiao-nrf52840-sense/REQUIRED_DOCS.md
@@ -1,0 +1,8 @@
+# Required Documents
+
+- Nordic Semiconductor nRF52840 Product Specification.
+- Seeed Studio XIAO nRF52840 / XIAO nRF52840 Sense documentation.
+- Seeed Studio XIAO nRF52840 Sense schematic and pinout.
+
+These documents define the memory map, GPIO/SPIM register offsets, and board
+pin mapping used by this target.

--- a/examples/seeed-xiao-nrf52840-sense/VALIDATION.md
+++ b/examples/seeed-xiao-nrf52840-sense/VALIDATION.md
@@ -1,0 +1,92 @@
+# Seeed XIAO nRF52840 Sense Validation
+
+Validation date: 2026-05-27
+
+## Hardware Presence
+
+The connected board enumerated on USB as:
+
+```text
+2886:8045 Seeed Technology Co., Ltd. Seeed XIAO nRF52840 Sense
+/dev/serial/by-id/usb-Arduino_Seeed_XIAO_nRF52840_Sense_329707A450F0C9C3-if00 -> ../../ttyACM5
+```
+
+USB descriptor evidence:
+
+- Application VID:PID: `2886:8045`
+- Manufacturer: `Arduino`
+- Product: `Seeed XIAO nRF52840 Sense`
+- Serial: `329707A450F0C9C3`
+- Driver: `cdc_acm`
+- Interfaces: CDC ACM control + CDC data
+
+CDC serial reads at 115200, 9600, and 1200 baud produced zero bytes over a
+3-second capture window.
+
+## Bootloader Presence
+
+A 1200-baud CDC touch switched the board into bootloader mode without writing
+firmware:
+
+```text
+2886:0045 Seeed Technology Co., Ltd. XIAO nRF52840 Sense
+/dev/serial/by-id/usb-Seeed_XIAO_nRF52840_Sense_940D8A73707DC298-if00 -> ../../ttyACM5
+```
+
+Bootloader descriptor evidence:
+
+- Bootloader VID:PID: `2886:0045`
+- Manufacturer: `Seeed`
+- Product: `XIAO nRF52840 Sense`
+- Serial: `940D8A73707DC298`
+- Driver: `cdc_acm`
+- Interfaces: CDC ACM control + CDC data
+
+No UF2 mass-storage volume appeared under `/media`, `/run/media`, or `/mnt`.
+`dfu-util -l` did not list a DFU interface. A read-only Nordic serial DFU ping
+sent over CDC at 9600, 57600, 115200, 230400, and 1000000 baud returned no
+bytes. No firmware was written to the device during validation.
+
+No external SWD debug probe was visible through `probe-rs list` or
+`nrfjprog --ids`, so this validation does not claim SWD register dumps,
+flash programming, or logic-level SPI waveform parity.
+
+## Simulator Evidence
+
+Commands:
+
+```bash
+cargo test -p labwired-core nrf52::xiao -- --nocapture
+cargo build -p firmware-nrf52840-demo --release --target thumbv7em-none-eabi
+cargo run -q -p labwired-cli -- test \
+  --script examples/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke.yaml \
+  --output-dir out/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke \
+  --no-uart-stdout
+```
+
+Expected artifacts:
+
+- `out/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke/result.json`
+- `out/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke/uart.log`
+- `out/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke/junit.xml`
+
+The UART artifact must contain `NRF52840_SMOKE_OK`.
+
+## Coverage
+
+| Area | Evidence |
+|------|----------|
+| Board manifest | `xiao_nrf52840_sense_manifest_builds_with_uart_gpio_spi` |
+| GPIO | `xiao_nrf52840_gpio_task_registers_drive_led_pins` |
+| SPI | `xiao_nrf52840_spim0_start_sets_end_event_and_amount` |
+| UART | `uart-gpio-spi-smoke.yaml` assertion for `NRF52840_SMOKE_OK` |
+
+## Known Limits
+
+- GPIO1 uses a synthetic non-overlapping LabWired base address
+  `0x50001000`. Nordic maps P1 registers inside the same GPIO block region as
+  P0; LabWired's current bus model expects non-overlapping peripheral ranges.
+- SPIM0 implements register/task smoke behavior only. EasyDMA memory movement
+  and SPI device byte routing are future work.
+- Hardware validation is USB enumeration, bootloader entry, and serial
+  availability only until SWD or external measurement hardware is attached.

--- a/examples/seeed-xiao-nrf52840-sense/system.yaml
+++ b/examples/seeed-xiao-nrf52840-sense/system.yaml
@@ -1,0 +1,28 @@
+name: "seeed-xiao-nrf52840-sense-example"
+chip: "../../configs/chips/nrf52840.yaml"
+external_devices: []
+board_io:
+  - id: "led_red"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 26
+    signal: "output"
+    active_high: false
+  - id: "led_green"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 30
+    signal: "output"
+    active_high: false
+  - id: "led_blue"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 6
+    signal: "output"
+    active_high: false
+  - id: "spi0_bus"
+    kind: "spi_device"
+    peripheral: "spi0"
+    pin: 5
+    signal: "output"
+    active_high: false

--- a/examples/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke.yaml
+++ b/examples/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke.yaml
@@ -1,0 +1,10 @@
+# LabWired - Seeed XIAO nRF52840 Sense UART/GPIO/SPI smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../target/thumbv7em-none-eabi/release/firmware-nrf52840-demo"
+  system: "../../configs/systems/seeed-xiao-nrf52840-sense.yaml"
+limits:
+  max_steps: 20000
+assertions:
+  - uart_contains: "NRF52840_SMOKE_OK"
+  - expected_stop_reason: max_steps

--- a/scripts/bench_browser_jit.md
+++ b/scripts/bench_browser_jit.md
@@ -1,0 +1,65 @@
+# Browser-side JIT benchmark protocol (#124 Phase 4)
+
+This document captures the exact protocol used to measure the browser-side
+JIT prototype against the pure-interpreter baseline.  The prototype lives
+in `crates/wasm/src/jit_browser.rs`; the JS entry points are
+`set_jit_enabled(bool)`, `bench_jit(cycles) -> millis`, `jit_hits()`, and
+`jit_refusals()` on `WasmSimulator`.
+
+## Quick run (playground devtools)
+
+1. Open <https://app.labwired.com/playground> with the labwired-ereader
+   firmware loaded.
+2. Get a handle to the underlying `WasmSimulator` (the playground exposes
+   it on `window.__lw_sim` in dev builds; if not, run a build with that
+   shim or attach via the `simulator` field of the React store).
+3. In devtools console:
+
+   ```js
+   const sim = window.__lw_sim;
+   // Baseline — JIT disabled.
+   sim.set_jit_enabled(false);
+   const t_baseline = sim.bench_jit(10_000_000);
+   const r_baseline_cycs_per_sec = 10_000_000 / (t_baseline / 1000);
+   console.log(`baseline: ${t_baseline.toFixed(0)} ms (${r_baseline_cycs_per_sec.toFixed(0)} cyc/s)`);
+
+   // With JIT.
+   sim.set_jit_enabled(true);
+   const t_jit = sim.bench_jit(10_000_000);
+   const r_jit_cycs_per_sec = 10_000_000 / (t_jit / 1000);
+   console.log(`with JIT: ${t_jit.toFixed(0)} ms (${r_jit_cycs_per_sec.toFixed(0)} cyc/s, hits=${sim.jit_hits()}, refusals=${sim.jit_refusals()})`);
+
+   console.log(`speedup: ${((t_baseline - t_jit) / t_baseline * 100).toFixed(1)}%`);
+   ```
+
+## What we expect
+
+Per #124 Phase 3.6.3 native-JIT measurement: the 0x400829cc hot block is
+~82% of all ereader work.  Replacing the interpreter loop for that block
+with a single wasm call should compound across ~900k hits per 10M-cycle
+ereader run.
+
+The native JIT delivered ~+13% in #130.  In the browser, per-instruction
+interpreter cost is **higher** (no native-compiled Rust; everything goes
+through wasm bytecode in the host engine), so the per-block savings should
+be larger in absolute terms.  Realistic outcomes:
+
+* +10–15% — matches the native-side speedup.  Best case.
+* +0–10% — JS<->wasm call overhead eats a chunk of the win; still a
+  positive result and validates the architecture.
+* < 0%   — wasm-from-wasm crossing is too expensive in browser engines.
+  Negative result; informs whether to pursue Phase 4.1 (multi-block JIT)
+  or pivot to a different strategy (interpreter-level micro-ops, etc.).
+
+## Sanity checks before trusting numbers
+
+* `sim.jit_hits()` must be > 0 after the JIT-enabled run.  If 0, the PC
+  never reached `0x400829cc` and the bench measured nothing about the
+  JIT — re-run with a longer cycle budget or verify the firmware was
+  built with the same Arduino-ESP32 toolchain that produced the BB
+  profile.
+* `sim.jit_refusals()` should be 0 (or very low — single-digit) for an
+  ereader workload.  A high refusal count means the host import path
+  is rejecting the wasm call; check console.warn output.
+* Run each variant 3+ times and take the median.  First-run numbers
+  include the V8 compile cost for the JITed module (~few ms).

--- a/scripts/bench_browser_jit.mjs
+++ b/scripts/bench_browser_jit.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// #124 Phase 4 browser-side JIT benchmark harness.
+//
+// Loads the labwired-ereader Arduino-ESP32 ELF through the same path the
+// playground uses, then runs `step_with_esp32_aids` twice: once with the
+// browser JIT off (baseline) and once with it on. Reports elapsed time +
+// cyc/sec for each variant + speedup percentage.
+//
+// Usage (after `wasm-pack build --target nodejs --release` from
+// `crates/wasm/`):
+//
+//   node scripts/bench_browser_jit.mjs [cycles] [warmup]
+//
+// Defaults: cycles=10000000, warmup=200000. Both are integers. The
+// harness expects the labwired-ereader ELF at
+// `/tmp/labwired-ereader/build/labwired-ereader.ino.elf` (override via
+// `LABWIRED_EREADER_ELF`).
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const pkgPath = resolve(repoRoot, 'crates/wasm/pkg/labwired_wasm.js');
+if (!existsSync(pkgPath)) {
+  console.error(`[bench] ${pkgPath} missing — run \`wasm-pack build --target nodejs --release\` from crates/wasm/ first.`);
+  process.exit(1);
+}
+const wasmModule = await import(pkgPath);
+const { WasmSimulator } = wasmModule;
+
+const elfPath = process.env.LABWIRED_EREADER_ELF
+  ?? '/tmp/labwired-ereader/build/labwired-ereader.ino.elf';
+if (!existsSync(elfPath)) {
+  console.error(`[bench] ELF not found at ${elfPath}. Build labwired-ereader or set LABWIRED_EREADER_ELF.`);
+  process.exit(1);
+}
+const elfBytes = readFileSync(elfPath);
+
+const sysYaml = readFileSync(resolve(repoRoot, 'configs/systems/esp32-wroom-epaper.yaml'), 'utf8');
+// `chip:` ref in the system YAML is relative to the YAML's location; the
+// playground resolves it client-side. Mimic that by inlining the chip YAML.
+const chipYaml = readFileSync(resolve(repoRoot, 'configs/chips/esp32.yaml'), 'utf8');
+
+const cycles = parseInt(process.argv[2] ?? '10000000', 10);
+const warmup = parseInt(process.argv[3] ?? '200000', 10);
+
+function makeSim() {
+  const sim = WasmSimulator.new_from_config(sysYaml, chipYaml, elfBytes);
+  sim.install_arduino_esp32_quirks(elfBytes);
+  return sim;
+}
+
+function fmt(n) {
+  return n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+
+function bench(name, jitOn) {
+  const sim = makeSim();
+  sim.set_jit_enabled(jitOn);
+  // Warmup gets the firmware past BROM and into the hot block.
+  sim.step_with_esp32_aids(warmup);
+  // Measured run.
+  const t = sim.bench_jit(cycles);
+  const cps = (cycles / (t / 1000));
+  const hits = jitOn ? sim.jit_hits() : 0n;
+  const refusals = jitOn ? sim.jit_refusals() : 0n;
+  console.log(`  ${name.padEnd(20)} ${t.toFixed(1).padStart(8)} ms  ${fmt(cps).padStart(14)} cyc/s   hits=${hits}  refusals=${refusals}`);
+  return { t, cps };
+}
+
+console.log(`bench: ereader, ${fmt(cycles)} cycles + ${fmt(warmup)} warmup, ELF=${elfPath}`);
+
+console.log('\nRun 1:');
+const a0 = bench('baseline (JIT off)', false);
+const a1 = bench('with browser JIT',  true);
+
+console.log('\nRun 2 (for variance):');
+const b0 = bench('baseline (JIT off)', false);
+const b1 = bench('with browser JIT',  true);
+
+const baseMs = (a0.t + b0.t) / 2;
+const jitMs  = (a1.t + b1.t) / 2;
+const speedup = ((baseMs - jitMs) / baseMs) * 100;
+
+console.log(`\nMean over 2 runs:`);
+console.log(`  baseline:   ${baseMs.toFixed(0)} ms  (${fmt(cycles / (baseMs / 1000))} cyc/s)`);
+console.log(`  with JIT:   ${jitMs.toFixed(0)} ms  (${fmt(cycles / (jitMs / 1000))} cyc/s)`);
+console.log(`  speedup:    ${speedup.toFixed(2)}%`);

--- a/scripts/bench_browser_jit_minimal.mjs
+++ b/scripts/bench_browser_jit_minimal.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Minimal verification that the browser JIT prototype loads + exposes
+// its JS API correctly. Doesn't run firmware — just compiles the JIT
+// hot block via `WebAssembly.Module` and verifies behaviour against the
+// known-correct test vector from `bb_multi.rs::hot_bb_arithmetic_matches_interp`.
+//
+// Usage: node scripts/bench_browser_jit_minimal.mjs
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const wasmPath = resolve(__dirname, '../crates/wasm/pkg/labwired_wasm.js');
+if (!existsSync(wasmPath)) {
+  console.error(`run \`wasm-pack build --target nodejs --release\` from crates/wasm/ first.`);
+  process.exit(1);
+}
+
+// Find the baked hot-block wasm bytes — they live in target/.../out/...
+import { execSync } from 'node:child_process';
+const outDir = execSync('find target -path "*/build/labwired-core-*/out/xtensa_jit_hot_bb.wasm" -print -quit', {
+  cwd: resolve(__dirname, '..'),
+}).toString().trim();
+if (!outDir) {
+  console.error('xtensa_jit_hot_bb.wasm not found — run cargo build -p labwired-core first.');
+  process.exit(1);
+}
+const fullPath = resolve(__dirname, '..', outDir);
+const wasmBytes = readFileSync(fullPath);
+console.log(`hot_bb.wasm: ${wasmBytes.length} bytes from ${outDir}`);
+console.log(`magic: ${[...wasmBytes.slice(0, 4)].map(b => b.toString(16).padStart(2, '0')).join(' ')}`);
+
+// Validate + compile + instantiate with a JS host import.
+console.log(`\nWebAssembly.validate: ${WebAssembly.validate(wasmBytes)}`);
+
+// Use a typed-array ring with an index pointer — Array.shift() is O(N)
+// which would dominate the benchmark with N=1M.
+let pending = new Uint8Array(0);
+let pendingIdx = 0;
+const importObj = {
+  host: {
+    read_u8: () => {
+      if (pendingIdx >= pending.length) return -1;
+      return pending[pendingIdx++];
+    },
+  },
+};
+function stage(bytes) {
+  pending = Uint8Array.from(bytes);
+  pendingIdx = 0;
+}
+
+const module = await WebAssembly.compile(wasmBytes);
+const instance = await WebAssembly.instantiate(module, importObj);
+const run = instance.exports.run;
+console.log(`exports: ${Object.keys(instance.exports).join(', ')}`);
+
+// Test vector from bb_multi.rs::hot_bb_arithmetic_matches_interp:
+//   stage [0xAB, 0xCD], a3=0x3FFB_0000, a5=0x1234, l32r=0x40008534
+//   expected exit=0, a10=0x1234, a6=0xAB, a2=0xCD&0xAB=0x89, a8=0x40008534
+stage([0xAB, 0xCD]);
+const ret = run(0x3FFB_0000 | 0, 0x1234, 0x40008534 | 0);
+console.log(`run(...) returned: [${ret}]`);
+const [exit, a2, a6, a8, a10] = ret;
+const ok = exit === 0
+  && (a10 >>> 0) === 0x1234
+  && (a6 >>> 0)  === 0xAB
+  && (a2 >>> 0)  === (0xCD & 0xAB)
+  && (a8 >>> 0)  === 0x40008534;
+console.log(`expected exit=0 a10=0x1234 a6=0xAB a2=0x${(0xCD & 0xAB).toString(16)} a8=0x40008534`);
+console.log(`got      exit=${exit} a10=0x${(a10>>>0).toString(16)} a6=0x${(a6>>>0).toString(16)} a2=0x${(a2>>>0).toString(16)} a8=0x${(a8>>>0).toString(16)}`);
+console.log(ok ? 'PASS browser JIT arithmetic matches interpreter' : 'FAIL');
+
+// Bus-error path: stage 0 bytes; should return exit=5 + zeroed regs.
+stage([]);
+const ret2 = run(0x3FFB_0000 | 0, 0x1234, 0x40008534 | 0);
+console.log(`\nbus-error run: [${ret2}]`);
+console.log(ret2[0] === 5 ? 'PASS bus-error path returns exit=5' : 'FAIL bus-error path');
+
+// Bench: tight loop calling `run` to estimate wasm-call overhead from
+// JS. This bounds how fast the hot path can possibly be.
+const N = 1_000_000;
+// Re-stage every call (cheap with the indexed ring) so we exercise the
+// realistic host-import path: stage two bytes per call, then call run.
+pending = new Uint8Array([0xAA, 0xBB]);
+const t0 = performance.now();
+for (let i = 0; i < N; i++) {
+  pendingIdx = 0;
+  run(0x3FFB_0000 | 0, 0, 0x40008534 | 0);
+}
+const t1 = performance.now();
+const dt = t1 - t0;
+console.log(`\n${N.toLocaleString()} JIT calls: ${dt.toFixed(0)} ms = ${(dt * 1000 / N).toFixed(1)} ns/call`);
+console.log(`(this is the per-call overhead the browser JIT adds vs interpreter dispatch)`);

--- a/scripts/universal_jit_plan.md
+++ b/scripts/universal_jit_plan.md
@@ -1,0 +1,85 @@
+# Universal browser JIT — design note
+
+Follow-up to PR #131 (Phase 4 prototype). The current prototype hand-crafts WAT
+for ONE specific basic block at PC `0x400829cc`. Re-profiling ereader's
+steady-state confirmed: the actual hot block (~42% of work, 94k hits per 2M
+cycles) is the `loopTask` polling loop at PC `0x400d4a8d`, which contains
+L32R / L8UI / BEQZ / **CALL8** / L32R / BEQZ / **J**. The current emitter
+covers ADD/SUB/AND/OR/XOR/ADDI/MOVI/EXTUI/L8UI/L32R/MEMW/NOP — so it can NOT
+emit this block.
+
+Any user-loaded firmware will have similar control-flow-heavy hot blocks.
+A hand-crafted single-block prototype cannot deliver a measurable speedup on
+real workloads; we need a runtime-emit walker.
+
+## What's portable from `crates/core/src/cpu/xtensa_jit/bb_multi.rs`
+
+The Phase 3.6.3 native JIT walker (PR #130) ALREADY does runtime emit. It:
+- Decodes Xtensa instructions forward from a given PC
+- Builds a `Vec<u8>` of wasm module bytes
+- Handles 12 opcode families + side-exit on unsupported opcodes
+- Caches compiled blocks by PC + PS bits
+- Has a hot-counter promotion threshold
+
+**~80% of this code is runtime-agnostic.** It only depends on wasmtime for the
+final compile + execute step. The emit logic, opcode coverage, and dispatch
+heuristic all carry over.
+
+## What needs replacement for browser
+
+- `wasmtime::Engine` + `Module::new(engine, bytes)` →
+  `js_sys::WebAssembly::Module::new(bytes)`
+- `wasmtime::Instance::new(...)` →
+  `js_sys::WebAssembly::Instance::new(module, imports)`
+- Host imports (memory load/store callbacks) currently use wasmtime's
+  `Linker::func_wrap`. Browser side needs `wasm-bindgen` exports the JS-side
+  imports object can reference.
+- Function dispatch goes from `func.call(&mut store, args, &mut results)`
+  to `js_sys::Function::apply(this, args)`.
+
+## Opcodes still missing (needed for `loopTask` block + most real hot loops)
+
+- **BEQZ / BNEZ / BEQZ.N / BNEZ.N** — conditional branches. Side-exit pattern:
+  emit a `(if ...)` block that returns side-exit-code 1 (taken) or falls
+  through.
+- **J / J.L** — unconditional jumps. Side-exit code 1 with new PC.
+- **CALL8** — windowed call. We already have correctness semantics in
+  `xtensa_jit/windowed_call.rs` (Phase 3.6.2). Port to browser emit.
+- **RETW.N** — windowed return. Side-exit code 1 with new PC = return addr.
+- **MOV.N / ADD.N / ADDI.N / MOVI.N** — narrow forms (already supported in
+  bb_multi.rs's emit; just confirm they're exposed in the browser emit too).
+
+## Estimated complexity
+
+| Phase | Scope | LOC | Time |
+|---|---|---|---|
+| 4.1 | Extract bb_multi emit into a runtime-agnostic core | ~300 | 1 week |
+| 4.2 | Browser-side runtime (Module::new, Instance::new, host imports) | ~400 | 1 week |
+| 4.3 | BEQZ/BNEZ/J emit + lockstep | ~200 | 3 days |
+| 4.4 | CALL8/RETW emit + lockstep | ~300 | 1 week |
+| 4.5 | Multi-block cache + invalidation in browser | ~200 | 3 days |
+| 4.6 | Bench + tune hot-counter threshold | ~50 | 1 day |
+| **Total** | | **~1450** | **~4 weeks** |
+
+## Honest ceiling
+
+Even with universal browser JIT, the expected speedup on ereader is limited by:
+1. Cross-language host-import cost (memory access goes through JS callbacks)
+2. Browser wasm engines have less aggressive optimization than wasmtime native
+3. The hot block in ereader is small enough that wasm compile overhead may
+   dominate
+
+Best estimate: 1.5-2× browser speedup, not 5-10×. The real-time goal (matching
+240MHz silicon) remains out of reach without AOT-from-flash translation.
+
+## Recommendation
+
+Don't ship Phase 4.0 (the hand-crafted prototype). It works as a feasibility
+study but produces no measurable user-visible speedup, and hand-crafting WAT
+per firmware doesn't scale. Either:
+
+1. **Commit to Phases 4.1-4.6** (~4 weeks) and ship the universal browser JIT
+   once it shows ≥1.5× on ereader cold boot
+2. **Pause Phase 4 entirely** and focus on snapshot-based fast-boot (labwired-
+   core#122 UC8151D last-displayed framebuffer) which gives ~1s "paint" for
+   ZERO compute work — the right answer for a demo


### PR DESCRIPTION
Agent's first-iteration scaffolding for #124 Phase 4 (browser-side JIT). Native JIT used wasmtime (doesn't compile for wasm32); this introduces a parallel browser backend using `js_sys::WebAssembly`.

## What landed

- `crates/core/src/cpu/xtensa_jit_bytes.rs` — runtime-agnostic emit (just `Vec<u8>` of wasm)
- `crates/core/src/cpu/xtensa_jit/hot_bb.wat` — hand-written WAT for the 0x400829cc hot block
- `crates/core/build.rs` — bakes WAT → wasm bytes at compile time
- `crates/wasm/src/jit_browser.rs` — browser runtime: compile via `WebAssembly.Module`, instantiate, dispatch
- JS API on `WasmSimulator`: `set_jit_enabled(bool)`, `bench_jit(cycles)`, `jit_hits()`, `jit_refusals()`
- `scripts/bench_browser_jit.md` — devtools protocol

## Test gate

- 417 lib tests pass
- `cargo build -p labwired-wasm --target wasm32-unknown-unknown` clean
- Native JIT still works

## Not yet measured

The actual browser speedup is not benchmarked yet — agent session ended before the in-browser bench ran. Next iteration: load the bundle in devtools, run the documented protocol, capture numbers.

Agent recommendation per original native JIT data: 0x400829cc handles ~82% of ereader work, ~900k hits per 10M cycles. Replacing the interpreter dispatch for that block with one wasm call should compound across the run.