### PR TITLE
feat(nrf52): proper RADIO — Easy DMA + BLE whitening + CRC-24

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1689,6 +1689,23 @@ impl SystemBus {
             }
         }
 
+        // Bus-aware tick pass: for peripherals that need to read/write the
+        // bus during their tick (Easy DMA on RADIO, currently). We swap each
+        // such peripheral OUT of the vector temporarily so the borrow
+        // checker is happy with `&mut self` passed into `tick_with_bus`.
+        // A no-op for peripherals whose `needs_bus_tick` returns false
+        // (the default for everyone except RADIO).
+        for i in 0..self.peripherals.len() {
+            if !self.peripherals[i].dev.needs_bus_tick() {
+                continue;
+            }
+            let placeholder: Box<dyn Peripheral> =
+                Box::new(crate::peripherals::stub::StubPeripheral::new(0));
+            let mut dev = std::mem::replace(&mut self.peripherals[i].dev, placeholder);
+            dev.tick_with_bus(self);
+            self.peripherals[i].dev = dev;
+        }
+
         (
             interrupts,
             costs,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -381,6 +381,14 @@ pub trait Peripheral: std::fmt::Debug + Send {
     /// is configured to watch a matching (port, pin) with a matching
     /// polarity. Default no-op.
     fn observe_gpio_change(&mut self, _changes: &[(u8, u8, u8)]) {}
+
+    /// Bus-aware tick hook for peripherals that need to read or write the
+    /// bus themselves (e.g. Easy DMA on RADIO). Default no-op.
+    fn tick_with_bus(&mut self, _bus: &mut dyn Bus) {}
+
+    /// True if this peripheral wants the bus to call `tick_with_bus`.
+    /// Default false so the bus skips the swap dance for everyone else.
+    fn needs_bus_tick(&self) -> bool { false }
     fn as_any(&self) -> Option<&dyn Any> {
         None
     }

--- a/crates/core/src/peripherals/nrf52/radio.rs
+++ b/crates/core/src/peripherals/nrf52/radio.rs
@@ -775,7 +775,8 @@ mod tests {
         let res = r.tick();
         assert!(res.fired_events.contains(&(OFF_EVENTS_END as u32)));
         assert_eq!(r.read_u32(OFF_EVENTS_END).unwrap(), 1);
-        assert_eq!(r.read_u32(OFF_CRCSTATUS).unwrap(), 1);
+        // CRCSTATUS is the live receive-side CRC verdict; TX doesn't touch
+        // it, so it stays at the reset value (0) here.
         assert_eq!(r.read_u32(OFF_STATE).unwrap(), STATE_TXIDLE);
     }
 

--- a/crates/core/src/peripherals/nrf52/radio.rs
+++ b/crates/core/src/peripherals/nrf52/radio.rs
@@ -29,7 +29,8 @@
 //! * Cyclic-bit-rate accuracy. EVENTS_END fires the next tick after
 //!   TASKS_START regardless of MODE/DATARATE.
 
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{Bus, Peripheral, PeripheralTickResult, SimResult};
+use std::collections::VecDeque;
 
 // ── Tasks (PS §6.20.13, table 222) ───────────────────────────────────────────
 
@@ -198,6 +199,26 @@ pub struct Nrf52Radio {
     pending_payload: bool,
     pending_end: bool,
     pending_disabled: bool,
+
+    // ── Easy DMA staging ──────────────────────────────────────────────────
+    /// Bytes captured by `tick_with_bus` on a TX TASKS_START. The most
+    /// recent packet stays here for tests to inspect / for cross-instance
+    /// routing to pick up.
+    pub last_tx_packet: Option<Vec<u8>>,
+    /// Inbox of pre-loaded packets that RX will hand out one at a time
+    /// (FIFO). Loopback tests push here; in a future cross-instance
+    /// model another Radio instance would push here too.
+    pub rx_inbox: VecDeque<Vec<u8>>,
+    /// Set when TASKS_START fires in a TX state. The next tick_with_bus
+    /// reads PACKETPTR-pointed RAM, computes CRC + whitening, stores in
+    /// last_tx_packet, then sets EVENTS_END.
+    pending_tx_dma: bool,
+    /// Set when TASKS_START fires in an RX state. The next tick_with_bus
+    /// pulls a packet from rx_inbox, de-whitens, verifies CRC, writes
+    /// to PACKETPTR-pointed RAM.
+    pending_rx_dma: bool,
+    /// CRCSTATUS for the most recent RX (1 = OK, 0 = ERROR).
+    crc_status: u32,
 }
 
 impl Nrf52Radio {
@@ -276,8 +297,10 @@ impl Nrf52Radio {
     fn start_packet(&mut self) {
         if self.state == STATE_TXIDLE {
             self.state = STATE_TX;
+            self.pending_tx_dma = true;
         } else if self.state == STATE_RXIDLE {
             self.state = STATE_RX;
+            self.pending_rx_dma = true;
         } else {
             return;
         }
@@ -297,6 +320,89 @@ impl Nrf52Radio {
             _ => {}
         }
         self.pending_disabled = true;
+    }
+
+    /// PN9 BLE whitening — XORs `data` in place with the LFSR output.
+    /// Init value comes from `DATAWHITEIV` bits [6:0] (bit 6 is fixed 1
+    /// in real silicon per PS §6.20.12.32).
+    ///
+    /// This is symmetric: applying it twice cancels out, so the same
+    /// routine is used on TX (whiten) and RX (de-whiten).
+    fn ble_whiten(data: &mut [u8], whitening_iv: u8) {
+        let mut lfsr: u8 = (whitening_iv & 0x7F) | 0x40;
+        for byte in data.iter_mut() {
+            let mut out = 0u8;
+            for bit in 0..8 {
+                let bit_lfsr = (lfsr >> 6) & 1;
+                let bit_in = (*byte >> bit) & 1;
+                out |= (bit_in ^ bit_lfsr) << bit;
+                // Advance LFSR: x^7 + x^4 + 1
+                let feedback = bit_lfsr;
+                lfsr = ((lfsr << 1) | feedback) & 0x7F;
+                if feedback != 0 {
+                    lfsr ^= 0x04; // x^4 tap
+                }
+            }
+            *byte = out;
+        }
+    }
+
+    /// BLE CRC-24 (polynomial 0x100065B). Init value from CRCINIT.
+    /// Returns the 24-bit CRC of `data`.
+    fn ble_crc24(data: &[u8], init: u32) -> u32 {
+        let mut crc = init & 0xFFFFFF;
+        for &byte in data {
+            crc ^= (byte as u32) << 16;
+            for _ in 0..8 {
+                if crc & (1 << 23) != 0 {
+                    crc = ((crc << 1) ^ 0x65B) & 0xFFFFFF;
+                } else {
+                    crc = (crc << 1) & 0xFFFFFF;
+                }
+            }
+        }
+        crc
+    }
+
+    /// Pull PCNF0/PCNF1 fields into a packet descriptor used by both
+    /// TX and RX DMA.
+    fn packet_descriptor(&self) -> PacketDescriptor {
+        PacketDescriptor {
+            lflen: (self.pcnf0 & 0xF) as u8,
+            s0len: ((self.pcnf0 >> 8) & 1) as u8,
+            s1len: ((self.pcnf0 >> 16) & 0xF) as u8,
+            maxlen: (self.pcnf1 & 0xFF) as u8,
+            statlen: ((self.pcnf1 >> 8) & 0xFF) as u8,
+            whiteen: (self.pcnf1 >> 25) & 1 != 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PacketDescriptor {
+    /// LENGTH field bit width (0..8).
+    lflen: u8,
+    /// S0 byte present (0 or 1).
+    s0len: u8,
+    /// S1 field bit width (0..15).
+    s1len: u8,
+    /// Maximum payload bytes addressable from PACKETPTR.
+    maxlen: u8,
+    /// Static-length payload bytes appended after the dynamic LENGTH.
+    statlen: u8,
+    /// Whitening enabled.
+    whiteen: bool,
+}
+
+impl PacketDescriptor {
+    /// Returns the byte offset of the start of the payload within the
+    /// PACKETPTR buffer (S0 + LENGTH + S1 rounded up to whole bytes).
+    fn payload_offset(&self) -> usize {
+        let s1_bytes = self.s1len.div_ceil(8);
+        // LENGTH field is always 1 byte in the buffer regardless of LFLEN
+        // (PS §6.20.6.1: "stored in the byte after S0").
+        let length_bytes = if self.lflen == 0 { 0 } else { 1 };
+        self.s0len as usize + length_bytes as usize + s1_bytes as usize
     }
 }
 
@@ -332,7 +438,7 @@ impl Peripheral for Nrf52Radio {
             OFF_SHORTS => self.shorts,
             OFF_INTENSET | OFF_INTENCLR => self.inten,
 
-            OFF_CRCSTATUS => 1, // CRC OK — no actual computation
+            OFF_CRCSTATUS => self.crc_status & 1,
             OFF_RXMATCH => self.rxaddresses & 0x7, // hint at logical address 0
             OFF_RXCRC => self.crcinit,
             OFF_DAI => 0,
@@ -545,6 +651,102 @@ impl Peripheral for Nrf52Radio {
             ..Default::default()
         }
     }
+
+    fn needs_bus_tick(&self) -> bool {
+        self.pending_tx_dma || self.pending_rx_dma
+    }
+
+    fn tick_with_bus(&mut self, bus: &mut dyn Bus) {
+        // ── TX Easy DMA ──────────────────────────────────────────────────
+        // Read S0 + LENGTH + S1 + payload from PACKETPTR, compute total
+        // size, apply BLE whitening (if PCNF1.WHITEEN), append CRC, store
+        // in last_tx_packet for tests / cross-instance routing.
+        if self.pending_tx_dma {
+            self.pending_tx_dma = false;
+            let desc = self.packet_descriptor();
+            let base = self.packetptr;
+
+            // Read header bytes into a small staging buffer first.
+            let mut header = Vec::new();
+            for i in 0..desc.payload_offset() {
+                header.push(bus.read_u8((base as u64).wrapping_add(i as u64)).unwrap_or(0));
+            }
+
+            // LENGTH is the byte at offset s0len (right after S0).
+            let length = if desc.lflen == 0 {
+                desc.statlen
+            } else {
+                let len_byte = header
+                    .get(desc.s0len as usize)
+                    .copied()
+                    .unwrap_or(0);
+                // Mask to LFLEN bits.
+                let mask = if desc.lflen >= 8 {
+                    0xFFu8
+                } else {
+                    ((1u16 << desc.lflen) - 1) as u8
+                };
+                (len_byte & mask).min(desc.maxlen).saturating_add(desc.statlen)
+            };
+
+            // Read the payload right after the header bytes.
+            let payload_off = desc.payload_offset();
+            let mut packet = header.clone();
+            for i in 0..length as usize {
+                packet.push(
+                    bus.read_u8((base as u64).wrapping_add((payload_off + i) as u64))
+                        .unwrap_or(0),
+                );
+            }
+
+            // Whiten (in place — symmetric, so RX reverses by applying
+            // the same routine).
+            if desc.whiteen {
+                Self::ble_whiten(&mut packet, self.datawhiteiv as u8);
+            }
+
+            // Append CRC-24 to capture downstream.
+            let crc = Self::ble_crc24(&packet, self.crcinit);
+            packet.push((crc & 0xFF) as u8);
+            packet.push(((crc >> 8) & 0xFF) as u8);
+            packet.push(((crc >> 16) & 0xFF) as u8);
+
+            self.last_tx_packet = Some(packet);
+        }
+
+        // ── RX Easy DMA ──────────────────────────────────────────────────
+        // Pop the next packet from rx_inbox, strip the trailing CRC and
+        // verify it (in whitened form, since the air-side carries the
+        // whitened frame). De-whiten the payload, write back to RAM at
+        // PACKETPTR + payload_offset; copy header bytes verbatim.
+        if self.pending_rx_dma {
+            self.pending_rx_dma = false;
+            if let Some(mut pkt) = self.rx_inbox.pop_front() {
+                let desc = self.packet_descriptor();
+
+                // Trailing 3 bytes are the CRC (LE).
+                let crc_ok = if pkt.len() >= 3 {
+                    let crc_lo = pkt.pop().unwrap_or(0) as u32;
+                    let crc_md = pkt.pop().unwrap_or(0) as u32;
+                    let crc_hi = pkt.pop().unwrap_or(0) as u32;
+                    let received = (crc_lo << 16) | (crc_md << 8) | crc_hi;
+                    Self::ble_crc24(&pkt, self.crcinit) == received
+                } else {
+                    false
+                };
+                self.crc_status = if crc_ok { 1 } else { 0 };
+
+                if desc.whiteen {
+                    Self::ble_whiten(&mut pkt, self.datawhiteiv as u8);
+                }
+
+                let base = self.packetptr;
+                for (i, b) in pkt.iter().enumerate() {
+                    let _ = bus.write_u8((base as u64).wrapping_add(i as u64), *b);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -631,5 +833,162 @@ mod tests {
         assert_eq!(r.read_u32(OFF_BASE0).unwrap(), 0xCAFEBABE);
         assert_eq!(r.read_u32(OFF_PREFIX0).unwrap(), 0xDEAD);
         assert_eq!(r.read_u32(OFF_PACKETPTR).unwrap(), 0x2000_1234);
+    }
+
+    #[test]
+    fn whitening_is_symmetric() {
+        let original = vec![0xAA, 0x55, 0xFF, 0x00, 0x12, 0x34];
+        let mut work = original.clone();
+        Nrf52Radio::ble_whiten(&mut work, 0x40);
+        assert_ne!(work, original, "whitening should change the bytes");
+        Nrf52Radio::ble_whiten(&mut work, 0x40);
+        assert_eq!(work, original, "applying twice should cancel out");
+    }
+
+    #[test]
+    fn crc24_deterministic() {
+        let data = b"hello";
+        let crc1 = Nrf52Radio::ble_crc24(data, 0x555555);
+        let crc2 = Nrf52Radio::ble_crc24(data, 0x555555);
+        assert_eq!(crc1, crc2);
+        assert!(crc1 <= 0xFFFFFF);
+        // CRC of empty input with init=0 is 0.
+        assert_eq!(Nrf52Radio::ble_crc24(&[], 0), 0);
+    }
+
+    #[test]
+    fn tx_easy_dma_reads_packetptr_and_stores_packet() {
+        use crate::bus::SystemBus;
+        use crate::Bus;
+
+        let mut bus = SystemBus::new();
+        // Stage S0 + LENGTH + payload at 0x20000000 in RAM.
+        let pkt = [0xAB, 0x03, 0xDE, 0xAD, 0xBE];
+        for (i, b) in pkt.iter().enumerate() {
+            bus.write_u8(0x2000_0000 + i as u64, *b).unwrap();
+        }
+
+        let mut r = Nrf52Radio::new();
+        // S0LEN=1, LFLEN=8 → PCNF0 bits 0..3=8, bit 8=1.
+        r.write_u32(OFF_PCNF0, (8) | (1 << 8)).unwrap();
+        // MAXLEN=255, WHITEEN=0 (off so we can check raw bytes).
+        r.write_u32(OFF_PCNF1, 0xFF).unwrap();
+        r.write_u32(OFF_PACKETPTR, 0x2000_0000).unwrap();
+        r.write_u32(OFF_CRCINIT, 0x555555).unwrap();
+
+        r.write_u32(OFF_TASKS_TXEN, 1).unwrap();
+        r.tick();
+        r.write_u32(OFF_TASKS_START, 1).unwrap();
+        // tick() will request DMA; bus normally calls tick_with_bus.
+        r.tick();
+        r.tick_with_bus(&mut bus);
+
+        let stored = r.last_tx_packet.as_ref().expect("tx packet captured");
+        // S0 + LENGTH + 3 payload bytes + 3 CRC bytes = 8 bytes.
+        assert_eq!(stored.len(), 8);
+        assert_eq!(stored[0], 0xAB);
+        assert_eq!(stored[1], 0x03);
+        assert_eq!(&stored[2..5], &[0xDE, 0xAD, 0xBE]);
+    }
+
+    #[test]
+    fn rx_easy_dma_loopback_through_inbox() {
+        use crate::bus::SystemBus;
+        use crate::Bus;
+
+        let mut bus = SystemBus::new();
+
+        // Build an inbox packet with a valid CRC over [S0, LENGTH, payload].
+        // Wire format matches what TX produces: payload first, then CRC
+        // bytes in little-endian order (LSB first).
+        let head_and_payload = vec![0xCD, 0x04, 0xCA, 0xFE, 0xBA, 0xBE];
+        let crc = Nrf52Radio::ble_crc24(&head_and_payload, 0x555555);
+        let mut inbox_pkt = head_and_payload.clone();
+        inbox_pkt.push((crc & 0xFF) as u8);
+        inbox_pkt.push(((crc >> 8) & 0xFF) as u8);
+        inbox_pkt.push(((crc >> 16) & 0xFF) as u8);
+
+        let mut r = Nrf52Radio::new();
+        r.rx_inbox.push_back(inbox_pkt);
+        r.write_u32(OFF_PCNF0, 8 | (1 << 8)).unwrap();
+        r.write_u32(OFF_PCNF1, 0xFF).unwrap();
+        r.write_u32(OFF_PACKETPTR, 0x2000_1000).unwrap();
+        r.write_u32(OFF_CRCINIT, 0x555555).unwrap();
+
+        r.write_u32(OFF_TASKS_RXEN, 1).unwrap();
+        r.tick();
+        r.write_u32(OFF_TASKS_START, 1).unwrap();
+        r.tick();
+        r.tick_with_bus(&mut bus);
+
+        // Verify the bytes landed in RAM at PACKETPTR.
+        assert_eq!(bus.read_u8(0x2000_1000).unwrap(), 0xCD);
+        assert_eq!(bus.read_u8(0x2000_1001).unwrap(), 0x04);
+        assert_eq!(bus.read_u8(0x2000_1002).unwrap(), 0xCA);
+        assert_eq!(bus.read_u8(0x2000_1003).unwrap(), 0xFE);
+        assert_eq!(bus.read_u8(0x2000_1004).unwrap(), 0xBA);
+        assert_eq!(bus.read_u8(0x2000_1005).unwrap(), 0xBE);
+        // CRC was good.
+        assert_eq!(r.crc_status, 1);
+    }
+
+    #[test]
+    fn tx_rx_full_loopback_with_whitening() {
+        use crate::bus::SystemBus;
+        use crate::Bus;
+
+        // TX in one instance, RX in another — verify the payload survives
+        // a round trip through whitening + CRC.
+        let payload_orig = vec![0xC0, 0xFF, 0xEE, 0x42, 0x69];
+        let mut bus_tx = SystemBus::new();
+        bus_tx.write_u8(0x2000_0000, 0xAA).unwrap(); // S0
+        bus_tx
+            .write_u8(0x2000_0001, payload_orig.len() as u8)
+            .unwrap();
+        for (i, b) in payload_orig.iter().enumerate() {
+            bus_tx.write_u8(0x2000_0002 + i as u64, *b).unwrap();
+        }
+
+        let mut tx = Nrf52Radio::new();
+        tx.write_u32(OFF_PCNF0, 8 | (1 << 8)).unwrap();
+        // WHITEEN bit set.
+        tx.write_u32(OFF_PCNF1, 0xFF | (1 << 25)).unwrap();
+        tx.write_u32(OFF_PACKETPTR, 0x2000_0000).unwrap();
+        tx.write_u32(OFF_DATAWHITEIV, 37).unwrap(); // BLE adv ch 37 init
+        tx.write_u32(OFF_CRCINIT, 0x555555).unwrap();
+
+        tx.write_u32(OFF_TASKS_TXEN, 1).unwrap();
+        tx.tick();
+        tx.write_u32(OFF_TASKS_START, 1).unwrap();
+        tx.tick();
+        tx.tick_with_bus(&mut bus_tx);
+        let on_air = tx.last_tx_packet.clone().unwrap();
+
+        // RX side.
+        let mut bus_rx = SystemBus::new();
+        let mut rx = Nrf52Radio::new();
+        rx.write_u32(OFF_PCNF0, 8 | (1 << 8)).unwrap();
+        rx.write_u32(OFF_PCNF1, 0xFF | (1 << 25)).unwrap();
+        rx.write_u32(OFF_PACKETPTR, 0x2000_2000).unwrap();
+        rx.write_u32(OFF_DATAWHITEIV, 37).unwrap();
+        rx.write_u32(OFF_CRCINIT, 0x555555).unwrap();
+        rx.rx_inbox.push_back(on_air);
+
+        rx.write_u32(OFF_TASKS_RXEN, 1).unwrap();
+        rx.tick();
+        rx.write_u32(OFF_TASKS_START, 1).unwrap();
+        rx.tick();
+        rx.tick_with_bus(&mut bus_rx);
+
+        assert_eq!(rx.crc_status, 1, "CRC must verify after whitening round-trip");
+        // Payload bytes should match the original after the round trip.
+        for (i, expected) in payload_orig.iter().enumerate() {
+            assert_eq!(
+                bus_rx.read_u8(0x2000_2002 + i as u64).unwrap(),
+                *expected,
+                "payload byte {} corrupted by round-trip",
+                i
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the actual transmission/reception machinery on top of the prior register-surface RADIO model. RADIO peripheral now does real PACKETPTR-pointed DMA, BLE PN9 whitening, and CRC-24 computation/verification.

## Trait extension

- `Peripheral::tick_with_bus(&mut self, bus: &mut dyn Bus)` — bus-aware hook called after the regular tick pass. Default no-op.
- `Peripheral::needs_bus_tick() -> bool` — default false; bus skips the swap dance unless this returns true.
- Bus uses `std::mem::replace` with a stub to lend `&mut self` to the peripheral safely.

## RADIO TX

Reads S0 + LENGTH + S1 + payload from PACKETPTR-pointed RAM per PCNF0/PCNF1. Whitens with PN9 (LFSR x^7+x^4+1 seeded by DATAWHITEIV) if PCNF1.WHITEEN. Computes CRC-24 (poly 0x100065B, init from CRCINIT). Stores result in `last_tx_packet` for inspection.

## RADIO RX

Pops a packet from `rx_inbox` (loopback for tests). Splits trailing 3 CRC bytes (LE), recomputes, sets CRCSTATUS. De-whitens (symmetric routine). Writes bytes to PACKETPTR-pointed RAM.

## Tests (11/11 passing, 5 new)

- whitening_is_symmetric
- crc24_deterministic
- tx_easy_dma_reads_packetptr_and_stores_packet
- rx_easy_dma_loopback_through_inbox
- tx_rx_full_loopback_with_whitening (TX→whiten→CRC→RX→verify→de-whiten→assert payload matches)

## Honest scope

- No air or actual peer beyond rx_inbox loopback.
- Bit-rate timing collapsed (END fires next tick after START).
- Address matching (BASE/PREFIX/RXADDRESSES) not yet enforced — packets unconditionally delivered to the receiver.
- Cross-instance virtual-air routing is the next big lift if you want sim-to-sim BLE.

## Test plan

- [x] cargo test -p labwired-core --lib → 517/517 pass
- [x] cargo test -p labwired-core --lib peripherals::nrf52::radio → 11/11 pass
- [x] cargo test -p labwired-hw-oracle --test nrf52_mmio_diff --features hw-oracle-nrf52 -- --ignored → 16/16 pass
- [x] cargo test -p labwired-hw-oracle --test nrf52_onboarding_diff --features hw-oracle-nrf52 -- --ignored → 22 MODELLED, 1 WRONG_LAYOUT (pre-existing)