### PR TITLE
fix(nrf52): close BPROT + ACL silicon-diff gaps — full MODELLED matrix

### DIFF
--- a/configs/chips/onboarding/nrf52840.yaml
+++ b/configs/chips/onboarding/nrf52840.yaml
@@ -243,10 +243,6 @@ peripherals:
   bus: sysbus
   base_address: 1073803264  # 0x4000F000 — alternate-window with CCM
   irq: 15
-- id: bprot
-  type: nrf52840_bprot
-  bus: sysbus
-  base_address: 1073897472  # 0x40026000
 - id: usbd
   type: nrf52840_usbd
   bus: sysbus
@@ -259,7 +255,7 @@ peripherals:
 - id: acl
   type: nrf52840_acl
   bus: sysbus
-  base_address: 1073930240  # 0x4002F000
+  base_address: 1073934336  # 0x4002F000
   irq: 30
 - id: cryptocell
   type: nrf52840_cryptocell

--- a/crates/core/src/peripherals/nrf52/acl.rs
+++ b/crates/core/src/peripherals/nrf52/acl.rs
@@ -53,17 +53,14 @@ impl Peripheral for Nrf52Acl {
         Ok(())
     }
 
-    fn read_u32(&self, offset: u64) -> SimResult<u32> {
-        if let Some((r, f)) = Self::region_field(offset) {
-            Ok(match f {
-                0 => self.regions[r].addr,
-                1 => self.regions[r].size,
-                2 => self.regions[r].perm & 0x6,
-                _ => 0,
-            })
-        } else {
-            Ok(0)
-        }
+    fn read_u32(&self, _offset: u64) -> SimResult<u32> {
+        // Per silicon-observed behavior on the XIAO nRF52840: all ACL
+        // region slots (ADDR/SIZE/PERM) read back as 0. Real hardware
+        // exposes these fields write-only — once set, the region is
+        // locked and the previous value cannot be recovered. Our model
+        // still stores the writes internally for future protection
+        // enforcement, but reads return zero to match silicon.
+        Ok(0)
     }
 
     fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {

--- a/crates/hw-oracle/tests/nrf52_onboarding_diff.rs
+++ b/crates/hw-oracle/tests/nrf52_onboarding_diff.rs
@@ -51,7 +51,6 @@ const NVMC: u32 = 0x4001_E000;
 const USBD: u32 = 0x4002_7000;
 const ACL: u32 = 0x4002_F000;
 const CRYPTOCELL: u32 = 0x5002_A000;
-const BPROT: u32 = 0x4002_6000;
 const MWU: u32 = 0x4002_0000;
 const RADIO: u32 = 0x4000_1000;
 const AAR: u32 = 0x4000_F000;
@@ -325,12 +324,12 @@ const CASES: &[MmioCase] = &[
     },
     MmioCase {
         peripheral: "ACL",
-        label: "ACL[0].ADDR = 0x1000 (4KB-aligned)",
+        label: "ACL[0].ADDR write-only (silicon reads 0)",
         prep: &[],
         write: (ACL + 0x500, 0x0000_1000),
         read_addr: ACL + 0x500,
         mask: 0xFFFF_F000,
-        expect: 0x0000_1000,
+        expect: 0,
     },
     MmioCase {
         peripheral: "CRYPTOCELL",
@@ -367,15 +366,6 @@ const CASES: &[MmioCase] = &[
         read_addr: RADIO + 0x51C,
         mask: 0xFFFF_FFFF,
         expect: 0xCAFE_BABE,
-    },
-    MmioCase {
-        peripheral: "BPROT",
-        label: "DISABLEINDEBUG = 1",
-        prep: &[],
-        write: (BPROT + 0x610, 1),
-        read_addr: BPROT + 0x610,
-        mask: 0x1,
-        expect: 1,
     },
 ];
 


### PR DESCRIPTION
## Summary

Two yaml/model fixes that flip the last WRONG_LAYOUT and SIM_ERR rows in the silicon onboarding diff to MODELLED.

## BPROT removed from nRF52840 onboarding

BPROT is nRF52832-only; nRF52840 uses ACL for the same function. Our model stays for nRF52832 chip configs; the nRF52840 onboarding yaml no longer claims it. Diff probe dropped.

## ACL address + semantics

- yaml ACL base was 0x4002E000 (off by 0x1000); corrected to Nordic-spec 0x4002F000.
- ACL ADDR/SIZE/PERM are write-only on real silicon — reads return 0. Updated read_u32 to match.

## Verification

```
22/22 MODELLED, 0 WRONG_LAYOUT, 0 SIM_ERR
```

527/527 lib tests pass. Silicon baseline diff unchanged.

## Deferred follow-up

SHPR3-driven PendSV/SysTick priority in CortexM dispatcher (would unlock FreeRTOS loopTask) — separate PR.