### PR TITLE
feat(radio): expose virtual_air TX trace to WASM

### DIFF
--- a/crates/core/src/peripherals/nrf52/radio.rs
+++ b/crates/core/src/peripherals/nrf52/radio.rs
@@ -78,6 +78,31 @@ struct VirtualAir {
     /// the same FREQUENCY can both share air (RX simply doesn't decode
     /// the wrong-mode frame).
     queues: HashMap<u8, VecDeque<AirFrame>>,
+    /// Ring buffer of the last ~200 TX frames pushed into the air.
+    /// Lives independently of `queues` (which gets drained by RX) so
+    /// the playground UI can poll a stable trace for visualization.
+    tx_history: VecDeque<AirFrameTrace>,
+}
+
+const TX_HISTORY_CAP: usize = 200;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AirFrameTrace {
+    pub channel: u8,
+    pub addr_base: u32,
+    pub addr_prefix: u8,
+    pub mode: u32,
+    pub bytes: Vec<u8>,
+}
+
+/// Public view of the current TX trace, intended for WASM consumption
+/// by the playground's BLE-air visualization. Most recent frames first.
+pub fn virtual_air_trace_snapshot() -> Vec<AirFrameTrace> {
+    let air = match virtual_air().lock() {
+        Ok(a) => a,
+        Err(_) => return Vec::new(),
+    };
+    air.tx_history.iter().rev().cloned().collect()
 }
 
 fn virtual_air() -> &'static Mutex<VirtualAir> {
@@ -967,7 +992,18 @@ impl Peripheral for Nrf52Radio {
             // band correctly fail to decode.
             if let Ok(mut air) = virtual_air().lock() {
                 let key = self.frequency as u8;
+                let trace = AirFrameTrace {
+                    channel: key,
+                    addr_base: frame.addr_base,
+                    addr_prefix: frame.addr_prefix,
+                    mode: frame.mode,
+                    bytes: frame.bytes.clone(),
+                };
                 air.queues.entry(key).or_default().push_back(frame);
+                air.tx_history.push_back(trace);
+                while air.tx_history.len() > TX_HISTORY_CAP {
+                    air.tx_history.pop_front();
+                }
             }
 
             // Bit-rate countdown until EVENTS_END. cycles_for_packet returns

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -688,6 +688,18 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&states).unwrap_or(JsValue::NULL)
     }
 
+    /// Snapshot of the shared virtual-air TX trace ring buffer (last
+    /// ~200 BLE/proprietary frames pushed by any chip in this WASM
+    /// instance, most-recent-first). The playground's BLE-on-canvas
+    /// visualization polls this to render the packet trace panel; the
+    /// underlying state lives in a Rust static, so any WasmSimulator
+    /// can return the same snapshot — pick whichever chip is alive.
+    #[wasm_bindgen]
+    pub fn air_trace_snapshot(&self) -> JsValue {
+        let trace = labwired_core::peripherals::nrf52::radio::virtual_air_trace_snapshot();
+        serde_wasm_bindgen::to_value(&trace).unwrap_or(JsValue::NULL)
+    }
+
     /// Drain UART TX output bytes accumulated since the last call.
     #[wasm_bindgen]
     pub fn drain_uart_output(&self) -> Vec<u8> {


### PR DESCRIPTION
## Summary
Adds a ring-buffered TX history inside \`VirtualAir\` (last 200 frames), independent of the per-channel \`queues\` that RX drains. Surfaced via:
- Rust: \`virtual_air_trace_snapshot() -> Vec<AirFrameTrace>\`
- WASM: \`WasmSimulator::air_trace_snapshot() -> JsValue\`

## Why
The playground's Phase 4 BLE-on-canvas visualization needs a stable view of recent BLE traffic to render the animated BleAirEdge between two nRF52840s and a per-frame trace panel (channel / addresses / payload hex).

Because \`VirtualAir\` is a process static (\`OnceLock<Mutex<VirtualAir>>\`), every \`WasmSimulator\` in the same WASM instance returns the same snapshot — TS picks any live chip.

## Test plan
- [x] 529/529 \`labwired-core --lib\` tests pass
- [x] \`wasm-pack build --target web --release\` clean