### PR TITLE
perf: cache rtc_cntl index + word-granular Dport/Timg/RtcCntl + dense DPORT storage

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -585,10 +585,25 @@ pub struct Machine<C: Cpu> {
     pub last_breakpoint: Option<u32>,
     pub total_cycles: u64,
     pub config: SimulationConfig,
+    /// Cached bus index of the (single) RTC_CNTL peripheral, resolved at
+    /// construction. `step()` drains the SW_SYS_RST latch every cycle; the
+    /// pre-cache code walked the full ~40-peripheral list and downcast each
+    /// to `RtcCntl` per cycle. With the index cached this collapses to one
+    /// indexed access + one downcast. `None` for configs that don't register
+    /// an RTC_CNTL peripheral (every non-ESP32-classic target).
+    rtc_cntl_index: Option<usize>,
 }
 
 impl<C: Cpu> Machine<C> {
     pub fn new(cpu: C, bus: bus::SystemBus) -> Self {
+        let rtc_cntl_index = bus.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .and_then(|a| {
+                    a.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>()
+                })
+                .is_some()
+        });
         Self {
             cpu,
             cpu_secondary: None,
@@ -598,6 +613,7 @@ impl<C: Cpu> Machine<C> {
             last_breakpoint: None,
             total_cycles: 0,
             config: SimulationConfig::default(),
+            rtc_cntl_index,
         }
     }
 
@@ -777,25 +793,26 @@ impl<C: Cpu> Machine<C> {
         Ok(())
     }
 
-    /// Returns true (and clears the latch) if any registered RTC_CNTL
+    /// Returns true (and clears the latch) if the registered RTC_CNTL
     /// peripheral has a pending software-system-reset request. Used by
     /// `step()` to honor OPTIONS0 bit 31 writes at a clean instruction
-    /// boundary. Walks the bus's peripheral list and downcasts; in
-    /// practice there's at most one RTC_CNTL on the bus, so this is O(N)
-    /// over a short vector.
+    /// boundary. Uses the cached `rtc_cntl_index` resolved at construction
+    /// — non-ESP32-classic configs (no RTC_CNTL on the bus) short-circuit
+    /// to `false` without touching the peripheral vector at all.
     fn drain_rtc_cntl_reset_request(&self) -> bool {
-        for p in &self.bus.peripherals {
-            if let Some(any) = p.dev.as_any() {
-                if let Some(rtc) =
-                    any.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>()
-                {
-                    if rtc.drain_reset_request() {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        let Some(idx) = self.rtc_cntl_index else {
+            return false;
+        };
+        let Some(p) = self.bus.peripherals.get(idx) else {
+            return false;
+        };
+        p.dev
+            .as_any()
+            .and_then(|a| {
+                a.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>()
+            })
+            .map(|rtc| rtc.drain_reset_request())
+            .unwrap_or(false)
     }
 
     pub fn snapshot(&self) -> snapshot::MachineSnapshot {

--- a/crates/core/src/peripherals/esp32/dport.rs
+++ b/crates/core/src/peripherals/esp32/dport.rs
@@ -196,6 +196,22 @@ impl Peripheral for Dport {
         Ok(())
     }
 
+    // Word-granular fast paths: the firmware DPORT polling loop (WASM IPI
+    // bridge, intmatrix mapping reads) hits these every CPU cycle. The
+    // default Peripheral trait impl issues four byte reads/writes, each
+    // hashing the offset through SipHash to index `regs`. Overriding here
+    // collapses that to one lookup. Reads and writes are pure
+    // last-write-wins storage with no side effects, so a single-word
+    // operation is byte-identical to the four-byte default path.
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(self.read_word(offset as u32 & !3))
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        self.write_word(offset as u32 & !3, value);
+        Ok(())
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32/dport.rs
+++ b/crates/core/src/peripherals/esp32/dport.rs
@@ -68,7 +68,6 @@
 //! delivery) without churning the rest of the catch-all.
 
 use crate::{Peripheral, SimResult};
-use std::collections::HashMap;
 
 // ── Register offsets (per ESP32 TRM v5.0 §6 + §7) ───────────────────────────
 
@@ -117,16 +116,20 @@ pub const DPORT_APP_INTR_FROM_CPU_3_OFFSET: u32 = 0x0174;
 
 /// DPORT peripheral.
 ///
-/// Word-granular sparse storage keeps the model compact — most of the
-/// 4 KiB DPORT window is unused at any given moment. Read/write are
-/// plain last-write-wins so the WASM IPI bridge (which reads back its
-/// own writes) keeps working.
+/// Word-granular dense storage — DPORT is exactly 4 KiB / 1024 words, so a
+/// flat `[u32; 1024]` (heap-boxed to keep the peripheral handle small) is
+/// the same memory order as a real `HashMap` entry plus the SipHash work,
+/// minus the hashing. The WASM IPI bridge polls this peripheral every
+/// cycle; cache-resident array reads beat hashed lookups by a wide margin
+/// on the bench.
 #[derive(Debug)]
 pub struct Dport {
     /// Base MMIO address (informational; bus dispatches by offset).
     base: u32,
-    /// Backing word store. Indexed by 4-byte-aligned offset within DPORT.
-    regs: HashMap<u32, u32>,
+    /// Backing word store. `regs[word_off >> 2]` is the value at byte
+    /// offset `word_off`. Heap-boxed so the peripheral handle stays
+    /// pointer-sized.
+    regs: Box<[u32; Self::WORDS]>,
 }
 
 impl Default for Dport {
@@ -140,6 +143,8 @@ impl Dport {
     pub const BASE: u32 = 0x3FF0_0000;
     /// DPORT window size (4 KiB per TRM).
     pub const SIZE: u32 = 0x1000;
+    /// Number of 32-bit words in the DPORT window.
+    pub const WORDS: usize = (Self::SIZE / 4) as usize;
 
     /// Construct a freshly-powered DPORT block.
     ///
@@ -151,10 +156,10 @@ impl Dport {
     ///     real silicon reset value.
     ///   * Every other offset reads back 0 until written.
     pub fn new() -> Self {
-        let mut regs = HashMap::new();
-        regs.insert(DPORT_PERIP_CLK_EN_OFFSET, 0xFFFF_FFFF);
-        regs.insert(DPORT_PERIP_RST_EN_OFFSET, 0);
-        regs.insert(DPORT_CPU_PER_CONF_OFFSET, 0);
+        let mut regs = Box::new([0u32; Self::WORDS]);
+        regs[(DPORT_PERIP_CLK_EN_OFFSET >> 2) as usize] = 0xFFFF_FFFF;
+        regs[(DPORT_PERIP_RST_EN_OFFSET >> 2) as usize] = 0;
+        regs[(DPORT_CPU_PER_CONF_OFFSET >> 2) as usize] = 0;
         Self {
             base: Self::BASE,
             regs,
@@ -167,11 +172,14 @@ impl Dport {
     }
 
     fn read_word(&self, word_off: u32) -> u32 {
-        self.regs.get(&word_off).copied().unwrap_or(0)
+        // Bus already clamps offset to the registered SIZE, so the index
+        // is bounded by WORDS. The cast is checked in debug via the array
+        // bounds check; release builds elide it.
+        self.regs[(word_off >> 2) as usize]
     }
 
     fn write_word(&mut self, word_off: u32, value: u32) {
-        self.regs.insert(word_off, value);
+        self.regs[(word_off >> 2) as usize] = value;
     }
 }
 
@@ -189,7 +197,7 @@ impl Peripheral for Dport {
         // Read-modify-write so partial-byte writes don't clobber the
         // other three bytes of the word. PERIP_CLK_EN's all-ones seed
         // survives a single-byte poke this way.
-        let mut word = self.regs.get(&word_off).copied().unwrap_or(0);
+        let mut word = self.read_word(word_off);
         word &= !(0xFFu32 << byte_off);
         word |= (value as u32) << byte_off;
         self.write_word(word_off, word);
@@ -225,8 +233,17 @@ impl Peripheral for Dport {
         struct Snap {
             regs: Vec<(u32, u32)>,
         }
+        // Preserve the sparse on-wire format. Skip zero words so the
+        // snapshot stays small (most of the 4 KiB window is unwritten
+        // in practice).
         let snap = Snap {
-            regs: self.regs.iter().map(|(k, v)| (*k, *v)).collect(),
+            regs: self
+                .regs
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| **v != 0)
+                .map(|(i, v)| ((i as u32) << 2, *v))
+                .collect(),
         };
         bincode::serialize(&snap).expect("bincode serialize Dport")
     }
@@ -239,7 +256,10 @@ impl Peripheral for Dport {
         let snap: Snap = bincode::deserialize(bytes).map_err(|e| {
             crate::SimulationError::NotImplemented(format!("Dport snapshot decode: {e}"))
         })?;
-        self.regs = snap.regs.into_iter().collect();
+        self.regs = Box::new([0u32; Self::WORDS]);
+        for (off, val) in snap.regs {
+            self.regs[(off >> 2) as usize] = val;
+        }
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/esp32/rtc_cntl.rs
+++ b/crates/core/src/peripherals/esp32/rtc_cntl.rs
@@ -223,6 +223,13 @@ impl Peripheral for RtcCntl {
         Ok(((word >> byte_off) & 0xFF) as u8)
     }
 
+    // Word-granular read fast path: same `read_word` as the byte path,
+    // looked up once instead of four times. Pure register lookup +
+    // TIME0/TIME1 live-counter view; no side effects on read.
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(self.read_word((offset & !3) as u32))
+    }
+
     fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
         let word_off = (offset & !3) as u32;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/timg.rs
+++ b/crates/core/src/peripherals/esp32/timg.rs
@@ -215,6 +215,33 @@ impl Timg {
         self.latch_t1();
     }
 
+    /// Dispatch the per-word side effects of a register write. Factored
+    /// out so both byte-granular `write` and word-granular `write_u32`
+    /// produce identical observable state. Idempotent for all the
+    /// triggers below (they read live state from `regs`/counters and
+    /// write back deterministic values), so calling once per word or
+    /// four times per word produces the same outcome.
+    fn apply_write_side_effects(&mut self, word_off: u64) {
+        match word_off {
+            T0_UPDATE => self.latch_t0(),
+            T1_UPDATE => self.latch_t1(),
+            T0_LOAD => self.preload_t0(),
+            T1_LOAD => self.preload_t1(),
+            WDT_FEED | WDT_WPROTECT => {
+                // Watchdog feed / write-protect: round-trip the value.
+                // WDT timing/reset behavior isn't modeled.
+            }
+            INT_CLR => {
+                // Write-1-to-clear: clear matching bits in INT_RAW.
+                let mask = self.word(INT_CLR);
+                let raw = self.word(INT_RAW);
+                self.regs.insert(INT_RAW, raw & !mask);
+            }
+            RTCCALICFG => self.maybe_complete_rtc_calibration(),
+            _ => {}
+        }
+    }
+
     /// Apply RTC calibration completion semantics (carried over from the
     /// pre-existing `TimgStub`). When firmware sets `RTCCALICFG.START`,
     /// we immediately mark `RDY` and stash a derived value in
@@ -273,36 +300,48 @@ impl Peripheral for Timg {
         let entry = self.regs.entry(word_off).or_insert(0);
         *entry &= !(0xFFu32 << byte_off);
         *entry |= (value as u32) << byte_off;
+        self.apply_write_side_effects(word_off);
+        Ok(())
+    }
 
-        // Side effects on the word that was just touched.
-        match word_off {
-            T0_UPDATE => self.latch_t0(),
-            T1_UPDATE => self.latch_t1(),
-            T0_LOAD => self.preload_t0(),
-            T1_LOAD => self.preload_t1(),
-            WDT_FEED => {
-                // Watchdog feed: silently accepted. We don't model the
-                // WDT timing path or reset behavior — the value written
-                // doesn't matter. We also don't clear the WDTFEED
-                // register itself; firmware never reads it back.
-            }
-            WDT_WPROTECT => {
-                // Round-trip; real silicon uses 0x50D83AA1 to unlock
-                // subsequent WDTCONFIG* writes. We accept any value.
-            }
-            INT_CLR => {
-                // Write-1-to-clear semantics: clear matching INT_RAW bits.
-                let mask = self.word(INT_CLR);
-                let raw = self.word(INT_RAW);
-                self.regs.insert(INT_RAW, raw & !mask);
-                // INT_CLR itself is conventionally readable-as-zero; we
-                // leave the written bits in place since callers don't
-                // read them back. Firmware that does will see the last
-                // write value, which is harmless.
-            }
-            RTCCALICFG => self.maybe_complete_rtc_calibration(),
-            _ => {}
-        }
+    // Word-granular fast paths. The default trait impls would issue 4×
+    // byte ops (each hashing through `regs`); the bench polls T0_LO and
+    // INT_RAW heavily. Reads look up the word once with the same LO/HI
+    // counter fallback as the byte path. Writes overwrite the word in
+    // one shot, then dispatch side effects via the shared helper so the
+    // observable state is identical to four byte writes.
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        let word_off = offset & !3;
+        let word = match word_off {
+            T0_LO => self
+                .regs
+                .get(&T0_LO)
+                .copied()
+                .unwrap_or(self.counter_t0 as u32),
+            T0_HI => self
+                .regs
+                .get(&T0_HI)
+                .copied()
+                .unwrap_or((self.counter_t0 >> 32) as u32),
+            T1_LO => self
+                .regs
+                .get(&T1_LO)
+                .copied()
+                .unwrap_or(self.counter_t1 as u32),
+            T1_HI => self
+                .regs
+                .get(&T1_HI)
+                .copied()
+                .unwrap_or((self.counter_t1 >> 32) as u32),
+            _ => self.word(word_off),
+        };
+        Ok(word)
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        let word_off = offset & !3;
+        self.regs.insert(word_off, value);
+        self.apply_write_side_effects(word_off);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Profiler on the ereader bench showed the Rust CPU interpreter was only ~4.5% of wall time; the rest was orchestration overhead. Three small, surgical fixes here close most of that gap:

1. **Cache RTC_CNTL peripheral index in `Machine`** (`crates/core/src/lib.rs`).
   `drain_rtc_cntl_reset_request` used to walk the full ~40-peripheral list every CPU cycle, downcasting each to `RtcCntl` to check a latch that's almost never set. The index is now resolved once at `Machine::new`; the per-cycle path becomes one indexed access + one downcast (and short-circuits to `false` for non-ESP32-classic configs with no RtcCntl on the bus).

2. **Word-granular `read_u32` / `write_u32` overrides on `Dport`, `Timg`, `RtcCntl`** (`crates/core/src/peripherals/esp32/{dport,timg,rtc_cntl}.rs`).
   The default `Peripheral::read_u32`/`write_u32` issues four byte ops, each hashing through SipHash. The bench polls DPORT and TIMG word registers every cycle, so that's 16 SipHash hashes per polled word. Overrides collapse this to one lookup. Timg factors the per-word write side effects (T0_UPDATE/T0_LOAD, INT_CLR W1C, RTCCALICFG completion, WDT feed/wprotect) into a shared `apply_write_side_effects` helper so byte and word writes produce identical observable state. RtcCntl gets a `read_u32` override only — its OPTIONS0 SW_SYS_RST trigger is intricate enough that the safer choice was to leave `write_u32` on the default byte path (the bench reads RtcCntl but doesn't write it on the hot path).

3. **`Dport` register storage: `HashMap<u32, u32>` → `Box<[u32; 1024]>`** (`crates/core/src/peripherals/esp32/dport.rs`).
   DPORT is exactly 4 KiB / 1024 words. A heap-boxed flat array is the same memory order as a HashMap entry minus the SipHash work. Snapshot wire format stays sparse `Vec<(offset, value)>` so on-disk snapshots interoperate across the layout change. Timg is **not** converted because its `T0_LO`/`T0_HI`/`T1_LO`/`T1_HI` reads rely on HashMap presence-vs-zero distinction to fall back to the live counter — preserving that with a flat array would need a side bitmap, which isn't worth the extra surface for this PR.

Cycle-accurate observable behavior is preserved end-to-end (lockstep / determinism tests pass on default + jit features).

## Bench numbers (ereader, 10M cycles + 200k warmup, mean of 2 runs)

| Stage | Baseline (JIT off) cyc/s | Notes |
|---|---:|---|
| `main` tip `aa016d8` | **284,351** | reference |
| + Fix 1 + Fix 2 (post c628873) | **463,275** | +63% |
| + Fix 3 (this PR tip 50be76c) | **484,693** | **+70% / 1.70× end-to-end** |

The +49% / +27% deltas from the original profiler experiment were quick-and-dirty stubs; the clean implementations land at +63% combined for fix 1+2 and +70% with the array stretch. Below the ×2.44 the profiler projected, but a real, lockstep-clean speedup measured on the same harness.

The ``with browser JIT`` numbers are dominated by JIT compile/refusal overhead and are not the focus of this PR.

## Test plan
- [x] `cargo build -p labwired-core --lib` clean
- [x] `cargo build -p labwired-core --lib --features jit` clean
- [x] `cargo test -p labwired-core --lib` — 529 passed
- [x] `cargo test -p labwired-core --lib --features jit` — 541 passed (lockstep / JIT-feature tests)
- [x] `wasm-pack build --target nodejs --release crates/wasm` clean
- [x] `node scripts/bench_browser_jit.mjs` — numbers above
- [x] Pre-existing failures (`runtime_snapshot::agentdeck_snapshot_file_restores_post_paint_panel`, `labwired-dap` build) reproduce on baseline `aa016d8` and are unrelated to this branch.