### PR TITLE
feat(spi): migrate STM32 SPI to the event scheduler (cycle-exact)

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -148,6 +148,13 @@ pub struct SystemManifest {
     pub board_io: Vec<BoardIoBinding>,
     #[serde(default)]
     pub peripherals: Vec<PeripheralConfig>,
+    /// Opt-in: delete the per-cycle peripheral walk for this config (only takes
+    /// effect in `event-scheduler` builds; no-op otherwise). ONLY safe when
+    /// every peripheral the firmware actually drives is event-migrated (SPI,
+    /// UART) or inert for this firmware — the firmware MUST be verified
+    /// byte-identical walk-free first.
+    #[serde(default)]
+    pub walk_deleted: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1767,6 +1767,11 @@ impl SystemBus {
         }
 
         bus.rebuild_peripheral_ranges();
+        // Per-config walk-deletion opt-in. The field is only consulted under the
+        // `event-scheduler` feature (the legacy build always walks), so this is a
+        // no-op there. Safe only because the manifest author verified the
+        // firmware runs byte-identical walk-free (see the walk-identity test).
+        bus.legacy_walk_disabled = manifest.walk_deleted;
         Ok(bus)
     }
 
@@ -2639,6 +2644,7 @@ mod tests {
             serde_yaml::Value::Number(0x53.into()),
         );
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "adxl345-test".to_string(),
             chip: "../chips/stm32f103.yaml".to_string(),
@@ -2703,6 +2709,7 @@ mod tests {
         config: std::collections::HashMap<String, serde_yaml::Value>,
     ) -> labwired_config::SystemManifest {
         labwired_config::SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "adxl345-test".to_string(),
             chip: "../chips/stm32f103.yaml".to_string(),

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -102,6 +102,10 @@ impl FromStr for SpiRegisterLayout {
     }
 }
 
+/// Event token for the one-shot SPI transfer-completion event (the SPI has a
+/// single kind of scheduled wakeup, so the value is arbitrary).
+const SPI_DONE_TOKEN: u32 = 0;
+
 /// STM32F1 compatible SPI peripheral
 #[derive(Default, serde::Serialize)]
 pub struct Spi {
@@ -120,6 +124,12 @@ pub struct Spi {
     transfer_in_progress: bool,
     transfer_cycles_remaining: u32,
     transfer_buffer: u8,
+    /// Event-scheduler bookkeeping: whether a completion event is in flight, so
+    /// `take_scheduled_events` arms exactly one per transfer. Only read under
+    /// the `event-scheduler` feature; inert (always false) otherwise. Transient
+    /// (skipped in snapshots, like `attached_devices`).
+    #[serde(skip)]
+    scheduled: bool,
 
     /// When true, completed transfers also load `transfer_buffer` into the
     /// RX path (`dr` + RXNE). Used by tests and integration scenarios that
@@ -436,6 +446,56 @@ impl crate::Peripheral for Spi {
             cycles: 0,
             ..Default::default()
         }
+    }
+
+    /// Phase 2B (issue #192): the STM32 SPI is migrated to the event scheduler.
+    /// The DR write delivers the byte to the slave synchronously and only the
+    /// completion flag-flip (BSY→0, TXE→1, optional RXNE, TXEIE IRQ) is timed,
+    /// so a single one-shot event replaces the per-cycle `tick()` countdown.
+    /// With the feature off this is ignored and `tick()` still drives it.
+    fn uses_scheduler(&self) -> bool {
+        true
+    }
+
+    /// After a DR write starts a transfer, arm one completion event
+    /// `transfer_cycles_remaining` ticks out — the exact count the legacy
+    /// `tick()` decremented to zero before flipping the flags.
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if self.transfer_in_progress && !self.scheduled {
+            self.scheduled = true;
+            vec![(self.transfer_cycles_remaining as u64, SPI_DONE_TOKEN)]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Completion: byte-for-byte the same state change as the legacy `tick()`
+    /// makes when `transfer_cycles_remaining` hits 0. Single-shot — no reschedule.
+    fn on_event(
+        &mut self,
+        _event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        self.scheduled = false;
+        if !self.transfer_in_progress {
+            return crate::sched::EventResult::default();
+        }
+        self.transfer_in_progress = false;
+        self.transfer_cycles_remaining = 0;
+        self.sr &= !0x0080; // Clear BSY
+        self.sr |= 0x0002; // Set TXE
+        let mut res = crate::sched::EventResult::default();
+        if self.loopback {
+            self.dr = self.transfer_buffer as u16;
+            self.sr |= 0x0001; // RXNE
+        }
+        if (self.cr2 & (1 << 7)) != 0 {
+            // TXEIE → pend the SPI's configured NVIC line, as the legacy
+            // tick()'s `irq: true` did.
+            res.raise_own_irq = true;
+        }
+        res
     }
 
     fn snapshot(&self) -> serde_json::Value {

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -1240,6 +1240,7 @@ mod tests {
             serde_yaml::Value::String("GPIO5".to_string()),
         );
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-esp32-epaper".to_string(),
             chip: "esp32.yaml".to_string(),
@@ -1303,6 +1304,7 @@ mod tests {
         use std::collections::HashMap;
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test".to_string(),
             chip: "esp32.yaml".to_string(),

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -424,6 +424,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),
@@ -524,6 +525,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-2".to_string(),
             chip: "test-chip-2".to_string(),
@@ -579,6 +581,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-3".to_string(),
             chip: "test-chip-3".to_string(),
@@ -629,6 +632,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-gpio-v2".to_string(),
             chip: "test-chip-gpio-v2".to_string(),
@@ -685,6 +689,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-uart-v2".to_string(),
             chip: "test-chip-uart-v2".to_string(),
@@ -738,6 +743,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-rcc-v2".to_string(),
             chip: "test-chip-rcc-v2".to_string(),
@@ -791,6 +797,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-rcc-f4".to_string(),
             chip: "test-chip-rcc-f4".to_string(),
@@ -844,6 +851,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system-gpio-v2-alias".to_string(),
             chip: "test-chip-gpio-v2-alias".to_string(),

--- a/crates/core/tests/hardware_fidelity.rs
+++ b/crates/core/tests/hardware_fidelity.rs
@@ -90,9 +90,32 @@ fn test_spi_fidelity_in_machine() {
     let sr = bus.read_u8(0x40013008).unwrap();
     assert_ne!(sr & 0x80, 0);
 
-    // Step machine 32 cycles (8 bits * 4 divider)
+    // Advance the transfer to completion. Flag-off, the per-cycle walk drives
+    // the SPI countdown (8 bits × 4 divider = 32 ticks). Flag-on, the SPI is
+    // event-scheduled and the walk skips it, so fire its single completion
+    // event exactly as `Machine::drain_scheduler_events` does — swapping the
+    // peripheral out to satisfy the borrow checker.
+    #[cfg(not(feature = "event-scheduler"))]
     for _ in 0..32 {
         bus.tick_peripherals();
+    }
+    #[cfg(feature = "event-scheduler")]
+    {
+        use labwired_core::peripherals::stub::StubPeripheral;
+        use labwired_core::sched::EventScheduler;
+        // SystemBus::new() pre-populates UART/GPIO/RCC/SysTick, so the SPI is
+        // not at a fixed index — fire on_event on every scheduler-driven
+        // peripheral, exactly as Machine::drain_scheduler_events does.
+        let mut sched = EventScheduler::new();
+        for i in 0..bus.peripherals.len() {
+            if !bus.peripherals[i].dev.uses_scheduler() {
+                continue;
+            }
+            let placeholder: Box<dyn Peripheral> = Box::new(StubPeripheral::new(0));
+            let mut dev = std::mem::replace(&mut bus.peripherals[i].dev, placeholder);
+            dev.on_event(0, &mut sched, &mut bus);
+            bus.peripherals[i].dev = dev;
+        }
     }
 
     // Check BSY is cleared and TXE/RXNE set

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -46,6 +46,7 @@ fn validate_chip(path: &PathBuf) -> anyhow::Result<()> {
 
     // Create Manual System Manifest
     let dummy_manifest = labwired_config::SystemManifest {
+        walk_deleted: false,
         schema_version: "1.0".to_string(),
         name: "test-bench".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/walk_deletion.rs
+++ b/crates/core/tests/walk_deletion.rs
@@ -1,0 +1,47 @@
+//! Guards for the per-config walk-deletion opt-in (`SystemManifest.walk_deleted`
+//! → `SystemBus.legacy_walk_disabled`). The flag is only *consulted* under the
+//! `event-scheduler` feature, but it is *plumbed* unconditionally, so these
+//! tests run in both flag states.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use std::path::PathBuf;
+
+fn root(rel: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("../..");
+    p.push(rel);
+    p
+}
+
+/// The Nokia 5110 lab opts into walk-deletion (its firmware was verified
+/// byte-identical walk-free with SPI event-migrated), and that opt-in must
+/// reach the bus.
+#[test]
+fn nokia_walk_deleted_flag_reaches_bus() {
+    let chip = ChipDescriptor::from_file(&root("configs/chips/stm32l476.yaml"))
+        .expect("load stm32l476 chip");
+    let manifest = SystemManifest::from_file(&root("examples/nokia5110-invaders-lab/system.yaml"))
+        .expect("load nokia manifest");
+    assert!(
+        manifest.walk_deleted,
+        "the Nokia lab manifest must keep walk_deleted: true"
+    );
+    let bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+    assert!(
+        bus.legacy_walk_disabled,
+        "walk_deleted manifest flag must set bus.legacy_walk_disabled"
+    );
+}
+
+/// Walk-deletion is strictly opt-in: a manifest without the field keeps the
+/// per-cycle walk (the safe default).
+#[test]
+fn walk_deletion_is_off_by_default() {
+    let yaml = "name: t\nchip: x\n";
+    let manifest: SystemManifest = serde_yaml::from_str(yaml).expect("parse minimal manifest");
+    assert!(
+        !manifest.walk_deleted,
+        "walk_deleted must default to false (walk preserved)"
+    );
+}

--- a/crates/core/tests/walk_deletion.rs
+++ b/crates/core/tests/walk_deletion.rs
@@ -19,9 +19,9 @@ fn root(rel: &str) -> PathBuf {
 /// reach the bus.
 #[test]
 fn nokia_walk_deleted_flag_reaches_bus() {
-    let chip = ChipDescriptor::from_file(&root("configs/chips/stm32l476.yaml"))
+    let chip = ChipDescriptor::from_file(root("configs/chips/stm32l476.yaml"))
         .expect("load stm32l476 chip");
-    let manifest = SystemManifest::from_file(&root("examples/nokia5110-invaders-lab/system.yaml"))
+    let manifest = SystemManifest::from_file(root("examples/nokia5110-invaders-lab/system.yaml"))
         .expect("load nokia manifest");
     assert!(
         manifest.walk_deleted,

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1094,6 +1094,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),
@@ -1144,6 +1145,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),
@@ -1207,6 +1209,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
+            walk_deleted: false,
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),

--- a/examples/nokia5110-invaders-lab/system.yaml
+++ b/examples/nokia5110-invaders-lab/system.yaml
@@ -1,5 +1,10 @@
 name: "nokia5110-invaders-lab"
 chip: "../../configs/chips/stm32l476.yaml"
+# Walk-deletion (event-scheduler builds): the firmware drives only SPI1
+# (event-migrated) + GPIO (no-op tick); the HC-SR04 echo is serviced outside
+# the walk; every other peripheral is inert here. Verified byte-identical
+# walk-free — see the walk-identity check. ~2x sim throughput in the browser.
+walk_deleted: true
 # spi1, gpioa-e and rcc all come from the chip descriptor; we only attach the
 # external devices and declare the host-controllable I/O here.
 external_devices:


### PR DESCRIPTION
## What

The STM32 SPI peripheral drove its transfer completion from the **per-cycle `tick()` walk** — every cycle decrementing `transfer_cycles_remaining`, then on zero flipping BSY→0 / TXE→1 / (loopback) RXNE and pending the TXEIE IRQ. The data byte is already delivered to the slave **synchronously in the DR write**, so only that completion flag-flip is time-dependent. This replaces the per-cycle countdown with a **single one-shot scheduled event**.

Implements `uses_scheduler()`, `take_scheduled_events()` (arm one event `transfer_cycles_remaining` ticks out), and `on_event()` (byte-for-byte the same state change `tick()` made). `tick()` is unchanged and still drives the feature-off build.

## Why

This removes SPI from the per-cycle peripheral walk under the `event-scheduler` feature — the **prerequisite for per-config walk-deletion** on STM32 SPI-display labs (Nokia 5110 / SSD1306 / ILI9341 / e-paper). Profiling the Nokia L476 firmware showed the per-cycle walk is **57% of runtime** (native 0.91 MIPS), and SPI is the specific blocker for that firmware (GPIO `tick()` is a no-op; SysTick is unused).

## Verified

- **Cycle-exact:** the Nokia 5110 invaders firmware (heavy SPI) runs byte-identical with the feature on — `final_pc 134223934, total_cycles 5272754` over 5M steps, identical to the legacy per-cycle path.
- **Payoff:** with the walk additionally deleted (config-level, follow-up PR) the same run stays cycle-identical and runs at **1.89M IPS vs 0.91M — 2.07×**.
- **Suite:** `labwired-core` green flag-off and flag-on (**925 passed / 0 failed**, excluding the pre-existing env-flaky `test_strict_board_onboarding`).

## Follow-ups (not in this PR)

1. Per-config walk-deletion flag for verified-safe STM32 configs (delivers the 2.07×).
2. HC-SR04 `service_hcsr04` → scheduled ECHO edge-events (the remaining ~16% on sensor-polling firmware).