### PR TITLE
feat(iolink): trace ring + iolink_trace_snapshot for the IO-Link Analyzer

### DIFF
--- a/crates/core/src/peripherals/components/iolink_master.rs
+++ b/crates/core/src/peripherals/components/iolink_master.rs
@@ -87,6 +87,50 @@ pub enum IolinkLinkState {
     Operate,
 }
 
+/// Which frame in the startup/cyclic schedule a trace record came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IolinkFrameKind {
+    WakeUp,
+    Idle,
+    OperateReq,
+    Cyclic,
+}
+
+/// One captured master↔device exchange, decoded where the master already
+/// builds requests and parses responses. Serialized to JS as a plain object.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IolinkXfer {
+    pub seq: u32,
+    pub kind: IolinkFrameKind,
+    pub com: IolinkComSpeed,
+    pub pd_out: Vec<u8>,
+    pub pd_in: Vec<u8>,
+    pub od: u8,
+    /// `None` for non-cyclic frames (no decodable OPERATE response).
+    pub ck_ok: Option<bool>,
+    pub pd_valid: Option<bool>,
+    pub link_state: IolinkLinkState,
+    pub raw_master: Vec<u8>,
+    pub raw_device: Vec<u8>,
+}
+
+/// In-flight frame: request bytes known at queue time; the device response
+/// accumulates until the next frame is queued, then it's finalized.
+#[derive(Debug, Clone)]
+struct PendingXfer {
+    seq: u32,
+    kind: IolinkFrameKind,
+    pd_out: Vec<u8>,
+    link_state: IolinkLinkState,
+    raw_master: Vec<u8>,
+    raw_device: Vec<u8>,
+}
+
+/// Max trace records retained (oldest dropped).
+#[allow(dead_code)]
+const TRACE_CAP: usize = 256;
+
 /// Ticks the master waits (one `poll` per UART tick) between frames. The
 /// simulated device executes far slower than the UART advances, so frames are
 /// paced generously to guarantee the device has fully processed (and replied
@@ -160,6 +204,35 @@ impl IolinkMaster {
 
     fn operate_response_len(&self) -> usize {
         1 + self.pd_in_len + self.od_len + 1
+    }
+
+    /// Turn a completed in-flight frame into a trace record, decoding the
+    /// device response only for cyclic (OPERATE) frames.
+    fn finalize_xfer(&self, p: PendingXfer) -> IolinkXfer {
+        let (pd_in, ck_ok, pd_valid) = if matches!(p.kind, IolinkFrameKind::Cyclic) {
+            let n = self.operate_response_len();
+            if p.raw_device.len() >= n {
+                let r = decode_operate(&p.raw_device[..n], self.pd_in_len, self.od_len);
+                (r.pd, Some(r.checksum_ok), Some(r.pd_valid))
+            } else {
+                (Vec::new(), Some(false), Some(false))
+            }
+        } else {
+            (Vec::new(), None, None)
+        };
+        IolinkXfer {
+            seq: p.seq,
+            kind: p.kind,
+            com: self.com,
+            pd_out: p.pd_out,
+            pd_in,
+            od: 0x00,
+            ck_ok,
+            pd_valid,
+            link_state: p.link_state,
+            raw_master: p.raw_master,
+            raw_device: p.raw_device,
+        }
     }
 
     /// Queue the next frame in the startup/cyclic schedule and advance `step`.
@@ -282,6 +355,43 @@ mod tests {
         assert!(resp.checksum_ok);
         assert!(resp.pd_valid);
         assert_eq!(resp.pd, vec![0xA5]);
+    }
+
+    #[test]
+    fn finalize_cyclic_decodes_response_and_marks_ck() {
+        let m = IolinkMaster::new(1, 1, IolinkComSpeed::Com2);
+        let resp = [0x20u8, 0xA5, 0x00, crc6(&[0x20, 0xA5, 0x00])];
+        let p = PendingXfer {
+            seq: 7,
+            kind: IolinkFrameKind::Cyclic,
+            pd_out: vec![],
+            link_state: IolinkLinkState::Operate,
+            raw_master: encode_type1_cycle(&[]),
+            raw_device: resp.to_vec(),
+        };
+        let x = m.finalize_xfer(p);
+        assert_eq!(x.seq, 7);
+        assert_eq!(x.kind, IolinkFrameKind::Cyclic);
+        assert_eq!(x.pd_in, vec![0xA5]);
+        assert_eq!(x.ck_ok, Some(true));
+        assert_eq!(x.pd_valid, Some(true));
+    }
+
+    #[test]
+    fn finalize_startup_frame_has_no_crc_verdict() {
+        let m = IolinkMaster::new(1, 1, IolinkComSpeed::Com2);
+        let p = PendingXfer {
+            seq: 0,
+            kind: IolinkFrameKind::WakeUp,
+            pd_out: vec![],
+            link_state: IolinkLinkState::Startup,
+            raw_master: vec![0x55],
+            raw_device: vec![],
+        };
+        let x = m.finalize_xfer(p);
+        assert_eq!(x.ck_ok, None);
+        assert_eq!(x.pd_valid, None);
+        assert!(x.pd_in.is_empty());
     }
 
     #[test]

--- a/crates/core/src/peripherals/components/iolink_master.rs
+++ b/crates/core/src/peripherals/components/iolink_master.rs
@@ -480,11 +480,17 @@ mod tests {
             let _ = m.poll(1000);
         }
         let trace = m.trace_snapshot();
-        assert!(trace.len() >= 5, "expected several frames, got {}", trace.len());
+        assert!(
+            trace.len() >= 5,
+            "expected several frames, got {}",
+            trace.len()
+        );
         assert_eq!(trace[0].kind, IolinkFrameKind::WakeUp);
         assert!(
-            trace.iter().any(|x| x.kind == IolinkFrameKind::Cyclic
-                && x.link_state == IolinkLinkState::Operate),
+            trace
+                .iter()
+                .any(|x| x.kind == IolinkFrameKind::Cyclic
+                    && x.link_state == IolinkLinkState::Operate),
             "expected a cyclic OPERATE frame in the trace"
         );
         for w in trace.windows(2) {

--- a/crates/core/src/peripherals/components/iolink_master.rs
+++ b/crates/core/src/peripherals/components/iolink_master.rs
@@ -128,7 +128,6 @@ struct PendingXfer {
 }
 
 /// Max trace records retained (oldest dropped).
-#[allow(dead_code)]
 const TRACE_CAP: usize = 256;
 
 /// Ticks the master waits (one `poll` per UART tick) between frames. The
@@ -173,6 +172,15 @@ pub struct IolinkMaster {
     latest_pd: Vec<u8>,
     /// Latches true on the first valid cyclic frame and is intentionally sticky.
     pub pd_valid: bool,
+    /// Bounded ring of completed transactions (oldest→newest), for the analyzer.
+    #[serde(skip)]
+    trace: VecDeque<IolinkXfer>,
+    /// The frame currently in flight (request sent, response accumulating).
+    #[serde(skip)]
+    current: Option<PendingXfer>,
+    /// Monotonic per-frame sequence number.
+    #[serde(skip)]
+    frame_seq: u32,
 }
 
 impl IolinkMaster {
@@ -188,6 +196,9 @@ impl IolinkMaster {
             gap_ticks: 0,
             latest_pd: vec![0u8; pd_in_len.max(1)],
             pd_valid: false,
+            trace: VecDeque::new(),
+            current: None,
+            frame_seq: 0,
         };
         m.queue_next_frame(); // queue the wake-up immediately
         m
@@ -200,6 +211,16 @@ impl IolinkMaster {
 
     pub fn com_speed(&self) -> IolinkComSpeed {
         self.com
+    }
+
+    /// Snapshot of captured transactions, oldest→newest. Cloned for the UI.
+    pub fn trace_snapshot(&self) -> Vec<IolinkXfer> {
+        self.trace.iter().cloned().collect()
+    }
+
+    /// Clear the trace ring (the analyzer's "Clear" control).
+    pub fn trace_clear(&mut self) {
+        self.trace.clear();
     }
 
     fn operate_response_len(&self) -> usize {
@@ -236,25 +257,44 @@ impl IolinkMaster {
     }
 
     /// Queue the next frame in the startup/cyclic schedule and advance `step`.
+    /// Also finalizes the previous in-flight frame into the trace ring.
     fn queue_next_frame(&mut self) {
-        self.rx_accum.clear();
-        let idle_end = 1 + IDLE_FRAMES; // steps [1..=IDLE_FRAMES] are IDLE
-        if self.step == 0 {
-            self.tx_queue.push_back(0x55); // wake-up pulse (once)
-        } else if self.step < idle_end {
-            for b in encode_type0(0x00) {
-                self.tx_queue.push_back(b); // Type 0 IDLE → PREOPERATE
+        // Finalize the previous frame (its response accumulated during the gap).
+        if let Some(p) = self.current.take() {
+            let x = self.finalize_xfer(p);
+            if self.trace.len() >= TRACE_CAP {
+                self.trace.pop_front();
             }
-        } else if self.step == idle_end {
-            for b in encode_type0(0x0F) {
-                self.tx_queue.push_back(b); // OPERATE transition (MC=0x0F) → ESTAB_COM
-            }
-        } else {
-            for b in encode_type1_cycle(&[]) {
-                self.tx_queue.push_back(b); // cyclic Type 1 → OPERATE + process data
-            }
-            self.link_state = IolinkLinkState::Operate;
+            self.trace.push_back(x);
         }
+        self.rx_accum.clear();
+
+        let idle_end = 1 + IDLE_FRAMES; // steps [1..=IDLE_FRAMES] are IDLE
+        let (frame, kind): (Vec<u8>, IolinkFrameKind) = if self.step == 0 {
+            (vec![0x55], IolinkFrameKind::WakeUp) // wake-up pulse (once)
+        } else if self.step < idle_end {
+            (encode_type0(0x00), IolinkFrameKind::Idle) // Type 0 IDLE → PREOPERATE
+        } else if self.step == idle_end {
+            (encode_type0(0x0F), IolinkFrameKind::OperateReq) // OPERATE transition
+        } else {
+            self.link_state = IolinkLinkState::Operate;
+            (encode_type1_cycle(&[]), IolinkFrameKind::Cyclic) // cyclic Type 1
+        };
+
+        let pd_out: Vec<u8> = Vec::new(); // DI device: master sends no PD out
+        for &b in &frame {
+            self.tx_queue.push_back(b);
+        }
+        self.current = Some(PendingXfer {
+            seq: self.frame_seq,
+            kind,
+            pd_out,
+            link_state: self.link_state,
+            raw_master: frame,
+            raw_device: Vec::new(),
+        });
+        self.frame_seq = self.frame_seq.wrapping_add(1);
+
         // Hold `step` at the first cyclic index so it keeps repeating Type 1.
         if self.step <= idle_end {
             self.step += 1;
@@ -282,6 +322,11 @@ impl UartStreamDevice for IolinkMaster {
         // (OPERATE) response is complete, decode and latch the process data.
         if self.rx_accum.len() < 64 {
             self.rx_accum.push(byte);
+        }
+        if let Some(p) = self.current.as_mut() {
+            if p.raw_device.len() < 64 {
+                p.raw_device.push(byte);
+            }
         }
         if self.link_state == IolinkLinkState::Operate
             && self.rx_accum.len() >= self.operate_response_len()
@@ -426,6 +471,36 @@ mod tests {
         assert_eq!(drain(&mut m), vec![0x00, 0x00, 0x00, 0x09]);
         assert_eq!(m.link_state, IolinkLinkState::Operate);
         assert_eq!(drain(&mut m), vec![0x00, 0x00, 0x00, 0x09]);
+    }
+
+    #[test]
+    fn trace_ring_captures_startup_then_cyclic() {
+        let mut m = IolinkMaster::new(1, 1, IolinkComSpeed::Com2);
+        for _ in 0..(FRAME_GAP_TICKS as u64 * 10 + 64) {
+            let _ = m.poll(1000);
+        }
+        let trace = m.trace_snapshot();
+        assert!(trace.len() >= 5, "expected several frames, got {}", trace.len());
+        assert_eq!(trace[0].kind, IolinkFrameKind::WakeUp);
+        assert!(
+            trace.iter().any(|x| x.kind == IolinkFrameKind::Cyclic
+                && x.link_state == IolinkLinkState::Operate),
+            "expected a cyclic OPERATE frame in the trace"
+        );
+        for w in trace.windows(2) {
+            assert!(w[1].seq > w[0].seq);
+        }
+    }
+
+    #[test]
+    fn trace_clear_empties_ring() {
+        let mut m = IolinkMaster::new(1, 1, IolinkComSpeed::Com2);
+        for _ in 0..(FRAME_GAP_TICKS as u64 * 3 + 16) {
+            let _ = m.poll(1000);
+        }
+        assert!(!m.trace_snapshot().is_empty());
+        m.trace_clear();
+        assert!(m.trace_snapshot().is_empty());
     }
 
     #[test]

--- a/crates/core/src/peripherals/components/mod.rs
+++ b/crates/core/src/peripherals/components/mod.rs
@@ -28,7 +28,9 @@ pub use bme280::Bme280;
 pub use bmp280::Bmp280;
 pub use i2c_factory::build_i2c_device;
 pub use ili9341::Ili9341;
-pub use iolink_master::{IolinkComSpeed, IolinkFrameKind, IolinkLinkState, IolinkMaster, IolinkXfer};
+pub use iolink_master::{
+    IolinkComSpeed, IolinkFrameKind, IolinkLinkState, IolinkMaster, IolinkXfer,
+};
 pub use max31855::Max31855;
 pub use mpu6050::Mpu6050;
 pub use neo6m::Neo6mGps;

--- a/crates/core/src/peripherals/components/mod.rs
+++ b/crates/core/src/peripherals/components/mod.rs
@@ -28,7 +28,7 @@ pub use bme280::Bme280;
 pub use bmp280::Bmp280;
 pub use i2c_factory::build_i2c_device;
 pub use ili9341::Ili9341;
-pub use iolink_master::{IolinkComSpeed, IolinkLinkState, IolinkMaster};
+pub use iolink_master::{IolinkComSpeed, IolinkFrameKind, IolinkLinkState, IolinkMaster, IolinkXfer};
 pub use max31855::Max31855;
 pub use mpu6050::Mpu6050;
 pub use neo6m::Neo6mGps;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1709,6 +1709,58 @@ impl WasmSimulator {
         JsValue::NULL
     }
 
+    /// Snapshot of the IO-Link master's captured transactions (oldest→newest),
+    /// for the IO-Link Analyzer instrument. Empty array if no master is wired.
+    #[wasm_bindgen]
+    pub fn iolink_trace_snapshot(&self) -> JsValue {
+        use labwired_core::peripherals::components::IolinkMaster;
+        let Some(machine) = self.machine.as_ref() else {
+            return serde_wasm_bindgen::to_value(
+                &Vec::<labwired_core::peripherals::components::IolinkXfer>::new(),
+            )
+            .unwrap_or(JsValue::NULL);
+        };
+        for p in &machine.bus.peripherals {
+            let Some(any) = p.dev.as_any() else { continue };
+            let Some(uart) =
+                any.downcast_ref::<labwired_core::peripherals::uart::Uart>()
+            else {
+                continue;
+            };
+            for stream in &uart.attached_streams {
+                if let Some(m) = stream.as_any().and_then(|a| a.downcast_ref::<IolinkMaster>()) {
+                    let trace = m.trace_snapshot();
+                    return serde_wasm_bindgen::to_value(&trace).unwrap_or(JsValue::NULL);
+                }
+            }
+        }
+        serde_wasm_bindgen::to_value(
+            &Vec::<labwired_core::peripherals::components::IolinkXfer>::new(),
+        )
+        .unwrap_or(JsValue::NULL)
+    }
+
+    /// Clear the IO-Link master's trace ring.
+    #[wasm_bindgen]
+    pub fn iolink_trace_clear(&mut self) {
+        use labwired_core::peripherals::components::IolinkMaster;
+        let Some(machine) = self.machine.as_mut() else { return };
+        for p in &mut machine.bus.peripherals {
+            let Some(any) = p.dev.as_any_mut() else { continue };
+            let Some(uart) =
+                any.downcast_mut::<labwired_core::peripherals::uart::Uart>()
+            else {
+                continue;
+            };
+            for stream in &mut uart.attached_streams {
+                if let Some(m) = stream.as_any_mut().and_then(|a| a.downcast_mut::<IolinkMaster>()) {
+                    m.trace_clear();
+                    return;
+                }
+            }
+        }
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     //  Arduino-ESP32 bootstrap glue. Call after constructing the WasmSimulator
     //  with an ESP32-classic manifest + an Arduino-ESP32 firmware ELF (e.g.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1718,20 +1718,21 @@ impl WasmSimulator {
     pub fn iolink_trace_snapshot(&self) -> JsValue {
         use labwired_core::peripherals::components::IolinkMaster;
         let Some(machine) = self.machine.as_ref() else {
-            return serde_wasm_bindgen::to_value(
-                &Vec::<labwired_core::peripherals::components::IolinkXfer>::new(),
-            )
+            return serde_wasm_bindgen::to_value(&Vec::<
+                labwired_core::peripherals::components::IolinkXfer,
+            >::new())
             .unwrap_or(JsValue::NULL);
         };
         for p in &machine.bus.peripherals {
             let Some(any) = p.dev.as_any() else { continue };
-            let Some(uart) =
-                any.downcast_ref::<labwired_core::peripherals::uart::Uart>()
-            else {
+            let Some(uart) = any.downcast_ref::<labwired_core::peripherals::uart::Uart>() else {
                 continue;
             };
             for stream in &uart.attached_streams {
-                if let Some(m) = stream.as_any().and_then(|a| a.downcast_ref::<IolinkMaster>()) {
+                if let Some(m) = stream
+                    .as_any()
+                    .and_then(|a| a.downcast_ref::<IolinkMaster>())
+                {
                     let trace = m.trace_snapshot();
                     return serde_wasm_bindgen::to_value(&trace).unwrap_or(JsValue::NULL);
                 }
@@ -1747,16 +1748,21 @@ impl WasmSimulator {
     #[wasm_bindgen]
     pub fn iolink_trace_clear(&mut self) {
         use labwired_core::peripherals::components::IolinkMaster;
-        let Some(machine) = self.machine.as_mut() else { return };
+        let Some(machine) = self.machine.as_mut() else {
+            return;
+        };
         for p in &mut machine.bus.peripherals {
-            let Some(any) = p.dev.as_any_mut() else { continue };
-            let Some(uart) =
-                any.downcast_mut::<labwired_core::peripherals::uart::Uart>()
-            else {
+            let Some(any) = p.dev.as_any_mut() else {
+                continue;
+            };
+            let Some(uart) = any.downcast_mut::<labwired_core::peripherals::uart::Uart>() else {
                 continue;
             };
             for stream in &mut uart.attached_streams {
-                if let Some(m) = stream.as_any_mut().and_then(|a| a.downcast_mut::<IolinkMaster>()) {
+                if let Some(m) = stream
+                    .as_any_mut()
+                    .and_then(|a| a.downcast_mut::<IolinkMaster>())
+                {
                     m.trace_clear();
                     return;
                 }


### PR DESCRIPTION
Adds a bounded trace ring to the IO-Link master and exposes it to JS, so the playground can render the live master↔device protocol (IO-Link Analyzer instrument). Stacked on the IO-Link DI demo (`feat/iolink-dido-device-demo`).

- `iolink_master.rs`: `IolinkFrameKind`, `IolinkXfer`, a 256-entry ring; `queue_next_frame` now records each frame's raw bytes + finalizes the previous one (decoding cyclic responses via the existing `decode_operate`); `on_tx_byte` accumulates the device reply; `trace_snapshot()`/`trace_clear()`. Startup-frame CRC verdicts are `None` (honest '—', not a false fail). Schedule semantics unchanged (existing walk test passes).
- `crates/wasm`: `iolink_trace_snapshot` + `iolink_trace_clear` exports, mirroring the existing `get_iolink_master_state` UART→master lookup.
- Tests: 11/11 core unit/integration (ring fills WAKE-UP→…→CYCLIC(OPERATE), monotonic seq, clear empties). Verified end-to-end headlessly through the rebuilt wasm against the real AL2205 demo: cyclic frames with decoded `pd_in=0xA5`, CRC ✓.