### PR TITLE
perf(hc-sr04): arm echo on TRIG write, drive ECHO on transition (cycle-exact)

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -184,9 +184,10 @@ pub struct SystemBus {
     /// Read only under the `event-scheduler` feature; flag-off the walk always
     /// runs, so the shipped build is unchanged.
     pub legacy_walk_disabled: bool,
-    /// HC-SR04 ultrasonic sensors wired to GPIO TRIG/ECHO pins. Serviced once
-    /// per peripheral-tick: the bus reads each sensor's TRIG output level and
-    /// drives the computed ECHO input level. Empty by default → zero cost.
+    /// HC-SR04 ultrasonic sensors wired to GPIO TRIG/ECHO pins. The echo window
+    /// is armed by the TRIG GPIO write-hook (`maybe_arm_hcsr04`); a cheap
+    /// per-tick pass (`service_hcsr04`) drives the computed ECHO input level,
+    /// touching the bus only on a transition. Empty by default → zero cost.
     pub hcsr04: Vec<crate::peripherals::hc_sr04::HcSr04>,
 }
 
@@ -540,22 +541,25 @@ impl SystemBus {
         Some((base + idr_off, bit))
     }
 
-    /// Service all HC-SR04 sensors for one tick: read each sensor's TRIG
-    /// output level, advance its echo window, and drive the resulting ECHO
-    /// input level. No-op when no sensors are wired.
+    /// Service all HC-SR04 sensors for one tick: compute each sensor's ECHO
+    /// level from its (write-hook-armed) echo window and drive it onto the ECHO
+    /// input register, touching the bus only on a level transition. TRIG is NOT
+    /// polled here — `maybe_arm_hcsr04` arms the window on the GPIO write, which
+    /// is cycle-exact (see `Machine::step`). No-op when no sensors are wired.
     pub(crate) fn service_hcsr04(&mut self) {
         if self.hcsr04.is_empty() {
             return;
         }
         let now = self.current_cycle;
         for i in 0..self.hcsr04.len() {
-            let trig_addr = self.hcsr04[i].trig_odr_addr;
-            let trig_bit = self.hcsr04[i].trig_bit;
-            let trig_high = self
-                .read_u32(trig_addr)
-                .map(|v| (v >> trig_bit) & 1 != 0)
-                .unwrap_or(false);
-            let echo_high = self.hcsr04[i].service(trig_high, now);
+            // TRIG is no longer polled here — `maybe_arm_hcsr04` arms the window
+            // on the GPIO write (cycle-exact, see the note in `Machine::step`).
+            // The per-cycle work is two integer comparisons plus, only on a
+            // transition, one read-modify-write of the ECHO input bit.
+            let echo_high = self.hcsr04[i].echo_high_at(now);
+            if echo_high == self.hcsr04[i].last_echo_high() {
+                continue;
+            }
             let echo_addr = self.hcsr04[i].echo_idr_addr;
             let echo_bit = self.hcsr04[i].echo_bit;
             let idr = self.read_u32(echo_addr).unwrap_or(0);
@@ -567,6 +571,49 @@ impl SystemBus {
             if new_idr != idr {
                 let _ = self.write_u32(echo_addr, new_idr);
             }
+            self.hcsr04[i].set_last_echo_high(echo_high);
+        }
+    }
+
+    /// Write-hook mirror of [`maybe_latch_dc`](Self::maybe_latch_dc) for the
+    /// HC-SR04: after an MMIO write to peripheral `idx`, if that peripheral is
+    /// the GPIO hosting any sensor's TRIG line, re-read the TRIG ODR bit and run
+    /// the sensor's rising-edge/arm logic at `now = self.current_cycle`.
+    ///
+    /// Because TRIG only changes via a GPIO write, edge detection on the write is
+    /// exactly equivalent to the old per-cycle TRIG poll, and `current_cycle`
+    /// here equals the value the immediately-following `service_hcsr04` tick sees
+    /// (see `Machine::step`), so the arming is cycle-exact.
+    fn maybe_arm_hcsr04(&mut self, idx: usize) {
+        if self.hcsr04.is_empty() {
+            return;
+        }
+        let now = self.current_cycle;
+        for i in 0..self.hcsr04.len() {
+            // Resolve & cache the TRIG GPIO's peripheral index on first use.
+            let trig_idx = match self.hcsr04[i].trig_peripheral_idx() {
+                Some(t) => t,
+                None => {
+                    let trig_addr = self.hcsr04[i].trig_odr_addr;
+                    match self.find_peripheral_index(trig_addr) {
+                        Some(t) => {
+                            self.hcsr04[i].set_trig_peripheral_idx(t);
+                            t
+                        }
+                        None => continue,
+                    }
+                }
+            };
+            if trig_idx != idx {
+                continue;
+            }
+            let trig_addr = self.hcsr04[i].trig_odr_addr;
+            let trig_bit = self.hcsr04[i].trig_bit;
+            let trig_high = self
+                .read_u32(trig_addr)
+                .map(|v| (v >> trig_bit) & 1 != 0)
+                .unwrap_or(false);
+            self.hcsr04[i].observe_trig(trig_high, now);
         }
     }
 
@@ -1837,6 +1884,7 @@ impl SystemBus {
             let p = &mut self.peripherals[idx];
             p.ticks_remaining = 0;
             let r = p.dev.write_u32(addr - p.base, value);
+            self.maybe_arm_hcsr04(idx);
             #[cfg(feature = "event-scheduler")]
             self.collect_scheduled_events(idx);
             return r;
@@ -1889,6 +1937,7 @@ impl SystemBus {
             let p = &mut self.peripherals[idx];
             p.ticks_remaining = 0;
             let r = p.dev.write_u16(addr - p.base, value);
+            self.maybe_arm_hcsr04(idx);
             #[cfg(feature = "event-scheduler")]
             self.collect_scheduled_events(idx);
             return r;
@@ -2305,6 +2354,7 @@ impl crate::Bus for SystemBus {
                 self.maybe_latch_dc(idx);
                 let p = &mut self.peripherals[idx];
                 let r = p.dev.write(addr - p.base, value);
+                self.maybe_arm_hcsr04(idx);
                 #[cfg(feature = "event-scheduler")]
                 self.collect_scheduled_events(idx);
                 r
@@ -2395,6 +2445,7 @@ impl crate::Bus for SystemBus {
             let p = &mut self.peripherals[idx];
             p.ticks_remaining = 0;
             let r = p.dev.write_u16(addr - p.base, value);
+            self.maybe_arm_hcsr04(idx);
             #[cfg(feature = "event-scheduler")]
             self.collect_scheduled_events(idx);
             return r;
@@ -2434,6 +2485,7 @@ impl crate::Bus for SystemBus {
             let p = &mut self.peripherals[idx];
             p.ticks_remaining = 0;
             let r = p.dev.write_u32(addr - p.base, value);
+            self.maybe_arm_hcsr04(idx);
             #[cfg(feature = "event-scheduler")]
             self.collect_scheduled_events(idx);
             return r;

--- a/crates/core/src/peripherals/hc_sr04.rs
+++ b/crates/core/src/peripherals/hc_sr04.rs
@@ -13,11 +13,16 @@
 //!
 //! Because the sensor observes one GPIO and drives another, it can't be a plain
 //! MMIO peripheral. Instead the [`SystemBus`](crate::bus::SystemBus) holds a
-//! list of [`HcSr04`] links and, once per peripheral-tick, reads the TRIG
-//! output bit and writes the computed ECHO level back into the input register.
+//! list of [`HcSr04`] links. A TRIG **write-hook** ([`observe_trig`]) arms the
+//! echo window on the GPIO write that toggles TRIG, and a cheap per-tick pass
+//! ([`echo_high_at`]) drives the computed ECHO level back into the input
+//! register, touching the bus only when that level changes.
 //! Timing is **window-based**: a TRIG rising edge arms an echo window measured
 //! in simulated CPU cycles, so the pulse the firmware times matches real
 //! hardware in simulated time regardless of how fast the host runs.
+//!
+//! [`observe_trig`]: HcSr04::observe_trig
+//! [`echo_high_at`]: HcSr04::echo_high_at
 //!
 //! `distance_cm` is host-controlled (e.g. a "hand distance" slider in the
 //! playground), which is what makes gesture control possible.
@@ -64,6 +69,15 @@ pub struct HcSr04 {
     last_trig: bool,
     echo_start_cycle: u64,
     echo_end_cycle: u64,
+    /// Last ECHO level this sensor drove onto the input register. The per-cycle
+    /// pass only touches the bus when the computed level differs from this, so a
+    /// steady ECHO costs zero bus accesses.
+    last_echo_high: bool,
+    /// Cached peripheral index of the GPIO that hosts `trig_odr_addr`, resolved
+    /// lazily on the first TRIG write so the write-hook can tell in O(1) whether
+    /// a given peripheral write touches this sensor's TRIG line. `None` until
+    /// resolved.
+    trig_peripheral_idx: Option<usize>,
 }
 
 impl HcSr04 {
@@ -87,7 +101,30 @@ impl HcSr04 {
             last_trig: false,
             echo_start_cycle: 0,
             echo_end_cycle: 0,
+            last_echo_high: false,
+            trig_peripheral_idx: None,
         }
+    }
+
+    /// Cached peripheral index of the GPIO hosting `trig_odr_addr`, if resolved.
+    pub(crate) fn trig_peripheral_idx(&self) -> Option<usize> {
+        self.trig_peripheral_idx
+    }
+
+    /// Cache the resolved peripheral index of the TRIG GPIO (called once, lazily,
+    /// by the bus write-hook the first time this sensor's TRIG line is written).
+    pub(crate) fn set_trig_peripheral_idx(&mut self, idx: usize) {
+        self.trig_peripheral_idx = Some(idx);
+    }
+
+    /// The last ECHO level driven onto the input register.
+    pub(crate) fn last_echo_high(&self) -> bool {
+        self.last_echo_high
+    }
+
+    /// Record the ECHO level just driven onto the input register.
+    pub(crate) fn set_last_echo_high(&mut self, high: bool) {
+        self.last_echo_high = high;
     }
 
     /// Set the measured distance (the "hand position"), clamped to range.
@@ -111,6 +148,19 @@ impl HcSr04 {
     /// `[now + delay, now + delay + echo_µs]` (in cycles); ECHO reads high
     /// while `now` is inside it.
     pub fn service(&mut self, trig_high: bool, now: u64) -> bool {
+        self.observe_trig(trig_high, now);
+        self.echo_high_at(now)
+    }
+
+    /// Observe the live TRIG output level and, on a rising edge, arm the echo
+    /// window `[now + delay, now + delay + echo_µs]` (in cycles). Updates the
+    /// stored `last_trig` so the next call detects the next edge.
+    ///
+    /// This is the "arm" half of [`service`](Self::service): with TRIG only ever
+    /// changing via a GPIO write, calling this from the bus write-hook (with the
+    /// same `now` the per-cycle poll would have used — see the cycle-exactness
+    /// note in `bus::SystemBus`) is exactly equivalent to polling every cycle.
+    pub fn observe_trig(&mut self, trig_high: bool, now: u64) {
         if trig_high && !self.last_trig {
             let cpu = self.cycles_per_us();
             let delay = (TRIG_TO_ECHO_US as f64 * cpu) as u64;
@@ -119,6 +169,12 @@ impl HcSr04 {
             self.echo_end_cycle = self.echo_start_cycle + pulse.max(1);
         }
         self.last_trig = trig_high;
+    }
+
+    /// The ECHO input level for the current cycle: high while `now` is inside the
+    /// armed window `[echo_start, echo_end)`. Pure query — no state change — used
+    /// by the cheap per-cycle ECHO drive. Same `>=`/`<` rule as the legacy poll.
+    pub fn echo_high_at(&self, now: u64) -> bool {
         now >= self.echo_start_cycle && now < self.echo_end_cycle
     }
 }
@@ -140,7 +196,10 @@ mod tests {
         let pulse = (100.0 * US_PER_CM) as u64; // 5800 cycles
 
         // Rising edge at cycle 0 arms the window.
-        assert!(!s.service(true, 0), "echo not high immediately (within delay)");
+        assert!(
+            !s.service(true, 0),
+            "echo not high immediately (within delay)"
+        );
         // Still low during the trig→echo delay.
         assert!(!s.service(true, delay - 1));
         // High once the window opens, through its width.


### PR DESCRIPTION
## Summary

The HC-SR04 ultrasonic sensor was serviced **once per CPU cycle** by `SystemBus::service_hcsr04()`, doing 2-3 bus accesses every cycle (read TRIG ODR, read ECHO IDR, conditional write ECHO). On the Nokia 5110 invaders lab (which polls the sensor hard) profiling put this per-cycle servicing at ~16% of runtime.

This eliminates the per-cycle bus **reads** while staying byte-for-byte **cycle-exact**.

## What changed

**1. TRIG via write-hook.** New `maybe_arm_hcsr04(idx)` mirrors the existing `maybe_latch_dc` pattern and is invoked right after the peripheral write in every write path (`write_u32`/`write_u16`/`write_u8`, both inherent and `Bus`-trait). When the written peripheral is the GPIO hosting a sensor's TRIG line — peripheral index resolved lazily via `find_peripheral_index` and cached on `HcSr04` — it re-reads the TRIG ODR bit and runs the rising-edge/arm logic at `now = current_cycle`.

TRIG only ever changes via a GPIO write, so edge detection on the write is exactly equivalent to the old per-cycle poll. And because `bus.current_cycle` at the write equals the value the immediately-following `service_hcsr04` tick observes (see `Machine::step`), the arming is off-by-zero.

**2. Cheap per-cycle ECHO drive.** `service_hcsr04()` no longer reads TRIG or ECHO. Per sensor it computes `echo_high` (two integer comparisons over the armed window) and only read-modify-writes the ECHO IDR bit when that level differs from the last-driven level (`last_echo_high`).

`service()` is refactored into `observe_trig` (arm) + `echo_high_at` (query); the window math, clamps and `>=`/`<` edge rule are unchanged, so the legacy unit tests and `echo_driven_through_bus` pass untouched.

## Cycle-exactness (the gate)

Nokia 5110 invaders lab, `--max-steps 5000000`, event-scheduler build:

| | final_pc | total_cycles | average_ips |
|---|---|---|---|
| **before** (origin/main) | 134223934 | 5272754 | ~1.68-1.74M |
| **after** | 134223934 | 5272754 | ~2.2-2.47M |

`final_pc` and `total_cycles` are **identical** — the change is cycle-exact. Speedup ~1.4x on this lab; no off-by-one was needed (the arm uses the same `now` and the same window math).

## Tests

Full core suite green in **both** flag states (only `test_strict_board_onboarding` skipped, which is env-flaky on a clean checkout too):

- `cargo test -p labwired-core --release` — no failures
- `cargo test -p labwired-core --release --features event-scheduler` — no failures

HC-SR04-specific coverage (`hc_sr04` unit module incl. `echo_driven_through_bus`, and `hardware_fidelity.rs`) passes unchanged. `cargo fmt --check` and `cargo clippy` clean for the touched code.