### PR TITLE
fix(cpu): decode wide conditional branches (B<cond>.W, T3)

### DIFF
--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -1302,7 +1302,10 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
     }
 
     // MOVW: 1111 0 i 10 0100 imm4 0 imm3 rd imm8 -> F24..
-    if (h1 & 0xFBF0) == 0xF240 {
+    // h2[15]==0 distinguishes the plain-immediate data-processing group from the
+    // branch/misc-control group (h2[15]==1); without it a B<cond>.W (T3) whose
+    // first halfword is 0xF24x (cond=LS) is mis-decoded as MOVW and never branches.
+    if (h1 & 0xFBF0) == 0xF240 && (h2 & 0x8000) == 0 {
         let i = (h1 >> 10) & 1;
         let imm4 = h1 & 0xF;
         let imm3 = (h2 >> 12) & 7;
@@ -1313,7 +1316,8 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
     }
 
     // MOVT: 1111 0 i 10 1100 imm4 0 imm3 rd imm8 -> F2C..
-    if (h1 & 0xFBF0) == 0xF2C0 {
+    // (h2[15]==0 guard: see MOVW above — keeps B<cond>.W out of this arm.)
+    if (h1 & 0xFBF0) == 0xF2C0 && (h2 & 0x8000) == 0 {
         let i = (h1 >> 10) & 1;
         let imm4 = h1 & 0xF;
         let imm3 = (h2 >> 12) & 7;
@@ -1368,7 +1372,8 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
     // ADDW (T4 plain immediate, Rn != PC) / ADR.W (T3, Rn == PC, positive offset):
     //   1111 0 i 10 0000 nnnn 0 imm3 dddd imm8 -> F200..F20F (with i bit at 10).
     // imm12 = i:imm3:imm8, zero-extended to 32 bits — NOT ThumbExpandImm.
-    if (h1 & 0xFBF0) == 0xF200 {
+    // (h2[15]==0 guard: see MOVW above — F20x also collides with B<cond>.W, cond=HI.)
+    if (h1 & 0xFBF0) == 0xF200 && (h2 & 0x8000) == 0 {
         let i = (h1 >> 10) & 1;
         let rn = (h1 & 0xF) as u8;
         let imm3 = (h2 >> 12) & 7;
@@ -1384,7 +1389,8 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
 
     // SUBW (T4) / ADR.W (T2, Rn == PC, negative offset):
     //   1111 0 i 10 1010 nnnn 0 imm3 dddd imm8 -> F2A0..F2AF.
-    if (h1 & 0xFBF0) == 0xF2A0 {
+    // (h2[15]==0 guard: see MOVW above — keeps B<cond>.W out of this arm.)
+    if (h1 & 0xFBF0) == 0xF2A0 && (h2 & 0x8000) == 0 {
         let i = (h1 >> 10) & 1;
         let rn = (h1 & 0xF) as u8;
         let imm3 = (h2 >> 12) & 7;
@@ -1420,7 +1426,8 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
     }
 
     // SBFX / UBFX
-    if (h1 & 0xFFF0) == 0xF340 || (h1 & 0xFFF0) == 0xF3C0 {
+    // (h2[15]==0 guard: see MOVW above — F34x also collides with B<cond>.W, cond=LE.)
+    if ((h1 & 0xFFF0) == 0xF340 || (h1 & 0xFFF0) == 0xF3C0) && (h2 & 0x8000) == 0 {
         let is_unsigned = (h1 & 0x0080) != 0; // F3C0 vs F340 (0x0080 bit)
         let rn = (h1 & 0xF) as u8;
         let rd = ((h2 >> 8) & 0xF) as u8;
@@ -2055,6 +2062,45 @@ mod tests {
                 cond: 0,
                 offset: -6
             }
+        );
+    }
+
+    #[test]
+    fn test_decode_wide_cond_branch_t3() {
+        // B<cond>.W (T3, 32-bit). The first halfword shares its top bits with the
+        // plain-immediate data-processing group (MOVW/MOVT/ADDW/SUBW/SBFX), so the
+        // decoder must only pick those when h2[15]==0. With h2[15]==1 these must
+        // decode as conditional branches. Regression: BLS.W was mis-decoded as
+        // MOVW (h1=0xF240) and silently never branched — see the Nokia paddle bug.
+
+        // BLS.W +452: F240 80E2 (cond=LS=9). Real encoding from the invaders ELF.
+        assert_eq!(
+            decode_thumb_32(0xF240, 0x80E2),
+            Instruction::BranchCond {
+                cond: 0x9,
+                offset: 452
+            }
+        );
+        // BHI.W (cond=HI=8) shares h1 with ADDW (0xF200).
+        assert_eq!(
+            decode_thumb_32(0xF200, 0x8000),
+            Instruction::BranchCond {
+                cond: 0x8,
+                offset: 0
+            }
+        );
+        // BLE.W (cond=LE=D) shares h1 with SBFX (0xF340).
+        assert_eq!(
+            decode_thumb_32(0xF340, 0x8000),
+            Instruction::BranchCond {
+                cond: 0xD,
+                offset: 0
+            }
+        );
+        // The same h1 with h2[15]==0 must still decode as the data-processing op.
+        assert_eq!(
+            decode_thumb_32(0xF240, 0x0000),
+            Instruction::Movw { rd: 0, imm: 0 }
         );
     }
 

--- a/crates/core/tests/capture_nokia5110_frames.rs
+++ b/crates/core/tests/capture_nokia5110_frames.rs
@@ -146,6 +146,46 @@ fn collects_animated_frames() {
     );
 }
 
+/// The 16-px-wide player paddle (`PADDLE_W=16`, rows 45-47, bank 5) must render
+/// as one contiguous 16-wide run. Regression for the Thumb-2 decoder bug where
+/// `B<cond>.W` (T3) was mis-decoded as MOVW/ADDW/SBFX and never branched, which
+/// collapsed LLVM's fully-unrolled paddle `rect` to a single pixel.
+#[test]
+#[ignore = "slow: builds + runs the firmware in-sim (~20s)"]
+fn paddle_renders_full_width() {
+    let elf = ensure_firmware_built();
+    let mut machine = build_machine(&elf);
+    machine.bus.hcsr04[0].set_distance_cm(50.0);
+    step_frames(&mut machine, WARMUP_CYCLES);
+    // a few game-loop frames to settle the EMA-smoothed paddle position
+    for _ in 0..30 {
+        step_frames(&mut machine, CYCLES_PER_FRAME);
+    }
+    let fb = framebuffer(&machine);
+    let widest = {
+        let (mut best, mut start, mut len) = (0usize, 0usize, 0usize);
+        for x in 0..=W {
+            if x < W && fb[5 * W + x] != 0 {
+                if len == 0 {
+                    start = x;
+                }
+                len += 1;
+            } else {
+                if len > best {
+                    best = len;
+                }
+                let _ = start;
+                len = 0;
+            }
+        }
+        best
+    };
+    assert_eq!(
+        widest, 16,
+        "paddle should be one contiguous 16-px run in bank 5, got widest run {widest}"
+    );
+}
+
 fn pack(frames: &[Vec<u8>]) -> Vec<u8> {
     let mut out = Vec::with_capacity(12 + frames.len() * FRAME_BYTES);
     out.extend_from_slice(b"NK51"); // magic


### PR DESCRIPTION
## Problem

The CortexM decoder mis-decoded **32-bit conditional branches** (`B<cond>.W`, Thumb-2 T3 encoding). The plain-immediate data-processing decoders (MOVW `0xF240`, MOVT `0xF2C0`, ADDW `0xF200`, SUBW `0xF2A0`, SBFX/UBFX `0xF340`/`0xF3C0`) matched on the first halfword alone, missing the `h2[15]==0` guard that ARMv7-M uses to separate the plain-immediate group from branch/misc-control.

A `B<cond>.W` shares its first halfword with those ops for several conditions:
- `LS` → `0xF240` (= MOVW)
- `HI` → `0xF200` (= ADDW)
- `LE` → `0xF340` (= SBFX)

So the branch was decoded as a register move and **silently never branched**. The 16-bit `b<cond>.n` (T1) form was fine, so this only surfaced when the branch target was beyond ±256 B — e.g. LLVM's fully-unrolled framebuffer fills.

## Symptom

The Nokia 5110 invaders demo rendered the bricks but **not the paddle**. Its 16×3 paddle `rect` unrolls into far `bls.w`-guarded stores; only the single `bhi.n` (16-bit) column survived, so the paddle collapsed to one pixel. Confirmed bit-exact: the PCD8544 ddram matched the firmware's own RAM framebuffer — i.e. the CPU never wrote the paddle.

## Fix

Add the `&& (h2 & 0x8000) == 0` guard to all five plain-immediate checks so `B<cond>.W` reaches the existing `BranchCond` decode.

## Verification

- New decoder unit test `test_decode_wide_cond_branch_t3` (BLS.W/BHI.W/BLE.W decode as branches; MOVW with `h2[15]==0` still decodes as MOVW).
- New integration regression `capture_nokia5110_frames::paddle_renders_full_width`: paddle goes from a 1-px run to the full **16-wide** run.
- Full `labwired-core` lib suite: 553 passed.
- Browser-verified on the Nokia lab with the rebuilt wasm engine: paddle renders.

