### PR TITLE
Calibrate Nokia HC-SR04 timing

### DIFF
--- a/examples/nokia5110-invaders-lab/system.yaml
+++ b/examples/nokia5110-invaders-lab/system.yaml
@@ -22,7 +22,7 @@ external_devices:
       trig_pin: "PA8"
       echo_pin: "PB10"
       distance_cm: 30.0
-      cpu_hz: 4000000
+      cpu_hz: 250000
 board_io:
   - id: "lcd"
     kind: "spi_device"


### PR DESCRIPTION
## Summary
- calibrate the Nokia lab HC-SR04 manifest timing to the simulator instruction-step clock
- fixes the distance-tracking e2e where near/far both saturated to the same paddle position

## Verification
- `cargo test -p labwired-core --test e2e_nokia5110_invaders firmware_draws_and_ship_tracks_distance -- --ignored --nocapture`