### PR TITLE
fix(config): accept UART board IO devices

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -104,6 +104,7 @@ pub enum BoardIoKind {
     PwmOutput,
     I2cDevice,
     SpiDevice,
+    UartDevice,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -773,6 +774,24 @@ limits:
         let script: TestScript = serde_yaml::from_str(yaml).unwrap();
         let err = script.validate().unwrap_err();
         assert!(err.to_string().contains("firmware"));
+    }
+
+    #[test]
+    fn test_system_manifest_accepts_uart_device_board_io_kind() {
+        let yaml = r#"
+name: "uart-device-smoke"
+chip: "inline"
+board_io:
+  - id: "iolink_master"
+    kind: "uart_device"
+    peripheral: "uart2"
+    pin: 2
+    signal: "output"
+    active_high: true
+"#;
+
+        let manifest: SystemManifest = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(manifest.board_io[0].kind, BoardIoKind::UartDevice);
     }
 
     fn write_temp_file(prefix: &str, contents: &str) -> std::path::PathBuf {

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -938,6 +938,7 @@ fn board_io_kind_str(kind: labwired_config::BoardIoKind) -> &'static str {
         labwired_config::BoardIoKind::PwmOutput => "pwm_output",
         labwired_config::BoardIoKind::I2cDevice => "i2c_device",
         labwired_config::BoardIoKind::SpiDevice => "spi_device",
+        labwired_config::BoardIoKind::UartDevice => "uart_device",
     }
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -239,8 +239,11 @@ impl WasmSimulator {
         let register = match binding.kind {
             BoardIoKind::Led | BoardIoKind::PwmOutput => "odr",
             BoardIoKind::Button => "idr",
-            // Analog/bus kinds are not boolean — handled by get_board_io_analog_states
-            BoardIoKind::AdcInput | BoardIoKind::I2cDevice | BoardIoKind::SpiDevice => {
+            // Analog/bus kinds are not boolean and are exposed through typed state accessors.
+            BoardIoKind::AdcInput
+            | BoardIoKind::I2cDevice
+            | BoardIoKind::SpiDevice
+            | BoardIoKind::UartDevice => {
                 return false;
             }
         };


### PR DESCRIPTION
## Summary
- add uart_device to BoardIoKind
- keep UART board IO out of boolean state reads
- serialize uart_device through DAP board IO config

## Test Plan
- cargo test -p labwired-config test_system_manifest_accepts_uart_device_board_io_kind -- --nocapture
- cargo check -p labwired-wasm -p labwired-dap