### PR TITLE
Rename HC-SR04 distance wording

### DIFF
--- a/crates/core/src/peripherals/hc_sr04.rs
+++ b/crates/core/src/peripherals/hc_sr04.rs
@@ -24,7 +24,7 @@
 //! [`observe_trig`]: HcSr04::observe_trig
 //! [`echo_high_at`]: HcSr04::echo_high_at
 //!
-//! `distance_cm` is host-controlled (e.g. a "hand distance" slider in the
+//! `distance_cm` is host-controlled (e.g. a distance control in the
 //! playground), which is what makes gesture control possible.
 //!
 //! Modelled from the ElecFreaks HC-SR04 datasheet:

--- a/crates/core/tests/capture_nokia5110_frames.rs
+++ b/crates/core/tests/capture_nokia5110_frames.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Offline capture harness: runs the real nokia5110-invaders-lab firmware,
-// scripts the host-controlled HC-SR04 "hand distance" so the ship sweeps
+// scripts the host-controlled HC-SR04 distance so the ship sweeps
 // back and forth, samples the PCD8544 framebuffer on a fixed cycle cadence,
 // and writes a packed `.bin` consumed by the landing-page hero renderer.
 //
@@ -103,7 +103,7 @@ fn step_frames(machine: &mut Cm, steps: u64) {
     }
 }
 
-/// Triangle sweep of the "hand distance" across the capture window: two full
+/// Triangle sweep of the HC-SR04 distance across the capture window: two full
 /// near->far->near passes, so the ship visibly tracks back and forth.
 fn scripted_distance_cm(frame: usize, total: usize) -> f32 {
     let phase = (frame as f32) / (total as f32) * 2.0; // 0..2 (two passes)

--- a/examples/nokia5110-invaders-lab/src/main.rs
+++ b/examples/nokia5110-invaders-lab/src/main.rs
@@ -16,7 +16,7 @@
 //! HC-SR04 (5V module; ECHO needs a divider to 3V3 on real hardware):
 //!   TRIG → PA8 (output)              ECHO → PB10 (input)
 //!
-//! Hand distance → ship X: the firmware counts loop iterations while ECHO is
+//! HC-SR04 distance → ship X: the firmware counts loop iterations while ECHO is
 //! high. Because the echo pulse is a fixed number of CPU cycles (sim and HW
 //! both run 4 MHz), the count — and therefore the ship position — is identical
 //! on silicon and in the simulator.
@@ -277,7 +277,7 @@ const PADDLE_Y: i32 = (H as i32) - PADDLE_H; // bottom row
 const BALL_SZ: i32 = 2;
 
 /// Breakout: a ball smashes the brick grid; the player moves the paddle (via
-/// the HC-SR04 hand distance) to bounce it back up.
+/// the HC-SR04 distance) to bounce it back up.
 struct Game {
     bricks: [[bool; BCOLS]; BROWS],
     paddle_x: i32,
@@ -479,9 +479,9 @@ fn main() -> ! {
     }
     delay(1_000_000);
 
-    // Paddle control: HC-SR04 hand distance, smoothed (median-of-3 to drop
+    // Paddle control: HC-SR04 distance, smoothed (median-of-3 to drop
     // spikes + an exponential moving average to tame jitter). A missed echo is
-    // treated as "hand is at the nearest edge" so the valid minimum distance
+    // treated as "object is at the nearest edge" so the valid minimum distance
     // remains visible even when the polling loop misses that very short pulse.
     let center = (W as i32 - PADDLE_W) / 2;
     let mut filt: i32 = center << 3; // paddle X in 1/8-px fixed point


### PR DESCRIPTION
## Summary
- replace confusing "hand distance" wording with HC-SR04/distance terminology in demo source and comments
- no behavior change

## Verification
- rg -n "Hand distance|HC-SR04 hand distance|hand distance" . -g '*.{rs,ts,tsx}' from the app worktree now only finds the playground regression test