### PR TITLE
Map HC-SR04 max distance to paddle edge

### DIFF
--- a/crates/core/tests/e2e_nokia5110_invaders.rs
+++ b/crates/core/tests/e2e_nokia5110_invaders.rs
@@ -124,7 +124,7 @@ fn firmware_draws_and_ship_tracks_distance() {
     let elf = ensure_firmware_built();
     let mut machine = build_machine(&elf);
 
-    // Near hand → short echo → ship to the left.
+    // Near target → short echo → ship to the right edge.
     machine.bus.hcsr04[0].set_distance_cm(8.0);
     step_frames(&mut machine, 4_000_000);
     let fb_near = framebuffer(&machine);
@@ -134,15 +134,15 @@ fn firmware_draws_and_ship_tracks_distance() {
     );
     let near = ship_left(&fb_near).expect("ship visible (near)");
 
-    // Far hand → long echo → ship to the right.
+    // Far target → long echo → ship to the left edge.
     machine.bus.hcsr04[0].set_distance_cm(300.0);
     step_frames(&mut machine, 4_000_000);
     let fb_far = framebuffer(&machine);
     let far = ship_left(&fb_far).expect("ship visible (far)");
 
     assert!(
-        far > near,
-        "ship should move right as the hand moves away: near_x={near}, far_x={far}"
+        far < near,
+        "ship should move left as the target moves away: near_x={near}, far_x={far}"
     );
 }
 
@@ -160,8 +160,8 @@ fn firmware_tracks_minimum_hcsr04_distance() {
     let min = ship_left(&framebuffer(&machine)).expect("ship visible (minimum distance)");
 
     assert!(
-        min <= 8,
-        "minimum distance should visibly move the paddle left, got min_x={min}"
+        min >= 56,
+        "minimum distance should visibly move the paddle right, got min_x={min}"
     );
 
     machine.bus.hcsr04[0].set_distance_cm(200.0);
@@ -169,7 +169,7 @@ fn firmware_tracks_minimum_hcsr04_distance() {
     let far = ship_left(&framebuffer(&machine)).expect("ship visible (far distance)");
 
     assert!(
-        min < far,
-        "ship should move right as distance increases from minimum: min_x={min}, far_x={far}"
+        far <= 8,
+        "200 cm should move the paddle to the left edge: min_x={min}, far_x={far}"
     );
 }

--- a/examples/nokia5110-invaders-lab/src/main.rs
+++ b/examples/nokia5110-invaders-lab/src/main.rs
@@ -410,11 +410,11 @@ impl Game {
 fn count_to_paddle_x(count: u32) -> i32 {
     let span = (W as i32 - PADDLE_W).max(1);
     // The polling loop has a fixed overhead before it starts counting ECHO high
-    // time, so the HC-SR04's valid minimum distance lands around the centered
-    // startup position if the raw count is used directly. Subtract that floor
-    // and scale the remaining pulse width across the playable range.
+    // time. Subtract that floor, scale the remaining pulse width across the
+    // playable range, and invert the result so the demo's maximum distance
+    // reaches the left edge.
     let raw = (count / 16) as i32;
-    let v = (raw - span / 2) * 2;
+    let v = span - (((raw - span / 2) * 13) / 4);
     v.clamp(0, span)
 }
 


### PR DESCRIPTION
## Summary
- invert and rescale the Nokia 5110 demo distance mapping so 200 cm reaches the left edge
- update the slow firmware e2e expectations to cover both distance extremes

## Verification
- RED before fix: cargo test -p labwired-core --test e2e_nokia5110_invaders firmware_tracks_minimum_hcsr04_distance -- --ignored --nocapture failed with min_x=1 under the new edge expectation
- GREEN after fix: same command passed, 1 test passed, finished in 171.04s
- cargo test -p labwired-core peripherals::hc_sr04, 5 tests passed