### PR TITLE
Migrate 11 peripherals to PeripheralKit

### DIFF
--- a/crates/cli/src/bin/gen_peripherals_manifest.rs
+++ b/crates/cli/src/bin/gen_peripherals_manifest.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     }
 
     let manifest = Manifest {
-        schema_version: 1,
+        schema_version: 2,
         peripherals: registry::kits().iter().map(|k| k.metadata()).collect(),
     };
     let json = serde_json::to_string_pretty(&manifest)?;

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -12,9 +12,7 @@ use crate::peripherals::uart::Uart;
 use crate::peripherals::uart::UartRegisterLayout;
 use crate::{Bus, DmaRequest, Peripheral, SimResult, SimulationError};
 use anyhow::Context;
-use labwired_config::{
-    parse_size, ChipDescriptor, ExternalDevice, PeripheralConfig, SystemManifest,
-};
+use labwired_config::{parse_size, ChipDescriptor, PeripheralConfig, SystemManifest};
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
@@ -365,174 +363,6 @@ impl SystemBus {
         }
     }
 
-    fn adxl345_i2c_address(ext: &ExternalDevice) -> anyhow::Result<u8> {
-        let Some(value) = ext.config.get("i2c_address") else {
-            return Ok(0x53);
-        };
-
-        let Some(address) = value.as_u64() else {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has invalid i2c_address '{}'",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                serde_yaml::to_string(value)
-                    .unwrap_or_else(|_| "<unprintable>".to_string())
-                    .trim()
-            ));
-        };
-
-        if address > 0x7f {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has out-of-range 7-bit i2c_address 0x{:x}",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                address
-            ));
-        }
-
-        Ok(address as u8)
-    }
-
-    fn mpu6050_i2c_address(ext: &ExternalDevice) -> anyhow::Result<u8> {
-        let Some(value) = ext.config.get("i2c_address") else {
-            return Ok(0x68);
-        };
-
-        let Some(address) = value.as_u64() else {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has invalid i2c_address '{}'",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                serde_yaml::to_string(value)
-                    .unwrap_or_else(|_| "<unprintable>".to_string())
-                    .trim()
-            ));
-        };
-
-        if address > 0x7f {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has out-of-range 7-bit i2c_address 0x{:x}",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                address
-            ));
-        }
-
-        Ok(address as u8)
-    }
-
-    fn bme280_i2c_address(ext: &ExternalDevice) -> anyhow::Result<u8> {
-        let Some(value) = ext.config.get("i2c_address") else {
-            return Ok(0x76);
-        };
-
-        let Some(address) = value.as_u64() else {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has invalid i2c_address '{}'",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                serde_yaml::to_string(value)
-                    .unwrap_or_else(|_| "<unprintable>".to_string())
-                    .trim()
-            ));
-        };
-
-        if address > 0x7f {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has out-of-range 7-bit i2c_address 0x{:x}",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                address
-            ));
-        }
-
-        Ok(address as u8)
-    }
-
-    fn max31855_cs_pin(ext: &ExternalDevice) -> String {
-        ext.config
-            .get("cs_pin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("PA4")
-            .to_string()
-    }
-
-    fn sn74hc165_cs_pin(ext: &ExternalDevice) -> String {
-        ext.config
-            .get("cs_pin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("PA4")
-            .to_string()
-    }
-
-    fn iolink_master_config(
-        ext: &ExternalDevice,
-    ) -> (usize, usize, crate::peripherals::components::IolinkComSpeed) {
-        use crate::peripherals::components::IolinkComSpeed;
-        let pd_in_len = ext
-            .config
-            .get("pd_in_len")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1) as usize;
-        let m_seq_type = ext
-            .config
-            .get("m_seq_type")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1);
-        let od_len = if m_seq_type >= 4 { 2 } else { 1 };
-        let com = match ext
-            .config
-            .get("com")
-            .and_then(|v| v.as_str())
-            .unwrap_or("COM2")
-            .to_ascii_uppercase()
-            .as_str()
-        {
-            "COM1" => IolinkComSpeed::Com1,
-            "COM3" => IolinkComSpeed::Com3,
-            _ => IolinkComSpeed::Com2,
-        };
-        (pd_in_len, od_len, com)
-    }
-
-    fn ili9341_cs_pin(ext: &ExternalDevice) -> String {
-        ext.config
-            .get("cs_pin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("PA4")
-            .to_string()
-    }
-
-    fn ssd1680_cs_pin(ext: &ExternalDevice) -> String {
-        ext.config
-            .get("cs_pin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("PA4")
-            .to_string()
-    }
-
-    fn pcd8544_cs_pin(ext: &ExternalDevice) -> String {
-        ext.config
-            .get("cs_pin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("PB6")
-            .to_string()
-    }
-
-    fn pcd8544_dc_pin(ext: &ExternalDevice) -> String {
-        ext.config
-            .get("dc_pin")
-            .and_then(|v| v.as_str())
-            .unwrap_or("PC7")
-            .to_string()
-    }
-
     /// Parse an STM32 pin label like "PC7" into `("gpioc", 7)`.
     fn parse_stm32_pin(pin: &str) -> Option<(String, u8)> {
         let s = pin.trim();
@@ -553,6 +383,12 @@ impl SystemBus {
 
     /// Resolve an STM32 pin label to its `(ODR address, bit)` so a display's
     /// D/C line can be sampled directly from the driving GPIO's output register.
+    /// Public wrapper exposed via [`AttachCtx::resolve_pin_odr`] so kits can
+    /// hook MCU GPIO outputs into a SPI device's D/C line.
+    pub fn resolve_pin_odr_pub(bus: &SystemBus, pin: &str) -> Option<(u64, u8)> {
+        Self::resolve_pin_odr(bus, pin)
+    }
+
     fn resolve_pin_odr(bus: &SystemBus, pin: &str) -> Option<(u64, u8)> {
         let (port_name, bit) = Self::parse_stm32_pin(pin)?;
         let idx = bus.find_peripheral_index_by_name(&port_name)?;
@@ -697,36 +533,6 @@ impl SystemBus {
                 }
             }
         }
-    }
-
-    fn ssd1306_i2c_address(ext: &ExternalDevice) -> anyhow::Result<u8> {
-        let Some(value) = ext.config.get("i2c_address") else {
-            return Ok(0x3C);
-        };
-
-        let Some(address) = value.as_u64() else {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has invalid i2c_address '{}'",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                serde_yaml::to_string(value)
-                    .unwrap_or_else(|_| "<unprintable>".to_string())
-                    .trim()
-            ));
-        };
-
-        if address > 0x7f {
-            return Err(anyhow::anyhow!(
-                "External device '{}' type '{}' on connection '{}' has out-of-range 7-bit i2c_address 0x{:x}",
-                ext.id,
-                ext.r#type,
-                ext.connection,
-                address
-            ));
-        }
-
-        Ok(address as u8)
     }
 
     fn is_peripheral_addr(p: &PeripheralEntry, addr: u64) -> bool {
@@ -1485,301 +1291,12 @@ impl SystemBus {
                 continue;
             }
             match ext.r#type.as_str() {
-                "ili9341" => {
-                    // SPI device path
-                    let cs_pin = Self::ili9341_cs_pin(ext);
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let spi = any
-                        .downcast_mut::<crate::peripherals::spi::Spi>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an SPI peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    spi.attach(Box::new(crate::peripherals::components::Ili9341::new(
-                        cs_pin,
-                    )));
-                }
-                "adxl345" | "mpu6050" | "bme280" | "oled-ssd1306" => {
-                    // I2C device path
-                    let address = match ext.r#type.as_str() {
-                        "mpu6050" => Self::mpu6050_i2c_address(ext)?,
-                        "bme280" => Self::bme280_i2c_address(ext)?,
-                        "oled-ssd1306" => Self::ssd1306_i2c_address(ext)?,
-                        _ => Self::adxl345_i2c_address(ext)?,
-                    };
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let i2c = any
-                        .downcast_mut::<crate::peripherals::i2c::I2c>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an I2C peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    match ext.r#type.as_str() {
-                        "mpu6050" => i2c.attach(Box::new(
-                            crate::peripherals::components::Mpu6050::new(address),
-                        )),
-                        "bme280" => i2c.attach(Box::new(
-                            crate::peripherals::components::Bme280::new(address),
-                        )),
-                        "oled-ssd1306" => i2c.attach(Box::new(
-                            crate::peripherals::components::Ssd1306::new(address),
-                        )),
-                        _ => i2c.attach(Box::new(crate::peripherals::components::Adxl345::new(
-                            address,
-                        ))),
-                    }
-                }
-                // neo6m-gps and bg770a-cellular dispatch through the
-                // PeripheralKit registry above — see `peripherals::kit`.
-                "iolink-master" => {
-                    // UART stream device path
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let uart = any
-                        .downcast_mut::<crate::peripherals::uart::Uart>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not a UART peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let (pd_in_len, od_len, com) = Self::iolink_master_config(ext);
-                    uart.attach_stream(Box::new(
-                        crate::peripherals::components::IolinkMaster::new(pd_in_len, od_len, com),
-                    ));
-                }
-                "max31855" => {
-                    // SPI device path
-                    let cs_pin = Self::max31855_cs_pin(ext);
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let spi = any
-                        .downcast_mut::<crate::peripherals::spi::Spi>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an SPI peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    spi.attach(Box::new(crate::peripherals::components::Max31855::new(
-                        cs_pin,
-                    )));
-                }
-                "sn74hc165" => {
-                    // SPI device path
-                    let cs_pin = Self::sn74hc165_cs_pin(ext);
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let spi = any
-                        .downcast_mut::<crate::peripherals::spi::Spi>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an SPI peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let mut shifter = crate::peripherals::components::Sn74hc165::new(cs_pin);
-                    // Optional preset of the 8 input channels (test/demo stimulus
-                    // before the UI can toggle them live).
-                    if let Some(v) = ext.config.get("inputs").and_then(|v| v.as_u64()) {
-                        shifter.set_inputs(v as u8);
-                    }
-                    spi.attach(Box::new(shifter));
-                }
-                "ssd1680_tricolor_290" | "epd-2in9-tricolor" => {
-                    // SPI device path — Waveshare 2.9" tri-color e-paper.
-                    let cs_pin = Self::ssd1680_cs_pin(ext);
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let spi = any
-                        .downcast_mut::<crate::peripherals::spi::Spi>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an SPI peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    spi.attach(Box::new(
-                        crate::peripherals::components::Ssd1680Tricolor290::new(cs_pin),
-                    ));
-                }
-                "pcd8544" | "nokia-5110" => {
-                    // SPI device path — Nokia 5110 (PCD8544) monochrome LCD.
-                    // Distinguishes command vs data by a D/C GPIO line, which
-                    // we resolve to a concrete ODR address up front.
-                    let cs_pin = Self::pcd8544_cs_pin(ext);
-                    let dc_pin = Self::pcd8544_dc_pin(ext);
-                    let dc_src = Self::resolve_pin_odr(&bus, &dc_pin);
-
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let spi = any
-                        .downcast_mut::<crate::peripherals::spi::Spi>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an SPI peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let mut dev = crate::peripherals::components::Pcd8544::new(cs_pin, dc_pin);
-                    if let Some((odr_addr, bit)) = dc_src {
-                        crate::peripherals::spi::SpiDevice::set_dc_source(&mut dev, odr_addr, bit);
-                    }
-                    spi.attach(Box::new(dev));
-                }
+                // ili9341, adxl345/mpu6050/bme280/oled-ssd1306, neo6m-gps,
+                // and bg770a-cellular dispatch through the PeripheralKit
+                // registry above — see `peripherals::kit`.
+                // iolink-master dispatches through the PeripheralKit registry above.
+                // max31855, sn74hc165, ssd1680_tricolor_290, and pcd8544
+                // dispatch through the PeripheralKit registry above.
                 "hc-sr04" | "hcsr04" => {
                     // GPIO-wired ultrasonic sensor — no SPI/I2C connection. The
                     // bus services it each tick: reads TRIG (an MCU output) and
@@ -1835,57 +1352,7 @@ impl SystemBus {
                         distance_cm,
                     ));
                 }
-                "ntc-thermistor" => {
-                    // Analog source path: NTC connects directly to an ADC channel.
-                    // Read channel + initial temperature from config.
-                    let channel = ext
-                        .config
-                        .get("channel")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as u8;
-                    let initial_temp_c = ext
-                        .config
-                        .get("initial_temperature_c")
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(25.0) as f32;
-
-                    // Find the ADC peripheral by the connection name.
-                    let idx = bus
-                        .find_peripheral_index_by_name(&ext.connection)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' references missing connection '{}'",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' type '{}' connection '{}' cannot be downcast",
-                            ext.id,
-                            ext.r#type,
-                            ext.connection
-                        )
-                    })?;
-
-                    let adc = any
-                        .downcast_mut::<crate::peripherals::adc::Adc>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "External device '{}' type '{}' connection '{}' is not an ADC peripheral",
-                                ext.id,
-                                ext.r#type,
-                                ext.connection
-                            )
-                        })?;
-
-                    // Seed the ADC channel with the initial temperature's voltage.
-                    let ntc =
-                        crate::peripherals::components::NtcThermistor::new(channel, initial_temp_c);
-                    adc.set_channel_input(channel, ntc.divider_output_mv());
-                }
+                // ntc-thermistor dispatches through the PeripheralKit registry above.
                 _ => {
                     tracing::warn!(
                         "Unsupported external device '{}' type '{}' on connection '{}'; skipping",
@@ -2398,6 +1865,9 @@ impl crate::Bus for SystemBus {
             return p.dev.read(addr - p.base);
         }
 
+        if std::env::var("LABWIRED_TRACE_VIOLATIONS").is_ok() {
+            eprintln!("BUS_VIOLATION read_u8 addr=0x{:08X}", addr);
+        }
         Err(SimulationError::MemoryViolation(addr))
     }
 
@@ -2444,6 +1914,12 @@ impl crate::Bus for SystemBus {
                 self.collect_scheduled_events(idx);
                 r
             } else {
+                if std::env::var("LABWIRED_TRACE_VIOLATIONS").is_ok() {
+                    eprintln!(
+                        "BUS_VIOLATION write_u8 addr=0x{:08X} val=0x{:02X}",
+                        addr, value
+                    );
+                }
                 Err(SimulationError::MemoryViolation(addr))
             }
         };

--- a/crates/core/src/peripherals/components/adxl345.rs
+++ b/crates/core/src/peripherals/components/adxl345.rs
@@ -110,3 +110,46 @@ impl I2cDevice for Adxl345 {
         Some(self)
     }
 }
+
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Adxl345Kit;
+pub static ADXL345_KIT: Adxl345Kit = Adxl345Kit;
+
+static ADXL345_METADATA: KitMetadata = KitMetadata {
+    device_type: "adxl345",
+    label: "ADXL345 Tilt",
+    summary: "3-axis ±2/4/8/16 g digital accelerometer over I2C.",
+    detail: "Analog Devices ADXL345 with the canonical 0x53 / 0x1D 7-bit address pair. \
+             Wired through the simulated I2C bus; host stimulus seeds X/Y/Z and the firmware \
+             reads them through the DATAX/Y/Z registers.",
+    transport: Transport::I2c,
+    category: Category::I2c,
+    config_keys: &[ConfigKey {
+        name: "i2c_address",
+        ty: ConfigType::Int,
+        doc: "7-bit slave address. Defaults to 0x53; 0x1D selects the alternate-pin variant.",
+    }],
+    labs: &[LabRef {
+        board_id: "adxl345-sensor-lab",
+        chip: "stm32f103",
+        example_dir: "adxl345-sensor-lab",
+        demo_elf: "demo-adxl345-sensor-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Adxl345Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &ADXL345_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let address = ctx.i2c_address_or(0x53)?;
+        let i2c = ctx.i2c()?;
+        i2c.attach(Box::new(Adxl345::new(address)));
+        Ok(())
+    }
+}

--- a/crates/core/src/peripherals/components/bg770a.rs
+++ b/crates/core/src/peripherals/components/bg770a.rs
@@ -2583,12 +2583,12 @@ static BG770A_METADATA: KitMetadata = KitMetadata {
             doc: "If true, the modem reports itself already registered + attached at boot.",
         },
     ],
-    lab: Some(LabRef {
+    labs: &[LabRef {
         board_id: "quectel-bg770a-lab",
         chip: "stm32f103",
         example_dir: "quectel-bg770a-lab",
         demo_elf: "demo-quectel-bg770a-lab.elf",
-    }),
+    }],
 };
 
 impl PeripheralKit for QuectelBg770aKit {

--- a/crates/core/src/peripherals/components/bme280.rs
+++ b/crates/core/src/peripherals/components/bme280.rs
@@ -153,3 +153,45 @@ impl I2cDevice for Bme280 {
         Some(self)
     }
 }
+
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Bme280Kit;
+pub static BME280_KIT: Bme280Kit = Bme280Kit;
+
+static BME280_METADATA: KitMetadata = KitMetadata {
+    device_type: "bme280",
+    label: "BME280 Weather",
+    summary: "Bosch BME280 temp + humidity + pressure sensor over I2C.",
+    detail: "Returns the same factory dummy readings the real silicon ships with (≈25 °C, \
+             50 % RH, sea-level pressure). Real-time stimulus comes from the WASM bridge.",
+    transport: Transport::I2c,
+    category: Category::I2c,
+    config_keys: &[ConfigKey {
+        name: "i2c_address",
+        ty: ConfigType::Int,
+        doc: "7-bit slave address. Defaults to 0x76; 0x77 selects the SDO=VDDIO variant.",
+    }],
+    labs: &[LabRef {
+        board_id: "bme280-weather-lab",
+        chip: "stm32f103",
+        example_dir: "bme280-weather-lab",
+        demo_elf: "demo-bme280-weather-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Bme280Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &BME280_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let address = ctx.i2c_address_or(0x76)?;
+        let i2c = ctx.i2c()?;
+        i2c.attach(Box::new(Bme280::new(address)));
+        Ok(())
+    }
+}

--- a/crates/core/src/peripherals/components/ili9341.rs
+++ b/crates/core/src/peripherals/components/ili9341.rs
@@ -328,6 +328,49 @@ impl SpiDevice for Ili9341 {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Ili9341Kit;
+pub static ILI9341_KIT: Ili9341Kit = Ili9341Kit;
+
+static ILI9341_METADATA: KitMetadata = KitMetadata {
+    device_type: "ili9341",
+    label: "ILI9341 TFT",
+    summary: "240×320 RGB565 SPI TFT display.",
+    detail: "Implements the cmd / RAMWR SPI protocol against an in-memory framebuffer. \
+             The playground surfaces pixels through the simulator bridge so the host can render \
+             the display verbatim.",
+    transport: Transport::Spi,
+    category: Category::Spi,
+    config_keys: &[ConfigKey {
+        name: "cs_pin",
+        ty: ConfigType::Str,
+        doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
+    }],
+    labs: &[LabRef {
+        board_id: "ili9341-tft-lab",
+        chip: "stm32f103",
+        example_dir: "ili9341-tft-lab",
+        demo_elf: "demo-ili9341-tft-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Ili9341Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &ILI9341_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
+        let spi = ctx.spi()?;
+        spi.attach(Box::new(Ili9341::new(cs_pin)));
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/iolink_master.rs
+++ b/crates/core/src/peripherals/components/iolink_master.rs
@@ -350,6 +350,72 @@ impl UartStreamDevice for IolinkMaster {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct IolinkMasterKit;
+pub static IOLINK_MASTER_KIT: IolinkMasterKit = IolinkMasterKit;
+
+static IOLINK_MASTER_METADATA: KitMetadata = KitMetadata {
+    device_type: "iolink-master",
+    label: "IO-Link Master",
+    summary: "IO-Link master state machine over UART.",
+    detail: "Drives wake-up / startup / operate cycles, m-sequence types, process-data \
+             exchange. The AL2205 DI device demo uses this to host two digital-input channels.",
+    transport: Transport::Uart,
+    category: Category::Uart,
+    config_keys: &[
+        ConfigKey {
+            name: "pd_in_len",
+            ty: ConfigType::Int,
+            doc: "Process-data input length in bytes. Defaults to 1 (single-byte DI device).",
+        },
+        ConfigKey {
+            name: "m_seq_type",
+            ty: ConfigType::Int,
+            doc: "M-sequence type (1..6). Used to derive od_len: types ≥ 4 use 2-byte OD frames.",
+        },
+        ConfigKey {
+            name: "com",
+            ty: ConfigType::Str,
+            doc: "Communication speed: \"COM1\" (4.8 kbaud), \"COM2\" (38.4 kbaud, default), or \"COM3\" (230.4 kbaud).",
+        },
+    ],
+    labs: &[LabRef {
+        board_id: "al2205-iolink-dido",
+        chip: "stm32l476",
+        example_dir: "al2205-iolink-dido",
+        demo_elf: "demo-al2205-iolink-dido.elf",
+    }],
+};
+
+impl PeripheralKit for IolinkMasterKit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &IOLINK_MASTER_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let pd_in_len = ctx.config_i64("pd_in_len").unwrap_or(1) as usize;
+        let m_seq_type = ctx.config_i64("m_seq_type").unwrap_or(1);
+        let od_len: usize = if m_seq_type >= 4 { 2 } else { 1 };
+        let com = match ctx
+            .config_str("com")
+            .unwrap_or("COM2")
+            .to_ascii_uppercase()
+            .as_str()
+        {
+            "COM1" => IolinkComSpeed::Com1,
+            "COM3" => IolinkComSpeed::Com3,
+            _ => IolinkComSpeed::Com2,
+        };
+        let uart = ctx.uart()?;
+        uart.attach_stream(Box::new(IolinkMaster::new(pd_in_len, od_len, com)));
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/max31855.rs
+++ b/crates/core/src/peripherals/components/max31855.rs
@@ -107,6 +107,49 @@ impl SpiDevice for Max31855 {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Max31855Kit;
+pub static MAX31855_KIT: Max31855Kit = Max31855Kit;
+
+static MAX31855_METADATA: KitMetadata = KitMetadata {
+    device_type: "max31855",
+    label: "MAX31855 Thermocouple",
+    summary: "Cold-junction-compensated K-type thermocouple amplifier (read-only SPI).",
+    detail: "Returns the 32-bit MAX31855 response on every CS-framed transaction. Host \
+             stimulus seeds thermocouple + cold-junction temperatures; bit layout matches the \
+             real silicon's datasheet exactly.",
+    transport: Transport::Spi,
+    category: Category::Spi,
+    config_keys: &[ConfigKey {
+        name: "cs_pin",
+        ty: ConfigType::Str,
+        doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
+    }],
+    labs: &[LabRef {
+        board_id: "max31855-thermocouple-lab",
+        chip: "stm32f103",
+        example_dir: "max31855-thermocouple-lab",
+        demo_elf: "demo-max31855-thermocouple-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Max31855Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &MAX31855_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
+        let spi = ctx.spi()?;
+        spi.attach(Box::new(Max31855::new(cs_pin)));
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Max31855;

--- a/crates/core/src/peripherals/components/mpu6050.rs
+++ b/crates/core/src/peripherals/components/mpu6050.rs
@@ -145,3 +145,45 @@ impl I2cDevice for Mpu6050 {
         Some(self)
     }
 }
+
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Mpu6050Kit;
+pub static MPU6050_KIT: Mpu6050Kit = Mpu6050Kit;
+
+static MPU6050_METADATA: KitMetadata = KitMetadata {
+    device_type: "mpu6050",
+    label: "MPU6050 IMU",
+    summary: "6-axis gyro + accelerometer over I2C.",
+    detail: "InvenSense MPU-6050 with WHO_AM_I = 0x68. Reports static sample values today; \
+             host stimulus hooks into the WASM bridge for live updates.",
+    transport: Transport::I2c,
+    category: Category::I2c,
+    config_keys: &[ConfigKey {
+        name: "i2c_address",
+        ty: ConfigType::Int,
+        doc: "7-bit slave address. Defaults to 0x68; 0x69 selects the AD0=high variant.",
+    }],
+    labs: &[LabRef {
+        board_id: "mpu6050-sensor-lab",
+        chip: "stm32f103",
+        example_dir: "mpu6050-sensor-lab",
+        demo_elf: "demo-mpu6050-sensor-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Mpu6050Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &MPU6050_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let address = ctx.i2c_address_or(0x68)?;
+        let i2c = ctx.i2c()?;
+        i2c.attach(Box::new(Mpu6050::new(address)));
+        Ok(())
+    }
+}

--- a/crates/core/src/peripherals/components/neo6m.rs
+++ b/crates/core/src/peripherals/components/neo6m.rs
@@ -194,12 +194,12 @@ static NEO6M_METADATA: KitMetadata = KitMetadata {
             doc: "Initial longitude in decimal degrees (paired with lat_deg).",
         },
     ],
-    lab: Some(LabRef {
+    labs: &[LabRef {
         board_id: "neo6m-gps-lab",
         chip: "stm32f103",
         example_dir: "neo6m-gps-lab",
         demo_elf: "demo-neo6m-gps-lab.elf",
-    }),
+    }],
 };
 
 impl PeripheralKit for Neo6mGpsKit {

--- a/crates/core/src/peripherals/components/ntc_thermistor.rs
+++ b/crates/core/src/peripherals/components/ntc_thermistor.rs
@@ -90,6 +90,61 @@ impl NtcThermistor {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct NtcThermistorKit;
+pub static NTC_THERMISTOR_KIT: NtcThermistorKit = NtcThermistorKit;
+
+static NTC_THERMISTOR_METADATA: KitMetadata = KitMetadata {
+    device_type: "ntc-thermistor",
+    label: "NTC Thermistor",
+    summary: "10 kΩ NTC + voltage divider on an ADC channel.",
+    detail: "Beta-equation thermistor model. Constructor takes a channel + initial temperature; \
+             the kit seeds the ADC channel with the corresponding divider voltage. Live updates \
+             come from the WASM bridge as the host moves the temperature slider.",
+    transport: Transport::Analog,
+    category: Category::Analog,
+    config_keys: &[
+        ConfigKey {
+            name: "channel",
+            ty: ConfigType::Int,
+            doc: "ADC channel index (0..N). Defaults to 0.",
+        },
+        ConfigKey {
+            name: "initial_temperature_c",
+            ty: ConfigType::Float,
+            doc: "Initial temperature in °C used to seed the channel voltage. Defaults to 25.0.",
+        },
+    ],
+    labs: &[LabRef {
+        board_id: "ntc-thermistor-lab",
+        chip: "stm32f103",
+        example_dir: "ntc-thermistor-lab",
+        demo_elf: "demo-ntc-thermistor-lab.elf",
+    }],
+};
+
+impl PeripheralKit for NtcThermistorKit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &NTC_THERMISTOR_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let channel = ctx.config_i64("channel").unwrap_or(0).clamp(0, 255) as u8;
+        let initial_temp_c = ctx.config_f64("initial_temperature_c").unwrap_or(25.0) as f32;
+        // Compute the divider voltage up front; the NtcThermistor instance
+        // itself is not stored — the bus seeds the ADC channel once and the
+        // wasm bridge mutates that channel directly on host stimulus.
+        let mv = NtcThermistor::new(channel, initial_temp_c).divider_output_mv();
+        let adc = ctx.adc()?;
+        adc.set_channel_input(channel, mv);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -216,6 +216,62 @@ impl SpiDevice for Pcd8544 {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Pcd8544Kit;
+pub static PCD8544_KIT: Pcd8544Kit = Pcd8544Kit;
+
+static PCD8544_METADATA: KitMetadata = KitMetadata {
+    device_type: "pcd8544",
+    label: "Nokia 5110 LCD",
+    summary: "Nokia 5110 (PCD8544) monochrome 84×48 LCD over SPI.",
+    detail: "Tracks the 504-byte (84×48 / 8) DDRAM, command vs data discrimination via a host \
+             GPIO D/C line that the bus resolves to a concrete GPIO ODR address at attach time.",
+    transport: Transport::Spi,
+    category: Category::Spi,
+    config_keys: &[
+        ConfigKey {
+            name: "cs_pin",
+            ty: ConfigType::Str,
+            doc: "Chip-select GPIO pin (e.g. \"PB6\"). Defaults to PB6.",
+        },
+        ConfigKey {
+            name: "dc_pin",
+            ty: ConfigType::Str,
+            doc: "Data/command GPIO pin (e.g. \"PC7\"). Defaults to PC7. \
+                  Resolved to the driving GPIO's ODR address at attach time.",
+        },
+    ],
+    labs: &[LabRef {
+        board_id: "nokia5110-invaders-lab",
+        chip: "stm32l476",
+        example_dir: "nokia5110-invaders-lab",
+        demo_elf: "demo-nokia5110-invaders-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Pcd8544Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &PCD8544_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let cs_pin = ctx.config_str("cs_pin").unwrap_or("PB6").to_string();
+        let dc_pin = ctx.config_str("dc_pin").unwrap_or("PC7").to_string();
+        let dc_src = ctx.resolve_pin_odr(&dc_pin);
+        let spi = ctx.spi()?;
+        let mut dev = Pcd8544::new(cs_pin, dc_pin);
+        if let Some((odr_addr, bit)) = dc_src {
+            crate::peripherals::spi::SpiDevice::set_dc_source(&mut dev, odr_addr, bit);
+        }
+        spi.attach(Box::new(dev));
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/sn74hc165.rs
+++ b/crates/core/src/peripherals/components/sn74hc165.rs
@@ -83,6 +83,60 @@ impl SpiDevice for Sn74hc165 {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Sn74hc165Kit;
+pub static SN74HC165_KIT: Sn74hc165Kit = Sn74hc165Kit;
+
+static SN74HC165_METADATA: KitMetadata = KitMetadata {
+    device_type: "sn74hc165",
+    label: "74HC165 Shift Register",
+    summary: "8-bit parallel-in / serial-out shift register over SPI.",
+    detail: "Lets a host MCU sample 8 GPIO inputs through one SPI clock burst. Used in the \
+             AL2205 IO-Link DI lab to surface field-side switch state.",
+    transport: Transport::Spi,
+    category: Category::Spi,
+    config_keys: &[
+        ConfigKey {
+            name: "cs_pin",
+            ty: ConfigType::Str,
+            doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
+        },
+        ConfigKey {
+            name: "inputs",
+            ty: ConfigType::Int,
+            doc: "Optional initial 8-bit input state (0..0xFF) — useful for static test stimulus.",
+        },
+    ],
+    labs: &[LabRef {
+        board_id: "al2205-iolink-dido",
+        chip: "stm32l476",
+        example_dir: "al2205-iolink-dido",
+        demo_elf: "demo-al2205-iolink-dido.elf",
+    }],
+};
+
+impl PeripheralKit for Sn74hc165Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &SN74HC165_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
+        let inputs = ctx.config_i64("inputs");
+        let spi = ctx.spi()?;
+        let mut shifter = Sn74hc165::new(cs_pin);
+        if let Some(v) = inputs {
+            shifter.set_inputs(v as u8);
+        }
+        spi.attach(Box::new(shifter));
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/ssd1306.rs
+++ b/crates/core/src/peripherals/components/ssd1306.rs
@@ -225,3 +225,46 @@ impl I2cDevice for Ssd1306 {
         Some(self)
     }
 }
+
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Ssd1306Kit;
+pub static SSD1306_KIT: Ssd1306Kit = Ssd1306Kit;
+
+static SSD1306_METADATA: KitMetadata = KitMetadata {
+    device_type: "oled-ssd1306",
+    label: "SSD1306 OLED",
+    summary: "128×64 monochrome OLED display over I2C with a paged framebuffer.",
+    detail: "Solomon Systech SSD1306 with the canonical 0x3C / 0x3D address pair. Tracks the \
+             8-page-by-128-column framebuffer; the WASM bridge surfaces pixel state for the \
+             playground's display overlay.",
+    transport: Transport::I2c,
+    category: Category::I2c,
+    config_keys: &[ConfigKey {
+        name: "i2c_address",
+        ty: ConfigType::Int,
+        doc: "7-bit slave address. Defaults to 0x3C; 0x3D selects the SA0=high variant.",
+    }],
+    labs: &[LabRef {
+        board_id: "ssd1306-hello-lab",
+        chip: "stm32f103",
+        example_dir: "ssd1306-hello-lab",
+        demo_elf: "demo-ssd1306-hello-lab.elf",
+    }],
+};
+
+impl PeripheralKit for Ssd1306Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &SSD1306_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let address = ctx.i2c_address_or(0x3C)?;
+        let i2c = ctx.i2c()?;
+        i2c.attach(Box::new(Ssd1306::new(address)));
+        Ok(())
+    }
+}

--- a/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
@@ -443,6 +443,57 @@ impl SpiDevice for Ssd1680Tricolor290 {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+};
+
+pub struct Ssd1680Tricolor290Kit;
+pub static SSD1680_TRICOLOR_290_KIT: Ssd1680Tricolor290Kit = Ssd1680Tricolor290Kit;
+
+static SSD1680_TRICOLOR_290_METADATA: KitMetadata = KitMetadata {
+    device_type: "ssd1680_tricolor_290",
+    label: "SSD1680 Tri-Color E-Paper",
+    summary: "2.9\" tri-color (black/white/red) SSD1680 e-paper over SPI.",
+    detail: "Full SPI command + display-data RAM state machine, validated by the e2e e-paper \
+             integration test. Same model drives both the STM32F103 lab and the ESP32 \
+             playground board.",
+    transport: Transport::Spi,
+    category: Category::Spi,
+    config_keys: &[ConfigKey {
+        name: "cs_pin",
+        ty: ConfigType::Str,
+        doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
+    }],
+    labs: &[
+        LabRef {
+            board_id: "epaper-tricolor-lab",
+            chip: "stm32f103",
+            example_dir: "epaper-tricolor-lab",
+            demo_elf: "demo-epaper-tricolor-lab.elf",
+        },
+        LabRef {
+            board_id: "esp32-epaper-lab",
+            chip: "esp32",
+            example_dir: "esp32-epaper-lab",
+            demo_elf: "demo-esp32-epaper-lab.elf",
+        },
+    ],
+};
+
+impl PeripheralKit for Ssd1680Tricolor290Kit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &SSD1680_TRICOLOR_290_METADATA
+    }
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
+        let spi = ctx.spi()?;
+        spi.attach(Box::new(Ssd1680Tricolor290::new(cs_pin)));
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/kit/ctx.rs
+++ b/crates/core/src/peripherals/kit/ctx.rs
@@ -16,6 +16,7 @@ use anyhow::{anyhow, Result};
 use labwired_config::ExternalDevice;
 
 use crate::bus::SystemBus;
+use crate::peripherals::adc::Adc;
 use crate::peripherals::i2c::I2c;
 use crate::peripherals::spi::Spi;
 use crate::peripherals::uart::Uart;
@@ -93,6 +94,62 @@ impl<'a> AttachCtx<'a> {
             .ok_or_else(|| downcast_err(ext))?;
         any.downcast_mut::<I2c>()
             .ok_or_else(|| wrong_transport_err(ext, "I2C"))
+    }
+
+    /// Acquire the ADC peripheral declared in the system.yaml `connection:`
+    /// field. Used by analog peripherals (e.g. NTC thermistor) that "seed"
+    /// a channel rather than attach a stream/device.
+    pub fn adc(&mut self) -> Result<&mut Adc> {
+        let ext = self.ext;
+        let idx = self
+            .bus
+            .find_peripheral_index_by_name(&ext.connection)
+            .ok_or_else(|| missing_connection_err(ext))?;
+        let any = self.bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .ok_or_else(|| downcast_err(ext))?;
+        any.downcast_mut::<Adc>()
+            .ok_or_else(|| wrong_transport_err(ext, "ADC"))
+    }
+
+    /// Resolve an STM32 pin label (e.g. `"PC7"`) to its `(ODR address, bit)`
+    /// so a SPI display can sample the host's D/C line directly from the
+    /// driving GPIO's output register. Returns None for unknown ports or
+    /// pin labels.
+    pub fn resolve_pin_odr(&self, pin: &str) -> Option<(u64, u8)> {
+        SystemBus::resolve_pin_odr_pub(self.bus, pin)
+    }
+
+    /// Read the optional `i2c_address` config key, returning `default` when
+    /// absent. Rejects non-integer values and any address outside the 7-bit
+    /// range — same validation every legacy hand-written I2C bus arm did,
+    /// hoisted here so every I2C kit gets it for free.
+    pub fn i2c_address_or(&self, default: u8) -> Result<u8> {
+        let Some(value) = self.ext.config.get("i2c_address") else {
+            return Ok(default);
+        };
+        let Some(address) = value.as_u64() else {
+            return Err(anyhow!(
+                "External device '{}' type '{}' on connection '{}' has invalid i2c_address '{}'",
+                self.ext.id,
+                self.ext.r#type,
+                self.ext.connection,
+                serde_yaml::to_string(value)
+                    .unwrap_or_else(|_| "<unprintable>".to_string())
+                    .trim()
+            ));
+        };
+        if address > 0x7f {
+            return Err(anyhow!(
+                "External device '{}' type '{}' on connection '{}' has out-of-range 7-bit i2c_address 0x{:x}",
+                self.ext.id,
+                self.ext.r#type,
+                self.ext.connection,
+                address
+            ));
+        }
+        Ok(address as u8)
     }
 }
 

--- a/crates/core/src/peripherals/kit/mod.rs
+++ b/crates/core/src/peripherals/kit/mod.rs
@@ -75,9 +75,11 @@ pub struct KitMetadata {
     /// `external_devices` entry. Used for docs + manifest schema; not (yet)
     /// enforced at parse time.
     pub config_keys: &'static [ConfigKey],
-    /// Optional starter-lab association — the boardId in `BOARD_CONFIGS`
-    /// that ships a one-click demo using this peripheral.
-    pub lab: Option<LabRef>,
+    /// Starter labs that ship a one-click demo using this peripheral. A
+    /// peripheral may appear in zero, one, or several labs (e.g. the same
+    /// e-paper model used in both an STM32 and ESP32 example). The first
+    /// entry is treated as the primary lab by tooling that wants a default.
+    pub labs: &'static [LabRef],
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]

--- a/crates/core/src/peripherals/kit/registry.rs
+++ b/crates/core/src/peripherals/kit/registry.rs
@@ -22,6 +22,17 @@ use crate::peripherals::components;
 pub static KITS: &[&'static dyn PeripheralKit] = &[
     &components::bg770a::BG770A_KIT,
     &components::neo6m::NEO6M_KIT,
+    &components::adxl345::ADXL345_KIT,
+    &components::mpu6050::MPU6050_KIT,
+    &components::bme280::BME280_KIT,
+    &components::ssd1306::SSD1306_KIT,
+    &components::ili9341::ILI9341_KIT,
+    &components::max31855::MAX31855_KIT,
+    &components::ssd1680_tricolor_290::SSD1680_TRICOLOR_290_KIT,
+    &components::sn74hc165::SN74HC165_KIT,
+    &components::pcd8544::PCD8544_KIT,
+    &components::iolink_master::IOLINK_MASTER_KIT,
+    &components::ntc_thermistor::NTC_THERMISTOR_KIT,
 ];
 
 /// Borrow the registry slice.

--- a/crates/core/tests/peripheral_kit_gate.rs
+++ b/crates/core/tests/peripheral_kit_gate.rs
@@ -150,7 +150,7 @@ fn manifest_json_matches_registry() {
         peripherals: Vec<&'a labwired_core::peripherals::kit::KitMetadata>,
     }
     let expected_value = Manifest {
-        schema_version: 1,
+        schema_version: 2,
         peripherals: registry::kits().iter().map(|k| k.metadata()).collect(),
     };
     let mut expected = serde_json::to_string_pretty(&expected_value).unwrap();
@@ -175,24 +175,23 @@ fn manifest_json_matches_registry() {
 fn lab_example_dirs_exist_on_disk() {
     let examples = workspace_root().join("examples");
     for kit in registry::kits() {
-        let Some(lab) = kit.metadata().lab.as_ref() else {
-            continue;
-        };
-        let dir = examples.join(lab.example_dir);
-        assert!(
-            dir.is_dir(),
-            "kit '{}' references example_dir '{}' but {:?} is not a directory",
-            kit.metadata().device_type,
-            lab.example_dir,
-            dir
-        );
-        let system_yaml = dir.join("system.yaml");
-        assert!(
-            system_yaml.is_file(),
-            "kit '{}' lab '{}' is missing system.yaml at {:?}",
-            kit.metadata().device_type,
-            lab.example_dir,
-            system_yaml
-        );
+        for lab in kit.metadata().labs {
+            let dir = examples.join(lab.example_dir);
+            assert!(
+                dir.is_dir(),
+                "kit '{}' references example_dir '{}' but {:?} is not a directory",
+                kit.metadata().device_type,
+                lab.example_dir,
+                dir
+            );
+            let system_yaml = dir.join("system.yaml");
+            assert!(
+                system_yaml.is_file(),
+                "kit '{}' lab '{}' is missing system.yaml at {:?}",
+                kit.metadata().device_type,
+                lab.example_dir,
+                system_yaml
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Continues the kit migration started in [#160](https://github.com/w1ne/labwired-core/pull/160). After this PR every production peripheral that ships a starter lab is reached through the unified contract; the legacy hand-written arms in \`bus/mod.rs\` are gone along with their per-peripheral helper functions.

**Net: -575 / +658 lines.** ~80 lines of helper functions disappear from \`bus/mod.rs\`, replaced by trait impls next to each model.

## What migrates

| Transport | Peripherals |
|---|---|
| I2C       | adxl345, mpu6050, bme280, ssd1306 |
| SPI       | ili9341, max31855, ssd1680_tricolor_290, sn74hc165, pcd8544 |
| UART      | iolink-master |
| Analog    | ntc-thermistor |

## Kit machinery extensions

- **\`KitMetadata.labs: &'static [LabRef]\`** (schema_version → 2). Replaces \`Option<LabRef>\` so peripherals like \`ssd1680_tricolor_290\` can advertise both their STM32 and ESP32 labs.
- **\`AttachCtx::adc()\`** + **\`::resolve_pin_odr()\`** — the two transports the initial bg770a/neo6m migration did not need.
- **\`AttachCtx::i2c_address_or(default)\`** — shared validation hoisted from four hand-rolled bus arms.

## "Ensure demos still run"

CLI smoke ran every migrated lab against its pre-built firmware ELF:

| Lab | Final PC | Status |
|---|---|---|
| neo6m-gps-lab | 0x8000502 | ✅ |
| quectel-bg770a-lab | 0x8000572 | ✅ |
| adxl345-sensor-lab | 0x80005ca | ✅ |
| mpu6050-sensor-lab | 0x8000b9a | ✅ |
| bme280-weather-lab | 0x80006ca | ✅ |
| ssd1306-hello-lab | 0x800075a | ✅ |
| ili9341-tft-lab | 0x80006a4 | ✅ |
| max31855-thermocouple-lab | 0x8000696 | ✅ |
| nokia5110-invaders-lab | 0x800058e | ✅ |
| al2205-iolink-dido | 0x800007a | ✅ |
| epaper-tricolor-lab | 0x80004d6 | ✅ |
| ntc-thermistor-lab | — | ⚠ pre-existing |
| esp32-epaper-lab | — | ⚠ pre-existing |

The two ⚠ rows fail the CLI on the same chip-yaml issues they had on \`main\` (\`adc1\` declared as a stub; \`spi3\` missing). My migration preserves baseline behavior — same line, same error — and does not introduce the regression.

## Test results

- 613/613 core lib pass
- 4/4 \`bg770a_validation\` integration
- 7/7 \`peripheral_kit_gate\` (including the JSON-drift check that binds the manifest to \`KITS\` byte-for-byte)
- \`cargo clippy --lib --tests -- -D warnings\` clean
- \`cargo fmt --all --check\` clean

## Companion

Parent labwired PR coming next: bumps the submodule, regenerates the manifest, and adds the missing 5 playground surface entries (chip-row chips for the e-paper labs, library tiles for nokia5110 / al2205-iolink-dido, command-palette categories for the 5 new SPI/UART devices). The playground gate's per-kit assertions now cover all 13 registered kits.

## Adding a peripheral after this PR

1. Implement \`PeripheralKit\` for the model.
2. Append \`&MY_KIT\` to \`registry::KITS\`.
3. \`cargo run -p labwired-cli --bin gen-peripherals-manifest -- --out packages/ui/src/peripherals/manifest.json\` in the parent repo.

CI catches the rest — missing lab dir, drifted manifest, missing playground UI surface, blank metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)