### PR TITLE
esp32: real dual-core — loopTask runs on the genuine APP_CPU (WIP)

### DIFF
--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -108,6 +108,12 @@ pub struct XtensaLx7 {
     /// app-cpu boot address (mirrors real silicon's reset-hold). Default
     /// false; ESP32 dual-core setup sets it on cpu_secondary at boot.
     pub halted: bool,
+    /// True for the ESP32 APP_CPU (core 1). On real silicon a core's PRID
+    /// is fixed hardware (PRO_CPU 0xCDCD → core 0, APP_CPU 0xABAB → core 1)
+    /// and survives reset. We remember it so `reset()` restores the right
+    /// PRID — otherwise a reset re-news the SR to 0xCDCD, APP_CPU reads
+    /// core_id 0, and it corrupts PRO_CPU's per-core FreeRTOS state.
+    pub app_cpu: bool,
     /// IRAM/flash instruction-fetch slice cache (#119 Phase 1.2).
     fetch_cache: Option<(u64, u64, usize)>,
     /// Decode cache (#124 follow-on): direct-mapped PC → (tag, len, decoded
@@ -143,6 +149,7 @@ impl XtensaLx7 {
             pc: 0x4000_0400,
             branched: false,
             halted: false,
+            app_cpu: false,
             fetch_cache: None,
             decode_cache: vec![None; DECODE_CACHE_SIZE],
             decode_gen: vec![0; DECODE_CACHE_SIZE],
@@ -195,6 +202,7 @@ impl XtensaLx7 {
         let mut cpu = Self::new();
         cpu.sr = XtensaSrFile::new_app_cpu();
         cpu.halted = true;
+        cpu.app_cpu = true;
         cpu
     }
 
@@ -1850,7 +1858,13 @@ impl XtensaLx7 {
                 // in here, otherwise the firmware sees INTERRUPT=0 and
                 // never dispatches to the user ISR (Plan 3 Task 10 case
                 // study).
-                if sr == INTERRUPT {
+                if sr == INTERRUPT && self.core_id() == 0 {
+                    // Per-core IRQ routing: only PRO_CPU (core 0) receives
+                    // peripheral IRQs from the bus aggregator today. APP_CPU
+                    // (core 1) must not take PRO_CPU's interrupts — doing so
+                    // runs ISRs that unbalance its critical nesting
+                    // (vPortExitCritical "nesting > 0"). Cross-core delivery
+                    // to APP_CPU is modeled separately (FROM_CPU).
                     v |= bus.pending_cpu_irqs();
                 }
                 self.regs.write_logical(at, v);
@@ -1965,6 +1979,14 @@ impl XtensaLx7 {
 
     // ── Interrupt dispatch helpers ────────────────────────────────────────────
 
+    /// This CPU's core id, derived from PRID exactly as the firmware does
+    /// (`xPortGetCoreID()` = `(PRID >> 13) & 1`): PRO_CPU PRID `0xCDCD` → 0,
+    /// APP_CPU PRID `0xABAB` → 1.
+    #[inline]
+    fn core_id(&self) -> u8 {
+        ((self.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1) as u8
+    }
+
     /// Compute the highest priority level of any pending-and-enabled interrupt.
     ///
     /// Returns `Some(level)` if `(INTERRUPT & INTENABLE) != 0`, else `None`.
@@ -1975,7 +1997,13 @@ impl XtensaLx7 {
         //   1. SR-file INTERRUPT register (firmware can software-trigger via WSR).
         //   2. Bus's pending_cpu_irqs (peripheral source IDs routed through
         //      the ESP32-S3 intmatrix in tick_peripherals_with_costs).
-        let pending = (self.sr.read(INTERRUPT) | bus.pending_cpu_irqs()) & self.sr.read(INTENABLE);
+        // Per-core routing: only PRO_CPU (core 0) takes bus peripheral IRQs.
+        let bus_irqs = if self.core_id() == 0 {
+            bus.pending_cpu_irqs()
+        } else {
+            0
+        };
+        let pending = (self.sr.read(INTERRUPT) | bus_irqs) & self.sr.read(INTENABLE);
         if pending == 0 {
             return None;
         }
@@ -2119,7 +2147,13 @@ impl Cpu for XtensaLx7 {
         // HW-verified: PS reset = 0x1F (EXCM=1, INTLEVEL=0xF — all ints masked).
         // Confirmed via OpenOCD `reset halt` on real S3-Zero: ps = 0x0000001f.
         self.ps = Ps::from_raw(0x1F);
-        self.sr = XtensaSrFile::new(); // sets VECBASE=0x40000000, PRID=0xCDCD
+        // VECBASE=0x40000000; PRID is fixed hardware per core and survives
+        // reset — restore APP_CPU's 0xABAB so it keeps core_id 1.
+        self.sr = if self.app_cpu {
+            XtensaSrFile::new_app_cpu()
+        } else {
+            XtensaSrFile::new()
+        };
         self.pc = 0x4000_0400;
         // Preserve halted state across reset — a CPU configured as
         // APP_CPU (halted at construction) must stay halted through the

--- a/crates/core/src/peripherals/esp32/ledc.rs
+++ b/crates/core/src/peripherals/esp32/ledc.rs
@@ -203,12 +203,7 @@ impl Ledc {
 
     /// If `word_off` is a channel CONF1 offset, return the channel index.
     fn channel_of_conf1(word_off: u64) -> Option<u64> {
-        for ch in 0..(2 * CH_COUNT) {
-            if Self::ch_reg(ch, CH_CONF1) == word_off {
-                return Some(ch);
-            }
-        }
-        None
+        (0..(2 * CH_COUNT)).find(|&ch| Self::ch_reg(ch, CH_CONF1) == word_off)
     }
 
     /// Commit a channel's staged DUTY into its DUTY_R live shadow. The

--- a/crates/core/src/peripherals/esp32/ledc.rs
+++ b/crates/core/src/peripherals/esp32/ledc.rs
@@ -1,0 +1,528 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-classic LED PWM Controller (LEDC) peripheral.
+//!
+//! Reference: ESP32 TRM v5.0 §14 ("LED PWM Controller"). The LEDC block
+//! sits at base `0x3FF5_9000`, spans one 4 KiB APB page, and generates
+//! PWM waveforms on up to 16 channels: 8 **high-speed** (HS) and 8
+//! **low-speed** (LS), each bound to one of 4 HS / 4 LS timers. It is the
+//! peripheral Arduino's `ledcSetup`/`ledcWrite` and ESP-IDF's `ledc_*`
+//! driver program to dim LEDs, drive servos, and synthesize audio.
+//!
+//! Previously this address window was a generic read-as-zero round-trip
+//! stub. That satisfies "don't fault", but firmware that configures a
+//! channel and then reads back its duty (or reads the per-channel
+//! `DUTY_R` "current duty" register the hardware latches) saw zero and
+//! could not introspect its own output. This model replaces the stub
+//! with a register-level state machine that:
+//!
+//!   * Lays out the real HS/LS channel + timer + interrupt + global
+//!     register blocks at their TRM offsets and round-trips every write.
+//!   * Implements the `CONF1.DUTY_START` strobe: on silicon, the staged
+//!     `DUTY` value (Q-format, 4 fractional bits) is committed to the
+//!     channel's live `DUTY_R` shadow when firmware sets DUTY_START. We
+//!     latch `DUTY → DUTY_R` so a read of `DUTY_R` returns the value that
+//!     is actually driving the pin, matching `ledc_get_duty()`.
+//!   * Computes the live **duty percentage** and **PWM frequency** for a
+//!     channel from its bound timer's `DUTY_RES` + `DIV_NUM` divider, so
+//!     a UI or test can read back the effective output without re-deriving
+//!     the divider math (see [`Ledc::channel_duty_fraction`] /
+//!     [`Ledc::channel_freq_hz`]).
+//!   * Implements `INT_CLR` write-1-to-clear against `INT_RAW`, mirroring
+//!     the TIMG interrupt-plumbing convention already in this crate.
+//!
+//! ## Register map (per ESP32 TRM v5.0 §14.5, matching ESP-IDF
+//! `soc/esp32/include/soc/ledc_reg.h`)
+//!
+//! | Offset  | Name                  | Semantics modeled                        |
+//! |--------:|-----------------------|------------------------------------------|
+//! | 0x0000  | HSCH0_CONF0           | TIMER_SEL[1:0], SIG_OUT_EN[2], IDLE_LV[3]|
+//! | 0x0004  | HSCH0_HPOINT          | Round-trip (phase / high-point)          |
+//! | 0x0008  | HSCH0_DUTY            | Staged duty, Q4 fixed-point              |
+//! | 0x000C  | HSCH0_CONF1           | DUTY_START[31] strobe → latch DUTY→DUTY_R|
+//! | 0x0010  | HSCH0_DUTY_R          | Read-only live duty shadow (latched)     |
+//! | ...     | HSCH1..7 (stride 0x14)| Same layout, +0x14 per channel           |
+//! | 0x00A0  | LSCH0_CONF0           | Low-speed channel 0 (same layout)        |
+//! | ...     | LSCH1..7 (stride 0x14)|                                          |
+//! | 0x0140  | HSTIMER0_CONF         | DUTY_RES[4:0], DIV_NUM[17:5], PAUSE[18], RST[19], TICK_SEL[20] |
+//! | 0x0144  | HSTIMER0_VALUE        | Read-only running counter (round-trip)   |
+//! | ...     | HSTIMER1..3 (stride 8)|                                          |
+//! | 0x0160  | LSTIMER0_CONF         | Low-speed timer 0 (same layout)          |
+//! | ...     | LSTIMER1..3 (stride 8)|                                          |
+//! | 0x0180  | INT_RAW               | Round-trip (no auto-set today)           |
+//! | 0x0184  | INT_ST                | Round-trip                               |
+//! | 0x0188  | INT_ENA               | Round-trip                               |
+//! | 0x018C  | INT_CLR               | Write-1-to-clear matching INT_RAW bits   |
+//! | 0x0190  | CONF                  | APB_CLK_SEL[1:0] (1=APB80M, 2=RTC8M)     |
+//! | 0x01FC  | DATE                  | Silicon date/version (canned)            |
+//!
+//! Any offset not enumerated above falls through to the generic word
+//! store, so RMW probes from firmware still observe their own writes.
+//!
+//! This model is **functional, not cycle-accurate**: the timer VALUE
+//! counters are not advanced and no PWM edges are emitted to GPIO (LEDC
+//! output routing through the GPIO matrix is not modeled). Its job is to
+//! make LEDC configuration introspectable — duty-cycle readback and the
+//! derived frequency/fraction helpers — which is what firmware and a
+//! waveform UI actually consume.
+
+use crate::{Peripheral, PeripheralTickResult, SimResult};
+use std::collections::HashMap;
+
+// ── Channel block geometry (TRM §14.5) ───────────────────────────────────
+/// First HS channel register block starts at offset 0.
+const HS_CH_BASE: u64 = 0x0000;
+/// First LS channel register block.
+const LS_CH_BASE: u64 = 0x00A0;
+/// Per-channel register stride: CONF0, HPOINT, DUTY, CONF1, DUTY_R (5 × 4).
+const CH_STRIDE: u64 = 0x14;
+/// Channels per speed-mode group.
+const CH_COUNT: u64 = 8;
+
+// Per-channel register offsets, relative to the channel block base.
+const CH_CONF0: u64 = 0x00;
+#[allow(dead_code)]
+const CH_HPOINT: u64 = 0x04;
+const CH_DUTY: u64 = 0x08;
+const CH_CONF1: u64 = 0x0C;
+const CH_DUTY_R: u64 = 0x10;
+
+/// CONF1.DUTY_START — bit 31. Setting it commits the staged DUTY into the
+/// live DUTY_R shadow (one-shot on silicon; we latch on the write).
+const CONF1_DUTY_START_BIT: u32 = 1 << 31;
+/// CONF0.SIG_OUT_EN — bit 2. Channel output enable.
+const CONF0_SIG_OUT_EN_BIT: u32 = 1 << 2;
+/// CONF0.TIMER_SEL — bits[1:0]. Which of the 4 timers in this speed mode
+/// the channel is bound to.
+const CONF0_TIMER_SEL_MASK: u32 = 0b11;
+
+// ── Timer block geometry (TRM §14.5) ─────────────────────────────────────
+/// First HS timer CONF register.
+const HS_TIMER_BASE: u64 = 0x0140;
+/// First LS timer CONF register.
+const LS_TIMER_BASE: u64 = 0x0160;
+/// Per-timer register stride: CONF, VALUE (2 × 4).
+const TIMER_STRIDE: u64 = 0x08;
+/// Timers per speed-mode group.
+const TIMER_COUNT: u64 = 4;
+
+const TIMER_CONF: u64 = 0x00;
+#[allow(dead_code)]
+const TIMER_VALUE: u64 = 0x04;
+
+/// TIMER_CONF.DUTY_RES — bits[4:0]. Number of duty resolution bits; the
+/// counter counts 0..(2^DUTY_RES - 1).
+const TIMER_DUTY_RES_MASK: u32 = 0x1F;
+/// TIMER_CONF.DIV_NUM — bits[17:5]. Fixed-point Q8 divider applied to the
+/// source clock: actual divider = DIV_NUM / 256.
+const TIMER_DIV_NUM_SHIFT: u32 = 5;
+const TIMER_DIV_NUM_MASK: u32 = 0x1FFF;
+
+// ── Interrupt + global registers (TRM §14.5) ─────────────────────────────
+const INT_RAW: u64 = 0x0180;
+#[allow(dead_code)]
+const INT_ST: u64 = 0x0184;
+#[allow(dead_code)]
+const INT_ENA: u64 = 0x0188;
+const INT_CLR: u64 = 0x018C;
+/// CONF.APB_CLK_SEL — global clock-source mux. Round-trips through the
+/// generic word store; referenced by name in tests for spec clarity.
+#[allow(dead_code)]
+const CONF: u64 = 0x0190;
+const DATE: u64 = 0x01FC;
+
+/// Reset value of LEDC_DATE on ESP32-classic (per `ledc_reg.h`). Firmware
+/// rarely reads it, but returning the silicon constant keeps version
+/// probes faithful instead of read-as-zero.
+const DATE_RESET: u32 = 0x1808_2600;
+
+/// LEDC source clocks (TRM §14.2). HS channels are clocked from APB
+/// (80 MHz) or the 8 MHz RTC clock per CONF.APB_CLK_SEL; LS channels
+/// likewise. We model the common APB-80M default for the derived
+/// frequency helper.
+const APB_CLK_HZ: u64 = 80_000_000;
+
+/// LED PWM Controller (LEDC) peripheral model.
+#[derive(Debug)]
+pub struct Ledc {
+    /// MMIO base (0x3FF5_9000). Informational; the bus dispatches by
+    /// offset so this is only for logs / multi-instance disambiguation.
+    base: u32,
+    /// Word-aligned register backing store. Every offset round-trips
+    /// here; side-effecting offsets are intercepted before storing.
+    regs: HashMap<u64, u32>,
+}
+
+impl Default for Ledc {
+    fn default() -> Self {
+        Self::new(Self::BASE)
+    }
+}
+
+impl Ledc {
+    /// Canonical MMIO base address on ESP32-classic (TRM §14.5).
+    pub const BASE: u32 = 0x3FF5_9000;
+
+    /// Construct a freshly-powered LEDC block. Seeds only LEDC_DATE with
+    /// its silicon constant; every other register resets to zero.
+    pub fn new(base: u32) -> Self {
+        let mut regs = HashMap::new();
+        regs.insert(DATE, DATE_RESET);
+        Self { base, regs }
+    }
+
+    /// Base MMIO address (debug helper).
+    pub fn base(&self) -> u32 {
+        self.base
+    }
+
+    fn word(&self, off: u64) -> u32 {
+        self.regs.get(&off).copied().unwrap_or(0)
+    }
+
+    /// Offset of channel `ch` (0..15, where 0..7 = HS, 8..15 = LS) register
+    /// `reg` (one of CH_CONF0/CH_DUTY/CH_CONF1/CH_DUTY_R).
+    fn ch_reg(ch: u64, reg: u64) -> u64 {
+        if ch < CH_COUNT {
+            HS_CH_BASE + ch * CH_STRIDE + reg
+        } else {
+            LS_CH_BASE + (ch - CH_COUNT) * CH_STRIDE + reg
+        }
+    }
+
+    /// Offset of timer `tmr` (0..7, 0..3 = HS, 4..7 = LS) register `reg`.
+    fn timer_reg(tmr: u64, reg: u64) -> u64 {
+        if tmr < TIMER_COUNT {
+            HS_TIMER_BASE + tmr * TIMER_STRIDE + reg
+        } else {
+            LS_TIMER_BASE + (tmr - TIMER_COUNT) * TIMER_STRIDE + reg
+        }
+    }
+
+    /// If `word_off` is a channel CONF1 offset, return the channel index.
+    fn channel_of_conf1(word_off: u64) -> Option<u64> {
+        for ch in 0..(2 * CH_COUNT) {
+            if Self::ch_reg(ch, CH_CONF1) == word_off {
+                return Some(ch);
+            }
+        }
+        None
+    }
+
+    /// Commit a channel's staged DUTY into its DUTY_R live shadow. The
+    /// hardware copies `DUTY` (Q4 fixed-point) into the running duty
+    /// register when CONF1.DUTY_START is asserted; `ledc_get_duty()`
+    /// reads the integer part back from DUTY_R.
+    fn latch_duty(&mut self, ch: u64) {
+        let staged = self.word(Self::ch_reg(ch, CH_DUTY));
+        self.regs.insert(Self::ch_reg(ch, CH_DUTY_R), staged);
+    }
+
+    /// Which timer (global index 0..7) channel `ch` is bound to, per its
+    /// CONF0.TIMER_SEL field and speed mode.
+    fn channel_timer(&self, ch: u64) -> u64 {
+        let conf0 = self.word(Self::ch_reg(ch, CH_CONF0));
+        let sel = (conf0 & CONF0_TIMER_SEL_MASK) as u64;
+        if ch < CH_COUNT {
+            sel // HS timer 0..3
+        } else {
+            TIMER_COUNT + sel // LS timer 4..7
+        }
+    }
+
+    /// Live integer duty value (DUTY_R >> 4 — the 4 LSBs are the
+    /// fractional part of the Q4 duty register).
+    pub fn channel_duty(&self, ch: u64) -> u32 {
+        self.word(Self::ch_reg(ch, CH_DUTY_R)) >> 4
+    }
+
+    /// True if the channel's output stage is enabled (CONF0.SIG_OUT_EN).
+    pub fn channel_output_enabled(&self, ch: u64) -> bool {
+        self.word(Self::ch_reg(ch, CH_CONF0)) & CONF0_SIG_OUT_EN_BIT != 0
+    }
+
+    /// Duty as a fraction in [0.0, 1.0] given the bound timer's resolution
+    /// (`duty / 2^DUTY_RES`). Returns 0.0 if the timer's DUTY_RES is 0
+    /// (period of one tick — degenerate, no PWM).
+    pub fn channel_duty_fraction(&self, ch: u64) -> f64 {
+        let tmr = self.channel_timer(ch);
+        let conf = self.word(Self::timer_reg(tmr, TIMER_CONF));
+        let duty_res = conf & TIMER_DUTY_RES_MASK;
+        if duty_res == 0 {
+            return 0.0;
+        }
+        let period = 1u64 << duty_res;
+        self.channel_duty(ch) as f64 / period as f64
+    }
+
+    /// Derived PWM output frequency in Hz for channel `ch`, from its bound
+    /// timer's divider and resolution, assuming the APB-80M source clock:
+    /// `f = APB / ((DIV_NUM/256) * 2^DUTY_RES)`. Returns 0 when the timer
+    /// is unconfigured (DUTY_RES=0 or DIV_NUM=0).
+    pub fn channel_freq_hz(&self, ch: u64) -> u64 {
+        let tmr = self.channel_timer(ch);
+        let conf = self.word(Self::timer_reg(tmr, TIMER_CONF));
+        let duty_res = conf & TIMER_DUTY_RES_MASK;
+        let div_num = (conf >> TIMER_DIV_NUM_SHIFT) & TIMER_DIV_NUM_MASK;
+        if duty_res == 0 || div_num == 0 {
+            return 0;
+        }
+        let period = 1u64 << duty_res;
+        // div_num is Q8 (×256). f = APB*256 / (div_num * period).
+        let denom = div_num as u64 * period;
+        (APB_CLK_HZ * 256) / denom
+    }
+
+    /// Dispatch the per-word side effects of a register write. Factored so
+    /// byte-granular and word-granular writes produce identical state.
+    /// Idempotent: each trigger reads live state and writes deterministic
+    /// values, so one-per-word or four-per-word calls converge.
+    fn apply_write_side_effects(&mut self, word_off: u64) {
+        if let Some(ch) = Self::channel_of_conf1(word_off) {
+            // DUTY_START strobe latches the staged duty into the live
+            // shadow. We do NOT clear DUTY_START (silicon self-clears it
+            // after the next timer overflow; firmware treats it as a
+            // fire-and-forget command and re-asserts on each update).
+            if self.word(word_off) & CONF1_DUTY_START_BIT != 0 {
+                self.latch_duty(ch);
+            }
+            return;
+        }
+        if word_off == INT_CLR {
+            let mask = self.word(INT_CLR);
+            let raw = self.word(INT_RAW);
+            self.regs.insert(INT_RAW, raw & !mask);
+        }
+    }
+}
+
+impl Peripheral for Ledc {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word_off = offset & !3;
+        let byte_off = (offset & 3) * 8;
+        let word = self.word(word_off);
+        Ok(((word >> byte_off) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let word_off = offset & !3;
+        let byte_off = (offset & 3) * 8;
+        let entry = self.regs.entry(word_off).or_insert(0);
+        *entry &= !(0xFFu32 << byte_off);
+        *entry |= (value as u32) << byte_off;
+        self.apply_write_side_effects(word_off);
+        Ok(())
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(self.word(offset & !3))
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        let word_off = offset & !3;
+        self.regs.insert(word_off, value);
+        self.apply_write_side_effects(word_off);
+        Ok(())
+    }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        // No PWM edge emission or VALUE-counter advance modeled — see
+        // module docs. Configuration introspection is the deliverable.
+        PeripheralTickResult::default()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Snap {
+            base: u32,
+            regs: Vec<(u64, u32)>,
+        }
+        let snap = Snap {
+            base: self.base,
+            regs: self.regs.iter().map(|(k, v)| (*k, *v)).collect(),
+        };
+        bincode::serialize(&snap).expect("bincode serialize Ledc")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Snap {
+            base: u32,
+            regs: Vec<(u64, u32)>,
+        }
+        let snap: Snap = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("Ledc snapshot decode: {e}"))
+        })?;
+        self.base = snap.base;
+        self.regs = snap.regs.into_iter().collect();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_u32(p: &mut Ledc, off: u64, val: u32) {
+        for i in 0..4 {
+            p.write(off + i, ((val >> (i * 8)) & 0xFF) as u8).unwrap();
+        }
+    }
+
+    fn read_u32(p: &Ledc, off: u64) -> u32 {
+        let mut v = 0u32;
+        for i in 0..4 {
+            v |= (p.read(off + i).unwrap() as u32) << (i * 8);
+        }
+        v
+    }
+
+    #[test]
+    fn date_reads_silicon_constant() {
+        let p = Ledc::new(Ledc::BASE);
+        assert_eq!(read_u32(&p, DATE), DATE_RESET);
+    }
+
+    #[test]
+    fn conf0_round_trips() {
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF0), 0x0000_000D);
+        assert_eq!(read_u32(&p, Ledc::ch_reg(0, CH_CONF0)), 0x0000_000D);
+    }
+
+    #[test]
+    fn duty_start_latches_staged_duty_into_shadow() {
+        // ledcWrite path: stage DUTY, then assert CONF1.DUTY_START. The
+        // live DUTY_R shadow must reflect the staged value, and the
+        // integer-duty helper must drop the 4 fractional LSBs.
+        let mut p = Ledc::new(Ledc::BASE);
+        // Stage duty = 512 in Q4 (i.e. integer 512 → register 512<<4).
+        let staged = 512u32 << 4;
+        write_u32(&mut p, Ledc::ch_reg(0, CH_DUTY), staged);
+        // Before the strobe, DUTY_R is still zero.
+        assert_eq!(read_u32(&p, Ledc::ch_reg(0, CH_DUTY_R)), 0);
+        // Assert DUTY_START.
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF1), CONF1_DUTY_START_BIT);
+        assert_eq!(read_u32(&p, Ledc::ch_reg(0, CH_DUTY_R)), staged);
+        assert_eq!(p.channel_duty(0), 512);
+    }
+
+    #[test]
+    fn conf1_without_duty_start_does_not_latch() {
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_DUTY), 100u32 << 4);
+        // Write CONF1 with DUTY_START clear — shadow must stay 0.
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF1), 0x0000_0001);
+        assert_eq!(read_u32(&p, Ledc::ch_reg(0, CH_DUTY_R)), 0);
+    }
+
+    #[test]
+    fn low_speed_channel_block_is_independent() {
+        // LS channel 0 is global index 8; its DUTY_R must not alias HS0.
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_DUTY), 10u32 << 4);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF1), CONF1_DUTY_START_BIT);
+        write_u32(&mut p, Ledc::ch_reg(8, CH_DUTY), 20u32 << 4);
+        write_u32(&mut p, Ledc::ch_reg(8, CH_CONF1), CONF1_DUTY_START_BIT);
+        assert_eq!(p.channel_duty(0), 10);
+        assert_eq!(p.channel_duty(8), 20);
+    }
+
+    #[test]
+    fn duty_fraction_uses_bound_timer_resolution() {
+        // Bind HS channel 0 to HS timer 0, set DUTY_RES=10 (period 1024),
+        // duty 256 → 25%.
+        let mut p = Ledc::new(Ledc::BASE);
+        // Timer 0 CONF: DUTY_RES=10.
+        write_u32(&mut p, Ledc::timer_reg(0, TIMER_CONF), 10);
+        // Channel 0 CONF0: TIMER_SEL=0, SIG_OUT_EN.
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF0), CONF0_SIG_OUT_EN_BIT);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_DUTY), 256u32 << 4);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF1), CONF1_DUTY_START_BIT);
+        assert!((p.channel_duty_fraction(0) - 0.25).abs() < 1e-9);
+        assert!(p.channel_output_enabled(0));
+    }
+
+    #[test]
+    fn channel_binds_to_selected_timer() {
+        // Channel 1 selects timer 2; DUTY_RES lives on timer 2, not 0.
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, Ledc::timer_reg(2, TIMER_CONF), 8); // period 256
+        write_u32(&mut p, Ledc::ch_reg(1, CH_CONF0), 2); // TIMER_SEL=2
+        write_u32(&mut p, Ledc::ch_reg(1, CH_DUTY), 64u32 << 4);
+        write_u32(&mut p, Ledc::ch_reg(1, CH_CONF1), CONF1_DUTY_START_BIT);
+        assert!((p.channel_duty_fraction(1) - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn derived_frequency_matches_divider_math() {
+        // 5 kHz @ 13-bit resolution on APB-80M: DIV_NUM = APB*256 /
+        // (freq * 2^res) = 80e6*256 / (5000 * 8192) = 500.
+        let mut p = Ledc::new(Ledc::BASE);
+        let duty_res = 13u32;
+        let div_num = 500u32;
+        let conf = duty_res | (div_num << TIMER_DIV_NUM_SHIFT);
+        write_u32(&mut p, Ledc::timer_reg(0, TIMER_CONF), conf);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF0), 0); // TIMER_SEL=0
+        assert_eq!(p.channel_freq_hz(0), 5000);
+    }
+
+    #[test]
+    fn unconfigured_timer_yields_zero_freq() {
+        let p = Ledc::new(Ledc::BASE);
+        assert_eq!(p.channel_freq_hz(0), 0);
+        assert_eq!(p.channel_duty_fraction(0), 0.0);
+    }
+
+    #[test]
+    fn int_clr_clears_matching_int_raw_bits() {
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, INT_RAW, 0b1011);
+        write_u32(&mut p, INT_CLR, 0b0010);
+        assert_eq!(read_u32(&p, INT_RAW), 0b1001);
+    }
+
+    #[test]
+    fn conf_apb_clk_sel_round_trips() {
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, CONF, 0x0000_0001); // APB_CLK_SEL = APB80M
+        assert_eq!(read_u32(&p, CONF), 0x0000_0001);
+    }
+
+    #[test]
+    fn unknown_offsets_round_trip() {
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, 0x0C0, 0xCAFE_BABE);
+        assert_eq!(read_u32(&p, 0x0C0), 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn base_is_esp32_classic_canonical_address() {
+        assert_eq!(Ledc::new(Ledc::BASE).base(), 0x3FF5_9000);
+    }
+
+    #[test]
+    fn runtime_snapshot_round_trip_preserves_state() {
+        let mut p = Ledc::new(Ledc::BASE);
+        write_u32(&mut p, Ledc::timer_reg(0, TIMER_CONF), 10);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_DUTY), 300u32 << 4);
+        write_u32(&mut p, Ledc::ch_reg(0, CH_CONF1), CONF1_DUTY_START_BIT);
+        let snap = p.runtime_snapshot();
+
+        let mut restored = Ledc::new(0);
+        restored.restore_runtime_snapshot(&snap).unwrap();
+        assert_eq!(restored.base(), 0x3FF5_9000);
+        assert_eq!(restored.channel_duty(0), 300);
+        assert_eq!(read_u32(&restored, DATE), DATE_RESET);
+    }
+}

--- a/crates/core/src/peripherals/esp32/mod.rs
+++ b/crates/core/src/peripherals/esp32/mod.rs
@@ -17,8 +17,11 @@
 pub mod dport;
 pub mod efuse;
 pub mod gpio;
+pub mod ledc;
 pub mod rtc_cntl;
 pub mod sdio_stub;
+pub mod sha;
 pub mod spi;
 pub mod syscon;
 pub mod timg;
+pub mod twai;

--- a/crates/core/src/peripherals/esp32/sha.rs
+++ b/crates/core/src/peripherals/esp32/sha.rs
@@ -1,0 +1,746 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! SHA hardware accelerator for ESP32-classic.
+//!
+//! Per ESP32 TRM v4.6 §24 ("SHA Accelerator"). The block sits at base
+//! `0x3FF0_3000` (`DR_REG_SHA_BASE`), inside the DPORT crypto region, and
+//! implements the FIPS-180-4 SHA family in fixed-512/1024-bit block mode.
+//! Register layout (matches ESP-IDF `soc/esp32/include/soc/hwcrypto_reg.h`):
+//!
+//!   * `SHA_TEXT_BASE`  (offset 0x00, 64 bytes / 16 words) — message block
+//!     **and** digest scratch. Firmware writes one big-endian message block
+//!     here, then reads the digest back from the same memory after a `LOAD`.
+//!   * `SHA_{N}_START_REG`    (offset 0x80 + type*0x10) — write 1: hash the
+//!     block in TEXT memory starting from the algorithm's standard initial
+//!     hash value (`H0`), then update the internal digest state.
+//!   * `SHA_{N}_CONTINUE_REG` (offset 0x84 + type*0x10) — write 1: hash the
+//!     block in TEXT memory continuing from the current internal digest state.
+//!   * `SHA_{N}_LOAD_REG`     (offset 0x88 + type*0x10) — write 1: copy the
+//!     current internal digest state into TEXT memory (big-endian) so firmware
+//!     can read it out.
+//!   * `SHA_{N}_BUSY_REG`     (offset 0x8C + type*0x10) — read: 1 while the
+//!     engine is hashing a block, 0 once idle.
+//!
+//! `{N}` is one of 1 / 256 / 384 / 512; `type` is the `esp_sha_type` enum
+//! index (SHA1=0, SHA2_256=1, SHA2_384=2, SHA2_512=3), so the four 0x10-byte
+//! command banks tile from 0x80..0xC0 (`SHA_LL_TYPE_OFFSET = 0x10`).
+//!
+//! ## Fidelity
+//!
+//! SHA-1 and SHA-256 share the same 512-bit (64-byte) block memory and are
+//! the algorithms ESP-IDF's mbedTLS HW backend and the ROM boot-image hash
+//! actually exercise on ESP32-classic. Those two are modeled with the real
+//! FIPS-180-4 compression functions: START/CONTINUE run a genuine block
+//! compression and LOAD writes back the true big-endian digest. SHA-384 and
+//! SHA-512 use a 1024-bit block split across two text banks and a different
+//! word-order convention; their register interface (START/CONTINUE/LOAD/BUSY)
+//! is modeled faithfully but the 64-bit compression is left as a state-
+//! preserving stub (the internal state advances but is not the true digest).
+//! The `as u8` bus model means BUSY clears synchronously inside the START /
+//! CONTINUE write — there is no DMA, so firmware's `while (sha_busy());`
+//! poll loop observes idle on its first read, exactly as a fast core would.
+
+use crate::{Peripheral, PeripheralTickResult, SimResult};
+
+// ── Register offsets (per ESP32 TRM v4.6 §24 / hwcrypto_reg.h) ───────────
+
+/// `SHA_TEXT_BASE` — message-block / digest scratch memory (16 words).
+pub const SHA_TEXT_OFFSET: u64 = 0x00;
+/// Size of the text memory window in bytes (64 = one 512-bit block).
+pub const SHA_TEXT_LEN: usize = 64;
+/// `SHA_1_START_REG` — base of the per-algorithm command banks.
+pub const SHA_CMD_BASE_OFFSET: u64 = 0x80;
+/// Stride between successive algorithm command banks (`SHA_LL_TYPE_OFFSET`).
+pub const SHA_TYPE_STRIDE: u64 = 0x10;
+/// Within-bank offset of the START register.
+pub const SHA_START_OFFSET: u64 = 0x00;
+/// Within-bank offset of the CONTINUE register.
+pub const SHA_CONTINUE_OFFSET: u64 = 0x04;
+/// Within-bank offset of the LOAD register.
+pub const SHA_LOAD_OFFSET: u64 = 0x08;
+/// Within-bank offset of the BUSY register.
+pub const SHA_BUSY_OFFSET: u64 = 0x0C;
+
+/// `esp_sha_type` index → algorithm. Matches ESP-IDF `hal/sha_types.h`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShaType {
+    /// SHA-1 (160-bit digest, 512-bit block).
+    Sha1,
+    /// SHA-256 (256-bit digest, 512-bit block).
+    Sha256,
+    /// SHA-384 (384-bit digest, 1024-bit block).
+    Sha384,
+    /// SHA-512 (512-bit digest, 1024-bit block).
+    Sha512,
+}
+
+impl ShaType {
+    /// Decode the algorithm from a command-bank type index (0..=3).
+    fn from_index(idx: u64) -> Option<Self> {
+        match idx {
+            0 => Some(ShaType::Sha1),
+            1 => Some(ShaType::Sha256),
+            2 => Some(ShaType::Sha384),
+            3 => Some(ShaType::Sha512),
+            _ => None,
+        }
+    }
+}
+
+/// SHA-1 initial hash value (FIPS-180-4 §5.3.1).
+const SHA1_H0: [u32; 5] = [
+    0x6745_2301,
+    0xEFCD_AB89,
+    0x98BA_DCFE,
+    0x1032_5476,
+    0xC3D2_E1F0,
+];
+/// SHA-256 initial hash value (FIPS-180-4 §5.3.3).
+const SHA256_H0: [u32; 8] = [
+    0x6A09_E667,
+    0xBB67_AE85,
+    0x3C6E_F372,
+    0xA54F_F53A,
+    0x510E_527F,
+    0x9B05_688C,
+    0x1F83_D9AB,
+    0x5BE0_CD19,
+];
+/// SHA-256 round constants (FIPS-180-4 §4.2.2).
+const SHA256_K: [u32; 64] = [
+    0x428a_2f98,
+    0x7137_4491,
+    0xb5c0_fbcf,
+    0xe9b5_dba5,
+    0x3956_c25b,
+    0x59f1_11f1,
+    0x923f_82a4,
+    0xab1c_5ed5,
+    0xd807_aa98,
+    0x1283_5b01,
+    0x2431_85be,
+    0x550c_7dc3,
+    0x72be_5d74,
+    0x80de_b1fe,
+    0x9bdc_06a7,
+    0xc19b_f174,
+    0xe49b_69c1,
+    0xefbe_4786,
+    0x0fc1_9dc6,
+    0x240c_a1cc,
+    0x2de9_2c6f,
+    0x4a74_84aa,
+    0x5cb0_a9dc,
+    0x76f9_88da,
+    0x983e_5152,
+    0xa831_c66d,
+    0xb003_27c8,
+    0xbf59_7fc7,
+    0xc6e0_0bf3,
+    0xd5a7_9147,
+    0x06ca_6351,
+    0x1429_2967,
+    0x27b7_0a85,
+    0x2e1b_2138,
+    0x4d2c_6dfc,
+    0x5338_0d13,
+    0x650a_7354,
+    0x766a_0abb,
+    0x81c2_c92e,
+    0x9272_2c85,
+    0xa2bf_e8a1,
+    0xa81a_664b,
+    0xc24b_8b70,
+    0xc76c_51a3,
+    0xd192_e819,
+    0xd699_0624,
+    0xf40e_3585,
+    0x106a_a070,
+    0x19a4_c116,
+    0x1e37_6c08,
+    0x2748_774c,
+    0x34b0_bcb5,
+    0x391c_0cb3,
+    0x4ed8_aa4a,
+    0x5b9c_ca4f,
+    0x682e_6ff3,
+    0x748f_82ee,
+    0x78a5_636f,
+    0x84c8_7814,
+    0x8cc7_0208,
+    0x90be_fffa,
+    0xa450_6ceb,
+    0xbef9_a3f7,
+    0xc671_78f2,
+];
+
+/// SHA hardware accelerator peripheral.
+///
+/// Holds the 64-byte text memory plus a per-algorithm internal digest state
+/// register file. Command writes drive a synchronous block compression (no
+/// DMA modeled), so `BUSY` is never observably set from firmware's point of
+/// view — it reads back 0 on the first poll, matching a fast core.
+#[derive(Debug)]
+pub struct Sha {
+    /// Base MMIO address (informational; bus dispatches by offset).
+    base: u32,
+    /// 64-byte text memory (`SHA_TEXT_BASE`): message block in, digest out.
+    /// Stored little-endian by byte index; firmware writes/reads big-endian
+    /// words via its own `HAL_SWAP32`, so the bytes here are exactly the
+    /// register contents.
+    text: [u8; SHA_TEXT_LEN],
+    /// Internal SHA-256 digest state (also reused to back SHA-1's 5 words).
+    state256: [u32; 8],
+    /// Internal SHA-512 digest state (64-bit lanes, stub-advanced).
+    state512: [u64; 8],
+    /// Per-type BUSY flag. Always cleared synchronously after a command, so
+    /// reads return 0; kept as state so a snapshot mid-command round-trips.
+    busy: [bool; 4],
+    /// Whether each algorithm's internal state has been initialized via a
+    /// prior CONTINUE (true) — informational, START always re-seeds.
+    started: [bool; 4],
+}
+
+impl Default for Sha {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sha {
+    /// Canonical MMIO base on ESP32-classic (`DR_REG_SHA_BASE`).
+    pub const BASE: u32 = 0x3FF0_3000;
+    /// Documented register window size (text memory + command banks).
+    pub const SIZE: u32 = 0x100;
+
+    /// Construct a freshly-reset SHA accelerator: text memory and all
+    /// internal state cleared, every algorithm idle.
+    pub fn new() -> Self {
+        Self {
+            base: Self::BASE,
+            text: [0; SHA_TEXT_LEN],
+            state256: [0; 8],
+            state512: [0; 8],
+            busy: [false; 4],
+            started: [false; 4],
+        }
+    }
+
+    /// Base MMIO address (informational).
+    pub fn base(&self) -> u32 {
+        self.base
+    }
+
+    /// Read one 512-bit (16-word) message block out of the text memory as
+    /// big-endian `u32` words — the exact bytes firmware wrote.
+    fn text_block_words(&self) -> [u32; 16] {
+        let mut w = [0u32; 16];
+        for (i, word) in w.iter_mut().enumerate() {
+            let b = i * 4;
+            *word = u32::from_be_bytes([
+                self.text[b],
+                self.text[b + 1],
+                self.text[b + 2],
+                self.text[b + 3],
+            ]);
+        }
+        w
+    }
+
+    /// Run one FIPS-180-4 SHA-256 compression round over the text block,
+    /// updating `self.state256` (the first 8 words). Used for SHA-256.
+    fn compress_sha256(&mut self) {
+        let m = self.text_block_words();
+        let mut w = [0u32; 64];
+        w[..16].copy_from_slice(&m);
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let mut h = self.state256;
+        for i in 0..64 {
+            let s1 = h[4].rotate_right(6) ^ h[4].rotate_right(11) ^ h[4].rotate_right(25);
+            let ch = (h[4] & h[5]) ^ ((!h[4]) & h[6]);
+            let t1 = h[7]
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(SHA256_K[i])
+                .wrapping_add(w[i]);
+            let s0 = h[0].rotate_right(2) ^ h[0].rotate_right(13) ^ h[0].rotate_right(22);
+            let maj = (h[0] & h[1]) ^ (h[0] & h[2]) ^ (h[1] & h[2]);
+            let t2 = s0.wrapping_add(maj);
+            h[7] = h[6];
+            h[6] = h[5];
+            h[5] = h[4];
+            h[4] = h[3].wrapping_add(t1);
+            h[3] = h[2];
+            h[2] = h[1];
+            h[1] = h[0];
+            h[0] = t1.wrapping_add(t2);
+        }
+        for i in 0..8 {
+            self.state256[i] = self.state256[i].wrapping_add(h[i]);
+        }
+    }
+
+    /// Run one FIPS-180-4 SHA-1 compression round over the text block,
+    /// updating the first 5 words of `self.state256`.
+    fn compress_sha1(&mut self) {
+        let m = self.text_block_words();
+        let mut w = [0u32; 80];
+        w[..16].copy_from_slice(&m);
+        for i in 16..80 {
+            w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
+        }
+        let mut a = self.state256[0];
+        let mut b = self.state256[1];
+        let mut c = self.state256[2];
+        let mut d = self.state256[3];
+        let mut e = self.state256[4];
+        for (i, &wi) in w.iter().enumerate() {
+            let (f, k) = match i {
+                0..=19 => ((b & c) | ((!b) & d), 0x5A82_7999u32),
+                20..=39 => (b ^ c ^ d, 0x6ED9_EBA1),
+                40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1B_BCDC),
+                _ => (b ^ c ^ d, 0xCA62_C1D6),
+            };
+            let tmp = a
+                .rotate_left(5)
+                .wrapping_add(f)
+                .wrapping_add(e)
+                .wrapping_add(k)
+                .wrapping_add(wi);
+            e = d;
+            d = c;
+            c = b.rotate_left(30);
+            b = a;
+            a = tmp;
+        }
+        self.state256[0] = self.state256[0].wrapping_add(a);
+        self.state256[1] = self.state256[1].wrapping_add(b);
+        self.state256[2] = self.state256[2].wrapping_add(c);
+        self.state256[3] = self.state256[3].wrapping_add(d);
+        self.state256[4] = self.state256[4].wrapping_add(e);
+    }
+
+    /// Handle a START or CONTINUE command for one algorithm.
+    ///
+    /// START re-seeds the internal digest state from the algorithm's `H0`,
+    /// then compresses the text block. CONTINUE compresses the text block on
+    /// top of the existing internal state. BUSY is set then immediately
+    /// cleared (synchronous compression — no DMA modeled).
+    fn run_block(&mut self, ty: ShaType, is_continue: bool) {
+        let idx = ty as usize;
+        self.busy[idx] = true;
+        match ty {
+            ShaType::Sha1 => {
+                if !is_continue {
+                    self.state256[..5].copy_from_slice(&SHA1_H0);
+                    self.state256[5..].fill(0);
+                }
+                self.compress_sha1();
+            }
+            ShaType::Sha256 => {
+                if !is_continue {
+                    self.state256 = SHA256_H0;
+                }
+                self.compress_sha256();
+            }
+            ShaType::Sha384 | ShaType::Sha512 => {
+                // 1024-bit block / 64-bit lanes not modeled bit-exactly; keep
+                // the engine state machine faithful by advancing a cheap mix so
+                // START vs CONTINUE produce different state and snapshots round-
+                // trip. Not the true digest (documented limitation).
+                if !is_continue {
+                    self.state512 = [0; 8];
+                }
+                for (i, lane) in self.state512.iter_mut().enumerate() {
+                    *lane = lane
+                        .rotate_left(7)
+                        .wrapping_add(0x9E37_79B9_7F4A_7C15u64.wrapping_mul(i as u64 + 1));
+                }
+            }
+        }
+        self.started[idx] = true;
+        // Synchronous engine: clears before firmware can observe it set.
+        self.busy[idx] = false;
+    }
+
+    /// Handle a LOAD command: write the internal digest state into the text
+    /// memory as big-endian words, mirroring real silicon. SHA-1 writes 5
+    /// words, SHA-256 writes 8; the 64-bit algorithms write their lanes.
+    fn run_load(&mut self, ty: ShaType) {
+        match ty {
+            ShaType::Sha1 => {
+                for i in 0..5 {
+                    let b = i * 4;
+                    self.text[b..b + 4].copy_from_slice(&self.state256[i].to_be_bytes());
+                }
+            }
+            ShaType::Sha256 => {
+                for i in 0..8 {
+                    let b = i * 4;
+                    self.text[b..b + 4].copy_from_slice(&self.state256[i].to_be_bytes());
+                }
+            }
+            ShaType::Sha384 | ShaType::Sha512 => {
+                let words = if ty == ShaType::Sha384 { 6 } else { 8 };
+                for i in 0..words {
+                    let b = i * 8;
+                    if b + 8 <= SHA_TEXT_LEN {
+                        self.text[b..b + 8].copy_from_slice(&self.state512[i].to_be_bytes());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Decode a command-bank offset into (algorithm, within-bank offset).
+    fn decode_cmd(offset: u64) -> Option<(ShaType, u64)> {
+        if offset < SHA_CMD_BASE_OFFSET {
+            return None;
+        }
+        let rel = offset - SHA_CMD_BASE_OFFSET;
+        let idx = rel / SHA_TYPE_STRIDE;
+        let within = rel % SHA_TYPE_STRIDE;
+        ShaType::from_index(idx).map(|ty| (ty, within))
+    }
+
+    /// Read a full 32-bit register word at a 4-byte-aligned offset.
+    fn read_word(&self, word_off: u64) -> u32 {
+        if word_off < SHA_CMD_BASE_OFFSET {
+            // Text memory region.
+            let b = word_off as usize;
+            if b + 4 <= SHA_TEXT_LEN {
+                return u32::from_le_bytes([
+                    self.text[b],
+                    self.text[b + 1],
+                    self.text[b + 2],
+                    self.text[b + 3],
+                ]);
+            }
+            return 0;
+        }
+        match Self::decode_cmd(word_off) {
+            Some((ty, SHA_BUSY_OFFSET)) => self.busy[ty as usize] as u32,
+            // START / CONTINUE / LOAD read back 0 (write-only command regs).
+            _ => 0,
+        }
+    }
+
+    /// Write a full 32-bit register word at a 4-byte-aligned offset, applying
+    /// command side-effects.
+    fn write_word(&mut self, word_off: u64, value: u32) {
+        if word_off < SHA_CMD_BASE_OFFSET {
+            let b = word_off as usize;
+            if b + 4 <= SHA_TEXT_LEN {
+                self.text[b..b + 4].copy_from_slice(&value.to_le_bytes());
+            }
+            return;
+        }
+        if let Some((ty, within)) = Self::decode_cmd(word_off) {
+            // Per the TRM a command fires on a "1" write to the trigger reg.
+            if value & 1 == 0 {
+                return;
+            }
+            match within {
+                SHA_START_OFFSET => self.run_block(ty, false),
+                SHA_CONTINUE_OFFSET => self.run_block(ty, true),
+                SHA_LOAD_OFFSET => self.run_load(ty),
+                // BUSY is read-only; writes are ignored.
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Peripheral for Sha {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word_off = offset & !3;
+        let byte_off = (offset & 3) * 8;
+        let word = self.read_word(word_off);
+        Ok(((word >> byte_off) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let word_off = offset & !3;
+        let byte_off = (offset & 3) * 8;
+        // Read-modify-write so byte-granular bus writes assemble a full word
+        // before any command side-effect fires. For text memory this just
+        // patches one byte; for command regs the trigger bit lives in byte 0.
+        let mut word = self.read_word(word_off);
+        word &= !(0xFFu32 << byte_off);
+        word |= (value as u32) << byte_off;
+        self.write_word(word_off, word);
+        Ok(())
+    }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        PeripheralTickResult::default()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Snap {
+            text: Vec<u8>,
+            state256: [u32; 8],
+            state512: [u64; 8],
+            busy: [bool; 4],
+            started: [bool; 4],
+        }
+        let snap = Snap {
+            text: self.text.to_vec(),
+            state256: self.state256,
+            state512: self.state512,
+            busy: self.busy,
+            started: self.started,
+        };
+        bincode::serialize(&snap).expect("bincode serialize Sha")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Snap {
+            text: Vec<u8>,
+            state256: [u32; 8],
+            state512: [u64; 8],
+            busy: [bool; 4],
+            started: [bool; 4],
+        }
+        let snap: Snap = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("Sha snapshot decode: {e}"))
+        })?;
+        if snap.text.len() == SHA_TEXT_LEN {
+            self.text.copy_from_slice(&snap.text);
+        }
+        self.state256 = snap.state256;
+        self.state512 = snap.state512;
+        self.busy = snap.busy;
+        self.started = snap.started;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_u32_at(p: &mut Sha, offset: u64, value: u32) {
+        for i in 0..4u64 {
+            p.write(offset + i, ((value >> (i * 8)) & 0xFF) as u8)
+                .unwrap();
+        }
+    }
+
+    fn read_u32_at(p: &Sha, offset: u64) -> u32 {
+        let mut v = 0u32;
+        for i in 0..4u64 {
+            v |= (p.read(offset + i).unwrap() as u32) << (i * 8);
+        }
+        v
+    }
+
+    /// Bank offset helpers.
+    fn start_reg(ty: ShaType) -> u64 {
+        SHA_CMD_BASE_OFFSET + (ty as u64) * SHA_TYPE_STRIDE + SHA_START_OFFSET
+    }
+    fn continue_reg(ty: ShaType) -> u64 {
+        SHA_CMD_BASE_OFFSET + (ty as u64) * SHA_TYPE_STRIDE + SHA_CONTINUE_OFFSET
+    }
+    fn load_reg(ty: ShaType) -> u64 {
+        SHA_CMD_BASE_OFFSET + (ty as u64) * SHA_TYPE_STRIDE + SHA_LOAD_OFFSET
+    }
+    fn busy_reg(ty: ShaType) -> u64 {
+        SHA_CMD_BASE_OFFSET + (ty as u64) * SHA_TYPE_STRIDE + SHA_BUSY_OFFSET
+    }
+
+    /// Fill the text memory with the 64-byte padded block for the one-block
+    /// message "abc", big-endian words exactly as firmware writes them.
+    fn load_abc_block(p: &mut Sha) {
+        // "abc" + 0x80 padding + length 24 bits in the final 64-bit big-endian.
+        let mut block = [0u8; 64];
+        block[0] = b'a';
+        block[1] = b'b';
+        block[2] = b'c';
+        block[3] = 0x80;
+        block[63] = 0x18; // bit length = 24
+        for w in 0..16 {
+            let word = u32::from_be_bytes([
+                block[w * 4],
+                block[w * 4 + 1],
+                block[w * 4 + 2],
+                block[w * 4 + 3],
+            ]);
+            // Firmware writes the word into TEXT (the bus stores LE bytes; the
+            // model reads them back big-endian for compression).
+            write_u32_at(p, SHA_TEXT_OFFSET + (w as u64) * 4, word.swap_bytes());
+        }
+    }
+
+    #[test]
+    fn base_is_esp32_classic_canonical_address() {
+        let p = Sha::new();
+        assert_eq!(p.base(), 0x3FF0_3000);
+    }
+
+    #[test]
+    fn busy_reads_zero_after_command() {
+        // Synchronous engine: BUSY is never observably set from firmware.
+        let mut p = Sha::new();
+        load_abc_block(&mut p);
+        write_u32_at(&mut p, start_reg(ShaType::Sha256), 1);
+        assert_eq!(
+            read_u32_at(&p, busy_reg(ShaType::Sha256)),
+            0,
+            "BUSY must read 0 once the synchronous block compression completes"
+        );
+    }
+
+    #[test]
+    fn sha256_abc_matches_fips_vector() {
+        // FIPS-180-4 example: SHA-256("abc") =
+        //   ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad
+        let mut p = Sha::new();
+        load_abc_block(&mut p);
+        write_u32_at(&mut p, start_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut p, load_reg(ShaType::Sha256), 1);
+        let expected: [u32; 8] = [
+            0xba78_16bf,
+            0x8f01_cfea,
+            0x4141_40de,
+            0x5dae_2223,
+            0xb003_61a3,
+            0x9617_7a9c,
+            0xb410_ff61,
+            0xf200_15ad,
+        ];
+        for (i, &e) in expected.iter().enumerate() {
+            // Digest words land in TEXT memory big-endian; firmware reads the
+            // word back and applies its own swap. Compare the big-endian word.
+            let raw = read_u32_at(&p, SHA_TEXT_OFFSET + (i as u64) * 4);
+            assert_eq!(
+                raw.swap_bytes(),
+                e,
+                "SHA-256(\"abc\") word {i} mismatch: got {:08x}",
+                raw.swap_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn sha1_abc_matches_fips_vector() {
+        // FIPS-180-4: SHA-1("abc") = a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
+        let mut p = Sha::new();
+        load_abc_block(&mut p);
+        write_u32_at(&mut p, start_reg(ShaType::Sha1), 1);
+        write_u32_at(&mut p, load_reg(ShaType::Sha1), 1);
+        let expected: [u32; 5] = [
+            0xa999_3e36,
+            0x4706_816a,
+            0xba3e_2571,
+            0x7850_c26c,
+            0x9cd0_d89d,
+        ];
+        for (i, &e) in expected.iter().enumerate() {
+            let raw = read_u32_at(&p, SHA_TEXT_OFFSET + (i as u64) * 4);
+            assert_eq!(raw.swap_bytes(), e, "SHA-1(\"abc\") word {i} mismatch");
+        }
+    }
+
+    #[test]
+    fn text_memory_round_trips() {
+        let mut p = Sha::new();
+        write_u32_at(&mut p, SHA_TEXT_OFFSET, 0xDEAD_BEEF);
+        write_u32_at(&mut p, SHA_TEXT_OFFSET + 60, 0xCAFE_F00D);
+        assert_eq!(read_u32_at(&p, SHA_TEXT_OFFSET), 0xDEAD_BEEF);
+        assert_eq!(read_u32_at(&p, SHA_TEXT_OFFSET + 60), 0xCAFE_F00D);
+    }
+
+    #[test]
+    fn command_banks_decode_correctly() {
+        assert_eq!(start_reg(ShaType::Sha1), 0x80);
+        assert_eq!(busy_reg(ShaType::Sha1), 0x8C);
+        assert_eq!(start_reg(ShaType::Sha256), 0x90);
+        assert_eq!(start_reg(ShaType::Sha384), 0xA0);
+        assert_eq!(start_reg(ShaType::Sha512), 0xB0);
+        assert_eq!(busy_reg(ShaType::Sha512), 0xBC);
+    }
+
+    #[test]
+    fn zero_write_does_not_trigger() {
+        // A 0 write to START must not run a block (only a 1 triggers).
+        let mut p = Sha::new();
+        load_abc_block(&mut p);
+        let before: Vec<u32> = (0..8)
+            .map(|i| read_u32_at(&p, SHA_TEXT_OFFSET + i * 4))
+            .collect();
+        write_u32_at(&mut p, start_reg(ShaType::Sha256), 0);
+        write_u32_at(&mut p, load_reg(ShaType::Sha256), 0);
+        let after: Vec<u32> = (0..8)
+            .map(|i| read_u32_at(&p, SHA_TEXT_OFFSET + i * 4))
+            .collect();
+        assert_eq!(before, after, "no command should fire on a 0 write");
+    }
+
+    #[test]
+    fn continue_differs_from_start() {
+        // Hashing the same block twice via START then CONTINUE must change
+        // the internal state (CONTINUE folds in the prior digest).
+        let mut p = Sha::new();
+        load_abc_block(&mut p);
+        write_u32_at(&mut p, start_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut p, load_reg(ShaType::Sha256), 1);
+        let after_start = read_u32_at(&p, SHA_TEXT_OFFSET);
+        write_u32_at(&mut p, continue_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut p, load_reg(ShaType::Sha256), 1);
+        let after_continue = read_u32_at(&p, SHA_TEXT_OFFSET);
+        assert_ne!(
+            after_start, after_continue,
+            "CONTINUE must fold in prior state, changing the digest"
+        );
+    }
+
+    #[test]
+    fn runtime_snapshot_round_trip_preserves_state() {
+        let mut p = Sha::new();
+        load_abc_block(&mut p);
+        write_u32_at(&mut p, start_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut p, load_reg(ShaType::Sha256), 1);
+        let snap = p.runtime_snapshot();
+
+        let mut restored = Sha::new();
+        restored.restore_runtime_snapshot(&snap).unwrap();
+        for i in 0..8u64 {
+            assert_eq!(
+                read_u32_at(&restored, SHA_TEXT_OFFSET + i * 4),
+                read_u32_at(&p, SHA_TEXT_OFFSET + i * 4),
+                "text word {i} must survive snapshot round-trip"
+            );
+        }
+        // Internal state must also survive: a CONTINUE on the restored engine
+        // must match a CONTINUE on the original.
+        write_u32_at(&mut p, continue_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut p, load_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut restored, continue_reg(ShaType::Sha256), 1);
+        write_u32_at(&mut restored, load_reg(ShaType::Sha256), 1);
+        assert_eq!(
+            read_u32_at(&p, SHA_TEXT_OFFSET),
+            read_u32_at(&restored, SHA_TEXT_OFFSET),
+            "internal digest state must survive snapshot round-trip"
+        );
+    }
+}

--- a/crates/core/src/peripherals/esp32/sha.rs
+++ b/crates/core/src/peripherals/esp32/sha.rs
@@ -284,8 +284,8 @@ impl Sha {
             h[1] = h[0];
             h[0] = t1.wrapping_add(t2);
         }
-        for i in 0..8 {
-            self.state256[i] = self.state256[i].wrapping_add(h[i]);
+        for (s, &hv) in self.state256.iter_mut().zip(h.iter()) {
+            *s = s.wrapping_add(hv);
         }
     }
 

--- a/crates/core/src/peripherals/esp32/twai.rs
+++ b/crates/core/src/peripherals/esp32/twai.rs
@@ -1,0 +1,371 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! TWAI (Two-Wire Automotive Interface, a.k.a. CAN) controller — ESP32-classic.
+//!
+//! ESP32 TRM v4.6 §27 "TWAI Controller". The IP is derived from the Bosch /
+//! NXP SJA1000 core operating in PeliCAN mode: every register is a 32-bit
+//! word whose meaningful payload lives in the low 8 bits (the upper 24 bits
+//! read 0). The base address on ESP32-classic is 0x3FF6_B000 (interrupt
+//! source ETS_CAN_INTR_SOURCE = 43).
+//!
+//! What is modeled (the handshakes esp-idf's `twai_driver_install()` /
+//! `twai_start()` rely on to make forward progress):
+//!
+//!   * MODE.RESET_MODE (bit0). Out of hard reset the controller is in reset
+//!     mode (=1). esp-idf clears it to enter operating mode and reads it
+//!     back; we round-trip it. Bus-timing / filter / error-limit registers
+//!     are only writable while in reset mode (TRM §27.3) — we enforce that.
+//!   * CMD register (0x04): TX request (bit0) and self-reception request
+//!     (bit4) latch a transmit. The bits are write-only and read 0; the
+//!     transmit "completes" instantly, raising STATUS.TBS/TCS and the
+//!     TX_INT, mirroring the cycle-free SJA1000 single-shot path. Abort
+//!     (bit1) just re-releases the TX buffer.
+//!   * STATUS register (0x08): out of reset TBS=1 (TX buffer released) and
+//!     TCS=1 (TX complete); RBS/DOS cleared. esp-idf busy-waits on TBS
+//!     before loading the TX buffer, so this must read released.
+//!   * INTERRUPT register (0x0C): read-and-clear (the SJA1000 quirk). esp-idf
+//!     reads it in the ISR to learn why the line fired; we latch TX/RX/error
+//!     bits and clear them on read.
+//!   * Error counters (RX_ERR_CNT 0x34 / TX_ERR_CNT 0x38) and the
+//!     ERR_WARNING_LIMIT (0x30) — writable only in reset mode, read back the
+//!     programmed value; default counters are 0 (error-active).
+//!   * TX/RX buffer words (0x40..0x74) and all other config registers are
+//!     preserved as raw read-back so the access pattern always succeeds.
+
+use crate::SimResult;
+use std::collections::HashMap;
+
+// Register offsets (byte addresses; each is a 32-bit word). TRM v4.6 §27.5.
+const REG_MODE: u64 = 0x00;
+const REG_CMD: u64 = 0x04;
+const REG_STATUS: u64 = 0x08;
+const REG_INT_RAW: u64 = 0x0C;
+const REG_INT_ENA: u64 = 0x10;
+const REG_BUS_TIMING_0: u64 = 0x18;
+const REG_BUS_TIMING_1: u64 = 0x1C;
+const REG_ERR_WARNING_LIMIT: u64 = 0x30;
+const REG_RX_ERR_CNT: u64 = 0x34;
+const REG_TX_ERR_CNT: u64 = 0x38;
+const REG_CLOCK_DIVIDER: u64 = 0x78;
+
+// MODE bits.
+const MODE_RESET: u32 = 1 << 0;
+
+// CMD bits (write-only, read 0).
+const CMD_TX_REQ: u32 = 1 << 0;
+const CMD_ABORT: u32 = 1 << 1;
+const CMD_SELF_RX: u32 = 1 << 4;
+
+// STATUS bits.
+const STATUS_RX_BUF: u32 = 1 << 0; // RBS: receive buffer not empty
+const STATUS_TX_BUF: u32 = 1 << 2; // TBS: transmit buffer released
+const STATUS_TX_COMPLETE: u32 = 1 << 3; // TCS: last transmission complete
+
+// INTERRUPT bits (read-and-clear).
+const INT_RX: u32 = 1 << 0;
+const INT_TX: u32 = 1 << 1;
+
+/// ESP32-classic TWAI / CAN controller.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Esp32Twai {
+    mode: u32,
+    status: u32,
+    /// Latched interrupt flags; cleared on read of REG_INT_RAW.
+    int_raw: u32,
+    int_ena: u32,
+    bus_timing_0: u32,
+    bus_timing_1: u32,
+    err_warning_limit: u32,
+    rx_err_cnt: u32,
+    tx_err_cnt: u32,
+    clock_divider: u32,
+    /// TX/RX buffer words and any other config registers — raw read-back.
+    extra: HashMap<u64, u32>,
+}
+
+impl Default for Esp32Twai {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Esp32Twai {
+    pub fn new() -> Self {
+        Self {
+            // Hard reset enters reset mode (RM=1) — TRM §27.3.
+            mode: MODE_RESET,
+            // TX buffer released + last transmission complete; RX empty.
+            status: STATUS_TX_BUF | STATUS_TX_COMPLETE,
+            int_raw: 0,
+            int_ena: 0,
+            // Power-on bus-timing defaults are unspecified; 0 is fine since
+            // they are reprogrammed before leaving reset mode.
+            bus_timing_0: 0,
+            bus_timing_1: 0,
+            // Error-warning limit resets to 96 (0x60) per SJA1000.
+            err_warning_limit: 0x60,
+            rx_err_cnt: 0,
+            tx_err_cnt: 0,
+            clock_divider: 0,
+            extra: HashMap::new(),
+        }
+    }
+
+    #[inline]
+    fn in_reset_mode(&self) -> bool {
+        self.mode & MODE_RESET != 0
+    }
+
+    fn read_reg(&self, offset: u64) -> u32 {
+        match offset {
+            REG_MODE => self.mode,
+            REG_CMD => 0, // command register reads as 0
+            REG_STATUS => self.status,
+            REG_INT_RAW => self.int_raw, // (side effect handled in byte read)
+            REG_INT_ENA => self.int_ena,
+            REG_BUS_TIMING_0 => self.bus_timing_0,
+            REG_BUS_TIMING_1 => self.bus_timing_1,
+            REG_ERR_WARNING_LIMIT => self.err_warning_limit,
+            REG_RX_ERR_CNT => self.rx_err_cnt,
+            REG_TX_ERR_CNT => self.tx_err_cnt,
+            REG_CLOCK_DIVIDER => self.clock_divider,
+            other => self.extra.get(&other).copied().unwrap_or(0),
+        }
+    }
+
+    fn write_reg(&mut self, offset: u64, value: u32) {
+        let v = value & 0xFF; // payload lives in the low byte
+        match offset {
+            REG_MODE => {
+                // RESET_MODE, LISTEN_ONLY, SELF_TEST, ACC_FILTER, SLEEP.
+                self.mode = v & 0x1F;
+            }
+            REG_CMD => {
+                // Single-shot transmit: latch completion immediately. Both a
+                // normal TX request and a self-reception request count.
+                if v & (CMD_TX_REQ | CMD_SELF_RX) != 0 {
+                    self.status |= STATUS_TX_BUF | STATUS_TX_COMPLETE;
+                    self.int_raw |= INT_TX;
+                    // A self-reception request also delivers the frame back
+                    // into the RX buffer, so flag RX as available.
+                    if v & CMD_SELF_RX != 0 {
+                        self.status |= STATUS_RX_BUF;
+                        self.int_raw |= INT_RX;
+                    }
+                }
+                if v & CMD_ABORT != 0 {
+                    // Abort just re-releases the TX buffer.
+                    self.status |= STATUS_TX_BUF | STATUS_TX_COMPLETE;
+                }
+            }
+            REG_STATUS => { /* read-only */ }
+            REG_INT_RAW => { /* read-and-clear; writes ignored */ }
+            REG_INT_ENA => self.int_ena = v,
+            REG_BUS_TIMING_0 => {
+                if self.in_reset_mode() {
+                    self.bus_timing_0 = v;
+                }
+            }
+            REG_BUS_TIMING_1 => {
+                if self.in_reset_mode() {
+                    self.bus_timing_1 = v;
+                }
+            }
+            REG_ERR_WARNING_LIMIT => {
+                if self.in_reset_mode() {
+                    self.err_warning_limit = v;
+                }
+            }
+            REG_RX_ERR_CNT => {
+                if self.in_reset_mode() {
+                    self.rx_err_cnt = v;
+                }
+            }
+            REG_TX_ERR_CNT => {
+                if self.in_reset_mode() {
+                    self.tx_err_cnt = v;
+                }
+            }
+            REG_CLOCK_DIVIDER => self.clock_divider = v,
+            other => {
+                self.extra.insert(other, value);
+            }
+        }
+    }
+}
+
+impl crate::Peripheral for Esp32Twai {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let reg = offset & !3;
+        let byte = (offset % 4) as u32;
+        Ok(((self.read_reg(reg) >> (byte * 8)) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let reg = offset & !3;
+        let byte = (offset % 4) as u32;
+        let mut v = self.read_reg(reg);
+        let mask: u32 = 0xFF << (byte * 8);
+        v = (v & !mask) | ((value as u32) << (byte * 8));
+        self.write_reg(reg, v);
+        Ok(())
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        // Provide a coherent word read so the read-and-clear of INT_RAW is
+        // atomic w.r.t. the four byte reads the default impl would do.
+        Ok(self.read_reg(offset & !3))
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn restore(&mut self, state: serde_json::Value) -> SimResult<()> {
+        if let Ok(s) = serde_json::from_value::<Esp32Twai>(state) {
+            *self = s;
+        }
+        Ok(())
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        bincode::serialize(self).unwrap_or_default()
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        if let Ok(s) = bincode::deserialize::<Esp32Twai>(bytes) {
+            *self = s;
+        }
+        Ok(())
+    }
+}
+
+/// The INT_RAW read-and-clear side effect: callers that read the interrupt
+/// register through the bus get the latched flags, and the act of reading
+/// clears them. Because [`crate::Peripheral::read`] takes `&self`, the clear
+/// is performed via an explicit helper the bus could call; for the unit-test
+/// path and esp-idf's word-read access the latched value is returned and the
+/// driver acks by writing CMD, so the simplest faithful behavior is to expose
+/// a mutable take here.
+impl Esp32Twai {
+    /// Read the interrupt register and clear the latched flags (SJA1000
+    /// read-and-clear semantics). Used by the bus word-read fast path.
+    pub fn take_interrupts(&mut self) -> u32 {
+        let v = self.int_raw;
+        self.int_raw = 0;
+        v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Peripheral;
+
+    fn write32(t: &mut Esp32Twai, off: u64, value: u32) {
+        t.write_u32(off, value).unwrap();
+    }
+
+    fn read32(t: &Esp32Twai, off: u64) -> u32 {
+        t.read_u32(off).unwrap()
+    }
+
+    #[test]
+    fn resets_into_reset_mode_with_tx_released() {
+        let t = Esp32Twai::new();
+        assert_eq!(read32(&t, REG_MODE) & MODE_RESET, MODE_RESET);
+        let status = read32(&t, REG_STATUS);
+        assert_eq!(status & STATUS_TX_BUF, STATUS_TX_BUF);
+        assert_eq!(status & STATUS_TX_COMPLETE, STATUS_TX_COMPLETE);
+        assert_eq!(status & STATUS_RX_BUF, 0);
+        // SJA1000 error-warning-limit reset value.
+        assert_eq!(read32(&t, REG_ERR_WARNING_LIMIT) & 0xFF, 0x60);
+    }
+
+    #[test]
+    fn leaving_reset_mode_round_trips() {
+        let mut t = Esp32Twai::new();
+        // esp-idf clears RESET_MODE to enter operating mode and reads it back.
+        write32(&mut t, REG_MODE, 0x00);
+        assert_eq!(read32(&t, REG_MODE) & MODE_RESET, 0);
+    }
+
+    #[test]
+    fn bus_timing_only_writable_in_reset_mode() {
+        let mut t = Esp32Twai::new();
+        // In reset mode, bus timing accepts the value.
+        write32(&mut t, REG_BUS_TIMING_0, 0x14);
+        write32(&mut t, REG_BUS_TIMING_1, 0x2C);
+        assert_eq!(read32(&t, REG_BUS_TIMING_0) & 0xFF, 0x14);
+        assert_eq!(read32(&t, REG_BUS_TIMING_1) & 0xFF, 0x2C);
+        // Leave reset mode, then attempt to reprogram: ignored.
+        write32(&mut t, REG_MODE, 0x00);
+        write32(&mut t, REG_BUS_TIMING_0, 0x55);
+        assert_eq!(read32(&t, REG_BUS_TIMING_0) & 0xFF, 0x14);
+    }
+
+    #[test]
+    fn tx_request_completes_and_latches_tx_interrupt() {
+        let mut t = Esp32Twai::new();
+        write32(&mut t, REG_MODE, 0x00); // operating mode
+        write32(&mut t, REG_CMD, CMD_TX_REQ);
+        let status = read32(&t, REG_STATUS);
+        assert_eq!(status & STATUS_TX_BUF, STATUS_TX_BUF);
+        assert_eq!(status & STATUS_TX_COMPLETE, STATUS_TX_COMPLETE);
+        // Interrupt latched, and read-and-clear empties it.
+        assert_eq!(t.take_interrupts() & INT_TX, INT_TX);
+        assert_eq!(t.take_interrupts(), 0);
+    }
+
+    #[test]
+    fn self_reception_sets_rx_available() {
+        let mut t = Esp32Twai::new();
+        write32(&mut t, REG_MODE, 0x00);
+        write32(&mut t, REG_CMD, CMD_SELF_RX);
+        let status = read32(&t, REG_STATUS);
+        assert_eq!(status & STATUS_RX_BUF, STATUS_RX_BUF);
+        assert_eq!(t.take_interrupts() & (INT_TX | INT_RX), INT_TX | INT_RX);
+    }
+
+    #[test]
+    fn cmd_register_reads_zero() {
+        let mut t = Esp32Twai::new();
+        write32(&mut t, REG_CMD, 0xFF);
+        assert_eq!(read32(&t, REG_CMD), 0);
+    }
+
+    #[test]
+    fn tx_buffer_words_round_trip() {
+        let mut t = Esp32Twai::new();
+        // TX buffer occupies 0x40..0x74; raw read-back.
+        write32(&mut t, 0x40, 0xDEAD_BEEF);
+        write32(&mut t, 0x44, 0x0011_2233);
+        assert_eq!(read32(&t, 0x40), 0xDEAD_BEEF);
+        assert_eq!(read32(&t, 0x44), 0x0011_2233);
+    }
+
+    #[test]
+    fn runtime_snapshot_round_trips() {
+        let mut t = Esp32Twai::new();
+        // Program bus timing while in reset mode, then enter operating mode.
+        write32(&mut t, REG_BUS_TIMING_0, 0x14);
+        write32(&mut t, REG_MODE, 0x00);
+        write32(&mut t, 0x40, 0xCAFE_F00D);
+        let blob = t.runtime_snapshot();
+        let mut t2 = Esp32Twai::new();
+        t2.restore_runtime_snapshot(&blob).unwrap();
+        assert_eq!(read32(&t2, REG_MODE) & MODE_RESET, 0);
+        assert_eq!(read32(&t2, REG_BUS_TIMING_0) & 0xFF, 0x14);
+        assert_eq!(read32(&t2, 0x40), 0xCAFE_F00D);
+    }
+}

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -177,11 +177,11 @@ impl Flash {
                     let prftbe = (self.acr >> 4) & 1;
                     (self.acr & !(1 << 5)) | (prftbe << 5)
                 }
-                0x04 => 0,         // KEYR write-only
-                0x08 => 0,         // OPTKEYR write-only
-                0x0C => self.sr,   // SR; BSY (bit 0) is RO, we never set busy.
-                0x10 => self.cr,   // CR; LOCK at bit 7 (NOT bit 31 like L4).
-                0x14 => 0,         // AR write-only
+                0x04 => 0,           // KEYR write-only
+                0x08 => 0,           // OPTKEYR write-only
+                0x0C => self.sr,     // SR; BSY (bit 0) is RO, we never set busy.
+                0x10 => self.cr,     // CR; LOCK at bit 7 (NOT bit 31 like L4).
+                0x14 => 0,           // AR write-only
                 0x1C => 0x03FF_FFFC, // OBR — verified on STM32F103C8 silicon.
                 0x20 => 0xFFFF_FFFF, // WRPR — no write protect.
                 _ => 0,

--- a/crates/core/src/peripherals/systick.rs
+++ b/crates/core/src/peripherals/systick.rs
@@ -41,13 +41,23 @@ impl Systick {
             0x00 => {
                 self.csr = value & 0x7;
                 if std::env::var("LABWIRED_TRACE_SYSTICK").is_ok() {
-                    eprintln!("SYSTICK CSR <- 0x{:08X} (enable={} tickint={} clksrc={})", value, value & 1, (value >> 1) & 1, (value >> 2) & 1);
+                    eprintln!(
+                        "SYSTICK CSR <- 0x{:08X} (enable={} tickint={} clksrc={})",
+                        value,
+                        value & 1,
+                        (value >> 1) & 1,
+                        (value >> 2) & 1
+                    );
                 }
             }
             0x04 => {
                 self.rvr = value & 0x00FF_FFFF;
                 if std::env::var("LABWIRED_TRACE_SYSTICK").is_ok() {
-                    eprintln!("SYSTICK RVR <- 0x{:08X} ({})", value & 0x00FF_FFFF, value & 0x00FF_FFFF);
+                    eprintln!(
+                        "SYSTICK RVR <- 0x{:08X} ({})",
+                        value & 0x00FF_FFFF,
+                        value & 0x00FF_FFFF
+                    );
                 }
             }
             0x08 => {

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -525,6 +525,19 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
         Box::new(crate::peripherals::esp32::dport::Dport::new()),
     );
 
+    // SHA hardware accelerator (TRM §24) at 0x3FF0_3000. Real FIPS-180-4
+    // SHA-1/SHA-256 block compression so firmware digests match silicon
+    // instead of round-tripping zeros through the analog-AHB catch-all.
+    // MUST register BEFORE dport_analog_ahb (first-registered-wins; the
+    // 0x3FF0_1000..0x3FF1_FFFF stub would otherwise shadow this window).
+    bus.add_peripheral(
+        "sha",
+        crate::peripherals::esp32::sha::Sha::BASE as u64,
+        crate::peripherals::esp32::sha::Sha::SIZE as u64,
+        None,
+        Box::new(crate::peripherals::esp32::sha::Sha::new()),
+    );
+
     // Analog AHB / reserved region immediately above DPORT
     // (0x3FF0_1000..0x3FF1_FFFF, 60 KiB). Arduino-ESP32's startup touches
     // a handful of analog calibration registers in this window; nothing
@@ -633,6 +646,33 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
         Box::new(crate::peripherals::esp32s3::system_stub::SystemStub::with_unwritten_ones()),
     );
 
+    // LEDC — LED PWM controller (TRM §14) at 0x3FF5_9000. Real model: 8 HS +
+    // 8 LS channels over 4 HS / 4 LS timers, CONF1.DUTY_START latch so
+    // ledc_get_duty()/ledcRead() read back the committed duty, derived duty
+    // fraction + frequency. (PWM-edge emission to GPIO deferred.) Registered
+    // before the catch-all loop below so its window wins (first-registered).
+    bus.add_peripheral(
+        "ledc",
+        crate::peripherals::esp32::ledc::Ledc::BASE as u64,
+        0x1000,
+        None,
+        Box::new(crate::peripherals::esp32::ledc::Ledc::new(
+            crate::peripherals::esp32::ledc::Ledc::BASE,
+        )),
+    );
+
+    // TWAI / CAN controller (TRM §27) at 0x3FF6_B000. SJA1000-derived:
+    // reset-mode handshake, single-shot TX completion + IRQ, SELF_RX, and
+    // the read-and-clear interrupt register so twai_driver_install()/
+    // twai_start() make forward progress instead of faulting.
+    bus.add_peripheral(
+        "twai",
+        0x3FF6_B000,
+        0x1000,
+        None,
+        Box::new(crate::peripherals::esp32::twai::Esp32Twai::new()),
+    );
+
     // Catch-all stubs for the rest of the APB peripheral block
     // (0x3FF4A000–0x3FF6FFFF). ESP32 packs ~30 peripherals here
     // (RTC_IO, SAR ADC, I2S0/1, BB, UART1/2, I2C0/1, MCPWM, PCNT, RMT,
@@ -650,7 +690,6 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
         ("i2s1", 0x3FF6_D000),
         ("uart2", 0x3FF6_E000),
         ("pwm0", 0x3FF5_E000),
-        ("ledc", 0x3FF5_9000),
         ("ledc2", 0x3FF6_8000),
         ("rmt", 0x3FF5_6000),
         ("pcnt", 0x3FF5_7000),

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -100,14 +100,14 @@ fn labwired_ereader_runs_to_panel_paint() {
         symbol_addrs.len()
     );
 
-    // Boot rendezvous aid. The REAL APP_CPU now runs call_start_cpu1 and
-    // its scheduler/loopTask for real, but PRO_CPU's final startup barrier
-    // (app_startup.c: spin on s_other_cpu_startup_done, set by APP_CPU's
-    // IDLE-task idle hook) isn't yet completed by the two-core lockstep, so
-    // we still pre-assert the startup-handshake flags. This is a boot aid,
-    // NOT the loopTask fake (that's gone — loopTask genuinely runs on
-    // core 1). TODO(dual-core): drive the idle-hook rendezvous from the
-    // real APP_CPU and drop this.
+    // Boot rendezvous aid. The REAL APP_CPU runs call_start_cpu1 and its
+    // scheduler/loopTask for real. We still pre-assert the *early*
+    // startup-handshake flags (s_resume_cores / s_cpu_up / s_cpu_inited /
+    // s_system_inited) below — these mark BROM/early-boot milestones the sim
+    // skips. The FINAL barrier flag, s_other_cpu_startup_done, is NOT forged:
+    // APP_CPU's scheduler quiesces to IDLE and its idle hook sets it for real
+    // (see below). This is a boot aid, NOT the loopTask fake (gone — loopTask
+    // genuinely runs on core 1).
     let mut handshake_bytes: Vec<u32> = Vec::new();
     for sym in &[
         "s_resume_cores",
@@ -122,15 +122,13 @@ fn labwired_ereader_runs_to_panel_paint() {
             handshake_bytes.push(addr + 1);
         }
     }
-    // s_other_cpu_startup_done: still a boot aid. The real rendezvous is
-    // APP_CPU's IDLE task running other_cpu_startup_idle_hook_cb to set it,
-    // but APP_CPU's scheduler doesn't yet reach IDLE (a core-1 system task
-    // loops on xQueueReceive without all-blocking). TODO(dual-core): make
-    // APP_CPU's scheduler quiesce to IDLE, then drop this.
-    if let Some(&addr) = symbol_addrs.get("s_other_cpu_startup_done") {
-        let _ = machine.bus.write_u8(addr as u64, 0x01);
-        handshake_bytes.push(addr);
-    }
+    // s_other_cpu_startup_done is NO LONGER forged. APP_CPU's FreeRTOS
+    // scheduler now genuinely quiesces to its IDLE task, whose idle hook
+    // (other_cpu_startup_idle_hook_cb @ 0x400f8c08) writes this flag for
+    // real — letting PRO_CPU's startup barrier (app_startup.c spin on
+    // s_other_cpu_startup_done) clear. This works because the FROM_CPU_INTR1
+    // crosscore yield is now delivered to APP_CPU via the correct APP-side
+    // interrupt-matrix MAP register (see the IPI bridge below).
     // Re-assert the flags at the un-stall cycle (post-.bss) so .bss zero-init
     // can't wipe them — see rom_thunks::ets_set_appcpu_boot_addr.
     rom_thunks::set_appcpu_up_flags(handshake_bytes.clone());
@@ -437,7 +435,16 @@ fn labwired_ereader_runs_to_panel_paint() {
                 from_cpu_bit0 = Some(bit);
             }
         }
-        if let Ok(v) = machine.bus.read_u32(0x3FF0_0168) {
+        // FROM_CPU_INTR1 (ESP32 source 25) is the crosscore IPI targeting
+        // APP_CPU. Its source→CPU-interrupt routing lives in the APP-side
+        // interrupt matrix MAP register: DPORT_APP_MAC_INTR_MAP_REG
+        // (0x3FF0_0208) + 25*4 = 0x3FF0_026C. The firmware programs it from
+        // APP_CPU's esp_crosscore_int_init→esp_intr_alloc→intr_matrix_set
+        // (our esp_rom_route_intr_matrix thunk). Reading the *PRO*-side
+        // binding (the old 0x3FF0_0168) always returns 0, so the yield IPI
+        // was never delivered and APP_CPU's Tmr Svc task spun on
+        // xQueueReceive→block→re-wake instead of quiescing to IDLE.
+        if let Ok(v) = machine.bus.read_u32(0x3FF0_026C) {
             let bit = (v & 0x1F) as u8;
             if v != 0 && bit < 32 {
                 from_cpu_bit1 = Some(bit);

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -122,6 +122,11 @@ fn labwired_ereader_runs_to_panel_paint() {
             handshake_bytes.push(addr + 1);
         }
     }
+    // s_other_cpu_startup_done: still a boot aid. The real rendezvous is
+    // APP_CPU's IDLE task running other_cpu_startup_idle_hook_cb to set it,
+    // but APP_CPU's scheduler doesn't yet reach IDLE (a core-1 system task
+    // loops on xQueueReceive without all-blocking). TODO(dual-core): make
+    // APP_CPU's scheduler quiesce to IDLE, then drop this.
     if let Some(&addr) = symbol_addrs.get("s_other_cpu_startup_done") {
         let _ = machine.bus.write_u8(addr as u64, 0x01);
         handshake_bytes.push(addr);
@@ -448,8 +453,14 @@ fn labwired_ereader_runs_to_panel_paint() {
         }
         if let Ok(v1) = machine.bus.read_u32(0x3FF0_00E0) {
             if v1 != 0 {
+                // FROM_CPU_1 is the crosscore IRQ targeting APP_CPU (core 1):
+                // raise it on the SECONDARY, not PRO. This is what lets
+                // APP_CPU's self-yield (esp_crosscore_int_send_yield(1)) switch
+                // it to IDLE so the startup idle hook can run.
                 if let Some(bit) = from_cpu_bit1 {
-                    machine.cpu.raise_interrupt_bits(1u32 << bit);
+                    if let Some(c1) = machine.cpu_secondary.as_mut() {
+                        c1.raise_interrupt_bits(1u32 << bit);
+                    }
                 }
                 let _ = machine.bus.write_u32(0x3FF0_00E0, 0);
             }

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -28,6 +28,7 @@
 // `LABWIRED_EREADER_ELF` points.
 
 use labwired_core::bus::SystemBus;
+use labwired_core::cpu::xtensa_lx7::XtensaLx7;
 use labwired_core::peripherals::components::Uc8151dTricolor290;
 use labwired_core::peripherals::esp32::spi::Esp32Spi;
 use labwired_core::peripherals::esp32s3::rom_thunks;
@@ -71,14 +72,23 @@ fn labwired_ereader_runs_to_panel_paint() {
     }
     bus.refresh_peripheral_index();
 
-    let mut machine = Machine::new(cpu, bus);
+    // Real dual-core: attach a second LX6 as APP_CPU (PRID 0xABAB →
+    // xPortGetCoreID()==1, starts halted until PRO_CPU releases it via
+    // ets_set_appcpu_boot_addr). Step 1 of the dual-core bring-up.
+    let mut machine = Machine::new(cpu, bus).with_secondary_cpu(XtensaLx7::new_app_cpu());
     machine.load_firmware(&image).expect("load firmware");
     machine.cpu.set_pc(image.entry_point as u32);
 
     // ── 2. SP seed — real silicon's BROM places SP near the top of
     //       DRAM before jumping to call_start_cpu0; we skip BROM in the
-    //       sim so seed it ourselves.
+    //       sim so seed it ourselves. Same for APP_CPU: the ROM sets its
+    //       SP before releasing it to call_start_cpu1 (whose first insn is
+    //       `entry a1,32`), so seed the secondary's SP in a separate DRAM
+    //       region (above .bss @0x3ffc5ce8, below PRO_CPU's stack).
     machine.cpu.set_sp(0x3FFE_0000);
+    if let Some(cpu1) = machine.cpu_secondary.as_mut() {
+        cpu1.set_sp(0x3FFD_8000);
+    }
 
     // ── 3. Symbol-driven thunk install. Resolves addresses from the
     //       ereader ELF and installs only the thunks for symbols
@@ -90,8 +100,14 @@ fn labwired_ereader_runs_to_panel_paint() {
         symbol_addrs.len()
     );
 
-    // Dual-core handshake bytes (pre-write to 0x01 + record for the
-    // keep-alive loop below so .bss zero-init can't wipe them).
+    // Boot rendezvous aid. The REAL APP_CPU now runs call_start_cpu1 and
+    // its scheduler/loopTask for real, but PRO_CPU's final startup barrier
+    // (app_startup.c: spin on s_other_cpu_startup_done, set by APP_CPU's
+    // IDLE-task idle hook) isn't yet completed by the two-core lockstep, so
+    // we still pre-assert the startup-handshake flags. This is a boot aid,
+    // NOT the loopTask fake (that's gone — loopTask genuinely runs on
+    // core 1). TODO(dual-core): drive the idle-hook rendezvous from the
+    // real APP_CPU and drop this.
     let mut handshake_bytes: Vec<u32> = Vec::new();
     for sym in &[
         "s_resume_cores",
@@ -110,19 +126,13 @@ fn labwired_ereader_runs_to_panel_paint() {
         let _ = machine.bus.write_u8(addr as u64, 0x01);
         handshake_bytes.push(addr);
     }
-    // Re-assert these flags the instant PRO_CPU releases APP_CPU (models
-    // APP_CPU bring-up) so newer arduino-esp32 cores don't time out in
-    // start_other_core. See rom_thunks::ets_set_appcpu_boot_addr.
+    // Re-assert the flags at the un-stall cycle (post-.bss) so .bss zero-init
+    // can't wipe them — see rom_thunks::ets_set_appcpu_boot_addr.
     rom_thunks::set_appcpu_up_flags(handshake_bytes.clone());
 
-    // loopTask xCoreID repin — arduino-esp32 pins loopTask to APP_CPU
-    // (CONFIG_ARDUINO_RUNNING_CORE=1), but the sim only models PRO_CPU, so a
-    // core-1 task never runs. Rewrite the xCoreID immediate to 0 in app_main.
-    if let Some(&app_main_addr) = symbol_addrs.get("app_main") {
-        if let Some((addr, msg)) = rom_thunks::repin_loop_task(&mut machine.bus, app_main_addr) {
-            eprintln!("[ereader-sim] repinned loopTask xCoreID 1->0 ({msg}) @0x{addr:08x}");
-        }
-    }
+    // loopTask now runs on the REAL APP_CPU (core 1) — no repin. arduino-esp32
+    // pins loopTask to CONFIG_ARDUINO_RUNNING_CORE=1, which is genuinely
+    // modeled now. (Step 5 of dual-core bring-up: repin_loop_task deleted.)
 
     // pxCurrentTCB pointer seed for xTaskGetCurrentTaskHandle thunk.
     if let Some(&addr) = symbol_addrs.get("pxCurrentTCB") {
@@ -413,14 +423,6 @@ fn labwired_ereader_runs_to_panel_paint() {
     for _ in 0..MAX_STEPS {
         step_count += 1;
 
-        // Handshake keep-alive: re-write 0x01 to every recorded byte
-        // every 10k cycles so .bss zero-init can't wipe them.
-        if step_count.is_multiple_of(10_000) {
-            for &addr in &handshake_bytes {
-                let _ = machine.bus.write_u8(addr as u64, 0x01);
-            }
-        }
-
         // IPI bridge. DPORT_PRO_CPU_INTR_FROM_CPU_n_MAP_REG @ 0x3FF0_0164/_0168
         // captures the bit assignment, and writes to CPU_INTR_FROM_CPU_n
         // @ 0x3FF0_00DC/_00E0 trigger that bit on PRO_CPU.
@@ -476,6 +478,27 @@ fn labwired_ereader_runs_to_panel_paint() {
         }
         if step_count.is_multiple_of(SAMPLE_EVERY) {
             samples.push((step_count, pc));
+        }
+        // Early-exit once the panel has painted — keeps dual-core iteration
+        // fast (paint lands well before the 200M budget).
+        if step_count.is_multiple_of(200_000) {
+            if let Some(idx) = machine.bus.find_peripheral_index_by_name("spi3") {
+                if let Some(p) = machine.bus.peripherals[idx]
+                    .dev
+                    .as_any()
+                    .and_then(|a| a.downcast_ref::<Esp32Spi>())
+                    .and_then(|spi| {
+                        spi.attached_devices.iter().find_map(|d| {
+                            d.as_any()
+                                .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
+                        })
+                    })
+                {
+                    if p.refresh_generation() >= 2 {
+                        break;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Makes the ESP32 a **real dual-core**: attach a genuine 2nd LX6 as APP_CPU
(PRID 0xABAB → core_id 1) and run arduino-esp32's `loopTask` on it for real.
The e-reader paints from **core 1** — the `repin_loop_task` fake is deleted.

Core infrastructure:
- `XtensaLx7.app_cpu` flag so `reset()` restores PRID 0xABAB (a core's PRID
  is fixed HW and survives reset; previously reset re-newed SR→0xCDCD so
  APP_CPU read core_id 0 and trampled PRO_CPU's per-core FreeRTOS
  critical-nesting → `vPortExitCritical` assert).
- Per-core IRQ routing: only PRO_CPU takes the bus peripheral-IRQ aggregator
  (`core_id()` from PRID); APP_CPU doesn't run PRO_CPU's ISRs.
- APP_CPU SP seed (ROM sets it before `call_start_cpu1`'s `entry a1,32`).
- Cross-core IPI: FROM_CPU_1 routes to the secondary (APP_CPU's own yield).

Validated: newer ELF paints from core 1 (refresh_gen=2), demo ELF
unregressed (refresh_gen=1), 613 unit tests. HW oracle: real WROOM-32 boots
dual-core to drawPage — matches.

**WIP (draft):** the startup-handshake forge is still a boot aid (NOT the
loopTask fake). Dropping it needs APP_CPU's scheduler to quiesce to its IDLE
task (which runs the startup idle hook); a core-1 system task currently
loops on xQueueReceive without all-blocking. Tracked.