### PR TITLE
esp32: model cross-core FROM_CPU IPI in the DPORT (drop test bridge)

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -791,6 +791,21 @@ impl SystemBus {
         None
     }
 
+    /// Cross-core `FROM_CPU` IPI slots currently asserted for `core_id`,
+    /// read live from the ESP32-classic DPORT interrupt matrix. Replaces the
+    /// old test-harness IPI bridge that polled the same registers from
+    /// outside the core. Returns 0 when no DPORT is mapped (non-ESP32 buses).
+    fn dport_cross_core_pending(&self, core_id: u8) -> u32 {
+        for p in &self.peripherals {
+            if let Some(any) = p.dev.as_any() {
+                if let Some(dport) = any.downcast_ref::<crate::peripherals::esp32::dport::Dport>() {
+                    return dport.cross_core_pending(core_id);
+                }
+            }
+        }
+        0
+    }
+
     /// Attach a UART TX capture sink to any UART peripherals on this bus.
     ///
     /// When `echo_stdout` is false, UART writes will no longer be printed to stdout.
@@ -2155,8 +2170,16 @@ impl crate::Bus for SystemBus {
         SystemBus::route_irq_source_to_cpu_irq(self, source_id)
     }
 
-    fn pending_cpu_irqs(&self) -> u32 {
-        self.pending_cpu_irqs
+    fn pending_cpu_irqs(&self, core_id: u8) -> u32 {
+        // PRO_CPU (core 0) sees peripheral source IRQs routed through the
+        // intmatrix aggregator. Both cores additionally see cross-core
+        // FROM_CPU IPIs delivered per-core by the DPORT interrupt matrix.
+        let peripheral_irqs = if core_id == 0 {
+            self.pending_cpu_irqs
+        } else {
+            0
+        };
+        peripheral_irqs | self.dport_cross_core_pending(core_id)
     }
 
     fn clear_cpu_irq_pending(&mut self, slot: u8) {

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -1858,14 +1858,13 @@ impl XtensaLx7 {
                 // in here, otherwise the firmware sees INTERRUPT=0 and
                 // never dispatches to the user ISR (Plan 3 Task 10 case
                 // study).
-                if sr == INTERRUPT && self.core_id() == 0 {
-                    // Per-core IRQ routing: only PRO_CPU (core 0) receives
-                    // peripheral IRQs from the bus aggregator today. APP_CPU
-                    // (core 1) must not take PRO_CPU's interrupts — doing so
-                    // runs ISRs that unbalance its critical nesting
-                    // (vPortExitCritical "nesting > 0"). Cross-core delivery
-                    // to APP_CPU is modeled separately (FROM_CPU).
-                    v |= bus.pending_cpu_irqs();
+                if sr == INTERRUPT {
+                    // Per-core IRQ routing handled by the bus aggregator:
+                    // PRO_CPU (core 0) gets peripheral source IRQs; both cores
+                    // get their own cross-core FROM_CPU IPIs. APP_CPU never
+                    // sees PRO_CPU's peripheral interrupts (which would unbalance
+                    // its critical nesting → vPortExitCritical "nesting > 0").
+                    v |= bus.pending_cpu_irqs(self.core_id());
                 }
                 self.regs.write_logical(at, v);
                 self.pc = self.pc.wrapping_add(len);
@@ -1997,12 +1996,9 @@ impl XtensaLx7 {
         //   1. SR-file INTERRUPT register (firmware can software-trigger via WSR).
         //   2. Bus's pending_cpu_irqs (peripheral source IDs routed through
         //      the ESP32-S3 intmatrix in tick_peripherals_with_costs).
-        // Per-core routing: only PRO_CPU (core 0) takes bus peripheral IRQs.
-        let bus_irqs = if self.core_id() == 0 {
-            bus.pending_cpu_irqs()
-        } else {
-            0
-        };
+        // Per-core routing handled by the bus: PRO_CPU takes peripheral IRQs,
+        // both cores take their own cross-core FROM_CPU IPIs.
+        let bus_irqs = bus.pending_cpu_irqs(self.core_id());
         let pending = (self.sr.read(INTERRUPT) | bus_irqs) & self.sr.read(INTENABLE);
         if pending == 0 {
             return None;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -506,10 +506,12 @@ pub trait Bus {
         None
     }
 
-    /// Plan 3: bitmask of pending cpu0 IRQ slots aggregated by the bus
-    /// from peripheral tick results routed through the intmatrix. Default
-    /// returns 0; non-ESP32-S3 buses don't model this.
-    fn pending_cpu_irqs(&self) -> u32 {
+    /// Bitmask of pending CPU IRQ slots the bus has aggregated for the given
+    /// core (`core_id` 0 = PRO_CPU, 1 = APP_CPU). Combines peripheral source
+    /// IDs routed through the intmatrix (PRO_CPU only today) with cross-core
+    /// `FROM_CPU` IPIs delivered per-core via the DPORT interrupt matrix.
+    /// Default returns 0; non-ESP32 buses don't model this.
+    fn pending_cpu_irqs(&self, _core_id: u8) -> u32 {
         0
     }
 

--- a/crates/core/src/peripherals/esp32/dport.rs
+++ b/crates/core/src/peripherals/esp32/dport.rs
@@ -39,12 +39,18 @@
 //!     directly observable on the next read, which our plain HashMap
 //!     storage satisfies.
 //!
+//! ## Cross-core IPIs
+//!
+//! `cross_core_pending(core)` resolves the `CPU_INTR_FROM_CPU_0..3`
+//! trigger registers against the per-core interrupt-matrix MAP registers
+//! and reports which CPU-interrupt slots that core should take. The bus
+//! ORs this into `pending_cpu_irqs(core_id)` so a `FROM_CPU` write made by
+//! one core's firmware is delivered as a real interrupt to the target
+//! core inside `Machine::step` — no external bridge. The receiving ISR
+//! de-asserts the source by writing the trigger register back to 0.
+//!
 //! ## What's intentionally NOT modeled
 //!
-//!   * No interrupt firing or side effects on writes to the FROM_CPU
-//!     trigger registers. The WASM IPI bridge is the policy layer that
-//!     observes those writes and raises the corresponding CPU INTERRUPT
-//!     bits; this peripheral is the storage layer.
 //!   * No clock-gate enforcement. PERIP_CLK_EN is seeded all-ones at
 //!     construction so any code that consults the bitmap before writing
 //!     it (rare, but it happens in vendor headers gated behind
@@ -97,10 +103,17 @@ pub const DPORT_CPU_INTR_FROM_CPU_0_OFFSET: u32 = 0x00DC;
 pub const DPORT_CPU_INTR_FROM_CPU_1_OFFSET: u32 = 0x00E0;
 pub const DPORT_CPU_INTR_FROM_CPU_2_OFFSET: u32 = 0x00E4;
 pub const DPORT_CPU_INTR_FROM_CPU_3_OFFSET: u32 = 0x00E8;
-/// DPORT_PRO_MAC_INTR_MAP_REG — first PRO_CPU intmatrix source entry.
-/// Subsequent peripheral source IDs are at +4 byte strides up to
-/// roughly `0x3FF0_0160`. Round-trips through `regs` like every other word.
-pub const DPORT_PRO_MAC_INTR_MAP_REG_OFFSET: u32 = 0x0100;
+/// DPORT_PRO_MAC_INTR_MAP_REG — first PRO_CPU intmatrix source entry
+/// (`DR_REG_DPORT_BASE + 0x104`, per ESP-IDF `dport_reg.h`). Source `s`
+/// maps at `base + s*4`, so e.g. the cross-core source 24 (`FROM_CPU_INTR0`)
+/// binding lives at `0x104 + 24*4 = 0x0164`. Round-trips through `regs`
+/// like every other word.
+pub const DPORT_PRO_MAC_INTR_MAP_REG_OFFSET: u32 = 0x0104;
+/// DPORT_APP_MAC_INTR_MAP_REG — first APP_CPU intmatrix source entry.
+/// The APP-side matrix mirrors the PRO-side layout (source `s` at
+/// `base + s*4`) but starts at 0x208, so e.g. the cross-core source 25
+/// (`FROM_CPU_INTR1`) binding lives at `0x208 + 25*4 = 0x026C`.
+pub const DPORT_APP_MAC_INTR_MAP_REG_OFFSET: u32 = 0x0208;
 /// DPORT_PRO_INTR_FROM_CPU_0..3 — PRO_CPU bindings for the FROM_CPU
 /// triggers above. The WASM bridge reads these to learn which CPU
 /// INTERRUPT bit to raise when a trigger fires.
@@ -180,6 +193,51 @@ impl Dport {
 
     fn write_word(&mut self, word_off: u32, value: u32) {
         self.regs[(word_off >> 2) as usize] = value;
+    }
+
+    /// Cross-core IPI delivery: which CPU-interrupt slots `core` should see
+    /// asserted right now, driven by the `CPU_INTR_FROM_CPU_0..3` trigger
+    /// registers.
+    ///
+    /// On real silicon each `CPU_INTR_FROM_CPU_n` register is a single
+    /// interrupt SOURCE — `ETS_FROM_CPU_INTR{n}_SOURCE` = `24 + n` — wired
+    /// into *both* the PRO and APP interrupt matrices. While its bit 0 is
+    /// set the source is level-asserted; each core delivers it to whatever
+    /// CPU interrupt its own matrix MAP register binds the source to (or
+    /// not at all if that core left it unmapped). The receiving ISR clears
+    /// the source by writing the trigger register back to 0
+    /// (`esp_crosscore_isr`), so this is a pure read of current register
+    /// state — no latch.
+    ///
+    /// ESP-IDF's `esp_crosscore_int_init` allocates
+    /// `ETS_FROM_CPU_INTR0_SOURCE + core_id`, so core 0 listens on source 24
+    /// (trigger `FROM_CPU_0`) and core 1 on source 25 (trigger `FROM_CPU_1`);
+    /// `esp_crosscore_int_send_yield(1)` writes `FROM_CPU_1` to yield APP_CPU.
+    pub fn cross_core_pending(&self, core: u8) -> u32 {
+        /// `ETS_FROM_CPU_INTR0_SOURCE` — the first cross-core interrupt source.
+        const FROM_CPU_INTR0_SOURCE: u32 = 24;
+        // Per-core interrupt-matrix MAP base: source `s` maps at `base + s*4`.
+        let map_base = if core == 0 {
+            DPORT_PRO_MAC_INTR_MAP_REG_OFFSET
+        } else {
+            DPORT_APP_MAC_INTR_MAP_REG_OFFSET
+        };
+        let mut slots = 0u32;
+        for n in 0..4u32 {
+            let trigger = self.read_word(DPORT_CPU_INTR_FROM_CPU_0_OFFSET + n * 4);
+            if trigger & 1 == 0 {
+                continue;
+            }
+            let source = FROM_CPU_INTR0_SOURCE + n;
+            let map = self.read_word(map_base + source * 4);
+            // The MAP register's low 5 bits select the CPU interrupt number.
+            // A value of 0 means this core left the source unbound (matches
+            // the reset state), so it takes no interrupt.
+            if map != 0 {
+                slots |= 1u32 << (map & 0x1F);
+            }
+        }
+        slots
     }
 }
 
@@ -313,6 +371,63 @@ mod tests {
         // (the bringup path is only entered when this reads non-zero).
         let p = Dport::new();
         assert_eq!(read_u32_at(&p, 0x30), 0);
+    }
+
+    #[test]
+    fn cross_core_yield_ipi_delivers_to_app_cpu_only() {
+        // The path that quiesces APP_CPU to IDLE in the e-reader boot:
+        // core 1 binds FROM_CPU_INTR1 (source 25) to a CPU interrupt via its
+        // APP-side matrix MAP (0x208 + 25*4 = 0x26C), then a FROM_CPU_1 write
+        // (esp_crosscore_int_send_yield(1)) delivers that interrupt to core 1
+        // — and to core 1 only, since PRO left source 25 unbound.
+        let mut p = Dport::new();
+        write_u32_at(
+            &mut p,
+            (DPORT_APP_MAC_INTR_MAP_REG_OFFSET + 25 * 4) as u64,
+            7,
+        );
+
+        assert_eq!(p.cross_core_pending(1), 0, "no IPI until the trigger fires");
+
+        write_u32_at(&mut p, DPORT_CPU_INTR_FROM_CPU_1_OFFSET as u64, 1);
+        assert_eq!(
+            p.cross_core_pending(1),
+            1 << 7,
+            "APP_CPU takes the CPU interrupt its matrix bound source 25 to"
+        );
+        assert_eq!(
+            p.cross_core_pending(0),
+            0,
+            "PRO_CPU left source 25 unbound, so it ignores FROM_CPU_1"
+        );
+
+        // The receiving ISR clears the trigger; the source de-asserts.
+        write_u32_at(&mut p, DPORT_CPU_INTR_FROM_CPU_1_OFFSET as u64, 0);
+        assert_eq!(p.cross_core_pending(1), 0);
+    }
+
+    #[test]
+    fn cross_core_trigger_with_unmapped_source_delivers_nothing() {
+        // A trigger whose per-core MAP is still at its reset value (0) must
+        // not synthesize a phantom interrupt 0.
+        let mut p = Dport::new();
+        write_u32_at(&mut p, DPORT_CPU_INTR_FROM_CPU_1_OFFSET as u64, 1);
+        assert_eq!(p.cross_core_pending(1), 0);
+    }
+
+    #[test]
+    fn cross_core_from_cpu_0_routes_source_24_to_pro_cpu() {
+        // FROM_CPU_0 is source 24, the core-0 crosscore IPI; PRO binds it in
+        // its own matrix (0x100 + 24*4 = 0x160).
+        let mut p = Dport::new();
+        write_u32_at(
+            &mut p,
+            (DPORT_PRO_MAC_INTR_MAP_REG_OFFSET + 24 * 4) as u64,
+            13,
+        );
+        write_u32_at(&mut p, DPORT_CPU_INTR_FROM_CPU_0_OFFSET as u64, 1);
+        assert_eq!(p.cross_core_pending(0), 1 << 13);
+        assert_eq!(p.cross_core_pending(1), 0);
     }
 
     #[test]

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -13,8 +13,9 @@
 //
 // This is the native-Rust counterpart to the wasm playground path —
 // same panel attach, same SP seed, same handshake bytes, same ROM
-// thunks, same IPI bridge, same step budget. If this test paints,
-// the firmware paints in the playground too.
+// thunks, same step budget. The cross-core FROM_CPU yield IPI is
+// modeled in the core (DPORT interrupt matrix), not bridged here. If
+// this test paints, the firmware paints in the playground too.
 //
 // Heavy and slow (~200M cycles in the worst case), so `#[ignore]`d by
 // default. Run with:
@@ -128,7 +129,8 @@ fn labwired_ereader_runs_to_panel_paint() {
     // real — letting PRO_CPU's startup barrier (app_startup.c spin on
     // s_other_cpu_startup_done) clear. This works because the FROM_CPU_INTR1
     // crosscore yield is now delivered to APP_CPU via the correct APP-side
-    // interrupt-matrix MAP register (see the IPI bridge below).
+    // interrupt-matrix MAP register, modeled in the core's DPORT
+    // (Dport::cross_core_pending → bus.pending_cpu_irqs(core_id)).
     // Re-assert the flags at the un-stall cycle (post-.bss) so .bss zero-init
     // can't wipe them — see rom_thunks::ets_set_appcpu_boot_addr.
     rom_thunks::set_appcpu_up_flags(handshake_bytes.clone());
@@ -404,9 +406,10 @@ fn labwired_ereader_runs_to_panel_paint() {
     eprintln!("[ereader-sim] installed {installed} flash thunks");
 
     // ── 4. Step loop. Mirrors step_with_esp32_aids: handshake keep-alive
-    //       every 10k cycles, plus the cross-core IPI bridge sampling
-    //       DPORT FROM_CPU_n mapping + trigger registers and synthesising
-    //       the matching CPU interrupt edge.
+    //       every 10k cycles. The cross-core FROM_CPU yield IPI that quiesces
+    //       APP_CPU to IDLE is now modeled inside the core (DPORT
+    //       `cross_core_pending` → per-core `bus.pending_cpu_irqs`), so this
+    //       harness no longer bridges it — `machine.step()` delivers it.
     const MAX_STEPS: u64 = 200_000_000;
     const SAMPLE_EVERY: u64 = 1_000_000;
     let mut step_count = 0u64;
@@ -416,62 +419,11 @@ fn labwired_ereader_runs_to_panel_paint() {
     let mut last_distinct: std::collections::VecDeque<u32> =
         std::collections::VecDeque::with_capacity(64);
 
-    // IPI bridge state.
-    let mut from_cpu_bit0: Option<u8> = None;
-    let mut from_cpu_bit1: Option<u8> = None;
-
     let mut step_err: Option<String> = None;
     let mut stalled = false;
 
     for _ in 0..MAX_STEPS {
         step_count += 1;
-
-        // IPI bridge. DPORT_PRO_CPU_INTR_FROM_CPU_n_MAP_REG @ 0x3FF0_0164/_0168
-        // captures the bit assignment, and writes to CPU_INTR_FROM_CPU_n
-        // @ 0x3FF0_00DC/_00E0 trigger that bit on PRO_CPU.
-        if let Ok(v) = machine.bus.read_u32(0x3FF0_0164) {
-            let bit = (v & 0x1F) as u8;
-            if v != 0 && bit < 32 {
-                from_cpu_bit0 = Some(bit);
-            }
-        }
-        // FROM_CPU_INTR1 (ESP32 source 25) is the crosscore IPI targeting
-        // APP_CPU. Its source→CPU-interrupt routing lives in the APP-side
-        // interrupt matrix MAP register: DPORT_APP_MAC_INTR_MAP_REG
-        // (0x3FF0_0208) + 25*4 = 0x3FF0_026C. The firmware programs it from
-        // APP_CPU's esp_crosscore_int_init→esp_intr_alloc→intr_matrix_set
-        // (our esp_rom_route_intr_matrix thunk). Reading the *PRO*-side
-        // binding (the old 0x3FF0_0168) always returns 0, so the yield IPI
-        // was never delivered and APP_CPU's Tmr Svc task spun on
-        // xQueueReceive→block→re-wake instead of quiescing to IDLE.
-        if let Ok(v) = machine.bus.read_u32(0x3FF0_026C) {
-            let bit = (v & 0x1F) as u8;
-            if v != 0 && bit < 32 {
-                from_cpu_bit1 = Some(bit);
-            }
-        }
-        if let Ok(v0) = machine.bus.read_u32(0x3FF0_00DC) {
-            if v0 != 0 {
-                if let Some(bit) = from_cpu_bit0 {
-                    machine.cpu.raise_interrupt_bits(1u32 << bit);
-                }
-                let _ = machine.bus.write_u32(0x3FF0_00DC, 0);
-            }
-        }
-        if let Ok(v1) = machine.bus.read_u32(0x3FF0_00E0) {
-            if v1 != 0 {
-                // FROM_CPU_1 is the crosscore IRQ targeting APP_CPU (core 1):
-                // raise it on the SECONDARY, not PRO. This is what lets
-                // APP_CPU's self-yield (esp_crosscore_int_send_yield(1)) switch
-                // it to IDLE so the startup idle hook can run.
-                if let Some(bit) = from_cpu_bit1 {
-                    if let Some(c1) = machine.cpu_secondary.as_mut() {
-                        c1.raise_interrupt_bits(1u32 << bit);
-                    }
-                }
-                let _ = machine.bus.write_u32(0x3FF0_00E0, 0);
-            }
-        }
 
         if let Err(e) = machine.step() {
             step_err = Some(format!("{e}"));


### PR DESCRIPTION
Continues the dual-core work (#162) toward a fully in-model implementation: the cross-core yield IPI that quiesces APP_CPU to its IDLE task was the last boot aid living *outside* the Rust HW model — a polling bridge in the e2e test harness. It now lives in the core.

## What
- **`Dport::cross_core_pending(core)`** — resolves the `CPU_INTR_FROM_CPU_0..3` trigger registers against the per-core interrupt-matrix MAP registers (PRO @`0x104 + src*4`, APP @`0x208 + src*4`) and returns the CPU-interrupt slots that core should take. Level-asserted while a trigger's bit 0 is set; the receiving ISR de-asserts by writing the trigger back to 0 (`esp_crosscore_isr`).
- **`bus.pending_cpu_irqs(core_id)`** is now core-aware: PRO_CPU gets intmatrix peripheral IRQs, both cores get their own `FROM_CPU` IPIs. The `core_id==0` gate moved out of `XtensaLx7` into the bus.
- **e2e_labwired_ereader**: the FROM_CPU IPI bridge is deleted — `machine.step()` delivers the yield natively.
- **Bug fix**: `DPORT_PRO_MAC_INTR_MAP_REG` base `0x100`→`0x104` (per ESP-IDF `dport_reg.h`). The old bridge masked this by reading source 25's binding at the wrong PRO offset; with the correct base, `FROM_CPU_1` routes to APP_CPU (`0x26C`) only, not spuriously to PRO_CPU.

## Validation
- idf5 arduino-esp32 e-reader paints `refresh_gen=2` (cross-core IPI delivered by the core).
- legacy demo paints `refresh_gen=1` (regression-checked against main: the base fix prevents a spurious PRO_CPU interrupt that crashed it).
- 647 lib tests; `cross_core_pending` unit-tested for both cores + the unmapped case.

The redundant `FROM_CPU` bridges in wasm/cli are left untouched — they pre-clear the trigger each cycle so the core path stays dormant there (no double-delivery); removing them is a follow-up gated on wasm validation.