### PR TITLE
examples: arduino-esp32 WiFi fixture (WiFi model groundwork)

### DIFF
--- a/examples/platformio/esp32-wifi-fixture/README.md
+++ b/examples/platformio/esp32-wifi-fixture/README.md
@@ -1,0 +1,52 @@
+# esp32-wifi-fixture
+
+A minimal arduino-esp32 WiFi sketch — the **firmware fixture** driving the
+LabWired ESP32 WiFi functional model (the "simulated endpoints" track).
+
+It joins an AP, HTTP `GET`s an in-sim server, and prints the result:
+
+```cpp
+WiFi.begin("labwired", "hunter2");
+while (WiFi.status() != WL_CONNECTED) delay(100);
+HTTPClient http;
+http.begin("http://192.168.4.1/status");
+int code = http.GET();
+```
+
+## Build
+
+```sh
+cd examples/platformio/esp32-wifi-fixture
+pio run                       # → .pio/build/esp32dev/firmware.elf (classic ESP32)
+```
+
+## Why it exists
+
+The WiFi model is **simulated endpoints**: cycle-accurate radio is
+infeasible (closed blob on an RF coprocessor), so instead the simulator
+hosts the servers (`crates/core/src/network/{sim,mqtt}.rs` — `VirtualAp`,
+`SimNet`, `EchoServer`/`HttpServer`/`MqttBroker`) and **thunks** the
+firmware's WiFi + socket calls onto them. This sketch is the test target
+for that bring-up.
+
+### Thunk targets (resolved from this fixture's ELF, classic ESP32)
+
+The bring-up intercepts these PCs, marshals the Xtensa call args (a2–a7),
+routes to `SimNet`, and writes the return register:
+
+| Concern              | Symbol                        |
+|----------------------|-------------------------------|
+| WiFi connected?      | `WiFiSTAClass::status` → `WL_CONNECTED` |
+| DNS resolve          | `dns_gethostbyname_addrtype` → `SimNet::resolve` |
+| open socket          | `lwip_socket` → fd alloc       |
+| connect              | `lwip_connect` → `SimNet::connect` |
+| send / write         | `lwip_send` / `lwip_write` → `SimNet::send` |
+| recv / read          | `lwip_recv` / `lwip_read` → `SimNet::recv` |
+| close                | `lwip_close` → `SimNet::close` |
+
+(Addresses are build-specific; resolve them from the symbol table per ELF,
+like the arduino-esp32 ROM thunks already do.)
+
+Getting the full ELF to run through `esp_wifi` init to these call sites is
+an e-reader-scale bring-up — this fixture + the resolved target list is the
+groundwork.

--- a/examples/platformio/esp32-wifi-fixture/platformio.ini
+++ b/examples/platformio/esp32-wifi-fixture/platformio.ini
@@ -1,0 +1,5 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200

--- a/examples/platformio/esp32-wifi-fixture/src/main.cpp
+++ b/examples/platformio/esp32-wifi-fixture/src/main.cpp
@@ -1,0 +1,25 @@
+// Minimal arduino-esp32 WiFi fixture for the LabWired simulated-endpoints
+// WiFi model: join an AP, HTTP GET an in-sim server, print the result.
+#include <WiFi.h>
+#include <HTTPClient.h>
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin("labwired", "hunter2");
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(100);
+  }
+  Serial.println("WIFI OK");
+  Serial.println(WiFi.localIP());
+
+  HTTPClient http;
+  http.begin("http://192.168.4.1/status");
+  int code = http.GET();
+  Serial.printf("HTTP %d\n", code);
+  if (code > 0) {
+    Serial.println(http.getString());
+  }
+  http.end();
+}
+
+void loop() {}


### PR DESCRIPTION
The firmware test target for Phase 2 of the WiFi functional model (firmware reachability). A minimal arduino-esp32 sketch — join AP, HTTP `GET` an in-sim server — that the lwIP/WiFi thunks will drive onto the `SimNet` backend (#167/#168).

The README documents the **resolved thunk targets** from this fixture's ELF: `WiFiSTAClass::status`, `dns_gethostbyname_addrtype`, `lwip_socket`/`connect`/`send`/`recv`/`close` → `SimNet`. Sketch only (reproducible via `pio run`); no 13 MB ELF committed.

Pure example/docs — no core changes. Sets up the e-reader-scale bring-up that makes real arduino WiFi firmware reach the simulated endpoints.