### PR TITLE
refactor(esp32): run the firmware's real FreeRTOS — delete the sync fakes

### DIFF
--- a/crates/core/src/peripherals/esp32s3/wifi_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/wifi_thunks.rs
@@ -374,17 +374,6 @@ pub fn pc_task_get_name(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()>
     Ok(())
 }
 
-/// Returns the call's 2nd argument unchanged. Stubs
-/// `xEventGroupSetBits`/`xEventGroupWaitBits` (whose handles come from a
-/// faked `xEventGroupCreate`): report the requested bits as already set so
-/// waiters proceed and the fake handle is never dereferenced (which trips
-/// the `event_groups.c` list asserts).
-pub fn return_arg1(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
-    let v = arg(cpu, 1);
-    RomThunkBank::return_with(cpu, v);
-    Ok(())
-}
-
 /// Read a NUL-terminated C string from firmware memory (bounded).
 fn read_cstr(bus: &dyn Bus, ptr: u32, max: u64) -> String {
     if ptr == 0 {

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -259,24 +259,16 @@ fn labwired_ereader_runs_to_panel_paint() {
         "uartWrite",
         "uartWriteBuf",
         "_Z14serialEventRunv",
-        "vListInsert",
     ] {
         push_named(&mut thunks, sym, rom_thunks::nop_return_zero);
     }
 
-    // Non-NULL fake handle returns for FreeRTOS object creation.
-    for sym in &[
-        "xQueueCreateMutex",
-        "xQueueCreateMutexStatic",
-        "xQueueGenericCreate",
-        "xSemaphoreCreateMutex",
-        "xSemaphoreCreateBinary",
-        "xSemaphoreCreateCounting",
-        "xQueueCreateCountingSemaphore",
-        "xEventGroupCreate",
-    ] {
-        push_named(&mut thunks, sym, rom_thunks::nop_return_fake_ptr);
-    }
+    // Real FreeRTOS: queue/mutex/event-group create + vListInsert are NOT
+    // thunked — the firmware's own FreeRTOS runs on the emulated registers +
+    // heap. (The old fakes — nop'd vListInsert + fake-handle creates + always-
+    // succeed ops — were pure debt: faking the create functions left their
+    // list structures uninitialised, which forced faking everything built on
+    // them. Removing all of it still paints refresh_gen=2.)
 
     // SPI-flash lock stubs (real impl asserts on uninitialised mutex).
     for sym in &[
@@ -321,17 +313,8 @@ fn labwired_ereader_runs_to_panel_paint() {
         "xTaskGetCurrentTaskHandle",
         rom_thunks::x_task_get_current_task_handle,
     );
-    push_named(
-        &mut thunks,
-        "xQueueSemaphoreTake",
-        rom_thunks::return_pd_true,
-    );
-    push_named(&mut thunks, "xQueueGenericSend", rom_thunks::return_pd_true);
-    push_named(
-        &mut thunks,
-        "ulTaskGenericNotifyTake",
-        rom_thunks::return_pd_true,
-    );
+    // (Real FreeRTOS: xQueueSemaphoreTake / xQueueGenericSend /
+    // ulTaskGenericNotifyTake run for real — no always-succeed fakes.)
     push_named(&mut thunks, "spiStartBus", rom_thunks::spi_start_bus_fake);
     push_named(
         &mut thunks,

--- a/crates/core/tests/e2e_labwired_wifi.rs
+++ b/crates/core/tests/e2e_labwired_wifi.rs
@@ -257,24 +257,14 @@ fn labwired_wifi_fixture_connects_and_gets() {
         "uartWrite",
         "uartWriteBuf",
         "_Z14serialEventRunv",
-        "vListInsert",
     ] {
         push_named(&mut thunks, sym, rom_thunks::nop_return_zero);
     }
 
-    // Non-NULL fake handle returns for FreeRTOS object creation.
-    for sym in &[
-        "xQueueCreateMutex",
-        "xQueueCreateMutexStatic",
-        "xQueueGenericCreate",
-        "xSemaphoreCreateMutex",
-        "xSemaphoreCreateBinary",
-        "xSemaphoreCreateCounting",
-        "xQueueCreateCountingSemaphore",
-        "xEventGroupCreate",
-    ] {
-        push_named(&mut thunks, sym, rom_thunks::nop_return_fake_ptr);
-    }
+    // Real FreeRTOS: queue/mutex/event-group create + vListInsert are NOT
+    // thunked — the firmware's own FreeRTOS runs on the emulated registers +
+    // heap (proven by the e-reader e2e). Only xQueueCreateMutexStatic keeps
+    // its echo helper (returns the static buffer as the handle).
 
     // SPI-flash lock stubs (real impl asserts on uninitialised mutex).
     for sym in &[
@@ -319,17 +309,8 @@ fn labwired_wifi_fixture_connects_and_gets() {
         "xTaskGetCurrentTaskHandle",
         rom_thunks::x_task_get_current_task_handle,
     );
-    push_named(
-        &mut thunks,
-        "xQueueSemaphoreTake",
-        rom_thunks::return_pd_true,
-    );
-    push_named(&mut thunks, "xQueueGenericSend", rom_thunks::return_pd_true);
-    push_named(
-        &mut thunks,
-        "ulTaskGenericNotifyTake",
-        rom_thunks::return_pd_true,
-    );
+    // (Real FreeRTOS: xQueueSemaphoreTake/xQueueGenericSend/notify run for
+    // real — no always-succeed fakes.)
     // WiFi + lwIP socket thunks — the firmware-reachability layer. Resolve
     // each by its exact (possibly C++-mangled) symbol from the ELF and route
     // to the simulated network. WiFi.begin/status short-circuit the esp_wifi
@@ -367,25 +348,8 @@ fn labwired_wifi_fixture_connects_and_gets() {
     // arduino's NetworkClient::connect waits via the VFS select wrapper
     // (esp_vfs_select), not lwip_select directly — route it the same way.
     push_sym(&mut thunks, "esp_vfs_select", wifi_thunks::lwip_select);
-    // Event-group ops on the faked xEventGroupCreate handle would deref it
-    // and trip the FreeRTOS list asserts; stub set/wait to report bits set.
-    push_sym(&mut thunks, "xEventGroupSetBits", wifi_thunks::return_arg1);
-    push_sym(&mut thunks, "xEventGroupWaitBits", wifi_thunks::return_arg1);
-    push_sym(
-        &mut thunks,
-        "xEventGroupClearBits",
-        rom_thunks::nop_return_zero,
-    );
-    push_sym(
-        &mut thunks,
-        "xEventGroupGetBits",
-        rom_thunks::nop_return_zero,
-    );
-    push_sym(
-        &mut thunks,
-        "vEventGroupDelete",
-        rom_thunks::nop_return_zero,
-    );
+    // (Real FreeRTOS: event groups — create + set/wait/clear/get/delete — run
+    // for real, on the real handle, with real list ops. No fakes.)
     // IDF logging — its registered vprint func path aborts in the sim; the
     // firmware's own markers go through Serial, not esp_log. Not in the
     // fixed arduino-thunk set, so resolve it from the ELF.


### PR DESCRIPTION
**We emulate registers — FreeRTOS is the firmware's own code and should execute, not be modeled or faked.** This deletes the FreeRTOS sync-primitive thunks; the firmware's real FreeRTOS now runs on the emulated registers + heap.

### The debt was a cascade
Faking `xQueueGenericCreate` / `xEventGroupCreate` (return a bogus handle) left their list structures un-`vListInitialise`d → real `vListInsert`'s sorted loop would spin on garbage → so `vListInsert` got no-op'd too → so every queue/mutex/event-group op had to be faked on top. **Break the root** (let the real create functions run) and the whole layer is real.

### Removed (both e2e harnesses)
`vListInsert`, the `xQueue*`/`xSemaphore*`/`xEventGroupCreate` create fakes, the `xQueueGenericSend`/`xQueueSemaphoreTake`/`ulTaskGenericNotifyTake` always-succeed fakes, and the WiFi event-group fakes.

### Validated
- **e-reader** still paints `refresh_gen=2` — now **83 thunks (was ~90)**.
- **WiFi** e2e still exchanges a real `200 OK`.
- 670 lib tests; fmt + clippy clean. Net −64 lines.

### Why no hardware change was needed
The per-core **CCOMPARE/CCOUNT tick already drives real FreeRTOS** (each CPU raises its own `_xt_int6`), so the scheduler/queues/event-groups just work. The fakes were unnecessary all along — debt from the original bring-up taking shortcuts. This is the first chunk of paying down the thunk layer toward a fuller model.