### PR TITLE
test(esp32): diagnose the real-heap un-thunk wall to its true root cause

### DIFF
--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -139,12 +139,29 @@ fn labwired_ereader_runs_to_panel_paint() {
 
     // Heap: the sim-side bump allocator (default). It's debt — the real
     // ESP-IDF heap_caps should run on emulated DRAM. LABWIRED_REAL_HEAP=1
-    // un-thunks it, but that currently walls: the real heap_caps_init
-    // registers a heap region that collides with the harness's SEEDED stacks
-    // (we seed SP at 0x3FFE_0000 / 0x3FFD_8000 instead of the real top-of-DRAM
-    // layout), so a malloc'd struct lands on stack data and esp_intr_alloc
-    // dereferences "lock" (0x6b636f6c). Fix = faithful stack/heap layout, then
-    // delete this bump allocator. (Reproduce: LABWIRED_REAL_HEAP=1.)
+    // un-thunks it, but that currently walls.
+    //
+    // Diagnosed root cause (2026-06-04, via the WiFi fixture — same wall):
+    // the real heap_caps_init mis-registers a heap region, so heap_caps_malloc
+    // hands out pointers into non-heap memory. A vector_desc node ends up
+    // pointing at memory whose first word is the bytes "lock" (0x6b636f6c),
+    // and APP_CPU's esp_intr_alloc_intrstatus_bind faults dereferencing it
+    // (node->next = "lock") while PRO_CPU spins in main_task waiting for
+    // s_other_cpu_startup_done.
+    //
+    // Eliminated hypotheses (don't re-tread):
+    //   * seeded-stack collision (#173) — moving SP to top-of-DRAM gives the
+    //     IDENTICAL crash, and "lock" is a fixed string, not stack noise;
+    //   * unbacked DRAM — 0x3FFA_0000..0x4000_0000 is fully RamPeripheral-backed;
+    //   * broken atomic CAS — S32C1I is correct and the sim interleaves cores
+    //     at instruction granularity, so spinlocks serialize;
+    //   * unshared memory — both cores step against the same SystemBus.
+    // Remaining suspect: the real heap_caps_init mis-registers a heap region
+    // (wrong soc_memory_regions read via flash XIP, or a subtle instruction
+    // mis-emulation in the TLSF/multi_heap registration path), so malloc
+    // returns an out-of-region pointer. Next step: trace heap_caps_malloc
+    // returns / multi_heap_register args under LABWIRED_REAL_HEAP=1. Real fix
+    // lands there; then delete this bump allocator.
     if std::env::var("LABWIRED_REAL_HEAP").is_err() {
         push_named(
             &mut thunks,

--- a/crates/core/tests/e2e_labwired_wifi.rs
+++ b/crates/core/tests/e2e_labwired_wifi.rs
@@ -133,32 +133,36 @@ fn labwired_wifi_fixture_connects_and_gets() {
             }
         };
 
-    // Heap caps suite (bump allocator).
-    push_named(
-        &mut thunks,
-        "heap_caps_init",
-        rom_thunks::esp_idf_heap_caps_init,
-    );
-    push_named(
-        &mut thunks,
-        "heap_caps_malloc",
-        rom_thunks::esp_idf_heap_caps_malloc,
-    );
-    push_named(
-        &mut thunks,
-        "heap_caps_calloc",
-        rom_thunks::esp_idf_heap_caps_calloc,
-    );
-    push_named(
-        &mut thunks,
-        "heap_caps_free",
-        rom_thunks::esp_idf_heap_caps_free,
-    );
-    push_named(
-        &mut thunks,
-        "heap_caps_realloc",
-        rom_thunks::esp_idf_heap_caps_realloc,
-    );
+    // Heap caps suite (bump allocator). Debt — the real ESP-IDF heap_caps
+    // should run on emulated DRAM. LABWIRED_REAL_HEAP=1 un-thunks it to let
+    // the firmware's own allocator run, for diagnosing the un-thunk path.
+    if std::env::var("LABWIRED_REAL_HEAP").is_err() {
+        push_named(
+            &mut thunks,
+            "heap_caps_init",
+            rom_thunks::esp_idf_heap_caps_init,
+        );
+        push_named(
+            &mut thunks,
+            "heap_caps_malloc",
+            rom_thunks::esp_idf_heap_caps_malloc,
+        );
+        push_named(
+            &mut thunks,
+            "heap_caps_calloc",
+            rom_thunks::esp_idf_heap_caps_calloc,
+        );
+        push_named(
+            &mut thunks,
+            "heap_caps_free",
+            rom_thunks::esp_idf_heap_caps_free,
+        );
+        push_named(
+            &mut thunks,
+            "heap_caps_realloc",
+            rom_thunks::esp_idf_heap_caps_realloc,
+        );
+    }
 
     // No-op stubs for ESP-IDF / Arduino-ESP32 init paths we don't model.
     for sym in &[
@@ -473,7 +477,10 @@ fn labwired_wifi_fixture_connects_and_gets() {
 
     eprintln!("[wifi-sim] ── final state ─────────────────────────────────");
     eprintln!("[wifi-sim] cycles executed:    {step_count}");
-    eprintln!("[wifi-sim] final PC:           0x{final_pc:08x}");
+    eprintln!("[wifi-sim] final PC (PRO_CPU): 0x{final_pc:08x}");
+    if let Some(cpu1) = machine.cpu_secondary.as_ref() {
+        eprintln!("[wifi-sim] final PC (APP_CPU): 0x{:08x}", cpu1.get_pc());
+    }
     eprintln!("[wifi-sim] same-PC streak:     {same_pc_streak}");
     if let Some(e) = &step_err {
         eprintln!("[wifi-sim] cpu step error:    {e}");


### PR DESCRIPTION
Reproduced `LABWIRED_REAL_HEAP=1` on the arduino-esp32 WiFi fixture (the IDF5 ereader fixture was lost to the /tmp reboot wipe) — **identical wall** to the ereader path. Added a `REAL_HEAP` gate + **both-core PC reporting** to the WiFi harness, which pins the true fault:

> APP_CPU faults in `esp_intr_alloc_intrstatus_bind` (`0x400e477c`) traversing the `vector_desc` linked list — `node->next` reads the bytes **"lock"** (`0x6b636f6c`) and dereferences it. PRO_CPU is merely spinning in `main_task` waiting for `s_other_cpu_startup_done` (which APP_CPU never sets) — which is why the single-core PC report looked like a harmless spin.

**Corrects the #173 hypothesis:** not a seeded-stack collision (moving SP to top-of-DRAM gives the identical crash; "lock" is a fixed string, not random stack noise). The real `heap_caps_init` mis-registers a heap region, so `malloc` returns pointers into non-heap memory. Real fix = faithfully model heap region registration (`soc_memory_regions` + `SOC_RESERVE_MEMORY_REGION` via XIP); tracked as a dedicated follow-up. The bump allocator stays the default (test-only diagnostics; no production change).