### PR TITLE
feat(tier1): chip-regression validation matrix — infrastructure (Part A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 target/
 examples/*/target/
 # Generated test fixtures (build artifacts) — but allow committed reference
-# binaries like the Espressif ESP32 BROM ELF in crates/*/tests/fixtures/.
+# binaries like the Espressif ESP32 BROM ELF in crates/*/tests/fixtures/
+# and the workspace-root tier1 fixture tree.
 fixtures/
 !crates/*/tests/fixtures/
 !crates/*/tests/fixtures/**
+!tests/fixtures/
+!tests/fixtures/tier1/
+!tests/fixtures/tier1/**
 /*.rlib
 
 # Local release/test run outputs

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,3 +5,4 @@
 // See the LICENSE file in the project root for full license information.
 
 pub mod coverage;
+pub mod tier1;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -122,6 +122,21 @@ enum Commands {
     /// classifies each as Modelled / Indeterminate / Unmodelled. Prints a
     /// human-readable table and optionally writes the full matrix as JSON.
     Coverage(CoverageArgs),
+
+    /// Run the Tier-1 chip × peripheral validation matrix and export it.
+    Tier1Matrix(Tier1MatrixArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct Tier1MatrixArgs {
+    /// Write the matrix as JSON (the committed snapshot path is
+    /// docs/coverage/tier1-matrix.json).
+    #[arg(long = "json-out")]
+    pub json_out: Option<PathBuf>,
+
+    /// Evidence link stamped into every non-unrecorded cell (CI passes its run URL).
+    #[arg(long = "run-url")]
+    pub run_url: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -713,6 +728,7 @@ fn main() -> ExitCode {
         Some(Commands::Run(args)) => run_firmware(args),
         Some(Commands::Snapshot(args)) => run_snapshot(args),
         Some(Commands::Coverage(args)) => run_coverage(args),
+        Some(Commands::Tier1Matrix(args)) => run_tier1_matrix(args),
         None => run_interactive(cli),
     }
 }
@@ -1176,6 +1192,45 @@ fn run_coverage(args: CoverageArgs) -> ExitCode {
                  or install the espressif32 PlatformIO platform"
             );
             ExitCode::from(EXIT_CONFIG_ERROR)
+        }
+    }
+}
+
+fn run_tier1_matrix(args: Tier1MatrixArgs) -> ExitCode {
+    let self_bin = std::env::current_exe().expect("current exe");
+    match labwired_cli::tier1::run_all(&self_bin) {
+        Ok((mut matrix, skipped)) => {
+            for chip in &skipped {
+                eprintln!("SKIP: {chip} (fixture not present)");
+            }
+            if let Some(url) = &args.run_url {
+                use labwired_cli::tier1::CellStatus;
+                for row in matrix.0.values_mut() {
+                    for cell in row.values_mut() {
+                        if cell.status != CellStatus::Unrecorded && cell.status != CellStatus::Na {
+                            cell.run_url = Some(url.clone());
+                        }
+                    }
+                }
+            }
+            // Text grid for humans.
+            for (chip, row) in &matrix.0 {
+                let cells: Vec<String> = row
+                    .iter()
+                    .map(|(class, cell)| format!("{class}={}", cell.status.as_str()))
+                    .collect();
+                println!("{chip}: {}", cells.join(" "));
+            }
+            if let Some(out) = &args.json_out {
+                let json = serde_json::to_string_pretty(&matrix).expect("serialize tier1 matrix");
+                std::fs::write(out, json.as_bytes()).expect("write tier1 json");
+                eprintln!("wrote {}", out.display());
+            }
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("tier1-matrix failed: {e}");
+            ExitCode::FAILURE
         }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -134,7 +134,7 @@ pub struct Tier1MatrixArgs {
     #[arg(long = "json-out")]
     pub json_out: Option<PathBuf>,
 
-    /// Evidence link stamped into every non-unrecorded cell (CI passes its run URL).
+    /// Evidence link stamped into every cell that carries evidence (skips na and unrecorded).
     #[arg(long = "run-url")]
     pub run_url: Option<String>,
 }
@@ -1197,11 +1197,23 @@ fn run_coverage(args: CoverageArgs) -> ExitCode {
 }
 
 fn run_tier1_matrix(args: Tier1MatrixArgs) -> ExitCode {
-    let self_bin = std::env::current_exe().expect("current exe");
+    let self_bin = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: cannot resolve current executable: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
     match labwired_cli::tier1::run_all(&self_bin) {
         Ok((mut matrix, skipped)) => {
             for chip in &skipped {
                 eprintln!("SKIP: {chip} (fixture not present)");
+            }
+            // --run-url given but nothing was actually exercised → vacuous green
+            // is not permitted; fail loudly so CI notices the misconfiguration.
+            if args.run_url.is_some() && matrix.0.is_empty() {
+                eprintln!("error: --run-url given but no fixtures were exercised");
+                return ExitCode::FAILURE;
             }
             if let Some(url) = &args.run_url {
                 use labwired_cli::tier1::CellStatus;
@@ -1222,8 +1234,17 @@ fn run_tier1_matrix(args: Tier1MatrixArgs) -> ExitCode {
                 println!("{chip}: {}", cells.join(" "));
             }
             if let Some(out) = &args.json_out {
-                let json = serde_json::to_string_pretty(&matrix).expect("serialize tier1 matrix");
-                std::fs::write(out, json.as_bytes()).expect("write tier1 json");
+                let json = match serde_json::to_string_pretty(&matrix) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        eprintln!("error: failed to serialize tier1 matrix: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                };
+                if let Err(e) = std::fs::write(out, json.as_bytes()) {
+                    eprintln!("error: failed to write {}: {e}", out.display());
+                    return ExitCode::FAILURE;
+                }
                 eprintln!("wrote {}", out.display());
             }
             ExitCode::SUCCESS

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -163,6 +163,32 @@ pub fn apply_na(row: &mut BTreeMap<String, Cell>, declared: &std::collections::B
     }
 }
 
+/// Cells recorded `Pass` in the snapshot must still pass live. Everything else
+/// (partial/blocked/na/unrecorded, chips missing from the live run) moves freely.
+pub fn ratchet_regressions(snapshot: &Tier1Matrix, live: &Tier1Matrix) -> Vec<String> {
+    let mut out = Vec::new();
+    for (chip, row) in &snapshot.0 {
+        for (class, snap_cell) in row {
+            if snap_cell.status != CellStatus::Pass {
+                continue;
+            }
+            let live_status = live
+                .0
+                .get(chip)
+                .and_then(|r| r.get(class))
+                .map(|c| c.status);
+            match live_status {
+                Some(CellStatus::Pass) | None => {} // None = chip not exercised in this run
+                Some(s) => out.push(format!(
+                    "{chip}/{class}: pass -> {}",
+                    serde_json::to_string(&s).unwrap().trim_matches('"')
+                )),
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,5 +274,67 @@ peripherals:
         assert_eq!(row["clock"].status, CellStatus::Pass);
         assert_eq!(row["dma"].status, CellStatus::Na); // undeclared
         assert_eq!(row["gpio"].status, CellStatus::Na); // undeclared
+    }
+
+    fn cell(s: CellStatus) -> Cell {
+        Cell {
+            status: s,
+            run_url: None,
+        }
+    }
+
+    #[test]
+    fn ratchet_flags_pass_regressions_only() {
+        let mut snap = Tier1Matrix::default();
+        snap.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("gpio".into(), cell(CellStatus::Pass));
+        snap.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("dma".into(), cell(CellStatus::Blocked));
+
+        let mut live = Tier1Matrix::default();
+        live.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("gpio".into(), cell(CellStatus::Blocked)); // regression!
+        live.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("dma".into(), cell(CellStatus::Pass)); // improvement — fine
+
+        let regressions = ratchet_regressions(&snap, &live);
+        assert_eq!(
+            regressions,
+            vec!["esp32s3/gpio: pass -> blocked".to_string()]
+        );
+    }
+
+    #[test]
+    fn ratchet_ignores_unrecorded_and_missing_chips() {
+        let mut snap = Tier1Matrix::default();
+        snap.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("gpio".into(), cell(CellStatus::Unrecorded));
+        let live = Tier1Matrix::default(); // chip absent from live run
+        assert!(ratchet_regressions(&snap, &live).is_empty());
+    }
+
+    #[test]
+    fn snapshot_roundtrip_is_deterministic() {
+        let mut m = Tier1Matrix::default();
+        m.0.entry("b".into())
+            .or_default()
+            .insert("z".into(), cell(CellStatus::Pass));
+        m.0.entry("a".into())
+            .or_default()
+            .insert("gpio".into(), cell(CellStatus::Na));
+        let j1 = serde_json::to_string_pretty(&m).unwrap();
+        let j2 = serde_json::to_string_pretty(&serde_json::from_str::<Tier1Matrix>(&j1).unwrap())
+            .unwrap();
+        assert_eq!(j1, j2);
     }
 }

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -101,6 +101,68 @@ impl ParsedTier1 {
     }
 }
 
+/// peripheral-id substring → tier1 class. First match wins; order matters
+/// (e.g. "gdma" must map to dma before "dma" generic).
+const CLASS_MARKERS: &[(&str, &str)] = &[
+    ("uart", "uart"),
+    ("usb_serial", "uart"), // S3 console can be USB-Serial-JTAG
+    ("gpio", "gpio"),
+    ("timg", "timer"),
+    ("systimer", "timer"),
+    ("tim", "timer"),
+    ("gdma", "dma"),
+    ("dma", "dma"),
+    ("intmatrix", "irq"),
+    ("interrupt", "irq"),
+    ("nvic", "irq"),
+    ("rcc", "clock"),
+    ("clk", "clock"),
+    ("rtc_cntl", "clock"),
+    ("system", "clock"),
+    ("mcpwm", "mcpwm"),
+    ("i2c", "i2c"),
+    ("rmt", "rmt"),
+];
+
+#[derive(Deserialize)]
+struct ChipYamlPeripheral {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct ChipYamlDoc {
+    #[serde(default)]
+    peripherals: Vec<ChipYamlPeripheral>,
+}
+
+/// Which tier1 classes a chip YAML declares, by peripheral-id heuristics.
+pub fn declared_classes_from_yaml(
+    yaml: &str,
+) -> Result<std::collections::BTreeSet<String>, String> {
+    let doc: ChipYamlDoc = serde_yaml::from_str(yaml).map_err(|e| e.to_string())?;
+    let mut classes = std::collections::BTreeSet::new();
+    for p in &doc.peripherals {
+        let id = p.id.to_lowercase();
+        for (marker, class) in CLASS_MARKERS {
+            if id.contains(marker) {
+                classes.insert(class.to_string());
+                break;
+            }
+        }
+    }
+    Ok(classes)
+}
+
+/// Cells whose class is not declared by the chip become `Na`.
+pub fn apply_na(row: &mut BTreeMap<String, Cell>, declared: &std::collections::BTreeSet<String>) {
+    for (class, cell) in row.iter_mut() {
+        if !declared.contains(class) {
+            cell.status = CellStatus::Na;
+            cell.run_url = None;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +215,38 @@ mod tests {
         let parsed = parse_tier1_uart(b"TIER1 clock PASS\nTIER1 done\n");
         let row = parsed.into_row(&["clock", "uart"]);
         assert_eq!(row["uart"].status, CellStatus::Pass);
+    }
+
+    #[test]
+    fn derives_na_from_chip_yaml_peripheral_ids() {
+        // Minimal chip yaml shape — only `peripherals[].id` matters here.
+        let yaml = r#"
+name: "fakechip"
+arch: "xtensa"
+peripherals:
+  - { id: "uart0", type: "uart", base_address: 0x60000000 }
+  - { id: "gpio", type: "declarative", base_address: 0x60004000 }
+  - { id: "timg0", type: "declarative", base_address: 0x6001F000 }
+  - { id: "interrupt_core0", type: "declarative", base_address: 0x600C2000 }
+"#;
+        let declared = declared_classes_from_yaml(yaml).unwrap();
+        assert!(declared.contains("uart"));
+        assert!(declared.contains("gpio"));
+        assert!(declared.contains("timer"));
+        assert!(declared.contains("irq"));
+        assert!(!declared.contains("dma")); // not declared → n/a, not blocked
+        assert!(!declared.contains("mcpwm"));
+    }
+
+    #[test]
+    fn na_overrides_blocked_in_row_resolution() {
+        let parsed = parse_tier1_uart(b"TIER1 clock PASS\nTIER1 done\n");
+        let mut row = parsed.into_row(RUBRIC_CLASSES);
+        let declared: std::collections::BTreeSet<String> =
+            ["clock", "uart"].iter().map(|s| s.to_string()).collect();
+        apply_na(&mut row, &declared);
+        assert_eq!(row["clock"].status, CellStatus::Pass);
+        assert_eq!(row["dma"].status, CellStatus::Na); // undeclared
+        assert_eq!(row["gpio"].status, CellStatus::Na); // undeclared
     }
 }

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -1,0 +1,157 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Tier-1 chip × peripheral validation matrix (spec:
+//! labwired docs/superpowers/specs/2026-06-07-tier1-chip-matrix-design.md).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// One cell's status. `Na` = chip YAML declares no peripheral of this class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CellStatus {
+    Pass,
+    Partial,
+    Blocked,
+    Na,
+    Unrecorded,
+}
+
+/// A cell with its evidence link (CI run that produced it; None until CI stamps it).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cell {
+    pub status: CellStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_url: Option<String>,
+}
+
+/// chip → class → cell. BTreeMaps keep JSON output deterministic (sorted keys).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tier1Matrix(pub BTreeMap<String, BTreeMap<String, Cell>>);
+
+/// The six rubric classes every chip reports.
+pub const RUBRIC_CLASSES: &[&str] = &["clock", "gpio", "uart", "timer", "dma", "irq"];
+
+/// Parsed `TIER1` protocol from a UART capture.
+#[derive(Debug, Default)]
+pub struct ParsedTier1 {
+    /// class → status from explicit `TIER1 <class> PASS|FAIL` lines.
+    pub classes: BTreeMap<String, CellStatus>,
+    /// `TIER1 done` seen — the fixture completed its sequence.
+    pub done: bool,
+}
+
+/// Parse `TIER1 <class> PASS|FAIL[ code=..]` lines + `TIER1 done` out of a raw
+/// UART byte capture. Non-UTF8 and unrelated lines are skipped; malformed
+/// `TIER1` lines are ignored (never fatal — boot noise is expected).
+pub fn parse_tier1_uart(uart: &[u8]) -> ParsedTier1 {
+    let mut out = ParsedTier1::default();
+    for line in String::from_utf8_lossy(uart).lines() {
+        let mut it = line.split_whitespace();
+        if it.next() != Some("TIER1") {
+            continue;
+        }
+        match (it.next(), it.next()) {
+            (Some("done"), _) => out.done = true,
+            (Some(class), Some("PASS")) => {
+                out.classes.insert(class.to_string(), CellStatus::Pass);
+            }
+            (Some(class), Some("FAIL")) => {
+                out.classes.insert(class.to_string(), CellStatus::Blocked);
+            }
+            _ => {} // malformed TIER1 line — ignore
+        }
+    }
+    out
+}
+
+impl ParsedTier1 {
+    /// Resolve a full row over `classes`. Rules (spec §2 conventions):
+    /// - `uart` is implicitly Pass once any protocol arrived AND done was seen
+    ///   (receiving the lines is the proof), Blocked otherwise.
+    /// - missing `done` degrades every reported Pass to Partial (hung mid-sequence);
+    /// - classes never reported are Blocked.
+    pub fn into_row(&self, classes: &[&str]) -> BTreeMap<String, Cell> {
+        let mut row = BTreeMap::new();
+        for &class in classes {
+            let status = if class == "uart" {
+                if self.done && !self.classes.is_empty() {
+                    CellStatus::Pass
+                } else {
+                    CellStatus::Blocked
+                }
+            } else {
+                match self.classes.get(class) {
+                    Some(CellStatus::Pass) if !self.done => CellStatus::Partial,
+                    Some(s) => *s,
+                    None => CellStatus::Blocked,
+                }
+            };
+            row.insert(
+                class.to_string(),
+                Cell {
+                    status,
+                    run_url: None,
+                },
+            );
+        }
+        row
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pass_fail_lines_and_done() {
+        let uart =
+            b"boot noise\nTIER1 clock PASS\nTIER1 gpio PASS\nTIER1 dma FAIL code=gdma-idle\nTIER1 done\ntrailing";
+        let parsed = parse_tier1_uart(uart);
+        assert!(parsed.done);
+        assert_eq!(parsed.classes["clock"], CellStatus::Pass);
+        assert_eq!(parsed.classes["gpio"], CellStatus::Pass);
+        assert_eq!(parsed.classes["dma"], CellStatus::Blocked);
+    }
+
+    #[test]
+    fn missing_done_marks_row_partial_for_reported_passes() {
+        let uart = b"TIER1 clock PASS\nTIER1 gpio PASS\n"; // hung before done
+        let parsed = parse_tier1_uart(uart);
+        assert!(!parsed.done);
+        let row = parsed.into_row(&["clock", "gpio", "uart"]);
+        // reported passes degrade to partial; unreported classes are blocked
+        assert_eq!(row["clock"].status, CellStatus::Partial);
+        assert_eq!(row["gpio"].status, CellStatus::Partial);
+        assert_eq!(row["uart"].status, CellStatus::Blocked);
+    }
+
+    #[test]
+    fn no_tier1_lines_blocks_uart_and_everything_else() {
+        let parsed = parse_tier1_uart(b"garbage \xff\xfe binary noise");
+        assert!(!parsed.done);
+        assert!(parsed.classes.is_empty());
+        let row = parsed.into_row(RUBRIC_CLASSES);
+        for class in RUBRIC_CLASSES {
+            assert_eq!(row[*class].status, CellStatus::Blocked, "{class}");
+        }
+    }
+
+    #[test]
+    fn garbage_tier1_lines_are_ignored_not_fatal() {
+        let uart = b"TIER1 gpio MAYBE\nTIER1\nTIER1 gpio PASS\nTIER1 done\n";
+        let parsed = parse_tier1_uart(uart);
+        assert_eq!(parsed.classes["gpio"], CellStatus::Pass);
+        assert_eq!(parsed.classes.len(), 1);
+    }
+
+    #[test]
+    fn uart_class_is_implicitly_pass_when_done_arrives() {
+        // The fixture never prints "TIER1 uart ..." — receiving the protocol IS the proof.
+        let parsed = parse_tier1_uart(b"TIER1 clock PASS\nTIER1 done\n");
+        let row = parsed.into_row(&["clock", "uart"]);
+        assert_eq!(row["uart"].status, CellStatus::Pass);
+    }
+}

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -338,7 +338,11 @@ pub fn run_target(
             let s = String::from_utf8_lossy(&out.stderr);
             let trimmed = s.trim_end();
             if trimmed.len() > 500 {
-                trimmed[trimmed.len() - 500..].to_string()
+                let cut = trimmed.len().saturating_sub(500);
+                let cut = (cut..=trimmed.len())
+                    .find(|&i| trimmed.is_char_boundary(i))
+                    .unwrap_or(trimmed.len());
+                trimmed[cut..].to_string()
             } else {
                 trimmed.to_string()
             }
@@ -718,6 +722,22 @@ peripherals:
         let err = run_target(target, &fake).unwrap_err();
         assert!(err.contains("boom-stderr"), "{err}");
         assert!(err.contains("esp32s3"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stderr_tail_truncation_is_char_boundary_safe() {
+        let dir = std::env::temp_dir().join(format!("tier1-crash-utf8-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fake = dir.join("labwired-fake");
+        // >500 bytes of multibyte stderr (U+2744 = 3 bytes each × 200 = 600 bytes)
+        // so the naive len-500 cut lands mid-char.
+        std::fs::write(&fake, "#!/bin/sh\npython3 << 'PYEOF'\nimport sys\nfor i in range(200):\n    sys.stderr.buffer.write(b'\\xe2\\x9d\\x84')\nsys.exit(3)\nPYEOF\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let target = &TIER1_TARGETS[0];
+        let err = run_target(target, &fake).unwrap_err();
+        assert!(err.contains("exited"), "{err}");
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -267,14 +267,16 @@ struct ManifestEntry {
 }
 
 /// Verify every blob listed in `<dir>/MANIFEST.json` against its sha256.
-/// Returns Err naming the first mismatching file.
-pub fn verify_fixture_manifest(dir: &Path) -> Result<(), String> {
+/// Returns the set of verified file names on success, or Err naming the first
+/// mismatching file. The returned set is used by `run_all` to check that every
+/// blob a target uses is explicitly listed.
+pub fn verify_fixture_manifest(dir: &Path) -> Result<BTreeSet<String>, String> {
     let manifest_path = dir.join("MANIFEST.json");
     let manifest: BTreeMap<String, ManifestEntry> = serde_json::from_str(
         &std::fs::read_to_string(&manifest_path)
             .map_err(|e| format!("{}: {e}", manifest_path.display()))?,
     )
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| format!("{}: {e}", manifest_path.display()))?;
     for (file, entry) in &manifest {
         let bytes = std::fs::read(dir.join(file)).map_err(|e| format!("{file}: {e}"))?;
         let got = format!("{:x}", Sha256::digest(&bytes));
@@ -285,7 +287,7 @@ pub fn verify_fixture_manifest(dir: &Path) -> Result<(), String> {
             ));
         }
     }
-    Ok(())
+    Ok(manifest.into_keys().collect())
 }
 
 /// Run one target through the `labwired` binary and parse its TIER1 row.
@@ -303,15 +305,50 @@ pub fn run_target(
         .arg(root.join(target.elf))
         .arg("--max-steps")
         .arg(target.max_steps.to_string());
+
+    // Scrub any inherited LABWIRED_* vars so the matrix is deterministic
+    // regardless of the caller's shell environment, then set only the ones
+    // this target actually needs.
+    for (key, _) in std::env::vars() {
+        if key.starts_with("LABWIRED_") {
+            cmd.env_remove(&key);
+        }
+    }
+
     if target.rom_boot {
         cmd.arg("--rom-boot");
         let flash = target.flash_bin.ok_or("rom_boot target needs flash_bin")?;
         cmd.env("LABWIRED_ESP32S3_FLASH", root.join(flash));
     }
-    let out = cmd.output().map_err(|e| format!("spawn labwired: {e}"))?;
+    let out = cmd
+        .output()
+        .map_err(|e| format!("spawn {}: {e}", labwired_bin.display()))?;
+
     // UART echoes on stdout; the sim may exit nonzero on step-limit — that's
     // fine, the protocol lines are the verdict.
+    //
+    // No wall-clock timeout here: step-count bound is sufficient because the
+    // sim step loop has no blocking paths (no I/O waits, no sleeps).
     let parsed = parse_tier1_uart(&out.stdout);
+
+    // A crash (non-zero exit, no TIER1 output, no `done`) must surface as an
+    // error rather than silently producing a row of Blocked cells.
+    if parsed.classes.is_empty() && !parsed.done && !out.status.success() {
+        let stderr_tail = {
+            let s = String::from_utf8_lossy(&out.stderr);
+            let trimmed = s.trim_end();
+            if trimmed.len() > 500 {
+                trimmed[trimmed.len() - 500..].to_string()
+            } else {
+                trimmed.to_string()
+            }
+        };
+        return Err(format!(
+            "{}: labwired exited {} with no TIER1 output; stderr tail: {}",
+            target.chip, out.status, stderr_tail,
+        ));
+    }
+
     let classes: Vec<&str> = RUBRIC_CLASSES
         .iter()
         .chain(target.extra_classes.iter())
@@ -329,9 +366,57 @@ pub fn run_target(
 pub fn run_all(labwired_bin: &Path) -> Result<(Tier1Matrix, Vec<String>), String> {
     let root = workspace_root();
     let fixture_dir = root.join("tests/fixtures/tier1");
-    if fixture_dir.join("MANIFEST.json").exists() {
-        verify_fixture_manifest(&fixture_dir)?;
+
+    // Determine which targets have ELF files present.
+    let any_elf_present = TIER1_TARGETS.iter().any(|t| root.join(t.elf).exists());
+
+    // If any ELF exists, MANIFEST.json is mandatory and must cover every blob
+    // that a non-skipped target uses.
+    let verified: Option<BTreeSet<String>> = if any_elf_present {
+        let manifest_path = fixture_dir.join("MANIFEST.json");
+        if !manifest_path.exists() {
+            return Err(format!(
+                "MANIFEST.json is required when fixture ELFs are present but was not found at {}",
+                manifest_path.display()
+            ));
+        }
+        Some(verify_fixture_manifest(&fixture_dir)?)
+    } else {
+        None
+    };
+
+    // Before running any target, verify that every blob it uses is listed in
+    // the manifest — an omitted blob is an error naming the file.
+    if let Some(ref listed) = verified {
+        for target in TIER1_TARGETS {
+            if !root.join(target.elf).exists() {
+                continue; // will be skipped below
+            }
+            let elf_name = Path::new(target.elf)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(target.elf);
+            if !listed.contains(elf_name) {
+                return Err(format!(
+                    "fixture blob '{elf_name}' used by target '{}' is not listed in MANIFEST.json",
+                    target.chip
+                ));
+            }
+            if let Some(flash) = target.flash_bin {
+                let flash_name = Path::new(flash)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(flash);
+                if !listed.contains(flash_name) {
+                    return Err(format!(
+                        "fixture blob '{flash_name}' used by target '{}' is not listed in MANIFEST.json",
+                        target.chip
+                    ));
+                }
+            }
+        }
     }
+
     let mut matrix = Tier1Matrix::default();
     let mut skipped = Vec::new();
     for target in TIER1_TARGETS {
@@ -534,6 +619,20 @@ peripherals:
 
     #[test]
     fn target_table_paths_resolve_relative_to_workspace_root() {
+        let root = workspace_root();
+        for t in TIER1_TARGETS {
+            assert!(
+                t.chip_yaml.ends_with(".yaml"),
+                "{}: chip_yaml does not end with .yaml",
+                t.chip
+            );
+            assert!(
+                root.join(t.chip_yaml).exists(),
+                "{}: chip_yaml {} does not exist",
+                t.chip,
+                t.chip_yaml
+            );
+        }
         let t = &TIER1_TARGETS[0];
         assert_eq!(t.chip, "esp32s3");
         assert!(t.chip_yaml.ends_with("configs/chips/esp32s3.yaml"));
@@ -546,12 +645,79 @@ peripherals:
 
     #[test]
     fn manifest_verification_rejects_corrupt_blob() {
-        let dir = std::env::temp_dir().join("tier1-manifest-test");
+        let dir =
+            std::env::temp_dir().join(format!("tier1-manifest-corrupt-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("esp32s3.elf"), b"not the real elf").unwrap();
         let manifest = r#"{ "esp32s3.elf": { "sha256": "0000000000000000000000000000000000000000000000000000000000000000" } }"#;
         std::fs::write(dir.join("MANIFEST.json"), manifest).unwrap();
         let err = verify_fixture_manifest(&dir).unwrap_err();
         assert!(err.contains("esp32s3.elf"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn manifest_verification_happy_path() {
+        let dir = std::env::temp_dir().join(format!("tier1-manifest-happy-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let body = b"good-blob-bytes";
+        std::fs::write(dir.join("esp32s3.elf"), body).unwrap();
+        let sha = format!("{:x}", <sha2::Sha256 as sha2::Digest>::digest(body));
+        std::fs::write(
+            dir.join("MANIFEST.json"),
+            format!(r#"{{ "esp32s3.elf": {{ "sha256": "{sha}" }} }}"#),
+        )
+        .unwrap();
+        let verified = verify_fixture_manifest(&dir).unwrap();
+        assert!(verified.contains("esp32s3.elf"), "{verified:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn manifest_verification_missing_blob_file() {
+        let dir =
+            std::env::temp_dir().join(format!("tier1-manifest-missing-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // MANIFEST.json references a file that doesn't exist in the dir.
+        let manifest = r#"{ "nonexistent.bin": { "sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" } }"#;
+        std::fs::write(dir.join("MANIFEST.json"), manifest).unwrap();
+        let err = verify_fixture_manifest(&dir).unwrap_err();
+        assert!(err.contains("nonexistent.bin"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_all_style_manifest_listing_is_enforced() {
+        // verify_fixture_manifest returns the set of verified file names
+        let dir = std::env::temp_dir().join(format!("tier1-manifest-list-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let body = b"blob-bytes";
+        std::fs::write(dir.join("esp32s3.elf"), body).unwrap();
+        let sha = format!("{:x}", <sha2::Sha256 as sha2::Digest>::digest(body));
+        std::fs::write(
+            dir.join("MANIFEST.json"),
+            format!(r#"{{ "esp32s3.elf": {{ "sha256": "{sha}" }} }}"#),
+        )
+        .unwrap();
+        let verified = verify_fixture_manifest(&dir).unwrap();
+        assert!(verified.contains("esp32s3.elf"));
+        assert!(!verified.contains("esp32s3-flash.bin"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_target_surfaces_child_crash_instead_of_blocked_row() {
+        let dir = std::env::temp_dir().join(format!("tier1-crash-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fake = dir.join("labwired-fake");
+        std::fs::write(&fake, "#!/bin/sh\necho boom-stderr >&2\nexit 3\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let target = &TIER1_TARGETS[0];
+        // chip yaml exists in-repo, ELF path doesn't need to exist for the spawn itself
+        let err = run_target(target, &fake).unwrap_err();
+        assert!(err.contains("boom-stderr"), "{err}");
+        assert!(err.contains("esp32s3"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -195,6 +195,25 @@ pub fn apply_na(row: &mut BTreeMap<String, Cell>, declared: &BTreeSet<String>) {
     }
 }
 
+/// Chips that the snapshot records with at least one `pass` cell but which the
+/// live run skipped (fixture missing). A deleted fixture must not silently
+/// disarm the ratchet — these are reported as regressions by the gate.
+pub fn skipped_chips_with_recorded_passes(
+    snapshot: &Tier1Matrix,
+    skipped: &[String],
+) -> Vec<String> {
+    skipped
+        .iter()
+        .filter(|chip| {
+            snapshot
+                .0
+                .get(chip.as_str())
+                .is_some_and(|row| row.values().any(|c| c.status == CellStatus::Pass))
+        })
+        .cloned()
+        .collect()
+}
+
 /// Cells recorded `Pass` in the snapshot must still pass live. Everything else
 /// (partial/blocked/na/unrecorded, chips missing from the live run) moves freely.
 pub fn ratchet_regressions(snapshot: &Tier1Matrix, live: &Tier1Matrix) -> Vec<String> {
@@ -613,6 +632,38 @@ peripherals:
             .unwrap();
         assert_eq!(j1, j2);
         assert!(j1.find("\"a\"").unwrap() < j1.find("\"b\"").unwrap());
+    }
+
+    #[test]
+    fn skipped_chips_with_passes_detects_disarmed_fixture() {
+        // Snapshot has esp32s3 with a pass cell — it gets flagged when skipped.
+        let mut snap = Tier1Matrix::default();
+        snap.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("gpio".into(), cell(CellStatus::Pass));
+
+        let skipped = vec!["esp32s3".to_string(), "other".to_string()];
+        let disarmed = skipped_chips_with_recorded_passes(&snap, &skipped);
+        assert_eq!(disarmed, vec!["esp32s3".to_string()]);
+    }
+
+    #[test]
+    fn skipped_chips_with_only_blocked_cells_not_flagged() {
+        // Snapshot has a chip but only blocked/na cells — not a disarmed gate.
+        let mut snap = Tier1Matrix::default();
+        snap.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("gpio".into(), cell(CellStatus::Blocked));
+        snap.0
+            .entry("esp32s3".into())
+            .or_default()
+            .insert("dma".into(), cell(CellStatus::Na));
+
+        let skipped = vec!["esp32s3".to_string()];
+        let disarmed = skipped_chips_with_recorded_passes(&snap, &skipped);
+        assert!(disarmed.is_empty());
     }
 
     #[test]

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -7,6 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 /// One cell's status. `Na` = chip YAML declares no peripheral of this class.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,6 +18,19 @@ pub enum CellStatus {
     Blocked,
     Na,
     Unrecorded,
+}
+
+impl CellStatus {
+    /// Snapshot vocabulary — must stay in sync with the serde snake_case names.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CellStatus::Pass => "pass",
+            CellStatus::Partial => "partial",
+            CellStatus::Blocked => "blocked",
+            CellStatus::Na => "na",
+            CellStatus::Unrecorded => "unrecorded",
+        }
+    }
 }
 
 /// A cell with its evidence link (CI run that produced it; None until CI stamps it).
@@ -38,6 +52,9 @@ pub const RUBRIC_CLASSES: &[&str] = &["clock", "gpio", "uart", "timer", "dma", "
 #[derive(Debug, Default)]
 pub struct ParsedTier1 {
     /// class → status from explicit `TIER1 <class> PASS|FAIL` lines.
+    /// Repeated reports for a class take the last occurrence — supports
+    /// fixture-internal retries. Class tokens are case-sensitive: `TIER1 GPIO
+    /// PASS` records a class `GPIO` that no standard row consumes.
     pub classes: BTreeMap<String, CellStatus>,
     /// `TIER1 done` seen — the fixture completed its sequence.
     pub done: bool,
@@ -45,7 +62,9 @@ pub struct ParsedTier1 {
 
 /// Parse `TIER1 <class> PASS|FAIL[ code=..]` lines + `TIER1 done` out of a raw
 /// UART byte capture. Non-UTF8 and unrelated lines are skipped; malformed
-/// `TIER1` lines are ignored (never fatal — boot noise is expected).
+/// `TIER1` lines are ignored (never fatal — boot noise is expected). Leading and
+/// trailing whitespace on each token is normalised by `split_whitespace`; CRLF
+/// line endings are handled by `lines()`.
 pub fn parse_tier1_uart(uart: &[u8]) -> ParsedTier1 {
     let mut out = ParsedTier1::default();
     for line in String::from_utf8_lossy(uart).lines() {
@@ -69,18 +88,28 @@ pub fn parse_tier1_uart(uart: &[u8]) -> ParsedTier1 {
 
 impl ParsedTier1 {
     /// Resolve a full row over `classes`. Rules (spec §2 conventions):
-    /// - `uart` is implicitly Pass once any protocol arrived AND done was seen
-    ///   (receiving the lines is the proof), Blocked otherwise.
-    /// - missing `done` degrades every reported Pass to Partial (hung mid-sequence);
-    /// - classes never reported are Blocked.
-    pub fn into_row(&self, classes: &[&str]) -> BTreeMap<String, Cell> {
+    ///
+    /// - If the fixture explicitly reported `uart` (a `TIER1 uart PASS|FAIL`
+    ///   line), that explicit status wins, subject to the same done-degradation
+    ///   rule as every other class (explicit Pass without done → Partial).
+    /// - Otherwise `uart` is Pass iff `done` was seen — receiving a `TIER1
+    ///   done` line over UART is itself the proof of a working UART channel.
+    ///   `!classes.is_empty()` is **not** required.
+    /// - Missing `done` degrades every reported Pass to Partial (hung
+    ///   mid-sequence).
+    /// - Classes never reported are Blocked.
+    pub fn resolve_row(&self, classes: &[&str]) -> BTreeMap<String, Cell> {
         let mut row = BTreeMap::new();
         for &class in classes {
             let status = if class == "uart" {
-                if self.done && !self.classes.is_empty() {
-                    CellStatus::Pass
-                } else {
-                    CellStatus::Blocked
+                match self.classes.get("uart") {
+                    // Explicit uart verdict from the fixture — honour it, same
+                    // done-degradation as every other class.
+                    Some(CellStatus::Pass) if !self.done => CellStatus::Partial,
+                    Some(s) => *s,
+                    // No explicit uart line: done alone proves UART is alive.
+                    None if self.done => CellStatus::Pass,
+                    None => CellStatus::Blocked,
                 }
             } else {
                 match self.classes.get(class) {
@@ -101,8 +130,9 @@ impl ParsedTier1 {
     }
 }
 
-/// peripheral-id substring → tier1 class. First match wins; order matters
-/// (e.g. "gdma" must map to dma before "dma" generic).
+/// peripheral-id substring → tier1 class. First match wins; currently no pair
+/// is order-sensitive — keep it that way or document the pair explicitly if one
+/// is added.
 const CLASS_MARKERS: &[(&str, &str)] = &[
     ("uart", "uart"),
     ("usb_serial", "uart"), // S3 console can be USB-Serial-JTAG
@@ -136,11 +166,9 @@ struct ChipYamlDoc {
 }
 
 /// Which tier1 classes a chip YAML declares, by peripheral-id heuristics.
-pub fn declared_classes_from_yaml(
-    yaml: &str,
-) -> Result<std::collections::BTreeSet<String>, String> {
+pub fn declared_classes_from_yaml(yaml: &str) -> Result<BTreeSet<String>, String> {
     let doc: ChipYamlDoc = serde_yaml::from_str(yaml).map_err(|e| e.to_string())?;
-    let mut classes = std::collections::BTreeSet::new();
+    let mut classes = BTreeSet::new();
     for p in &doc.peripherals {
         let id = p.id.to_lowercase();
         for (marker, class) in CLASS_MARKERS {
@@ -153,8 +181,10 @@ pub fn declared_classes_from_yaml(
     Ok(classes)
 }
 
-/// Cells whose class is not declared by the chip become `Na`.
-pub fn apply_na(row: &mut BTreeMap<String, Cell>, declared: &std::collections::BTreeSet<String>) {
+/// Cells whose class is not declared by the chip become `Na`. This deliberately
+/// downgrades even Pass cells — heuristic misses surface as `pass -> na` in the
+/// ratchet diff rather than silently shadow-passing.
+pub fn apply_na(row: &mut BTreeMap<String, Cell>, declared: &BTreeSet<String>) {
     for (class, cell) in row.iter_mut() {
         if !declared.contains(class) {
             cell.status = CellStatus::Na;
@@ -179,10 +209,7 @@ pub fn ratchet_regressions(snapshot: &Tier1Matrix, live: &Tier1Matrix) -> Vec<St
                 .map(|c| c.status);
             match live_status {
                 Some(CellStatus::Pass) | None => {} // None = chip not exercised in this run
-                Some(s) => out.push(format!(
-                    "{chip}/{class}: pass -> {}",
-                    serde_json::to_string(&s).unwrap().trim_matches('"')
-                )),
+                Some(s) => out.push(format!("{chip}/{class}: pass -> {}", s.as_str())),
             }
         }
     }
@@ -209,7 +236,7 @@ mod tests {
         let uart = b"TIER1 clock PASS\nTIER1 gpio PASS\n"; // hung before done
         let parsed = parse_tier1_uart(uart);
         assert!(!parsed.done);
-        let row = parsed.into_row(&["clock", "gpio", "uart"]);
+        let row = parsed.resolve_row(&["clock", "gpio", "uart"]);
         // reported passes degrade to partial; unreported classes are blocked
         assert_eq!(row["clock"].status, CellStatus::Partial);
         assert_eq!(row["gpio"].status, CellStatus::Partial);
@@ -221,7 +248,7 @@ mod tests {
         let parsed = parse_tier1_uart(b"garbage \xff\xfe binary noise");
         assert!(!parsed.done);
         assert!(parsed.classes.is_empty());
-        let row = parsed.into_row(RUBRIC_CLASSES);
+        let row = parsed.resolve_row(RUBRIC_CLASSES);
         for class in RUBRIC_CLASSES {
             assert_eq!(row[*class].status, CellStatus::Blocked, "{class}");
         }
@@ -239,8 +266,40 @@ mod tests {
     fn uart_class_is_implicitly_pass_when_done_arrives() {
         // The fixture never prints "TIER1 uart ..." — receiving the protocol IS the proof.
         let parsed = parse_tier1_uart(b"TIER1 clock PASS\nTIER1 done\n");
-        let row = parsed.into_row(&["clock", "uart"]);
+        let row = parsed.resolve_row(&["clock", "uart"]);
         assert_eq!(row["uart"].status, CellStatus::Pass);
+    }
+
+    #[test]
+    fn explicit_uart_fail_wins_over_implicit_rule() {
+        let parsed =
+            parse_tier1_uart(b"TIER1 clock PASS\nTIER1 uart FAIL code=parity\nTIER1 done\n");
+        let row = parsed.resolve_row(&["clock", "uart"]);
+        assert_eq!(row["uart"].status, CellStatus::Blocked);
+    }
+
+    #[test]
+    fn done_alone_proves_uart() {
+        let parsed = parse_tier1_uart(b"TIER1 done\n");
+        let row = parsed.resolve_row(&["uart", "gpio"]);
+        assert_eq!(row["uart"].status, CellStatus::Pass);
+        assert_eq!(row["gpio"].status, CellStatus::Blocked);
+    }
+
+    #[test]
+    fn duplicate_class_lines_last_wins() {
+        let parsed = parse_tier1_uart(b"TIER1 gpio PASS\nTIER1 gpio FAIL code=retry\nTIER1 done\n");
+        assert_eq!(parsed.classes["gpio"], CellStatus::Blocked);
+        // and the reverse: a retry that recovers
+        let parsed = parse_tier1_uart(b"TIER1 gpio FAIL code=first\nTIER1 gpio PASS\nTIER1 done\n");
+        assert_eq!(parsed.classes["gpio"], CellStatus::Pass);
+    }
+
+    #[test]
+    fn whitespace_and_crlf_are_tolerated() {
+        let parsed = parse_tier1_uart(b"  TIER1\tclock   PASS\r\nTIER1 done\r\n");
+        assert_eq!(parsed.classes["clock"], CellStatus::Pass);
+        assert!(parsed.done);
     }
 
     #[test]
@@ -267,9 +326,8 @@ peripherals:
     #[test]
     fn na_overrides_blocked_in_row_resolution() {
         let parsed = parse_tier1_uart(b"TIER1 clock PASS\nTIER1 done\n");
-        let mut row = parsed.into_row(RUBRIC_CLASSES);
-        let declared: std::collections::BTreeSet<String> =
-            ["clock", "uart"].iter().map(|s| s.to_string()).collect();
+        let mut row = parsed.resolve_row(RUBRIC_CLASSES);
+        let declared: BTreeSet<String> = ["clock", "uart"].iter().map(|s| s.to_string()).collect();
         apply_na(&mut row, &declared);
         assert_eq!(row["clock"].status, CellStatus::Pass);
         assert_eq!(row["dma"].status, CellStatus::Na); // undeclared
@@ -336,5 +394,12 @@ peripherals:
         let j2 = serde_json::to_string_pretty(&serde_json::from_str::<Tier1Matrix>(&j1).unwrap())
             .unwrap();
         assert_eq!(j1, j2);
+        assert!(j1.find("\"a\"").unwrap() < j1.find("\"b\"").unwrap());
+    }
+
+    #[test]
+    fn cell_status_as_str_matches_serde() {
+        assert_eq!(serde_json::to_string(&CellStatus::Na).unwrap(), "\"na\"");
+        assert_eq!(CellStatus::Na.as_str(), "na");
     }
 }

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -6,8 +6,10 @@
 //! labwired docs/superpowers/specs/2026-06-07-tier1-chip-matrix-design.md).
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 /// One cell's status. `Na` = chip YAML declares no peripheral of this class.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -216,6 +218,133 @@ pub fn ratchet_regressions(snapshot: &Tier1Matrix, live: &Tier1Matrix) -> Vec<St
     out
 }
 
+/// One matrix target. Paths are workspace-root-relative.
+pub struct Tier1Target {
+    pub chip: &'static str,
+    pub chip_yaml: &'static str,
+    pub elf: &'static str,
+    /// Flash image for `--rom-boot` (None = fast-boot ELF entry).
+    pub flash_bin: Option<&'static str>,
+    pub rom_boot: bool,
+    pub max_steps: u64,
+    /// Beachhead classes beyond RUBRIC_CLASSES (spec wedge-alignment §4).
+    pub extra_classes: &'static [&'static str],
+}
+
+pub const TIER1_TARGETS: &[Tier1Target] = &[
+    Tier1Target {
+        chip: "esp32s3",
+        chip_yaml: "configs/chips/esp32s3.yaml",
+        elf: "tests/fixtures/tier1/esp32s3.elf",
+        flash_bin: Some("tests/fixtures/tier1/esp32s3-flash.bin"),
+        rom_boot: true,
+        max_steps: 40_000_000, // real ROM + bootloader + app + self-tests
+        extra_classes: &["mcpwm", "i2c", "rmt"],
+    },
+    Tier1Target {
+        chip: "esp32s3-zero",
+        chip_yaml: "configs/chips/esp32s3-zero.yaml",
+        elf: "tests/fixtures/tier1/esp32s3.elf", // same silicon, same fixture
+        flash_bin: Some("tests/fixtures/tier1/esp32s3-flash.bin"),
+        rom_boot: true,
+        max_steps: 40_000_000,
+        extra_classes: &["mcpwm", "i2c", "rmt"],
+    },
+];
+
+/// Workspace root = two parents up from the cli crate (crates/cli → core).
+pub fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+#[derive(Deserialize)]
+struct ManifestEntry {
+    sha256: String,
+}
+
+/// Verify every blob listed in `<dir>/MANIFEST.json` against its sha256.
+/// Returns Err naming the first mismatching file.
+pub fn verify_fixture_manifest(dir: &Path) -> Result<(), String> {
+    let manifest_path = dir.join("MANIFEST.json");
+    let manifest: BTreeMap<String, ManifestEntry> = serde_json::from_str(
+        &std::fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("{}: {e}", manifest_path.display()))?,
+    )
+    .map_err(|e| e.to_string())?;
+    for (file, entry) in &manifest {
+        let bytes = std::fs::read(dir.join(file)).map_err(|e| format!("{file}: {e}"))?;
+        let got = format!("{:x}", Sha256::digest(&bytes));
+        if got != entry.sha256 {
+            return Err(format!(
+                "{file}: sha256 mismatch (manifest {}, got {got})",
+                entry.sha256
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Run one target through the `labwired` binary and parse its TIER1 row.
+/// `labwired_bin` lets integration tests pass `env!("CARGO_BIN_EXE_labwired")`.
+pub fn run_target(
+    target: &Tier1Target,
+    labwired_bin: &Path,
+) -> Result<BTreeMap<String, Cell>, String> {
+    let root = workspace_root();
+    let mut cmd = std::process::Command::new(labwired_bin);
+    cmd.arg("run")
+        .arg("--chip")
+        .arg(root.join(target.chip_yaml))
+        .arg("--firmware")
+        .arg(root.join(target.elf))
+        .arg("--max-steps")
+        .arg(target.max_steps.to_string());
+    if target.rom_boot {
+        cmd.arg("--rom-boot");
+        let flash = target.flash_bin.ok_or("rom_boot target needs flash_bin")?;
+        cmd.env("LABWIRED_ESP32S3_FLASH", root.join(flash));
+    }
+    let out = cmd.output().map_err(|e| format!("spawn labwired: {e}"))?;
+    // UART echoes on stdout; the sim may exit nonzero on step-limit — that's
+    // fine, the protocol lines are the verdict.
+    let parsed = parse_tier1_uart(&out.stdout);
+    let classes: Vec<&str> = RUBRIC_CLASSES
+        .iter()
+        .chain(target.extra_classes.iter())
+        .copied()
+        .collect();
+    let mut row = parsed.resolve_row(&classes);
+    let chip_yaml =
+        std::fs::read_to_string(root.join(target.chip_yaml)).map_err(|e| e.to_string())?;
+    apply_na(&mut row, &declared_classes_from_yaml(&chip_yaml)?);
+    Ok(row)
+}
+
+/// Run every target whose fixture blobs exist. Returns the live matrix and the
+/// list of skipped chips (missing fixtures — fresh clone or fixtures not landed yet).
+pub fn run_all(labwired_bin: &Path) -> Result<(Tier1Matrix, Vec<String>), String> {
+    let root = workspace_root();
+    let fixture_dir = root.join("tests/fixtures/tier1");
+    if fixture_dir.join("MANIFEST.json").exists() {
+        verify_fixture_manifest(&fixture_dir)?;
+    }
+    let mut matrix = Tier1Matrix::default();
+    let mut skipped = Vec::new();
+    for target in TIER1_TARGETS {
+        if !root.join(target.elf).exists() {
+            skipped.push(target.chip.to_string());
+            continue;
+        }
+        let row = run_target(target, labwired_bin)?;
+        matrix.0.insert(target.chip.to_string(), row);
+    }
+    Ok((matrix, skipped))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -401,5 +530,28 @@ peripherals:
     fn cell_status_as_str_matches_serde() {
         assert_eq!(serde_json::to_string(&CellStatus::Na).unwrap(), "\"na\"");
         assert_eq!(CellStatus::Na.as_str(), "na");
+    }
+
+    #[test]
+    fn target_table_paths_resolve_relative_to_workspace_root() {
+        let t = &TIER1_TARGETS[0];
+        assert_eq!(t.chip, "esp32s3");
+        assert!(t.chip_yaml.ends_with("configs/chips/esp32s3.yaml"));
+        assert!(t.elf.ends_with("tests/fixtures/tier1/esp32s3.elf"));
+        assert!(t
+            .flash_bin
+            .unwrap()
+            .ends_with("tests/fixtures/tier1/esp32s3-flash.bin"));
+    }
+
+    #[test]
+    fn manifest_verification_rejects_corrupt_blob() {
+        let dir = std::env::temp_dir().join("tier1-manifest-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("esp32s3.elf"), b"not the real elf").unwrap();
+        let manifest = r#"{ "esp32s3.elf": { "sha256": "0000000000000000000000000000000000000000000000000000000000000000" } }"#;
+        std::fs::write(dir.join("MANIFEST.json"), manifest).unwrap();
+        let err = verify_fixture_manifest(&dir).unwrap_err();
+        assert!(err.contains("esp32s3.elf"), "{err}");
     }
 }

--- a/crates/cli/tests/tier1_matrix.rs
+++ b/crates/cli/tests/tier1_matrix.rs
@@ -10,7 +10,7 @@ use labwired_cli::tier1;
 #[test]
 fn tier1_matrix_runs_all_available_fixtures() {
     let bin = std::path::Path::new(env!("CARGO_BIN_EXE_labwired"));
-    let (matrix, skipped) = tier1::run_all(bin).expect("tier1 run_all");
+    let (matrix, skipped) = tier1::run_all(bin).unwrap_or_else(|e| panic!("tier1 run_all: {e}"));
     for chip in &skipped {
         eprintln!("SKIP: {chip} (fixture not present)");
     }

--- a/crates/cli/tests/tier1_matrix.rs
+++ b/crates/cli/tests/tier1_matrix.rs
@@ -1,0 +1,26 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+// Per-PR Tier-1 matrix harness. Runs every target whose committed fixture
+// exists; skips cleanly (like svd_coverage_ratchet) on fresh clones or before
+// the fixture blobs land.
+use labwired_cli::tier1;
+
+#[test]
+fn tier1_matrix_runs_all_available_fixtures() {
+    let bin = std::path::Path::new(env!("CARGO_BIN_EXE_labwired"));
+    let (matrix, skipped) = tier1::run_all(bin).expect("tier1 run_all");
+    for chip in &skipped {
+        eprintln!("SKIP: {chip} (fixture not present)");
+    }
+    // Every exercised chip must produce a full row (rubric + extra classes).
+    for (chip, row) in &matrix.0 {
+        let target = tier1::TIER1_TARGETS
+            .iter()
+            .find(|t| t.chip == chip.as_str())
+            .expect("target for chip");
+        let expected = tier1::RUBRIC_CLASSES.len() + target.extra_classes.len();
+        assert_eq!(row.len(), expected, "{chip}: row incomplete: {row:?}");
+    }
+}

--- a/crates/cli/tests/tier1_matrix_ratchet.rs
+++ b/crates/cli/tests/tier1_matrix_ratchet.rs
@@ -19,10 +19,17 @@ fn tier1_matrix_does_not_regress() {
             .expect("parse snapshot");
 
     let bin = std::path::Path::new(env!("CARGO_BIN_EXE_labwired"));
-    let (live, skipped) = tier1::run_all(bin).expect("tier1 run_all");
+    let (live, skipped) = tier1::run_all(bin).unwrap_or_else(|e| panic!("tier1 run_all: {e}"));
     for chip in &skipped {
         eprintln!("SKIP: {chip} (fixture not present)");
     }
+
+    let disarmed = tier1::skipped_chips_with_recorded_passes(&snapshot, &skipped);
+    assert!(
+        disarmed.is_empty(),
+        "fixtures missing for chips with recorded passes (gate would be silently disarmed): {disarmed:?}. \
+         Restore tests/fixtures/tier1/ blobs or explicitly edit the snapshot."
+    );
 
     let regressions = tier1::ratchet_regressions(&snapshot, &live);
     assert!(

--- a/crates/cli/tests/tier1_matrix_ratchet.rs
+++ b/crates/cli/tests/tier1_matrix_ratchet.rs
@@ -1,0 +1,34 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+// Regression ratchet: recorded `pass` cells in docs/coverage/tier1-matrix.json
+// may never silently regress. Skips before the snapshot exists.
+use labwired_cli::tier1;
+
+#[test]
+fn tier1_matrix_does_not_regress() {
+    let root = tier1::workspace_root();
+    let snapshot_path = root.join("docs/coverage/tier1-matrix.json");
+    if !snapshot_path.exists() {
+        eprintln!("SKIP: no tier1 snapshot at {}", snapshot_path.display());
+        return;
+    }
+    let snapshot: tier1::Tier1Matrix =
+        serde_json::from_str(&std::fs::read_to_string(&snapshot_path).expect("read snapshot"))
+            .expect("parse snapshot");
+
+    let bin = std::path::Path::new(env!("CARGO_BIN_EXE_labwired"));
+    let (live, skipped) = tier1::run_all(bin).expect("tier1 run_all");
+    for chip in &skipped {
+        eprintln!("SKIP: {chip} (fixture not present)");
+    }
+
+    let regressions = tier1::ratchet_regressions(&snapshot, &live);
+    assert!(
+        regressions.is_empty(),
+        "tier1 matrix regressed: {regressions:?}. If intentional, edit the snapshot \
+         explicitly; to record improvements regenerate: \
+         cargo run -p labwired-cli -- tier1-matrix --json-out docs/coverage/tier1-matrix.json"
+    );
+}

--- a/docs/coverage_scoreboard.md
+++ b/docs/coverage_scoreboard.md
@@ -55,6 +55,6 @@ Additional matrix sentinel target:
 3. Update this file when the Top-5 scope, thresholds, or status policy changes.
 4. Do not mark `green` without deterministic re-run evidence.
 
-## Tier-1 validation matrix
+## Tier-1 Validation Matrix
 
 Per-chip, per-peripheral real-firmware validation: [tier1-scoreboard](coverage/tier1-scoreboard.md).

--- a/docs/coverage_scoreboard.md
+++ b/docs/coverage_scoreboard.md
@@ -54,3 +54,7 @@ Additional matrix sentinel target:
 2. Matrix CI aggregates and publishes scoreboard artifacts via `scripts/generate_coverage_matrix_scoreboard.py`.
 3. Update this file when the Top-5 scope, thresholds, or status policy changes.
 4. Do not mark `green` without deterministic re-run evidence.
+
+## Tier-1 validation matrix
+
+Per-chip, per-peripheral real-firmware validation: [tier1-scoreboard](coverage/tier1-scoreboard.md).

--- a/scripts/generate_tier1_scoreboard.py
+++ b/scripts/generate_tier1_scoreboard.py
@@ -17,7 +17,7 @@ def render(matrix: dict) -> str:
     extras = sorted({c for row in matrix.values() for c in row if c not in RUBRIC})
     classes = RUBRIC + extras
     lines = [
-        "# Tier-1 validation matrix",
+        "# Tier-1 Validation Matrix",
         "",
         "Every cell links the CI run that produced it; no link → `·` unrecorded.",
         "",
@@ -32,7 +32,11 @@ def render(matrix: dict) -> str:
             if cell is None:
                 cells.append("·")
                 continue
-            status, url = cell.get("status", "unrecorded"), cell.get("run_url")
+            status = cell.get("status", "unrecorded")
+            url = cell.get("run_url")
+            # Malformed evidence demotes to unrecorded.
+            if url and (not url.startswith("https://") or any(c in url for c in " |()")):
+                url = None
             if status not in ("na", "unrecorded") and not url:
                 status = "unrecorded"  # no evidence, no claim
             icon = ICONS.get(status, "·")
@@ -46,7 +50,11 @@ def main() -> None:
     ap.add_argument("--matrix", default="docs/coverage/tier1-matrix.json")
     ap.add_argument("--out", default="docs/coverage/tier1-scoreboard.md")
     args = ap.parse_args()
-    matrix = json.loads(Path(args.matrix).read_text())
+    path = Path(args.matrix)
+    if not path.exists():
+        raise SystemExit(f"matrix not found: {path}")
+    matrix = json.loads(path.read_text())
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     Path(args.out).write_text(render(matrix))
     print(f"wrote {args.out}")
 

--- a/scripts/generate_tier1_scoreboard.py
+++ b/scripts/generate_tier1_scoreboard.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Render docs/coverage/tier1-matrix.json as a chip × peripheral markdown grid.
+
+Proof-artifact bar (spec wedge-alignment): a cell renders its real status
+ONLY if it carries a run_url; cells without evidence render as unrecorded.
+"""
+import argparse
+import json
+from pathlib import Path
+
+ICONS = {"pass": "✅", "partial": "🟡", "blocked": "⛔", "na": "—", "unrecorded": "·"}
+RUBRIC = ["clock", "gpio", "uart", "timer", "dma", "irq"]
+
+
+def render(matrix: dict) -> str:
+    # Column set = rubric order, then any extra classes seen (e.g. S3 beachhead).
+    extras = sorted({c for row in matrix.values() for c in row if c not in RUBRIC})
+    classes = RUBRIC + extras
+    lines = [
+        "# Tier-1 validation matrix",
+        "",
+        "Every cell links the CI run that produced it; no link → `·` unrecorded.",
+        "",
+        "| chip | " + " | ".join(classes) + " |",
+        "|---|" + "---|" * len(classes),
+    ]
+    for chip in sorted(matrix):
+        row = matrix[chip]
+        cells = []
+        for cls in classes:
+            cell = row.get(cls)
+            if cell is None:
+                cells.append("·")
+                continue
+            status, url = cell.get("status", "unrecorded"), cell.get("run_url")
+            if status not in ("na", "unrecorded") and not url:
+                status = "unrecorded"  # no evidence, no claim
+            icon = ICONS.get(status, "·")
+            cells.append(f"[{icon}]({url})" if url else icon)
+        lines.append(f"| {chip} | " + " | ".join(cells) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--matrix", default="docs/coverage/tier1-matrix.json")
+    ap.add_argument("--out", default="docs/coverage/tier1-scoreboard.md")
+    args = ap.parse_args()
+    matrix = json.loads(Path(args.matrix).read_text())
+    Path(args.out).write_text(render(matrix))
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part A of the Tier-1 validation matrix (spec + plan in the parent repo: docs/superpowers/{specs,plans}/2026-06-07-tier1-*). Infrastructure only — fixture blobs + snapshot land in Part B, so every gate here skips cleanly today.

## What's in
- `labwired_cli::tier1`: matrix types, `TIER1 <class> PASS|FAIL` UART protocol parser (explicit verdicts win, `done` alone proves UART, last-wins retries), chip-YAML `n/a` derivation, ratchet comparison (recorded `pass` can never silently regress — including via fixture deletion), content-hash manifest verification (mandatory once fixtures exist, must cover every used blob), and a runner that drives the `labwired` binary (`run --rom-boot`) with `LABWIRED_*` env scrubbed for determinism
- `labwired tier1-matrix` subcommand: `--json-out` snapshot export, `--run-url` evidence stamping (fails rather than stamping a vacuous green when nothing ran), panic-free error paths
- Integration gates: `tier1_matrix` harness + `tier1_matrix_ratchet` (skip cleanly pre-fixtures, `svd_coverage_ratchet` style)
- `scripts/generate_tier1_scoreboard.py`: chip × peripheral markdown grid with the proof-artifact bar — status without a CI `run_url` renders as unrecorded; malformed URLs demote
- `.gitignore` exception so `tests/fixtures/tier1/` blobs are committable in Part B

## Verification
- 26 lib tests + 2 integration tests, fmt + clippy `-D warnings` clean
- Crash-path hardening tested: child crash surfaces stderr (char-boundary-safe truncation) instead of recording a Blocked row