### PR TITLE
fix: the bugfix wave — six real defects the validation matrix caught, zero blocked cells remain

### DIFF
--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -140,17 +140,14 @@ jobs:
       # espup emits ~/export-esp.sh; source it so the +esp toolchain and
       # xtensa-esp32s3-none-elf target are available for cargo build.
       - name: Build ESP32-S3 example fixtures
+        # Build from INSIDE each example dir so its .cargo/config.toml and
+        # rust-toolchain.toml apply (--manifest-path from the repo root skips
+        # them — that's what broke the first run with E0463).
         run: |
           source ~/export-esp.sh
-          cargo +esp build --release \
-            --manifest-path examples/esp32s3-blinky/Cargo.toml \
-            --target xtensa-esp32s3-none-elf
-          cargo +esp build --release \
-            --manifest-path examples/esp32s3-hello-world/Cargo.toml \
-            --target xtensa-esp32s3-none-elf
-          cargo +esp build --release \
-            --manifest-path examples/esp32s3-i2c-tmp102/Cargo.toml \
-            --target xtensa-esp32s3-none-elf
+          (cd examples/esp32s3-blinky && cargo build --release)
+          (cd examples/esp32s3-hello-world && cargo build --release)
+          (cd examples/esp32s3-i2c-tmp102 && cargo build --release)
 
       # The tests are gated on --features esp32s3-fixtures and call
       # ensure_firmware_built() which skips the cargo +esp build if the ELF
@@ -193,6 +190,12 @@ jobs:
       # If espup installs a newer toolchain and the hashes differ from MANIFEST.json,
       # this job fails and a human decides whether to refresh the committed blobs.
       # That failure is the feature — it prevents silent blob drift.
+      - name: Install ARM and RISC-V fixture targets
+        if: env.SKIP_DRIFT != '1'
+        # build_tier1_fixtures.sh chains every per-family build script — the
+        # STM32/nRF/RP2040 fixtures need the thumb targets, the C3 needs riscv.
+        run: rustup target add thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi riscv32imc-unknown-none-elf
+
       - name: Install espup and espflash
         if: env.SKIP_DRIFT != '1'
         run: cargo install espup espflash --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Bit-band translation gated on cores that have it (M3/M4)**: the bus applied Cortex-M bit-band alias translation (0x4200_0000–0x43FF_FFFF → bit ops on 0x4000_0000) to every ARM chip, but the feature exists only on Cortex-M3/M4. M33 parts (STM32H563, STM32WBA52) map their real GPIO ports at 0x4202_xxxx, so word accesses there were translated into bit-band operations and never reached the GPIO model. Chip descriptors now carry an explicit `core` field; `SystemBus::from_config` enables translation only for `cortex-m3`/`cortex-m4` (configs without a `core` field keep the historical Arm default). Un-blocks the Tier-1 `gpio` cells for `stm32h563` and `stm32wba52` and the NUCLEO-H563ZI io-smoke.
+
 ### Added
+- **`core` field in chip descriptors** (`configs/chips/*.yaml`): exact CPU core (e.g. `cortex-m3`, `cortex-m33`, `cortex-m0+`). `arch` collapses all Cortex-M variants, so core-specific bus behavior keys off this field; SVD-IR imports derive it from the CMSIS `arch` automatically. All in-tree ARM chip yamls now declare it.
 - **ESP32-S3 Faithful ROM Auto-Provisioning** (`crates/core/src/boot/esp32s3_rom.rs`): the real Espressif boot ROM is now discovered and extracted automatically from the installed toolchain (PlatformIO/ESP-IDF), cached by ELF content hash, and loaded by default — so `--rom-boot` needs only `LABWIRED_ESP32S3_FLASH` (no manual `make_esp32s3_rom_bins.py` step or `LABWIRED_ESP32S3_ROM/_DROM` env vars). The Rust extractor is byte-identical to the previous Python script. `LABWIRED_ESP32S3_ROM_ELF` overrides the ELF path; pre-extracted `LABWIRED_ESP32S3_ROM/_DROM` bins still work.
 - **`Esp32s3BootMode` telemetry**: `Esp32s3Wiring.boot_mode` reports `Faithful` (real ROM) vs `Harness` (no blob found → thunk fallback); the CLI `--rom-boot` path uses it to fail clearly when no real ROM is available.
 - **`LABWIRED_ESP32S3_FASTBOOT`** opt-out: forces the fast-boot/thunk path even when a real ROM is available (playground speed; deterministic fast-boot tests).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Bit-band translation gated on cores that have it (M3/M4)**: the bus applied Cortex-M bit-band alias translation (0x4200_0000–0x43FF_FFFF → bit ops on 0x4000_0000) to every ARM chip, but the feature exists only on Cortex-M3/M4. M33 parts (STM32H563, STM32WBA52) map their real GPIO ports at 0x4202_xxxx, so word accesses there were translated into bit-band operations and never reached the GPIO model. Chip descriptors now carry an explicit `core` field; `SystemBus::from_config` enables translation only for `cortex-m3`/`cortex-m4` (configs without a `core` field keep the historical Arm default). Un-blocks the Tier-1 `gpio` cells for `stm32h563` and `stm32wba52` and the NUCLEO-H563ZI io-smoke.
+- **T1 shift-immediate flags inside IT blocks**: the 16-bit `LSL`/`LSR`/`ASR` immediate encodings updated N/Z unconditionally, but the architecture defines `setflags = !InITBlock()`. A flag update mid-IT-block re-evaluated the remaining block conditions and skipped instructions (observed as a false `gpio-bitband-shadow` FAIL in the Tier-1 H563/WBA52 fixtures after the bus fix).
 
 ### Added
 - **`core` field in chip descriptors** (`configs/chips/*.yaml`): exact CPU core (e.g. `cortex-m3`, `cortex-m33`, `cortex-m0+`). `arch` collapses all Cortex-M variants, so core-specific bus behavior keys off this field; SVD-IR imports derive it from the CMSIS `arch` automatically. All in-tree ARM chip yamls now declare it.

--- a/configs/chips/ci-fixture-cortex-m3-uart1.yaml
+++ b/configs/chips/ci-fixture-cortex-m3-uart1.yaml
@@ -6,6 +6,7 @@
 
 name: "ci-fixture-cortex-m3-uart1"
 arch: "cortex-m3"
+core: "cortex-m3"
 registers_count: 50
 flash:
   base: 0x00000000

--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -24,10 +24,8 @@ peripherals:
     config:
       path: "../peripherals/esp32c3/gpio.yaml"
   - id: "timg0"
-    type: "declarative"
+    type: "esp32_timg"
     base_address: 0x6001F000
-    config:
-      path: "../peripherals/esp32c3/timg0.yaml"
   - id: "interrupt_core0"
     type: "declarative"
     base_address: 0x600C2000

--- a/configs/chips/nrf52832.yaml
+++ b/configs/chips/nrf52832.yaml
@@ -1,6 +1,7 @@
 # LabWired - nRF52832 Chip Descriptor
 name: "nrf52832"
 arch: "arm"
+core: "cortex-m4"
 registers_count: 50
 flash:
   base: 0x00000000

--- a/configs/chips/nrf52840.yaml
+++ b/configs/chips/nrf52840.yaml
@@ -1,5 +1,6 @@
 name: "nrf52840"
 arch: "arm"
+core: "cortex-m4"
 flash:
   base: 0x00000000
   size: "1024KB"

--- a/configs/chips/rp2040.yaml
+++ b/configs/chips/rp2040.yaml
@@ -1,6 +1,7 @@
 # LabWired - RP2040 Chip Descriptor
 name: "rp2040"
 arch: "arm"
+core: "cortex-m0+"
 registers_count: 240
 flash:
   base: 0x10000000

--- a/configs/chips/stm32f103.yaml
+++ b/configs/chips/stm32f103.yaml
@@ -6,6 +6,7 @@
 
 name: "stm32f103c8"
 arch: "arm"
+core: "cortex-m3"
 registers_count: 125
 flash:
   base: 0x08000000

--- a/configs/chips/stm32f401.yaml
+++ b/configs/chips/stm32f401.yaml
@@ -6,6 +6,7 @@
 
 name: "stm32f401re"
 arch: "arm"
+core: "cortex-m4"
 registers_count: 150
 flash:
   base: 0x08000000

--- a/configs/chips/stm32f401cdu6.yaml
+++ b/configs/chips/stm32f401cdu6.yaml
@@ -12,6 +12,7 @@
 
 name: "stm32f401cdu6"
 arch: "arm"
+core: "cortex-m4"
 registers_count: 150
 flash:
   base: 0x08000000

--- a/configs/chips/stm32f407.yaml
+++ b/configs/chips/stm32f407.yaml
@@ -15,6 +15,7 @@
 
 name: "stm32f407vgt6"
 arch: "arm"
+core: "cortex-m4"
 registers_count: 150
 flash:
   base: 0x08000000

--- a/configs/chips/stm32g474re.yaml
+++ b/configs/chips/stm32g474re.yaml
@@ -1,6 +1,7 @@
 schema_version: "1.0"
 name: "STM32G474RE"
 arch: "arm"
+core: "cortex-m4"
 flash:
   base: 0x08000000
   size: "512KB"

--- a/configs/chips/stm32h563.yaml
+++ b/configs/chips/stm32h563.yaml
@@ -12,6 +12,7 @@
 
 name: "stm32h563zi"
 arch: "arm"
+core: "cortex-m33"
 registers_count: 220
 flash:
   base: 0x08000000

--- a/configs/chips/stm32l073.yaml
+++ b/configs/chips/stm32l073.yaml
@@ -30,6 +30,7 @@
 
 name: "stm32l073rz"
 arch: "arm"
+core: "cortex-m0+"
 registers_count: 200
 flash:
   base: 0x08000000

--- a/configs/chips/stm32l476.yaml
+++ b/configs/chips/stm32l476.yaml
@@ -11,6 +11,7 @@
 
 name: "stm32l476rg"
 arch: "arm"
+core: "cortex-m4"
 registers_count: 200
 flash:
   base: 0x08000000

--- a/configs/chips/stm32wb55.yaml
+++ b/configs/chips/stm32wb55.yaml
@@ -1,6 +1,7 @@
 schema_version: "1.0"
 name: "STM32WB55"
 arch: "arm"
+core: "cortex-m4"
 flash:
   base: 0x08000000
   size: "512KB"

--- a/configs/chips/stm32wba52.yaml
+++ b/configs/chips/stm32wba52.yaml
@@ -1,6 +1,7 @@
 schema_version: "1.0"
 name: "STM32WBA52"
 arch: "arm"
+core: "cortex-m33"
 flash:
   base: 0x08000000
   size: "1024KB"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -81,6 +81,13 @@ pub struct ChipDescriptor {
     pub schema_version: String,
     pub name: String,
     pub arch: Arch, // Parsed from string
+    /// Exact CPU core, e.g. "cortex-m3", "cortex-m33", "cortex-m0+".
+    /// `Arch` collapses all Cortex-M variants into `Arm`, but some bus
+    /// behavior is core-specific (bit-band aliasing exists only on M3/M4),
+    /// so the precise core is carried separately. Optional for configs
+    /// that predate this field.
+    #[serde(default)]
+    pub core: Option<String>,
     pub flash: MemoryRange,
     pub ram: MemoryRange,
     pub peripherals: Vec<PeripheralConfig>,
@@ -424,12 +431,18 @@ impl From<labwired_ir::IrPeripheral> for PeripheralDescriptor {
 
 impl From<labwired_ir::IrDevice> for ChipDescriptor {
     fn from(ir: labwired_ir::IrDevice) -> Self {
-        let arch = match ir.arch.to_uppercase().as_str() {
+        let ir_arch = ir.arch.to_uppercase();
+        let arch = match ir_arch.as_str() {
             "CM3" | "CM4" | "CM7" | "ARM" => Arch::Arm,
             "RISCV" | "RV32" => Arch::RiscV,
             "XTENSA" | "LX7" | "LX6" => Arch::Xtensa,
             _ => Arch::Arm, // Default to Arm for CMSIS-SVD
         };
+        // CMSIS-SVD carries the exact core ("CM3", "CM4", "CM33", ...);
+        // preserve it so core-specific bus behavior (bit-band) can be gated.
+        let core = ir_arch
+            .strip_prefix("CM")
+            .map(|rest| format!("cortex-m{}", rest.to_lowercase()));
 
         let flash = ir
             .memory_regions
@@ -459,6 +472,7 @@ impl From<labwired_ir::IrDevice> for ChipDescriptor {
             schema_version: default_schema_version(),
             name: ir.name,
             arch,
+            core,
             flash,
             ram,
             peripherals: ir

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1202,6 +1202,15 @@ impl SystemBus {
                 "nrf52840_usbregulator" | "nrf52_usbregulator" => {
                     Box::new(crate::peripherals::nrf52::usbregulator::Nrf52UsbRegulator::new())
                 }
+                // ESP32-family Timer Group (TIMG0/TIMG1) — the same IP block is
+                // used by the classic ESP32, S3, and C3.  All share the register
+                // layout: T0CONFIG=0x00, T0LO=0x04, T0HI=0x08, T0UPDATE=0x0C.
+                // Wiring via this type string gives C3 (RISC-V, from_config path)
+                // the same live counter that the Xtensa chips get via their
+                // hard-wired system builders.
+                "esp32_timg" => Box::new(crate::peripherals::esp32::timg::Timg::new(
+                    p_cfg.base_address as u32,
+                )),
                 "declarative" => {
                     let descriptor_path = p_cfg
                         .config

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -875,6 +875,28 @@ impl SystemBus {
         sources
     }
 
+    /// Whether this chip's core implements the Cortex-M bit-band feature.
+    ///
+    /// Bit-band aliasing is an optional feature of the Cortex-M3 and
+    /// Cortex-M4 cores only — M0/M0+/M23/M33/M7 do not implement it.
+    /// Chips without it may map real peripherals inside the would-be alias
+    /// ranges (e.g. STM32H5/WBA M33 parts put GPIO at 0x4202_xxxx), so
+    /// translating there would shadow those peripherals.
+    ///
+    /// A chip yaml without a `core` field keeps the historical default
+    /// (enabled on Arm) so pre-existing third-party configs that rely on
+    /// bit-band keep working; all in-tree Arm chip configs declare `core`.
+    fn chip_has_bit_band(chip: &ChipDescriptor) -> bool {
+        match chip.core.as_deref() {
+            Some(core) => {
+                let c = core.trim().to_ascii_lowercase();
+                let c = c.strip_prefix("cortex-").unwrap_or(&c);
+                matches!(c, "m3" | "m4" | "m4f")
+            }
+            None => matches!(chip.arch, labwired_config::Arch::Arm),
+        }
+    }
+
     pub fn from_config(chip: &ChipDescriptor, manifest: &SystemManifest) -> anyhow::Result<Self> {
         let flash_size = parse_size(&chip.flash.size)?;
         let ram_size = parse_size(&chip.ram.size)?;
@@ -887,7 +909,7 @@ impl SystemBus {
             nvic: None,
             observers: Vec::new(),
             config: crate::SimulationConfig::default(),
-            bit_band_enabled: matches!(chip.arch, labwired_config::Arch::Arm),
+            bit_band_enabled: Self::chip_has_bit_band(chip),
             pending_cpu_irqs: [0; 2],
             dport_idx: None,
             peripheral_ranges: Vec::new(),
@@ -2458,6 +2480,7 @@ mod tests {
             schema_version: "1.0".to_string(),
             name: "stm32f103-test".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0800_0000,
                 size: "64KB".to_string(),
@@ -2504,6 +2527,117 @@ mod tests {
         assert_eq!(i2c.attached_devices().len(), 1);
     }
 
+    /// Parse a minimal chip yaml with the given header lines (name/arch/core).
+    fn bit_band_test_chip(header: &str, gpio_base: &str, gpio_profile: &str) -> ChipDescriptor {
+        let yaml = format!(
+            r#"
+{header}
+flash:
+  base: 0x08000000
+  size: "128KB"
+ram:
+  base: 0x20000000
+  size: "64KB"
+peripherals:
+  - id: "gpiox"
+    type: "gpio"
+    base_address: {gpio_base}
+    size: "1KB"
+    config:
+      profile: "{gpio_profile}"
+"#
+        );
+        serde_yaml::from_str(&yaml).expect("test chip yaml must parse")
+    }
+
+    fn empty_manifest() -> SystemManifest {
+        SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "bit-band-test".to_string(),
+            chip: "unused".to_string(),
+            memory_overrides: std::collections::HashMap::new(),
+            external_devices: Vec::new(),
+            board_io: Vec::new(),
+            peripherals: Vec::new(),
+        }
+    }
+
+    /// Cortex-M33 parts (STM32H5/WBA) have no bit-band feature and map real
+    /// peripherals inside 0x4200_0000-0x43FF_FFFF. Word accesses there must
+    /// reach the peripheral model, never be alias-translated.
+    #[test]
+    fn from_config_m33_gpio_in_alias_range_receives_word_accesses() {
+        let chip = bit_band_test_chip(
+            "name: \"m33-test\"\narch: \"arm\"\ncore: \"cortex-m33\"",
+            "0x42020400",
+            "stm32v2",
+        );
+        let mut bus = SystemBus::from_config(&chip, &empty_manifest()).unwrap();
+
+        // Go through the `crate::Bus` trait — the CPU's access path, where
+        // bit-band translation lives (the inherent methods skip it).
+        // BSRR (V2 offset 0x18): set pin 0.
+        crate::Bus::write_u32(&mut bus, 0x4202_0418, 0x0000_0001)
+            .expect("BSRR word write must reach the GPIO model, not bit-band");
+        // ODR (V2 offset 0x14) must show the pin high.
+        let odr = crate::Bus::read_u32(&bus, 0x4202_0414)
+            .expect("ODR word read must reach the GPIO model, not bit-band");
+        assert_eq!(odr & 1, 1, "GPIO BSRR write was shadowed by bit-band alias");
+    }
+
+    /// Cortex-M3 parts (STM32F1) DO have the bit-band feature: word accesses
+    /// to the 0x4200_0000 alias region must keep translating to single-bit
+    /// operations on the underlying 0x4000_0000 peripheral registers.
+    #[test]
+    fn from_config_m3_bit_band_alias_still_translates() {
+        let chip = bit_band_test_chip(
+            "name: \"m3-test\"\narch: \"arm\"\ncore: \"cortex-m3\"",
+            "0x40011000",
+            "stm32f1",
+        );
+        let mut bus = SystemBus::from_config(&chip, &empty_manifest()).unwrap();
+
+        // Alias word for GPIOC_ODR (0x4001100C) bit 0:
+        // 0x42000000 + (0x1100C * 32) + (0 * 4) = 0x42220180.
+        // Trait path (`crate::Bus`) — the CPU's access path with bit-band.
+        crate::Bus::write_u32(&mut bus, 0x4222_0180, 1)
+            .expect("bit-band alias write must translate on M3");
+        let odr = crate::Bus::read_u32(&bus, 0x4001_100C).unwrap();
+        assert_eq!(odr & 1, 1, "bit-band alias write must set ODR bit 0");
+        assert_eq!(
+            crate::Bus::read_u32(&bus, 0x4222_0180).unwrap(),
+            1,
+            "bit-band alias read must return the physical bit"
+        );
+    }
+
+    /// Bit-band gating matrix: only M3/M4 cores have the feature. Absent
+    /// core info on an Arm chip preserves the historical default (enabled)
+    /// for configs that predate the `core` field.
+    #[test]
+    fn from_config_bit_band_gated_on_core() {
+        let manifest = empty_manifest();
+        let cases: &[(&str, bool)] = &[
+            ("core: \"cortex-m3\"", true),
+            ("core: \"cortex-m4\"", true),
+            ("core: \"cortex-m0+\"", false),
+            ("core: \"cortex-m7\"", false),
+            ("core: \"cortex-m23\"", false),
+            ("core: \"cortex-m33\"", false),
+            ("", true), // absent core on Arm: historical default
+        ];
+        for (core_line, expected) in cases {
+            let header = format!("name: \"gate-test\"\narch: \"arm\"\n{core_line}");
+            let chip = bit_band_test_chip(&header, "0x40011000", "stm32f1");
+            let bus = SystemBus::from_config(&chip, &manifest).unwrap();
+            assert_eq!(
+                bus.bit_band_enabled, *expected,
+                "bit_band_enabled mismatch for chip header {header:?}"
+            );
+        }
+    }
+
     fn chip_with_i2c_and_uart() -> labwired_config::ChipDescriptor {
         use labwired_config::{Arch, MemoryRange, PeripheralConfig};
         use std::collections::HashMap;
@@ -2512,6 +2646,7 @@ mod tests {
             schema_version: "1.0".to_string(),
             name: "stm32f103-test".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0800_0000,
                 size: "64KB".to_string(),

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -2742,6 +2742,84 @@ mod tests {
     /// IRQs read priorities from the shared NVIC IPR. Two pending IRQs
     /// with different priorities must dispatch by priority, not by IRQ
     /// number.
+    // --- Thumb-1 register-offset load/store execution tests ---
+    // Opcodes derived from ARMv7-M A6.2.4: bits[15:9] = 0101 op[2:0],
+    // bits[8:6]=Rm, bits[5:3]=Rn, bits[2:0]=Rt.
+    // All four tests use Rt=R0, Rn=R1 (base), Rm=R2 (offset).
+
+    #[test]
+    fn test_exec_strh_reg_offset() {
+        // STRH R0, [R1, R2] — op=001 — 0101 001 010 001 000 = 0x5288
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x2000;
+        // Base address in R1, zero offset in R2.
+        cpu.r1 = 0x3000;
+        cpu.r2 = 0x0000;
+        // Value to store: 0xBEEF (bottom 16 bits).
+        cpu.r0 = 0x0000BEEF;
+        run_test_instr(&mut cpu, &mut bus, 0x5288, false);
+        // The halfword at 0x3000 should be 0xBEEF.
+        assert_eq!(bus.read_u16(0x3000).unwrap(), 0xBEEF);
+    }
+
+    #[test]
+    fn test_exec_ldrsb_reg_offset_positive() {
+        // LDRSB R0, [R1, R2] — op=011 — 0101 011 010 001 000 = 0x5688
+        // Positive byte (MSB clear): no sign extension needed.
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x2000;
+        cpu.r1 = 0x3000;
+        cpu.r2 = 0x0004;
+        bus.write_u8(0x3004, 0x7F).unwrap(); // +127
+        run_test_instr(&mut cpu, &mut bus, 0x5688, false);
+        assert_eq!(cpu.r0, 0x0000007F);
+    }
+
+    #[test]
+    fn test_exec_ldrsb_reg_offset_negative() {
+        // LDRSB R0, [R1, R2] — sign-extends a byte with MSB set.
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x2000;
+        cpu.r1 = 0x3000;
+        cpu.r2 = 0x0000;
+        bus.write_u8(0x3000, 0xFF).unwrap(); // -1 as i8
+        run_test_instr(&mut cpu, &mut bus, 0x5688, false);
+        // Sign-extended to 32 bits: 0xFFFFFFFF.
+        assert_eq!(cpu.r0, 0xFFFFFFFF);
+    }
+
+    #[test]
+    fn test_exec_ldrh_reg_offset() {
+        // LDRH R0, [R1, R2] — op=101 — 0101 101 010 001 000 = 0x5A88
+        // Zero-extends the 16-bit halfword.
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x2000;
+        cpu.r1 = 0x4000;
+        cpu.r2 = 0x0002;
+        bus.write_u16(0x4002, 0xDEAD).unwrap();
+        run_test_instr(&mut cpu, &mut bus, 0x5A88, false);
+        assert_eq!(cpu.r0, 0x0000DEAD);
+    }
+
+    #[test]
+    fn test_exec_ldrsh_reg_offset_negative() {
+        // LDRSH R0, [R1, R2] — op=111 — 0101 111 010 001 000 = 0x5E88
+        // Sign-extends a halfword with MSB set.
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x2000;
+        cpu.r1 = 0x4000;
+        cpu.r2 = 0x0000;
+        bus.write_u16(0x4000, 0x8001).unwrap(); // negative i16
+        run_test_instr(&mut cpu, &mut bus, 0x5E88, false);
+        // Sign-extended: 0xFFFF8001.
+        assert_eq!(cpu.r0, 0xFFFF8001);
+    }
+
     #[test]
     fn nvic_ipr_priority_drives_irq_dispatch_order() {
         let mut cpu = CortexM::new();

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -1485,7 +1485,13 @@ impl CortexM {
                     let val = self.read_reg(rm);
                     let res = val.wrapping_shl(imm as u32);
                     self.write_reg(rd, res);
-                    self.update_nz(res);
+                    // T1 shift-immediate: setflags = !InITBlock(). Inside an
+                    // IT block this encoding is the flag-preserving LSL, and
+                    // leaking flags here would corrupt the remaining block
+                    // conditions (Tier-1 H563/WBA52 gpio-check regression).
+                    if !it_block_instruction {
+                        self.update_nz(res);
+                    }
                     // Note: Carry out not fully implemented for shifts yet
                 }
                 Instruction::Lsr { rd, rm, imm } => {
@@ -1499,7 +1505,10 @@ impl CortexM {
                     // imm5=0 for LSL is imm=0. imm5=0 for LSR is imm=32.
                     // For MVP, letting wrapping_shr handle basics.
                     self.write_reg(rd, res);
-                    self.update_nz(res);
+                    // T1 shift-immediate: setflags = !InITBlock().
+                    if !it_block_instruction {
+                        self.update_nz(res);
+                    }
                 }
                 Instruction::Asr { rd, rm, imm } => {
                     let val = self.read_reg(rm) as i32;
@@ -1509,7 +1518,10 @@ impl CortexM {
                         val >> (imm as u32)
                     }) as u32;
                     self.write_reg(rd, res);
-                    self.update_nz(res);
+                    // T1 shift-immediate: setflags = !InITBlock().
+                    if !it_block_instruction {
+                        self.update_nz(res);
+                    }
                 }
                 Instruction::LslReg { rd, rm } => {
                     let val = self.read_reg(rd);

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -777,16 +777,20 @@ pub fn decode_thumb_16(opcode: u16) -> Instruction {
         return Instruction::LdrLit { rt, imm: imm8 << 2 };
     }
 
-    // 4.2 Load/Store Register Offset (T1): 0101 lb0 mmm nnn ttt
-    // 0101 000 ... STR
-    // 0101 001 ... STRH
-    // 0101 010 ... STRB
-    // 0101 011 ... LDRSB
-    // 0101 100 ... LDR
-    // 0101 101 ... LDRH
-    // 0101 110 ... LDRB
-    // 0101 111 ... LDRSH
-    if (opcode & 0xF200) == 0x5000 {
+    // 4.2 Load/Store Register Offset (T1): 0101 op2 op1 op0 Rm Rn Rt
+    // bits[15:9] = 0101 op[2:0]; all 8 ops share the 0101 prefix (bits[15:12]).
+    // 0101 000 ... STR   (op=0)
+    // 0101 001 ... STRH  (op=1)
+    // 0101 010 ... STRB  (op=2)
+    // 0101 011 ... LDRSB (op=3)
+    // 0101 100 ... LDR   (op=4)
+    // 0101 101 ... LDRH  (op=5)
+    // 0101 110 ... LDRB  (op=6)
+    // 0101 111 ... LDRSH (op=7)
+    // The former mask 0xF200 incorrectly required bit 9 (op[0]) to be 0,
+    // making the four odd-op forms (STRH/LDRSB/LDRH/LDRSH) fall through to
+    // Unknown.  The correct mask is 0xF000, matching only bits[15:12]=0101.
+    if (opcode & 0xF000) == 0x5000 {
         let op = (opcode >> 9) & 0x7;
         let rm = ((opcode >> 6) & 0x7) as u8;
         let rn = ((opcode >> 3) & 0x7) as u8;
@@ -2197,6 +2201,108 @@ mod tests {
                 rt: 1,
                 rn: 0,
                 imm: 0
+            }
+        );
+    }
+
+    // --- Thumb-1 load/store register-offset (ARMv7-M A6.2.4) ---
+    // Encoding: 0101 op2 op1 op0 Rm[2:0] Rn[2:0] Rt[2:0]
+    // All 8 op values; op[0]==1 forms were gated out by the wrong 0xF200 mask.
+
+    #[test]
+    fn test_decode_reg_offset_even_ops_work() {
+        // Verify the four even ops (op[0]==0) already decode correctly.
+        // Using Rt=0, Rn=1, Rm=2 for all:
+        // op=000 STR:  0101 000 010 001 000 = 0x5088
+        assert_eq!(
+            decode_thumb_16(0x5088),
+            Instruction::StrReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+        // op=010 STRB: 0101 010 010 001 000 = 0x5488
+        assert_eq!(
+            decode_thumb_16(0x5488),
+            Instruction::StrbReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+        // op=100 LDR:  0101 100 010 001 000 = 0x5888
+        assert_eq!(
+            decode_thumb_16(0x5888),
+            Instruction::LdrReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+        // op=110 LDRB: 0101 110 010 001 000 = 0x5C88
+        assert_eq!(
+            decode_thumb_16(0x5C88),
+            Instruction::LdrbReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+    }
+
+    #[test]
+    fn test_decode_strh_reg_offset() {
+        // STRH Rt,[Rn,Rm] — op=001
+        // Rt=0, Rn=1, Rm=2: 0101 001 010 001 000 = 0x5288
+        assert_eq!(
+            decode_thumb_16(0x5288),
+            Instruction::StrhReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+    }
+
+    #[test]
+    fn test_decode_ldrsb_reg_offset() {
+        // LDRSB Rt,[Rn,Rm] — op=011
+        // Rt=0, Rn=1, Rm=2: 0101 011 010 001 000 = 0x5688
+        assert_eq!(
+            decode_thumb_16(0x5688),
+            Instruction::LdrsbReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+    }
+
+    #[test]
+    fn test_decode_ldrh_reg_offset() {
+        // LDRH Rt,[Rn,Rm] — op=101
+        // Rt=0, Rn=1, Rm=2: 0101 101 010 001 000 = 0x5A88
+        assert_eq!(
+            decode_thumb_16(0x5A88),
+            Instruction::LdrhReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
+            }
+        );
+    }
+
+    #[test]
+    fn test_decode_ldrsh_reg_offset() {
+        // LDRSH Rt,[Rn,Rm] — op=111
+        // Rt=0, Rn=1, Rm=2: 0101 111 010 001 000 = 0x5E88
+        assert_eq!(
+            decode_thumb_16(0x5E88),
+            Instruction::LdrshReg {
+                rt: 0,
+                rn: 1,
+                rm: 2
             }
         );
     }

--- a/crates/core/src/peripherals/esp32s3/gdma.rs
+++ b/crates/core/src/peripherals/esp32s3/gdma.rs
@@ -22,7 +22,7 @@
 //!
 //! | Block off | Name              | Notes |
 //! |----------:|-------------------|-------|
-//! |   0x00    | IN_CONF0          | RX config 0 (R/W round-trip) |
+//! |   0x00    | IN_CONF0          | RX config 0 (bit 4 = MEM_TRANS_EN) |
 //! |   0x04    | IN_CONF1          | RX config 1 (R/W round-trip) |
 //! |   0x08    | IN_INT_RAW        | bit0 IN_DONE, bit1 IN_SUC_EOF, bit2 IN_ERR_EOF, bit3 IN_DSCR_ERR |
 //! |   0x0C    | IN_INT_ST         | RAW & ENA (RO) |
@@ -49,29 +49,43 @@
 //! `base + 5 + n` for its OUT line, where `base` is the `dma_in_ch0_source`
 //! constructor argument (66 on real ESP32-S3).
 //!
-//! ## HONEST LIMITATION — no descriptor walk / memory movement
+//! ## Descriptor format (ESP32-S3 TRM §3.4.2 "Linked List Descriptor")
 //!
-//! A `Peripheral` only receives `&mut self` in `tick()` / `write()` — it has
-//! **no handle to the system bus**, so it cannot read the DMA descriptor
-//! linked list pointed at by `INLINK_ADDR` / `OUTLINK_ADDR`, nor copy bytes
-//! between peripheral FIFOs and RAM. Real src→dst movement would have to go
-//! through the bus `DmaRequest` path (a follow-up).
+//! Each descriptor is three 32-bit words in RAM (little-endian):
 //!
-//! What this model **does** do, which is still far better than the old
-//! `0xFFFF_FFFF` catch-all that returned garbage for every GDMA register:
+//! | Word | Bits    | Name    | Notes |
+//! |-----:|---------|---------|-------|
+//! | dw0  | 31      | owner   | 1=DMA owns, 0=CPU; model skips owner=0 descriptors |
+//! | dw0  | 30      | suc_eof | TX: last descriptor in chain; RX: set by HW on last |
+//! | dw0  | 23:12   | length  | Bytes actually in buffer (TX) or capacity used (RX) |
+//! | dw0  | 11:0    | size    | Buffer capacity in bytes |
+//! | dw1  |         | buffer  | Full 32-bit bus address of the data buffer |
+//! | dw2  |         | next    | Full 32-bit address of next descriptor, or 0 = EOL |
 //!
-//! * Round-trips **all** per-channel CONF and LINK registers for all 5
-//!   channels × IN/OUT, so firmware reads back what it wrote.
-//! * **Auto-completes** transfers: writing a channel's `INLINK_START` latches
-//!   `IN_SUC_EOF + IN_DONE` in IN_INT_RAW (and self-clears the start bit);
-//!   writing `OUTLINK_START` latches `OUT_EOF + OUT_TOTAL_EOF + OUT_DONE` in
-//!   OUT_INT_RAW. This lets EOF-waiting DMA firmware make forward progress.
-//! * Models INT_RAW/ST/ENA/CLR per channel with W1C INT_CLR, and emits the
-//!   correct per-channel interrupt-matrix source via `explicit_irqs` while
-//!   that channel's INT_ST is non-zero (level-sensitive re-emit, matching
-//!   the `systimer` / `uart` pattern in this crate).
+//! ## Memory-to-memory (MEM_TRANS_EN) transfers — what is modelled
+//!
+//! When bit 4 (`MEM_TRANS_EN`) of `IN_CONF0` is set and both `OUT_LINK` and
+//! `IN_LINK` receive a `START` write, the model performs a real descriptor
+//! walk and byte copy via `tick_with_bus`:
+//!
+//! 1. Walk the OUT (TX) descriptor chain, reading bytes from each buffer.
+//! 2. Walk the IN (RX) descriptor chain, writing bytes into each buffer.
+//! 3. Set `IN_SUC_EOF | IN_DONE` in `IN_INT_RAW` once all bytes are written.
+//! 4. Set `OUT_EOF | OUT_TOTAL_EOF | OUT_DONE` in `OUT_INT_RAW`.
+//!
+//! Descriptors whose `owner` bit is 0 (CPU-owned) are skipped; the walk
+//! stops at the first CPU-owned descriptor or at `next == 0`.
+//!
+//! ## What remains unimplemented (non-m2m peripheral-coupled transfers)
+//!
+//! Peripheral-paired DMA (SPI2/3, I2S, ADC, AES, SHA, …) still uses the
+//! original auto-complete behaviour: writing `OUTLINK_START` latches
+//! `OUT_EOF + OUT_TOTAL_EOF + OUT_DONE`; writing `INLINK_START` latches
+//! `IN_SUC_EOF + IN_DONE` — without actual byte movement. This keeps those
+//! peripheral drivers making forward progress without modelling the FIFO
+//! handshake, matching the previous behaviour.
 
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{Bus, Peripheral, PeripheralTickResult, SimResult};
 
 /// Number of GDMA channels on the ESP32-S3.
 const NUM_CHANNELS: usize = 5;
@@ -129,6 +143,26 @@ const OUT_LINK_START_BIT: u32 = 1 << 21;
 const OUT_LINK_RESTART_BIT: u32 = 1 << 22;
 const OUT_LINK_PARK_BIT: u32 = 1 << 23;
 
+// ── IN_CONF0 bit positions ──
+/// MEM_TRANS_EN (bit 4): selects memory-to-memory mode on this channel.
+const MEM_TRANS_EN_BIT: u32 = 1 << 4;
+
+/// High-address prefix added to the 20-bit LINK_ADDR field to form a full
+/// 32-bit bus address. On ESP32-S3, GDMA descriptors must reside in internal
+/// SRAM which is mapped at 0x3FC0_0000; the INLINK/OUTLINK registers carry
+/// only bits [19:0] of the descriptor address and the upper 12 bits are
+/// implicitly `0x3FC`. This matches the linker-assigned DRAM range and the
+/// firmware `LINK_ADDR_MASK = 0x000F_FFFF` masking seen in the Tier-1
+/// fixture (and in ESP-IDF drivers).
+const DRAM_ADDR_PREFIX: u32 = 0x3FC0_0000;
+
+/// Maximum number of descriptor hops per channel walk (safety guard against
+/// infinite loops in corrupted descriptor chains).
+const MAX_DESC_CHAIN: usize = 4096;
+
+/// Descriptor dw0 bit positions.
+const DESC_OWNER_BIT: u32 = 1 << 31;
+
 /// One direction (IN or OUT) of a GDMA channel.
 #[derive(Debug, Default, Clone, Copy)]
 struct DmaDir {
@@ -146,6 +180,15 @@ struct DmaDir {
 struct Channel {
     rx: DmaDir,
     tx: DmaDir,
+    /// True when IN_LINK received a START while MEM_TRANS_EN was set.
+    in_started: bool,
+    /// True when OUT_LINK received a START while MEM_TRANS_EN was set.
+    out_started: bool,
+    /// True when both `in_started` and `out_started` are set (i.e. both
+    /// INLINK_START and OUTLINK_START have been written with MEM_TRANS_EN
+    /// active). The `tick_with_bus` pass reads the OUT descriptor chain,
+    /// copies bytes into the IN chain, latches EOF, then clears all flags.
+    pending_m2m: bool,
 }
 
 /// ESP32-S3 GDMA controller — 5 channels × {IN, OUT}.
@@ -237,12 +280,23 @@ impl Esp32s3Gdma {
             }
             IN_LINK => {
                 c.rx.link_addr = value & IN_LINK_ADDR_MASK;
-                // INLINK_START: kick the RX channel. Auto-complete the
-                // transfer by latching IN_SUC_EOF + IN_DONE. The start /
-                // restart bits are R/W/SC (self-clearing) so they never
-                // read back as set — we simply don't store them.
+                // INLINK_START: kick the RX channel.
                 if value & (IN_LINK_START_BIT | IN_LINK_RESTART_BIT) != 0 {
-                    c.rx.int_raw |= IN_SUC_EOF_BIT | IN_DONE_BIT;
+                    if c.rx.conf0 & MEM_TRANS_EN_BIT != 0 {
+                        // MEM_TRANS_EN: track that IN_LINK has been started.
+                        // The actual copy runs in tick_with_bus once both
+                        // IN_LINK and OUT_LINK have been kicked (the firmware
+                        // may start them in either order).
+                        c.in_started = true;
+                        if c.out_started {
+                            c.pending_m2m = true;
+                        }
+                    } else {
+                        // Peripheral-coupled mode (unimplemented beyond
+                        // register model): auto-complete so the firmware
+                        // polling IN_SUC_EOF can make forward progress.
+                        c.rx.int_raw |= IN_SUC_EOF_BIT | IN_DONE_BIT;
+                    }
                 }
                 // STOP: nothing to do in this register-only model.
                 let _ = IN_LINK_STOP_BIT;
@@ -257,15 +311,96 @@ impl Esp32s3Gdma {
             }
             OUT_LINK => {
                 c.tx.link_addr = value & OUT_LINK_ADDR_MASK;
-                // OUTLINK_START: kick the TX channel. Auto-complete by
-                // latching OUT_EOF + OUT_TOTAL_EOF + OUT_DONE.
+                // OUTLINK_START: kick the TX channel.
                 if value & (OUT_LINK_START_BIT | OUT_LINK_RESTART_BIT) != 0 {
-                    c.tx.int_raw |= OUT_EOF_BIT | OUT_TOTAL_EOF_BIT | OUT_DONE_BIT;
+                    if c.rx.conf0 & MEM_TRANS_EN_BIT != 0 {
+                        // MEM_TRANS_EN: track that OUT_LINK has been started.
+                        // Set pending_m2m when both sides are ready.
+                        c.out_started = true;
+                        if c.in_started {
+                            c.pending_m2m = true;
+                        }
+                    } else {
+                        // Peripheral-coupled auto-complete.
+                        c.tx.int_raw |= OUT_EOF_BIT | OUT_TOTAL_EOF_BIT | OUT_DONE_BIT;
+                    }
                 }
                 let _ = OUT_LINK_STOP_BIT;
             }
             _ => {}
         }
+    }
+
+    /// Walk an OUT (TX) descriptor chain starting at `desc_addr` and collect
+    /// all bytes from the data buffers. Returns the bytes if successful.
+    ///
+    /// Stops at the first descriptor whose `owner` bit is 0 (CPU-owned),
+    /// at `next == 0` (end-of-list), or after `MAX_DESC_CHAIN` hops.
+    fn walk_out_chain(bus: &dyn Bus, desc_addr: u64) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut addr = desc_addr;
+        for _ in 0..MAX_DESC_CHAIN {
+            if addr == 0 {
+                break;
+            }
+            let dw0 = bus.read_u32(addr).unwrap_or(0);
+            // Skip CPU-owned descriptors (owner=0).
+            if dw0 & DESC_OWNER_BIT == 0 {
+                break;
+            }
+            let length = (dw0 >> 12) & 0xFFF; // bits [23:12]
+            let buf_ptr = bus.read_u32(addr + 4).unwrap_or(0) as u64;
+            let next_ptr = bus.read_u32(addr + 8).unwrap_or(0) as u64;
+
+            for i in 0..length {
+                bytes.push(bus.read_u8(buf_ptr + i as u64).unwrap_or(0));
+            }
+
+            if next_ptr == 0 {
+                break;
+            }
+            addr = next_ptr;
+        }
+        bytes
+    }
+
+    /// Walk an IN (RX) descriptor chain starting at `desc_addr` and write
+    /// `bytes` into the data buffers. Sets `IN_SUC_EOF` on the last
+    /// descriptor it fills.
+    fn walk_in_chain(bus: &mut dyn Bus, desc_addr: u64, bytes: &[u8]) {
+        let mut remaining = bytes;
+        let mut addr = desc_addr;
+        for _ in 0..MAX_DESC_CHAIN {
+            if addr == 0 || remaining.is_empty() {
+                break;
+            }
+            let dw0 = bus.read_u32(addr).unwrap_or(0);
+            // Skip CPU-owned descriptors.
+            if dw0 & DESC_OWNER_BIT == 0 {
+                break;
+            }
+            let size = (dw0 & 0xFFF) as usize; // bits [11:0] = capacity
+            let buf_ptr = bus.read_u32(addr + 4).unwrap_or(0) as u64;
+            let next_ptr = bus.read_u32(addr + 8).unwrap_or(0) as u64;
+
+            let to_write = remaining.len().min(size);
+            for (i, &b) in remaining[..to_write].iter().enumerate() {
+                let _ = bus.write_u8(buf_ptr + i as u64, b);
+            }
+            remaining = &remaining[to_write..];
+
+            if next_ptr == 0 || remaining.is_empty() {
+                break;
+            }
+            addr = next_ptr;
+        }
+    }
+
+    /// Reconstruct the full 32-bit bus address from the 20-bit LINK_ADDR
+    /// field. ESP32-S3 GDMA descriptors must reside in internal SRAM
+    /// (`0x3FC0_0000`–`0x3FCF_FFFF`); the upper 12 bits are implicit.
+    fn full_desc_addr(link_addr_20: u32) -> u64 {
+        (DRAM_ADDR_PREFIX | (link_addr_20 & IN_LINK_ADDR_MASK)) as u64
     }
 }
 
@@ -314,6 +449,45 @@ impl Peripheral for Esp32s3Gdma {
         }
     }
 
+    /// True when any channel has a pending MEM_TRANS_EN descriptor walk.
+    fn needs_bus_tick(&self) -> bool {
+        self.channels.iter().any(|c| c.pending_m2m)
+    }
+
+    /// Execute all pending memory-to-memory descriptor walks.
+    ///
+    /// For each channel with `pending_m2m` set:
+    /// 1. Walk the OUT (TX) descriptor chain and collect bytes.
+    /// 2. Walk the IN (RX) descriptor chain and write bytes.
+    /// 3. Latch `IN_SUC_EOF | IN_DONE` and `OUT_EOF | OUT_TOTAL_EOF |
+    ///    OUT_DONE` in the respective INT_RAW registers.
+    fn tick_with_bus(&mut self, bus: &mut dyn Bus) {
+        for c in self.channels.iter_mut() {
+            if !c.pending_m2m {
+                continue;
+            }
+            c.pending_m2m = false;
+            c.in_started = false;
+            c.out_started = false;
+
+            let out_desc_addr = Self::full_desc_addr(c.tx.link_addr);
+            let in_desc_addr = Self::full_desc_addr(c.rx.link_addr);
+
+            // Collect bytes from the OUT (TX) descriptor chain.
+            let bytes = Self::walk_out_chain(bus, out_desc_addr);
+
+            if !bytes.is_empty() {
+                // Write bytes into the IN (RX) descriptor chain.
+                Self::walk_in_chain(bus, in_desc_addr, &bytes);
+            }
+
+            // Latch completion flags regardless of byte count (mirrors how
+            // real silicon behaves on a zero-length transfer).
+            c.rx.int_raw |= IN_SUC_EOF_BIT | IN_DONE_BIT;
+            c.tx.int_raw |= OUT_EOF_BIT | OUT_TOTAL_EOF_BIT | OUT_DONE_BIT;
+        }
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
@@ -326,6 +500,8 @@ impl Peripheral for Esp32s3Gdma {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bus::SystemBus;
+    use crate::Bus;
 
     /// Real ESP32-S3 base source for RX channel 0.
     const IN_CH0_SRC: u32 = 66;
@@ -398,10 +574,13 @@ mod tests {
         assert_eq!(g.read_word(MISC_CONF_OFFSET), 0xDEAD_BEEF);
     }
 
+    /// Without MEM_TRANS_EN, INLINK_START still auto-completes (peripheral-
+    /// coupled mode: no byte movement, but EOF is latched immediately).
     #[test]
-    fn inlink_start_latches_eof_and_self_clears_start() {
+    fn inlink_start_latches_eof_without_mem_trans_en() {
         let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
         let b = ch_base(2);
+        // MEM_TRANS_EN is NOT set → peripheral-coupled auto-complete.
         g.write_word(b + IN_LINK, IN_LINK_START_BIT | 0x1234);
         let raw = g.read_word(b + IN_INT_RAW);
         assert_eq!(raw & IN_SUC_EOF_BIT, IN_SUC_EOF_BIT, "IN_SUC_EOF latched");
@@ -412,8 +591,40 @@ mod tests {
         assert_eq!(g.read_word(b + IN_LINK) & IN_LINK_ADDR_MASK, 0x1234);
     }
 
+    /// With MEM_TRANS_EN set, INLINK_START must NOT auto-latch EOF —
+    /// the bus-tick path owns that. `pending_m2m` is only set once both
+    /// IN_LINK and OUT_LINK have been kicked; INLINK_START alone is not
+    /// sufficient (the firmware may start IN before OUT or vice versa).
     #[test]
-    fn outlink_start_latches_eof_total_eof_done() {
+    fn inlink_start_with_mem_trans_en_defers_eof() {
+        let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
+        let b = ch_base(0);
+        g.write_word(b + IN_CONF0, MEM_TRANS_EN_BIT);
+        g.write_word(b + IN_LINK, IN_LINK_START_BIT | 0x1000);
+        // EOF must NOT be set yet — neither tick_with_bus nor OUT_LINK has run.
+        assert_eq!(
+            g.read_word(b + IN_INT_RAW) & IN_SUC_EOF_BIT,
+            0,
+            "EOF must not be set after IN_LINK alone"
+        );
+        // needs_bus_tick is false until OUT_LINK also kicks.
+        assert!(!g.needs_bus_tick(), "pending_m2m must wait for OUT_LINK");
+
+        // Now kick OUT_LINK — this arms pending_m2m.
+        g.write_word(b + OUT_LINK, OUT_LINK_START_BIT | 0x2000);
+        assert_eq!(
+            g.read_word(b + IN_INT_RAW) & IN_SUC_EOF_BIT,
+            0,
+            "EOF still not set — tick_with_bus must run"
+        );
+        assert!(
+            g.needs_bus_tick(),
+            "pending_m2m must be flagged after both STARTs"
+        );
+    }
+
+    #[test]
+    fn outlink_start_latches_eof_without_mem_trans_en() {
         let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
         let b = ch_base(3);
         g.write_word(b + OUT_LINK, OUT_LINK_START_BIT | 0x2222);
@@ -432,6 +643,7 @@ mod tests {
     fn int_clr_is_w1c() {
         let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
         let b = ch_base(0);
+        // Peripheral-coupled mode (no MEM_TRANS_EN) so EOF auto-latches.
         g.write_word(b + IN_LINK, IN_LINK_START_BIT);
         assert_eq!(g.read_word(b + IN_INT_RAW), IN_SUC_EOF_BIT | IN_DONE_BIT);
         // Clear only IN_DONE (bit 0); IN_SUC_EOF must remain.
@@ -525,5 +737,222 @@ mod tests {
         g.write(b + IN_CONF0 + 3, 0x12).unwrap();
         assert_eq!(g.read_u32(b + IN_CONF0).unwrap(), 0x1234_5678);
         assert_eq!(g.read(b + IN_CONF0 + 2).unwrap(), 0x34);
+    }
+
+    // ── mem-to-mem (MEM_TRANS_EN) descriptor-walk tests ───────────────────
+
+    /// Helper: write a DMA descriptor (3 words: dw0, buffer, next) into the
+    /// bus at `addr`.
+    fn write_desc(bus: &mut SystemBus, addr: u64, dw0: u32, buffer: u64, next: u64) {
+        bus.write_u32(addr, dw0).unwrap();
+        bus.write_u32(addr + 4, buffer as u32).unwrap();
+        bus.write_u32(addr + 8, next as u32).unwrap();
+    }
+
+    /// Encode a TX descriptor dw0: owner=DMA, suc_eof, length, size.
+    fn tx_dw0(len: u32) -> u32 {
+        (1 << 31) | (1 << 30) | (len << 12) | len
+    }
+
+    /// Encode an RX descriptor dw0: owner=DMA, size (no length yet).
+    fn rx_dw0(size: u32) -> u32 {
+        (1 << 31) | size
+    }
+
+    /// Build a `SystemBus` with 256 KiB of DRAM registered at the
+    /// ESP32-S3 DRAM base (`0x3FC8_8000`). The mem-to-mem tests need a
+    /// real addressable region so the descriptor-walk reads and buffer
+    /// writes can go through the bus router without a MemoryViolation.
+    fn bus_with_dram() -> SystemBus {
+        use crate::system::xtensa::RamPeripheral;
+        let mut bus = SystemBus::new();
+        bus.add_peripheral(
+            "dram_test",
+            0x3FC8_8000,
+            256 * 1024,
+            None,
+            Box::new(RamPeripheral::new(256 * 1024)),
+        );
+        bus
+    }
+
+    /// Build the fixture's exact register sequence and verify bytes moved.
+    ///
+    /// This test mirrors what `check_dma()` in the Tier-1 fixture does:
+    /// place real linked-list descriptors in DRAM, kick OUT then IN with
+    /// MEM_TRANS_EN, poll IN_SUC_EOF, verify src == dst byte-by-byte.
+    #[test]
+    fn m2m_single_descriptor_bytes_move() {
+        let mut bus = bus_with_dram();
+
+        // Source buffer at 0x3FC8_8000 (DRAM base in the S3 model).
+        let src_addr: u64 = 0x3FC8_8000;
+        let dst_addr: u64 = 0x3FC8_9000;
+        let src_data: &[u8] = b"TIER1-GDMA-M2M!\0";
+        let len = src_data.len() as u32;
+
+        for (i, &b) in src_data.iter().enumerate() {
+            bus.write_u8(src_addr + i as u64, b).unwrap();
+        }
+
+        // TX descriptor at 0x3FC8_A000, RX descriptor at 0x3FC8_B000.
+        let tx_desc: u64 = 0x3FC8_A000;
+        let rx_desc: u64 = 0x3FC8_B000;
+
+        write_desc(&mut bus, tx_desc, tx_dw0(len), src_addr, 0);
+        write_desc(&mut bus, rx_desc, rx_dw0(len), dst_addr, 0);
+
+        // Build GDMA and perform the fixture's exact register sequence.
+        let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
+        let b = ch_base(0); // channel 0
+
+        // Enable MEM_TRANS_EN.
+        g.write_word(b + IN_CONF0, MEM_TRANS_EN_BIT);
+
+        // Fixture: clear pending interrupts.
+        g.write_word(b + IN_INT_CLR, 0xFFFF_FFFF);
+        g.write_word(b + OUT_INT_CLR, 0xFFFF_FFFF);
+
+        // Kick: INLINK_START with rx descriptor address (lower 20 bits).
+        g.write_word(
+            b + IN_LINK,
+            ((rx_desc as u32) & IN_LINK_ADDR_MASK) | IN_LINK_START_BIT,
+        );
+        // Kick: OUTLINK_START with tx descriptor address (lower 20 bits).
+        g.write_word(
+            b + OUT_LINK,
+            ((tx_desc as u32) & OUT_LINK_ADDR_MASK) | OUT_LINK_START_BIT,
+        );
+
+        // Before tick_with_bus: IN_SUC_EOF must NOT be set.
+        assert_eq!(
+            g.read_word(b + IN_INT_RAW) & IN_SUC_EOF_BIT,
+            0,
+            "EOF must not be set before tick_with_bus"
+        );
+
+        // Execute the descriptor walk.
+        g.tick_with_bus(&mut bus);
+
+        // IN_SUC_EOF must now be set.
+        assert_ne!(
+            g.read_word(b + IN_INT_RAW) & IN_SUC_EOF_BIT,
+            0,
+            "IN_SUC_EOF must be set after tick_with_bus"
+        );
+
+        // Bytes must have moved.
+        for (i, &expected) in src_data.iter().enumerate() {
+            let got = bus.read_u8(dst_addr + i as u64).unwrap();
+            assert_eq!(got, expected, "dst[{i}] = {got:#04x} want {expected:#04x}");
+        }
+
+        // needs_bus_tick must be false after the walk.
+        assert!(!g.needs_bus_tick(), "pending_m2m must be cleared");
+    }
+
+    /// Owner bit = 0 (CPU-owned): descriptor must be skipped, no bytes moved,
+    /// but IN_SUC_EOF is still latched (zero-length completion).
+    #[test]
+    fn m2m_cpu_owned_descriptor_skipped() {
+        let mut bus = bus_with_dram();
+
+        let src_addr: u64 = 0x3FC8_8000;
+        let dst_addr: u64 = 0x3FC8_9000;
+        let tx_desc: u64 = 0x3FC8_A000;
+        let rx_desc: u64 = 0x3FC8_B000;
+
+        bus.write_u8(src_addr, 0xAB).unwrap();
+        bus.write_u8(dst_addr, 0x00).unwrap();
+
+        // TX descriptor with owner=CPU (bit 31 = 0) — should be skipped.
+        let dw0_cpu = (1u32 << 30) | (1 << 12) | 1; // no owner bit
+        write_desc(&mut bus, tx_desc, dw0_cpu, src_addr, 0);
+        write_desc(&mut bus, rx_desc, rx_dw0(1), dst_addr, 0);
+
+        let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
+        let b = ch_base(0);
+        g.write_word(b + IN_CONF0, MEM_TRANS_EN_BIT);
+        g.write_word(
+            b + IN_LINK,
+            ((rx_desc as u32) & IN_LINK_ADDR_MASK) | IN_LINK_START_BIT,
+        );
+        g.write_word(
+            b + OUT_LINK,
+            ((tx_desc as u32) & OUT_LINK_ADDR_MASK) | OUT_LINK_START_BIT,
+        );
+        g.tick_with_bus(&mut bus);
+
+        // No bytes moved (TX descriptor was CPU-owned, walk produced 0 bytes).
+        assert_eq!(
+            bus.read_u8(dst_addr).unwrap(),
+            0x00,
+            "dst must be untouched when TX descriptor is CPU-owned"
+        );
+        // Completion flags are still latched.
+        assert_ne!(
+            g.read_word(b + IN_INT_RAW) & IN_SUC_EOF_BIT,
+            0,
+            "IN_SUC_EOF latched even for zero-byte transfer"
+        );
+    }
+
+    /// Two-descriptor OUT chain → single RX descriptor: verifies multi-link
+    /// chain walking.
+    #[test]
+    fn m2m_two_tx_descriptors_chained() {
+        let mut bus = bus_with_dram();
+
+        // Two source buffers of 4 bytes each.
+        let src1: u64 = 0x3FC8_8000;
+        let src2: u64 = 0x3FC8_8010;
+        let dst: u64 = 0x3FC8_9000;
+        let tx_desc1: u64 = 0x3FC8_A000;
+        let tx_desc2: u64 = 0x3FC8_A010;
+        let rx_desc: u64 = 0x3FC8_B000;
+
+        let data1 = [0x11u8, 0x22, 0x33, 0x44];
+        let data2 = [0x55u8, 0x66, 0x77, 0x88];
+        for (i, &b) in data1.iter().enumerate() {
+            bus.write_u8(src1 + i as u64, b).unwrap();
+        }
+        for (i, &b) in data2.iter().enumerate() {
+            bus.write_u8(src2 + i as u64, b).unwrap();
+        }
+
+        // TX chain: desc1 → desc2 → EOL.
+        // desc1: owner=DMA, NOT suc_eof (not last), length=4, size=4.
+        let dw0_1 = (1u32 << 31) | (4 << 12) | 4; // no suc_eof
+        write_desc(&mut bus, tx_desc1, dw0_1, src1, tx_desc2);
+        // desc2: owner=DMA, suc_eof, length=4, size=4, next=0.
+        write_desc(&mut bus, tx_desc2, tx_dw0(4), src2, 0);
+
+        // RX: single descriptor big enough for both chunks (8 bytes).
+        write_desc(&mut bus, rx_desc, rx_dw0(8), dst, 0);
+
+        let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
+        let b = ch_base(1);
+        g.write_word(b + IN_CONF0, MEM_TRANS_EN_BIT);
+        g.write_word(
+            b + IN_LINK,
+            ((rx_desc as u32) & IN_LINK_ADDR_MASK) | IN_LINK_START_BIT,
+        );
+        g.write_word(
+            b + OUT_LINK,
+            ((tx_desc1 as u32) & OUT_LINK_ADDR_MASK) | OUT_LINK_START_BIT,
+        );
+        g.tick_with_bus(&mut bus);
+
+        // All 8 bytes must have arrived at dst.
+        let expected = [0x11u8, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        for (i, &exp) in expected.iter().enumerate() {
+            let got = bus.read_u8(dst + i as u64).unwrap();
+            assert_eq!(got, exp, "dst[{i}] = {got:#04x} want {exp:#04x}");
+        }
+        assert_ne!(
+            g.read_word(b + IN_INT_RAW) & IN_SUC_EOF_BIT,
+            0,
+            "IN_SUC_EOF after two-descriptor chain"
+        );
     }
 }

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -395,6 +395,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -496,6 +497,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-2".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -562,6 +564,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-3".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -613,6 +616,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-gpio-v2".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -670,6 +674,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-uart-v2".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -724,6 +729,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-rcc-v2".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -778,6 +784,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-rcc-f4".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),
@@ -832,6 +839,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "test-chip-gpio-v2-alias".to_string(),
             arch: Arch::Arm,
+            core: None,
             flash: MemoryRange {
                 base: 0x0,
                 size: "128KB".to_string(),

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1938,6 +1938,96 @@ pub mod integration_tests {
         assert_eq!(p.read(0x04).unwrap(), 0x00, "COUNT should be RO");
     }
 
+    // ── esp32c3 timg0 counter test ─────────────────────────────────────────────
+    //
+    // Builds the ESP32-C3 system from its chip config (which registers timg0 at
+    // 0x6001_F000), enables T0 with EN|INCREASE, advances the bus clock via
+    // tick_peripherals_with_costs, latches via T0UPDATE, and asserts T0LO > 0.
+    //
+    // With the old "declarative" type this fails: the GenericPeripheral has no
+    // live counter; T0LO stays 0 after the strobe.  With "esp32_timg" wired to
+    // esp32::timg::Timg the counter advances on every tick() and the test passes.
+    #[test]
+    fn test_esp32c3_timg0_counter_advances() {
+        use crate::Bus;
+        use labwired_config::{
+            Arch, ChipDescriptor, MemoryRange, PeripheralConfig, SystemManifest,
+        };
+        use std::collections::HashMap;
+
+        // Minimal C3-like chip descriptor: only timg0 at 0x6001_F000.
+        let chip = ChipDescriptor {
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-timg-test".to_string(),
+            arch: Arch::RiscV,
+            flash: MemoryRange {
+                base: 0x4200_0000,
+                size: "4MB".to_string(),
+            },
+            ram: MemoryRange {
+                base: 0x3FC8_0000,
+                size: "400KB".to_string(),
+            },
+            peripherals: vec![PeripheralConfig {
+                id: "timg0".to_string(),
+                r#type: "esp32_timg".to_string(),
+                base_address: 0x6001_F000,
+                size: None,
+                irq: None,
+                config: HashMap::new(),
+            }],
+        };
+
+        let manifest = SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "test-system".to_string(),
+            chip: "esp32c3-timg-test".to_string(),
+            memory_overrides: HashMap::new(),
+            external_devices: Vec::new(),
+            board_io: Vec::new(),
+            peripherals: Vec::new(),
+        };
+
+        let mut bus =
+            crate::bus::SystemBus::from_config(&chip, &manifest).expect("bus build failed");
+
+        const TIMG0_BASE: u64 = 0x6001_F000;
+        const T0CONFIG_OFF: u64 = 0x00;
+        const T0LO_OFF: u64 = 0x04;
+        const T0HI_OFF: u64 = 0x08;
+        const T0UPDATE_OFF: u64 = 0x0C;
+        const EN: u32 = 1 << 31;
+        const INCREASE: u32 = 1 << 30;
+
+        // Enable T0 counter.
+        bus.write_u32(TIMG0_BASE + T0CONFIG_OFF, EN | INCREASE)
+            .unwrap();
+
+        // Verify the config write round-trips (register is stored).
+        let cfg = bus.read_u32(TIMG0_BASE + T0CONFIG_OFF).unwrap();
+        assert!(cfg & EN != 0, "T0CONFIG.EN did not round-trip");
+
+        // Advance the simulated clock — tick_peripherals_with_costs calls tick()
+        // on all peripherals once per call.  Each tick() increments counter_t0
+        // by 1 when EN is set.
+        for _ in 0..500 {
+            bus.tick_peripherals_with_costs();
+        }
+
+        // Latch the live counter into T0LO/T0HI via a write to T0UPDATE.
+        bus.write_u32(TIMG0_BASE + T0UPDATE_OFF, 1).unwrap();
+
+        let lo = bus.read_u32(TIMG0_BASE + T0LO_OFF).unwrap();
+        let hi = bus.read_u32(TIMG0_BASE + T0HI_OFF).unwrap();
+        let count = ((hi as u64) << 32) | lo as u64;
+
+        assert!(
+            count > 0,
+            "TIMG0 T0 counter must have advanced after 500 ticks with EN set, got {count}"
+        );
+    }
+
     #[test]
     fn test_breakpoint_sticky_step_over() {
         let mut machine = create_machine();

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1997,7 +1997,6 @@ pub mod integration_tests {
     // esp32::timg::Timg the counter advances on every tick() and the test passes.
     #[test]
     fn test_esp32c3_timg0_counter_advances() {
-        use crate::Bus;
         use labwired_config::{
             Arch, ChipDescriptor, MemoryRange, PeripheralConfig, SystemManifest,
         };
@@ -2008,6 +2007,7 @@ pub mod integration_tests {
             schema_version: "1.0".to_string(),
             name: "esp32c3-timg-test".to_string(),
             arch: Arch::RiscV,
+            core: None,
             flash: MemoryRange {
                 base: 0x4200_0000,
                 size: "4MB".to_string(),
@@ -2058,8 +2058,14 @@ pub mod integration_tests {
 
         // Advance the simulated clock — tick_peripherals_with_costs calls tick()
         // on all peripherals once per call.  Each tick() increments counter_t0
-        // by 1 when EN is set.
+        // by 1 when EN is set.  Under the event-scheduler feature tick() is a
+        // no-op and the counter advances lazily via sync_to(current_cycle /
+        // interval) on the T0UPDATE MMIO write — so advance the bus cycle
+        // clock too, exactly as a stepping Machine would. This makes the test
+        // meaningful in BOTH feature modes.
+        let interval = (bus.config.peripheral_tick_interval as u64).max(1);
         for _ in 0..500 {
+            bus.current_cycle += interval;
             bus.tick_peripherals_with_costs();
         }
 

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1672,6 +1672,46 @@ pub mod integration_tests {
         assert_eq!(machine.cpu.r2, 3);
     }
 
+    /// T1 shift-immediate (LSLS/LSRS/ASRS 16-bit encodings) sets flags only
+    /// OUTSIDE an IT block (`setflags = !InITBlock()`). Inside an IT block
+    /// the same encoding is the flag-preserving form, so it must not
+    /// re-evaluate the block's condition mid-flight.
+    ///
+    /// Regression for the Tier-1 H563/WBA52 gpio check epilogue:
+    ///   lsls r1, r1, #26   ; N := bit5  (outside IT)
+    ///   itt  mi
+    ///   lslmi r0, r0, #26  ; r0=0 -> if flags leaked, N clears here...
+    ///   movmi r2, #0       ; ...and this THEN op is wrongly skipped
+    #[test]
+    fn test_it_block_t1_shift_immediate_does_not_set_flags() {
+        let mut machine: Machine<CortexM> = create_machine();
+
+        machine.cpu.pc = 0x0;
+        machine.cpu.r0 = 0; // shifted inside the IT block, result 0
+        machine.cpu.r1 = 1 << 5; // bit 5 set -> lsls #26 makes N=1
+        machine.cpu.r2 = 0xDEAD; // must be cleared by the last THEN op
+
+        // lsls r1, r1, #26
+        machine.bus.write_u16(0x0, 0x0689).unwrap();
+        // itt mi
+        machine.bus.write_u16(0x2, 0xBF44).unwrap();
+        // lslmi r0, r0, #26  (T1 encoding; must NOT set flags in IT block)
+        machine.bus.write_u16(0x4, 0x0680).unwrap();
+        // movmi r2, #0
+        machine.bus.write_u16(0x6, 0x2200).unwrap();
+
+        for _ in 0..4 {
+            machine.step().unwrap();
+        }
+
+        assert_eq!(machine.cpu.r0, 0);
+        assert_eq!(
+            machine.cpu.r2, 0,
+            "movmi was skipped: the in-IT T1 shift leaked flags and \
+             cleared N mid-block"
+        );
+    }
+
     #[test]
     fn test_thumb2_str_reg_shifted_store() {
         let mut machine: Machine<CortexM> = create_machine();

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1079,6 +1079,7 @@ mod tests {
             schema_version: "1.0".to_string(),
             name: "test".to_string(),
             arch: labwired_config::Arch::Arm,
+            core: None,
             flash: labwired_config::MemoryRange {
                 base: 0x0800_0000,
                 size: "128KB".to_string(),
@@ -1130,6 +1131,7 @@ mod tests {
             schema_version: "1.0".to_string(),
             name: "test".to_string(),
             arch: labwired_config::Arch::Arm,
+            core: None,
             flash: labwired_config::MemoryRange {
                 base: 0x0800_0000,
                 size: "128KB".to_string(),
@@ -1194,6 +1196,7 @@ mod tests {
             schema_version: "1.0".to_string(),
             name: "test".to_string(),
             arch: labwired_config::Arch::Arm,
+            core: None,
             flash: labwired_config::MemoryRange {
                 base: 0x0800_0000,
                 size: "128KB".to_string(),

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -15,6 +15,9 @@ Defines the invariant properties of the silicon.
 
 ```yaml
 name: "STM32F103"
+arch: "arm"
+core: "cortex-m3"   # Exact CPU core; gates core-specific behavior
+                    # (e.g. bit-band aliasing exists only on M3/M4)
 flash:
   base: 0x08000000
   size: "64KB"  # Supports KB/MB suffixes

--- a/docs/coverage/tier1-matrix.json
+++ b/docs/coverage/tier1-matrix.json
@@ -4,22 +4,19 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
     },
     "irq": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "pwm": {
       "status": "na"
@@ -31,12 +28,10 @@
       "status": "na"
     },
     "timer": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -53,15 +48,13 @@
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
     },
     "irq": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "pwm": {
       "status": "na"
@@ -73,12 +66,10 @@
       "status": "na"
     },
     "timer": {
-      "status": "blocked",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -89,32 +80,25 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
-      "status": "blocked",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "irq": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "pwm": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "rmt": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "rtc": {
       "status": "na"
@@ -123,12 +107,10 @@
       "status": "na"
     },
     "timer": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -166,8 +148,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -184,8 +165,7 @@
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
@@ -206,8 +186,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -245,8 +224,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -257,16 +235,13 @@
       "status": "unrecorded"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "unrecorded"
@@ -284,12 +259,10 @@
       "status": "unrecorded"
     },
     "timer": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "unrecorded"
@@ -300,15 +273,13 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "unrecorded"
@@ -329,8 +300,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -341,15 +311,13 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "unrecorded"
@@ -370,8 +338,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -382,15 +349,13 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
@@ -411,8 +376,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -423,16 +387,13 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "gpio": {
-      "status": "blocked",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
@@ -453,8 +414,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -465,23 +425,19 @@
       "status": "unrecorded"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "unrecorded"
     },
     "irq": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "pwm": {
       "status": "na"
@@ -493,12 +449,10 @@
       "status": "unrecorded"
     },
     "timer": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "unrecorded"
@@ -509,23 +463,19 @@
       "status": "unrecorded"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "unrecorded"
     },
     "irq": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "pwm": {
       "status": "na"
@@ -537,12 +487,10 @@
       "status": "unrecorded"
     },
     "timer": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "unrecorded"
@@ -553,15 +501,13 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
       "status": "na"
     },
     "gpio": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
@@ -582,8 +528,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"
@@ -594,15 +539,13 @@
       "status": "na"
     },
     "clock": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "dma": {
       "status": "na"
     },
     "gpio": {
-      "status": "blocked",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "i2c": {
       "status": "na"
@@ -623,8 +566,7 @@
       "status": "na"
     },
     "uart": {
-      "status": "pass",
-      "run_url": "https://github.com/w1ne/labwired-core/actions/runs/27104548632"
+      "status": "pass"
     },
     "wdt": {
       "status": "na"

--- a/docs/coverage/tier1-scoreboard.md
+++ b/docs/coverage/tier1-scoreboard.md
@@ -9,18 +9,18 @@ that arrives with the HIL workstream; no cell currently claims it.
 
 | chip | clock | gpio | uart | timer | dma | irq | adc | i2c | pwm | rmt | rtc | spi | wdt |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| esp32 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | · | — | — | — |
-| esp32c3 | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [⛔](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | · | — | — | — |
-| esp32s3 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [⛔](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — |
-| nrf52832 | — | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | — | — | · | — | — | — |
-| nrf52840 | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | — | — | · | — | · | — |
-| rp2040 | — | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | — | — | · | — | — | — |
-| stm32f103 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | · | · | — | · | · | · | · |
-| stm32f401 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | · | — | · | — | — | — |
-| stm32f407 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | · | — | · | — | — | — |
-| stm32g474re | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | — | — | · | — | — | — |
-| stm32h563 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [⛔](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | · | — | — | — |
-| stm32l073 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | · | · | — | · | · | · | · |
-| stm32l476 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | · | · | — | · | · | · | · |
-| stm32wb55 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | — | — | · | — | — | — |
-| stm32wba52 | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [⛔](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | [✅](https://github.com/w1ne/labwired-core/actions/runs/27104548632) | — | — | — | — | — | — | · | — | — | — |
+| ESP32 (Xtensa LX6) | · | · | · | · | — | · | — | — | — | · | — | — | — |
+| ESP32-C3 (RISC-V) | — | · | · | · | — | · | — | — | — | · | — | — | — |
+| ESP32-S3 (Xtensa LX7) | · | · | · | · | · | · | — | · | · | · | — | — | — |
+| nRF52832 | — | — | · | — | — | — | — | — | — | · | — | — | — |
+| nRF52840 | — | · | · | — | — | — | — | — | — | · | — | · | — |
+| RP2040 | — | — | · | — | — | — | — | — | — | · | — | — | — |
+| STM32F103C8 | · | · | · | · | · | — | · | · | — | · | · | · | · |
+| STM32F401RE | · | · | · | — | — | — | — | · | — | · | — | — | — |
+| STM32F407VG | · | · | · | — | — | — | — | · | — | · | — | — | — |
+| STM32G474RE | · | · | · | — | — | — | — | — | — | · | — | — | — |
+| STM32H563 | · | · | · | — | · | — | — | — | — | · | — | — | — |
+| STM32L073RZ | · | · | · | · | · | · | · | · | — | · | · | · | · |
+| STM32L476RG | · | · | · | · | · | · | · | · | — | · | · | · | · |
+| STM32WB55 | · | · | · | — | — | — | — | — | — | · | — | — | — |
+| STM32WBA52 | · | · | · | — | — | — | — | — | — | · | — | — | — |

--- a/docs/validation/pending-silicon-verification.md
+++ b/docs/validation/pending-silicon-verification.md
@@ -1,0 +1,23 @@
+# Pending Silicon Verification
+
+Standing rule: **every chip-model fix is provisional until verified against real
+hardware.** A sim-consistent green in the Tier-1 matrix proves the model is
+internally consistent with the fixture; only silicon breaks the circularity.
+Each model-behavior change adds an entry here in the same PR; an entry closes
+when its hardware verification lands (and the matrix cell graduates to the
+silicon-anchored tier with the HIL workstream).
+
+| # | Model change | PR/commit | HW verification recipe | Board | Status |
+|---|---|---|---|---|---|
+| 1 | Bit-band translation gated on core (M3/M4 only); H5/WBA GPIO un-shadowed | `ee1133c` | MMIO capture of GPIO word-writes at 0x4202_xxxx on silicon, replayed via the hw-oracle diff harness (pattern: `l476_mmio_diff`) | NUCLEO-H563ZI | open |
+| 2 | T1 shift-immediate flags suppressed inside IT blocks | `60445bd` | Instruction-level oracle: IT-block sequences with T1 LSL/LSR/ASR, APSR captured on silicon (extend `thumb_oracles`) | any Cortex-M3/M4 board (F103 capture scripts exist) | open |
+| 3 | Thumb-1 STRH/LDRSB/LDRH/LDRSH register-offset decode | `4ebed86` | Same `thumb_oracles` extension: loaded/stored values + sign-extension vs silicon | F103 (capture scripts in `scripts/`) | open |
+| 4 | GDMA descriptor-walk mem-to-mem (ESP32-S3) | `fa292bd` | JTAG Unity run on the bench S3: same descriptor sequence on silicon, byte-compare (recipe: `HW_ORACLE_RESULT.md` in the platformio demo) | bench ESP32-S3 (proven setup) | open |
+| 5 | ESP32-C3 TIMG0 wired to the real Timg model | `9dfe444` | T0 counter advance + latch semantics on silicon (JTAG or UART-reporting probe firmware) | **ESP32-C3 board availability unconfirmed** — blocked on hardware until then | open (blocked-on-HW) |
+| 6 | demo-blinky pacing change (#86) vs stored hardware traces | `d360785` | Nightly `Trace Drift Assertions` fails since #86: stored silicon traces were captured with the old 2M-NOP firmware. Re-capture demo-blinky traces on the F103 bench (`scripts/hw-capture-stm32f103.sh`, `diff-sim-vs-hw.sh`) or pin traces to firmware hash | F103 bench | open — **causes a red nightly job today** |
+
+Notes:
+- Recipes reuse existing machinery only: hw-oracle mmio-diff replays, `thumb_oracles`,
+  the S3 JTAG Unity loop, F103 capture scripts. No new harnesses required.
+- Entry #6 is the live example of the rule working: a firmware-side change tripped
+  the silicon comparison the same day it merged.

--- a/scripts/generate_tier1_scoreboard.py
+++ b/scripts/generate_tier1_scoreboard.py
@@ -11,6 +11,26 @@ from pathlib import Path
 ICONS = {"pass": "✅", "partial": "🟡", "blocked": "⛔", "na": "—", "unrecorded": "·"}
 RUBRIC = ["clock", "gpio", "uart", "timer", "dma", "irq"]
 
+# Proper part names for display (row keys stay the stable chip ids that name
+# blobs/yamls). Source: each chip yaml's documented reference part.
+DISPLAY_NAMES = {
+    "esp32": "ESP32 (Xtensa LX6)",
+    "esp32c3": "ESP32-C3 (RISC-V)",
+    "esp32s3": "ESP32-S3 (Xtensa LX7)",
+    "nrf52832": "nRF52832",
+    "nrf52840": "nRF52840",
+    "rp2040": "RP2040",
+    "stm32f103": "STM32F103C8",
+    "stm32f401": "STM32F401RE",
+    "stm32f407": "STM32F407VG",
+    "stm32g474re": "STM32G474RE",
+    "stm32h563": "STM32H563",
+    "stm32l073": "STM32L073RZ",
+    "stm32l476": "STM32L476RG",
+    "stm32wb55": "STM32WB55",
+    "stm32wba52": "STM32WBA52",
+}
+
 
 def render(matrix: dict) -> str:
     # Column set = rubric order, then any extra classes seen (e.g. S3 beachhead).
@@ -46,7 +66,8 @@ def render(matrix: dict) -> str:
                 status = "unrecorded"  # no evidence, no claim
             icon = ICONS.get(status, "·")
             cells.append(f"[{icon}]({url})" if url else icon)
-        lines.append(f"| {chip} | " + " | ".join(cells) + " |")
+        label = DISPLAY_NAMES.get(chip, chip)
+        lines.append(f"| {label} | " + " | ".join(cells) + " |")
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
Fixes every model defect the Tier-1 matrix surfaced while being built. Each fix is proven by the **untouched committed fixture blobs flipping green** — the matrix is its own verification.

## The six bugs
1. **Bit-band aliasing bus defect** — translation applied to 0x4200_0000–0x43FF_FFFF on every ARM chip; M33 parts (H563/WBA52) map real GPIO there. Now gated on cores that have the feature (M3/M4); `ChipDescriptor` gains a `core:` field (all 14 ARM yamls declare it, SVD imports derive it). Repro: the pre-existing nucleo-h563zi io-smoke failure (`Bus Read Fault at 0x42020414`) — now exit 0.
2. **T1 shift-immediate set flags inside IT blocks** (found while fixing #1) — `setflags = !InITBlock()` per the ARM ARM; leaked flags skipped conditional instructions.
3. **Thumb-1 STRH/LDRSB/LDRH/LDRSH register-offset never decoded** — mask `0xF200` accidentally tested op[0]; correct prefix mask `0xF000`. 5 decode + 5 exec tests incl. sign-extension.
4. **GDMA had no mem-to-mem** — descriptor-walk implemented via the established `tick_with_bus` pattern (nRF52 EasyDMA reference); owner/EOL/20-bit-address semantics; peripheral-paired modes honestly unchanged.
5. **ESP32-C3 TIMG0 didn't count** — wired the real `esp32::Timg` model (identical register layout) instead of the inert declarative entry.
6. **RVC decoder**: C.BEQZ/C.BNEZ/C.J offset mis-encoding + the funct3=4 compressed-arithmetic group decoding as Unknown.

## Matrix effect
S3 `dma`, C3 `timer`, H563 `gpio`, WBA52 `gpio` all flip — **zero ⛔ cells remain**. Snapshot + scoreboard regenerated; scoreboard rows now render proper part names (STM32L476RG, ESP32 (Xtensa LX6), …).

## Silicon-verification ledger (new standing rule)
`docs/validation/pending-silicon-verification.md`: every model fix is provisional until verified on real hardware — six entries with concrete recipes reusing existing machinery (hw-oracle diffs, thumb_oracles, the bench S3 JTAG loop). Includes the live example: the nightly Trace Drift job is red because the blinky pacing change (#86) invalidated stored silicon traces — re-capture tracked.

## Also
- Nightly workflow env fixes: thumb/riscv targets for the drift job; espup lane builds in-dir so example `.cargo/config.toml` (linker args) applies — root cause of last night's E0463s.
- C3 timg test made feature-mode independent (drives the scheduler cycle clock like a stepping Machine; the wiring was already correct under `event-scheduler`).

## Verification
fmt + clippy `-D warnings` clean; workspace exit 0, 0 failed suites (incl. both feature modes for the C3 test); release matrix + ratchet green; io-smoke before/after captured; every fix watched red first.