### PR TITLE
ci(hil): hardware-in-the-loop oracle runner (inert until deployed)

### DIFF
--- a/.github/workflows/core-hil.yml
+++ b/.github/workflows/core-hil.yml
@@ -1,0 +1,78 @@
+name: Core HIL (hardware-in-the-loop)
+
+# Runs the silicon-anchored oracle bank (the _hw/_diff tests) on real boards
+# attached to self-hosted runners, so the "silicon-verified" anchor is continuous
+# instead of a one-off bench snapshot.
+#
+# INERT UNTIL DEPLOYED: this workflow only triggers on manual dispatch and only
+# runs on self-hosted runners labelled `hil` + the board's `runner_label`. Until
+# such a runner is registered (see hil/README.md), dispatched jobs simply queue —
+# nothing here touches the hosted PR/CI path. Flip on the `schedule` trigger once
+# at least one runner is live.
+on:
+  workflow_dispatch:
+    inputs:
+      board:
+        description: "Board id from hil/boards.json, or 'all'"
+        default: all
+        type: string
+  # Enable once a runner is live so the anchor stays fresh:
+  # schedule:
+  #   - cron: "0 6 * * *"
+
+concurrency:
+  group: core-hil-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Read hil/boards.json on a hosted runner and emit the matrix of ACTIVE boards.
+  # Planned boards are listed in the manifest for visibility but make no jobs.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+      count: ${{ steps.set.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set
+        name: Build board matrix from hil/boards.json
+        run: |
+          python3 - "${{ inputs.board }}" <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
+          want = sys.argv[1] if len(sys.argv) > 1 else "all"
+          boards = json.load(open("hil/boards.json"))["boards"]
+          active = [b for b in boards
+                    if b.get("status") == "active" and want in ("all", b["id"])]
+          inc = [{"id": b["id"], "runner_label": b["runner_label"]} for b in active]
+          print("matrix=" + json.dumps({"include": inc}))
+          print("count=" + str(len(inc)))
+          PY
+
+  hil:
+    needs: prepare
+    if: needs.prepare.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    # The board's runner must carry both the shared `hil` label and its own
+    # board label (e.g. `stm32f103`). See hil/README.md.
+    runs-on: ["self-hosted", "hil", "${{ matrix.runner_label }}"]
+    steps:
+      - uses: actions/checkout@v4
+
+      # The self-hosted runner is expected to have a persistent Rust toolchain;
+      # this is a cheap no-op if rustup is already present, and a guard otherwise.
+      - name: Verify toolchain
+        run: |
+          rustc --version
+          cargo --version
+
+      - name: Run HIL oracle bank for ${{ matrix.id }}
+        run: bash hil/run-hil.sh "${{ matrix.id }}"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### HIL — ${{ matrix.id }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- runner: \`${{ matrix.runner_label }}\` (+ \`hil\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- result: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/hil/README.md
+++ b/hil/README.md
@@ -1,0 +1,74 @@
+# HIL — Hardware-in-the-Loop oracle runners
+
+The `_hw` / `_diff` oracle tests cross-check the simulator against **real
+silicon** over a debug probe. Run on a developer bench they prove the model
+once; run here — on a self-hosted runner with the board permanently attached —
+they prove it **on every push**, so the "silicon-verified" anchor stops decaying
+the moment the bench is unplugged.
+
+This directory is the registry + runner; the workflow is
+`.github/workflows/core-hil.yml`. It is **inert until a runner is registered** —
+it only triggers on manual dispatch and only schedules onto self-hosted runners
+labelled `hil` + a board label, so nothing here affects the hosted PR/CI path.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `boards.json` | board registry — one entry per board, `status: active` puts it under HIL |
+| `run-hil.sh` | manifest-driven runner; works on a runner or standalone on a bench |
+| `../.github/workflows/core-hil.yml` | the inert workflow (matrix from `boards.json`) |
+
+## Smoke-test on a bench (no runner needed)
+
+With a board plugged in and `openocd` installed:
+
+```bash
+hil/run-hil.sh stm32f103-bluepill   # or: hil/run-hil.sh all
+```
+
+This is exactly what the runner job executes — so a green bench run means the
+runner will be green too.
+
+## Bring up a runner (the Mac server)
+
+1. **Toolchain** (once):
+   ```bash
+   brew install openocd        # provides openocd + libusb
+   curl https://sh.rustup.rs -sSf | sh
+   ```
+   Confirm `openocd --version` and `cargo --version` work in a fresh shell.
+
+2. **Attach the board** and confirm the probe enumerates:
+   ```bash
+   # ST-Link should appear as 0483:374b
+   system_profiler SPUSBDataType | grep -i st-link
+   hil/run-hil.sh stm32f103-bluepill   # should pass before you register the runner
+   ```
+
+3. **Register the GitHub Actions self-hosted runner** (repo → Settings → Actions
+   → Runners → New self-hosted runner → macOS), and give it the **labels for
+   every board attached to that host**, plus the shared `hil` label:
+   ```
+   ./config.sh --url https://github.com/w1ne/labwired-core \
+               --token <TOKEN> \
+               --labels hil,stm32f103 \
+               --name mac-396-hil
+   ./run.sh    # or install as a service: ./svc.sh install && ./svc.sh start
+   ```
+   A board's job runs on `["self-hosted", "hil", "<runner_label>"]`, so the
+   runner must carry that board's `runner_label` (here `stm32f103`). One host can
+   serve several boards — give it all their labels.
+
+4. **Go live**: set the matching `boards.json` entry to `status: active`, and
+   uncomment the `schedule:` trigger in `core-hil.yml` so the anchor refreshes
+   without a manual dispatch. (Make the `hil` check **required** in branch
+   protection only once a runner is reliably online — otherwise it would block
+   merges whenever the bench is offline.)
+
+## Adding a board
+
+Add an entry to `boards.json` (copy an existing one), point `test`/`features` at
+its oracle bank, give it a `runner_label`, and attach it to a host carrying that
+label. `status: planned` lists it here without creating jobs; flip to `active`
+when its runner is up. Every supported chip should end up with an entry.

--- a/hil/boards.json
+++ b/hil/boards.json
@@ -1,0 +1,58 @@
+{
+  "_comment": [
+    "HIL (hardware-in-the-loop) board registry. Each board maps to a self-hosted",
+    "GitHub Actions runner labelled with the shared `hil` label plus its own",
+    "`runner_label`, and to the oracle test bank that exercises it on real silicon.",
+    "Adding a board here AND bringing up a runner with the matching labels puts that",
+    "board under continuous HIL — the _hw/_diff oracle tests run on every push so the",
+    "'silicon-verified' anchor stops decaying. See hil/README.md for runner setup.",
+    "Set `status` to `active` once a runner exists; `planned` boards are listed for",
+    "visibility but produce no CI jobs."
+  ],
+  "boards": [
+    {
+      "id": "stm32f103-bluepill",
+      "status": "active",
+      "arch": "arm-cortex-m3",
+      "probe": "st-link-v2",
+      "runner_label": "stm32f103",
+      "env": { "STM32_TARGET": "stm32f1x" },
+      "test": "stm32f1_exec_oracle",
+      "features": "hw-oracle-stm32",
+      "notes": "Blue Pill on ST-Link V2.1 (0483:374b). 11-oracle exec bank."
+    },
+    {
+      "id": "esp32s3-devkit",
+      "status": "planned",
+      "arch": "xtensa-lx7",
+      "probe": "usb-jtag",
+      "runner_label": "esp32s3",
+      "env": { "ESP32_S3_ONLYCPU": "1" },
+      "test": "oracles",
+      "features": "hw-oracle",
+      "notes": "ESP32-S3 instruction + GDMA oracle bank (ledger #4)."
+    },
+    {
+      "id": "esp32c3-devkit",
+      "status": "planned",
+      "arch": "riscv32imc",
+      "probe": "usb-jtag",
+      "runner_label": "esp32c3",
+      "env": {},
+      "test": "riscv_oracles",
+      "features": "hw-oracle-c3",
+      "notes": "ESP32-C3 RV32IMC oracle bank (ledger #5/#7, board TBD)."
+    },
+    {
+      "id": "nrf52840-dk",
+      "status": "planned",
+      "arch": "arm-cortex-m4",
+      "probe": "j-link",
+      "runner_label": "nrf52840",
+      "env": {},
+      "test": "nrf52_mmio_diff",
+      "features": "hw-oracle-nrf52",
+      "notes": "nRF52840 MMIO-diff bank over SWD."
+    }
+  ]
+}

--- a/hil/run-hil.sh
+++ b/hil/run-hil.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# LabWired - HIL oracle runner.
+#
+# Runs the silicon-anchored oracle bank for one (or all active) HIL board(s)
+# described in hil/boards.json. Designed to run on a self-hosted runner that has
+# the board attached, but also works standalone on a dev bench with the board
+# plugged in — that's how you smoke-test the harness before deploying a runner.
+#
+# Usage:
+#   hil/run-hil.sh <board-id|all>
+#
+# Requires: cargo, openocd on PATH (the script adds the common Homebrew and
+# xpack install locations defensively), python3, and the probe attached.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+manifest="$here/boards.json"
+target="${1:-all}"
+
+# openocd is rarely on PATH by default; add the usual suspects.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/xpack-openocd/bin:$PATH"
+command -v openocd >/dev/null 2>&1 || {
+  echo "::error::openocd not found on PATH (looked in Homebrew + ~/.local/xpack-openocd/bin)"
+  exit 1
+}
+echo "openocd: $(openocd --version 2>&1 | head -1)"
+
+# Emit a tab-separated row per active board to run: id, test, features, env-json.
+boards="$(python3 - "$manifest" "$target" <<'PY'
+import json, sys
+manifest, target = sys.argv[1], sys.argv[2]
+data = json.load(open(manifest))
+for b in data["boards"]:
+    if b.get("status") != "active":
+        continue
+    if target not in ("all", b["id"]):
+        continue
+    print("\t".join([b["id"], b["test"], b.get("features", ""), json.dumps(b.get("env", {}))]))
+PY
+)"
+
+if [ -z "$boards" ]; then
+  echo "::warning::no active board matched '$target' in $manifest"
+  exit 0
+fi
+
+fail=0
+while IFS=$'\t' read -r id test features env_json; do
+  [ -z "$id" ] && continue
+  echo "::group::HIL $id ($test)"
+  # Export the board's env (e.g. STM32_TARGET).
+  while IFS=$'\t' read -r k v; do
+    [ -z "$k" ] && continue
+    export "$k=$v"
+    echo "env: $k=$v"
+  done < <(python3 -c 'import json,sys; [print(f"{k}\t{v}") for k,v in json.loads(sys.argv[1]).items()]' "$env_json")
+
+  feat_args=()
+  [ -n "$features" ] && feat_args=(--features "$features")
+
+  # The oracle _hw/_diff tests are #[ignore]; --test-threads=1 serialises the
+  # single physical board.
+  if cargo test --manifest-path "$root/Cargo.toml" \
+       -p labwired-hw-oracle --test "$test" "${feat_args[@]}" \
+       -- --ignored --test-threads=1; then
+    echo "HIL $id: PASS"
+  else
+    echo "::error::HIL $id: FAIL"
+    fail=1
+  fi
+  echo "::endgroup::"
+done <<< "$boards"
+
+exit "$fail"


### PR DESCRIPTION
Stands up the HIL infrastructure so the silicon-anchored `_hw`/`_diff` oracle tests run on **every push** instead of decaying to a one-off bench snapshot — the #1 gap from the oracle self-review.

## What lands
- **`hil/boards.json`** — board registry. F103 `active`; ESP32-S3/C3 + nRF52840 listed as `planned`. `status: active` puts a board under HIL.
- **`hil/run-hil.sh`** — manifest-driven runner; adds openocd to PATH defensively, runs each active board's oracle bank single-threaded. **Smoke-tested standalone against the bench F103: 22 `_hw`/`_diff` tests pass.**
- **`.github/workflows/core-hil.yml`** — **inert** workflow: manual dispatch only, matrix built from the active boards, jobs scheduled onto self-hosted runners labelled `hil` + the board label. Until such a runner registers it does nothing — the hosted PR/CI path is untouched. Enable the `schedule:` trigger once a runner is live.
- **`hil/README.md`** — Mac-server runner bring-up (openocd, rust, labels) + how to add a board.

## Why inert
Deploy on the Mac server later. The workflow can't run until a `self-hosted, hil, <board>` runner exists, and it never triggers on PRs — so this is pure scaffolding with zero CI impact today. The runner script is already proven on the connected F103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)