### PR TITLE
feat(fuzz): Phase 0 — fuzz target + crash oracle, silicon-confirmed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,10 @@ name = "firmware-f103-conformance"
 version = "0.1.0"
 
 [[package]]
+name = "firmware-f103-fuzztarget"
+version = "0.1.0"
+
+[[package]]
 name = "firmware-f103-i2c-demo"
 version = "0.15.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/firmware-f103-i2c-demo",
     "crates/firmware-f401-demo",
     "crates/firmware-f103-conformance",
+    "crates/firmware-f103-fuzztarget",
     "crates/firmware-f401cdu6-blackpill-demo",
     "crates/firmware-f407-demo",
     "crates/firmware-h563-demo",
@@ -138,6 +139,10 @@ codegen-units = 1
 opt-level = "s"
 
 [profile.release.package.firmware-f103-conformance]
+codegen-units = 1
+opt-level = "s"
+
+[profile.release.package.firmware-f103-fuzztarget]
 codegen-units = 1
 opt-level = "s"
 

--- a/crates/firmware-f103-fuzztarget/Cargo.toml
+++ b/crates/firmware-f103-fuzztarget/Cargo.toml
@@ -1,0 +1,19 @@
+# LabWired - Firmware Simulation Platform
+# SPDX-License-Identifier: MIT
+#
+# Fuzz target: a bare-metal STM32F103 binary command parser that reads its input
+# from a fixed RAM buffer (filled by the fuzz harness in sim, by openocd on the
+# HIL bench) so a crash can be replayed on real silicon. It has normal command
+# paths (coverage structure) plus one planted `unsafe` stack overflow. See
+# docs/plans/2026-06-09-firmware-fuzzing.md (Phase 0).
+[package]
+name = "firmware-f103-fuzztarget"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[[bin]]
+name = "firmware-f103-fuzztarget"
+path = "src/main.rs"
+test = false
+bench = false

--- a/crates/firmware-f103-fuzztarget/build.rs
+++ b/crates/firmware-f103-fuzztarget/build.rs
@@ -1,0 +1,17 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("link.ld"))
+        .unwrap()
+        .write_all(include_bytes!("link.ld"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rustc-link-arg=-Tlink.ld");
+    println!("cargo:rerun-if-changed=link.ld");
+}

--- a/crates/firmware-f103-fuzztarget/link.ld
+++ b/crates/firmware-f103-fuzztarget/link.ld
@@ -1,0 +1,37 @@
+/* LabWired - conformance firmware linker script (STM32F103C8: 64K flash, 20K RAM).
+ * NB: Rust/LLVM thumbv7m function symbols already carry the Thumb bit (odd
+ * address), so vector entries use the symbol directly — adding 1 would clear it
+ * and fault the core on the first instruction. */
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 64K
+  RAM   : ORIGIN = 0x20000000, LENGTH = 20K
+}
+ENTRY(Reset)
+SECTIONS
+{
+  .vector_table 0x08000000 :
+  {
+    LONG(0x20005000);       /*  0 initial SP — top of 20K SRAM */
+    LONG(Reset);            /*  1 Reset */
+    LONG(DefaultHandler);   /*  2 NMI */
+    LONG(HardFaultHandler); /*  3 HardFault */
+    LONG(DefaultHandler);   /*  4 MemManage */
+    LONG(DefaultHandler);   /*  5 BusFault */
+    LONG(DefaultHandler);   /*  6 UsageFault */
+    LONG(0); LONG(0); LONG(0); LONG(0); /* 7-10 reserved */
+    LONG(DefaultHandler);   /* 11 SVCall */
+    LONG(DefaultHandler);   /* 12 Debug */
+    LONG(0);                /* 13 reserved */
+    LONG(DefaultHandler);   /* 14 PendSV */
+    LONG(DefaultHandler);   /* 15 SysTick */
+  } > FLASH
+
+  .text :
+  {
+    *(.text*)
+    *(.rodata*)
+  } > FLASH
+
+  /DISCARD/ : { *(.ARM.exidx*) *(.ARM.extab*) }
+}

--- a/crates/firmware-f103-fuzztarget/src/main.rs
+++ b/crates/firmware-f103-fuzztarget/src/main.rs
@@ -1,0 +1,153 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+//
+//! STM32F103 **fuzz target** (Phase 0 of the firmware-fuzzing plan).
+//!
+//! A binary command parser whose input is a byte stream in a fixed RAM buffer
+//! (`FUZZ_LEN` words then `FUZZ_DATA` bytes). The harness fills it — in sim from
+//! the fuzzer's `&[u8]`, on the HIL bench via openocd — then runs the firmware;
+//! the same crashing input can therefore be **replayed on real silicon**.
+//!
+//! Input format: a sequence of frames `[op:u8][len:u8][data:len bytes]`.
+//! Commands P/A/E are well-behaved (they give the fuzzer coverage structure to
+//! explore); **C is the planted bug** — an `unsafe`, unbounded copy of `len`
+//! bytes into a 16-byte stack buffer, i.e. a classic firmware stack overflow.
+//!
+//! Outcome (the crash oracle), written to `VERDICT[0]`:
+//!   * `DONE`  — all frames parsed cleanly
+//!   * `FAULT` — a fault handler ran (HardFault/Bus/Usage/MemManage)
+//!   * neither, after the harness timeout — a hang (lockup / infinite loop)
+#![no_std]
+#![no_main]
+
+use core::ptr::{read_volatile, write_volatile};
+
+const FUZZ_LEN: u32 = 0x2000_2800; // u32: number of input bytes the harness wrote
+const FUZZ_DATA: u32 = 0x2000_2804; // the input bytes
+const FUZZ_MAX: usize = 1024; // cap, so a corrupt length can't run away
+
+const VERDICT: u32 = 0x2000_3000;
+const DONE_MAGIC: u32 = 0xC0DE_F022;
+const FAULT_MAGIC: u32 = 0xDEAD_FA17;
+
+#[inline(always)]
+unsafe fn wr(addr: u32, val: u32) {
+    write_volatile(addr as *mut u32, val);
+}
+#[inline(always)]
+unsafe fn rd(addr: u32) -> u32 {
+    read_volatile(addr as *const u32)
+}
+#[inline(always)]
+unsafe fn rd8(addr: u32) -> u8 {
+    read_volatile(addr as *const u8)
+}
+
+#[no_mangle]
+pub extern "C" fn HardFaultHandler() -> ! {
+    unsafe { wr(VERDICT, FAULT_MAGIC) };
+    loop {}
+}
+#[no_mangle]
+pub extern "C" fn DefaultHandler() -> ! {
+    unsafe { wr(VERDICT, FAULT_MAGIC) };
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn Reset() -> ! {
+    main()
+}
+
+fn main() -> ! {
+    unsafe {
+        wr(VERDICT, 0); // clear the outcome; harness already wrote the input buffer
+        let len = core::cmp::min(rd(FUZZ_LEN) as usize, FUZZ_MAX);
+        parse(len);
+        wr(VERDICT, DONE_MAGIC);
+    }
+    loop {}
+}
+
+/// Walk the frame stream. Bounds the per-frame data read to the remaining input
+/// — the ONLY out-of-bounds is the planted `C` handler.
+unsafe fn parse(len: usize) {
+    let mut i = 0usize;
+    while i < len {
+        let op = rd8(FUZZ_DATA + i as u32);
+        i += 1;
+        if i >= len {
+            break;
+        }
+        let want = rd8(FUZZ_DATA + i as u32) as usize;
+        i += 1;
+        let avail = len - i; // bytes actually present
+        let flen = core::cmp::min(want, avail);
+        handle(op, FUZZ_DATA + i as u32, flen, want);
+        i += flen;
+    }
+}
+
+/// `want` is the attacker-controlled length byte; `flen` is what's actually
+/// present. Well-behaved handlers use `flen`; the bug uses `want`.
+unsafe fn handle(op: u8, data: u32, flen: usize, want: usize) {
+    match op {
+        b'P' => {
+            // ping: a no-op branch (coverage)
+            core::hint::black_box(op);
+        }
+        b'A' => {
+            // add: fold the data bytes (coverage + bounded read)
+            let mut acc: u32 = 0;
+            let mut j = 0;
+            while j < flen {
+                acc = acc.wrapping_add(rd8(data + j as u32) as u32);
+                j += 1;
+            }
+            core::hint::black_box(acc);
+        }
+        b'E' => {
+            // echo: SAFE bounded copy into a stack scratch (no statics → no .bss)
+            let mut echo = [0u8; 64];
+            let n = core::cmp::min(flen, 64);
+            let mut j = 0;
+            while j < n {
+                echo[j] = rd8(data + j as u32);
+                j += 1;
+            }
+            core::hint::black_box(echo[0]);
+        }
+        b'C' => {
+            // ── PLANTED BUG ──────────────────────────────────────────────────
+            // Reachable only via op 'C' + a large length; the overflow lives in
+            // its own (never-inlined) frame so its smashed return address is
+            // actually used.
+            vuln_copy(data, want);
+        }
+        _ => {
+            // unknown opcode: ignore (coverage: the default arm)
+        }
+    }
+}
+
+/// Classic firmware stack overflow: copy the attacker-controlled `want` bytes
+/// into a 16-byte stack buffer with no bound check. Not inlined, so its smashed
+/// saved-LR is the address the core actually returns through → fault.
+#[inline(never)]
+unsafe fn vuln_copy(data: u32, want: usize) {
+    let mut buf = [0u8; 16];
+    let mut j = 0;
+    while j < want {
+        core::ptr::write_volatile(buf.as_mut_ptr().add(j), rd8(data + j as u32));
+        j += 1;
+    }
+    core::hint::black_box(buf[0]);
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // A Rust panic is a logic bug, not a hardware fault — mark it as FAULT too so
+    // the harness treats a panic as a crash, not a hang.
+    unsafe { wr(VERDICT, FAULT_MAGIC) };
+    loop {}
+}

--- a/crates/hw-oracle/tests/f103_fuzz_phase0.rs
+++ b/crates/hw-oracle/tests/f103_fuzz_phase0.rs
@@ -1,0 +1,179 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! Firmware-fuzzing **Phase 0** check: the fuzz target + crash oracle.
+//!
+//! Proves the injection contract and the oracle end to end: write an input byte
+//! stream into the firmware's RAM input buffer, run `firmware-f103-fuzztarget`,
+//! read the verdict — a clean input reaches DONE, the planted `C`-overflow input
+//! reaches FAULT — in sim, and (feature-gated) the same on the bench F103 via
+//! openocd (RAM-injected so the crashing input is replayable on real silicon).
+//!
+//! ```text
+//! cargo build -p firmware-f103-fuzztarget --target thumbv7m-none-eabi --release
+//! cargo test  -p labwired-hw-oracle --test f103_fuzz_phase0
+//! STM32_TARGET=stm32f1x cargo test -p labwired-hw-oracle --test f103_fuzz_phase0 \
+//!     --features hw-oracle-stm32 -- --ignored --test-threads=1
+//! ```
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{Bus, Machine};
+use labwired_loader::load_elf;
+use std::path::PathBuf;
+
+const FUZZ_LEN: u32 = 0x2000_2800;
+const FUZZ_DATA: u32 = 0x2000_2804;
+const VERDICT: u32 = 0x2000_3000;
+const DONE: u32 = 0xC0DE_F022;
+const FAULT: u32 = 0xDEAD_FA17;
+
+/// A clean frame stream (ping + add) — parses to DONE.
+const CLEAN: &[u8] = &[b'P', 0, b'A', 3, 1, 2, 3];
+
+/// `C` with length 64 (>16) followed by 64 `0xFF` bytes — the planted stack
+/// overflow smashes the saved return address to 0xFFFFFFFF, so the handler's
+/// return faults. (Zero filler wouldn't fault: PC=0 is a valid flash alias.)
+fn crash_input() -> Vec<u8> {
+    let mut v = vec![b'C', 64];
+    v.extend(std::iter::repeat(0xFF).take(64));
+    v
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+fn firmware_elf() -> Option<PathBuf> {
+    let base = repo_root().join("target/thumbv7m-none-eabi");
+    ["release", "debug"]
+        .iter()
+        .map(|p| base.join(p).join("firmware-f103-fuzztarget"))
+        .find(|p| p.exists())
+}
+
+/// LE-pack `input` into 32-bit words for the RAM buffer.
+fn packed(input: &[u8]) -> Vec<u32> {
+    input
+        .chunks(4)
+        .map(|c| {
+            let mut w = [0u8; 4];
+            w[..c.len()].copy_from_slice(c);
+            u32::from_le_bytes(w)
+        })
+        .collect()
+}
+
+/// Run the fuzz target in sim on `input`; return the verdict word.
+fn run_sim(elf: &PathBuf, input: &[u8]) -> u32 {
+    let chip = ChipDescriptor::from_file(repo_root().join("configs/chips/stm32f103.yaml")).unwrap();
+    let system_path = repo_root().join("configs/systems/stm32f103-bare.yaml");
+    let mut manifest = SystemManifest::from_file(&system_path).unwrap();
+    manifest.chip = system_path
+        .parent()
+        .unwrap()
+        .join(&manifest.chip)
+        .to_str()
+        .unwrap()
+        .to_string();
+    let mut bus = SystemBus::from_config(&chip, &manifest).unwrap();
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+    machine.load_firmware(&load_elf(elf).unwrap()).unwrap();
+
+    // Inject the input AFTER loading the firmware, BEFORE running.
+    machine
+        .bus
+        .write_u32(FUZZ_LEN as u64, input.len() as u32)
+        .unwrap();
+    for (i, w) in packed(input).iter().enumerate() {
+        machine
+            .bus
+            .write_u32((FUZZ_DATA + (i as u32) * 4) as u64, *w)
+            .unwrap();
+    }
+
+    for _ in 0..1_000_000 {
+        // A CPU fault (bad fetch/access from the smashed return) surfaces as a
+        // step error in sim rather than vectoring to the HardFault handler the
+        // way silicon does — either way it's a crash. (The sim-vs-silicon
+        // representation gap is a fidelity item: ideally the sim would take the
+        // HardFault exception so the firmware's handler runs identically.)
+        if machine.step().is_err() {
+            return FAULT;
+        }
+        match machine.bus.read_u32(VERDICT as u64) {
+            Ok(v) if v != 0 => return v,
+            _ => {}
+        }
+    }
+    0 // timeout = hang
+}
+
+#[test]
+fn fuzz_oracle_sim() {
+    let Some(elf) = firmware_elf() else {
+        eprintln!(
+            "skip: build firmware-f103-fuzztarget --target thumbv7m-none-eabi --release first"
+        );
+        return;
+    };
+    assert_eq!(run_sim(&elf, CLEAN), DONE, "clean input should reach DONE");
+    assert_eq!(
+        run_sim(&elf, &crash_input()),
+        FAULT,
+        "planted C-overflow should reach FAULT"
+    );
+}
+
+#[cfg(feature = "hw-oracle-stm32")]
+fn run_hw(elf: &PathBuf, input: &[u8]) -> u32 {
+    use labwired_hw_oracle::openocd::OpenOcd;
+    use std::time::{Duration, Instant};
+
+    let target = std::env::var("STM32_TARGET").unwrap_or_else(|_| "stm32f1x".to_string());
+    let mut oc = OpenOcd::spawn_stm32(&target).expect("openocd");
+    oc.reset_halt().expect("reset_halt");
+    let resp = oc
+        .tcl(&format!(
+            "flash write_image erase {}",
+            elf.to_str().unwrap()
+        ))
+        .expect("flash");
+    assert!(!resp.contains("Error"), "flash: {resp}");
+    // reset_halt keeps RAM; inject the input while halted, then run.
+    oc.reset_halt().expect("reset_halt 2");
+    oc.write_memory(FUZZ_LEN, &[input.len() as u32])
+        .expect("len");
+    oc.write_memory(FUZZ_DATA, &packed(input)).expect("data");
+    oc.write_memory(VERDICT, &[0]).expect("clear verdict");
+    oc.resume().expect("resume");
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if let Ok(v) = oc.read_memory(VERDICT, 1) {
+            if v[0] != 0 {
+                oc.shutdown().ok();
+                return v[0];
+            }
+        }
+        if Instant::now() >= deadline {
+            oc.shutdown().ok();
+            return 0; // hang
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[cfg(feature = "hw-oracle-stm32")]
+#[test]
+#[ignore]
+fn fuzz_oracle_hw() {
+    let elf = firmware_elf().expect("build firmware-f103-fuzztarget first");
+    assert_eq!(run_hw(&elf, CLEAN), DONE, "clean input → DONE on silicon");
+    assert_eq!(
+        run_hw(&elf, &crash_input()),
+        FAULT,
+        "C-overflow → FAULT on silicon"
+    );
+}


### PR DESCRIPTION
First step of the firmware-fuzzing wedge (docs/plans/2026-06-09-firmware-fuzzing.md).

- **firmware-f103-fuzztarget**: binary command parser — P/A/E well-behaved (coverage structure), C = planted unbounded stack copy (`inline(never)` so the smashed return is used). Input = RAM buffer the harness fills (sim direct / HIL via openocd), so crashing inputs are **replayable on real silicon**.
- **f103_fuzz_phase0.rs**: clean input → DONE, planted overflow → FAULT — in sim AND on the bench F103 (same crash input crashes the real chip). Foundation of fuzz-in-sim-confirm-on-silicon.

Finding: the sim surfaces a CPU fault as a step `Err`, not by vectoring to the HardFault handler like silicon — a Phase-1 fidelity item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)