### PR TITLE
feat(fuzz): Phase 1 — coverage-guided engine finds the planted bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "labwired-fuzz"
+version = "0.15.0"
+dependencies = [
+ "anyhow",
+ "labwired-config",
+ "labwired-core",
+ "labwired-loader",
+]
+
+[[package]]
 name = "labwired-gdbstub"
 version = "0.15.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/firmware-f401-demo",
     "crates/firmware-f103-conformance",
     "crates/firmware-f103-fuzztarget",
+    "crates/labwired-fuzz",
     "crates/firmware-f401cdu6-blackpill-demo",
     "crates/firmware-f407-demo",
     "crates/firmware-h563-demo",
@@ -82,7 +83,7 @@ exclude = [
     "examples/tier1-fixture/esp32s3",
     "examples/tier1-fixture/esp32",
 ]
-default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader"]
+default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
 version = "0.15.0"

--- a/crates/labwired-fuzz/Cargo.toml
+++ b/crates/labwired-fuzz/Cargo.toml
@@ -1,0 +1,17 @@
+# LabWired - Firmware Simulation Platform
+# SPDX-License-Identifier: MIT
+#
+# Firmware fuzzing engine: runs a firmware in the silicon-validated simulator
+# with edge-coverage capture + a crash oracle, and a minimal coverage-guided
+# loop. See docs/plans/2026-06-09-firmware-fuzzing.md.
+[package]
+name = "labwired-fuzz"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+labwired-core = { path = "../core" }
+labwired-config = { path = "../config" }
+labwired-loader = { path = "../loader" }
+anyhow = { workspace = true }

--- a/crates/labwired-fuzz/src/lib.rs
+++ b/crates/labwired-fuzz/src/lib.rs
@@ -1,0 +1,251 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! Firmware fuzzing engine (Phase 1).
+//!
+//! Runs a firmware in the silicon-validated simulator with **edge coverage**
+//! capture (AFL-style, read from the CPU PC each step — no core changes) and a
+//! **crash oracle**, plus a minimal **coverage-guided** loop. The wedge: any
+//! crash found here can be replayed on real silicon (HIL-confirm, Phase 3), so
+//! reported crashes are silicon-true, not emulation false positives.
+
+use anyhow::{Context, Result};
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::memory::ProgramImage;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{Cpu, Machine};
+use labwired_loader::load_elf;
+use std::path::Path;
+
+/// Edge-coverage map size (AFL default — a power of two).
+pub const MAP_SIZE: usize = 1 << 16;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Verdict {
+    /// Firmware signalled DONE.
+    Clean,
+    /// CPU fault (sim step error) or the firmware's FAULT marker.
+    Crash,
+    /// Ran past the step budget without finishing.
+    Hang,
+}
+
+/// AFL-style hit-count edge bitmap.
+pub struct CovMap(pub Vec<u8>);
+
+impl Default for CovMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CovMap {
+    pub fn new() -> Self {
+        Self(vec![0u8; MAP_SIZE])
+    }
+    /// Merge `other` into `self`; return true if `other` lit any **new** edge.
+    pub fn merge_new(&mut self, other: &CovMap) -> bool {
+        let mut novel = false;
+        for (g, o) in self.0.iter_mut().zip(other.0.iter()) {
+            if *o != 0 && *g == 0 {
+                novel = true;
+            }
+            *g |= *o;
+        }
+        novel
+    }
+}
+
+/// The RAM injection + verdict contract the target firmware follows.
+#[derive(Clone, Copy)]
+pub struct Contract {
+    pub input_len: u32,
+    pub input_data: u32,
+    pub verdict: u32,
+    pub done_magic: u32,
+    pub fault_magic: u32,
+}
+
+/// A loaded fuzz target: chip + manifest + firmware image, parsed once.
+pub struct Target {
+    chip: ChipDescriptor,
+    manifest: SystemManifest,
+    image: ProgramImage,
+    contract: Contract,
+    max_steps: usize,
+}
+
+impl Target {
+    /// Parse the chip yaml, system manifest, and firmware ELF (once).
+    pub fn from_elf(
+        chip_yaml: &Path,
+        system_yaml: &Path,
+        elf: &Path,
+        contract: Contract,
+        max_steps: usize,
+    ) -> Result<Self> {
+        let chip = ChipDescriptor::from_file(chip_yaml).context("chip")?;
+        let mut manifest = SystemManifest::from_file(system_yaml).context("manifest")?;
+        let anchored = system_yaml.parent().unwrap().join(&manifest.chip);
+        manifest.chip = anchored.to_str().unwrap().to_string();
+        let image = load_elf(elf).context("elf")?;
+        Ok(Self {
+            chip,
+            manifest,
+            image,
+            contract,
+            max_steps,
+        })
+    }
+
+    /// Run `input` once, accumulating edge coverage into `cov`. Returns the
+    /// verdict. A fresh machine per run keeps iterations independent (snapshot
+    /// fast-reset is a perf follow-up; correctness first).
+    pub fn run(&self, input: &[u8], cov: &mut CovMap) -> Verdict {
+        let mut bus = SystemBus::from_config(&self.chip, &self.manifest).expect("bus");
+        let (cpu, _nvic) = configure_cortex_m(&mut bus);
+        let mut machine = Machine::new(cpu, bus);
+        machine.load_firmware(&self.image).expect("load");
+
+        // Inject the input into the RAM buffer.
+        let c = &self.contract;
+        machine
+            .bus
+            .write_u32(c.input_len as u64, input.len() as u32)
+            .ok();
+        for (i, chunk) in input.chunks(4).enumerate() {
+            let mut w = [0u8; 4];
+            w[..chunk.len()].copy_from_slice(chunk);
+            machine
+                .bus
+                .write_u32(
+                    (c.input_data + (i as u32) * 4) as u64,
+                    u32::from_le_bytes(w),
+                )
+                .ok();
+        }
+
+        // Step with edge coverage (AFL: idx = (prev ^ cur) & mask, prev = cur>>1).
+        let mut prev: usize = 0;
+        for _ in 0..self.max_steps {
+            if machine.step().is_err() {
+                return Verdict::Crash;
+            }
+            let cur = (machine.cpu.get_pc() as usize) >> 1;
+            let idx = (prev ^ cur) & (MAP_SIZE - 1);
+            cov.0[idx] = cov.0[idx].saturating_add(1);
+            prev = cur >> 1;
+
+            match machine.bus.read_u32(c.verdict as u64) {
+                Ok(v) if v == c.done_magic => return Verdict::Clean,
+                Ok(v) if v == c.fault_magic => return Verdict::Crash,
+                _ => {}
+            }
+        }
+        Verdict::Hang
+    }
+}
+
+/// Deterministic xorshift64 — no system randomness (reproducible fuzzing).
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+/// One havoc mutation of `base`.
+fn mutate(base: &[u8], rng: &mut Rng) -> Vec<u8> {
+    let mut v = base.to_vec();
+    if v.is_empty() {
+        v.push(0);
+    }
+    match rng.below(4) {
+        0 => {
+            // set a random byte to a random value
+            let i = rng.below(v.len());
+            v[i] = (rng.next() & 0xFF) as u8;
+        }
+        1 => {
+            // insert a random byte
+            let i = rng.below(v.len() + 1);
+            v.insert(i, (rng.next() & 0xFF) as u8);
+        }
+        2 if v.len() > 1 => {
+            // delete a byte
+            let i = rng.below(v.len());
+            v.remove(i);
+        }
+        _ => {
+            // flip a random bit
+            let i = rng.below(v.len());
+            v[i] ^= 1 << (rng.below(8));
+        }
+    }
+    v.truncate(256);
+    v
+}
+
+/// Result of a fuzzing campaign.
+pub struct FuzzReport {
+    pub crash: Option<Vec<u8>>,
+    pub iterations: usize,
+    pub corpus_size: usize,
+    pub edges_hit: usize,
+}
+
+/// Minimal coverage-guided fuzzer: mutate corpus inputs, keep ones that hit new
+/// edges, stop on the first crash. Deterministic for a given `seed`.
+pub fn fuzz(target: &Target, seeds: Vec<Vec<u8>>, max_iters: usize, seed: u64) -> FuzzReport {
+    let mut corpus: Vec<Vec<u8>> = if seeds.is_empty() {
+        vec![vec![0u8]]
+    } else {
+        seeds
+    };
+    let mut global = CovMap::new();
+    // prime global coverage with the seeds
+    for inp in &corpus {
+        let mut cov = CovMap::new();
+        target.run(inp, &mut cov);
+        global.merge_new(&cov);
+    }
+    let mut rng = Rng::new(seed);
+    for it in 0..max_iters {
+        let base = corpus[rng.below(corpus.len())].clone();
+        let input = mutate(&base, &mut rng);
+        let mut cov = CovMap::new();
+        match target.run(&input, &mut cov) {
+            Verdict::Crash => {
+                return FuzzReport {
+                    crash: Some(input),
+                    iterations: it + 1,
+                    corpus_size: corpus.len(),
+                    edges_hit: global.0.iter().filter(|&&b| b != 0).count(),
+                };
+            }
+            _ => {
+                if global.merge_new(&cov) {
+                    corpus.push(input);
+                }
+            }
+        }
+    }
+    FuzzReport {
+        crash: None,
+        iterations: max_iters,
+        corpus_size: corpus.len(),
+        edges_hit: global.0.iter().filter(|&&b| b != 0).count(),
+    }
+}

--- a/crates/labwired-fuzz/tests/finds_planted_bug.rs
+++ b/crates/labwired-fuzz/tests/finds_planted_bug.rs
@@ -1,0 +1,69 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! The coverage-guided fuzzer finds the planted overflow in
+//! `firmware-f103-fuzztarget` from a benign seed — the Phase-1 "it works" proof.
+
+use labwired_fuzz::{fuzz, Contract, Target, Verdict};
+use std::path::PathBuf;
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn target() -> Option<Target> {
+    let elf = root().join("target/thumbv7m-none-eabi/release/firmware-f103-fuzztarget");
+    let elf = if elf.exists() {
+        elf
+    } else {
+        root().join("target/thumbv7m-none-eabi/debug/firmware-f103-fuzztarget")
+    };
+    if !elf.exists() {
+        return None;
+    }
+    Target::from_elf(
+        &root().join("configs/chips/stm32f103.yaml"),
+        &root().join("configs/systems/stm32f103-bare.yaml"),
+        &elf,
+        Contract {
+            input_len: 0x2000_2800,
+            input_data: 0x2000_2804,
+            verdict: 0x2000_3000,
+            done_magic: 0xC0DE_F022,
+            fault_magic: 0xDEAD_FA17,
+        },
+        100_000,
+    )
+    .ok()
+}
+
+#[test]
+fn fuzzer_finds_the_planted_overflow() {
+    let Some(t) = target() else {
+        eprintln!(
+            "skip: build firmware-f103-fuzztarget --target thumbv7m-none-eabi --release first"
+        );
+        return;
+    };
+    // Sanity: a benign seed is clean.
+    let mut cov = labwired_fuzz::CovMap::new();
+    assert_eq!(t.run(&[b'P', 0], &mut cov), Verdict::Clean);
+
+    // Fuzz from the benign seed — coverage-guided — find the crash.
+    let report = fuzz(&t, vec![vec![b'P', 0]], 200_000, 0xC0FFEE);
+    let crash = report
+        .crash
+        .expect("fuzzer should find the planted overflow");
+    println!(
+        "found crash in {} iters (corpus {}, {} edges): {:02X?}",
+        report.iterations, report.corpus_size, report.edges_hit, crash
+    );
+    // The only crashing path is op 'C' with an over-long length.
+    assert!(
+        crash.contains(&b'C'),
+        "crash input must drive the 'C' path: {crash:02X?}"
+    );
+    // Confirm it reproduces deterministically.
+    let mut cov2 = labwired_fuzz::CovMap::new();
+    assert_eq!(t.run(&crash, &mut cov2), Verdict::Crash);
+}


### PR DESCRIPTION
`crates/labwired-fuzz`: the fuzzing engine. Edge coverage read from the CPU PC each step (AFL-style, no core changes); `Target::run` → `(CovMap, Verdict)`; a minimal coverage-guided loop.

**It finds the planted overflow in 239 iterations** from a benign seed (`finds_planted_bug`) — the Phase-1 it-works proof. Crash = `['C', 0x55, ...]` (op C + len>16). Deterministic.

Fast-reset = fresh machine per run (snapshot is a perf follow-up). Phase-3 insight: the crash over-reads RAM past the input, so the input region must be zeroed on sim AND silicon for identical reproduction. Phase 2 swaps the toy loop for AFL++/LibAFL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)