### PR TITLE
fix(ci): re-baseline register-coverage after IWDG key-gating (#199)

### DIFF
--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -19,6 +19,13 @@
 //! reset != 0)`. It under-counts write-only and read-only-reset-0 registers
 //! that are modeled but indistinguishable from an unhandled-offset default, so
 //! treat it as a lower bound; `mapped` is the upper bound.
+//!
+//! It also under-counts **write-protected** registers whose reset value is 0:
+//! the probe writes without any unlock sequence, so a register that correctly
+//! refuses the write (e.g. IWDG_PR after #199 gated PR/RLR on the 0x5555 key,
+//! RM0008 §19.4) reads back its reset 0 and looks unresponsive — even though it
+//! is faithfully modeled. A fidelity fix that adds such gating therefore *lowers*
+//! this proxy by design; re-baseline (see below), it is not a coverage loss.
 
 use labwired_config::{Arch, ChipDescriptor};
 use labwired_core::bus::SystemBus;

--- a/docs/coverage/register-modeling.json
+++ b/docs/coverage/register-modeling.json
@@ -24,7 +24,7 @@
     "total": 1182
   },
   "stm32f103": {
-    "modeled": 211,
+    "modeled": 210,
     "total": 722
   },
   "stm32f401": {
@@ -44,11 +44,11 @@
     "total": 4426
   },
   "stm32l073": {
-    "modeled": 296,
+    "modeled": 295,
     "total": 524
   },
   "stm32l476": {
-    "modeled": 724,
+    "modeled": 723,
     "total": 1485
   },
   "stm32wb55": {


### PR DESCRIPTION
**Fixes the red `Rust Core CI`** (`register_coverage_ratchet`).

Root cause: #199 correctly gated IWDG `PR`/`RLR` writes on the `0x5555` unlock key (RM0008 §19.4). The coverage probe writes `0xFFFF`/`0` with no unlock, so `IWDG_PR` (reset 0) now correctly refuses the write and reads back 0 — invisible to the crude `responsive` heuristic. It's still faithfully modeled; the lower-bound proxy just can't observe a write-protected reset-0 register.

Drop is exactly **one register (IWDG_PR) on each of the three shared-IWDG chips** (f103/l073/l476); all totals and every other chip unchanged (verified by diff). Documented intentional-model-change path — re-baseline + a note in the test explaining the write-protected under-count case. Not a coverage loss.

Verified: ratchet green locally after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)