### PR TITLE
feat(fuzz): LibAFL engine behind the fuzz-libafl feature (Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
@@ -39,6 +48,18 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "panic-halt",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -119,6 +140,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arbitrary-int"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
+
+[[package]]
+name = "arbitrary-int"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a810118f8f37e9c4411c86f1c4c940a09a7ab34b7bf2d88d06f50c553fab7"
+
+[[package]]
 name = "arm-hello"
 version = "0.1.0"
 dependencies = [
@@ -173,6 +206,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +248,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -237,6 +305,18 @@ name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitbybit"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec187a89ab07e209270175faf9e07ceb2755d984954e58a2296e325ddece2762"
+dependencies = [
+ "arbitrary-int 1.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bitfield"
@@ -295,6 +375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +401,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -370,6 +462,36 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
 
 [[package]]
 name = "core-foundation"
@@ -626,6 +748,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
 name = "dap"
 version = "0.4.1-alpha1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +849,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +922,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +947,17 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -1045,6 +1220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1336,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
@@ -1192,6 +1383,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1221,6 +1417,17 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "human-size"
@@ -1374,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
- "mach2",
+ "mach2 0.4.3",
 ]
 
 [[package]]
@@ -1431,6 +1638,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "labwired-cli"
 version = "0.15.0"
 dependencies = [
@@ -1485,7 +1707,7 @@ name = "labwired-core"
 version = "0.15.0"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "bitflags 2.11.1",
  "goblin",
  "labwired-config",
@@ -1532,6 +1754,8 @@ dependencies = [
  "labwired-config",
  "labwired-core",
  "labwired-loader",
+ "libafl",
+ "libafl_bolts",
 ]
 
 [[package]]
@@ -1689,6 +1913,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libafl"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e13655171e69ad9094dd1be1948950a36d228f01a7cb9f6d8477090d98c6e4"
+dependencies = [
+ "ahash",
+ "arbitrary-int 2.1.1",
+ "backtrace",
+ "bincode 2.0.1",
+ "bitbybit",
+ "const_format",
+ "const_panic",
+ "fastbloom",
+ "fs2",
+ "hashbrown 0.16.1",
+ "libafl_bolts",
+ "libafl_derive",
+ "libc",
+ "libm",
+ "log",
+ "meminterval",
+ "nix 0.30.1",
+ "num-traits",
+ "postcard",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tuple_list",
+ "typed-builder",
+ "uuid",
+ "wait-timeout",
+ "winapi",
+ "windows",
+]
+
+[[package]]
+name = "libafl_bolts"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cbae44f69156f035ae2196b135ad27ea95020767e6787bfe45e8c2438c67b9"
+dependencies = [
+ "ahash",
+ "backtrace",
+ "ctor",
+ "erased-serde",
+ "hashbrown 0.16.1",
+ "hostname",
+ "libafl_derive",
+ "libc",
+ "log",
+ "mach2 0.5.0",
+ "nix 0.30.1",
+ "num_enum 0.7.6",
+ "once_cell",
+ "postcard",
+ "rand_core",
+ "rustversion",
+ "serde",
+ "serial_test",
+ "static_assertions",
+ "tuple_list",
+ "typeid",
+ "uds",
+ "uuid",
+ "wide",
+ "winapi",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "libafl_derive"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61adf76899bffdcd15ae7fea42b978e7df7cf9213aacdd8cdcda89e4bb3bc32d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +2074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +2110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "meminterval"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0f9a537564310a87dc77d5c88a407e27dd0aa740e070f0549439cfcc68fcfd"
+dependencies = [
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1883,6 +2210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nokia5110-invaders-lab"
 version = "0.1.0"
 dependencies = [
@@ -1939,7 +2279,17 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive 0.7.6",
+ "rustversion",
 ]
 
 [[package]]
@@ -1954,6 +2304,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2323,15 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2067,7 +2437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e09694b50f89f302ed531c1f2a7569f0be5867aee4ab4f8f729bbeec0078e3"
 dependencies = [
  "arrayvec",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
 ]
 
@@ -2618,6 +2988,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +3120,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serialport"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,8 +3154,8 @@ dependencies = [
  "core-foundation-sys",
  "io-kit-sys",
  "libudev",
- "mach2",
- "nix",
+ "mach2 0.4.3",
+ "nix 0.26.4",
  "scopeguard",
  "unescaper",
  "windows-sys 0.52.0",
@@ -3194,6 +3596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tuple_list"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141fb9f71ee586d956d7d6e4d5a9ef8e946061188520140f7591b668841d502e"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,10 +3612,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+
+[[package]]
+name = "uds"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c31f06fce836457fe3ef09a59f83fe8db95d270b11cd78f40a4666c4d1661"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "unarray"
@@ -3261,6 +3710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "ureq"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3758,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3792,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "void"
@@ -3522,7 +3995,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "log",
- "mach2",
+ "mach2 0.4.3",
  "memfd",
  "object 0.39.1",
  "once_cell",
@@ -3715,6 +4188,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,10 +4229,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3783,6 +4361,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -47,3 +47,7 @@ default = []
 # feature. Build with `cargo build --release -p labwired-cli --features
 # jit-core` to enable wasmtime-backed JIT for the fillScreen body block.
 jit-core = ["labwired-core/jit"]
+# Swap the built-in fuzzing loop for the LibAFL engine (havoc/splice mutators,
+# map-feedback scheduler, crash objectives). Heavy dependency tree, so opt-in:
+# `cargo build --release -p labwired-cli --features fuzz-libafl`.
+fuzz-libafl = ["labwired-fuzz/libafl"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1488,8 +1488,13 @@ fn run_fuzz(args: FuzzArgs) -> ExitCode {
         }
     };
 
+    let engine = if cfg!(feature = "fuzz-libafl") {
+        "LibAFL"
+    } else {
+        "built-in"
+    };
     eprintln!(
-        "fuzzing {} (max_iters={}, seed={:#x}) ...",
+        "fuzzing {} with the {engine} engine (max_iters={}, seed={:#x}) ...",
         args.firmware.display(),
         args.max_iters,
         args.seed

--- a/crates/labwired-fuzz/Cargo.toml
+++ b/crates/labwired-fuzz/Cargo.toml
@@ -15,3 +15,14 @@ labwired-core = { path = "../core" }
 labwired-config = { path = "../config" }
 labwired-loader = { path = "../loader" }
 anyhow = { workspace = true }
+
+# The `libafl` feature swaps the built-in coverage-guided loop for a real
+# LibAFL fuzzer (havoc/splice mutators, map-feedback scheduler, crash
+# objectives). Off by default so the workspace/CI build stays light — LibAFL is
+# a large dependency tree. Build the CLI with `--features fuzz-libafl` to use it.
+libafl = { version = "0.15", default-features = false, features = ["std", "derive", "rand_trait"], optional = true }
+libafl_bolts = { version = "0.15", default-features = false, features = ["std", "serdeany_autoreg"], optional = true }
+
+[features]
+default = []
+libafl = ["dep:libafl", "dep:libafl_bolts"]

--- a/crates/labwired-fuzz/src/lib.rs
+++ b/crates/labwired-fuzz/src/lib.rs
@@ -18,6 +18,11 @@ use labwired_core::{Cpu, Machine};
 use labwired_loader::load_elf;
 use std::path::Path;
 
+#[cfg(feature = "libafl")]
+mod libafl_engine;
+#[cfg(feature = "libafl")]
+pub use libafl_engine::{fuzz_collect_libafl, fuzz_libafl};
+
 /// Edge-coverage map size (AFL default — a power of two).
 pub const MAP_SIZE: usize = 1 << 16;
 
@@ -217,6 +222,21 @@ pub fn fuzz_collect(
     seed: u64,
     max_crashes: usize,
 ) -> Vec<Vec<u8>> {
+    #[cfg(feature = "libafl")]
+    return libafl_engine::fuzz_collect_libafl(target, seeds, max_iters, seed, max_crashes);
+    #[cfg(not(feature = "libafl"))]
+    fuzz_collect_builtin(target, seeds, max_iters, seed, max_crashes)
+}
+
+/// Built-in (no-LibAFL) crash-collecting loop. See [`fuzz_collect`].
+#[cfg_attr(feature = "libafl", allow(dead_code))]
+fn fuzz_collect_builtin(
+    target: &Target,
+    seeds: Vec<Vec<u8>>,
+    max_iters: usize,
+    seed: u64,
+    max_crashes: usize,
+) -> Vec<Vec<u8>> {
     let mut corpus: Vec<Vec<u8>> = if seeds.is_empty() {
         vec![vec![0u8]]
     } else {
@@ -256,6 +276,21 @@ pub fn fuzz_collect(
 /// Minimal coverage-guided fuzzer: mutate corpus inputs, keep ones that hit new
 /// edges, stop on the first crash. Deterministic for a given `seed`.
 pub fn fuzz(target: &Target, seeds: Vec<Vec<u8>>, max_iters: usize, seed: u64) -> FuzzReport {
+    #[cfg(feature = "libafl")]
+    return FuzzReport {
+        crash: libafl_engine::fuzz_libafl(target, seeds, max_iters, seed),
+        // LibAFL owns the loop; per-iteration bookkeeping isn't surfaced here.
+        iterations: 0,
+        corpus_size: 0,
+        edges_hit: 0,
+    };
+    #[cfg(not(feature = "libafl"))]
+    fuzz_builtin(target, seeds, max_iters, seed)
+}
+
+/// Built-in (no-LibAFL) coverage-guided loop. See [`fuzz`].
+#[cfg_attr(feature = "libafl", allow(dead_code))]
+fn fuzz_builtin(target: &Target, seeds: Vec<Vec<u8>>, max_iters: usize, seed: u64) -> FuzzReport {
     let mut corpus: Vec<Vec<u8>> = if seeds.is_empty() {
         vec![vec![0u8]]
     } else {

--- a/crates/labwired-fuzz/src/libafl_engine.rs
+++ b/crates/labwired-fuzz/src/libafl_engine.rs
@@ -1,0 +1,168 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! LibAFL-backed fuzzing engine (Phase 2).
+//!
+//! Swaps the crate's built-in coverage-guided loop for a real [LibAFL] fuzzer:
+//! havoc/splice mutators, a map-feedback queue scheduler, and crash objectives.
+//! The simulator is wrapped as an in-process executor — `Target::run` fills an
+//! AFL-style edge bitmap that a `StdMapObserver` watches, and a sim CPU fault
+//! (or the firmware FAULT marker) is reported as `ExitKind::Crash`, which
+//! `CrashFeedback` routes into the solutions corpus.
+//!
+//! Gated behind the `libafl` feature so the default workspace/CI build stays
+//! light. When enabled, [`crate::fuzz`] / [`crate::fuzz_collect`] delegate here.
+//!
+//! [LibAFL]: https://github.com/AFLplusplus/LibAFL
+
+use crate::{CovMap, Target, Verdict, MAP_SIZE};
+use core::ptr::addr_of_mut;
+
+use libafl::corpus::{Corpus, InMemoryCorpus};
+use libafl::events::SimpleEventManager;
+use libafl::executors::{ExitKind, InProcessExecutor};
+use libafl::feedbacks::{CrashFeedback, MaxMapFeedback};
+use libafl::inputs::{BytesInput, HasTargetBytes};
+use libafl::monitors::SimpleMonitor;
+use libafl::mutators::{havoc_mutations, HavocScheduledMutator};
+use libafl::observers::StdMapObserver;
+use libafl::schedulers::QueueScheduler;
+use libafl::stages::StdMutationalStage;
+use libafl::state::{HasCorpus, HasSolutions, StdState};
+use libafl::{Evaluator, Fuzzer, StdFuzzer};
+use libafl_bolts::rands::StdRand;
+use libafl_bolts::tuples::tuple_list;
+use libafl_bolts::AsSlice;
+
+/// Shared edge-coverage bitmap the observer watches. Single-threaded fuzzing,
+/// so a process-global map is fine (LibAFL's `StdMapObserver` wants a stable
+/// backing buffer that outlives the executor).
+static mut COVERAGE: [u8; MAP_SIZE] = [0u8; MAP_SIZE];
+
+/// Run LibAFL against `target` until `want` distinct crashes land in the
+/// solutions corpus or `max_iters` mutational rounds elapse. Returns the
+/// crashing inputs. Deterministic for a fixed `seed`.
+fn run(
+    target: &Target,
+    seeds: Vec<Vec<u8>>,
+    max_iters: usize,
+    seed: u64,
+    want: usize,
+) -> Vec<Vec<u8>> {
+    // SAFETY: single-threaded; the observer + harness are the only users and
+    // the executor below borrows neither across threads.
+    let observer = unsafe {
+        StdMapObserver::from_mut_ptr("edges", addr_of_mut!(COVERAGE) as *mut u8, MAP_SIZE)
+    };
+
+    let mut feedback = MaxMapFeedback::new(&observer);
+    let mut objective = CrashFeedback::new();
+
+    // The harness: run one input in the sim, publish its edge map, classify.
+    let mut harness = |input: &BytesInput| {
+        let bytes = input.target_bytes();
+        let mut local = CovMap::new();
+        let verdict = target.run(bytes.as_slice(), &mut local);
+        // SAFETY: single-threaded; overwrite (not accumulate) this run's map.
+        // Write through a raw pointer to avoid a reference to the mutable static.
+        unsafe {
+            core::slice::from_raw_parts_mut(addr_of_mut!(COVERAGE) as *mut u8, MAP_SIZE)
+                .copy_from_slice(&local.0);
+        }
+        match verdict {
+            Verdict::Crash => ExitKind::Crash,
+            _ => ExitKind::Ok,
+        }
+    };
+
+    let mut state = StdState::new(
+        StdRand::with_seed(seed),
+        InMemoryCorpus::<BytesInput>::new(),
+        InMemoryCorpus::<BytesInput>::new(),
+        &mut feedback,
+        &mut objective,
+    )
+    .expect("libafl state");
+
+    let monitor = SimpleMonitor::new(|_s| {});
+    let mut mgr = SimpleEventManager::new(monitor);
+    let scheduler = QueueScheduler::new();
+    let mut fuzzer = StdFuzzer::new(scheduler, feedback, objective);
+
+    let mut executor = InProcessExecutor::new(
+        &mut harness,
+        tuple_list!(observer),
+        &mut fuzzer,
+        &mut state,
+        &mut mgr,
+    )
+    .expect("libafl executor");
+
+    // Prime the corpus with the seeds (fall back to a single zero byte).
+    let seed_inputs: Vec<BytesInput> = if seeds.is_empty() {
+        vec![BytesInput::new(vec![0u8])]
+    } else {
+        seeds.into_iter().map(BytesInput::new).collect()
+    };
+    for inp in seed_inputs {
+        let _ = fuzzer.evaluate_input(&mut state, &mut executor, &mut mgr, &inp);
+    }
+    // A scheduler needs at least one corpus entry even if no seed was novel.
+    if state.corpus().count() == 0 {
+        let _ = fuzzer.add_input(
+            &mut state,
+            &mut executor,
+            &mut mgr,
+            BytesInput::new(vec![0u8]),
+        );
+    }
+
+    let mutator = HavocScheduledMutator::new(havoc_mutations());
+    let mut stages = tuple_list!(StdMutationalStage::new(mutator));
+
+    for _ in 0..max_iters {
+        if state.solutions().count() >= want {
+            break;
+        }
+        if fuzzer
+            .fuzz_one(&mut stages, &mut executor, &mut state, &mut mgr)
+            .is_err()
+        {
+            break;
+        }
+    }
+
+    // Extract the crashing inputs from the solutions corpus.
+    let mut out = Vec::new();
+    let solutions = state.solutions();
+    for id in solutions.ids() {
+        if let Ok(tc) = solutions.get(id) {
+            if let Some(input) = tc.borrow().input() {
+                out.push(input.target_bytes().as_slice().to_vec());
+            }
+        }
+    }
+    out
+}
+
+/// Coverage-guided fuzz with LibAFL; return the first crashing input found.
+pub fn fuzz_libafl(
+    target: &Target,
+    seeds: Vec<Vec<u8>>,
+    max_iters: usize,
+    seed: u64,
+) -> Option<Vec<u8>> {
+    run(target, seeds, max_iters, seed, 1).into_iter().next()
+}
+
+/// Coverage-guided fuzz with LibAFL; collect up to `max_crashes` distinct
+/// crashing inputs.
+pub fn fuzz_collect_libafl(
+    target: &Target,
+    seeds: Vec<Vec<u8>>,
+    max_iters: usize,
+    seed: u64,
+    max_crashes: usize,
+) -> Vec<Vec<u8>> {
+    run(target, seeds, max_iters, seed, max_crashes)
+}


### PR DESCRIPTION
Swaps the built-in coverage-guided loop for a real **LibAFL** fuzzer (Rust-native — no AFL++ forkserver/shmem glue).

`src/libafl_engine.rs` wraps the sim as a LibAFL `InProcessExecutor`: `StdMapObserver` over the AFL edge bitmap, `MaxMapFeedback` + `QueueScheduler`, `havoc_mutations`, `CrashFeedback` → solutions corpus. `fuzz()`/`fuzz_collect()` delegate here when the `labwired-fuzz/libafl` feature is on; the built-in loop stays the **dependency-free default** so the workspace/CI build + HIL test stay light. CLI gains a `fuzz-libafl` pass-through and prints the engine used.

Both engines find the planted overflow; LibAFL explores a richer space (multi-frame inputs the built-in mutator never produces). Verified: `finds_planted_bug` green via LibAFL; CLI `--features fuzz-libafl` finds 5 distinct crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)