### PR TITLE
feat(oracle): sweep USART2 — model was missing BRR/CR2/GTPR entirely

### DIFF
--- a/crates/core/src/peripherals/uart.rs
+++ b/crates/core/src/peripherals/uart.rs
@@ -131,6 +131,13 @@ pub struct Uart {
     /// CR1 register (tracks TXEIE and TE bits for interrupt-driven TX simulation).
     cr1: u32,
     cr3: u32,
+    /// F1-layout config registers, captured for read-back fidelity (BRR/CR2/GTPR
+    /// have no behavioural effect in this instruction-level model, but firmware
+    /// reads them back). Masked to the silicon writable bits on read. Unused by
+    /// the V2 layout, whose register map differs.
+    cr2: u32,
+    brr: u32,
+    gtpr: u32,
     dma_tx_pending: bool,
     /// Stream devices attached to the RX path (e.g. GPS modules).
     #[serde(skip)]
@@ -177,6 +184,9 @@ impl Uart {
             echo_stdout: true,
             cr1: 0,
             cr3: 0,
+            cr2: 0,
+            brr: 0,
+            gtpr: 0,
             dma_tx_pending: false,
             attached_streams: Vec::new(),
             trace: VecDeque::new(),
@@ -264,6 +274,63 @@ impl Uart {
     fn cr3_offset(&self) -> u64 {
         self.layout.regmap().cr3
     }
+
+    /// F1-layout config registers as `(base offset, silicon writable mask)`.
+    /// Masks silicon-confirmed on the bench F103 (RM0008 §27.6): BRR 0xFFFF,
+    /// CR1 0x3FFD, CR2 0x7F6F, CR3 0x07FF, GTPR 0xFFFF.
+    const F1_CONFIG: [(u64, u32); 5] = [
+        (0x08, 0x0000_FFFF), // BRR
+        (0x0C, 0x0000_3FFD), // CR1
+        (0x10, 0x0000_7F6F), // CR2
+        (0x14, 0x0000_07FF), // CR3
+        (0x18, 0x0000_FFFF), // GTPR
+    ];
+
+    fn f1_config_value(&self, base: u64) -> u32 {
+        match base {
+            0x08 => self.brr,
+            0x0C => self.cr1,
+            0x10 => self.cr2,
+            0x14 => self.cr3,
+            0x18 => self.gtpr,
+            _ => 0,
+        }
+    }
+
+    /// Masked read-back byte for an F1 config register, or `None` if `offset` is
+    /// not one. F1 layout only.
+    fn f1_config_byte(&self, offset: u64) -> Option<u8> {
+        for (base, mask) in Self::F1_CONFIG {
+            let bo = offset.wrapping_sub(base);
+            if bo < 4 {
+                return Some((((self.f1_config_value(base) & mask) >> (bo * 8)) & 0xFF) as u8);
+            }
+        }
+        None
+    }
+
+    /// Accumulate one written byte into an F1 config register. Returns true if
+    /// `offset` belonged to one. F1 layout only.
+    fn f1_config_write(&mut self, offset: u64, value: u8) -> bool {
+        for (base, _mask) in Self::F1_CONFIG {
+            let bo = offset.wrapping_sub(base);
+            if bo < 4 {
+                let shift = bo * 8;
+                let set =
+                    |reg: &mut u32| *reg = (*reg & !(0xFF << shift)) | ((value as u32) << shift);
+                match base {
+                    0x08 => set(&mut self.brr),
+                    0x0C => set(&mut self.cr1),
+                    0x10 => set(&mut self.cr2),
+                    0x14 => set(&mut self.cr3),
+                    0x18 => set(&mut self.gtpr),
+                    _ => {}
+                }
+                return true;
+            }
+        }
+        false
+    }
     /// Offset of the CR1 register. `None` for layouts without a CR1 interrupt concept.
     fn cr1_offset(&self) -> Option<u64> {
         self.layout.regmap().cr1
@@ -344,6 +411,12 @@ impl crate::Peripheral for Uart {
             }
             return Ok(0x00);
         }
+        // F1 config registers (BRR/CR1/CR2/CR3/GTPR), masked read-back.
+        if matches!(self.layout, UartRegisterLayout::Stm32F1) {
+            if let Some(b) = self.f1_config_byte(offset) {
+                return Ok(b);
+            }
+        }
         if offset == self.cr3_offset() {
             return Ok(self.cr3 as u8);
         }
@@ -364,6 +437,14 @@ impl crate::Peripheral for Uart {
         if offset == self.tx_offset() || is_legacy_tx_alias {
             self.push_tx(value);
             // If DMAT bit is set, we might be in a DMA sequence.
+            if (self.cr3 & (1 << 7)) != 0 {
+                self.dma_tx_pending = true;
+            }
+        } else if matches!(self.layout, UartRegisterLayout::Stm32F1)
+            && self.f1_config_write(offset, value)
+        {
+            // F1 config register (BRR/CR1/CR2/CR3/GTPR) captured. CR3.DMAT
+            // (bit 7) still gates DMA-driven TX.
             if (self.cr3 & (1 << 7)) != 0 {
                 self.dma_tx_pending = true;
             }
@@ -451,6 +532,11 @@ impl crate::Peripheral for Uart {
                 return Some(*guard.front().unwrap_or(&0x00));
             }
             return Some(0x00);
+        }
+        if matches!(self.layout, UartRegisterLayout::Stm32F1) {
+            if let Some(b) = self.f1_config_byte(offset) {
+                return Some(b);
+            }
         }
         if offset == self.cr3_offset() {
             return Some(self.cr3 as u8);

--- a/crates/hw-oracle/tests/stm32f1_mmio_diff.rs
+++ b/crates/hw-oracle/tests/stm32f1_mmio_diff.rs
@@ -161,6 +161,11 @@ const WWDGEN: u32 = 1 << 11; // RCC APB1ENR
 const USART2_BASE: u32 = 0x4000_4400;
 const USART2_SR: u32 = USART2_BASE + 0x00;
 const USART2_SR_RESET: u32 = 0x0000_00C0; // TXE | TC set out of reset
+const USART2_BRR: u32 = USART2_BASE + 0x08;
+const USART2_CR1: u32 = USART2_BASE + 0x0C;
+const USART2_CR2: u32 = USART2_BASE + 0x10;
+const USART2_CR3: u32 = USART2_BASE + 0x14;
+const USART2_GTPR: u32 = USART2_BASE + 0x18;
 
 // ── DMA1 (0x4002_0000 — AHB, 7-channel controller) ───────────────────────────
 const DMA1_BASE: u32 = 0x4002_0000;
@@ -733,6 +738,38 @@ const SWEEP_CASES: &[SweepCase] = &[
         label: "TIM2.CR1 (last: sets CEN)",
         prep: &[(RCC_APB1ENR, TIM2EN)],
         addr: TIM2_CR1,
+        write: 0xFFFF_FFFF,
+    },
+    // ── USART2 config registers ──────────────────────────────────────────────
+    // SR/DR excluded (status / data with side effects). CR1 last (sets UE).
+    SweepCase {
+        label: "USART2.BRR",
+        prep: &[(RCC_APB1ENR, USART2EN)],
+        addr: USART2_BRR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "USART2.CR2",
+        prep: &[(RCC_APB1ENR, USART2EN)],
+        addr: USART2_CR2,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "USART2.CR3",
+        prep: &[(RCC_APB1ENR, USART2EN)],
+        addr: USART2_CR3,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "USART2.GTPR",
+        prep: &[(RCC_APB1ENR, USART2EN)],
+        addr: USART2_GTPR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "USART2.CR1 (last: sets UE)",
+        prep: &[(RCC_APB1ENR, USART2EN)],
+        addr: USART2_CR1,
         write: 0xFFFF_FFFF,
     },
 ];

--- a/docs/coverage/register-modeling.json
+++ b/docs/coverage/register-modeling.json
@@ -24,7 +24,7 @@
     "total": 1182
   },
   "stm32f103": {
-    "modeled": 210,
+    "modeled": 219,
     "total": 722
   },
   "stm32f401": {


### PR DESCRIPTION
Second peripheral through the address-only silicon sweep (Haiku enumerated the addresses; the bench supplied truth).

The sweep caught the F1 UART model was significantly under-modeled — **5 divergences, now all silicon-matched** (`diverge=0`, match=70):

| Register | gap | now |
|---|---|---|
| BRR / CR2 / GTPR | **not stored** (read 0) — baud register invisible | F1-layout config storage |
| CR1 | unmasked `0xFFFFFFFF` | `0x3FFD` |
| CR3 | low byte only `0xFF` | `0x07FF` |

New storage + masks gated on `UartRegisterLayout::Stm32F1` (V2/H5 untouched). Masks silicon-confirmed (RM0008 §27.6). Re-baselined F103 coverage 210→219 (only the silicon-validated part is locked).

No regressions: 27 uart unit tests + l0/l476/f1 sim-only + ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)