### PR TITLE
feat(f407): proper onboarding — full peripheral set + F4 RCC map fix, silicon-validated

### DIFF
--- a/configs/chips/stm32f407.yaml
+++ b/configs/chips/stm32f407.yaml
@@ -63,6 +63,105 @@ peripherals:
     base_address: 0x40005400
     size: "1KB"
     irq: 31
+  - id: "gpioe"
+    type: "stm32f4_gpio"
+    base_address: 0x40021000
+    size: "1KB"
+  - id: "tim1"
+    type: "timer"
+    base_address: 0x40010000
+    size: "1KB"
+    irq: 27
+    config:
+      advanced: true
+  - id: "tim2"
+    type: "timer"
+    base_address: 0x40000000
+    size: "1KB"
+    irq: 28
+    config:
+      width: 32
+  - id: "tim3"
+    type: "timer"
+    base_address: 0x40000400
+    size: "1KB"
+    irq: 29
+  - id: "tim4"
+    type: "timer"
+    base_address: 0x40000800
+    size: "1KB"
+    irq: 30
+  - id: "tim5"
+    type: "timer"
+    base_address: 0x40000C00
+    size: "1KB"
+    irq: 50
+    config:
+      width: 32
+  - id: "usart1"
+    type: "uart"
+    base_address: 0x40011000
+    size: "1KB"
+    irq: 37
+    config:
+      cr3_mask: 0xFFF
+  - id: "usart3"
+    type: "uart"
+    base_address: 0x40004800
+    size: "1KB"
+    irq: 39
+    config:
+      cr3_mask: 0xFFF
+  - id: "usart6"
+    type: "uart"
+    base_address: 0x40011400
+    size: "1KB"
+    irq: 71
+    config:
+      cr3_mask: 0xFFF
+  - id: "spi1"
+    type: "spi"
+    base_address: 0x40013000
+    size: "1KB"
+    irq: 35
+    # F4 classic SPI CR2 adds bit 4 (FRF/TI-mode) over the F1 map → 0xF7.
+    config:
+      cr2_mask: 0xF7
+  - id: "spi2"
+    type: "spi"
+    base_address: 0x40003800
+    size: "1KB"
+    irq: 36
+    config:
+      cr2_mask: 0xF7
+  - id: "spi3"
+    type: "spi"
+    base_address: 0x40003C00
+    size: "1KB"
+    irq: 51
+    config:
+      cr2_mask: 0xF7
+  - id: "i2c2"
+    type: "i2c"
+    base_address: 0x40005800
+    size: "1KB"
+    irq: 33
+  - id: "i2c3"
+    type: "i2c"
+    base_address: 0x40005C00
+    size: "1KB"
+    irq: 72
+  - id: "adc1"
+    type: "adc"
+    base_address: 0x40012000
+    size: "1KB"
+    irq: 18
+  - id: "exti"
+    type: "exti"
+    base_address: 0x40013C00
+    size: "1KB"
+    config:
+      lines: 23
   - id: "dbgmcu"
     type: "dbgmcu"
     base_address: 0xE0042000

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1121,7 +1121,17 @@ impl SystemBus {
                         } else {
                             Self::parse_profile_or_default(p_cfg, "SPI")?
                         };
-                    Box::new(crate::peripherals::spi::Spi::new_with_layout(layout))
+                    // Classic-SPI CR2 mask is a per-part delta: F1 0xE7, F4 adds
+                    // FRF bit 4 → 0xF7. YAML: `config: { cr2_mask: 0xF7 }`.
+                    let cr2_mask: u32 = p_cfg
+                        .config
+                        .get("cr2_mask")
+                        .and_then(|v| v.as_u64())
+                        .map(|n| n as u32)
+                        .unwrap_or(0x0000_00E7);
+                    Box::new(crate::peripherals::spi::Spi::new_with_layout_cr2(
+                        layout, cr2_mask,
+                    ))
                 }
                 "pwr" => Box::new(crate::peripherals::pwr::Pwr::new()),
                 "flash" | "flash_iface" => {

--- a/crates/core/src/peripherals/rcc.rs
+++ b/crates/core/src/peripherals/rcc.rs
@@ -160,11 +160,14 @@ impl RccModel for F1Rcc {
 #[derive(Debug, Default, serde::Serialize)]
 pub struct F4Rcc {
     cr: u32,
-    cfgr: u32,     // 0x04 (see note)
+    pllcfgr: u32,  // 0x04 (real F4 map — was wrongly conflated with CFGR)
+    cfgr: u32,     // 0x08
+    cir: u32,      // 0x0C
     ahbenr: u32,   // AHB1ENR 0x30
+    ahb2enr: u32,  // 0x34
     apb1enr: u32,  // 0x40
     apb2enr: u32,  // 0x44
-    ahbrstr: u32,  // 0x10
+    ahbrstr: u32,  // AHB1RSTR 0x10
     apb1rstr: u32, // 0x20
     apb2rstr: u32, // 0x24
 }
@@ -173,6 +176,9 @@ impl F4Rcc {
     fn new() -> Self {
         Self {
             cr: classic_cr_ready(1 << 0),
+            // PLLCFGR reset = 0x24003010 (RM0090 §6.3.2) — the factory default
+            // PLL config word; firmware reads it back before reconfiguring.
+            pllcfgr: 0x2400_3010,
             ..Default::default()
         }
     }
@@ -182,11 +188,14 @@ impl RccModel for F4Rcc {
     fn read_reg(&self, offset: u64) -> u32 {
         match offset {
             0x00 => self.cr,
-            0x04 => self.cfgr,
+            0x04 => self.pllcfgr,
+            0x08 => self.cfgr,
+            0x0C => self.cir,
             0x10 => self.ahbrstr,
             0x20 => self.apb1rstr,
             0x24 => self.apb2rstr,
             0x30 => self.ahbenr,
+            0x34 => self.ahb2enr,
             0x40 => self.apb1enr,
             0x44 => self.apb2enr,
             _ => 0,
@@ -195,11 +204,20 @@ impl RccModel for F4Rcc {
     fn write_reg(&mut self, offset: u64, value: u32) {
         match offset {
             0x00 => self.cr = classic_cr_ready(value),
-            0x04 => self.cfgr = cfgr_with_optimistic_sws(value),
+            // PLLCFGR writable = PLLM/PLLN/PLLP/PLLSRC/PLLQ = 0x7F43_7FFF
+            // (silicon-confirmed on F407). Reserved bits read 0.
+            0x04 => self.pllcfgr = value & 0x7F43_7FFF,
+            // CFGR at 0x08 on F4 (not 0x04). The optimistic SW->SWS fake lets
+            // firmware that switches SYSCLK to PLL/HSE see the switch complete.
+            0x08 => self.cfgr = cfgr_with_optimistic_sws(value),
+            // CIR interrupt-enable bits 13:8 = 0x3F00 (F4 adds PLLI2SRDYIE bit
+            // 13 over the F1's 5 bits) — silicon-confirmed on F407.
+            0x0C => self.cir = value & 0x0000_3F00,
             0x10 => self.ahbrstr = value,
             0x20 => self.apb1rstr = value,
             0x24 => self.apb2rstr = value,
             0x30 => self.ahbenr = value,
+            0x34 => self.ahb2enr = value,
             0x40 => self.apb1enr = value,
             0x44 => self.apb2enr = value,
             _ => {}

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -249,6 +249,12 @@ pub struct Spi {
     /// path (`dr` + RXNE), as if MOSI were jumpered to MISO. Defaults false.
     loopback: bool,
 
+    /// Classic-SPI CR2 writable mask — a per-part delta on the shared classic
+    /// layout. F1 implements 0xE7; F4 adds bit 4 (FRF, TI-mode) → 0xF7,
+    /// silicon-confirmed on the bench F103 (0xE7) and F407 (0xF7). Set from the
+    /// chip config's `cr2_mask`. Ignored by the FIFO layout (its own CR2 logic).
+    cr2_mask: u32,
+
     #[serde(skip)]
     pub attached_devices: Vec<Box<dyn SpiDevice>>,
 }
@@ -270,6 +276,12 @@ impl Spi {
     }
 
     pub fn new_with_layout(layout: SpiRegisterLayout) -> Self {
+        Self::new_with_layout_cr2(layout, 0x0000_00E7)
+    }
+
+    /// Like [`new_with_layout`] but with an explicit classic-SPI CR2 writable
+    /// mask — the per-part delta (F1 `0xE7`, F4 `0xF7` for the FRF bit).
+    pub fn new_with_layout_cr2(layout: SpiRegisterLayout, cr2_mask: u32) -> Self {
         let regs = match layout {
             // CR2 reset is silicon-verified over SWD:
             //   FIFO SPI (L4/F7/H5): CR2 = 0x0700 (DS=0b0111 8-bit + FRXTH).
@@ -290,6 +302,7 @@ impl Spi {
         };
         Self {
             regs,
+            cr2_mask,
             ..Default::default()
         }
     }
@@ -323,7 +336,9 @@ impl Spi {
                 // frame size. Values below 0b0011 are reserved and hardware
                 // forces them to 0b0111 (8-bit) on FIFO parts — verified on
                 // NUCLEO-L476RG (CR2=0x0000 reads back 0x0700). Classic SPI
-                // has no DS field, so it stores the value verbatim.
+                // has no DS field; its writable mask is the per-part `cr2_mask`
+                // (F1 0xE7, F4 0xF7 for the FRF bit).
+                let cr2_mask = self.cr2_mask as u16;
                 if let SpiRegs::Stm32(r) = &mut self.regs {
                     if r.fifo {
                         let ds = (value >> 8) & 0xF;
@@ -333,9 +348,7 @@ impl Spi {
                             value
                         };
                     } else {
-                        // Classic SPI CR2 writable mask 0xE7 (RXDMAEN/TXDMAEN/
-                        // SSOE/ERRIE/RXNEIE/TXEIE) — silicon-confirmed on F103.
-                        r.cr2 = value & 0x00E7;
+                        r.cr2 = value & cr2_mask;
                     }
                 }
             }

--- a/crates/hw-oracle/tests/stm32f4_mmio_diff.rs
+++ b/crates/hw-oracle/tests/stm32f4_mmio_diff.rs
@@ -64,6 +64,39 @@ const I2C1_TRISE: u32 = I2C1_BASE + 0x20;
 const DBGMCU_IDCODE: u32 = 0xE004_2000;
 const F407_IDCODE: u32 = 0x1001_6413; // DEV_ID 0x413, REV_ID 0x1001
 
+// ── EXTI (0x4001_3C00 on F4 — 23 lines, set via config: {lines: 23}) ──────────
+const EXTI_BASE: u32 = 0x4001_3C00;
+const EXTI_IMR: u32 = EXTI_BASE + 0x00;
+const EXTI_EMR: u32 = EXTI_BASE + 0x04;
+const EXTI_RTSR: u32 = EXTI_BASE + 0x08;
+const EXTI_FTSR: u32 = EXTI_BASE + 0x0C;
+
+// ── RCC extra registers (F4 map) + clock-enable bits used as sweep prep ───────
+const RCC_PLLCFGR: u32 = RCC_BASE + 0x04;
+const RCC_CIR: u32 = RCC_BASE + 0x0C;
+const RCC_AHB1ENR: u32 = RCC_BASE + 0x30;
+const RCC_APB2ENR: u32 = RCC_BASE + 0x44;
+const PLLCFGR_RESET: u32 = 0x2400_3010; // RM0090 §6.3.2 factory default
+const GPIOCEN: u32 = 1 << 2; // AHB1ENR
+const SPI1EN: u32 = 1 << 12; // APB2ENR
+
+// ── GPIOC (0x4002_0800) — swept instead of GPIOA (avoids SWD pins PA13/PA14) ──
+const GPIOC_BASE: u32 = 0x4002_0800;
+const GPIOC_MODER: u32 = GPIOC_BASE + 0x00;
+const GPIOC_OTYPER: u32 = GPIOC_BASE + 0x04;
+const GPIOC_OSPEEDR: u32 = GPIOC_BASE + 0x08;
+const GPIOC_PUPDR: u32 = GPIOC_BASE + 0x0C;
+const GPIOC_AFRL: u32 = GPIOC_BASE + 0x20;
+const GPIOC_AFRH: u32 = GPIOC_BASE + 0x24;
+
+// ── SPI1 (0x4001_3000 — APB2, classic SPI) ───────────────────────────────────
+const SPI1_BASE: u32 = 0x4001_3000;
+const SPI1_CR1: u32 = SPI1_BASE + 0x00;
+const SPI1_CR2: u32 = SPI1_BASE + 0x04;
+const SPI1_CRCPR: u32 = SPI1_BASE + 0x10;
+const SPI1_I2SCFGR: u32 = SPI1_BASE + 0x1C;
+const SPI1_I2SPR: u32 = SPI1_BASE + 0x20;
+
 struct ResetCase {
     label: &'static str,
     read_addr: u32,
@@ -71,12 +104,20 @@ struct ResetCase {
     expect: u32,
 }
 
-const RESET_CASES: &[ResetCase] = &[ResetCase {
-    label: "DBGMCU IDCODE = 0x10016413 (DEV_ID 0x413)",
-    read_addr: DBGMCU_IDCODE,
-    mask: 0x0FFF_FFFF, // REV_ID upper bits vary by die; pin DEV_ID + low rev
-    expect: F407_IDCODE & 0x0FFF_FFFF,
-}];
+const RESET_CASES: &[ResetCase] = &[
+    ResetCase {
+        label: "DBGMCU IDCODE = 0x10016413 (DEV_ID 0x413)",
+        read_addr: DBGMCU_IDCODE,
+        mask: 0x0FFF_FFFF, // REV_ID upper bits vary by die; pin DEV_ID + low rev
+        expect: F407_IDCODE & 0x0FFF_FFFF,
+    },
+    ResetCase {
+        label: "RCC.PLLCFGR reset = 0x24003010 (F4 map @0x04)",
+        read_addr: RCC_PLLCFGR,
+        mask: 0xFFFF_FFFF,
+        expect: PLLCFGR_RESET,
+    },
+];
 
 struct SweepCase {
     label: &'static str,
@@ -171,6 +212,112 @@ const SWEEP_CASES: &[SweepCase] = &[
         prep: &[(RCC_APB1ENR, I2C1EN)],
         addr: I2C1_CR1,
         write: 0x0000_2CFB,
+    },
+    // ── RCC F4 config registers (PLLCFGR, CIR) — first F4 validation. ─────────
+    SweepCase {
+        label: "RCC.PLLCFGR",
+        prep: &[],
+        addr: RCC_PLLCFGR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "RCC.CIR",
+        prep: &[],
+        addr: RCC_CIR,
+        write: 0xFFFF_FFFF,
+    },
+    // ── GPIOC (stm32f4_gpio) — first F4 GPIO validation. ─────────────────────
+    SweepCase {
+        label: "GPIOC.MODER",
+        prep: &[(RCC_AHB1ENR, GPIOCEN)],
+        addr: GPIOC_MODER,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "GPIOC.OTYPER",
+        prep: &[(RCC_AHB1ENR, GPIOCEN)],
+        addr: GPIOC_OTYPER,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "GPIOC.OSPEEDR",
+        prep: &[(RCC_AHB1ENR, GPIOCEN)],
+        addr: GPIOC_OSPEEDR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "GPIOC.PUPDR",
+        prep: &[(RCC_AHB1ENR, GPIOCEN)],
+        addr: GPIOC_PUPDR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "GPIOC.AFRL",
+        prep: &[(RCC_AHB1ENR, GPIOCEN)],
+        addr: GPIOC_AFRL,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "GPIOC.AFRH",
+        prep: &[(RCC_AHB1ENR, GPIOCEN)],
+        addr: GPIOC_AFRH,
+        write: 0xFFFF_FFFF,
+    },
+    // ── SPI1 (classic SPI) — cross-validates the shared masks on F4. ──────────
+    SweepCase {
+        label: "SPI1.CR2",
+        prep: &[(RCC_APB2ENR, SPI1EN)],
+        addr: SPI1_CR2,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "SPI1.CRCPR",
+        prep: &[(RCC_APB2ENR, SPI1EN)],
+        addr: SPI1_CRCPR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "SPI1.I2SCFGR",
+        prep: &[(RCC_APB2ENR, SPI1EN)],
+        addr: SPI1_I2SCFGR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "SPI1.I2SPR",
+        prep: &[(RCC_APB2ENR, SPI1EN)],
+        addr: SPI1_I2SPR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "SPI1.CR1 (last: SPE)",
+        prep: &[(RCC_APB2ENR, SPI1EN)],
+        addr: SPI1_CR1,
+        write: 0xFFFF_FFFF,
+    },
+    // ── EXTI mask registers — F4 base 0x40013C00, 23 lines (0x7FFFFF). ────────
+    SweepCase {
+        label: "EXTI.IMR (23 lines)",
+        prep: &[],
+        addr: EXTI_IMR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "EXTI.EMR",
+        prep: &[],
+        addr: EXTI_EMR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "EXTI.RTSR",
+        prep: &[],
+        addr: EXTI_RTSR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "EXTI.FTSR",
+        prep: &[],
+        addr: EXTI_FTSR,
+        write: 0xFFFF_FFFF,
     },
 ];
 


### PR DESCRIPTION
Brings the STM32F407 from a minimal stub (rcc/gpio/systick/uart/i2c) to a properly onboarded chip, validated on the bench F407: **match=30 diverge=0** across RCC / GPIO / USART / SPI / I2C / EXTI.

**Model fixes (silicon-confirmed):**
- F4Rcc register map corrected: PLLCFGR@0x04 (reset 0x24003010, mask 0x7F437FFF), CFGR moved to 0x08 (was wrongly at 0x04 — real F4 firmware writes 0x08 for the PLL SYSCLK switch), CIR@0x0C (0x3F00, F4 adds PLLI2SRDYIE), AHB2ENR@0x34.
- SPI classic CR2: per-part cr2_mask (F1 0xE7, F4 adds FRF bit4 → 0xF7) — same delta pattern as UART cr3_mask.
- stm32f4_gpio first silicon validation (MODER/OTYPER/OSPEEDR/PUPDR/AFRL/AFRH all match, no fixes).

**Config:** stm32f407.yaml expanded with TIM1-5, USART1/3/6, SPI1-3, I2C2-3, ADC1, GPIOE, EXTI (F4 base, 23 lines). New oracle cases for RCC/GPIO/SPI/EXTI.

No regressions: 1037 lib + firmware_survival(26) + e2e_stm32f407_i2c(4) + strict_onboarding + all mmio sim-only + ratchet.