### PR TITLE
feat(f407): per-part RCC ENR masks — completes the F407 onboarding (diverge=0)

### DIFF
--- a/configs/chips/stm32f407.yaml
+++ b/configs/chips/stm32f407.yaml
@@ -30,6 +30,12 @@ peripherals:
     size: "1KB"
     config:
       profile: "stm32f4"
+      # ENR writable masks = the F407's implemented-peripheral set, silicon-
+      # confirmed on the bench F407 (stm32f4_mmio_diff). Per-part: the smaller
+      # F401 sharing F4Rcc keeps the default (unmasked) until benched.
+      rcc_ahb1enr_mask: 0x7E7411FF
+      rcc_apb1enr_mask: 0x36FEC9FF
+      rcc_apb2enr_mask: 0x00075F33
   - id: "gpioa"
     type: "stm32f4_gpio"
     base_address: 0x40020000

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1008,7 +1008,24 @@ impl SystemBus {
                 }
                 "rcc" => {
                     let layout: RccRegisterLayout = Self::parse_profile_or_default(p_cfg, "RCC")?;
-                    Box::new(crate::peripherals::rcc::Rcc::new_with_layout(layout))
+                    let mut rcc = crate::peripherals::rcc::Rcc::new_with_layout(layout);
+                    // F4 ENR writable masks are per-part (implemented-peripheral
+                    // set). YAML: `config: { rcc_ahb1enr_mask, rcc_apb1enr_mask,
+                    // rcc_apb2enr_mask }`; default unmasked (0xFFFF_FFFF).
+                    let m = |k: &str| -> u32 {
+                        p_cfg
+                            .config
+                            .get(k)
+                            .and_then(|v| v.as_u64())
+                            .map(|n| n as u32)
+                            .unwrap_or(0xFFFF_FFFF)
+                    };
+                    rcc.set_f4_enr_masks(
+                        m("rcc_ahb1enr_mask"),
+                        m("rcc_apb1enr_mask"),
+                        m("rcc_apb2enr_mask"),
+                    );
+                    Box::new(rcc)
                 }
                 "dbgmcu" => {
                     // Pull IDCODE from YAML config (`idcode: "0x10076415"` or

--- a/crates/core/src/peripherals/rcc.rs
+++ b/crates/core/src/peripherals/rcc.rs
@@ -154,13 +154,17 @@ impl RccModel for F1Rcc {
 }
 
 // ── STM32F4 ─────────────────────────────────────────────────────────────────
-// NOTE: preserves the existing model exactly, including CFGR mapped at 0x04
-// (real F4 silicon has PLLCFGR@0x04 / CFGR@0x08 — a known approximation that
-// the F4 boards' tests currently rely on; to be revisited per-board on HW).
+// F4 RCC register map silicon-confirmed on the bench F407 (RM0090 §6.3):
+// PLLCFGR@0x04, CFGR@0x08, CIR@0x0C, AHB1ENR@0x30, AHB2ENR@0x34, APB1/2ENR@0x40/44.
+// The clock-enable (ENR) writable masks are PER-PART (which peripherals the
+// device physically has) — F4Rcc is shared with the smaller F401 — so they are
+// per-instance fields set from the chip config (default 0xFFFF_FFFF = unmasked,
+// so an un-pinned part keeps the permissive behaviour). F407's masks are filled
+// from `configs/chips/stm32f407.yaml`; F401's stay default until benched.
 #[derive(Debug, Default, serde::Serialize)]
 pub struct F4Rcc {
     cr: u32,
-    pllcfgr: u32,  // 0x04 (real F4 map — was wrongly conflated with CFGR)
+    pllcfgr: u32,  // 0x04
     cfgr: u32,     // 0x08
     cir: u32,      // 0x0C
     ahbenr: u32,   // AHB1ENR 0x30
@@ -170,6 +174,10 @@ pub struct F4Rcc {
     ahbrstr: u32,  // AHB1RSTR 0x10
     apb1rstr: u32, // 0x20
     apb2rstr: u32, // 0x24
+    // Per-part ENR writable masks (silicon-pinned); 0xFFFF_FFFF = unmasked.
+    ahb1_mask: u32,
+    apb1_mask: u32,
+    apb2_mask: u32,
 }
 
 impl F4Rcc {
@@ -179,6 +187,9 @@ impl F4Rcc {
             // PLLCFGR reset = 0x24003010 (RM0090 §6.3.2) — the factory default
             // PLL config word; firmware reads it back before reconfiguring.
             pllcfgr: 0x2400_3010,
+            ahb1_mask: 0xFFFF_FFFF,
+            apb1_mask: 0xFFFF_FFFF,
+            apb2_mask: 0xFFFF_FFFF,
             ..Default::default()
         }
     }
@@ -216,10 +227,12 @@ impl RccModel for F4Rcc {
             0x10 => self.ahbrstr = value,
             0x20 => self.apb1rstr = value,
             0x24 => self.apb2rstr = value,
-            0x30 => self.ahbenr = value,
+            // ENR writable bits = the part's implemented peripherals (per-part
+            // mask, silicon-pinned). AHB2ENR unmasked for now (OTG/RNG/etc.).
+            0x30 => self.ahbenr = value & self.ahb1_mask,
             0x34 => self.ahb2enr = value,
-            0x40 => self.apb1enr = value,
-            0x44 => self.apb2enr = value,
+            0x40 => self.apb1enr = value & self.apb1_mask,
+            0x44 => self.apb2enr = value & self.apb2_mask,
             _ => {}
         }
     }
@@ -520,6 +533,17 @@ impl Rcc {
             RccRegisterLayout::Stm32V2 => Self::Stm32V2(V2Rcc::new()),
             RccRegisterLayout::Stm32L4 => Self::Stm32L4(L4Rcc::new()),
             RccRegisterLayout::Stm32L0 => Self::Stm32L0(L0Rcc::new()),
+        }
+    }
+
+    /// Set the F4 clock-enable (ENR) writable masks — the per-part delta (which
+    /// peripherals the device has). No-op for non-F4 layouts. `0xFFFF_FFFF`
+    /// leaves a register unmasked.
+    pub fn set_f4_enr_masks(&mut self, ahb1: u32, apb1: u32, apb2: u32) {
+        if let Self::Stm32F4(r) = self {
+            r.ahb1_mask = ahb1;
+            r.apb1_mask = apb1;
+            r.apb2_mask = apb2;
         }
     }
 

--- a/crates/hw-oracle/tests/stm32f4_mmio_diff.rs
+++ b/crates/hw-oracle/tests/stm32f4_mmio_diff.rs
@@ -138,11 +138,11 @@ struct SweepCase {
 /// and silicon-confirmed here. (The pattern the user asked for: one shared map,
 /// the differing bit separated per part.)
 ///
-/// Still EXCLUDED, deferred to per-part gating (docs/plans/2026-06-09-register-
-/// coverage-part-specific-tier.md): RCC AHB1ENR/APB1ENR/APB2ENR — silicon
-/// `0x7E7411FF` / `0x36FEC9FF` / `0x00075F33`. The implemented-peripheral set is
-/// part-specific and `F4Rcc` is shared with the smaller STM32F401, so they need
-/// the same per-part mask field (no F401 bench yet to pin F401's set).
+/// RCC AHB1ENR/APB1ENR/APB2ENR (silicon `0x7E7411FF` / `0x36FEC9FF` /
+/// `0x00075F33`) are the F407 implemented-peripheral set — part-specific, since
+/// `F4Rcc` is shared with the smaller STM32F401. Pinned here via the per-part
+/// `rcc_*enr_mask` config fields (F4Rcc per-instance masks); F401 keeps the
+/// unmasked default until it is benched.
 const SWEEP_CASES: &[SweepCase] = &[
     // USART2 — shared F1 USART layout.
     SweepCase {
@@ -317,6 +317,25 @@ const SWEEP_CASES: &[SweepCase] = &[
         label: "EXTI.FTSR",
         prep: &[],
         addr: EXTI_FTSR,
+        write: 0xFFFF_FFFF,
+    },
+    // ── RCC ENR — per-part masks (F407 implemented-peripheral set, via config). ─
+    SweepCase {
+        label: "RCC.AHB1ENR",
+        prep: &[],
+        addr: RCC_AHB1ENR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "RCC.APB1ENR",
+        prep: &[],
+        addr: RCC_APB1ENR,
+        write: 0xFFFF_FFFF,
+    },
+    SweepCase {
+        label: "RCC.APB2ENR",
+        prep: &[],
+        addr: RCC_APB2ENR,
         write: 0xFFFF_FFFF,
     },
 ];


### PR DESCRIPTION
The deferred piece: F4 RCC AHB1/APB1/APB2ENR writable masks are the device's implemented-peripheral set — part-specific (F4Rcc shared with the smaller F401). Added per-instance ENR mask fields (default unmasked, so F401 untouched), set from chip config via Rcc::set_f4_enr_masks. F407 pins its silicon set in the yaml.

Same per-part-delta pattern as UART cr3_mask / SPI cr2_mask. Bench F407 now **match=33 diverge=0** across RCC (incl. PLLCFGR/CIR/ENR) / GPIO / USART / SPI / I2C / EXTI. No regressions: rcc units + firmware_survival(26) + e2e_stm32f407_i2c(4) + sim-only.