### PR TITLE
feat(sim): boot real IDF apps on the RISC-V/ESP32 sim (memory windows + SP)

### DIFF
--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -13,6 +13,19 @@ flash:
 ram:
   base: 0x3FC80000
   size: "400KB"
+# Additional CPU-visible memory windows real IDF apps link into. On silicon the
+# C3's 400KB SRAM is reachable via both the data bus (the `ram` window above,
+# 0x3FC80000) and the instruction bus (IRAM, 0x4037C000); flash is cached at
+# both the IROM window (`flash`, 0x42000000, code) and the DROM window
+# (0x3C000000, rodata). Without these, an IDF app's entry (IRAM) and rodata
+# (DROM) segments fall outside the memory map and never load.
+memory_regions:
+  - name: "iram"
+    base: 0x4037C000
+    size: "384KB"
+  - name: "drom"
+    base: 0x3C000000
+    size: "8MB"
 peripherals:
   - id: "uart0"
     type: "uart"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -867,15 +867,35 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
         return ExitCode::from(EXIT_RUNTIME_ERROR);
     }
 
+    // Fast-boot skips the ROM/2nd-stage bootloader that normally sets the stack
+    // pointer before jumping to the app, so SP=0 and the app's first prologue
+    // store faults near 0xffffffff. Seed SP at the top of DRAM (16-byte aligned,
+    // RISC-V ABI) so real IDF apps can boot.
+    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    machine.cpu.set_sp(sp_top & !0xF);
+
+    let break_at: Vec<u32> = args
+        .break_at
+        .iter()
+        .filter_map(|s| u32::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+        .collect();
+    let mut break_hit = vec![false; break_at.len()];
     let limit = args.max_steps.unwrap_or(u64::MAX);
     for i in 0..limit {
+        let pc = machine.cpu.get_pc();
+        if let Some(bi) = break_at.iter().position(|&b| b == pc) {
+            if !break_hit[bi] {
+                break_hit[bi] = true;
+                eprintln!("[break] step {i} pc={pc:#010x}");
+            }
+        }
         if let Err(e) = machine.step() {
-            tracing::debug!(
-                "labwired-riscv: step {} pc={:#010x} halt: {}",
-                i,
-                machine.cpu.get_pc(),
-                e
-            );
+            // Surface the halt (was a silent debug log): the fault PC + reason is
+            // the key signal when bringing real firmware up on the sim.
+            tracing::debug!("labwired-riscv: step {i} pc={pc:#010x} halt: {e}");
+            if !break_at.is_empty() {
+                eprintln!("[halt] step {i} pc={pc:#010x} err={e}");
+            }
             break;
         }
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -61,6 +61,18 @@ pub struct MemoryRange {
     pub size: String, // e.g. "128KB"
 }
 
+/// An additional named RAM/ROM-backed memory window beyond the primary
+/// `flash`/`ram`. Needed by SoCs that expose several CPU-visible memory windows
+/// (e.g. the ESP32-C3's separate IRAM `0x4037C000` and flash-DROM `0x3C000000`
+/// views), which real firmware links code/rodata into.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NamedMemoryRange {
+    pub name: String,
+    #[serde(deserialize_with = "deserialize_u64_lax")]
+    pub base: u64,
+    pub size: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PeripheralConfig {
     pub id: String,
@@ -90,6 +102,10 @@ pub struct ChipDescriptor {
     pub core: Option<String>,
     pub flash: MemoryRange,
     pub ram: MemoryRange,
+    /// Extra CPU-visible memory windows beyond `flash`/`ram` (e.g. ESP32 IRAM
+    /// and flash-DROM). Empty for chips with a simple two-region map.
+    #[serde(default)]
+    pub memory_regions: Vec<NamedMemoryRange>,
     pub peripherals: Vec<PeripheralConfig>,
 }
 
@@ -475,6 +491,7 @@ impl From<labwired_ir::IrDevice> for ChipDescriptor {
             core,
             flash,
             ram,
+            memory_regions: Vec::new(),
             peripherals: ir
                 .peripherals
                 .into_values()

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -131,6 +131,10 @@ pub struct PeripheralEntry {
 pub struct SystemBus {
     pub flash: LinearMemory,
     pub ram: LinearMemory,
+    /// Extra CPU-visible RAM/ROM windows beyond `flash`/`ram` (e.g. ESP32 IRAM
+    /// `0x4037C000` and flash-DROM `0x3C000000`), from the chip's
+    /// `memory_regions`. Checked after `ram`/`flash`, before peripherals.
+    pub extra_mem: Vec<LinearMemory>,
     pub peripherals: Vec<PeripheralEntry>,
     pub nvic: Option<Arc<NvicState>>,
     pub observers: Vec<Arc<dyn crate::SimulationObserver>>,
@@ -665,6 +669,7 @@ impl SystemBus {
             flash_thunks: std::collections::HashMap::new(),
             flash: LinearMemory::new(1024 * 1024, 0x0),
             ram: LinearMemory::new(1024 * 1024, 0x2000_0000),
+            extra_mem: Vec::new(),
             peripherals: vec![
                 PeripheralEntry {
                     name: "uart1".to_string(),
@@ -731,6 +736,7 @@ impl SystemBus {
             flash_thunks: std::collections::HashMap::new(),
             flash: LinearMemory::new(0, 0),
             ram: LinearMemory::new(0, 0),
+            extra_mem: Vec::new(),
             peripherals: Vec::new(),
             nvic: None,
             observers: Vec::new(),
@@ -932,10 +938,17 @@ impl SystemBus {
         let flash_size = parse_size(&chip.flash.size)?;
         let ram_size = parse_size(&chip.ram.size)?;
 
+        let mut extra_mem = Vec::with_capacity(chip.memory_regions.len());
+        for region in &chip.memory_regions {
+            let size = parse_size(&region.size)?;
+            extra_mem.push(LinearMemory::new(size as usize, region.base));
+        }
+
         let mut bus = Self {
             flash_thunks: std::collections::HashMap::new(),
             flash: LinearMemory::new(flash_size as usize, chip.flash.base),
             ram: LinearMemory::new(ram_size as usize, chip.ram.base),
+            extra_mem,
             peripherals: Vec::new(),
             nvic: None,
             observers: Vec::new(),
@@ -1695,6 +1708,11 @@ impl SystemBus {
             if let Some(val) = self.flash.read_u32(addr) {
                 return Ok(val);
             }
+            for mem in &self.extra_mem {
+                if let Some(val) = mem.read_u32(addr) {
+                    return Ok(val);
+                }
+            }
             // Boot alias handle
             if self.flash.base_addr != 0 {
                 let alias_end = self.flash.data.len() as u64;
@@ -1721,6 +1739,13 @@ impl SystemBus {
     pub fn write_u32(&mut self, addr: u64, value: u32) -> SimResult<()> {
         if self.config.optimized_bus_access && self.ram.write_u32(addr, value) {
             return Ok(());
+        }
+        if self.config.optimized_bus_access {
+            for mem in &mut self.extra_mem {
+                if mem.write_u32(addr, value) {
+                    return Ok(());
+                }
+            }
         }
         // Flash is read-only via bus writes usually, but let's stick to the behavior of write_u8
         // which would likely fail or do nothing if it's flash.
@@ -1753,6 +1778,11 @@ impl SystemBus {
             }
             if let Some(val) = self.flash.read_u16(addr) {
                 return Ok(val);
+            }
+            for mem in &self.extra_mem {
+                if let Some(val) = mem.read_u16(addr) {
+                    return Ok(val);
+                }
             }
             // Boot alias handle
             if self.flash.base_addr != 0 {
@@ -2213,6 +2243,11 @@ impl crate::Bus for SystemBus {
         if let Some(val) = self.flash.read_u8(addr) {
             return Ok(val);
         }
+        for mem in &self.extra_mem {
+            if let Some(val) = mem.read_u8(addr) {
+                return Ok(val);
+            }
+        }
         // Cortex-M boot alias: address 0x0000_0000 mirrors flash start on many STM32 parts.
         // This lets reset-vector fetch work when flash is configured at 0x0800_0000.
         if self.flash.base_addr != 0 {
@@ -2249,6 +2284,7 @@ impl crate::Bus for SystemBus {
             .read_u8(addr)
             .or_else(|| self.flash.read_u8(addr))
             .or(flash_alias_old)
+            .or_else(|| self.extra_mem.iter().find_map(|m| m.read_u8(addr)))
             .or_else(|| {
                 self.find_peripheral_index(addr).and_then(|idx| {
                     let p = &self.peripherals[idx];
@@ -2264,6 +2300,7 @@ impl crate::Bus for SystemBus {
         let res = if self.ram.write_u8(addr, value)
             || self.flash.write_u8(addr, value)
             || flash_alias_write
+            || self.extra_mem.iter_mut().any(|m| m.write_u8(addr, value))
         {
             Ok(())
         } else {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -770,6 +770,15 @@ impl<C: Cpu> Machine<C> {
             if self.bus.ram.load_from_segment(segment) {
                 continue;
             }
+            // 2b. Try extra CPU-visible memory windows (ESP32 IRAM/DROM, etc).
+            if self
+                .bus
+                .extra_mem
+                .iter_mut()
+                .any(|m| m.load_from_segment(segment))
+            {
+                continue;
+            }
             // 3. Fall back to peripheral-backed memory (ESP32 IRAM /
             //    flash XIP, RP2040 SRAM, etc — anything registered as a
             //    Peripheral rather than living in bus.flash/bus.ram).

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -404,6 +404,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![
                 PeripheralConfig {
                     id: "uart1".to_string(),
@@ -506,6 +507,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![
                 PeripheralConfig {
                     id: "systick".to_string(),
@@ -573,6 +575,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "uart1".to_string(),
                 r#type: "uart".to_string(),
@@ -625,6 +628,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "gpioa".to_string(),
                 r#type: "gpio".to_string(),
@@ -683,6 +687,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "uart3".to_string(),
                 r#type: "uart".to_string(),
@@ -738,6 +743,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "rcc".to_string(),
                 r#type: "rcc".to_string(),
@@ -793,6 +799,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "rcc".to_string(),
                 r#type: "rcc".to_string(),
@@ -848,6 +855,7 @@ pub mod integration_tests {
                 base: 0x2000_0000,
                 size: "20KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "gpioa".to_string(),
                 r#type: "gpio".to_string(),
@@ -2016,6 +2024,7 @@ pub mod integration_tests {
                 base: 0x3FC8_0000,
                 size: "400KB".to_string(),
             },
+            memory_regions: Vec::new(),
             peripherals: vec![PeripheralConfig {
                 id: "timg0".to_string(),
                 r#type: "esp32_timg".to_string(),


### PR DESCRIPTION
Toward the ESP32-C3 **digital twin**: get an unmodified ESP-IDF app to actually *execute* on the simulator — the prerequisite for running the real, un-thunked WiFi/BT stack rather than the current high-level thunks.

Booting `wifi_probe` (a real `esp_wifi_init`/`esp_wifi_start` IDF app) hit two faithful gaps, both fixed:

### 1. Memory map — IRAM + DROM windows
The C3 chip mapped only DRAM + flash-IROM. But a real IDF app's entry/hot code lives in **IRAM (`0x4037C000`)** and rodata in **flash-DROM (`0x3C000000`)** — alias windows of the same SRAM/flash on silicon. Those segments fell outside the map and never loaded (`Failed to load segment ... outside of memory map`).

- Added a generic `memory_regions` list to the chip schema (`NamedMemoryRange`).
- Added `extra_mem: Vec<LinearMemory>` to `SystemBus`, routed in `read/write_u8/u16/u32` + the ELF loader.
- Wired the C3's IRAM + DROM windows.

### 2. Stack pointer on RISC-V fast-boot
Fast-boot skips the ROM/2nd-stage bootloader that sets SP, so `SP=0` and the app's first prologue store faulted near `0xffffffff`. Now seed SP at the top of DRAM (RISC-V 16-byte aligned). Also gave `run_firmware_riscv` the `--break-at` support the Xtensa/main paths already have, and surface the halt PC/reason when debugging a boot.

### Result
`wifi_probe` now executes **~196k instructions of IDF C startup** in sim (up from **1**). The next blocker is the **unmodeled C3 ROM** (no `rom_thunks` like the S3) — a ROM call lands at `0x40060000`. That's the next rung (dump the real C3 ROM from silicon and load it).

### No regression
`firmware_survival` (26 chips) ✓ · `esp32c3_reset_conformance` (90 regs) ✓ · `labwired-config` ✓ · `cargo fmt`/`clippy` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)