### PR TITLE
feat(esp32c3): load real mask ROM from silicon dump (env-var image)

### DIFF
--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -26,6 +26,21 @@ memory_regions:
   - name: "drom"
     base: 0x3C000000
     size: "8MB"
+  # Mask ROM (the C3 calls ROM routines during early boot). The dump is the
+  # chip's copyrighted mask ROM, so it's loaded from a path in
+  # LABWIRED_ESP32C3_ROM rather than committed; region stays zero if unset.
+  # Dump it from live silicon: openocd dump_image rom.bin 0x40000000 0x60000.
+  - name: "rom"
+    base: 0x40000000
+    size: "384KB"
+    image_env: "LABWIRED_ESP32C3_ROM"
+  # ROM constant data (jump tables, function-pointer tables the ROM code reads).
+  # Without it, ROM jump tables read zeros and the ROM jumps to garbage.
+  # Dump: openocd dump_image rom_data.bin 0x3FF00000 0x20000.
+  - name: "rom_data"
+    base: 0x3FF00000
+    size: "128KB"
+    image_env: "LABWIRED_ESP32C3_ROM_DATA"
 peripherals:
   - id: "uart0"
     type: "uart"
@@ -248,9 +263,5 @@ peripherals:
     size: "12KB"
     config:
       path: "../peripherals/esp32c3/wifi_mac.yaml"
-  - id: "rom"
-    type: "declarative"
-    base_address: 0x40000000
-    size: "384KB"
-    config:
-      path: "../peripherals/esp32c3/rom.yaml"
+  # (ROM is now a real memory_region above, loaded from LABWIRED_ESP32C3_ROM,
+  # so the C3's actual mask-ROM routines execute during boot.)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -881,8 +881,18 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
         .collect();
     let mut break_hit = vec![false; break_at.len()];
     let limit = args.max_steps.unwrap_or(u64::MAX);
+    // Recent-PC trail for boot debugging — only maintained when --break-at is in
+    // use, so the normal hot loop pays nothing.
+    let debug = !break_at.is_empty();
+    let mut recent = std::collections::VecDeque::with_capacity(17);
     for i in 0..limit {
         let pc = machine.cpu.get_pc();
+        if debug {
+            if recent.len() == 16 {
+                recent.pop_front();
+            }
+            recent.push_back(pc);
+        }
         if let Some(bi) = break_at.iter().position(|&b| b == pc) {
             if !break_hit[bi] {
                 break_hit[bi] = true;
@@ -895,6 +905,8 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
             tracing::debug!("labwired-riscv: step {i} pc={pc:#010x} halt: {e}");
             if !break_at.is_empty() {
                 eprintln!("[halt] step {i} pc={pc:#010x} err={e}");
+                let trail: Vec<String> = recent.iter().map(|p| format!("{p:#010x}")).collect();
+                eprintln!("[trail] {}", trail.join(" -> "));
             }
             break;
         }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -71,6 +71,11 @@ pub struct NamedMemoryRange {
     #[serde(deserialize_with = "deserialize_u64_lax")]
     pub base: u64,
     pub size: String,
+    /// Optional env var naming a path to a raw binary loaded into this region at
+    /// `base` (e.g. a chip's mask ROM dump). Used for copyrighted vendor blobs
+    /// that can't be committed — the region stays zero-filled if unset/missing.
+    #[serde(default)]
+    pub image_env: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -941,7 +941,30 @@ impl SystemBus {
         let mut extra_mem = Vec::with_capacity(chip.memory_regions.len());
         for region in &chip.memory_regions {
             let size = parse_size(&region.size)?;
-            extra_mem.push(LinearMemory::new(size as usize, region.base));
+            let mut mem = LinearMemory::new(size as usize, region.base);
+            // Optionally preload a raw binary image (e.g. a dumped mask ROM)
+            // from a path given by an env var. Copyrighted vendor blobs are not
+            // committed, so a missing image just leaves the region zero-filled.
+            if let Some(env) = &region.image_env {
+                if let Ok(path) = std::env::var(env) {
+                    match std::fs::read(&path) {
+                        Ok(bytes) => {
+                            let n = bytes.len().min(mem.data.len());
+                            mem.data[..n].copy_from_slice(&bytes[..n]);
+                            tracing::info!(
+                                "loaded {n} bytes into '{}' region @ {:#010x} from {path}",
+                                region.name,
+                                region.base
+                            );
+                        }
+                        Err(e) => tracing::warn!(
+                            "region '{}' image {path} (${env}) unreadable: {e}",
+                            region.name
+                        ),
+                    }
+                }
+            }
+            extra_mem.push(mem);
         }
 
         let mut bus = Self {


### PR DESCRIPTION
Builds on #240 (IDF apps booting). The next boot blocker: the C3 calls **mask-ROM routines** during early startup, but the ROM was a zero stub (no `rom_thunks` like the S3), so a ROM call jumped to garbage at `0x40060000`. This loads the **real ROM, dumped from live silicon**, so those routines execute.

## Mechanism (follows the S3 env-var convention)
The mask ROM is Espressif-copyrighted and must not be committed, so:
- `NamedMemoryRange` gains optional **`image_env`** — an env var naming a raw binary that's loaded into the region at `base`. Unset → region stays **zero-filled**, so existing CI/tests are unaffected.
- The C3 config maps ROM code (`0x40000000`, 384KB, `$LABWIRED_ESP32C3_ROM`) and ROM data (`0x3FF00000`, 128KB, `$LABWIRED_ESP32C3_ROM_DATA`) as image-backed regions; the declarative `rom` stub is dropped.

Dump from silicon:
```
openocd ... -c "dump_image rom.bin 0x40000000 0x60000"        # code
openocd ... -c "dump_image rom_data.bin 0x3FF00000 0x20000"   # data (jump tables)
```

## Result
With code **and** data loaded, real ROM executes. The next blocker is precisely located: a ROM callback dispatcher (`jalr a5` @ `0x40039256`) is handed a garbage function pointer by its caller — needs deeper register/state tracing (next rung).

Also adds an optional recent-PC **trail on halt** (gated behind `--break-at`, zero hot-loop cost otherwise) — the diagnostic that located this.

## No regression (ROM env unset)
`esp32c3_reset_conformance` (90) ✓ · `esp32c3_demo` survival ✓ · `labwired-config` ✓ · `fmt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)