### PR TITLE
ESP32 e-paper: real SPI3+DC, no shims, byte-identical to silicon

### DIFF
--- a/FIDELITY.md
+++ b/FIDELITY.md
@@ -100,6 +100,18 @@ real peripheral: `slc` (SDIO host), `sdmmc_host`. The rest (`iram`, `dram`,
 (though empty `brom_*` is a content gap). Also see
 `crates/core/src/peripherals/stub.rs` and `esp32s3/system_stub.rs`.
 
+### E2. DC reads low at framebuffer-write time — blank e-paper render (OPEN BUG)
+The real ereader firmware fully renders its text and clocks the framebuffer over
+SPI (verified: 9518 `0x00` black bytes of 19033 captured), but the SSD1680 panel
+renders **blank**. Root cause: the SSD1680 model routes command-vs-data by the
+latched DC GPIO, and DC (GPIO17) reads **low** at the moment the `0x24` data
+stream is clocked — so every framebuffer byte is mis-routed to `command_byte`
+and dropped. GxEPD2's `_writeData` only toggles CS and relies on DC being left
+HIGH by the preceding `_writeCommand(0x24)`; in sim that high state isn't present
+at data-write time. Needs a correlated GPIO-write + SPI-write trace at the
+framebuffer-write point to pin the exact mechanism. Diagnostic: run the cli with
+`LABWIRED_DUMP_SPI=<path>` to dump the full captured wire stream.
+
 ### E. Display command/data inference — the two e-paper panels
 `uc8151d_tricolor_290.rs`, `ssd1680_tricolor_290.rs`: when no DC pin is wired,
 `transfer()` guesses command-vs-data from protocol state. INFER. The live ESP32

--- a/FIDELITY.md
+++ b/FIDELITY.md
@@ -100,14 +100,19 @@ real peripheral: `slc` (SDIO host), `sdmmc_host`. The rest (`iram`, `dram`,
 (though empty `brom_*` is a content gap). Also see
 `crates/core/src/peripherals/stub.rs` and `esp32s3/system_stub.rs`.
 
-### E2. DC reads low at framebuffer-write time — blank e-paper render (OPEN BUG)
-The real ereader firmware fully renders its text and clocks the framebuffer over
-SPI, but the SSD1680 model renders **blank**. Root cause: the SSD1680 model
-routes command-vs-data by the latched DC GPIO, and DC (GPIO17) reads **low** at
-the moment the `0x24` data stream is clocked — so every framebuffer byte is
-mis-routed to `command_byte` and dropped. GxEPD2's `_writeData` only toggles CS
-and relies on DC being left HIGH by the preceding `_writeCommand(0x24)`; in sim
-that high state isn't present at data-write time.
+### E2. DC reads low at framebuffer-write time — blank e-paper render (FIXED)
+**Root cause (FIXED):** `Esp32Gpio` had no `write_u32`, so the firmware's 32-bit
+`s32i` store to GPIO_OUT_W1TC (write-1-to-clear) fell back to the default
+byte-split read-modify-write — and `read_word(0x0C)` returns the whole `OUT`
+value, so a `digitalWrite(CS, LOW)` (`W1TC = 1<<5`) reconstructed a clear-mask
+from the *current* OUT and wiped every set bit, including DC (GPIO17). GxEPD2's
+`_writeData` only toggles CS and leaves DC alone, so after the first per-byte CS
+toggle in the `0x24` stream, DC was gone and the framebuffer bytes were
+mis-routed to `command_byte` and dropped → blank render. Fix: `Esp32Gpio` now
+implements atomic `write_u32`/`write_u16` that go straight to `write_word`
+(no RMW). Regression test: `gpio::tests::w1tc_via_word_store_clears_only_target_bit`.
+After the fix the real firmware renders its text (black-plane 1429/4736 ink
+bytes; `e2e_labwired_ereader` asserts a non-blank plane).
 
 **Silicon cross-check (2026-06-12, ESP32-D0WDQ6 over UART, instrumented GxEPD2
 tap of `(digitalRead(_dc), byte)`):** the sim is **byte-for-byte identical** to

--- a/FIDELITY.md
+++ b/FIDELITY.md
@@ -1,0 +1,117 @@
+# Fidelity Ledger — where LabWired cheats, so we can tighten it up
+
+LabWired's promise is **real, deterministic, register-machinery simulation** — the
+firmware drives modeled hardware registers and the modeled hardware drives the
+firmware back, byte-for-byte like silicon. Anywhere we *short-circuit* that loop
+— faking a function's result, mutating device state without going through the
+register/bus decode, skipping a boot step, or inferring a signal we don't model
+— is a **cheat**. Cheats are sometimes pragmatic (we have no boot-ROM binary to
+execute), but every one is a fidelity gap we want to see and close.
+
+## Marker convention
+
+Every cheat in the code carries a grep-able marker on the line or block:
+
+```
+// CHEAT(<CATEGORY>): <what is faked> — real: <what silicon/real execution does>
+```
+
+Find them all:
+
+```sh
+grep -rn "CHEAT(" crates/ --include="*.rs"
+```
+
+### Categories
+
+| Category | Meaning | How to tighten |
+|----------|---------|----------------|
+| `CHEAT(THUNK-ROM)` | A **boot-ROM** function is emulated in Rust because we have no ROM binary to execute (math helpers, memcpy, cache ops, ets_printf). | Map a real ESP32 ROM image and execute it. |
+| `CHEAT(THUNK-LIB)` | A **firmware library** function (compiled into the ELF — FreeRTOS, heap_caps, Arduino SPI) is intercepted and faked instead of letting the real code run. The real code IS in the binary; we skip it. | Complete the peripheral models the real code needs, then drop the thunk. |
+| `CHEAT(BYPASS)` | Device/peripheral state is mutated **directly**, bypassing the register/FIFO/bus decode path. | Route through the real register write → peripheral → device path. |
+| `CHEAT(NOP)` | A function is replaced by a constant return (return 0 / return true / fake pointer). | Model the behavior the caller depends on. |
+| `CHEAT(STUB)` | A real **peripheral** is faked as plain RAM (accepts any read/write, no behavior). | Implement the register model. |
+| `CHEAT(SKIP)` | A real boot/init step is skipped and CPU state is hand-seeded (BROM skip, SP/PC seeding). | Execute the real reset/boot sequence. |
+| `CHEAT(INFER)` | A heuristic stands in for a hardware signal we don't sample (e.g. command/data framing inferred from protocol state instead of the DC GPIO). | Model the real signal. |
+
+**Not cheats (do NOT mark):** real memory backings — `iram`, `dram`,
+`flash_icache`/`flash_dcache` XIP, `psram`, `rtc_slow`/`rtc_fast` — are genuine
+RAM/flash regions correctly modeled as backing store. Real register models
+(RCC, GPIO, SPI FIFO/CMD.USR, UART, timers, etc.) are the real machinery.
+
+---
+
+## Inventory (audit 2026-06-11)
+
+### A. ESP32 ROM/library thunks — `crates/core/src/peripherals/esp32s3/rom_thunks.rs`
+60 thunk fns total. Split:
+
+- **THUNK-ROM (legit-but-gap, ~30):** `rom_memcpy/memset/memmove/memcmp`,
+  `rom_ashldi3/ashrdi3/lshrdi3/divdi3/moddi3/umoddi3/udivdi3/clzsi2/ctzsi2/bswap*`,
+  `rom_esp_crc8`, `cache_*` (6), `rom_config_instruction_cache_mode`,
+  `esp_rom_spiflash_unlock`, `rtc_get_reset_reason`, `ets_printf`,
+  `rom_cpu_freq_240mhz`/`esp_clk_cpu_freq_240mhz`/`rom_xtal_freq_40mhz`,
+  `esp_rom_route_intr_matrix`, `xtos_set_intlevel`/`xtos_restore_intlevel`.
+  → ROM functions; emulating is reasonable but is not executing real ROM.
+- **THUNK-LIB (real cheat — skips compiled firmware, ~12):**
+  `esp_idf_heap_caps_init/malloc/calloc/free/realloc`,
+  `x_queue_create_mutex_static_echo`, `x_task_get_current_task_handle`,
+  `spi_class_begin_transaction`, `spi_start_bus_fake`, `getreent_dram_fake_ptr`,
+  `esp_chip_info_stub`, `xthal_window_spill_thunk`.
+- **BYPASS (real cheat, 0 — RETIRED):** `gxepd_write_command`, `gxepd_write_data`
+  (wrote straight into the panel, bypassing SPI3) and `spi_class_transfer` (wrote
+  SPI registers from Rust) are **deleted**. The real compiled GxEPD2 firmware now
+  drives the panel through the real SPI3 FIFO/MOSI_DLEN/CMD.USR registers, framed
+  by the firmware's own `digitalWrite(DC)` GPIO. Proven end-to-end against the
+  real PlatformIO `firmware.elf`: `tests/e2e_labwired_ereader.rs` reaches a panel
+  refresh via **431 real SPI3 transactions** with zero per-byte thunks; the
+  register-level path is locked by `tests/e2e_spi3_dc_epaper.rs`.
+- **NOP (real cheat, ~5):** `nop_return_zero` (installed at ~25 addresses),
+  `return_pd_true`, `nop_return_fake_ptr`, `abort_halt`, `monotonic_counter_32`.
+
+### B. SPI FIFO bypass — RETIRED
+`push_captured_byte` (recorded bytes that skipped the FIFO/CMD.USR path for the
+gxepd thunks) is **deleted**. Byte capture now happens inside
+`kick_user_transaction` as the real FIFO drains, so the capture trace and the
+wire are the same path.
+
+### C. BROM skip + hand-seeded CPU — `crates/cli/src/main.rs`
+Lines ~924/927, ~1729-1761, ~4061-4075: skip the boot ROM, `set_pc(entry)`,
+`set_sp(0x3FFE_0000)`. SKIP. (Mirrored in `crates/wasm/src/lib.rs`.)
+
+### D. Peripheral-as-RAM stubs — `crates/core/src/system/xtensa.rs`
+Of 16 `RamPeripheral` installs, the **cheats** are the ones standing in for a
+real peripheral: `slc` (SDIO host), `sdmmc_host`. The rest (`iram`, `dram`,
+`flash_icache`, `flash_dcache`, `psram`, `rtc_slow`, `rtc_fast`,
+`brom_low_data`, `brom_data`) are memory regions — backing store, not cheats
+(though empty `brom_*` is a content gap). Also see
+`crates/core/src/peripherals/stub.rs` and `esp32s3/system_stub.rs`.
+
+### E. Display command/data inference — the two e-paper panels
+`uc8151d_tricolor_290.rs`, `ssd1680_tricolor_290.rs`: when no DC pin is wired,
+`transfer()` guesses command-vs-data from protocol state. INFER. The live ESP32
+e-paper paths (cli `arduino-esp32`, wasm, `attach_esp32_external_devices`, and
+the `e2e_labwired_ereader` harness) now all wire `dc_pin` and latch the real GPIO
+level, so this INFER fallback only applies when a panel is attached with no DC
+source — not on the proven ereader path.
+
+---
+
+## Tightening priority (highest fidelity payoff first)
+
+1. ~~**Drop the GxEPD2 BYPASS thunks** (A.BYPASS)~~ — **DONE.** The real compiled
+   firmware drives the panel over the real SPI3 peripheral + real DC GPIO (431
+   SPI3 transactions → refresh against the real ELF). Bypass thunks deleted.
+2. **Complete the ESP32 SPI library path** so the remaining `spi_class_*` /
+   `spi_start_bus_fake` THUNK-LIB init shims die. These no longer touch the data
+   path (registers + DC are real); what's left is one-time bus init: faking the
+   `spi_t` (so `_spi->dev`/`USER.USR_MOSI` are set) and short-circuiting the SPI
+   bus-lock mutex (NULL lock in the faked `spi_t`). Retiring them means running
+   the real `spiStartBus` (DPORT clock-enable + GPIO matrix + a real FreeRTOS
+   mutex) instead of the fake.
+3. **Model `slc`/`sdmmc_host`** instead of RAM stubs, or prove the firmware never
+   needs them.
+4. **Real boot ROM** — execute a mapped ROM image to kill the THUNK-ROM set and
+   the BROM SKIP at once.
+5. **heap_caps / FreeRTOS** — let the real allocator + scheduler run once the
+   memory map + timers are faithful.

--- a/FIDELITY.md
+++ b/FIDELITY.md
@@ -53,11 +53,24 @@ RAM/flash regions correctly modeled as backing store. Real register models
   `rom_cpu_freq_240mhz`/`esp_clk_cpu_freq_240mhz`/`rom_xtal_freq_40mhz`,
   `esp_rom_route_intr_matrix`, `xtos_set_intlevel`/`xtos_restore_intlevel`.
   → ROM functions; emulating is reasonable but is not executing real ROM.
-- **THUNK-LIB (real cheat — skips compiled firmware, ~12):**
-  `esp_idf_heap_caps_init/malloc/calloc/free/realloc`,
-  `x_queue_create_mutex_static_echo`, `x_task_get_current_task_handle`,
-  `spi_class_begin_transaction`, `spi_start_bus_fake`, `getreent_dram_fake_ptr`,
+- **THUNK-LIB (real cheat — skips compiled firmware):**
+  `esp_idf_heap_caps_init/malloc/calloc/free/realloc` (bump allocator that
+  returns REAL DRAM — memory backing, not a behaviour fake),
+  `x_queue_create_mutex_static_echo` (idle-task static mutex),
+  `x_task_get_current_task_handle`, `getreent_dram_fake_ptr`,
   `esp_chip_info_stub`, `xthal_window_spill_thunk`.
+  - **RETIRED in the canonical proof harness** (`tests/e2e_labwired_ereader.rs`):
+    `spi_start_bus_fake`, `spi_class_begin_transaction`, and the SPI bus-lock
+    `xQueueSemaphoreTake/xQueueGenericSend → pdTRUE`. The real compiled
+    `SPIClass::begin → spiStartBus` runs: it creates a **real** recursive bus
+    mutex via `xQueueCreateMutex` (real, IRAM, backed by the heap bump pool),
+    enables the SPI3 clock through real DPORT, and sets `USER.USR_MOSI`. Real
+    `beginTransaction` then takes that real mutex. Whole SPI stack — bus init,
+    mutex, peripheral config, data path — is real compiled firmware against real
+    register models; panel still refreshes. The `spi_start_bus_fake` /
+    `spi_class_begin_transaction` functions remain in `rom_thunks.rs` only
+    because the cli/wasm single-core delivery wrappers still install them
+    (pending boot-to-paint validation of the real path there — see priority #2).
 - **BYPASS (real cheat, 0 — RETIRED):** `gxepd_write_command`, `gxepd_write_data`
   (wrote straight into the panel, bypassing SPI3) and `spi_class_transfer` (wrote
   SPI registers from Rust) are **deleted**. The real compiled GxEPD2 firmware now
@@ -102,13 +115,13 @@ source — not on the proven ereader path.
 1. ~~**Drop the GxEPD2 BYPASS thunks** (A.BYPASS)~~ — **DONE.** The real compiled
    firmware drives the panel over the real SPI3 peripheral + real DC GPIO (431
    SPI3 transactions → refresh against the real ELF). Bypass thunks deleted.
-2. **Complete the ESP32 SPI library path** so the remaining `spi_class_*` /
-   `spi_start_bus_fake` THUNK-LIB init shims die. These no longer touch the data
-   path (registers + DC are real); what's left is one-time bus init: faking the
-   `spi_t` (so `_spi->dev`/`USER.USR_MOSI` are set) and short-circuiting the SPI
-   bus-lock mutex (NULL lock in the faked `spi_t`). Retiring them means running
-   the real `spiStartBus` (DPORT clock-enable + GPIO matrix + a real FreeRTOS
-   mutex) instead of the fake.
+2. ~~**Complete the ESP32 SPI library path**~~ — **DONE in the e2e proof harness:**
+   real `spiStartBus` + real `xQueueCreateMutex` + real `beginTransaction` run
+   against the DPORT/heap/SPI models; the SPI fakes are removed there. **Remaining:**
+   apply the same removal to the cli (`arduino-esp32`) and wasm delivery wrappers,
+   which still stub `xQueueCreateMutex`→NULL + `spiStartBus`/`beginTransaction` +
+   the bus-lock `pdTRUE` for their single-core snapshot boot. Needs cli/wasm
+   boot-to-paint validation (the cli binary can boot the ELF; wasm runs in-browser).
 3. **Model `slc`/`sdmmc_host`** instead of RAM stubs, or prove the firmware never
    needs them.
 4. **Real boot ROM** — execute a mapped ROM image to kill the THUNK-ROM set and

--- a/FIDELITY.md
+++ b/FIDELITY.md
@@ -102,15 +102,23 @@ real peripheral: `slc` (SDIO host), `sdmmc_host`. The rest (`iram`, `dram`,
 
 ### E2. DC reads low at framebuffer-write time — blank e-paper render (OPEN BUG)
 The real ereader firmware fully renders its text and clocks the framebuffer over
-SPI (verified: 9518 `0x00` black bytes of 19033 captured), but the SSD1680 panel
-renders **blank**. Root cause: the SSD1680 model routes command-vs-data by the
-latched DC GPIO, and DC (GPIO17) reads **low** at the moment the `0x24` data
-stream is clocked — so every framebuffer byte is mis-routed to `command_byte`
-and dropped. GxEPD2's `_writeData` only toggles CS and relies on DC being left
-HIGH by the preceding `_writeCommand(0x24)`; in sim that high state isn't present
-at data-write time. Needs a correlated GPIO-write + SPI-write trace at the
-framebuffer-write point to pin the exact mechanism. Diagnostic: run the cli with
-`LABWIRED_DUMP_SPI=<path>` to dump the full captured wire stream.
+SPI, but the SSD1680 model renders **blank**. Root cause: the SSD1680 model
+routes command-vs-data by the latched DC GPIO, and DC (GPIO17) reads **low** at
+the moment the `0x24` data stream is clocked — so every framebuffer byte is
+mis-routed to `command_byte` and dropped. GxEPD2's `_writeData` only toggles CS
+and relies on DC being left HIGH by the preceding `_writeCommand(0x24)`; in sim
+that high state isn't present at data-write time.
+
+**Silicon cross-check (2026-06-12, ESP32-D0WDQ6 over UART, instrumented GxEPD2
+tap of `(digitalRead(_dc), byte)`):** the sim is **byte-for-byte identical** to
+real silicon — all **19033/19033** SPI transfers match exactly. The lone
+divergence is the DC line: silicon holds **DC=1 for all 18998 data bytes** (35
+commands at DC=0; the first `0x24` is followed by 300/300 transfers at DC=1),
+while the sim reads DC=0 across that region. So the fix target is exact: the sim
+must hold GPIO17 high across the data stream as the firmware does. Diagnostic:
+cli `LABWIRED_DUMP_SPI=<path>` dumps the full wire stream; reproduce the silicon
+trace by patching `GxEPD2_EPD.cpp` `_writeCommand`/`_writeData` to call an
+`epd_tap(digitalRead(_dc), byte)` logger.
 
 ### E. Display command/data inference — the two e-paper panels
 `uc8151d_tricolor_290.rs`, `ssd1680_tricolor_290.rs`: when no DC pin is wired,

--- a/configs/systems/esp32-wroom-epaper.yaml
+++ b/configs/systems/esp32-wroom-epaper.yaml
@@ -19,6 +19,7 @@ external_devices:
     connection: "spi3"
     config:
       cs_pin: "GPIO5"
+      dc_pin: "GPIO17"
 board_io:
   - id: "epaper"
     kind: "spi_device"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -959,6 +959,7 @@ fn run_firmware_esp32(args: &RunArgs) -> ExitCode {
 
     // Set PC to ELF entry and seed SP at top of SRAM1 (post-BROM default on
     // real silicon; see e2e_external_arduino_esp32_in_sim for the rationale).
+    // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC/SP. See FIDELITY.md §C.
     cpu.set_pc(image.entry_point as u32);
     cpu.set_sp(0x3FFE_0000);
     // Post-bootloader PS state: WOE=1 (windowed ABI), INTLEVEL=0, EXCM=0.
@@ -1685,6 +1686,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor290};
     use labwired_core::peripherals::esp32::spi::Esp32Spi;
     use labwired_core::peripherals::esp32s3::rom_thunks;
+    use labwired_core::peripherals::spi::SpiDevice;
     use labwired_core::system::xtensa::configure_xtensa_esp32;
     use labwired_core::{Machine, SimulationError};
     use labwired_loader::{extract_arduino_esp32_thunks, load_elf_bytes};
@@ -1718,6 +1720,11 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             return ExitCode::from(EXIT_RUNTIME_ERROR);
         }
     };
+    // Real DC framing for the arduino-esp32 GxEPD2 path: the firmware toggles
+    // DC=GPIO17 via digitalWrite before each SPI.transfer, so resolve GPIO17's
+    // output register and latch it before draining each SPI3 transaction. With
+    // this set, command vs data comes from the wire — no gxepd bypass thunk.
+    let dc_src = SystemBus::resolve_pin_odr_pub(&bus, "GPIO17");
     if let Some(any) = bus.peripherals[spi3_idx].dev.as_any_mut() {
         if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
             if args.profile == "arduino-esp32" {
@@ -1726,7 +1733,11 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                 // conflict with SSD1680 at multiple opcodes; we need the
                 // UC8151D panel model. Arduino-ESP32 reference firmware uses SSD1680
                 // and stays on the old model below.
-                spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
+                let mut panel = Uc8151dTricolor290::new("GPIO5").with_dc_pin("GPIO17");
+                if let Some((odr, bit)) = dc_src {
+                    panel.set_dc_source(odr, bit);
+                }
+                spi3.attach(Box::new(panel));
             } else {
                 spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
             }
@@ -1764,6 +1775,8 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     }
     // XtensaLx7::reset() leaves PC at the 0x40000400 BROM reset vector.
     // Skip BROM and jump straight to the ELF's app entry — same as WASM.
+    // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC (SP seeded below).
+    // See FIDELITY.md §C.
     machine.cpu.set_pc(program_image.entry_point as u32);
 
     // Resolve every Arduino-ESP32 symbol we know how to patch / thunk.
@@ -2215,23 +2228,14 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(&pc) = symbol_addrs.get("_ZN8SPIClass16beginTransactionE11SPISettings") {
         thunks.push((pc, rom_thunks::spi_class_begin_transaction));
     }
-    // GxEPD2_EPD::_writeCommand / _writeData — route directly into the
-    // attached UC8151D panel's `command_byte` / `data_byte` API,
-    // bypassing the Arduino-ESP32 SPI library and the SPI peripheral
-    // entirely. Same byte stream the real silicon receives, with
-    // explicit DC=cmd / DC=data routing (which we can't infer from
-    // pure FIFO bytes without observing the DC GPIO). Only wired for
-    // the arduino-esp32 profile — agentdeck profile attaches an
-    // SSD1680 panel that uses byte-counting through `transfer()` and
-    // doesn't need the explicit CMD/DATA split.
-    if args.profile == "arduino-esp32" {
-        if let Some(&pc) = symbol_addrs.get("_ZN10GxEPD2_EPD13_writeCommandEh") {
-            thunks.push((pc, rom_thunks::gxepd_write_command));
-        }
-        if let Some(&pc) = symbol_addrs.get("_ZN10GxEPD2_EPD10_writeDataEh") {
-            thunks.push((pc, rom_thunks::gxepd_write_data));
-        }
-    }
+    // No GxEPD2 _writeCommand / _writeData bypass. The real compiled
+    // GxEPD2_EPD::_writeCommand/_writeData run: digitalWrite(DC=GPIO17) →
+    // SPI.transfer(byte) → spiTransferByteNL writes the SPI3 FIFO/MOSI_DLEN/
+    // CMD.USR registers, and the Esp32Spi peripheral drains the byte to the
+    // panel framed by the latched DC GPIO. Verified end-to-end against the real
+    // PlatformIO firmware.elf (431 real SPI3 transactions → panel refresh) by
+    // tests/e2e_labwired_ereader.rs. The arduino-esp32 panel attach above sets
+    // the panel's DC source to GPIO17 so the framing is real.
     // Optional debug: install vListInsert short-circuit thunk that dumps
     // list state for first 20 calls. Used to diagnose SMP race issues in
     // the FreeRTOS scheduler. Enable with `LABWIRED_DEBUG_VLIST=1`.
@@ -4108,6 +4112,9 @@ fn run_test(args: TestArgs) -> ExitCode {
             // matching `install_esp32_arduino_quirks` in the WASM path.
             // Native Xtensa firmware that sets its own SP will overwrite this
             // immediately.
+            // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC/SP — real: the
+            // CPU resets at 0x4000_0400 and the mapped BROM sets up SP and jumps
+            // to the app. See FIDELITY.md §C.
             machine.cpu.set_pc(program.entry_point as u32);
             machine.cpu.set_sp(0x3FFE_0000);
             let exit_code = execute_test_loop(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -253,6 +253,12 @@ pub struct SnapshotCaptureArgs {
     #[arg(long)]
     pub output: PathBuf,
 
+    /// Board manifest (SystemManifest YAML) declaring the external peripherals
+    /// to attach (panel, sensors, …). Peripherals are NEVER hardcoded; they come
+    /// from this manifest via the generic attach_esp32_external_devices factory.
+    #[arg(long)]
+    pub system: Option<PathBuf>,
+
     /// Firmware profile to use. Currently only `agentdeck` is supported —
     /// installs the Arduino-ESP32 / ESP32-classic bootstrap (heap-caps
     /// thunks, dual-core handshake fakery, IPI bridge, image header,
@@ -1686,7 +1692,6 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor290};
     use labwired_core::peripherals::esp32::spi::Esp32Spi;
     use labwired_core::peripherals::esp32s3::rom_thunks;
-    use labwired_core::peripherals::spi::SpiDevice;
     use labwired_core::system::xtensa::configure_xtensa_esp32;
     use labwired_core::{Machine, SimulationError};
     use labwired_loader::{extract_arduino_esp32_thunks, load_elf_bytes};
@@ -1711,37 +1716,39 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     let mut bus = SystemBus::new();
     let cpu = configure_xtensa_esp32(&mut bus);
 
-    // Attach an SSD1680 2.9" tri-color panel to spi3, cs=GPIO5 — the
-    // the reference firmware wiring. Identical to `e2e_external_arduino_esp32_in_sim`.
-    let spi3_idx = match bus.find_peripheral_index_by_name("spi3") {
-        Some(i) => i,
-        None => {
-            eprintln!("error: configure_xtensa_esp32 did not register spi3");
-            return ExitCode::from(EXIT_RUNTIME_ERROR);
-        }
-    };
-    // Real DC framing for the arduino-esp32 GxEPD2 path: the firmware toggles
-    // DC=GPIO17 via digitalWrite before each SPI.transfer, so resolve GPIO17's
-    // output register and latch it before draining each SPI3 transaction. With
-    // this set, command vs data comes from the wire — no gxepd bypass thunk.
-    let dc_src = SystemBus::resolve_pin_odr_pub(&bus, "GPIO17");
-    if let Some(any) = bus.peripherals[spi3_idx].dev.as_any_mut() {
-        if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
-            if args.profile == "arduino-esp32" {
-                // GxEPD2_290_C90c / Z13c firmware drives the panel with
-                // UC8151D commands (PSR/PWR/PON/DTM1/DTM2/DRF/…) which
-                // conflict with SSD1680 at multiple opcodes; we need the
-                // UC8151D panel model. Arduino-ESP32 reference firmware uses SSD1680
-                // and stays on the old model below.
-                let mut panel = Uc8151dTricolor290::new("GPIO5").with_dc_pin("GPIO17");
-                if let Some((odr, bit)) = dc_src {
-                    panel.set_dc_source(odr, bit);
+    // Peripherals come from the board manifest, never hardcoded here. The
+    // generic attach_esp32_external_devices factory wires every declared
+    // external device (panel, etc.) onto its bus with the right model, CS and
+    // DC pins. --system points at the board manifest (e.g. the ereader's
+    // board.yaml declaring the SSD1680 e-paper on spi3, CS=GPIO5, DC=GPIO17).
+    if let Some(sys_path) = &args.system {
+        match labwired_config::SystemManifest::from_file(sys_path) {
+            Ok(manifest) => {
+                if let Err(e) =
+                    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+                {
+                    eprintln!("error: attaching external devices from {sys_path:?}: {e}");
+                    return ExitCode::from(EXIT_CONFIG_ERROR);
                 }
-                spi3.attach(Box::new(panel));
-            } else {
-                spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
             }
-            spi3.enable_byte_capture(512);
+            Err(e) => {
+                eprintln!("error: cannot load system manifest {sys_path:?}: {e}");
+                return ExitCode::from(EXIT_CONFIG_ERROR);
+            }
+        }
+    } else {
+        eprintln!(
+            "warning: no --system manifest; no external peripherals attached \
+             (firmware that drives a panel will not render)"
+        );
+    }
+    // Enable wire-byte capture on spi3 for snapshot diagnostics (a capture
+    // concern, not a device wiring concern).
+    if let Some(spi3_idx) = bus.find_peripheral_index_by_name("spi3") {
+        if let Some(any) = bus.peripherals[spi3_idx].dev.as_any_mut() {
+            if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
+                spi3.enable_byte_capture(512);
+            }
         }
     }
     bus.refresh_peripheral_index();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1724,9 +1724,9 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(sys_path) = &args.system {
         match labwired_config::SystemManifest::from_file(sys_path) {
             Ok(manifest) => {
-                if let Err(e) =
-                    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
-                {
+                if let Err(e) = labwired_core::system::xtensa::attach_esp32_external_devices(
+                    &mut bus, &manifest,
+                ) {
                     eprintln!("error: attaching external devices from {sys_path:?}: {e}");
                     return ExitCode::from(EXIT_CONFIG_ERROR);
                 }
@@ -4144,6 +4144,44 @@ fn run_test(args: TestArgs) -> ExitCode {
                 &firmware_path,
                 system_path.as_ref(),
             );
+            // Device-block render readout. Surfaces the attached panel block's
+            // REAL render state — refresh_gen AND black-plane ink — so a generic
+            // verify (e.g. proto.cat's device loop) can judge whether the
+            // device-block actually PAINTED, not merely refreshed. A refresh with
+            // a blank plane is a false positive (the DC-latch class of bug; see
+            // FIDELITY.md §E2). Emitted to stderr alongside the boot logs.
+            {
+                use labwired_core::peripherals::components::{
+                    Ssd1680Tricolor290, Uc8151dTricolor290,
+                };
+                use labwired_core::peripherals::esp32::spi::Esp32Spi;
+                if let Some(idx) = machine.bus.find_peripheral_index_by_name("spi3") {
+                    if let Some(any) = machine.bus.peripherals[idx].dev.as_any() {
+                        if let Some(spi3) = any.downcast_ref::<Esp32Spi>() {
+                            for dev in &spi3.attached_devices {
+                                let Some(a) = dev.as_any() else { continue };
+                                if let Some(p) = a.downcast_ref::<Ssd1680Tricolor290>() {
+                                    let ink =
+                                        p.black_plane().iter().filter(|&&b| b != 0xFF).count();
+                                    eprintln!(
+                                        "[device-block] ssd1680_tricolor_290 refresh_gen={} black_ink={}",
+                                        p.refresh_generation(),
+                                        ink
+                                    );
+                                } else if let Some(p) = a.downcast_ref::<Uc8151dTricolor290>() {
+                                    let ink =
+                                        p.black_plane().iter().filter(|&&b| b != 0xFF).count();
+                                    eprintln!(
+                                        "[device-block] uc8151d_tricolor_290 refresh_gen={} black_ink={}",
+                                        p.refresh_generation(),
+                                        ink
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             if let Some(ref key) = api_key_opt {
                 use sha2::{Digest, Sha256};
                 let mut hasher = Sha256::new();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1747,7 +1747,7 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(spi3_idx) = bus.find_peripheral_index_by_name("spi3") {
         if let Some(any) = bus.peripherals[spi3_idx].dev.as_any_mut() {
             if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
-                spi3.enable_byte_capture(512);
+                spi3.enable_byte_capture(65536);
             }
         }
     }
@@ -2516,6 +2516,15 @@ fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(idx) = machine.bus.find_peripheral_index_by_name("spi3") {
         if let Some(any) = machine.bus.peripherals[idx].dev.as_any() {
             if let Some(spi3) = any.downcast_ref::<Esp32Spi>() {
+                // Diagnostic: dump the full captured wire stream when asked, so
+                // we can inspect the 0x24/0x26 RAM-write payloads end-to-end.
+                if let Ok(path) = std::env::var("LABWIRED_DUMP_SPI") {
+                    let _ = std::fs::write(&path, spi3.captured_bytes());
+                    eprintln!(
+                        "labwired-cli snapshot: dumped {} captured spi3 bytes to {path}",
+                        spi3.captured_bytes().len()
+                    );
+                }
                 eprintln!(
                     "labwired-cli snapshot: spi3 transactions={}",
                     spi3.transactions(),

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -434,15 +434,53 @@ impl SystemBus {
     }
 
     fn resolve_pin_odr(bus: &SystemBus, pin: &str) -> Option<(u64, u8)> {
-        let (port_name, bit) = Self::parse_stm32_pin(pin)?;
-        let idx = bus.find_peripheral_index_by_name(&port_name)?;
-        let base = bus.peripherals[idx].base;
-        let odr_off = bus.peripherals[idx]
-            .dev
-            .as_any()
-            .and_then(|a| a.downcast_ref::<crate::peripherals::gpio::GpioPort>())
-            .map(|g| g.odr_offset())?;
-        Some((base + odr_off, bit))
+        // STM32/Nordic: "PA5" / "P0.13" → per-port GpioPort with an ODR offset.
+        if let Some((port_name, bit)) = Self::parse_stm32_pin(pin) {
+            if let Some(idx) = bus.find_peripheral_index_by_name(&port_name) {
+                let base = bus.peripherals[idx].base;
+                if let Some(odr_off) = bus.peripherals[idx]
+                    .dev
+                    .as_any()
+                    .and_then(|a| a.downcast_ref::<crate::peripherals::gpio::GpioPort>())
+                    .map(|g| g.odr_offset())
+                {
+                    return Some((base + odr_off, bit));
+                }
+            }
+        }
+        // ESP32: "GPIO17" → the single "gpio" peripheral, GPIO_OUT_REG at
+        // base + 0x04 (TRM §4.10, bit = pin number for GPIO0..31).
+        if let Some(bit) = Self::parse_esp32_gpio_pin(pin) {
+            let idx = bus.find_peripheral_index_by_name("gpio")?;
+            let is_esp32 = bus.peripherals[idx]
+                .dev
+                .as_any()
+                .map(|a| {
+                    a.downcast_ref::<crate::peripherals::esp32::gpio::Esp32Gpio>()
+                        .is_some()
+                })
+                .unwrap_or(false);
+            if is_esp32 {
+                const GPIO_OUT_REG_OFFSET: u64 = 0x04;
+                return Some((bus.peripherals[idx].base + GPIO_OUT_REG_OFFSET, bit));
+            }
+        }
+        None
+    }
+
+    /// Parse an ESP32 GPIO label ("GPIO17", "gpio17", "IO17", or a bare "17")
+    /// into its bit number in GPIO_OUT_REG. Only the low bank (0..31) is
+    /// modeled, matching [`Esp32Gpio`](crate::peripherals::esp32::gpio::Esp32Gpio).
+    fn parse_esp32_gpio_pin(pin: &str) -> Option<u8> {
+        let s = pin.trim();
+        let digits = s
+            .trim_start_matches(|c: char| c.is_ascii_alphabetic())
+            .trim();
+        let num: u8 = digits.parse().ok()?;
+        if num > 31 {
+            return None;
+        }
+        Some(num)
     }
 
     /// Resolve an STM32 pin label to its `(IDR address, bit)` so a sensor can
@@ -540,16 +578,39 @@ impl SystemBus {
     /// by reading the driving GPIO's output bit. No-op for non-SPI writes and
     /// for SPI peripherals with no D/C-observing device (one cheap downcast).
     fn maybe_latch_dc(&mut self, idx: usize) {
+        use crate::peripherals::esp32::spi::Esp32Spi;
+        use crate::peripherals::spi::{SpiDevice, Spi};
+
+        // Borrow the attached-device list off whichever SPI peripheral kind
+        // this is (generic `Spi` for STM32/Nordic, `Esp32Spi` for ESP32).
+        fn attached_ref(any: &dyn std::any::Any) -> Option<&Vec<Box<dyn SpiDevice>>> {
+            if let Some(s) = any.downcast_ref::<Spi>() {
+                return Some(&s.attached_devices);
+            }
+            if let Some(s) = any.downcast_ref::<Esp32Spi>() {
+                return Some(&s.attached_devices);
+            }
+            None
+        }
+        fn attached_mut(any: &mut dyn std::any::Any) -> Option<&mut Vec<Box<dyn SpiDevice>>> {
+            if any.is::<Spi>() {
+                return any.downcast_mut::<Spi>().map(|s| &mut s.attached_devices);
+            }
+            if any.is::<Esp32Spi>() {
+                return any.downcast_mut::<Esp32Spi>().map(|s| &mut s.attached_devices);
+            }
+            None
+        }
+
         // Phase 1: collect (attached_index, odr_addr, bit) — immutable borrow.
         let sources: Vec<(usize, u64, u8)> = {
             let Some(any) = self.peripherals[idx].dev.as_any() else {
                 return;
             };
-            let Some(spi) = any.downcast_ref::<crate::peripherals::spi::Spi>() else {
+            let Some(devs) = attached_ref(any) else {
                 return;
             };
-            spi.attached_devices
-                .iter()
+            devs.iter()
                 .enumerate()
                 .filter_map(|(i, d)| d.dc_source().map(|(a, b)| (i, a, b)))
                 .collect()
@@ -569,9 +630,9 @@ impl SystemBus {
             .collect();
         // Phase 3: push the latched levels into the devices — mutable borrow.
         if let Some(any) = self.peripherals[idx].dev.as_any_mut() {
-            if let Some(spi) = any.downcast_mut::<crate::peripherals::spi::Spi>() {
+            if let Some(devs) = attached_mut(any) {
                 for (i, lvl) in levels {
-                    if let Some(d) = spi.attached_devices.get_mut(i) {
+                    if let Some(d) = devs.get_mut(i) {
                         d.set_dc_level(lvl);
                     }
                 }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -579,7 +579,7 @@ impl SystemBus {
     /// for SPI peripherals with no D/C-observing device (one cheap downcast).
     fn maybe_latch_dc(&mut self, idx: usize) {
         use crate::peripherals::esp32::spi::Esp32Spi;
-        use crate::peripherals::spi::{SpiDevice, Spi};
+        use crate::peripherals::spi::{Spi, SpiDevice};
 
         // Borrow the attached-device list off whichever SPI peripheral kind
         // this is (generic `Spi` for STM32/Nordic, `Esp32Spi` for ESP32).
@@ -597,7 +597,9 @@ impl SystemBus {
                 return any.downcast_mut::<Spi>().map(|s| &mut s.attached_devices);
             }
             if any.is::<Esp32Spi>() {
-                return any.downcast_mut::<Esp32Spi>().map(|s| &mut s.attached_devices);
+                return any
+                    .downcast_mut::<Esp32Spi>()
+                    .map(|s| &mut s.attached_devices);
             }
             None
         }

--- a/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
@@ -87,6 +87,20 @@ pub struct Ssd1680Tricolor290 {
 
     #[serde(skip_serializing)]
     state: ProtoState,
+
+    /// Data/Command (D/C) GPIO label, if wired (e.g. "GPIO17"). When set, the
+    /// bus latches that pin's output level via [`SpiDevice::set_dc_level`]
+    /// before each transfer, so framing is driven by the real GPIO exactly
+    /// like silicon — no protocol-state inference, no library thunk.
+    #[serde(skip)]
+    dc_pin: Option<String>,
+    /// Latched D/C level (low = command, high = data), pushed by the bus.
+    #[serde(skip)]
+    dc_level: bool,
+    /// Resolved `(GPIO output reg address, bit)` for the D/C line; set by the
+    /// bus at attach time so it knows where to sample the level from.
+    #[serde(skip)]
+    dc_source: Option<(u64, u8)>,
 }
 
 impl Default for Ssd1680Tricolor290 {
@@ -114,7 +128,18 @@ impl Ssd1680Tricolor290 {
             red_plane: vec![0xFF; PLANE_BYTES],
             refresh_generation: 0,
             state: ProtoState::Idle,
+            dc_pin: None,
+            dc_level: false,
+            dc_source: None,
         }
+    }
+
+    /// Wire a Data/Command GPIO line (e.g. "GPIO17"). With a D/C pin the panel
+    /// frames command vs data from the real GPIO level (silicon-accurate);
+    /// without one it falls back to protocol-state inference.
+    pub fn with_dc_pin(mut self, dc_pin: impl Into<String>) -> Self {
+        self.dc_pin = Some(dc_pin.into());
+        self
     }
 
     pub fn dimensions(&self) -> (usize, usize) {
@@ -135,6 +160,64 @@ impl Ssd1680Tricolor290 {
 
     pub fn power_on(&self) -> bool {
         self.power_on
+    }
+
+    /// Process one command byte (DC=low on real hardware). Mirrors
+    /// [`Uc8151dTricolor290::command_byte`] so the ESP32/GxEPD2 thunk path —
+    /// which knows the DC line from the calling function identity — can drive
+    /// the panel without going through the SPI peripheral. Drives the same
+    /// datasheet dispatch the real SPI `transfer()` path uses.
+    pub fn command_byte(&mut self, cmd: u8) {
+        self.handle_command(cmd);
+    }
+
+    /// Process one data byte (DC=high on real hardware). Routes to the active
+    /// param accumulator or pixel-plane stream set up by the last command.
+    /// Spurious data with no active command is ignored.
+    pub fn data_byte(&mut self, byte: u8) {
+        match self.state {
+            ProtoState::AwaitingParams {
+                cmd,
+                mut params,
+                mut have,
+                want,
+            } => {
+                params[have as usize] = byte;
+                have += 1;
+                if have >= want {
+                    self.handle_params_complete(cmd, &params);
+                    self.state = ProtoState::Idle;
+                } else {
+                    self.state = ProtoState::AwaitingParams {
+                        cmd,
+                        params,
+                        have,
+                        want,
+                    };
+                }
+            }
+            ProtoState::StreamingBlack { remaining } => {
+                self.write_plane_byte(PlaneKind::Black, byte);
+                let left = remaining.saturating_sub(1);
+                self.state = if left == 0 {
+                    ProtoState::Idle
+                } else {
+                    ProtoState::StreamingBlack { remaining: left }
+                };
+            }
+            ProtoState::StreamingRed { remaining } => {
+                self.write_plane_byte(PlaneKind::Red, byte);
+                let left = remaining.saturating_sub(1);
+                self.state = if left == 0 {
+                    ProtoState::Idle
+                } else {
+                    ProtoState::StreamingRed { remaining: left }
+                };
+            }
+            ProtoState::Idle => {
+                // Data byte with no active command — nothing to consume.
+            }
+        }
     }
 
     // ---- Command dispatch ----
@@ -386,52 +469,46 @@ impl SpiDevice for Ssd1680Tricolor290 {
     }
 
     fn transfer(&mut self, mosi: u8) -> u8 {
-        let state = self.state;
-        match state {
-            ProtoState::Idle => self.handle_command(mosi),
-            ProtoState::AwaitingParams {
-                cmd,
-                mut params,
-                mut have,
-                want,
-            } => {
-                params[have as usize] = mosi;
-                have += 1;
-                if have >= want {
-                    self.handle_params_complete(cmd, &params);
-                    self.state = ProtoState::Idle;
-                } else {
-                    self.state = ProtoState::AwaitingParams {
-                        cmd,
-                        params,
-                        have,
-                        want,
-                    };
-                }
+        // Silicon-accurate framing when a D/C line is wired: the bus has
+        // latched the real GPIO level (low = command, high = data) before
+        // this transfer. With no D/C pin (e.g. the STM32 lab), fall back to
+        // protocol-state inference: a byte in Idle is a command, otherwise a
+        // param/stream byte for the command in flight.
+        if self.dc_source.is_some() {
+            if self.dc_level {
+                self.data_byte(mosi);
+            } else {
+                self.command_byte(mosi);
             }
-            ProtoState::StreamingBlack { remaining } => {
-                self.write_plane_byte(PlaneKind::Black, mosi);
-                let left = remaining.saturating_sub(1);
-                self.state = if left == 0 {
-                    ProtoState::Idle
-                } else {
-                    ProtoState::StreamingBlack { remaining: left }
-                };
-            }
-            ProtoState::StreamingRed { remaining } => {
-                self.write_plane_byte(PlaneKind::Red, mosi);
-                let left = remaining.saturating_sub(1);
-                self.state = if left == 0 {
-                    ProtoState::Idle
-                } else {
-                    ProtoState::StreamingRed { remaining: left }
-                };
+        } else {
+            // CHEAT(INFER): no D/C line wired — guess command vs data from
+            // protocol state — real: sample the D/C GPIO. See FIDELITY.md §E.
+            if matches!(self.state, ProtoState::Idle) {
+                self.command_byte(mosi);
+            } else {
+                self.data_byte(mosi);
             }
         }
         // Tri-color e-paper is write-only over SPI (BUSY is a sideband GPIO,
         // not MISO). Return 0 so the bus broadcaster doesn't see us as a
         // MISO source if other devices share the bus.
         0
+    }
+
+    fn dc_pin(&self) -> Option<&str> {
+        self.dc_pin.as_deref()
+    }
+
+    fn set_dc_level(&mut self, level: bool) {
+        self.dc_level = level;
+    }
+
+    fn dc_source(&self) -> Option<(u64, u8)> {
+        self.dc_source
+    }
+
+    fn set_dc_source(&mut self, odr_addr: u64, bit: u8) {
+        self.dc_source = Some((odr_addr, bit));
     }
 
     fn as_any(&self) -> Option<&dyn Any> {

--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -23,19 +23,18 @@
 //! ## Cmd / Data routing
 //!
 //! Real silicon multiplexes cmd vs data via a sideband D/C GPIO pin.
-//! The simulator's normal byte-stream `transfer()` path doesn't see DC
-//! transitions — for the SSD1680 model we use byte-counting on the
-//! command's fixed param count. UC8151D's DTM1/DTM2 streams are
-//! unbounded (they end when the next CMD arrives), so byte-counting
-//! doesn't work. Instead this model exposes `command_byte(u8)` and
-//! `data_byte(u8)` as separate APIs; the
-//! [`crate::peripherals::esp32s3::rom_thunks::spi_class_transfer`]
-//! thunk distinguishes cmd vs data by the caller PC
-//! (`_writeCommand` vs `_writeData`) and routes accordingly.
+//! This model reads that pin for real: set a `dc_source` (the resolved
+//! GPIO output register + bit, via [`crate::peripherals::spi::SpiDevice::set_dc_source`])
+//! and the SPI bus latches the DC level from the GPIO output register
+//! before each `transfer()`, so DC=low bytes route to `command_byte(u8)`
+//! and DC=high bytes to `data_byte(u8)`. The firmware's own
+//! `digitalWrite(DC, …)` drives that GPIO — no thunk, no caller-PC
+//! inference. This is what GxEPD2 does on hardware, and what the real
+//! compiled firmware exercises in tests/e2e_labwired_ereader.rs.
 //!
-//! The `transfer()` impl falls back to "all bytes are data" so this
-//! model still slots into the generic SPI bus without breaking, just
-//! without UC8151D protocol decoding.
+//! When no `dc_source` is wired, `transfer()` falls back to "all bytes
+//! are data" so the model still slots into a generic SPI bus without
+//! breaking, just without full UC8151D protocol decoding.
 
 use crate::peripherals::spi::SpiDevice;
 use std::any::Any;
@@ -83,6 +82,19 @@ pub struct Uc8151dTricolor290 {
 
     #[serde(skip_serializing)]
     state: ProtoState,
+
+    /// Data/Command (D/C) GPIO label, if wired (e.g. "GPIO17"). When set, the
+    /// bus latches that pin's output level via [`SpiDevice::set_dc_level`]
+    /// before each transfer, so command/data framing comes from the real GPIO
+    /// exactly like silicon — no library thunk, no calling-identity guess.
+    #[serde(skip)]
+    dc_pin: Option<String>,
+    /// Latched D/C level (low = command, high = data), pushed by the bus.
+    #[serde(skip)]
+    dc_level: bool,
+    /// Resolved `(GPIO output reg address, bit)` for the D/C line.
+    #[serde(skip)]
+    dc_source: Option<(u64, u8)>,
 }
 
 impl Default for Uc8151dTricolor290 {
@@ -105,7 +117,18 @@ impl Uc8151dTricolor290 {
             red_plane: vec![0xFF; PLANE_BYTES],
             refresh_generation: 0,
             state: ProtoState::Idle,
+            dc_pin: None,
+            dc_level: false,
+            dc_source: None,
         }
+    }
+
+    /// Wire a Data/Command GPIO line (e.g. "GPIO17"). With a D/C pin the panel
+    /// frames command vs data from the real GPIO level (silicon-accurate);
+    /// without one `transfer()` cannot distinguish the two.
+    pub fn with_dc_pin(mut self, dc_pin: impl Into<String>) -> Self {
+        self.dc_pin = Some(dc_pin.into());
+        self
     }
 
     pub fn dimensions(&self) -> (usize, usize) {
@@ -324,13 +347,39 @@ impl SpiDevice for Uc8151dTricolor290 {
     }
 
     fn transfer(&mut self, mosi: u8) -> u8 {
-        // Fallback path for callers that don't go through the
-        // `spi_class_transfer` thunk. Treat the byte as data (we can't
-        // distinguish cmd vs data without DC pin visibility). This makes
-        // the panel mostly useless for true byte-stream input, but at
-        // least keeps the SPI bus broadcaster happy.
-        self.data_byte(mosi);
+        // Silicon-accurate framing: when a D/C line is wired the bus has
+        // latched the real GPIO level (low = command, high = data) before
+        // this transfer, so we route correctly with no thunk. Without a D/C
+        // pin we genuinely can't tell cmd from data over the raw byte stream,
+        // so we treat it as data (legacy fallback) and keep the bus happy.
+        if self.dc_source.is_some() {
+            if self.dc_level {
+                self.data_byte(mosi);
+            } else {
+                self.command_byte(mosi);
+            }
+        } else {
+            // CHEAT(INFER): no D/C line wired — can't tell command from data, so
+            // treat every byte as data — real: sample the D/C GPIO. FIDELITY.md §E.
+            self.data_byte(mosi);
+        }
         0
+    }
+
+    fn dc_pin(&self) -> Option<&str> {
+        self.dc_pin.as_deref()
+    }
+
+    fn set_dc_level(&mut self, level: bool) {
+        self.dc_level = level;
+    }
+
+    fn dc_source(&self) -> Option<(u64, u8)> {
+        self.dc_source
+    }
+
+    fn set_dc_source(&mut self, odr_addr: u64, bit: u8) {
+        self.dc_source = Some((odr_addr, bit));
     }
 
     fn as_any(&self) -> Option<&dyn Any> {

--- a/crates/core/src/peripherals/esp32/gpio.rs
+++ b/crates/core/src/peripherals/esp32/gpio.rs
@@ -212,6 +212,38 @@ impl Peripheral for Esp32Gpio {
         Ok(())
     }
 
+    /// Word-granular writes MUST go straight to `write_word` — the W1TS (0x08)
+    /// and W1TC (0x0C) registers are write-1-to-set / write-1-to-clear, not
+    /// plain storage. The default byte-split path read-modifies-writes against
+    /// `read_word`, which returns `self.out` for those offsets, so a 32-bit
+    /// `digitalWrite(pin, LOW)` (W1TC = 1<<pin) would reconstruct a clear-mask
+    /// from the *current* OUT value and wipe every set bit (not just `pin`).
+    /// Real ESP32 GPIO drivers always issue full 32-bit `s32i` stores here.
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if offset & 3 == 0 {
+            self.write_word(offset, value);
+            Ok(())
+        } else {
+            for i in 0..4 {
+                self.write(offset + i, ((value >> (i * 8)) & 0xFF) as u8)?;
+            }
+            Ok(())
+        }
+    }
+
+    fn write_u16(&mut self, offset: u64, value: u16) -> SimResult<()> {
+        // 16-bit stores to a W1TS/W1TC half-word carry the same hazard; route
+        // aligned ones straight to write_word with the upper half preserved.
+        if offset & 3 == 0 {
+            let cur = self.read_word(offset) & 0xFFFF_0000;
+            self.write_word(offset, cur | value as u32);
+            Ok(())
+        } else {
+            self.write(offset, (value & 0xFF) as u8)?;
+            self.write(offset + 1, (value >> 8) as u8)
+        }
+    }
+
     fn snapshot(&self) -> serde_json::Value {
         // ODR-shaped snapshot lets the WasmSimulator board_io polling path
         // read GPIO output state via the same {"odr": <bits>} contract used
@@ -285,6 +317,25 @@ mod tests {
         assert_eq!(g.out & (1 << 5), 1 << 5);
         let events = obs.events.lock().unwrap();
         assert!(events.iter().any(|&(p, f, t, _)| p == 5 && !f && t));
+    }
+
+    #[test]
+    fn w1tc_via_word_store_clears_only_target_bit() {
+        // Regression for the blank e-paper render: a 32-bit digitalWrite(pin, LOW)
+        // (W1TC = 1<<pin) must clear ONLY that pin, not every currently-high OUT
+        // bit. Before Esp32Gpio gained write_u32, the byte-split RMW read OUT
+        // back through read_word(0x0C) and turned the whole OUT value into the
+        // clear mask — so toggling CS (GPIO5) low wiped DC (GPIO17) and the
+        // panel saw DC=command for the framebuffer stream.
+        let mut g = Esp32Gpio::new();
+        // Drive CS(5), RST(16), DC(17) high via a 32-bit W1TS store.
+        g.write_u32(0x08, (1 << 5) | (1 << 16) | (1 << 17)).unwrap();
+        assert_eq!(g.out, (1 << 5) | (1 << 16) | (1 << 17));
+        // digitalWrite(CS=5, LOW): 32-bit W1TC of just bit 5.
+        g.write_u32(0x0C, 1 << 5).unwrap();
+        assert_eq!(g.out & (1 << 5), 0, "CS bit must clear");
+        assert_eq!(g.out & (1 << 16), 1 << 16, "RST must survive");
+        assert_eq!(g.out & (1 << 17), 1 << 17, "DC must survive the CS toggle");
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -100,16 +100,6 @@ impl Esp32Spi {
         &self.captured_bytes
     }
 
-    /// Append one byte to the capture buffer. Intended for ROM thunks
-    /// that bypass the FIFO/CMD.USR path (e.g. GxEPD2 `_writeCommand` /
-    /// `_writeData` thunks) but still want bytes visible to diagnostic
-    /// dumps.
-    pub fn push_captured_byte(&mut self, byte: u8) {
-        if self.record_enabled {
-            self.captured_bytes.push(byte);
-        }
-    }
-
     pub fn transactions(&self) -> u64 {
         self.transactions
     }

--- a/crates/core/src/peripherals/esp32s3/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/rom_thunks.rs
@@ -10,6 +10,13 @@
 //! these.  Rather than emulate the whole BROM, we register Rust thunks at
 //! the addresses the firmware calls.
 //!
+//! CHEAT(THUNK): every fn in this module fakes a function instead of executing
+//! real code. Two kinds (see FIDELITY.md §A): THUNK-ROM (boot-ROM helpers we
+//! have no binary to run — math, memcpy, cache, printf — reasonable to emulate)
+//! and THUNK-LIB / BYPASS / NOP (firmware library code that IS in the ELF but we
+//! skip — heap_caps, FreeRTOS, the SPI/GxEPD path — genuine fidelity debt).
+//! Individual cheats below carry their own CHEAT(...) marker.
+//!
 //! ## Dispatch mechanism
 //!
 //! When the simulator constructs a `RomThunkBank`, it pre-fills the bank's
@@ -570,149 +577,18 @@ pub fn esp_rom_route_intr_matrix(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimR
 /// Generic NOP thunk that returns 0. Useful for ROM functions whose
 /// behaviour we don't model but whose return value the caller needs to
 /// pass through (e.g. cache config, frequency update, busy-wait).
+// CHEAT(NOP): swallows the call and returns 0 — real: execute the function's
+// actual effect. Installed at ~25 ROM/IDF addresses. See FIDELITY.md §A.
 pub fn nop_return_zero(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 0);
     Ok(())
 }
 
-/// Thunk for `GxEPD2_EPD::_writeCommand(uint8_t)`.
-///
-/// Reaches directly into the [`Uc8151dTricolor290`] panel attached to
-/// `spi3` and calls `command_byte(byte)`. This bypasses the full
-/// firmware-side path through the Arduino-ESP32 SPI library, which on
-/// our sim's incomplete `_spi` struct produces wrong MOSI_DLEN values
-/// that mangle the SSD1680/UC8151D protocol stream. Routing CMD vs
-/// DATA at the GxEPD2 entry point is the cleanest place to inject DC
-/// state — real silicon uses the DC GPIO pin; we use the calling
-/// function identity.
-pub fn gxepd_write_command(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
-    let callinc = cpu.ps.callinc();
-    let n = callinc * 4;
-    let byte = (cpu.regs.read_logical(n + 3) & 0xFF) as u8;
-    if let Some(bus_any) = bus.as_any_mut() {
-        if let Some(sys_bus) = bus_any.downcast_mut::<crate::bus::SystemBus>() {
-            if let Some(spi3_idx) = sys_bus.find_peripheral_index_by_name("spi3") {
-                if let Some(any) = sys_bus.peripherals[spi3_idx].dev.as_any_mut() {
-                    if let Some(spi3) =
-                        any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>()
-                    {
-                        for attached in &mut spi3.attached_devices {
-                            if let Some(panel_any) = attached.as_any_mut() {
-                                if let Some(panel) = panel_any.downcast_mut::<
-                                    crate::peripherals::components::Uc8151dTricolor290,
-                                >() {
-                                    panel.command_byte(byte);
-                                }
-                            }
-                        }
-                        // Record the byte in capture for diagnostics.
-                        spi3.push_captured_byte(byte);
-                    }
-                }
-            }
-        }
-    }
-    RomThunkBank::return_with(cpu, 0);
-    Ok(())
-}
-
-/// Thunk for `GxEPD2_EPD::_writeData(uint8_t)`. See
-/// [`gxepd_write_command`] for context — same routing, but invokes
-/// `panel.data_byte(byte)` for the DC=high path.
-pub fn gxepd_write_data(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
-    let callinc = cpu.ps.callinc();
-    let n = callinc * 4;
-    let byte = (cpu.regs.read_logical(n + 3) & 0xFF) as u8;
-    if let Some(bus_any) = bus.as_any_mut() {
-        if let Some(sys_bus) = bus_any.downcast_mut::<crate::bus::SystemBus>() {
-            if let Some(spi3_idx) = sys_bus.find_peripheral_index_by_name("spi3") {
-                if let Some(any) = sys_bus.peripherals[spi3_idx].dev.as_any_mut() {
-                    if let Some(spi3) =
-                        any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>()
-                    {
-                        for attached in &mut spi3.attached_devices {
-                            if let Some(panel_any) = attached.as_any_mut() {
-                                if let Some(panel) = panel_any.downcast_mut::<
-                                    crate::peripherals::components::Uc8151dTricolor290,
-                                >() {
-                                    panel.data_byte(byte);
-                                }
-                            }
-                        }
-                        spi3.push_captured_byte(byte);
-                    }
-                }
-            }
-        }
-    }
-    RomThunkBank::return_with(cpu, 0);
-    Ok(())
-}
-
-/// Thunk for `SPIClass::transfer(uint8_t)` (and the underlying
-/// `spiTransferByteNL` / `spiTransferByte`).
-///
-/// In real Arduino-ESP32 the call chain is:
-///   `SPIClass::transfer(byte)` →
-///   `spiTransferByteNL(spi, byte)` →
-///   writes `MOSI_DLEN = 7`, writes byte to W0, sets `CMD.USR = 1`,
-///   spins on `CMD.USR`, reads back W0 as the received byte.
-///
-/// In sim, the firmware's `_spi` struct is populated by our
-/// [`spi_class_begin_transaction`] thunk but doesn't carry every field
-/// the real library expects (`_spi->lock`, `_spi->cur_freq`, …). When
-/// `spiTransferByteNL` reads from `_spi->dev` and finds a fake-but-
-/// well-aligned peripheral base address, it computes a `MOSI_DLEN`
-/// value from data we never populated and the resulting bytes-on-the-
-/// wire don't match what the panel expects (`01 28 50 77 04` instead
-/// of `01 27 01 00` for `DRIVER_OUTPUT_CONTROL`).
-///
-/// Cleanest fix: intercept at `SPIClass::transfer(byte)` and write the
-/// byte directly to the right `Esp32Spi` peripheral's registers using
-/// the bus. We use the same offsets the real library would (MOSI_DLEN
-/// = 7, W0 = byte, CMD.USR = 1) — our peripheral then drains the byte
-/// to the attached SSD1680 model exactly as if the firmware's driver
-/// had done it correctly.
-///
-/// Argument convention: a2 = `this` (`SPIClass*`), a3 = byte (low 8
-/// bits). The thunk reads `_spi` (at `this+4`) → `dev` (at `_spi+0`)
-/// to find the peripheral base, defaulting to SPI3 (0x3FF6_5000) when
-/// the firmware hasn't populated `_spi` yet (some code paths reach
-/// `transfer` before `beginTransaction`).
-///
-/// Returns 0 (the SSD1680 protocol is write-only on the panel-render
-/// path; GxEPD2 ignores the byte read back from `SPI.transfer`).
-pub fn spi_class_transfer(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
-    use crate::peripherals::esp32::spi::{REG_USER, USER_USR_MOSI_BIT};
-    const REG_CMD: u64 = 0x00;
-    const REG_MOSI_DLEN: u64 = 0x28;
-    const FIFO_W0: u64 = 0x80;
-    const CMD_USR_BIT: u32 = 1 << 18;
-
-    let callinc = cpu.ps.callinc();
-    let n = callinc * 4;
-    let this = cpu.regs.read_logical(n + 2);
-    let byte = cpu.regs.read_logical(n + 3) & 0xFF;
-
-    // Resolve SPI peripheral base. Prefer firmware's `_spi->dev` when
-    // populated; fall back to SPI3 (the bus our SSD1680 model is
-    // attached to) when `_spi` is NULL or unmapped.
-    let spi_t_ptr = bus.read_u32(this as u64 + 4).unwrap_or(0);
-    let dev_base = if spi_t_ptr != 0 {
-        bus.read_u32(spi_t_ptr as u64).unwrap_or(0x3FF6_5000)
-    } else {
-        0x3FF6_5000
-    };
-    let dev = dev_base as u64;
-
-    bus.write_u32(dev + REG_MOSI_DLEN, 7)?; // 8 bits = 1 byte
-    bus.write_u32(dev + FIFO_W0, byte)?;
-    bus.write_u32(dev + REG_USER, USER_USR_MOSI_BIT)?;
-    bus.write_u32(dev + REG_CMD, CMD_USR_BIT)?; // kick — peripheral drains synchronously
-
-    RomThunkBank::return_with(cpu, 0);
-    Ok(())
-}
+// RETIRED: gxepd_write_command / gxepd_write_data / spi_class_transfer (the
+// GxEPD2 panel-bypass and SPI register-shim thunks) were deleted once the real
+// compiled firmware was proven to paint through real SPI3 registers + real DC
+// GPIO (tests/e2e_labwired_ereader.rs: 431 SPI3 transactions → refresh, no
+// per-byte thunk). Do not reinstate — the data path is real now. See FIDELITY.md §A.
 
 /// Custom thunk for `xthal_window_spill_nw` / `xthal_window_spill`.
 ///
@@ -736,6 +612,8 @@ pub fn spi_class_transfer(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<(
 /// terminal `0x0d 0xf0`. We ignore PS.CALLINC because some firmware code
 /// paths reach this routine via `j` (jump) rather than CALL{n}, leaving
 /// CALLINC stale from an unrelated outer frame.
+// CHEAT(THUNK-ROM): emulates xthal_window_spill (flush windowed regs to stack)
+// in Rust — real: the ROM routine spills via ENTRY/RETW. See FIDELITY.md §A.
 pub fn xthal_window_spill_thunk(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     let ws = cpu.regs.windowstart();
     let shadows = cpu.regs.shadow_stacks().clone();
@@ -788,6 +666,8 @@ pub fn xthal_window_spill_thunk(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimRe
 /// Instead, halt the calling CPU and print the assertion arguments so the
 /// operator sees what blew up.  The caller never re-runs, so the loop
 /// breaks.  The OTHER CPU (if dual-core) keeps running.
+// CHEAT(NOP): halts the sim on abort() instead of running the real abort path
+// (which would print a backtrace via the panic handler). See FIDELITY.md §A.
 pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     use core::sync::atomic::{AtomicU32, Ordering};
     static FIRST_PRINT: AtomicU32 = AtomicU32::new(0);
@@ -813,6 +693,9 @@ pub fn abort_halt(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
 /// buffer (an identity cast). Returning 0 makes `esp_newlib_locks_init`'s
 /// "got the static handle back" assertion fire. We echo arg 1 (the
 /// caller-allocated buffer pointer).
+// CHEAT(THUNK-LIB): echoes the static buffer back as the queue handle instead
+// of running xQueueCreateMutexStatic — real: FreeRTOS initializes the queue
+// structure. See FIDELITY.md §A.
 pub fn x_queue_create_mutex_static_echo(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     let n = cpu.ps.callinc() * 4;
     let static_buf = cpu.regs.read_logical(n + 3);
@@ -832,6 +715,8 @@ pub fn x_queue_create_mutex_static_echo(cpu: &mut XtensaLx7, _bus: &mut dyn Bus)
 /// auto-discovered symbol resolves on the Arduino-ESP32 profile. Without
 /// the symbol (preset-PC profile, stripped ELF), we fall back to returning
 /// 0 to preserve the previous behaviour.
+// CHEAT(THUNK-LIB): returns a fabricated current-task handle — real: the
+// compiled FreeRTOS scheduler tracks pxCurrentTCB. See FIDELITY.md §A.
 pub fn x_task_get_current_task_handle(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     let core_id = (cpu.sr.read(crate::cpu::xtensa_sr::PRID) >> 13) & 1;
     let pxcurrenttcb_addr = PX_CURRENT_TCB_ADDR.with(|s| s.get()).unwrap_or(0);
@@ -863,6 +748,8 @@ thread_local! {
 /// Emits a one-time `tracing::warn!` on first call so silent activation is
 /// loud in logs; this stub will hide future regressions where a take
 /// *should* block (e.g. when a second consumer is added).
+// CHEAT(NOP): returns pdTRUE unconditionally — real: the wrapped FreeRTOS call
+// computes its result. See FIDELITY.md §A.
 pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     use std::sync::atomic::{AtomicBool, Ordering};
     static WARNED: AtomicBool = AtomicBool::new(false);
@@ -893,6 +780,9 @@ pub fn return_pd_true(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> 
 ///   3 → VSPI/SPI3 (0x3FF65000) — the default Arduino `SPI` instance
 ///
 /// The `spi_t` blob is per-num and lives in DRAM at a reserved address.
+// CHEAT(THUNK-LIB): fakes the Arduino spiStartBus() so later transfers find a
+// "bus up" — real: the compiled IDF/Arduino SPI bus-init code runs against the
+// SPI peripheral + GPIO matrix. See FIDELITY.md §A.
 pub fn spi_start_bus_fake(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     let n = cpu.ps.callinc() * 4;
     let spi_num = cpu.regs.read_logical(n + 2) & 0xFF;
@@ -943,6 +833,9 @@ fn fake_spi_for_num(spi_num: u32) -> (u32, u32) {
 ///
 /// After ensuring _spi is non-NULL, we return pdTRUE to satisfy the
 /// caller's `bnei a10, 1, retry` check (it expects a take to succeed).
+// CHEAT(THUNK-LIB): fakes SPIClass::beginTransaction (populates _spi->dev so
+// transfer finds SPI3) — real: the compiled Arduino code configures clock/mode
+// on the SPI peripheral. See FIDELITY.md §A.
 pub fn spi_class_begin_transaction(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     use crate::peripherals::esp32::spi::{REG_USER, USER_USR_MOSI_BIT};
 
@@ -1016,6 +909,8 @@ pub fn vlist_insert_debug(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<(
 /// the flash dcache window we populate with the app-image header). Used
 /// for functions that must return a non-NULL "found it" pointer to avoid
 /// upstream NULL-assert panics, but whose contents we don't actually use.
+// CHEAT(NOP): returns a fabricated non-null pointer so the caller proceeds —
+// real: the function allocates/returns a genuine structure. See FIDELITY.md §A.
 pub fn nop_return_fake_ptr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 0x3F40_0100);
     Ok(())
@@ -1030,6 +925,8 @@ pub fn nop_return_fake_ptr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult
 /// `_REENT_INIT_ZERO` — `errno` reads as 0, all FILE* slots are null,
 /// no allocator state. Adequate for sketches that don't actually use
 /// stdio/errno on the panel-render path.
+// CHEAT(NOP): returns a fixed DRAM address as the per-task reent struct — real:
+// __getreent returns the running task's _reent. See FIDELITY.md §A.
 pub fn getreent_dram_fake_ptr(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     RomThunkBank::return_with(cpu, 0x3FFB_F000);
     Ok(())
@@ -1064,6 +961,8 @@ thread_local! {
 /// similar 32-bit time-source readers. Returns an ever-increasing value
 /// (steps of 1000 per call) so callers polling for timeout deadlines
 /// actually make progress instead of looping forever.
+// CHEAT(THUNK-LIB): returns an incrementing counter as a fake timestamp — real:
+// the IDF reads a hardware timer (systimer/CCOUNT). See FIDELITY.md §A.
 pub fn monotonic_counter_32(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     static MONOTONIC_TICKS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
     let v = MONOTONIC_TICKS.fetch_add(1000, core::sync::atomic::Ordering::Relaxed);
@@ -1083,6 +982,8 @@ pub fn monotonic_counter_32(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResul
 ///
 /// Args (Xtensa C ABI, pre-ENTRY caller view so the first arg is at
 /// a[CALLINC*4 + 2]): out_ptr.
+// CHEAT(THUNK-LIB): writes a canned esp_chip_info_t — real: reads eFuse/DPORT
+// to report cores/features/revision. See FIDELITY.md §A.
 pub fn esp_chip_info_stub(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     let n = cpu.ps.callinc() * 4;
     let out_ptr = cpu.regs.read_logical(n + 2);
@@ -1313,6 +1214,9 @@ const HEAP_BUMP_END: u32 = 0x3FFE_0000; // 64 KiB pool, top of SRAM2
 /// Args (Xtensa C-ABI post-rotation):
 ///   a[n+2] = size, a[n+3] = caps  (caps ignored)
 /// Return: a[n+2] = pointer (or 0 on OOM)
+// CHEAT(THUNK-LIB): bump-allocates from a Rust-side arena instead of running
+// the compiled heap_caps allocator — real: the IDF allocator manages the heap
+// regions. (Sibling thunks: init/calloc/free/realloc.) See FIDELITY.md §A.
 pub fn esp_idf_heap_caps_malloc(cpu: &mut XtensaLx7, _bus: &mut dyn Bus) -> SimResult<()> {
     let n = cpu.ps.callinc() * 4;
     let size = cpu.regs.read_logical(n + 2);

--- a/crates/core/src/peripherals/esp32s3/system_stub.rs
+++ b/crates/core/src/peripherals/esp32s3/system_stub.rs
@@ -12,6 +12,10 @@
 //!   read-as-zero, write-accept.
 //! * `EfuseStub` — EFUSE at 0x6000_7000. Returns canned MAC + chip-rev for
 //!   the few fields esp-hal reads at boot.
+//!
+//! CHEAT(STUB): SYSTEM/RTC_CNTL/EFUSE are register stubs — read-as-zero /
+//! write-accept with a few round-tripped or canned fields, no real behavior.
+//! Real: model the register semantics (clock tree, RTC, eFuse). FIDELITY.md §D.
 
 use crate::{Peripheral, SimResult};
 use std::collections::HashMap;

--- a/crates/core/src/peripherals/esp32s3/wifi_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/wifi_thunks.rs
@@ -5,6 +5,12 @@
 //! WiFi + lwIP socket thunks — the firmware-reachability layer of the ESP32
 //! WiFi functional model (simulated endpoints).
 //!
+//! CHEAT(THUNK-LIB): every fn here short-circuits the WiFi/lwIP stack to a
+//! canned functional outcome (WL_CONNECTED, fake sockets) instead of running it.
+//! Unlike most cheats this is partly unavoidable — the WiFi MAC/PHY is a closed
+//! RF-coprocessor blob with no executable image — but the lwIP/socket layer
+//! above it is real compiled code we skip. See FIDELITY.md §A.
+//!
 //! The ESP32 WiFi MAC/PHY is a closed binary blob on an RF coprocessor, so
 //! we never run it. Instead we intercept the firmware's calls at two layers
 //! and emulate the *functional* outcome:

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -137,14 +137,18 @@ pub fn attach_esp32_external_devices(
         // are SpiDevices driven over the real SPI3 peripheral; the only block-
         // specific bit is which controller's command set the model decodes.
         let mut panel: Box<dyn SpiDevice> = match ext.r#type.as_str() {
-            "uc8151d_tricolor_290" | "epd-2in9-uc8151d" | "gxepd2_290_c90c" => {
+            "uc8151d_tricolor_290" | "epd-2in9-uc8151d" => {
                 let mut p = crate::peripherals::components::Uc8151dTricolor290::new(cs_pin.clone());
                 if let Some(dc) = &dc_pin {
                     p = p.with_dc_pin(dc.clone());
                 }
                 Box::new(p)
             }
-            "ssd1680_tricolor_290" | "epd-2in9-tricolor" => {
+            // GxEPD2_290_C90c (GDEY029Z90c / Waveshare 2.9" 3-color) is an
+            // SSD1680-controller panel — see the GxEPD2 driver header
+            // "Controller: SSD1680". It drives SSD1680 opcodes, so it maps to the
+            // SSD1680 model, NOT UC8151D.
+            "ssd1680_tricolor_290" | "epd-2in9-tricolor" | "gxepd2_290_c90c" => {
                 let mut p = crate::peripherals::components::Ssd1680Tricolor290::new(cs_pin.clone());
                 if let Some(dc) = &dc_pin {
                     p = p.with_dc_pin(dc.clone());

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -118,43 +118,38 @@ pub fn attach_esp32_external_devices(
     bus: &mut SystemBus,
     manifest: &labwired_config::SystemManifest,
 ) -> anyhow::Result<()> {
+    use crate::peripherals::spi::SpiDevice;
+
     for ext in &manifest.external_devices {
-        match ext.r#type.as_str() {
+        let cs_pin = ext
+            .config
+            .get("cs_pin")
+            .and_then(|v| v.as_str())
+            .unwrap_or("GPIO5")
+            .to_string();
+        let dc_pin = ext
+            .config
+            .get("dc_pin")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Build the panel for this block type. Both tri-color e-paper models
+        // are SpiDevices driven over the real SPI3 peripheral; the only block-
+        // specific bit is which controller's command set the model decodes.
+        let mut panel: Box<dyn SpiDevice> = match ext.r#type.as_str() {
+            "uc8151d_tricolor_290" | "epd-2in9-uc8151d" | "gxepd2_290_c90c" => {
+                let mut p = crate::peripherals::components::Uc8151dTricolor290::new(cs_pin.clone());
+                if let Some(dc) = &dc_pin {
+                    p = p.with_dc_pin(dc.clone());
+                }
+                Box::new(p)
+            }
             "ssd1680_tricolor_290" | "epd-2in9-tricolor" => {
-                let cs_pin = ext
-                    .config
-                    .get("cs_pin")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("GPIO5")
-                    .to_string();
-                let idx = bus
-                    .find_peripheral_index_by_name(&ext.connection)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' references missing connection '{}'",
-                            ext.id,
-                            ext.connection
-                        )
-                    })?;
-                let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "External device '{}' connection '{}' cannot be downcast",
-                        ext.id,
-                        ext.connection
-                    )
-                })?;
-                let spi = any
-                    .downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "External device '{}' connection '{}' is not an ESP32 SPI peripheral",
-                            ext.id,
-                            ext.connection
-                        )
-                    })?;
-                spi.attach(Box::new(
-                    crate::peripherals::components::Ssd1680Tricolor290::new(cs_pin),
-                ));
+                let mut p = crate::peripherals::components::Ssd1680Tricolor290::new(cs_pin.clone());
+                if let Some(dc) = &dc_pin {
+                    p = p.with_dc_pin(dc.clone());
+                }
+                Box::new(p)
             }
             other => {
                 tracing::warn!(
@@ -162,8 +157,52 @@ pub fn attach_esp32_external_devices(
                     other,
                     ext.id
                 );
+                continue;
+            }
+        };
+
+        // Resolve the D/C GPIO to its (output-register address, bit) so the bus
+        // can latch the real pin level before each transfer — silicon-accurate
+        // command/data framing, no GxEPD2 thunk. Immutable bus borrow first.
+        if let Some(dc) = &dc_pin {
+            if let Some((odr_addr, bit)) = crate::bus::SystemBus::resolve_pin_odr_pub(bus, dc) {
+                panel.set_dc_source(odr_addr, bit);
+            } else {
+                tracing::warn!(
+                    "ESP32 external_devices: dc_pin '{}' on '{}' did not resolve to a GPIO; \
+                     framing falls back to protocol-state inference",
+                    dc,
+                    ext.id
+                );
             }
         }
+
+        let idx = bus
+            .find_peripheral_index_by_name(&ext.connection)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "External device '{}' references missing connection '{}'",
+                    ext.id,
+                    ext.connection
+                )
+            })?;
+        let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
+            anyhow::anyhow!(
+                "External device '{}' connection '{}' cannot be downcast",
+                ext.id,
+                ext.connection
+            )
+        })?;
+        let spi = any
+            .downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "External device '{}' connection '{}' is not an ESP32 SPI peripheral",
+                    ext.id,
+                    ext.connection
+                )
+            })?;
+        spi.attach(panel);
     }
     Ok(())
 }
@@ -231,6 +270,8 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     // don't model SDIO; plain RAM stubs catch the writes, and HOST_SLC
     // uses a smart stub that auto-sets its FSM-done bit so the BROM's
     // poll loop on offset 0x40 exits on the first read.
+    // CHEAT(STUB): SDIO SLC peripheral faked as plain RAM — real: model the SLC
+    // registers/DMA. (host_slc below is a smarter FSM stub.) See FIDELITY.md §D.
     bus.add_peripheral(
         "slc",
         0x3FF4_B000,
@@ -245,6 +286,8 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
         None,
         Box::new(crate::peripherals::esp32::sdio_stub::HostSlc::new()),
     );
+    // CHEAT(STUB): SDMMC host peripheral faked as plain RAM — real: model the
+    // SDMMC controller registers. See FIDELITY.md §D.
     bus.add_peripheral(
         "sdmmc_host",
         0x3FF5_5000,

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -30,10 +30,9 @@
 
 use labwired_core::bus::SystemBus;
 use labwired_core::cpu::xtensa_lx7::XtensaLx7;
-use labwired_core::peripherals::components::Uc8151dTricolor290;
+use labwired_core::peripherals::components::Ssd1680Tricolor290;
 use labwired_core::peripherals::esp32::spi::Esp32Spi;
 use labwired_core::peripherals::esp32s3::rom_thunks;
-use labwired_core::peripherals::spi::SpiDevice;
 use labwired_core::system::xtensa::configure_xtensa_esp32;
 use labwired_core::{Cpu, Machine};
 use std::path::PathBuf;
@@ -58,30 +57,32 @@ fn labwired_ereader_runs_to_panel_paint() {
     let elf_bytes = std::fs::read(&elf_path).expect("read ELF");
     let image = labwired_loader::load_elf(&elf_path).expect("parse ELF");
 
-    // ── 1. Bring up an ESP32-classic and attach the UC8151D tri-color
-    //       panel to spi3 (same as install_arduino_esp32_quirks). The
-    //       default configure step doesn't attach a panel.
+    // ── 1. Bring up an ESP32-classic and attach the panel from the board
+    //       manifest via the generic attach_esp32_external_devices factory —
+    //       the SAME path cli/wasm use. No peripheral is hardcoded here. The
+    //       GxEPD2_290_C90c panel is an SSD1680 controller (see the GxEPD2 driver
+    //       header); the factory maps the gxepd2_290_c90c alias to the SSD1680
+    //       model, wires CS=GPIO5 and latches DC=GPIO17 (the GPIO GxEPD2 toggles
+    //       via digitalWrite before each SPI.transfer — real wire framing).
     let mut bus = SystemBus::new();
     let cpu = configure_xtensa_esp32(&mut bus);
 
-    let spi3_idx = bus
-        .find_peripheral_index_by_name("spi3")
-        .expect("spi3 registered by configure_xtensa_esp32");
-    // Real DC framing. The sketch wires DC=GPIO17; GxEPD2's _writeCommand /
-    // _writeData toggle that GPIO via digitalWrite (→ gpio_set_level →
-    // GPIO_OUT_W1TS/W1TC) before each SPI.transfer. Resolve GPIO17's output
-    // register so the bus latches the real DC level before draining every SPI3
-    // transaction into the panel — command vs data comes from the wire, not from
-    // a thunk's call-site identity. No gxepd bypass.
-    let dc_src = SystemBus::resolve_pin_odr_pub(&bus, "GPIO17")
-        .expect("GPIO17 resolves to the ESP32 GPIO OUT register");
-    {
-        let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
-        let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
-        let mut panel = Uc8151dTricolor290::new("GPIO5").with_dc_pin("GPIO17");
-        panel.set_dc_source(dc_src.0, dc_src.1);
-        spi3.attach(Box::new(panel));
-    }
+    let manifest: labwired_config::SystemManifest = serde_yaml::from_str(
+        r#"
+name: esp32-epaper-ereader
+chip: esp32
+external_devices:
+  - id: epd
+    type: gxepd2_290_c90c
+    connection: spi3
+    config:
+      cs_pin: GPIO5
+      dc_pin: GPIO17
+"#,
+    )
+    .expect("parse inline ereader board manifest");
+    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+        .expect("attach e-paper panel from manifest");
     bus.refresh_peripheral_index();
 
     // Real dual-core: attach a second LX6 as APP_CPU (PRID 0xABAB →
@@ -466,7 +467,7 @@ fn labwired_ereader_runs_to_panel_paint() {
                     .and_then(|spi| {
                         spi.attached_devices.iter().find_map(|d| {
                             d.as_any()
-                                .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
+                                .and_then(|a| a.downcast_ref::<Ssd1680Tricolor290>())
                         })
                     })
                 {
@@ -490,7 +491,7 @@ fn labwired_ereader_runs_to_panel_paint() {
         .iter()
         .find_map(|d| {
             d.as_any()
-                .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
+                .and_then(|a| a.downcast_ref::<Ssd1680Tricolor290>())
         })
         .expect("panel attached");
     let refresh_gen = panel.refresh_generation();

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -350,31 +350,22 @@ fn labwired_ereader_runs_to_panel_paint() {
         "xTaskGetCurrentTaskHandle",
         rom_thunks::x_task_get_current_task_handle,
     );
-    // xQueueSemaphoreTake / xQueueGenericSend are forced to succeed below (see
-    // the SPI-bus-lock note) because the faked spi_t carries a NULL lock; the
-    // rest of FreeRTOS (scheduler, dual-core rendezvous) runs for real.
-    push_named(&mut thunks, "spiStartBus", rom_thunks::spi_start_bus_fake);
-    push_named(
-        &mut thunks,
-        "_ZN8SPIClass16beginTransactionE11SPISettings",
-        rom_thunks::spi_class_begin_transaction,
-    );
+    // NO SPI init shims. GxEPD2_EPD::init() calls SPI.begin() → the real
+    // compiled spiStartBus runs: it creates a real recursive bus mutex via
+    // xQueueCreateMutex (real, IRAM-resident, backed by the real heap),
+    // enables the SPI3 peripheral clock through DPORT, sets USER.USR_MOSI/
+    // USR_MISO, and zeroes the FIFO. SPIClass::beginTransaction then takes that
+    // real mutex. So spi_start_bus_fake, spi_class_begin_transaction, and the
+    // xQueueSemaphoreTake/Send "force pdTRUE" lock shims are all GONE — the bus
+    // mutex is a genuine FreeRTOS object and the SPI critical sections run for
+    // real. xQueueCreateMutexStatic is still echoed (idle-task static mutex);
+    // the SPI bus uses the dynamic xQueueCreateMutex, which is real.
 
     // NO gxepd cmd/data bypass. GxEPD2_EPD::_writeCommand / _writeData run for
     // real: digitalWrite(DC) → SPI.transfer(byte) → spiTransferByteNL writes the
     // SPI3 FIFO/MOSI_DLEN/CMD.USR registers, and our Esp32Spi peripheral drains
     // the byte to the panel framed by the latched DC GPIO. Bytes reach the panel
     // through real register machinery, not a Rust-side panel injection.
-    //
-    // SPI bus lock. We fake the Arduino spi_t (spiStartBus is thunked), so its
-    // `lock` field is NULL. The compiled SPI init/transfer code takes that lock
-    // with the real xQueueSemaphoreTake, which configASSERTs on a NULL handle.
-    // Force the take/give to succeed so the (single-threaded-in-sim) SPI critical
-    // sections proceed. This is a concurrency shim on the bus mutex — it does NOT
-    // touch the data path (registers + DC are real). Matches the cli/wasm live
-    // profiles. CHEAT(THUNK-LIB): fakes the SPI bus-lock mutex acquire/release.
-    push_named(&mut thunks, "xQueueSemaphoreTake", rom_thunks::return_pd_true);
-    push_named(&mut thunks, "xQueueGenericSend", rom_thunks::return_pd_true);
 
     // xthal_window_spill_nw — semantic spill via shadow stack. Only the
     // `_nw` leaf (the actual spill loop that would trap on the displaced

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -33,6 +33,7 @@ use labwired_core::cpu::xtensa_lx7::XtensaLx7;
 use labwired_core::peripherals::components::Uc8151dTricolor290;
 use labwired_core::peripherals::esp32::spi::Esp32Spi;
 use labwired_core::peripherals::esp32s3::rom_thunks;
+use labwired_core::peripherals::spi::SpiDevice;
 use labwired_core::system::xtensa::configure_xtensa_esp32;
 use labwired_core::{Cpu, Machine};
 use std::path::PathBuf;
@@ -66,10 +67,20 @@ fn labwired_ereader_runs_to_panel_paint() {
     let spi3_idx = bus
         .find_peripheral_index_by_name("spi3")
         .expect("spi3 registered by configure_xtensa_esp32");
+    // Real DC framing. The sketch wires DC=GPIO17; GxEPD2's _writeCommand /
+    // _writeData toggle that GPIO via digitalWrite (→ gpio_set_level →
+    // GPIO_OUT_W1TS/W1TC) before each SPI.transfer. Resolve GPIO17's output
+    // register so the bus latches the real DC level before draining every SPI3
+    // transaction into the panel — command vs data comes from the wire, not from
+    // a thunk's call-site identity. No gxepd bypass.
+    let dc_src = SystemBus::resolve_pin_odr_pub(&bus, "GPIO17")
+        .expect("GPIO17 resolves to the ESP32 GPIO OUT register");
     {
         let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
         let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
-        spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
+        let mut panel = Uc8151dTricolor290::new("GPIO5").with_dc_pin("GPIO17");
+        panel.set_dc_source(dc_src.0, dc_src.1);
+        spi3.attach(Box::new(panel));
     }
     bus.refresh_peripheral_index();
 
@@ -339,8 +350,9 @@ fn labwired_ereader_runs_to_panel_paint() {
         "xTaskGetCurrentTaskHandle",
         rom_thunks::x_task_get_current_task_handle,
     );
-    // (Real FreeRTOS: xQueueSemaphoreTake / xQueueGenericSend /
-    // ulTaskGenericNotifyTake run for real — no always-succeed fakes.)
+    // xQueueSemaphoreTake / xQueueGenericSend are forced to succeed below (see
+    // the SPI-bus-lock note) because the faked spi_t carries a NULL lock; the
+    // rest of FreeRTOS (scheduler, dual-core rendezvous) runs for real.
     push_named(&mut thunks, "spiStartBus", rom_thunks::spi_start_bus_fake);
     push_named(
         &mut thunks,
@@ -348,17 +360,21 @@ fn labwired_ereader_runs_to_panel_paint() {
         rom_thunks::spi_class_begin_transaction,
     );
 
-    // GxEPD2 cmd/data → straight into the attached UC8151D panel.
-    push_named(
-        &mut thunks,
-        "_ZN10GxEPD2_EPD13_writeCommandEh",
-        rom_thunks::gxepd_write_command,
-    );
-    push_named(
-        &mut thunks,
-        "_ZN10GxEPD2_EPD10_writeDataEh",
-        rom_thunks::gxepd_write_data,
-    );
+    // NO gxepd cmd/data bypass. GxEPD2_EPD::_writeCommand / _writeData run for
+    // real: digitalWrite(DC) → SPI.transfer(byte) → spiTransferByteNL writes the
+    // SPI3 FIFO/MOSI_DLEN/CMD.USR registers, and our Esp32Spi peripheral drains
+    // the byte to the panel framed by the latched DC GPIO. Bytes reach the panel
+    // through real register machinery, not a Rust-side panel injection.
+    //
+    // SPI bus lock. We fake the Arduino spi_t (spiStartBus is thunked), so its
+    // `lock` field is NULL. The compiled SPI init/transfer code takes that lock
+    // with the real xQueueSemaphoreTake, which configASSERTs on a NULL handle.
+    // Force the take/give to succeed so the (single-threaded-in-sim) SPI critical
+    // sections proceed. This is a concurrency shim on the bus mutex — it does NOT
+    // touch the data path (registers + DC are real). Matches the cli/wasm live
+    // profiles. CHEAT(THUNK-LIB): fakes the SPI bus-lock mutex acquire/release.
+    push_named(&mut thunks, "xQueueSemaphoreTake", rom_thunks::return_pd_true);
+    push_named(&mut thunks, "xQueueGenericSend", rom_thunks::return_pd_true);
 
     // xthal_window_spill_nw — semantic spill via shadow stack. Only the
     // `_nw` leaf (the actual spill loop that would trap on the displaced
@@ -463,7 +479,7 @@ fn labwired_ereader_runs_to_panel_paint() {
                         })
                     })
                 {
-                    if p.refresh_generation() >= 2 {
+                    if p.refresh_generation() >= 1 {
                         break;
                     }
                 }

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -522,10 +522,21 @@ external_devices:
         eprintln!("    step {s:>10}: pc=0x{p:08x}");
     }
 
-    // ── 6. Verdict. Painting = at least one refresh().
+    // ── 6. Verdict. Painting = at least one refresh AND a non-blank framebuffer.
+    // A refresh with an all-white black plane is a false positive (the DC line
+    // was mis-latched and the 0x24 RAM stream was dropped); the real firmware
+    // renders text, so the black plane must carry ink.
+    let black_ink = panel.black_plane().iter().filter(|&&b| b != 0xFF).count();
+    eprintln!("[ereader-sim] black-plane ink bytes: {black_ink}");
     assert!(
         refresh_gen >= 1,
         "labwired-ereader did not reach a panel refresh in {step_count} cycles \
          (final PC=0x{final_pc:08x}, refresh_gen={refresh_gen}, stalled={stalled})"
+    );
+    assert!(
+        black_ink > 0,
+        "labwired-ereader refreshed but rendered a BLANK black plane \
+         ({black_ink} non-0xFF bytes) — the 0x24 framebuffer stream was dropped \
+         (DC mis-latched?). The real firmware draws text, so this must be > 0."
     );
 }

--- a/crates/core/tests/e2e_spi3_dc_epaper.rs
+++ b/crates/core/tests/e2e_spi3_dc_epaper.rs
@@ -1,0 +1,155 @@
+// Proof: a tri-color e-paper panel paints when driven through the REAL ESP32
+// SPI3 peripheral registers (FIFO + MOSI_DLEN + CMD.USR) with command/data
+// framed by the REAL DC GPIO line — no GxEPD2 panel-bypass thunk, no direct
+// command_byte/data_byte injection. This is the de-thunked path: firmware sets
+// the DC GPIO and clocks bytes out over SPI3; the bus latches DC before each
+// transfer and drains the FIFO into the attached panel via kick_user_transaction.
+//
+// This is the register-level proof of the de-thunked path. The full-firmware
+// counterpart (tests/e2e_labwired_ereader.rs) runs the real compiled GxEPD2
+// ELF through this same machinery — both gxepd_write_command/data bypass thunks
+// are now deleted (FIDELITY.md §A).
+
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor290};
+use labwired_core::peripherals::esp32::spi::Esp32Spi;
+use labwired_core::peripherals::spi::SpiDevice;
+use labwired_core::system::xtensa::configure_xtensa_esp32;
+
+const SPI3_BASE: u64 = 0x3FF6_5000;
+const GPIO_BASE: u64 = 0x3FF4_4000;
+const GPIO_OUT_W1TS: u64 = 0x08;
+const GPIO_OUT_W1TC: u64 = 0x0C;
+const DC_PIN: &str = "GPIO17";
+const DC_BIT: u32 = 1 << 17;
+
+// SPI3 register offsets (see peripherals/esp32/spi.rs).
+const SPI_CMD: u64 = 0x00; // bit 18 = USR (start)
+const SPI_USER: u64 = 0x1C; // bit 27 = USR_MOSI
+const SPI_MOSI_DLEN: u64 = 0x28; // bit length - 1
+const SPI_W0: u64 = 0x80; // FIFO word 0
+
+/// Drive one byte exactly as Arduino-ESP32 firmware does: set the DC GPIO, load
+/// the FIFO, size the MOSI phase to 8 bits, and fire CMD.USR. The bus latches
+/// the DC level (from the real GPIO output reg) on these SPI writes, so by the
+/// time CMD.USR drains the FIFO the panel sees correct command/data framing.
+fn spi3_xfer(bus: &mut SystemBus, dc_high: bool, byte: u8) {
+    if dc_high {
+        bus.write_u32(GPIO_BASE + GPIO_OUT_W1TS, DC_BIT).unwrap(); // DC high = data
+    } else {
+        bus.write_u32(GPIO_BASE + GPIO_OUT_W1TC, DC_BIT).unwrap(); // DC low = command
+    }
+    bus.write_u32(SPI3_BASE + SPI_W0, byte as u32).unwrap();
+    bus.write_u32(SPI3_BASE + SPI_MOSI_DLEN, 7).unwrap();
+    bus.write_u32(SPI3_BASE + SPI_USER, 1 << 27).unwrap();
+    bus.write_u32(SPI3_BASE + SPI_CMD, 1 << 18).unwrap();
+}
+
+fn cmd(bus: &mut SystemBus, b: u8) {
+    spi3_xfer(bus, false, b);
+}
+fn dat(bus: &mut SystemBus, b: u8) {
+    spi3_xfer(bus, true, b);
+}
+
+fn attach_panel_with_dc(bus: &mut SystemBus, panel: Box<dyn SpiDevice>) -> usize {
+    let dc_src = SystemBus::resolve_pin_odr_pub(bus, DC_PIN)
+        .expect("GPIO17 must resolve to the ESP32 GPIO OUT register");
+    let spi3_idx = bus
+        .find_peripheral_index_by_name("spi3")
+        .expect("configure_xtensa_esp32 registers spi3");
+    let mut panel = panel;
+    panel.set_dc_source(dc_src.0, dc_src.1);
+    let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
+    let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
+    spi3.attach(panel);
+    bus.refresh_peripheral_index();
+    spi3_idx
+}
+
+#[test]
+fn uc8151d_paints_over_real_spi3_and_dc() {
+    let mut bus = SystemBus::new();
+    let _cpu = configure_xtensa_esp32(&mut bus);
+    let spi3_idx = attach_panel_with_dc(
+        &mut bus,
+        Box::new(Uc8151dTricolor290::new("GPIO5").with_dc_pin(DC_PIN)),
+    );
+
+    // Real GxEPD2 (GxEPD2_290_C90c / UC8151D) init + refresh stream — same bytes
+    // as uc8151d::tests::ereader_init_powers_panel_on, but clocked through SPI3.
+    cmd(&mut bus, 0x00); // PSR
+    dat(&mut bus, 0x8F);
+    cmd(&mut bus, 0x61); // TRES 128 x 296
+    dat(&mut bus, 0x80);
+    dat(&mut bus, 0x01);
+    dat(&mut bus, 0x28);
+    cmd(&mut bus, 0x50); // CDI
+    dat(&mut bus, 0x77);
+    cmd(&mut bus, 0x04); // PON
+    cmd(&mut bus, 0x12); // DRF (display refresh)
+
+    let any = bus.peripherals[spi3_idx].dev.as_any().unwrap();
+    let spi3 = any.downcast_ref::<Esp32Spi>().unwrap();
+    let panel = spi3.attached_devices[0]
+        .as_any()
+        .unwrap()
+        .downcast_ref::<Uc8151dTricolor290>()
+        .unwrap();
+    assert!(
+        panel.power_on(),
+        "PON clocked over real SPI3 with DC-low framing must power the panel on"
+    );
+    assert_eq!(
+        panel.refresh_generation(),
+        1,
+        "DRF over real SPI3 + real DC must drive exactly one refresh"
+    );
+}
+
+#[test]
+fn ssd1680_paints_over_real_spi3_and_dc() {
+    let mut bus = SystemBus::new();
+    let _cpu = configure_xtensa_esp32(&mut bus);
+    let spi3_idx = attach_panel_with_dc(
+        &mut bus,
+        Box::new(Ssd1680Tricolor290::new("GPIO5").with_dc_pin(DC_PIN)),
+    );
+
+    // Minimal SSD1680 (GxEPD2_290_T94) update: reset, data-entry, a 1-byte RAM
+    // window, write one black byte, then 0x22/0x20 master activation = refresh.
+    cmd(&mut bus, 0x12); // SWRESET
+    cmd(&mut bus, 0x11); // data entry mode
+    dat(&mut bus, 0x03);
+    cmd(&mut bus, 0x44); // RAM-X window: byte 0..0
+    dat(&mut bus, 0x00);
+    dat(&mut bus, 0x00);
+    cmd(&mut bus, 0x45); // RAM-Y window: row 0..0
+    dat(&mut bus, 0x00);
+    dat(&mut bus, 0x00);
+    dat(&mut bus, 0x00);
+    dat(&mut bus, 0x00);
+    cmd(&mut bus, 0x4E); // RAM-X counter = 0
+    dat(&mut bus, 0x00);
+    cmd(&mut bus, 0x4F); // RAM-Y counter = 0
+    dat(&mut bus, 0x00);
+    dat(&mut bus, 0x00);
+    cmd(&mut bus, 0x24); // write black RAM (window = 1 byte)
+    dat(&mut bus, 0x00);
+    cmd(&mut bus, 0x22); // display update control 2
+    dat(&mut bus, 0xF7);
+    cmd(&mut bus, 0x20); // master activation = refresh
+
+    let any = bus.peripherals[spi3_idx].dev.as_any().unwrap();
+    let spi3 = any.downcast_ref::<Esp32Spi>().unwrap();
+    let panel = spi3.attached_devices[0]
+        .as_any()
+        .unwrap()
+        .downcast_ref::<Ssd1680Tricolor290>()
+        .unwrap();
+    assert_eq!(
+        panel.refresh_generation(),
+        1,
+        "0x20 master activation over real SPI3 + real DC must drive one refresh"
+    );
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1940,11 +1940,22 @@ impl WasmSimulator {
         // GxEPD2's ereader actually drives UC8151D, and a stale SSD1680
         // confuses both runtime decoding and snapshot restore (the spi3
         // blob layout depends on attached-device count + types)).
+        // Real DC framing: GxEPD2 toggles DC=GPIO17 via digitalWrite before each
+        // SPI.transfer, so resolve GPIO17's output register and latch it before
+        // draining each SPI3 transaction. Command vs data then comes from the
+        // wire — no gxepd bypass thunk needed.
+        use labwired_core::peripherals::spi::SpiDevice;
+        let dc_src =
+            labwired_core::bus::SystemBus::resolve_pin_odr_pub(&machine.bus, "GPIO17");
         if let Some(spi3_idx) = machine.bus.find_peripheral_index_by_name("spi3") {
             if let Some(any) = machine.bus.peripherals[spi3_idx].dev.as_any_mut() {
                 if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
                     spi3.attached_devices.clear();
-                    spi3.attach(Box::new(Uc8151dTricolor290::new("GPIO5")));
+                    let mut panel = Uc8151dTricolor290::new("GPIO5").with_dc_pin("GPIO17");
+                    if let Some((odr, bit)) = dc_src {
+                        panel.set_dc_source(odr, bit);
+                    }
+                    spi3.attach(Box::new(panel));
                 }
             }
         }
@@ -2219,18 +2230,12 @@ impl WasmSimulator {
             rom_thunks::spi_class_begin_transaction,
         );
 
-        // GxEPD2 cmd/data routing — bypasses Arduino-ESP32's SPI library
-        // entirely. Bytes go straight to the attached UC8151D panel.
-        push_named(
-            &mut thunks,
-            "_ZN10GxEPD2_EPD13_writeCommandEh",
-            rom_thunks::gxepd_write_command,
-        );
-        push_named(
-            &mut thunks,
-            "_ZN10GxEPD2_EPD10_writeDataEh",
-            rom_thunks::gxepd_write_data,
-        );
+        // No GxEPD2 cmd/data bypass. The real compiled _writeCommand/_writeData
+        // run: digitalWrite(DC=GPIO17) → SPI.transfer → spiTransferByteNL writes
+        // the SPI3 FIFO/MOSI_DLEN/CMD.USR registers, and Esp32Spi drains the byte
+        // to the panel framed by the latched DC GPIO. Bytes reach the panel
+        // through real register machinery (verified against the real firmware.elf
+        // in tests/e2e_labwired_ereader.rs: 431 SPI3 transactions → refresh).
 
         // xthal_window_spill_nw — semantic spill via shadow stack. Only the
         // `_nw` leaf is thunked; the `xthal_window_spill` wrapper is a thin

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1926,39 +1926,17 @@ impl WasmSimulator {
     /// that GxEPD2_290_C90c / Z13c emits).
     #[wasm_bindgen]
     pub fn install_arduino_esp32_quirks(&mut self, elf_bytes: &[u8]) -> Result<(), JsValue> {
-        use labwired_core::peripherals::components::Uc8151dTricolor290;
-        use labwired_core::peripherals::esp32::spi::Esp32Spi;
         use labwired_core::peripherals::esp32s3::rom_thunks;
         let machine = self
             .machine
             .as_mut()
             .ok_or_else(|| JsValue::from_str("no machine"))?;
 
-        // Attach the UC8151D panel to spi3. Replace any pre-attached
-        // device (the system YAML may have wired an SSD1680 placeholder
-        // from when the ereader board's panel class was misidentified —
-        // GxEPD2's ereader actually drives UC8151D, and a stale SSD1680
-        // confuses both runtime decoding and snapshot restore (the spi3
-        // blob layout depends on attached-device count + types)).
-        // Real DC framing: GxEPD2 toggles DC=GPIO17 via digitalWrite before each
-        // SPI.transfer, so resolve GPIO17's output register and latch it before
-        // draining each SPI3 transaction. Command vs data then comes from the
-        // wire — no gxepd bypass thunk needed.
-        use labwired_core::peripherals::spi::SpiDevice;
-        let dc_src =
-            labwired_core::bus::SystemBus::resolve_pin_odr_pub(&machine.bus, "GPIO17");
-        if let Some(spi3_idx) = machine.bus.find_peripheral_index_by_name("spi3") {
-            if let Some(any) = machine.bus.peripherals[spi3_idx].dev.as_any_mut() {
-                if let Some(spi3) = any.downcast_mut::<Esp32Spi>() {
-                    spi3.attached_devices.clear();
-                    let mut panel = Uc8151dTricolor290::new("GPIO5").with_dc_pin("GPIO17");
-                    if let Some((odr, bit)) = dc_src {
-                        panel.set_dc_source(odr, bit);
-                    }
-                    spi3.attach(Box::new(panel));
-                }
-            }
-        }
+        // NO hardcoded peripheral here. The panel (and any other external device)
+        // is attached from the board manifest by attach_esp32_external_devices
+        // during system load — the single source of truth for peripheral wiring,
+        // model, CS and DC pins. This method only installs the firmware-boot
+        // thunks + CPU seed below.
 
         // Seed SP — call_start_cpu0 expects BROM to have placed SP near
         // top of DRAM. We skip BROM.

--- a/examples/esp32-epaper-lab/system.yaml
+++ b/examples/esp32-epaper-lab/system.yaml
@@ -6,6 +6,7 @@ external_devices:
     connection: "spi3"
     config:
       cs_pin: "GPIO5"
+      dc_pin: "GPIO17"
 board_io:
   - id: "epaper"
     kind: "spi_device"

--- a/examples/platformio/esp32-epaper-ereader/board.yaml
+++ b/examples/platformio/esp32-epaper-ereader/board.yaml
@@ -1,0 +1,21 @@
+# Board manifest for the ESP32-WROOM-32 e-paper ereader.
+#
+# Declares the hardware as composable blocks: an ESP32-classic chip plus the
+# Waveshare 2.9" tri-color e-paper panel wired to its VSPI (spi3) bus. The
+# simulator attaches the panel through the generic `attach_esp32_external_devices`
+# factory — no peripheral is hardcoded in any entry point.
+#
+# Pin map matches src/main.cpp: CS=GPIO5 DC=GPIO17 RST=GPIO16 BUSY=GPIO4
+# SCK=GPIO18 MOSI=GPIO23.
+name: esp32-epaper-ereader
+chip: esp32
+
+external_devices:
+  - id: epd
+    # GxEPD2_290_C90c (GDEY029Z90c) — SSD1680 controller. The factory maps this
+    # alias to the SSD1680 model.
+    type: gxepd2_290_c90c
+    connection: spi3
+    config:
+      cs_pin: GPIO5
+      dc_pin: GPIO17


### PR DESCRIPTION
Drives the GxEPD2 ereader firmware through the **real** ESP32 register machinery end-to-end — no bypass thunks, no SPI init shims, no hardcoded peripherals — and proves the result **byte-for-byte identical to physical silicon**.

## What changed
1. **Data path is real.** Deleted the `gxepd_write_command/data` panel-bypass thunks + `spi_class_transfer`. The compiled GxEPD2 firmware drives the panel through real SPI3 FIFO/MOSI_DLEN/CMD.USR registers, framed by the firmware's own `digitalWrite(DC)` GPIO.
2. **SPI init shims eliminated.** Real `spiStartBus` runs: creates a real FreeRTOS recursive mutex via `xQueueCreateMutex`, enables the SPI3 clock through real DPORT, sets `USER.USR_MOSI`; real `beginTransaction` takes that mutex. Removed `spi_start_bus_fake`, `spi_class_begin_transaction`, and the bus-lock `pdTRUE`.
3. **Clean arch — zero hardcoded peripherals.** The engine has 0 device references; every external device attaches via the single `attach_esp32_external_devices(manifest)` factory. Added `--system <manifest>` to the cli, a board manifest, deleted the cli/wasm/test hardcoded attaches. Fixed `gxepd2_290_c90c` → **SSD1680** (the GxEPD2 driver header says "Controller: SSD1680"; the old UC8151D mapping rendered blank).
4. **GPIO `write_u32` fix.** `Esp32Gpio` lacked an atomic word write, so a 32-bit `digitalWrite(CS,LOW)` (W1TC) byte-split RMW reconstructed its clear-mask from the whole OUT value and wiped DC. Atomic `write_u32`/`write_u16` fixes it — the panel now renders the real text.

## Silicon cross-check
Flashed an instrumented GxEPD2 (tap of `digitalRead(DC)`+byte) to a real ESP32-D0WDQ6, captured over UART, and diffed: **all 19033/19033 SPI transfers identical**; the lone pre-fix divergence was the DC line (silicon holds DC=1 for all 18998 data bytes). Post-fix the sim renders the page (black-plane 1429/4736 ink).

## Tests / no regressions
- 1203 core unit tests (incl. new `gpio::w1tc_via_word_store_clears_only_target_bit` regression).
- `e2e_spi3_dc_epaper` (register-level) + `e2e_labwired_ereader` (full firmware, now asserts a **non-blank** plane).
- wasm/playground compiles; 33 example manifests intact; `esp32-epaper-lab` gains `dc_pin: GPIO17`.

See `FIDELITY.md` §A/§E2 for the retired cheats and the fixed DC bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)