### PR TITLE
Add real FDCAN trace for H563 UDS ECU

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -200,6 +200,19 @@ pub struct SystemBus {
     /// per-tick pass (`service_hcsr04`) drives the computed ECHO input level,
     /// touching the bus only on a transition. Empty by default → zero cost.
     pub hcsr04: Vec<crate::peripherals::hc_sr04::HcSr04>,
+    /// Reusable CAN diagnostic clients declared as external devices. They
+    /// inject configured CAN frames into a named FDCAN peripheral once it is
+    /// running, so ECU examples can be driven by a virtual off-board tester
+    /// instead of self-loopback firmware.
+    pub can_diagnostic_testers: Vec<CanDiagnosticTester>,
+}
+
+pub struct CanDiagnosticTester {
+    pub id: String,
+    pub connection: String,
+    pub request_id: u32,
+    pub request_data: Vec<u8>,
+    pub sent: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -531,6 +544,80 @@ impl SystemBus {
         }
     }
 
+    pub(crate) fn service_can_diagnostic_testers(&mut self) {
+        if self.can_diagnostic_testers.is_empty() {
+            return;
+        }
+
+        for i in 0..self.can_diagnostic_testers.len() {
+            if self.can_diagnostic_testers[i].sent {
+                continue;
+            }
+
+            let connection = self.can_diagnostic_testers[i].connection.clone();
+            let Some(idx) = self.find_peripheral_index_by_name(&connection) else {
+                continue;
+            };
+            let Some(fdcan) = self.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<crate::peripherals::fdcan::Fdcan>())
+            else {
+                continue;
+            };
+
+            let frame = crate::network::CanFrame {
+                id: self.can_diagnostic_testers[i].request_id,
+                data: self.can_diagnostic_testers[i].request_data.clone(),
+                extended: false,
+                fd: self.can_diagnostic_testers[i].request_data.len() > 8,
+                bitrate_switch: self.can_diagnostic_testers[i].request_data.len() > 8,
+                remote: false,
+            };
+            if fdcan.receive_frame(frame) {
+                self.can_diagnostic_testers[i].sent = true;
+            }
+        }
+    }
+
+    fn yaml_u32(value: Option<&serde_yaml::Value>, default: u32) -> u32 {
+        match value {
+            Some(serde_yaml::Value::Number(n)) => n.as_u64().map(|v| v as u32).unwrap_or(default),
+            Some(serde_yaml::Value::String(s)) => {
+                let s = s.trim();
+                if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                    u32::from_str_radix(&hex.replace('_', ""), 16).unwrap_or(default)
+                } else {
+                    s.replace('_', "").parse::<u32>().unwrap_or(default)
+                }
+            }
+            _ => default,
+        }
+    }
+
+    fn yaml_bytes(value: Option<&serde_yaml::Value>, default: &[u8]) -> Vec<u8> {
+        match value {
+            Some(serde_yaml::Value::Sequence(seq)) => seq
+                .iter()
+                .map(|value| Self::yaml_u32(Some(value), 0) as u8)
+                .collect(),
+            Some(serde_yaml::Value::String(s)) => s
+                .split(|c: char| c.is_ascii_whitespace() || c == ',' || c == ':')
+                .filter(|part| !part.is_empty())
+                .map(|part| {
+                    let part = part.trim();
+                    if let Some(hex) = part.strip_prefix("0x").or_else(|| part.strip_prefix("0X")) {
+                        u8::from_str_radix(hex, 16).unwrap_or(0)
+                    } else {
+                        u8::from_str_radix(part, 16)
+                            .unwrap_or_else(|_| part.parse::<u8>().unwrap_or(0))
+                    }
+                })
+                .collect(),
+            _ => default.to_vec(),
+        }
+    }
+
     /// Write-hook mirror of [`maybe_latch_dc`](Self::maybe_latch_dc) for the
     /// HC-SR04: after an MMIO write to peripheral `idx`, if that peripheral is
     /// the GPIO hosting any sensor's TRIG line, re-read the TRIG ODR bit and run
@@ -784,6 +871,7 @@ impl SystemBus {
             pending_schedule: Vec::new(),
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -814,6 +902,7 @@ impl SystemBus {
             pending_schedule: Vec::new(),
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -1049,6 +1138,7 @@ impl SystemBus {
             pending_schedule: Vec::new(),
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
         };
 
         let mut merged_peripherals = chip.peripherals.clone();
@@ -1768,6 +1858,25 @@ impl SystemBus {
                         distance_cm,
                     ));
                 }
+                "can-diagnostic-tester" | "uds-diagnostic-tester" => {
+                    if bus.find_peripheral_index_by_name(&ext.connection).is_none() {
+                        return Err(anyhow::anyhow!(
+                            "CAN diagnostic tester '{}' connection '{}' was not found",
+                            ext.id,
+                            ext.connection
+                        ));
+                    }
+                    let request_id = Self::yaml_u32(ext.config.get("request_id"), 0x7E0);
+                    let request_data =
+                        Self::yaml_bytes(ext.config.get("request_data"), &[0x03, 0x22, 0xF1, 0x90]);
+                    bus.can_diagnostic_testers.push(CanDiagnosticTester {
+                        id: ext.id.clone(),
+                        connection: ext.connection.clone(),
+                        request_id,
+                        request_data,
+                        sent: false,
+                    });
+                }
                 // ntc-thermistor dispatches through the PeripheralKit registry above.
                 _ => {
                     tracing::warn!(
@@ -2128,6 +2237,7 @@ impl SystemBus {
         // HC-SR04 service pass: read each sensor's TRIG output level and drive
         // the computed ECHO input level. Empty list → skipped entirely.
         self.service_hcsr04();
+        self.service_can_diagnostic_testers();
 
         (
             interrupts,
@@ -2974,6 +3084,76 @@ mod tests {
         assert_eq!(i2c.attached_devices().len(), 1);
     }
 
+    #[test]
+    fn test_from_config_can_diagnostic_tester_injects_frame_into_fdcan() {
+        let chip: ChipDescriptor = serde_yaml::from_str(
+            r#"
+name: "h563-test"
+arch: "arm"
+core: "cortex-m33"
+flash:
+  base: 0x08000000
+  size: "128KB"
+ram:
+  base: 0x20000000
+  size: "64KB"
+peripherals:
+  - id: "fdcan1"
+    type: "fdcan"
+    base_address: 0x4000A400
+    size: "4KB"
+"#,
+        )
+        .unwrap();
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "uds-tester"
+chip: "unused"
+external_devices:
+  - id: "uds_tester"
+    type: "can-diagnostic-tester"
+    connection: "fdcan1"
+    config:
+      request_id: "0x7E0"
+      request_data: "03 22 F1 90"
+board_io: []
+"#,
+        )
+        .unwrap();
+        let mut bus = SystemBus::from_config(&chip, &manifest).unwrap();
+        assert_eq!(bus.can_diagnostic_testers.len(), 1);
+
+        // Still in INIT: tester retries but cannot inject into a stopped FDCAN.
+        bus.tick_peripherals_fully();
+        {
+            let idx = bus.find_peripheral_index_by_name("fdcan1").unwrap();
+            let fdcan = bus.peripherals[idx]
+                .dev
+                .as_any()
+                .unwrap()
+                .downcast_ref::<crate::peripherals::fdcan::Fdcan>()
+                .unwrap();
+            assert!(fdcan.trace_snapshot("fdcan1").is_empty());
+        }
+
+        // Leave INIT; next bus tick lets the reusable tester drive the CAN frame.
+        bus.write_u32(0x4000_A400 + 0x018, 0).unwrap();
+        bus.tick_peripherals_fully();
+        let idx = bus.find_peripheral_index_by_name("fdcan1").unwrap();
+        let fdcan = bus.peripherals[idx]
+            .dev
+            .as_any()
+            .unwrap()
+            .downcast_ref::<crate::peripherals::fdcan::Fdcan>()
+            .unwrap();
+        let trace = fdcan.trace_snapshot("fdcan1");
+        assert_eq!(trace.len(), 1);
+        assert_eq!(trace[0].direction, "rx");
+        assert_eq!(trace[0].id, 0x7E0);
+        assert_eq!(trace[0].data, vec![0x03, 0x22, 0xF1, 0x90]);
+        assert!(bus.can_diagnostic_testers[0].sent);
+    }
+
     /// Parse a minimal chip yaml with the given header lines (name/arch/core).
     fn bit_band_test_chip(header: &str, gpio_base: &str, gpio_profile: &str) -> ChipDescriptor {
         let yaml = format!(
@@ -3299,6 +3479,7 @@ peripherals:
             pending_schedule: Vec::new(),
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
         };
 
         bus.flash.write_u8(0x0800_0000, 0x12);
@@ -3353,6 +3534,7 @@ peripherals:
             pending_schedule: Vec::new(),
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
         };
 
         bus.rebuild_peripheral_ranges();
@@ -3410,6 +3592,7 @@ peripherals:
             pending_schedule: Vec::new(),
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
         };
         bus.rebuild_peripheral_ranges();
 

--- a/crates/core/src/peripherals/fdcan.rs
+++ b/crates/core/src/peripherals/fdcan.rs
@@ -139,6 +139,19 @@ const IR_TFE: u32 = 1 << 9;
 
 const ILE_EINT0: u32 = 1 << 0;
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct FdcanTraceFrame {
+    pub seq: u64,
+    pub peripheral: String,
+    pub direction: String,
+    pub id: u32,
+    pub data: Vec<u8>,
+    pub extended: bool,
+    pub fd: bool,
+    pub bitrate_switch: bool,
+    pub remote: bool,
+}
+
 /// STM32H5 FDCAN instance (FDCAN1) plus the shared CONFIG block and
 /// SRAMCAN window.
 ///
@@ -189,6 +202,10 @@ pub struct Fdcan {
     /// attached. Bounded: oldest dropped past 64.
     #[serde(skip)]
     pub tx_frames: VecDeque<CanFrame>,
+    #[serde(skip)]
+    trace_seq: u64,
+    #[serde(skip)]
+    trace: VecDeque<FdcanTraceFrame>,
     /// `CanBus` interconnect endpoints (`new_with_bus`). NOTE: the
     /// current CanBus broadcasts to every attached node including the
     /// transmitter; a real CAN node does not receive its own frame.
@@ -236,6 +253,8 @@ impl Fdcan {
             bus_active: false,
             message_ram: vec![0; RAM_WORDS],
             tx_frames: VecDeque::new(),
+            trace_seq: 0,
+            trace: VecDeque::new(),
             bus_tx: None,
             bus_rx: None,
         }
@@ -249,6 +268,35 @@ impl Fdcan {
         dev.bus_tx = Some(tx);
         dev.bus_rx = Some(rx);
         dev
+    }
+
+    pub fn trace_snapshot(&self, peripheral: &str) -> Vec<FdcanTraceFrame> {
+        self.trace
+            .iter()
+            .cloned()
+            .map(|mut frame| {
+                frame.peripheral = peripheral.to_string();
+                frame
+            })
+            .collect()
+    }
+
+    fn push_trace(&mut self, direction: &'static str, frame: &CanFrame) {
+        self.trace_seq = self.trace_seq.wrapping_add(1);
+        if self.trace.len() >= 200 {
+            self.trace.pop_front();
+        }
+        self.trace.push_back(FdcanTraceFrame {
+            seq: self.trace_seq,
+            peripheral: String::new(),
+            direction: direction.to_string(),
+            id: frame.id,
+            data: frame.data.clone(),
+            extended: frame.extended,
+            fd: frame.fd,
+            bitrate_switch: frame.bitrate_switch,
+            remote: frame.remote,
+        });
     }
 
     fn config_unlocked(&self) -> bool {
@@ -420,6 +468,7 @@ impl Fdcan {
             if self.txbtie & bit != 0 {
                 self.ir |= IR_TC;
             }
+            self.push_trace("tx", &frame);
             if self.loopback() {
                 self.receive_frame(frame);
             } else if let Some(tx) = &self.bus_tx {
@@ -471,6 +520,7 @@ impl Fdcan {
             self.ir |= IR_RF0L;
             return false;
         }
+        self.push_trace("rx", &frame);
         let base = RAM_RF0_WORDS + self.rxf0_put as usize * ELEMENT_WORDS;
         self.encode_rx_element(base, &frame);
         self.rxf0_put = (self.rxf0_put + 1) % FIFO_DEPTH;
@@ -708,6 +758,25 @@ mod tests {
         assert_ne!(r1 & (1 << 31), 0, "ANMF");
         assert_eq!(rd(&dev, RAM_BASE + 0xB8), 0xDEAD_BEEF);
         assert_eq!(rd(&dev, RAM_BASE + 0xBC), 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn loopback_frames_are_exposed_as_can_trace_events() {
+        let mut dev = Fdcan::new();
+        enter_loopback(&mut dev);
+        wr(&mut dev, REG_TXBAR, 0x1);
+
+        let trace = dev.trace_snapshot("fdcan1");
+        assert_eq!(trace.len(), 2);
+        assert_eq!(trace[0].peripheral, "fdcan1");
+        assert_eq!(trace[0].direction, "tx");
+        assert_eq!(trace[0].id, 0x123);
+        assert_eq!(
+            trace[0].data,
+            vec![0xEF, 0xBE, 0xAD, 0xDE, 0xBE, 0xBA, 0xFE, 0xCA]
+        );
+        assert_eq!(trace[1].direction, "rx");
+        assert_eq!(trace[1].id, 0x123);
     }
 
     #[test]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -701,6 +701,33 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&snapshots).unwrap_or(JsValue::NULL)
     }
 
+    /// Non-consuming FDCAN frame trace snapshot for CAN/UDS instruments.
+    #[wasm_bindgen]
+    pub fn fdcan_trace_snapshot(&self) -> JsValue {
+        let Some(machine) = self.machine.as_ref() else {
+            return serde_wasm_bindgen::to_value(&Vec::<serde_json::Value>::new())
+                .unwrap_or(JsValue::NULL);
+        };
+
+        let snapshots = machine
+            .bus
+            .peripherals
+            .iter()
+            .flat_map(|p| {
+                let Some(any) = p.dev.as_any() else {
+                    return Vec::new();
+                };
+                let Some(fdcan) = any.downcast_ref::<labwired_core::peripherals::fdcan::Fdcan>()
+                else {
+                    return Vec::new();
+                };
+                fdcan.trace_snapshot(&p.name)
+            })
+            .collect::<Vec<_>>();
+
+        serde_wasm_bindgen::to_value(&snapshots).unwrap_or(JsValue::NULL)
+    }
+
     /// Execute up to max_cycles steps, returning the number actually executed.
     #[wasm_bindgen]
     pub fn step_batch(&mut self, max_cycles: u32) -> Result<u32, JsValue> {

--- a/examples/h563-uds-ecu/README.md
+++ b/examples/h563-uds-ecu/README.md
@@ -1,9 +1,9 @@
 # STM32H563 FDCAN UDS ECU
 
 This example proves the STM32H563 FDCAN model with a small UDS ECU firmware.
-The firmware links UDSLib from `UDSLIB_DIR`, enables FDCAN internal loopback,
-injects a tester ReadDataByIdentifier request for DID `0xF190`, and validates
-the CAN-FD ISO-TP positive response.
+The firmware links UDSLib from `UDSLIB_DIR`, enables FDCAN, waits for the
+`can-diagnostic-tester` external device to send ReadDataByIdentifier DID
+`0xF190`, and validates the CAN-FD ISO-TP positive response.
 
 Build:
 
@@ -19,4 +19,3 @@ cargo run -q -p labwired-cli -- test \
   --output-dir out/h563-uds-ecu \
   --no-uart-stdout
 ```
-

--- a/examples/h563-uds-ecu/firmware/main.c
+++ b/examples/h563-uds-ecu/firmware/main.c
@@ -75,6 +75,7 @@ void *__aeabi_memclr8(void *dst, size_t n)
 
 static volatile uint32_t g_now_ms;
 static volatile bool g_positive_response_sent;
+static volatile bool g_tester_request_seen;
 
 #define REG32(addr) (*(volatile uint32_t *) (addr))
 
@@ -180,12 +181,11 @@ static void read_payload(uint32_t payload_addr, uint8_t *data, uint8_t len)
     }
 }
 
-static void fdcan_start_loopback(void)
+static void fdcan_start(void)
 {
     REG32(fdcan_reg(FDCAN_REG_CCCR)) = CCCR_INIT | CCCR_CCE;
-    REG32(fdcan_reg(FDCAN_REG_CCCR)) = CCCR_INIT | CCCR_CCE | CCCR_TEST | CCCR_MON;
-    REG32(fdcan_reg(FDCAN_REG_TEST)) = TEST_LBCK;
-    REG32(fdcan_reg(FDCAN_REG_CCCR)) = CCCR_TEST | CCCR_MON;
+    REG32(fdcan_reg(FDCAN_REG_TEST)) = 0u;
+    REG32(fdcan_reg(FDCAN_REG_CCCR)) = 0u;
     while ((REG32(fdcan_reg(FDCAN_REG_CCCR)) & CCCR_INIT) != 0u) {
     }
 }
@@ -277,6 +277,10 @@ static void pump_one_tester_request(uds_ctx_t *ctx)
     can_frame_t frame;
     while (fdcan_poll_rx_frame(&frame)) {
         if (frame.id == 0x7E0u) {
+            if (!g_tester_request_seen) {
+                uart_puts("UDS_REQ_22_F190\n");
+                g_tester_request_seen = true;
+            }
             uds_isotp_rx_callback(ctx, frame.id, frame.data, frame.len);
             return;
         }
@@ -315,7 +319,7 @@ int main(void)
     uart_init();
     uart_puts("H563-UDS-ECU\n");
 
-    fdcan_start_loopback();
+    fdcan_start();
     uds_tp_isotp_init(can_send, 0x7E8u, 0x7E0u);
     uds_tp_isotp_set_fd(true);
 
@@ -339,10 +343,6 @@ int main(void)
         for (;;) {
         }
     }
-    static const uint8_t request[] = {0x03u, 0x22u, 0xF1u, 0x90u};
-    uart_puts("UDS_REQ_22_F190\n");
-    (void) fdcan_send_frame(0x7E0u, request, sizeof(request), false);
-
     bool ok = false;
     for (uint32_t i = 0; i < 64u && !ok; ++i) {
         pump_one_tester_request(&ctx);

--- a/examples/h563-uds-ecu/system.yaml
+++ b/examples/h563-uds-ecu/system.yaml
@@ -1,5 +1,10 @@
 name: "h563-uds-ecu"
 chip: "../../configs/chips/stm32h563.yaml"
-external_devices: []
+external_devices:
+  - id: "uds_tester"
+    type: "can-diagnostic-tester"
+    connection: "fdcan1"
+    config:
+      request_id: "0x7E0"
+      request_data: "03 22 F1 90"
 board_io: []
-


### PR DESCRIPTION
## Summary
- add reusable CAN diagnostic tester external device injection into FDCAN peripherals
- add non-consuming FDCAN frame trace snapshots and WASM export for analyzers
- update the H563 UDS ECU example to receive tester CAN traffic instead of using internal loopback

## Verification
- cargo fmt
- cargo test -p labwired-core test_from_config_can_diagnostic_tester_injects_frame_into_fdcan
- cargo test -p labwired-core loopback_frames_are_exposed_as_can_trace_events
- cargo check -p labwired-wasm
- wasm-pack build --dev --target web --out-dir /tmp/labwired-wasm-fdcan-trace-final
- cargo run -q -p labwired-cli -- test --script examples/h563-uds-ecu/uds-smoke.yaml --output-dir out/h563-uds-ecu --no-uart-stdout