### PR TITLE
fix(cli): cycle-accurate GPIO labs + byte-width memory_value assertions

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4551,6 +4551,10 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     let batch_size = if machine.config.batch_mode_enabled
         && args.breakpoint.is_empty()
         && detect_stuck.is_none()
+        // Cycle-tight GPIO-timing devices (e.g. HC-SR04 ECHO pulse) only behave
+        // correctly when peripherals tick between every instruction; instruction
+        // batching freezes them across the batch and the firmware measures 0.
+        && !machine.bus.requires_cycle_accurate()
     {
         10000.min(max_steps)
     } else {
@@ -4715,19 +4719,26 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             TestAssertion::UartRegex(a) => simple_regex_is_match(&a.uart_regex, &uart_text),
             TestAssertion::ExpectedStopReason(a) => a.expected_stop_reason == stop_reason,
             TestAssertion::MemoryValue(a) => {
+                // `size` is the value width. Accept either bytes (1/2/4) or
+                // bits (8/16/32) — both name the same u8/u16/u32 reads — so a
+                // natural "4 bytes" guess for a u32 RAM word works as well as
+                // the historical bit-width form. Defaults to a 32-bit (u32) word.
                 let size = a.memory_value.size.unwrap_or(32);
                 let result = match size {
-                    8 => machine
+                    1 | 8 => machine
                         .bus
                         .read_u8(a.memory_value.address)
                         .map(|v| v as u32),
-                    16 => machine
+                    2 | 16 => machine
                         .bus
                         .read_u16(a.memory_value.address)
                         .map(|v| v as u32),
-                    32 => machine.bus.read_u32(a.memory_value.address),
+                    4 | 32 => machine.bus.read_u32(a.memory_value.address),
                     _ => {
-                        error!("Unsupported memory assertion size: {}", size);
+                        error!(
+                            "Unsupported memory assertion size: {} — use 1/2/4 (bytes) or 8/16/32 (bits)",
+                            size
+                        );
                         Err(labwired_core::SimulationError::Other("Invalid size".into()))
                     }
                 };

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -585,6 +585,9 @@ pub struct MemoryValueDetails {
     pub expected_value: u64,
     #[serde(default)]
     pub mask: Option<u64>,
+    /// Value width to read at `address`. Accepts bytes (1/2/4) or the
+    /// equivalent bit width (8/16/32); both map to a u8/u16/u32 read.
+    /// Defaults to a 32-bit (u32) word.
     #[serde(default)]
     pub size: Option<u8>,
 }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -510,6 +510,18 @@ impl SystemBus {
         Some((base + idr_off, bit))
     }
 
+    /// True when the wired devices need cycle-accurate (non-batched) execution
+    /// to behave correctly. Some external devices are driven from `tick_peripherals`
+    /// and observed by cycle-tight firmware loops — e.g. the HC-SR04 holds ECHO
+    /// high for a pulse the firmware times by polling GPIO IN in a busy loop.
+    /// Batched execution advances many instructions before ticking peripherals,
+    /// so the firmware polls a frozen ECHO and measures nothing. Runners should
+    /// disable instruction batching when this returns true (correctness > speed).
+    /// New per-tick GPIO-timing devices should extend this predicate.
+    pub fn requires_cycle_accurate(&self) -> bool {
+        !self.hcsr04.is_empty()
+    }
+
     /// Service all HC-SR04 sensors for one tick: compute each sensor's ECHO
     /// level from its (write-hook-armed) echo window and drive it onto the ECHO
     /// input register, touching the bus only on a level transition. TRIG is NOT

--- a/examples/nrf52840-proximity-lab/proximity-smoke.yaml
+++ b/examples/nrf52840-proximity-lab/proximity-smoke.yaml
@@ -1,0 +1,41 @@
+schema_version: "1.0"
+# CLI smoke test for the nRF52840 + HC-SR04 proximity lab.
+#
+# Mirrors the browser demo and the Rust e2e test (e2e_nrf52840_proximity.rs),
+# but exercises the SAME firmware through the `labwired-cli test` harness so the
+# lab has a reproducible command-line entry point.
+#
+# IMPORTANT: this drives the lab via `test --script` (which loads system.yaml and
+# therefore WIRES the HC-SR04). `run --chip ...` does NOT attach the sensor, so
+# the ECHO line never fires and the ranging statics stay 0.
+#
+# The firmware ranges the sensor and BLE-broadcasts every cycle; a full cycle
+# (TRIG -> ECHO timing -> RADIO TX with blocking event waits) costs millions of
+# CPU steps, so the assertions need a multi-million step budget — a small budget
+# reads the statics before the first cycle completes (they are still 0).
+#
+# Build the firmware first:
+#   cargo build -p firmware-nrf52840-proximity --target thumbv7em-none-eabi --release
+# Then run:
+#   cargo run -q -p labwired-cli -- test \
+#     --script examples/nrf52840-proximity-lab/proximity-smoke.yaml \
+#     --output-dir out/nrf52840-proximity
+inputs:
+  system: "./system.yaml"
+  firmware: "../../target/thumbv7em-none-eabi/release/firmware-nrf52840-proximity"
+limits:
+  max_steps: 6000000
+assertions:
+  # DISTANCE_MM (0x20000000) ranges the 10 cm target to ~99 mm (0x63). Proves
+  # the ECHO pulse was actually timed (not left at the 0 reset value).
+  - memory_value:
+      address: 0x20000000
+      expected_value: 99
+      size: 4
+  # IN_RANGE (0x20000004) latches to 1: 99 mm is inside the firmware's 150 mm
+  # threshold.
+  - memory_value:
+      address: 0x20000004
+      expected_value: 1
+      size: 4
+  - expected_stop_reason: max_steps


### PR DESCRIPTION
## What

Two fixes surfaced by the nRF52840 + HC-SR04 proximity lab failing under the `labwired-cli test` harness while the browser and Rust e2e paths worked.

### 1. `memory_value` assertion `size` accepts byte widths
The assertion `size` only accepted bit widths (8/16/32); the natural `4` (bytes) produced a cryptic "Invalid size". Now accepts both byte (1/2/4) and bit (8/16/32) widths; error message lists both.

### 2. Cycle-accurate GPIO-timing labs are not instruction-batched
Root cause of the proximity lab reading `DISTANCE_MM=0`: the CLI `test` harness batches 10k instructions before ticking peripherals, which freezes the GPIO ECHO register mid-pulse so the firmware times a zero-width echo. The register model was always correct — the scheduling froze it.

Added a reusable `SystemBus::requires_cycle_accurate()` predicate (true when a cycle-tight device such as HC-SR04 is wired) that disables instruction batching for those systems. General — any future GPIO-timing device opts in the same way, no per-lab hack.

### 3. Proximity CLI smoke test
New `examples/nrf52840-proximity-lab/proximity-smoke.yaml` gives the lab a reproducible command-line entry point, asserting `DISTANCE_MM=99` / `IN_RANGE=1` through the same firmware the browser demo runs.

## Verification
- proximity smoke: `status: pass`, all 3 assertions (`@0x20000000=0x63`, `@0x20000004=0x1`, stop=max_steps)
- `cargo check` workspace: clean
- `labwired-cli` unit tests: 6 pass