### PR TITLE
fix(proximity): pin build target so the crate builds out of the box

### DIFF
--- a/crates/firmware-nrf52840-proximity/.cargo/config.toml
+++ b/crates/firmware-nrf52840-proximity/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"


### PR DESCRIPTION
## Problem

`cargo build -p firmware-nrf52840-proximity` fails out of the box:

```
ld: unknown options: -T
clang: error: linker command failed with exit code 1
```

## Root cause

The crate was **missing its `.cargo/config.toml`** that pins the embedded target. Every working sibling (`firmware-nrf52840-demo`, `-conformance`) has one; this crate didn't. Without it, a bare `-p` build defaults to the **host** target (aarch64-apple-darwin) and the host linker chokes on `-Tlink.x`.

## Not the cause (for the record)

An earlier report blamed the `build.rs` `-Tlink.x` line as a double-emit against the workspace config. That's wrong: the workspace `.cargo/config.toml` only injects `link.x` for **thumbv6m** (Cortex-M0), not **thumbv7em** (nrf52840). The build.rs line is correct and required — removing it is not the fix.

## Fix

Add the same one-line target pin the sibling crates already use:

```toml
[build]
target = "thumbv7em-none-eabi"
```

Verified: `cargo build -p firmware-nrf52840-proximity` now builds clean.

## Note

`-isr-blinky`, `-timer-blinky`, and the four `-ble-*` nrf52840 crates have the same missing-config gap and will hit the identical failure on a bare `-p` build. Not addressed here to keep this scoped.