### PR TITLE
fix(nrf52840): pin build target on remaining crates so they build out of the box

### DIFF
--- a/crates/firmware-nrf52840-ble-collector/.cargo/config.toml
+++ b/crates/firmware-nrf52840-ble-collector/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/crates/firmware-nrf52840-ble-rx/.cargo/config.toml
+++ b/crates/firmware-nrf52840-ble-rx/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/crates/firmware-nrf52840-ble-sensor/.cargo/config.toml
+++ b/crates/firmware-nrf52840-ble-sensor/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/crates/firmware-nrf52840-ble-tx/.cargo/config.toml
+++ b/crates/firmware-nrf52840-ble-tx/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/crates/firmware-nrf52840-isr-blinky/.cargo/config.toml
+++ b/crates/firmware-nrf52840-isr-blinky/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/crates/firmware-nrf52840-timer-blinky/.cargo/config.toml
+++ b/crates/firmware-nrf52840-timer-blinky/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"


### PR DESCRIPTION
## Problem

Follow-up to #252. The same missing-config gap affects six more nrf52840 crates — a bare `cargo build -p <crate>` fails:

```
ld: unknown options: -T
```

because without a `.cargo/config.toml` the build defaults to the **host** target and the host linker chokes on `-Tlink.x`.

## Affected crates

- `firmware-nrf52840-isr-blinky`
- `firmware-nrf52840-timer-blinky`
- `firmware-nrf52840-ble-collector`
- `firmware-nrf52840-ble-rx`
- `firmware-nrf52840-ble-sensor`
- `firmware-nrf52840-ble-tx`

## Fix

Add the same one-line target pin every working sibling uses:

```toml
[build]
target = "thumbv7em-none-eabi"
```

Verified each of the six builds clean. This completes the nrf52840 family — no remaining crates are missing the config.