### PR TITLE
esp32c3 rom-boot: route XIP reads through the MMU (BROM reads real flash)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -929,6 +929,12 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
             flash_path
         );
         let backing = Arc::new(Mutex::new(flash_bytes));
+        // Route reads through peripherals first: the fast path checks the
+        // chip's `flash`/`drom` memory-regions (zero-filled in rom-boot) before
+        // peripherals, which would shadow the FlashXip windows we install at the
+        // same XIP addresses. Disabling it lets the MMU-translating FlashXip
+        // serve 0x4200_0000 / 0x3C00_0000 from the real flash image.
+        bus.config.optimized_bus_access = false;
         // SPIMEM1 flash-command controller (0x6000_2000) backed by the real
         // image, overriding the declarative stub — a narrower, later-registered
         // window wins, so the BROM's READ/RDID/RDSR commands return real bytes.

--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -185,13 +185,21 @@ impl FlashXipPeripheral {
 
 impl Peripheral for FlashXipPeripheral {
     fn read(&self, offset: u64) -> SimResult<u8> {
-        match self.translate(offset) {
+        let r = match self.translate(offset) {
             Some(phys) => {
                 let backing = self.backing.lock().unwrap();
-                Ok(*backing.get(phys as usize).unwrap_or(&0))
+                *backing.get(phys as usize).unwrap_or(&0)
             }
-            None => Ok(0), // unmapped page reads as 0
+            None => 0, // unmapped page reads as 0
+        };
+        if offset < 0x40 && std::env::var("LABWIRED_XIP_DEBUG").is_ok() {
+            eprintln!(
+                "xip: base=0x{:08x} off=0x{offset:x} -> phys={:?} = 0x{r:02x}",
+                self.base,
+                self.translate(offset)
+            );
         }
+        Ok(r)
     }
 
     fn write(&mut self, offset: u64, _value: u8) -> SimResult<()> {
@@ -254,6 +262,9 @@ impl Peripheral for Esp32s3MmuTable {
 
     fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
         if let Some(i) = Self::entry_index(offset & !3) {
+            if std::env::var("LABWIRED_XIP_DEBUG").is_ok() {
+                eprintln!("mmu: entry[{i}] <- 0x{value:08x}");
+            }
             self.table.lock().unwrap()[i] = value;
         }
         Ok(())


### PR DESCRIPTION
Follow-up to #254. The fast bus path checks the chip's `flash`/`drom` memory-regions (zero-filled under `--rom-boot`) before peripherals, shadowing the `FlashXip` windows installed at the same XIP addresses. Disable `optimized_bus_access` on the C3 rom-boot bus so reads route through peripherals first — the MMU-translating `FlashXip` now serves `0x3C00_0000` from the real flash image, and the BROM reads the real bootloader ESP-image header (`e9 03 02 1f…`) through the MMU entry it programs (`entry[0] → flash page 0`).

Scope: `--rom-boot` C3 path only (opt-in); plus an env-gated XIP/MMU debug (`LABWIRED_XIP_DEBUG`) for bring-up. No effect on fast-boot or other chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)