### PR TITLE
esp32c3 rom-boot: through the 2nd-stage bootloader (cycle CSR, cache state, analog I2C, eFuse rev)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -993,6 +993,16 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
             None,
             Box::new(labwired_core::peripherals::esp32c3::cache::Esp32c3Cache::new()),
         );
+        // Analog I²C master / ANA_CONFIG block (0x6000_E000, DR_REG_RTC_I2C_BASE):
+        // rom_i2c_writeReg drives it (read-modify-write of ANA_CONFIG regs) during
+        // PHY/clock bring-up. Register-backed read-back keeps that path mapped.
+        bus.add_peripheral(
+            "rtc_i2c_ana",
+            0x6000_E000,
+            0x100,
+            None,
+            Box::new(labwired_core::peripherals::esp32c3::reg_block::Esp32c3RegBlock::new(0x100)),
+        );
         bus.add_peripheral(
             "flash_irom_xip",
             0x4200_0000,
@@ -1026,6 +1036,11 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
         //     Xtensa rom-boot strap).
         let _ = bus.write_u32(0x6000_8038, 0x0000_0001);
         let _ = bus.write_u32(0x6000_4038, 0x0000_0008);
+        //   * eFuse wafer version (EFUSE_RD_MAC_SPI_SYS_3 @ 0x6000_8850,
+        //     WAFER_VERSION_MINOR_LO bits[20:18]) = 4 → chip rev v0.4. The real
+        //     C3 is v0.4; without it eFuse reads v0.0 and the 2nd-stage
+        //     bootloader rejects the app ("requires chip rev >= v0.3").
+        let _ = bus.write_u32(0x6000_8850, 0x0010_0000);
         let mut cpu = labwired_core::system::riscv::configure_riscv(&mut bus);
         cpu.set_pc(0x4000_0000);
         labwired_core::Machine::new(cpu, bus)

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -66,6 +66,12 @@ impl RiscV {
             // Timer CSR stubs (Standard RISC-V shadow non-privileged? No, these are machine mode)
             0xB00 => (self.mtime & 0xFFFFFFFF) as u32,
             0xB80 => (self.mtime >> 32) as u32,
+            // Free-running cycle counters. 0xC00/0xC80 = standard cycle[h];
+            // 0x802 is the ESP32-C3 machine cycle CSR that `ets_delay_us`
+            // busy-reads (while now-start < target_cycles). Without an advancing
+            // value the delay spins forever. Back them with the per-step mtime.
+            0xC00 | 0x802 => (self.mtime & 0xFFFFFFFF) as u32,
+            0xC80 => (self.mtime >> 32) as u32,
             _ => 0,
         }
     }

--- a/crates/core/src/peripherals/esp32c3/cache.rs
+++ b/crates/core/src/peripherals/esp32c3/cache.rs
@@ -34,11 +34,14 @@ const NUM_REGS: usize = 0x100;
 ///   0x028 ICACHE_SYNC_CTRL     SYNC_DONE     = BIT(1)
 ///   0x034 ICACHE_PRELOAD_CTRL  PRELOAD_DONE  = BIT(1)
 ///   0x040 ICACHE_AUTOLOAD_CTRL AUTOLOAD_DONE = BIT(3)
-const DONE_BITS: [(usize, u32); 4] = [
+///   0x0B0 CACHE_STATE       ICACHE_STATE[11:0] rests at 0x1 (idle); the ROM
+///                           cache enable/disable routines spin until state==1.
+const DONE_BITS: [(usize, u32); 5] = [
     (0x01C, 1 << 2),
     (0x028, 1 << 1),
     (0x034, 1 << 1),
     (0x040, 1 << 3),
+    (0x0B0, 1 << 0), // CACHE_STATE = idle (0x1)
 ];
 
 /// `(byte_offset, request_mask, ack_mask)` — *level* handshakes where firmware

--- a/crates/core/src/peripherals/esp32c3/mod.rs
+++ b/crates/core/src/peripherals/esp32c3/mod.rs
@@ -5,3 +5,4 @@
 //! ESP32-C3 (RISC-V) specific peripheral models.
 
 pub mod cache;
+pub mod reg_block;

--- a/crates/core/src/peripherals/esp32c3/reg_block.rs
+++ b/crates/core/src/peripherals/esp32c3/reg_block.rs
@@ -1,0 +1,62 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Generic register-backed MMIO block for ESP32-C3 bring-up.
+//!
+//! A plain read/write register file: writes are stored, reads return the last
+//! written value (reset 0). Used for blocks the boot path only configures via
+//! read-modify-write and read-back — e.g. the analog I²C master / `ANA_CONFIG`
+//! registers at `0x6000_E000` (`DR_REG_RTC_I2C_BASE`) that `rom_i2c_writeReg`
+//! drives during PHY/clock bring-up. It is NOT a behavioural model; if a block
+//! turns out to need launch/done or busy semantics, promote it to a real model
+//! (see [`super::cache`]).
+
+use crate::{Peripheral, SimResult};
+
+#[derive(Debug)]
+pub struct Esp32c3RegBlock {
+    regs: Vec<u32>,
+}
+
+impl Esp32c3RegBlock {
+    /// `size_bytes` is rounded up to whole 32-bit words.
+    pub fn new(size_bytes: usize) -> Self {
+        Self {
+            regs: vec![0u32; size_bytes.div_ceil(4)],
+        }
+    }
+}
+
+impl Peripheral for Esp32c3RegBlock {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let w = self.read_u32(offset & !3)?;
+        Ok((w >> ((offset & 3) * 8)) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let aligned = offset & !3;
+        let sh = (offset & 3) * 8;
+        let cur = self.read_u32(aligned)?;
+        self.write_u32(aligned, (cur & !(0xFFu32 << sh)) | ((value as u32) << sh))
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(*self.regs.get((offset / 4) as usize).unwrap_or(&0))
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if let Some(slot) = self.regs.get_mut((offset / 4) as usize) {
+            *slot = value;
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}


### PR DESCRIPTION
Follow-on to #254/#255/#256/#257. With the C.ADDI4SPN decode fixed, the real C3 mask ROM reaches the 2nd-stage bootloader; these four small additions take it through the full ESP-IDF bootloader and into app-image mapping:

- **cycle CSR**: back `0x802` (C3 machine cycle) + `0xC00/0xC80` with per-step `mtime` — `ets_delay_us` busy-reads `0x802` and spun forever on 0.
- **cache state**: `EXTMEM_CACHE_STATE` (`0x0B0`) rests at `0x1` (idle); `Cache_Enable/Disable_ICache` spin until state==1.
- **reg_block + analog I2C**: generic register-backed block wired at the analog-I2C/`ANA_CONFIG` region (`0x6000_E000`) that `rom_i2c_writeReg` drives during PHY/clock bring-up.
- **eFuse wafer version**: seed `0x6000_8850` bits[20:18]=4 → chip rev v0.4; otherwise the bootloader rejects the app (`requires chip rev >= v0.3`).

Boot now prints the real IDF bootloader log (`chip revision: v0.4`, partition table, `esp_image` segment load). `--rom-boot` C3 only; all 1301 core lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)