### PR TITLE
fix(riscv): back C3 perf counter CSR 0x7E2 with mtime

### DIFF
--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -70,7 +70,9 @@ impl RiscV {
             // 0x802 is the ESP32-C3 machine cycle CSR that `ets_delay_us`
             // busy-reads (while now-start < target_cycles). Without an advancing
             // value the delay spins forever. Back them with the per-step mtime.
-            0xC00 | 0x802 => (self.mtime & 0xFFFFFFFF) as u32,
+            // 0x7E2 is the C3 machine performance counter (PCCR), which
+            // bootloader_fill_random reads as an entropy/timing delta.
+            0xC00 | 0x802 | 0x7E2 => (self.mtime & 0xFFFFFFFF) as u32,
             0xC80 => (self.mtime >> 32) as u32,
             _ => 0,
         }


### PR DESCRIPTION
`bootloader_fill_random` (RNG early entropy source) reads CSR `0x7E2` (C3 machine performance counter, PCCR) as `elapsed = now - start` and busy-loops per byte while `elapsed <= 0x13ff`. Returning 0 spun it forever. Back `0x7E2` with the per-step `mtime` like the other free-running cycle CSRs (`0x802`/`0xC00`) so the bootloader's entropy gathering progresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)