### PR TITLE
perf(esp32c3): scaled cycle CSR + hardware RNG (full bootloader runs)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1003,6 +1003,17 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
             None,
             Box::new(labwired_core::peripherals::esp32c3::reg_block::Esp32c3RegBlock::new(0x100)),
         );
+        // Hardware RNG data register (WDEV_RND_REG, 0x6002_60B0): yields a fresh
+        // word per read. bootloader_fill_random XORs successive reads and
+        // process_segments refills ram_obfs_value until non-zero — a constant
+        // RNG gives 0 and spins forever. Override the SYSCON stub at this word.
+        bus.add_peripheral(
+            "wdev_rnd",
+            0x6002_60B0,
+            0x4,
+            None,
+            Box::new(labwired_core::peripherals::esp32c3::rng::Esp32c3Rng::new()),
+        );
         bus.add_peripheral(
             "flash_irom_xip",
             0x4200_0000,

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -88,9 +88,7 @@ impl RiscV {
             // pure delay. Delay loops only need to *complete*, not match wall
             // time, so a coarse cycle estimate is correct in sim; the real-time
             // CLINT timer (mtime vs mtimecmp, CSR 0xB00) stays unscaled.
-            0xC00 | 0x802 | 0x7E2 => {
-                (self.mtime.wrapping_mul(CYCLE_SCALE) & 0xFFFFFFFF) as u32
-            }
+            0xC00 | 0x802 | 0x7E2 => (self.mtime.wrapping_mul(CYCLE_SCALE) & 0xFFFFFFFF) as u32,
             0xC80 => (self.mtime.wrapping_mul(CYCLE_SCALE) >> 32) as u32,
             _ => 0,
         }

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -8,6 +8,16 @@ use crate::decoder::riscv::{decode_rv32, Instruction};
 use crate::{Bus, Cpu, SimResult, SimulationObserver};
 use std::sync::Arc;
 
+/// Estimated CPU clocks per interpreted instruction, used to scale the
+/// free-running cycle/perf-counter CSRs (0x802/0x7E2/0xC00). Firmware busy-wait
+/// delays compute a target in CPU clocks (e.g. `us * cpu_freq_mhz`); reporting
+/// the cycle counter as `mtime * CYCLE_SCALE` lets those delays elapse in
+/// ~1/CYCLE_SCALE the interpreted instructions instead of one-per-clock. Sim
+/// delays only need to complete, not match wall-clock, so a coarse value is
+/// correct here. Kept a power of two; tuned so the C3 bootloader's entropy fill
+/// drops from ~380M instructions to a few million.
+const CYCLE_SCALE: u64 = 256;
+
 #[derive(Debug, Default)]
 pub struct RiscV {
     pub x: [u32; 32], // x0..x31. x0 is correctly hardwired to 0 in logic.
@@ -67,13 +77,21 @@ impl RiscV {
             0xB00 => (self.mtime & 0xFFFFFFFF) as u32,
             0xB80 => (self.mtime >> 32) as u32,
             // Free-running cycle counters. 0xC00/0xC80 = standard cycle[h];
-            // 0x802 is the ESP32-C3 machine cycle CSR that `ets_delay_us`
-            // busy-reads (while now-start < target_cycles). Without an advancing
-            // value the delay spins forever. Back them with the per-step mtime.
-            // 0x7E2 is the C3 machine performance counter (PCCR), which
-            // bootloader_fill_random reads as an entropy/timing delta.
-            0xC00 | 0x802 | 0x7E2 => (self.mtime & 0xFFFFFFFF) as u32,
-            0xC80 => (self.mtime >> 32) as u32,
+            // 0x802 is the ESP32-C3 machine cycle CSR (`ets_delay_us` busy-reads
+            // it as while(now-start < target_cycles)); 0x7E2 is the C3 perf
+            // counter PCCR (bootloader_fill_random reads it as an entropy delta).
+            //
+            // These are reported as mtime * CYCLE_SCALE so that cycle-budget
+            // delays (which the firmware computes in CPU clocks, e.g. µs*freq)
+            // elapse in ~1/CYCLE_SCALE as many interpreted instructions. Without
+            // it the bootloader's entropy fill alone burns ~380M instructions of
+            // pure delay. Delay loops only need to *complete*, not match wall
+            // time, so a coarse cycle estimate is correct in sim; the real-time
+            // CLINT timer (mtime vs mtimecmp, CSR 0xB00) stays unscaled.
+            0xC00 | 0x802 | 0x7E2 => {
+                (self.mtime.wrapping_mul(CYCLE_SCALE) & 0xFFFFFFFF) as u32
+            }
+            0xC80 => (self.mtime.wrapping_mul(CYCLE_SCALE) >> 32) as u32,
             _ => 0,
         }
     }

--- a/crates/core/src/peripherals/esp32c3/mod.rs
+++ b/crates/core/src/peripherals/esp32c3/mod.rs
@@ -6,3 +6,4 @@
 
 pub mod cache;
 pub mod reg_block;
+pub mod rng;

--- a/crates/core/src/peripherals/esp32c3/rng.rs
+++ b/crates/core/src/peripherals/esp32c3/rng.rs
@@ -1,0 +1,72 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 hardware RNG data register (`WDEV_RND_REG`, `0x6002_60B0`).
+//!
+//! On silicon this is a single read-only register that yields a fresh random
+//! word on every read. Firmware (and the 2nd-stage bootloader) depend on that:
+//! `bootloader_fill_random` builds each entropy byte from `RNG ^ RNG` of two
+//! successive reads, and `process_segments` refills `ram_obfs_value` until it is
+//! non-zero — so a constant RNG (the declarative stub returns 0) yields 0 and
+//! spins forever. Model it as a fast xorshift32 that advances on every read,
+//! giving varying, deterministic (reproducible) words. Not cryptographic, which
+//! is fine for sim — it only has to *vary*.
+
+use crate::{Peripheral, SimResult};
+use std::cell::Cell;
+
+#[derive(Debug)]
+pub struct Esp32c3Rng {
+    state: Cell<u32>,
+}
+
+impl Default for Esp32c3Rng {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Esp32c3Rng {
+    pub fn new() -> Self {
+        Self {
+            state: Cell::new(0xACE1_5EED), // non-zero xorshift seed
+        }
+    }
+
+    fn next_word(&self) -> u32 {
+        let mut x = self.state.get();
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.state.set(x);
+        x
+    }
+}
+
+impl Peripheral for Esp32c3Rng {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let w = self.next_word();
+        Ok((w >> ((offset & 3) * 8)) as u8)
+    }
+
+    fn write(&mut self, _offset: u64, _value: u8) -> SimResult<()> {
+        Ok(()) // read-only
+    }
+
+    fn read_u32(&self, _offset: u64) -> SimResult<u32> {
+        Ok(self.next_word())
+    }
+
+    fn write_u32(&mut self, _offset: u64, _value: u32) -> SimResult<()> {
+        Ok(())
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}


### PR DESCRIPTION
Two changes that take C3 `--rom-boot` through the entire ESP-IDF 2nd-stage bootloader (all app segments load):

- **scaled cycle CSR**: report `0x802`/`0x7E2`/`0xC00` as `mtime * 256`. Firmware delays compute a budget in CPU clocks; at one-clock-per-instruction the bootloader entropy fill alone burned ~380M instructions. Delays only need to *complete* in sim; the real-time CLINT timer (`mtime`/`mtimecmp`, `0xB00`) stays unscaled.
- **hardware RNG**: model `WDEV_RND_REG` (`0x6002_60B0`) as xorshift32 (fresh word/read). `bootloader_fill_random` XORs successive RNG reads and `process_segments` refills until non-zero — a constant RNG gave 0 and spun forever.

Boot now reaches chip rev v0.4, the partition table, and all 5 `esp_image` segments loaded. Next blocker: app SHA-256 verify (accelerator unmodeled). `--rom-boot` C3 only; 1301 core lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)