### PR TITLE
fix(bus): read_u16/read_u32 peripheral precedence (fixes XIP instruction-fetch misalignment)

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2696,17 +2696,35 @@ impl crate::Bus for SystemBus {
         if let Some(val) = self.ram.read_u16(addr) {
             return Ok(val);
         }
-        if let Some(val) = self.flash.read_u16(addr) {
-            return Ok(val);
-        }
-        if self.flash.base_addr != 0 && addr + 1 < self.flash.data.len() as u64 {
-            if let Some(val) = self.flash.read_u16(self.flash.base_addr + addr) {
+        // See read_u32: with optimized_bus_access off, peripherals (FlashXip)
+        // win over the plain flash region at the same XIP address.
+        let flash_and_alias = |s: &Self| -> Option<u16> {
+            if let Some(val) = s.flash.read_u16(addr) {
+                return Some(val);
+            }
+            if s.flash.base_addr != 0 && addr + 1 < s.flash.data.len() as u64 {
+                return s.flash.read_u16(s.flash.base_addr + addr);
+            }
+            None
+        };
+        if self.config.optimized_bus_access {
+            if let Some(val) = flash_and_alias(self) {
                 return Ok(val);
             }
-        }
-        if let Some(idx) = self.find_peripheral_index(addr) {
-            let p = &self.peripherals[idx];
-            return p.dev.read_u16(addr - p.base);
+            if let Some(idx) = self.find_peripheral_index(addr) {
+                return self.peripherals[idx]
+                    .dev
+                    .read_u16(addr - self.peripherals[idx].base);
+            }
+        } else {
+            if let Some(idx) = self.find_peripheral_index(addr) {
+                return self.peripherals[idx]
+                    .dev
+                    .read_u16(addr - self.peripherals[idx].base);
+            }
+            if let Some(val) = flash_and_alias(self) {
+                return Ok(val);
+            }
         }
         let b0 = self.read_u8(addr)? as u16;
         let b1 = self.read_u8(addr + 1)? as u16;
@@ -2725,17 +2743,39 @@ impl crate::Bus for SystemBus {
         if let Some(val) = self.ram.read_u32(addr) {
             return Ok(val);
         }
-        if let Some(val) = self.flash.read_u32(addr) {
-            return Ok(val);
-        }
-        if self.flash.base_addr != 0 && addr + 3 < self.flash.data.len() as u64 {
-            if let Some(val) = self.flash.read_u32(self.flash.base_addr + addr) {
+        // Flash region + boot alias, and peripherals. With optimized_bus_access
+        // off (C3 rom-boot) peripherals win over the plain flash region so an
+        // MMU-translating FlashXip window overrides the zero-filled flash at the
+        // same XIP address — otherwise a 4-byte instruction fetch at an XIP
+        // address reads 0, misdecodes as 2-byte and the PC drifts (mirrors the
+        // read_u8 fix). The fallback to per-byte read_u8 covers either order.
+        let flash_and_alias = |s: &Self| -> Option<u32> {
+            if let Some(val) = s.flash.read_u32(addr) {
+                return Some(val);
+            }
+            if s.flash.base_addr != 0 && addr + 3 < s.flash.data.len() as u64 {
+                return s.flash.read_u32(s.flash.base_addr + addr);
+            }
+            None
+        };
+        if self.config.optimized_bus_access {
+            if let Some(val) = flash_and_alias(self) {
                 return Ok(val);
             }
-        }
-        if let Some(idx) = self.find_peripheral_index(addr) {
-            let p = &self.peripherals[idx];
-            return p.dev.read_u32(addr - p.base);
+            if let Some(idx) = self.find_peripheral_index(addr) {
+                return self.peripherals[idx]
+                    .dev
+                    .read_u32(addr - self.peripherals[idx].base);
+            }
+        } else {
+            if let Some(idx) = self.find_peripheral_index(addr) {
+                return self.peripherals[idx]
+                    .dev
+                    .read_u32(addr - self.peripherals[idx].base);
+            }
+            if let Some(val) = flash_and_alias(self) {
+                return Ok(val);
+            }
         }
         let b0 = self.read_u8(addr)? as u32;
         let b1 = self.read_u8(addr + 1)? as u32;


### PR DESCRIPTION
Follow-up to #256 (which fixed `read_u8`). The Bus-trait `read_u16`/`read_u32` — the CPU's instruction-fetch and load path — checked `self.flash` before peripherals unconditionally. Under C3 `--rom-boot` (`optimized_bus_access` off), a 4-byte instruction fetched from an XIP address read **0** from the zero-filled flash region instead of the MMU-translating `FlashXip` window. The opcode's low bits then looked compressed, the fetch advanced 2 bytes instead of 4, PC drifted off-boundary, and the app ground through real code at the wrong alignment until it faulted.

Mirror the `read_u8` fix: RAM first; with the flag off, peripherals before the flash region (flash stays the fallback for unmapped addresses). All 1302 core lib tests pass. With it, the C3 app boots past `call_start_cpu0` into real startup + PHY bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)