### PR TITLE
feat(esp32c3): rom-boot reaches FreeRTOS scheduler + app_main (RTC/SYSTIMER/SAR-ADC models + RISC-V interrupt delivery)

### DIFF
--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -26,6 +26,12 @@ memory_regions:
   - name: "drom"
     base: 0x3C000000
     size: "8MB"
+  # RTC FAST memory (8KB): CPU-visible retention RAM the IDF uses for boot-time
+  # timekeeping (esp_rtc_get_time_us reads s_boot_time here) and deep-sleep
+  # stubs. Unmapped, esp_rtc_get_time_us faults during cpu_start.
+  - name: "rtc_fast"
+    base: 0x50000000
+    size: "8KB"
   # Mask ROM (the C3 calls ROM routines during early boot). The dump is the
   # chip's copyrighted mask ROM, so it's loaded from a path in
   # LABWIRED_ESP32C3_ROM rather than committed; region stays zero if unset.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -995,13 +995,15 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
         );
         // Analog I²C master / ANA_CONFIG block (0x6000_E000, DR_REG_RTC_I2C_BASE):
         // rom_i2c_writeReg drives it (read-modify-write of ANA_CONFIG regs) during
-        // PHY/clock bring-up. Register-backed read-back keeps that path mapped.
+        // PHY/clock bring-up; the libphy full RF calibration also touches regs up
+        // past 0x6000_E130, so the window spans 0x400. Register-backed read-back
+        // keeps that path mapped.
         bus.add_peripheral(
             "rtc_i2c_ana",
             0x6000_E000,
-            0x100,
+            0x400,
             None,
-            Box::new(labwired_core::peripherals::esp32c3::reg_block::Esp32c3RegBlock::new(0x100)),
+            Box::new(labwired_core::peripherals::esp32c3::reg_block::Esp32c3RegBlock::new(0x400)),
         );
         // Hardware RNG data register (WDEV_RND_REG, 0x6002_60B0): yields a fresh
         // word per read. bootloader_fill_random XORs successive reads and
@@ -1075,7 +1077,15 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
             0x6002_3000,
             0x100,
             None,
-            Box::new(labwired_core::peripherals::esp32s3::systimer::Systimer::new(160_000_000)),
+            // C3 SYSTIMER_TARGET0 routes through the interrupt matrix on source
+            // 37 (TARGET1/2 at 38/39), unlike the S3's 57; the FreeRTOS tick
+            // alarm fires on that source.
+            Box::new(
+                labwired_core::peripherals::esp32s3::systimer::Systimer::new_with_source(
+                    160_000_000,
+                    37,
+                ),
+            ),
         );
         // RTC_CNTL main timer (0x6000_8000): the free-running slow-clock counter
         // the IDF reads via rtc_time_get (set TIME_UPDATE @0x0C bit31 to latch,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1108,8 +1108,17 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
         //     C3 is v0.4; without it eFuse reads v0.0 and the 2nd-stage
         //     bootloader rejects the app ("requires chip rev >= v0.3").
         let _ = bus.write_u32(0x6000_8850, 0x0010_0000);
+        // Enable C3 RISC-V interrupt routing: the bus routes asserted peripheral
+        // sources + the SYSTEM FROM_CPU IPI registers through the INTERRUPT_CORE0
+        // matrix into the CPU's external interrupt lines. FreeRTOS's first
+        // context switch (vPortYield → FROM_CPU SW interrupt) depends on this.
+        bus.esp32c3_irq_routing = true;
         let mut cpu = labwired_core::system::riscv::configure_riscv(&mut bus);
         cpu.set_pc(0x4000_0000);
+        // Disable the internal CLINT timer: the C3 has no standard MTIP — its
+        // 31 interrupt lines (incl. line 7) are ESP matrix lines, so a
+        // self-pending MTIP would collide. mtimecmp=MAX keeps mip bit7 clear.
+        cpu.mtimecmp = u64::MAX;
         labwired_core::Machine::new(cpu, bus)
     } else {
         let cpu = labwired_core::system::riscv::configure_riscv(&mut bus);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1048,6 +1048,52 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
                 MMU_FMT_C3,
             )),
         );
+        // SAR ADC (APB_SARADC, 0x6004_0000): the IDF's adc_hal_self_calibration
+        // triggers single conversions and polls a data-valid flag (0x44 bit31/
+        // bit30) before reading the result; the declarative stub never asserts
+        // it, so read_cal_channel spins forever after spi_flash init. Model
+        // conversions as instant (valid flags set, mid-scale sample) so the
+        // bounded cal search converges and boot continues.
+        bus.add_peripheral(
+            "apb_saradc",
+            0x6004_0000,
+            0x100,
+            None,
+            Box::new(labwired_core::peripherals::esp32c3::sar_adc::Esp32c3SarAdc::new()),
+        );
+        // SYSTIMER (0x6002_3000): the 16 MHz free-running counter behind
+        // esp_timer and the FreeRTOS tick. systimer_hal_get_counter_value sets
+        // UNITx_OP bit30 (UPDATE) then polls bit29 (VALUE_VALID) before reading
+        // the snapshot; the declarative stub never asserts VALUE_VALID, so the
+        // counter read spins forever right after heap_init. The C3 SYSTIMER is
+        // the same IP as the S3 (identical register layout), so the S3 model
+        // drops in: it asserts VALUE_VALID, advances the counter, and supports
+        // the alarm/IRQ path FreeRTOS needs. Clocked relative to the 160 MHz
+        // CPU (10 CPU cycles per 16 MHz tick).
+        bus.add_peripheral(
+            "systimer",
+            0x6002_3000,
+            0x100,
+            None,
+            Box::new(labwired_core::peripherals::esp32s3::systimer::Systimer::new(160_000_000)),
+        );
+        // RTC_CNTL main timer (0x6000_8000): the free-running slow-clock counter
+        // the IDF reads via rtc_time_get (set TIME_UPDATE @0x0C bit31 to latch,
+        // read TIME0 @0x10 / TIME1 @0x14). A frozen counter makes every
+        // RTC-deadline wait spin forever — most notably calibrate_ocode, which
+        // polls a regi2c comparator that never settles without real RF and
+        // relies on a ~10 ms RTC timeout to give up and continue. A real
+        // advancing timer lets that loop (and other RTC delays) reach the
+        // timeout exactly as silicon does. Overrides the declarative RTC_CNTL
+        // stub for this window; non-timer regs stay register-backed so the
+        // reset-cause seed at 0x38 below still reads back.
+        bus.add_peripheral(
+            "rtc_cntl_timer",
+            0x6000_8000,
+            0x100,
+            None,
+            Box::new(labwired_core::peripherals::esp32c3::rtc_timer::Esp32c3RtcTimer::new()),
+        );
         // Seed the power-on hardware reset state the BROM reads to decide it's a
         // normal flash boot (silicon has this at reset; the sim starts zeroed):
         //   * RTC_CNTL reset-cause (0x6000_8038, bits[5:0]) = 1 (POWERON_RESET).

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -205,6 +205,16 @@ pub struct SystemBus {
     /// running, so ECU examples can be driven by a virtual off-board tester
     /// instead of self-loopback firmware.
     pub can_diagnostic_testers: Vec<CanDiagnosticTester>,
+    /// ESP32-C3 (RISC-V) interrupt routing: when true, each tick the bus routes
+    /// asserted peripheral sources and the SYSTEM FROM_CPU IPI registers
+    /// (0x600C0028..0x34) through the INTERRUPT_CORE0 matrix MAP registers into
+    /// `riscv_irq_lines`. Set by the C3 rom-boot setup; false everywhere else
+    /// so no other architecture's bus is affected.
+    pub esp32c3_irq_routing: bool,
+    /// ESP32-C3 level-sensitive bitmask of asserted CPU interrupt lines (1..31),
+    /// recomputed every tick by `aggregate_esp32c3_irqs`. Read by the RISC-V
+    /// core via `Bus::external_irq_lines`. 0 when `esp32c3_irq_routing` is false.
+    pub riscv_irq_lines: u32,
 }
 
 pub struct CanDiagnosticTester {
@@ -884,6 +894,8 @@ impl SystemBus {
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
             can_diagnostic_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -915,6 +927,8 @@ impl SystemBus {
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
             can_diagnostic_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -1151,6 +1165,8 @@ impl SystemBus {
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
             can_diagnostic_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
         };
 
         let mut merged_peripherals = chip.peripherals.clone();
@@ -2299,6 +2315,72 @@ impl SystemBus {
     /// pushes the per-source assertion bitmap into the intmatrix's
     /// PRO_INTR_STATUS_REG_n mirror via `set_pending_sources`. No-op for buses
     /// without an intmatrix peripheral.
+    /// ESP32-C3 (RISC-V) interrupt routing. Each tick, build the level-sensitive
+    /// bitmask of asserted CPU interrupt lines from the SYSTEM FROM_CPU IPI
+    /// registers (0x600C0028..0x34, bit0) — the mechanism FreeRTOS `vPortYield`
+    /// uses to request a context switch. Each asserted source is routed to a CPU
+    /// line via its INTERRUPT_CORE0 MAP register (0x600C2000 + source*4, low 5
+    /// bits), gated by CPU_INT_ENABLE and per-line priority vs CPU_INT_THRESH.
+    /// The result lands in `riscv_irq_lines`, which the core ORs into `mip`.
+    /// No-op unless `esp32c3_irq_routing` is set (only the C3 rom-boot path sets
+    /// it). Peripheral `explicit_irqs` (e.g. the reused S3 SYSTIMER model) are
+    /// not routed yet — their source IDs don't match the C3 matrix.
+    fn aggregate_esp32c3_irqs(&mut self, source_ids: &[u32]) {
+        if !self.esp32c3_irq_routing {
+            return;
+        }
+        const INTMATRIX_BASE: u64 = 0x600C_2000;
+        // SYSTEM FROM_CPU IPI registers → source IDs 50..53 (matching the
+        // INTERRUPT_CORE0 CPU_INTR_FROM_CPU_n_MAP offsets at 200..212).
+        const FROM_CPU: [(u64, u32); 4] = [
+            (0x600C_0028, 50),
+            (0x600C_002C, 51),
+            (0x600C_0030, 52),
+            (0x600C_0034, 53),
+        ];
+
+        // NOTE: peripheral `explicit_irqs` (e.g. the reused S3 SYSTIMER model,
+        // which emits S3 source 57) are NOT routed here yet — the C3 SYSTIMER
+        // source is 37, so the S3 IDs don't match the C3 matrix. Only the
+        // FROM_CPU IPI sources (the FreeRTOS yield mechanism) are routed, which
+        // is all that's needed to reach the first context switch / app_main.
+        let _ = source_ids;
+        let mut asserted: Vec<u32> = Vec::new();
+        for (addr, src) in FROM_CPU {
+            if self.read_u32(addr).map(|v| v & 1 != 0).unwrap_or(false) {
+                asserted.push(src);
+            }
+        }
+
+        // INTC control registers (offsets verified against interrupt_core0.yaml):
+        //   CPU_INT_ENABLE 0x104, CPU_INT_PRI_n 0x114+n*4, CPU_INT_THRESH 0x194.
+        // A line fires only while it is enabled AND its priority >= threshold —
+        // the C3 enables/masks via these INTC registers, NOT the RISC-V `mie`
+        // CSR (FreeRTOS critical sections raise the threshold to mask).
+        let enable = self.read_u32(INTMATRIX_BASE + 0x104).unwrap_or(0);
+        let thresh = self.read_u32(INTMATRIX_BASE + 0x194).unwrap_or(0) & 0xF;
+
+        let mut mask = 0u32;
+        for src in asserted {
+            // MAP register holds the destination CPU interrupt line (1..31).
+            let line = self
+                .read_u32(INTMATRIX_BASE + (src as u64) * 4)
+                .map(|v| v & 0x1F)
+                .unwrap_or(0);
+            if line == 0 || (enable & (1 << line)) == 0 {
+                continue;
+            }
+            let pri = self
+                .read_u32(INTMATRIX_BASE + 0x114 + (line as u64) * 4)
+                .unwrap_or(0)
+                & 0xF;
+            if pri >= thresh {
+                mask |= 1u32 << line;
+            }
+        }
+        self.riscv_irq_lines = mask;
+    }
+
     fn aggregate_esp32s3_explicit_irqs(&mut self, source_ids: &[u32]) {
         // Rebuild the per-core routed pending bitmap as a faithful LEVEL
         // reflection of the sources asserting THIS tick — set while a source
@@ -2451,6 +2533,7 @@ impl SystemBus {
         // Plan 3: route ESP32-S3 source IDs through the intmatrix and update
         // the pending cpu IRQ bitmap + intmatrix INTR_STATUS mirror.
         self.aggregate_esp32s3_explicit_irqs(&explicit_source_ids);
+        self.aggregate_esp32c3_irqs(&explicit_source_ids);
         self.collect_enabled_nvic_interrupts(&mut interrupts);
 
         (interrupts, costs, dma_requests)
@@ -2461,6 +2544,7 @@ impl SystemBus {
             self.tick_peripherals_phase1();
         // Plan 3: route ESP32-S3 source IDs through the intmatrix.
         self.aggregate_esp32s3_explicit_irqs(&explicit_source_ids);
+        self.aggregate_esp32c3_irqs(&explicit_source_ids);
 
         // Phase 1.5: Route DMA signals
         for (source_name, request_id) in dma_signals {
@@ -2906,6 +2990,10 @@ impl crate::Bus for SystemBus {
 
     fn config(&self) -> &crate::SimulationConfig {
         &self.config
+    }
+
+    fn external_irq_lines(&self) -> u32 {
+        self.riscv_irq_lines
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -3591,6 +3679,8 @@ peripherals:
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
             can_diagnostic_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
         };
 
         bus.flash.write_u8(0x0800_0000, 0x12);
@@ -3646,6 +3736,8 @@ peripherals:
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
             can_diagnostic_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
         };
 
         bus.rebuild_peripheral_ranges();
@@ -3704,6 +3796,8 @@ peripherals:
             legacy_walk_disabled: false,
             hcsr04: Vec::new(),
             can_diagnostic_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
         };
         bus.rebuild_peripheral_ranges();
 

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2339,13 +2339,10 @@ impl SystemBus {
             (0x600C_0034, 53),
         ];
 
-        // NOTE: peripheral `explicit_irqs` (e.g. the reused S3 SYSTIMER model,
-        // which emits S3 source 57) are NOT routed here yet — the C3 SYSTIMER
-        // source is 37, so the S3 IDs don't match the C3 matrix. Only the
-        // FROM_CPU IPI sources (the FreeRTOS yield mechanism) are routed, which
-        // is all that's needed to reach the first context switch / app_main.
-        let _ = source_ids;
-        let mut asserted: Vec<u32> = Vec::new();
+        // Route peripheral `explicit_irqs` (e.g. the SYSTIMER tick alarm, which
+        // the C3 wiring configures to emit matrix source 37) plus the FROM_CPU
+        // IPI sources (the FreeRTOS yield mechanism).
+        let mut asserted: Vec<u32> = source_ids.to_vec();
         for (addr, src) in FROM_CPU {
             if self.read_u32(addr).map(|v| v & 1 != 0).unwrap_or(false) {
                 asserted.push(src);

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -109,6 +109,16 @@ impl RiscV {
     }
 
     fn handle_trap(&mut self, cause: u32, epc: u32) {
+        if std::env::var("LABWIRED_TRAP_DEBUG").is_ok() {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static N: AtomicU32 = AtomicU32::new(0);
+            if N.fetch_add(1, Ordering::Relaxed) < 60 {
+                eprintln!(
+                    "[trap] cause={cause:#010x} epc={epc:#010x} mtvec={:#010x} ra={:#010x} sp={:#010x} a0={:#010x}",
+                    self.mtvec, self.x[1], self.x[2], self.x[10]
+                );
+            }
+        }
         self.mepc = epc;
         self.mcause = cause;
         // mtvec handling (Direct vs Vectored)
@@ -121,8 +131,15 @@ impl RiscV {
         } else {
             self.pc = base;
         }
-        // Disable interrupts (saving previous status in MPIE if we supported it fully)
-        self.mstatus &= !(1 << 3); // Clear MIE
+        // Update mstatus per the privileged spec on trap entry:
+        //   MPIE <- MIE, MIE <- 0, MPP <- current privilege (M-mode = 0b11).
+        // The IDF trap handler saves/restores mstatus around nested interrupts
+        // and ends with MRET, which relies on MPIE carrying the pre-trap MIE.
+        let mie = (self.mstatus >> 3) & 1;
+        self.mstatus &= !(1 << 7); // clear MPIE
+        self.mstatus |= mie << 7; // MPIE <- MIE
+        self.mstatus &= !(1 << 3); // MIE <- 0
+        self.mstatus |= 0b11 << 11; // MPP <- M-mode
     }
 }
 
@@ -350,6 +367,11 @@ impl Cpu for RiscV {
             Instruction::Fence => {
                 // No-op in single threaded core model
             }
+            Instruction::Wfi => {
+                // Wait-for-interrupt: implemented as a no-op busy-wait. The step
+                // loop already polls pending interrupts every instruction, so
+                // the idle task's WFI spin wakes as soon as a line asserts.
+            }
             Instruction::Ecall | Instruction::Ebreak => {
                 // Should trap. For now, we can just log or halt.
                 tracing::warn!("ECALL/EBREAK encountered at {:#x}", self.pc);
@@ -364,11 +386,13 @@ impl Cpu for RiscV {
                 return Ok(());
             }
             Instruction::Mret => {
-                // Return from trap
+                // Return from trap. Per the privileged spec:
+                //   MIE <- MPIE, MPIE <- 1 (privilege <- MPP, but we stay M-mode).
                 self.pc = self.mepc;
-                // mstatus.MIE = mstatus.MPIE. For now we just set MIE=1 if we assume it was enabled.
-                // Simple version:
-                self.mstatus |= 1 << 3; // Re-enable MIE
+                let mpie = (self.mstatus >> 7) & 1;
+                self.mstatus &= !(1 << 3); // clear MIE
+                self.mstatus |= mpie << 3; // MIE <- MPIE
+                self.mstatus |= 1 << 7; // MPIE <- 1
                 return Ok(());
             }
             Instruction::Csrrw { rd, rs1, csr } => {
@@ -668,12 +692,21 @@ impl Cpu for RiscV {
             self.mip &= !(1 << 7);
         }
 
-        // Check for interrupts
+        // Check for interrupts. On the ESP32-C3 the custom interrupt controller
+        // exposes its 31 sources as CPU interrupt lines 1..31 directly in
+        // mip/mie (no standard MEIP/MSIP/MTIP semantics); the bus drives those
+        // lines level-sensitively via `external_irq_lines()` after routing
+        // asserted sources through the interrupt matrix. OR them into the local
+        // mip view so a line stays asserted only while its source does.
         if (self.mstatus & (1 << 3)) != 0 {
-            let pending = self.mip & self.mie;
+            // Standard machine sources are masked by `mie`; ESP32-C3 external
+            // lines arrive already gated (enable + priority/threshold) by the
+            // bus, so they bypass `mie` (which the C3 firmware leaves at 0).
+            let pending = (self.mip & self.mie) | bus.external_irq_lines();
             if pending != 0 {
-                // Find highest priority interrupt (Simplified: MTIP=7, MSIP=3, MEIP=11)
-                // Priority: External > Software > Timer
+                // Standard machine interrupts keep their spec priority
+                // (External > Software > Timer); any other set bit is an ESP
+                // interrupt-matrix line, taken highest-line-first.
                 let irq = if (pending & (1 << 11)) != 0 {
                     11
                 } else if (pending & (1 << 3)) != 0 {
@@ -681,7 +714,7 @@ impl Cpu for RiscV {
                 } else if (pending & (1 << 7)) != 0 {
                     7
                 } else {
-                    0xFFFFFFFF // Should not happen
+                    31 - pending.leading_zeros()
                 };
 
                 if irq != 0xFFFFFFFF {
@@ -1004,6 +1037,70 @@ mod tests {
             3,
             "ADDI at 0x8 must not be re-executed (would read 4 if bug present)"
         );
+    }
+
+    #[test]
+    fn test_riscv_external_irq_line_vectored_and_mret_restores_mie() {
+        // ESP32-C3-style external interrupt: the bus drives a CPU interrupt
+        // line (1..31) via `external_irq_lines()`; with vectored mtvec the core
+        // traps to base + line*4, and MRET restores MIE from MPIE.
+        let mut bus = SystemBus::new();
+        let mut cpu = RiscV::new();
+        cpu.mtvec = 0x2000 | 1; // vectored
+        cpu.mstatus = 1 << 3; // MIE
+        cpu.mtimecmp = u64::MAX; // no CLINT timer interference
+
+        bus.flash.data = vec![0; 0x3000];
+        // NOP loop at 0x0 (ADDI x0,x0,0) and the per-line handlers are NOPs+MRET.
+        bus.write_u32(0x0, 0x00000013).unwrap();
+        bus.write_u32(0x4, 0x00000013).unwrap();
+        // Line 5 vector (0x2000 + 5*4 = 0x2014): MRET.
+        bus.write_u32(0x2014, 0x30200073).unwrap();
+        // Assert external line 5 (esp32c3_irq_routing stays false, so the C3
+        // aggregation leaves riscv_irq_lines untouched between ticks).
+        bus.riscv_irq_lines = 1 << 5;
+
+        cpu.pc = 0x0;
+        let mut machine = Machine::new(cpu, bus);
+        // First step executes the NOP at 0x0, then takes the pending line-5 trap.
+        machine.step().unwrap();
+        assert_eq!(
+            machine.cpu.pc, 0x2014,
+            "vectored trap must jump to mtvec base + line*4"
+        );
+        assert_eq!(
+            machine.cpu.mcause,
+            0x8000_0000 | 5,
+            "mcause = interrupt|line"
+        );
+        assert_eq!(machine.cpu.mstatus & (1 << 3), 0, "MIE cleared on trap");
+        assert_ne!(machine.cpu.mstatus & (1 << 7), 0, "MPIE holds prior MIE");
+        // Drop the line so MRET doesn't immediately re-trap, then MRET.
+        machine.bus.riscv_irq_lines = 0;
+        machine.step().unwrap();
+        assert_ne!(
+            machine.cpu.mstatus & (1 << 3),
+            0,
+            "MRET restores MIE from MPIE"
+        );
+    }
+
+    #[test]
+    fn test_riscv_wfi_is_nop() {
+        // WFI must decode and execute as a no-op (PC advances by 4); the idle
+        // task's WFI spin relies on this.
+        assert_eq!(
+            crate::decoder::riscv::decode_rv32(0x1050_0073),
+            crate::decoder::riscv::Instruction::Wfi
+        );
+        let mut bus = SystemBus::new();
+        let mut cpu = RiscV::new();
+        bus.flash.data = vec![0; 0x100];
+        bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
+        cpu.pc = 0x0;
+        let mut machine = Machine::new(cpu, bus);
+        machine.step().unwrap();
+        assert_eq!(machine.cpu.pc, 0x4, "WFI advances PC like a NOP");
     }
 
     #[test]

--- a/crates/core/src/decoder/riscv.rs
+++ b/crates/core/src/decoder/riscv.rs
@@ -48,6 +48,7 @@ pub enum Instruction {
     Ecall,                                // ECALL
     Ebreak,                               // EBREAK
     Mret,                                 // MRET
+    Wfi,                                  // WFI (wait for interrupt)
     Csrrw { rd: u8, rs1: u8, csr: u16 },  // CSRRW
     Csrrs { rd: u8, rs1: u8, csr: u16 },  // CSRRS
     Csrrc { rd: u8, rs1: u8, csr: u16 },  // CSRRC
@@ -298,6 +299,7 @@ pub fn decode_rv32(inst: u32) -> Instruction {
                     0x000 => Instruction::Ecall,
                     0x001 => Instruction::Ebreak,
                     0x302 => Instruction::Mret,
+                    0x105 => Instruction::Wfi, // WFI (0x10500073)
                     _ => Instruction::Unknown(inst),
                 },
                 1 => Instruction::Csrrw { rd, rs1, csr },

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -544,6 +544,18 @@ pub trait Bus {
     /// Plan 3: clear the pending bit for cpu IRQ `slot` on `core_id`.
     fn clear_cpu_irq_pending(&mut self, _core_id: u8, _slot: u8) {}
 
+    /// ESP32-C3 (RISC-V) external-interrupt delivery: the level-sensitive
+    /// bitmask of CPU interrupt lines (1..31) currently asserted, after the bus
+    /// has routed asserted peripheral sources (and the SYSTEM FROM_CPU IPI
+    /// registers) through the INTERRUPT_CORE0 matrix MAP registers. The RISC-V
+    /// core ORs this into `mip` when deciding whether to trap, so a source that
+    /// de-asserts (e.g. the FROM_CPU yield register cleared by the ISR) drops
+    /// its line on the next tick — no latching. Default 0 for buses that don't
+    /// model it (the line stays low and nothing changes).
+    fn external_irq_lines(&self) -> u32 {
+        0
+    }
+
     /// Plan 2: deliver a coherent 32-bit value to peripherals after the
     /// four byte writes that compose a write_u32 have been dispatched.
     /// Default: no-op for buses that don't route to peripherals.

--- a/crates/core/src/peripherals/esp32c3/mod.rs
+++ b/crates/core/src/peripherals/esp32c3/mod.rs
@@ -7,4 +7,6 @@
 pub mod cache;
 pub mod reg_block;
 pub mod rng;
+pub mod rtc_timer;
+pub mod sar_adc;
 pub mod sha;

--- a/crates/core/src/peripherals/esp32c3/rtc_timer.rs
+++ b/crates/core/src/peripherals/esp32c3/rtc_timer.rs
@@ -1,0 +1,163 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 RTC_CNTL main timer (`0x6000_8000`) — the free-running RTC
+//! slow-clock counter the IDF reads via `rtc_time_get`.
+//!
+//! `rtc_time_get` does: set `RTC_CNTL_TIME_UPDATE` (offset `0x0C`, bit31) to
+//! latch the 48-bit counter into the readout registers, then read the low word
+//! (`RTC_CNTL_TIME0`, `0x10`) and high word (`RTC_CNTL_TIME1`, `0x14`).
+//!
+//! A plain register-backed stub returns a *constant* timer, so every IDF loop
+//! that waits on an RTC deadline spins forever. The most load-bearing example
+//! is `calibrate_ocode` (RTC bandgap offset-code calibration): it polls a
+//! regi2c comparator and exits either when the comparator settles *or* when a
+//! ~10 ms RTC deadline expires. With no real RF/analog the comparator never
+//! settles, so the loop relies entirely on the timeout — which never fires if
+//! the timer is frozen. Modelling the counter as a real advancing timer lets
+//! that loop (and every other RTC-deadline wait: clock cal, PHY cal, delays)
+//! reach its designed timeout and continue, exactly as silicon does when the
+//! calibration can't converge.
+//!
+//! The counter advances one tick per simulated CPU step (`tick()` is called
+//! every step at the default `peripheral_tick_interval = 1`). The absolute
+//! slow-clock rate is not modelled — only that time *advances* monotonically,
+//! which is all the deadline comparisons observe. All other registers in the
+//! window are register-backed (writes stored, reads return the last value) so
+//! the rest of RTC_CNTL bring-up (reset-cause seed at `0x38`, ANA config, …)
+//! behaves like the previous declarative stub.
+
+use crate::{Peripheral, SimResult};
+use std::cell::Cell;
+
+const TIME_UPDATE: u64 = 0x0C; // bit31 = latch request
+const TIME_LOW: u64 = 0x10;
+const TIME_HIGH: u64 = 0x14;
+const TIME_UPDATE_BIT: u32 = 1 << 31;
+
+#[derive(Debug)]
+pub struct Esp32c3RtcTimer {
+    /// Register-backed storage for the whole window (non-timer registers).
+    regs: Vec<u32>,
+    /// Free-running 48-bit slow-clock counter, advanced once per step.
+    counter: Cell<u64>,
+    /// Counter value latched by the most recent TIME_UPDATE write; what the
+    /// TIME0/TIME1 readout registers return.
+    latched: Cell<u64>,
+}
+
+impl Default for Esp32c3RtcTimer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Esp32c3RtcTimer {
+    /// `size_bytes` is the window size (rounded up to whole 32-bit words).
+    pub fn new_sized(size_bytes: usize) -> Self {
+        Self {
+            regs: vec![0u32; size_bytes.div_ceil(4)],
+            counter: Cell::new(0),
+            latched: Cell::new(0),
+        }
+    }
+
+    pub fn new() -> Self {
+        Self::new_sized(0x100)
+    }
+}
+
+impl Peripheral for Esp32c3RtcTimer {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let w = self.read_u32(offset & !3)?;
+        Ok((w >> ((offset & 3) * 8)) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let aligned = offset & !3;
+        let sh = (offset & 3) * 8;
+        let cur = self.read_u32(aligned)?;
+        self.write_u32(aligned, (cur & !(0xFFu32 << sh)) | ((value as u32) << sh))
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(match offset {
+            TIME_LOW => self.latched.get() as u32,
+            TIME_HIGH => (self.latched.get() >> 32) as u32,
+            _ => *self.regs.get((offset / 4) as usize).unwrap_or(&0),
+        })
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if offset == TIME_UPDATE && (value & TIME_UPDATE_BIT) != 0 {
+            // Latch the current counter into the readout registers.
+            self.latched.set(self.counter.get());
+        }
+        if let Some(slot) = self.regs.get_mut((offset / 4) as usize) {
+            *slot = value;
+        }
+        Ok(())
+    }
+
+    fn tick(&mut self) -> crate::PeripheralTickResult {
+        // One slow-clock tick per simulated step — time advances monotonically.
+        self.counter.set(self.counter.get().wrapping_add(1));
+        crate::PeripheralTickResult::default()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rtc_time_get(t: &mut Esp32c3RtcTimer) -> u64 {
+        // Mirror the IDF sequence: set TIME_UPDATE, read low then high.
+        t.write_u32(TIME_UPDATE, TIME_UPDATE_BIT).unwrap();
+        let lo = t.read_u32(TIME_LOW).unwrap() as u64;
+        let hi = t.read_u32(TIME_HIGH).unwrap() as u64;
+        lo | (hi << 32)
+    }
+
+    #[test]
+    fn timer_advances_and_latches() {
+        let mut t = Esp32c3RtcTimer::new();
+        let t0 = rtc_time_get(&mut t);
+        for _ in 0..1000 {
+            t.tick();
+        }
+        let t1 = rtc_time_get(&mut t);
+        assert!(t1 > t0, "RTC timer must advance ({t0} -> {t1})");
+        assert_eq!(t1 - t0, 1000, "one tick per step");
+    }
+
+    #[test]
+    fn readout_frozen_until_next_update() {
+        let mut t = Esp32c3RtcTimer::new();
+        t.write_u32(TIME_UPDATE, TIME_UPDATE_BIT).unwrap();
+        let snap = t.read_u32(TIME_LOW).unwrap();
+        for _ in 0..50 {
+            t.tick();
+        }
+        // No new latch: readout is unchanged even though the counter advanced.
+        assert_eq!(t.read_u32(TIME_LOW).unwrap(), snap);
+        t.write_u32(TIME_UPDATE, TIME_UPDATE_BIT).unwrap();
+        assert_eq!(t.read_u32(TIME_LOW).unwrap(), snap + 50);
+    }
+
+    #[test]
+    fn other_registers_are_register_backed() {
+        let mut t = Esp32c3RtcTimer::new();
+        // e.g. the reset-cause seed at offset 0x38.
+        t.write_u32(0x38, 0x1).unwrap();
+        assert_eq!(t.read_u32(0x38).unwrap(), 0x1);
+    }
+}

--- a/crates/core/src/peripherals/esp32c3/sar_adc.rs
+++ b/crates/core/src/peripherals/esp32c3/sar_adc.rs
@@ -1,0 +1,117 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 SAR ADC controller (`APB_SARADC`, `0x6004_0000`) — enough of the
+//! conversion handshake to let the IDF's ADC self-calibration complete.
+//!
+//! During PHY/clock bring-up the IDF runs `adc_hal_self_calibration`, a
+//! successive-approximation search for each ADC's offset-calibration code. Each
+//! step (`read_cal_channel`) triggers a single conversion (set start bit at
+//! `0x20`) and busy-polls the data-valid flag (`0x44` bit31 for SAR1 / bit30
+//! for SAR2) before reading the 12-bit result (`0x2C` / `0x30`). The
+//! declarative stub never asserts the valid flag, so the poll spins forever
+//! right after `spi_flash` init.
+//!
+//! We model conversions as instantaneous: the valid flags always read set, and
+//! the data registers return a mid-scale (2048) sample. The search is bounded
+//! and only compares readings against a midpoint reference, so a constant
+//! sample makes it converge to a deterministic (meaningless, but harmless) cal
+//! code — exactly the "no real analog, complete gracefully" behaviour. All
+//! other registers are register-backed (writes stored, reads return them).
+
+use crate::{Peripheral, SimResult};
+
+const SAR1_DATA: u64 = 0x2C;
+const SAR2_DATA: u64 = 0x30;
+const DATA_STATUS: u64 = 0x44; // bit31 SAR1 valid, bit30 SAR2 valid
+const VALID_BITS: u32 = (1 << 31) | (1 << 30);
+/// Mid-scale 12-bit sample (2048). The cal search only needs a stable value to
+/// compare against its midpoint reference.
+const MID_SAMPLE: u32 = 0x800;
+
+#[derive(Debug)]
+pub struct Esp32c3SarAdc {
+    regs: Vec<u32>,
+}
+
+impl Default for Esp32c3SarAdc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Esp32c3SarAdc {
+    pub fn new() -> Self {
+        Self {
+            regs: vec![0u32; 0x100 / 4],
+        }
+    }
+}
+
+impl Peripheral for Esp32c3SarAdc {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let w = self.read_u32(offset & !3)?;
+        Ok((w >> ((offset & 3) * 8)) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let aligned = offset & !3;
+        let sh = (offset & 3) * 8;
+        let cur = self.read_u32(aligned)?;
+        self.write_u32(aligned, (cur & !(0xFFu32 << sh)) | ((value as u32) << sh))
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(match offset {
+            // Conversion completes instantly: both data-valid flags read set so
+            // read_cal_channel's busy-poll exits immediately.
+            DATA_STATUS => *self.regs.get((offset / 4) as usize).unwrap_or(&0) | VALID_BITS,
+            // Mid-scale sample for the offset-cal search.
+            SAR1_DATA | SAR2_DATA => MID_SAMPLE,
+            _ => *self.regs.get((offset / 4) as usize).unwrap_or(&0),
+        })
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if let Some(slot) = self.regs.get_mut((offset / 4) as usize) {
+            *slot = value;
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_valid_flags_always_set() {
+        let a = Esp32c3SarAdc::new();
+        let st = a.read_u32(DATA_STATUS).unwrap();
+        assert_ne!(st & (1 << 31), 0, "SAR1 valid");
+        assert_ne!(st & (1 << 30), 0, "SAR2 valid");
+    }
+
+    #[test]
+    fn data_registers_return_mid_scale() {
+        let a = Esp32c3SarAdc::new();
+        assert_eq!(a.read_u32(SAR1_DATA).unwrap() & 0xFFF, 0x800);
+        assert_eq!(a.read_u32(SAR2_DATA).unwrap() & 0xFFF, 0x800);
+    }
+
+    #[test]
+    fn other_registers_are_register_backed() {
+        let mut a = Esp32c3SarAdc::new();
+        a.write_u32(0x20, 0xDEAD_0000).unwrap();
+        assert_eq!(a.read_u32(0x20).unwrap(), 0xDEAD_0000);
+    }
+}

--- a/crates/core/src/peripherals/esp32s3/systimer.rs
+++ b/crates/core/src/peripherals/esp32s3/systimer.rs
@@ -176,10 +176,22 @@ pub struct Systimer {
     /// DATE register (0xFC). Silicon-validated reset = 0x02012251.
     /// RW storage; firmware may write but reset value is the revision ID.
     date: u32,
+    /// Interrupt-matrix source ID emitted for TARGET0 (TARGET1/2 follow at
+    /// +1/+2). Defaults to the ESP32-S3 PAC value (57); the ESP32-C3 reuses
+    /// this same IP but its matrix source IDs are 37/38/39, so the C3 wiring
+    /// constructs the model with `new_with_source(_, 37)`.
+    target0_source: u32,
 }
 
 impl Systimer {
     pub fn new(cpu_clock_hz: u32) -> Self {
+        Self::new_with_source(cpu_clock_hz, SYSTIMER_TARGET0_SOURCE)
+    }
+
+    /// Construct with an explicit TARGET0 interrupt-matrix source ID (TARGET1/2
+    /// at +1/+2). The ESP32-C3 reuses this IP but maps the comparators to
+    /// matrix sources 37/38/39 rather than the S3's 57/58/59.
+    pub fn new_with_source(cpu_clock_hz: u32, target0_source: u32) -> Self {
         Self {
             // SVD/silicon reset = 0x46000000:
             //   bit 30 (UNIT0_WORK_EN) = 1 → UNIT0 runs immediately at reset.
@@ -202,6 +214,7 @@ impl Systimer {
             int_ena: 0,
             // Silicon-validated date/revision register (read via OpenOCD).
             date: 0x0201_2251,
+            target0_source,
         }
     }
 
@@ -531,7 +544,7 @@ impl Peripheral for Systimer {
             // because we re-emit each tick, the firmware sees a stable
             // pending_cpu_irqs/INTERRUPT bit while it iterates handlers.
             if alarm.pending && (self.int_ena & (1 << i) != 0) {
-                explicit_irqs.push(SYSTIMER_TARGET0_SOURCE + i as u32);
+                explicit_irqs.push(self.target0_source + i as u32);
             }
         }
 


### PR DESCRIPTION
## What

Advances the ESP32-C3 `--rom-boot` path from **stuck in `rtc_init` o_code calibration** to a **running FreeRTOS scheduler executing `app_main()`**. Two layers:

### 1. Peripheral models (clear the device-done-bit spins)
| Model | Addr | Was stuck |
|---|---|---|
| `esp32c3::rtc_timer` | 0x60008000 | frozen RTC slow-clock counter → `calibrate_ocode`'s ~10ms timeout never fires |
| `rtc_fast` region | 0x50000000 (8KB) | `esp_rtc_get_time_us` faults |
| SYSTIMER (reuse S3 model) | 0x60023000 | VALUE_VALID poll never asserts (after heap_init) |
| `esp32c3::sar_adc` | 0x60040000 | ADC self-cal data-valid poll never asserts |

`calibrate_ocode` reaching its designed timeout (`W rtc_init: o_code calibration fail`) is the **faithful no-RF behavior**, not a thunk.

### 2. RISC-V interrupt delivery (start the scheduler)
The scheduler's first context switch is a `vPortYield` → FROM_CPU IPI (write 0x600C0028) that must trap the CPU. Added:
- CPU takes ESP32-C3 external lines 1..31 (`mcause=0x80000000|line`, vectored `mtvec`), proper MPIE/MPP save+restore on trap/MRET, and **WFI** decode (idle-task no-op).
- Bus `aggregate_esp32c3_irqs`: routes the FROM_CPU IPI regs through the INTERRUPT_CORE0 matrix MAP regs into CPU lines, gated by CPU_INT_ENABLE + per-line priority vs CPU_INT_THRESH (level-sensitive; the C3 masks via INTC regs, not `mie`). Behind `esp32c3_irq_routing` (C3 rom-boot only).

## Result

`ROM → bootloader → app_init → heap_init → spi_flash → ADC cal → esp_startup_start_app → context switch → 'main_task: Calling app_main()' → app_main executes.`

## Faithfulness

Real register-level models + a real RISC-V interrupt path (vectored trap, INTC enable/priority/threshold gating, level-sensitive lines), not functional thunks.

## Tests

New unit tests: rtc_timer, sar_adc, external-line vectored trap + MRET MIE restore, WFI-is-nop. Full core lib suite green (1310, 0 failed).

## Next (follow-up)

Periodic SYSTIMER tick (C3 source 37) so delayed tasks wake — `app_main` currently blocks and the idle task spins on WFI — then → `esp_wifi_init/start` → MAC↔SimNet for virtual comms.