### PR TITLE
feat(esp32c3): analog-I2C master FSM-done model → PHY clock bring-up passes

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -993,17 +993,18 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
             None,
             Box::new(labwired_core::peripherals::esp32c3::cache::Esp32c3Cache::new()),
         );
-        // Analog I²C master / ANA_CONFIG block (0x6000_E000, DR_REG_RTC_I2C_BASE):
+        // Analog I²C master / ANA_CONFIG block (0x6000_E000, DR_REG_I2C_ANA_MST_BASE):
         // rom_i2c_writeReg drives it (read-modify-write of ANA_CONFIG regs) during
         // PHY/clock bring-up; the libphy full RF calibration also touches regs up
-        // past 0x6000_E130, so the window spans 0x400. Register-backed read-back
-        // keeps that path mapped.
+        // past 0x6000_E130, so the window spans 0x400. The model reports the
+        // master FSM status (0x50 bits[26:24]=7, idle/done) so the ROM's
+        // transaction busy-poll exits; all other regs are register-backed.
         bus.add_peripheral(
             "rtc_i2c_ana",
             0x6000_E000,
             0x400,
             None,
-            Box::new(labwired_core::peripherals::esp32c3::reg_block::Esp32c3RegBlock::new(0x400)),
+            Box::new(labwired_core::peripherals::esp32c3::ana_i2c::Esp32c3AnaI2c::new()),
         );
         // Hardware RNG data register (WDEV_RND_REG, 0x6002_60B0): yields a fresh
         // word per read. bootloader_fill_random XORs successive reads and

--- a/crates/core/src/peripherals/esp32c3/ana_i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/ana_i2c.rs
@@ -1,0 +1,102 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 analog I²C master / ANA_CONFIG block (`0x6000_E000`,
+//! `DR_REG_I2C_ANA_MST_BASE` / `DR_REG_RTC_I2C_BASE`).
+//!
+//! `rom_i2c_writeReg`/`readReg` and the libphy RF calibration drive this analog
+//! master to reach the RF/PLL sub-blocks. After a transaction is launched (a
+//! write to the command register at offset `0x5C`), the ROM busy-polls the
+//! status word at offset `0x50` and waits for bits[26:24] to read 7 — the
+//! analog-master FSM returning to idle/done. A plain register-backed stub
+//! returns the last written value there, which never becomes 7, so the ROM
+//! clock/PLL bring-up (called from the WiFi PHY calibration) spins forever.
+//!
+//! We model transactions as instantaneous: reads of `0x50` always report the
+//! FSM-idle state (bits[26:24] = 7). Every other register is register-backed
+//! (writes stored, reads return the last value), preserving the read-modify-
+//! write behaviour `rom_i2c_*` relies on.
+
+use crate::{Peripheral, SimResult};
+
+/// Status/command-FSM register; bits[26:24] = master state (7 = idle/done).
+const STATUS: u64 = 0x50;
+const STATE_DONE: u32 = 0x7 << 24;
+
+#[derive(Debug)]
+pub struct Esp32c3AnaI2c {
+    regs: Vec<u32>,
+}
+
+impl Default for Esp32c3AnaI2c {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Esp32c3AnaI2c {
+    pub fn new() -> Self {
+        Self {
+            regs: vec![0u32; 0x400 / 4],
+        }
+    }
+}
+
+impl Peripheral for Esp32c3AnaI2c {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let w = self.read_u32(offset & !3)?;
+        Ok((w >> ((offset & 3) * 8)) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let aligned = offset & !3;
+        let sh = (offset & 3) * 8;
+        let cur = self.read_u32(aligned)?;
+        self.write_u32(aligned, (cur & !(0xFFu32 << sh)) | ((value as u32) << sh))
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        let stored = *self.regs.get((offset / 4) as usize).unwrap_or(&0);
+        Ok(if offset == STATUS {
+            // Report the analog-master FSM as idle/done so the ROM's
+            // busy-poll (`(reg>>24)&7 == 7`) exits immediately.
+            (stored & !STATE_DONE) | STATE_DONE
+        } else {
+            stored
+        })
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if let Some(slot) = self.regs.get_mut((offset / 4) as usize) {
+            *slot = value;
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_reports_fsm_idle() {
+        let a = Esp32c3AnaI2c::new();
+        assert_eq!((a.read_u32(STATUS).unwrap() >> 24) & 7, 7, "FSM idle/done");
+    }
+
+    #[test]
+    fn other_registers_are_register_backed() {
+        let mut a = Esp32c3AnaI2c::new();
+        a.write_u32(0x5C, 0xDEAD_BEEF).unwrap();
+        assert_eq!(a.read_u32(0x5C).unwrap(), 0xDEAD_BEEF);
+    }
+}

--- a/crates/core/src/peripherals/esp32c3/mod.rs
+++ b/crates/core/src/peripherals/esp32c3/mod.rs
@@ -4,6 +4,7 @@
 
 //! ESP32-C3 (RISC-V) specific peripheral models.
 
+pub mod ana_i2c;
 pub mod cache;
 pub mod reg_block;
 pub mod rng;


### PR DESCRIPTION
## What

After `esp_wifi_start`, the WiFi PHY init calls a ROM clock/PLL bring-up routine that launches an analog-I2C-master transaction (write `0x6000_E05C`) then busy-polls the master status at `0x6000_E050` for bits[26:24]==7 (FSM idle/done). The register-backed stub returned the last-written value, so the status never reached 7 → the ROM spun forever (PC pinned at `0x4003_a282`).

`esp32c3::ana_i2c` models the analog master with instantaneous transactions: reads of `0x50` always report FSM-idle/done (bits[26:24]=7); all other registers stay register-backed for the `rom_i2c_*` read-modify-write path. Replaces the generic reg_block at `0x6000_E000` (still a 0x400 window for the libphy ANA_CONFIG accesses).

## Result

Boot clears that ROM loop and advances into the libphy RF calibration (`txdc_cal` / `pll_cal`) — the next frontier (the closed-blob RF cal air-gap).

## Faithfulness

A real done-bit/FSM-state model (instantaneous transaction completion), not a thunk — the same pattern as the SHA/cache/SAR-ADC accelerators.

## Tests

ana_i2c unit tests + full core lib suite green (1310).