### PR TITLE
feat(bus): host ESP32-S3 peripherals via from_config family factory

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1112,6 +1112,30 @@ impl SystemBus {
         }
     }
 
+    /// Place a built peripheral on the bus using the descriptor's window size
+    /// (default 4KB) and IRQ. Shared by the per-family factory dispatch and the
+    /// generic-match path in [`Self::from_config`] so both stay in lockstep.
+    fn push_peripheral(
+        &mut self,
+        p_cfg: &labwired_config::PeripheralConfig,
+        dev: Box<dyn Peripheral>,
+    ) -> anyhow::Result<()> {
+        let size = match &p_cfg.size {
+            Some(size) => parse_size(size)?,
+            None => 0x1000,
+        };
+        self.peripherals.push(PeripheralEntry {
+            name: p_cfg.id.clone(),
+            base: p_cfg.base_address,
+            size,
+            irq: p_cfg.irq,
+            dev,
+            ticks_remaining: 0,
+            generation: 0,
+        });
+        Ok(())
+    }
+
     pub fn from_config(chip: &ChipDescriptor, manifest: &SystemManifest) -> anyhow::Result<Self> {
         let flash_size = parse_size(&chip.flash.size)?;
         let ram_size = parse_size(&chip.ram.size)?;
@@ -1200,6 +1224,16 @@ impl SystemBus {
                     canonical_type,
                     p_cfg.id
                 );
+            }
+
+            // Per-family factories own their peripheral arms in their own modules,
+            // so this central match stops growing (and shrinks as families migrate
+            // out). Try them first; unmigrated families fall through to the match.
+            if let Some(dev) =
+                crate::peripherals::esp32s3::factory::try_build(&canonical_type, p_cfg)
+            {
+                bus.push_peripheral(p_cfg, dev)?;
+                continue;
             }
 
             let dev: Box<dyn Peripheral> = match canonical_type.as_str() {
@@ -1824,28 +1858,7 @@ impl SystemBus {
                 }
             };
 
-            // Map peripheral window size + IRQ from descriptor when provided.
-            // Defaults keep older descriptors working.
-            let size = if let Some(size) = &p_cfg.size {
-                parse_size(size)?
-            } else {
-                0x1000 // Default 4KB page
-            };
-
-            // SysTick raises its IRQ via PeripheralTickResult::system_exception,
-            // not via the NVIC IRQ position field — leave its irq as None
-            // unless the yaml explicitly sets one.
-            let irq = p_cfg.irq;
-
-            bus.peripherals.push(PeripheralEntry {
-                name: p_cfg.id.clone(),
-                base: p_cfg.base_address,
-                size,
-                irq,
-                dev,
-                ticks_remaining: 0,
-                generation: 0,
-            });
+            bus.push_peripheral(p_cfg, dev)?;
         }
 
         for ext in &manifest.external_devices {

--- a/crates/core/src/peripherals/esp32s3/factory.rs
+++ b/crates/core/src/peripherals/esp32s3/factory.rs
@@ -1,0 +1,163 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Data-driven factory for ESP32-S3 (Xtensa LX7) peripheral models.
+//!
+//! [`try_build`] maps a canonical peripheral `type` string + its descriptor to a
+//! boxed model, letting a chip YAML assemble an ESP32-S3 through the same
+//! `SystemBus::from_config` path the Cortex-M and RISC-V chips already use —
+//! instead of the hand-wired `system::xtensa::configure_xtensa_esp32s3`.
+//!
+//! Keeping the family's arms here (not inline in `bus::from_config`) is the
+//! migration pattern: each chip family owns its factory, so the central
+//! `from_config` match stops growing and shrinks as families move out.
+//!
+//! Most S3 peripherals take an ESP-IDF interrupt *source id*
+//! (`ets_isr_source_t` ordinal); it must match what the firmware's
+//! interrupt-allocator expects or the ISR never dispatches. The canonical id is
+//! the default and may be overridden per instance via the descriptor's `irq`
+//! field (e.g. SPI2=21 vs SPI3=22, TIMG0=50 vs TIMG1=53).
+
+use crate::Peripheral;
+use labwired_config::PeripheralConfig;
+
+/// Build an ESP32-S3 peripheral model for `canonical_type`, or `None` if this
+/// family does not own that type (so the caller falls through to other
+/// factories / the generic match).
+pub fn try_build(canonical_type: &str, p_cfg: &PeripheralConfig) -> Option<Box<dyn Peripheral>> {
+    use super::*;
+
+    // Read the interrupt source id from the descriptor, defaulting to the
+    // canonical ESP-IDF ordinal for this peripheral when the YAML omits it.
+    let src = |default: u32| p_cfg.irq.unwrap_or(default);
+
+    let dev: Box<dyn Peripheral> = match canonical_type {
+        "esp32s3_uart" => {
+            // uart0 echoes to stdout (source 27); uart1/uart2 do not (28/29).
+            let echo = p_cfg
+                .config
+                .get("echo_stdout")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            Box::new(uart::Esp32s3Uart::new(echo, src(27)))
+        }
+        "esp32s3_timer_group" => {
+            // TIMG0 base source id 50, TIMG1 = 53; CPU clock drives the
+            // RTCCALICFG auto-RDY the 2nd-stage bootloader polls.
+            let cpu_clock_hz = p_cfg
+                .config
+                .get("cpu_clock_hz")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(240_000_000) as u32;
+            Box::new(timer_group::Esp32s3TimerGroup::new(src(50), cpu_clock_hz))
+        }
+        "esp32s3_gdma" => Box::new(gdma::Esp32s3Gdma::new(src(66))),
+        "esp32s3_spi" => Box::new(gpspi::Esp32s3Spi::new(src(21))),
+        "esp32s3_i2s" => Box::new(i2s::Esp32s3I2s::new(src(25))),
+        "esp32s3_mcpwm" => Box::new(mcpwm::Esp32s3Mcpwm::new(src(38))),
+        "esp32s3_rmt" => Box::new(rmt::Esp32s3Rmt::new(src(40))),
+        "esp32s3_pcnt" => Box::new(pcnt::Esp32s3Pcnt::new(src(41))),
+        "esp32s3_lcd_cam" => Box::new(lcd_cam::Esp32s3LcdCam::new(src(24))),
+        "esp32s3_sdmmc" => Box::new(sdmmc::Esp32s3Sdmmc::new(src(36))),
+        "esp32s3_twai" => Box::new(twai::Esp32s3Twai::new(src(37))),
+        "esp32s3_usb_otg" => Box::new(usb_otg::Esp32s3UsbOtg::new(src(23))),
+        "esp32s3_sar_adc" => Box::new(sar_adc::Esp32s3SarAdc::new(src(64))),
+        "esp32s3_aes" => Box::new(aes::Esp32s3Aes::new(src(77))),
+        "esp32s3_rsa" => Box::new(rsa::Esp32s3Rsa::new(src(76))),
+        "esp32s3_hmac" => Box::new(hmac::Esp32s3Hmac::new(src(0))),
+        "esp32s3_ds" => Box::new(ds::Esp32s3Ds::new(src(0))),
+        "esp32s3_sha" => Box::new(sha::Esp32s3Sha::new()),
+        "esp32s3_rng" => Box::new(rng::Esp32s3Rng::new()),
+        "esp32s3_ledc" => Box::new(ledc::Esp32s3Ledc::new()),
+        "esp32s3_sens" => Box::new(sens::Esp32s3Sens::new()),
+        "esp32s3_extmem" => Box::new(extmem::Esp32s3Extmem::new()),
+        "esp32s3_system" => Box::new(system::Esp32s3System::new()),
+        "esp32s3_system_stub" => Box::new(system_stub::SystemStub::new()),
+        "esp32s3_core1_control" => Box::new(core1_control::Esp32s3Core1Control::new()),
+        "esp32s3_crosscore_ipi" => Box::new(crosscore_ipi::Esp32s3CrossCoreIpi::new()),
+        _ => return None,
+    };
+    Some(dev)
+}
+
+/// Canonical type strings this factory owns. Kept next to [`try_build`] so the
+/// two cannot drift; the migration's Stage-3 chip YAML draws from this set.
+pub const SUPPORTED_TYPES: &[&str] = &[
+    "esp32s3_uart",
+    "esp32s3_timer_group",
+    "esp32s3_gdma",
+    "esp32s3_spi",
+    "esp32s3_i2s",
+    "esp32s3_mcpwm",
+    "esp32s3_rmt",
+    "esp32s3_pcnt",
+    "esp32s3_lcd_cam",
+    "esp32s3_sdmmc",
+    "esp32s3_twai",
+    "esp32s3_usb_otg",
+    "esp32s3_sar_adc",
+    "esp32s3_aes",
+    "esp32s3_rsa",
+    "esp32s3_hmac",
+    "esp32s3_ds",
+    "esp32s3_sha",
+    "esp32s3_rng",
+    "esp32s3_ledc",
+    "esp32s3_sens",
+    "esp32s3_extmem",
+    "esp32s3_system",
+    "esp32s3_system_stub",
+    "esp32s3_core1_control",
+    "esp32s3_crosscore_ipi",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn cfg(ty: &str) -> PeripheralConfig {
+        PeripheralConfig {
+            id: ty.to_string(),
+            r#type: ty.to_string(),
+            base_address: 0x6000_0000,
+            size: None,
+            irq: None,
+            config: HashMap::new(),
+        }
+    }
+
+    /// Every ESP32-S3 model that `configure_xtensa_esp32s3` wires by hand must be
+    /// buildable from a descriptor, so a chip YAML can assemble the SoC through
+    /// `from_config` instead.
+    #[test]
+    fn builds_every_supported_type() {
+        for ty in SUPPORTED_TYPES {
+            assert!(
+                try_build(ty, &cfg(ty)).is_some(),
+                "factory should build {ty}"
+            );
+        }
+    }
+
+    /// Types this family does not own must return `None` so `from_config` falls
+    /// through to other factories / the generic match.
+    #[test]
+    fn declines_foreign_types() {
+        for ty in ["uart", "esp32_timg", "i2c", "nrf52840_uart", "unknown_xyz"] {
+            assert!(try_build(ty, &cfg(ty)).is_none(), "{ty} is not ours");
+        }
+    }
+
+    /// A descriptor `irq` overrides the canonical default (e.g. SPI2=21 vs
+    /// SPI3=22) without panicking — the per-instance path the YAML relies on.
+    #[test]
+    fn honors_descriptor_irq_override() {
+        let mut c = cfg("esp32s3_spi");
+        c.irq = Some(22);
+        assert!(try_build("esp32s3_spi", &c).is_some());
+    }
+}

--- a/crates/core/src/peripherals/esp32s3/mod.rs
+++ b/crates/core/src/peripherals/esp32s3/mod.rs
@@ -9,6 +9,7 @@ pub mod core1_control;
 pub mod crosscore_ipi;
 pub mod ds;
 pub mod extmem;
+pub mod factory;
 pub mod flash_xip;
 pub mod gdma;
 pub mod gpio;

--- a/docs/migration/soc-factory/README.md
+++ b/docs/migration/soc-factory/README.md
@@ -1,0 +1,33 @@
+# SoC factory migration
+
+Goal: every chip builds through the data-driven `SystemBus::from_config` path
+(walk the chip YAML → per-family factory → place at base), with arch code
+shrinking to a thin CPU-core overlay. Models stay statically linked; **topology
+becomes data**. Today the Cortex-M and RISC-V chips already build this way; the
+ESP32-S3 is the lone holdout, assembled by the 2186-line hand-wired
+`system::xtensa::configure_xtensa_esp32s3`.
+
+Strangler migration, each stage gated by the ESP32/Xtensa test suite as a golden
+oracle (no behavior change until Stage 3):
+
+- **Stage 0 — pin the oracle.** Baseline pass/fail of the ESP32/Xtensa test
+  binaries (321 tests). See `STAGE0_golden_baseline.txt`.
+- **Stage 1 — pre-stock the factory.** `peripherals/esp32s3/factory.rs::try_build`
+  hosts the 26 ESP32-S3 peripheral types; `from_config` delegates to it before
+  the generic match. Pure addition — no chip YAML references these types yet, so
+  behavior is unchanged (regression identical to Stage 0). **← current**
+- **Stage 2 — extract the Xtensa core overlay.** Carve the genuinely
+  shared-CPU-state wiring (interrupt matrix, interconnect, boot ROM, RAM banks)
+  out of `configure_xtensa_esp32s3` into `configure_xtensa_core`, ~150 lines.
+- **Stage 3 — flip esp32s3 to `from_config`.** Complete `esp32s3.yaml` (all ~35
+  peripherals), build via `from_config` + `configure_xtensa_core`, diff against
+  the golden, then delete the per-peripheral body of `configure_xtensa_esp32s3`.
+- **Stage 4 — repeat for esp32 / esp32c3.**
+- **Stage 5 — feature-gate families** (`cortex-m`/`xtensa`/`esp32`/`nrf52`) so
+  the wasm build and CI fixtures compile only what they need.
+
+## Pattern
+
+Per-family factories live in their own module (`peripherals/<family>/factory.rs`),
+not inline in `bus::from_config`. This keeps the central match from growing and
+lets it shrink as other families (nRF52, STM32) move out the same way.

--- a/docs/migration/soc-factory/STAGE0_golden_baseline.txt
+++ b/docs/migration/soc-factory/STAGE0_golden_baseline.txt
@@ -1,0 +1,18 @@
+     Running tests/brom_boot_smoke.rs (target/debug/deps/brom_boot_smoke-4849e2adf216c30b)
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
+     Running tests/chip_conformance.rs (target/debug/deps/chip_conformance-19ae6716d6d190c1)
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s
+     Running tests/intmatrix_alarm.rs (target/debug/deps/intmatrix_alarm-e98374656f6dc848)
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+     Running tests/ir_component_equivalence.rs (target/debug/deps/ir_component_equivalence-842b944c2d047be1)
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+     Running tests/register_compliance.rs (target/debug/deps/register_compliance-1927edec77129804)
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
+     Running tests/xtensa_decode.rs (target/debug/deps/xtensa_decode-772920a8a723afff)
+test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+     Running tests/xtensa_exec.rs (target/debug/deps/xtensa_exec-44deddef77085fe0)
+test result: ok. 194 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.08s
+     Running tests/xtensa_lx7.rs (target/debug/deps/xtensa_lx7-d8ceabfd8d971443)
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+     Running tests/xtensa_regs.rs (target/debug/deps/xtensa_regs-d670ddabba9db572)
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


### PR DESCRIPTION
Stage 1 of the SoC factory migration (see `docs/migration/soc-factory/README.md`): move ESP32-S3 onto the data-driven `SystemBus::from_config` path the Cortex-M and RISC-V chips already use, instead of the 2186-line hand-wired `configure_xtensa_esp32s3`.

## What
- New `peripherals/esp32s3/factory.rs` owns the 26 ESP32-S3 peripheral type arms (`try_build`), so the central `from_config` match stops growing — per-family factories are the pattern, and the match shrinks as other families move out.
- `from_config` delegates to the factory before the generic match; extracted a shared `push_peripheral` helper so both paths place peripherals identically. The 600-line match body is untouched.

## Safety
Pure addition — no chip YAML references these types yet, so behavior is unchanged. IRQ-source defaults are transcribed from the current `xtensa.rs` literals; they get proven correct at Stage 3 when a `from_config`-built ESP32-S3 is diffed against this golden.

## Verification
- `cargo build` (workspace), `cargo fmt`, `cargo clippy -p labwired-core` — clean
- 3 factory unit tests pass
- ESP32/Xtensa golden suite: **321 tests, identical pre/post** (`docs/migration/soc-factory/STAGE0_golden_baseline.txt`)