### PR TITLE
feat(esp32c3): force MAC-ready bit → WiFi comes up (STA mode) in sim

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1045,6 +1045,22 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
                 ),
             ),
         );
+        // WiFi MAC-ready status (WIFI_MAC 0x6003_3000 + 0xD14, bit0): the MAC
+        // HAL init (hal_init) busy-polls this bit for the MAC clock/reset to
+        // come ready before mac_txrx_init. Force-assert it over that one word
+        // (the declarative wifi_mac window stays intact elsewhere).
+        bus.add_peripheral(
+            "wifi_mac_ready",
+            0x6003_3D14,
+            0x4,
+            None,
+            Box::new(
+                labwired_core::peripherals::esp32c3::forced_status::Esp32c3ForcedStatus::new(
+                    0x4,
+                    vec![(0x0, 1 << 0)],
+                ),
+            ),
+        );
         // Hardware RNG data register (WDEV_RND_REG, 0x6002_60B0): yields a fresh
         // word per read. bootloader_fill_random XORs successive reads and
         // process_segments refills ram_obfs_value until non-zero — a constant


### PR DESCRIPTION
## What

The WiFi MAC HAL init (`hal_init`) busy-polls `WIFI_MAC 0x6003_3D14` bit0 for the MAC clock/reset to come ready before `mac_txrx_init`. The declarative `wifi_mac` window returns 0 there, so it spun. Force-assert that one word (`forced_status`) and the MAC HAL completes.

## Result 🎉

An **unmodified ESP32-C3 ESP-IDF binary** boots from the real mask ROM and brings **WiFi all the way up** in the simulator:

```
ROM → 2nd-stage bootloader → FreeRTOS → app_main → esp_wifi_init → esp_wifi_start
  → PHY full RF cal (completes) → MAC init → wifi:mode : sta / enable tsf → app 'wifi up'
```

This is the culmination of the whole `--rom-boot` effort: real register/instruction models for the entire boot + scheduler + WiFi-init path, with the only cut at the irreducible RF air-gap.

## Notes

- MAC address reads `00:00:00:00:00:00` (eFuse MAC bytes are zero in sim) — cosmetic, can seed later.
- `wifi_probe` then idles ("idling for trace"); it doesn't scan/connect by design.

## Next

MAC TX/RX DMA ↔ SimNet bridge + a connecting app/virtual-AP for actual virtual communication (the data path).