### PR TITLE
feat(esp32c3): WiFi MAC↔SimNet bridge groundwork — design doc + connecting probe

### DIFF
--- a/docs/esp32c3_wifi_mac_bridge.md
+++ b/docs/esp32c3_wifi_mac_bridge.md
@@ -1,0 +1,73 @@
+# ESP32-C3 WiFi MAC ↔ SimNet bridge (design + RE notes)
+
+Status: **in progress.** Boot brings WiFi fully up in sim (see
+`esp32c3_rom_boot.md`); this doc covers the next phase — making the **real** MAC
+move packets to/from the in-sim virtual network, *without* the `wifi_thunks`
+shortcut the ESP32-S3 used.
+
+## Why this is its own phase (the impedance mismatch)
+
+- The **real C3 MAC** operates on raw **802.11 frames** in hardware DMA rings.
+  The running firmware (lmac/pp/wdev + the libnet80211 driver) does real
+  scan → auth → assoc → data, programming the MAC registers and DMA descriptors.
+- The existing **`SimNet`** (`crates/core/src/network/sim.rs`) is an **L4
+  socket** simulation (TCP `connect`/`send`/`recv`, HTTP/echo servers,
+  `VirtualAp.associate`). The S3 bridged to it by **thunking at the lwIP socket
+  layer** (`esp32s3::wifi_thunks`) and faking `WL_CONNECTED` — i.e. it never ran
+  esp_wifi/MAC at all. That is the thunk we are explicitly removing.
+
+Bridging the real MAC to `SimNet` therefore needs a **frame-level** layer in
+between (802.11 ↔ Ethernet ↔ the existing L4 SimNet), not a socket shim.
+
+## MAC interrupt / event anatomy (RE'd from `wifi_probe.elf` + ROM)
+
+- **MAC interrupt event register**: `hal_mac_interrupt_get_event` reads
+  `0x6003_3C3C`; `hal_mac_interrupt_clr_event` writes `0x6003_3C40` (W1C).
+- **ISR** `wDev_ProcessFiq` (0x4038_34A4) reads the event word and dispatches:
+  | event mask | handler | meaning |
+  |---|---|---|
+  | `0x0100_4000` | `lmacProcessRxSucData` (ROM 0x4000_1614) | **RX frame received** |
+  | `0x80`        | `lmacPostTxComplete`   (ROM 0x4000_1608) | TX complete |
+  | `0x100`       | `lmacProcessCollisions`(ROM 0x4000_1610) | TX collision |
+  | `0x1E`        | `wdev_process_tbtt`    | beacon timing |
+  | `0x1E0`       | `wdev_process_tsf_timer` | TSF |
+- **RX is a descriptor linked list** (`wdev_record_rx_linked_list`,
+  `wdev_dump_rx_linked_list`); `lmacProcessRxSucData` walks it.
+- **MAC interrupt = interrupt-matrix source 0** (`MAC_INTR_MAP` @ offset 0 in
+  `interrupt_core0.yaml`), routed to a CPU line by the C3 interrupt matrix we
+  already model — so raising it delivers to `wDev_ProcessFiq` via the normal
+  trap path.
+
+## RX-inject mechanism (target design)
+
+1. Place the received 802.11 frame into the next free RX DMA descriptor's
+   buffer (RX ring base register: **TODO — finish RE'ing where the driver
+   programs it in `mac_txrx_init` / `ppRxPkt`**).
+2. Set the RX-success bits in the event register `0x6003_3C3C` (`0x0100_4000`).
+3. Assert MAC interrupt source 0 → matrix → CPU line → trap → `wDev_ProcessFiq`
+   → `lmacProcessRxSucData` consumes the descriptor and hands the frame up.
+
+## TX-capture mechanism (target design)
+
+The driver fills a TX descriptor and writes a TX-kick register; the model reads
+the frame out of the descriptor buffer and hands it to the frame-level AP, then
+sets the TX-complete event bit (`0x80`) + raises the MAC interrupt so
+`lmacPostTxComplete` runs. **TODO — RE the TX-kick register + descriptor format.**
+
+## Remaining build (sequence)
+
+1. **MAC DMA model** (`esp32c3::wifi_mac`, behavioral, replacing the declarative
+   window but preserving the bring-up register-backing + MAC-ready bit): event
+   register + interrupt raise + RX descriptor inject + TX descriptor capture.
+   Finish the RX-ring-base / TX-kick RE first.
+2. **Frame-level `VirtualAp`**: handle the 802.11 management the driver sends
+   (probe/auth/assoc) so it associates, and relay data-frame payloads to/from
+   the existing L4 `SimNet` (de/encapsulate 802.11 ↔ Ethernet ↔ IP).
+3. **A connecting C3 app**: the current `wifi_probe` fixture brings WiFi up and
+   idles ("idling for trace") — it never scans/connects, so it generates **no
+   MAC traffic**. A minimal `esp_wifi_connect` + socket app (C3 IDF build) is
+   needed to exercise and validate the bridge end-to-end.
+
+The natural first milestone is **association over the real MAC** (driver TX of
+probe/auth/assoc via the real DMA ring → frame-level AP responds via RX inject →
+driver reaches connected) — the first true "real MAC, no thunks" comms.

--- a/scripts/hw-oracle/wifi-re/main/wifi_probe.c
+++ b/scripts/hw-oracle/wifi-re/main/wifi_probe.c
@@ -1,25 +1,46 @@
-// Minimal ESP32-C3 radio-init probe: bring the WiFi driver up to the point
-// where PHY + MAC registers are configured, then idle. No connect/scan — keeps
-// the JTAG MMIO trace focused on phy_enable + esp_wifi_init/start.
+// ESP32-C3 WiFi bring-up + connect probe. Brings the WiFi driver up and then
+// attempts to associate with an AP, so the REAL MAC transmits the scan/auth/
+// assoc frame sequence through its DMA rings — the traffic the LabWired MAC <->
+// SimNet bridge consumes. (Originally a radio-init-only probe; extended to
+// connect for the bridge work — see docs/esp32c3_wifi_mac_bridge.md.)
 #include "nvs_flash.h"
 #include "esp_netif.h"
 #include "esp_event.h"
 #include "esp_wifi.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <string.h>
 
 static const char *TAG = "probe";
 
-// Trace anchors — set JTAG breakpoints on these symbols.
+#define PROBE_SSID "labwired-ap"
+#define PROBE_PASS "labwired123"
+
+// Trace anchors — set JTAG/sim breakpoints on these symbols.
 void __attribute__((noinline)) probe_before_init(void) { __asm__ volatile("nop"); }
 void __attribute__((noinline)) probe_after_init(void)  { __asm__ volatile("nop"); }
-// Tight bracket around esp_wifi_start(): the busy-wait *poll surface* (the MAC
-// status bits the driver spins on while bringing the MAC + DMA rings up) lives
-// between these two anchors. trace_poll.sh arms a read-watchpoint over the MAC
-// window only across this bracket, so the capture isn't drowned out by the
-// config-write surface that trace_radio.sh already recovered.
 void __attribute__((noinline)) probe_start_enter(void) { __asm__ volatile("nop"); }
 void __attribute__((noinline)) probe_after_start(void) { __asm__ volatile("nop"); }
+void __attribute__((noinline)) probe_connect_enter(void) { __asm__ volatile("nop"); }
 void __attribute__((noinline)) probe_idle(void)        { __asm__ volatile("nop"); }
+
+static void wifi_event_handler(void *arg, esp_event_base_t base,
+                               int32_t id, void *data)
+{
+    if (base == WIFI_EVENT && id == WIFI_EVENT_STA_START) {
+        ESP_LOGI(TAG, "sta start -> connect");
+        probe_connect_enter();
+        esp_wifi_connect();
+    } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_CONNECTED) {
+        ESP_LOGI(TAG, "STA CONNECTED");
+    } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
+        ESP_LOGI(TAG, "sta disconnected -> retry");
+        esp_wifi_connect();
+    } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
+        ESP_LOGI(TAG, "GOT IP");
+    }
+}
 
 void app_main(void)
 {
@@ -28,15 +49,25 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     esp_netif_create_default_wifi_sta();
 
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL, NULL));
+
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     probe_before_init();
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));          // allocates MAC, phy_enable
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
     probe_after_init();
+
+    wifi_config_t wc = { 0 };
+    strncpy((char *)wc.sta.ssid, PROBE_SSID, sizeof(wc.sta.ssid));
+    strncpy((char *)wc.sta.password, PROBE_PASS, sizeof(wc.sta.password));
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wc));
     probe_start_enter();
-    ESP_ERROR_CHECK(esp_wifi_start());             // MAC/DMA ring + PHY RF on
+    ESP_ERROR_CHECK(esp_wifi_start());   // STA start event -> esp_wifi_connect()
     probe_after_start();
-    ESP_LOGI(TAG, "wifi up; idling for trace");
+    ESP_LOGI(TAG, "wifi up; connecting to %s", PROBE_SSID);
     probe_idle();
     while (1) { vTaskDelay(1000); }
 }


### PR DESCRIPTION
First step of the real-MAC virtual-comms bridge (no `wifi_thunks`).

## Contents
- **`docs/esp32c3_wifi_mac_bridge.md`**: design + RE notes — the MAC interrupt/event anatomy (event reg `0x6003_3C3C`, `wDev_ProcessFiq` dispatch, RX-success→`lmacProcessRxSucData`, MAC interrupt = matrix source 0), the RX-inject/TX-capture target design, the impedance mismatch (real MAC = raw 802.11 frames vs `SimNet` = L4 sockets), and the 3-part remaining build.
- **Connecting probe** (`wifi_probe.c`): extended from radio-init-only to `esp_wifi_connect` so the **real MAC transmits** the scan/auth/assoc sequence — the traffic the bridge consumes. Runs clean in sim (`sta start -> connect`, scans/idles with no AP yet).

## Why groundwork first
The bridge needs three substantial pieces (MAC TX/RX DMA model, frame-level `VirtualAp`, a connecting app). This lands the connecting app + the design so the model work has a target and a traffic source. No functional sim-model change yet.

## Next
Capture the live scan TX frame (instrument the MAC window), then RX-inject + a frame-level `VirtualAp` for association.