### PR TITLE
feat(esp32c3): RX delivery validated — real driver receives injected frames (lldesc fix)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1221,7 +1221,47 @@ fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode {
     };
     let trail_cap = 600;
     let mut recent = std::collections::VecDeque::with_capacity(trail_cap + 1);
+    // WiFi bridge RX-header RE harness (env-gated): once, after the MAC is up,
+    // inject a frame whose byte[i]=i into the driver's RX ring so the RX-buffer
+    // read-trace (LABWIRED_RXBUF_TRACE) reveals which offsets the driver's RX
+    // callback parses — i.e. the rx-control header layout. The read value at a
+    // traced offset equals the source offset, mapping reads → header fields.
+    let bridge_re = std::env::var("LABWIRED_WIFI_BRIDGE_RE").is_ok();
+    let bridge_inject_at: u64 = 25_000_000;
+    // Find the BEHAVIORAL wifi_mac model by type (the declarative chip-yaml
+    // "wifi_mac" shares the name; routing uses ours via greatest-start-wins, but
+    // name lookup would return the declarative one).
+    let wifi_mac_idx = machine.bus.peripherals.iter().position(|p| {
+        p.dev
+            .as_any()
+            .and_then(|a| {
+                a.downcast_ref::<labwired_core::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac>()
+            })
+            .is_some()
+    });
+    let mut bridge_injected = false;
+    if bridge_re {
+        eprintln!(
+            "[bridge] RE mode on; wifi_mac_idx={wifi_mac_idx:?} inject_at={bridge_inject_at}"
+        );
+    }
+
     for i in 0..limit {
+        if bridge_re && !bridge_injected && i >= bridge_inject_at {
+            if let Some(idx) = wifi_mac_idx {
+                if let Some(any) = machine.bus.peripherals[idx].dev.as_any_mut() {
+                    if let Some(mac) = any
+                        .downcast_mut::<labwired_core::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac>(
+                        )
+                    {
+                        let frame: Vec<u8> = (0..320u32).map(|b| (b & 0xFF) as u8).collect();
+                        mac.queue_rx_frame(frame);
+                        eprintln!("[bridge] injected RX-RE frame at step {i}");
+                        bridge_injected = true;
+                    }
+                }
+            }
+        }
         let pc = machine.cpu.get_pc();
         if debug {
             if recent.len() == trail_cap {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2364,13 +2364,23 @@ impl SystemBus {
                 .read_u32(INTMATRIX_BASE + (src as u64) * 4)
                 .map(|v| v & 0x1F)
                 .unwrap_or(0);
-            if line == 0 || (enable & (1 << line)) == 0 {
-                continue;
-            }
             let pri = self
                 .read_u32(INTMATRIX_BASE + 0x114 + (line as u64) * 4)
                 .unwrap_or(0)
                 & 0xF;
+            if src == 0 && std::env::var("LABWIRED_RXBUF_TRACE").is_ok() {
+                use std::sync::atomic::{AtomicU32, Ordering};
+                static N: AtomicU32 = AtomicU32::new(0);
+                if N.fetch_add(1, Ordering::Relaxed) < 3 {
+                    eprintln!(
+                        "[macirq] src0 line={line} enable_bit={} pri={pri} thresh={thresh}",
+                        (enable >> line) & 1
+                    );
+                }
+            }
+            if line == 0 || (enable & (1 << line)) == 0 {
+                continue;
+            }
             if pri >= thresh {
                 mask |= 1u32 << line;
             }
@@ -2813,6 +2823,22 @@ impl crate::Bus for SystemBus {
     }
 
     fn read_u32(&self, addr: u64) -> SimResult<u32> {
+        // Debug (env-gated): trace the driver's reads of a freshly-injected RX
+        // buffer, to RE the rx-control header format the RX callback parses.
+        if std::env::var("LABWIRED_RXBUF_TRACE").is_ok() {
+            let base = crate::peripherals::esp32c3::wifi_mac::RX_DBG_BUF
+                .load(std::sync::atomic::Ordering::Relaxed) as u64;
+            // Trace from 0x100 BEFORE the buffer (to catch the descriptor-list
+            // reads, e.g. the descriptor at buf-0x7c) through the buffer.
+            if base != 0 && (base.saturating_sub(0x100)..base + 512).contains(&addr) {
+                use std::sync::atomic::{AtomicU32, Ordering};
+                static N: AtomicU32 = AtomicU32::new(0);
+                if N.fetch_add(1, Ordering::Relaxed) < 200 {
+                    let v = self.ram.read_u32(addr).unwrap_or(0);
+                    eprintln!("[rxrd] +{:#05x} ({addr:#010x}) = {v:#010x}", addr - base);
+                }
+            }
+        }
         // Cortex-M bit-band alias: return 0 or 1 based on the physical bit.
         if self.bit_band_enabled {
             if let Some((phys_byte, bit)) = Self::bit_band_translate(addr) {

--- a/crates/core/src/peripherals/esp32c3/wifi_mac.rs
+++ b/crates/core/src/peripherals/esp32c3/wifi_mac.rs
@@ -31,6 +31,13 @@
 
 use crate::{Bus, Peripheral, PeripheralTickResult, SimResult};
 use std::collections::VecDeque;
+use std::sync::atomic::AtomicU32;
+
+/// Debug: base address of the RX buffer the model most recently delivered a
+/// frame into. The bus's `LABWIRED_RXBUF_TRACE` read-trace reads this to log
+/// the driver's reads relative to the buffer (RE'ing the rx-control header
+/// format). 0 = no delivery yet.
+pub static RX_DBG_BUF: AtomicU32 = AtomicU32::new(0);
 
 const MAC_READY: u64 = 0xD14; // bit0 polled by hal_init
 const RX_RING_BASE: u64 = 0x88; // driver writes the RX descriptor-list head here
@@ -39,8 +46,12 @@ const EVENT_CLR: u64 = 0xC40; // hal_mac_interrupt_clr_event writes (W1C)
 
 /// RX-success event bits `wDev_ProcessFiq` routes to `lmacProcessRxSucData`.
 const EVENT_RX_DONE: u32 = 0x0100_4000;
-/// Descriptor word0 owner bit (HW may fill the buffer).
+// RX descriptor word0 is an ESP `lldesc_t`: size[11:0], length[23:12],
+// offset[28:24], sosf[29], eof[30], owner[31]. An empty (HW-owned) descriptor
+// reads e.g. 0x80640640 (owner=1, length=size=1600); after the MAC fills it the
+// driver expects owner=0, eof=1, length=actual-rx-bytes, size preserved.
 const DESC_OWNER: u32 = 1 << 31;
+const DESC_EOF: u32 = 1 << 30;
 /// Interrupt-matrix source ID for the WiFi MAC (MAC_INTR_MAP @ offset 0).
 const MAC_INTR_SOURCE: u32 = 0;
 
@@ -105,17 +116,24 @@ impl Esp32c3WifiMac {
             let w0 = bus.read_u32(desc as u64).unwrap_or(0);
             let buf = bus.read_u32(desc as u64 + 4).unwrap_or(0);
             let next = bus.read_u32(desc as u64 + 8).unwrap_or(0);
-            let cap = (w0 & 0xFFFF) as usize;
+            let cap = (w0 & 0xFFF) as usize; // lldesc size field (buffer capacity)
             if w0 & DESC_OWNER != 0 && buf != 0 && cap > 0 {
                 let frame = self.pending_rx.pop_front().unwrap();
                 let n = frame.len().min(cap);
                 for (i, b) in frame.iter().take(n).enumerate() {
                     let _ = bus.write_u8(buf as u64 + i as u64, *b);
                 }
-                // Write back word0: received length in low 16, owner cleared.
-                let new_w0 = (w0 & !0xFFFF & !DESC_OWNER) | (n as u32 & 0xFFFF);
+                // Write back the lldesc the way HW does on RX completion: owner
+                // cleared, eof set, length[23:12] = received bytes, size[11:0]
+                // preserved. (Putting the length in the wrong field made the
+                // driver's RX callback skip the descriptor.)
+                let new_w0 = DESC_EOF | (((n as u32) & 0xFFF) << 12) | (w0 & 0xFFF);
                 let _ = bus.write_u32(desc as u64, new_w0);
                 self.set_event(EVENT_RX_DONE);
+                RX_DBG_BUF.store(buf, std::sync::atomic::Ordering::Relaxed);
+                if std::env::var("LABWIRED_RXBUF_TRACE").is_ok() {
+                    eprintln!("[rxinj] desc={desc:#010x} buf={buf:#010x} len={n}");
+                }
                 return true;
             }
             desc = next;
@@ -253,10 +271,13 @@ mod tests {
         mac.queue_rx_frame(frame.clone());
         mac.tick_with_bus(&mut bus);
 
-        // Descriptor word0: owner cleared, length = 4.
+        // Descriptor word0 (lldesc): owner cleared, eof set, length[23:12]=4,
+        // size[11:0]=1600 preserved.
         let w0 = bus.read_u32(desc as u64).unwrap();
         assert_eq!(w0 & DESC_OWNER, 0, "owner cleared after RX");
-        assert_eq!(w0 & 0xFFFF, 4, "received length written");
+        assert_ne!(w0 & DESC_EOF, 0, "eof set");
+        assert_eq!((w0 >> 12) & 0xFFF, 4, "rx length in length field");
+        assert_eq!(w0 & 0xFFF, 1600, "buffer size preserved");
         // Frame bytes DMA'd into the buffer.
         for (i, b) in frame.iter().enumerate() {
             assert_eq!(bus.read_u8(buf as u64 + i as u64).unwrap(), *b);

--- a/docs/esp32c3_wifi_mac_bridge.md
+++ b/docs/esp32c3_wifi_mac_bridge.md
@@ -55,8 +55,17 @@ brings WiFi up and starts a scan:
 - Other config seen: `0x6003_3c60`/`c64`/`c6c` (a second ring/EOF pointer at
   `0x6003_3c64` ← `0x3fc00000`, zeroed), `0x6003_3d04`, `0x6003_3084`.
 
-**RX-completion (still to confirm):** how `lmacProcessRxSucData` reads back the
-received length / owner from word0 — needed so an injected frame is accepted.
+**RX descriptor is an ESP `lldesc_t`** (CONFIRMED by tracing the driver's reads
+of an injected descriptor): word0 = `size[11:0] | length[23:12] | offset[28:24]
+| sosf[29] | eof[30] | owner[31]`. Empty/HW-owned reads `0x80640640`
+(owner=1, length=size=1600). On RX completion HW writes `owner=0, eof=1,
+length=actual-rx-bytes, size preserved` (e.g. `0x40140640` for a 320-byte
+frame). **VALIDATED end-to-end:** with that writeback, the real driver's RX
+callback follows word1 (buffer ptr) and reads the injected frame bytes out of
+the buffer, then recycles the descriptor (`owner` re-set to `0xc0140640`). The
+RX inject path (queue → DMA → lldesc → MAC IRQ → `wDev_ProcessFiq` →
+`lmacProcessRxSucData` → driver reads frame) works against the real firmware.
+The 802.11 frame starts at buffer offset 0 (no rx-control prefix in the buffer).
 
 **TX ring (still to RE):** the scan probe-request TX path hadn't queued a TX
 descriptor within the traced window; needs a longer trace / break on the lmac


### PR DESCRIPTION
The bridge's **RX path now works end-to-end against the real C3 WiFi firmware.**

## RE finding (validated)
By tracing the driver's reads of an injected descriptor, the RX descriptor word0 is an ESP `lldesc_t`: `size[11:0] | length[23:12] | offset[28:24] | sosf[29] | eof[30] | owner[31]`. Empty/HW-owned reads `0x80640640`. The model previously wrote the rx length into the wrong field (low 16) with eof clear, so the driver's RX callback walked past the descriptor.

## Fix
On RX delivery, write back the lldesc the way HW does: `owner=0, eof=1, length=rx-bytes (bits 23:12), size preserved` (e.g. `0x40140640`).

## Validated end-to-end
With the corrected lldesc, the driver follows word1 (buffer ptr) and **reads the injected frame bytes out of the RX buffer** (`0x3fca4980 = 0x03020100`… = the injected `byte[i]=i`), then recycles the descriptor (owner re-set). Full path: `queue_rx_frame → DMA → lldesc → MAC IRQ (matrix source 0) → wDev_ProcessFiq → lmacProcessRxSucData → driver consumes the frame`.

## Also
Env-gated bridge RE harness (run-loop RX inject `LABWIRED_WIFI_BRIDGE_RE`; read/write traces `LABWIRED_RXBUF_TRACE`/`LABWIRED_MAC_TRACE`).

## Tests
wifi_mac unit tests (lldesc writeback) + full core lib green (1318).

## Next
Craft a valid 802.11 beacon so the scan accepts the AP → auth/assoc → comms.