### PR TITLE
fix(coverage): measure esp32s3 register coverage against the real model

### DIFF
--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -221,11 +221,13 @@ fn measure_chip(yaml: &str, svd: &str) -> Option<(usize, usize, usize, usize)> {
             // only. Mirrors cli::coverage::build_matrix.
             let cpu = match chip.name.as_str() {
                 "esp32" => system::xtensa::configure_xtensa_esp32(&mut bus),
-                "esp32s3" => system::xtensa::configure_xtensa_esp32s3(
-                    &mut bus,
-                    &system::xtensa::Esp32s3Opts::default(),
-                )
-                .cpu,
+                "esp32s3" => {
+                    system::xtensa::configure_xtensa_esp32s3(
+                        &mut bus,
+                        &system::xtensa::Esp32s3Opts::default(),
+                    )
+                    .cpu
+                }
                 _ => system::xtensa::configure_xtensa(&mut bus),
             };
             let mut m = Machine::new(cpu, bus);

--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -212,10 +212,21 @@ fn measure_chip(yaml: &str, svd: &str) -> Option<(usize, usize, usize, usize)> {
             probe_all(&mut m.bus, &regs)
         }
         Arch::Xtensa => {
-            let cpu = if chip.name == "esp32" {
-                system::xtensa::configure_xtensa_esp32(&mut bus)
-            } else {
-                system::xtensa::configure_xtensa(&mut bus)
+            // Build the real per-chip peripheral set, the same way the runtime
+            // does, so coverage reflects the actual model — not the vestigial
+            // chip-yaml peripheral list that from_config seeded above (these
+            // system builders clear and repopulate the bus). esp32s3 previously
+            // fell through to the generic `configure_xtensa`, which registers no
+            // peripherals, so its coverage was measured against the yaml stub
+            // only. Mirrors cli::coverage::build_matrix.
+            let cpu = match chip.name.as_str() {
+                "esp32" => system::xtensa::configure_xtensa_esp32(&mut bus),
+                "esp32s3" => system::xtensa::configure_xtensa_esp32s3(
+                    &mut bus,
+                    &system::xtensa::Esp32s3Opts::default(),
+                )
+                .cpu,
+                _ => system::xtensa::configure_xtensa(&mut bus),
             };
             let mut m = Machine::new(cpu, bus);
             probe_all(&mut m.bus, &regs)

--- a/docs/coverage/register-modeling.json
+++ b/docs/coverage/register-modeling.json
@@ -8,7 +8,7 @@
     "total": 2606
   },
   "esp32s3": {
-    "modeled": 3321,
+    "modeled": 3331,
     "total": 4283
   },
   "nrf52832": {


### PR DESCRIPTION
Follow-up to the SoC factory migration (the validation-matrix correction flagged for the end).

`register_coverage::measure_chip` dispatched `esp32` → `configure_xtensa_esp32` but let **esp32s3 fall through to the generic `configure_xtensa`**, which registers no peripherals. So esp32s3 register-coverage was measured against the vestigial chip-yaml stub `from_config` seeded — not the shipping 33-peripheral model.

Add an esp32s3 arm calling `configure_xtensa_esp32s3` (the data-driven factory path), matching how `cli::coverage::build_matrix` already measures it. esp32s3 baseline 3321 → 3331 modeled (now reflects the real model). Other chips' (stale, understated) baselines left untouched to keep this focused.

Verified: `register_coverage_ratchet` green.