### PR TITLE
feat(esp32): classic-ESP32 (LX6) peripheral factory + parity test

### DIFF
--- a/crates/core/src/peripherals/esp32/factory.rs
+++ b/crates/core/src/peripherals/esp32/factory.rs
@@ -1,0 +1,70 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Data-driven factory for classic ESP32 (Xtensa LX6) peripheral models.
+//!
+//! Mirrors `peripherals::esp32s3::factory`: [`try_build`] maps a canonical
+//! peripheral `type` string + its descriptor to a boxed model, so the LX6
+//! peripheral set can be assembled from a table instead of hand-wired
+//! `add_peripheral` calls in `system::xtensa::configure_xtensa_esp32`.
+//!
+//! UART takes an ESP-IDF interrupt source id (`ETS_UART{0,1,2}_INTR_SOURCE` =
+//! 34/35/36) and an echo flag (UART0 echoes the console). The timer-group, LEDC
+//! and MCPWM models take their register base, read from the descriptor.
+
+use crate::Peripheral;
+use labwired_config::PeripheralConfig;
+
+/// Build a classic-ESP32 peripheral model for `canonical_type`, or `None` if
+/// this family does not own that type (so the caller falls through).
+pub fn try_build(canonical_type: &str, p_cfg: &PeripheralConfig) -> Option<Box<dyn Peripheral>> {
+    use super::*;
+
+    let base = p_cfg.base_address as u32;
+    let dev: Box<dyn Peripheral> = match canonical_type {
+        "esp32_uart" => {
+            // UART0 echoes TX to the host console (source 34); UART1/2 are
+            // capture-only (35/36).
+            let echo = p_cfg
+                .config
+                .get("echo_stdout")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            Box::new(uart::Esp32Uart::new(echo, p_cfg.irq.unwrap_or(34)))
+        }
+        "esp32_spi" => Box::new(spi::Esp32Spi::new()),
+        "esp32_gpio" => Box::new(gpio::Esp32Gpio::new()),
+        "esp32_dport" => Box::new(dport::Dport::new()),
+        "esp32_sha" => Box::new(sha::Sha::new()),
+        "esp32_rtc_cntl" => Box::new(rtc_cntl::RtcCntl::new()),
+        "esp32_timg" => Box::new(timg::Timg::new(base)),
+        "esp32_efuse" => Box::new(efuse::Efuse::new()),
+        "esp32_syscon" => Box::new(syscon::Syscon::new()),
+        "esp32_ledc" => Box::new(ledc::Ledc::new(base)),
+        "esp32_twai" => Box::new(twai::Esp32Twai::new()),
+        "esp32_mcpwm" => Box::new(mcpwm::Mcpwm::new(base)),
+        "esp32_sdio" => Box::new(sdio_stub::HostSlc::new()),
+        _ => return None,
+    };
+    Some(dev)
+}
+
+/// Canonical type strings this factory owns. Kept next to [`try_build`].
+pub const SUPPORTED_TYPES: &[&str] = &[
+    "esp32_uart",
+    "esp32_spi",
+    "esp32_gpio",
+    "esp32_dport",
+    "esp32_sha",
+    "esp32_rtc_cntl",
+    "esp32_timg",
+    "esp32_efuse",
+    "esp32_syscon",
+    "esp32_ledc",
+    "esp32_twai",
+    "esp32_mcpwm",
+    "esp32_sdio",
+];

--- a/crates/core/src/peripherals/esp32/mod.rs
+++ b/crates/core/src/peripherals/esp32/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod dport;
 pub mod efuse;
+pub mod factory;
 pub mod gpio;
 pub mod ledc;
 pub mod mcpwm;

--- a/crates/core/src/system/xtensa.rs
+++ b/crates/core/src/system/xtensa.rs
@@ -1668,11 +1668,74 @@ pub(crate) const ESP32S3_PERIPHERALS: &[(&str, &str, u64, u64, Option<u32>)] = &
     ("uart2_s3",        "esp32s3_uart",            0x6002_E000, 0x0100, Some(29)),
 ];
 
+/// Canonical `(id, factory type, window base, window size, irq source)` for the
+/// classic ESP32 (Xtensa LX6) peripheral models that `configure_xtensa_esp32`
+/// installs by hand. The `peripherals::esp32::factory` source of truth, parallel
+/// to [`ESP32S3_PERIPHERALS`]; proven equivalent to the hand-wired path by
+/// `esp32_factory_descriptors_match_hardwired`.
+#[allow(dead_code)]
+#[rustfmt::skip]
+pub(crate) const ESP32_PERIPHERALS: &[(&str, &str, u64, u64, Option<u32>)] = &[
+    ("uart0",    "esp32_uart",     0x3FF4_0000, 0x0100, Some(34)),
+    ("uart1",    "esp32_uart",     0x3FF5_0000, 0x0100, Some(35)),
+    ("uart2",    "esp32_uart",     0x3FF6_E000, 0x0100, Some(36)),
+    ("spi0",     "esp32_spi",      0x3FF4_3000, 0x1000, None),
+    ("spi1",     "esp32_spi",      0x3FF4_2000, 0x1000, None),
+    ("spi3",     "esp32_spi",      0x3FF6_5000, 0x1000, None),
+    ("gpio",     "esp32_gpio",     0x3FF4_4000, 0x1000, None),
+    ("dport",    "esp32_dport",    0x3FF0_0000, 0x1000, None),
+    ("sha",      "esp32_sha",      0x3FF0_3000, 0x0100, None),
+    ("rtc_cntl", "esp32_rtc_cntl", 0x3FF4_8000, 0x0200, None),
+    ("timg0",    "esp32_timg",     0x3FF5_F000, 0x1000, None),
+    ("timg1",    "esp32_timg",     0x3FF6_0000, 0x1000, None),
+    ("efuse",    "esp32_efuse",    0x3FF5_A000, 0x1000, None),
+    ("syscon",   "esp32_syscon",   0x3FF6_6000, 0x0100, None),
+    ("ledc",     "esp32_ledc",     0x3FF5_9000, 0x1000, None),
+    ("twai",     "esp32_twai",     0x3FF6_B000, 0x1000, None),
+    ("mcpwm0",   "esp32_mcpwm",    0x3FF5_E000, 0x1000, None),
+    ("host_slc", "esp32_sdio",     0x3FF5_8000, 0x1000, None),
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::Bus;
     use crate::Peripheral;
+
+    /// The esp32 (LX6) factory + ESP32_PERIPHERALS table must build each
+    /// peripheral with the same window (base, size) as the hand-wired
+    /// `configure_xtensa_esp32`. That builder also registers memory regions and
+    /// catch-all stubs, so this checks the table's peripherals by name rather
+    /// than comparing whole buses. Pins the factory path as equivalent before it
+    /// replaces the hand-wired registrations.
+    #[test]
+    fn esp32_factory_descriptors_match_hardwired() {
+        use labwired_config::PeripheralConfig;
+        use std::collections::HashMap;
+
+        let mut hw = SystemBus::new();
+        let _ = configure_xtensa_esp32(&mut hw);
+
+        for &(id, ty, base, size, irq) in ESP32_PERIPHERALS {
+            let cfg = PeripheralConfig {
+                id: id.to_string(),
+                r#type: ty.to_string(),
+                base_address: base,
+                size: None,
+                irq,
+                config: HashMap::new(),
+            };
+            assert!(
+                crate::peripherals::esp32::factory::try_build(ty, &cfg).is_some(),
+                "esp32 factory missing type {ty} for {id}"
+            );
+            let idx = hw
+                .find_peripheral_index_by_name(id)
+                .unwrap_or_else(|| panic!("hand-wired esp32 bus missing {id}"));
+            let p = &hw.peripherals[idx];
+            assert_eq!((p.base, p.size), (base, size), "window mismatch for {id}");
+        }
+    }
 
     /// The esp32s3 factory + canonical descriptor table must place exactly the
     /// same peripheral windows (name, base, size) as the hand-wired


### PR DESCRIPTION
Propagates the esp32s3 factory pattern to the classic ESP32 (Xtensa LX6).

- `peripherals/esp32/factory.rs` — `try_build` for the 13 LX6 peripheral model types.
- `ESP32_PERIPHERALS` — canonical (id, type, base, size, irq) table for the 18 instances `configure_xtensa_esp32` hand-wires.
- `esp32_factory_descriptors_match_hardwired` — proves the factory builds each with the same window as the hand-wired path.

**Additive** — `configure_xtensa_esp32` still hand-wires. The flip to a table+factory loop is a follow-up (needs the core/peripheral split with same-base ordering care — `syscon` shares 0x3FF6_6000 with the `apb_ctrl` catch-all — plus firmware_survival/brom_boot on the SMP path).