### PR TITLE
feat(esp32c3): WiFi 802.11 network analyzer — frame-trace + WASM snapshot

### DIFF
--- a/crates/core/src/peripherals/esp32c3/wifi_mac.rs
+++ b/crates/core/src/peripherals/esp32c3/wifi_mac.rs
@@ -74,6 +74,26 @@ const TXQ_DONE_STATE: u64 = 0xCB0; // hal_mac_get_txq_state mode2 reads &0xF her
 /// DRAM window the low-20-bit TX buffer pointer resolves into.
 const DRAM_BASE: u32 = 0x3FC0_0000;
 
+/// Capacity of the network-analyzer frame-trace ring buffer.
+const TRACE_CAP: usize = 512;
+
+/// One captured 802.11 frame, for the WiFi network analyzer (the WiFi analog of
+/// the BLE `AirFrameTrace`). `bytes` is the raw 802.11 frame as it crossed the
+/// MAC; the analyzer UI decodes the type/addresses/payload. Direction is from
+/// the device's point of view: `"tx"` = transmitted by this STA, `"rx"` =
+/// delivered to this STA from the (virtual) air.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WifiFrameTrace {
+    /// Monotonic capture sequence (per MAC), so the UI can order/dedup.
+    pub seq: u64,
+    /// `"tx"` or `"rx"` from this device's perspective.
+    pub dir: &'static str,
+    /// Raw 802.11 frame bytes (no rx-control header / FCS).
+    pub bytes: Vec<u8>,
+    /// Receive signal strength (dBm, signed) for `"rx"` frames; 0 for `"tx"`.
+    pub rssi: i8,
+}
+
 #[derive(Debug)]
 pub struct Esp32c3WifiMac {
     regs: Vec<u32>,
@@ -87,6 +107,10 @@ pub struct Esp32c3WifiMac {
     /// 0xC000_0000 write; processed (frame captured + TX-complete signaled) on
     /// the next bus tick, which has bus access to read the frame from DRAM.
     pending_tx: VecDeque<(u8, u32)>,
+    /// Network-analyzer ring buffer of recently captured frames (TX + RX).
+    trace: VecDeque<WifiFrameTrace>,
+    /// Next capture sequence number.
+    trace_seq: u64,
 }
 
 impl Default for Esp32c3WifiMac {
@@ -103,7 +127,36 @@ impl Esp32c3WifiMac {
             pending_rx: VecDeque::new(),
             tx_out: VecDeque::new(),
             pending_tx: VecDeque::new(),
+            trace: VecDeque::new(),
+            trace_seq: 0,
         }
+    }
+
+    /// Record a captured frame in the analyzer ring buffer (oldest dropped at
+    /// `TRACE_CAP`). `dir` is `"tx"` or `"rx"` from this device's perspective.
+    fn trace_push(&mut self, dir: &'static str, bytes: &[u8], rssi: i8) {
+        if self.trace.len() == TRACE_CAP {
+            self.trace.pop_front();
+        }
+        self.trace.push_back(WifiFrameTrace {
+            seq: self.trace_seq,
+            dir,
+            bytes: bytes.to_vec(),
+            rssi,
+        });
+        self.trace_seq += 1;
+    }
+
+    /// Non-consuming snapshot of the analyzer frame trace, most-recent first.
+    /// The network-analyzer UI polls this each tick (mirrors the BLE
+    /// `air_trace_snapshot`).
+    pub fn trace_snapshot(&self) -> Vec<WifiFrameTrace> {
+        self.trace.iter().rev().cloned().collect()
+    }
+
+    /// Clear the analyzer frame trace (UI "reset").
+    pub fn trace_clear(&mut self) {
+        self.trace.clear();
     }
 
     /// Length of the 802.11 frame in a captured TX buffer: parse the MAC header,
@@ -158,6 +211,7 @@ impl Esp32c3WifiMac {
                 head.join(" ")
             );
         }
+        self.trace_push("tx", &raw, 0);
         self.tx_out.push_back(raw);
         // Signal TX-complete: set the per-queue done state (mode2 reads &0xF at
         // 0xCB0) and the TX-done event bit, then the level-sensitive MAC IRQ
@@ -217,6 +271,7 @@ impl Esp32c3WifiMac {
             let cap = (w0 & 0xFFF) as usize; // lldesc size field (buffer capacity)
             if w0 & DESC_OWNER != 0 && buf != 0 && cap > 0 {
                 let frame = self.pending_rx.pop_front().unwrap();
+                self.trace_push("rx", &frame, -60);
                 // HW DMA layout: a RX_CTRL_HDR_LEN-byte rx-control header, then
                 // the 802.11 frame (CSI off → no CSI block). The driver reads
                 // the frame at buf + 48 and rssi/rate from header bytes 44/45.
@@ -399,6 +454,28 @@ mod tests {
             m.tick().explicit_irqs.as_deref(),
             Some(&[MAC_INTR_SOURCE][..])
         );
+    }
+
+    #[test]
+    fn analyzer_trace_captures_rx_and_caps() {
+        let mut m = Esp32c3WifiMac::new();
+        // RX capture path.
+        m.trace_push("rx", &[0x80, 0x00, 0xde, 0xad], -42);
+        m.trace_push("tx", &[0x40, 0x00], 0);
+        let snap = m.trace_snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].dir, "tx"); // most-recent first
+        assert_eq!(snap[1].dir, "rx");
+        assert_eq!(snap[1].rssi, -42);
+        assert_eq!(snap[1].bytes, vec![0x80, 0x00, 0xde, 0xad]);
+        assert_eq!(snap[1].seq, 0);
+        // Ring cap: oldest dropped beyond TRACE_CAP.
+        for _ in 0..TRACE_CAP {
+            m.trace_push("rx", &[0u8; 4], -60);
+        }
+        assert_eq!(m.trace_snapshot().len(), TRACE_CAP);
+        m.trace_clear();
+        assert!(m.trace_snapshot().is_empty());
     }
 
     #[test]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -701,6 +701,36 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&snapshots).unwrap_or(JsValue::NULL)
     }
 
+    /// Non-consuming WiFi 802.11 frame-trace snapshot for the network analyzer
+    /// (the WiFi analog of `air_trace_snapshot`). Returns, per ESP32-C3 WiFi MAC,
+    /// the recently captured TX/RX frames (most-recent first); the analyzer UI
+    /// decodes 802.11 type/addresses and the L3 payload (DHCP/ARP/IP).
+    #[wasm_bindgen]
+    pub fn wifi_trace_snapshot(&self) -> JsValue {
+        let Some(machine) = self.machine.as_ref() else {
+            return serde_wasm_bindgen::to_value(&Vec::<serde_json::Value>::new())
+                .unwrap_or(JsValue::NULL);
+        };
+
+        let snapshots = machine
+            .bus
+            .peripherals
+            .iter()
+            .filter_map(|p| {
+                let any = p.dev.as_any()?;
+                let mac = any
+                    .downcast_ref::<labwired_core::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac>(
+                    )?;
+                Some(serde_json::json!({
+                    "peripheral": p.name,
+                    "frames": mac.trace_snapshot(),
+                }))
+            })
+            .collect::<Vec<_>>();
+
+        serde_wasm_bindgen::to_value(&snapshots).unwrap_or(JsValue::NULL)
+    }
+
     /// Non-consuming FDCAN frame trace snapshot for CAN/UDS instruments.
     #[wasm_bindgen]
     pub fn fdcan_trace_snapshot(&self) -> JsValue {


### PR DESCRIPTION
The WiFi analog of the existing BLE air-trace analyzer — a **network analyzer** for the playground.

## What
- `wifi_mac` records every 802.11 frame crossing it (TX captured on the PLCP0 kick, RX injected from the virtual air) into a 512-entry ring of `WifiFrameTrace { seq, dir, bytes, rssi }`.
- `trace_snapshot()` — non-consuming, most-recent-first (mirrors BLE `air_trace_snapshot`); `trace_clear()` resets.
- WASM: `WasmSimulator::wifi_trace_snapshot()` aggregates per-MAC frame lists (same shape as uart/fdcan snapshots). The analyzer UI decodes 802.11 type/addresses + L3 (beacon/probe/auth/assoc/DHCP/ARP/IP).

## Why
Lets the web playground visualize the full association + DHCP DORA + ARP exchange that already runs over the real MAC (and, next, two-device traffic). Foundation for the two-C3 WiFi lab.

Unit-tested: capture order, rssi, ring cap, clear.