### PR TITLE
feat(esp32c3): UDP echo round-trip over simulated WiFi — full app-data path

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1164,9 +1164,87 @@ fn ap_respond(tx: &[u8]) -> Vec<(Vec<u8>, &'static str)> {
             if oper == 1 && tpa != STA_IP {
                 out.push((build_arp_reply(tpa, STA_IP), "arp-req->reply"));
             }
+        } else if let Some(echo) = build_udp_echo(tx, UDP_ECHO_PORT) {
+            // A tiny UDP echo server at AP_IP:UDP_ECHO_PORT — proves real
+            // bidirectional socket data over the simulated WiFi.
+            out.push((echo, "udp->echo"));
         }
     }
     out
+}
+
+/// UDP echo-server port the bridge hosts at AP_IP (matches the firmware probe).
+const UDP_ECHO_PORT: u16 = 9999;
+
+/// If the captured TX frame is a UDP datagram from the STA to the AP's echo
+/// port, build the echoed reply (same payload) as an AP→STA 802.11 data frame.
+fn build_udp_echo(frame: &[u8], echo_port: u16) -> Option<Vec<u8>> {
+    if frame.len() < 2 || (frame[0] >> 2) & 3 != 2 {
+        return None;
+    }
+    let hdr = if frame[0] & 0x80 != 0 { 26 } else { 24 };
+    let snap = hdr + 8;
+    let ip = snap;
+    if frame.len() < ip + 20 || frame[ip] >> 4 != 4 || frame[ip + 9] != 17 {
+        return None; // not IPv4/UDP
+    }
+    let ihl = (frame[ip] & 0xF) as usize * 4;
+    let udp = ip + ihl;
+    if frame.len() < udp + 8 {
+        return None;
+    }
+    let sport = u16::from_be_bytes([frame[udp], frame[udp + 1]]);
+    let dport = u16::from_be_bytes([frame[udp + 2], frame[udp + 3]]);
+    if dport != echo_port {
+        return None;
+    }
+    let ulen = u16::from_be_bytes([frame[udp + 4], frame[udp + 5]]) as usize;
+    if ulen < 8 || frame.len() < udp + ulen {
+        return None;
+    }
+    let payload = &frame[udp + 8..udp + ulen];
+
+    // Echo: UDP src=echo_port → dst=sport, same payload, checksum 0.
+    let udp_len = (8 + payload.len()) as u16;
+    let mut u = Vec::new();
+    u.extend_from_slice(&echo_port.to_be_bytes());
+    u.extend_from_slice(&sport.to_be_bytes());
+    u.extend_from_slice(&udp_len.to_be_bytes());
+    u.extend_from_slice(&[0, 0]);
+    u.extend_from_slice(payload);
+
+    let ip_total = (20 + u.len()) as u16;
+    let mut iph = vec![
+        0x45,
+        0x00,
+        (ip_total >> 8) as u8,
+        ip_total as u8,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x40,
+        0x11,
+        0x00,
+        0x00,
+    ];
+    iph.extend_from_slice(&AP_IP);
+    iph.extend_from_slice(&STA_IP);
+    let cks = inet_checksum(&iph);
+    iph[10] = (cks >> 8) as u8;
+    iph[11] = cks as u8;
+    iph.extend_from_slice(&u);
+
+    let mut f = Vec::new();
+    f.extend_from_slice(&[0x08, 0x02]); // data, from-DS
+    f.extend_from_slice(&[0x00, 0x00]);
+    f.extend_from_slice(&BRIDGE_STA); // addr1 = DA (STA)
+    f.extend_from_slice(&BRIDGE_BSSID); // addr2 = BSSID
+    f.extend_from_slice(&BRIDGE_BSSID); // addr3 = SA
+    f.extend_from_slice(&[0x00, 0x00]);
+    f.extend_from_slice(&[0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x08, 0x00]); // LLC/SNAP IPv4
+    f.extend_from_slice(&iph);
+    Some(f)
 }
 
 /// Short human label for a captured STA TX frame, for bridge tracing.

--- a/scripts/hw-oracle/wifi-re/main/CMakeLists.txt
+++ b/scripts/hw-oracle/wifi-re/main/CMakeLists.txt
@@ -1,1 +1,2 @@
-idf_component_register(SRCS "wifi_probe.c" INCLUDE_DIRS ".")
+idf_component_register(SRCS "wifi_probe.c" INCLUDE_DIRS "."
+                       REQUIRES nvs_flash esp_wifi esp_netif esp_event lwip)

--- a/scripts/hw-oracle/wifi-re/main/wifi_probe.c
+++ b/scripts/hw-oracle/wifi-re/main/wifi_probe.c
@@ -10,9 +10,44 @@
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "lwip/sockets.h"
 #include <string.h>
 
 static const char *TAG = "probe";
+
+// Virtual-AP / UDP-echo server the LabWired bridge hosts.
+#define AP_IP_STR   "192.168.4.1"
+#define UDP_PORT    9999
+
+// After GOT IP, prove real bidirectional socket data over the simulated WiFi:
+// send a UDP datagram to the AP's echo port and wait for the echo back.
+static void udp_echo_task(void *arg)
+{
+    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    struct sockaddr_in dst = { 0 };
+    dst.sin_family = AF_INET;
+    dst.sin_port = htons(UDP_PORT);
+    dst.sin_addr.s_addr = inet_addr(AP_IP_STR);
+    struct timeval tv = { .tv_sec = 5, .tv_usec = 0 };
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    const char *msg = "hello from c3";
+    for (int seq = 0; ; seq++) {
+        sendto(sock, msg, strlen(msg), 0, (struct sockaddr *)&dst, sizeof(dst));
+        ESP_LOGI(TAG, "UDP TX -> %s:%d '%s' (seq %d)", AP_IP_STR, UDP_PORT, msg, seq);
+        char rx[64];
+        struct sockaddr_in src;
+        socklen_t sl = sizeof(src);
+        int n = recvfrom(sock, rx, sizeof(rx) - 1, 0, (struct sockaddr *)&src, &sl);
+        if (n > 0) {
+            rx[n] = 0;
+            ESP_LOGI(TAG, "UDP RX <- echo '%s' (%d bytes)", rx, n);
+        } else {
+            ESP_LOGI(TAG, "UDP RX timeout");
+        }
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+}
 
 #define PROBE_SSID "labwired-ap"
 // OPEN auth (no password) — the bridge's first comms milestone associates with
@@ -40,7 +75,9 @@ static void wifi_event_handler(void *arg, esp_event_base_t base,
         ESP_LOGI(TAG, "sta disconnected -> retry");
         esp_wifi_connect();
     } else if (base == IP_EVENT && id == IP_EVENT_STA_GOT_IP) {
-        ESP_LOGI(TAG, "GOT IP");
+        ip_event_got_ip_t *evt = (ip_event_got_ip_t *)data;
+        ESP_LOGI(TAG, "GOT IP " IPSTR, IP2STR(&evt->ip_info.ip));
+        xTaskCreate(udp_echo_task, "udp_echo", 4096, NULL, 5, NULL);
     }
 }
 


### PR DESCRIPTION
Completes the network-stack demo: an **unmodified ESP-IDF C3 binary sends and receives real UDP socket data** over the real MAC.

- **firmware**: after `IP_EVENT_STA_GOT_IP`, a udp_echo task `sendto`s 'hello from c3' to 192.168.4.1:9999 and `recvfrom`s the echo.
- **virtual AP** (`build_udp_echo`): a tiny UDP echo server at AP_IP:9999, wired into `ap_respond`.

## Verified end-to-end (real ROM boot)
```
GOT IP 192.168.4.2
arp-req->reply           (STA bound, resolves the gateway)
UDP TX -> 192.168.4.1:9999 'hello from c3' (seq 0)
udp->echo
UDP RX <- echo 'hello from c3' (13 bytes)
```
boot → 802.11 assoc → DHCP → ARP → UDP sockets — all real models over the real MAC, every frame visible in the WiFi network analyzer (#284).