### PR TITLE
refactor(bus): extract generic peripheral arms into a cross-vendor factory

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -7,7 +7,6 @@
 use crate::memory::LinearMemory;
 use crate::peripherals::gpio::GpioRegisterLayout;
 use crate::peripherals::nvic::NvicState;
-use crate::peripherals::rcc::RccRegisterLayout;
 use crate::peripherals::uart::Uart;
 use crate::peripherals::uart::UartRegisterLayout;
 use crate::{Bus, DmaRequest, Peripheral, SimResult, SimulationError};
@@ -367,7 +366,7 @@ impl SystemBus {
         t
     }
 
-    fn profile_name(p_cfg: &PeripheralConfig) -> anyhow::Result<Option<&str>> {
+    pub(crate) fn profile_name(p_cfg: &PeripheralConfig) -> anyhow::Result<Option<&str>> {
         if let Some(value) = p_cfg.config.get("profile") {
             return value.as_str().map(Some).ok_or_else(|| {
                 anyhow::anyhow!("Peripheral '{}' config.profile must be a string", p_cfg.id)
@@ -384,7 +383,7 @@ impl SystemBus {
         Ok(None)
     }
 
-    fn parse_profile_or_default<T>(
+    pub(crate) fn parse_profile_or_default<T>(
         p_cfg: &PeripheralConfig,
         peripheral_kind: &str,
     ) -> anyhow::Result<T>
@@ -1248,9 +1247,17 @@ impl SystemBus {
                 bus.push_peripheral(p_cfg, dev)?;
                 continue;
             }
+            // Cross-vendor / generic peripherals (fallible: size + profile parsing).
+            if let Some(dev) =
+                crate::peripherals::generic_factory::try_build(&canonical_type, p_cfg, manifest)?
+            {
+                bus.push_peripheral(p_cfg, dev)?;
+                continue;
+            }
 
+            // Remaining: the YAML descriptor loaders (declarative / strict_ir) and
+            // the unknown-type stub fallback.
             let dev: Box<dyn Peripheral> = match canonical_type.as_str() {
-                // nRF52 UARTE: full register surface including PSEL/BAUDRATE/CONFIG/DMA.
                 "uart" | "stm32_uart" | "stm32f1_uart" | "stm32f2_uart" | "stm32f4_uart"
                 | "stm32f7_usart" | "stm32h5_usart" | "efm32_uart" | "nxp_lpuart" | "ns16550"
                 | "pl011" | "gaislerapbuart" => {
@@ -1274,16 +1281,6 @@ impl SystemBus {
                     Box::new(crate::peripherals::uart::Uart::new_with_layout_cr3(
                         layout, cr3_mask,
                     ))
-                }
-                "systick" | "arm_generictimer" => {
-                    // CALIB is implementation-defined per chip; the yaml can
-                    // supply the silicon value via `config: { calib: ... }`.
-                    match p_cfg.config.get("calib").and_then(|v| v.as_u64()) {
-                        Some(calib) => Box::new(crate::peripherals::systick::Systick::with_calib(
-                            calib as u32,
-                        )),
-                        None => Box::new(crate::peripherals::systick::Systick::new()),
-                    }
                 }
                 "gpio" | "stm32_gpioport" | "stm32f4_gpio" | "efmgpioport" | "npcx_gpio"
                 | "imxrt_gpio" => {
@@ -1327,102 +1324,6 @@ impl SystemBus {
                         Box::new(crate::peripherals::gpio::GpioPort::new_with_layout(layout))
                     }
                 }
-                "rcc" => {
-                    let layout: RccRegisterLayout = Self::parse_profile_or_default(p_cfg, "RCC")?;
-                    let mut rcc = crate::peripherals::rcc::Rcc::new_with_layout(layout);
-                    // F4 ENR writable masks are per-part (implemented-peripheral
-                    // set). YAML: `config: { rcc_ahb1enr_mask, rcc_apb1enr_mask,
-                    // rcc_apb2enr_mask }`; default unmasked (0xFFFF_FFFF).
-                    let m = |k: &str| -> u32 {
-                        p_cfg
-                            .config
-                            .get(k)
-                            .and_then(|v| v.as_u64())
-                            .map(|n| n as u32)
-                            .unwrap_or(0xFFFF_FFFF)
-                    };
-                    rcc.set_f4_enr_masks(
-                        m("rcc_ahb1enr_mask"),
-                        m("rcc_apb1enr_mask"),
-                        m("rcc_apb2enr_mask"),
-                    );
-                    Box::new(rcc)
-                }
-                "dbgmcu" => {
-                    // Pull IDCODE from YAML config (`idcode: "0x10076415"` or
-                    // `idcode: 269009941`). Default 0 — firmware probing
-                    // DBGMCU_IDCODE will then read 0; logged.
-                    let idcode: u32 = p_cfg
-                        .config
-                        .get("idcode")
-                        .and_then(|v| {
-                            if let Some(s) = v.as_str() {
-                                let s = s.trim();
-                                if let Some(rest) =
-                                    s.strip_prefix("0x").or_else(|| s.strip_prefix("0X"))
-                                {
-                                    u32::from_str_radix(rest, 16).ok()
-                                } else {
-                                    s.parse::<u32>().ok()
-                                }
-                            } else {
-                                v.as_u64().map(|n| n as u32)
-                            }
-                        })
-                        .unwrap_or(0);
-                    if idcode == 0 {
-                        tracing::warn!(
-                            "dbgmcu peripheral '{}' has no idcode configured \
-                             — firmware probing DBGMCU_IDCODE will read 0",
-                            p_cfg.id
-                        );
-                    }
-                    Box::new(crate::peripherals::dbgmcu::Dbgmcu::new(idcode))
-                }
-                "timer" | "stm32_timer" | "efm32timer" | "renesasra_agt" | "stm32l0_lptimer" => {
-                    if p_cfg.r#type.contains("nrf") {
-                        // Nordic TIMER is task/event-driven and shares no
-                        // register layout with the STM32 TIMx family —
-                        // route to the dedicated nRF52 model.
-                        // TIMER3/4 have 6 CC; TIMER0/1/2 have 4 (default).
-                        let num_cc: usize = p_cfg
-                            .config
-                            .get("num_cc")
-                            .and_then(|v| v.as_u64())
-                            .map(|n| n as usize)
-                            .unwrap_or(4);
-                        Box::new(crate::peripherals::nrf52::timer::Nrf52Timer::new_with_cc(
-                            num_cc,
-                        ))
-                    } else {
-                        // Width selector for 32-bit TIM2/TIM5 (STM32L4 etc).
-                        // YAML: `config: { width: 32 }`. Defaults to 16 for
-                        // back-compat with F1-class general-purpose timers.
-                        // `advanced: true` enables RCR/BDTR/CCR5/6 (TIM1/TIM8).
-                        let width: u8 = p_cfg
-                            .config
-                            .get("width")
-                            .and_then(|v| v.as_u64())
-                            .map(|n| n as u8)
-                            .unwrap_or(16);
-                        let advanced = p_cfg
-                            .config
-                            .get("advanced")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        // `basic: true` (TIM6/TIM7) → counter + UIF only, no
-                        // capture/compare channels.
-                        let basic = p_cfg
-                            .config
-                            .get("basic")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false);
-                        Box::new(
-                            crate::peripherals::timer::Timer::new_with_layout(width, advanced)
-                                .basic(basic),
-                        )
-                    }
-                }
                 "i2c"
                 | "stm32f1_i2c"
                 | "stm32f2_i2c"
@@ -1461,150 +1362,6 @@ impl SystemBus {
                     }
                     Box::new(i2c)
                 }
-                "spi" | "stm32spi" => {
-                    let layout: crate::peripherals::spi::SpiRegisterLayout =
-                        if p_cfg.r#type.contains("nrf") {
-                            crate::peripherals::spi::SpiRegisterLayout::Nrf52Spim
-                        } else {
-                            Self::parse_profile_or_default(p_cfg, "SPI")?
-                        };
-                    // Classic-SPI CR2 mask is a per-part delta: F1 0xE7, F4 adds
-                    // FRF bit 4 → 0xF7. YAML: `config: { cr2_mask: 0xF7 }`.
-                    let cr2_mask: u32 = p_cfg
-                        .config
-                        .get("cr2_mask")
-                        .and_then(|v| v.as_u64())
-                        .map(|n| n as u32)
-                        .unwrap_or(0x0000_00E7);
-                    let mut spi =
-                        crate::peripherals::spi::Spi::new_with_layout_cr2(layout, cr2_mask);
-                    // Declarative IR SPI devices (`type: ir`) attach here,
-                    // mirroring the I2C path. Hand-written SPI devices attach via
-                    // the PeripheralKit registry pass, which ignores `type: ir`,
-                    // so the two dispatch paths never double-attach the same bus.
-                    for ext in &manifest.external_devices {
-                        if ext.connection != p_cfg.id || !ext.r#type.eq_ignore_ascii_case("ir") {
-                            continue;
-                        }
-                        match crate::peripherals::components::build_spi_device(
-                            &ext.r#type,
-                            &ext.config,
-                        ) {
-                            Some(device) => {
-                                tracing::info!(
-                                    "spi attach: '{}' (type=ir) -> '{}'",
-                                    ext.id,
-                                    p_cfg.id
-                                );
-                                spi.attach(device);
-                            }
-                            None => {
-                                tracing::warn!(
-                                    "spi attach skipped: invalid ir spec for external id '{}' on bus '{}'",
-                                    ext.id,
-                                    p_cfg.id
-                                );
-                            }
-                        }
-                    }
-                    Box::new(spi)
-                }
-                "pwr" => {
-                    // `config: { profile: stm32h5 }` selects the H5 layout
-                    // (VOSCR/VOSSR voltage scaling); default stays L4.
-                    match p_cfg.config.get("profile").and_then(|v| v.as_str()) {
-                        Some("stm32h5") | Some("h5") => {
-                            Box::new(crate::peripherals::pwr::PwrH5::new())
-                        }
-                        // L0 has a two-register surface (CR/CSR), not the L4
-                        // CR1..CR4 / PUCRx set — a distinct reset shape.
-                        Some("stm32l0") | Some("l0") => {
-                            Box::new(crate::peripherals::pwr::PwrL0::new())
-                        }
-                        _ => Box::new(crate::peripherals::pwr::Pwr::new()),
-                    }
-                }
-                "flash" | "flash_iface" => {
-                    // Layout selected via `config: { profile: stm32f1 | stm32l4 }`
-                    // in the chip yaml. Missing/unknown profile keeps the L4
-                    // default — backward compatible with existing chip configs.
-                    let layout: crate::peripherals::flash::FlashRegisterLayout =
-                        Self::parse_profile_or_default(p_cfg, "FLASH")?;
-                    Box::new(crate::peripherals::flash::Flash::new_with_layout(layout))
-                }
-                "rng" => Box::new(crate::peripherals::rng::Rng::new()),
-                "crc" => {
-                    // IDR scratch register width: 8-bit on F0/F1/L0, 32-bit
-                    // on F2+/L4+. YAML: `config: { idr_width: 8 }`; default 32.
-                    let idr_width: u8 = p_cfg
-                        .config
-                        .get("idr_width")
-                        .and_then(|v| v.as_u64())
-                        .map(|n| n as u8)
-                        .unwrap_or(32);
-                    Box::new(crate::peripherals::crc::Crc::new().with_idr_width(idr_width))
-                }
-                "rtc" => Box::new(crate::peripherals::rtc::Rtc::new()),
-                "rtc_f1" => Box::new(crate::peripherals::rtc_f1::RtcF1::new()),
-                "rtc_v3" => Box::new(crate::peripherals::rtc_v3::RtcV3::new()),
-                "iwdg" => Box::new(crate::peripherals::iwdg::Iwdg::new()),
-                "wwdg" => Box::new(crate::peripherals::wwdg::Wwdg::new()),
-                "dac" => Box::new(crate::peripherals::dac::Dac::new()),
-                "lptim" => Box::new(crate::peripherals::lptim::Lptim::new()),
-                "quadspi" => Box::new(crate::peripherals::quadspi::Quadspi::new()),
-                "sai" => Box::new(crate::peripherals::sai::Sai::new()),
-                "usb_otg" => Box::new(crate::peripherals::usb_otg::UsbOtg::new()),
-                "bxcan" => Box::new(crate::peripherals::bxcan::BxCan::new()),
-                "fdcan" => Box::new(crate::peripherals::fdcan::Fdcan::new()),
-                "sdmmc" => Box::new(crate::peripherals::sdmmc::Sdmmc::new()),
-                "comp" => Box::new(crate::peripherals::comp::Comp::new()),
-                "tsc" => Box::new(crate::peripherals::tsc::Tsc::new()),
-                "fmc" => Box::new(crate::peripherals::fmc::Fmc::new()),
-                "exti" => {
-                    let layout: crate::peripherals::exti::ExtiRegisterLayout =
-                        Self::parse_profile_or_default(p_cfg, "EXTI")?;
-                    // Implemented-line count is part-specific (F103 = 19). YAML:
-                    // `config: { lines: 19 }`; default 20 for back-compat.
-                    let lines: u32 = p_cfg
-                        .config
-                        .get("lines")
-                        .and_then(|v| v.as_u64())
-                        .map(|n| n as u32)
-                        .unwrap_or(20);
-                    let line_mask = if lines >= 32 {
-                        0xFFFF_FFFF
-                    } else {
-                        (1u32 << lines) - 1
-                    };
-                    Box::new(crate::peripherals::exti::Exti::new_with_layout_lines(
-                        layout, line_mask,
-                    ))
-                }
-                "afio" => Box::new(crate::peripherals::afio::Afio::new()),
-                "dma" | "stm32dma" => Box::new(crate::peripherals::dma::Dma1::new()),
-                "gpdma" => {
-                    // `config: { irq_base: N }` routes channel n to NVIC
-                    // line N + n (H563 GPDMA1: 27..34). Without it the
-                    // block's single `irq:` line serves every channel.
-                    let g = crate::peripherals::gpdma::Gpdma::new()
-                        .with_base(p_cfg.base_address as u32);
-                    match p_cfg.config.get("irq_base").and_then(|v| v.as_u64()) {
-                        Some(base) => Box::new(g.with_irq_base(base as u32)),
-                        None => Box::new(g),
-                    }
-                }
-                "adc" => {
-                    let layout: crate::peripherals::adc::AdcRegisterLayout =
-                        Self::parse_profile_or_default(p_cfg, "ADC")?;
-                    Box::new(crate::peripherals::adc::Adc::new_with_layout(layout))
-                }
-                "pio" => {
-                    let mut pio = crate::peripherals::pio::Pio::new();
-                    if let Some(program) = p_cfg.config.get("program").and_then(|v| v.as_str()) {
-                        pio.load_program_asm(program)?;
-                    }
-                    Box::new(pio)
-                }
                 // Nordic peripherals — register-surface models cross-validated
                 // by hw-oracle::nrf52_onboarding_diff. See peripherals/nrf52/.
                 // TWIM (I²C master with EasyDMA) — nRF52840 PS §6.31.
@@ -1617,9 +1374,6 @@ impl SystemBus {
                 // Wiring via this type string gives C3 (RISC-V, from_config path)
                 // the same live counter that the Xtensa chips get via their
                 // hard-wired system builders.
-                "esp32_timg" => Box::new(crate::peripherals::esp32::timg::Timg::new(
-                    p_cfg.base_address as u32,
-                )),
                 "declarative" => {
                     let descriptor_path = p_cfg
                         .config

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -1,0 +1,268 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Cross-vendor (generic Cortex-M / shared) peripheral factory.
+//!
+//! Owns the peripheral arms that are not specific to one chip family (UART,
+//! timers, SPI, I2C, RCC, flash, DMA, ADC, …) and used to live inline in
+//! `bus::from_config`. Family-specific peripherals live in their own factories
+//! (`esp32s3::factory`, `esp32::factory`, `nrf52::factory`); the descriptor
+//! loaders (`declarative`, `strict_ir`) stay in `from_config` itself.
+
+use crate::bus::SystemBus;
+use crate::peripherals::rcc::RccRegisterLayout;
+use crate::Peripheral;
+use labwired_config::{PeripheralConfig, SystemManifest};
+
+/// Build a generic peripheral model for `canonical_type`, or `None` if it is not
+/// a generic type (so `from_config` falls through to the descriptor loaders).
+pub fn try_build(
+    canonical_type: &str,
+    p_cfg: &PeripheralConfig,
+    manifest: &SystemManifest,
+) -> anyhow::Result<Option<Box<dyn Peripheral>>> {
+    let dev: Box<dyn Peripheral> = match canonical_type {
+        "systick" | "arm_generictimer" => {
+            // CALIB is implementation-defined per chip; the yaml can
+            // supply the silicon value via `config: { calib: ... }`.
+            match p_cfg.config.get("calib").and_then(|v| v.as_u64()) {
+                Some(calib) => Box::new(crate::peripherals::systick::Systick::with_calib(
+                    calib as u32,
+                )),
+                None => Box::new(crate::peripherals::systick::Systick::new()),
+            }
+        }
+        "rcc" => {
+            let layout: RccRegisterLayout = SystemBus::parse_profile_or_default(p_cfg, "RCC")?;
+            let mut rcc = crate::peripherals::rcc::Rcc::new_with_layout(layout);
+            // F4 ENR writable masks are per-part (implemented-peripheral
+            // set). YAML: `config: { rcc_ahb1enr_mask, rcc_apb1enr_mask,
+            // rcc_apb2enr_mask }`; default unmasked (0xFFFF_FFFF).
+            let m = |k: &str| -> u32 {
+                p_cfg
+                    .config
+                    .get(k)
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as u32)
+                    .unwrap_or(0xFFFF_FFFF)
+            };
+            rcc.set_f4_enr_masks(
+                m("rcc_ahb1enr_mask"),
+                m("rcc_apb1enr_mask"),
+                m("rcc_apb2enr_mask"),
+            );
+            Box::new(rcc)
+        }
+        "dbgmcu" => {
+            // Pull IDCODE from YAML config (`idcode: "0x10076415"` or
+            // `idcode: 269009941`). Default 0 — firmware probing
+            // DBGMCU_IDCODE will then read 0; logged.
+            let idcode: u32 = p_cfg
+                .config
+                .get("idcode")
+                .and_then(|v| {
+                    if let Some(s) = v.as_str() {
+                        let s = s.trim();
+                        if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                            u32::from_str_radix(rest, 16).ok()
+                        } else {
+                            s.parse::<u32>().ok()
+                        }
+                    } else {
+                        v.as_u64().map(|n| n as u32)
+                    }
+                })
+                .unwrap_or(0);
+            if idcode == 0 {
+                tracing::warn!(
+                    "dbgmcu peripheral '{}' has no idcode configured \
+                                 — firmware probing DBGMCU_IDCODE will read 0",
+                    p_cfg.id
+                );
+            }
+            Box::new(crate::peripherals::dbgmcu::Dbgmcu::new(idcode))
+        }
+        "timer" | "stm32_timer" | "efm32timer" | "renesasra_agt" | "stm32l0_lptimer" => {
+            if p_cfg.r#type.contains("nrf") {
+                // Nordic TIMER is task/event-driven and shares no
+                // register layout with the STM32 TIMx family —
+                // route to the dedicated nRF52 model.
+                // TIMER3/4 have 6 CC; TIMER0/1/2 have 4 (default).
+                let num_cc: usize = p_cfg
+                    .config
+                    .get("num_cc")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as usize)
+                    .unwrap_or(4);
+                Box::new(crate::peripherals::nrf52::timer::Nrf52Timer::new_with_cc(
+                    num_cc,
+                ))
+            } else {
+                // Width selector for 32-bit TIM2/TIM5 (STM32L4 etc).
+                // YAML: `config: { width: 32 }`. Defaults to 16 for
+                // back-compat with F1-class general-purpose timers.
+                // `advanced: true` enables RCR/BDTR/CCR5/6 (TIM1/TIM8).
+                let width: u8 = p_cfg
+                    .config
+                    .get("width")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as u8)
+                    .unwrap_or(16);
+                let advanced = p_cfg
+                    .config
+                    .get("advanced")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                // `basic: true` (TIM6/TIM7) → counter + UIF only, no
+                // capture/compare channels.
+                let basic = p_cfg
+                    .config
+                    .get("basic")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                Box::new(
+                    crate::peripherals::timer::Timer::new_with_layout(width, advanced).basic(basic),
+                )
+            }
+        }
+        "spi" | "stm32spi" => {
+            let layout: crate::peripherals::spi::SpiRegisterLayout = if p_cfg.r#type.contains("nrf")
+            {
+                crate::peripherals::spi::SpiRegisterLayout::Nrf52Spim
+            } else {
+                SystemBus::parse_profile_or_default(p_cfg, "SPI")?
+            };
+            // Classic-SPI CR2 mask is a per-part delta: F1 0xE7, F4 adds
+            // FRF bit 4 → 0xF7. YAML: `config: { cr2_mask: 0xF7 }`.
+            let cr2_mask: u32 = p_cfg
+                .config
+                .get("cr2_mask")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as u32)
+                .unwrap_or(0x0000_00E7);
+            let mut spi = crate::peripherals::spi::Spi::new_with_layout_cr2(layout, cr2_mask);
+            // Declarative IR SPI devices (`type: ir`) attach here,
+            // mirroring the I2C path. Hand-written SPI devices attach via
+            // the PeripheralKit registry pass, which ignores `type: ir`,
+            // so the two dispatch paths never double-attach the same bus.
+            for ext in &manifest.external_devices {
+                if ext.connection != p_cfg.id || !ext.r#type.eq_ignore_ascii_case("ir") {
+                    continue;
+                }
+                match crate::peripherals::components::build_spi_device(&ext.r#type, &ext.config) {
+                    Some(device) => {
+                        tracing::info!("spi attach: '{}' (type=ir) -> '{}'", ext.id, p_cfg.id);
+                        spi.attach(device);
+                    }
+                    None => {
+                        tracing::warn!(
+                            "spi attach skipped: invalid ir spec for external id '{}' on bus '{}'",
+                            ext.id,
+                            p_cfg.id
+                        );
+                    }
+                }
+            }
+            Box::new(spi)
+        }
+        "pwr" => {
+            // `config: { profile: stm32h5 }` selects the H5 layout
+            // (VOSCR/VOSSR voltage scaling); default stays L4.
+            match p_cfg.config.get("profile").and_then(|v| v.as_str()) {
+                Some("stm32h5") | Some("h5") => Box::new(crate::peripherals::pwr::PwrH5::new()),
+                // L0 has a two-register surface (CR/CSR), not the L4
+                // CR1..CR4 / PUCRx set — a distinct reset shape.
+                Some("stm32l0") | Some("l0") => Box::new(crate::peripherals::pwr::PwrL0::new()),
+                _ => Box::new(crate::peripherals::pwr::Pwr::new()),
+            }
+        }
+        "flash" | "flash_iface" => {
+            // Layout selected via `config: { profile: stm32f1 | stm32l4 }`
+            // in the chip yaml. Missing/unknown profile keeps the L4
+            // default — backward compatible with existing chip configs.
+            let layout: crate::peripherals::flash::FlashRegisterLayout =
+                SystemBus::parse_profile_or_default(p_cfg, "FLASH")?;
+            Box::new(crate::peripherals::flash::Flash::new_with_layout(layout))
+        }
+        "rng" => Box::new(crate::peripherals::rng::Rng::new()),
+        "crc" => {
+            // IDR scratch register width: 8-bit on F0/F1/L0, 32-bit
+            // on F2+/L4+. YAML: `config: { idr_width: 8 }`; default 32.
+            let idr_width: u8 = p_cfg
+                .config
+                .get("idr_width")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as u8)
+                .unwrap_or(32);
+            Box::new(crate::peripherals::crc::Crc::new().with_idr_width(idr_width))
+        }
+        "rtc" => Box::new(crate::peripherals::rtc::Rtc::new()),
+        "rtc_f1" => Box::new(crate::peripherals::rtc_f1::RtcF1::new()),
+        "rtc_v3" => Box::new(crate::peripherals::rtc_v3::RtcV3::new()),
+        "iwdg" => Box::new(crate::peripherals::iwdg::Iwdg::new()),
+        "wwdg" => Box::new(crate::peripherals::wwdg::Wwdg::new()),
+        "dac" => Box::new(crate::peripherals::dac::Dac::new()),
+        "lptim" => Box::new(crate::peripherals::lptim::Lptim::new()),
+        "quadspi" => Box::new(crate::peripherals::quadspi::Quadspi::new()),
+        "sai" => Box::new(crate::peripherals::sai::Sai::new()),
+        "usb_otg" => Box::new(crate::peripherals::usb_otg::UsbOtg::new()),
+        "bxcan" => Box::new(crate::peripherals::bxcan::BxCan::new()),
+        "fdcan" => Box::new(crate::peripherals::fdcan::Fdcan::new()),
+        "sdmmc" => Box::new(crate::peripherals::sdmmc::Sdmmc::new()),
+        "comp" => Box::new(crate::peripherals::comp::Comp::new()),
+        "tsc" => Box::new(crate::peripherals::tsc::Tsc::new()),
+        "fmc" => Box::new(crate::peripherals::fmc::Fmc::new()),
+        "exti" => {
+            let layout: crate::peripherals::exti::ExtiRegisterLayout =
+                SystemBus::parse_profile_or_default(p_cfg, "EXTI")?;
+            // Implemented-line count is part-specific (F103 = 19). YAML:
+            // `config: { lines: 19 }`; default 20 for back-compat.
+            let lines: u32 = p_cfg
+                .config
+                .get("lines")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as u32)
+                .unwrap_or(20);
+            let line_mask = if lines >= 32 {
+                0xFFFF_FFFF
+            } else {
+                (1u32 << lines) - 1
+            };
+            Box::new(crate::peripherals::exti::Exti::new_with_layout_lines(
+                layout, line_mask,
+            ))
+        }
+        "afio" => Box::new(crate::peripherals::afio::Afio::new()),
+        "dma" | "stm32dma" => Box::new(crate::peripherals::dma::Dma1::new()),
+        "gpdma" => {
+            // `config: { irq_base: N }` routes channel n to NVIC
+            // line N + n (H563 GPDMA1: 27..34). Without it the
+            // block's single `irq:` line serves every channel.
+            let g = crate::peripherals::gpdma::Gpdma::new().with_base(p_cfg.base_address as u32);
+            match p_cfg.config.get("irq_base").and_then(|v| v.as_u64()) {
+                Some(base) => Box::new(g.with_irq_base(base as u32)),
+                None => Box::new(g),
+            }
+        }
+        "adc" => {
+            let layout: crate::peripherals::adc::AdcRegisterLayout =
+                SystemBus::parse_profile_or_default(p_cfg, "ADC")?;
+            Box::new(crate::peripherals::adc::Adc::new_with_layout(layout))
+        }
+        "pio" => {
+            let mut pio = crate::peripherals::pio::Pio::new();
+            if let Some(program) = p_cfg.config.get("program").and_then(|v| v.as_str()) {
+                pio.load_program_asm(program)?;
+            }
+            Box::new(pio)
+        }
+        "esp32_timg" => Box::new(crate::peripherals::esp32::timg::Timg::new(
+            p_cfg.base_address as u32,
+        )),
+        _ => return Ok(None),
+    };
+    Ok(Some(dev))
+}

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -24,6 +24,7 @@ pub mod exti;
 pub mod fdcan;
 pub mod flash;
 pub mod fmc;
+pub mod generic_factory;
 pub mod gpdma;
 pub mod gpio;
 pub mod hc_sr04;


### PR DESCRIPTION
Continues shrinking the central `from_config` match (after the nRF52 extract in #283).

Moves the **32 cross-vendor / generic Cortex-M peripheral arms** (uart, timer, spi, i2c, rcc, flash, dma, adc, rtc, usb_otg, can, …) into `peripherals/generic_factory.rs`. The match now holds **only** the YAML descriptor loaders (`declarative`/`strict_ir`) + the unknown-type stub.

`from_config` delegates in order: esp32s3 + nrf52 family factories → generic factory (fallible: size/profile parsing) → descriptor loaders. `parse_profile_or_default`/`profile_name` made `pub(crate)`.

**from_config: −393 lines** (≈−530 with #283). Behaviour identical — `register_coverage_ratchet` unchanged across all 15 chips (stm32×9, nrf52×2, esp32×3, rp2040), + firmware_survival (26) + workspace lib + clippy clean.