### PR TITLE
fix(examples): forward-declare drawPage() in the e-reader sketch

### DIFF
--- a/examples/labwired-ereader-arduino/labwired-ereader.ino
+++ b/examples/labwired-ereader-arduino/labwired-ereader.ino
@@ -24,6 +24,11 @@
 GxEPD2_3C<GxEPD2_290_C90c, GxEPD2_290_C90c::HEIGHT> display(
     GxEPD2_290_C90c(/*CS=*/5, /*DC=*/17, /*RST=*/16, /*BUSY=*/4));
 
+// Forward declaration: the Arduino IDE auto-generates prototypes, but tools that
+// compile the .ino straight as a .cpp (e.g. the proto.cat compile service) don't
+// — so without this, setup()'s call to drawPage() fails to compile.
+void drawPage();
+
 void setup() {
   Serial.begin(115200);
   delay(200);


### PR DESCRIPTION
The `labwired-ereader-arduino` sketch calls `drawPage()` in `setup()` but defines it afterward, relying on the Arduino IDE's automatic prototype generation. Tools that compile the `.ino` straight as `main.cpp` — including the **proto.cat compile service** — don't generate those prototypes, so the build fails:

```
src/main.cpp:41:3: error: 'drawPage' was not declared in this scope
```

Found while running the proto.cat publish-gate e2e against this firmware. Fix is a one-line forward declaration so the sketch compiles on both the Arduino-IDE path and the straight-`.cpp` path.

**Verified:** with the fix, the sketch compiles clean (ELF produced) through the compile service and the e-paper paints on the LabWired oracle (`refresh_gen=1, ink=895/4736`).