### PR TITLE
ci(release): build x86_64-apple-darwin on macos-latest

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -24,7 +24,7 @@ jobs:
             platform: linux-aarch64
             cross: true
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             platform: darwin-x86_64
           - target: aarch64-apple-darwin
             runner: macos-latest


### PR DESCRIPTION
The `macos-13` (Intel) runner never gets assigned — the `x86_64-apple-darwin` build leg queues indefinitely. Since the release job has `needs: build`, the GitHub release never publishes; v0.15.0 and v0.16.0 both hung ~24h and were cancelled with **0 binary assets**.

Fix: build `x86_64-apple-darwin` on `macos-latest` (Apple Silicon), which cross-compiles the x86_64 target natively (the toolchain action already adds it via `targets:`). All four binaries now build on available runners.

After merge: re-tag v0.16.0 onto the fixed workflow so the full 4-binary release publishes.