### PR TITLE
feat(nrf52840-proximity): raise ALARM threshold to 50 cm

### DIFF
--- a/crates/core/tests/e2e_nrf52840_proximity.rs
+++ b/crates/core/tests/e2e_nrf52840_proximity.rs
@@ -5,7 +5,7 @@
 // End-to-end test for the nrf52840-proximity-lab: the same firmware ELF that
 // flashes to a real nRF52840 must, in the simulator, range the HC-SR04 and
 // raise the ALARM line (P0.06) when the host-controlled target distance is
-// inside the 150 mm threshold — and drop it when the target moves away.
+// inside the 500 mm (50 cm) threshold — and drop it when the target moves away.
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::cpu::cortex_m::CortexM;
@@ -82,7 +82,7 @@ fn alarm_tracks_target_distance() {
     let elf = ensure_firmware_built();
     let mut machine = build_machine(&elf);
 
-    // Near target (system.yaml default 10 cm = 100 mm < 150 mm threshold):
+    // Near target (system.yaml default 10 cm = 100 mm < 500 mm threshold):
     // the firmware must raise ALARM.
     run_steps(&mut machine, 3_000_000);
     assert!(
@@ -90,12 +90,13 @@ fn alarm_tracks_target_distance() {
         "ALARM (P0.06) should be HIGH with the target at 10 cm"
     );
 
-    // Move the target out of range; the next ranging cycles must drop ALARM.
-    machine.bus.hcsr04[0].set_distance_cm(50.0);
+    // Move the target out of range (100 cm > 50 cm threshold); the next ranging
+    // cycles must drop ALARM.
+    machine.bus.hcsr04[0].set_distance_cm(100.0);
     run_steps(&mut machine, 3_000_000);
     assert!(
         !alarm_high(&machine),
-        "ALARM (P0.06) should be LOW with the target at 50 cm"
+        "ALARM (P0.06) should be LOW with the target at 100 cm"
     );
 
     // And bring it back in range.

--- a/crates/firmware-nrf52840-proximity/src/main.rs
+++ b/crates/firmware-nrf52840-proximity/src/main.rs
@@ -73,13 +73,18 @@ const PAYLOAD_OFF: usize = 2;
 const BLE_PAYLOAD_LEN: u8 = 4;
 
 /// Target distance: raise ALARM when the measured distance is at or below this.
-const THRESHOLD_MM: u32 = 150;
+/// 500 mm (50 cm) sits in the middle of the HC-SR04's useful range, so dragging
+/// the host "hand distance" down past it visibly toggles the ALARM.
+const THRESHOLD_MM: u32 = 500;
 
-/// ECHO-high tick count corresponding to THRESHOLD_MM. Calibrated against the
-/// simulator at distance_cm = 15.0 (= 150 mm) with cpu_hz = 64 MHz: the ECHO
-/// pulse there is measured as 8950 of this loop's iterations. Deterministic for
-/// a given HC-SR04 `cpu_hz` and this measurement loop. See README "Calibration".
-const THRESHOLD_TICKS: u32 = 8950;
+/// ECHO-high tick count corresponding to THRESHOLD_MM. The ECHO pulse the
+/// simulator drives is strictly proportional to distance (it holds ECHO high for
+/// `distance_cm × 58 µs`), so this loop's iteration count is linear in distance:
+/// the original calibration measured 8950 ticks at 150 mm (cpu_hz = 64 MHz), i.e.
+/// 59.67 ticks/mm. 500 mm × 59.67 = 29833 ticks. Keeping ticks/mm identical leaves
+/// the reported `distance_mm` calibrated; only the in-range boundary moves to
+/// 50 cm. Deterministic for a given HC-SR04 `cpu_hz`. See README "Calibration".
+const THRESHOLD_TICKS: u32 = 29833;
 
 /// Safety bound so a missing/!wired ECHO never hangs the firmware.
 const MAX_TICKS: u32 = 4_000_000;

--- a/examples/nrf52840-proximity-lab/proximity-smoke.yaml
+++ b/examples/nrf52840-proximity-lab/proximity-smoke.yaml
@@ -32,8 +32,8 @@ assertions:
       address: 0x20000000
       expected_value: 99
       size: 4
-  # IN_RANGE (0x20000004) latches to 1: 99 mm is inside the firmware's 150 mm
-  # threshold.
+  # IN_RANGE (0x20000004) latches to 1: 99 mm is inside the firmware's 500 mm
+  # (50 cm) threshold.
   - memory_value:
       address: 0x20000004
       expected_value: 1

--- a/examples/nrf52840-proximity-lab/system.yaml
+++ b/examples/nrf52840-proximity-lab/system.yaml
@@ -8,7 +8,8 @@
 #
 # `distance_cm` is the host-controlled "hand position" — change it to move the
 # target nearer/farther and watch the firmware's ALARM flag follow. 10 cm
-# (100 mm) is inside the firmware's 150 mm threshold, so ALARM is HIGH here.
+# (100 mm) is inside the firmware's 500 mm (50 cm) threshold, so ALARM is HIGH
+# here; drag past 50 cm to drop it.
 name: "nrf52840-proximity-lab"
 chip: "../../configs/chips/nrf52840.yaml"
 external_devices:


### PR DESCRIPTION
Moves the proximity lab's ALARM in-range boundary from 150 mm to **500 mm (50 cm)** so dragging the host hand-distance down past 50 cm visibly toggles the ALARM — the old 15 cm trip point sat at the very bottom of the slider and the lab defaulted inside it (always-on).

### Change
- `THRESHOLD_MM` 150 → 500
- `THRESHOLD_TICKS` 8950 → 29833

ticks/mm is held constant (both ≈ 59.67 ticks/mm), so the reported `distance_mm` stays calibrated — only the in-range boundary moves. The ECHO pulse the simulator drives is strictly proportional to distance, so the scaling is exact.

### Tests
- `e2e_nrf52840_proximity`: out-of-range probe moved 50 cm → 100 cm (50 cm is now the boundary). Passes (`--ignored`).
- `proximity-smoke.yaml`: unchanged assertions still hold (10 cm → 99 mm, in-range), since the calibration ratio is preserved.

Same ELF flashes to real nRF52840 silicon.

Base is `feat/bxcan-bus-filter` (the line the app pins).