### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-19
+
+### Added
+- **Classical CAN (bxCAN) model** for STM32F1: loopback + frame trace, strict silicon-pinned acceptance filtering, bit-timing bus-off and bus-attach, and a real two-node CAN bus (a virtual UDS tester driving an F103 ECU).
+- **RCC clock-gating model** for STM32F1 / L4: gated peripherals are inaccessible until their RCC enable bit is set (opt-in via the chip-YAML `clock:` field).
+- **STM32F103C8 SRAM** modeled at its physical 20 KB.
+- **nRF52840 proximity lab**: ALARM in-range threshold raised to 50 cm.
+
+### Fixed
+- **STMIA.W** decoded as STMDB (struct-copy idiom wrote below the destination).
+- **Register-coverage probe** is now clock-gating-independent (`SystemBus::set_clock_gating_bypass`, measurement-only) so coverage reflects whether a register is modeled, not whether its clock is currently on. Runtime gating is unchanged.
+
 ## [0.16.0] - 2026-06-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1665,7 +1665,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1817,15 +1817,15 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "labwired-ir"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3273,7 +3273,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
Version bump + CHANGELOG for **v0.17.0**, which packages the `feat/bxcan-bus-filter` reconciliation (#315):

- Classical CAN (bxCAN) model for STM32F1 — loopback, frame trace, strict silicon-pinned filtering, bus-off/bus-attach, two-node CAN bus with a virtual UDS tester
- RCC clock-gating for STM32F1 / L4
- STM32F103C8 SRAM modeled at physical 20 KB
- nRF52840 proximity ALARM threshold → 50 cm
- STMIA.W decode fix; register-coverage probe made clock-gating-independent

After merge I'll tag `v0.17.0` and re-pin the app to it.