### PR TITLE
validation: re-capture ESP32-S3 + STM32L073 on live silicon

### DIFF
--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -12,10 +12,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32h563` | 🟢 silicon-verified | 2026-06-17 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-17 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-17 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-06-19 | ✅ fresh |
 | `stm32f407` | 🟢 silicon-smoke | 2026-05-11 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-07 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-07 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-07 | no silicon capture |
@@ -66,10 +66,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 - Doc: [`docs/boards/nucleo-l073rz.md`](nucleo-l073rz.md)  ·  Chip: `configs/chips/stm32l073.yaml`
 - Note: Register diff covers RCC/GPIO/SPI1/TIM2/TIM21 (20 mmio cases) — not a full-chip sweep. Caught + fixed a real model bug: L0 TIM2 was declared 32-bit (L4 assumption); genuine L0 TIM2 is 16-bit, yaml corrected to width:16.
-- Silicon: **2026-06-17** on ST-LINK V2 J28 (NUCLEO-L073RZ, IDCODE 0x2008_6447) — l0_mmio_diff 20/20, 0 divergence (L073_STRICT) — incl. the TIM2-16-bit fix
+- Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-06-19 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -93,10 +93,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 - Doc: [`docs/boards/esp32s3.md`](esp32s3.md)  ·  Chip: `configs/chips/esp32s3.yaml`
 - Note: Deep model: 35 peripheral models + full Xtensa LX7 JIT; boots real firmware in sim (green e2e i2c_tmp102/hello_world/xtensa_exec/e-paper). Silicon anchor is reset-state (9 regs) on the firmware-path bus. KNOWN GAPS: (1) broader register + behavioural silicon diff still future work; (2) declarative from_config path falls back to generic ARM peripherals for type:i2c — the coded S3 models only wire via configure_xtensa_esp32s3; (3) full-firmware bring-up rides ~60 boot/ROM/WiFi thunks (FIDELITY.md).
-- Silicon: **2026-06-17** on USB-JTAG built-in (MAC 9C:13:9E:F4:40:C0, openocd-esp32, Tensilica tap 0x120034e5) — reset-state oracle: SYSTIMER CONF 0x46000000 + I2C0 timing block (TO/FIFO_CONF/SCL holds/FILTER_CFG/CLK_CONF) 9/9 match live silicon
+- Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-06-19 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -148,10 +148,9 @@ boards:
       - "stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}"
       - "firmware_survival L073 smoke case"
     silicon:
-      last_capture: 2026-06-17
-      probe: "ST-LINK V2 J28 (NUCLEO-L073RZ, IDCODE 0x2008_6447)"
-      result: "l0_mmio_diff 20/20, 0 divergence (L073_STRICT) — incl. the TIM2-16-bit fix"
-    drift_ack: 2026-06-19   # merged feat/bxcan-bus-filter (CAN + RCC clock-gating + bus-routing models changed 2026-06-19); re-capture pending, no board connected
+      last_capture: 2026-06-20
+      probe: "ST-LINK V2.1 (NUCLEO-L073RZ over SWD)"
+      result: "Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack."
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -223,10 +222,9 @@ boards:
       - "esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)"
       - "e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)"
     silicon:
-      last_capture: 2026-06-17
-      probe: "USB-JTAG built-in (MAC 9C:13:9E:F4:40:C0, openocd-esp32, Tensilica tap 0x120034e5)"
-      result: "reset-state oracle: SYSTIMER CONF 0x46000000 + I2C0 timing block (TO/FIFO_CONF/SCL holds/FILTER_CFG/CLK_CONF) 9/9 match live silicon"
-    drift_ack: 2026-06-19   # merged feat/bxcan-bus-filter (CAN + RCC clock-gating + bus-routing models changed 2026-06-19); re-capture pending, no board connected
+      last_capture: 2026-06-20
+      probe: "USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5)"
+      result: "Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack."
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Two more of the post-v0.17.0 drift-acked boards re-validated against real hardware:

- **esp32s3** (ESP32-S3-Zero, built-in USB-JTAG `303a:1001`, openocd-esp32, Tensilica tap 0x120034e5): reset-state oracle **9/9** pinned registers match live silicon; `esp32s3_reset_conformance` (sim vs frozen) passes.
- **nucleo-l073rz** (NUCLEO-L073RZ, ST-LINK SWD): `l0_mmio_diff` **20/20**, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21).

Bumps `last_capture` → 2026-06-20 and drops both 2026-06-19 drift_acks.

**Progress:** 3 of 6 boards now genuinely re-captured (this + F103 in #317). Still acked (no board connected): `stm32h563`, `nucleo-l476rg`, `stm32f407`.