### PR TITLE
validation: re-capture STM32H563 + STM32L476 on live silicon

### DIFF
--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,9 +9,9 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-17 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-17 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-06-19 | ✅ fresh |
 | `stm32f407` | 🟢 silicon-smoke | 2026-05-11 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
@@ -40,10 +40,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 ## `stm32h563` — 🟢 silicon-verified
 
 - Doc: [`docs/boards/stm32h563.md`](stm32h563.md)  ·  Chip: `configs/chips/stm32h563.yaml`
-- Silicon: **2026-06-17** on ST-LINK V3 (J13) — class 65/65; GPIO mmio 8/8; GPIO parity 48/48 — 0 divergence (dapdirect AP1 recipe)
+- Silicon: **2026-06-20** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — Live re-capture after the v0.17.0 merge: h563_mmio_diff + h563_parity_diff + h563_class_diff all pass (class 65/65, GPIO mmio + parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-06-19 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -57,10 +57,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 - Doc: [`docs/boards/nucleo-l476rg.md`](nucleo-l476rg.md)  ·  Chip: `configs/chips/stm32l476.yaml`
 - Note: Register diff covers RCC/GPIO/SPI1/TIM2 (15 mmio cases + 104-pattern parity sweep), NOT a full-chip sweep — the prose doc's 'every peripheral exercised' is still an overstatement; this is the honest scope.
-- Silicon: **2026-06-17** on ST-LINK V2 J36 (NUCLEO-L476RG onboard) — mass-erased to clean reset state — l476_mmio_diff 15/15 + parity 104/104, 0 divergence vs live silicon (L476_STRICT)
+- Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-06-19 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -72,10 +72,9 @@ boards:
       - "h563_conformance (5 tests vs frozen 2026-06-10..12 captures)"
       - "h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}"
     silicon:
-      last_capture: 2026-06-17
-      probe: "ST-LINK V3 (J13)"
-      result: "class 65/65; GPIO mmio 8/8; GPIO parity 48/48 — 0 divergence (dapdirect AP1 recipe)"
-    drift_ack: 2026-06-19   # merged feat/bxcan-bus-filter (CAN + RCC clock-gating + bus-routing models changed 2026-06-19); re-capture pending, no board connected
+      last_capture: 2026-06-20
+      probe: "STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe)"
+      result: "Live re-capture after the v0.17.0 merge: h563_mmio_diff + h563_parity_diff + h563_class_diff all pass (class 65/65, GPIO mmio + parity), 0 divergence. Supersedes the 2026-06-19 drift_ack."
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -121,10 +120,9 @@ boards:
       - "l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}"
       - "firmware_survival L476 cases (UART byte stream)"
     silicon:
-      last_capture: 2026-06-17
-      probe: "ST-LINK V2 J36 (NUCLEO-L476RG onboard) — mass-erased to clean reset state"
-      result: "l476_mmio_diff 15/15 + parity 104/104, 0 divergence vs live silicon (L476_STRICT)"
-    drift_ack: 2026-06-19   # merged feat/bxcan-bus-filter (CAN + RCC clock-gating + bus-routing models changed 2026-06-19); re-capture pending, no board connected
+      last_capture: 2026-06-20
+      probe: "STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard)"
+      result: "Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack."
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
Two more drift-acked boards re-validated against real hardware (both ST-Links attached, selected by serial):

- **stm32h563** (NUCLEO-H563ZI, STLINK-V3 `0483:374e`, dapdirect AP1): `h563_mmio_diff` + `h563_parity_diff` + `h563_class_diff` all pass (**65 class cases**, GPIO mmio + parity), 0 divergence.
- **nucleo-l476rg** (STLINK-V2.1 `0483:374b`): `l476_mmio_diff` + `l476_parity_diff` pass (15 mmio + 104 parity), 0 divergence.

Bumps `last_capture` → 2026-06-20, drops both 2026-06-19 drift_acks.

**Progress: 5 of 6 re-captured** (F103 #317, S3+L0 #318, H5+L4 here). Only **stm32f407** remains acked (no board connected).