### PR TITLE
fix(spi): F407 CR1 bit 12 (CRCNEXT) not latched + re-capture F407 (last drift cleared)

### DIFF
--- a/configs/chips/stm32f407.yaml
+++ b/configs/chips/stm32f407.yaml
@@ -133,6 +133,9 @@ peripherals:
     # F4 classic SPI CR2 adds bit 4 (FRF/TI-mode) over the F1 map → 0xF7.
     config:
       cr2_mask: 0xF7
+      # F407 silicon does not latch CR1 bit 12 (CRCNEXT): writing 0xFFFF reads
+      # back 0xEFFF (silicon-confirmed over SWD). F1/L0/L4 leave it writable.
+      cr1_mask: 0xEFFF
   - id: "spi2"
     type: "spi"
     base_address: 0x40003800
@@ -140,6 +143,9 @@ peripherals:
     irq: 36
     config:
       cr2_mask: 0xF7
+      # F407 silicon does not latch CR1 bit 12 (CRCNEXT): writing 0xFFFF reads
+      # back 0xEFFF (silicon-confirmed over SWD). F1/L0/L4 leave it writable.
+      cr1_mask: 0xEFFF
   - id: "spi3"
     type: "spi"
     base_address: 0x40003C00
@@ -147,6 +153,9 @@ peripherals:
     irq: 51
     config:
       cr2_mask: 0xF7
+      # F407 silicon does not latch CR1 bit 12 (CRCNEXT): writing 0xFFFF reads
+      # back 0xEFFF (silicon-confirmed over SWD). F1/L0/L4 leave it writable.
+      cr1_mask: 0xEFFF
   - id: "i2c2"
     type: "i2c"
     base_address: 0x40005800

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -144,6 +144,12 @@ pub fn try_build(
                 .map(|n| n as u32)
                 .unwrap_or(0x0000_00E7);
             let mut spi = crate::peripherals::spi::Spi::new_with_layout_cr2(layout, cr2_mask);
+            // Classic-SPI CR1 writable mask, also a per-part delta: F407 silicon
+            // does not latch CR1 bit 12 (CRCNEXT) → 0xEFFF; F1/L0/L4 leave it
+            // fully writable (the default). YAML: `config: { cr1_mask: 0xEFFF }`.
+            if let Some(cr1_mask) = p_cfg.config.get("cr1_mask").and_then(|v| v.as_u64()) {
+                spi.set_cr1_mask(cr1_mask as u16);
+            }
             // Declarative IR SPI devices (`type: ir`) attach here,
             // mirroring the I2C path. Hand-written SPI devices attach via
             // the PeripheralKit registry pass, which ignores `type: ir`,

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -471,6 +471,12 @@ pub struct Spi {
     /// chip config's `cr2_mask`. Ignored by the FIFO layout (its own CR2 logic).
     cr2_mask: u32,
 
+    /// Classic-SPI CR1 writable mask — a per-part delta. `None` = fully writable
+    /// (0xFFFF), the default that matches F103/L0/L476 silicon (CR1 reads back
+    /// 0xFFFF). F407 silicon does NOT latch CR1 bit 12 (CRCNEXT): writing
+    /// 0xFFFF reads back 0xEFFF, so its chip config sets `cr1_mask: 0xEFFF`.
+    cr1_mask: Option<u16>,
+
     #[serde(skip)]
     pub attached_devices: Vec<Box<dyn SpiDevice>>,
 }
@@ -528,6 +534,12 @@ impl Spi {
         self.loopback = on;
     }
 
+    /// Override the classic-SPI CR1 writable mask (default fully writable). Used
+    /// by chips like F407 whose silicon does not latch CR1 bit 12 (CRCNEXT).
+    pub fn set_cr1_mask(&mut self, mask: u16) {
+        self.cr1_mask = Some(mask);
+    }
+
     pub fn attach(&mut self, device: Box<dyn SpiDevice>) {
         self.attached_devices.push(device);
     }
@@ -541,12 +553,15 @@ impl Spi {
     fn write_stm32_reg(&mut self, offset: u64, value: u16) {
         match offset {
             0x00 => {
+                // Classic SPI CR1 is fully writable incl. CRCNEXT (bit 12) on
+                // F103/L0/L476 (silicon-confirmed, CR1 reads back 0xFFFF). F407
+                // silicon does NOT latch CRCNEXT — writing 0xFFFF reads back
+                // 0xEFFF — so its chip config sets `cr1_mask: 0xEFFF`. The FIFO
+                // variant (L4/F7/H5) has a different CR1 bit map; both store the
+                // (masked) written value verbatim.
+                let cr1_mask = self.cr1_mask.unwrap_or(0xFFFF);
                 if let SpiRegs::Stm32(r) = &mut self.regs {
-                    // Classic SPI CR1 is fully writable incl. CRCNEXT (bit 12) —
-                    // silicon-confirmed on a genuine STM32F103 SPI1 (2026-06-17,
-                    // CR1 reads back 0xFFFF). The FIFO variant (L4/F7/H5) has a
-                    // different CR1 bit map; both store the written value verbatim.
-                    r.cr1 = value;
+                    r.cr1 = value & cr1_mask;
                 }
             }
             0x04 => {

--- a/crates/hw-oracle/src/openocd.rs
+++ b/crates/hw-oracle/src/openocd.rs
@@ -231,6 +231,22 @@ impl OpenOcd {
                     full_args.push("-c".to_string());
                     full_args.push(format!("adapter usb location {location}"));
                 }
+                // LABWIRED_OPENOCD_CONNECT_UNDER_RESET: assert SRST during the
+                // initial connect/examine. Needed for targets whose running
+                // firmware disables or repurposes the SWD pins (e.g. an
+                // STM32F407 that boots straight into such firmware) — without
+                // it openocd reports "examination failed". Requires NRST wired.
+                if std::env::var("LABWIRED_OPENOCD_CONNECT_UNDER_RESET").is_ok() {
+                    full_args.push("-c".to_string());
+                    full_args
+                        .push("reset_config srst_only srst_nogate connect_assert_srst".to_string());
+                }
+                // LABWIRED_ADAPTER_SPEED overrides the SWD clock (kHz) — lower it
+                // for marginal signal integrity on clone/standalone ST-Links.
+                if let Ok(speed) = std::env::var("LABWIRED_ADAPTER_SPEED") {
+                    full_args.push("-c".to_string());
+                    full_args.push(format!("adapter speed {speed}"));
+                }
             }
         }
         full_args.push("-c".to_string());

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-06-19 | ✅ fresh |
-| `stm32f407` | 🟢 silicon-smoke | 2026-05-11 | 2026-06-18 | ⚠ drift acked 2026-06-19 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-06-20 | ✅ fresh |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-06-18 | ✅ fresh |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-07 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-07 | no silicon capture |
@@ -84,10 +84,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 - Doc: [`docs/boards/stm32f407.md`](stm32f407.md)  ·  Chip: `configs/chips/stm32f407.yaml`
 - Note: examples/nucleo-f407-i2c/VALIDATION.md badges '✅ Hardware-validated 2026-05-11' but I²C/UART/GPIO models were rewritten in June with no re-capture — STALE.
-- Silicon: **2026-05-11** on ST-LINK SWD (NUCLEO-F407, IDCODE 0x1001_6413) — smoke + I²C survival UART traces (now stale relative to June model rewrites)
+- Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-06-19 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -196,10 +196,9 @@ boards:
       - "stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}"
       - "firmware_survival F407 smoke + i2c cases (sim-self-pinned)"
     silicon:
-      last_capture: 2026-05-11
-      probe: "ST-LINK SWD (NUCLEO-F407, IDCODE 0x1001_6413)"
-      result: "smoke + I²C survival UART traces (now stale relative to June model rewrites)"
-    drift_ack: 2026-06-19   # merged feat/bxcan-bus-filter (CAN + RCC clock-gating + bus-routing models changed 2026-06-19); re-capture pending, no board connected
+      last_capture: 2026-06-20
+      probe: "ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz"
+      result: "Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)"
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
Live F407 oracle (the board's firmware was holding SWD → added connect-under-reset) caught a **real model bug**: writing 0xFFFF to SPI1 CR1 reads back **0xEFFF** on F407 silicon — bit 12 (CRCNEXT) doesn't latch — whereas F103 keeps it writable (0xFFFF). The shared classic-SPI model treated F1/F4 identically.

## Fix
- Per-part classic-SPI `cr1_mask` (default fully-writable 0xFFFF; F407 chip config sets `0xEFFF`), mirroring the existing per-part `cr2_mask`. **F103 / L0 / L476 unchanged** (sim-only oracles still read 0xFFFF; verified).
- Env-gated **connect-under-reset** + adapter-speed in the openocd wrapper (`LABWIRED_OPENOCD_CONNECT_UNDER_RESET` / `LABWIRED_ADAPTER_SPEED`) for boards whose firmware disables SWD.

## Result
F407 `stm32f4_mmio_diff` now **37/37, 0 divergence**. last_capture → 2026-06-20, drift_ack dropped.

**🎉 All 6 boards re-captured on live silicon — zero drift_acks remain** (F103 #317, S3+L0 #318, H5+L4 #319, F407 here). The post-v0.17.0 silicon drift is fully cleared, not just acknowledged.

Verified: full `cargo test -p labwired-core` (TEST_EXIT=0), all sim-only oracles pass, `cargo +1.95.0 fmt --all --check` clean, clippy clean.