### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-06-20
+
+### Fixed
+- **STM32F407 SPI1 CR1 bit 12 (CRCNEXT)**: F407 silicon does not latch CRCNEXT (writing 0xFFFF reads back 0xEFFF), unlike F103 which keeps it writable. The shared classic-SPI model treated F1/F4 identically; it now applies a per-part `cr1_mask` (chip-config driven, default fully-writable 0xFFFF; F407 → 0xEFFF), mirroring the existing `cr2_mask`. Caught by the live F407 register diff.
+
+### Added
+- **hw-oracle connect-under-reset**: `LABWIRED_OPENOCD_CONNECT_UNDER_RESET` (assert SRST during connect/examine) + `LABWIRED_ADAPTER_SPEED` overrides in the OpenOCD wrapper, for boards whose running firmware disables/repurposes the SWD pins.
+
+### Validation
+- All six silicon-tier boards (stm32f103, stm32l073, stm32l476, stm32h563, stm32f407, esp32s3) re-captured on live silicon 2026-06-20; drift_acks cleared.
+
 ## [0.17.0] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
 ]
@@ -1665,7 +1665,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1817,15 +1817,15 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.0"
+version = "0.17.1"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.0"
+version = "0.17.1"
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3273,7 +3273,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
Patch release on top of v0.17.0.

### Fixed
- **STM32F407 SPI1 CR1 bit 12 (CRCNEXT)** not latched on F407 silicon (reads 0xEFFF) — per-part `cr1_mask` added (F1/L0/L4 unchanged). Caught by the live F407 register diff.

### Added
- hw-oracle **connect-under-reset** (`LABWIRED_OPENOCD_CONNECT_UNDER_RESET`) + `LABWIRED_ADAPTER_SPEED` for SWD-disabling firmware.

### Validation
- All 6 silicon-tier boards re-captured on live silicon 2026-06-20; zero drift_acks.