### PR TITLE
feat(flash): model STM32H5 sector-erase + bank-swap (UDS OTA bootloader enablement)

### DIFF
--- a/configs/chips/stm32h563.yaml
+++ b/configs/chips/stm32h563.yaml
@@ -38,10 +38,14 @@ core: "cortex-m33"
 registers_count: 220
 flash:
   base: 0x08000000
-  size: "2MB"
+  # Binary units (MiB) so the buffer is exactly 2 * 0x100000 = 2,097,152 bytes,
+  # matching real H563 silicon: two 1 MiB (0x100000) banks. SI "2MB" would parse
+  # as 2,000,000 (human_size) and break dual-bank addressing (bank 2 @ 0x08100000).
+  size: "2MiB"
 ram:
   base: 0x20000000
-  size: "640KB"
+  # 640 KiB = 655,360 bytes, matching silicon (initial SP read = 0x200A0000 = RAM top).
+  size: "640KiB"
 peripherals:
   - id: "rcc"
     type: "rcc"

--- a/configs/chips/stm32h563.yaml
+++ b/configs/chips/stm32h563.yaml
@@ -290,8 +290,10 @@ peripherals:
     size: "1KB"
     config:
       profile: "stm32h5"
-  # FLASH interface registers (RM0481) — ACR latency/WRHIGHFREQ read-back
-  # for clock bring-up; program/erase not modeled.
+  # FLASH interface registers (RM0481) — ACR latency/WRHIGHFREQ read-back for
+  # clock bring-up; NSKEYR/OPTKEYR unlock, NSCR sector-erase and
+  # OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH (drained in Machine::step) model the
+  # UDS OTA reprogramming path. Programming is plain writes to the flash region.
   - id: "flash_iface"
     type: "flash"
     base_address: 0x40022000

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -73,6 +73,7 @@ impl SystemBus {
             can_uds_testers: Vec::new(),
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
+            flash_models_ops: false,
         };
 
         let mut merged_peripherals = chip.peripherals.clone();

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -162,6 +162,13 @@ pub struct SystemBus {
     /// recomputed every tick by `aggregate_esp32c3_irqs`. Read by the RISC-V
     /// core via `Bus::external_irq_lines`. 0 when `esp32c3_irq_routing` is false.
     pub riscv_irq_lines: u32,
+    /// True when a FLASH peripheral on this bus models hardware operations
+    /// (H5 sector erase / bank swap) as pending ops that the machine layer must
+    /// drain and apply per instruction. Cached in `rebuild_peripheral_ranges`
+    /// (same staleness contract as `dport_idx`/`rcc_idx`) so
+    /// `requires_cycle_accurate` — called per run-loop iteration — never scans
+    /// peripherals. `false` on every bus without an H5 op-modeling FLASH.
+    flash_models_ops: bool,
 }
 
 pub struct CanDiagnosticTester {
@@ -486,8 +493,15 @@ impl SystemBus {
     /// so the firmware polls a frozen ECHO and measures nothing. Runners should
     /// disable instruction batching when this returns true (correctness > speed).
     /// New per-tick GPIO-timing devices should extend this predicate.
+    ///
+    /// Also true when an H5 op-modeling FLASH is on the bus (`flash_models_ops`,
+    /// cached in `rebuild_peripheral_ranges`): its erase/bank-swap ops are
+    /// recorded as pending and drained+applied per instruction by the machine
+    /// layer, an invariant that only holds at batch size 1. Without this the
+    /// CLI/batch run path would record the op in the FLASH cell but never apply
+    /// it (no 0xFF fill, no bank swap, no reset).
     pub fn requires_cycle_accurate(&self) -> bool {
-        !self.hcsr04.is_empty() || self.has_iolink_master()
+        !self.hcsr04.is_empty() || self.has_iolink_master() || self.flash_models_ops
     }
 
     /// True when an IO-Link master peer is attached to any UART. The master is
@@ -958,6 +972,7 @@ impl SystemBus {
             can_uds_testers: Vec::new(),
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
+            flash_models_ops: false,
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -994,6 +1009,7 @@ impl SystemBus {
             can_uds_testers: Vec::new(),
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
+            flash_models_ops: false,
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -2475,6 +2491,7 @@ peripherals:
             can_uds_testers: Vec::new(),
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
+            flash_models_ops: false,
         };
 
         bus.flash.write_u8(0x0800_0000, 0x12);
@@ -2537,6 +2554,7 @@ peripherals:
             can_uds_testers: Vec::new(),
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
+            flash_models_ops: false,
         };
 
         bus.rebuild_peripheral_ranges();
@@ -2601,6 +2619,7 @@ peripherals:
             can_uds_testers: Vec::new(),
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
+            flash_models_ops: false,
         };
         bus.rebuild_peripheral_ranges();
 

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -138,6 +138,17 @@ impl SystemBus {
         // read/write path is O(1). Matched by id, as the clock-gate config
         // references the RCC by the conventional "rcc" peripheral id.
         self.rcc_idx = self.peripherals.iter().position(|p| p.name == "rcc");
+        // Cache whether any FLASH peripheral models hardware ops (H5 erase /
+        // bank swap). Those ops are recorded as pending and must be drained and
+        // applied per instruction, which only holds under cycle-accurate
+        // execution — so `requires_cycle_accurate` reads this cached bool
+        // instead of scanning peripherals on every run-loop iteration.
+        self.flash_models_ops = self.peripherals.iter().any(|p| {
+            p.dev
+                .as_any()
+                .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
+                .is_some_and(|f| f.models_ops())
+        });
     }
 
     pub fn refresh_peripheral_index(&mut self) {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -697,6 +697,12 @@ pub struct Machine<C: Cpu> {
     /// indexed access + one downcast. `None` for configs that don't register
     /// an RTC_CNTL peripheral (every non-ESP32-classic target).
     rtc_cntl_index: Option<usize>,
+    /// Cached bus index of the FLASH peripheral (H5 layout). Resolved once at
+    /// construction; `step()` drains pending FLASH ops (sector erase,
+    /// bank-swap+reset) at clean instruction boundaries without walking the
+    /// full peripheral list every cycle. `None` for configs with no FLASH
+    /// peripheral on the bus (e.g. bare-bus unit tests).
+    flash_index: Option<usize>,
     /// Phase 2B.3b (issue #192): whether the one-time scheduler bootstrap has
     /// run. On the first `drain_scheduler_events`, peripherals with setup-time
     /// work (e.g. a UART with an RX stream attached before any MMIO write) get
@@ -714,6 +720,12 @@ impl<C: Cpu> Machine<C> {
                 .and_then(|a| a.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>())
                 .is_some()
         });
+        let flash_index = bus.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
+                .is_some()
+        });
         Self {
             cpu,
             cpu_secondary: None,
@@ -726,6 +738,7 @@ impl<C: Cpu> Machine<C> {
             sched: sched::EventScheduler::new(),
             clocks: sched::ClockGraph::new(),
             rtc_cntl_index,
+            flash_index,
             scheduler_bootstrapped: false,
         }
     }
@@ -927,6 +940,43 @@ impl<C: Cpu> Machine<C> {
             tracing::debug!("RTC_CNTL SW_SYS_RST: CPU re-pointed at reset vector 0x40000400");
         }
 
+        // H5 FLASH pending ops: sector erase fills flash with 0xFF; bank-swap
+        // swaps the two 1 MB banks in the flash buffer then re-runs reset so
+        // the CPU boots from the new bank-1 vector table.
+        if let Some(op) = self.drain_flash_op() {
+            use crate::peripherals::flash::h5;
+            use crate::peripherals::flash::FlashOp;
+            match op {
+                FlashOp::EraseSector { bank, sector } => {
+                    let offset = (bank as u64) * h5::BANK_SIZE + (sector as u64) * h5::SECTOR_SIZE;
+                    self.bus.flash.fill(offset, h5::SECTOR_SIZE, 0xFF);
+                    tracing::debug!(
+                        "FLASH EraseSector bank={bank} sector={sector} offset={offset:#010x}"
+                    );
+                }
+                FlashOp::SwapAndReset => {
+                    // Swap the two architectural 1 MiB (0x100000) banks. The
+                    // H563 flash buffer is sized to exactly 2 * BANK_SIZE by the
+                    // chip yaml (`size: "2MiB"`), so the same BANK_SIZE used by
+                    // EraseSector above also bounds the swap — keeping erase and
+                    // swap on one consistent bank-size notion (real silicon:
+                    // bank 2 @ 0x08100000). swap_banks returns false if the
+                    // buffer is not exactly two banks; debug-assert that here so
+                    // a mis-sized chip yaml fails loudly in tests.
+                    let swapped = self.bus.flash.swap_banks(h5::BANK_SIZE);
+                    debug_assert!(
+                        swapped,
+                        "SWAP_BANK: flash buffer ({} bytes) is not 2 * BANK_SIZE ({}); \
+                         check the chip yaml flash size uses binary (MiB) units",
+                        self.bus.flash.data.len(),
+                        2 * h5::BANK_SIZE
+                    );
+                    tracing::debug!("FLASH SwapAndReset: banks swapped, resetting CPU");
+                    self.reset()?;
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -1081,6 +1131,20 @@ impl<C: Cpu> Machine<C> {
             .and_then(|a| a.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>())
             .map(|rtc| rtc.drain_reset_request())
             .unwrap_or(false)
+    }
+
+    /// Drain a pending FLASH hardware operation recorded by the H5 FLASH
+    /// peripheral (sector erase or bank-swap+reset). Returns `None` for
+    /// configs that have no FLASH peripheral on the bus. The caller is
+    /// responsible for applying the returned op to `bus.flash` and issuing
+    /// a CPU reset when required.
+    fn drain_flash_op(&self) -> Option<crate::peripherals::flash::FlashOp> {
+        let idx = self.flash_index?;
+        let p = self.bus.peripherals.get(idx)?;
+        p.dev
+            .as_any()
+            .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
+            .and_then(|f| f.drain_pending_op())
     }
 
     pub fn snapshot(&self) -> snapshot::MachineSnapshot {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -942,7 +942,23 @@ impl<C: Cpu> Machine<C> {
 
         // H5 FLASH pending ops: sector erase fills flash with 0xFF; bank-swap
         // swaps the two 1 MB banks in the flash buffer then re-runs reset so
-        // the CPU boots from the new bank-1 vector table.
+        // the CPU boots from the new bank-1 vector table. Also drained on the
+        // batch/CLI run path (`Machine::run`), which executes cycle-accurately
+        // when an H5 op-modeling FLASH is present so this fires per instruction.
+        self.apply_pending_flash_op()?;
+
+        Ok(())
+    }
+
+    /// Drain and apply the single pending H5 FLASH hardware operation, if any.
+    ///
+    /// The FLASH peripheral records at most one op per instruction (in a `Cell`);
+    /// this helper must therefore run once per instruction so no op is lost. It
+    /// is called from both `step()` and the `Machine::run` batch loop body. The
+    /// run loop clamps its batch to 1 when `requires_cycle_accurate()` is true
+    /// (which an H5 op-modeling FLASH forces), preserving the one-op-per-
+    /// instruction invariant and the correct erase-before-program ordering.
+    fn apply_pending_flash_op(&mut self) -> SimResult<()> {
         if let Some(op) = self.drain_flash_op() {
             use crate::peripherals::flash::h5;
             use crate::peripherals::flash::FlashOp;
@@ -976,7 +992,6 @@ impl<C: Cpu> Machine<C> {
                 }
             }
         }
-
         Ok(())
     }
 
@@ -1229,11 +1244,22 @@ impl<C: Cpu> DebugControl for Machine<C> {
             let tick_interval = self.config.peripheral_tick_interval as u64;
             let remaining_until_tick = (tick_interval - (current_cycles % tick_interval)) as u32;
 
-            let current_batch = if let Some(limit) = max_steps {
+            let mut current_batch = if let Some(limit) = max_steps {
                 remaining_until_tick.min(limit - steps)
             } else {
                 remaining_until_tick
             };
+
+            // Cycle-accurate buses (HC-SR04, IO-Link, H5 op-modeling FLASH) must
+            // execute one instruction per batch so per-instruction services —
+            // notably the H5 FLASH pending-op drain below — fire on every
+            // instruction. Without this clamp the FLASH op would be recorded in
+            // the peripheral cell but applied at most once per tick interval (or
+            // not at all), losing all but the last op and breaking erase-before-
+            // program ordering.
+            if self.bus.requires_cycle_accurate() {
+                current_batch = current_batch.min(1);
+            }
 
             let executed =
                 self.cpu
@@ -1261,6 +1287,13 @@ impl<C: Cpu> DebugControl for Machine<C> {
 
             #[cfg(feature = "event-scheduler")]
             self.drain_scheduler_events();
+
+            // Apply any pending H5 FLASH op recorded by the instructions just
+            // executed. On a cycle-accurate bus the batch is clamped to 1 above,
+            // so this runs per instruction (matching `step()`); this is the path
+            // the CLI test runner and `Machine::run` take, where the op would
+            // otherwise never be applied.
+            self.apply_pending_flash_op()?;
 
             // If we executed less than requested, it means the CPU wanted to exit early (e.g. branch/exception)
             // or we just finished the batch naturally. The loop will continue and check breakpoints/limits.

--- a/crates/core/src/memory/mod.rs
+++ b/crates/core/src/memory/mod.rs
@@ -117,6 +117,41 @@ impl LinearMemory {
         }
     }
 
+    /// Fill `[offset, offset+len)` with `byte`, where `offset` is buffer-relative
+    /// (i.e. `absolute_addr - self.base_addr`, the same buffer space `read_u8`/
+    /// `write_u8` reach after subtracting `base_addr`). Returns false if the
+    /// range is outside the backing buffer.
+    pub fn fill(&mut self, offset: u64, len: u64, byte: u8) -> bool {
+        let (Ok(start), Some(Ok(end))) = (
+            usize::try_from(offset),
+            offset.checked_add(len).map(usize::try_from),
+        ) else {
+            return false;
+        };
+        if end > self.data.len() {
+            return false;
+        }
+        self.data[start..end].iter_mut().for_each(|b| *b = byte);
+        true
+    }
+
+    /// Swap the two `bank_size` halves of the buffer in place (models H5
+    /// hardware SWAP_BANK). Returns false unless the buffer is exactly two banks.
+    pub fn swap_banks(&mut self, bank_size: u64) -> bool {
+        let Some(total) = bank_size.checked_mul(2) else {
+            return false;
+        };
+        let (Ok(bank), Ok(total)) = (usize::try_from(bank_size), usize::try_from(total)) else {
+            return false;
+        };
+        if self.data.len() != total {
+            return false;
+        }
+        let (lo, hi) = self.data.split_at_mut(bank);
+        lo.swap_with_slice(hi);
+        true
+    }
+
     pub fn load_from_segment(&mut self, segment: &Segment) -> bool {
         // Simple overlap check
         let end_addr = segment.start_addr + segment.data.len() as u64;
@@ -128,6 +163,39 @@ impl LinearMemory {
             return true;
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod bank_tests {
+    use super::LinearMemory;
+
+    #[test]
+    fn fill_sets_range_relative_to_base() {
+        let mut m = LinearMemory::new(0x4000, 0x0800_0000);
+        assert!(m.fill(0x2000, 0x2000, 0xFF));
+        assert_eq!(m.read_u8(0x0800_1FFF).unwrap(), 0x00);
+        assert_eq!(m.read_u8(0x0800_2000).unwrap(), 0xFF);
+        assert_eq!(m.read_u8(0x0800_3FFF).unwrap(), 0xFF);
+    }
+
+    #[test]
+    fn fill_rejects_out_of_range() {
+        let mut m = LinearMemory::new(0x2000, 0x0800_0000);
+        assert!(!m.fill(0x1000, 0x2000, 0xFF));
+    }
+
+    #[test]
+    fn swap_banks_exchanges_halves() {
+        let mut m = LinearMemory::new(0x4, 0x0800_0000); // tiny 2-byte banks
+        m.write_u8(0x0800_0000, 0xA1);
+        m.write_u8(0x0800_0001, 0xA2);
+        m.write_u8(0x0800_0002, 0xB1);
+        m.write_u8(0x0800_0003, 0xB2);
+        assert!(m.swap_banks(0x2));
+        assert_eq!(m.read_u8(0x0800_0000).unwrap(), 0xB1);
+        assert_eq!(m.read_u8(0x0800_0001).unwrap(), 0xB2);
+        assert_eq!(m.read_u8(0x0800_0002).unwrap(), 0xA1);
     }
 }
 

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -33,6 +33,9 @@
 use crate::SimResult;
 use std::str::FromStr;
 
+#[path = "flash_h5_regs.rs"]
+mod h5;
+
 /// Register layout / reset-value profile for the FLASH interface.
 /// Adding a variant must NOT touch the read/write branches of existing
 /// variants — keep family-specific behaviour isolated.

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -52,7 +52,7 @@ pub enum FlashRegisterLayout {
     Stm32F1,
     /// STM32H5 (RM0481 §7). Models the OTA reprogramming path: ACR
     /// (LATENCY/WRHIGHFREQ/PRFTEN) read-back for clock bring-up; NSKEYR/OPTKEYR
-    /// unlock; NSCR sector-erase and OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH,
+    /// unlock; NSCR sector-erase and OPTSR_PRG.SWAP_BANK + OPTCR.OPTSTRT,
     /// recorded as pending ops drained by `Machine::step` (erase fills 0xFF;
     /// swap exchanges the two 1 MiB banks and resets). Programming is plain
     /// writes to the flash region (the bus routes them into the flash buffer).
@@ -85,7 +85,7 @@ impl FromStr for FlashRegisterLayout {
 pub enum FlashOp {
     /// Non-secure sector erase (`NSCR.SER + STRT`).
     EraseSector { bank: u8, sector: u32 },
-    /// Bank-swap + option-byte reload (`OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH`).
+    /// Bank-swap + option-byte reload (`OPTSR_PRG.SWAP_BANK + OPTCR.OPTSTRT`).
     SwapAndReset,
 }
 
@@ -111,7 +111,7 @@ pub struct Flash {
 
     // H5: OPTSR_PRG shadow (mirrors OPTSR_CUR at reset per silicon capture).
     optsr_prg: u32,
-    // H5: pending hardware op recorded on NSCR.STRT / OPTCR.OBL_LAUNCH.
+    // H5: pending hardware op recorded on NSCR.STRT / OPTCR.OPTSTRT.
     // Cell<Option<_>> gives interior mutability so drain_pending_op takes &self.
     // skip serde — Cell<Option<_>> is not Serialize; resets to None on restore.
     #[serde(skip)]
@@ -296,7 +296,7 @@ impl Flash {
                     };
                 }
                 // OPTKEYR (H5 offset 0x0C) — option-byte unlock sequence.
-                // Distinct from NSKEYR: option-byte programming and OBL_LAUNCH
+                // Distinct from NSKEYR: option-byte programming and OPTSTRT
                 // require this sequence (OPTKEY1 then OPTKEY2), not the flash key.
                 0x0C => {
                     self.optkeyr = value;
@@ -321,11 +321,13 @@ impl Flash {
                 }
                 h5::OPTSR_PRG_OFF => self.optsr_prg = value,
                 h5::OPTCR_OFF => {
-                    // OBL_LAUNCH requires the OPTION-key (OPTKEYR), not the
+                    // OPTSTRT (bit 1) requires the OPTION-key (OPTKEYR), not the
                     // flash key (NSKEYR). This matches silicon: option-byte
-                    // programming is a separate unlock domain on H5 (RM0481 §7).
+                    // programming is a separate unlock domain on H5 (RM0481 §7,
+                    // SVD-confirmed: OPTCR has OPTLOCK/bit0, OPTSTRT/bit1,
+                    // SWAP_BANK/bit31; there is no OBL_LAUNCH on H5).
                     if matches!(self.optkey_state, KeyUnlockState::Unlocked)
-                        && (value & h5::OPTCR_OBL_LAUNCH) != 0
+                        && (value & h5::OPTCR_OPTSTRT) != 0
                         && (self.optsr_prg & h5::OPTSR_SWAP_BANK) != 0
                     {
                         self.pending_op.set(Some(FlashOp::SwapAndReset));
@@ -490,8 +492,8 @@ mod h5_erase_swap_tests {
     use crate::Peripheral;
 
     fn unlock(f: &mut Flash) {
-        f.write_u32(0x08, 0x4567_0123).unwrap(); // NSKEYR key 1
-        f.write_u32(0x08, 0xCDEF_89AB).unwrap(); // NSKEYR key 2
+        f.write_u32(h5::NSKEYR_OFF, 0x4567_0123).unwrap(); // NSKEYR key 1
+        f.write_u32(h5::NSKEYR_OFF, 0xCDEF_89AB).unwrap(); // NSKEYR key 2
     }
 
     fn unlock_opt(f: &mut Flash) {
@@ -527,23 +529,23 @@ mod h5_erase_swap_tests {
     }
 
     #[test]
-    fn swap_bank_plus_obl_launch_records_swap_and_reset() {
+    fn swap_bank_plus_optstrt_records_swap_and_reset() {
         let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
         unlock(&mut f); // NSKEYR — required for sector erase, not swap
-        unlock_opt(&mut f); // OPTKEYR — required for OBL_LAUNCH / option-byte ops
+        unlock_opt(&mut f); // OPTKEYR — required for OPTSTRT / option-byte ops
         f.write_u32(h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK).unwrap();
-        f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH).unwrap();
+        f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OPTSTRT).unwrap();
         assert_eq!(f.drain_pending_op(), Some(FlashOp::SwapAndReset));
     }
 
     #[test]
-    fn obl_launch_ignored_without_optkey_unlock() {
+    fn optstrt_ignored_without_optkey_unlock() {
         // NSKEYR (flash-key) unlock alone must NOT trigger swap — silicon requires
         // the separate OPTKEYR sequence for option-byte operations (RM0481 §7).
         let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
         unlock(&mut f); // NSKEYR only — no OPTKEYR
         f.write_u32(h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK).unwrap();
-        f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH).unwrap();
+        f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OPTSTRT).unwrap();
         assert_eq!(f.drain_pending_op(), None);
     }
 

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -34,7 +34,7 @@ use crate::SimResult;
 use std::str::FromStr;
 
 #[path = "flash_h5_regs.rs"]
-mod h5;
+pub mod h5;
 
 /// Register layout / reset-value profile for the FLASH interface.
 /// Adding a variant must NOT touch the read/write branches of existing

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -291,6 +291,17 @@ impl Flash {
                         _ => KeyUnlockState::Locked,
                     };
                 }
+                // OPTKEYR (H5 offset 0x0C) — option-byte unlock sequence.
+                // Distinct from NSKEYR: option-byte programming and OBL_LAUNCH
+                // require this sequence (OPTKEY1 then OPTKEY2), not the flash key.
+                0x0C => {
+                    self.optkeyr = value;
+                    self.optkey_state = match (self.optkey_state, value) {
+                        (KeyUnlockState::Locked, OPTKEY1) => KeyUnlockState::HalfUnlocked,
+                        (KeyUnlockState::HalfUnlocked, OPTKEY2) => KeyUnlockState::Unlocked,
+                        _ => KeyUnlockState::Locked,
+                    };
+                }
                 h5::NSCR_OFF => {
                     self.cr = value;
                     if unlocked && (value & h5::NSCR_SER) != 0 && (value & h5::NSCR_STRT) != 0 {
@@ -306,7 +317,10 @@ impl Flash {
                 }
                 h5::OPTSR_PRG_OFF => self.optsr_prg = value,
                 h5::OPTCR_OFF => {
-                    if unlocked
+                    // OBL_LAUNCH requires the OPTION-key (OPTKEYR), not the
+                    // flash key (NSKEYR). This matches silicon: option-byte
+                    // programming is a separate unlock domain on H5 (RM0481 §7).
+                    if matches!(self.optkey_state, KeyUnlockState::Unlocked)
                         && (value & h5::OPTCR_OBL_LAUNCH) != 0
                         && (self.optsr_prg & h5::OPTSR_SWAP_BANK) != 0
                     {
@@ -463,8 +477,13 @@ mod h5_erase_swap_tests {
     use crate::Peripheral;
 
     fn unlock(f: &mut Flash) {
-        f.write_u32(0x08, 0x4567_0123).unwrap(); // NSKEYR
-        f.write_u32(0x08, 0xCDEF_89AB).unwrap();
+        f.write_u32(0x08, 0x4567_0123).unwrap(); // NSKEYR key 1
+        f.write_u32(0x08, 0xCDEF_89AB).unwrap(); // NSKEYR key 2
+    }
+
+    fn unlock_opt(f: &mut Flash) {
+        f.write_u32(0x0C, 0x0819_2A3B).unwrap(); // OPTKEYR key 1
+        f.write_u32(0x0C, 0x4C5D_6E7F).unwrap(); // OPTKEYR key 2
     }
 
     #[test]
@@ -497,10 +516,22 @@ mod h5_erase_swap_tests {
     #[test]
     fn swap_bank_plus_obl_launch_records_swap_and_reset() {
         let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
-        unlock(&mut f);
+        unlock(&mut f); // NSKEYR — required for sector erase, not swap
+        unlock_opt(&mut f); // OPTKEYR — required for OBL_LAUNCH / option-byte ops
         f.write_u32(h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK).unwrap();
         f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH).unwrap();
         assert_eq!(f.drain_pending_op(), Some(FlashOp::SwapAndReset));
+    }
+
+    #[test]
+    fn obl_launch_ignored_without_optkey_unlock() {
+        // NSKEYR (flash-key) unlock alone must NOT trigger swap — silicon requires
+        // the separate OPTKEYR sequence for option-byte operations (RM0481 §7).
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        unlock(&mut f); // NSKEYR only — no OPTKEYR
+        f.write_u32(h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK).unwrap();
+        f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH).unwrap();
+        assert_eq!(f.drain_pending_op(), None);
     }
 
     #[test]

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -320,18 +320,17 @@ impl Flash {
                     }
                 }
                 h5::OPTSR_PRG_OFF => self.optsr_prg = value,
-                h5::OPTCR_OFF => {
-                    // OPTSTRT (bit 1) requires the OPTION-key (OPTKEYR), not the
-                    // flash key (NSKEYR). This matches silicon: option-byte
-                    // programming is a separate unlock domain on H5 (RM0481 §7,
-                    // SVD-confirmed: OPTCR has OPTLOCK/bit0, OPTSTRT/bit1,
-                    // SWAP_BANK/bit31; there is no OBL_LAUNCH on H5).
+                // OPTSTRT (bit 1) requires the OPTION-key (OPTKEYR), not the flash
+                // key (NSKEYR): option-byte programming is a separate unlock domain
+                // on H5 (RM0481 §7, SVD-confirmed: OPTCR has OPTLOCK/bit0,
+                // OPTSTRT/bit1, SWAP_BANK/bit31; there is no OBL_LAUNCH on H5). A
+                // match guard keeps this one condition out of a nested `if`.
+                h5::OPTCR_OFF
                     if matches!(self.optkey_state, KeyUnlockState::Unlocked)
                         && (value & h5::OPTCR_OPTSTRT) != 0
-                        && (self.optsr_prg & h5::OPTSR_SWAP_BANK) != 0
-                    {
-                        self.pending_op.set(Some(FlashOp::SwapAndReset));
-                    }
+                        && (self.optsr_prg & h5::OPTSR_SWAP_BANK) != 0 =>
+                {
+                    self.pending_op.set(Some(FlashOp::SwapAndReset));
                 }
                 _ => {}
             }

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -74,6 +74,17 @@ impl FromStr for FlashRegisterLayout {
     }
 }
 
+/// Pending FLASH hardware operation recorded by the simulator.
+/// Drainable via [`Flash::drain_pending_op`]; consumed (and applied) by the
+/// machine layer so that bank-swap takes effect on the next boot cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum FlashOp {
+    /// Non-secure sector erase (`NSCR.SER + STRT`).
+    EraseSector { bank: u8, sector: u32 },
+    /// Bank-swap + option-byte reload (`OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH`).
+    SwapAndReset,
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Flash {
     layout: FlashRegisterLayout,
@@ -93,6 +104,14 @@ pub struct Flash {
     pcrop2er: u32,
     wrp2ar: u32,
     wrp2br: u32,
+
+    // H5: OPTSR_PRG shadow (mirrors OPTSR_CUR at reset per silicon capture).
+    optsr_prg: u32,
+    // H5: pending hardware op recorded on NSCR.STRT / OPTCR.OBL_LAUNCH.
+    // Cell<Option<_>> gives interior mutability so drain_pending_op takes &self.
+    // skip serde — Cell<Option<_>> is not Serialize; resets to None on restore.
+    #[serde(skip)]
+    pending_op: std::cell::Cell<Option<FlashOp>>,
 
     // Internal: tracks unlock sequence on KEYR (write 0x45670123 then 0xCDEF89AB).
     key_state: KeyUnlockState,
@@ -146,6 +165,9 @@ impl Flash {
             pcrop2er: 0,
             wrp2ar: 0,
             wrp2br: 0,
+            // OPTSR_PRG mirrors OPTSR_CUR at reset (silicon-confirmed).
+            optsr_prg: optr_reset,
+            pending_op: std::cell::Cell::new(None),
             key_state: KeyUnlockState::Locked,
             optkey_state: KeyUnlockState::Locked,
         }
@@ -174,6 +196,8 @@ impl Flash {
             pcrop2er: 0,
             wrp2ar: 0,
             wrp2br: 0,
+            optsr_prg: 0xFFEF_F8AA,
+            pending_op: std::cell::Cell::new(None),
             key_state: KeyUnlockState::Locked,
             optkey_state: KeyUnlockState::Locked,
         }
@@ -204,12 +228,17 @@ impl Flash {
         if matches!(self.layout, FlashRegisterLayout::Stm32H5) {
             return match offset {
                 0x00 => self.acr,
-                0x14 => 0,         // OPSR
+                // NSKEYR: write-only on real hardware; simulator reads back keyr
+                // so that the byte→word reconstruction in write() can assemble
+                // the full 32-bit key value before triggering the state machine.
+                h5::NSKEYR_OFF => self.keyr,
+                0x14 => 0,                           // OPSR
                 0x1C => 0x1,       // OPTCR (silicon reset; option flows not modeled)
                 0x20 => self.sr,   // NSSR
                 0x28 => self.cr,   // NSCR
                 0x30 => 0,         // NSCCR
                 0x50 => self.optr, // OPTSR_CUR
+                h5::OPTSR_PRG_OFF => self.optsr_prg, // OPTSR_PRG
                 _ => 0,
             };
         }
@@ -238,13 +267,53 @@ impl Flash {
     fn write_reg(&mut self, offset: u64, value: u32) {
         // ─── H5 layout (isolated) ───────────────────────────────────────
         if matches!(self.layout, FlashRegisterLayout::Stm32H5) {
-            if offset == 0x00 {
-                // ACR writable bits: LATENCY[3:0], WRHIGHFREQ[5:4],
-                // PRFTEN(8) = mask 0x13F. Round-trips silicon-pinned
-                // (0x11/0x23/0x02/0x25/0x13F — capture6+9; the original
-                // 0x133 mask dropped LATENCY bits 2:3 and broke HAL's
-                // latency-5 read-back check at 250 MHz).
-                self.acr = value & 0x0000_013F;
+            let unlocked = matches!(self.key_state, KeyUnlockState::Unlocked);
+            match offset {
+                0x00 => {
+                    // ACR writable bits: LATENCY[3:0], WRHIGHFREQ[5:4],
+                    // PRFTEN(8) = mask 0x13F. Round-trips silicon-pinned
+                    // (0x11/0x23/0x02/0x25/0x13F — capture6+9; the original
+                    // 0x133 mask dropped LATENCY bits 2:3 and broke HAL's
+                    // latency-5 read-back check at 250 MHz).
+                    self.acr = value & 0x0000_013F;
+                }
+                h5::NSKEYR_OFF => {
+                    // H5 non-secure key register — walks the unlock sequence.
+                    // Store in keyr so byte-level write() can read back + merge.
+                    self.keyr = value;
+                    self.key_state = match (self.key_state, value) {
+                        (KeyUnlockState::Locked, FLASH_KEY1) => KeyUnlockState::HalfUnlocked,
+                        (KeyUnlockState::HalfUnlocked, FLASH_KEY2) => {
+                            // NSCR.LOCK (bit 0) clears on valid key sequence.
+                            self.cr &= !1;
+                            KeyUnlockState::Unlocked
+                        }
+                        _ => KeyUnlockState::Locked,
+                    };
+                }
+                h5::NSCR_OFF => {
+                    self.cr = value;
+                    if unlocked && (value & h5::NSCR_SER) != 0 && (value & h5::NSCR_STRT) != 0 {
+                        let sector = (value & h5::NSCR_SNB_MASK) >> h5::NSCR_SNB_SHIFT;
+                        let bank = if value & h5::NSCR_BKSEL != 0 {
+                            1u8
+                        } else {
+                            0u8
+                        };
+                        self.pending_op
+                            .set(Some(FlashOp::EraseSector { bank, sector }));
+                    }
+                }
+                h5::OPTSR_PRG_OFF => self.optsr_prg = value,
+                h5::OPTCR_OFF => {
+                    if unlocked
+                        && (value & h5::OPTCR_OBL_LAUNCH) != 0
+                        && (self.optsr_prg & h5::OPTSR_SWAP_BANK) != 0
+                    {
+                        self.pending_op.set(Some(FlashOp::SwapAndReset));
+                    }
+                }
+                _ => {}
             }
             return;
         }
@@ -336,6 +405,17 @@ impl Flash {
     }
 }
 
+impl Flash {
+    /// Drain the pending FLASH hardware operation, if any.
+    ///
+    /// Returns `Some(op)` the first time after an operation is recorded;
+    /// subsequent calls return `None` until a new op is recorded. Uses
+    /// interior mutability so callers with a shared reference can drain.
+    pub fn drain_pending_op(&self) -> Option<FlashOp> {
+        self.pending_op.take()
+    }
+}
+
 impl Default for Flash {
     fn default() -> Self {
         Self::new()
@@ -359,7 +439,75 @@ impl crate::Peripheral for Flash {
         self.write_reg(reg, v);
         Ok(())
     }
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        // Bypass the byte-decompose path for 32-bit register writes so that
+        // key-unlock sequences (NSKEYR, OPTKEYR) see the full 32-bit word in
+        // a single write_reg call. The byte path is correct for data regs but
+        // would fragment each 32-bit key write into 4 independent sub-word
+        // triggers, none of which match FLASH_KEY1 / FLASH_KEY2.
+        self.write_reg(offset & !3, value);
+        Ok(())
+    }
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+#[cfg(test)]
+mod h5_erase_swap_tests {
+    use super::h5;
+    use super::{Flash, FlashOp, FlashRegisterLayout};
+    use crate::Peripheral;
+
+    fn unlock(f: &mut Flash) {
+        f.write_u32(0x08, 0x4567_0123).unwrap(); // NSKEYR
+        f.write_u32(0x08, 0xCDEF_89AB).unwrap();
+    }
+
+    #[test]
+    fn ser_strt_records_erase_of_selected_sector() {
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        unlock(&mut f);
+        // SER + SNB=7 (bank-1) + STRT
+        let nscr = h5::NSCR_SER | (7 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+        f.write_u32(h5::NSCR_OFF, nscr).unwrap();
+        assert_eq!(
+            f.drain_pending_op(),
+            Some(FlashOp::EraseSector { bank: 0, sector: 7 })
+        );
+        // op drains exactly once
+        assert_eq!(f.drain_pending_op(), None);
+    }
+
+    #[test]
+    fn ser_with_bksel_targets_bank2() {
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        unlock(&mut f);
+        let nscr = h5::NSCR_SER | h5::NSCR_BKSEL | (3 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+        f.write_u32(h5::NSCR_OFF, nscr).unwrap();
+        assert_eq!(
+            f.drain_pending_op(),
+            Some(FlashOp::EraseSector { bank: 1, sector: 3 })
+        );
+    }
+
+    #[test]
+    fn swap_bank_plus_obl_launch_records_swap_and_reset() {
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        unlock(&mut f);
+        f.write_u32(h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK).unwrap();
+        f.write_u32(h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH).unwrap();
+        assert_eq!(f.drain_pending_op(), Some(FlashOp::SwapAndReset));
+    }
+
+    #[test]
+    fn erase_ignored_while_locked() {
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        let nscr = h5::NSCR_SER | (7 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+        f.write_u32(h5::NSCR_OFF, nscr).unwrap();
+        assert_eq!(f.drain_pending_op(), None);
     }
 }

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -432,6 +432,15 @@ impl Flash {
     pub fn drain_pending_op(&self) -> Option<FlashOp> {
         self.pending_op.take()
     }
+
+    /// True when this FLASH models hardware operations (sector erase / bank
+    /// swap) as pending ops that must be drained and applied per instruction.
+    /// Only the H5 layout records such ops, so the runner must execute the
+    /// firmware cycle-accurately (batch size 1) for the drain to fire on every
+    /// instruction — see `SystemBus::requires_cycle_accurate`.
+    pub fn models_ops(&self) -> bool {
+        matches!(self.layout, FlashRegisterLayout::Stm32H5)
+    }
 }
 
 impl Default for Flash {

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -50,10 +50,14 @@ pub enum FlashRegisterLayout {
     /// register file is shorter (KEYR@0x04, SR@0x0C, CR@0x10, OBR@0x1C,
     /// WRPR@0x20). No ECCR / OPTR / PCROP / WRP1..2.
     Stm32F1,
-    /// STM32H5 (RM0481 §7). Interface registers only — program/erase is not
-    /// modeled. ACR (LATENCY/WRHIGHFREQ/PRFTEN) reads back what firmware
-    /// wrote, which is what HAL/embassy clock bring-up polls. Reset values
-    /// pinned to a NUCLEO-H563ZI SWD probe (silicon capture 2026-06-11):
+    /// STM32H5 (RM0481 §7). Models the OTA reprogramming path: ACR
+    /// (LATENCY/WRHIGHFREQ/PRFTEN) read-back for clock bring-up; NSKEYR/OPTKEYR
+    /// unlock; NSCR sector-erase and OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH,
+    /// recorded as pending ops drained by `Machine::step` (erase fills 0xFF;
+    /// swap exchanges the two 1 MiB banks and resets). Programming is plain
+    /// writes to the flash region (the bus routes them into the flash buffer).
+    /// Reset values pinned to a NUCLEO-H563ZI SWD probe (silicon capture
+    /// 2026-06-11, OPTSR re-confirmed 2026-06-20):
     /// ACR=0x13, OPTCR=1, NSCR=1, OPTSR_CUR=0x2D30EDF8 (this part's option
     /// bytes, representative).
     Stm32H5,

--- a/crates/core/src/peripherals/flash_h5_regs.rs
+++ b/crates/core/src/peripherals/flash_h5_regs.rs
@@ -16,6 +16,7 @@
 
 // ── Register offsets (relative to FLASH base 0x4002_2000) ───────────────────
 
+pub const NSKEYR_OFF: u64 = 0x08;
 pub const NSSR_OFF: u64 = 0x20;
 pub const NSCR_OFF: u64 = 0x28;
 pub const OPTCR_OFF: u64 = 0x1C;

--- a/crates/core/src/peripherals/flash_h5_regs.rs
+++ b/crates/core/src/peripherals/flash_h5_regs.rs
@@ -9,14 +9,18 @@
 //! silicon via SWD (2026-06-20): a read of 0x4002_2000×24 confirmed
 //! ACR=0x13, OPTCR=0x1, NSSR=0x0, NSCR=0x1, OPTSR_CUR=OPTSR_PRG=0x2D30_EDF8
 //! (bit31/SWAP_BANK clear → bank 1 active), matching the model reset values.
-//! Bitfield positions (SER/STRT/SNB/SWAP_BANK/OBL_LAUNCH) are architectural
-//! per RM0481 §7 (not reset-readable).
+//! Bitfield positions (SER/STRT/SNB/SWAP_BANK/OPTSTRT) are architectural
+//! per RM0481 §7 (not reset-readable). SVD-confirmed against
+//! `tests/fixtures/real_world/stm32h563.svd`: FLASH_NSKEYR=0x004,
+//! FLASH_SECKEYR=0x008 (secure, unused here), FLASH_OPTKEYR=0x00C;
+//! FLASH_OPTCR has OPTLOCK(bit0), OPTSTRT(bit1), SWAP_BANK(bit31) — there
+//! is no OBL_LAUNCH on H5 (that field exists on F4/L4 only).
 
 #![allow(dead_code)]
 
 // ── Register offsets (relative to FLASH base 0x4002_2000) ───────────────────
 
-pub const NSKEYR_OFF: u64 = 0x08;
+pub const NSKEYR_OFF: u64 = 0x04;
 pub const NSSR_OFF: u64 = 0x20;
 pub const NSCR_OFF: u64 = 0x28;
 pub const OPTCR_OFF: u64 = 0x1C;
@@ -54,8 +58,10 @@ pub const OPTSR_SWAP_BANK: u32 = 1 << 31;
 
 // ── FLASH_OPTCR bitfields (RM0481 §7.9.13) ──────────────────────────────────
 
-/// Bit 27 — OBL_LAUNCH: option byte loading launch.
-pub const OPTCR_OBL_LAUNCH: u32 = 1 << 27;
+/// Bit 1 — OPTSTRT: start option-byte programming (SVD-confirmed, H5 only).
+/// Writing 1 after OPTKEYR unlock and OPTSR_PRG.SWAP_BANK programs the option
+/// bytes; the swap takes effect on the next system reset.
+pub const OPTCR_OPTSTRT: u32 = 1 << 1;
 
 // ── Address / geometry constants ─────────────────────────────────────────────
 

--- a/crates/core/src/peripherals/flash_h5_regs.rs
+++ b/crates/core/src/peripherals/flash_h5_regs.rs
@@ -1,0 +1,66 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+
+//! STM32H5 FLASH register offsets + bitfields (RM0481 §7).
+//!
+//! Register offsets and reset values cross-checked against NUCLEO-H563ZI
+//! silicon via SWD (2026-06-20): a read of 0x4002_2000×24 confirmed
+//! ACR=0x13, OPTCR=0x1, NSSR=0x0, NSCR=0x1, OPTSR_CUR=OPTSR_PRG=0x2D30_EDF8
+//! (bit31/SWAP_BANK clear → bank 1 active), matching the model reset values.
+//! Bitfield positions (SER/STRT/SNB/SWAP_BANK/OBL_LAUNCH) are architectural
+//! per RM0481 §7 (not reset-readable).
+
+#![allow(dead_code)]
+
+// ── Register offsets (relative to FLASH base 0x4002_2000) ───────────────────
+
+pub const NSSR_OFF: u64 = 0x20;
+pub const NSCR_OFF: u64 = 0x28;
+pub const OPTCR_OFF: u64 = 0x1C;
+pub const OPTSR_CUR_OFF: u64 = 0x50;
+pub const OPTSR_PRG_OFF: u64 = 0x54;
+
+// ── FLASH_NSCR bitfields (RM0481 §7.9.9) ────────────────────────────────────
+
+/// Bit 0 — LOCK: FLASH_NSCR lock bit. 1 = locked (reset state).
+pub const NSCR_LOCK: u32 = 1 << 0;
+/// Bit 1 — PG: non-secure programming enable.
+pub const NSCR_PG: u32 = 1 << 1;
+/// Bit 2 — SER: non-secure sector erase.
+pub const NSCR_SER: u32 = 1 << 2;
+/// Bit 3 — BER: non-secure bank erase.
+pub const NSCR_BER: u32 = 1 << 3;
+/// Bit 5 — STRT: non-secure start erase/program.
+pub const NSCR_STRT: u32 = 1 << 5;
+/// Bits [12:6] — SNB: sector number (7 bits).
+pub const NSCR_SNB_SHIFT: u32 = 6;
+pub const NSCR_SNB_MASK: u32 = 0x7F << NSCR_SNB_SHIFT;
+/// Bit 31 — BKSEL: bank select (0 = bank 1, 1 = bank 2).
+pub const NSCR_BKSEL: u32 = 1 << 31;
+
+// ── FLASH_NSSR bitfields (RM0481 §7.9.8) ────────────────────────────────────
+
+/// Bit 0 — BSY: non-secure busy.
+pub const NSSR_BSY: u32 = 1 << 0;
+
+// ── FLASH_OPTSR_CUR / OPTSR_PRG bitfields (RM0481 §7.9.14) ─────────────────
+
+/// Bit 31 — SWAP_BANK: bank-swap option bit (0 = no swap, 1 = swapped).
+/// OPTSR_CUR bit 31 = 0 on the captured NUCLEO-H563ZI (0x2D30_EDF8).
+pub const OPTSR_SWAP_BANK: u32 = 1 << 31;
+
+// ── FLASH_OPTCR bitfields (RM0481 §7.9.13) ──────────────────────────────────
+
+/// Bit 27 — OBL_LAUNCH: option byte loading launch.
+pub const OPTCR_OBL_LAUNCH: u32 = 1 << 27;
+
+// ── Address / geometry constants ─────────────────────────────────────────────
+
+/// Flash base address (both banks start here before any bank swap).
+pub const FLASH_BASE: u64 = 0x0800_0000;
+/// Per-bank size: 1 MB (STM32H563ZI has 2 × 1 MB).
+pub const BANK_SIZE: u64 = 0x10_0000;
+/// Sector size: 8 KB (RM0481 §7.1).
+pub const SECTOR_SIZE: u64 = 0x2000;

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -4,7 +4,7 @@
 //! Integration tests for STM32H5 FLASH pending-op drain in Machine::step.
 //!
 //! Tests that NSCR sector-erase fills the flash buffer with 0xFF and that
-//! SWAP_BANK + OBL_LAUNCH swaps the two 1 MB banks and reloads the CPU
+//! SWAP_BANK + OPTSTRT swaps the two 1 MB banks and reloads the CPU
 //! reset vector from the new bank-1 content.
 //!
 //! Bus construction mirrors `h563_conformance.rs`: build a `SystemBus` from
@@ -41,8 +41,12 @@ fn h563_machine() -> Machine<labwired_core::cpu::CortexM> {
 
 /// Unlock the non-secure flash key register (NSKEYR) via the bus.
 fn unlock_nskeyr(m: &mut Machine<labwired_core::cpu::CortexM>) {
-    m.bus.write_u32(FLASH_BASE + 0x08, 0x4567_0123).unwrap(); // KEY1
-    m.bus.write_u32(FLASH_BASE + 0x08, 0xCDEF_89AB).unwrap(); // KEY2
+    m.bus
+        .write_u32(FLASH_BASE + h5::NSKEYR_OFF, 0x4567_0123)
+        .unwrap(); // KEY1
+    m.bus
+        .write_u32(FLASH_BASE + h5::NSKEYR_OFF, 0xCDEF_89AB)
+        .unwrap(); // KEY2
 }
 
 /// Unlock the option-byte key register (OPTKEYR) via the bus.
@@ -161,9 +165,9 @@ fn erase_targets_bank2_with_bksel() {
     );
 }
 
-// ── Test 2: SWAP_BANK + OBL_LAUNCH reboots into bank 2 ─────────────────────
+// ── Test 2: SWAP_BANK + OPTSTRT reboots into bank 2 ────────────────────────
 
-/// Verify that OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH causes Machine::step
+/// Verify that OPTSR_PRG.SWAP_BANK + OPTCR.OPTSTRT causes Machine::step
 /// to swap the two 1 MB flash banks and reload the CPU reset vector from the
 /// (now-swapped) new bank 1 content.
 ///
@@ -200,7 +204,7 @@ fn swap_bank_reboots_into_bank2() {
     write_flash_word(&mut m, bank2_base + 4, bank2_pc);
 
     // Arm the swap: unlock OPTKEYR, set SWAP_BANK in OPTSR_PRG, then
-    // OBL_LAUNCH in OPTCR.  (NSKEYR is NOT required for swap — only OPTKEYR.)
+    // OPTSTRT in OPTCR.  (NSKEYR is NOT required for swap — only OPTKEYR.)
     unlock_optkeyr(&mut m);
 
     // OPTSR_PRG: set SWAP_BANK (bit 31).
@@ -208,9 +212,9 @@ fn swap_bank_reboots_into_bank2() {
         .write_u32(FLASH_BASE + h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK)
         .unwrap();
 
-    // OPTCR: OBL_LAUNCH (bit 27) → records SwapAndReset in the peripheral.
+    // OPTCR: OPTSTRT (bit 1) → records SwapAndReset in the peripheral.
     m.bus
-        .write_u32(FLASH_BASE + h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH)
+        .write_u32(FLASH_BASE + h5::OPTCR_OFF, h5::OPTCR_OPTSTRT)
         .unwrap();
 
     // step() executes one NOP (bank1 instruction at PC=0), then applies
@@ -304,7 +308,7 @@ fn erase_applied_via_run() {
 // ── Test 5: bank swap + reset applied via the batch/run path ───────────────
 
 /// Same swap as `swap_bank_reboots_into_bank2`, but driven through
-/// `Machine::run`. Proves SWAP_BANK + OBL_LAUNCH swaps banks AND resets the CPU
+/// `Machine::run`. Proves SWAP_BANK + OPTSTRT swaps banks AND resets the CPU
 /// PC to bank2's reset vector on the shipping batch path.
 #[test]
 fn swap_applied_via_run() {
@@ -328,7 +332,7 @@ fn swap_applied_via_run() {
         .write_u32(FLASH_BASE + h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK)
         .unwrap();
     m.bus
-        .write_u32(FLASH_BASE + h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH)
+        .write_u32(FLASH_BASE + h5::OPTCR_OFF, h5::OPTCR_OPTSTRT)
         .unwrap();
 
     // Drive via run() (the shipping batch path), not step(). Limit to a single

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -14,7 +14,7 @@
 use labwired_config::ChipDescriptor;
 use labwired_core::peripherals::flash::h5;
 use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::{Cpu, Machine};
+use labwired_core::{Cpu, DebugControl, Machine};
 
 /// FLASH interface peripheral base address (RM0481, stm32h563.yaml).
 const FLASH_BASE: u64 = 0x4002_2000;
@@ -144,7 +144,8 @@ fn erase_targets_bank2_with_bksel() {
     write_flash_word(&mut m, bank2_addr, 0xBBBB_BBBB);
 
     unlock_nskeyr(&mut m);
-    let nscr = h5::NSCR_SER | h5::NSCR_BKSEL | ((sector as u32) << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+    let nscr =
+        h5::NSCR_SER | h5::NSCR_BKSEL | ((sector as u32) << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
     m.bus.write_u32(FLASH_BASE + h5::NSCR_OFF, nscr).unwrap();
     m.step().expect("step must not fail");
 
@@ -236,5 +237,121 @@ fn swap_bank_reboots_into_bank2() {
         m.cpu.get_pc(),
         bank2_pc & !1,
         "CPU PC should point to bank2 reset handler after swap+reset"
+    );
+}
+
+// ── Test 3: H563 forces cycle-accurate execution ───────────────────────────
+
+/// Lock the predicate that makes the batch/CLI run path apply FLASH ops: an
+/// H5 op-modeling FLASH on the bus must force `requires_cycle_accurate()` true,
+/// so the runner executes one instruction per batch and the per-instruction
+/// FLASH-op drain fires. A regression that drops this would silently strand the
+/// erase/swap on the shipping run path — this test fails loudly if so.
+#[test]
+fn h563_requires_cycle_accurate() {
+    let m = h563_machine();
+    assert!(
+        m.bus.requires_cycle_accurate(),
+        "H563 bus has an H5 op-modeling FLASH, so it must require cycle-accurate execution"
+    );
+}
+
+// ── Test 4: erase applied via the batch/run path (not just step) ───────────
+
+/// Same erase as `erase_fills_sector_with_ff`, but driven through `Machine::run`
+/// — the path the CLI test runner and `Machine::run` take. Proves the op is
+/// applied on the batch path (cycle-accurate clamp + per-iteration drain), not
+/// only inside `step()`.
+#[test]
+fn erase_applied_via_run() {
+    let mut m = h563_machine();
+
+    let bank0_base: u64 = h5::FLASH_BASE;
+    let sector1_start: u64 = bank0_base + h5::SECTOR_SIZE;
+
+    write_flash_word(&mut m, sector1_start, 0x1234_5678);
+    assert_eq!(
+        read_flash_word(&m, sector1_start),
+        0x1234_5678,
+        "sentinel before erase"
+    );
+
+    unlock_nskeyr(&mut m);
+    let nscr = h5::NSCR_SER | (1 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+    m.bus.write_u32(FLASH_BASE + h5::NSCR_OFF, nscr).unwrap();
+
+    // Drive via run() (the shipping batch path), not step().
+    m.run(Some(2)).expect("run must not fail");
+
+    assert_eq!(
+        read_flash_word(&m, sector1_start),
+        0xFFFF_FFFF,
+        "first word of sector after erase via run() should be 0xFFFF_FFFF"
+    );
+    let last_word_offset: u64 = sector1_start + h5::SECTOR_SIZE - 4;
+    assert_eq!(
+        read_flash_word(&m, last_word_offset),
+        0xFFFF_FFFF,
+        "last word of sector after erase via run() should be 0xFFFF_FFFF"
+    );
+    assert_eq!(
+        read_flash_word(&m, bank0_base),
+        0x0000_0000,
+        "sector 0 must be untouched by sector-1 erase via run()"
+    );
+}
+
+// ── Test 5: bank swap + reset applied via the batch/run path ───────────────
+
+/// Same swap as `swap_bank_reboots_into_bank2`, but driven through
+/// `Machine::run`. Proves SWAP_BANK + OBL_LAUNCH swaps banks AND resets the CPU
+/// PC to bank2's reset vector on the shipping batch path.
+#[test]
+fn swap_applied_via_run() {
+    let mut m = h563_machine();
+
+    let bank1_base: u64 = h5::FLASH_BASE;
+    let bank2_base: u64 = h5::FLASH_BASE + h5::BANK_SIZE;
+
+    let bank1_sp: u32 = 0x2000_0000;
+    let bank1_pc: u32 = 0x0800_0009;
+    write_flash_word(&mut m, bank1_base, bank1_sp);
+    write_flash_word(&mut m, bank1_base + 4, bank1_pc);
+
+    let bank2_sp: u32 = 0x2001_0000;
+    let bank2_pc: u32 = 0x0810_0005;
+    write_flash_word(&mut m, bank2_base, bank2_sp);
+    write_flash_word(&mut m, bank2_base + 4, bank2_pc);
+
+    unlock_optkeyr(&mut m);
+    m.bus
+        .write_u32(FLASH_BASE + h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK)
+        .unwrap();
+    m.bus
+        .write_u32(FLASH_BASE + h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH)
+        .unwrap();
+
+    // Drive via run() (the shipping batch path), not step(). Limit to a single
+    // instruction: the SwapAndReset op is already pending (recorded by the MMIO
+    // writes above), so the first executed instruction triggers the drain →
+    // swap + reset, landing the CPU exactly on bank2's reset vector. A larger
+    // budget would execute further instructions from the (now bank2) reset
+    // handler, advancing PC past the vector and making the landing PC fragile.
+    m.run(Some(1)).expect("run must not fail");
+
+    assert_eq!(
+        read_flash_word(&m, bank1_base),
+        bank2_sp,
+        "after swap via run(): flash[0x08000000] should hold bank2 SP"
+    );
+    assert_eq!(
+        read_flash_word(&m, bank1_base + 4),
+        bank2_pc,
+        "after swap via run(): flash[0x08000004] should hold bank2 PC"
+    );
+    assert_eq!(
+        m.cpu.get_pc(),
+        bank2_pc & !1,
+        "CPU PC should point to bank2 reset handler after swap+reset via run()"
     );
 }

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -1,0 +1,240 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! Integration tests for STM32H5 FLASH pending-op drain in Machine::step.
+//!
+//! Tests that NSCR sector-erase fills the flash buffer with 0xFF and that
+//! SWAP_BANK + OBL_LAUNCH swaps the two 1 MB banks and reloads the CPU
+//! reset vector from the new bank-1 content.
+//!
+//! Bus construction mirrors `h563_conformance.rs`: build a `SystemBus` from
+//! the stm32h563.yaml chip descriptor + a minimal manifest, then call
+//! `configure_cortex_m` to wire the CPU and shared SCB/NVIC peripherals.
+
+use labwired_config::ChipDescriptor;
+use labwired_core::peripherals::flash::h5;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{Cpu, Machine};
+
+/// FLASH interface peripheral base address (RM0481, stm32h563.yaml).
+const FLASH_BASE: u64 = 0x4002_2000;
+
+/// Build a SystemBus + CortexM CPU wired to the STM32H563 chip descriptor.
+fn h563_machine() -> Machine<labwired_core::cpu::CortexM> {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../configs/chips/stm32h563.yaml");
+    let chip = ChipDescriptor::from_file(&path).expect("load stm32h563.yaml");
+    let manifest = labwired_config::SystemManifest {
+        walk_deleted: false,
+        schema_version: "1.0".to_string(),
+        name: "flash-h5-ops".to_string(),
+        chip: path.to_string_lossy().to_string(),
+        external_devices: vec![],
+        board_io: vec![],
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    let mut bus = labwired_core::bus::SystemBus::from_config(&chip, &manifest).expect("build bus");
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    Machine::new(cpu, bus)
+}
+
+/// Unlock the non-secure flash key register (NSKEYR) via the bus.
+fn unlock_nskeyr(m: &mut Machine<labwired_core::cpu::CortexM>) {
+    m.bus.write_u32(FLASH_BASE + 0x08, 0x4567_0123).unwrap(); // KEY1
+    m.bus.write_u32(FLASH_BASE + 0x08, 0xCDEF_89AB).unwrap(); // KEY2
+}
+
+/// Unlock the option-byte key register (OPTKEYR) via the bus.
+fn unlock_optkeyr(m: &mut Machine<labwired_core::cpu::CortexM>) {
+    m.bus.write_u32(FLASH_BASE + 0x0C, 0x0819_2A3B).unwrap(); // OPTKEY1
+    m.bus.write_u32(FLASH_BASE + 0x0C, 0x4C5D_6E7F).unwrap(); // OPTKEY2
+}
+
+/// Write a 32-bit word directly into the flash buffer at an absolute address.
+/// Used to plant sentinel values and vector-table entries before tests run.
+fn write_flash_word(m: &mut Machine<labwired_core::cpu::CortexM>, abs_addr: u64, value: u32) {
+    let bytes = value.to_le_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        m.bus.flash.write_u8(abs_addr + i as u64, *b);
+    }
+}
+
+/// Read a 32-bit word from the flash buffer at an absolute address.
+fn read_flash_word(m: &Machine<labwired_core::cpu::CortexM>, abs_addr: u64) -> u32 {
+    m.bus.flash.read_u32(abs_addr).unwrap()
+}
+
+// ── Test 1: sector erase fills with 0xFF ────────────────────────────────────
+
+/// Verify that NSCR SER+STRT (bank 0, sector 1) causes Machine::step to fill
+/// the sector's flash range with 0xFF.
+///
+/// Sector 1 starts at offset SECTOR_SIZE (0x2000) from bank 0 base.
+/// The CPU executes the 0x0000 instruction (LSL R0,R0,#0 = effective NOP)
+/// from the zeroed flash buffer on every step, so `step()` always succeeds.
+#[test]
+fn erase_fills_sector_with_ff() {
+    let mut m = h563_machine();
+
+    // Flash base (absolute address of bank 0 sector 1).
+    let bank0_base: u64 = h5::FLASH_BASE;
+    let sector1_start: u64 = bank0_base + h5::SECTOR_SIZE; // offset = 0x2000
+
+    // Plant a sentinel byte in sector 1 that is NOT 0xFF.
+    write_flash_word(&mut m, sector1_start, 0x1234_5678);
+    assert_eq!(
+        read_flash_word(&m, sector1_start),
+        0x1234_5678,
+        "sentinel before erase"
+    );
+
+    // Unlock NSKEYR then trigger NSCR SER+SNB=1+STRT for bank 0 (BKSEL=0).
+    unlock_nskeyr(&mut m);
+    let nscr = h5::NSCR_SER | (1 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+    m.bus.write_u32(FLASH_BASE + h5::NSCR_OFF, nscr).unwrap();
+
+    // step() executes one NOP from zeroed flash, then drains the pending op.
+    m.step().expect("step must not fail");
+
+    // Sector 1 should now be all 0xFF.
+    let first_word = read_flash_word(&m, sector1_start);
+    assert_eq!(
+        first_word, 0xFFFF_FFFF,
+        "first word of sector after erase should be 0xFFFF_FFFF"
+    );
+
+    // Spot-check the last word of sector 1.
+    let last_word_offset: u64 = sector1_start + h5::SECTOR_SIZE - 4;
+    assert_eq!(
+        read_flash_word(&m, last_word_offset),
+        0xFFFF_FFFF,
+        "last word of sector after erase should be 0xFFFF_FFFF"
+    );
+
+    // Sector 0 must be untouched (still zeroed — no erase was requested).
+    assert_eq!(
+        read_flash_word(&m, bank0_base),
+        0x0000_0000,
+        "sector 0 must be untouched by sector-1 erase"
+    );
+}
+
+// ── Test 1b: sector erase targets bank 2 when BKSEL is set ─────────────────
+
+/// Verify NSCR SER+BKSEL+STRT erases the sector in BANK 2 (offset
+/// BANK_SIZE + sector*SECTOR_SIZE), leaving the same sector in bank 0 intact.
+/// This covers the BKSEL→bank-2 path that the bank-0 test cannot, and pins the
+/// invariant that bank 2 lives one BANK_SIZE above the flash base.
+#[test]
+fn erase_targets_bank2_with_bksel() {
+    let mut m = h563_machine();
+    assert_eq!(
+        m.bus.flash.data.len() as u64,
+        2 * h5::BANK_SIZE,
+        "H563 flash buffer must be exactly 2 * BANK_SIZE"
+    );
+
+    let sector: u64 = 2;
+    let bank0_addr = h5::FLASH_BASE + sector * h5::SECTOR_SIZE;
+    let bank2_addr = h5::FLASH_BASE + h5::BANK_SIZE + sector * h5::SECTOR_SIZE;
+
+    // Distinct sentinels in the same sector of each bank.
+    write_flash_word(&mut m, bank0_addr, 0xAAAA_AAAA);
+    write_flash_word(&mut m, bank2_addr, 0xBBBB_BBBB);
+
+    unlock_nskeyr(&mut m);
+    let nscr = h5::NSCR_SER | h5::NSCR_BKSEL | ((sector as u32) << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+    m.bus.write_u32(FLASH_BASE + h5::NSCR_OFF, nscr).unwrap();
+    m.step().expect("step must not fail");
+
+    assert_eq!(
+        read_flash_word(&m, bank2_addr),
+        0xFFFF_FFFF,
+        "bank-2 sector should be erased to 0xFF"
+    );
+    assert_eq!(
+        read_flash_word(&m, bank0_addr),
+        0xAAAA_AAAA,
+        "bank-0 sentinel must be untouched by a BKSEL (bank-2) erase"
+    );
+}
+
+// ── Test 2: SWAP_BANK + OBL_LAUNCH reboots into bank 2 ─────────────────────
+
+/// Verify that OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH causes Machine::step
+/// to swap the two 1 MB flash banks and reload the CPU reset vector from the
+/// (now-swapped) new bank 1 content.
+///
+/// Bank 1 vector table lives at flash[0]: SP=0x2000_0000, PC=0x0800_0009 (bank1-entry).
+/// Bank 2 vector table lives at flash[BANK_SIZE]: SP=0x2001_0000, PC=0x0800_0405 (bank2-entry).
+///
+/// After swap_banks(BANK_SIZE), what was bank 2 is now at offset 0 of the
+/// buffer → reset() reads bank2's SP and PC.
+#[test]
+fn swap_bank_reboots_into_bank2() {
+    let mut m = h563_machine();
+
+    // The chip yaml sizes flash as "2MiB" (binary) so the buffer is exactly
+    // two architectural 1 MiB banks; bank 2 therefore lives at 0x08100000,
+    // matching real silicon and the drain's swap_banks(h5::BANK_SIZE).
+    assert_eq!(
+        m.bus.flash.data.len() as u64,
+        2 * h5::BANK_SIZE,
+        "H563 flash buffer must be exactly 2 * BANK_SIZE (chip yaml must use MiB units)"
+    );
+    let bank1_base: u64 = h5::FLASH_BASE;
+    let bank2_base: u64 = h5::FLASH_BASE + h5::BANK_SIZE;
+
+    // Bank 1 reset vector (at flash buffer offset 0).
+    let bank1_sp: u32 = 0x2000_0000;
+    let bank1_pc: u32 = 0x0800_0009; // Thumb bit set = 0x0800_0008
+    write_flash_word(&mut m, bank1_base, bank1_sp);
+    write_flash_word(&mut m, bank1_base + 4, bank1_pc);
+
+    // Bank 2 reset vector (at flash buffer offset BANK_SIZE).
+    let bank2_sp: u32 = 0x2001_0000;
+    let bank2_pc: u32 = 0x0810_0005; // Thumb bit set = 0x0810_0004
+    write_flash_word(&mut m, bank2_base, bank2_sp);
+    write_flash_word(&mut m, bank2_base + 4, bank2_pc);
+
+    // Arm the swap: unlock OPTKEYR, set SWAP_BANK in OPTSR_PRG, then
+    // OBL_LAUNCH in OPTCR.  (NSKEYR is NOT required for swap — only OPTKEYR.)
+    unlock_optkeyr(&mut m);
+
+    // OPTSR_PRG: set SWAP_BANK (bit 31).
+    m.bus
+        .write_u32(FLASH_BASE + h5::OPTSR_PRG_OFF, h5::OPTSR_SWAP_BANK)
+        .unwrap();
+
+    // OPTCR: OBL_LAUNCH (bit 27) → records SwapAndReset in the peripheral.
+    m.bus
+        .write_u32(FLASH_BASE + h5::OPTCR_OFF, h5::OPTCR_OBL_LAUNCH)
+        .unwrap();
+
+    // step() executes one NOP (bank1 instruction at PC=0), then applies
+    // swap_banks + reset.  After reset, VTOR=0 so SP/PC come from the start
+    // of the flash buffer (boot alias 0 → 0x0800_0000 + 0) which now holds
+    // bank 2's vector table.
+    m.step().expect("step must not fail");
+
+    // Banks are now swapped: bank2's content is at offset 0 of the buffer.
+    assert_eq!(
+        read_flash_word(&m, bank1_base),
+        bank2_sp,
+        "after swap: flash[0x08000000] should hold bank2 SP"
+    );
+    assert_eq!(
+        read_flash_word(&m, bank1_base + 4),
+        bank2_pc,
+        "after swap: flash[0x08000004] should hold bank2 PC"
+    );
+
+    // CPU PC was reloaded from the swapped vector table.
+    // reset() clears Thumb bit: pc = bank2_pc & !1.
+    assert_eq!(
+        m.cpu.get_pc(),
+        bank2_pc & !1,
+        "CPU PC should point to bank2 reset handler after swap+reset"
+    );
+}

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,7 +9,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-20 | 2026-06-21 | ⚠ drift acked 2026-06-21 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-20 | ⚠ drift acked 2026-06-20 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
@@ -43,7 +43,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — Live re-capture after the v0.17.0 merge: h563_mmio_diff + h563_parity_diff + h563_class_diff all pass (class 65/65, GPIO mmio + parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **✅ fresh**
+- Drift status: **⚠ drift acked 2026-06-21 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -75,6 +75,13 @@ boards:
       last_capture: 2026-06-20
       probe: "STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe)"
       result: "Live re-capture after the v0.17.0 merge: h563_mmio_diff + h563_parity_diff + h563_class_diff all pass (class 65/65, GPIO mmio + parity), 0 divergence. Supersedes the 2026-06-19 drift_ack."
+    # FLASH model extended for UDS OTA: NSCR sector-erase + OPTSR_PRG.SWAP_BANK/
+    # OBL_LAUNCH (drained in Machine::step / batched run) + H563 sized in MiB.
+    # FLASH register offsets + reset values silicon-confirmed on the live board
+    # 2026-06-20 (ACR/OPTCR/NSSR/NSCR/OPTSR_CUR/OPTSR_PRG); the erase/swap
+    # *behavioural* live-diff (writes real flash) is not yet run — tracked for a
+    # follow-up hw-oracle capture. This ack covers the model change only.
+    drift_ack: 2026-06-21
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
## What

Extends the STM32H5 FLASH peripheral model so firmware can erase flash, swap
banks, and reboot into the new bank — entirely in simulation. This is the
labwired-core prerequisite for a UDS service-based OTA bootloader example
(context: w1ne/udslib#64).

Previously the H5 FLASH model was interface-registers-only ("program/erase is
not modeled"). Now:

- **Register constants** (`flash_h5_regs.rs`) — offsets + bitfields from RM0481 §7,
  reset values cross-checked against real NUCLEO-H563ZI silicon over SWD
  (ACR/OPTCR/NSSR/NSCR/OPTSR_CUR/OPTSR_PRG all match; bank 1 active at probe time).
- **`LinearMemory::fill` / `swap_banks`** — overflow-safe primitives.
- **NSCR sector-erase** and **OPTSR_PRG.SWAP_BANK + OPTCR.OBL_LAUNCH** recorded as
  pending ops; erase gated on NSKEYR unlock, swap gated on the OPTKEYR option-key
  (silicon-faithful per RM0481).
- **`Machine` drain** applies erase (fill 0xFF) and swap (exchange the two 1 MiB
  banks + CPU reset) — on **both** `step()` and the batched `run()`/CLI path.
- **H563 sized in binary units** (`2MiB` flash / `640KiB` RAM) so bank 2 lands at
  `0x08100000` like real silicon, and H563 now runs cycle-accurate so the
  side-effecting flash ops apply per instruction.

Programming itself needs no new modeling — direct writes to the `0x08000000`
region already route into the flash buffer.

## Why cycle-accurate for H563

The flash ops are side-effecting and must apply at instruction granularity
(erase before subsequent program writes; one op per instruction). This follows
the existing `requires_cycle_accurate()` convention ("correctness > speed;
extend this predicate for new per-tick side-effecting devices").

## Validation

- New integration tests (`crates/core/tests/flash_h5_ops.rs`) cover bank-0/bank-2
  erase, swap-reboot, and the same ops driven through the **batched run path**
  (not just `step()`), plus a guard asserting H563 is cycle-accurate.
- `flash` unit tests, `h563_conformance`, and `fdcan` all green; L4/F1 and all
  non-H563 chips unaffected (family-isolated; only the H563 chip yaml changed).
- Full default-members `cargo test` passes except the pre-existing
  `labwired-dap --test e2e` fixture test (unrelated; needs a CI-built thumbv7m
  firmware fixture). `clippy` clean.

## Follow-ups (intentionally deferred)

- AIRCR `SYSRESETREQ` (UDS `0x11` ECUReset for a plain, non-swap reset) — not on
  the OTA critical path (activation resets via OBL_LAUNCH).