### PR TITLE
fix(cpu): decode wide T2 register-extends (UXTH.W/UXTB.W/SXTH.W/SXTB.W)

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -1487,6 +1487,17 @@ impl CortexM {
                     let val = self.read_reg(rm) as u16 as i16 as i32 as u32;
                     self.write_reg(rd, val);
                 }
+                Instruction::ExtendW { rd, rm, rotate, op } => {
+                    // ROR Rm by `rotate` (0/8/16/24), then extract+extend.
+                    let v = self.read_reg(rm).rotate_right(rotate as u32);
+                    let out = match op {
+                        0b000 => v as u16 as i16 as i32 as u32, // SXTH.W
+                        0b001 => v & 0xFFFF,                    // UXTH.W
+                        0b100 => v as u8 as i8 as i32 as u32,   // SXTB.W
+                        _ => v & 0xFF,                          // UXTB.W (0b101)
+                    };
+                    self.write_reg(rd, out);
+                }
 
                 Instruction::It { cond, mask } => {
                     self.it_state = (cond << 4) | mask;
@@ -2999,6 +3010,52 @@ mod tests {
         run_test_instr(&mut cpu, &mut bus, 0x5288, false);
         // The halfword at 0x3000 should be 0xBEEF.
         assert_eq!(bus.read_u16(0x3000).unwrap(), 0xBEEF);
+    }
+
+    #[test]
+    fn test_exec_wide_register_extend() {
+        // Regression: the wide (T2) register-extend instructions were not
+        // decoded (fell to Unknown32 and were skipped), leaving Rd stale.
+        // clang emits e.g. `uxth.w r2, ip` = FA1F F28C when extending a high
+        // register, which corrupted a UDS routine-id argument (read as 0).
+        // UXTH.W R2, R12  = FA1F F28C — zero-extend low 16 bits.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r2 = 0xDEAD_BEEF; // stale value that must be overwritten
+            cpu.r12 = 0x1234_FF00;
+            run_test_instr(&mut cpu, &mut bus, 0xFA1FF28C, true);
+            assert_eq!(cpu.r2, 0x0000_FF00, "UXTH.W must zero-extend low 16 bits");
+        }
+        // UXTB.W R0, R1   = FA5F F081 — zero-extend low 8 bits.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r1 = 0x0000_0085;
+            run_test_instr(&mut cpu, &mut bus, 0xFA5FF081, true);
+            assert_eq!(cpu.r0, 0x0000_0085, "UXTB.W must zero-extend low 8 bits");
+        }
+        // SXTB.W R0, R1   = FA4F F081 — sign-extend low 8 bits.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r1 = 0x0000_0085;
+            run_test_instr(&mut cpu, &mut bus, 0xFA4FF081, true);
+            assert_eq!(cpu.r0, 0xFFFF_FF85, "SXTB.W must sign-extend low 8 bits");
+        }
+        // UXTH.W R0, R1, ROR #8 = FA1F F091 — rotate then zero-extend.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r1 = 0x0085_0000;
+            run_test_instr(&mut cpu, &mut bus, 0xFA1FF091, true);
+            // ROR #8 of 0x00850000 = 0x00008500; & 0xFFFF = 0x8500.
+            assert_eq!(cpu.r0, 0x0000_8500, "UXTH.W ROR #8 must rotate then extend");
+        }
     }
 
     #[test]

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -311,6 +311,15 @@ pub enum Instruction {
         rd: u8,
         rm: u8,
     },
+    /// Wide register-extend (T2): {S,U}XT{B,H}.W Rd, Rm, ROR #rotate.
+    /// `rotate` is 0/8/16/24 (applied to Rm before the extract).
+    ExtendW {
+        rd: u8,
+        rm: u8,
+        rotate: u8,
+        /// 0=SXTH, 1=UXTH, 4=SXTB, 5=UXTB (ARM op field h1[6:4]).
+        op: u8,
+    },
     Adr {
         rd: u8,
         imm: u16,
@@ -1462,6 +1471,23 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
             return Instruction::Ubfx { rd, rn, lsb, width };
         } else {
             return Instruction::Sbfx { rd, rn, lsb, width };
+        }
+    }
+
+    // Register-extend, wide (T2): SXTH.W/UXTH.W/SXTB.W/UXTB.W Rd, Rm{, ROR #r}.
+    //   h1 = 1111 1010 0 op 1111  (Rn=0xF, no add);  op: 000=SXTH 001=UXTH
+    //   100=SXTB 101=UXTB (010/011 = SXTB16/UXTB16, not modeled).
+    //   h2 = 1111 dddd 10 rr mmmm  (rr = rotate/8).
+    // clang emits e.g. `uxth.w r2, ip` = FA1F F28C when extending via a high
+    // register; without this the insn decoded to Unknown32 and was skipped,
+    // leaving the destination register stale.
+    if (h1 & 0xFF8F) == 0xFA0F && (h2 & 0xF080) == 0xF080 {
+        let rd = ((h2 >> 8) & 0xF) as u8;
+        let rm = (h2 & 0xF) as u8;
+        let rotate = (((h2 >> 4) & 0x3) * 8) as u8;
+        let op = ((h1 >> 4) & 0x7) as u8;
+        if op == 0b000 || op == 0b001 || op == 0b100 || op == 0b101 {
+            return Instruction::ExtendW { rd, rm, rotate, op };
         }
     }
 


### PR DESCRIPTION
## Summary

The decoder only handled the 16-bit (T1) register-extends `SXTH/SXTB/UXTH/UXTB`
(`0xB2xx`). The **wide Thumb-2 (T2)** forms — `SXTH.W`/`UXTH.W`/`SXTB.W`/`UXTB.W`
(`0xFA0F`/`0xFA1F`/`0xFA4F`/`0xFA5F`, `Rn=0xF`) — fell through to `Unknown32` and
were **silently skipped**, leaving the destination register stale.

clang emits the wide form when extending via a high register (r8–r12), e.g.
`uxth.w r2, ip` = `FA1F F28C`. In real Cortex-M33 firmware this corrupted a value:
a udslib `RoutineControl` handler computes its 16-bit routine id with
`orr.w ip, ...; uxth.w r2, ip`. With `uxth.w` skipped, r2 kept its prior value
(`len-4` = 0), so the ECU saw routine id `0x0000` and rejected the request.

## Fix

Decode all four wide register-extends (with `ROR #rotate` support) and execute
them (rotate-then-extract-then-extend). New `Instruction::ExtendW { rd, rm, rotate, op }`.

## Test

`test_exec_wide_register_extend` covers `UXTH.W` (incl. a stale-register
overwrite check), `UXTB.W`, `SXTB.W`, and a rotated `UXTH.W ROR #8`. Full
`labwired-core` lib suite green (1398 + 1).
