### PR TITLE
chore: bump to 0.17.2 (Cortex-M33 wide-instruction decoder fixes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
Releases #328 (LDRB.W/LDRH.W zero-extend) and #329 (wide register-extend decode). Tag v0.17.2 after merge to trigger the release build.