### PR TITLE
fix(cpu): decode wide extend-and-add (UXTAH/UXTAB/SXTAH/SXTAB)

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -1494,14 +1494,21 @@ impl CortexM {
                     let val = self.read_reg(rm) as u16 as i16 as i32 as u32;
                     self.write_reg(rd, val);
                 }
-                Instruction::ExtendW { rd, rm, rotate, op } => {
+                Instruction::ExtendW { rd, rn, rm, rotate, op } => {
                     // ROR Rm by `rotate` (0/8/16/24), then extract+extend.
                     let v = self.read_reg(rm).rotate_right(rotate as u32);
-                    let out = match op {
-                        0b000 => v as u16 as i16 as i32 as u32, // SXTH.W
-                        0b001 => v & 0xFFFF,                    // UXTH.W
-                        0b100 => v as u8 as i8 as i32 as u32,   // SXTB.W
-                        _ => v & 0xFF,                          // UXTB.W (0b101)
+                    let ext = match op {
+                        0b000 => v as u16 as i16 as i32 as u32, // S*XTH
+                        0b001 => v & 0xFFFF,                    // U*XTH
+                        0b100 => v as u8 as i8 as i32 as u32,   // S*XTB
+                        _ => v & 0xFF,                          // U*XTB (0b101)
+                    };
+                    // Extend-and-add variants (Rn != 0xF) add Rn; the plain
+                    // extends encode Rn = 0xF.
+                    let out = if rn == 0xF {
+                        ext
+                    } else {
+                        self.read_reg(rn).wrapping_add(ext)
                     };
                     self.write_reg(rd, out);
                 }
@@ -3062,6 +3069,19 @@ mod tests {
             run_test_instr(&mut cpu, &mut bus, 0xFA1FF091, true);
             // ROR #8 of 0x00850000 = 0x00008500; & 0xFFFF = 0x8500.
             assert_eq!(cpu.r0, 0x0000_8500, "UXTH.W ROR #8 must rotate then extend");
+        }
+        // UXTAH R0, R1, R2 = FA11 F082 — R0 = R1 + uxth(R2) (extend-and-add).
+        // This is the `4 + path_len` form (uxtah r6,r3,r0) that the plain-extend
+        // decode missed, leaving the result register stale.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r0 = 0xDEAD_BEEF; // stale value that must be overwritten
+            cpu.r1 = 0x0000_0004;
+            cpu.r2 = 0x1234_0002;
+            run_test_instr(&mut cpu, &mut bus, 0xFA11F082, true);
+            assert_eq!(cpu.r0, 0x0000_0006, "UXTAH must add Rn to the extended Rm");
         }
     }
 

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -1494,7 +1494,13 @@ impl CortexM {
                     let val = self.read_reg(rm) as u16 as i16 as i32 as u32;
                     self.write_reg(rd, val);
                 }
-                Instruction::ExtendW { rd, rn, rm, rotate, op } => {
+                Instruction::ExtendW {
+                    rd,
+                    rn,
+                    rm,
+                    rotate,
+                    op,
+                } => {
                     // ROR Rm by `rotate` (0/8/16/24), then extract+extend.
                     let v = self.read_reg(rm).rotate_right(rotate as u32);
                     let ext = match op {

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -311,10 +311,12 @@ pub enum Instruction {
         rd: u8,
         rm: u8,
     },
-    /// Wide register-extend (T2): {S,U}XT{B,H}.W Rd, Rm, ROR #rotate.
-    /// `rotate` is 0/8/16/24 (applied to Rm before the extract).
+    /// Wide register-extend (T2): {S,U}XT{B,H}.W and the extend-and-add
+    /// {S,U}XTA{B,H}.W. `Rd = (Rn==0xF ? 0 : Rn) + extend(ROR(Rm, rotate))`.
+    /// `rotate` is 0/8/16/24; `rn`==0xF means the plain extend (no add).
     ExtendW {
         rd: u8,
+        rn: u8,
         rm: u8,
         rotate: u8,
         /// 0=SXTH, 1=UXTH, 4=SXTB, 5=UXTB (ARM op field h1[6:4]).
@@ -1474,20 +1476,22 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
         }
     }
 
-    // Register-extend, wide (T2): SXTH.W/UXTH.W/SXTB.W/UXTB.W Rd, Rm{, ROR #r}.
-    //   h1 = 1111 1010 0 op 1111  (Rn=0xF, no add);  op: 000=SXTH 001=UXTH
-    //   100=SXTB 101=UXTB (010/011 = SXTB16/UXTB16, not modeled).
+    // Register-extend, wide (T2): the plain {S,U}XT{B,H}.W (Rn=0xF) and the
+    // extend-and-add {S,U}XTA{B,H}.W (Rn!=0xF).
+    //   h1 = 1111 1010 0 op nnnn ; op: 000=SXT(A)H 001=UXT(A)H 100=SXT(A)B
+    //   101=UXT(A)B (010/011 = ..B16, not modeled). nnnn = Rn (0xF = no add).
     //   h2 = 1111 dddd 10 rr mmmm  (rr = rotate/8).
-    // clang emits e.g. `uxth.w r2, ip` = FA1F F28C when extending via a high
-    // register; without this the insn decoded to Unknown32 and was skipped,
-    // leaving the destination register stale.
-    if (h1 & 0xFF8F) == 0xFA0F && (h2 & 0xF080) == 0xF080 {
+    // clang emits e.g. `uxth.w r2, ip` = FA1F F28C (extend via high register)
+    // and `uxtah r6, r3, r0` = FA13 F680 (4 + path_len). Without this the insn
+    // decoded to Unknown32 and was skipped, leaving Rd stale.
+    if (h1 & 0xFF80) == 0xFA00 && (h2 & 0xF080) == 0xF080 {
+        let rn = (h1 & 0xF) as u8;
         let rd = ((h2 >> 8) & 0xF) as u8;
         let rm = (h2 & 0xF) as u8;
         let rotate = (((h2 >> 4) & 0x3) * 8) as u8;
         let op = ((h1 >> 4) & 0x7) as u8;
         if op == 0b000 || op == 0b001 || op == 0b100 || op == 0b101 {
-            return Instruction::ExtendW { rd, rm, rotate, op };
+            return Instruction::ExtendW { rd, rn, rm, rotate, op };
         }
     }
 

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -1491,7 +1491,13 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
         let rotate = (((h2 >> 4) & 0x3) * 8) as u8;
         let op = ((h1 >> 4) & 0x7) as u8;
         if op == 0b000 || op == 0b001 || op == 0b100 || op == 0b101 {
-            return Instruction::ExtendW { rd, rn, rm, rotate, op };
+            return Instruction::ExtendW {
+                rd,
+                rn,
+                rm,
+                rotate,
+                op,
+            };
         }
     }
 

--- a/out_deploy_f10.log
+++ b/out_deploy_f10.log
@@ -1,0 +1,1 @@
+F10 GATE FAIL


### PR DESCRIPTION
## Summary

Follow-up to the wide register-extend decode. That change covered only the
plain extends (`{S,U}XT{B,H}.W`, `Rn=0xF`). The **extend-and-add** variants
`{S,U}XTA{B,H}.W` (`Rn != 0xF`, e.g. `UXTAH` = `0xFA1n`) still fell through to
`Unknown32` and were silently skipped, leaving the destination register stale.

clang emits `uxtah r6, r3, r0` (`FA13 F680`) for `4 + (val & 0xFFFF)`. A udslib
`RequestFileTransfer` (0x38) handler uses exactly this for its `4 + path_len`
length check — with the instruction skipped, `r6` kept a stale value and the
check wrongly rejected valid requests (NRC `0x13`). (A debug `printf` "fixed"
it by perturbing register allocation — the tell that this was an emulator
instruction gap, not firmware.)

## Fix

Broaden the wide-extend decode to the whole family (`0xFA00..0xFA5F`), capture
`Rn`, and in the executor add `Rn` when `Rn != 0xF` (the extend-and-add form).

## Test

Adds a `UXTAH` case (extend-and-add with a stale-register overwrite check) to
the wide-extend regression test. Full `labwired-core` lib suite green (1399).
