### PR TITLE
chore: bump to 0.17.3 (extend-and-add decode fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.2"
+version = "0.17.3"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
Releases #331 (UXTAH/UXTAB/SXTAH/SXTAB decode). Tag v0.17.3 after merge.