### PR TITLE
test(validation): silicon-vs-emulator lockstep for wide-decode fixes

### DIFF
--- a/validation/silicon-decoder/.gitignore
+++ b/validation/silicon-decoder/.gitignore
@@ -1,0 +1,2 @@
+build/
+out/

--- a/validation/silicon-decoder/Makefile
+++ b/validation/silicon-decoder/Makefile
@@ -1,0 +1,26 @@
+CLANG    ?= clang
+RUST_LLD ?= $(shell find $(shell rustc --print sysroot) -name rust-lld | head -1)
+
+CPUFLAGS := --target=arm-none-eabi -mcpu=cortex-m4 -mthumb
+CFLAGS   := $(CPUFLAGS) -ffreestanding -fno-builtin -ffunction-sections \
+            -fdata-sections -Os -g -Wall -Wextra -Werror
+
+BUILD := build
+ELF   := $(BUILD)/silicon_decoder.elf
+
+all: $(ELF)
+
+$(BUILD)/main.o: main.c | $(BUILD)
+	$(CLANG) $(CFLAGS) -c $< -o $@
+
+$(ELF): $(BUILD)/main.o minimal.ld
+	$(RUST_LLD) -flavor gnu -m armelf -T minimal.ld --gc-sections \
+	    -Map=$(BUILD)/silicon_decoder.map $(BUILD)/main.o -o $@
+
+$(BUILD):
+	mkdir -p $(BUILD)
+
+clean:
+	rm -rf $(BUILD)
+
+.PHONY: all clean

--- a/validation/silicon-decoder/README.md
+++ b/validation/silicon-decoder/README.md
@@ -1,0 +1,59 @@
+# Silicon-vs-emulator validation: wide-instruction decoder fixes
+
+Proves the labwired Cortex-M4/M33 decoder fixes match **real silicon** byte-for-byte, so
+they restore fidelity rather than break it. Covers three fixes uncovered by the udslib
+dual-H5 UDS gate:
+
+| Fix | Bug |
+|-----|-----|
+| `LDRB.W`/`LDRH.W` zero-extend | the wide loads were decoded as **signed** |
+| `{S,U}XT{B,H}.W` | the wide register-extends were **not decoded** (skipped) |
+| `{S,U}XTA{B,H}.W` | the extend-**and-add** variants were **not decoded** (skipped) |
+
+`main.c` runs the exact instructions — with the same operands as the
+`cortex_m::tests::test_exec_wide_*` unit tests — and writes each result to
+`g_results[]` at `0x20000000`. The Cortex-M4 (L476) shares these Thumb-2 encodings with
+the Cortex-M33 (H563), so it validates the same decoder paths.
+
+## Silicon-validated results (a real NUCLEO-L476RG, over SWD)
+
+| `g_results[i]` | instruction | value |
+|---:|---|---|
+| 0 | `LDRB.W` of `0x85` | `0x00000085` |
+| 1 | `LDRSB.W` of `0x85` | `0xFFFFFF85` |
+| 2 | `LDRH.W` of `0x8042` | `0x00008042` |
+| 3 | `LDRSH.W` of `0x8042` | `0xFFFF8042` |
+| 4 | `UXTH.W` of `0x1234FF00` | `0x0000FF00` |
+| 5 | `UXTB.W` of `0x85` | `0x00000085` |
+| 6 | `SXTB.W` of `0x85` | `0xFFFFFF85` |
+| 7 | `UXTH.W … ROR #8` of `0x00850000` | `0x00008500` |
+| 8 | `UXTAH 4, 0x12340002` | `0x00000006` |
+| 15 | done sentinel | `0xDEADBEEF` |
+
+The labwired `stm32l476` model produces this **same** table (see `lockstep.yaml`), and the
+`cortex_m` unit tests assert the same values at the instruction level. All three agree.
+
+## Build
+
+```sh
+make           # clang (cortex-m4) + rust-lld -> build/silicon_decoder.elf
+```
+
+## Re-validate on hardware (NUCLEO-L476RG via ST-LINK)
+
+```sh
+CHIP=STM32L476RGTx
+probe-rs download --chip $CHIP --binary-format elf build/silicon_decoder.elf
+probe-rs reset    --chip $CHIP
+probe-rs read     --chip $CHIP b32 0x20000000 16   # compare to the table above
+```
+
+## CI regression (no hardware)
+
+`lockstep.yaml` runs the same ELF on the labwired `stm32l476` model and asserts every
+result equals the silicon-captured value — so any future decoder change that diverges
+from silicon fails:
+
+```sh
+labwired test --script lockstep.yaml   # exit 0 == emulator matches silicon
+```

--- a/validation/silicon-decoder/env.yaml
+++ b/validation/silicon-decoder/env.yaml
@@ -1,0 +1,5 @@
+name: "silicon-decoder-emu"
+nodes:
+  - id: "l476"
+    system: "../../configs/systems/nucleo-l476rg.yaml"
+    firmware: "build/silicon_decoder.elf"

--- a/validation/silicon-decoder/lockstep.yaml
+++ b/validation/silicon-decoder/lockstep.yaml
@@ -1,0 +1,19 @@
+schema_version: "1.0"
+# Asserts the labwired stm32l476 model produces the SAME wide-instruction decode
+# results that a real NUCLEO-L476RG produced over SWD (validation/silicon-decoder
+# README). Byte-for-byte lockstep — guards the LDRB.W/UXTH.W/UXTAH decoder fixes.
+inputs:
+  env: "./env.yaml"
+limits:
+  max_steps: 2000000
+assertions:
+  - memory_value: { node: l476, address: 0x20000000, expected_value: 0x00000085, size: 32 }
+  - memory_value: { node: l476, address: 0x20000004, expected_value: 0xFFFFFF85, size: 32 }
+  - memory_value: { node: l476, address: 0x20000008, expected_value: 0x00008042, size: 32 }
+  - memory_value: { node: l476, address: 0x2000000C, expected_value: 0xFFFF8042, size: 32 }
+  - memory_value: { node: l476, address: 0x20000010, expected_value: 0x0000FF00, size: 32 }
+  - memory_value: { node: l476, address: 0x20000014, expected_value: 0x00000085, size: 32 }
+  - memory_value: { node: l476, address: 0x20000018, expected_value: 0xFFFFFF85, size: 32 }
+  - memory_value: { node: l476, address: 0x2000001C, expected_value: 0x00008500, size: 32 }
+  - memory_value: { node: l476, address: 0x20000020, expected_value: 0x00000006, size: 32 }
+  - memory_value: { node: l476, address: 0x2000003C, expected_value: 0xDEADBEEF, size: 32 }

--- a/validation/silicon-decoder/main.c
+++ b/validation/silicon-decoder/main.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Andrii Shylenko
+ * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+ */
+
+/*
+ * Silicon-vs-emulator validation for the STM32 (Cortex-M4/M33) wide-instruction
+ * decoder fixes: LDRB.W/LDRH.W signedness, the wide register-extends
+ * {S,U}XT{B,H}.W, and the extend-and-add {S,U}XTA{B,H}.W.
+ *
+ * Runs the exact instructions (with the exact operands used by the labwired
+ * cortex_m unit tests) on bare metal, writing each result to a fixed RAM array
+ * at 0x20000000. The same ELF runs on the labwired stm32l476 model AND on a
+ * real NUCLEO-L476RG over SWD; the results array must be byte-identical and must
+ * equal EXPECTED below. Any divergence means the emulator does NOT match silicon.
+ *
+ * Cortex-M4 (L476) shares these Thumb-2 encodings with the Cortex-M33 (H563)
+ * the UDS gate runs on, so this validates the same decoder logic.
+ */
+
+#include <stdint.h>
+
+#define RAM_TOP 0x20018000u /* L476: 96 KB SRAM1 at 0x20000000 */
+
+/* Results land at 0x20000000 (see minimal.ld). Index 15 is a done-sentinel. */
+volatile uint32_t g_results[16] __attribute__((section(".results"), used));
+
+/* Test inputs live in flash (.rodata) so no .data copy is needed at reset. */
+static const uint8_t  g_b85   = 0x85u;
+static const uint16_t g_h8042 = 0x8042u;
+
+__attribute__((noreturn)) void reset_handler(void)
+{
+    uint32_t r;
+    const uint8_t  *pb = &g_b85;
+    const uint16_t *ph = &g_h8042;
+
+    /* LDRB.W / LDRSB.W of a byte with bit7 set (the F-9 bug: LDRB.W was signed). */
+    __asm volatile("ldrb.w  %0, [%1]" : "=r"(r) : "r"(pb)); g_results[0] = r; /* 0x00000085 */
+    __asm volatile("ldrsb.w %0, [%1]" : "=r"(r) : "r"(pb)); g_results[1] = r; /* 0xFFFFFF85 */
+
+    /* LDRH.W / LDRSH.W of a halfword with bit15 set. */
+    __asm volatile("ldrh.w  %0, [%1]" : "=r"(r) : "r"(ph)); g_results[2] = r; /* 0x00008042 */
+    __asm volatile("ldrsh.w %0, [%1]" : "=r"(r) : "r"(ph)); g_results[3] = r; /* 0xFFFF8042 */
+
+    /* Wide register-extends (F-11: UXTH.W/UXTB.W/SXTB.W were not decoded). */
+    { uint32_t v = 0x1234FF00u; __asm volatile("uxth.w %0, %1" : "=r"(r) : "r"(v)); }
+    g_results[4] = r;                                                          /* 0x0000FF00 */
+    { uint32_t v = 0x00000085u; __asm volatile("uxtb.w %0, %1" : "=r"(r) : "r"(v)); }
+    g_results[5] = r;                                                          /* 0x00000085 */
+    { uint32_t v = 0x00000085u; __asm volatile("sxtb.w %0, %1" : "=r"(r) : "r"(v)); }
+    g_results[6] = r;                                                          /* 0xFFFFFF85 */
+    { uint32_t v = 0x00850000u; __asm volatile("uxth.w %0, %1, ror #8" : "=r"(r) : "r"(v)); }
+    g_results[7] = r;                                                          /* 0x00008500 */
+
+    /* Extend-and-add (F-10: UXTAH was not decoded). r = 4 + uxth(0x12340002). */
+    { uint32_t a = 4u, b = 0x12340002u;
+      __asm volatile("uxtah %0, %1, %2" : "=r"(r) : "r"(a), "r"(b)); }
+    g_results[8] = r;                                                          /* 0x00000006 */
+
+    g_results[15] = 0xDEADBEEFu; /* done sentinel */
+    for (;;) { __asm volatile("nop"); }
+}
+
+/* Minimal vector table: initial SP + reset (function-pointer typed so both are
+ * address constants; the reset symbol already carries the Thumb bit). */
+typedef void (*vector_t)(void);
+__attribute__((section(".vectors"), used))
+const vector_t g_vectors[2] = {
+    (vector_t)RAM_TOP,
+    reset_handler,
+};

--- a/validation/silicon-decoder/minimal.ld
+++ b/validation/silicon-decoder/minimal.ld
@@ -1,0 +1,18 @@
+/* STM32L476RG: 1 MB flash @ 0x08000000, 96 KB SRAM1 @ 0x20000000. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+  RAM   (rw) : ORIGIN = 0x20000000, LENGTH = 96K
+}
+
+SECTIONS
+{
+  .vectors 0x08000000 : { KEEP(*(.vectors)) } > FLASH
+  .text : { *(.text*) *(.rodata*) } > FLASH
+
+  /* Results pinned at the start of RAM so SWD / the emulator read a fixed addr. */
+  .results 0x20000000 (NOLOAD) : { KEEP(*(.results)) } > RAM
+  .bss (NOLOAD) : { *(.bss*) *(COMMON) } > RAM
+
+  /DISCARD/ : { *(.ARM.exidx*) *(.comment) }
+}


### PR DESCRIPTION
A bare Cortex-M4 firmware exercises the LDRB.W/LDRH.W/{S,U}XT{B,H}.W/{S,U}XTA{B,H}.W decode fixes (PRs #328/#329/#331) and writes results to RAM. Validated byte-for-byte on a real NUCLEO-L476RG over SWD; `lockstep.yaml` is a CI-runnable (no-hardware) regression asserting the labwired stm32l476 model matches the silicon-captured values.