### PR TITLE
feat(core): H563 UDS OTA bootloader sim smoke + 3 missing Cortex-M decode paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
 ]
@@ -1665,7 +1665,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1818,15 +1818,15 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.1"
+version = "0.17.3"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.1"
+version = "0.17.3"
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3274,7 +3274,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -999,9 +999,79 @@ impl CortexM {
                     let _ = bus.write_u32(addr as u64, val);
                     pc_increment = 4;
                 }
-                Instruction::Ldrd { rt, rt2, rn, imm8 } => {
+                Instruction::LdrImm32Idx {
+                    rt,
+                    rn,
+                    imm8,
+                    pre_index,
+                    add,
+                    writeback,
+                } => {
+                    // LDR T4 indexed. Offset address = base ± imm8. The access
+                    // uses the offset address when pre_index, else the base
+                    // (post-index). Writeback stores the offset address in Rn.
                     let base = self.read_reg(rn);
-                    let addr = base.wrapping_add(imm8 << 2);
+                    let offset = imm8 as u32;
+                    let offset_addr = if add {
+                        base.wrapping_add(offset)
+                    } else {
+                        base.wrapping_sub(offset)
+                    };
+                    let access_addr = if pre_index { offset_addr } else { base };
+                    if let Ok(val) = bus.read_u32(access_addr as u64) {
+                        // Commit writeback before branching so a load-to-PC
+                        // (function return) leaves Rn=SP correct.
+                        if writeback {
+                            self.write_reg(rn, offset_addr);
+                        }
+                        if rt == 15 {
+                            // LDR PC, [...] — interworking branch (function return).
+                            self.branch_to(val, bus)?;
+                            pc_increment = 0;
+                        } else {
+                            self.write_reg(rt, val);
+                            pc_increment = 4;
+                        }
+                    } else {
+                        pc_increment = 4;
+                    }
+                }
+                Instruction::StrImm32Idx {
+                    rt,
+                    rn,
+                    imm8,
+                    pre_index,
+                    add,
+                    writeback,
+                } => {
+                    let base = self.read_reg(rn);
+                    let offset = imm8 as u32;
+                    let offset_addr = if add {
+                        base.wrapping_add(offset)
+                    } else {
+                        base.wrapping_sub(offset)
+                    };
+                    let access_addr = if pre_index { offset_addr } else { base };
+                    let val = self.read_reg(rt);
+                    let _ = bus.write_u32(access_addr as u64, val);
+                    if writeback {
+                        self.write_reg(rn, offset_addr);
+                    }
+                    pc_increment = 4;
+                }
+                Instruction::Ldrd {
+                    rt,
+                    rt2,
+                    rn,
+                    imm8,
+                    add_imm,
+                } => {
+                    let base = self.read_reg(rn);
+                    let addr = if add_imm {
+                        base.wrapping_add(imm8 << 2)
+                    } else {
+                        base.wrapping_sub(imm8 << 2)
+                    };
                     if let Ok(v1) = bus.read_u32(addr as u64) {
                         self.write_reg(rt, v1);
                     }
@@ -1010,9 +1080,19 @@ impl CortexM {
                     }
                     pc_increment = 4;
                 }
-                Instruction::Strd { rt, rt2, rn, imm8 } => {
+                Instruction::Strd {
+                    rt,
+                    rt2,
+                    rn,
+                    imm8,
+                    add_imm,
+                } => {
                     let base = self.read_reg(rn);
-                    let addr = base.wrapping_add(imm8 << 2);
+                    let addr = if add_imm {
+                        base.wrapping_add(imm8 << 2)
+                    } else {
+                        base.wrapping_sub(imm8 << 2)
+                    };
                     let v1 = self.read_reg(rt);
                     let v2 = self.read_reg(rt2);
                     let _ = bus.write_u32(addr as u64, v1);
@@ -2650,6 +2730,68 @@ mod tests {
     }
 
     #[test]
+    fn test_arm_ldrd_negative_offset() {
+        // Regression: LDRD T1 with U=0 must subtract imm8*4 from the base.
+        // `ldrd r0, r7, [r1, #-32]` = E951 0708 — mbedTLS AES round-key load.
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x4000;
+        cpu.r1 = 0x5020; // base = 0x5020; addr = 0x5020 - 32 = 0x5000
+        bus.write_u32(0x5000, 0xDEAD_BEEF).unwrap();
+        bus.write_u32(0x5004, 0xCAFE_BABE).unwrap();
+        // E951 0708: ldrd r0, r7, [r1, #-32] (U=0, imm8=8 → offset=32)
+        run_test_instr(&mut cpu, &mut bus, 0xE9510708, true);
+        assert_eq!(cpu.r0, 0xDEAD_BEEF);
+        assert_eq!(cpu.r7, 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn test_ldr_t4_post_index_pc_function_return() {
+        // Regression: `ldr.w pc, [sp], #4` = F85D FB04 (T4 post-index, U=1,
+        // W=1) is the clang function-return idiom. Previously decoded to
+        // Unknown32 and silently skipped, so the return branched nowhere and
+        // execution fell through to a wrong address. Verify it loads PC from
+        // [sp] and post-increments sp by 4.
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x4000;
+        cpu.sp = 0x6000;
+        bus.write_u32(0x6000, 0x0000_1235).unwrap(); // return addr (thumb bit set)
+        run_test_instr(&mut cpu, &mut bus, 0xF85DFB04, true);
+        assert_eq!(
+            cpu.pc, 0x0000_1234,
+            "PC must come from [sp] (thumb bit cleared)"
+        );
+        assert_eq!(cpu.sp, 0x6004, "post-index writeback: sp += 4");
+    }
+
+    #[test]
+    fn test_ldr_t4_pre_index_writeback() {
+        // `ldr.w r3, [r1, #8]!` = F851 3F08 (T4 pre-index, U=1, W=1).
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x4000;
+        cpu.r1 = 0x5000;
+        bus.write_u32(0x5008, 0xABCD_1234).unwrap();
+        run_test_instr(&mut cpu, &mut bus, 0xF8513F08, true);
+        assert_eq!(cpu.r3, 0xABCD_1234, "loaded from r1+8");
+        assert_eq!(cpu.r1, 0x5008, "pre-index writeback: r1 = r1+8");
+    }
+
+    #[test]
+    fn test_str_t4_pre_decrement_writeback() {
+        // `str.w r2, [r1, #-4]!` = F841 2D04 (T4 pre-index, U=0, W=1).
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x4000;
+        cpu.r1 = 0x5008;
+        cpu.r2 = 0xDEAD_BEEF;
+        run_test_instr(&mut cpu, &mut bus, 0xF8412D04, true);
+        assert_eq!(bus.read_u32(0x5004).unwrap(), 0xDEAD_BEEF, "stored at r1-4");
+        assert_eq!(cpu.r1, 0x5004, "pre-index writeback: r1 = r1-4");
+    }
+
+    #[test]
     fn test_thumb2_stmia_ldmdb_wide_addressing() {
         // Regression: the 0xE8xx/0xE9xx LDM/STM group was decoded as STM=>DB,
         // LDM=>IA unconditionally, so STMIA.W (the compiler's struct-copy idiom)
@@ -3198,6 +3340,55 @@ mod tests {
         run_test_instr(&mut cpu, &mut bus, 0x5E88, false);
         // Sign-extended: 0xFFFF8001.
         assert_eq!(cpu.r0, 0xFFFF8001);
+    }
+
+    #[test]
+    fn test_exec_rev_t1_16bit() {
+        // REV T1: `rev r3, r3` = 0xBA1B — byte-reverse a 32-bit word.
+        // 0x11223344 → 0x44332211.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r3 = 0x1122_3344;
+            run_test_instr(&mut cpu, &mut bus, 0xBA1B, false);
+            assert_eq!(cpu.r3, 0x4433_2211, "REV T1 must byte-swap the whole word");
+        }
+        // REV16 T1: `rev16 r5, r5` = 0xBA6D — swap bytes within each halfword.
+        // 0x11223344 → bytes in low half swapped + bytes in high half swapped
+        // = 0x22114433.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r5 = 0x1122_3344;
+            run_test_instr(&mut cpu, &mut bus, 0xBA6D, false);
+            assert_eq!(
+                cpu.r5, 0x2211_4433,
+                "REV16 T1 must swap bytes within each halfword"
+            );
+        }
+        // REVSH T1: `revsh r0, r1` = 0xBAC8 — swap low two bytes, sign-extend.
+        // Input r1=0x00008001: low halfword bytes swapped → 0x0180, sign-extended
+        // as i16 = 0x0180 (positive, MSB not set) → 0x00000180.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r1 = 0x0000_8001;
+            run_test_instr(&mut cpu, &mut bus, 0xBAC8, false);
+            assert_eq!(cpu.r0, 0x0000_0180, "REVSH T1 positive case");
+        }
+        // REVSH sign case: input r1=0x00000180 — low halfword bytes swapped
+        // → 0x8001, sign-extended as i16 → 0xFFFF8001.
+        {
+            let mut cpu = CortexM::new();
+            let mut bus = MockBus::new();
+            cpu.pc = 0x2000;
+            cpu.r1 = 0x0000_0180;
+            run_test_instr(&mut cpu, &mut bus, 0xBAC8, false);
+            assert_eq!(cpu.r0, 0xFFFF_8001, "REVSH T1 sign-extend case");
+        }
     }
 
     #[test]

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -180,6 +180,30 @@ pub enum Instruction {
         rn: u8,
         imm12: u16,
     },
+    /// LDR (immediate) T4: indexed forms with optional base writeback.
+    /// `pre_index` true → offset applied before the load (`[Rn, #±imm]{!}`);
+    /// false → post-index (`[Rn], #±imm`, writeback implied). `add` selects
+    /// add vs subtract. Models the `ldr.w pc, [sp], #4` function-return idiom
+    /// (post-index, writeback) that the T3 form cannot express.
+    LdrImm32Idx {
+        rt: u8,
+        rn: u8,
+        imm8: u8,
+        pre_index: bool,
+        add: bool,
+        writeback: bool,
+    },
+    /// STR (immediate) T4: indexed forms with optional base writeback.
+    /// Mirror of [`Instruction::LdrImm32Idx`] for stores (`str.w rt,[rn],#imm`
+    /// and `str.w rt,[rn,#imm]!`), e.g. clang's pre-decrement stack pushes.
+    StrImm32Idx {
+        rt: u8,
+        rn: u8,
+        imm8: u8,
+        pre_index: bool,
+        add: bool,
+        writeback: bool,
+    },
     LdrbImm {
         rt: u8,
         rn: u8,
@@ -476,12 +500,14 @@ pub enum Instruction {
         rt2: u8,
         rn: u8,
         imm8: u32,
+        add_imm: bool,
     },
     Strd {
         rt: u8,
         rt2: u8,
         rn: u8,
         imm8: u32,
+        add_imm: bool,
     },
     Tbb {
         rn: u8,
@@ -959,6 +985,21 @@ pub fn decode_thumb_16(opcode: u16) -> Instruction {
             let rm = ((opcode >> 3) & 0x7) as u8;
             let rd = (opcode & 0x7) as u8;
             return Instruction::Sxtb { rd, rm };
+        }
+
+        // REV/REV16/REVSH (T1, 16-bit): 1011 1010 op Rm Rd
+        //   op=00 → REV  (0xBA00..0xBA3F)
+        //   op=01 → REV16 (0xBA40..0xBA7F)
+        //   op=11 → REVSH (0xBAC0..0xBAFF)
+        // Distinct from the 32-bit FA90 forms already handled in decode_32.
+        if (opcode & 0xFF00) == 0xBA00 {
+            let rm = ((opcode >> 3) & 0x7) as u8;
+            let rd = (opcode & 0x7) as u8;
+            return match (opcode >> 6) & 0x3 {
+                0b00 => Instruction::Rev { rd, rm },
+                0b01 => Instruction::Rev16 { rd, rm },
+                _ => Instruction::RevSh { rd, rm },
+            };
         }
 
         // CBZ/CBNZ (T1): 1011 op i 1 imm5 rn
@@ -1442,6 +1483,48 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
         }
     }
 
+    // LDR (immediate) T4: 1111 1000 0101 Rn | Rt 1 P U W imm8 -> F85x.
+    // h2 bit 11 == 1 marks the indexed/writeback (T4) form; distinguished from
+    // the LDR (register) T2 form (h2 bit 11 == 0). The plain positive-offset
+    // case (P=1,U=1,W=0) overlaps T3 semantics but is encoded here on F85x.
+    // Models `ldr.w pc, [sp], #4` (P=0,U=1,W=1) — the function-return idiom
+    // that was previously Unknown32, silently skipping the return branch.
+    if (h1 & 0xFFF0) == 0xF850 && (h2 & 0x0800) != 0 {
+        let rn = (h1 & 0xF) as u8;
+        let rt = ((h2 >> 12) & 0xF) as u8;
+        let pre_index = (h2 & 0x0400) != 0; // P
+        let add = (h2 & 0x0200) != 0; // U
+        let writeback = (h2 & 0x0100) != 0; // W
+        let imm8 = (h2 & 0xFF) as u8;
+        return Instruction::LdrImm32Idx {
+            rt,
+            rn,
+            imm8,
+            pre_index,
+            add,
+            writeback,
+        };
+    }
+
+    // STR (immediate) T4: 1111 1000 0100 Rn | Rt 1 P U W imm8 -> F84x.
+    // Same h2 bit-11 marker. Models `str.w rt,[rn],#imm` / `[rn,#imm]!`.
+    if (h1 & 0xFFF0) == 0xF840 && (h2 & 0x0800) != 0 {
+        let rn = (h1 & 0xF) as u8;
+        let rt = ((h2 >> 12) & 0xF) as u8;
+        let pre_index = (h2 & 0x0400) != 0;
+        let add = (h2 & 0x0200) != 0;
+        let writeback = (h2 & 0x0100) != 0;
+        let imm8 = (h2 & 0xFF) as u8;
+        return Instruction::StrImm32Idx {
+            rt,
+            rn,
+            imm8,
+            pre_index,
+            add,
+            writeback,
+        };
+    }
+
     // LDR.W (immediate) (T3): 1111 1000 1101 ... -> F8D..
     if (h1 & 0xFFF0) == 0xF8D0 {
         let rn = (h1 & 0xF) as u8;
@@ -1633,7 +1716,17 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
             if (h2 & 0x0F00) == 0x0F00 {
                 return Instruction::Unknown32(h1, h2);
             }
-            return Instruction::Ldrd { rt, rt2, rn, imm8 };
+            // U bit (h1[7]): 1 = add imm8*4, 0 = subtract. mbedTLS AES reads
+            // round keys via `ldrd Rt,Rt2,[Rn,#-imm]` (U=0); ignoring U read
+            // the wrong key and corrupted the cipher output.
+            let add_imm = (h1 & 0x80) != 0;
+            return Instruction::Ldrd {
+                rt,
+                rt2,
+                rn,
+                imm8,
+                add_imm,
+            };
         } else {
             // STREX (T1, B6.7.198) — distinguished from STRD the same
             // way. h2[15:12]=Rt (value), h2[11:8]=Rd (success flag);
@@ -1655,7 +1748,14 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
                 // Unlikely for STRD; treat as STREX.
                 return Instruction::Unknown32(h1, h2);
             }
-            return Instruction::Strd { rt, rt2, rn, imm8 };
+            let add_imm = (h1 & 0x80) != 0;
+            return Instruction::Strd {
+                rt,
+                rt2,
+                rn,
+                imm8,
+                add_imm,
+            };
         }
     }
 
@@ -1917,6 +2017,42 @@ mod tests {
         assert_eq!(
             decode_thumb_32(0xFA92, 0xF081),
             Instruction::Rev { rd: 0, rm: 2 }
+        );
+    }
+
+    #[test]
+    fn test_decode_rev_t1_16bit() {
+        // REV T1 (16-bit): `rev r3, r3` = 0xBA1B (0xBA00 | (rm=3<<3) | rd=3).
+        assert_eq!(decode_thumb_16(0xBA1B), Instruction::Rev { rd: 3, rm: 3 });
+        // REV16 T1: `rev16 r5, r5` = 0xBA6D (0xBA40 | (rm=5<<3) | rd=5).
+        assert_eq!(decode_thumb_16(0xBA6D), Instruction::Rev16 { rd: 5, rm: 5 });
+        // REVSH T1: `revsh r0, r1` = 0xBAC8 (0xBAC0 | (rm=1<<3) | rd=0).
+        assert_eq!(decode_thumb_16(0xBAC8), Instruction::RevSh { rd: 0, rm: 1 });
+    }
+
+    #[test]
+    fn test_decode_ldrd_negative_offset() {
+        // e951 0708 → ldrd r0, r7, [r1, #-32]  (U=0, subtract).
+        assert_eq!(
+            decode_thumb_32(0xE951, 0x0708),
+            Instruction::Ldrd {
+                rt: 0,
+                rt2: 7,
+                rn: 1,
+                imm8: 8,
+                add_imm: false
+            }
+        );
+        // e9d1 0708 → ldrd r0, r7, [r1, #32]  (U=1, add).
+        assert_eq!(
+            decode_thumb_32(0xE9D1, 0x0708),
+            Instruction::Ldrd {
+                rt: 0,
+                rt2: 7,
+                rn: 1,
+                imm8: 8,
+                add_imm: true
+            }
         );
     }
 

--- a/examples/h563-uds-bootloader/README.md
+++ b/examples/h563-uds-bootloader/README.md
@@ -1,0 +1,62 @@
+# H563 UDS OTA Bootloader Sim Smoke
+
+End-to-end smoke test for the STM32H563 dual-bank UDS OTA bootloader, driven
+entirely on-chip over FDCAN internal loopback.
+
+The firmware (`h563_uds_bootloader_sim.elf`) is built from
+`udslib/examples/h563_uds_bootloader/` with `SIM_TESTER=1`. That build links a
+baked-in tester (`sim_tester/sim_tester.c`) which, in one firmware image, runs
+both the UDS **server** (the bootloader) and a UDS **client** that injects the
+full OTA reprogramming sequence into the server over the loopback FDCAN bus:
+
+    DiagnosticSessionControl (0x10 02)
+      -> SecurityAccess seed/key (0x27 01 / 0x27 02, AES-128-CMAC, multi-byte key)
+      -> RoutineControl EraseMemory (0x31 01 FF00)
+      -> RequestDownload (0x34, inactive-bank app base, App-B image size)
+      -> TransferData x N (0x36, embedded App-B image)
+      -> RequestTransferExit (0x37)
+      -> RoutineControl CheckProgrammingDependencies (0x31 01 FF01)
+      -> RoutineControl ActivateSoftware (0x31 01 FF02, SWAP_BANK + reset)
+
+The App-B image is embedded as a C byte array (`sim_tester/app_b_image_blob.h`,
+generated from `app/app_b_image.bin`). Before the swap the tester first copies
+the bootloader (sectors 0-11) into bank 2 so the post-swap bank 1 view still
+boots a valid bootloader.
+
+## Running
+
+```
+cargo run -p labwired-cli -- test --script examples/h563-uds-bootloader/ota-smoke.yaml \
+  --output-dir out/h563-uds-bootloader --no-uart-stdout
+```
+
+## Building the firmware
+
+```
+UDSLIB_DIR=/path/to/udslib \
+  make -C /path/to/udslib/examples/h563_uds_bootloader/bootloader SIM_TESTER=1
+```
+
+The ELF is written to that example's `build/` directory; `ota-smoke.yaml`
+references it directly via a relative path.
+
+## Asserted milestones (pass)
+
+The smoke verifies the full OTA cycle end-to-end — handshake, download, verify,
+bank-swap, reset, and boot into the new app:
+
+- `BL-START` — bootloader entry
+- `BL-RECOVERY` — no valid active-bank app, server loop entered
+- `BL: UDS server ready`
+- `SIM: copy OK` — bootloader copied into the inactive bank
+- `BL: routine erase` / `BL: erasing inactive app` — EraseMemory routine ran
+- `BL: download armed` — RequestDownload accepted; DiagSession + SecurityAccess
+  (multi-frame ISO-TP AES-128-CMAC key) + Erase + RequestDownload all completed
+  with correct positive server responses
+- `OTA-WRITE-OK` — TransferData wrote the App-B image to the inactive bank
+- `OTA-VERIFY-OK` — image CRC check passed (`BL: image check PASS`)
+- `OTA-ACTIVATE` / `BL: marking inactive bank pending` / `BL: activate software`
+  — ActivateSoftware routine programmed `OPTSR_PRG.SWAP_BANK` and committed it
+  with `OPTCR.OPTSTRT`, which the FLASH model applies as a bank-swap + reset
+- `BL-JUMP` — the rebooted bootloader validated the swapped bank and jumped
+- `APP-B v2` — the freshly programmed application is running

--- a/examples/h563-uds-bootloader/ota-smoke.yaml
+++ b/examples/h563-uds-bootloader/ota-smoke.yaml
@@ -1,0 +1,24 @@
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "../../../udslib/examples/h563_uds_bootloader/bootloader/build/h563_uds_bootloader_sim.elf"
+limits:
+  # The full OTA flow (handshake → download → verify → activate → bank-swap →
+  # reset → boot APP-B) completes in ~440k steps; the new app then idles, so
+  # the run terminates on max_steps after every milestone has printed.
+  max_steps: 1000000
+assertions:
+  - uart_contains: "BL-START"
+  - uart_contains: "BL-RECOVERY"
+  - uart_contains: "BL: UDS server ready"
+  - uart_contains: "SIM: copy OK"
+  - uart_contains: "BL: routine erase"
+  - uart_contains: "BL: erasing inactive app"
+  - uart_contains: "BL: download armed"
+  - uart_contains: "OTA-WRITE-OK"
+  - uart_contains: "OTA-VERIFY-OK"
+  - uart_contains: "OTA-ACTIVATE"
+  - uart_contains: "BL: marking inactive bank pending"
+  - uart_contains: "BL: activate software"
+  - uart_contains: "BL-JUMP"
+  - uart_contains: "APP-B v2"

--- a/examples/h563-uds-bootloader/system.yaml
+++ b/examples/h563-uds-bootloader/system.yaml
@@ -1,0 +1,4 @@
+name: "h563-uds-bootloader"
+chip: "../../configs/chips/stm32h563.yaml"
+external_devices: []
+board_io: []


### PR DESCRIPTION
Adds an end-to-end simulation smoke for a dual-bank STM32H563 UDS OTA bootloader, plus three Cortex-M decode/execute paths the firmware needs that `main` did not yet handle. The decoder changes are additive; no existing instruction behavior changes.

The example runs the full reprogramming cycle on-chip over FDCAN internal loopback: DiagSession, SecurityAccess (real AES-CMAC), Erase, Download, TransferData, ActivateSoftware (hardware `SWAP_BANK` then reset), and boot into the freshly written bank. The smoke asserts the whole UART narrative and ends on `BL-JUMP` then `APP-B v2`.

Decode/execute gaps closed (each covered by decoder and executor unit tests):

1. REV/REV16/REVSH (T1, 16-bit, `0xBA00`-`0xBAFF`). `main` decoded only the 32-bit `FA90` forms, so the 16-bit forms fell through to `Unknown16` and byte-swaps were left stale.
2. LDRD/STRD (T1) U-bit. The executor always added the `imm8*4` offset. mbedTLS AES-128 reads round keys via `ldrd Rt,Rt2,[Rn,#-32]` (U=0), so it read the wrong address, the cipher output was corrupt, and the SecurityAccess key check never matched. Now decodes `add_imm` from `h1[7]` and subtracts when U=0.
3. LDR/STR (immediate) T4 indexed with writeback (`0xF85x`/`0xF84x`). The pre- and post-indexed forms decoded as `Unknown32`. `ldr.w pc, [sp], #4` is clang's function-return idiom; skipping it returned to the wrong address, which left `SWAP_BANK` cleared instead of set so the swap+reset never fired. Added `LdrImm32Idx`/`StrImm32Idx` covering pre/post-index, add/sub, and writeback; a load into PC routes through `branch_to`.

The FLASH bank-swap and reset model was already correct on `main`. Fix 3 is what lets the firmware actually set `SWAP_BANK`, after which the existing swap+reset path fires and the rebooted bootloader jumps into the new bank.

Companion to the udslib `examples/h563_uds_bootloader/` bootloader (w1ne/udslib#64).

Gates: `cargo test -p labwired-core --lib` 1407 passed; `cargo fmt --check` and `cargo clippy -D warnings` clean; smoke 14/14.
