### PR TITLE
feat(core): opt-in H5 FLASH fidelity gates — program write-buffer/errors + read-while-write (silicon-validated)

### DIFF
--- a/crates/core/src/bus/accessors.rs
+++ b/crates/core/src/bus/accessors.rs
@@ -98,13 +98,15 @@ impl crate::Bus for SystemBus {
             })
             .unwrap_or(0);
 
-        // OPT-IN H5 program-error fidelity gate. When a FLASH peripheral has the
-        // gate enabled, a program (a write that lands in the flash region) is
-        // validated against silicon programming rules BEFORE it commits: a
-        // non-16-byte-aligned target, or a target not in the erased (0xFF)
-        // state, sets the NSSR PGSERR/INCERR flags on the FLASH peripheral and
-        // the write is rejected (does not store), exactly as real H5 silicon
-        // behaves. `None` (gate off) ⇒ this block is skipped and the write
+        // OPT-IN H5 program write-buffer fidelity gate. When a FLASH peripheral
+        // has the gate enabled, a flash-region write feeds the silicon-true
+        // quad-word write-buffer state machine instead of committing directly:
+        // bytes accumulate into a 16-byte buffer (WBNE), commit only on a full
+        // aligned quad-word as the bitwise AND of new & existing (flash flips
+        // only 1→0, setting EOP), and a misaligned/inconsistent quad-word
+        // raises INCERR alone with no commit. The peripheral owns the NSSR
+        // status; the bus owns the flash backing memory, so the AND-commit is
+        // done here. `None` (gate off) ⇒ this block is skipped and the write
         // commits as before — byte-identical to prior behaviour.
         if let Some(flash_idx) = self.flash_error_flags_idx {
             // Resolve the flash-region offset this write targets, if any. The
@@ -118,20 +120,36 @@ impl crate::Bus for SystemBus {
                 None
             };
             if let Some(off) = region_off {
-                let current = self
-                    .flash
-                    .read_u8(self.flash.base_addr + off)
-                    .unwrap_or(0xFF);
-                let allowed = self.peripherals[flash_idx]
+                use crate::peripherals::flash::H5ProgAction;
+                let action = self.peripherals[flash_idx]
                     .dev
                     .as_any_mut()
                     .and_then(|a| a.downcast_mut::<crate::peripherals::flash::Flash>())
-                    .map(|f| f.h5_check_program(off, current))
-                    .unwrap_or(true);
-                if !allowed {
-                    // Program rejected: NSSR flag already set by the check; the
-                    // byte is not stored. Observers see no write.
-                    return Ok(());
+                    .map(|f| f.h5_program_byte(off, value));
+                match action {
+                    // Quad-word complete: read the 16 existing bytes, AND each
+                    // with the buffered value, write back. This is the only
+                    // store on the gate-on path.
+                    Some(H5ProgAction::Commit { base, bytes }) => {
+                        for (i, &nb) in bytes.iter().enumerate() {
+                            let qoff = base + i as u64;
+                            let existing = self
+                                .flash
+                                .read_u8(self.flash.base_addr + qoff)
+                                .unwrap_or(0xFF);
+                            self.flash
+                                .write_u8(self.flash.base_addr + qoff, existing & nb);
+                        }
+                        for observer in &self.observers {
+                            observer.on_memory_write(addr, old_value, value);
+                        }
+                        return Ok(());
+                    }
+                    // Buffered / inconsistent / not-programming: nothing stored
+                    // (NSSR status already updated by the state machine).
+                    Some(_) => return Ok(()),
+                    // Downcast failed (should not happen): fall through.
+                    None => {}
                 }
             }
         }

--- a/crates/core/src/bus/accessors.rs
+++ b/crates/core/src/bus/accessors.rs
@@ -98,6 +98,44 @@ impl crate::Bus for SystemBus {
             })
             .unwrap_or(0);
 
+        // OPT-IN H5 program-error fidelity gate. When a FLASH peripheral has the
+        // gate enabled, a program (a write that lands in the flash region) is
+        // validated against silicon programming rules BEFORE it commits: a
+        // non-16-byte-aligned target, or a target not in the erased (0xFF)
+        // state, sets the NSSR PGSERR/INCERR flags on the FLASH peripheral and
+        // the write is rejected (does not store), exactly as real H5 silicon
+        // behaves. `None` (gate off) ⇒ this block is skipped and the write
+        // commits as before — byte-identical to prior behaviour.
+        if let Some(flash_idx) = self.flash_error_flags_idx {
+            // Resolve the flash-region offset this write targets, if any. The
+            // backing buffer is addressed at `flash.base_addr`; the boot alias
+            // (addr < buffer len) mirrors the same offset.
+            let region_off = if self.flash.read_u8(addr).is_some() {
+                Some(addr - self.flash.base_addr)
+            } else if self.flash.base_addr != 0 && addr < self.flash.data.len() as u64 {
+                Some(addr) // boot-alias write: offset is addr itself
+            } else {
+                None
+            };
+            if let Some(off) = region_off {
+                let current = self
+                    .flash
+                    .read_u8(self.flash.base_addr + off)
+                    .unwrap_or(0xFF);
+                let allowed = self.peripherals[flash_idx]
+                    .dev
+                    .as_any_mut()
+                    .and_then(|a| a.downcast_mut::<crate::peripherals::flash::Flash>())
+                    .map(|f| f.h5_check_program(off, current))
+                    .unwrap_or(true);
+                if !allowed {
+                    // Program rejected: NSSR flag already set by the check; the
+                    // byte is not stored. Observers see no write.
+                    return Ok(());
+                }
+            }
+        }
+
         let flash_alias_write = self.flash.base_addr != 0
             && addr < self.flash.data.len() as u64
             && self.flash.write_u8(self.flash.base_addr + addr, value);

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -74,6 +74,7 @@ impl SystemBus {
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
             flash_models_ops: false,
+            flash_error_flags_idx: None,
         };
 
         let mut merged_peripherals = chip.peripherals.clone();

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2576,32 +2576,87 @@ peripherals:
         bus.read_u32(0x4002_2000 + NSSR_OFF).unwrap()
     }
 
-    #[test]
-    fn h5_gate_on_misaligned_program_rejected_sets_pgserr() {
+    /// Enable NSCR.PG on the H5 FLASH peripheral so the write-buffer machine
+    /// programs (silicon requires PG for a flash-region write to land).
+    fn h5_set_pg(bus: &mut SystemBus) {
         use crate::peripherals::flash::h5;
-        let mut bus = h5_flash_bus(true);
-        assert!(bus.flash_error_flags_idx.is_some(), "gate index cached");
-        // Program a byte at a non-16-byte-aligned flash offset (0x08000003).
-        bus.write_u8(0x0800_0003, 0x42).unwrap();
-        // Write rejected: flash byte still erased.
-        assert_eq!(bus.flash.read_u8(0x0800_0003), Some(0xFF));
-        let nssr = read_nssr(&bus);
-        assert_ne!(nssr & h5::NSSR_PGSERR, 0, "PGSERR set");
-        assert_ne!(nssr & h5::NSSR_INCERR, 0, "INCERR set");
+        bus.write_u32(0x4002_2000 + h5::NSCR_OFF, h5::NSCR_PG)
+            .unwrap();
     }
 
     #[test]
-    fn h5_gate_on_program_over_not_erased_rejected_sets_pgserr() {
+    fn h5_gate_on_full_quadword_commits_as_and() {
         use crate::peripherals::flash::h5;
         let mut bus = h5_flash_bus(true);
-        // First aligned program of an erased location succeeds.
-        bus.write_u8(0x0800_0010, 0xAA).unwrap();
-        assert_eq!(bus.flash.read_u8(0x0800_0010), Some(0xAA));
-        assert_eq!(read_nssr(&bus) & h5::NSSR_W1C_MASK, 0, "no flag yet");
-        // Re-programming the same (now non-0xFF) location is rejected.
-        bus.write_u8(0x0800_0010, 0xBB).unwrap();
-        assert_eq!(bus.flash.read_u8(0x0800_0010), Some(0xAA), "unchanged");
-        assert_ne!(read_nssr(&bus) & h5::NSSR_PGSERR, 0, "PGSERR set");
+        assert!(bus.flash_error_flags_idx.is_some(), "gate index cached");
+        h5_set_pg(&mut bus);
+        // Pre-load the quad-word at 0x08000020 with 0xAA in the first lane so the
+        // commit must AND with it (flash only flips 1→0). Write the lower 15
+        // lanes via the buffer first... but to exercise the AND we re-program a
+        // committed quad-word below; here verify a clean commit from erased.
+        for i in 0..16u64 {
+            bus.write_u8(0x0800_0020 + i, 0x33).unwrap();
+        }
+        // 0xFF (erased) & 0x33 = 0x33 — full quad-word committed.
+        for i in 0..16u64 {
+            assert_eq!(bus.flash.read_u8(0x0800_0020 + i), Some(0x33));
+        }
+        assert_ne!(read_nssr(&bus) & h5::NSSR_EOP, 0, "EOP set on commit");
+        assert_eq!(read_nssr(&bus) & h5::NSSR_WBNE, 0, "WBNE clear on commit");
+    }
+
+    #[test]
+    fn h5_gate_on_partial_quadword_buffers_no_commit() {
+        use crate::peripherals::flash::h5;
+        let mut bus = h5_flash_bus(true);
+        h5_set_pg(&mut bus);
+        // Only 4 of 16 bytes: still buffering, flash unchanged, WBNE set.
+        for i in 0..4u64 {
+            bus.write_u8(0x0800_0020 + i, 0x55).unwrap();
+            assert_eq!(bus.flash.read_u8(0x0800_0020 + i), Some(0xFF), "not yet");
+        }
+        assert_ne!(read_nssr(&bus) & h5::NSSR_WBNE, 0, "WBNE set");
+        assert_eq!(read_nssr(&bus) & h5::NSSR_EOP, 0, "no EOP");
+    }
+
+    #[test]
+    fn h5_gate_on_reprogram_committed_quadword_ands_no_pgserr() {
+        use crate::peripherals::flash::h5;
+        let mut bus = h5_flash_bus(true);
+        h5_set_pg(&mut bus);
+        // First program: 0xFF & 0xF0 = 0xF0.
+        for i in 0..16u64 {
+            bus.write_u8(0x0800_0040 + i, 0xF0).unwrap();
+        }
+        assert_eq!(bus.flash.read_u8(0x0800_0040), Some(0xF0));
+        // Clear EOP via NSCCR, then re-program the SAME (now-not-erased) word.
+        bus.write_u32(0x4002_2000 + h5::NSCCR_OFF, h5::NSSR_EOP)
+            .unwrap();
+        for i in 0..16u64 {
+            bus.write_u8(0x0800_0040 + i, 0x0F).unwrap();
+        }
+        // Re-program ALLOWED, result is the AND: 0xF0 & 0x0F = 0x00. No PGSERR.
+        assert_eq!(bus.flash.read_u8(0x0800_0040), Some(0x00), "AND of old&new");
+        assert_eq!(read_nssr(&bus) & h5::NSSR_PGSERR, 0, "no PGSERR over-write");
+        assert_ne!(read_nssr(&bus) & h5::NSSR_EOP, 0, "EOP set (success)");
+    }
+
+    #[test]
+    fn h5_gate_on_misaligned_run_sets_incerr_alone_no_commit() {
+        use crate::peripherals::flash::h5;
+        let mut bus = h5_flash_bus(true);
+        h5_set_pg(&mut bus);
+        // Start at base+4 (quad-word 0x20), then jump into the next quad-word
+        // (0x30) before completing — an inconsistent program run.
+        bus.write_u8(0x0800_0024, 0x11).unwrap();
+        assert_ne!(read_nssr(&bus) & h5::NSSR_WBNE, 0, "WBNE while partial");
+        bus.write_u8(0x0800_0030, 0x22).unwrap();
+        // INCERR alone, nothing committed (both targets stay erased).
+        assert_eq!(bus.flash.read_u8(0x0800_0024), Some(0xFF), "no commit");
+        assert_eq!(bus.flash.read_u8(0x0800_0030), Some(0xFF), "no commit");
+        let nssr = read_nssr(&bus);
+        assert_ne!(nssr & h5::NSSR_INCERR, 0, "INCERR set");
+        assert_eq!(nssr & h5::NSSR_PGSERR, 0, "INCERR alone (no PGSERR)");
     }
 
     #[test]
@@ -2609,12 +2664,14 @@ peripherals:
         use crate::peripherals::flash::h5;
         let mut bus = h5_flash_bus(false);
         assert!(bus.flash_error_flags_idx.is_none(), "gate off ⇒ no index");
-        // Misaligned + over-not-erased: both commit, no flag (old behaviour).
+        // No buffering, no flags: every byte commits straight through, even
+        // misaligned and over-not-erased (old byte-identical behaviour).
         bus.write_u8(0x0800_0003, 0x42).unwrap();
         assert_eq!(bus.flash.read_u8(0x0800_0003), Some(0x42));
         bus.write_u8(0x0800_0003, 0x99).unwrap();
         assert_eq!(bus.flash.read_u8(0x0800_0003), Some(0x99));
         assert_eq!(read_nssr(&bus) & h5::NSSR_W1C_MASK, 0, "no flag ever");
+        assert_eq!(read_nssr(&bus) & h5::NSSR_WBNE, 0, "no WBNE ever");
     }
 
     #[test]

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2674,6 +2674,273 @@ peripherals:
         assert_eq!(read_nssr(&bus) & h5::NSSR_WBNE, 0, "no WBNE ever");
     }
 
+    // ── H5 read-while-write fidelity gate (opt-in, default off) ─────────────
+
+    use crate::Cpu as _RwwCpuTrait;
+
+    /// Minimal CPU stub with a settable PC for the RWW Machine-level tests.
+    /// `step` is a no-op (the tests drive `apply_pending_flash_op` directly via
+    /// a manually recorded erase, so the CPU never needs to execute).
+    #[derive(Default)]
+    struct PcCpu {
+        pc: u32,
+    }
+
+    impl crate::Cpu for PcCpu {
+        fn reset(&mut self, _bus: &mut dyn crate::Bus) -> crate::SimResult<()> {
+            Ok(())
+        }
+        fn step(
+            &mut self,
+            _bus: &mut dyn crate::Bus,
+            _observers: &[std::sync::Arc<dyn crate::SimulationObserver>],
+            _config: &crate::SimulationConfig,
+        ) -> crate::SimResult<()> {
+            Ok(())
+        }
+        fn set_pc(&mut self, val: u32) {
+            self.pc = val;
+        }
+        fn get_pc(&self) -> u32 {
+            self.pc
+        }
+        fn set_sp(&mut self, _val: u32) {}
+        fn set_exception_pending(&mut self, _n: u32) {}
+        fn get_register(&self, _id: u8) -> u32 {
+            0
+        }
+        fn set_register(&mut self, _id: u8, _val: u32) {}
+        fn snapshot(&self) -> crate::snapshot::CpuSnapshot {
+            crate::snapshot::CpuSnapshot::Arm(crate::snapshot::ArmCpuSnapshot {
+                registers: vec![0; 16],
+                pc: self.pc,
+                xpsr: 0,
+                primask: false,
+                pending_exceptions: 0,
+                pending_exceptions_hi: Vec::new(),
+                vtor: 0,
+            })
+        }
+        fn apply_snapshot(&mut self, _snapshot: &crate::snapshot::CpuSnapshot) {}
+        fn get_register_names(&self) -> Vec<String> {
+            vec![]
+        }
+        fn index_of_register(&self, _name: &str) -> Option<u8> {
+            None
+        }
+    }
+
+    /// Build a bus with a 2 MiB flash region (two 1 MiB banks, as on the H563)
+    /// and an H5 FLASH register peripheral, with the opt-in read-while-write gate
+    /// set to `gate`. The flash is unlocked so a NSCR.SER|STRT write records an
+    /// erase op straight away.
+    fn h5_rww_bus(gate: bool) -> SystemBus {
+        use crate::peripherals::flash::h5;
+        let mut flash = LinearMemory::new((2 * h5::BANK_SIZE) as usize, h5::FLASH_BASE);
+        flash.data.iter_mut().for_each(|b| *b = 0xFF);
+        let mut bus = SystemBus {
+            flash,
+            ram: LinearMemory::new(0x1000, 0x2000_0000),
+            extra_mem: Vec::new(),
+            peripherals: vec![PeripheralEntry {
+                name: "flash".to_string(),
+                base: 0x4002_2000,
+                size: 0x400,
+                irq: None,
+                dev: Box::new(
+                    crate::peripherals::flash::Flash::new_with_layout(
+                        crate::peripherals::flash::FlashRegisterLayout::Stm32H5,
+                    )
+                    .with_read_while_write(gate),
+                ),
+                ticks_remaining: 0,
+                generation: 0,
+                clock_gate: None,
+            }],
+            nvic: None,
+            observers: Vec::new(),
+            config: crate::SimulationConfig::default(),
+            bit_band_enabled: false,
+            pending_cpu_irqs: [0; 2],
+            dport_idx: None,
+            rcc_idx: None,
+            clock_gating_bypass: false,
+            flash_thunks: std::collections::HashMap::new(),
+            peripheral_ranges: Vec::new(),
+            peripheral_hint: Cell::new(None),
+            last_gpio_in: [0; 2],
+            current_cycle: 0,
+            pending_schedule: Vec::new(),
+            legacy_walk_disabled: false,
+            hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
+            can_uds_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
+            flash_models_ops: false,
+            flash_error_flags_idx: None,
+        };
+        bus.rebuild_peripheral_ranges();
+        bus
+    }
+
+    /// Unlock NSKEYR then record a sector erase of `bank` (BKSEL logical) on the
+    /// bus, so a subsequent `apply_pending_flash_op` drains it.
+    fn h5_record_erase(bus: &mut SystemBus, bank: u8, sector: u32) {
+        use crate::peripherals::flash::h5;
+        bus.write_u32(0x4002_2000 + h5::NSKEYR_OFF, 0x4567_0123)
+            .unwrap();
+        bus.write_u32(0x4002_2000 + h5::NSKEYR_OFF, 0xCDEF_89AB)
+            .unwrap();
+        let mut nscr = h5::NSCR_SER | (sector << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
+        if bank == 1 {
+            nscr |= h5::NSCR_BKSEL;
+        }
+        bus.write_u32(0x4002_2000 + h5::NSCR_OFF, nscr).unwrap();
+    }
+
+    #[test]
+    fn rww_gate_on_same_bank_erase_faults() {
+        use crate::peripherals::flash::h5;
+        let mut cpu = PcCpu::default();
+        // PC executing from bank 1 (boot view at 0x08000000), sector 11.
+        cpu.set_pc(0x0801_6000);
+        let mut bus = h5_rww_bus(true);
+        h5_record_erase(&mut bus, 0, 11); // erase bank 1 (BKSEL=0), sector 11
+        let mut machine = crate::Machine::new(cpu, bus);
+        let err = machine
+            .apply_pending_flash_op()
+            .expect_err("same-bank erase under the RWW gate must fault");
+        match err {
+            crate::SimulationError::Other(msg) => {
+                assert!(msg.contains("RWW"), "reason names the RWW violation: {msg}");
+                assert!(
+                    msg.contains("SRAM"),
+                    "reason tells firmware to use SRAM: {msg}"
+                );
+            }
+            other => panic!("expected SimulationError::Other, got {other:?}"),
+        }
+        // Faulted before the fill: the erased sector is NOT cleared to 0xFF by us
+        // (it was already 0xFF), but more importantly the op did not silently
+        // "succeed" — the error propagated.
+        let _ = h5::BANK_SIZE;
+    }
+
+    #[test]
+    fn rww_gate_on_other_bank_erase_proceeds() {
+        use crate::peripherals::flash::h5;
+        let mut cpu = PcCpu::default();
+        // PC in bank 1; erase targets bank 2 — the normal cross-bank OTA case.
+        cpu.set_pc(0x0801_6000);
+        let mut bus = h5_rww_bus(true);
+        // Dirty the bank-2 boot-state sector so we can see the erase land.
+        let off = h5::BANK_SIZE + 11 * h5::SECTOR_SIZE;
+        bus.flash.write_u8(h5::FLASH_BASE + off, 0x00);
+        h5_record_erase(&mut bus, 1, 11); // erase bank 2 (BKSEL=1)
+        let mut machine = crate::Machine::new(cpu, bus);
+        machine
+            .apply_pending_flash_op()
+            .expect("cross-bank erase must proceed");
+        assert_eq!(
+            machine.bus.flash.read_u8(h5::FLASH_BASE + off),
+            Some(0xFF),
+            "bank-2 sector erased to 0xFF"
+        );
+    }
+
+    #[test]
+    fn rww_gate_on_pc_in_sram_never_faults() {
+        // The intended production layout: the flash routine runs from SRAM, so
+        // PC is not in any flash bank — even a same-(logical-)bank erase is fine.
+        use crate::peripherals::flash::h5;
+        let mut cpu = PcCpu::default();
+        cpu.set_pc(0x2000_0100); // SRAM
+        let mut bus = h5_rww_bus(true);
+        h5_record_erase(&mut bus, 0, 11);
+        let mut machine = crate::Machine::new(cpu, bus);
+        machine
+            .apply_pending_flash_op()
+            .expect("erase from a SRAM-resident routine must proceed");
+        let _ = h5::FLASH_BASE;
+    }
+
+    #[test]
+    fn rww_gate_on_respects_swap_bank_mapping() {
+        // After a SWAP_BANK, the physical second bank answers at 0x08000000.
+        // PC at 0x08000000 is then in physical bank 2; an erase that lands in
+        // that physical bank (BKSEL=0, which now maps to physical bank 2) must
+        // fault, while BKSEL=1 (physical bank 1, the inactive one) proceeds.
+        use crate::peripherals::flash::h5;
+
+        // Same-physical-bank under swap → fault.
+        {
+            let mut cpu = PcCpu::default();
+            cpu.set_pc(0x0800_4000); // bank presented at 0x08000000
+            let mut bus = h5_rww_bus(true);
+            // Toggle the FLASH's swap state directly to model an applied swap.
+            let idx = bus.find_peripheral_index_by_name("flash").unwrap();
+            bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<crate::peripherals::flash::Flash>())
+                .unwrap()
+                .mark_swapped();
+            h5_record_erase(&mut bus, 0, 2); // BKSEL=0 → physical bank 2 under swap
+            let mut machine = crate::Machine::new(cpu, bus);
+            let err = machine
+                .apply_pending_flash_op()
+                .expect_err("swapped: BKSEL=0 erase hits PC's physical bank");
+            assert!(matches!(err, crate::SimulationError::Other(_)));
+        }
+
+        // Cross-physical-bank under swap → proceeds.
+        {
+            let mut cpu = PcCpu::default();
+            cpu.set_pc(0x0800_4000);
+            let mut bus = h5_rww_bus(true);
+            let idx = bus.find_peripheral_index_by_name("flash").unwrap();
+            bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<crate::peripherals::flash::Flash>())
+                .unwrap()
+                .mark_swapped();
+            // BKSEL=1 → physical bank 1, which sits at buffer offset 0..1 MiB?
+            // No: under swap, logical bank 1 maps to physical bank 0, the bank
+            // NOT presented at 0x08000000 — the cross-bank case.
+            let off = h5::BANK_SIZE + 2 * h5::SECTOR_SIZE;
+            bus.flash.write_u8(h5::FLASH_BASE + off, 0x00);
+            h5_record_erase(&mut bus, 1, 2);
+            let mut machine = crate::Machine::new(cpu, bus);
+            machine
+                .apply_pending_flash_op()
+                .expect("swapped: cross-physical-bank erase proceeds");
+        }
+    }
+
+    #[test]
+    fn rww_gate_off_same_bank_erase_succeeds_silently() {
+        // Default behaviour (gate off): a same-bank erase succeeds, byte-
+        // identical to before this gate existed.
+        use crate::peripherals::flash::h5;
+        let mut cpu = PcCpu::default();
+        cpu.set_pc(0x0801_6000);
+        let mut bus = h5_rww_bus(false);
+        let off = 11 * h5::SECTOR_SIZE;
+        bus.flash.write_u8(h5::FLASH_BASE + off, 0x00);
+        h5_record_erase(&mut bus, 0, 11);
+        let mut machine = crate::Machine::new(cpu, bus);
+        machine
+            .apply_pending_flash_op()
+            .expect("gate off: same-bank erase succeeds");
+        assert_eq!(
+            machine.bus.flash.read_u8(h5::FLASH_BASE + off),
+            Some(0xFF),
+            "gate off: sector erased to 0xFF as before"
+        );
+    }
+
     #[test]
     fn test_peripheral_range_index_lookup() {
         let mut bus = SystemBus {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -169,6 +169,15 @@ pub struct SystemBus {
     /// `requires_cycle_accurate` — called per run-loop iteration — never scans
     /// peripherals. `false` on every bus without an H5 op-modeling FLASH.
     flash_models_ops: bool,
+    /// Index of the FLASH register peripheral whose opt-in H5 program-error
+    /// fidelity gate is enabled, if any. Cached in `rebuild_peripheral_ranges`
+    /// (same staleness contract as `rcc_idx`). `None` on every bus where the
+    /// gate is off — the common case — so the flash-region write path stays
+    /// byte-identical to prior behaviour. When `Some(idx)`, a program (a write
+    /// into the flash region) is validated against H5 silicon programming rules
+    /// before committing, and `peripherals[idx]` (the `Flash`) records the
+    /// resulting NSSR error flags.
+    flash_error_flags_idx: Option<usize>,
 }
 
 pub struct CanDiagnosticTester {
@@ -973,6 +982,7 @@ impl SystemBus {
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
             flash_models_ops: false,
+            flash_error_flags_idx: None,
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -1010,6 +1020,7 @@ impl SystemBus {
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
             flash_models_ops: false,
+            flash_error_flags_idx: None,
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -2492,6 +2503,7 @@ peripherals:
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
             flash_models_ops: false,
+            flash_error_flags_idx: None,
         };
 
         bus.flash.write_u8(0x0800_0000, 0x12);
@@ -2504,6 +2516,105 @@ peripherals:
         // Write through alias and verify backing flash changed.
         bus.write_u8(0x0000_0001, 0xAB).unwrap();
         assert_eq!(bus.flash.read_u8(0x0800_0001), Some(0xAB));
+    }
+
+    /// Build a bus with a 1 KiB flash region (erased to 0xFF, like real silicon
+    /// after erase) and an H5 FLASH register peripheral at 0x4002_2000, with the
+    /// opt-in program-error gate set to `gate`.
+    fn h5_flash_bus(gate: bool) -> SystemBus {
+        let mut flash = LinearMemory::new(0x400, 0x0800_0000);
+        // Erased state is all-ones; the gate's not-erased check keys off this.
+        flash.data.iter_mut().for_each(|b| *b = 0xFF);
+        let mut bus = SystemBus {
+            flash,
+            ram: LinearMemory::new(256, 0x2000_0000),
+            extra_mem: Vec::new(),
+            peripherals: vec![PeripheralEntry {
+                name: "flash".to_string(),
+                base: 0x4002_2000,
+                size: 0x400,
+                irq: None,
+                dev: Box::new(
+                    crate::peripherals::flash::Flash::new_with_layout(
+                        crate::peripherals::flash::FlashRegisterLayout::Stm32H5,
+                    )
+                    .with_error_flags(gate),
+                ),
+                ticks_remaining: 0,
+                generation: 0,
+                clock_gate: None,
+            }],
+            nvic: None,
+            observers: Vec::new(),
+            config: crate::SimulationConfig::default(),
+            bit_band_enabled: false,
+            pending_cpu_irqs: [0; 2],
+            dport_idx: None,
+            rcc_idx: None,
+            clock_gating_bypass: false,
+            flash_thunks: std::collections::HashMap::new(),
+            peripheral_ranges: Vec::new(),
+            peripheral_hint: Cell::new(None),
+            last_gpio_in: [0; 2],
+            current_cycle: 0,
+            pending_schedule: Vec::new(),
+            legacy_walk_disabled: false,
+            hcsr04: Vec::new(),
+            can_diagnostic_testers: Vec::new(),
+            can_uds_testers: Vec::new(),
+            esp32c3_irq_routing: false,
+            riscv_irq_lines: 0,
+            flash_models_ops: false,
+            flash_error_flags_idx: None,
+        };
+        bus.rebuild_peripheral_ranges();
+        bus
+    }
+
+    fn read_nssr(bus: &SystemBus) -> u32 {
+        use crate::peripherals::flash::h5::NSSR_OFF;
+        bus.read_u32(0x4002_2000 + NSSR_OFF).unwrap()
+    }
+
+    #[test]
+    fn h5_gate_on_misaligned_program_rejected_sets_pgserr() {
+        use crate::peripherals::flash::h5;
+        let mut bus = h5_flash_bus(true);
+        assert!(bus.flash_error_flags_idx.is_some(), "gate index cached");
+        // Program a byte at a non-16-byte-aligned flash offset (0x08000003).
+        bus.write_u8(0x0800_0003, 0x42).unwrap();
+        // Write rejected: flash byte still erased.
+        assert_eq!(bus.flash.read_u8(0x0800_0003), Some(0xFF));
+        let nssr = read_nssr(&bus);
+        assert_ne!(nssr & h5::NSSR_PGSERR, 0, "PGSERR set");
+        assert_ne!(nssr & h5::NSSR_INCERR, 0, "INCERR set");
+    }
+
+    #[test]
+    fn h5_gate_on_program_over_not_erased_rejected_sets_pgserr() {
+        use crate::peripherals::flash::h5;
+        let mut bus = h5_flash_bus(true);
+        // First aligned program of an erased location succeeds.
+        bus.write_u8(0x0800_0010, 0xAA).unwrap();
+        assert_eq!(bus.flash.read_u8(0x0800_0010), Some(0xAA));
+        assert_eq!(read_nssr(&bus) & h5::NSSR_W1C_MASK, 0, "no flag yet");
+        // Re-programming the same (now non-0xFF) location is rejected.
+        bus.write_u8(0x0800_0010, 0xBB).unwrap();
+        assert_eq!(bus.flash.read_u8(0x0800_0010), Some(0xAA), "unchanged");
+        assert_ne!(read_nssr(&bus) & h5::NSSR_PGSERR, 0, "PGSERR set");
+    }
+
+    #[test]
+    fn h5_gate_off_commits_every_program_with_no_flag() {
+        use crate::peripherals::flash::h5;
+        let mut bus = h5_flash_bus(false);
+        assert!(bus.flash_error_flags_idx.is_none(), "gate off ⇒ no index");
+        // Misaligned + over-not-erased: both commit, no flag (old behaviour).
+        bus.write_u8(0x0800_0003, 0x42).unwrap();
+        assert_eq!(bus.flash.read_u8(0x0800_0003), Some(0x42));
+        bus.write_u8(0x0800_0003, 0x99).unwrap();
+        assert_eq!(bus.flash.read_u8(0x0800_0003), Some(0x99));
+        assert_eq!(read_nssr(&bus) & h5::NSSR_W1C_MASK, 0, "no flag ever");
     }
 
     #[test]
@@ -2555,6 +2666,7 @@ peripherals:
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
             flash_models_ops: false,
+            flash_error_flags_idx: None,
         };
 
         bus.rebuild_peripheral_ranges();
@@ -2620,6 +2732,7 @@ peripherals:
             esp32c3_irq_routing: false,
             riscv_irq_lines: 0,
             flash_models_ops: false,
+            flash_error_flags_idx: None,
         };
         bus.rebuild_peripheral_ranges();
 

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -149,6 +149,15 @@ impl SystemBus {
                 .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
                 .is_some_and(|f| f.models_ops())
         });
+        // Cache the index of a FLASH peripheral whose opt-in H5 program-error
+        // gate is on, so the flash-region write path can validate programs
+        // without scanning. `None` (gate off) ⇒ that path is unchanged.
+        self.flash_error_flags_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
+                .is_some_and(|f| f.h5_error_flags_enabled())
+        });
     }
 
     pub fn refresh_peripheral_index(&mut self) {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -958,12 +958,40 @@ impl<C: Cpu> Machine<C> {
     /// run loop clamps its batch to 1 when `requires_cycle_accurate()` is true
     /// (which an H5 op-modeling FLASH forces), preserving the one-op-per-
     /// instruction invariant and the correct erase-before-program ordering.
-    fn apply_pending_flash_op(&mut self) -> SimResult<()> {
+    pub(crate) fn apply_pending_flash_op(&mut self) -> SimResult<()> {
         if let Some(op) = self.drain_flash_op() {
             use crate::peripherals::flash::h5;
             use crate::peripherals::flash::FlashOp;
             match op {
                 FlashOp::EraseSector { bank, sector } => {
+                    // OPT-IN read-while-write fidelity gate (H5 only, default
+                    // off). On real STM32H563 silicon a bank cannot be fetched
+                    // from while it is being erased — code running from that bank
+                    // stalls and cannot make progress, so production flash
+                    // routines run from SRAM. When the gate is on, an erase of
+                    // the SAME physical bank the CPU is currently executing from
+                    // is an unrecoverable access fault rather than a silent
+                    // success. The bank comparison is SWAP_BANK-aware: both the
+                    // BKSEL logical erase bank and PC's bank are mapped to a
+                    // physical bank through the active swap state (see
+                    // `Flash::rww_erase_violates`). Gate off ⇒ this branch is
+                    // skipped entirely and the erase proceeds as before.
+                    let pc = self.cpu.get_pc() as u64;
+                    let in_flash =
+                        (h5::FLASH_BASE..h5::FLASH_BASE + 2 * h5::BANK_SIZE).contains(&pc);
+                    if let Some(flash) = self.flash_peripheral() {
+                        if flash.h5_rww_enabled()
+                            && in_flash
+                            && flash.rww_erase_violates(bank, pc - h5::FLASH_BASE)
+                        {
+                            let phys = flash.physical_bank_of_offset(pc - h5::FLASH_BASE);
+                            return Err(SimulationError::Other(format!(
+                                "flash RWW violation: erase of bank {phys} while executing \
+                                 from bank {phys} (PC={pc:#010x}) — run the flash routine \
+                                 from SRAM"
+                            )));
+                        }
+                    }
                     let offset = (bank as u64) * h5::BANK_SIZE + (sector as u64) * h5::SECTOR_SIZE;
                     self.bus.flash.fill(offset, h5::SECTOR_SIZE, 0xFF);
                     tracing::debug!(
@@ -987,6 +1015,12 @@ impl<C: Cpu> Machine<C> {
                         self.bus.flash.data.len(),
                         2 * h5::BANK_SIZE
                     );
+                    // Record the swap so the RWW bank mapping reflects the new
+                    // active view (the physical second bank now answers at
+                    // 0x08000000). No-op for the gate-off path beyond a bool.
+                    if let Some(flash) = self.flash_peripheral_mut() {
+                        flash.mark_swapped();
+                    }
                     tracing::debug!("FLASH SwapAndReset: banks swapped, resetting CPU");
                     self.reset()?;
                 }
@@ -1160,6 +1194,30 @@ impl<C: Cpu> Machine<C> {
             .as_any()
             .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
             .and_then(|f| f.drain_pending_op())
+    }
+
+    /// Borrow the H5 FLASH peripheral, if one is on the bus. Used by the
+    /// read-while-write gate to query the swap state / bank mapping.
+    fn flash_peripheral(&self) -> Option<&crate::peripherals::flash::Flash> {
+        let idx = self.flash_index?;
+        self.bus
+            .peripherals
+            .get(idx)?
+            .dev
+            .as_any()
+            .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
+    }
+
+    /// Mutably borrow the FLASH peripheral, if one is on the bus. Used to record
+    /// the applied SWAP_BANK so the RWW bank mapping tracks the active view.
+    fn flash_peripheral_mut(&mut self) -> Option<&mut crate::peripherals::flash::Flash> {
+        let idx = self.flash_index?;
+        self.bus
+            .peripherals
+            .get_mut(idx)?
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<crate::peripherals::flash::Flash>())
     }
 
     pub fn snapshot(&self) -> snapshot::MachineSnapshot {

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -121,14 +121,48 @@ pub struct Flash {
     key_state: KeyUnlockState,
     optkey_state: KeyUnlockState,
 
-    // OPT-IN fidelity gate (H5 only). When true, a program (a write into the
-    // flash region) that violates silicon programming rules — non-16-byte
-    // aligned target, or a target not in the erased (0xFF) state — sets the
-    // NSSR PGSERR/INCERR error flags and the write is rejected. Default false:
-    // gate off ⇒ byte-identical to prior behaviour (every program committed,
-    // no flag). Mirrors the per-peripheral opt-in pattern (clock-gating).
+    // OPT-IN fidelity gate (H5 only). When true, a flash-region write is fed
+    // through the silicon-true write-buffer state machine (see
+    // [`Flash::h5_program_byte`]): writes accumulate into a 16-byte quad-word
+    // buffer and commit (as the bitwise AND of new & existing) only on a full
+    // aligned quad-word, setting EOP; a misaligned/inconsistent quad-word
+    // raises INCERR alone and commits nothing. Default false: gate off ⇒
+    // byte-identical to prior behaviour (every write commits, no buffering, no
+    // flag). Mirrors the per-peripheral opt-in pattern (clock-gating).
     #[serde(default)]
     error_flags: bool,
+
+    // H5 write-buffer state. `Some(base)` means a quad-word program is in
+    // progress at the 16-aligned offset `base`; `written` marks which of the
+    // 16 bytes have been supplied, `bytes` holds the buffered values. Only used
+    // when the gate is on and NSCR.PG is set. Resets to empty on snapshot
+    // restore (a half-written quad-word is never persisted on real silicon).
+    #[serde(skip)]
+    h5_wbuf: Option<H5WriteBuffer>,
+}
+
+/// In-progress H5 quad-word write buffer (16 bytes at a 16-aligned base).
+#[derive(Debug, Clone, Copy)]
+struct H5WriteBuffer {
+    base: u64,
+    written: [bool; 16],
+    bytes: [u8; 16],
+}
+
+/// Outcome of feeding one flash-region byte to the H5 write-buffer state
+/// machine ([`Flash::h5_program_byte`]). The bus acts on this:
+/// * `Buffered`     — byte accepted into the pending quad-word; commit nothing.
+/// * `Commit`       — quad-word complete; the bus reads the 16 existing bytes
+///   at `base`, ANDs each with `bytes[i]` (flash only flips 1→0), writes back.
+/// * `Inconsistent` — misaligned/inconsistent quad-word; INCERR already set,
+///   buffer discarded; commit nothing.
+/// * `NotProgramming` — gate on but NSCR.PG clear; no programming occurs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum H5ProgAction {
+    Buffered,
+    Commit { base: u64, bytes: [u8; 16] },
+    Inconsistent,
+    NotProgramming,
 }
 
 #[derive(Debug, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -184,6 +218,7 @@ impl Flash {
             key_state: KeyUnlockState::Locked,
             optkey_state: KeyUnlockState::Locked,
             error_flags: false,
+            h5_wbuf: None,
         }
     }
 
@@ -202,42 +237,78 @@ impl Flash {
         self.error_flags && matches!(self.layout, FlashRegisterLayout::Stm32H5)
     }
 
-    /// H5 program-error check for a single byte write into the flash region.
+    /// Feed one flash-region byte write into the H5 write-buffer state machine.
     ///
     /// `flash_offset` is the byte offset within the flash bank (absolute addr
-    /// minus the flash base); `current_byte` is the value currently stored at
-    /// that offset (the erased state is 0xFF). Returns `true` when the program
-    /// is allowed to commit, `false` when it violates a silicon programming
-    /// rule — in which case the corresponding NSSR sticky flags are set and the
-    /// caller must NOT commit the write (a misaligned / over-not-erased
-    /// quad-word program does not store on real silicon).
+    /// minus the flash base). Returns the [`H5ProgAction`] the bus must apply:
+    /// it owns the flash backing memory, so this peripheral only tracks the
+    /// pending quad-word and the NSSR status; the commit (read 16 / AND /
+    /// write back) happens on the bus side.
+    ///
+    /// Silicon model (verified NUCLEO-H563ZI, 2026-06-22):
+    ///   * NSCR.PG must be set, else `NotProgramming` (no commit, no flag).
+    ///   * Writes accumulate into a 16-byte quad-word buffer at the 16-aligned
+    ///     base. WBNE is set while the buffer is partial.
+    ///   * A full aligned quad-word commits as new & existing (flash flips only
+    ///     1→0), sets EOP, clears WBNE, clears the buffer.
+    ///   * A misaligned / inconsistent quad-word — a write that targets a
+    ///     different quad-word base than the in-progress one before it
+    ///     completes, or a first write not at the 16-aligned base — raises
+    ///     INCERR alone, discards the buffer, commits nothing.
+    ///   * Program-over-not-erased is NOT an error here; the AND models it.
     ///
     /// Only meaningful when [`h5_error_flags_enabled`](Self::h5_error_flags_enabled)
     /// is true; with the gate off the bus never calls this and every write
-    /// commits, exactly as before.
-    ///
-    /// Rules (RM0481 §7):
-    ///   * target not 16-byte (quad-word) aligned → PGSERR + INCERR
-    ///   * target not in the erased (0xFF) state    → PGSERR
-    ///
-    /// WRPERR (write-protected/locked region) is intentionally out of scope:
-    /// this model does not yet track per-region write protection, so faking it
-    /// would be silicon-inaccurate.
-    pub fn h5_check_program(&mut self, flash_offset: u64, current_byte: u8) -> bool {
+    /// commits straight through, exactly as before.
+    pub fn h5_program_byte(&mut self, flash_offset: u64, value: u8) -> H5ProgAction {
         if !self.h5_error_flags_enabled() {
-            return true;
+            return H5ProgAction::Buffered; // unreachable: bus gates on the index
         }
-        let mut ok = true;
-        if flash_offset % h5::PROG_GRANULARITY != 0 {
-            // Misaligned quad-word program: sequence + inconsistency error.
-            self.sr |= h5::NSSR_PGSERR | h5::NSSR_INCERR;
-            ok = false;
-        } else if current_byte != 0xFF {
-            // Program over a location not erased to all-ones.
-            self.sr |= h5::NSSR_PGSERR;
-            ok = false;
+        // PG (NSCR.PG, bit 1) must be set for a flash-region write to program.
+        // Silicon detail for a PG-clear write is unverified on this part, so
+        // the simplest faithful choice is taken: no commit, no flag. (A real
+        // part would typically ignore or fault the write; we conservatively
+        // drop it rather than invent a flag.)
+        if self.cr & h5::NSCR_PG == 0 {
+            return H5ProgAction::NotProgramming;
         }
-        ok
+
+        let base = flash_offset & !(h5::PROG_GRANULARITY - 1);
+        let lane = (flash_offset - base) as usize;
+
+        // A write that jumps to a different quad-word while one is still partial
+        // is an inconsistent program run: INCERR alone, discard, commit nothing.
+        if let Some(buf) = self.h5_wbuf {
+            if buf.base != base {
+                self.h5_wbuf = None;
+                self.sr = (self.sr & !h5::NSSR_WBNE) | h5::NSSR_INCERR;
+                return H5ProgAction::Inconsistent;
+            }
+        }
+
+        let buf = self.h5_wbuf.get_or_insert(H5WriteBuffer {
+            base,
+            written: [false; 16],
+            bytes: [0xFF; 16],
+        });
+        buf.written[lane] = true;
+        buf.bytes[lane] = value;
+
+        if buf.written.iter().all(|&w| w) {
+            // Full aligned quad-word: commit (bus ANDs with existing), set EOP.
+            let bytes = buf.bytes;
+            let commit_base = buf.base;
+            self.h5_wbuf = None;
+            self.sr = (self.sr & !h5::NSSR_WBNE) | h5::NSSR_EOP;
+            H5ProgAction::Commit {
+                base: commit_base,
+                bytes,
+            }
+        } else {
+            // Partial quad-word: WBNE live, nothing committed, no error.
+            self.sr |= h5::NSSR_WBNE;
+            H5ProgAction::Buffered
+        }
     }
 
     // (legacy `new()` body replaced; kept as the no-op below for the
@@ -268,6 +339,7 @@ impl Flash {
             key_state: KeyUnlockState::Locked,
             optkey_state: KeyUnlockState::Locked,
             error_flags: false,
+            h5_wbuf: None,
         }
     }
 
@@ -383,11 +455,15 @@ impl Flash {
                             .set(Some(FlashOp::EraseSector { bank, sector }));
                     }
                 }
-                // NSSR error flags are sticky / write-1-to-clear. Firmware (or a
-                // test) clears WRPERR/PGSERR/INCERR by writing 1 to the bit.
-                // BSY and other read-only status bits are unaffected. Mirrors the
-                // L4 SR rc_w1 handling below.
-                h5::NSSR_OFF => self.sr &= !(value & h5::NSSR_W1C_MASK),
+                // NSSR is read-only status on H5: writing it does NOT clear the
+                // flags (verified on silicon — NSSR<-0x20 left EOP/error set).
+                // Flags are cleared via NSCCR (0x30) below. Accept the write,
+                // change nothing.
+                h5::NSSR_OFF => {}
+                // NSCCR @ 0x30 — clear register. Writing 1 to a bit clears the
+                // matching sticky flag in NSSR (EOP/WRPERR/PGSERR/STRBERR/
+                // INCERR). WBNE/BSY are live status, not clearable here.
+                h5::NSCCR_OFF => self.sr &= !(value & h5::NSSR_W1C_MASK),
                 h5::OPTSR_PRG_OFF => self.optsr_prg = value,
                 // OPTSTRT (bit 1) requires the OPTION-key (OPTKEYR), not the flash
                 // key (NSKEYR): option-byte programming is a separate unlock domain
@@ -632,11 +708,14 @@ mod h5_erase_swap_tests {
 #[cfg(test)]
 mod h5_program_error_tests {
     use super::h5;
-    use super::{Flash, FlashRegisterLayout};
+    use super::{Flash, FlashRegisterLayout, H5ProgAction};
     use crate::Peripheral;
 
     fn h5_gate_on() -> Flash {
-        Flash::new_with_layout(FlashRegisterLayout::Stm32H5).with_error_flags(true)
+        // Gate on + PG set: write-buffer programming is armed.
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5).with_error_flags(true);
+        f.write_u32(h5::NSCR_OFF, h5::NSCR_PG).unwrap();
+        f
     }
 
     fn nssr(f: &Flash) -> u32 {
@@ -648,65 +727,90 @@ mod h5_program_error_tests {
             | (b(h5::NSSR_OFF + 3) << 24)
     }
 
-    #[test]
-    fn gate_off_program_commits_and_sets_no_flag() {
-        // Gate OFF (default) ⇒ misaligned, over-not-erased: still allowed,
-        // no NSSR flag. This is the byte-identical-to-before path.
-        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
-        assert!(!f.h5_error_flags_enabled());
-        // misaligned offset, current byte not erased — both rule violations
-        assert!(f.h5_check_program(0x3, 0x00));
-        assert_eq!(nssr(&f), 0, "gate off must never set an NSSR flag");
+    /// Program a full aligned quad-word at `base` byte-by-byte, returning the
+    /// action from the final (16th) byte (which should be a Commit).
+    fn program_full_quadword(f: &mut Flash, base: u64, fill: u8) -> H5ProgAction {
+        let mut last = H5ProgAction::Buffered;
+        for i in 0..16u64 {
+            last = f.h5_program_byte(base + i, fill);
+        }
+        last
     }
 
     #[test]
-    fn misaligned_program_sets_pgserr_incerr_and_rejects() {
+    fn partial_quadword_sets_wbne_no_commit_no_error() {
         let mut f = h5_gate_on();
-        // offset 0x4 is 4-byte but NOT 16-byte (quad-word) aligned
-        let allowed = f.h5_check_program(0x4, 0xFF);
-        assert!(!allowed, "misaligned program must be rejected");
-        assert_ne!(nssr(&f) & h5::NSSR_PGSERR, 0, "PGSERR must be set");
-        assert_ne!(nssr(&f) & h5::NSSR_INCERR, 0, "INCERR must be set");
+        // Three bytes of a 16-byte quad-word: still buffering.
+        for i in 0..3u64 {
+            assert_eq!(f.h5_program_byte(0x20 + i, 0xAA), H5ProgAction::Buffered);
+        }
+        assert_ne!(nssr(&f) & h5::NSSR_WBNE, 0, "WBNE set while partial");
+        assert_eq!(nssr(&f) & h5::NSSR_EOP, 0, "no EOP — not committed");
+        assert_eq!(nssr(&f) & h5::NSSR_INCERR, 0, "no error");
     }
 
     #[test]
-    fn program_over_not_erased_sets_pgserr() {
+    fn full_aligned_quadword_commits_sets_eop_clears_wbne() {
         let mut f = h5_gate_on();
-        // aligned, but current byte is not the erased state (0xFF)
-        let allowed = f.h5_check_program(0x10, 0x00);
-        assert!(
-            !allowed,
-            "program over non-erased location must be rejected"
+        let action = program_full_quadword(&mut f, 0x20, 0xAA);
+        assert_eq!(
+            action,
+            H5ProgAction::Commit {
+                base: 0x20,
+                bytes: [0xAA; 16]
+            },
+            "full quad-word commits with the buffered bytes"
         );
-        assert_ne!(nssr(&f) & h5::NSSR_PGSERR, 0, "PGSERR must be set");
+        assert_ne!(nssr(&f) & h5::NSSR_EOP, 0, "EOP set on commit");
+        assert_eq!(nssr(&f) & h5::NSSR_WBNE, 0, "WBNE cleared on commit");
     }
 
     #[test]
-    fn aligned_erased_program_is_allowed() {
+    fn misaligned_first_write_then_jump_sets_incerr_alone() {
         let mut f = h5_gate_on();
-        assert!(
-            f.h5_check_program(0x20, 0xFF),
-            "valid program must be allowed"
-        );
-        assert_eq!(nssr(&f), 0, "valid program sets no error flag");
+        // First write at base+4 starts a buffer at base 0x20 (the quad-word it
+        // belongs to). A subsequent write into a DIFFERENT quad-word (0x30)
+        // before the first completes is the inconsistent program run.
+        assert_eq!(f.h5_program_byte(0x24, 0x11), H5ProgAction::Buffered);
+        assert_ne!(nssr(&f) & h5::NSSR_WBNE, 0, "WBNE while partial");
+        let action = f.h5_program_byte(0x30, 0x22);
+        assert_eq!(action, H5ProgAction::Inconsistent);
+        assert_ne!(nssr(&f) & h5::NSSR_INCERR, 0, "INCERR set");
+        assert_eq!(nssr(&f) & h5::NSSR_PGSERR, 0, "INCERR alone (no PGSERR)");
+        assert_eq!(nssr(&f) & h5::NSSR_WBNE, 0, "buffer discarded ⇒ WBNE clear");
     }
 
     #[test]
-    fn nssr_error_flags_are_w1c() {
+    fn nsccr_clears_eop_and_incerr_but_nssr_write_does_not() {
         let mut f = h5_gate_on();
-        f.h5_check_program(0x4, 0xFF); // sets PGSERR + INCERR
-        assert_ne!(nssr(&f) & (h5::NSSR_PGSERR | h5::NSSR_INCERR), 0);
-        // Write 1 to PGSERR and INCERR positions to clear them.
-        f.write_u32(h5::NSSR_OFF, h5::NSSR_PGSERR | h5::NSSR_INCERR)
-            .unwrap();
-        assert_eq!(nssr(&f) & h5::NSSR_W1C_MASK, 0, "W1C must clear the flags");
+        // Commit a quad-word to set EOP.
+        program_full_quadword(&mut f, 0x20, 0xAA);
+        assert_ne!(nssr(&f) & h5::NSSR_EOP, 0, "EOP set");
+        // Writing NSSR (0x20) must NOT clear it (silicon: NSSR is RO status).
+        f.write_u32(h5::NSSR_OFF, h5::NSSR_EOP).unwrap();
+        assert_ne!(nssr(&f) & h5::NSSR_EOP, 0, "NSSR write does NOT clear EOP");
+        // Writing NSCCR (0x30) DOES clear it.
+        f.write_u32(h5::NSCCR_OFF, h5::NSSR_EOP).unwrap();
+        assert_eq!(nssr(&f) & h5::NSSR_EOP, 0, "NSCCR clears EOP");
+    }
+
+    #[test]
+    fn pg_clear_does_not_program() {
+        // Gate on but NSCR.PG clear ⇒ no programming, no flag.
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5).with_error_flags(true);
+        assert_eq!(f.cr & h5::NSCR_PG, 0, "PG clear at reset");
+        assert_eq!(f.h5_program_byte(0x20, 0xAA), H5ProgAction::NotProgramming);
+        assert_eq!(nssr(&f), 0, "no flag when PG clear");
     }
 
     #[test]
     fn gate_is_noop_on_non_h5_layout() {
-        // Enabling the gate on L4 must not arm the H5 program check.
+        // Enabling the gate on L4 must not arm the H5 write-buffer machine.
         let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32L4).with_error_flags(true);
         assert!(!f.h5_error_flags_enabled());
-        assert!(f.h5_check_program(0x3, 0x00), "non-H5 layout never rejects");
+        // h5_program_byte short-circuits to Buffered (bus never calls it here).
+        // Note: on L4 offset 0x20 is OPTR, not NSSR, so reading "nssr" is
+        // meaningless here — the meaningful assertion is the no-op action.
+        assert_eq!(f.h5_program_byte(0x3, 0x00), H5ProgAction::Buffered);
     }
 }

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -139,6 +139,29 @@ pub struct Flash {
     // restore (a half-written quad-word is never persisted on real silicon).
     #[serde(skip)]
     h5_wbuf: Option<H5WriteBuffer>,
+
+    // OPT-IN read-while-write fidelity gate (H5 only). On real STM32H563 silicon
+    // (RM0481 §7, "read-while-write") a bank cannot be read — including
+    // instruction fetch — while that SAME bank is being erased or programmed:
+    // the bus stalls and code executing from that bank can never make progress.
+    // Production flash routines therefore run from SRAM. When this gate is on,
+    // an erase whose target bank is the one the CPU is executing from FAULTS
+    // (the machine layer turns the check into an unrecoverable error) instead of
+    // silently succeeding, forcing the firmware to relocate the routine to SRAM.
+    // Default false: gate off ⇒ byte-identical to prior behaviour (same-bank
+    // erase succeeds). Independent of `error_flags`; mirrors the same opt-in
+    // pattern.
+    #[serde(default)]
+    read_while_write: bool,
+
+    // H5 bank-swap state. Toggled each time a SWAP_BANK op is applied (the
+    // machine layer calls [`Flash::mark_swapped`] after `swap_banks`). With the
+    // RWW gate on this lets the bank-mapping translate a BKSEL logical bank and a
+    // PC physical bank consistently: under SWAP_BANK the bank presented at
+    // 0x08000000 is the physical second bank. `#[serde(default)]` so older
+    // snapshots restore as not-swapped (reset state).
+    #[serde(default)]
+    swapped: bool,
 }
 
 /// In-progress H5 quad-word write buffer (16 bytes at a 16-aligned base).
@@ -219,6 +242,8 @@ impl Flash {
             optkey_state: KeyUnlockState::Locked,
             error_flags: false,
             h5_wbuf: None,
+            read_while_write: false,
+            swapped: false,
         }
     }
 
@@ -235,6 +260,72 @@ impl Flash {
     /// whether to run the program-error check.
     pub fn h5_error_flags_enabled(&self) -> bool {
         self.error_flags && matches!(self.layout, FlashRegisterLayout::Stm32H5)
+    }
+
+    /// Enable (or disable) the opt-in H5 read-while-write fidelity gate.
+    /// Returns `self` so chip-factory construction can stay one expression.
+    /// No effect on non-H5 layouts (the RWW check is H5-only).
+    pub fn with_read_while_write(mut self, on: bool) -> Self {
+        self.read_while_write = on;
+        self
+    }
+
+    /// True when the H5 read-while-write fidelity gate is enabled AND this is
+    /// the H5 layout. The machine layer consults this before applying a flash
+    /// erase to decide whether the same-bank-as-PC check fires.
+    pub fn h5_rww_enabled(&self) -> bool {
+        self.read_while_write && matches!(self.layout, FlashRegisterLayout::Stm32H5)
+    }
+
+    /// Record that a SWAP_BANK has been applied (the machine layer calls this
+    /// right after `LinearMemory::swap_banks`). Each call toggles the active
+    /// mapping so the RWW bank translation stays consistent across repeated
+    /// swaps. No-op semantics beyond the bool; only meaningful with the RWW
+    /// gate on.
+    pub fn mark_swapped(&mut self) {
+        self.swapped = !self.swapped;
+    }
+
+    /// True if a SWAP_BANK is currently in effect (odd number of applied swaps).
+    pub fn is_swapped(&self) -> bool {
+        self.swapped
+    }
+
+    /// Map a BKSEL logical bank (0 or 1, as written to NSCR.BKSEL) to the
+    /// physical bank under the current SWAP_BANK state. Without a swap, logical
+    /// bank N is physical bank N; under SWAP_BANK the mapping is inverted (the
+    /// physical second bank is presented at 0x08000000, i.e. as logical bank 0).
+    fn logical_to_physical_bank(&self, logical: u8) -> u8 {
+        if self.swapped {
+            logical ^ 1
+        } else {
+            logical
+        }
+    }
+
+    /// Physical bank (0 or 1) containing the flash buffer offset `buf_off`
+    /// (= `absolute_addr - FLASH_BASE`). The CPU fetches code from 0x08000000+
+    /// (the boot view), so PC's buffer offset under the current swap state names
+    /// the physical bank it executes from. The sim physically rearranges the
+    /// backing buffer on swap, so buffer-half N already holds physical bank
+    /// `logical_to_physical_bank(N)`'s contents — translate the same way.
+    pub fn physical_bank_of_offset(&self, buf_off: u64) -> u8 {
+        let half = if buf_off >= h5::BANK_SIZE { 1u8 } else { 0u8 };
+        self.logical_to_physical_bank(half)
+    }
+
+    /// Read-while-write violation test: returns true when an erase of BKSEL
+    /// logical bank `erase_bank` collides with the physical bank the CPU is
+    /// executing from (`pc_buf_off` = `PC - FLASH_BASE`). Both sides are
+    /// translated to a physical bank through the active SWAP_BANK mapping, so a
+    /// same-physical-bank erase faults regardless of which logical view the
+    /// firmware addressed. Only meaningful when [`h5_rww_enabled`] is true.
+    ///
+    /// [`h5_rww_enabled`]: Self::h5_rww_enabled
+    pub fn rww_erase_violates(&self, erase_bank: u8, pc_buf_off: u64) -> bool {
+        let op_phys = self.logical_to_physical_bank(erase_bank & 1);
+        let pc_phys = self.physical_bank_of_offset(pc_buf_off);
+        op_phys == pc_phys
     }
 
     /// Feed one flash-region byte write into the H5 write-buffer state machine.
@@ -340,6 +431,8 @@ impl Flash {
             optkey_state: KeyUnlockState::Locked,
             error_flags: false,
             h5_wbuf: None,
+            read_while_write: false,
+            swapped: false,
         }
     }
 
@@ -702,6 +795,72 @@ mod h5_erase_swap_tests {
         let nscr = h5::NSCR_SER | (7 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
         f.write_u32(h5::NSCR_OFF, nscr).unwrap();
         assert_eq!(f.drain_pending_op(), None);
+    }
+}
+
+#[cfg(test)]
+mod h5_rww_mapping_tests {
+    use super::h5;
+    use super::{Flash, FlashRegisterLayout};
+
+    fn rww_flash() -> Flash {
+        Flash::new_with_layout(FlashRegisterLayout::Stm32H5).with_read_while_write(true)
+    }
+
+    #[test]
+    fn gate_off_by_default_and_noop_on_non_h5() {
+        let off = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        assert!(!off.h5_rww_enabled(), "gate off by default");
+        let l4 = Flash::new_with_layout(FlashRegisterLayout::Stm32L4).with_read_while_write(true);
+        assert!(!l4.h5_rww_enabled(), "gate is a no-op on non-H5 layout");
+        let h5 = rww_flash();
+        assert!(h5.h5_rww_enabled(), "gate on for H5 when opted in");
+    }
+
+    #[test]
+    fn no_swap_logical_bank_equals_physical() {
+        let f = rww_flash();
+        assert!(!f.is_swapped());
+        // PC in bank 0 (offset 0): erase of bank 0 collides, bank 1 does not.
+        assert!(f.rww_erase_violates(0, 0x0000), "erase bank0 vs PC bank0");
+        assert!(
+            !f.rww_erase_violates(1, 0x0000),
+            "erase bank1 vs PC bank0 OK"
+        );
+        // PC in bank 1 (offset >= BANK_SIZE): erase of bank 1 collides.
+        assert!(f.rww_erase_violates(1, h5::BANK_SIZE + 0x16000));
+        assert!(!f.rww_erase_violates(0, h5::BANK_SIZE + 0x16000));
+    }
+
+    #[test]
+    fn swap_inverts_the_physical_mapping() {
+        let mut f = rww_flash();
+        f.mark_swapped();
+        assert!(f.is_swapped());
+        // Under SWAP_BANK the bank presented at 0x08000000 (buffer offset 0) is
+        // physical bank 1. The firmware still erases with BKSEL=0 (logical bank
+        // 0), which now maps to physical bank 1 — same physical bank as PC.
+        assert_eq!(
+            f.physical_bank_of_offset(0x0000),
+            1,
+            "PC@0x08000000 → phys1"
+        );
+        assert!(
+            f.rww_erase_violates(0, 0x0000),
+            "swapped: logical-bank0 erase hits PC's physical bank1"
+        );
+        // An erase of logical bank 1 maps to physical bank 0 — the OTHER bank.
+        assert!(!f.rww_erase_violates(1, 0x0000), "swapped: cross-bank OK");
+    }
+
+    #[test]
+    fn two_swaps_restore_identity_mapping() {
+        let mut f = rww_flash();
+        f.mark_swapped();
+        f.mark_swapped();
+        assert!(!f.is_swapped(), "even swaps cancel");
+        assert!(f.rww_erase_violates(0, 0x0000));
+        assert!(!f.rww_erase_violates(1, 0x0000));
     }
 }
 

--- a/crates/core/src/peripherals/flash.rs
+++ b/crates/core/src/peripherals/flash.rs
@@ -120,6 +120,15 @@ pub struct Flash {
     // Internal: tracks unlock sequence on KEYR (write 0x45670123 then 0xCDEF89AB).
     key_state: KeyUnlockState,
     optkey_state: KeyUnlockState,
+
+    // OPT-IN fidelity gate (H5 only). When true, a program (a write into the
+    // flash region) that violates silicon programming rules — non-16-byte
+    // aligned target, or a target not in the erased (0xFF) state — sets the
+    // NSSR PGSERR/INCERR error flags and the write is rejected. Default false:
+    // gate off ⇒ byte-identical to prior behaviour (every program committed,
+    // no flag). Mirrors the per-peripheral opt-in pattern (clock-gating).
+    #[serde(default)]
+    error_flags: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -174,7 +183,61 @@ impl Flash {
             pending_op: std::cell::Cell::new(None),
             key_state: KeyUnlockState::Locked,
             optkey_state: KeyUnlockState::Locked,
+            error_flags: false,
         }
+    }
+
+    /// Enable (or disable) the opt-in H5 programming-error fidelity gate.
+    /// Returns `self` so chip-factory construction can stay one expression.
+    /// No effect on non-H5 layouts (the program checks are H5-only).
+    pub fn with_error_flags(mut self, on: bool) -> Self {
+        self.error_flags = on;
+        self
+    }
+
+    /// True when the H5 programming-error fidelity gate is enabled AND this is
+    /// the H5 layout. The bus consults this on flash-region writes to decide
+    /// whether to run the program-error check.
+    pub fn h5_error_flags_enabled(&self) -> bool {
+        self.error_flags && matches!(self.layout, FlashRegisterLayout::Stm32H5)
+    }
+
+    /// H5 program-error check for a single byte write into the flash region.
+    ///
+    /// `flash_offset` is the byte offset within the flash bank (absolute addr
+    /// minus the flash base); `current_byte` is the value currently stored at
+    /// that offset (the erased state is 0xFF). Returns `true` when the program
+    /// is allowed to commit, `false` when it violates a silicon programming
+    /// rule — in which case the corresponding NSSR sticky flags are set and the
+    /// caller must NOT commit the write (a misaligned / over-not-erased
+    /// quad-word program does not store on real silicon).
+    ///
+    /// Only meaningful when [`h5_error_flags_enabled`](Self::h5_error_flags_enabled)
+    /// is true; with the gate off the bus never calls this and every write
+    /// commits, exactly as before.
+    ///
+    /// Rules (RM0481 §7):
+    ///   * target not 16-byte (quad-word) aligned → PGSERR + INCERR
+    ///   * target not in the erased (0xFF) state    → PGSERR
+    ///
+    /// WRPERR (write-protected/locked region) is intentionally out of scope:
+    /// this model does not yet track per-region write protection, so faking it
+    /// would be silicon-inaccurate.
+    pub fn h5_check_program(&mut self, flash_offset: u64, current_byte: u8) -> bool {
+        if !self.h5_error_flags_enabled() {
+            return true;
+        }
+        let mut ok = true;
+        if flash_offset % h5::PROG_GRANULARITY != 0 {
+            // Misaligned quad-word program: sequence + inconsistency error.
+            self.sr |= h5::NSSR_PGSERR | h5::NSSR_INCERR;
+            ok = false;
+        } else if current_byte != 0xFF {
+            // Program over a location not erased to all-ones.
+            self.sr |= h5::NSSR_PGSERR;
+            ok = false;
+        }
+        ok
     }
 
     // (legacy `new()` body replaced; kept as the no-op below for the
@@ -204,6 +267,7 @@ impl Flash {
             pending_op: std::cell::Cell::new(None),
             key_state: KeyUnlockState::Locked,
             optkey_state: KeyUnlockState::Locked,
+            error_flags: false,
         }
     }
 
@@ -319,6 +383,11 @@ impl Flash {
                             .set(Some(FlashOp::EraseSector { bank, sector }));
                     }
                 }
+                // NSSR error flags are sticky / write-1-to-clear. Firmware (or a
+                // test) clears WRPERR/PGSERR/INCERR by writing 1 to the bit.
+                // BSY and other read-only status bits are unaffected. Mirrors the
+                // L4 SR rc_w1 handling below.
+                h5::NSSR_OFF => self.sr &= !(value & h5::NSSR_W1C_MASK),
                 h5::OPTSR_PRG_OFF => self.optsr_prg = value,
                 // OPTSTRT (bit 1) requires the OPTION-key (OPTKEYR), not the flash
                 // key (NSKEYR): option-byte programming is a separate unlock domain
@@ -479,6 +548,9 @@ impl crate::Peripheral for Flash {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }
@@ -554,5 +626,87 @@ mod h5_erase_swap_tests {
         let nscr = h5::NSCR_SER | (7 << h5::NSCR_SNB_SHIFT) | h5::NSCR_STRT;
         f.write_u32(h5::NSCR_OFF, nscr).unwrap();
         assert_eq!(f.drain_pending_op(), None);
+    }
+}
+
+#[cfg(test)]
+mod h5_program_error_tests {
+    use super::h5;
+    use super::{Flash, FlashRegisterLayout};
+    use crate::Peripheral;
+
+    fn h5_gate_on() -> Flash {
+        Flash::new_with_layout(FlashRegisterLayout::Stm32H5).with_error_flags(true)
+    }
+
+    fn nssr(f: &Flash) -> u32 {
+        // NSSR is the H5 status register (offset 0x20). Reassemble from bytes.
+        let b = |o: u64| f.read(o).unwrap() as u32;
+        b(h5::NSSR_OFF)
+            | (b(h5::NSSR_OFF + 1) << 8)
+            | (b(h5::NSSR_OFF + 2) << 16)
+            | (b(h5::NSSR_OFF + 3) << 24)
+    }
+
+    #[test]
+    fn gate_off_program_commits_and_sets_no_flag() {
+        // Gate OFF (default) ⇒ misaligned, over-not-erased: still allowed,
+        // no NSSR flag. This is the byte-identical-to-before path.
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32H5);
+        assert!(!f.h5_error_flags_enabled());
+        // misaligned offset, current byte not erased — both rule violations
+        assert!(f.h5_check_program(0x3, 0x00));
+        assert_eq!(nssr(&f), 0, "gate off must never set an NSSR flag");
+    }
+
+    #[test]
+    fn misaligned_program_sets_pgserr_incerr_and_rejects() {
+        let mut f = h5_gate_on();
+        // offset 0x4 is 4-byte but NOT 16-byte (quad-word) aligned
+        let allowed = f.h5_check_program(0x4, 0xFF);
+        assert!(!allowed, "misaligned program must be rejected");
+        assert_ne!(nssr(&f) & h5::NSSR_PGSERR, 0, "PGSERR must be set");
+        assert_ne!(nssr(&f) & h5::NSSR_INCERR, 0, "INCERR must be set");
+    }
+
+    #[test]
+    fn program_over_not_erased_sets_pgserr() {
+        let mut f = h5_gate_on();
+        // aligned, but current byte is not the erased state (0xFF)
+        let allowed = f.h5_check_program(0x10, 0x00);
+        assert!(
+            !allowed,
+            "program over non-erased location must be rejected"
+        );
+        assert_ne!(nssr(&f) & h5::NSSR_PGSERR, 0, "PGSERR must be set");
+    }
+
+    #[test]
+    fn aligned_erased_program_is_allowed() {
+        let mut f = h5_gate_on();
+        assert!(
+            f.h5_check_program(0x20, 0xFF),
+            "valid program must be allowed"
+        );
+        assert_eq!(nssr(&f), 0, "valid program sets no error flag");
+    }
+
+    #[test]
+    fn nssr_error_flags_are_w1c() {
+        let mut f = h5_gate_on();
+        f.h5_check_program(0x4, 0xFF); // sets PGSERR + INCERR
+        assert_ne!(nssr(&f) & (h5::NSSR_PGSERR | h5::NSSR_INCERR), 0);
+        // Write 1 to PGSERR and INCERR positions to clear them.
+        f.write_u32(h5::NSSR_OFF, h5::NSSR_PGSERR | h5::NSSR_INCERR)
+            .unwrap();
+        assert_eq!(nssr(&f) & h5::NSSR_W1C_MASK, 0, "W1C must clear the flags");
+    }
+
+    #[test]
+    fn gate_is_noop_on_non_h5_layout() {
+        // Enabling the gate on L4 must not arm the H5 program check.
+        let mut f = Flash::new_with_layout(FlashRegisterLayout::Stm32L4).with_error_flags(true);
+        assert!(!f.h5_error_flags_enabled());
+        assert!(f.h5_check_program(0x3, 0x00), "non-H5 layout never rejects");
     }
 }

--- a/crates/core/src/peripherals/flash_h5_regs.rs
+++ b/crates/core/src/peripherals/flash_h5_regs.rs
@@ -23,6 +23,10 @@
 pub const NSKEYR_OFF: u64 = 0x04;
 pub const NSSR_OFF: u64 = 0x20;
 pub const NSCR_OFF: u64 = 0x28;
+/// NSCCR @ 0x30 — clear register. Writing 1 to a bit clears the corresponding
+/// NSSR flag (EOP/WRPERR/PGSERR/STRBERR/INCERR). Verified on NUCLEO-H563ZI
+/// silicon (2026-06-22): writing NSSR itself does NOT clear; NSCCR does.
+pub const NSCCR_OFF: u64 = 0x30;
 pub const OPTCR_OFF: u64 = 0x1C;
 pub const OPTSR_CUR_OFF: u64 = 0x50;
 pub const OPTSR_PRG_OFF: u64 = 0x54;
@@ -49,24 +53,36 @@ pub const NSCR_BKSEL: u32 = 1 << 31;
 
 /// Bit 0 — BSY: non-secure busy.
 pub const NSSR_BSY: u32 = 1 << 0;
+/// Bit 1 — WBNE: write buffer not empty. Live status — set while a partial
+/// quad-word is buffered, cleared when the quad-word commits or on reset. NOT
+/// W1C. Verified on silicon (NSSR=0x2 after the 1st word of a quad-word).
+pub const NSSR_WBNE: u32 = 1 << 1;
+/// Bit 16 — EOP: end of (successful) operation. Set when a quad-word commits.
+/// Sticky, cleared via NSCCR. Verified on silicon (NSSR=0x10000 after commit).
+pub const NSSR_EOP: u32 = 1 << 16;
 /// Bit 17 — WRPERR: write-protection error (program/erase of a protected or
-/// locked region). RM0481 §7.9.8. Sticky W1C.
+/// locked region). RM0481 §7.9.8. Sticky, cleared via NSCCR. Out of scope here
+/// (no per-region protection modeled) — the constant exists, set nowhere.
 pub const NSSR_WRPERR: u32 = 1 << 17;
-/// Bit 18 — PGSERR: programming-sequence error (program to a non-quad-word
-/// aligned address, or program of a location not in the erased state).
-/// RM0481 §7.9.8. Sticky W1C.
+/// Bit 18 — PGSERR: programming-sequence error. RM0481 §7.9.8. Sticky, cleared
+/// via NSCCR. NOT raised by program-over-not-erased on this part (silicon
+/// allows that with the result being the bitwise AND — verified 2026-06-22).
 pub const NSSR_PGSERR: u32 = 1 << 18;
-/// Bit 20 — INCERR: inconsistency error (the programmed flash word does not
-/// match the requested value, e.g. a misaligned/over-not-erased quad-word
-/// program). RM0481 §7.9.8. Sticky W1C.
+/// Bit 19 — STRBERR: strobe error. RM0481 §7.9.8. Sticky, cleared via NSCCR.
+pub const NSSR_STRBERR: u32 = 1 << 19;
+/// Bit 20 — INCERR: inconsistency error. RM0481 §7.9.8. Raised ALONE on a
+/// misaligned / inconsistent quad-word program (a 16-byte run that does not
+/// align to a single quad-word); nothing is committed. Verified on silicon
+/// (NSSR=0x100000 = INCERR alone after 4 writes from a non-aligned base).
+/// Sticky, cleared via NSCCR.
 pub const NSSR_INCERR: u32 = 1 << 20;
 
-/// Mask of the W1C error/status flags in NSSR (everything except read-only
-/// BSY/WBNE/DBNE-type status). Writing 1 to any of these clears it.
-pub const NSSR_W1C_MASK: u32 = NSSR_WRPERR | NSSR_PGSERR | NSSR_INCERR;
+/// Mask of the sticky operation/error flags cleared by writing 1 to the
+/// matching bit in NSCCR (0x30). WBNE/BSY are live status, NOT in this mask.
+pub const NSSR_W1C_MASK: u32 = NSSR_EOP | NSSR_WRPERR | NSSR_PGSERR | NSSR_STRBERR | NSSR_INCERR;
 
-/// Quad-word (16-byte) programming granularity. A non-secure program whose
-/// target flash offset is not 16-byte aligned is a sequence error on H5.
+/// Quad-word (16-byte) programming granularity. A program commits only when a
+/// full 16-byte run aligned to this granularity has been buffered.
 pub const PROG_GRANULARITY: u64 = 16;
 
 // ── FLASH_OPTSR_CUR / OPTSR_PRG bitfields (RM0481 §7.9.14) ─────────────────

--- a/crates/core/src/peripherals/flash_h5_regs.rs
+++ b/crates/core/src/peripherals/flash_h5_regs.rs
@@ -49,6 +49,25 @@ pub const NSCR_BKSEL: u32 = 1 << 31;
 
 /// Bit 0 — BSY: non-secure busy.
 pub const NSSR_BSY: u32 = 1 << 0;
+/// Bit 17 — WRPERR: write-protection error (program/erase of a protected or
+/// locked region). RM0481 §7.9.8. Sticky W1C.
+pub const NSSR_WRPERR: u32 = 1 << 17;
+/// Bit 18 — PGSERR: programming-sequence error (program to a non-quad-word
+/// aligned address, or program of a location not in the erased state).
+/// RM0481 §7.9.8. Sticky W1C.
+pub const NSSR_PGSERR: u32 = 1 << 18;
+/// Bit 20 — INCERR: inconsistency error (the programmed flash word does not
+/// match the requested value, e.g. a misaligned/over-not-erased quad-word
+/// program). RM0481 §7.9.8. Sticky W1C.
+pub const NSSR_INCERR: u32 = 1 << 20;
+
+/// Mask of the W1C error/status flags in NSSR (everything except read-only
+/// BSY/WBNE/DBNE-type status). Writing 1 to any of these clears it.
+pub const NSSR_W1C_MASK: u32 = NSSR_WRPERR | NSSR_PGSERR | NSSR_INCERR;
+
+/// Quad-word (16-byte) programming granularity. A non-secure program whose
+/// target flash offset is not 16-byte aligned is a sequence error on H5.
+pub const PROG_GRANULARITY: u64 = 16;
 
 // ── FLASH_OPTSR_CUR / OPTSR_PRG bitfields (RM0481 §7.9.14) ─────────────────
 

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -200,9 +200,20 @@ pub fn try_build(
                 .get("error_flags")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
+            // Opt-in H5 read-while-write fidelity gate. `config: { read_while_write:
+            // true }` makes an erase of the bank the CPU is executing from fault
+            // (the firmware must run the flash routine from SRAM) instead of
+            // silently succeeding. Default false (no-op on non-H5 layouts) —
+            // existing configs unchanged. Independent of `error_flags`.
+            let read_while_write = p_cfg
+                .config
+                .get("read_while_write")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             Box::new(
                 crate::peripherals::flash::Flash::new_with_layout(layout)
-                    .with_error_flags(error_flags),
+                    .with_error_flags(error_flags)
+                    .with_read_while_write(read_while_write),
             )
         }
         "rng" => Box::new(crate::peripherals::rng::Rng::new()),

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -191,7 +191,19 @@ pub fn try_build(
             // default — backward compatible with existing chip configs.
             let layout: crate::peripherals::flash::FlashRegisterLayout =
                 SystemBus::parse_profile_or_default(p_cfg, "FLASH")?;
-            Box::new(crate::peripherals::flash::Flash::new_with_layout(layout))
+            // Opt-in H5 program-error fidelity gate. `config: { error_flags: true }`
+            // makes a misaligned / over-not-erased program raise the silicon
+            // NSSR error flags instead of silently committing. Default false
+            // (and a no-op on non-H5 layouts) — existing configs are unchanged.
+            let error_flags = p_cfg
+                .config
+                .get("error_flags")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            Box::new(
+                crate::peripherals::flash::Flash::new_with_layout(layout)
+                    .with_error_flags(error_flags),
+            )
         }
         "rng" => Box::new(crate::peripherals::rng::Rng::new()),
         "crc" => {

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,7 +9,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-14 | ✅ fresh |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-20 | 2026-06-21 | ⚠ drift acked 2026-06-21 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-06-22 | ✅ fresh |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-20 | ⚠ drift acked 2026-06-20 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-20 | ✅ fresh |
@@ -40,10 +40,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 ## `stm32h563` — 🟢 silicon-verified
 
 - Doc: [`docs/boards/stm32h563.md`](stm32h563.md)  ·  Chip: `configs/chips/stm32h563.yaml`
-- Silicon: **2026-06-20** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — Live re-capture after the v0.17.0 merge: h563_mmio_diff + h563_parity_diff + h563_class_diff all pass (class 65/65, GPIO mmio + parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
+- Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-06-21 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `esp32c3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -72,16 +72,16 @@ boards:
       - "h563_conformance (5 tests vs frozen 2026-06-10..12 captures)"
       - "h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}"
     silicon:
-      last_capture: 2026-06-20
+      last_capture: 2026-06-22
       probe: "STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe)"
-      result: "Live re-capture after the v0.17.0 merge: h563_mmio_diff + h563_parity_diff + h563_class_diff all pass (class 65/65, GPIO mmio + parity), 0 divergence. Supersedes the 2026-06-19 drift_ack."
+      result: "FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds."
     # FLASH model extended for UDS OTA: NSCR sector-erase + OPTSR_PRG.SWAP_BANK/
-    # OBL_LAUNCH (drained in Machine::step / batched run) + H563 sized in MiB.
-    # FLASH register offsets + reset values silicon-confirmed on the live board
-    # 2026-06-20 (ACR/OPTCR/NSSR/NSCR/OPTSR_CUR/OPTSR_PRG); the erase/swap
-    # *behavioural* live-diff (writes real flash) is not yet run — tracked for a
-    # follow-up hw-oracle capture. This ack covers the model change only.
-    drift_ack: 2026-06-21
+    # OBL_LAUNCH (drained in Machine::step / batched run) + H563 sized in MiB,
+    # plus opt-in program error-flag (WRPERR/PGSERR/INCERR) and read-while-write
+    # fidelity gates (default off). The erase/program *behavioural* live-diff
+    # (writes real flash over SWD) WAS run on 2026-06-22 and the model corrected
+    # to match silicon (write-buffer/EOP/INCERR/NSCCR; see result above).
+    drift_ack: 2026-06-22
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
Adds two opt-in STM32H5 FLASH fidelity gates that make the simulator refuse the kinds of operations real H563 silicon rejects, so firmware bugs that the forgiving model used to pass become visible. Both default OFF (per-peripheral `config:` keys), so every existing example and chip is byte-identical; a chip/example opts in explicitly.

Both gates were validated against a real NUCLEO-H563ZI over SWD, and the silicon corrected the datasheet-from-memory model on several points (recorded below).

## 1. Program write-buffer + error fidelity (`config: { error_flags: true }`)
Models the H5 quad-word programming path as it actually behaves on silicon, rather than writing every store straight through:
- Sub-quad-word writes accumulate in a 16-byte write buffer and set WBNE; nothing commits until a full aligned quad-word is present, which then commits and sets EOP.
- A misaligned/inconsistent quad-word (a program run that does not align to a single 16-byte slot) raises INCERR alone and commits nothing.
- Program-over-not-erased is allowed (no error); the result is the bitwise AND of old and new, since flash only flips 1 to 0.
- Status flags are cleared via NSCCR (0x30); writing NSSR does not clear them.

Silicon corrections captured during validation: the first cut raised PGSERR on misaligned (silicon raises INCERR alone), rejected program-over-not-erased with PGSERR (silicon allows it and ANDs), and made NSSR write-to-clear (silicon clears via NSCCR). All three were wrong and are now fixed to match the chip.

## 2. Read-while-write fault (`config: { read_while_write: true }`)
On real H5 you cannot fetch/read from a flash bank while that same bank is being erased or programmed. When enabled, a sector erase whose target physical bank equals the bank the CPU is executing from faults (SWAP_BANK-aware), instead of silently succeeding. Cross-bank operations (execute from the active bank, erase/program the inactive one) proceed unchanged. This forces firmware that erases a sector of its own bank to run the flash routine from SRAM, as silicon requires.

## Scope notes
- WRPERR is not raised (no per-region write-protection modeled yet); the constant is defined but unset.
- Program-commit RWW is not gated (only erase); the H5 program path is direct bus writes with no FlashOp to hook, and the erase gate already covers the boot-state-sector hazard.

Companion to the udslib `examples/h563_uds_bootloader/` work (w1ne/udslib#64); these gates underpin upcoming firmware-correctness hardening.

Gates: `cargo test -p labwired-core --lib` 1427 passed; `cargo fmt --check` and `cargo clippy -D warnings` clean.
