### PR TITLE
feat(sim): scriptable UDS tester + real Cortex-M system reset

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2370,7 +2370,10 @@ fn assertion_short_name(assertion: &TestAssertion) -> String {
             a.memory_value.address, a.memory_value.expected_value
         ),
         TestAssertion::UdsTester(a) => {
-            format!("uds_tester: {} result={:?}", a.uds_tester.id, a.uds_tester.result)
+            format!(
+                "uds_tester: {} result={:?}",
+                a.uds_tester.id, a.uds_tester.result
+            )
         }
     };
 
@@ -2394,11 +2397,7 @@ pub(crate) fn evaluate_uds_tester(
             if t.state == labwired_core::bus::CanUdsTesterState::Done {
                 Ok(())
             } else {
-                let reason = t
-                    .failure
-                    .as_deref()
-                    .unwrap_or("not completed")
-                    .to_string();
+                let reason = t.failure.as_deref().unwrap_or("not completed").to_string();
                 Err(format!("tester '{}': {}", details.id, reason))
             }
         }
@@ -2462,9 +2461,9 @@ pub(crate) fn simple_regex_is_match(pattern: &str, text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use labwired_core::bus::{CanUdsTester, CanUdsTesterState};
     use labwired_config::UdsTesterDetails;
     use labwired_config::UdsTesterResult;
+    use labwired_core::bus::{CanUdsTester, CanUdsTesterState};
 
     fn make_tester(id: &str, state: CanUdsTesterState, failure: Option<&str>) -> CanUdsTester {
         let mut t = CanUdsTester::new(id.to_string(), "bxcan1".to_string());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,7 +26,9 @@ mod gpio_observer;
 mod size_limited_writer;
 mod vcd_trace;
 
-use labwired_config::{load_test_script, LoadedTestScript, StopReason, TestAssertion, TestLimits};
+use labwired_config::{
+    load_test_script, LoadedTestScript, StopReason, TestAssertion, TestLimits, UdsTesterDetails,
+};
 
 pub(crate) const EXIT_PASS: u8 = 0;
 pub(crate) const EXIT_ASSERT_FAIL: u8 = 1;
@@ -1751,6 +1753,15 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                     }
                 }
             }
+            TestAssertion::UdsTester(a) => {
+                match evaluate_uds_tester(&machine.bus.can_uds_testers, &a.uds_tester) {
+                    Ok(()) => true,
+                    Err(msg) => {
+                        error!("Assertion failed: {}", msg);
+                        false
+                    }
+                }
+            }
         };
 
         if matches!(assertion, TestAssertion::ExpectedStopReason(_)) && passed {
@@ -2323,6 +2334,9 @@ fn assertion_short_name(assertion: &TestAssertion) -> String {
             "memory_value: @{:#x}={:#x}",
             a.memory_value.address, a.memory_value.expected_value
         ),
+        TestAssertion::UdsTester(a) => {
+            format!("uds_tester: {} result={:?}", a.uds_tester.id, a.uds_tester.result)
+        }
     };
 
     if s.len() <= MAX_LEN {
@@ -2332,6 +2346,28 @@ fn assertion_short_name(assertion: &TestAssertion) -> String {
     let mut truncated = s.chars().take(MAX_LEN - 1).collect::<String>();
     truncated.push('…');
     truncated
+}
+
+/// Returns `Ok(())` if the named tester ended in `Done`; `Err(message)` otherwise.
+pub(crate) fn evaluate_uds_tester(
+    testers: &[labwired_core::bus::CanUdsTester],
+    details: &UdsTesterDetails,
+) -> Result<(), String> {
+    match testers.iter().find(|t| t.id == details.id) {
+        None => Err(format!("tester '{}': not found", details.id)),
+        Some(t) => {
+            if t.state == labwired_core::bus::CanUdsTesterState::Done {
+                Ok(())
+            } else {
+                let reason = t
+                    .failure
+                    .as_deref()
+                    .unwrap_or_else(|| "not completed")
+                    .to_string();
+                Err(format!("tester '{}': {}", details.id, reason))
+            }
+        }
+    }
 }
 
 // Minimal regex matcher supporting: '^' anchor, '$' anchor, '.' and '*' (Kleene star).
@@ -2386,4 +2422,59 @@ pub(crate) fn simple_regex_is_match(pattern: &str, text: &str) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use labwired_core::bus::{CanUdsTester, CanUdsTesterState};
+    use labwired_config::UdsTesterDetails;
+    use labwired_config::UdsTesterResult;
+
+    fn make_tester(id: &str, state: CanUdsTesterState, failure: Option<&str>) -> CanUdsTester {
+        let mut t = CanUdsTester::new(id.to_string(), "bxcan1".to_string());
+        t.state = state;
+        t.failure = failure.map(|s| s.to_string());
+        t
+    }
+
+    #[test]
+    fn evaluate_uds_tester_done_passes() {
+        let testers = vec![make_tester("my-tester", CanUdsTesterState::Done, None)];
+        let details = UdsTesterDetails {
+            id: "my-tester".to_string(),
+            result: UdsTesterResult::Done,
+        };
+        assert!(evaluate_uds_tester(&testers, &details).is_ok());
+    }
+
+    #[test]
+    fn evaluate_uds_tester_failed_returns_err_with_failure_text() {
+        let testers = vec![make_tester(
+            "my-tester",
+            CanUdsTesterState::Failed,
+            Some("step 0: unexpected response 0x7F"),
+        )];
+        let details = UdsTesterDetails {
+            id: "my-tester".to_string(),
+            result: UdsTesterResult::Done,
+        };
+        let err = evaluate_uds_tester(&testers, &details).unwrap_err();
+        assert!(err.contains("my-tester"), "missing id in: {err}");
+        assert!(
+            err.contains("step 0: unexpected response 0x7F"),
+            "missing failure text in: {err}"
+        );
+    }
+
+    #[test]
+    fn evaluate_uds_tester_unknown_id_returns_err() {
+        let testers = vec![make_tester("other", CanUdsTesterState::Done, None)];
+        let details = UdsTesterDetails {
+            id: "ghost-tester".to_string(),
+            result: UdsTesterResult::Done,
+        };
+        let err = evaluate_uds_tester(&testers, &details).unwrap_err();
+        assert!(err.contains("ghost-tester"), "missing id in: {err}");
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1617,6 +1617,41 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         }
                     }
 
+                    // Honor a firmware-requested system reset (AIRCR
+                    // SYSRESETREQ with VECTKEY) latched by the batch just
+                    // executed. The single-step `else` branch gets this via
+                    // `machine.step()`; the batched path must drain it
+                    // explicitly or the reboot never fires.
+                    if machine.drain_scb_reset_request() {
+                        if let Err(e) = machine.reset() {
+                            sim_error_happened = true;
+                            stop_reason = match e {
+                                labwired_core::SimulationError::MemoryViolation(_) => {
+                                    StopReason::MemoryViolation
+                                }
+                                labwired_core::SimulationError::DecodeError(_) => {
+                                    StopReason::DecodeError
+                                }
+                                labwired_core::SimulationError::Halt => StopReason::Halt,
+                                labwired_core::SimulationError::SnapshotSchemaMismatch {
+                                    ..
+                                } => StopReason::Exception,
+                                labwired_core::SimulationError::Other(_) => StopReason::Exception,
+                                labwired_core::SimulationError::NotImplemented(_) => {
+                                    StopReason::Exception
+                                }
+                                labwired_core::SimulationError::BreakpointHit(_) => {
+                                    StopReason::Halt
+                                }
+                                labwired_core::SimulationError::ExceptionRaised { .. } => {
+                                    StopReason::Exception
+                                }
+                            };
+                            error!("Reset error at step {}: {}", step, e);
+                            break;
+                        }
+                    }
+
                     if executed < to_execute {
                         // Bailed out early (e.g. exception/branch)
                         continue;
@@ -2362,7 +2397,7 @@ pub(crate) fn evaluate_uds_tester(
                 let reason = t
                     .failure
                     .as_deref()
-                    .unwrap_or_else(|| "not completed")
+                    .unwrap_or("not completed")
                     .to_string();
                 Err(format!("tester '{}': {}", details.id, reason))
             }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -620,12 +620,32 @@ pub struct MemoryValueAssertion {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum UdsTesterResult {
+    Done,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct UdsTesterDetails {
+    pub id: String,
+    pub result: UdsTesterResult,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct UdsTesterAssertion {
+    pub uds_tester: UdsTesterDetails,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum TestAssertion {
     UartContains(UartContainsAssertion),
     UartRegex(UartRegexAssertion),
     ExpectedStopReason(StopReasonAssertion),
     MemoryValue(MemoryValueAssertion),
+    UdsTester(UdsTesterAssertion),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -916,5 +936,23 @@ registers:
             desc.registers[1].side_effects.as_ref().unwrap().on_read,
             Some("clear_rxne".to_string())
         );
+    }
+
+    #[test]
+    fn uds_tester_assertion_parses_result_done() {
+        let yaml = r#"
+- uds_tester:
+    id: "uds-tester"
+    result: done
+"#;
+        let assertions: Vec<TestAssertion> = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(assertions.len(), 1);
+        match &assertions[0] {
+            TestAssertion::UdsTester(a) => {
+                assert_eq!(a.uds_tester.id, "uds-tester");
+                assert!(matches!(a.uds_tester.result, UdsTesterResult::Done));
+            }
+            other => panic!("expected UdsTester variant, got {:?}", other),
+        }
     }
 }

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -566,6 +566,13 @@ impl SystemBus {
                         } else {
                             0
                         };
+                        if ext.config.contains_key("first_frame") && (ff.len() < 2 || pdu_len == 0) {
+                            tracing::warn!(
+                                "[uds-tester] '{}': first_frame is too short or decodes pdu_len=0 \
+                                 — synthesized send will be empty",
+                                ext.id
+                            );
+                        }
                         let ff_payload: &[u8] = if ff.len() >= 2 { &ff[2..] } else { &[] };
                         let cf_payload: &[u8] =
                             if !tester.consecutive_frame.is_empty() {
@@ -579,6 +586,13 @@ impl SystemBus {
                             .copied()
                             .take(pdu_len)
                             .collect();
+                        if raw.is_empty() && ext.config.contains_key("first_frame") {
+                            tracing::warn!(
+                                "[uds-tester] '{}': reassembled send payload is empty \
+                                 — check first_frame / consecutive_frame config",
+                                ext.id
+                            );
+                        }
                         tester.script = vec![UdsStep {
                             send: raw,
                             expect: vec![Some(0x06), Some(0x67)],

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -598,8 +598,6 @@ impl SystemBus {
                             send: raw,
                             expect: vec![Some(0x06), Some(0x67)],
                             expect_nrc: None,
-                            expect_silence: false,
-                            timeout_ticks: CanUdsTester::DEFAULT_MAX_TICKS,
                         }];
                     }
                     bus.can_uds_testers.push(tester);

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -556,6 +556,37 @@ impl SystemBus {
                         &CanUdsTester::DEFAULT_CONSECUTIVE_FRAME,
                     );
                     tester.script = Self::parse_script(ext.config.get("script"));
+                    // When no `script:` key is present, synthesize a single step
+                    // from the legacy first_frame / consecutive_frame fields.
+                    if !ext.config.contains_key("script") {
+                        let ff = &tester.first_frame;
+                        // FF: byte0 high nibble == 1; 12-bit length in (byte0 & 0x0F) << 8 | byte1
+                        let pdu_len = if ff.len() >= 2 {
+                            (((ff[0] & 0x0F) as usize) << 8) | (ff[1] as usize)
+                        } else {
+                            0
+                        };
+                        let ff_payload: &[u8] = if ff.len() >= 2 { &ff[2..] } else { &[] };
+                        let cf_payload: &[u8] =
+                            if !tester.consecutive_frame.is_empty() {
+                                &tester.consecutive_frame[1..]
+                            } else {
+                                &[]
+                            };
+                        let raw: Vec<u8> = ff_payload
+                            .iter()
+                            .chain(cf_payload.iter())
+                            .copied()
+                            .take(pdu_len)
+                            .collect();
+                        tester.script = vec![UdsStep {
+                            send: raw,
+                            expect: vec![Some(0x06), Some(0x67)],
+                            expect_nrc: None,
+                            expect_silence: false,
+                            timeout_ticks: CanUdsTester::DEFAULT_MAX_TICKS,
+                        }];
+                    }
                     bus.can_uds_testers.push(tester);
                 }
                 // ntc-thermistor dispatches through the PeripheralKit registry above.

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -567,7 +567,8 @@ impl SystemBus {
                         } else {
                             0
                         };
-                        if ext.config.contains_key("first_frame") && (ff.len() < 2 || pdu_len == 0) {
+                        if ext.config.contains_key("first_frame") && (ff.len() < 2 || pdu_len == 0)
+                        {
                             tracing::warn!(
                                 "[uds-tester] '{}': first_frame is too short or decodes pdu_len=0 \
                                  — synthesized send will be empty",
@@ -575,12 +576,11 @@ impl SystemBus {
                             );
                         }
                         let ff_payload: &[u8] = if ff.len() >= 2 { &ff[2..] } else { &[] };
-                        let cf_payload: &[u8] =
-                            if !tester.consecutive_frame.is_empty() {
-                                &tester.consecutive_frame[1..]
-                            } else {
-                                &[]
-                            };
+                        let cf_payload: &[u8] = if !tester.consecutive_frame.is_empty() {
+                            &tester.consecutive_frame[1..]
+                        } else {
+                            &[]
+                        };
                         let raw: Vec<u8> = ff_payload
                             .iter()
                             .chain(cf_payload.iter())

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -555,6 +555,7 @@ impl SystemBus {
                         ext.config.get("consecutive_frame"),
                         &CanUdsTester::DEFAULT_CONSECUTIVE_FRAME,
                     );
+                    tester.script = Self::parse_script(ext.config.get("script"));
                     bus.can_uds_testers.push(tester);
                 }
                 // ntc-thermistor dispatches through the PeripheralKit registry above.

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -358,15 +358,12 @@ impl CanUdsTester {
         match self.state {
             CanUdsTesterState::AwaitFc => {
                 if data.first().map(|b| b & 0xF0) == Some(0x30) {
-                    // FlowControl received: inject all pending CFs.
-                    // Return the first one now; the rest are queued.
-                    // (For the test harness there is only 1 CF, but handle N.)
-                    if !self.pending_cfs.is_empty() {
-                        let first_cf = self.pending_cfs.remove(0);
-                        self.state = CanUdsTesterState::AwaitResp;
-                        return Some(first_cf);
-                    }
-                    self.state = CanUdsTesterState::AwaitResp;
+                    // FlowControl received: signal the next CF to inject.
+                    // Do NOT change state here — the injected block in
+                    // service_can_uds_testers advances AwaitFc→AwaitResp only
+                    // after the last CF has been successfully accepted, draining
+                    // pending_cfs one entry per tick.
+                    return self.pending_cfs.first().cloned();
                 }
                 None
             }
@@ -438,7 +435,7 @@ impl CanUdsTester {
             }
         } else {
             let msg = format!(
-                "step {}: expected {:?}, got {:02X?}",
+                "step {}: expected {:02X?}, got {:02X?}",
                 self.step_idx, step.expect, payload
             );
             self.failure = Some(msg);
@@ -882,7 +879,12 @@ impl SystemBus {
                             None
                         }
                     }
-                    CanUdsTesterState::AwaitFc => pending_inject,
+                    // Use the observe result when an FC arrived this tick, or
+                    // the front of pending_cfs when additional CFs remain from
+                    // a previous tick's FC (no new ECU frame → pending_inject
+                    // is None but the queue is non-empty).
+                    CanUdsTesterState::AwaitFc => pending_inject
+                        .or_else(|| self.can_uds_testers[i].pending_cfs.first().cloned()),
                     _ => None,
                 }
             } else {
@@ -934,6 +936,16 @@ impl SystemBus {
                     }
                     CanUdsTesterState::Start => {
                         self.can_uds_testers[i].state = CanUdsTesterState::AwaitFc
+                    }
+                    CanUdsTesterState::AwaitFc if has_script => {
+                        // Pop the CF that was just successfully injected.
+                        if !self.can_uds_testers[i].pending_cfs.is_empty() {
+                            self.can_uds_testers[i].pending_cfs.remove(0);
+                        }
+                        // Only advance to AwaitResp once all CFs have been sent.
+                        if self.can_uds_testers[i].pending_cfs.is_empty() {
+                            self.can_uds_testers[i].state = CanUdsTesterState::AwaitResp;
+                        }
                     }
                     CanUdsTesterState::AwaitFc => {
                         self.can_uds_testers[i].state = CanUdsTesterState::AwaitResp
@@ -3365,5 +3377,128 @@ board_io: []
             .as_ref()
             .unwrap()
             .contains("step 0"));
+    }
+
+    /// Script-path FF+1CF request: send.len() == 8 (one CF required).
+    /// Verifies that the ConsecutiveFrame is injected onto the bus after the
+    /// ECU's FlowControl arrives, and that the step reaches Done.
+    ///
+    /// This test exercises the bug fixed in this commit: before the fix,
+    /// observe_ecu_frame_script set state=AwaitResp before service_can_uds_testers
+    /// evaluated to_send, so the CF payload was silently discarded.
+    #[test]
+    fn uds_tester_script_ff_plus_one_cf_request_completes() {
+        use crate::peripherals::bxcan::BxCan;
+
+        // 8-byte payload: FF carries bytes 0..5, CF carries bytes 6..7.
+        // Expected response for 0x27 service: 0x67 0x02 (single-frame).
+        let mut bus = bus_with_script(&[("27 01 02 03 04 05 06 07", "67 02")]);
+
+        // bus_with_script already ran tick 1: FF sent, state=AwaitFc.
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitFc);
+        assert_eq!(bus.can_uds_testers[0].pending_cfs.len(), 1,
+            "one CF must be queued after FF");
+
+        // ECU responds with FlowControl (ContinueToSend).
+        inject_ecu_reply(&mut bus, 0x222, &[0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        // Tick 2: tester drains the FC and injects the CF.
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitResp,
+            "CF must be injected and state must advance to AwaitResp");
+        assert!(bus.can_uds_testers[0].pending_cfs.is_empty(),
+            "pending_cfs must be drained after the only CF is sent");
+
+        // Confirm the CF actually landed in the bxCAN RX buffer (direction=rx
+        // means the tester delivered it into the ECU-side FIFO).
+        {
+            let idx = bus.find_peripheral_index_by_name("bxcan1").unwrap();
+            let bx = bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<BxCan>()
+                .unwrap();
+            let trace = bx.trace_snapshot("bxcan1");
+            // trace contains all rx frames: FF (tick 1) + CF (tick 2).
+            assert!(
+                trace.iter().any(|f| f.direction == "rx"
+                    && f.id == 0x111
+                    && f.data.first() == Some(&0x21)),
+                "CF (SN=0x21) must appear as an rx frame in the bxCAN trace"
+            );
+        }
+
+        // ECU sends the positive response (single-frame: len=3, 0x67 0x02 0xAB).
+        inject_ecu_reply(&mut bus, 0x222, &[0x03, 0x67, 0x02, 0xAB]);
+
+        // Tick 3: tester matches the response → Done.
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+    }
+
+    /// Script-path FF+2CF request: send.len() == 14 (two CFs required).
+    /// Verifies that both ConsecutiveFrames are injected on successive ticks
+    /// and the step reaches Done.
+    #[test]
+    fn uds_tester_script_ff_plus_two_cf_request_completes() {
+        use crate::peripherals::bxcan::BxCan;
+
+        // 14-byte payload: FF carries bytes 0..5, CF1 carries 6..12, CF2 carries 13.
+        // Expected response: 0x76 0x01.
+        let mut bus =
+            bus_with_script(&[("36 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D", "76 01")]);
+
+        // Tick 1 already ran: FF sent, two CFs queued.
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitFc);
+        assert_eq!(bus.can_uds_testers[0].pending_cfs.len(), 2,
+            "two CFs must be queued after FF");
+
+        // ECU replies with FlowControl.
+        inject_ecu_reply(&mut bus, 0x222, &[0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        // Tick 2: CF1 injected; one CF still pending, state stays AwaitFc.
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitFc,
+            "state must stay AwaitFc while CFs remain");
+        assert_eq!(bus.can_uds_testers[0].pending_cfs.len(), 1,
+            "one CF must remain after CF1 is sent");
+
+        // Tick 3: no new ECU frame; CF2 taken from pending_cfs → AwaitResp.
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitResp,
+            "state must advance to AwaitResp after last CF is sent");
+        assert!(bus.can_uds_testers[0].pending_cfs.is_empty());
+
+        // Verify both CFs appear in the trace (SN 0x21 and 0x22).
+        {
+            let idx = bus.find_peripheral_index_by_name("bxcan1").unwrap();
+            let bx = bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<BxCan>()
+                .unwrap();
+            let trace = bx.trace_snapshot("bxcan1");
+            assert!(
+                trace.iter().any(|f| f.direction == "rx"
+                    && f.id == 0x111
+                    && f.data.first() == Some(&0x21)),
+                "CF1 (SN=0x21) must appear as an rx frame"
+            );
+            assert!(
+                trace.iter().any(|f| f.direction == "rx"
+                    && f.id == 0x111
+                    && f.data.first() == Some(&0x22)),
+                "CF2 (SN=0x22) must appear as an rx frame"
+            );
+        }
+
+        // ECU single-frame positive response.
+        inject_ecu_reply(&mut bus, 0x222, &[0x02, 0x76, 0x01]);
+
+        // Tick 4: match → Done.
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
     }
 }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -405,9 +405,8 @@ impl CanUdsTester {
             }
             CanUdsTesterState::AwaitMultiResp => {
                 if data.first().map(|b| b & 0xF0) == Some(0x20) {
-                    self.resp_buf.extend_from_slice(
-                        data.get(1..).unwrap_or(&[]),
-                    );
+                    self.resp_buf
+                        .extend_from_slice(data.get(1..).unwrap_or(&[]));
                     if self.resp_buf.len() >= self.resp_expected_len {
                         let payload = self.resp_buf[..self.resp_expected_len].to_vec();
                         self.resp_buf.clear();
@@ -904,9 +903,7 @@ impl SystemBus {
                 }
             } else {
                 match self.can_uds_testers[i].state {
-                    CanUdsTesterState::Start => {
-                        Some(self.can_uds_testers[i].first_frame.clone())
-                    }
+                    CanUdsTesterState::Start => Some(self.can_uds_testers[i].first_frame.clone()),
                     CanUdsTesterState::AwaitFc => pending_inject,
                     _ => None,
                 }
@@ -1052,10 +1049,7 @@ impl SystemBus {
         seq.iter()
             .map(|entry| {
                 let send = Self::yaml_bytes(entry.get("send"), &[]);
-                let expect_str = entry
-                    .get("expect")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let expect_str = entry.get("expect").and_then(|v| v.as_str()).unwrap_or("");
                 let expect = Self::parse_expect(expect_str);
                 let expect_nrc = entry
                     .get("expect_nrc")
@@ -3821,18 +3815,30 @@ board_io: []
 
         // bus_with_script already ran tick 1: FF sent, state=AwaitFc.
         assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitFc);
-        assert_eq!(bus.can_uds_testers[0].pending_cfs.len(), 1,
-            "one CF must be queued after FF");
+        assert_eq!(
+            bus.can_uds_testers[0].pending_cfs.len(),
+            1,
+            "one CF must be queued after FF"
+        );
 
         // ECU responds with FlowControl (ContinueToSend).
-        inject_ecu_reply(&mut bus, 0x222, &[0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        inject_ecu_reply(
+            &mut bus,
+            0x222,
+            &[0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        );
 
         // Tick 2: tester drains the FC and injects the CF.
         bus.service_can_uds_testers();
-        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitResp,
-            "CF must be injected and state must advance to AwaitResp");
-        assert!(bus.can_uds_testers[0].pending_cfs.is_empty(),
-            "pending_cfs must be drained after the only CF is sent");
+        assert_eq!(
+            bus.can_uds_testers[0].state,
+            CanUdsTesterState::AwaitResp,
+            "CF must be injected and state must advance to AwaitResp"
+        );
+        assert!(
+            bus.can_uds_testers[0].pending_cfs.is_empty(),
+            "pending_cfs must be drained after the only CF is sent"
+        );
 
         // Confirm the CF actually landed in the bxCAN RX buffer (direction=rx
         // means the tester delivered it into the ECU-side FIFO).
@@ -3847,9 +3853,9 @@ board_io: []
             let trace = bx.trace_snapshot("bxcan1");
             // trace contains all rx frames: FF (tick 1) + CF (tick 2).
             assert!(
-                trace.iter().any(|f| f.direction == "rx"
-                    && f.id == 0x111
-                    && f.data.first() == Some(&0x21)),
+                trace
+                    .iter()
+                    .any(|f| f.direction == "rx" && f.id == 0x111 && f.data.first() == Some(&0x21)),
                 "CF (SN=0x21) must appear as an rx frame in the bxCAN trace"
             );
         }
@@ -3871,28 +3877,43 @@ board_io: []
 
         // 14-byte payload: FF carries bytes 0..5, CF1 carries 6..12, CF2 carries 13.
         // Expected response: 0x76 0x01.
-        let mut bus =
-            bus_with_script(&[("36 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D", "76 01")]);
+        let mut bus = bus_with_script(&[("36 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D", "76 01")]);
 
         // Tick 1 already ran: FF sent, two CFs queued.
         assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitFc);
-        assert_eq!(bus.can_uds_testers[0].pending_cfs.len(), 2,
-            "two CFs must be queued after FF");
+        assert_eq!(
+            bus.can_uds_testers[0].pending_cfs.len(),
+            2,
+            "two CFs must be queued after FF"
+        );
 
         // ECU replies with FlowControl.
-        inject_ecu_reply(&mut bus, 0x222, &[0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        inject_ecu_reply(
+            &mut bus,
+            0x222,
+            &[0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        );
 
         // Tick 2: CF1 injected; one CF still pending, state stays AwaitFc.
         bus.service_can_uds_testers();
-        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitFc,
-            "state must stay AwaitFc while CFs remain");
-        assert_eq!(bus.can_uds_testers[0].pending_cfs.len(), 1,
-            "one CF must remain after CF1 is sent");
+        assert_eq!(
+            bus.can_uds_testers[0].state,
+            CanUdsTesterState::AwaitFc,
+            "state must stay AwaitFc while CFs remain"
+        );
+        assert_eq!(
+            bus.can_uds_testers[0].pending_cfs.len(),
+            1,
+            "one CF must remain after CF1 is sent"
+        );
 
         // Tick 3: no new ECU frame; CF2 taken from pending_cfs → AwaitResp.
         bus.service_can_uds_testers();
-        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::AwaitResp,
-            "state must advance to AwaitResp after last CF is sent");
+        assert_eq!(
+            bus.can_uds_testers[0].state,
+            CanUdsTesterState::AwaitResp,
+            "state must advance to AwaitResp after last CF is sent"
+        );
         assert!(bus.can_uds_testers[0].pending_cfs.is_empty());
 
         // Verify both CFs appear in the trace (SN 0x21 and 0x22).
@@ -3906,15 +3927,15 @@ board_io: []
                 .unwrap();
             let trace = bx.trace_snapshot("bxcan1");
             assert!(
-                trace.iter().any(|f| f.direction == "rx"
-                    && f.id == 0x111
-                    && f.data.first() == Some(&0x21)),
+                trace
+                    .iter()
+                    .any(|f| f.direction == "rx" && f.id == 0x111 && f.data.first() == Some(&0x21)),
                 "CF1 (SN=0x21) must appear as an rx frame"
             );
             assert!(
-                trace.iter().any(|f| f.direction == "rx"
-                    && f.id == 0x111
-                    && f.data.first() == Some(&0x22)),
+                trace
+                    .iter()
+                    .any(|f| f.direction == "rx" && f.id == 0x111 && f.data.first() == Some(&0x22)),
                 "CF2 (SN=0x22) must appear as an rx frame"
             );
         }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -212,10 +212,6 @@ pub struct UdsStep {
     pub expect: Vec<Option<u8>>,
     /// Optional expected NRC byte (response 0x7F <sid> <nrc>).
     pub expect_nrc: Option<u8>,
-    /// When `true`, no response is expected within `timeout_ticks`.
-    pub expect_silence: bool,
-    /// Tick budget for this step before declaring a timeout.
-    pub timeout_ticks: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -443,10 +439,20 @@ impl CanUdsTester {
                 self.state = CanUdsTesterState::Start;
             }
         } else {
-            let msg = format!(
-                "step {}: expected {:02X?}, got {:02X?}",
-                self.step_idx, step.expect, payload
-            );
+            let msg = if let Some(nrc) = step.expect_nrc {
+                format!(
+                    "step {}: expected NRC 7F {:02X} {:02X}, got {:02X?}",
+                    self.step_idx,
+                    step.send.first().copied().unwrap_or(0),
+                    nrc,
+                    payload
+                )
+            } else {
+                format!(
+                    "step {}: expected {:02X?}, got {:02X?}",
+                    self.step_idx, step.expect, payload
+                )
+            };
             self.failure = Some(msg);
             self.state = CanUdsTesterState::Failed;
         }
@@ -1054,20 +1060,10 @@ impl SystemBus {
                 let expect_nrc = entry
                     .get("expect_nrc")
                     .map(|v| Self::yaml_u32(Some(v), 0) as u8);
-                let expect_silence = entry
-                    .get("expect_silence")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                let timeout_ticks = entry
-                    .get("timeout_ticks")
-                    .map(|v| Self::yaml_u32(Some(v), 0) as u64)
-                    .unwrap_or(CanUdsTester::DEFAULT_MAX_TICKS);
                 UdsStep {
                     send,
                     expect,
                     expect_nrc,
-                    expect_silence,
-                    timeout_ticks,
                 }
             })
             .collect()
@@ -2535,7 +2531,7 @@ board_io: []
     }
 
     #[test]
-    fn uds_script_parses_optional_step_fields() {
+    fn uds_script_parses_optional_expect_nrc() {
         let manifest: SystemManifest = serde_yaml::from_str(
             r#"
 name: "uds-script-opts"
@@ -2550,9 +2546,7 @@ external_devices:
       script:
         - send: "28 03"
           expect: "68 03"
-          timeout_ticks: 500
           expect_nrc: "0x22"
-          expect_silence: true
 board_io: []
 "#,
         )
@@ -2560,9 +2554,7 @@ board_io: []
         let chip: ChipDescriptor = serde_yaml::from_str(MIN_F103_CHIP).unwrap();
         let bus = SystemBus::from_config(&chip, &manifest).unwrap();
         let step = &bus.can_uds_testers[0].script[0];
-        assert_eq!(step.timeout_ticks, 500);
         assert_eq!(step.expect_nrc, Some(0x22));
-        assert!(step.expect_silence);
     }
 
     #[test]
@@ -2594,8 +2586,6 @@ board_io: []
             vec![0x27, 0x01, 0x5A, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]
         );
         assert_eq!(t.script[0].expect_nrc, None);
-        assert!(!t.script[0].expect_silence);
-        assert_eq!(t.script[0].timeout_ticks, CanUdsTester::DEFAULT_MAX_TICKS);
     }
 
     /// Parse a minimal chip yaml with the given header lines (name/arch/core).
@@ -3698,7 +3688,7 @@ board_io: []
     }
 
     // -----------------------------------------------------------------------
-    // Script-driven FSM tests (Task 3)
+    // Script-driven FSM tests
     // -----------------------------------------------------------------------
 
     /// Build a bus with an F103 + bxCAN in normal mode (filter accepts 0x111)
@@ -3747,8 +3737,6 @@ board_io: []
                 ),
                 expect: SystemBus::parse_expect(expect_str),
                 expect_nrc: None,
-                expect_silence: false,
-                timeout_ticks: CanUdsTester::DEFAULT_MAX_TICKS,
             })
             .collect();
 

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -192,6 +192,7 @@ pub struct CanDiagnosticTester {
 /// frames via `deliver_rx` (bxCAN) / `receive_frame` (FDCAN). Injection is
 /// filter-gated, so a `false` return (filter not yet configured, FIFO full)
 /// leaves the FSM parked on the same send to retry next tick.
+// -----
 /// One step in a UDS tester script: a raw payload to send and the
 /// expected response bytes (`None` = `..` wildcard, any byte matches).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -762,7 +763,16 @@ impl SystemBus {
                 .map(|part| {
                     let part = part.trim();
                     if let Some(hex) = part.strip_prefix("0x").or_else(|| part.strip_prefix("0X")) {
-                        u8::from_str_radix(hex, 16).unwrap_or(0)
+                        match u8::from_str_radix(hex, 16) {
+                            Ok(b) => b,
+                            Err(_) => {
+                                tracing::warn!(
+                                    "[uds-tester] malformed send byte {:?}, treating as 0x00",
+                                    part
+                                );
+                                0
+                            }
+                        }
                     } else {
                         u8::from_str_radix(part, 16)
                             .unwrap_or_else(|_| part.parse::<u8>().unwrap_or(0))
@@ -783,7 +793,16 @@ impl SystemBus {
                     None
                 } else {
                     let hex = tok.trim_start_matches("0x").trim_start_matches("0X");
-                    Some(u8::from_str_radix(hex, 16).unwrap_or(0))
+                    match u8::from_str_radix(hex, 16) {
+                        Ok(b) => Some(b),
+                        Err(_) => {
+                            tracing::warn!(
+                                "[uds-tester] malformed expect token {:?}, treating as 0x00",
+                                tok
+                            );
+                            Some(0)
+                        }
+                    }
                 }
             })
             .collect()
@@ -796,7 +815,7 @@ impl SystemBus {
             _ => return Vec::new(),
         };
         seq.iter()
-            .filter_map(|entry| {
+            .map(|entry| {
                 let send = Self::yaml_bytes(entry.get("send"), &[]);
                 let expect_str = entry
                     .get("expect")
@@ -814,13 +833,13 @@ impl SystemBus {
                     .get("timeout_ticks")
                     .map(|v| Self::yaml_u32(Some(v), 0) as u64)
                     .unwrap_or(CanUdsTester::DEFAULT_MAX_TICKS);
-                Some(UdsStep {
+                UdsStep {
                     send,
                     expect,
                     expect_nrc,
                     expect_silence,
                     timeout_ticks,
-                })
+                }
             })
             .collect()
     }
@@ -2282,6 +2301,37 @@ board_io: []
         assert_eq!(t.script[0].send, vec![0x11, 0x01]);
         assert_eq!(t.script[0].expect, vec![Some(0x51), Some(0x01)]);
         assert_eq!(t.script[1].expect, vec![Some(0x67), Some(0x01), None]); // .. = wildcard
+    }
+
+    #[test]
+    fn uds_script_parses_optional_step_fields() {
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "uds-script-opts"
+chip: "f103"
+external_devices:
+  - id: "uds-tester"
+    type: "uds-tester"
+    connection: "bxcan1"
+    config:
+      request_id: "0x111"
+      reply_id: "0x222"
+      script:
+        - send: "28 03"
+          expect: "68 03"
+          timeout_ticks: 500
+          expect_nrc: "0x22"
+          expect_silence: true
+board_io: []
+"#,
+        )
+        .unwrap();
+        let chip: ChipDescriptor = serde_yaml::from_str(MIN_F103_CHIP).unwrap();
+        let bus = SystemBus::from_config(&chip, &manifest).unwrap();
+        let step = &bus.can_uds_testers[0].script[0];
+        assert_eq!(step.timeout_ticks, 500);
+        assert_eq!(step.expect_nrc, Some(0x22));
+        assert!(step.expect_silence);
     }
 
     /// Parse a minimal chip yaml with the given header lines (name/arch/core).

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2358,6 +2358,13 @@ board_io: []
         let t = &bus.can_uds_testers[0];
         assert_eq!(t.script.len(), 1);
         assert_eq!(t.script[0].expect, vec![Some(0x06), Some(0x67)]);
+        assert_eq!(
+            t.script[0].send,
+            vec![0x27, 0x01, 0x5A, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]
+        );
+        assert_eq!(t.script[0].expect_nrc, None);
+        assert!(!t.script[0].expect_silence);
+        assert_eq!(t.script[0].timeout_ticks, CanUdsTester::DEFAULT_MAX_TICKS);
     }
 
     /// Parse a minimal chip yaml with the given header lines (name/arch/core).

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2334,6 +2334,32 @@ board_io: []
         assert!(step.expect_silence);
     }
 
+    #[test]
+    fn uds_legacy_config_becomes_one_step_script() {
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "uds-legacy"
+chip: "f103"
+external_devices:
+  - id: "uds_node"
+    type: "uds-tester"
+    connection: "bxcan1"
+    config:
+      request_id: "0x111"
+      reply_id: "0x222"
+      first_frame: "10 0B 27 01 5A 11 22 33"
+      consecutive_frame: "21 44 55 66 77 88 55 55"
+board_io: []
+"#,
+        )
+        .unwrap();
+        let chip: ChipDescriptor = serde_yaml::from_str(MIN_F103_CHIP).unwrap();
+        let bus = SystemBus::from_config(&chip, &manifest).unwrap();
+        let t = &bus.can_uds_testers[0];
+        assert_eq!(t.script.len(), 1);
+        assert_eq!(t.script[0].expect, vec![Some(0x06), Some(0x67)]);
+    }
+
     /// Parse a minimal chip yaml with the given header lines (name/arch/core).
     fn bit_band_test_chip(header: &str, gpio_base: &str, gpio_profile: &str) -> ChipDescriptor {
         let yaml = format!(

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -192,6 +192,22 @@ pub struct CanDiagnosticTester {
 /// frames via `deliver_rx` (bxCAN) / `receive_frame` (FDCAN). Injection is
 /// filter-gated, so a `false` return (filter not yet configured, FIFO full)
 /// leaves the FSM parked on the same send to retry next tick.
+/// One step in a UDS tester script: a raw payload to send and the
+/// expected response bytes (`None` = `..` wildcard, any byte matches).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UdsStep {
+    /// Raw bytes to send to the ECU (before ISO-TP framing).
+    pub send: Vec<u8>,
+    /// Expected response bytes; `None` entries match any byte.
+    pub expect: Vec<Option<u8>>,
+    /// Optional expected NRC byte (response 0x7F <sid> <nrc>).
+    pub expect_nrc: Option<u8>,
+    /// When `true`, no response is expected within `timeout_ticks`.
+    pub expect_silence: bool,
+    /// Tick budget for this step before declaring a timeout.
+    pub timeout_ticks: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CanUdsTesterState {
     /// Need to inject the FirstFrame.
@@ -224,6 +240,12 @@ pub struct CanUdsTester {
     pub ticks: u64,
     /// Tick budget before declaring `Failed`.
     pub max_ticks: u64,
+    /// Scripted exchange steps; empty when using legacy hardcoded payloads.
+    pub script: Vec<UdsStep>,
+    /// Index of the current step in `script`.
+    pub step_idx: usize,
+    /// Set when a step fails; describes what went wrong.
+    pub failure: Option<String>,
 }
 
 impl CanUdsTester {
@@ -246,6 +268,9 @@ impl CanUdsTester {
             state: CanUdsTesterState::Start,
             ticks: 0,
             max_ticks: Self::DEFAULT_MAX_TICKS,
+            script: Vec::new(),
+            step_idx: 0,
+            failure: None,
         }
     }
 
@@ -746,6 +771,58 @@ impl SystemBus {
                 .collect(),
             _ => default.to_vec(),
         }
+    }
+
+    /// Parse an expect string such as `"51 01 .."` into a mask vector.
+    /// `".."` becomes `None` (wildcard); any other token is parsed as a hex
+    /// byte and becomes `Some(byte)`.
+    fn parse_expect(s: &str) -> Vec<Option<u8>> {
+        s.split_ascii_whitespace()
+            .map(|tok| {
+                if tok == ".." {
+                    None
+                } else {
+                    let hex = tok.trim_start_matches("0x").trim_start_matches("0X");
+                    Some(u8::from_str_radix(hex, 16).unwrap_or(0))
+                }
+            })
+            .collect()
+    }
+
+    /// Parse an optional YAML `script:` sequence into a `Vec<UdsStep>`.
+    fn parse_script(value: Option<&serde_yaml::Value>) -> Vec<UdsStep> {
+        let seq = match value {
+            Some(serde_yaml::Value::Sequence(s)) => s,
+            _ => return Vec::new(),
+        };
+        seq.iter()
+            .filter_map(|entry| {
+                let send = Self::yaml_bytes(entry.get("send"), &[]);
+                let expect_str = entry
+                    .get("expect")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let expect = Self::parse_expect(expect_str);
+                let expect_nrc = entry
+                    .get("expect_nrc")
+                    .map(|v| Self::yaml_u32(Some(v), 0) as u8);
+                let expect_silence = entry
+                    .get("expect_silence")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let timeout_ticks = entry
+                    .get("timeout_ticks")
+                    .map(|v| Self::yaml_u32(Some(v), 0) as u64)
+                    .unwrap_or(CanUdsTester::DEFAULT_MAX_TICKS);
+                Some(UdsStep {
+                    send,
+                    expect,
+                    expect_nrc,
+                    expect_silence,
+                    timeout_ticks,
+                })
+            })
+            .collect()
     }
 
     /// Write-hook mirror of [`maybe_latch_dc`](Self::maybe_latch_dc) for the
@@ -2156,6 +2233,55 @@ board_io: []
             CanUdsTester::DEFAULT_CONSECUTIVE_FRAME.to_vec()
         );
         assert_eq!(t.state, CanUdsTesterState::Start);
+    }
+
+    /// Minimal F103 chip yaml reused across UDS script tests.
+    const MIN_F103_CHIP: &str = r#"
+name: "f103"
+arch: "arm"
+core: "cortex-m3"
+flash:
+  base: 0x08000000
+  size: "128KB"
+ram:
+  base: 0x20000000
+  size: "20KB"
+peripherals:
+  - id: "bxcan1"
+    type: "bxcan"
+    base_address: 0x40006400
+    size: "1KB"
+"#;
+
+    #[test]
+    fn uds_script_parses_send_expect_and_wildcards() {
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "uds-script"
+chip: "f103"
+external_devices:
+  - id: "uds-tester"
+    type: "uds-tester"
+    connection: "bxcan1"
+    config:
+      request_id: "0x111"
+      reply_id: "0x222"
+      script:
+        - send: "11 01"
+          expect: "51 01"
+        - send: "27 01"
+          expect: "67 01 .."
+board_io: []
+"#,
+        )
+        .unwrap();
+        let chip: ChipDescriptor = serde_yaml::from_str(MIN_F103_CHIP).unwrap();
+        let bus = SystemBus::from_config(&chip, &manifest).unwrap();
+        let t = &bus.can_uds_testers[0];
+        assert_eq!(t.script.len(), 2);
+        assert_eq!(t.script[0].send, vec![0x11, 0x01]);
+        assert_eq!(t.script[0].expect, vec![Some(0x51), Some(0x01)]);
+        assert_eq!(t.script[1].expect, vec![Some(0x67), Some(0x01), None]); // .. = wildcard
     }
 
     /// Parse a minimal chip yaml with the given header lines (name/arch/core).

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -217,6 +217,9 @@ pub enum CanUdsTesterState {
     AwaitFc,
     /// ConsecutiveFrame sent; waiting for the ECU's positive response.
     AwaitResp,
+    /// Tester sent FlowControl; collecting ECU ConsecutiveFrames until the
+    /// declared PDU length is reached (script-driven multi-frame response path).
+    AwaitMultiResp,
     /// SecurityAccess positive response observed — handshake complete.
     Done,
     /// Timed out before completion (broken / silent ECU).
@@ -247,6 +250,15 @@ pub struct CanUdsTester {
     pub step_idx: usize,
     /// Set when a step fails; describes what went wrong.
     pub failure: Option<String>,
+    /// PDU accumulator for the script-driven multi-frame ECU response path.
+    /// Cleared at the start of each step.
+    resp_buf: Vec<u8>,
+    /// Declared PDU length from the ECU's FF header (script path only).
+    resp_expected_len: usize,
+    /// Remaining ConsecutiveFrames to inject for a multi-frame tester request,
+    /// populated after the request FF is accepted and the ECU FlowControl is
+    /// received (script path only).
+    pending_cfs: Vec<Vec<u8>>,
 }
 
 impl CanUdsTester {
@@ -272,6 +284,165 @@ impl CanUdsTester {
             script: Vec::new(),
             step_idx: 0,
             failure: None,
+            resp_buf: Vec::new(),
+            resp_expected_len: 0,
+            pending_cfs: Vec::new(),
+        }
+    }
+
+    /// Build the ISO-TP request frame(s) for `script[step_idx]`.
+    /// Single-frame when `send.len() <= 7`; otherwise a FirstFrame followed by
+    /// ConsecutiveFrames. The caller sends the first frame and queues the rest
+    /// in `pending_cfs` after FlowControl.
+    fn build_request_frames(&self) -> Vec<Vec<u8>> {
+        let Some(step) = self.script.get(self.step_idx) else {
+            return Vec::new();
+        };
+        let data = &step.send;
+        let len = data.len();
+        if len <= 7 {
+            // Single-frame: [len, payload...]
+            let mut frame = Vec::with_capacity(len + 1);
+            frame.push(len as u8);
+            frame.extend_from_slice(data);
+            return vec![frame];
+        }
+        // Multi-frame: FF then CFs.
+        let mut frames = Vec::new();
+        // FirstFrame: [0x10 | (len>>8), len & 0xFF, first 6 bytes]
+        let mut ff = Vec::with_capacity(8);
+        ff.push(0x10 | ((len >> 8) as u8));
+        ff.push((len & 0xFF) as u8);
+        ff.extend_from_slice(&data[..6.min(len)]);
+        frames.push(ff);
+        // ConsecutiveFrames
+        let mut seq: u8 = 1;
+        let mut offset = 6;
+        while offset < len {
+            let end = (offset + 7).min(len);
+            let mut cf = Vec::with_capacity(8);
+            cf.push(0x20 | (seq & 0x0F));
+            cf.extend_from_slice(&data[offset..end]);
+            frames.push(cf);
+            seq = seq.wrapping_add(1);
+            offset = end;
+        }
+        frames
+    }
+
+    /// Return `true` when `resp` satisfies the match criteria of `step`.
+    /// If `step.expect_nrc` is `Some(nrc)`, matches `[0x7F, send[0], nrc]`.
+    /// Otherwise compares against `step.expect` element-wise (`None` = any byte),
+    /// allowing `resp` to be longer than the pattern (prefix match).
+    fn matches(resp: &[u8], step: &UdsStep) -> bool {
+        if let Some(nrc) = step.expect_nrc {
+            return resp == [0x7F, step.send.first().copied().unwrap_or(0), nrc];
+        }
+        let pattern = &step.expect;
+        if resp.len() < pattern.len() {
+            return false;
+        }
+        pattern
+            .iter()
+            .zip(resp.iter())
+            .all(|(p, b)| p.is_none_or(|expected| expected == *b))
+    }
+
+    /// Observe one ECU frame in the **script-driven** path. Returns the payload
+    /// to inject next (FlowControl or first pending CF), or `None`. Sets
+    /// `state = Done / Failed` when the exchange concludes.
+    fn observe_ecu_frame_script(&mut self, id: u32, data: &[u8]) -> Option<Vec<u8>> {
+        if id != self.reply_id {
+            return None;
+        }
+        match self.state {
+            CanUdsTesterState::AwaitFc => {
+                if data.first().map(|b| b & 0xF0) == Some(0x30) {
+                    // FlowControl received: inject all pending CFs.
+                    // Return the first one now; the rest are queued.
+                    // (For the test harness there is only 1 CF, but handle N.)
+                    if !self.pending_cfs.is_empty() {
+                        let first_cf = self.pending_cfs.remove(0);
+                        self.state = CanUdsTesterState::AwaitResp;
+                        return Some(first_cf);
+                    }
+                    self.state = CanUdsTesterState::AwaitResp;
+                }
+                None
+            }
+            CanUdsTesterState::AwaitResp => {
+                let ptype = data.first().map(|b| b & 0xF0).unwrap_or(0xFF);
+                if ptype == 0x00 {
+                    // ECU SingleFrame response
+                    let pdu_len = (data.first().copied().unwrap_or(0) & 0x0F) as usize;
+                    let payload: Vec<u8> = data
+                        .get(1..)
+                        .unwrap_or(&[])
+                        .iter()
+                        .copied()
+                        .take(pdu_len)
+                        .collect();
+                    self.complete_response(payload);
+                } else if ptype == 0x10 {
+                    // ECU FirstFrame: start reassembly, send FlowControl.
+                    let declared = if data.len() >= 2 {
+                        (((data[0] & 0x0F) as usize) << 8) | (data[1] as usize)
+                    } else {
+                        0
+                    };
+                    self.resp_expected_len = declared;
+                    self.resp_buf.clear();
+                    if data.len() > 2 {
+                        self.resp_buf.extend_from_slice(&data[2..]);
+                    }
+                    self.state = CanUdsTesterState::AwaitMultiResp;
+                    // FlowControl: ContinueToSend, block size 0, ST 0.
+                    return Some(vec![0x30, 0x00, 0x00]);
+                }
+                None
+            }
+            CanUdsTesterState::AwaitMultiResp => {
+                if data.first().map(|b| b & 0xF0) == Some(0x20) {
+                    self.resp_buf.extend_from_slice(
+                        data.get(1..).unwrap_or(&[]),
+                    );
+                    if self.resp_buf.len() >= self.resp_expected_len {
+                        let payload = self.resp_buf[..self.resp_expected_len].to_vec();
+                        self.resp_buf.clear();
+                        self.complete_response(payload);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Called when a complete PDU has been reassembled. Matches against the
+    /// current step and either advances to the next step (or `Done`) or sets
+    /// `Failed`.
+    fn complete_response(&mut self, payload: Vec<u8>) {
+        let Some(step) = self.script.get(self.step_idx) else {
+            self.state = CanUdsTesterState::Done;
+            return;
+        };
+        if Self::matches(&payload, step) {
+            self.step_idx += 1;
+            self.resp_buf.clear();
+            self.resp_expected_len = 0;
+            if self.step_idx >= self.script.len() {
+                self.state = CanUdsTesterState::Done;
+            } else {
+                // More steps: the driver will send the next request next tick.
+                self.state = CanUdsTesterState::Start;
+            }
+        } else {
+            let msg = format!(
+                "step {}: expected {:?}, got {:02X?}",
+                self.step_idx, step.expect, payload
+            );
+            self.failure = Some(msg);
+            self.state = CanUdsTesterState::Failed;
         }
     }
 
@@ -282,13 +453,19 @@ impl CanUdsTester {
         )
     }
 
-    /// Observe one frame the ECU transmitted. In `AwaitFc` an ISO-TP
-    /// FlowControl (`(data[0] & 0xF0) == 0x30`) on `reply_id` clears the wait;
-    /// in `AwaitResp` a SecurityAccess single-frame positive response
-    /// (`data[0] == 0x06 && data[1] == 0x67`) on `reply_id` completes the
-    /// handshake. Returns the payload to inject next (if the observation
-    /// unblocks a send), else `None`.
+    /// Observe one frame the ECU transmitted. Legacy path (empty `script`):
+    /// In `AwaitFc` an ISO-TP FlowControl (`(data[0] & 0xF0) == 0x30`) on
+    /// `reply_id` returns the ConsecutiveFrame payload to inject; in `AwaitResp`
+    /// a SecurityAccess single-frame positive response (`data[0] == 0x06 &&
+    /// data[1] == 0x67`) completes the handshake. Returns the payload to inject
+    /// next, else `None`.
+    ///
+    /// When `script` is non-empty, delegates to `observe_ecu_frame_script`
+    /// instead so the script-driven logic handles framing and matching.
     fn observe_ecu_frame(&mut self, id: u32, data: &[u8]) -> Option<Vec<u8>> {
+        if !self.script.is_empty() {
+            return self.observe_ecu_frame_script(id, data);
+        }
         if id != self.reply_id {
             return None;
         }
@@ -691,10 +868,31 @@ impl SystemBus {
             }
 
             // Decide what (if anything) to inject this tick.
-            let to_send: Option<Vec<u8>> = match self.can_uds_testers[i].state {
-                CanUdsTesterState::Start => Some(self.can_uds_testers[i].first_frame.clone()),
-                CanUdsTesterState::AwaitFc => pending_inject,
-                _ => None,
+            let has_script = !self.can_uds_testers[i].script.is_empty();
+            let to_send: Option<Vec<u8>> = if has_script {
+                match self.can_uds_testers[i].state {
+                    CanUdsTesterState::Start => {
+                        // Build request frames for the current script step.
+                        let frames = self.can_uds_testers[i].build_request_frames();
+                        if let Some((first, rest)) = frames.split_first() {
+                            // Queue any CFs for later (after FlowControl).
+                            self.can_uds_testers[i].pending_cfs = rest.to_vec();
+                            Some(first.clone())
+                        } else {
+                            None
+                        }
+                    }
+                    CanUdsTesterState::AwaitFc => pending_inject,
+                    _ => None,
+                }
+            } else {
+                match self.can_uds_testers[i].state {
+                    CanUdsTesterState::Start => {
+                        Some(self.can_uds_testers[i].first_frame.clone())
+                    }
+                    CanUdsTesterState::AwaitFc => pending_inject,
+                    _ => None,
+                }
             };
 
             let Some(payload) = to_send else {
@@ -723,7 +921,17 @@ impl SystemBus {
             if injected {
                 // Advance only on a successful (accepted) injection; otherwise
                 // stay parked and retry next tick.
+                let has_script = !self.can_uds_testers[i].script.is_empty();
                 match self.can_uds_testers[i].state {
+                    CanUdsTesterState::Start if has_script => {
+                        // SF (no pending CFs) → go straight to AwaitResp.
+                        // FF (pending CFs queued) → go to AwaitFc.
+                        if self.can_uds_testers[i].pending_cfs.is_empty() {
+                            self.can_uds_testers[i].state = CanUdsTesterState::AwaitResp;
+                        } else {
+                            self.can_uds_testers[i].state = CanUdsTesterState::AwaitFc;
+                        }
+                    }
                     CanUdsTesterState::Start => {
                         self.can_uds_testers[i].state = CanUdsTesterState::AwaitFc
                     }
@@ -3038,5 +3246,124 @@ board_io: []
             0x55,
             "clocked GPIOA must accept writes once ahb2enr.0 is set"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Script-driven FSM tests (Task 3)
+    // -----------------------------------------------------------------------
+
+    /// Build a bus with an F103 + bxCAN in normal mode (filter accepts 0x111)
+    /// and a UDS tester loaded with the given script steps. Each step is a
+    /// `(send_hex, expect_hex)` pair parsed the same way as the YAML config.
+    /// Returns the bus after the first service tick so the tester has already
+    /// sent its initial SF/FF and is in `AwaitResp` (or `AwaitFc` for a
+    /// multi-frame request).
+    fn bus_with_script(steps: &[(&str, &str)]) -> SystemBus {
+        use crate::peripherals::bxcan::BxCan;
+
+        // bxCAN register offsets (RM0008 §24.9).
+        const MCR: u64 = 0x000;
+        const BTR: u64 = 0x01C;
+        const FMR: u64 = 0x200;
+        const FM1R: u64 = 0x204;
+        const FS1R: u64 = 0x20C;
+        const FFA1R: u64 = 0x214;
+        const FA1R: u64 = 0x21C;
+        const FBANK: u64 = 0x240;
+        const VALID_BTR: u32 = 0x00DC_0009;
+        const BASE: u64 = 0x4000_6400;
+
+        let mut bus = SystemBus::empty();
+        bus.add_peripheral("bxcan1", BASE, 0x400, None, Box::new(BxCan::new()));
+
+        // Normal mode with bank-0 mask filter accepting 0x111 into FIFO0.
+        bus.write_u32(BASE + MCR, 1).unwrap();
+        bus.write_u32(BASE + BTR, VALID_BTR).unwrap();
+        bus.write_u32(BASE + FMR, 1).unwrap();
+        bus.write_u32(BASE + FS1R, 0x1).unwrap();
+        bus.write_u32(BASE + FM1R, 0x0).unwrap();
+        bus.write_u32(BASE + FFA1R, 0x0).unwrap();
+        bus.write_u32(BASE + FBANK, (0x111u32) << 21).unwrap();
+        bus.write_u32(BASE + FBANK + 4, (0x111u32) << 21).unwrap();
+        bus.write_u32(BASE + FA1R, 0x1).unwrap();
+        bus.write_u32(BASE + FMR, 0x0).unwrap();
+        bus.write_u32(BASE + MCR, 0).unwrap();
+
+        let script: Vec<UdsStep> = steps
+            .iter()
+            .map(|(send_str, expect_str)| UdsStep {
+                send: SystemBus::yaml_bytes(
+                    Some(&serde_yaml::Value::String(send_str.to_string())),
+                    &[],
+                ),
+                expect: SystemBus::parse_expect(expect_str),
+                expect_nrc: None,
+                expect_silence: false,
+                timeout_ticks: CanUdsTester::DEFAULT_MAX_TICKS,
+            })
+            .collect();
+
+        let mut tester = CanUdsTester::new("uds".into(), "bxcan1".into());
+        tester.script = script;
+        bus.can_uds_testers.push(tester);
+
+        // First tick: sends the initial request frame(s) for step 0.
+        bus.service_can_uds_testers();
+
+        bus
+    }
+
+    /// Push a simulated ECU frame into the connected bxCAN's `tx_frames` so
+    /// the next `service_can_uds_testers` call drains and processes it.
+    fn inject_ecu_reply(bus: &mut SystemBus, id: u32, data: &[u8]) {
+        use crate::peripherals::bxcan::BxCan;
+        let idx = bus
+            .find_peripheral_index_by_name("bxcan1")
+            .expect("bxcan1 must be registered");
+        let bx = bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<BxCan>()
+            .expect("bxcan1 must be BxCan");
+        bx.tx_frames
+            .push_back(crate::network::CanFrame::classic(id, data.to_vec()));
+    }
+
+    #[test]
+    fn uds_tester_single_step_sf_request_matches_reply() {
+        let mut bus = bus_with_script(&[("11 01", "51 01")]);
+        inject_ecu_reply(&mut bus, 0x222, &[0x02, 0x51, 0x01]);
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+    }
+
+    #[test]
+    fn uds_tester_wildcard_and_multistep() {
+        let mut bus = bus_with_script(&[("10 03", "50 03"), ("27 01", "67 01 ..")]);
+        // bus_with_script already sent step 0 request; inject step 0 reply.
+        inject_ecu_reply(&mut bus, 0x222, &[0x02, 0x50, 0x03]);
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].step_idx, 1);
+        // After step 0 completes, state returns to Start. The next service call
+        // sends step 1 request.
+        bus.service_can_uds_testers();
+        inject_ecu_reply(&mut bus, 0x222, &[0x03, 0x67, 0x01, 0xAB]);
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+    }
+
+    #[test]
+    fn uds_tester_nrc_mismatch_fails_with_reason() {
+        let mut bus = bus_with_script(&[("11 01", "51 01")]);
+        // NRC response (0x7F 0x11 0x22) — does not match expected "51 01".
+        inject_ecu_reply(&mut bus, 0x222, &[0x03, 0x7F, 0x11, 0x22]);
+        bus.service_can_uds_testers();
+        assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Failed);
+        assert!(bus.can_uds_testers[0]
+            .failure
+            .as_ref()
+            .unwrap()
+            .contains("step 0"));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -703,6 +703,13 @@ pub struct Machine<C: Cpu> {
     /// full peripheral list every cycle. `None` for configs with no FLASH
     /// peripheral on the bus (e.g. bare-bus unit tests).
     flash_index: Option<usize>,
+    /// Cached bus index of the SCB peripheral (Cortex-M). Resolved once at
+    /// construction; `step()` drains a pending SYSRESETREQ latch every cycle
+    /// and, when set, reboots the CPU through the vector table via the
+    /// existing `Machine::reset`. `None` for non-Cortex-M targets (no SCB on
+    /// the bus), so the per-cycle drain short-circuits without a peripheral
+    /// walk or downcast.
+    scb_index: Option<usize>,
     /// Phase 2B.3b (issue #192): whether the one-time scheduler bootstrap has
     /// run. On the first `drain_scheduler_events`, peripherals with setup-time
     /// work (e.g. a UART with an RX stream attached before any MMIO write) get
@@ -726,6 +733,12 @@ impl<C: Cpu> Machine<C> {
                 .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
                 .is_some()
         });
+        let scb_index = bus.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .and_then(|a| a.downcast_ref::<crate::peripherals::scb::Scb>())
+                .is_some()
+        });
         Self {
             cpu,
             cpu_secondary: None,
@@ -739,6 +752,7 @@ impl<C: Cpu> Machine<C> {
             clocks: sched::ClockGraph::new(),
             rtc_cntl_index,
             flash_index,
+            scb_index,
             scheduler_bootstrapped: false,
         }
     }
@@ -938,6 +952,20 @@ impl<C: Cpu> Machine<C> {
             self.cpu.set_pc(0x4000_0400);
             self.cpu.set_sp(0x3FFE_0000);
             tracing::debug!("RTC_CNTL SW_SYS_RST: CPU re-pointed at reset vector 0x40000400");
+        }
+
+        // Cortex-M SCB system reset (AIRCR.SYSRESETREQ with the VECTKEY).
+        // Firmware that asks for a reboot (e.g. a UDS ECUReset) writes
+        // AIRCR and does not expect the store to return; on real silicon the
+        // core restarts through the vector table. We drain the latch here, at
+        // the same clean instruction boundary as RTC_CNTL — after the
+        // AIRCR-writing store and any pending peripheral effects of this
+        // instruction have been applied — then reuse the power-on reset
+        // machinery so MSP/PC reload from vector[0]/vector[1] via the CPU
+        // reset path. No-op on non-Cortex-M targets (no SCB on the bus).
+        if self.drain_scb_reset_request() {
+            self.reset()?;
+            tracing::debug!("SCB SYSRESETREQ: CPU rebooted through vector table");
         }
 
         // H5 FLASH pending ops: sector erase fills flash with 0xFF; bank-swap
@@ -1145,6 +1173,27 @@ impl<C: Cpu> Machine<C> {
             .as_any()
             .and_then(|a| a.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>())
             .map(|rtc| rtc.drain_reset_request())
+            .unwrap_or(false)
+    }
+
+    /// Returns true (and clears the latch) if the registered SCB peripheral
+    /// has a pending SYSRESETREQ — an AIRCR write with the correct VECTKEY
+    /// and the SYSRESETREQ bit set (`Scb::write_reg`, offset 0x0C). Used by
+    /// `step()` to honor a firmware-requested system reset at a clean
+    /// instruction boundary. Uses the cached `scb_index` resolved at
+    /// construction — non-Cortex-M configs (no SCB on the bus) short-circuit
+    /// to `false` without touching the peripheral vector at all.
+    fn drain_scb_reset_request(&self) -> bool {
+        let Some(idx) = self.scb_index else {
+            return false;
+        };
+        let Some(p) = self.bus.peripherals.get(idx) else {
+            return false;
+        };
+        p.dev
+            .as_any()
+            .and_then(|a| a.downcast_ref::<crate::peripherals::scb::Scb>())
+            .map(|scb| scb.drain_reset_request())
             .unwrap_or(false)
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1183,7 +1183,7 @@ impl<C: Cpu> Machine<C> {
     /// instruction boundary. Uses the cached `scb_index` resolved at
     /// construction — non-Cortex-M configs (no SCB on the bus) short-circuit
     /// to `false` without touching the peripheral vector at all.
-    fn drain_scb_reset_request(&self) -> bool {
+    pub fn drain_scb_reset_request(&self) -> bool {
         let Some(idx) = self.scb_index else {
             return false;
         };
@@ -1343,6 +1343,14 @@ impl<C: Cpu> DebugControl for Machine<C> {
             // the CLI test runner and `Machine::run` take, where the op would
             // otherwise never be applied.
             self.apply_pending_flash_op()?;
+
+            // Honor a firmware-requested system reset (AIRCR SYSRESETREQ with
+            // VECTKEY) latched by the instructions just executed. `step()` drains
+            // this on every instruction boundary; the batched `run` path must do
+            // the same on every batch return or the reboot never fires.
+            if self.drain_scb_reset_request() {
+                self.reset()?;
+            }
 
             // If we executed less than requested, it means the CPU wanted to exit early (e.g. branch/exception)
             // or we just finished the batch naturally. The loop will continue and check breakpoints/limits.

--- a/crates/core/src/peripherals/scb.rs
+++ b/crates/core/src/peripherals/scb.rs
@@ -5,6 +5,7 @@
 // See the LICENSE file in the project root for full license information.
 
 use crate::SimResult;
+use std::cell::Cell;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -56,6 +57,10 @@ pub struct Scb {
     pub systick_pending: bool,
     /// NMI pend bit (ICSR.NMIPENDSET=bit 31).
     pub nmi_pending: bool,
+    /// Set when firmware writes AIRCR with the correct VECTKEY and SYSRESETREQ.
+    /// Drained by Task 6 reset routing via drain_reset_request().
+    #[serde(skip)]
+    pending_reset: Cell<bool>,
 }
 
 impl Scb {
@@ -94,7 +99,18 @@ impl Scb {
             pendsv_pending: false,
             systick_pending: false,
             nmi_pending: false,
+            pending_reset: Cell::new(false),
         }
+    }
+
+    /// Returns true once if a SYSRESETREQ was latched, then clears the latch.
+    pub fn drain_reset_request(&self) -> bool {
+        self.pending_reset.replace(false)
+    }
+
+    /// Write a 32-bit value to an SCB register at the given word-aligned offset.
+    pub fn write_register(&mut self, offset: u64, value: u32) {
+        self.write_reg(offset, value);
     }
 
     fn read_reg(&self, offset: u64) -> u32 {
@@ -147,7 +163,13 @@ impl Scb {
                 self.icsr = value;
             }
             0x08 => self.vtor.store(value, Ordering::Relaxed),
-            0x0C => self.aircr = value,
+            0x0C => {
+                if (value >> 16) == 0x05FA && value & (1 << 2) != 0 {
+                    self.pending_reset.set(true);
+                }
+                // Store masked: VECTKEY field reads back as 0 (matches silicon).
+                self.aircr = value & 0x0000_FFFF;
+            }
             0x10 => self.scr = value,
             0x14 => self.ccr = value,
             0x18 => self.shpr1.store(value, Ordering::Relaxed),
@@ -220,5 +242,25 @@ impl crate::Peripheral for Scb {
             );
         }
         value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aircr_sysresetreq_with_vectkey_latches_reset() {
+        let mut scb = Scb::new(Arc::new(AtomicU32::new(0)));
+        scb.write_register(0x0C, (0x05FA << 16) | (1 << 2)); // VECTKEY + SYSRESETREQ
+        assert!(scb.drain_reset_request());
+        assert!(!scb.drain_reset_request()); // latch cleared
+    }
+
+    #[test]
+    fn aircr_without_vectkey_does_not_reset() {
+        let mut scb = Scb::new(Arc::new(AtomicU32::new(0)));
+        scb.write_register(0x0C, 1 << 2); // SYSRESETREQ but no key
+        assert!(!scb.drain_reset_request());
     }
 }

--- a/crates/core/src/peripherals/scb.rs
+++ b/crates/core/src/peripherals/scb.rs
@@ -58,7 +58,7 @@ pub struct Scb {
     /// NMI pend bit (ICSR.NMIPENDSET=bit 31).
     pub nmi_pending: bool,
     /// Set when firmware writes AIRCR with the correct VECTKEY and SYSRESETREQ.
-    /// Drained by Task 6 reset routing via drain_reset_request().
+    /// Drained by the machine reset routing via drain_reset_request().
     #[serde(skip)]
     pending_reset: Cell<bool>,
 }

--- a/crates/core/src/peripherals/scb.rs
+++ b/crates/core/src/peripherals/scb.rs
@@ -203,6 +203,18 @@ impl crate::Peripheral for Scb {
         Ok(())
     }
 
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        // Firmware writes SCB registers with a full-word store (the CPU's
+        // STR lands on the bus's word path, which calls this). AIRCR is an
+        // action-on-write register whose VECTKEY (bits 31:16) reads back as
+        // 0 — so the default byte-by-byte decomposition would never see the
+        // VECTKEY and SYSRESETREQ together. Dispatch the coherent 32-bit
+        // value straight to `write_reg` so the reset latch (and the ICSR
+        // pend bits) react to the value the firmware actually wrote.
+        self.write_reg(offset & !3, value);
+        Ok(())
+    }
+
     fn tick(&mut self) -> crate::PeripheralTickResult {
         // Drain pending system-exception bits set by ICSR writes. NMI
         // takes priority over SysTick over PendSV when multiple are
@@ -232,6 +244,14 @@ impl crate::Peripheral for Scb {
             };
         }
         crate::PeripheralTickResult::default()
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
     }
 
     fn snapshot(&self) -> serde_json::Value {

--- a/crates/core/src/peripherals/scb.rs
+++ b/crates/core/src/peripherals/scb.rs
@@ -109,6 +109,8 @@ impl Scb {
     }
 
     /// Write a 32-bit value to an SCB register at the given word-aligned offset.
+    /// Only compiled in test builds; production MMIO goes through `Peripheral::write`.
+    #[cfg(test)]
     pub fn write_register(&mut self, offset: u64, value: u32) {
         self.write_reg(offset, value);
     }

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -7,4 +7,6 @@ pub mod nrf52;
 #[cfg(test)]
 pub mod rp2040;
 #[cfg(test)]
+pub mod scb_reset;
+#[cfg(test)]
 pub mod test_cycles;

--- a/crates/core/src/tests/scb_reset.rs
+++ b/crates/core/src/tests/scb_reset.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod scb_reset_tests {
-    use crate::{Cpu, Machine};
+    use crate::{Cpu, DebugControl, Machine};
 
     /// AIRCR address: SCB base (0xE000_ED00) + 0x0C.
     const SCB_AIRCR: u64 = 0xE000_ED0C;
@@ -59,6 +59,63 @@ mod scb_reset_tests {
             m.cpu.get_register(13),
             MSP,
             "SP must reload from vector[0] (MSP) after SYSRESETREQ"
+        );
+    }
+
+    /// Same SYSRESETREQ semantics, but exercised through the BATCHED execution
+    /// path (`Machine::run`) instead of a single `step()`. The batched path
+    /// bypasses `step()`, so it must drain the SCB reset latch on each batch
+    /// boundary — mirroring the flash-op drain — or the firmware-requested
+    /// reboot never fires. This regression guard fails without that drain
+    /// (PC keeps spinning in the post-AIRCR loop) and passes with it.
+    #[test]
+    fn sysresetreq_reboots_cpu_via_run() {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        let mut m = Machine::new(cpu, bus);
+
+        const MSP: u32 = 0x2000_1000;
+        // Keep the reset vector in the same region the start PC executes from so
+        // the post-reboot self-loop is fetchable on the bare test bus.
+        const RESET_ADDR: u32 = 0x2000_0100;
+
+        // Vector table at address 0 (VTOR defaults to 0).
+        m.bus.write_u32(0x0000_0000, MSP).unwrap();
+        m.bus.write_u32(0x0000_0004, RESET_ADDR | 1).unwrap(); // Thumb bit set
+
+        // After the reboot the core lands at the reset vector. Put a tight
+        // self-loop (`b .` == 0xE7FE) there so any post-reset steps keep PC
+        // pinned at RESET_ADDR, making the final state a deterministic proof
+        // of the reboot regardless of how many steps the batch ran.
+        m.bus.write_u16(RESET_ADDR as u64, 0xE7FE).unwrap();
+
+        // Firmware's pre-reset code: a NOP, then it would spin. We seed a NOP
+        // self-loop at the start PC too, but the AIRCR latch is already armed,
+        // so the first batch boundary must reboot before the loop matters.
+        const PC: u32 = 0x2000_0000;
+        m.bus.write_u16(PC as u64, 0xBF00).unwrap(); // NOP
+        m.bus.write_u16((PC + 2) as u64, 0xE7FE).unwrap(); // b . (spin)
+        m.cpu.set_pc(PC);
+        m.cpu.set_sp(0x2000_8000);
+
+        // Arm the reset latch via the exact MMIO path firmware uses.
+        m.bus
+            .write_u32(SCB_AIRCR, (0x05FA << 16) | (1 << 2))
+            .unwrap();
+
+        // Drive the BATCHED path. A small step budget is enough: the first
+        // batch boundary must drain the latch and reboot.
+        m.run(Some(8)).unwrap();
+
+        assert_eq!(
+            m.cpu.get_pc() & !1,
+            RESET_ADDR,
+            "PC must reload from vector[1] (reset vector) after SYSRESETREQ on the batched run path"
+        );
+        assert_eq!(
+            m.cpu.get_register(13),
+            MSP,
+            "SP must reload from vector[0] (MSP) after SYSRESETREQ on the batched run path"
         );
     }
 

--- a/crates/core/src/tests/scb_reset.rs
+++ b/crates/core/src/tests/scb_reset.rs
@@ -1,0 +1,99 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+#[cfg(test)]
+mod scb_reset_tests {
+    use crate::{Cpu, Machine};
+
+    /// AIRCR address: SCB base (0xE000_ED00) + 0x0C.
+    const SCB_AIRCR: u64 = 0xE000_ED0C;
+
+    /// A real Cortex-M write to AIRCR with the correct VECTKEY (0x05FA in
+    /// bits 31:16) and SYSRESETREQ (bit 2) must reboot the CPU through the
+    /// vector table on the next instruction boundary: MSP reloads from
+    /// vector[0] and PC from vector[1] (with the Thumb bit masked off),
+    /// reusing the existing power-on reset path.
+    #[test]
+    fn sysresetreq_reboots_cpu_via_vector_table() {
+        // Bare Cortex-M machine. `configure_cortex_m` registers the SCB at
+        // 0xE000_ED00 with VTOR defaulting to 0, so the vector table lives at
+        // address 0 (vector[0]=MSP, vector[1]=reset).
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        let mut m = Machine::new(cpu, bus);
+
+        const MSP: u32 = 0x2000_1000;
+        const RESET_ADDR: u32 = 0x0800_0100;
+
+        // Seed the vector table the same way power-on reset reads it.
+        m.bus.write_u32(0x0000_0000, MSP).unwrap();
+        m.bus.write_u32(0x0000_0004, RESET_ADDR | 1).unwrap(); // Thumb bit set
+
+        // Place a harmless instruction (NOP, 0xBF00) at the current PC so the
+        // step executes one full instruction before the reset latch is drained
+        // — mirroring firmware whose AIRCR store completes, then the core
+        // reboots at the next instruction boundary.
+        const PC: u32 = 0x2000_0000;
+        m.bus.write_u16(PC as u64, 0xBF00).unwrap(); // NOP
+        m.cpu.set_pc(PC);
+        m.cpu.set_sp(0x2000_8000);
+
+        // Trigger the latch through the exact MMIO path firmware uses: a real
+        // bus write to AIRCR. No test-only Scb setter.
+        m.bus
+            .write_u32(SCB_AIRCR, (0x05FA << 16) | (1 << 2))
+            .unwrap();
+
+        // One step: execute the NOP, then drain the SCB latch and reset.
+        m.step().unwrap();
+
+        assert_eq!(
+            m.cpu.get_pc() & !1,
+            RESET_ADDR,
+            "PC must reload from vector[1] (reset vector) after SYSRESETREQ"
+        );
+        assert_eq!(
+            m.cpu.get_register(13),
+            MSP,
+            "SP must reload from vector[0] (MSP) after SYSRESETREQ"
+        );
+    }
+
+    /// An AIRCR write missing the VECTKEY must NOT reset the CPU: the latch is
+    /// never set, so `step()` leaves PC/SP advancing normally.
+    #[test]
+    fn aircr_without_vectkey_does_not_reboot() {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        let mut m = Machine::new(cpu, bus);
+
+        const MSP: u32 = 0x2000_1000;
+        const RESET_ADDR: u32 = 0x0800_0100;
+        m.bus.write_u32(0x0000_0000, MSP).unwrap();
+        m.bus.write_u32(0x0000_0004, RESET_ADDR | 1).unwrap();
+
+        const PC: u32 = 0x2000_0000;
+        m.bus.write_u16(PC as u64, 0xBF00).unwrap(); // NOP
+        m.cpu.set_pc(PC);
+        m.cpu.set_sp(0x2000_8000);
+
+        // SYSRESETREQ bit set but no VECTKEY — silicon ignores it.
+        m.bus.write_u32(SCB_AIRCR, 1 << 2).unwrap();
+
+        m.step().unwrap();
+
+        assert_ne!(
+            m.cpu.get_pc() & !1,
+            RESET_ADDR,
+            "PC must not jump to the reset vector without the VECTKEY"
+        );
+        assert_eq!(
+            m.cpu.get_register(13),
+            0x2000_8000,
+            "SP must be untouched without a valid reset request"
+        );
+    }
+}

--- a/docs/superpowers/plans/2026-06-22-scriptable-uds-tester-and-reset.md
+++ b/docs/superpowers/plans/2026-06-22-scriptable-uds-tester-and-reset.md
@@ -1,0 +1,480 @@
+# Scriptable UDS Tester + Real Cortex-M System Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the ECU simulator drive any UDS service from a YAML script and assert its response, and make the emulator perform a real Cortex-M system reset so udslib issue #88 (0x11 answers before reboot) can be reproduced end-to-end.
+
+**Architecture:** Generalize `CanUdsTester` (`crates/core/src/bus/mod.rs`) from a hardcoded SecurityAccess FSM into a script-stepped request/expect engine that auto-frames ISO-TP. Add a `uds_tester` scenario assertion in the CLI runner. Make `SCB.AIRCR` honor SYSRESETREQ by latching a request that `Machine::step` drains and routes through the existing `Machine::reset()` — mirroring the established `drain_rtc_cntl_reset_request` pattern.
+
+**Tech Stack:** Rust (`labwired-core`, `labwired-cli`), serde_yaml, cargo test; ARM bare-metal example firmware (arm-none-eabi-gcc).
+
+## Global Constraints
+
+- Repo labwired-core has **no `develop`** — branch from latest `origin/main`; PR targets `main`. (Working branch: `feat/scriptable-uds-tester`.)
+- Integrate with `git merge`, never rebase. No "Claude"/AI references in commits. Commit identity: `w1ne <14119286+w1ne@users.noreply.github.com>`.
+- Must pass the **core-integrity** gate (clippy is default-members, not `--workspace`).
+- Reset must be a **real** silicon-faithful Cortex-M reset reusing existing `Machine::reset()` machinery — no shortcut/flag model. SRAM is not cleared by system reset; only what silicon resets is reset.
+- Backward compatibility: the existing `examples/f103-uds-ecu/uds-smoke.yaml` SecurityAccess scenario must still pass unchanged.
+- Core crate: `labwired-core`. CLI crate: `labwired-cli`, binary `labwired`. Scenario runner entry: `crates/cli/src/commands/test.rs::run_test`.
+
+---
+
+## Phase 1 — Scriptable UDS tester
+
+### Task 1: Script data model + config parsing
+
+**Files:**
+- Modify: `crates/core/src/bus/mod.rs` (the `CanUdsTester` struct ~209-286 and its config construction)
+- Test: `crates/core/src/bus/mod.rs` (`#[cfg(test)]` module, alongside `uds_tester_parsed_from_config` ~2110)
+
+**Interfaces:**
+- Produces:
+  - `pub struct UdsStep { pub send: Vec<u8>, pub expect: Vec<Option<u8>>, pub expect_nrc: Option<u8>, pub expect_silence: bool, pub timeout_ticks: u64 }` (`expect` byte `None` = `..` wildcard).
+  - `CanUdsTester` gains `pub script: Vec<UdsStep>`, `pub step_idx: usize`, and `pub failure: Option<String>`.
+  - `fn parse_script(value: Option<&serde_yaml::Value>) -> Vec<UdsStep>` and `fn parse_expect(s: &str) -> Vec<Option<u8>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn uds_script_parses_send_expect_and_wildcards() {
+    let manifest: SystemManifest = serde_yaml::from_str(
+        r#"
+name: "uds-script"
+chip: "f103"
+external_devices:
+  - id: "uds-tester"
+    type: "uds-tester"
+    connection: "bxcan1"
+    config:
+      request_id: "0x111"
+      reply_id: "0x222"
+      script:
+        - send: "11 01"
+          expect: "51 01"
+        - send: "27 01"
+          expect: "67 01 .."
+board_io: []
+"#,
+    )
+    .unwrap();
+    let chip: ChipDescriptor = serde_yaml::from_str(MIN_F103_CHIP).unwrap();
+    let bus = SystemBus::from_config(&chip, &manifest).unwrap();
+    let t = &bus.can_uds_testers[0];
+    assert_eq!(t.script.len(), 2);
+    assert_eq!(t.script[0].send, vec![0x11, 0x01]);
+    assert_eq!(t.script[0].expect, vec![Some(0x51), Some(0x01)]);
+    assert_eq!(t.script[1].expect, vec![Some(0x67), Some(0x01), None]); // .. = wildcard
+}
+```
+
+(Define `const MIN_F103_CHIP: &str` once at the top of the test module reusing the chip yaml already inlined in `uds_tester_parsed_from_config`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-core uds_script_parses_send_expect_and_wildcards`
+Expected: FAIL — `script` field / `UdsStep` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the struct and parsing. `parse_expect` splits on whitespace; `".."` → `None`, else `u8::from_str_radix(tok.trim_start_matches("0x"), 16)` → `Some`. `parse_script` walks the `script` sequence reading `send` (reuse existing `yaml_bytes`), `expect` (via `parse_expect`), optional `expect_nrc` (`yaml_u32 as u8`), `expect_silence` (bool), `timeout_ticks` (`yaml_u32 as u64`, default `DEFAULT_MAX_TICKS`). In the uds-tester construction branch, populate `script`; initialize `step_idx: 0`, `failure: None`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-core uds_script_parses_send_expect_and_wildcards`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/bus/mod.rs
+git commit -m "feat(sim): UDS tester script model + config parsing"
+```
+
+---
+
+### Task 2: Legacy-config translation (keep SecurityAccess smoke green)
+
+**Files:**
+- Modify: `crates/core/src/bus/mod.rs` (uds-tester construction)
+- Test: `crates/core/src/bus/mod.rs` test module
+
+**Interfaces:**
+- Consumes: `UdsStep`, `CanUdsTester.script` (Task 1).
+- Produces: when no `script:` key is present, a one-step script synthesized from `first_frame`/`consecutive_frame` with `expect` = `[Some(0x06), Some(0x67)]` (the legacy SecurityAccess completion).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn uds_legacy_config_becomes_one_step_script() {
+    let manifest: SystemManifest = serde_yaml::from_str(
+        r#"
+name: "uds-legacy"
+chip: "f103"
+external_devices:
+  - id: "uds_node"
+    type: "uds-tester"
+    connection: "bxcan1"
+    config:
+      request_id: "0x111"
+      reply_id: "0x222"
+      first_frame: "10 0B 27 01 5A 11 22 33"
+      consecutive_frame: "21 44 55 66 77 88 55 55"
+board_io: []
+"#,
+    )
+    .unwrap();
+    let chip: ChipDescriptor = serde_yaml::from_str(MIN_F103_CHIP).unwrap();
+    let bus = SystemBus::from_config(&chip, &manifest).unwrap();
+    let t = &bus.can_uds_testers[0];
+    assert_eq!(t.script.len(), 1);
+    assert_eq!(t.script[0].expect, vec![Some(0x06), Some(0x67)]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-core uds_legacy_config_becomes_one_step_script`
+Expected: FAIL — legacy path produces empty `script`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In the construction branch: if the `script` key is absent, build `vec![UdsStep { send: <decoded from first/consecutive frames as the raw UDS PDU 27 01 5A 11 22 33 44 55 66 77 88>, expect: vec![Some(0x06), Some(0x67)], expect_nrc: None, expect_silence: false, timeout_ticks: DEFAULT_MAX_TICKS }]`. Keep `first_frame`/`consecutive_frame` fields for the raw-injection path used by the framing engine in Task 3.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-core uds_legacy_config_becomes_one_step_script`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/bus/mod.rs
+git commit -m "feat(sim): translate legacy uds-tester config to a one-step script"
+```
+
+---
+
+### Task 3: ISO-TP framing + response reassembly + per-step FSM
+
+**Files:**
+- Modify: `crates/core/src/bus/mod.rs` — `CanUdsTesterState`, `observe_ecu_frame` (~265), `service_can_uds_testers` (~610)
+- Test: `crates/core/src/bus/mod.rs` test module
+
+**Interfaces:**
+- Consumes: `UdsStep`, `script`, `step_idx`, `failure`.
+- Produces: FSM that, per step, transmits the request (SF if `send.len() <= 7`, else FF + await FC + CF), reassembles the reply (SF or FF+CF with the tester emitting its own FlowControl), matches against `expect`/`expect_nrc`/`expect_silence`, then advances `step_idx` or sets `state = Failed` + `failure`. All steps matched → `Done`. New internal helpers `fn build_request_frames(&self) -> Vec<Vec<u8>>` and `fn matches(resp: &[u8], step: &UdsStep) -> bool`.
+
+- [ ] **Step 1: Write the failing test (single-frame request, exact reply)**
+
+```rust
+#[test]
+fn uds_tester_single_step_sf_request_matches_reply() {
+    // Build a bus with the f103 + a 1-step script: send 11 01, expect 51 01.
+    let mut bus = bus_with_script(&[("11 01", "51 01")]);
+    // ECU emits the SF positive response 02 51 01 on reply_id.
+    bus.inject_ecu_reply(0x222, &[0x02, 0x51, 0x01]);
+    bus.service_can_uds_testers();
+    assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+}
+```
+
+(Add two small test-only helpers in the test module: `bus_with_script(steps)` constructs the manifest+bus; `inject_ecu_reply(id, bytes)` pushes a `CanFrame` into the connected bxCAN `tx_frames` so the next `service_can_uds_testers` drains it. Model them on `uds_tester_fsm_drives_ff_fc_cf_response` ~1984.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-core uds_tester_single_step_sf_request_matches_reply`
+Expected: FAIL — current FSM only completes on `06 67`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the hardcoded completion. In `AwaitResp`, reassemble: SF (`data[0] & 0xF0 == 0x00`, len `data[0] & 0x0F`) yields the PDU directly; FF (`0x10`) starts reassembly, tester replies FlowControl `30 00 00`, CFs (`0x2N`) append until the FF-declared length is reached. On a complete PDU call `matches`; on match advance `step_idx` (→ build next request, or `Done` if none left); on mismatch set `Failed` + `failure`. `matches` checks `expect_nrc` (`7F <send[0]> <nrc>`), `expect_silence` (handled in the timeout branch: silence to `timeout_ticks` = pass), else compares `expect` element-wise treating `None` as wildcard, allowing the response to be longer than the pattern (prefix match). `build_request_frames` produces SF or FF+CF list for the current step's `send`. Drive sends in `service_can_uds_testers` from `script[step_idx]` instead of `first_frame`/`consecutive_frame`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-core uds_tester_single_step_sf_request_matches_reply`
+Expected: PASS
+
+- [ ] **Step 5: Add multiframe + wildcard + nrc tests**
+
+```rust
+#[test]
+fn uds_tester_wildcard_and_multistep() {
+    let mut bus = bus_with_script(&[("10 03", "50 03"), ("27 01", "67 01 ..")]);
+    bus.inject_ecu_reply(0x222, &[0x02, 0x50, 0x03]); bus.service_can_uds_testers();
+    assert_eq!(bus.can_uds_testers[0].step_idx, 1);
+    bus.inject_ecu_reply(0x222, &[0x03, 0x67, 0x01, 0xAB]); bus.service_can_uds_testers();
+    assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+}
+
+#[test]
+fn uds_tester_nrc_mismatch_fails_with_reason() {
+    let mut bus = bus_with_script(&[("11 01", "51 01")]);
+    bus.inject_ecu_reply(0x222, &[0x03, 0x7F, 0x11, 0x22]); // NRC, not 51 01
+    bus.service_can_uds_testers();
+    assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Failed);
+    assert!(bus.can_uds_testers[0].failure.as_ref().unwrap().contains("step 0"));
+}
+```
+
+- [ ] **Step 6: Run all tester tests**
+
+Run: `cargo test -p labwired-core uds_tester`
+Expected: PASS (incl. legacy `uds_tester_fsm_drives_ff_fc_cf_response`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/core/src/bus/mod.rs
+git commit -m "feat(sim): script-stepped UDS tester FSM with ISO-TP framing + matching"
+```
+
+---
+
+### Task 4: `uds_tester` scenario assertion in the CLI runner
+
+**Files:**
+- Modify: `crates/cli/src/commands/test.rs` (assertion enum/parse + evaluation, alongside `uart_contains`/`expected_stop_reason`)
+- Test: `crates/cli/tests/outputs.rs` (or the existing scenario-assertion test file; follow the pattern there)
+
+**Interfaces:**
+- Consumes: post-run access to `bus.can_uds_testers` (state + `failure`). If the runner does not already expose the bus after a run, add a read-only getter on the run result.
+- Produces: assertion `- uds_tester: { id: "<id>", result: done }`. `done` requires the named tester `state == Done`; otherwise the assertion fails and prints `tester <id>: <failure or current state>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn uds_tester_assertion_passes_when_done() {
+    // Drive a minimal scenario whose ECU answers 51 01; assert result: done.
+    let out = run_scenario_str(SCN_RESET_OK); // helper in this test file
+    assert!(out.passed, "expected pass, got: {}", out.report);
+}
+```
+
+(Define `SCN_RESET_OK` inline: a tiny scenario using an existing ELF that answers `0x11`, or a stub bus. If no ELF is convenient at unit scope, place this as an integration test under `crates/cli/tests/` driving a fixture scenario.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-cli uds_tester_assertion_passes_when_done`
+Expected: FAIL — `uds_tester` assertion type unknown.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the `uds_tester { id, result }` variant to the assertion parser and evaluation. After the run completes, look up the tester by `id` in `bus.can_uds_testers`; pass iff `state == Done` for `result: done`. On failure include `failure` text.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-cli uds_tester_assertion_passes_when_done`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cli/src/commands/test.rs crates/cli/tests/
+git commit -m "feat(cli): uds_tester scenario assertion (result: done)"
+```
+
+---
+
+## Phase 2 — Real Cortex-M system reset
+
+### Task 5: SCB AIRCR SYSRESETREQ latch
+
+**Files:**
+- Modify: `crates/core/src/peripherals/scb.rs` (struct + `write_register` arm `0x0C`)
+- Test: `crates/core/src/peripherals/scb.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Produces: `Scb` gains `pending_reset: std::cell::Cell<bool>` (init false); `pub fn drain_reset_request(&self) -> bool` (returns and clears). A write to AIRCR with `(value >> 16) == 0x05FA` and `value & (1 << 2) != 0` sets the latch; `aircr` still stores the value masked of the write key (read-back returns 0 in VECTKEY, as on silicon).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn aircr_sysresetreq_with_vectkey_latches_reset() {
+    let scb = Scb::new();
+    scb.write_register(0x0C, (0x05FA << 16) | (1 << 2)); // VECTKEY + SYSRESETREQ
+    assert!(scb.drain_reset_request());
+    assert!(!scb.drain_reset_request()); // latch cleared
+}
+
+#[test]
+fn aircr_without_vectkey_does_not_reset() {
+    let scb = Scb::new();
+    scb.write_register(0x0C, 1 << 2); // SYSRESETREQ but no key
+    assert!(!scb.drain_reset_request());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-core aircr_sysresetreq`
+Expected: FAIL — `drain_reset_request` missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `pending_reset: Cell<bool>` to `Scb` and `Default`/`new`. In `write_register` `0x0C`: `if (value >> 16) == 0x05FA && value & (1 << 2) != 0 { self.pending_reset.set(true); }` then `self.aircr = value & 0x0000_FFFF;`. Add `pub fn drain_reset_request(&self) -> bool { self.pending_reset.replace(false) }`. (If `write_register` takes `&self`, `Cell` fits; if `&mut self`, use a plain `bool` and `std::mem::take`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-core aircr_sysresetreq aircr_without_vectkey`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/peripherals/scb.rs
+git commit -m "feat(sim): SCB AIRCR SYSRESETREQ latch (drain_reset_request)"
+```
+
+---
+
+### Task 6: Route SCB reset through Machine::reset at an instruction boundary
+
+**Files:**
+- Modify: `crates/core/src/lib.rs` — add `scb_index` (resolve in constructor like `rtc_cntl_index`), `fn drain_scb_reset_request(&self) -> bool`, and a call site in `step()` next to `drain_rtc_cntl_reset_request`
+- Test: `crates/core/src/lib.rs` `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: `Scb::drain_reset_request` (Task 5), existing `Machine::reset()` (`lib.rs:865`).
+- Produces: after the instruction that writes AIRCR completes, `step()` calls `self.reset()`, reloading MSP from vector[0] and PC from the reset vector via the existing CPU reset path. No new reset semantics.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn sysresetreq_reboots_cpu_via_vector_table() {
+    // Minimal Cortex-M machine: vector table at flash base => [0]=MSP, [1]=reset+1.
+    let mut m = test_machine_m3_with_vectors(0x2000_1000, 0x0800_0101);
+    // Firmware writes AIRCR = 05FA0004 then would spin; we just step once past it.
+    m.poke_u32(SCB_AIRCR, (0x05FA << 16) | (1 << 2));
+    m.scb_set_pending_for_test(); // or execute the store; helper sets the latch
+    m.step().unwrap();
+    assert_eq!(m.cpu.pc() & !1, 0x0800_0100);
+    assert_eq!(m.cpu.sp(), 0x2000_1000);
+}
+```
+
+(Use the existing Cortex-M test-machine constructor in this module; if none exposes vector seeding, add a small `#[cfg(test)]` helper mirroring how power-on reset is tested.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-core sysresetreq_reboots_cpu_via_vector_table`
+Expected: FAIL — `step()` does not honor SCB reset.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Mirror `drain_rtc_cntl_reset_request`: add `scb_index: Option<usize>` resolved in the constructor (find peripheral downcasting to `Scb`). Add:
+
+```rust
+fn drain_scb_reset_request(&self) -> bool {
+    let Some(idx) = self.scb_index else { return false; };
+    let Some(p) = self.bus.peripherals.get(idx) else { return false; };
+    p.dev.as_any()
+        .and_then(|a| a.downcast_ref::<crate::peripherals::scb::Scb>())
+        .map(|scb| scb.drain_reset_request())
+        .unwrap_or(false)
+}
+```
+
+In `step()`, next to the RTC_CNTL drain: `if self.drain_scb_reset_request() { self.reset()?; }`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-core sysresetreq_reboots_cpu_via_vector_table`
+Expected: PASS
+
+- [ ] **Step 5: Run the full core suite (no regressions)**
+
+Run: `cargo test -p labwired-core`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/core/src/lib.rs
+git commit -m "feat(sim): honor SCB SYSRESETREQ via Machine::reset at instruction boundary"
+```
+
+---
+
+### Task 7: Resetting ECU example + #88 end-to-end smoke
+
+**Files:**
+- Modify: `examples/f103-uds-ecu/firmware/main.c` (wire `fn_reset` → `NVIC_SystemReset`; print a banner on boot so the reprint proves a real reboot)
+- Create: `examples/f103-uds-ecu/uds-reset-smoke.yaml`
+- Create/Modify: `examples/f103-uds-ecu/system.yaml` may be reused; if the smoke needs the script tester, add a sibling system file or extend with the `script:` config
+- Test: scenario run via `labwired test`
+
+**Interfaces:**
+- Consumes: scriptable tester (Tasks 1-4), real reset (Tasks 5-6).
+- Produces: a green scenario that sends `11 01`, asserts `51 01` (tester `done`), and asserts the boot banner appears twice (real reboot). Built against udslib ≥ v1.20.0.
+
+- [ ] **Step 1: Add the reset callback + boot banner to the firmware**
+
+In `main.c`: add `static void ecu_reset(uds_ctx_t *ctx, uint8_t type) { (void)ctx; (void)type; NVIC_SystemReset(); }`, set `cfg.fn_reset = ecu_reset;`, and ensure the init path prints `ECU_READY` on every boot (so a reboot reprints it). Confirm `UDSLIB_DIR` resolves to a v1.20.0+ source tree.
+
+- [ ] **Step 2: Write the smoke scenario**
+
+```yaml
+# examples/f103-uds-ecu/uds-reset-smoke.yaml
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"        # extend external_devices with the script below
+  firmware: "./firmware/build/f103_uds_ecu.elf"
+limits:
+  max_steps: 600000
+assertions:
+  - uart_contains: "ECU_READY"
+  - uds_tester: { id: "uds-tester", result: done }   # 51 01 received before reboot
+```
+
+In `system.yaml` (or a smoke-specific copy) set the tester config:
+
+```yaml
+    config:
+      request_id: 0x111
+      reply_id: 0x222
+      script:
+        - send: "11 01"
+          expect: "51 01"
+```
+
+- [ ] **Step 3: Build the firmware**
+
+Run: `make -C examples/f103-uds-ecu/firmware UDSLIB_DIR=<path to udslib v1.20.0+>`
+Expected: `f103_uds_ecu.elf` produced.
+
+- [ ] **Step 4: Run the smoke and verify it passes**
+
+Run: `cargo run -p labwired-cli --bin labwired -- test examples/f103-uds-ecu/uds-reset-smoke.yaml`
+Expected: PASS — tester `done` (saw `51 01`) and `ECU_READY` present.
+
+- [ ] **Step 5: Confirm it reproduces #88 against pre-fix udslib (manual, optional but recommended)**
+
+Rebuild the firmware with `UDSLIB_DIR` pointed at udslib v1.14.0 and rerun the smoke.
+Expected: FAIL — tester `Failed` (no `51 01`), proving the end-to-end regression catches #88.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/f103-uds-ecu/
+git commit -m "test(sim): end-to-end #88 reset smoke — 0x11 answers 51 01 before reboot"
+```
+
+---
+
+## Final: gate + PR
+
+- [ ] Run the gate locally: `cargo test -p labwired-core && cargo test -p labwired-cli && cargo clippy` (default-members).
+- [ ] Push branch and open PR → `main`. PR body references udslib #88 and links the spec. Confirm core-integrity is green before merge.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** scriptable tester (Tasks 1-3), assertion surfacing (Task 4), real Cortex-M reset reusing `Machine::reset` (Tasks 5-6), resetting ECU + end-to-end #88 smoke (Task 7), backward-compat legacy translation (Task 2). All spec sections mapped.
+- **Placeholder scan:** no TBD/TODO; each code step shows code; test helpers (`bus_with_script`, `inject_ecu_reply`, `test_machine_m3_with_vectors`) are named with their construction basis cited.
+- **Type consistency:** `UdsStep` fields, `script`/`step_idx`/`failure`, `drain_reset_request`, `drain_scb_reset_request` used consistently across tasks; assertion shape `uds_tester { id, result }` consistent between Task 4 and Task 7.

--- a/docs/superpowers/specs/2026-06-22-scriptable-uds-tester-and-reset-design.md
+++ b/docs/superpowers/specs/2026-06-22-scriptable-uds-tester-and-reset-design.md
@@ -1,0 +1,96 @@
+# Scriptable UDS tester + real Cortex-M system reset
+
+- Status: approved (brainstorm), pending spec review
+- Date: 2026-06-22
+- Repo: labwired-core (branch `feat/scriptable-uds-tester`, PR → `main`)
+- Motivation: udslib issue [#88](https://github.com/w1ne/udslib/issues/88) (0x11 ECUReset answers nothing when the reset reboots before the response is on the wire). udslib is fixed + unit-tested, but the ECU simulator cannot reproduce it end-to-end: the `uds-tester` is hardcoded to the SecurityAccess flow and the emulator does not honor a core reset.
+
+## Goals
+
+1. Make the simulator's `uds-tester` **scriptable** — drive any UDS service and assert its response.
+2. Make the emulator perform a **real Cortex-M system reset** when firmware requests it (no shortcut model).
+3. Reproduce #88 **end-to-end**: an ECU that actually reboots on `0x11`, with the harness asserting `51 01` reached the bus *before* the reboot.
+
+Non-goals: rewriting ISO-TP, multi-tester buses, FD-only services. CAN-FD framing reuse only where the existing tester already supports it.
+
+## Phase 1 — Scriptable UDS tester
+
+`CanUdsTester` (`crates/core/src/bus/mod.rs`) today: fixed FSM `Start → AwaitFc → AwaitResp(0x67) → Done`, completion hardcoded at `mod.rs:278` (`data[0]==0x06 && data[1]==0x67`).
+
+New config (`type: "uds-tester"`):
+
+```yaml
+config:
+  request_id: 0x111
+  reply_id: 0x222
+  script:
+    - send: "10 03"        # DiagnosticSessionControl extended
+      expect: "50 03"
+    - send: "11 01"        # ECUReset hardReset
+      expect: "51 01"
+    - send: "27 01"
+      expect: "67 01 .."   # .. = one wildcard byte (variable seed)
+```
+
+Step grammar:
+- `send: "<hex>"` — the raw UDS PDU (SID + payload). The harness frames it over ISO-TP: ≤7 bytes → single frame `0N ..`; >7 → FirstFrame, await FlowControl, ConsecutiveFrame(s).
+- `expect: "<hex pattern>"` — match against the reassembled response PDU. `..` matches exactly one byte; a pattern shorter than the response is a prefix match.
+- `expect_nrc: <byte>` (optional) — expect `7F <reqSID> <nrc>`.
+- `expect_silence: true` (optional) — no reply within `timeout_ticks` is a pass (suppressPosRsp / functional broadcast).
+- `timeout_ticks: <n>` (optional, default from `DEFAULT_MAX_TICKS`).
+
+FSM generalized to iterate steps: per step `SendReq → AwaitResp → match → (next | Failed)`. Response reassembly handles SF and FF+CF (tester sends FlowControl). On the last step's match → `Done`. Any mismatch/timeout → `Failed { step, reason, expected, actual }`.
+
+Backward compatibility: a config with legacy `first_frame`/`consecutive_frame` (no `script`) is translated internally into a single equivalent step, so the existing `f103-uds-ecu/uds-smoke.yaml` SecurityAccess scenario passes unchanged.
+
+## Phase 1 — Assertion surfacing
+
+Tester result is exposed to the scenario runner (`crates/cli/src/commands/test.rs`, alongside `uart_contains` / `expected_stop_reason`):
+
+```yaml
+assertions:
+  - uds_tester: { id: "uds-tester", result: done }
+```
+
+On `Failed`, the runner prints the failing step index, expected pattern, and actual bytes, and fails the run. `result: done` requires every step matched.
+
+## Phase 2 — Real Cortex-M system reset (no shortcut)
+
+Today `SCB.AIRCR` writes are stored only (`scb.rs:150`); SYSRESETREQ is ignored. This must become a faithful reset:
+
+- On a write to `AIRCR` with `VECTKEY == 0x05FA` (bits 31:16) and `SYSRESETREQ` (bit 2) set, request a system reset of the owning core.
+- The reset must match silicon semantics, reusing the existing core `reset()` machinery (`lib.rs` / `world.rs`), not a bespoke path:
+  - `MSP` reloaded from vector table `[0]`, `PC` from reset vector `[1]` (Thumb bit handling as on real hardware).
+  - Core registers and the relevant system/peripheral state return to reset values per the chip descriptor (same path used at power-on, so RAM-vs-register reset behavior stays consistent with silicon-fidelity work already in the tree).
+  - SRAM contents follow real-hardware behavior (system reset does not clear SRAM); only what silicon resets is reset.
+- **Ordering for #88**: the response frame udslib hands to bxCAN/FDCAN must be emitted onto the bus before the core reset takes effect. The reset is serviced at a tick boundary after the CAN peripheral has drained the pending TX mailbox for that step, so a tester observes `51 01` then the reboot — never silence. This ordering is the property under test, so it must be real, not arranged by the test.
+
+Validation that it's a *real* reset (not a flag): after SYSRESETREQ, firmware re-executes from the reset vector and re-runs its init (observable via UART banner reprinting, e.g. `ECU_READY` a second time).
+
+## Phase 2 — Resetting ECU example + #88 smoke
+
+- One ECU example (`f103-uds-ecu` or `h563-uds-ecu`) wires `fn_reset` → `NVIC_SystemReset` (writes AIRCR), built against udslib ≥ v1.20.0.
+- Smoke scenario:
+
+```yaml
+script:
+  - send: "11 01"
+    expect: "51 01"
+assertions:
+  - uds_tester: { id: "uds-tester", result: done }   # 51 01 seen before reboot
+  - uart_contains: "ECU_READY"                        # banner reprinted => real reboot
+```
+
+A pre-fix udslib (≤ v1.14.0) at the example's `UDSLIB_DIR` would leave the tester `Failed` (no `51 01`), giving an end-to-end regression for #88.
+
+## Testing
+
+- Rust unit tests in `bus/mod.rs`: script parsing, SF framing, FF/FC/CF framing, wildcard match, `expect_nrc`, `expect_silence`, legacy-config translation.
+- Rust unit test in `scb.rs`/core: AIRCR SYSRESETREQ triggers a core reset with correct MSP/PC reload; non-key writes do not.
+- Scenario tests: existing SecurityAccess smoke still green; new `0x11`-reset smoke green on udslib ≥ v1.20.0.
+- Gate: core-integrity must pass; PR targets `main`.
+
+## Risks
+
+- Reset/CAN TX ordering at the tick boundary is the crux — must verify the frame is on the bus before reset, deterministically.
+- Touching the CPU/SCB reset path risks regressions in unrelated chips; keep the trigger SCB-local and route through the existing reset machinery, covered by tests.

--- a/examples/f103-uds-ecu/firmware/Makefile
+++ b/examples/f103-uds-ecu/firmware/Makefile
@@ -21,8 +21,10 @@ UDS_SRCS := \
   $(UDSLIB_DIR)/src/services/uds_service_link.c \
   $(UDSLIB_DIR)/src/services/uds_service_maintenance.c \
   $(UDSLIB_DIR)/src/services/uds_service_mem.c \
+  $(UDSLIB_DIR)/src/services/uds_service_roe.c \
   $(UDSLIB_DIR)/src/services/uds_service_security.c \
   $(UDSLIB_DIR)/src/services/uds_service_session.c \
+  $(UDSLIB_DIR)/src/services/uds_dtc_store.c \
   $(UDSLIB_DIR)/src/transport/uds_tp_isotp.c
 
 APP_OBJS := $(patsubst %.c,$(BUILD_DIR)/%.o,$(APP_SRCS))

--- a/examples/f103-uds-ecu/firmware/main.c
+++ b/examples/f103-uds-ecu/firmware/main.c
@@ -224,6 +224,22 @@ static int isotp_send_adapter(struct uds_ctx *ctx, const uint8_t *data, uint16_t
     return uds_isotp_send(&g_iso, data, len);
 }
 
+/* UDSLib fn_reset hook: a faithful CMSIS NVIC_SystemReset. udslib's #88 fix
+ * calls this only AFTER the 0x11 positive response (51 01) has been handed to
+ * the transport, so by the time the AIRCR store latches the SYSRESETREQ the
+ * reply is already on the CAN bus. The model reboots the CPU through the vector
+ * table at the next instruction boundary; the reset never returns, so we spin. */
+static void ecu_reset(uds_ctx_t *ctx, uint8_t type)
+{
+    (void) ctx;
+    (void) type;
+    __asm volatile("dsb 0xF" ::: "memory");
+    REG32(0xE000ED0Cu) = (0x05FAu << 16) | (1u << 2); /* AIRCR: VECTKEY | SYSRESETREQ */
+    __asm volatile("dsb 0xF" ::: "memory");
+    for (;;) {
+    }
+}
+
 static int security_seed(struct uds_ctx *ctx, uint8_t level, uint8_t *seed, uint16_t max_len)
 {
     (void) ctx;
@@ -255,6 +271,7 @@ int main(void)
         .get_time_ms = get_time_ms,
         .fn_tp_send = isotp_send_adapter,
         .fn_security_seed = security_seed,
+        .fn_reset = ecu_reset,
         .rx_buffer = g_rx_buf,
         .rx_buffer_size = sizeof(g_rx_buf),
         .tx_buffer = g_tx_buf,

--- a/examples/f103-uds-ecu/system-reset.yaml
+++ b/examples/f103-uds-ecu/system-reset.yaml
@@ -1,0 +1,16 @@
+name: "f103-uds-ecu"
+chip: "../../configs/chips/stm32f103.yaml"
+external_devices:
+  # A real second CAN node: a virtual UDS tester scripted to send a 0x11 01
+  # ECUReset request and assert the 51 01 positive response lands on the bus
+  # BEFORE the ECU reboots (udslib issue #88).
+  - type: "uds-tester"
+    id: "uds-tester"
+    connection: "bxcan1"
+    config:
+      request_id: 0x111
+      reply_id: 0x222
+      script:
+        - send: "11 01"
+          expect: "51 01"
+board_io: []

--- a/examples/f103-uds-ecu/uds-reset-smoke.yaml
+++ b/examples/f103-uds-ecu/uds-reset-smoke.yaml
@@ -1,0 +1,12 @@
+schema_version: "1.0"
+inputs:
+  system: "./system-reset.yaml"
+  firmware: "./firmware/build/f103_uds_ecu.elf"
+limits:
+  max_steps: 600000
+assertions:
+  # The scripted tester sends 11 01 (ECUReset) and asserts 51 01 lands on the
+  # bus before the ECU reboots (udslib #88). ECU_READY is reprinted on the real
+  # AIRCR-triggered reboot, so the banner appears twice.
+  - uart_contains: "ECU_READY"
+  - uds_tester: { id: "uds-tester", result: done }


### PR DESCRIPTION
## Summary
Adds two simulator capabilities and uses them to reproduce udslib issue #88
end-to-end (https://github.com/w1ne/udslib/issues/88): a 0x11 ECUReset must
put 51 01 on the bus before the ECU reboots.

## What's included
- Scriptable UDS tester: a `uds-tester` CAN node can drive any UDS sequence
  via `config.script:` (`send`/`expect` with `..` wildcards and `expect_nrc`),
  framed over ISO-TP (SF and FF/FC/CF) with response reassembly and matching.
  Legacy `first_frame`/`consecutive_frame` configs are translated to a
  one-step script, so the existing SecurityAccess smoke is unchanged.
- CLI scenario assertion `- uds_tester: { id, result: done }`.
- Real Cortex-M system reset: a firmware write to SCB AIRCR with VECTKEY +
  SYSRESETREQ reboots the CPU through the vector table via the existing
  `Machine::reset()`, honored on the step, batched-run, and CLI test paths.
- #88 reproduction: an F103 UDS ECU whose `fn_reset` triggers the reset; the
  scripted tester sends 11 01 and asserts 51 01 arrives before the reboot
  (banner reprints, confirming a real restart).

## Testing
- `cargo test` (core/cli/config) green; `cargo clippy` clean.
- uds-reset-smoke: tester reaches `done`, ECU_READY printed twice; a wrong
  `expect` correctly fails the run.
- Branch merged latest `main`.

## Notes
- uds-reset-smoke.yaml needs a locally-built firmware ELF (arm-none-eabi +
  udslib >= v1.20.0), like the existing uds-smoke.yaml — not a clean-checkout
  CI gate; the Rust unit tests are the always-on regression for the reset and
  framing logic.
