### PR TITLE
example(h563-uds-bootloader): enable H5 flash fidelity gates + RSA step budget

### DIFF
--- a/examples/h563-uds-bootloader/ota-smoke.yaml
+++ b/examples/h563-uds-bootloader/ota-smoke.yaml
@@ -6,7 +6,7 @@ limits:
   # The full OTA flow (handshake → download → verify → activate → bank-swap →
   # reset → boot APP-B) completes in ~440k steps; the new app then idles, so
   # the run terminates on max_steps after every milestone has printed.
-  max_steps: 1000000
+  max_steps: 15000000
 assertions:
   - uart_contains: "BL-START"
   - uart_contains: "BL-RECOVERY"

--- a/examples/h563-uds-bootloader/system.yaml
+++ b/examples/h563-uds-bootloader/system.yaml
@@ -2,3 +2,17 @@ name: "h563-uds-bootloader"
 chip: "../../configs/chips/stm32h563.yaml"
 external_devices: []
 board_io: []
+# Enable the STM32H5 FLASH fidelity gates for this example: the bootloader's
+# flash driver is written to satisfy them (checks program-error flags, runs the
+# erase/program routines from SRAM). With the gates on, the simulator refuses a
+# misaligned program (INCERR) and a read-while-write erase of the running bank,
+# so this example exercises the honest model rather than the forgiving default.
+peripherals:
+  - id: "flash_iface"
+    type: "flash"
+    base_address: 0x40022000
+    size: "1KB"
+    config:
+      profile: "stm32h5"
+      error_flags: true
+      read_while_write: true


### PR DESCRIPTION
Enables the opt-in STM32H5 FLASH fidelity gates (`error_flags`, `read_while_write`) for the `h563-uds-bootloader` example, now that the example's firmware (in udslib) satisfies them — it checks program-error flags, clears them via NSCCR, and runs the erase/program routines from SRAM. With the gates on, the simulator refuses a misaligned program (INCERR) and a read-while-write erase of the running bank, so the example exercises the honest model rather than the forgiving default.

Also bumps the smoke `max_steps` to 15M so the RSA-2048 secure-boot image verification completes.

The full OTA smoke passes 14/14 to APP-B v2 with both gates enabled. (The firmware side — RSA secure boot, vendor LL drivers, etc. — is the companion udslib change w1ne/udslib#93; this PR only flips the example's simulator config.)
