### PR TITLE
ci: real gate for the IO-Link multi-chip station (fail-not-skip on missing ELFs)

### DIFF
--- a/.github/workflows/core-iolink-station.yml
+++ b/.github/workflows/core-iolink-station.yml
@@ -1,0 +1,82 @@
+name: Core Board Model - IO-Link Station (STM32L476)
+
+# Real gate for the multi-chip IO-Link station: builds the three STM32L476
+# firmwares (real iolinki device stack + real iolinki-master stack, as standard
+# STM32CubeL4 projects) and runs the world_multichip integration tests against
+# the freshly built ELFs.
+#
+# Why a dedicated job: the firmware ELFs are gitignored build artifacts and the
+# workspace `cargo test` gate has no arm-none-eabi toolchain or STM32CubeL4 pack,
+# so those tests skip there. This job provides the toolchain + Cube pack, builds
+# the ELFs, and runs the suite with LABWIRED_REQUIRE_IOLINK_ELFS=1 so a missing
+# or silently-broken firmware build fails the gate instead of skipping to green.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  STM32CUBEL4_TAG: v1.18.2
+
+jobs:
+  iolink-station:
+    name: iolink-station-l476
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # third_party/iolinki is a public submodule; iolinki-master is vendored.
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-iolink-station
+          workspaces: |
+            . -> target
+
+      - name: Install ARM bare-metal toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi
+
+      - name: Fetch STM32CubeL4 CMSIS device pack (pinned, sparse)
+        run: |
+          CUBE="$RUNNER_TEMP/STM32CubeL4"
+          git clone --depth 1 --branch "$STM32CUBEL4_TAG" \
+            --filter=blob:none --sparse \
+            https://github.com/STMicroelectronics/STM32CubeL4.git "$CUBE"
+          # List the submodule's PARENT dir (a real tree), not the gitlink path —
+          # cone-mode sparse-checkout rejects a submodule path with "not a directory".
+          git -C "$CUBE" sparse-checkout set \
+            Drivers/CMSIS/Include \
+            Drivers/CMSIS/Device/ST \
+            Projects/NUCLEO-L476RG/Templates/STM32CubeIDE
+          # The CMSIS device pack (startup/system/headers) is itself a submodule.
+          git -C "$CUBE" submodule update --init --depth 1 \
+            Drivers/CMSIS/Device/ST/STM32L4xx
+          echo "STM32CUBE_L4_DIR=$CUBE" >> "$GITHUB_ENV"
+
+      - name: Build IO-Link station firmwares (real stacks + CubeL4)
+        run: |
+          set -e
+          make -C examples/iolink-dido/firmware          STM32CUBE_L4_DIR="$STM32CUBE_L4_DIR"
+          make -C examples/iolink-station/master-fw       STM32CUBE_L4_DIR="$STM32CUBE_L4_DIR"
+          make -C examples/iolink-station/master-fw-4port  STM32CUBE_L4_DIR="$STM32CUBE_L4_DIR"
+          # Hard-fail if any ELF is missing, so a silent build miss can't slip the gate.
+          test -f examples/iolink-dido/firmware/iolink_dido.elf
+          test -f examples/iolink-station/master-fw/master.elf
+          test -f examples/iolink-station/master-fw-4port/master.elf
+
+      - name: Run multi-chip station integration tests (ELFs required)
+        env:
+          LABWIRED_REQUIRE_IOLINK_ELFS: "1"
+        run: cargo test -p labwired-core --release --test world_multichip -- --nocapture

--- a/crates/core/tests/world_multichip.rs
+++ b/crates/core/tests/world_multichip.rs
@@ -19,11 +19,41 @@ fn station_root() -> PathBuf {
 
 const DEVICE_FW: &str = "../iolink-dido/firmware/iolink_dido.elf";
 
+// Behaviour when a required prebuilt firmware ELF is absent.
+//
+// By default a missing ELF skips the test, so the workspace `cargo test` gate
+// (which has no arm-none-eabi toolchain or STM32CubeL4 pack) and local dev runs
+// stay green instead of demanding cross-built artifacts. The dedicated
+// `core-iolink-station` CI job builds the ELFs and sets
+// `LABWIRED_REQUIRE_IOLINK_ELFS=1`, which turns "missing" into a hard failure —
+// so a silently-broken firmware build can't sail through the gate as a no-op
+// skip that still reports `ok`.
+fn require_iolink_elfs() -> bool {
+    std::env::var_os("LABWIRED_REQUIRE_IOLINK_ELFS").is_some()
+}
+
+// Returns true if the caller should `return` (skip). Panics — failing the test —
+// when ELFs are required but absent.
+fn skip_or_fail_missing_elfs(build_hint: &str) -> bool {
+    if require_iolink_elfs() {
+        panic!(
+            "required IO-Link station ELF(s) missing while LABWIRED_REQUIRE_IOLINK_ELFS \
+             is set; build them: {build_hint}"
+        );
+    }
+    eprintln!("SKIP: IO-Link station ELF(s) not built; build them: {build_hint}");
+    true
+}
+
 #[test]
 fn from_manifest_builds_two_cortexm_nodes_and_uart_link() {
     // Two device-FW nodes wired uart2<->uart2. This exercises node construction,
     // ELF load + reset, the UART-link wiring, and lockstep stepping — without
     // needing the master firmware (Task 4).
+    if !station_root().join(DEVICE_FW).exists() {
+        skip_or_fail_missing_elfs("make -C examples/iolink-dido/firmware");
+        return;
+    }
     let env = EnvironmentManifest {
         schema_version: "1".into(),
         name: "twonode".into(),
@@ -70,9 +100,8 @@ fn master_chip_reaches_operate_with_real_sensor_chip() {
     let master_elf = root.join("master-fw/master.elf");
     let device_elf = root.join("../iolink-dido/firmware/iolink_dido.elf");
     if !master_elf.exists() || !device_elf.exists() {
-        eprintln!(
-            "SKIP: build ELFs first (make -C examples/iolink-station/master-fw && \
-             make -C examples/iolink-dido/firmware)"
+        skip_or_fail_missing_elfs(
+            "make -C examples/iolink-station/master-fw && make -C examples/iolink-dido/firmware",
         );
         return;
     }
@@ -134,9 +163,8 @@ fn four_port_station_all_sensors_operate_with_distinct_pd() {
     let master_elf = root.join("master-fw-4port/master.elf");
     let device_elf = root.join("../iolink-dido/firmware/iolink_dido.elf");
     if !master_elf.exists() || !device_elf.exists() {
-        eprintln!(
-            "SKIP: build ELFs first (make -C examples/iolink-station/master-fw-4port && \
-             make -C examples/iolink-dido/firmware)"
+        skip_or_fail_missing_elfs(
+            "make -C examples/iolink-station/master-fw-4port && make -C examples/iolink-dido/firmware",
         );
         return;
     }


### PR DESCRIPTION
## Problem

The `world_multichip` integration tests are the only thing that proves the multi-chip IO-Link station actually works (master reaches OPERATE, exchanges real PD with the device firmware). But the firmware ELFs they load are gitignored build artifacts, and **no CI job builds them** — the workspace `cargo test` lane has no `arm-none-eabi` toolchain or STM32CubeL4 pack. So those tests hit `if !elf.exists() { return; }` and **skip to green on every gate**. The proof was never run in CI; it only ever passed because someone built the ELFs locally.

## Fix

- **New workflow `core-iolink-station.yml`** (PR + push-to-main + dispatch): installs `gcc-arm-none-eabi`, fetches the pinned STM32CubeL4 CMSIS device pack (`v1.18.2`, shallow + sparse + submodule, ~48 MB), builds the three real station firmwares, and runs `world_multichip` against the freshly built ELFs.
- **`LABWIRED_REQUIRE_IOLINK_ELFS=1`** (set by that job) turns a missing ELF into a **hard test failure** instead of a silent skip — so a broken firmware build can't sail through as a no-op. Unset (workspace `cargo test`, local dev) the graceful skip is preserved so unrelated runs stay green.

## Verified locally

- `REQUIRE=1` + ELFs present → 3 pass.
- `REQUIRE=1` + ELF missing → **3 FAILED** with an actionable panic (`required IO-Link station ELF(s) missing … build them: make -C …`).
- `REQUIRE` unset + ELF missing → 3 skip→ok (workspace gate unaffected).
- Replayed the exact CI Cube fetch (sparse checkout + submodule at `v1.18.2`) into a temp dir: all required headers/startup/linker present, all three firmwares build.

## Follow-up

The job runs on every PR but isn't a *required* check until added to branch protection (`iolink-station-l476`) — that's a repo-settings step I can't do from code.