### PR TITLE
UDS ECU: shared app + h563 full diagnostic session over FDCAN

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2426,6 +2426,159 @@ board_io: []
         assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
     }
 
+    /// End-to-end against a real `Fdcan` registered on the bus and brought to
+    /// normal mode (CCCR.INIT cleared, TEST.LBCK = 0) so `receive_frame`
+    /// accepts the tester's frames. We drive a script-driven exchange where the
+    /// ECU responds with a multi-frame FirstFrame + CF, exercising the
+    /// FlowControl-delivery path on FDCAN — the same gap class that #343
+    /// identified on the analogous bxCAN path.
+    ///
+    /// Exchange (script: `send = "22 F1 90"`, `expect = "62 F1 90"`):
+    /// 1. Tick 1 (Start): tester sends SF ReadDataById request → AwaitResp.
+    /// 2. ECU replies with a FirstFrame (13-byte response) via `tx_frames`.
+    /// 3. Tick 2 (AwaitResp → AwaitMultiResp): tester sees the FF, transitions,
+    ///    and MUST inject a FlowControl ([0x30, 0x00, 0x00]) via `receive_frame`.
+    /// 4. ECU replies with the ConsecutiveFrame.
+    /// 5. Tick 3 (AwaitMultiResp → Done): PDU reassembled and matched.
+    ///
+    /// The discriminating assertion is the presence of a FlowControl entry
+    /// (`first_byte & 0xF0 == 0x30`) in the FDCAN "rx" trace after tick 2,
+    /// proving `receive_frame` was called — not merely that Done was reached.
+    #[test]
+    fn uds_tester_completes_against_real_fdcan() {
+        use crate::peripherals::fdcan::Fdcan;
+
+        // FDCAN1 on H563: RM0481 base 0x4000_A400.
+        const FDCAN_BASE: u64 = 0x4000_A400;
+        const REG_CCCR: u64 = 0x018; // CCCR offset within the peripheral window
+
+        let mut bus = SystemBus::empty();
+        bus.add_peripheral("fdcan1", FDCAN_BASE, 0x1000, None, Box::new(Fdcan::new()));
+
+        // Bring FDCAN to normal mode (mirrors fdcan_start in h563-uds-ecu/main.c):
+        //   Step 1: assert INIT + CCE (config unlock).
+        bus.write_u32(FDCAN_BASE + REG_CCCR, 0x3).unwrap();
+        //   Step 2: clear INIT — CCE clears with it (capture13: 0xA2→0xA0).
+        bus.write_u32(FDCAN_BASE + REG_CCCR, 0x0).unwrap();
+        // CCCR now reads 0x0: bus_active = true, receive_frame will accept frames.
+
+        // Script step: ReadDataByIdentifier 0xF190 (3 bytes), expect prefix 62 F1 90.
+        // The response is multi-frame (13 bytes), so the tester must send a
+        // FlowControl when the ECU sends its FirstFrame.
+        let mut tester = CanUdsTester::new("uds".into(), "fdcan1".into());
+        tester.request_id = 0x7E0;
+        tester.reply_id = 0x7E8;
+        tester.script = vec![UdsStep {
+            send: vec![0x22, 0xF1, 0x90],
+            expect: SystemBus::parse_expect("62 F1 90"),
+            expect_nrc: None,
+        }];
+        bus.can_uds_testers.push(tester);
+
+        // Tick 1: script-driven Start → tester sends SF request (3 bytes fit in SF)
+        // → AwaitResp (no pending CFs for a SF request).
+        bus.service_can_uds_testers();
+        assert_eq!(
+            bus.can_uds_testers[0].state,
+            CanUdsTesterState::AwaitResp,
+            "state must be AwaitResp after tester sends its SF request"
+        );
+
+        // Record trace length after tick 1 so the FC check ignores the SF request.
+        let trace_len_before = {
+            let idx = bus.find_peripheral_index_by_name("fdcan1").unwrap();
+            let fd = bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<Fdcan>()
+                .unwrap();
+            fd.trace_snapshot("fdcan1").len()
+        };
+
+        // ECU "transmits" a FirstFrame: 13-byte (0x0D) response, 6 payload bytes
+        // in the FF (62 F1 90 = RDBI positive response prefix + 3 VIN chars).
+        {
+            let idx = bus.find_peripheral_index_by_name("fdcan1").unwrap();
+            let fd = bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<Fdcan>()
+                .unwrap();
+            fd.tx_frames.push_back(crate::network::CanFrame::classic(
+                0x7E8,
+                vec![0x10, 0x0D, 0x62, 0xF1, 0x90, 0x31, 0x32, 0x33],
+            ));
+        }
+
+        // Tick 2: tester drains the ECU FirstFrame → observe_ecu_frame_script sees
+        // a 0x10 frame in AwaitResp, sets state = AwaitMultiResp, and returns the
+        // FlowControl payload [0x30, 0x00, 0x00].
+        // service_can_uds_testers picks that up in the AwaitMultiResp branch and
+        // MUST call receive_frame to inject it onto the FDCAN.
+        bus.service_can_uds_testers();
+        assert_eq!(
+            bus.can_uds_testers[0].state,
+            CanUdsTesterState::AwaitMultiResp,
+            "state must be AwaitMultiResp after receiving ECU FirstFrame"
+        );
+
+        // Discriminating assertion: a FlowControl frame (first byte & 0xF0 == 0x30)
+        // with the tester's request_id (0x7E0) must appear as an "rx" entry in the
+        // FDCAN trace after tick 1.  An absent FC means the tester silently dropped
+        // the CTS signal — the FDCAN analogue of the bxCAN #343 bug.
+        {
+            let idx = bus.find_peripheral_index_by_name("fdcan1").unwrap();
+            let fd = bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<Fdcan>()
+                .unwrap();
+            let trace = fd.trace_snapshot("fdcan1");
+            let new_frames = &trace[trace_len_before..];
+            assert!(
+                new_frames.iter().any(|f| {
+                    f.direction == "rx"
+                        && f.id == 0x7E0
+                        && f.data.first().map(|b| b & 0xF0 == 0x30).unwrap_or(false)
+                }),
+                "FlowControl (0x30 nibble) must appear in FDCAN rx trace after ECU FirstFrame; \
+                 new frames after tick 1: {:?}",
+                new_frames
+                    .iter()
+                    .map(|f| (f.direction.as_str(), f.id, f.data.clone()))
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        // ECU "transmits" the ConsecutiveFrame carrying the remaining 7 bytes.
+        // 13 - 6 (from FF) = 7 bytes in the CF.
+        {
+            let idx = bus.find_peripheral_index_by_name("fdcan1").unwrap();
+            let fd = bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<Fdcan>()
+                .unwrap();
+            fd.tx_frames.push_back(crate::network::CanFrame::classic(
+                0x7E8,
+                vec![0x21, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x30],
+            ));
+        }
+
+        // Tick 3: tester drains the CF, PDU buf reaches the declared 13 bytes,
+        // complete_response matches the expect prefix → Done.
+        bus.service_can_uds_testers();
+        assert_eq!(
+            bus.can_uds_testers[0].state,
+            CanUdsTesterState::Done,
+            "state must be Done after CF received and PDU matched"
+        );
+    }
+
     /// Config parsing: a `uds-tester` external device populates a
     /// `CanUdsTester` with the configured ids and payloads.
     #[test]

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -375,10 +375,20 @@ impl CanUdsTester {
             CanUdsTesterState::AwaitResp => {
                 let ptype = data.first().map(|b| b & 0xF0).unwrap_or(0xFF);
                 if ptype == 0x00 {
-                    // ECU SingleFrame response
-                    let pdu_len = (data.first().copied().unwrap_or(0) & 0x0F) as usize;
+                    // ECU SingleFrame response. Two ISO-TP SF encodings:
+                    //   * classic: byte0 = 0x0L, length L (1..=7) in the low
+                    //     nibble, payload from byte 1.
+                    //   * CAN-FD escape: byte0 = 0x00, real length in byte 1,
+                    //     payload from byte 2 (used for SF up to 62 bytes on FD
+                    //     frames — the ECU runs ISO-TP in FD mode).
+                    let b0 = data.first().copied().unwrap_or(0);
+                    let (pdu_len, data_off) = if b0 == 0x00 {
+                        (data.get(1).copied().unwrap_or(0) as usize, 2)
+                    } else {
+                        ((b0 & 0x0F) as usize, 1)
+                    };
                     let payload: Vec<u8> = data
-                        .get(1..)
+                        .get(data_off..)
                         .unwrap_or(&[])
                         .iter()
                         .copied()
@@ -2336,6 +2346,37 @@ board_io: []
             .observe_ecu_frame(0x222, &[0x06, 0x67, 0x01, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE])
             .is_none());
         assert_eq!(t.state, CanUdsTesterState::Done);
+        assert!(t.is_terminal());
+    }
+
+    /// Script-driven AwaitResp must decode the CAN-FD *escape* SingleFrame
+    /// (`0x00 LL <payload>`, length in byte 1, payload from byte 2), not just
+    /// the classic SF (`0x0L`). The H563 ECU runs ISO-TP in FD mode and answers
+    /// a 20-byte ReadDataByIdentifier as one 0x00-escape SF; the old parser read
+    /// the low nibble of 0x00 as length 0 and completed with an empty payload
+    /// ("got []"). Regression for the h563-uds-ecu smoke.
+    #[test]
+    fn scripted_tester_decodes_fd_escape_single_frame() {
+        let mut t = CanUdsTester::new("t".into(), "fdcan1".into());
+        t.reply_id = 0x7E8;
+        t.script = vec![UdsStep {
+            send: vec![0x22, 0xF1, 0x90],
+            expect: vec![Some(0x62), Some(0xF1), Some(0x90)],
+            expect_nrc: None,
+        }];
+        t.step_idx = 0;
+        t.state = CanUdsTesterState::AwaitResp;
+
+        // ECU FD escape SF: byte0 = 0x00, real length = 0x14 (20) in byte1,
+        // payload 62 F1 90 + 17-byte VIN string.
+        let mut resp = vec![0x00, 0x14, 0x62, 0xF1, 0x90];
+        resp.extend_from_slice(b"LABWIRED-H563-UDS");
+        assert!(t.observe_ecu_frame(0x7E8, &resp).is_none());
+        assert_eq!(
+            t.state,
+            CanUdsTesterState::Done,
+            "FD escape SF must decode the full payload and match step 0"
+        );
         assert!(t.is_terminal());
     }
 

--- a/docs/superpowers/plans/2026-06-23-uds-ecu-consolidate-h563.md
+++ b/docs/superpowers/plans/2026-06-23-uds-ecu-consolidate-h563.md
@@ -1,0 +1,497 @@
+# Consolidate UDS ECU app + extend h563 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Factor the board-agnostic UDS ECU application into one shared file used by both f103 and h563, restore h563 to build against current udslib, and extend it to the same full tester-driven diagnostic session as f103 — over FDCAN.
+
+**Architecture:** New `examples/common/uds_ecu_app.{c,h}` holds the DID table, seeded DTC store, and the routine/IO/comm/security-seed/reset handlers, plus `uds_ecu_app_fill_config(cfg, vin)`. A board-provided `uds_ecu_app_log()` hook lets the shared `security_seed` emit `UDS_SEED_SERVED` via each board's UART. f103 is refactored onto it (behavior-preserving, re-verified by its three smokes). h563 is ported to the instance ISO-TP API, converted to a pure tester-driven ECU, and driven by a scriptable `uds-tester` over FDCAN running the 12-step session.
+
+**Tech Stack:** Rust (labwired-core), C against udslib (`~/projects/udslib`, ISO-14229), arm-none-eabi firmware (Cortex-M3 bxCAN + Cortex-M33 FDCAN), YAML scenarios.
+
+## Global Constraints
+
+- Git identity `w1ne <14119286+w1ne@users.noreply.github.com>`; every commit `Signed-off-by` via `git -c user.name=w1ne -c user.email=14119286+w1ne@users.noreply.github.com commit -s`.
+- No "Claude"/"AI"/assistant references in commits, code, YAML, or docs.
+- Integrate with `git merge`, never rebase. Branch `feat/uds-ecu-consolidate-h563` off `origin/main`.
+- Pre-push Rust gate (`core-integrity`): `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` (default-members, NOT `--workspace`) + tests. Run all three before declaring a Rust task done.
+- Firmware uses only public udslib headers (`uds/uds_core.h`, `uds/uds_isotp.h`, `uds/uds_dtc.h`, `uds/uds_dtc_store.h`). Extended-session id `0x03` via a local `#define ECU_SESSION_EXTENDED 0x03u` (internal-only otherwise). NRC convention: negative literal with a trailing comment. `UDS_OK` = 0. Do not set `restrict_sessions`.
+- Both VINs are exactly 17 bytes: `LABWIRED-F103-UDS`, `LABWIRED-H563-UDS`. The shared DID table uses VIN `size = 17` and its `storage` pointer is set to the passed `vin` at config time.
+- Tester `expect` is a prefix match; `expect_nrc` matches `[0x7F, sid, nrc]` exactly.
+- Commit only intended source. The built ELF/`build/`/`Cargo.lock` are git-ignored. Never stage `third_party/iolinki`.
+- Freestanding `memcpy`/`memset` shims stay in each board's `main.c` (both already define them); the shared file must NOT define them (duplicate-symbol clash).
+
+---
+
+### Task 1: Shared UDS ECU app file + f103 refactor
+
+Extract f103's inline handlers into a shared file and refactor f103 to use it. Behavior-preserving: proven by f103's existing ELF build + three smokes.
+
+**Files:**
+- Create: `examples/common/uds_ecu_app.h`
+- Create: `examples/common/uds_ecu_app.c`
+- Modify: `examples/f103-uds-ecu/firmware/main.c` (remove inline handlers/storage, add log glue + fill_config call)
+- Modify: `examples/f103-uds-ecu/firmware/Makefile` (build the shared file + `-I../../common`)
+
+**Interfaces:**
+- Produces: `void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin);` and the board-provided contract `void uds_ecu_app_log(const char *msg);`. `fill_config` sets `did_table`, `app_data`, `fn_dtc_list`, `fn_dtc_clear`, `fn_routine_control`, `fn_io_control`, `fn_comm_control`, `fn_security_seed`, `fn_reset`. The board sets `ecu_address`, `get_time_ms`, `fn_tp_send`, `rx_buffer(_size)`, `tx_buffer(_size)`, `p2_ms`, `p2_star_ms`, and defines `uds_ecu_app_log`.
+
+- [ ] **Step 1: Create the header `examples/common/uds_ecu_app.h`**
+
+```c
+#ifndef UDS_ECU_APP_H
+#define UDS_ECU_APP_H
+
+#include "uds/uds_core.h"
+
+/* Board-provided: emit a NUL-terminated trace string via the board UART. */
+void uds_ecu_app_log(const char *msg);
+
+/* Populate the board-agnostic UDS handlers, DID table, and a seeded DTC store
+ * into `cfg`. Call AFTER setting the board-specific cfg fields and BEFORE
+ * uds_init. `vin` must point to a 17-byte VIN (reported by DID 0xF190). */
+void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin);
+
+#endif /* UDS_ECU_APP_H */
+```
+
+- [ ] **Step 2: Create `examples/common/uds_ecu_app.c` with the shared handlers**
+
+```c
+#include <stddef.h>
+#include <stdint.h>
+
+#include "uds/uds_core.h"
+#include "uds/uds_dtc.h"
+#include "uds/uds_dtc_store.h"
+#include "uds_ecu_app.h"
+
+#define REG32(addr) (*(volatile uint32_t *) (addr))
+#define ECU_SESSION_EXTENDED 0x03u /* UDS_SESSION_ID_EXTENDED (internal id) */
+
+/* Writable scratch DID 0x0123 (read+write, EXTENDED session only). */
+static uint8_t g_scratch[4];
+/* IO-controlled point 0xA001 ("test lamp") for InputOutputControl 0x2F. */
+static uint8_t g_lamp[1];
+
+/* DID table. The 0xF190 VIN storage pointer is set in fill_config (per board);
+ * the table is mutable for that reason. */
+static uds_did_entry_t g_dids[] = {
+    {0xF190u, 17u, 0u, 0u, NULL, NULL, NULL},
+    {0x0123u, 4u, UDS_SESSION_EXTENDED, 0u, NULL, NULL, g_scratch},
+    {0xA001u, 1u, 0u, 0u, NULL, NULL, g_lamp},
+};
+
+/* Reference DTC store, seeded with one failing DTC (0x123456). */
+static uds_dtc_record_t g_dtc_backing[4];
+static uds_dtc_store_t g_dtc_store;
+
+static int security_seed(struct uds_ctx *ctx, uint8_t level, uint8_t *seed, uint16_t max_len)
+{
+    (void) ctx;
+    (void) level;
+    (void) max_len;
+    uds_ecu_app_log("UDS_SEED_SERVED\n");
+    seed[0] = 0xDE;
+    seed[1] = 0xAD;
+    seed[2] = 0xBE;
+    seed[3] = 0xEF;
+    return 4;
+}
+
+/* fn_reset hook: faithful CMSIS NVIC_SystemReset via AIRCR (works on M3 + M33).
+ * udslib calls this only AFTER the 0x11 positive response (51 01) is on the
+ * transport, so the reply is on the bus before SYSRESETREQ latches. */
+static void ecu_reset(uds_ctx_t *ctx, uint8_t type)
+{
+    (void) ctx;
+    (void) type;
+    __asm volatile("dsb 0xF" ::: "memory");
+    REG32(0xE000ED0Cu) = (0x05FAu << 16) | (1u << 2); /* AIRCR: VECTKEY | SYSRESETREQ */
+    __asm volatile("dsb 0xF" ::: "memory");
+    for (;;) {
+    }
+}
+
+/* fn_routine_control: routine 0x0203, startRoutine in EXTENDED session only. */
+static int ecu_routine(uds_ctx_t *ctx, uint8_t type, uint16_t id, const uint8_t *data,
+                       uint16_t len, uint8_t *out, uint16_t max)
+{
+    (void) data;
+    (void) len;
+    (void) max;
+    if (id != 0x0203u) {
+        return -0x31; /* requestOutOfRange */
+    }
+    if (ctx->active_session != ECU_SESSION_EXTENDED) {
+        return -0x31; /* requestOutOfRange: routine requires extended session */
+    }
+    if (type == 0x01u) { /* startRoutine */
+        out[0] = 0x00u;  /* routine status: OK */
+        return 1;
+    }
+    return -0x31; /* requestOutOfRange: unsupported routine control type */
+}
+
+/* fn_io_control: IO point 0xA001 (test lamp) — store and echo state. */
+static int ecu_io(uds_ctx_t *ctx, uint16_t id, uint8_t type, const uint8_t *data, uint16_t len,
+                  uint8_t *out, uint16_t max)
+{
+    (void) ctx;
+    (void) type;
+    (void) max;
+    if (id != 0xA001u) {
+        return -0x31; /* requestOutOfRange */
+    }
+    if (len >= 1u) {
+        g_lamp[0] = data[0];
+    }
+    out[0] = g_lamp[0];
+    return 1;
+}
+
+/* fn_comm_control: accept the requested communication mode. */
+static int ecu_comm(uds_ctx_t *ctx, uint8_t ctrl_type, uint8_t comm_type, uint16_t node_id)
+{
+    (void) ctx;
+    (void) ctrl_type;
+    (void) comm_type;
+    (void) node_id;
+    return UDS_OK;
+}
+
+void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin)
+{
+    g_dids[0].storage = (void *) vin; /* 17-byte VIN reported by 0xF190 */
+
+    uds_dtc_store_init(&g_dtc_store, g_dtc_backing, 4u, 40u);
+    uds_dtc_store_register(&g_dtc_store, 0x123456u, UDS_DTC_SEVERITY_CHECK_IMMEDIATELY, 0x10u,
+                           UDS_DTC_FGID_EMISSIONS);
+    uds_dtc_store_report_test(&g_dtc_store, 0x123456u, true); /* set testFailed status */
+
+    cfg->did_table.entries = g_dids;
+    cfg->did_table.count = (uint16_t) (sizeof(g_dids) / sizeof(g_dids[0]));
+    cfg->app_data = &g_dtc_store;
+    cfg->fn_dtc_list = uds_dtc_store_list_cb;
+    cfg->fn_dtc_clear = uds_dtc_store_clear_cb;
+    cfg->fn_routine_control = ecu_routine;
+    cfg->fn_io_control = ecu_io;
+    cfg->fn_comm_control = ecu_comm;
+    cfg->fn_security_seed = security_seed;
+    cfg->fn_reset = ecu_reset;
+}
+```
+
+- [ ] **Step 3: Refactor `examples/f103-uds-ecu/firmware/main.c`**
+
+Delete these now-shared definitions from main.c: the `ECU_SESSION_EXTENDED` define, `g_vin`, `g_scratch`, `g_lamp`, `g_dids`, `g_dtc_backing`, `g_dtc_store`, and the functions `security_seed`, `ecu_reset`, `ecu_routine`, `ecu_io`, `ecu_comm`. (Keep `g_iso`, `g_iso_tx_sdu`, `g_rx_buf`, `g_tx_buf`, `g_now_ms`, `get_time_ms`, `isotp_send_adapter`, and all bxCAN/RCC/USART bring-up.)
+
+Add the include near the other UDS includes:
+```c
+#include "uds_ecu_app.h"
+```
+
+Add the board log glue (near `uart_puts`, after it is defined):
+```c
+void uds_ecu_app_log(const char *msg) { uart_puts(msg); }
+```
+
+In `main`, the `cfg` initializer keeps only board fields; the handler fields come from `fill_config`. Replace the `uds_config_t cfg = { ... };` so it reads:
+```c
+    uds_config_t cfg = {
+        .ecu_address = 0x10u,
+        .get_time_ms = get_time_ms,
+        .fn_tp_send = isotp_send_adapter,
+        .rx_buffer = g_rx_buf,
+        .rx_buffer_size = sizeof(g_rx_buf),
+        .tx_buffer = g_tx_buf,
+        .tx_buffer_size = sizeof(g_tx_buf),
+        .p2_ms = 50u,
+        .p2_star_ms = 2000u,
+    };
+    uds_ecu_app_fill_config(&cfg, "LABWIRED-F103-UDS");
+```
+(The DTC-store seeding lines that #343 placed before `cfg` are removed — `fill_config` now does the seeding.)
+
+- [ ] **Step 4: Wire the shared file into the f103 Makefile**
+
+In `examples/f103-uds-ecu/firmware/Makefile`: add `-I../../common` to `COMMON_CFLAGS` (line 8-9 region), add a `VPATH = .:../../common` line, and add `uds_ecu_app.c` to `APP_SRCS` (so it builds as `$(BUILD_DIR)/uds_ecu_app.o` via the existing `$(BUILD_DIR)/%.o: %.c` rule, found through VPATH).
+
+```make
+COMMON_CFLAGS := $(CPUFLAGS) -ffreestanding -fno-builtin -ffunction-sections \
+                 -fdata-sections -Os -g -I$(UDSLIB_DIR)/include -I$(UDSLIB_DIR)/src/core \
+                 -I../../common
+VPATH = .:../../common
+...
+APP_SRCS := startup.c main.c uds_ecu_app.c
+```
+(Note: f103's APP_SRCS may differ slightly; preserve existing entries and append `uds_ecu_app.c`. If f103 has no `startup.c`, keep whatever it lists and add `uds_ecu_app.c`.)
+
+- [ ] **Step 5: Build the f103 ELF clean**
+
+Run: `make -C examples/f103-uds-ecu/firmware UDSLIB_DIR=$HOME/projects/udslib`
+Expected: builds clean under `-Wall -Wextra -Werror`, produces `build/f103_uds_ecu.elf`, no duplicate-symbol or undefined-reference errors.
+
+- [ ] **Step 6: Re-verify all three f103 smokes (behavior-preserving)**
+
+Run each and confirm exit 0:
+```
+cargo run -p labwired-cli --bin labwired -- test --script examples/f103-uds-ecu/uds-session-smoke.yaml
+cargo run -p labwired-cli --bin labwired -- test --script examples/f103-uds-ecu/uds-reset-smoke.yaml
+cargo run -p labwired-cli --bin labwired -- test --script examples/f103-uds-ecu/uds-smoke.yaml
+```
+Expected: all exit 0. `uds-session` reports `uds_tester` done + `ECU_READY`; `uds-reset` reports done + `ECU_READY`; `uds-smoke` shows `F103-UDS-ECU`, `ECU_READY`, and `UDS_SEED_SERVED` (proves the shared `security_seed` + log hook works). If `UDS_SEED_SERVED` is missing, the log hook is not wired — fix before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/common/uds_ecu_app.h examples/common/uds_ecu_app.c examples/f103-uds-ecu/firmware/main.c examples/f103-uds-ecu/firmware/Makefile
+git commit -s -m "refactor(uds-ecu): extract shared UDS app; f103 uses it"
+```
+
+---
+
+### Task 2: Rust regression — scriptable tester over FDCAN
+
+The `uds-tester` has only ever driven bxCAN. Validate it drives an `Fdcan` peripheral in normal mode (where #343 found the bxCAN FlowControl-drop bug) and lock it with a test. If bring-up exposes a gap, fix it minimally and guard it.
+
+**Files:**
+- Modify: `crates/core/src/bus/mod.rs` (test module; production code only if a real gap is found)
+
+**Interfaces:**
+- Consumes: `service_can_uds_testers` (handles `Fdcan` via `tx_frames` drain + `receive_frame` inject), `CanUdsTester`, `CanUdsTesterState`, the `Fdcan` peripheral (`crates/core/src/peripherals/fdcan.rs`: `receive_frame`, `tx_frames`, normal-mode = `CCCR_INIT` cleared, non-loopback). Mirror the existing `uds_tester_completes_against_real_bxcan` test (around mod.rs:2350) and the firmware's `fdcan_start` register sequence (CCCR INIT|CCE → TEST=0 → CCCR=0) for the bring-up.
+
+- [ ] **Step 1: Write a failing/validating test driving the tester over a real Fdcan**
+
+Add a `#[test] uds_tester_completes_against_real_fdcan` to the test module. Build a `SystemBus` with an `Fdcan` peripheral named `fdcan1` at its base, bring it to normal mode (mirror `fdcan.rs`), attach a `CanUdsTester` with a script whose ECU reply is **multi-frame** (so the FC-delivery path is exercised on FDCAN). Inject the ECU FirstFrame via the Fdcan's `tx_frames` (the tester drains it), then assert the tester delivered a FlowControl frame to the Fdcan (via `receive_frame` / the Fdcan RX path), inject the CF, and assert the exchange reaches `Done`. Read `fdcan.rs` to use the exact RX-observation method (mirror how `uds_tester_completes_against_real_bxcan` observes injected frames, adapted for Fdcan).
+
+The assertion must verify FC **delivery** on FDCAN (not merely final `Done`), matching the discrimination standard from #343's `uds_tester_multiframe_ecu_response_injects_flowcontrol`.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p labwired-core --lib uds_tester_completes_against_real_fdcan -- --nocapture`
+Expected: PASS if the FDCAN tester path already works. If it FAILS (the tester can't drive Fdcan — e.g. normal-mode delivery, FD framing, or FC not injected), that is a real gap: go to Step 3.
+
+- [ ] **Step 3: If a gap was found, fix it minimally in production code**
+
+Apply the smallest fix to `service_can_uds_testers` / `Fdcan` that makes the path work (e.g. the FDCAN analogue of the #343 `AwaitMultiResp` FC forwarding, or a normal-mode delivery/filter fix in `fdcan.rs`). Keep the test from Step 1 as the guard; if you removed the fix the test must go RED. Document the gap + fix in the report. If NO gap was found, skip this step and note "FDCAN tester path worked unmodified."
+
+- [ ] **Step 4: Full Rust gate**
+
+Run: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test -p labwired-core --lib`
+Expected: fmt clean, clippy clean, all tests pass (including the new FDCAN test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/bus/mod.rs
+git commit -s -m "test(bus): cover scriptable uds-tester driving FDCAN in normal mode"
+```
+(If Step 3 applied a production fix, say so in the commit body.)
+
+---
+
+### Task 3: Port + extend the h563 ECU firmware
+
+Port h563's firmware to the instance ISO-TP API, convert it to a pure tester-driven ECU, and wire the shared handlers. Deliverable: clean ELF build (runtime proof is Task 4).
+
+**Files:**
+- Modify: `examples/h563-uds-ecu/firmware/main.c`
+- Modify: `examples/h563-uds-ecu/firmware/Makefile`
+
+**Interfaces:**
+- Consumes: `uds_ecu_app_fill_config` / `uds_ecu_app_log` (Task 1); current udslib instance ISO-TP API: `uds_tp_isotp_init(uds_isotp_ctx_t*, can_send, tx_id, rx_id, tx_sdu_buf, tx_sdu_size)`, `uds_tp_isotp_set_fd(uds_isotp_ctx_t*, bool)`, `uds_isotp_rx_callback(uds_isotp_ctx_t*, struct uds_ctx*, id, data, len)`, `uds_tp_isotp_process(uds_isotp_ctx_t*, time)`, `int uds_isotp_send(uds_isotp_ctx_t*, const uint8_t*, uint16_t)`. Keep all existing FDCAN/USART helpers (`fdcan_start`, `fdcan_send_frame`, `fdcan_poll_rx_frame`, `write_payload`/`read_payload`, `len_to_dlc`/`dlc_to_len`, `can_send`, `uart_*`, `get_time_ms`).
+- Produces: an h563 ECU that answers the full session via the shared handlers, reachable by an external tester on request id 0x7E0 / reply 0x7E8, and reboots via AIRCR on 0x11.
+
+- [ ] **Step 1: Remove the self-test + stale UDS plumbing from main.c**
+
+Delete: `g_positive_response_sent`, `g_dids`, `g_did_table`, `app_read_data_by_id`, `g_user_services`, `pump_one_tester_request`, `positive_vin_response_seen`, and the old `main` body's self-send/verify loop and `UDS_OK`/`UDS_FAIL`/`VIN=...` prints. Keep `g_rx_buffer`, `g_tx_buffer`, `g_vin`? — remove `g_vin` (VIN now passed to fill_config). Keep `g_now_ms`, `get_time_ms`, `can_send`, and all FDCAN/UART helpers.
+
+- [ ] **Step 2: Add the instance ISO-TP plumbing + shared includes + log glue**
+
+Add includes near the existing UDS includes:
+```c
+#include "uds_ecu_app.h"
+```
+Add ISO-TP instance state (near the buffers):
+```c
+static uds_isotp_ctx_t g_iso;
+static uint8_t g_iso_tx_sdu[64];
+```
+Add the transport adapter and the log glue:
+```c
+static int isotp_send_adapter(struct uds_ctx *ctx, const uint8_t *data, uint16_t len)
+{
+    (void) ctx;
+    return uds_isotp_send(&g_iso, data, len);
+}
+
+void uds_ecu_app_log(const char *msg) { uart_puts(msg); }
+```
+
+- [ ] **Step 3: Rewrite `main` as a pure tester-driven ECU**
+
+```c
+int main(void)
+{
+    uart_init();
+    uart_puts("H563-UDS-ECU\n");
+
+    fdcan_start();
+    uds_tp_isotp_init(&g_iso, can_send, 0x7E8u, 0x7E0u, g_iso_tx_sdu, sizeof(g_iso_tx_sdu));
+    uds_tp_isotp_set_fd(&g_iso, true);
+    uart_puts("ECU_READY\n");
+
+    uds_config_t cfg = {
+        .ecu_address = 0x10u,
+        .get_time_ms = get_time_ms,
+        .fn_tp_send = isotp_send_adapter,
+        .rx_buffer = g_rx_buffer,
+        .rx_buffer_size = sizeof(g_rx_buffer),
+        .tx_buffer = g_tx_buffer,
+        .tx_buffer_size = sizeof(g_tx_buffer),
+        .p2_ms = 50u,
+        .p2_star_ms = 2000u,
+    };
+    uds_ecu_app_fill_config(&cfg, "LABWIRED-H563-UDS");
+
+    uds_ctx_t ctx;
+    if (uds_init(&ctx, &cfg) != UDS_OK) {
+        uart_puts("UDS_INIT_FAIL\n");
+        for (;;) {
+        }
+    }
+
+    for (;;) {
+        can_frame_t frame;
+        if (fdcan_poll_rx_frame(&frame)) {
+            uds_isotp_rx_callback(&g_iso, &ctx, frame.id, frame.data, frame.len);
+        }
+        uds_process(&ctx);
+        uds_tp_isotp_process(&g_iso, g_now_ms);
+        ++g_now_ms;
+    }
+}
+```
+Ensure `fdcan_start()` leaves the controller in **normal mode** (it already clears TEST and INIT) and that the FDCAN RX accepts frames with id 0x7E0 into FIFO0. If the emulated FDCAN requires an acceptance-filter/RXGFC setup to receive 0x7E0 (verified in Task 4's smoke), add the minimal filter config in `fdcan_start` mirroring what the model needs; otherwise leave as-is.
+
+- [ ] **Step 4: Update the h563 Makefile**
+
+Add `$(UDSLIB_DIR)/src/services/uds_dtc_store.c` to `UDS_SRCS`. Add `-I../../common` to `COMMON_CFLAGS`, a `VPATH = .:../../common` line, and `uds_ecu_app.c` to `APP_SRCS`.
+
+- [ ] **Step 5: Build the h563 ELF clean (this currently fails on `main` — must now pass)**
+
+Run: `make -C examples/h563-uds-ecu/firmware UDSLIB_DIR=$HOME/projects/udslib`
+Expected: builds clean under `-Wall -Wextra -Werror`, produces the h563 ELF, no API-signature errors (the six pre-existing errors are gone), no duplicate-symbol/undefined-reference.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/h563-uds-ecu/firmware/main.c examples/h563-uds-ecu/firmware/Makefile
+git commit -s -m "feat(h563-uds): port to instance ISO-TP, pure tester-driven ECU on shared app"
+```
+
+---
+
+### Task 4: h563 full-session scenario, smoke, and docs
+
+Drive the h563 ECU through the full session over FDCAN and assert each reply; document. "Actually use what you ship": run the smoke + negative control.
+
+**Files:**
+- Modify: `examples/h563-uds-ecu/system.yaml` (replace `can-diagnostic-tester` with scriptable `uds-tester`)
+- Create: `examples/h563-uds-ecu/uds-session-smoke.yaml`
+- Modify: `examples/h563-uds-ecu/uds-smoke.yaml` (update to the new tester-driven model)
+- Modify: `examples/h563-uds-ecu/README.md`
+
+**Interfaces:**
+- Consumes: the Task 3 h563 firmware behavior; the scriptable `uds-tester` device on `fdcan1` (validated in Task 2); the CLI runner `labwired test --script` with `uart_contains` + `uds_tester: {id, result: done}` assertions.
+
+- [ ] **Step 1: Replace the tester in `system.yaml` with the scriptable full session**
+
+```yaml
+name: "h563-uds-ecu"
+chip: "../../configs/chips/stm32h563.yaml"
+external_devices:
+  - type: "uds-tester"
+    id: "uds-tester"
+    connection: "fdcan1"
+    config:
+      request_id: 0x7E0
+      reply_id: 0x7E8
+      script:
+        - send: "22 F1 90"
+          expect: "62 F1 90"
+        - send: "2E 01 23 DE AD BE EF"
+          expect_nrc: 0x31
+        - send: "10 03"
+          expect: "50 03"
+        - send: "3E 00"
+          expect: "7E 00"
+        - send: "2E 01 23 DE AD BE EF"
+          expect: "6E 01 23"
+        - send: "22 01 23"
+          expect: "62 01 23 DE AD BE EF"
+        - send: "19 01 09"
+          expect: "59 01"
+        - send: "14 FF FF FF"
+          expect: "54"
+        - send: "31 01 02 03"
+          expect: "71 01 02 03"
+        - send: "2F A0 01 03 01"
+          expect: "6F A0 01"
+        - send: "28 00 01"
+          expect: "68 00"
+        - send: "11 01"
+          expect: "51 01"
+board_io: []
+```
+
+- [ ] **Step 2: Create `examples/h563-uds-ecu/uds-session-smoke.yaml`**
+
+```yaml
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "./firmware/build/h563_uds_ecu.elf"
+limits:
+  max_steps: 2000000
+assertions:
+  - uart_contains: "ECU_READY"
+  - uds_tester: { id: "uds-tester", result: done }
+```
+(Use the actual h563 ELF filename produced by Task 3's Makefile; check `firmware/build/*.elf` and match it here.)
+
+- [ ] **Step 3: Build the ELF (if needed) and run the smoke**
+
+```
+make -C examples/h563-uds-ecu/firmware UDSLIB_DIR=$HOME/projects/udslib
+cargo run -p labwired-cli --bin labwired -- test --script examples/h563-uds-ecu/uds-session-smoke.yaml
+```
+Expected: exit 0; `uds-tester` assertion `done`; `ECU_READY` satisfied (appears twice — the 0x11 ECUReset reboots the ECU). If the smoke FAILS at a step and it is not a scenario typo, do NOT tweak bytes to force a pass — STOP and report BLOCKED with the failing step + tester failure message (it may be an FDCAN RX-filter gap in Task 3 or an FDCAN tester gap for Task 2 to fix).
+
+- [ ] **Step 4: Negative control — prove the assertion is live**
+
+Temporarily change step 1's `expect: "62 F1 90"` to `"62 F1 91"`, re-run the smoke, confirm non-zero exit with a step-0 failure, then revert and confirm pass again. Leave the file passing.
+
+- [ ] **Step 5: Reconcile `uds-smoke.yaml` to the new model**
+
+The old `uds-smoke.yaml` asserted the self-test UART strings (`UDS_REQ_22_F190`, `UDS_RESP_62_F190`, `VIN=...`, `UDS_OK`), which no longer exist. Update it to a minimal tester-driven VIN-read smoke (its own small system file or reusing the session system), asserting `uart_contains: "H563-UDS-ECU"`, `uart_contains: "ECU_READY"`, and `uds_tester: {id, result: done}` for a single `22 F1 90 → 62 F1 90` script — OR remove `uds-smoke.yaml` if `uds-session-smoke.yaml` supersedes it. Pick the smaller change; do not leave a scenario asserting strings the firmware no longer prints.
+
+- [ ] **Step 6: Update `examples/h563-uds-ecu/README.md`**
+
+Describe the new tester-driven full-session scenario (FDCAN), state the CI-vs-local split (smoke needs a locally-built ELF via `make -C firmware UDSLIB_DIR=$HOME/projects/udslib`, not a clean-checkout gate; always-on regression is the `uds_tester_*` tests including the FDCAN one), and that the ECU shares its UDS application with f103 via `examples/common/uds_ecu_app.c`. Mirror the structure of the f103 README's scenarios section.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/h563-uds-ecu/system.yaml examples/h563-uds-ecu/uds-session-smoke.yaml examples/h563-uds-ecu/uds-smoke.yaml examples/h563-uds-ecu/README.md
+git commit -s -m "feat(h563-uds): full diagnostic-session scenario over FDCAN and docs"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Rust gate: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test -p labwired-core --lib`
+- [ ] Both ELFs build clean: f103 and h563 firmware `make` under `-Werror`.
+- [ ] Smokes green: f103 `uds-session`/`uds-reset`/`uds-smoke` (refactor regression) and h563 `uds-session-smoke` (exit 0, `done`, `ECU_READY` ×2).
+- [ ] `git status` shows no staged `third_party/iolinki`; only intended files changed; all commits signed-off, no assistant references.

--- a/docs/superpowers/specs/2026-06-23-uds-ecu-consolidate-h563-design.md
+++ b/docs/superpowers/specs/2026-06-23-uds-ecu-consolidate-h563-design.md
@@ -1,0 +1,158 @@
+# Consolidate UDS ECU app + extend h563 to full session — Design
+
+**Date:** 2026-06-23
+**Status:** Approved (design), pending spec review
+**Branch:** `feat/uds-ecu-consolidate-h563` (off `origin/main` ab8fc6ec)
+
+## Problem
+
+Two issues with the UDS ECU examples:
+
+1. **Asymmetry.** After PR #343, `f103-uds-ecu` answers the full everyday UDS
+   diagnostic session, but `h563-uds-ecu` (the CAN-FD / FDCAN counterpart) only
+   handles a single DID read (VIN 0xF190).
+2. **h563 is broken.** Its firmware still uses the pre-instance udslib ISO-TP
+   API and **does not compile** against current udslib (verified: 6 errors —
+   `uds_tp_isotp_init`/`uds_isotp_rx_callback`/`uds_tp_isotp_process`/
+   `uds_tp_isotp_set_fd` signatures, `fn_tp_send` type, missing `address_mode`
+   service-entry field). The firmware build is not a CI gate, so it rotted.
+3. **Duplication.** f103's handler set (DID table, DTC store, routine/IO/comm,
+   security seed, reset) lives inline in its `main.c`; bringing h563 to parity
+   would duplicate all of it.
+
+This work consolidates the board-agnostic UDS application into one shared file,
+restores h563 to build against current udslib, and extends it to the same full
+tester-driven session as f103 — over FDCAN instead of bxCAN.
+
+## Goals / non-goals
+
+In scope: a shared `examples/common/uds_ecu_app.{c,h}`; f103 refactored to use
+it (re-verified); h563 ported to current udslib + converted to a pure
+tester-driven ECU running the full session over FDCAN; a Rust regression for the
+scriptable tester driving an FDCAN peripheral.
+
+Out of scope: `h563-uds-bootloader` (separate OTA example); new UDS services
+beyond the #343 set; any chip-model feature work unless a concrete gap blocks
+the FDCAN tester path.
+
+## Decisions (approved)
+
+- **h563 becomes a pure tester-driven ECU** (like f103): drop the self-send /
+  self-check loop and the `UDS_OK`/`UDS_FAIL` UART verdict; print `ECU_READY`
+  and answer the bus; the external scriptable `uds-tester` drives and asserts.
+- **VIN is parameterized per board**: the shared DID table reads a VIN the board
+  passes via `uds_ecu_app_fill_config(cfg, vin)`. f103 keeps
+  `LABWIRED-F103-UDS`; h563 keeps `LABWIRED-H563-UDS`.
+
+## Architecture
+
+### 1. Shared application (`examples/common/uds_ecu_app.{c,h}`)
+
+Board-agnostic, transport-agnostic. Holds exactly what #343 put in f103's
+`main.c`, made reusable:
+
+- Storage: `g_scratch[4]` (DID 0x0123), `g_lamp[1]` (IO 0xA001), the DTC backing
+  array + `uds_dtc_store`, and a VIN pointer set at config time.
+- DID table entries for `0xF190` (VIN, read-only, any session — storage set from
+  the `vin` arg), `0x0123` (scratch, read/write, `UDS_SESSION_EXTENDED`),
+  `0xA001` (IO point).
+- Handlers: `ecu_routine` (routine 0x0203, extended-only), `ecu_io` (0xA001),
+  `ecu_comm` (accept), `security_seed` (DE AD BE EF), `ecu_reset` (AIRCR
+  `0xE000ED0C` VECTKEY|SYSRESETREQ — works on both M3 and M33).
+- `void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin);` — seeds the
+  DTC store and sets `did_table`, `app_data`, `fn_dtc_list`, `fn_dtc_clear`,
+  `fn_routine_control`, `fn_io_control`, `fn_comm_control`, `fn_security_seed`,
+  `fn_reset`. The board's `main` sets the board-specific fields it must not own:
+  `ecu_address`, `get_time_ms`, `fn_tp_send`, `rx_buffer(_size)`,
+  `tx_buffer(_size)`, `p2_ms`, `p2_star_ms`.
+- The shared file declares its own freestanding `memcpy`/`memset` shims? **No** —
+  to avoid duplicate-symbol clashes, the shims stay in each board's `main.c`
+  (both already define them). The shared file uses only what udslib needs.
+
+The header exposes `uds_ecu_app_fill_config` and the VIN-length contract; nothing
+else is public.
+
+### 2. f103 refactor
+
+`examples/f103-uds-ecu/firmware/main.c`: remove the inline DID/DTC/IO storage and
+the `ecu_routine`/`ecu_io`/`ecu_comm`/`security_seed`/`ecu_reset` definitions
+(they move to the shared file), `#include "uds_ecu_app.h"`, and replace the
+hand-written `cfg` handler fields with one `uds_ecu_app_fill_config(&cfg,
+"LABWIRED-F103-UDS")` call plus the board-specific field assignments. Keep all
+bxCAN/RCC/USART/ISO-TP bring-up unchanged. **Re-verify the existing f103 smokes**
+(`uds-session-smoke.yaml`, `uds-reset-smoke.yaml`, `uds-smoke.yaml`) pass
+unchanged — this refactor must be behavior-preserving.
+
+### 3. h563 port + extend
+
+`examples/h563-uds-ecu/firmware/main.c`:
+- Port to the instance ISO-TP API: allocate `static uds_isotp_ctx_t g_iso;` and
+  `static uint8_t g_iso_tx_sdu[64];`; call `uds_tp_isotp_init(&g_iso, can_send,
+  0x7E8, 0x7E0, g_iso_tx_sdu, sizeof(g_iso_tx_sdu))`, `uds_tp_isotp_set_fd(&g_iso,
+  true)`, `uds_isotp_rx_callback(&g_iso, &ctx, id, data, len)`,
+  `uds_tp_isotp_process(&g_iso, t)`, and a `fn_tp_send` adapter
+  `int isotp_send_adapter(struct uds_ctx*, const uint8_t*, uint16_t)` that calls
+  `uds_isotp_send(&g_iso, data, len)` (matching f103).
+- Replace the single `user_services`/`app_read_data_by_id` handler with
+  `uds_ecu_app_fill_config(&cfg, "LABWIRED-H563-UDS")`.
+- Ensure FDCAN runs in **normal mode** (not loopback) and accepts 0x7E0 into the
+  RX FIFO so external tester frames arrive (today's `fdcan_start` configured for
+  the self-test path; confirm/adjust filtering for external RX).
+- Convert `main` to a pure ECU loop: `ECU_READY` banner, then
+  `poll → uds_isotp_rx_callback → uds_process → uds_tp_isotp_process` forever.
+  Remove `fdcan_send_frame(request)`, `positive_vin_response_seen`,
+  `g_positive_response_sent`, and the `UDS_OK`/`UDS_FAIL` verdict.
+- Reset: `ecu_reset` (shared) writes AIRCR; the M33 machine reboots via the same
+  core-implicit SCB path as f103.
+
+`examples/h563-uds-ecu/firmware/Makefile`: add `$(UDSLIB_DIR)/src/services/
+uds_dtc_store.c` to `UDS_SRCS`, add the shared file to the build (VPATH
+`../../common` + `uds_ecu_app.c` in `APP_SRCS`, or an explicit path), and add
+`-I../../common` to the C flags.
+
+`examples/h563-uds-ecu/system.yaml`: replace the `can-diagnostic-tester` device
+with a scriptable `uds-tester` on `fdcan1`, `request_id: 0x7E0`,
+`reply_id: 0x7E8`, running the same 12-step script as f103's `uds-session.yaml`
+(adjusted only for ids). `examples/h563-uds-ecu/uds-session-smoke.yaml`:
+assertions `uart_contains: ECU_READY` + `uds_tester: { id: <id>, result: done }`.
+Keep or update `uds-smoke.yaml` to the new model (the old self-test UART asserts
+no longer apply).
+
+### 4. Rust regression (FDCAN tester path)
+
+No example has driven the scriptable `uds-tester` over FDCAN before (f103 used
+bxCAN). The path exists (`service_can_uds_testers` handles `Fdcan` via
+`tx_frames`/`receive_frame`) but is unexercised — exactly where #343 found the
+bxCAN FlowControl-drop bug. Add an FSM test in `crates/core/src/bus/mod.rs`
+mirroring `uds_tester_completes_against_real_bxcan` but against a real `Fdcan`
+peripheral in normal mode: a multi-frame ECU response so the FC-delivery path is
+covered on FDCAN too. If end-to-end bring-up reveals an FDCAN-tester gap (normal
+mode, filtering, FD framing), fix it minimally and guard it with a test — same
+discipline as the #343 FC fix.
+
+## Testing
+
+- Rust gate: `cargo fmt --check && cargo clippy --all-targets -- -D warnings &&
+  cargo test -p labwired-core --lib` (the `core-integrity` gate).
+- Build both ELFs: `make -C examples/f103-uds-ecu/firmware
+  UDSLIB_DIR=$HOME/projects/udslib` and the h563 equivalent — both clean under
+  `-Wall -Wextra -Werror`.
+- Smokes (local, not clean-checkout gates): f103 `uds-session-smoke.yaml` /
+  `uds-reset-smoke.yaml` still pass (refactor regression); h563
+  `uds-session-smoke.yaml` passes (exit 0, `result: done`, `ECU_READY` ×2 from
+  the reset). Negative control on the h563 scenario.
+- READMEs for both examples updated; the CI-vs-local split restated.
+
+## Risks
+
+- **FDCAN tester path unexercised** (primary risk). Budget for a minimal Rust fix
+  + regression test if normal-mode FDCAN drive reveals a gap (FC delivery,
+  filtering, FD DLC). Reset on M33 is confirmed working (SCB core-implicit).
+- **h563 currently doesn't build** — porting to the instance ISO-TP API is the
+  first step; the design mirrors f103's known-good transport wiring verbatim.
+- **Refactoring the just-shipped f103** could regress it; mitigated by re-running
+  all three f103 smokes after the refactor.
+- **Shared-file symbol clashes** (memcpy/memset shims): keep the shims in each
+  board's `main.c`, not the shared file.
+- VIN length must match each board's DID `size` field; the shared table derives
+  size from the passed VIN to avoid a mismatch.

--- a/examples/common/uds_ecu_app.c
+++ b/examples/common/uds_ecu_app.c
@@ -1,0 +1,122 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "uds/uds_core.h"
+#include "uds/uds_dtc.h"
+#include "uds/uds_dtc_store.h"
+#include "uds_ecu_app.h"
+
+#define REG32(addr) (*(volatile uint32_t *) (addr))
+#define ECU_SESSION_EXTENDED 0x03u /* UDS_SESSION_ID_EXTENDED (internal id) */
+
+/* Writable scratch DID 0x0123 (read+write, EXTENDED session only). */
+static uint8_t g_scratch[4];
+/* IO-controlled point 0xA001 ("test lamp") for InputOutputControl 0x2F. */
+static uint8_t g_lamp[1];
+
+/* DID table. The 0xF190 VIN storage pointer is set in fill_config (per board);
+ * the table is mutable for that reason. */
+static uds_did_entry_t g_dids[] = {
+    {0xF190u, 17u, 0u, 0u, NULL, NULL, NULL},
+    {0x0123u, 4u, UDS_SESSION_EXTENDED, 0u, NULL, NULL, g_scratch},
+    {0xA001u, 1u, 0u, 0u, NULL, NULL, g_lamp},
+};
+
+/* Reference DTC store, seeded with one failing DTC (0x123456). */
+static uds_dtc_record_t g_dtc_backing[4];
+static uds_dtc_store_t g_dtc_store;
+
+static int security_seed(struct uds_ctx *ctx, uint8_t level, uint8_t *seed, uint16_t max_len)
+{
+    (void) ctx;
+    (void) level;
+    (void) max_len;
+    uds_ecu_app_log("UDS_SEED_SERVED\n");
+    seed[0] = 0xDE;
+    seed[1] = 0xAD;
+    seed[2] = 0xBE;
+    seed[3] = 0xEF;
+    return 4;
+}
+
+/* fn_reset hook: faithful CMSIS NVIC_SystemReset via AIRCR (works on M3 + M33).
+ * udslib calls this only AFTER the 0x11 positive response (51 01) is on the
+ * transport, so the reply is on the bus before SYSRESETREQ latches. */
+static void ecu_reset(uds_ctx_t *ctx, uint8_t type)
+{
+    (void) ctx;
+    (void) type;
+    __asm volatile("dsb 0xF" ::: "memory");
+    REG32(0xE000ED0Cu) = (0x05FAu << 16) | (1u << 2); /* AIRCR: VECTKEY | SYSRESETREQ */
+    __asm volatile("dsb 0xF" ::: "memory");
+    for (;;) {
+    }
+}
+
+/* fn_routine_control: routine 0x0203, startRoutine in EXTENDED session only. */
+static int ecu_routine(uds_ctx_t *ctx, uint8_t type, uint16_t id, const uint8_t *data,
+                       uint16_t len, uint8_t *out, uint16_t max)
+{
+    (void) data;
+    (void) len;
+    (void) max;
+    if (id != 0x0203u) {
+        return -0x31; /* requestOutOfRange */
+    }
+    if (ctx->active_session != ECU_SESSION_EXTENDED) {
+        return -0x31; /* requestOutOfRange: routine requires extended session */
+    }
+    if (type == 0x01u) { /* startRoutine */
+        out[0] = 0x00u;  /* routine status: OK */
+        return 1;
+    }
+    return -0x31; /* requestOutOfRange: unsupported routine control type */
+}
+
+/* fn_io_control: IO point 0xA001 (test lamp) — store and echo state. */
+static int ecu_io(uds_ctx_t *ctx, uint16_t id, uint8_t type, const uint8_t *data, uint16_t len,
+                  uint8_t *out, uint16_t max)
+{
+    (void) ctx;
+    (void) type;
+    (void) max;
+    if (id != 0xA001u) {
+        return -0x31; /* requestOutOfRange */
+    }
+    if (len >= 1u) {
+        g_lamp[0] = data[0];
+    }
+    out[0] = g_lamp[0];
+    return 1;
+}
+
+/* fn_comm_control: accept the requested communication mode. */
+static int ecu_comm(uds_ctx_t *ctx, uint8_t ctrl_type, uint8_t comm_type, uint16_t node_id)
+{
+    (void) ctx;
+    (void) ctrl_type;
+    (void) comm_type;
+    (void) node_id;
+    return UDS_OK;
+}
+
+void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin)
+{
+    g_dids[0].storage = (void *) vin; /* 17-byte VIN reported by 0xF190 */
+
+    uds_dtc_store_init(&g_dtc_store, g_dtc_backing, 4u, 40u);
+    uds_dtc_store_register(&g_dtc_store, 0x123456u, UDS_DTC_SEVERITY_CHECK_IMMEDIATELY, 0x10u,
+                           UDS_DTC_FGID_EMISSIONS);
+    uds_dtc_store_report_test(&g_dtc_store, 0x123456u, true); /* set testFailed status */
+
+    cfg->did_table.entries = g_dids;
+    cfg->did_table.count = (uint16_t) (sizeof(g_dids) / sizeof(g_dids[0]));
+    cfg->app_data = &g_dtc_store;
+    cfg->fn_dtc_list = uds_dtc_store_list_cb;
+    cfg->fn_dtc_clear = uds_dtc_store_clear_cb;
+    cfg->fn_routine_control = ecu_routine;
+    cfg->fn_io_control = ecu_io;
+    cfg->fn_comm_control = ecu_comm;
+    cfg->fn_security_seed = security_seed;
+    cfg->fn_reset = ecu_reset;
+}

--- a/examples/common/uds_ecu_app.h
+++ b/examples/common/uds_ecu_app.h
@@ -1,0 +1,14 @@
+#ifndef UDS_ECU_APP_H
+#define UDS_ECU_APP_H
+
+#include "uds/uds_core.h"
+
+/* Board-provided: emit a NUL-terminated trace string via the board UART. */
+void uds_ecu_app_log(const char *msg);
+
+/* Populate the board-agnostic UDS handlers, DID table, and a seeded DTC store
+ * into `cfg`. Call AFTER setting the board-specific cfg fields and BEFORE
+ * uds_init. `vin` must point to a 17-byte VIN (reported by DID 0xF190). */
+void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin);
+
+#endif /* UDS_ECU_APP_H */

--- a/examples/f103-uds-ecu/firmware/Makefile
+++ b/examples/f103-uds-ecu/firmware/Makefile
@@ -6,13 +6,15 @@ CC := $(CROSS)gcc
 
 CPUFLAGS := -mcpu=cortex-m3 -mthumb
 COMMON_CFLAGS := $(CPUFLAGS) -ffreestanding -fno-builtin -ffunction-sections \
-                 -fdata-sections -Os -g -I$(UDSLIB_DIR)/include -I$(UDSLIB_DIR)/src/core
+                 -fdata-sections -Os -g -I$(UDSLIB_DIR)/include -I$(UDSLIB_DIR)/src/core \
+                 -I../../common
+VPATH = .:../../common
 APP_CFLAGS := $(COMMON_CFLAGS) -Wall -Wextra -Werror
 UDS_CFLAGS := $(COMMON_CFLAGS) -Wall -Wextra -Wno-unused-parameter \
               -Wno-missing-field-initializers
 LDFLAGS := -nostdlib -T minimal.ld -Wl,--gc-sections -Wl,-Map=$(BUILD_DIR)/$(TARGET).map
 
-APP_SRCS := startup.c main.c
+APP_SRCS := startup.c main.c uds_ecu_app.c
 UDS_SRCS := \
   $(UDSLIB_DIR)/src/core/uds_core.c \
   $(UDSLIB_DIR)/src/services/uds_service_data.c \
@@ -39,9 +41,9 @@ all: check-udslib $(ELF) $(BROKEN_ELF)
 $(BUILD_DIR)/main_broken.o: main.c | $(BUILD_DIR)
 	$(CC) $(APP_CFLAGS) -DBROKEN_NCR -c $< -o $@
 
-$(BROKEN_ELF): $(BUILD_DIR)/startup.o $(BUILD_DIR)/main_broken.o $(UDS_OBJS) minimal.ld
+$(BROKEN_ELF): $(BUILD_DIR)/startup.o $(BUILD_DIR)/main_broken.o $(BUILD_DIR)/uds_ecu_app.o $(UDS_OBJS) minimal.ld
 	$(CC) $(CPUFLAGS) -nostdlib -T minimal.ld -Wl,--gc-sections \
-	  $(BUILD_DIR)/startup.o $(BUILD_DIR)/main_broken.o $(UDS_OBJS) -o $@
+	  $(BUILD_DIR)/startup.o $(BUILD_DIR)/main_broken.o $(BUILD_DIR)/uds_ecu_app.o $(UDS_OBJS) -o $@
 
 check-udslib:
 	@test -f "$(UDSLIB_DIR)/include/uds/uds_core.h" || \

--- a/examples/f103-uds-ecu/firmware/main.c
+++ b/examples/f103-uds-ecu/firmware/main.c
@@ -21,9 +21,8 @@
 #include <stdint.h>
 
 #include "uds/uds_core.h"
-#include "uds/uds_dtc.h"
-#include "uds/uds_dtc_store.h"
 #include "uds/uds_isotp.h"
+#include "uds_ecu_app.h"
 
 /* --- freestanding libc shims (no libc linked) --- */
 void *memcpy(void *dst, const void *src, size_t n)
@@ -97,6 +96,8 @@ static void uart_puts(const char *s)
 {
     while (*s) uart_putc(*s++);
 }
+
+void uds_ecu_app_log(const char *msg) { uart_puts(msg); }
 
 /* --- bxCAN @ 0x40006400 (RM0008 §24.9) --- */
 #define CAN_BASE 0x40006400u
@@ -226,104 +227,6 @@ static int isotp_send_adapter(struct uds_ctx *ctx, const uint8_t *data, uint16_t
     return uds_isotp_send(&g_iso, data, len);
 }
 
-/* UDSLib fn_reset hook: a faithful CMSIS NVIC_SystemReset. udslib's #88 fix
- * calls this only AFTER the 0x11 positive response (51 01) has been handed to
- * the transport, so by the time the AIRCR store latches the SYSRESETREQ the
- * reply is already on the CAN bus. The model reboots the CPU through the vector
- * table at the next instruction boundary; the reset never returns, so we spin. */
-static void ecu_reset(uds_ctx_t *ctx, uint8_t type)
-{
-    (void) ctx;
-    (void) type;
-    __asm volatile("dsb 0xF" ::: "memory");
-    REG32(0xE000ED0Cu) = (0x05FAu << 16) | (1u << 2); /* AIRCR: VECTKEY | SYSRESETREQ */
-    __asm volatile("dsb 0xF" ::: "memory");
-    for (;;) {
-    }
-}
-
-/* --- Diagnostic data: DIDs, one seeded DTC, one IO point --- */
-#define ECU_SESSION_EXTENDED 0x03u /* UDS_SESSION_ID_EXTENDED (internal id) */
-
-/* VIN reported by ReadDataByIdentifier 0xF190 (read-only, any session). */
-static const uint8_t g_vin[17] = {'L', 'A', 'B', 'W', 'I', 'R', 'E', 'D', '-',
-                                  'F', '1', '0', '3', '-', 'U', 'D', 'S'};
-/* Writable scratch DID 0x0123 (read+write, EXTENDED session only). */
-static uint8_t g_scratch[4];
-/* IO-controlled point 0xA001 ("test lamp") for InputOutputControl 0x2F. */
-static uint8_t g_lamp[1];
-
-static const uds_did_entry_t g_dids[] = {
-    {0xF190u, 17u, 0u, 0u, NULL, NULL, (void *) g_vin},
-    {0x0123u, 4u, UDS_SESSION_EXTENDED, 0u, NULL, NULL, g_scratch},
-    {0xA001u, 1u, 0u, 0u, NULL, NULL, g_lamp},
-};
-
-/* Reference DTC store, seeded with one failing DTC (0x123456). */
-static uds_dtc_record_t g_dtc_backing[4];
-static uds_dtc_store_t g_dtc_store;
-
-static int security_seed(struct uds_ctx *ctx, uint8_t level, uint8_t *seed, uint16_t max_len)
-{
-    (void) ctx;
-    (void) level;
-    (void) max_len;
-    /* The multi-frame request reassembled and dispatched to us — serve a seed. */
-    uart_puts("UDS_SEED_SERVED\n");
-    seed[0] = 0xDE;
-    seed[1] = 0xAD;
-    seed[2] = 0xBE;
-    seed[3] = 0xEF;
-    return 4;
-}
-
-/* UDSLib fn_routine_control: routine 0x0203, startRoutine in EXTENDED only. */
-static int ecu_routine(uds_ctx_t *ctx, uint8_t type, uint16_t id, const uint8_t *data,
-                       uint16_t len, uint8_t *out, uint16_t max)
-{
-    (void) data;
-    (void) len;
-    (void) max;
-    if (id != 0x0203u) {
-        return -0x31; /* requestOutOfRange */
-    }
-    if (ctx->active_session != ECU_SESSION_EXTENDED) {
-        return -0x31; /* requestOutOfRange: routine requires extended session */
-    }
-    if (type == 0x01u) { /* startRoutine */
-        out[0] = 0x00u;  /* routine status: OK */
-        return 1;
-    }
-    return -0x31; /* requestOutOfRange: unsupported routine control type */
-}
-
-/* UDSLib fn_io_control: IO point 0xA001 (test lamp) — store and echo state. */
-static int ecu_io(uds_ctx_t *ctx, uint16_t id, uint8_t type, const uint8_t *data,
-                  uint16_t len, uint8_t *out, uint16_t max)
-{
-    (void) ctx;
-    (void) type;
-    (void) max;
-    if (id != 0xA001u) {
-        return -0x31; /* requestOutOfRange */
-    }
-    if (len >= 1u) {
-        g_lamp[0] = data[0];
-    }
-    out[0] = g_lamp[0];
-    return 1;
-}
-
-/* UDSLib fn_comm_control: accept the requested communication mode. */
-static int ecu_comm(uds_ctx_t *ctx, uint8_t ctrl_type, uint8_t comm_type, uint16_t node_id)
-{
-    (void) ctx;
-    (void) ctrl_type;
-    (void) comm_type;
-    (void) node_id;
-    return UDS_OK;
-}
-
 int main(void)
 {
     rcc_init(); /* enable USART1/CAN1/GPIOA/AFIO clocks before touching them */
@@ -336,24 +239,10 @@ int main(void)
     uds_tp_isotp_init(&g_iso, can_send, ECU_TX_ID, ECU_RX_ID, g_iso_tx_sdu, sizeof(g_iso_tx_sdu));
     uds_tp_isotp_set_fd(&g_iso, false); /* classical CAN */
 
-    uds_dtc_store_init(&g_dtc_store, g_dtc_backing, 4u, 40u);
-    uds_dtc_store_register(&g_dtc_store, 0x123456u, UDS_DTC_SEVERITY_CHECK_IMMEDIATELY, 0x10u,
-                           UDS_DTC_FGID_EMISSIONS);
-    uds_dtc_store_report_test(&g_dtc_store, 0x123456u, true); /* set testFailed status */
-
     uds_config_t cfg = {
         .ecu_address = 0x10u,
         .get_time_ms = get_time_ms,
         .fn_tp_send = isotp_send_adapter,
-        .fn_security_seed = security_seed,
-        .fn_reset = ecu_reset,
-        .did_table = {.entries = g_dids, .count = (uint16_t) (sizeof(g_dids) / sizeof(g_dids[0]))},
-        .app_data = &g_dtc_store,
-        .fn_dtc_list = uds_dtc_store_list_cb,
-        .fn_dtc_clear = uds_dtc_store_clear_cb,
-        .fn_routine_control = ecu_routine,
-        .fn_io_control = ecu_io,
-        .fn_comm_control = ecu_comm,
         .rx_buffer = g_rx_buf,
         .rx_buffer_size = sizeof(g_rx_buf),
         .tx_buffer = g_tx_buf,
@@ -361,6 +250,8 @@ int main(void)
         .p2_ms = 50u,
         .p2_star_ms = 2000u,
     };
+    uds_ecu_app_fill_config(&cfg, "LABWIRED-F103-UDS");
+
     uds_ctx_t ctx;
     if (uds_init(&ctx, &cfg) != UDS_OK) {
         uart_puts("UDS_INIT_FAIL\n");

--- a/examples/h563-uds-ecu/README.md
+++ b/examples/h563-uds-ecu/README.md
@@ -1,21 +1,43 @@
 # STM32H563 FDCAN UDS ECU
 
-This example proves the STM32H563 FDCAN model with a small UDS ECU firmware.
-The firmware links UDSLib from `UDSLIB_DIR`, enables FDCAN, waits for the
-`can-diagnostic-tester` external device to send ReadDataByIdentifier DID
-`0xF190`, and validates the CAN-FD ISO-TP positive response.
+Proves the STM32H563 **FDCAN** model (CAN-FD) with a small UDS ECU firmware.
+The firmware links UDSLib from `UDSLIB_DIR` and shares its UDS application logic
+with the F103 example via `examples/common/uds_ecu_app.c`. On boot it prints
+`H563-UDS-ECU` and `ECU_READY`, enables FDCAN1, and processes incoming ISO-TP
+frames through the full UDSLib stack.
 
-Build:
+This is a **CLI regression example**, not a bundled web playground demo.
 
-```bash
-UDSLIB_DIR=/tmp/udslib-labwired-scope make -C examples/h563-uds-ecu/firmware
-```
-
-Smoke test:
+Build (needs an `arm-none-eabi` toolchain and UDSLib checked out):
 
 ```bash
-cargo run -q -p labwired-cli -- test \
-  --script examples/h563-uds-ecu/uds-smoke.yaml \
-  --output-dir out/h563-uds-ecu \
-  --no-uart-stdout
+make -C examples/h563-uds-ecu/firmware UDSLIB_DIR=$HOME/projects/udslib
 ```
+
+## Scenarios
+
+- `uds-session-smoke.yaml` — the full everyday diagnostic session driven by the
+  scripted tester over FDCAN1 (request_id 0x7E0, reply_id 0x7E8):
+  ReadDataByIdentifier (0x22), session switch (0x10) and TesterPresent (0x3E),
+  WriteDataByIdentifier (0x2E, extended-session gated), ReadDTCInformation /
+  ClearDTC (0x19/0x14), RoutineControl (0x31, extended-gated),
+  InputOutputControl (0x2F), CommunicationControl (0x28), and ECUReset (0x11).
+  The default-session write is asserted to return `7F 2E 31`, then succeeds after
+  `10 03`. `ECU_READY` appears twice because the 0x11 reset triggers a real
+  AIRCR reboot.
+
+- `uds-smoke.yaml` — minimal sanity check: banner + ECU_READY + tester result
+  done (VIN read only via the same session system.yaml).
+
+These smokes drive a locally-built ELF and are **not** clean-checkout CI gates.
+Build first:
+
+    make -C firmware UDSLIB_DIR=$HOME/projects/udslib
+
+Run the full-session smoke:
+
+    cargo run -p labwired-cli --bin labwired -- test --script examples/h563-uds-ecu/uds-session-smoke.yaml
+
+The always-on regression for the scriptable tester's framing (single/multi-frame
+requests and responses, wildcard and NRC matching) and the FDCAN model lives in
+the `uds_tester_*` tests in `crates/core/src/bus/mod.rs`, which run in CI.

--- a/examples/h563-uds-ecu/firmware/Makefile
+++ b/examples/h563-uds-ecu/firmware/Makefile
@@ -7,14 +7,15 @@ RUST_LLD ?= $(HOME)/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustl
 CPUFLAGS := --target=arm-none-eabi -mcpu=cortex-m33 -mthumb
 COMMON_CFLAGS := $(CPUFLAGS) -ffreestanding -fno-builtin -ffunction-sections \
                  -fdata-sections -Os -g -Iinclude -I$(UDSLIB_DIR)/include \
-                 -I$(UDSLIB_DIR)/src/core
+                 -I$(UDSLIB_DIR)/src/core -I../../common
+VPATH = .:../../common
 APP_CFLAGS := $(COMMON_CFLAGS) -Wall -Wextra -Werror
 UDS_CFLAGS := $(COMMON_CFLAGS) -Wall -Wextra -Wno-unused-parameter \
               -Wno-missing-field-initializers
 LDFLAGS := -flavor gnu -m armelf -T minimal.ld --gc-sections \
            -Map=$(BUILD_DIR)/$(TARGET).map
 
-APP_SRCS := startup.c main.c
+APP_SRCS := startup.c main.c uds_ecu_app.c
 UDS_SRCS := \
   $(UDSLIB_DIR)/src/core/uds_core.c \
   $(UDSLIB_DIR)/src/services/uds_service_data.c \
@@ -22,8 +23,11 @@ UDS_SRCS := \
   $(UDSLIB_DIR)/src/services/uds_service_io.c \
   $(UDSLIB_DIR)/src/services/uds_service_maintenance.c \
   $(UDSLIB_DIR)/src/services/uds_service_mem.c \
+  $(UDSLIB_DIR)/src/services/uds_service_link.c \
+  $(UDSLIB_DIR)/src/services/uds_service_roe.c \
   $(UDSLIB_DIR)/src/services/uds_service_security.c \
   $(UDSLIB_DIR)/src/services/uds_service_session.c \
+  $(UDSLIB_DIR)/src/services/uds_dtc_store.c \
   $(UDSLIB_DIR)/src/transport/uds_tp_isotp.c
 
 APP_OBJS := $(patsubst %.c,$(BUILD_DIR)/%.o,$(APP_SRCS))

--- a/examples/h563-uds-ecu/firmware/main.c
+++ b/examples/h563-uds-ecu/firmware/main.c
@@ -4,6 +4,7 @@
 
 #include "uds/uds_core.h"
 #include "uds/uds_isotp.h"
+#include "uds_ecu_app.h"
 
 void *memcpy(void *dst, const void *src, size_t n)
 {
@@ -74,8 +75,6 @@ void *__aeabi_memclr8(void *dst, size_t n)
 }
 
 static volatile uint32_t g_now_ms;
-static volatile bool g_positive_response_sent;
-static volatile bool g_tester_request_seen;
 
 #define REG32(addr) (*(volatile uint32_t *) (addr))
 
@@ -132,6 +131,8 @@ static void uart_puts(const char *s)
         uart_putc(*s++);
     }
 }
+
+void uds_ecu_app_log(const char *msg) { uart_puts(msg); }
 
 static uint32_t fdcan_reg(uint32_t offset)
 {
@@ -234,84 +235,15 @@ static int can_send(uint32_t id, const uint8_t *data, uint8_t len)
     return fdcan_send_frame(id, data, len, len > 8u);
 }
 
+static uds_isotp_ctx_t g_iso;
+static uint8_t g_iso_tx_sdu[64];
 static uint8_t g_rx_buffer[128];
 static uint8_t g_tx_buffer[128];
-static const uint8_t g_vin[] = "LABWIRED-H563-UDS";
-static const uds_did_entry_t g_dids[] = {
-    {0xF190u, sizeof(g_vin) - 1u, 0u, 0u, NULL, NULL, (void *) g_vin},
-};
-static const uds_did_table_t g_did_table = {
-    g_dids,
-    (uint16_t) (sizeof(g_dids) / sizeof(g_dids[0])),
-};
 
-static int app_read_data_by_id(struct uds_ctx *ctx, const uint8_t *data, uint16_t len)
+static int isotp_send_adapter(struct uds_ctx *ctx, const uint8_t *data, uint16_t len)
 {
-    (void) data;
-    if (len != 3u) {
-        return uds_send_nrc(ctx, 0x22u, 0x13u);
-    }
-
-    const uds_did_entry_t *entry = &g_dids[0];
-    if ((uint16_t) (3u + entry->size) > ctx->config->tx_buffer_size) {
-        return uds_send_nrc(ctx, 0x22u, 0x14u);
-    }
-
-    ctx->config->tx_buffer[0] = 0x62u;
-    ctx->config->tx_buffer[1] = (uint8_t) (entry->id >> 8u);
-    ctx->config->tx_buffer[2] = (uint8_t) entry->id;
-    memcpy(&ctx->config->tx_buffer[3], entry->storage, entry->size);
-    int rc = uds_send_response(ctx, (uint16_t) (3u + entry->size));
-    if (rc == 0) {
-        g_positive_response_sent = true;
-    }
-    return rc;
-}
-
-static const uds_service_entry_t g_user_services[] = {
-    {0x22u, 3u, UDS_SESSION_ALL, 0u, app_read_data_by_id, NULL},
-};
-
-static void pump_one_tester_request(uds_ctx_t *ctx)
-{
-    can_frame_t frame;
-    while (fdcan_poll_rx_frame(&frame)) {
-        if (frame.id == 0x7E0u) {
-            if (!g_tester_request_seen) {
-                uart_puts("UDS_REQ_22_F190\n");
-                g_tester_request_seen = true;
-            }
-            uds_isotp_rx_callback(ctx, frame.id, frame.data, frame.len);
-            return;
-        }
-    }
-}
-
-static bool positive_vin_response_seen(void)
-{
-    can_frame_t frame;
-    while (fdcan_poll_rx_frame(&frame)) {
-        if (frame.id != 0x7E8u) {
-            continue;
-        }
-        uint8_t offset = 0u;
-        uint8_t sdu_len = frame.data[0] & 0x0Fu;
-        if (sdu_len == 0u) {
-            sdu_len = frame.data[1];
-            offset = 2u;
-        } else {
-            offset = 1u;
-        }
-        if (sdu_len != (uint8_t) (3u + sizeof(g_vin) - 1u)) {
-            continue;
-        }
-        if (frame.data[offset + 0u] != 0x62u || frame.data[offset + 1u] != 0xF1u ||
-            frame.data[offset + 2u] != 0x90u) {
-            continue;
-        }
-        return true;
-    }
-    return false;
+    (void) ctx;
+    return uds_isotp_send(&g_iso, data, len);
 }
 
 int main(void)
@@ -320,46 +252,37 @@ int main(void)
     uart_puts("H563-UDS-ECU\n");
 
     fdcan_start();
-    uds_tp_isotp_init(can_send, 0x7E8u, 0x7E0u);
-    uds_tp_isotp_set_fd(true);
+    uds_tp_isotp_init(&g_iso, can_send, 0x7E8u, 0x7E0u, g_iso_tx_sdu, sizeof(g_iso_tx_sdu));
+    uds_tp_isotp_set_fd(&g_iso, true);
+    uart_puts("ECU_READY\n");
 
     uds_config_t cfg = {
         .ecu_address = 0x10u,
         .get_time_ms = get_time_ms,
-        .fn_tp_send = uds_isotp_send,
-        .p2_ms = 50u,
-        .p2_star_ms = 2000u,
+        .fn_tp_send = isotp_send_adapter,
         .rx_buffer = g_rx_buffer,
         .rx_buffer_size = sizeof(g_rx_buffer),
         .tx_buffer = g_tx_buffer,
         .tx_buffer_size = sizeof(g_tx_buffer),
-        .did_table = g_did_table,
-        .user_services = g_user_services,
-        .user_service_count = (uint16_t) (sizeof(g_user_services) / sizeof(g_user_services[0])),
+        .p2_ms = 50u,
+        .p2_star_ms = 2000u,
     };
+    uds_ecu_app_fill_config(&cfg, "LABWIRED-H563-UDS");
+
     uds_ctx_t ctx;
     if (uds_init(&ctx, &cfg) != UDS_OK) {
         uart_puts("UDS_INIT_FAIL\n");
         for (;;) {
         }
     }
-    bool ok = false;
-    for (uint32_t i = 0; i < 64u && !ok; ++i) {
-        pump_one_tester_request(&ctx);
-        uds_process(&ctx);
-        uds_tp_isotp_process(g_now_ms);
-        ok = positive_vin_response_seen() || g_positive_response_sent;
-        ++g_now_ms;
-    }
-
-    if (ok) {
-        uart_puts("UDS_RESP_62_F190\n");
-        uart_puts("VIN=LABWIRED-H563-UDS\n");
-        uart_puts("UDS_OK\n");
-    } else {
-        uart_puts("UDS_FAIL\n");
-    }
 
     for (;;) {
+        can_frame_t frame;
+        if (fdcan_poll_rx_frame(&frame)) {
+            uds_isotp_rx_callback(&g_iso, &ctx, frame.id, frame.data, frame.len);
+        }
+        uds_process(&ctx);
+        uds_tp_isotp_process(&g_iso, g_now_ms);
+        ++g_now_ms;
     }
 }

--- a/examples/h563-uds-ecu/system.yaml
+++ b/examples/h563-uds-ecu/system.yaml
@@ -1,10 +1,39 @@
 name: "h563-uds-ecu"
 chip: "../../configs/chips/stm32h563.yaml"
 external_devices:
-  - id: "uds_tester"
-    type: "can-diagnostic-tester"
+  # A real second CAN node: a virtual UDS tester scripted to walk the full
+  # everyday diagnostic session and assert each ECU reply on the bus. Sends are
+  # UDS-payload bytes; the tester frames ISO-TP. `expect` is a prefix match;
+  # `expect_nrc` matches a [7F sid nrc] negative response exactly.
+  - type: "uds-tester"
+    id: "uds-tester"
     connection: "fdcan1"
     config:
-      request_id: "0x7E0"
-      request_data: "03 22 F1 90"
+      request_id: 0x7E0
+      reply_id: 0x7E8
+      script:
+        - send: "22 F1 90"            # ReadDataByIdentifier VIN (open session)
+          expect: "62 F1 90"
+        - send: "2E 01 23 DE AD BE EF" # WriteDataByIdentifier rejected in default
+          expect_nrc: 0x31
+        - send: "10 03"               # DiagnosticSessionControl -> extended
+          expect: "50 03"
+        - send: "3E 00"               # TesterPresent
+          expect: "7E 00"
+        - send: "2E 01 23 DE AD BE EF" # WriteDataByIdentifier accepted in extended
+          expect: "6E 01 23"
+        - send: "22 01 23"            # read back proves the write persisted
+          expect: "62 01 23 DE AD BE EF"
+        - send: "19 01 09"            # ReadDTCInformation reportNumberOfDTCByStatusMask
+          expect: "59 01"
+        - send: "14 FF FF FF"         # ClearDiagnosticInformation (all groups)
+          expect: "54"
+        - send: "31 01 02 03"         # RoutineControl startRoutine 0x0203 (extended)
+          expect: "71 01 02 03"
+        - send: "2F A0 01 03 01"      # InputOutputControl shortTermAdjustment
+          expect: "6F A0 01"
+        - send: "28 00 01"            # CommunicationControl enableRxAndTx / normal
+          expect: "68 00"
+        - send: "11 01"              # ECUReset softReset (51 01 before reboot)
+          expect: "51 01"
 board_io: []

--- a/examples/h563-uds-ecu/uds-session-smoke.yaml
+++ b/examples/h563-uds-ecu/uds-session-smoke.yaml
@@ -9,5 +9,6 @@ assertions:
   # session switch, tester present, DTC count/clear, routine, IO control, comm
   # control) and finishes with 0x11 ECUReset. ECU_READY reprints on the real
   # AIRCR-triggered reboot, so the banner appears twice.
+  - uart_contains: "H563-UDS-ECU"
   - uart_contains: "ECU_READY"
   - uds_tester: { id: "uds-tester", result: done }

--- a/examples/h563-uds-ecu/uds-session-smoke.yaml
+++ b/examples/h563-uds-ecu/uds-session-smoke.yaml
@@ -1,0 +1,13 @@
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "./firmware/build/h563_uds_ecu.elf"
+limits:
+  max_steps: 2000000
+assertions:
+  # The scripted tester walks the full diagnostic session (read/write DID,
+  # session switch, tester present, DTC count/clear, routine, IO control, comm
+  # control) and finishes with 0x11 ECUReset. ECU_READY reprints on the real
+  # AIRCR-triggered reboot, so the banner appears twice.
+  - uart_contains: "ECU_READY"
+  - uds_tester: { id: "uds-tester", result: done }

--- a/examples/h563-uds-ecu/uds-smoke.yaml
+++ b/examples/h563-uds-ecu/uds-smoke.yaml
@@ -3,12 +3,8 @@ inputs:
   system: "./system.yaml"
   firmware: "./firmware/build/h563_uds_ecu.elf"
 limits:
-  max_steps: 200000
+  max_steps: 2000000
 assertions:
   - uart_contains: "H563-UDS-ECU"
-  - uart_contains: "UDS_REQ_22_F190"
-  - uart_contains: "UDS_RESP_62_F190"
-  - uart_contains: "VIN=LABWIRED-H563-UDS"
-  - uart_contains: "UDS_OK"
-  - expected_stop_reason: max_steps
-
+  - uart_contains: "ECU_READY"
+  - uds_tester: { id: "uds-tester", result: done }


### PR DESCRIPTION
## What

Consolidates the UDS ECU example application into one shared file used by both boards, **restores the h563 example** (which no longer compiled against current udslib), and **extends it to the full tester-driven diagnostic session over FDCAN** — matching what f103 already does over bxCAN (#343).

## Why

Two problems: (1) after #343, f103 answered the full UDS session but h563 only did a single VIN DID read; (2) h563's firmware still used the pre-instance udslib ISO-TP API and **did not compile** (6 errors) — its firmware build isn't a CI gate, so it had rotted.

## Changes

- **Shared app** — new `examples/common/uds_ecu_app.{c,h}`: board-agnostic DID table, seeded DTC store, and the routine/IO/comm/security-seed/reset handlers, plus `uds_ecu_app_fill_config(cfg, vin)`. A board-provided `uds_ecu_app_log()` hook keeps `UDS_SEED_SERVED` working per board. VIN is parameterized (f103 `LABWIRED-F103-UDS`, h563 `LABWIRED-H563-UDS`).
- **f103 refactor** — uses the shared app; behavior-preserving, re-verified by its three smokes (incl. `UDS_SEED_SERVED`). Classic-CAN path unchanged.
- **h563 port + extend** — firmware ported to the instance ISO-TP API, converted from a loopback self-test to a pure tester-driven ECU on the shared app; `system.yaml` now runs the scriptable `uds-tester` through the full 12-step session over FDCAN (0x7E0/0x7E8); `uds-session-smoke.yaml` added; `uds-smoke.yaml` reconciled; README updated.
- **Tester FD fix** — the scriptable tester only decoded classic ISO-TP SingleFrames; the FD-mode h563 ECU answers with the CAN-FD escape SF (`0x00 LL`). Now branches on the PCI byte (classic path byte-identical, so f103 is unaffected), with a regression test.
- **FDCAN regression** — a test proving the scriptable `uds-tester` drives an FDCAN peripheral in normal mode (the path had never been exercised by an example; the #343 FlowControl fix already covered both peripheral kinds).

## Verification

Both firmware ELFs build clean under `-Werror`. All four smokes exit 0 — f103 `uds-smoke`/`uds-reset`/`uds-session` (refactor + FD-fix regression) and h563 `uds-session` (result `done`, `ECU_READY` ×2 from the real AIRCR reset, negative control fails at step 0). Rust gate green: 1462 lib tests, clippy + fmt clean.

Follows up #343 (f103 full coverage).