### PR TITLE
Restore three rotted example firmware builds

### DIFF
--- a/examples/f103-uds-ecu/firmware/diff/Makefile
+++ b/examples/f103-uds-ecu/firmware/diff/Makefile
@@ -22,6 +22,7 @@ UDS_SRCS := \
   $(UDSLIB_DIR)/src/services/uds_service_link.c \
   $(UDSLIB_DIR)/src/services/uds_service_maintenance.c \
   $(UDSLIB_DIR)/src/services/uds_service_mem.c \
+  $(UDSLIB_DIR)/src/services/uds_service_roe.c \
   $(UDSLIB_DIR)/src/services/uds_service_security.c \
   $(UDSLIB_DIR)/src/services/uds_service_session.c \
   $(UDSLIB_DIR)/src/transport/uds_tp_isotp.c

--- a/examples/hil-displacement-showcase/firmware/main.c
+++ b/examples/hil-displacement-showcase/firmware/main.c
@@ -1,6 +1,11 @@
 #include <stdint.h>
 #include "stm32h563xx.h"
 
+// The CMSIS startup calls __libc_init_array (which pulls newlib's _init); under
+// -nostdlib that symbol is absent, so stub it empty (no C++ static ctors here).
+// Matches the nucleo-h563zi/board_firmware sibling example.
+void __libc_init_array(void) {}
+
 // Stress test parameters
 #define STRESS_BUFFER_SIZE 256U
 uint8_t stress_buffer[STRESS_BUFFER_SIZE];

--- a/examples/nucleo-h563zi/board_firmware/Makefile
+++ b/examples/nucleo-h563zi/board_firmware/Makefile
@@ -7,7 +7,7 @@
 TARGET := h563_blink_uart
 BUILD_DIR := build
 
-STM32CUBE_H5_DIR ?= $(abspath ../../../../../STM32CubeH5)
+STM32CUBE_H5_DIR ?= $(abspath ../../../../STM32CubeH5)
 
 DEVICE_INCLUDE := $(STM32CUBE_H5_DIR)/Drivers/CMSIS/Device/ST/STM32H5xx/Include
 CMSIS_INCLUDE := $(STM32CUBE_H5_DIR)/Drivers/CMSIS/Include


### PR DESCRIPTION
## What

A build-sweep of every example firmware Makefile — motivated by `h563-uds-ecu` having silently stopped compiling (fixed in #345) — found three more examples that no longer build against current toolchain/udslib. Their firmware builds aren't CI-gated, so the rot went unnoticed.

## Fixes

- **`f103-uds-ecu/firmware/diff`** — `UDS_SRCS` was missing `uds_service_roe.c`, so `uds_internal_roe_service` (referenced unconditionally by udslib's core dispatch table) was undefined. Same symbol-closure the main f103/h563 Makefiles already carry. Verified: builds clean and `diff-smoke.yaml` passes.
- **`hil-displacement-showcase`** — under `-nostdlib`, the CMSIS startup's `__libc_init_array` pulls newlib's `_init`, which isn't linked → undefined reference. Stub `__libc_init_array` empty (no C++ static ctors here), matching the `nucleo-h563zi/board_firmware` sibling. Verified: links to an ELF.
- **`nucleo-h563zi/board_firmware`** — `STM32CUBE_H5_DIR` had one extra `../` (five levels → `~/STM32CubeH5`) while the identically-deep hil example uses four (`~/projects/STM32CubeH5`, where the SDK lives). Verified: builds clean once the path resolves.

## Verification

All 11 example firmware Makefiles now build. The Rust gate (`core-integrity`) is unaffected — these are firmware-only changes.

## Note

Root cause is systemic: example firmware builds aren't a CI gate, so they rot silently. A follow-up worth considering is a CI job that builds the toolchain-available example firmwares (the UDS ones, arm-c-hello, esp32c3 — the STM32Cube examples need the external SDK, so they'd stay local-only). Flagging for a separate decision rather than bundling an infra change here.