### PR TITLE
examples(uds): pin UDSLib v2.0.0 and cover the v2.0.0 hardening

### DIFF
--- a/examples/common/uds_ecu_app.c
+++ b/examples/common/uds_ecu_app.c
@@ -9,10 +9,32 @@
 #define REG32(addr) (*(volatile uint32_t *) (addr))
 #define ECU_SESSION_EXTENDED 0x03u /* UDS_SESSION_ID_EXTENDED (internal id) */
 
+/* Size of the large calibration block reported by DID 0xF1A0. Chosen > 512 to
+ * exercise the udslib v2.0.0 snapshot-vs-send-under-lock TX split: the positive
+ * response (62 F1 A0 + 600 payload bytes = 603 bytes) is far larger than any
+ * single CAN/CAN-FD frame, so the ECU must reassemble it over multi-frame
+ * ISO-TP. The board tx_buffer and the ISO-TP SDU buffer must both exceed this. */
+#define ECU_BIGBLOB_DID 0xF1A0u
+#define ECU_BIGBLOB_SIZE 600u
+
 /* Writable scratch DID 0x0123 (read+write, EXTENDED session only). */
 static uint8_t g_scratch[4];
 /* IO-controlled point 0xA001 ("test lamp") for InputOutputControl 0x2F. */
 static uint8_t g_lamp[1];
+
+/* Dynamic read callback for the >512-byte calibration DID 0xF1A0. Fills a
+ * deterministic pattern (byte i = i & 0xFF) so the tester can assert it. */
+static int read_bigblob(struct uds_ctx *ctx, uint16_t did, uint8_t *buf, uint16_t max_len)
+{
+    (void) ctx;
+    if (did != ECU_BIGBLOB_DID || max_len < ECU_BIGBLOB_SIZE) {
+        return -0x31; /* requestOutOfRange */
+    }
+    for (uint16_t i = 0u; i < ECU_BIGBLOB_SIZE; ++i) {
+        buf[i] = (uint8_t) (i & 0xFFu);
+    }
+    return (int) ECU_BIGBLOB_SIZE;
+}
 
 /* DID table. The 0xF190 VIN storage pointer is set in fill_config (per board);
  * the table is mutable for that reason. */
@@ -20,6 +42,7 @@ static uds_did_entry_t g_dids[] = {
     {0xF190u, 17u, 0u, 0u, NULL, NULL, NULL},
     {0x0123u, 4u, UDS_SESSION_EXTENDED, 0u, NULL, NULL, g_scratch},
     {0xA001u, 1u, 0u, 0u, NULL, NULL, g_lamp},
+    {ECU_BIGBLOB_DID, ECU_BIGBLOB_SIZE, 0u, 0u, read_bigblob, NULL, NULL},
 };
 
 /* Reference DTC store, seeded with one failing DTC (0x123456). */
@@ -63,7 +86,7 @@ static int ecu_routine(uds_ctx_t *ctx, uint8_t type, uint16_t id, const uint8_t 
     if (id != 0x0203u) {
         return -0x31; /* requestOutOfRange */
     }
-    if (ctx->active_session != ECU_SESSION_EXTENDED) {
+    if (ctx->session.active != ECU_SESSION_EXTENDED) {
         return -0x31; /* requestOutOfRange: routine requires extended session */
     }
     if (type == 0x01u) { /* startRoutine */
@@ -119,4 +142,11 @@ void uds_ecu_app_fill_config(uds_config_t *cfg, const char *vin)
     cfg->fn_comm_control = ecu_comm;
     cfg->fn_security_seed = security_seed;
     cfg->fn_reset = ecu_reset;
+
+    /* Use case 3: configurable S3 server-side session timeout (udslib v2.0.0
+     * uds_config_t.s3_ms). 0 would fall back to UDS_S3_TIMEOUT_MS (5000 ms);
+     * pin it explicitly so the non-default session timeout is exercised. The
+     * board sets fn_tx_complete / reset_tx_wait_ms (use case 2) itself, since
+     * the TX-drain poll is peripheral-specific (bxCAN TSR vs FDCAN TXBRP). */
+    cfg->s3_ms = 4000u;
 }

--- a/examples/f103-uds-ecu/README.md
+++ b/examples/f103-uds-ecu/README.md
@@ -16,10 +16,41 @@ ECU -> tester (0x222): 06 67 01 DE AD BE EF      SecurityAccess seed response
 
 This is a **CLI regression example**, not a bundled web playground demo.
 
+## UDSLib version pin (v2.0.0)
+
+The firmware compiles UDSLib **from source** out of `UDSLIB_DIR` and is pinned to
+**UDSLib v2.0.0**. The build asserts `UDS_VERSION_STR "2.0.0"` in
+`uds_version.h`; a stale or mismatched checkout fails the `check-udslib` target
+loudly instead of compiling against the wrong API (v2.0.0 renamed
+`ctx->active_session` to `ctx->session.active`, which silently broke the old
+unpinned build). Fetch a matching tree, or point `UDSLIB_DIR` at an existing
+v2.0.0 checkout:
+
+```bash
+make -C examples/f103-uds-ecu/firmware fetch-udslib      # clones tag v2.0.0
+# or: UDSLIB_DIR=/path/to/udslib-v2.0.0 make -C examples/f103-uds-ecu/firmware
+```
+
+This example exercises the v2.0.0 hardening:
+
+- **>512-byte response** — DID `0xF1A0` returns a 600-byte calibration block
+  (`62 F1 A0` + 600 = 603 bytes). The `tx_buffer` and ISO-TP SDU buffer are
+  sized > 512 so the response is built then streamed as a multi-frame ISO-TP
+  reply (the snapshot-vs-send-under-lock TX split).
+- **ECUReset (0x11) post-TX deferral** — `fn_tx_complete` polls the bxCAN
+  `TSR.TME0` bit and `reset_tx_wait_ms` bounds the wait, so `NVIC_SystemReset`
+  cannot fire until `51 01` has left the mailbox (udslib #88).
+- **Configurable S3** — `uds_config_t.s3_ms` is set explicitly (4000 ms) instead
+  of the 5000 ms default.
+
+Concurrency/mutex hardening is **not applicable** here: this is a single-context
+polled super-loop (one thread drives both `uds_input_sdu` via the RX poll and
+`uds_process`), so there is no cross-context lock to exercise.
+
 Build (needs an `arm-none-eabi` toolchain):
 
 ```bash
-UDSLIB_DIR=/path/to/udslib make -C examples/f103-uds-ecu/firmware
+UDSLIB_DIR=/path/to/udslib-v2.0.0 make -C examples/f103-uds-ecu/firmware
 ```
 
 Smoke test:
@@ -35,7 +66,8 @@ cargo run -q -p labwired-cli -- test \
 - `uds-smoke.yaml` — multi-frame SecurityAccess (0x27) seed handshake.
 - `uds-reset-smoke.yaml` — ECUReset (0x11): `51 01` lands before the real reboot.
 - `uds-session-smoke.yaml` — the full everyday diagnostic session driven by the
-  scripted tester: ReadDataByIdentifier (0x22), session switch (0x10) and
+  scripted tester: ReadDataByIdentifier (0x22) incl. the >512-byte `0xF1A0`
+  multi-frame block, session switch (0x10) and
   TesterPresent (0x3E), WriteDataByIdentifier (0x2E, extended-session gated),
   ReadDTCInformation/ClearDTC (0x19/0x14), RoutineControl (0x31, extended-gated),
   InputOutputControl (0x2F), CommunicationControl (0x28), and ECUReset (0x11).
@@ -45,7 +77,7 @@ cargo run -q -p labwired-cli -- test \
 These smokes drive a locally-built ELF and are **not** clean-checkout CI gates.
 Build first:
 
-    make -C firmware UDSLIB_DIR=$HOME/projects/udslib
+    make -C firmware UDSLIB_DIR=$HOME/projects/udslib   # must be UDSLib v2.0.0
 
 Run:
 

--- a/examples/f103-uds-ecu/firmware/Makefile
+++ b/examples/f103-uds-ecu/firmware/Makefile
@@ -1,5 +1,12 @@
 TARGET := f103_uds_ecu
 BUILD_DIR := build
+# Pinned UDSLib version. The build asserts UDS_VERSION_STR matches so a stale or
+# mismatched checkout fails loudly instead of compiling against the wrong API
+# (v2.0.0 renamed ctx->active_session to ctx->session.active, for one). Fetch a
+# matching tree with `make fetch-udslib` (clones the tag into UDSLIB_DIR), or
+# point UDSLIB_DIR at an existing v2.0.0 checkout.
+UDSLIB_VERSION ?= 2.0.0
+UDSLIB_REPO ?= https://github.com/w1ne/udslib.git
 UDSLIB_DIR ?= $(HOME)/projects/udslib
 CROSS ?= arm-none-eabi-
 CC := $(CROSS)gcc
@@ -47,7 +54,18 @@ $(BROKEN_ELF): $(BUILD_DIR)/startup.o $(BUILD_DIR)/main_broken.o $(BUILD_DIR)/ud
 
 check-udslib:
 	@test -f "$(UDSLIB_DIR)/include/uds/uds_core.h" || \
-	  (echo "UDSLIB_DIR must point at a UDSLib checkout" >&2; exit 1)
+	  (echo "UDSLIB_DIR must point at a UDSLib checkout (try: make fetch-udslib)" >&2; exit 1)
+	@grep -q 'UDS_VERSION_STR "$(UDSLIB_VERSION)"' "$(UDSLIB_DIR)/include/uds/uds_version.h" || \
+	  (echo "UDSLIB_DIR is not UDSLib v$(UDSLIB_VERSION) (expected UDS_VERSION_STR \"$(UDSLIB_VERSION)\" in uds_version.h); run 'make fetch-udslib' or repoint UDSLIB_DIR" >&2; exit 1)
+
+# Clone the pinned tag into UDSLIB_DIR when it is absent (reproducible build).
+fetch-udslib:
+	@if [ ! -f "$(UDSLIB_DIR)/include/uds/uds_version.h" ]; then \
+	  echo "Cloning UDSLib v$(UDSLIB_VERSION) into $(UDSLIB_DIR)"; \
+	  git clone --branch "v$(UDSLIB_VERSION)" --depth 1 "$(UDSLIB_REPO)" "$(UDSLIB_DIR)"; \
+	else \
+	  echo "$(UDSLIB_DIR) already populated; skipping clone"; \
+	fi
 
 $(ELF): $(APP_OBJS) $(UDS_OBJS) minimal.ld
 	$(CC) $(CPUFLAGS) $(LDFLAGS) $(APP_OBJS) $(UDS_OBJS) -o $@
@@ -65,4 +83,4 @@ $(BUILD_DIR):
 clean:
 	rm -rf $(BUILD_DIR)
 
-.PHONY: all check-udslib clean
+.PHONY: all check-udslib fetch-udslib clean

--- a/examples/f103-uds-ecu/firmware/diff/Makefile
+++ b/examples/f103-uds-ecu/firmware/diff/Makefile
@@ -1,5 +1,7 @@
 TARGET := f103_uds_diff
 BUILD_DIR := build
+# Pinned UDSLib version (see ../Makefile). Fetch with `make -C .. fetch-udslib`.
+UDSLIB_VERSION ?= 2.0.0
 UDSLIB_DIR ?= $(HOME)/projects/udslib
 CROSS ?= arm-none-eabi-
 CC := $(CROSS)gcc
@@ -34,7 +36,9 @@ all: check-udslib $(ELF)
 
 check-udslib:
 	@test -f "$(UDSLIB_DIR)/include/uds/uds_core.h" || \
-	  (echo "UDSLIB_DIR must point at a UDSLib checkout" >&2; exit 1)
+	  (echo "UDSLIB_DIR must point at a UDSLib checkout (try: make -C .. fetch-udslib)" >&2; exit 1)
+	@grep -q 'UDS_VERSION_STR "$(UDSLIB_VERSION)"' "$(UDSLIB_DIR)/include/uds/uds_version.h" || \
+	  (echo "UDSLIB_DIR is not UDSLib v$(UDSLIB_VERSION); run 'make -C .. fetch-udslib' or repoint UDSLIB_DIR" >&2; exit 1)
 
 $(ELF): $(APP_OBJS) $(UDS_OBJS) diff.ld
 	$(CC) $(CPUFLAGS) $(LDFLAGS) $(APP_OBJS) $(UDS_OBJS) -o $@

--- a/examples/f103-uds-ecu/firmware/main.c
+++ b/examples/f103-uds-ecu/firmware/main.c
@@ -126,6 +126,7 @@ void uds_ecu_app_log(const char *msg) { uart_puts(msg); }
 #define MSR_INAK (1u << 0)
 #define TI_TXRQ (1u << 0)
 #define RF_RFOM (1u << 5)
+#define TSR_TME0 (1u << 26) /* Transmit mailbox 0 empty (frame left the mailbox) */
 /* Valid bit timing (TS1=12, TS2=5, BRP=9) — silicon-captured working value
  * (loopback used 0x40DC0009; normal mode drops the LBKM bit). A degenerate
  * BTR with zero segments would bus-off on the real chip and in the model. */
@@ -201,11 +202,14 @@ static bool can_poll(can_frame_t *f)
     return true;
 }
 
-/* --- UDS stack --- */
+/* --- UDS stack ---
+ * tx_buffer and the ISO-TP SDU buffer are sized > 512 so the >512-byte DID
+ * 0xF1A0 calibration block (62 F1 A0 + 600 bytes = 603 bytes) is built in
+ * tx_buffer and then streamed as a multi-frame ISO-TP response (use case 1). */
 static uds_isotp_ctx_t g_iso;
-static uint8_t g_iso_tx_sdu[64];
+static uint8_t g_iso_tx_sdu[768];
 static uint8_t g_rx_buf[128];
-static uint8_t g_tx_buf[128];
+static uint8_t g_tx_buf[768];
 static uint32_t g_now_ms;
 
 #ifdef BROKEN_NCR
@@ -225,6 +229,18 @@ static int isotp_send_adapter(struct uds_ctx *ctx, const uint8_t *data, uint16_t
 {
     (void) ctx;
     return uds_isotp_send(&g_iso, data, len);
+}
+
+/* fn_tx_complete hook (udslib v2.0.0, use case 2): report when the last TX
+ * frame has physically left the bxCAN mailbox. On real silicon fn_tp_send only
+ * QUEUES into TX mailbox 0; the 0x51 ECUReset response is not on the wire until
+ * the controller arbitrates it out and TME0 re-asserts. udslib polls this once
+ * per uds_process tick (bounded by reset_tx_wait_ms) and holds fn_reset until it
+ * returns true, so NVIC_SystemReset cannot drop the response (udslib #88). */
+static bool can_tx_complete(struct uds_ctx *ctx)
+{
+    (void) ctx;
+    return (CAN_TSR & TSR_TME0) != 0u;
 }
 
 int main(void)
@@ -249,6 +265,8 @@ int main(void)
         .tx_buffer_size = sizeof(g_tx_buf),
         .p2_ms = 50u,
         .p2_star_ms = 2000u,
+        .fn_tx_complete = can_tx_complete, /* gate 0x11 reset on frame-on-wire */
+        .reset_tx_wait_ms = 20u,           /* budget before forcing the reset */
     };
     uds_ecu_app_fill_config(&cfg, "LABWIRED-F103-UDS");
 

--- a/examples/f103-uds-ecu/uds-session.yaml
+++ b/examples/f103-uds-ecu/uds-session.yaml
@@ -14,6 +14,12 @@ external_devices:
       script:
         - send: "22 F1 90"            # ReadDataByIdentifier VIN (open session)
           expect: "62 F1 90"
+        - send: "22 F1 A0"            # ReadDataByIdentifier 600-byte calib block
+          # udslib v2.0.0 use case 1: a >512-byte response (62 F1 A0 + 600 bytes
+          # = 603) cannot fit one frame, so the ECU reassembles it over
+          # multi-frame ISO-TP. The pattern is byte i = i & 0xFF; assert the
+          # 62 F1 A0 header plus the first pattern bytes (prefix match).
+          expect: "62 F1 A0 00 01 02 03 04 05 06"
         - send: "2E 01 23 DE AD BE EF" # WriteDataByIdentifier rejected in default
           expect_nrc: 0x31
         - send: "10 03"               # DiagnosticSessionControl -> extended

--- a/examples/h563-uds-ecu/README.md
+++ b/examples/h563-uds-ecu/README.md
@@ -8,17 +8,41 @@ frames through the full UDSLib stack.
 
 This is a **CLI regression example**, not a bundled web playground demo.
 
-Build (needs an `arm-none-eabi` toolchain and UDSLib checked out):
+## UDSLib version pin (v2.0.0)
+
+The firmware compiles UDSLib **from source** out of `UDSLIB_DIR` and is pinned to
+**UDSLib v2.0.0**. The build asserts `UDS_VERSION_STR "2.0.0"`; a mismatched
+checkout fails `check-udslib` loudly. Fetch a matching tree, or point
+`UDSLIB_DIR` at an existing v2.0.0 checkout:
 
 ```bash
-make -C examples/h563-uds-ecu/firmware UDSLIB_DIR=$HOME/projects/udslib
+make -C examples/h563-uds-ecu/firmware fetch-udslib       # clones tag v2.0.0
+```
+
+This example exercises the v2.0.0 hardening:
+
+- **>512-byte response** — DID `0xF1A0` returns a 600-byte block (603-byte
+  response) reassembled over multi-frame ISO-TP in CAN-FD mode.
+- **ECUReset (0x11) post-TX deferral** — `fn_tx_complete` polls FDCAN `TXBRP`
+  bit 0 and `reset_tx_wait_ms` bounds the wait, so the SCB `SYSRESETREQ` reset
+  cannot fire until `51 01` has arbitrated onto the wire (udslib #88).
+- **Configurable S3** — `uds_config_t.s3_ms` set explicitly (4000 ms).
+
+Concurrency/mutex hardening is **not applicable**: this is a single-context
+polled super-loop, so there is no cross-context lock to exercise.
+
+Build (needs an `arm-none-eabi` toolchain and UDSLib v2.0.0 checked out):
+
+```bash
+make -C examples/h563-uds-ecu/firmware UDSLIB_DIR=/path/to/udslib-v2.0.0
 ```
 
 ## Scenarios
 
 - `uds-session-smoke.yaml` — the full everyday diagnostic session driven by the
   scripted tester over FDCAN1 (request_id 0x7E0, reply_id 0x7E8):
-  ReadDataByIdentifier (0x22), session switch (0x10) and TesterPresent (0x3E),
+  ReadDataByIdentifier (0x22) incl. the >512-byte `0xF1A0` multi-frame block,
+  session switch (0x10) and TesterPresent (0x3E),
   WriteDataByIdentifier (0x2E, extended-session gated), ReadDTCInformation /
   ClearDTC (0x19/0x14), RoutineControl (0x31, extended-gated),
   InputOutputControl (0x2F), CommunicationControl (0x28), and ECUReset (0x11).

--- a/examples/h563-uds-ecu/firmware/Makefile
+++ b/examples/h563-uds-ecu/firmware/Makefile
@@ -1,5 +1,12 @@
 TARGET := h563_uds_ecu
 BUILD_DIR := build
+# Pinned UDSLib version. The build asserts UDS_VERSION_STR matches so a stale or
+# mismatched checkout fails loudly instead of compiling against the wrong API
+# (v2.0.0 renamed ctx->active_session to ctx->session.active, for one). Fetch a
+# matching tree with `make fetch-udslib` (clones the tag into UDSLIB_DIR), or
+# point UDSLIB_DIR at an existing v2.0.0 checkout.
+UDSLIB_VERSION ?= 2.0.0
+UDSLIB_REPO ?= https://github.com/w1ne/udslib.git
 UDSLIB_DIR ?= /tmp/udslib-labwired-scope
 CLANG ?= clang
 RUST_LLD ?= $(HOME)/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/rust-lld
@@ -38,7 +45,18 @@ all: check-udslib $(ELF)
 
 check-udslib:
 	@test -f "$(UDSLIB_DIR)/include/uds/uds_core.h" || \
-	  (echo "UDSLIB_DIR must point at a UDSLib checkout" >&2; exit 1)
+	  (echo "UDSLIB_DIR must point at a UDSLib checkout (try: make fetch-udslib)" >&2; exit 1)
+	@grep -q 'UDS_VERSION_STR "$(UDSLIB_VERSION)"' "$(UDSLIB_DIR)/include/uds/uds_version.h" || \
+	  (echo "UDSLIB_DIR is not UDSLib v$(UDSLIB_VERSION) (expected UDS_VERSION_STR \"$(UDSLIB_VERSION)\" in uds_version.h); run 'make fetch-udslib' or repoint UDSLIB_DIR" >&2; exit 1)
+
+# Clone the pinned tag into UDSLIB_DIR when it is absent (reproducible build).
+fetch-udslib:
+	@if [ ! -f "$(UDSLIB_DIR)/include/uds/uds_version.h" ]; then \
+	  echo "Cloning UDSLib v$(UDSLIB_VERSION) into $(UDSLIB_DIR)"; \
+	  git clone --branch "v$(UDSLIB_VERSION)" --depth 1 "$(UDSLIB_REPO)" "$(UDSLIB_DIR)"; \
+	else \
+	  echo "$(UDSLIB_DIR) already populated; skipping clone"; \
+	fi
 
 $(ELF): $(APP_OBJS) $(UDS_OBJS) minimal.ld
 	$(RUST_LLD) $(LDFLAGS) $(APP_OBJS) $(UDS_OBJS) -o $@
@@ -56,4 +74,4 @@ $(BUILD_DIR):
 clean:
 	rm -rf $(BUILD_DIR)
 
-.PHONY: all check-udslib clean
+.PHONY: all check-udslib fetch-udslib clean

--- a/examples/h563-uds-ecu/firmware/main.c
+++ b/examples/h563-uds-ecu/firmware/main.c
@@ -92,6 +92,7 @@ static volatile uint32_t g_now_ms;
 #define FDCAN_REG_IR 0x050u
 #define FDCAN_REG_RXF0S 0x090u
 #define FDCAN_REG_RXF0A 0x094u
+#define FDCAN_REG_TXBRP 0x0C8u
 #define FDCAN_REG_TXBAR 0x0CCu
 
 #define FDCAN_RAM_BASE 0x800u
@@ -235,15 +236,30 @@ static int can_send(uint32_t id, const uint8_t *data, uint8_t len)
     return fdcan_send_frame(id, data, len, len > 8u);
 }
 
+/* tx_buffer and the ISO-TP SDU buffer are sized > 512 so the >512-byte DID
+ * 0xF1A0 calibration block (62 F1 A0 + 600 bytes = 603 bytes) is built in
+ * tx_buffer and then streamed as a multi-frame ISO-TP response (use case 1). */
 static uds_isotp_ctx_t g_iso;
-static uint8_t g_iso_tx_sdu[64];
+static uint8_t g_iso_tx_sdu[768];
 static uint8_t g_rx_buffer[128];
-static uint8_t g_tx_buffer[128];
+static uint8_t g_tx_buffer[768];
 
 static int isotp_send_adapter(struct uds_ctx *ctx, const uint8_t *data, uint16_t len)
 {
     (void) ctx;
     return uds_isotp_send(&g_iso, data, len);
+}
+
+/* fn_tx_complete hook (udslib v2.0.0, use case 2): TXBRP bit 0 stays set while
+ * TX buffer 0 still holds a pending request; it clears once the FDCAN has
+ * arbitrated the frame onto the wire. udslib polls this once per uds_process
+ * tick (bounded by reset_tx_wait_ms) and holds fn_reset until it returns true,
+ * so SCB SYSRESETREQ cannot reboot before the 0x51 response drains (udslib
+ * #88). */
+static bool can_tx_complete(struct uds_ctx *ctx)
+{
+    (void) ctx;
+    return (REG32(fdcan_reg(FDCAN_REG_TXBRP)) & 0x1u) == 0u;
 }
 
 int main(void)
@@ -266,6 +282,8 @@ int main(void)
         .tx_buffer_size = sizeof(g_tx_buffer),
         .p2_ms = 50u,
         .p2_star_ms = 2000u,
+        .fn_tx_complete = can_tx_complete, /* gate 0x11 reset on frame-on-wire */
+        .reset_tx_wait_ms = 20u,           /* budget before forcing the reset */
     };
     uds_ecu_app_fill_config(&cfg, "LABWIRED-H563-UDS");
 

--- a/examples/h563-uds-ecu/system.yaml
+++ b/examples/h563-uds-ecu/system.yaml
@@ -14,6 +14,11 @@ external_devices:
       script:
         - send: "22 F1 90"            # ReadDataByIdentifier VIN (open session)
           expect: "62 F1 90"
+        - send: "22 F1 A0"            # ReadDataByIdentifier 600-byte calib block
+          # udslib v2.0.0 use case 1: a >512-byte response (62 F1 A0 + 600 bytes
+          # = 603) reassembled over multi-frame ISO-TP (CAN-FD). Pattern is
+          # byte i = i & 0xFF; assert the header + first pattern bytes.
+          expect: "62 F1 A0 00 01 02 03 04 05 06"
         - send: "2E 01 23 DE AD BE EF" # WriteDataByIdentifier rejected in default
           expect_nrc: 0x31
         - send: "10 03"               # DiagnosticSessionControl -> extended


### PR DESCRIPTION
## Problem

The `f103-uds-ecu` and `h563-uds-ecu` examples compile UDSLib **from source** out of `UDSLIB_DIR`, but had **no version pin** — only a `test -f uds_core.h` existence gate. Two real consequences:

1. They silently broke against UDSLib **v2.0.0**, which renamed `ctx->active_session` to `ctx->session.active`. The shared `uds_ecu_app.c` no longer compiled against v2.0.0 at all.
2. They never exercised the v2.0.0 hardening paths (large multi-frame responses, the `fn_tx_complete` reset deferral, configurable S3).

## Pin (reproducible v2.0.0 build)

Both firmware Makefiles (and the f103 `diff/` sub-example) now:
- assert `UDS_VERSION_STR "2.0.0"` in `uds_version.h` in `check-udslib` — a stale/mismatched checkout **fails the build loudly** instead of mis-compiling;
- ship a `make fetch-udslib` target that clones tag `v2.0.0` into `UDSLIB_DIR` (`UDSLIB_VERSION`/`UDSLIB_REPO` overridable).

Verified: `make check-udslib` passes on a v2.0.0 tree and fails on a faked 1.21.0 tree.

## Hardening use cases

Implemented in the shared `examples/common/uds_ecu_app.c` plus per-board `main.c` (f103 bxCAN, h563 FDCAN):

| # | Use case | Status | How |
|---|----------|--------|-----|
| 1 | **>512-byte response** | Covered | New DID `0xF1A0` read callback returns a 600-byte block (`62 F1 A0` + 600 = 603 bytes). `tx_buffer` and the ISO-TP SDU buffer raised to 768 so the reply is built then streamed as multi-frame ISO-TP. Asserted in the session scripts. |
| 2 | **ECUReset 0x11 post-TX deferral** | Covered | `fn_tx_complete` polls bxCAN `TSR.TME0` (f103) / FDCAN `TXBRP` (h563); `reset_tx_wait_ms = 20` bounds the wait. The reset (`AIRCR`/`NVIC_SystemReset`) cannot fire until `51 01` is on the wire (udslib #88). |
| 3 | **Configurable S3** | Covered | `uds_config_t.s3_ms` set explicitly to 4000 ms (vs the 5000 ms default). |
| 4 | **Concurrency / mutex** | **N/A** | These ECUs are single-context polled super-loops — one thread drives both the RX poll (`uds_input_sdu`) and `uds_process`, so there is no cross-context lock to exercise. A concurrent-RX variant is a possible future follow-up. |

Also fixes the v2.0.0 `ctx->session.active` rename in the shared app.

## Build & verify evidence

All firmware cross-built against a fresh `v2.0.0` clone (`arm-none-eabi-gcc` for f103, `clang`+`rust-lld` for h563):

```
make -C examples/f103-uds-ecu/firmware      UDSLIB_DIR=/tmp/udslib-v2.0.0   -> exit 0
make -C examples/f103-uds-ecu/firmware/diff UDSLIB_DIR=/tmp/udslib-v2.0.0   -> exit 0
make -C examples/h563-uds-ecu/firmware      UDSLIB_DIR=/tmp/udslib-v2.0.0   -> exit 0
```

Sim smokes (built `labwired` CLI driving the scriptable `uds-tester`):

```
f103 uds-session-smoke.yaml  (UC1 + UC2 + UC3)  -> exit 0
f103 uds-reset-smoke.yaml     (UC2 in isolation) -> exit 0
f103 diff-smoke.yaml          (#29 regression)   -> exit 0
h563 uds-session-smoke.yaml                       -> exit 0
```

Negative control: changing the `0xF1A0` expect to wrong bytes fails at step 1, and the failure dump shows the **full 603-byte reassembled multi-frame response** (`62 F1 A0 00 01 02 ... 57`) — confirming UC1 is genuinely exercised end-to-end, not a false pass. The reset banner `ECU_READY` reprints (reboot after `51 01`) — confirming UC2.

Always-on Rust regression unaffected: `cargo test -p labwired-core --lib bus::` -> 52 passed.

## Notes

- No Rust source changed; `cargo fmt --all -- --check` is clean. The C example firmware is **not** a CI gate in labwired-core (CI runs Rust fmt/clippy/tests only; example firmware needs `arm-none-eabi` + a UDSLib checkout, run locally), so this is a local-build/sim-smoke verification.