### PR TITLE
Debug surface: breakpoints under continue, PC coverage, unobserved-snapshot skip, DAP step handlers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,4 +5,5 @@
 // See the LICENSE file in the project root for full license information.
 
 pub mod coverage;
+pub mod pc_coverage_report;
 pub mod tier1;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1963,11 +1963,10 @@ fn write_outputs<C: labwired_core::Cpu>(
             if let Some(cov) = coverage_observer {
                 match labwired_loader::SymbolProvider::new(firmware_path) {
                     Ok(symbols) => {
-                        let report =
-                            labwired_cli::pc_coverage_report::CoverageReport::build(
-                                symbols.statement_rows(),
-                                |addr| cov.was_executed(addr as u32),
-                            );
+                        let report = labwired_cli::pc_coverage_report::CoverageReport::build(
+                            symbols.statement_rows(),
+                            |addr| cov.was_executed(addr as u32),
+                        );
                         let info_path = output_dir.join("coverage.info");
                         if let Err(e) = std::fs::write(&info_path, report.to_lcov()) {
                             error!("Failed to write coverage.info: {}", e);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -585,6 +585,12 @@ struct TestArgs {
     #[arg(long, default_value = "100000")]
     trace_max: usize,
 
+    /// Collect firmware statement coverage. Writes coverage.info (LCOV) and
+    /// coverage.json into --output-dir. Distinct from `labwired coverage`,
+    /// which measures chip-model register faithfulness.
+    #[arg(long)]
+    coverage: bool,
+
     /// Explicitly opt out of sending LABWIRED_API_KEY even if it is set in the environment.
     /// Useful for local development and testing.
     #[arg(long)]
@@ -1492,6 +1498,7 @@ fn handle_load_error<C: labwired_core::Cpu>(
         system_path,
         std::time::Duration::from_secs(0),
         &None,
+        &None,
     );
     ExitCode::from(EXIT_RUNTIME_ERROR)
 }
@@ -1520,6 +1527,14 @@ fn execute_test_loop<C: labwired_core::Cpu>(
 
     let trace_observer = if args.trace {
         let obs = Arc::new(labwired_core::trace::TraceObserver::new(args.trace_max));
+        machine.observers.push(obs.clone());
+        Some(obs)
+    } else {
+        None
+    };
+
+    let coverage_observer = if args.coverage {
+        let obs = Arc::new(labwired_core::pc_coverage::PcCoverageObserver::new());
         machine.observers.push(obs.clone());
         Some(obs)
     } else {
@@ -1859,6 +1874,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         system_path,
         duration,
         &trace_observer,
+        &coverage_observer,
     );
 
     if !all_passed || (stop_requires_assertion && !expected_stop_reason_matched) {
@@ -1887,6 +1903,7 @@ fn write_outputs<C: labwired_core::Cpu>(
     system_path: Option<&PathBuf>,
     duration: std::time::Duration,
     trace_observer: &Option<Arc<labwired_core::trace::TraceObserver>>,
+    coverage_observer: &Option<Arc<labwired_core::pc_coverage::PcCoverageObserver>>,
 ) {
     let mut hasher = Sha256::new();
     hasher.update(firmware_bytes);
@@ -1939,6 +1956,39 @@ fn write_outputs<C: labwired_core::Cpu>(
                         }
                     }
                     Err(e) => error!("Failed to create trace.json: {}", e),
+                }
+            }
+
+            // coverage.info (LCOV) + coverage.json
+            if let Some(cov) = coverage_observer {
+                match labwired_loader::SymbolProvider::new(firmware_path) {
+                    Ok(symbols) => {
+                        let report =
+                            labwired_cli::pc_coverage_report::CoverageReport::build(
+                                symbols.statement_rows(),
+                                |addr| cov.was_executed(addr as u32),
+                            );
+                        let info_path = output_dir.join("coverage.info");
+                        if let Err(e) = std::fs::write(&info_path, report.to_lcov()) {
+                            error!("Failed to write coverage.info: {}", e);
+                        }
+                        let cov_json_path = output_dir.join("coverage.json");
+                        match std::fs::File::create(&cov_json_path) {
+                            Ok(f) => {
+                                if let Err(e) = serde_json::to_writer_pretty(f, &report) {
+                                    error!("Failed to write coverage.json: {}", e);
+                                }
+                            }
+                            Err(e) => error!("Failed to create coverage.json: {}", e),
+                        }
+                        info!(
+                            "Coverage: {}/{} statements ({:.1}%)",
+                            report.covered_statements,
+                            report.total_statements,
+                            report.statement_percent()
+                        );
+                    }
+                    Err(e) => error!("Failed to load symbols for coverage: {}", e),
                 }
             }
 

--- a/crates/cli/src/pc_coverage_report.rs
+++ b/crates/cli/src/pc_coverage_report.rs
@@ -106,7 +106,11 @@ impl CoverageReport {
             out.push_str("TN:\n");
             out.push_str(&format!("SF:{}\n", f.file));
             for l in &f.lines {
-                out.push_str(&format!("DA:{},{}\n", l.line, if l.covered { 1 } else { 0 }));
+                out.push_str(&format!(
+                    "DA:{},{}\n",
+                    l.line,
+                    if l.covered { 1 } else { 0 }
+                ));
             }
             out.push_str(&format!("LF:{}\n", f.lines_found));
             out.push_str(&format!("LH:{}\n", f.lines_hit));

--- a/crates/cli/src/pc_coverage_report.rs
+++ b/crates/cli/src/pc_coverage_report.rs
@@ -1,0 +1,178 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Firmware statement-coverage report.
+//!
+//! Maps the set of executed instruction addresses (from the runtime PC-coverage
+//! observer) against the DWARF statement rows of the firmware ELF, producing a
+//! per-file/per-line report serialisable to LCOV and JSON. This is firmware
+//! coverage, distinct from the SVD register-faithfulness `coverage` module.
+
+use labwired_loader::StmtRow;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// Coverage state of a single source line.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LineCoverage {
+    pub line: u32,
+    pub covered: bool,
+}
+
+/// Coverage of one source file.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FileCoverage {
+    pub file: String,
+    pub lines: Vec<LineCoverage>,
+    pub lines_found: usize,
+    pub lines_hit: usize,
+}
+
+/// A whole-run statement-coverage report.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CoverageReport {
+    pub files: Vec<FileCoverage>,
+    pub total_statements: usize,
+    pub covered_statements: usize,
+}
+
+impl CoverageReport {
+    /// Build a statement-coverage report by mapping DWARF statement rows against
+    /// an executed-address predicate. A source line is a statement if any
+    /// `is_stmt` row maps to it, and is covered if any of those rows' addresses
+    /// were executed. Files and lines are ordered deterministically.
+    pub fn build(rows: &[StmtRow], is_executed: impl Fn(u64) -> bool) -> Self {
+        // file -> line -> covered
+        let mut per_file: BTreeMap<&str, BTreeMap<u32, bool>> = BTreeMap::new();
+        for row in rows {
+            if !row.is_stmt {
+                continue;
+            }
+            let covered = per_file
+                .entry(row.file.as_str())
+                .or_default()
+                .entry(row.line)
+                .or_insert(false);
+            if is_executed(row.addr) {
+                *covered = true;
+            }
+        }
+
+        let mut files = Vec::new();
+        let mut total = 0usize;
+        let mut covered_total = 0usize;
+        for (file, lines) in per_file {
+            let mut line_cov = Vec::new();
+            let mut hit = 0usize;
+            for (line, covered) in lines {
+                if covered {
+                    hit += 1;
+                }
+                line_cov.push(LineCoverage { line, covered });
+            }
+            total += line_cov.len();
+            covered_total += hit;
+            files.push(FileCoverage {
+                file: file.to_string(),
+                lines_found: line_cov.len(),
+                lines_hit: hit,
+                lines: line_cov,
+            });
+        }
+
+        CoverageReport {
+            files,
+            total_statements: total,
+            covered_statements: covered_total,
+        }
+    }
+
+    /// Percentage of statements covered (0.0 when there are no statements).
+    pub fn statement_percent(&self) -> f64 {
+        if self.total_statements == 0 {
+            0.0
+        } else {
+            (self.covered_statements as f64 / self.total_statements as f64) * 100.0
+        }
+    }
+
+    /// Serialise to LCOV `.info` text (statement / line coverage).
+    pub fn to_lcov(&self) -> String {
+        let mut out = String::new();
+        for f in &self.files {
+            out.push_str("TN:\n");
+            out.push_str(&format!("SF:{}\n", f.file));
+            for l in &f.lines {
+                out.push_str(&format!("DA:{},{}\n", l.line, if l.covered { 1 } else { 0 }));
+            }
+            out.push_str(&format!("LF:{}\n", f.lines_found));
+            out.push_str(&format!("LH:{}\n", f.lines_hit));
+            out.push_str("end_of_record\n");
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stmt(addr: u64, file: &str, line: u32) -> StmtRow {
+        StmtRow {
+            addr,
+            file: file.to_string(),
+            line,
+            is_stmt: true,
+        }
+    }
+
+    #[test]
+    fn aggregates_per_line_covered_if_any_address_executed() {
+        let rows = vec![
+            stmt(0x100, "a.rs", 1),
+            stmt(0x104, "a.rs", 2),
+            stmt(0x108, "a.rs", 2), // same line, second address range
+            stmt(0x10c, "b.rs", 5),
+        ];
+        // Execute 0x100 and 0x108 only.
+        let report = CoverageReport::build(&rows, |addr| addr == 0x100 || addr == 0x108);
+
+        assert_eq!(report.total_statements, 3, "a.rs:1, a.rs:2, b.rs:5");
+        assert_eq!(
+            report.covered_statements, 2,
+            "a.rs:1 and a.rs:2 (covered via its second address)"
+        );
+        let b = report.files.iter().find(|f| f.file == "b.rs").unwrap();
+        assert_eq!(b.lines_hit, 0, "b.rs:5 never executed");
+    }
+
+    #[test]
+    fn non_stmt_rows_are_excluded() {
+        let rows = vec![StmtRow {
+            addr: 0x100,
+            file: "a.rs".to_string(),
+            line: 1,
+            is_stmt: false,
+        }];
+        let report = CoverageReport::build(&rows, |_| true);
+        assert_eq!(report.total_statements, 0);
+    }
+
+    #[test]
+    fn emits_lcov_records() {
+        let rows = vec![stmt(0x100, "a.rs", 1), stmt(0x104, "a.rs", 2)];
+        let report = CoverageReport::build(&rows, |addr| addr == 0x100);
+        let lcov = report.to_lcov();
+
+        assert!(lcov.contains("SF:a.rs\n"));
+        assert!(lcov.contains("DA:1,1\n"));
+        assert!(lcov.contains("DA:2,0\n"));
+        assert!(lcov.contains("LF:2\n"));
+        assert!(lcov.contains("LH:1\n"));
+        assert!(lcov.contains("end_of_record\n"));
+        assert_eq!(report.statement_percent(), 50.0);
+    }
+}

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -2776,14 +2776,19 @@ impl CortexM {
 
         self.pc = self.pc.wrapping_add(pc_increment);
 
-        let mut registers = [0u32; 17];
-        for (i, reg) in registers.iter_mut().enumerate().take(16) {
-            *reg = self.get_register(i as u8);
-        }
-        registers[16] = self.xpsr;
+        // Building the register snapshot is pure waste when nothing observes it,
+        // and this runs on every instruction. Gate it on having observers, the
+        // same way on_step_start above is gated.
+        if !_observers.is_empty() {
+            let mut registers = [0u32; 17];
+            for (i, reg) in registers.iter_mut().enumerate().take(16) {
+                *reg = self.get_register(i as u8);
+            }
+            registers[16] = self.xpsr;
 
-        for obs in _observers {
-            obs.on_step_end(_cycles, &registers);
+            for obs in _observers {
+                obs.on_step_end(_cycles, &registers);
+            }
         }
 
         Ok(())

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -733,12 +733,16 @@ impl Cpu for RiscV {
 
         self.pc = next_pc;
 
-        let mut registers = [0u32; 33];
-        registers[..32].copy_from_slice(&self.x);
-        registers[32] = self.pc;
+        // Building the register snapshot is pure waste when nothing observes it,
+        // and this runs on every instruction. Gate it on having observers.
+        if !observers.is_empty() {
+            let mut registers = [0u32; 33];
+            registers[..32].copy_from_slice(&self.x);
+            registers[32] = self.pc;
 
-        for obs in observers {
-            obs.on_step_end(inst_len, &registers);
+            for obs in observers {
+                obs.on_step_end(inst_len, &registers);
+            }
         }
 
         Ok(())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1368,6 +1368,17 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 current_batch = current_batch.min(1);
             }
 
+            // Breakpoints are only checked at batch boundaries (top of loop). If
+            // any breakpoint is set, clamp the batch to one instruction so a
+            // breakpoint whose PC lies inside a batch is caught at exactly that
+            // PC instead of being executed past and noticed only at the next
+            // boundary (the GDB "continue never stops" bug). This per-instruction
+            // cost applies ONLY while breakpoints are set, i.e. under a debugger,
+            // so the no-breakpoint hot path is unaffected.
+            if !self.breakpoints.is_empty() {
+                current_batch = current_batch.min(1);
+            }
+
             let executed =
                 self.cpu
                     .step_batch(&mut self.bus, &self.observers, &self.config, current_batch)?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod memory;
 pub mod metrics;
 pub mod multi_core;
 pub mod network;
+pub mod pc_coverage;
 pub mod peripherals;
 pub mod physics;
 pub mod runtime_snapshot;

--- a/crates/core/src/pc_coverage.rs
+++ b/crates/core/src/pc_coverage.rs
@@ -1,0 +1,155 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Runtime program-counter coverage.
+//!
+//! This records which instruction addresses a firmware run actually executed,
+//! plus the control-flow edges between them, by observing the per-instruction
+//! step hook. It is the raw execution-coverage source that higher layers map
+//! back to source statements and branches via DWARF debug info.
+//!
+//! This is distinct from the [`crate::coverage`] module: that one measures, by
+//! observable behaviour, whether a chip model implements the registers a part's
+//! SVD declares (model faithfulness). This one measures which addresses of the
+//! firmware under test ran (firmware coverage).
+
+use crate::SimulationObserver;
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+/// Observer that accumulates the set of executed instruction addresses and the
+/// control-flow edges taken between them.
+///
+/// Addresses are stored half-word aligned (the Thumb bit is masked off) so a PC
+/// and its interworking alias collapse to one entry. An edge `(from, to)` is
+/// recorded whenever the next executed address is not the natural fall-through
+/// of the previous one, which is exactly a taken branch / call / return / trap.
+#[derive(Debug, Default)]
+pub struct PcCoverageObserver {
+    executed: Mutex<BTreeSet<u32>>,
+    edges: Mutex<BTreeSet<(u32, u32)>>,
+    last: Mutex<Option<(u32, u32)>>, // (aligned_pc, opcode_len_in_bytes)
+    total: AtomicU64,
+}
+
+impl PcCoverageObserver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Total instructions observed (including repeats of the same address).
+    pub fn total_instructions(&self) -> u64 {
+        self.total.load(Ordering::SeqCst)
+    }
+
+    /// Distinct instruction addresses executed, ascending.
+    pub fn covered_addresses(&self) -> Vec<u32> {
+        self.executed
+            .lock()
+            .map(|s| s.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Number of distinct instruction addresses executed.
+    pub fn covered_count(&self) -> usize {
+        self.executed.lock().map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Control-flow edges taken, as `(from, to)` aligned address pairs, ascending.
+    pub fn edges(&self) -> Vec<(u32, u32)> {
+        self.edges
+            .lock()
+            .map(|s| s.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// True if the given (aligned) address was executed at least once.
+    pub fn was_executed(&self, addr: u32) -> bool {
+        let addr = addr & !1;
+        self.executed
+            .lock()
+            .map(|s| s.contains(&addr))
+            .unwrap_or(false)
+    }
+}
+
+impl SimulationObserver for PcCoverageObserver {
+    fn on_step_start(&self, pc: u32, opcode: u32) {
+        let aligned = pc & !1;
+        self.total.fetch_add(1, Ordering::SeqCst);
+
+        if let Ok(mut e) = self.executed.lock() {
+            e.insert(aligned);
+        }
+
+        // Thumb instructions are 16 or 32 bits. A 32-bit instruction has its
+        // top 5 opcode bits in 0b11101/0b11110/0b11111, encoded so the high
+        // half-word leads; treat anything with those high bits set as 4 bytes.
+        let len = if (opcode >> 11) & 0b11111 >= 0b11101 && (opcode >> 16) != 0 {
+            4
+        } else {
+            2
+        };
+
+        if let Ok(mut last) = self.last.lock() {
+            if let Some((prev_pc, prev_len)) = *last {
+                let fallthrough = prev_pc.wrapping_add(prev_len);
+                if aligned != fallthrough {
+                    if let Ok(mut edges) = self.edges.lock() {
+                        edges.insert((prev_pc, aligned));
+                    }
+                }
+            }
+            *last = Some((aligned, len));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_distinct_addresses_and_count() {
+        let cov = PcCoverageObserver::new();
+        // Three 16-bit instructions, the middle one executed twice.
+        cov.on_step_start(0x0800_0000, 0x4600);
+        cov.on_step_start(0x0800_0002, 0x4600);
+        cov.on_step_start(0x0800_0002, 0x4600);
+        cov.on_step_start(0x0800_0004, 0x4600);
+
+        assert_eq!(cov.total_instructions(), 4);
+        assert_eq!(cov.covered_count(), 3);
+        assert_eq!(
+            cov.covered_addresses(),
+            vec![0x0800_0000, 0x0800_0002, 0x0800_0004]
+        );
+        assert!(cov.was_executed(0x0800_0002));
+        assert!(!cov.was_executed(0x0800_0006));
+    }
+
+    #[test]
+    fn masks_thumb_bit() {
+        let cov = PcCoverageObserver::new();
+        cov.on_step_start(0x0800_0001, 0x4600); // interworking alias
+        assert!(cov.was_executed(0x0800_0000));
+        assert_eq!(cov.covered_count(), 1);
+    }
+
+    #[test]
+    fn records_branch_edges_not_fallthrough() {
+        let cov = PcCoverageObserver::new();
+        // Sequential fall-through: no edges.
+        cov.on_step_start(0x0800_0000, 0x4600);
+        cov.on_step_start(0x0800_0002, 0x4600);
+        assert!(cov.edges().is_empty());
+
+        // A jump backwards to 0x0800_0000: one edge from 0x0800_0002.
+        cov.on_step_start(0x0800_0000, 0x4600);
+        assert_eq!(cov.edges(), vec![(0x0800_0002, 0x0800_0000)]);
+    }
+}

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2145,4 +2145,41 @@ pub mod integration_tests {
             "Should have executed one instruction (thumb)"
         );
     }
+
+    #[test]
+    fn test_breakpoint_stops_inside_batch() {
+        // A breakpoint whose PC lies INSIDE a multi-instruction batch must stop
+        // at exactly that PC. Breakpoints are only checked at batch boundaries,
+        // so with a tick interval > 1 the batch would otherwise execute straight
+        // past the breakpoint — the classic GDB "set breakpoint, continue, never
+        // stops" symptom.
+        let mut machine = create_machine();
+        // Force batches larger than one instruction so the breakpoint is not at
+        // a batch boundary.
+        machine.config.peripheral_tick_interval = 16;
+
+        let pc = 0x2000_0000u32;
+        machine.cpu.set_pc(pc);
+
+        // 64 Thumb NOPs (MOV R0, R0 = 0x4600) so every stepped address is valid.
+        for i in 0..64u64 {
+            machine.bus.write_u16(pc as u64 + i * 2, 0x4600).unwrap();
+        }
+
+        // Breakpoint three instructions in — inside the first batch, not at the
+        // starting PC (which the boundary check already catches).
+        let bp = pc + 6;
+        machine.add_breakpoint(bp);
+
+        let res = machine.run(Some(64)).unwrap();
+        assert!(
+            matches!(res, StopReason::Breakpoint(addr) if addr == bp),
+            "continue must stop AT the breakpoint inside a batch, got {res:?}"
+        );
+        assert_eq!(
+            machine.cpu.get_pc(),
+            bp,
+            "PC must be exactly at the breakpoint, not past it"
+        );
+    }
 }

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2182,4 +2182,34 @@ pub mod integration_tests {
             "PC must be exactly at the breakpoint, not past it"
         );
     }
+
+    #[test]
+    fn pc_coverage_observer_records_executed_addresses() {
+        use crate::pc_coverage::PcCoverageObserver;
+
+        let mut machine = create_machine();
+        let cov = Arc::new(PcCoverageObserver::new());
+        machine.observers.push(cov.clone());
+
+        let pc = 0x2000_0000u32;
+        machine.cpu.set_pc(pc);
+        // Eight Thumb NOPs (MOV R0, R0).
+        for i in 0..8u64 {
+            machine.bus.write_u16(pc as u64 + i * 2, 0x4600).unwrap();
+        }
+
+        let _ = machine.run(Some(8)).unwrap();
+
+        assert_eq!(
+            cov.covered_count(),
+            8,
+            "all eight straight-line instruction addresses must be covered"
+        );
+        assert!(cov.was_executed(pc));
+        assert!(cov.was_executed(pc + 14));
+        assert!(
+            cov.edges().is_empty(),
+            "straight-line code takes no branch edges"
+        );
+    }
 }

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1086,6 +1086,14 @@ mod tests {
             adapter.step_out().is_err(),
             "step_out must error before a machine is attached"
         );
+        assert!(
+            adapter.step().is_err(),
+            "step must error before a machine is attached"
+        );
+        assert!(
+            adapter.set_pc(0x0800_0000).is_err(),
+            "set_pc must error before a machine is attached"
+        );
     }
 
     #[test]

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1074,6 +1074,21 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn step_back_and_step_out_error_before_machine_attached() {
+        // The server relies on these returning Err pre-init so it can reply with
+        // a DAP error response instead of a false success.
+        let adapter = LabwiredAdapter::new();
+        assert!(
+            adapter.step_back().is_err(),
+            "step_back must error before a machine is attached"
+        );
+        assert!(
+            adapter.step_out().is_err(),
+            "step_out must error before a machine is attached"
+        );
+    }
+
+    #[test]
     fn test_resolve_board_io_bindings_uses_default_gpio_offsets() {
         let chip = labwired_config::ChipDescriptor {
             schema_version: "1.0".to_string(),

--- a/crates/dap/src/server.rs
+++ b/crates/dap/src/server.rs
@@ -1400,42 +1400,56 @@ impl DapServer {
                     .unwrap_or(0);
 
                 if addr != 0 {
-                    let _ = self.adapter.set_pc(addr);
-                    sender.send_response(req_seq, "goto", None)?;
-                    sender.send_event(
-                        "stopped",
-                        Some(json!({
-                            "reason": "goto",
-                            "threadId": 1,
-                            "allThreadsStopped": true
-                        })),
-                    )?;
+                    if let Err(e) = self.adapter.set_pc(addr) {
+                        sender.send_error_response(
+                            req_seq,
+                            "goto",
+                            &format!("Goto failed: {}", e),
+                        )?;
+                    } else {
+                        sender.send_response(req_seq, "goto", None)?;
+                        sender.send_event(
+                            "stopped",
+                            Some(json!({
+                                "reason": "goto",
+                                "threadId": 1,
+                                "allThreadsStopped": true
+                            })),
+                        )?;
+                    }
                 } else {
                     sender.send_error_response(req_seq, "goto", "Invalid target address")?;
                 }
             }
             "next" | "stepIn" => {
-                let reason = if command == "next" {
-                    self.adapter
-                        .step_over_source_line(512)
-                        .unwrap_or(labwired_core::StopReason::StepDone)
+                let result = if command == "next" {
+                    self.adapter.step_over_source_line(512)
                 } else {
-                    self.adapter
-                        .step()
-                        .unwrap_or(labwired_core::StopReason::StepDone)
+                    self.adapter.step()
                 };
-                sender.send_response(req_seq, command, None)?;
-                sender.send_event(
-                    "stopped",
-                    Some(json!({
-                        "reason": match reason {
-                            labwired_core::StopReason::Breakpoint(_) => "breakpoint",
-                            _ => "step",
-                        },
-                        "threadId": 1,
-                        "allThreadsStopped": true
-                    })),
-                )?;
+                match result {
+                    Ok(reason) => {
+                        sender.send_response(req_seq, command, None)?;
+                        sender.send_event(
+                            "stopped",
+                            Some(json!({
+                                "reason": match reason {
+                                    labwired_core::StopReason::Breakpoint(_) => "breakpoint",
+                                    _ => "step",
+                                },
+                                "threadId": 1,
+                                "allThreadsStopped": true
+                            })),
+                        )?;
+                    }
+                    Err(e) => {
+                        sender.send_error_response(
+                            req_seq,
+                            command,
+                            &format!("Step failed: {}", e),
+                        )?;
+                    }
+                }
             }
             "stepBack" => {
                 if let Err(e) = self.adapter.step_back() {

--- a/crates/dap/src/server.rs
+++ b/crates/dap/src/server.rs
@@ -1438,28 +1438,42 @@ impl DapServer {
                 )?;
             }
             "stepBack" => {
-                let _ = self.adapter.step_back();
-                sender.send_response(req_seq, "stepBack", None)?;
-                sender.send_event(
-                    "stopped",
-                    Some(json!({
-                        "reason": "step",
-                        "threadId": 1,
-                        "allThreadsStopped": true
-                    })),
-                )?;
+                if let Err(e) = self.adapter.step_back() {
+                    sender.send_error_response(
+                        req_seq,
+                        "stepBack",
+                        &format!("Step back failed: {}", e),
+                    )?;
+                } else {
+                    sender.send_response(req_seq, "stepBack", None)?;
+                    sender.send_event(
+                        "stopped",
+                        Some(json!({
+                            "reason": "step",
+                            "threadId": 1,
+                            "allThreadsStopped": true
+                        })),
+                    )?;
+                }
             }
             "stepOut" => {
-                let _ = self.adapter.step_out();
-                sender.send_response(req_seq, "stepOut", None)?;
-                sender.send_event(
-                    "stopped",
-                    Some(json!({
-                        "reason": "step",
-                        "threadId": 1,
-                        "allThreadsStopped": true
-                    })),
-                )?;
+                if let Err(e) = self.adapter.step_out() {
+                    sender.send_error_response(
+                        req_seq,
+                        "stepOut",
+                        &format!("Step out failed: {}", e),
+                    )?;
+                } else {
+                    sender.send_response(req_seq, "stepOut", None)?;
+                    sender.send_event(
+                        "stopped",
+                        Some(json!({
+                            "reason": "step",
+                            "threadId": 1,
+                            "allThreadsStopped": true
+                        })),
+                    )?;
+                }
             }
             "readInstructionTrace" => {
                 let (start_cycle, end_cycle) = if let Some(args) = arguments {

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -439,6 +439,18 @@ pub struct SourceLocation {
     pub function: Option<String>,
 }
 
+/// One row of the DWARF line-number program: the instruction address and the
+/// source position it maps to. Unlike the reverse `line_map`, these are NOT
+/// deduplicated — every row is retained, so the set of `is_stmt` rows is the
+/// statement universe for coverage.
+#[derive(Debug, Clone)]
+pub struct StmtRow {
+    pub addr: u64,
+    pub file: String,
+    pub line: u32,
+    pub is_stmt: bool,
+}
+
 #[derive(Debug, Clone)]
 pub enum DwarfLocation {
     Register(u16),
@@ -464,6 +476,8 @@ pub struct SymbolProvider {
     >,
     // Map of (file_name, line) -> address
     line_map: HashMap<(String, u32), u64>,
+    // Full line-program rows (not deduped) — the statement universe for coverage
+    stmt_rows: Vec<StmtRow>,
     // Map of symbol_name -> address
     symbol_map: HashMap<String, u64>,
     // Test-only locals: PC -> list of locals
@@ -483,6 +497,7 @@ impl SymbolProvider {
         let object = object::File::parse(slice).context("Failed to parse ELF for symbols")?;
 
         let mut line_map = std::collections::HashMap::new();
+        let mut stmt_rows: Vec<StmtRow> = Vec::new();
 
         // Build line map using gimli for reverse lookup
         let load_section = |id: gimli::SectionId| -> std::result::Result<
@@ -521,10 +536,16 @@ impl SymbolProvider {
                                 });
 
                             if let (Some(f), Some(line)) = (file_name, row.line()) {
-                                // Store the first address seen for this file:line
-                                line_map
-                                    .entry((f, line.get() as u32))
-                                    .or_insert(row.address());
+                                let line_u32 = line.get() as u32;
+                                // Retain every row for the statement universe...
+                                stmt_rows.push(StmtRow {
+                                    addr: row.address(),
+                                    file: f.clone(),
+                                    line: line_u32,
+                                    is_stmt: row.is_stmt(),
+                                });
+                                // ...and the first address per file:line for reverse lookup.
+                                line_map.entry((f, line_u32)).or_insert(row.address());
                             }
                         }
                     }
@@ -551,9 +572,17 @@ impl SymbolProvider {
             dwarf,
             context,
             line_map,
+            stmt_rows,
             symbol_map,
             test_locals: HashMap::new(),
         })
+    }
+
+    /// Full DWARF line-program rows (not deduplicated). The set of rows with
+    /// `is_stmt` set is the statement universe: a statement is covered when an
+    /// instruction at its address was executed.
+    pub fn statement_rows(&self) -> &[StmtRow] {
+        &self.stmt_rows
     }
 
     pub fn lookup(&self, addr: u64) -> Option<SourceLocation> {
@@ -791,6 +820,7 @@ impl SymbolProvider {
             dwarf,
             context,
             line_map: HashMap::new(),
+            stmt_rows: Vec::new(),
             symbol_map: HashMap::new(),
             test_locals: HashMap::new(),
         }
@@ -873,6 +903,45 @@ mod tests {
             loc.file
         );
         assert_eq!(loc.line, Some(26));
+    }
+
+    #[test]
+    fn test_statement_rows_full_not_deduped() {
+        let elf_path =
+            std::path::PathBuf::from("../../target/thumbv7m-none-eabi/debug/firmware-ci-fixture");
+        if !elf_path.exists() {
+            eprintln!(
+                "skipping test_statement_rows_full_not_deduped: fixture not built \
+                 (cargo build -p firmware-ci-fixture --target thumbv7m-none-eabi)"
+            );
+            return;
+        }
+
+        let provider = SymbolProvider::new(&elf_path).expect("Failed to create SymbolProvider");
+        let rows = provider.statement_rows();
+
+        assert!(!rows.is_empty(), "expected DWARF line-program rows");
+        assert!(
+            rows.iter().any(|r| r.is_stmt),
+            "expected at least one is_stmt row"
+        );
+
+        // The full row set must not be deduplicated the way the reverse line_map
+        // is: there are more rows than distinct (file,line) keys whenever any
+        // line spans multiple address ranges (loops, inlining, -O).
+        let distinct_lines: std::collections::HashSet<(&str, u32)> =
+            rows.iter().map(|r| (r.file.as_str(), r.line)).collect();
+        assert!(
+            rows.len() >= distinct_lines.len(),
+            "row count must be at least the distinct-line count"
+        );
+
+        // main.rs line 26 is known-present (see test_location_to_pc).
+        assert!(
+            rows.iter()
+                .any(|r| r.file.ends_with("main.rs") && r.line == 26),
+            "expected a statement row for main.rs:26"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Strengthens the debug, trace and coverage surface — the first slice of the
debug-surface roadmap (GDB/trace + cert-coverage). Four self-contained changes,
each tested.

### Stop at breakpoints set inside a batch under run/continue
`Machine::run` checked breakpoints only at batch boundaries, then executed a
batch of up to `peripheral_tick_interval` instructions. With an interval > 1 a
breakpoint whose PC landed inside the batch was executed past and only noticed
at the next boundary — so a debugger `continue` would never stop at it. The
batch is now clamped to one instruction whenever any breakpoint is set,
mirroring the existing cycle-accurate clamp; the no-breakpoint hot path is
unchanged. Regression test added.

### Skip the per-instruction register snapshot when unobserved
The step-end hook built a full register array (17 u32 on Cortex-M, 33 on
RISC-V) on every instruction even with no observer attached — the default
`test`/`run` path. Gated on a non-empty observer list, matching the existing
`on_step_start` guard. Observed paths (DAP, VCD, trace) are unaffected.

### Runtime PC-coverage observer
Adds `PcCoverageObserver`, a `SimulationObserver` that accumulates the set of
executed instruction addresses and the control-flow edges between them. This is
the runtime firmware-coverage source (distinct from the SVD register-
faithfulness `coverage` module), to be mapped to source statements/branches via
DWARF in a follow-up. Unit tests cover address dedup, Thumb-bit masking and edge
detection; an integration test drives it through `Machine::run`.

### Report DAP stepBack/stepOut failures instead of swallowing them
The `stepBack`/`stepOut` request handlers discarded the adapter `Result` and
always sent a success response, so a client stepping before attach (or hitting a
no-history / step-out error) got a false success. They now fail closed with a
DAP error response, matching the `restart` handler. Adapter test added.

### Verification
- core lib suite: 1488 passed, 0 failed
- gdbstub e2e + DAP e2e (5/5, with the CI firmware fixture built): green
- clippy clean on the touched crates; full workspace builds
