### PR TITLE
Coverage: branch (BRDA) coverage in --coverage output

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1963,10 +1963,38 @@ fn write_outputs<C: labwired_core::Cpu>(
             if let Some(cov) = coverage_observer {
                 match labwired_loader::SymbolProvider::new(firmware_path) {
                     Ok(symbols) => {
-                        let report = labwired_cli::pc_coverage_report::CoverageReport::build(
+                        let mut report = labwired_cli::pc_coverage_report::CoverageReport::build(
                             symbols.statement_rows(),
                             |addr| cov.was_executed(addr as u32),
                         );
+                        // Resolve each observed branch site to its source line.
+                        let branch_cov = cov
+                            .branch_sites()
+                            .into_iter()
+                            .filter_map(|(src, counts)| {
+                                symbols.lookup(src as u64).and_then(|loc| {
+                                    loc.line.map(|line| {
+                                        // statement_rows uses the line-program
+                                        // file basename; lookup() returns the
+                                        // full path. Normalise to the basename
+                                        // so branches attach to the right SF.
+                                        let file = loc
+                                            .file
+                                            .rsplit('/')
+                                            .next()
+                                            .unwrap_or(&loc.file)
+                                            .to_string();
+                                        labwired_cli::pc_coverage_report::BranchCoverage {
+                                            file,
+                                            line,
+                                            taken: counts.taken,
+                                            not_taken: counts.not_taken,
+                                        }
+                                    })
+                                })
+                            })
+                            .collect();
+                        report.set_branches(branch_cov);
                         let info_path = output_dir.join("coverage.info");
                         if let Err(e) = std::fs::write(&info_path, report.to_lcov()) {
                             error!("Failed to write coverage.info: {}", e);
@@ -1981,10 +2009,13 @@ fn write_outputs<C: labwired_core::Cpu>(
                             Err(e) => error!("Failed to create coverage.json: {}", e),
                         }
                         info!(
-                            "Coverage: {}/{} statements ({:.1}%)",
+                            "Coverage: {}/{} statements ({:.1}%), {}/{} branches ({:.1}%)",
                             report.covered_statements,
                             report.total_statements,
-                            report.statement_percent()
+                            report.statement_percent(),
+                            report.covered_branches,
+                            report.total_branches,
+                            report.branch_percent()
                         );
                     }
                     Err(e) => error!("Failed to load symbols for coverage: {}", e),

--- a/crates/cli/src/pc_coverage_report.rs
+++ b/crates/cli/src/pc_coverage_report.rs
@@ -31,12 +31,25 @@ pub struct FileCoverage {
     pub lines_hit: usize,
 }
 
-/// A whole-run statement-coverage report.
+/// Branch coverage at one source position: how many times the instruction took
+/// a divergent path versus fell through.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BranchCoverage {
+    pub file: String,
+    pub line: u32,
+    pub taken: u64,
+    pub not_taken: u64,
+}
+
+/// A whole-run statement- and branch-coverage report.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct CoverageReport {
     pub files: Vec<FileCoverage>,
     pub total_statements: usize,
     pub covered_statements: usize,
+    pub branches: Vec<BranchCoverage>,
+    pub total_branches: usize,
+    pub covered_branches: usize,
 }
 
 impl CoverageReport {
@@ -87,7 +100,31 @@ impl CoverageReport {
             files,
             total_statements: total,
             covered_statements: covered_total,
+            branches: Vec::new(),
+            total_branches: 0,
+            covered_branches: 0,
         }
+    }
+
+    /// Attach branch coverage, sorted deterministically, and roll up totals.
+    /// Each branch site contributes two outcomes (taken, not-taken); an outcome
+    /// counts as covered when it was observed at least once.
+    pub fn set_branches(&mut self, mut branches: Vec<BranchCoverage>) {
+        branches.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+        let mut total = 0usize;
+        let mut covered = 0usize;
+        for b in &branches {
+            total += 2;
+            if b.taken > 0 {
+                covered += 1;
+            }
+            if b.not_taken > 0 {
+                covered += 1;
+            }
+        }
+        self.branches = branches;
+        self.total_branches = total;
+        self.covered_branches = covered;
     }
 
     /// Percentage of statements covered (0.0 when there are no statements).
@@ -99,7 +136,16 @@ impl CoverageReport {
         }
     }
 
-    /// Serialise to LCOV `.info` text (statement / line coverage).
+    /// Percentage of branch outcomes covered (0.0 when there are no branches).
+    pub fn branch_percent(&self) -> f64 {
+        if self.total_branches == 0 {
+            0.0
+        } else {
+            (self.covered_branches as f64 / self.total_branches as f64) * 100.0
+        }
+    }
+
+    /// Serialise to LCOV `.info` text (statement / line + branch coverage).
     pub fn to_lcov(&self) -> String {
         let mut out = String::new();
         for f in &self.files {
@@ -112,6 +158,27 @@ impl CoverageReport {
                     if l.covered { 1 } else { 0 }
                 ));
             }
+
+            // Branch data for this file. Each site emits two outcomes: block 0
+            // branch 0 = divergent (taken), branch 1 = fall-through (not taken).
+            let mut br_found = 0usize;
+            let mut br_hit = 0usize;
+            for b in self.branches.iter().filter(|b| b.file == f.file) {
+                out.push_str(&format!("BRDA:{},0,0,{}\n", b.line, b.taken));
+                out.push_str(&format!("BRDA:{},0,1,{}\n", b.line, b.not_taken));
+                br_found += 2;
+                if b.taken > 0 {
+                    br_hit += 1;
+                }
+                if b.not_taken > 0 {
+                    br_hit += 1;
+                }
+            }
+            if br_found > 0 {
+                out.push_str(&format!("BRF:{}\n", br_found));
+                out.push_str(&format!("BRH:{}\n", br_hit));
+            }
+
             out.push_str(&format!("LF:{}\n", f.lines_found));
             out.push_str(&format!("LH:{}\n", f.lines_hit));
             out.push_str("end_of_record\n");
@@ -178,5 +245,39 @@ mod tests {
         assert!(lcov.contains("LH:1\n"));
         assert!(lcov.contains("end_of_record\n"));
         assert_eq!(report.statement_percent(), 50.0);
+    }
+
+    #[test]
+    fn branches_roll_up_and_emit_brda() {
+        let rows = vec![stmt(0x100, "a.rs", 1), stmt(0x104, "a.rs", 2)];
+        let mut report = CoverageReport::build(&rows, |_| true);
+        report.set_branches(vec![
+            // Fully exercised conditional: both outcomes seen.
+            BranchCoverage {
+                file: "a.rs".to_string(),
+                line: 1,
+                taken: 3,
+                not_taken: 1,
+            },
+            // Only ever taken (e.g. an unconditional jump): one outcome covered.
+            BranchCoverage {
+                file: "a.rs".to_string(),
+                line: 2,
+                taken: 5,
+                not_taken: 0,
+            },
+        ]);
+
+        assert_eq!(report.total_branches, 4, "two sites, two outcomes each");
+        assert_eq!(report.covered_branches, 3, "both + taken-only");
+        assert_eq!(report.branch_percent(), 75.0);
+
+        let lcov = report.to_lcov();
+        assert!(lcov.contains("BRDA:1,0,0,3\n"));
+        assert!(lcov.contains("BRDA:1,0,1,1\n"));
+        assert!(lcov.contains("BRDA:2,0,0,5\n"));
+        assert!(lcov.contains("BRDA:2,0,1,0\n"));
+        assert!(lcov.contains("BRF:4\n"));
+        assert!(lcov.contains("BRH:3\n"));
     }
 }

--- a/crates/core/src/pc_coverage.rs
+++ b/crates/core/src/pc_coverage.rs
@@ -17,21 +17,34 @@
 //! firmware under test ran (firmware coverage).
 
 use crate::SimulationObserver;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
+/// Taken / not-taken counts observed for the instruction at one source address.
+///
+/// `taken` counts the times execution left via a non-fall-through path (a taken
+/// conditional branch, an unconditional jump, a call, a return or a trap);
+/// `not_taken` counts the times it fell through to the next instruction. A
+/// source address with `taken > 0` is a branch site.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BranchCounts {
+    pub taken: u64,
+    pub not_taken: u64,
+    pub target: Option<u32>,
+}
+
 /// Observer that accumulates the set of executed instruction addresses and the
-/// control-flow edges taken between them.
+/// per-instruction taken/not-taken control-flow outcomes between them.
 ///
 /// Addresses are stored half-word aligned (the Thumb bit is masked off) so a PC
-/// and its interworking alias collapse to one entry. An edge `(from, to)` is
-/// recorded whenever the next executed address is not the natural fall-through
-/// of the previous one, which is exactly a taken branch / call / return / trap.
+/// and its interworking alias collapse to one entry. For each source address we
+/// record whether execution fell through or diverged, which yields both branch
+/// edges and branch taken/not-taken coverage.
 #[derive(Debug, Default)]
 pub struct PcCoverageObserver {
     executed: Mutex<BTreeSet<u32>>,
-    edges: Mutex<BTreeSet<(u32, u32)>>,
+    branches: Mutex<BTreeMap<u32, BranchCounts>>,
     last: Mutex<Option<(u32, u32)>>, // (aligned_pc, opcode_len_in_bytes)
     total: AtomicU64,
 }
@@ -61,9 +74,27 @@ impl PcCoverageObserver {
 
     /// Control-flow edges taken, as `(from, to)` aligned address pairs, ascending.
     pub fn edges(&self) -> Vec<(u32, u32)> {
-        self.edges
+        self.branches
             .lock()
-            .map(|s| s.iter().copied().collect())
+            .map(|b| {
+                b.iter()
+                    .filter_map(|(src, c)| c.target.filter(|_| c.taken > 0).map(|t| (*src, t)))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Branch sites — source addresses that diverged at least once — with their
+    /// taken/not-taken counts, ascending by address.
+    pub fn branch_sites(&self) -> Vec<(u32, BranchCounts)> {
+        self.branches
+            .lock()
+            .map(|b| {
+                b.iter()
+                    .filter(|(_, c)| c.taken > 0)
+                    .map(|(src, c)| (*src, *c))
+                    .collect()
+            })
             .unwrap_or_default()
     }
 
@@ -98,9 +129,13 @@ impl SimulationObserver for PcCoverageObserver {
         if let Ok(mut last) = self.last.lock() {
             if let Some((prev_pc, prev_len)) = *last {
                 let fallthrough = prev_pc.wrapping_add(prev_len);
-                if aligned != fallthrough {
-                    if let Ok(mut edges) = self.edges.lock() {
-                        edges.insert((prev_pc, aligned));
+                if let Ok(mut branches) = self.branches.lock() {
+                    let counts = branches.entry(prev_pc).or_default();
+                    if aligned != fallthrough {
+                        counts.taken += 1;
+                        counts.target = Some(aligned);
+                    } else {
+                        counts.not_taken += 1;
                     }
                 }
             }
@@ -151,5 +186,27 @@ mod tests {
         // A jump backwards to 0x0800_0000: one edge from 0x0800_0002.
         cov.on_step_start(0x0800_0000, 0x4600);
         assert_eq!(cov.edges(), vec![(0x0800_0002, 0x0800_0000)]);
+    }
+
+    #[test]
+    fn records_branch_taken_and_not_taken_counts() {
+        let cov = PcCoverageObserver::new();
+        // Branch at 0x0800_0100: once falls through to 0x0800_0102, once taken
+        // to 0x0800_0200. (Re-entering the branch is itself a divergence from
+        // 0x0800_0102, so assert on 0x0800_0100's own counts, not the site
+        // total.)
+        cov.on_step_start(0x0800_0100, 0x4600);
+        cov.on_step_start(0x0800_0102, 0x4600); // 0x...0100 fell through
+        cov.on_step_start(0x0800_0100, 0x4600); // re-enter the branch
+        cov.on_step_start(0x0800_0200, 0x4600); // 0x...0100 taken to 0x...0200
+
+        let sites = cov.branch_sites();
+        let (_, counts) = sites
+            .iter()
+            .find(|(src, _)| *src == 0x0800_0100)
+            .expect("0x0800_0100 is a branch site");
+        assert_eq!(counts.not_taken, 1);
+        assert_eq!(counts.taken, 1);
+        assert_eq!(counts.target, Some(0x0800_0200));
     }
 }


### PR DESCRIPTION
Adds branch coverage to the `--coverage` output, building on the statement
coverage merged in #359. Second slice of the cert-evidence work.

- The PC-coverage observer now records, per source instruction, how many times
  execution diverged (taken) versus fell through (not taken). A source address
  with taken > 0 is a branch site; the existing `edges()` is derived from this.
- The coverage report resolves each branch site to its source line via DWARF and
  emits LCOV `BRDA`/`BRF`/`BRH` records, plus `total_branches`/`covered_branches`
  in `coverage.json`. A branch outcome counts as covered when observed at least
  once. The run log reports branch percentage alongside statements.
- Branch file names are normalised to the line-program basename so they attach to
  the correct `SF` record.

Verified end to end against the CI firmware fixture: 1220/2600 statements and
28/56 branches, with `BRDA` records emitted under the right files (e.g. main.rs
`BRF:26`). Unit tests cover taken/not-taken counting and BRDA emission.

Known limitation (documented for the follow-up): a conditional branch only
becomes a known site once observed taking at least once, and unconditional jumps
show a single outcome. DWARF-flagged branch sites and MC-DC remain future work.
