### PR TITLE
Coverage: signable, reproducible run-manifest.json (--run-manifest)

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,5 +5,6 @@
 // See the LICENSE file in the project root for full license information.
 
 pub mod coverage;
+pub mod manifest;
 pub mod pc_coverage_report;
 pub mod tier1;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -591,6 +591,12 @@ struct TestArgs {
     #[arg(long)]
     coverage: bool,
 
+    /// Write a signable, reproducible run-manifest.json into --output-dir
+    /// (input hashes, engine version, result subset, coverage summary, and a
+    /// wall-clock-free SHA-256 digest).
+    #[arg(long)]
+    run_manifest: bool,
+
     /// Explicitly opt out of sending LABWIRED_API_KEY even if it is set in the environment.
     /// Useful for local development and testing.
     #[arg(long)]
@@ -1960,6 +1966,7 @@ fn write_outputs<C: labwired_core::Cpu>(
             }
 
             // coverage.info (LCOV) + coverage.json
+            let mut coverage_summary: Option<labwired_cli::manifest::CoverageSummary> = None;
             if let Some(cov) = coverage_observer {
                 match labwired_loader::SymbolProvider::new(firmware_path) {
                     Ok(symbols) => {
@@ -2017,9 +2024,81 @@ fn write_outputs<C: labwired_core::Cpu>(
                             report.total_branches,
                             report.branch_percent()
                         );
+                        coverage_summary = Some(labwired_cli::manifest::CoverageSummary {
+                            statements_total: report.total_statements,
+                            statements_covered: report.covered_statements,
+                            branches_total: report.total_branches,
+                            branches_covered: report.covered_branches,
+                        });
                     }
                     Err(e) => error!("Failed to load symbols for coverage: {}", e),
                 }
+            }
+
+            // run-manifest.json (signable, reproducible)
+            if args.run_manifest {
+                use labwired_cli::manifest;
+                // Use the file basename, not the absolute path, so the digest
+                // depends only on file contents and is reproducible across
+                // machines with different checkout locations.
+                let basename = |p: &Path| -> String {
+                    p.file_name()
+                        .map(|s| s.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| p.display().to_string())
+                };
+                let hash_file = |p: &Path| -> manifest::HashedFile {
+                    let sha256 = std::fs::read(p)
+                        .map(|b| manifest::sha256_hex(&b))
+                        .unwrap_or_default();
+                    manifest::HashedFile {
+                        path: basename(p),
+                        sha256,
+                    }
+                };
+                let mut configs = vec![hash_file(&args.script)];
+                if let Some(sys) = system_path {
+                    configs.push(hash_file(sys));
+                }
+                let mut man = manifest::RunManifest {
+                    manifest_schema_version: manifest::MANIFEST_SCHEMA_VERSION.to_string(),
+                    engine_version: env!("CARGO_PKG_VERSION").to_string(),
+                    seed: 0,
+                    nondeterminism: "none".to_string(),
+                    firmware: manifest::HashedFile {
+                        path: basename(firmware_path),
+                        sha256: result.firmware_hash.clone(),
+                    },
+                    configs,
+                    results: manifest::ManifestResults {
+                        status: status.to_string(),
+                        stop_reason: format!("{:?}", result.stop_reason),
+                        steps_executed: result.steps_executed,
+                        cycles: result.cycles,
+                        instructions: result.instructions,
+                        assertions: assertions_for_junit
+                            .iter()
+                            .map(|a| manifest::AssertionOutcome {
+                                assertion: format!("{:?}", a.assertion),
+                                passed: a.passed,
+                            })
+                            .collect(),
+                        cpu_state_digest: manifest::digest_value(&cpu.snapshot()),
+                    },
+                    coverage: coverage_summary.clone(),
+                    fault_injections: Vec::new(),
+                    digest: String::new(),
+                };
+                man.finalize_digest();
+                let manifest_path = output_dir.join("run-manifest.json");
+                match std::fs::File::create(&manifest_path) {
+                    Ok(f) => {
+                        if let Err(e) = serde_json::to_writer_pretty(f, &man) {
+                            error!("Failed to write run-manifest.json: {}", e);
+                        }
+                    }
+                    Err(e) => error!("Failed to create run-manifest.json: {}", e),
+                }
+                info!("Run manifest digest: {}", man.digest);
             }
 
             // result.json handles cpu generically now

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -1,0 +1,211 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Signable, reproducible run manifest.
+//!
+//! A `RunManifest` records the inputs and deterministic outputs of a single
+//! `labwired test` run — firmware and config hashes, engine version, the
+//! result subset, and a coverage summary — together with a `digest`: a SHA-256
+//! over the canonical JSON of every other field. Wall-clock time is excluded, so
+//! two runs of the same inputs on different machines produce a byte-identical
+//! digest. The digest is the stable artifact a buyer signs.
+
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+pub const MANIFEST_SCHEMA_VERSION: &str = "1.0";
+
+/// A file referenced by the run, with the SHA-256 of its contents.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HashedFile {
+    pub path: String,
+    pub sha256: String,
+}
+
+/// One assertion and whether it passed.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AssertionOutcome {
+    pub assertion: String,
+    pub passed: bool,
+}
+
+/// The deterministic subset of the run result.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ManifestResults {
+    pub status: String,
+    pub stop_reason: String,
+    pub steps_executed: u64,
+    pub cycles: u64,
+    pub instructions: u64,
+    pub assertions: Vec<AssertionOutcome>,
+    pub cpu_state_digest: String,
+}
+
+/// Rolled-up coverage counts.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CoverageSummary {
+    pub statements_total: usize,
+    pub statements_covered: usize,
+    pub branches_total: usize,
+    pub branches_covered: usize,
+}
+
+/// The full run manifest. Serialised to `run-manifest.json`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunManifest {
+    pub manifest_schema_version: String,
+    pub engine_version: String,
+    /// Explicit run seed. The interpreter has no surfaced RNG today; determinism
+    /// comes from the absence of nondeterminism, asserted by the reproducibility
+    /// test, so this is 0 with `nondeterminism: "none"`.
+    pub seed: u64,
+    pub nondeterminism: String,
+    pub firmware: HashedFile,
+    pub configs: Vec<HashedFile>,
+    pub results: ManifestResults,
+    pub coverage: Option<CoverageSummary>,
+    /// Contract slot for fault-injection evidence (populated by a later plan).
+    pub fault_injections: Vec<Value>,
+    /// SHA-256 over the canonical JSON of every field above. Filled by
+    /// [`RunManifest::finalize_digest`].
+    pub digest: String,
+}
+
+impl RunManifest {
+    /// Compute and store `digest` as the SHA-256 of the canonical JSON of this
+    /// manifest with the `digest` field itself removed. Idempotent.
+    pub fn finalize_digest(&mut self) {
+        self.digest = String::new();
+        let mut value = serde_json::to_value(&*self).expect("manifest serialises");
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("digest");
+        }
+        self.digest = sha256_hex(canonical_json(&value).as_bytes());
+    }
+}
+
+/// SHA-256 of bytes as lowercase hex.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// SHA-256 of a serialisable value's canonical JSON. Used for the CPU-state
+/// digest so the manifest carries a stable fingerprint, not the whole snapshot.
+pub fn digest_value<T: Serialize>(value: &T) -> String {
+    let v = serde_json::to_value(value).unwrap_or(Value::Null);
+    sha256_hex(canonical_json(&v).as_bytes())
+}
+
+/// Serialise a JSON value with object keys sorted recursively, so logically
+/// equal values always produce identical bytes. Assumes a float-free value
+/// (the digested region is integers, strings and bools only).
+fn canonical_json(v: &Value) -> String {
+    match v {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let inner: Vec<String> = keys
+                .iter()
+                .map(|k| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(k).unwrap_or_else(|_| "\"\"".to_string()),
+                        canonical_json(&map[*k])
+                    )
+                })
+                .collect();
+            format!("{{{}}}", inner.join(","))
+        }
+        Value::Array(arr) => {
+            let inner: Vec<String> = arr.iter().map(canonical_json).collect();
+            format!("[{}]", inner.join(","))
+        }
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> RunManifest {
+        RunManifest {
+            manifest_schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
+            engine_version: "1.2.3".to_string(),
+            seed: 0,
+            nondeterminism: "none".to_string(),
+            firmware: HashedFile {
+                path: "fw.elf".to_string(),
+                sha256: "aa".to_string(),
+            },
+            configs: vec![HashedFile {
+                path: "sys.yaml".to_string(),
+                sha256: "bb".to_string(),
+            }],
+            results: ManifestResults {
+                status: "passed".to_string(),
+                stop_reason: "MaxStepsReached".to_string(),
+                steps_executed: 100,
+                cycles: 100,
+                instructions: 100,
+                assertions: vec![AssertionOutcome {
+                    assertion: "uart_contains(OK)".to_string(),
+                    passed: true,
+                }],
+                cpu_state_digest: "cc".to_string(),
+            },
+            coverage: Some(CoverageSummary {
+                statements_total: 10,
+                statements_covered: 5,
+                branches_total: 4,
+                branches_covered: 2,
+            }),
+            fault_injections: Vec::new(),
+            digest: String::new(),
+        }
+    }
+
+    #[test]
+    fn digest_is_stable_and_excludes_itself() {
+        let mut a = sample();
+        a.finalize_digest();
+        assert!(!a.digest.is_empty());
+
+        // Re-finalizing is idempotent (digest excludes the digest field).
+        let first = a.digest.clone();
+        a.finalize_digest();
+        assert_eq!(a.digest, first);
+
+        // A fresh manifest with the same inputs digests identically.
+        let mut b = sample();
+        b.finalize_digest();
+        assert_eq!(a.digest, b.digest);
+    }
+
+    #[test]
+    fn digest_changes_when_an_input_changes() {
+        let mut a = sample();
+        a.finalize_digest();
+
+        let mut b = sample();
+        b.firmware.sha256 = "different".to_string();
+        b.finalize_digest();
+
+        assert_ne!(
+            a.digest, b.digest,
+            "a changed firmware hash must move the digest"
+        );
+    }
+
+    #[test]
+    fn canonical_json_sorts_keys() {
+        let v = serde_json::json!({ "b": 1, "a": 2, "c": { "z": 1, "y": 2 } });
+        assert_eq!(canonical_json(&v), r#"{"a":2,"b":1,"c":{"y":2,"z":1}}"#);
+    }
+}

--- a/crates/cli/tests/manifest_reproducible.rs
+++ b/crates/cli/tests/manifest_reproducible.rs
@@ -1,0 +1,101 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! The run-manifest digest must be byte-identical across separate process
+//! invocations (proving it is wall-clock invariant) and must move when an input
+//! changes.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn labwired_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_labwired"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn run_manifest_digest(script: &std::path::Path, out_dir: &std::path::Path) -> String {
+    let output = Command::new(labwired_bin())
+        .arg("test")
+        .arg("--script")
+        .arg(script)
+        .arg("--output-dir")
+        .arg(out_dir)
+        .arg("--run-manifest")
+        .arg("--no-uart-stdout")
+        .output()
+        .expect("failed to run labwired");
+
+    let manifest_path = out_dir.join("run-manifest.json");
+    assert!(
+        manifest_path.exists(),
+        "run-manifest.json not produced. exit {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = std::fs::read_to_string(&manifest_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    json["digest"]
+        .as_str()
+        .expect("manifest has a string digest")
+        .to_string()
+}
+
+fn write_script(dir: &std::path::Path, firmware: &str, system: &str, max_steps: u32) -> PathBuf {
+    let content = format!(
+        "schema_version: \"1.0\"\ninputs:\n  firmware: \"{firmware}\"\n  system: \"{system}\"\nlimits:\n  max_steps: {max_steps}\nassertions: []\n"
+    );
+    let path = dir.join(format!("script-{max_steps}.yaml"));
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn manifest_digest_is_reproducible_and_input_sensitive() {
+    let root = workspace_root();
+    let firmware = root.join("tests/fixtures/uart-ok-thumbv7m.elf");
+    let system = root.join("configs/systems/ci-fixture-uart1.yaml");
+    if !firmware.exists() || !system.exists() {
+        eprintln!("skipping manifest reproducibility test: fixtures absent");
+        return;
+    }
+    let firmware = firmware.canonicalize().unwrap();
+    let system = system.canonicalize().unwrap();
+
+    let temp = std::env::temp_dir().join("labwired-manifest-reproducible");
+    let _ = std::fs::remove_dir_all(&temp);
+    std::fs::create_dir_all(&temp).unwrap();
+
+    let script = write_script(
+        &temp,
+        &firmware.display().to_string(),
+        &system.display().to_string(),
+        1000,
+    );
+
+    // Two separate process invocations (different wall-clock) -> same digest.
+    let d1 = run_manifest_digest(&script, &temp.join("run_0"));
+    let d2 = run_manifest_digest(&script, &temp.join("run_1"));
+    assert_eq!(d1, d2, "manifest digest must be reproducible across runs");
+    assert_eq!(d1.len(), 64, "digest must be a 64-char hex SHA-256");
+
+    // A changed input (different limit -> different steps + config hash) moves it.
+    let script2 = write_script(
+        &temp,
+        &firmware.display().to_string(),
+        &system.display().to_string(),
+        500,
+    );
+    let d3 = run_manifest_digest(&script2, &temp.join("run_2"));
+    assert_ne!(d1, d3, "a changed input must change the digest");
+}


### PR DESCRIPTION
Adds a signable, reproducible run manifest — the third slice of the
cert-evidence work, after statement (#359) and branch (#361) coverage.

`labwired test --run-manifest` writes `run-manifest.json` into `--output-dir`:
- manifest + engine version,
- content SHA-256 of the firmware and each config,
- the deterministic result subset (status, stop reason,
  steps/cycles/instructions, per-assertion pass/fail, a CPU-state digest),
- the coverage summary when `--coverage` also ran,
- a reserved `fault_injections` slot (contract for the fault-injection plan),
- a `digest`: SHA-256 over the canonical (recursively key-sorted) JSON of every
  other field.

Wall-clock time is excluded from the digested region and file paths are reduced
to basenames, so the same inputs produce a byte-identical digest across runs and
machines. The digest is the stable artifact a buyer signs.

Verified end to end on the CI fixture: two separate invocations produce an
identical digest. Unit tests cover digest stability, input-sensitivity and key
sorting; an integration test runs the binary twice and asserts the digest is
reproducible and moves when an input changes.

Deferred (noted for follow-up): a real chip-model version stamp, and an explicit
RNG seed if any nondeterministic source is ever introduced (today `seed: 0`,
`nondeterminism: "none"`, backed by the reproducibility test).
