### PR TITLE
Fault injection: apply faults from the test script + fire gate

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -8,6 +8,46 @@
 
 use crate::*;
 
+/// Apply the script's faults to the built bus, log and persist per-fault
+/// evidence, and enforce the require_fault_fired gate. Returns `Some(exit)` to
+/// abort the run when a required fault did not fire (the run is invalid, not a
+/// firmware pass); `None` to proceed.
+fn handle_faults(
+    args: &TestArgs,
+    bus: &mut labwired_core::bus::SystemBus,
+    faults: &[labwired_config::FaultSpec],
+    require_fault_fired: bool,
+) -> Option<ExitCode> {
+    if faults.is_empty() {
+        return None;
+    }
+    let evidence = labwired_cli::faults::apply_faults(bus, faults);
+    for e in &evidence {
+        if e.fired {
+            info!("fault '{}' ({}) fired", e.id, e.kind);
+        } else {
+            error!(
+                "fault '{}' ({}) did NOT fire: {}",
+                e.id,
+                e.kind,
+                e.error.as_deref().unwrap_or("")
+            );
+        }
+    }
+    if let Some(dir) = &args.output_dir {
+        let _ = std::fs::create_dir_all(dir);
+        if let Ok(f) = std::fs::File::create(dir.join("fault-evidence.json")) {
+            let _ = serde_json::to_writer_pretty(f, &evidence);
+        }
+    }
+    if require_fault_fired && evidence.iter().any(|e| !e.fired) {
+        let n = evidence.iter().filter(|e| !e.fired).count();
+        error!("require_fault_fired: {n} fault(s) did not fire; run is invalid");
+        return Some(ExitCode::from(EXIT_ASSERT_FAIL));
+    }
+    None
+}
+
 pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     // ── API key validation (Pro tier gate) ──────────────────────────────
     // If LABWIRED_API_KEY is set and --no-key is not passed, validate before
@@ -76,6 +116,8 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
         script_wall_time_ms,
         script_max_vcd_bytes,
         assertions,
+        faults,
+        verdict,
     ) = match loaded {
         LoadedTestScript::V1_0(script) => (
             Some(script.inputs.firmware),
@@ -87,6 +129,8 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             script.limits.wall_time_ms,
             script.limits.max_vcd_bytes,
             script.assertions,
+            script.faults,
+            script.verdict,
         ),
         LoadedTestScript::LegacyV1(script) => {
             tracing::warn!(
@@ -102,9 +146,23 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 script.wall_time_ms,
                 None,
                 script.assertions,
+                Vec::new(),
+                None,
             )
         }
     };
+
+    // Fault injection (schema_version 1.1): the verdict's safe_when entries are
+    // evaluated as ordinary assertions; require_fault_fired gates the run on the
+    // faults actually taking effect.
+    let require_fault_fired = verdict
+        .as_ref()
+        .map(|v| v.require_fault_fired)
+        .unwrap_or(false);
+    let mut assertions = assertions;
+    if let Some(v) = &verdict {
+        assertions.extend(v.safe_when.iter().cloned());
+    }
 
     let max_steps = args.max_steps.unwrap_or(script_max_steps);
     let max_cycles = args.max_cycles.or(script_max_cycles);
@@ -291,6 +349,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             // to the app. See FIDELITY.md §C.
             machine.cpu.set_pc(program.entry_point as u32);
             machine.cpu.set_sp(0x3FFE_0000);
+            if let Some(code) = handle_faults(&args, &mut machine.bus, &faults, require_fault_fired)
+            {
+                return code;
+            }
             let exit_code = execute_test_loop(
                 &args,
                 &mut machine,
@@ -422,6 +484,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     system_path.as_ref(),
                     e,
                 );
+            }
+            if let Some(code) = handle_faults(&args, &mut machine.bus, &faults, require_fault_fired)
+            {
+                return code;
             }
             execute_test_loop(
                 &args,

--- a/crates/cli/src/faults.rs
+++ b/crates/cli/src/faults.rs
@@ -1,0 +1,127 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Apply declarative faults to a built bus and record per-fault evidence.
+//!
+//! Faults are declared in the test script (schema_version 1.1) and validated at
+//! load. This module lowers each onto the engine and reports whether it actually
+//! fired — the false-pass gate. Only `wrong_reset_value` is wired today; other
+//! kinds report `fired: false` with a reason rather than silently passing.
+
+use labwired_config::{FaultKind, FaultSpec};
+use labwired_core::bus::SystemBus;
+use serde::Serialize;
+
+/// Per-fault evidence: did the injected fault actually take effect?
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FaultEvidence {
+    pub id: String,
+    pub kind: String,
+    pub fired: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Apply each fault to the bus in order, returning one evidence record per fault.
+pub fn apply_faults(bus: &mut SystemBus, faults: &[FaultSpec]) -> Vec<FaultEvidence> {
+    faults.iter().map(|f| apply_one(bus, f)).collect()
+}
+
+fn apply_one(bus: &mut SystemBus, f: &FaultSpec) -> FaultEvidence {
+    let kind = format!("{:?}", f.kind);
+    let (fired, error) = match &f.kind {
+        FaultKind::WrongResetValue => {
+            match (f.target.peripheral.as_deref(), f.target.register.as_deref()) {
+                (Some(p), Some(r)) => {
+                    let value = f.value.unwrap_or(0) as u32;
+                    match bus.inject_wrong_reset_value(p, r, value) {
+                        Ok(()) => (true, None),
+                        Err(e) => (false, Some(e)),
+                    }
+                }
+                _ => (
+                    false,
+                    Some("missing target.peripheral/register".to_string()),
+                ),
+            }
+        }
+        other => (
+            false,
+            Some(format!("fault kind {other:?} not yet implemented")),
+        ),
+    };
+    FaultEvidence {
+        id: f.id.clone(),
+        kind,
+        fired,
+        error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use labwired_config::{FaultKind, FaultSpec, FaultTarget, FaultTrigger};
+
+    fn spec(id: &str, kind: FaultKind, target: FaultTarget, value: Option<u64>) -> FaultSpec {
+        FaultSpec {
+            id: id.to_string(),
+            kind,
+            target,
+            trigger: FaultTrigger::AtStart,
+            level: None,
+            value,
+            xor: None,
+            to: None,
+            deny: None,
+            delay_cycles: None,
+            interrupt: None,
+            bits: None,
+            size: None,
+        }
+    }
+
+    #[test]
+    fn wrong_reset_value_on_missing_peripheral_does_not_fire() {
+        let mut bus = SystemBus::new();
+        let f = spec(
+            "x",
+            FaultKind::WrongResetValue,
+            FaultTarget {
+                peripheral: Some("nope".to_string()),
+                register: Some("cr".to_string()),
+                bit: None,
+                address: None,
+            },
+            Some(1),
+        );
+        let ev = apply_faults(&mut bus, std::slice::from_ref(&f));
+        assert_eq!(ev.len(), 1);
+        assert!(!ev[0].fired);
+        assert!(ev[0].error.as_ref().unwrap().contains("not found"));
+    }
+
+    #[test]
+    fn unsupported_kind_reports_not_implemented() {
+        let mut bus = SystemBus::new();
+        let f = spec(
+            "y",
+            FaultKind::DelayedIrq,
+            FaultTarget {
+                peripheral: Some("usart1".to_string()),
+                ..Default::default()
+            },
+            None,
+        );
+        let ev = apply_faults(&mut bus, std::slice::from_ref(&f));
+        assert!(!ev[0].fired);
+        assert!(ev[0]
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("not yet implemented"));
+    }
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,6 +5,7 @@
 // See the LICENSE file in the project root for full license information.
 
 pub mod coverage;
+pub mod faults;
 pub mod manifest;
 pub mod pc_coverage_report;
 pub mod tier1;


### PR DESCRIPTION
Wires fault injection into `labwired test`, on top of the schema (#363) and the
`wrong_reset_value` primitive (#364). This makes the feature runnable end to end.

- Extracts `faults`/`verdict` from a 1.1 script and applies each fault to the
  built bus before the run, in both the ARM/RISC-V and ESP paths.
- Records per-fault evidence (`fired` + reason) and writes `fault-evidence.json`
  into `--output-dir`.
- The verdict `safe_when` entries are evaluated as ordinary assertions;
  `require_fault_fired` (default true) aborts the run as invalid when a fault did
  not actually take effect — the false-pass gate.
- `wrong_reset_value` is lowered onto the engine primitive; other kinds report
  `fired: false` with a reason until wired, so nothing silently passes.

Unit tests cover the missing-peripheral and unsupported-kind paths. Verified end
to end: a `wrong_reset_value` fault targeting a non-declarative peripheral cannot
fire, so `require_fault_fired` correctly marks the run invalid and writes the
evidence.

Follow-ups: fold `FaultEvidence` into the signed run-manifest's reserved
`fault_injections` slot, and lower the remaining fault kinds.
