### PR TITLE
Fault injection: fold fault evidence into the signed run-manifest

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -17,9 +17,9 @@ fn handle_faults(
     bus: &mut labwired_core::bus::SystemBus,
     faults: &[labwired_config::FaultSpec],
     require_fault_fired: bool,
-) -> Option<ExitCode> {
+) -> Result<Vec<labwired_cli::faults::FaultEvidence>, ExitCode> {
     if faults.is_empty() {
-        return None;
+        return Ok(Vec::new());
     }
     let evidence = labwired_cli::faults::apply_faults(bus, faults);
     for e in &evidence {
@@ -43,9 +43,9 @@ fn handle_faults(
     if require_fault_fired && evidence.iter().any(|e| !e.fired) {
         let n = evidence.iter().filter(|e| !e.fired).count();
         error!("require_fault_fired: {n} fault(s) did not fire; run is invalid");
-        return Some(ExitCode::from(EXIT_ASSERT_FAIL));
+        return Err(ExitCode::from(EXIT_ASSERT_FAIL));
     }
-    None
+    Ok(evidence)
 }
 
 pub(crate) fn run_test(args: TestArgs) -> ExitCode {
@@ -349,10 +349,11 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             // to the app. See FIDELITY.md §C.
             machine.cpu.set_pc(program.entry_point as u32);
             machine.cpu.set_sp(0x3FFE_0000);
-            if let Some(code) = handle_faults(&args, &mut machine.bus, &faults, require_fault_fired)
-            {
-                return code;
-            }
+            let fault_evidence =
+                match handle_faults(&args, &mut machine.bus, &faults, require_fault_fired) {
+                    Ok(ev) => ev,
+                    Err(code) => return code,
+                };
             let exit_code = execute_test_loop(
                 &args,
                 &mut machine,
@@ -363,6 +364,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 &metrics,
                 &firmware_path,
                 system_path.as_ref(),
+                &fault_evidence,
             );
             // Device-block render readout. Surfaces the attached panel block's
             // REAL render state — refresh_gen AND black-plane ink — so a generic
@@ -485,10 +487,11 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     e,
                 );
             }
-            if let Some(code) = handle_faults(&args, &mut machine.bus, &faults, require_fault_fired)
-            {
-                return code;
-            }
+            let fault_evidence =
+                match handle_faults(&args, &mut machine.bus, &faults, require_fault_fired) {
+                    Ok(ev) => ev,
+                    Err(code) => return code,
+                };
             execute_test_loop(
                 &args,
                 &mut machine,
@@ -499,6 +502,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 &metrics,
                 &firmware_path,
                 system_path.as_ref(),
+                &fault_evidence,
             )
         }};
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1505,6 +1505,7 @@ fn handle_load_error<C: labwired_core::Cpu>(
         std::time::Duration::from_secs(0),
         &None,
         &None,
+        &[],
     );
     ExitCode::from(EXIT_RUNTIME_ERROR)
 }
@@ -1520,6 +1521,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     metrics: &Arc<labwired_core::metrics::PerformanceMetrics>,
     firmware_path: &Path,
     system_path: Option<&PathBuf>,
+    fault_evidence: &[labwired_cli::faults::FaultEvidence],
 ) -> ExitCode {
     let max_steps = resolved_limits.max_steps;
     let max_cycles = resolved_limits.max_cycles;
@@ -1881,6 +1883,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         duration,
         &trace_observer,
         &coverage_observer,
+        fault_evidence,
     );
 
     if !all_passed || (stop_requires_assertion && !expected_stop_reason_matched) {
@@ -1910,6 +1913,7 @@ fn write_outputs<C: labwired_core::Cpu>(
     duration: std::time::Duration,
     trace_observer: &Option<Arc<labwired_core::trace::TraceObserver>>,
     coverage_observer: &Option<Arc<labwired_core::pc_coverage::PcCoverageObserver>>,
+    fault_evidence: &[labwired_cli::faults::FaultEvidence],
 ) {
     let mut hasher = Sha256::new();
     hasher.update(firmware_bytes);
@@ -2085,7 +2089,7 @@ fn write_outputs<C: labwired_core::Cpu>(
                         cpu_state_digest: manifest::digest_value(&cpu.snapshot()),
                     },
                     coverage: coverage_summary.clone(),
-                    fault_injections: Vec::new(),
+                    fault_injections: fault_evidence.to_vec(),
                     digest: String::new(),
                 };
                 man.finalize_digest();

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -68,8 +68,9 @@ pub struct RunManifest {
     pub configs: Vec<HashedFile>,
     pub results: ManifestResults,
     pub coverage: Option<CoverageSummary>,
-    /// Contract slot for fault-injection evidence (populated by a later plan).
-    pub fault_injections: Vec<Value>,
+    /// Per-fault evidence for fault-injection runs; empty for ordinary runs.
+    /// Included in the digest so a faulted run's verdict is signed and reproducible.
+    pub fault_injections: Vec<crate::faults::FaultEvidence>,
     /// SHA-256 over the canonical JSON of every field above. Filled by
     /// [`RunManifest::finalize_digest`].
     pub digest: String,
@@ -200,6 +201,26 @@ mod tests {
         assert_ne!(
             a.digest, b.digest,
             "a changed firmware hash must move the digest"
+        );
+    }
+
+    #[test]
+    fn digest_includes_fault_injections() {
+        let mut a = sample();
+        a.finalize_digest();
+
+        let mut b = sample();
+        b.fault_injections.push(crate::faults::FaultEvidence {
+            id: "f1".to_string(),
+            kind: "WrongResetValue".to_string(),
+            fired: true,
+            error: None,
+        });
+        b.finalize_digest();
+
+        assert_ne!(
+            a.digest, b.digest,
+            "fault evidence must be part of the signed digest"
         );
     }
 


### PR DESCRIPTION
Folds fault-injection evidence into the signed run-manifest, completing the
cross-plan contract between fault injection (#363/#364/#365) and the cert
manifest (#362).

- The manifest `fault_injections` slot becomes a typed `Vec<FaultEvidence>`
  (was an empty placeholder) and is populated from the run.
- `handle_faults` returns the evidence, which is threaded through
  `execute_test_loop` into `write_outputs` and written into the `RunManifest`, so
  each fault's per-fault verdict (`fired` + reason) is part of the canonical
  digest a buyer signs.

A faulted run is now signed and reproducible including its fault outcomes.
Verified end to end: a `wrong_reset_value` fault appears in
`run-manifest.json`'s `fault_injections` and the digest covers it. A unit test
asserts that adding a fault moves the digest; the existing reproducibility test
still passes.
