### PR TITLE
core: add shared trace event stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "cc",
  "goblin",
  "labwired-config",
+ "labwired-hw-trace",
  "labwired-ir",
  "labwired-loader",
  "memmap2 0.9.10",
@@ -1832,6 +1833,10 @@ version = "0.17.3"
 [[package]]
 name = "labwired-hw-trace"
 version = "0.17.3"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "labwired-ir"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -41,6 +41,7 @@ bincode = "1.3"
 sha2 = { workspace = true, features = ["compress"] }
 goblin = { workspace = true }
 labwired-ir = { path = "../ir" }
+labwired-hw-trace = { path = "../hw-trace" }
 serde_yaml.workspace = true
 memmap2.workspace = true
 pio.workspace = true

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -856,6 +856,7 @@ impl CortexM {
             eprintln!("INSN pc=0x{:08X} op=0x{:08X}", self.pc, opcode);
         }
 
+        let retired_pc = self.pc;
         if !_observers.is_empty() {
             for observer in _observers {
                 observer.on_step_start(self.pc, opcode);
@@ -2786,6 +2787,13 @@ impl CortexM {
             }
             registers[16] = self.xpsr;
 
+            crate::emit_trace_event(
+                _observers,
+                labwired_hw_trace::TraceEvent::InstructionRetired {
+                    pc: retired_pc,
+                    opcode,
+                },
+            );
             for obs in _observers {
                 obs.on_step_end(_cycles, &registers);
             }

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -157,6 +157,7 @@ impl Cpu for RiscV {
     ) -> SimResult<()> {
         let opcode = bus.read_u32(self.pc as u64)?;
 
+        let retired_pc = self.pc;
         for observer in observers {
             observer.on_step_start(self.pc, opcode);
         }
@@ -724,6 +725,15 @@ impl Cpu for RiscV {
                     // at the instruction we just finished executing — passing
                     // it would cause MRET to re-execute, doubling side effects
                     // (ADDI counted twice, stores applied twice, etc).
+                    if !observers.is_empty() {
+                        crate::emit_trace_event(
+                            observers,
+                            labwired_hw_trace::TraceEvent::InstructionRetired {
+                                pc: retired_pc,
+                                opcode,
+                            },
+                        );
+                    }
                     self.handle_trap(0x80000000 | irq, next_pc);
                     // Trap taken, next instruction will be handled in trap handler
                     return Ok(());
@@ -740,6 +750,13 @@ impl Cpu for RiscV {
             registers[..32].copy_from_slice(&self.x);
             registers[32] = self.pc;
 
+            crate::emit_trace_event(
+                observers,
+                labwired_hw_trace::TraceEvent::InstructionRetired {
+                    pc: retired_pc,
+                    opcode,
+                },
+            );
             for obs in observers {
                 obs.on_step_end(inst_len, &registers);
             }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -149,10 +149,20 @@ impl PeripheralTickResult {
 pub trait SimulationObserver: std::fmt::Debug + Send + Sync {
     fn on_simulation_start(&self) {}
     fn on_simulation_stop(&self) {}
+    fn on_trace_event(&self, _event: labwired_hw_trace::TraceEvent) {}
     fn on_step_start(&self, _pc: u32, _opcode: u32) {}
     fn on_step_end(&self, _cycles: u32, _registers: &[u32]) {}
     fn on_memory_write(&self, _addr: u64, _old: u8, _new: u8) {}
     fn on_peripheral_tick(&self, _name: &str, _cycles: u32) {}
+}
+
+pub fn emit_trace_event(
+    observers: &[Arc<dyn SimulationObserver>],
+    event: labwired_hw_trace::TraceEvent,
+) {
+    for observer in observers {
+        observer.on_trace_event(event.clone());
+    }
 }
 
 /// Trait representing a CPU architecture

--- a/crates/core/tests/trace_event_contract.rs
+++ b/crates/core/tests/trace_event_contract.rs
@@ -1,0 +1,56 @@
+use labwired_core::{emit_trace_event, SimulationObserver};
+use labwired_hw_trace::TraceEvent;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Default)]
+struct EventRecorder {
+    events: Mutex<Vec<TraceEvent>>,
+}
+
+impl SimulationObserver for EventRecorder {
+    fn on_trace_event(&self, event: TraceEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+}
+
+#[test]
+fn simulation_observer_accepts_shared_trace_events() {
+    let recorder = EventRecorder::default();
+
+    recorder.on_trace_event(TraceEvent::InstructionRetired {
+        pc: 0x0800_0000,
+        opcode: 0xBF00,
+    });
+
+    assert_eq!(
+        recorder.events.lock().unwrap().as_slice(),
+        &[TraceEvent::InstructionRetired {
+            pc: 0x0800_0000,
+            opcode: 0xBF00,
+        }]
+    );
+}
+
+#[test]
+fn emit_trace_event_fans_out_to_all_observers() {
+    let first = Arc::new(EventRecorder::default());
+    let second = Arc::new(EventRecorder::default());
+    let observers: Vec<Arc<dyn SimulationObserver>> = vec![first.clone(), second.clone()];
+
+    emit_trace_event(
+        &observers,
+        TraceEvent::MemoryWrite {
+            addr: 0x2000_0000,
+            old: 0x12,
+            new: 0x34,
+        },
+    );
+
+    let expected = vec![TraceEvent::MemoryWrite {
+        addr: 0x2000_0000,
+        old: 0x12,
+        new: 0x34,
+    }];
+    assert_eq!(*first.events.lock().unwrap(), expected);
+    assert_eq!(*second.events.lock().unwrap(), expected);
+}

--- a/crates/hw-trace/Cargo.toml
+++ b/crates/hw-trace/Cargo.toml
@@ -6,3 +6,7 @@ license.workspace = true
 description = "Shared hardware trace event model for labwired-core (stub in Plan 1)."
 
 [dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/hw-trace/src/event.rs
+++ b/crates/hw-trace/src/event.rs
@@ -1,9 +1,53 @@
-//! Trace event types shared between sim and HW runner.
-//!
-//! Plan 1 carries only a placeholder enum. Populated fully in Plan 2.
+//! Trace event types shared between the simulator, debuggers, and hardware runners.
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TraceEvent {
-    /// Unimplemented placeholder; will be split into typed variants in Plan 2.
-    Placeholder,
+    InstructionRetired {
+        pc: u32,
+        opcode: u32,
+    },
+    BranchEdge {
+        src: u32,
+        target: u32,
+        taken: bool,
+    },
+    MemoryWrite {
+        addr: u64,
+        old: u8,
+        new: u8,
+    },
+    ExceptionEntry {
+        vector: u32,
+        handler_pc: u32,
+    },
+    FaultInjected {
+        kind: String,
+        target: String,
+        at_step: u64,
+        at_pc: u32,
+        effect: FaultEffect,
+    },
+}
+
+impl TraceEvent {
+    pub fn pc(&self) -> Option<u32> {
+        match self {
+            Self::InstructionRetired { pc, .. } => Some(*pc),
+            Self::BranchEdge { src, .. } => Some(*src),
+            Self::ExceptionEntry { handler_pc, .. } => Some(*handler_pc),
+            Self::FaultInjected { at_pc, .. } => Some(*at_pc),
+            Self::MemoryWrite { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FaultEffect {
+    DroppedClockGate,
+    RegisterBitFlip { addr: u64, bit: u8 },
+    MemoryBitFlip { addr: u64, bit: u8 },
+    PeripheralStall,
+    Custom(String),
 }

--- a/crates/hw-trace/src/lib.rs
+++ b/crates/hw-trace/src/lib.rs
@@ -3,3 +3,5 @@
 // SPDX-License-Identifier: MIT
 
 pub mod event;
+
+pub use event::{FaultEffect, TraceEvent};

--- a/crates/hw-trace/tests/event_contract.rs
+++ b/crates/hw-trace/tests/event_contract.rs
@@ -1,0 +1,50 @@
+use labwired_hw_trace::{FaultEffect, TraceEvent};
+
+#[test]
+fn trace_events_cover_the_shared_evidence_contract() {
+    let retired = TraceEvent::InstructionRetired {
+        pc: 0x0800_0124,
+        opcode: 0xD001,
+    };
+    let branch = TraceEvent::BranchEdge {
+        src: 0x0800_0124,
+        target: 0x0800_0130,
+        taken: true,
+    };
+    let write = TraceEvent::MemoryWrite {
+        addr: 0x4002_1000,
+        old: 0,
+        new: 1,
+    };
+    let fault = TraceEvent::FaultInjected {
+        kind: "missing_clock".to_string(),
+        target: "rcc.apb2enr.iopaen".to_string(),
+        at_step: 42,
+        at_pc: 0x0800_0200,
+        effect: FaultEffect::DroppedClockGate,
+    };
+
+    assert_eq!(retired.pc(), Some(0x0800_0124));
+    assert_eq!(branch.pc(), Some(0x0800_0124));
+    assert_eq!(write.pc(), None);
+    assert_eq!(fault.pc(), Some(0x0800_0200));
+}
+
+#[test]
+fn trace_events_are_json_round_trippable() {
+    let event = TraceEvent::FaultInjected {
+        kind: "register_bit_flip".to_string(),
+        target: "gpioa.odr".to_string(),
+        at_step: 7,
+        at_pc: 0x0800_0042,
+        effect: FaultEffect::RegisterBitFlip {
+            addr: 0x4002_000c,
+            bit: 5,
+        },
+    };
+
+    let encoded = serde_json::to_string(&event).expect("serialize trace event");
+    let decoded: TraceEvent = serde_json::from_str(&encoded).expect("deserialize trace event");
+
+    assert_eq!(decoded, event);
+}


### PR DESCRIPTION
## Summary
- Replace the placeholder hw-trace event enum with typed, serde-serializable trace events.
- Add a typed trace-event hook on SimulationObserver and emit InstructionRetired from Cortex-M/RISC-V step completion.
- Add focused contract tests for event shape, JSON round-trip, and observer fan-out.

## Test Plan
- cargo test -p labwired-hw-trace --test event_contract
- cargo test -p labwired-core --test trace_event_contract
- cargo check -p labwired-hw-trace -p labwired-core