### PR TITLE
Fault injection: wire missing_clock + post-run fired finalization

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -8,44 +8,27 @@
 
 use crate::*;
 
-/// Apply the script's faults to the built bus, log and persist per-fault
-/// evidence, and enforce the require_fault_fired gate. Returns `Some(exit)` to
-/// abort the run when a required fault did not fire (the run is invalid, not a
-/// firmware pass); `None` to proceed.
+/// Apply the script's faults to the built bus before the run, logging any that
+/// could not be applied. Returns the provisional evidence; runtime-observed
+/// outcomes (and the require_fault_fired gate) are finalised after the run in
+/// execute_test_loop.
 fn handle_faults(
-    args: &TestArgs,
     bus: &mut labwired_core::bus::SystemBus,
     faults: &[labwired_config::FaultSpec],
-    require_fault_fired: bool,
-) -> Result<Vec<labwired_cli::faults::FaultEvidence>, ExitCode> {
+) -> Vec<labwired_cli::faults::FaultEvidence> {
     if faults.is_empty() {
-        return Ok(Vec::new());
+        return Vec::new();
     }
     let evidence = labwired_cli::faults::apply_faults(bus, faults);
     for e in &evidence {
-        if e.fired {
-            info!("fault '{}' ({}) fired", e.id, e.kind);
-        } else {
+        if let Some(err) = &e.error {
             error!(
-                "fault '{}' ({}) did NOT fire: {}",
-                e.id,
-                e.kind,
-                e.error.as_deref().unwrap_or("")
+                "fault '{}' ({}) could not be applied: {}",
+                e.id, e.kind, err
             );
         }
     }
-    if let Some(dir) = &args.output_dir {
-        let _ = std::fs::create_dir_all(dir);
-        if let Ok(f) = std::fs::File::create(dir.join("fault-evidence.json")) {
-            let _ = serde_json::to_writer_pretty(f, &evidence);
-        }
-    }
-    if require_fault_fired && evidence.iter().any(|e| !e.fired) {
-        let n = evidence.iter().filter(|e| !e.fired).count();
-        error!("require_fault_fired: {n} fault(s) did not fire; run is invalid");
-        return Err(ExitCode::from(EXIT_ASSERT_FAIL));
-    }
-    Ok(evidence)
+    evidence
 }
 
 pub(crate) fn run_test(args: TestArgs) -> ExitCode {
@@ -349,11 +332,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             // to the app. See FIDELITY.md §C.
             machine.cpu.set_pc(program.entry_point as u32);
             machine.cpu.set_sp(0x3FFE_0000);
-            let fault_evidence =
-                match handle_faults(&args, &mut machine.bus, &faults, require_fault_fired) {
-                    Ok(ev) => ev,
-                    Err(code) => return code,
-                };
+            let fault_evidence = handle_faults(&mut machine.bus, &faults);
             let exit_code = execute_test_loop(
                 &args,
                 &mut machine,
@@ -364,7 +343,9 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 &metrics,
                 &firmware_path,
                 system_path.as_ref(),
-                &fault_evidence,
+                &faults,
+                require_fault_fired,
+                fault_evidence,
             );
             // Device-block render readout. Surfaces the attached panel block's
             // REAL render state — refresh_gen AND black-plane ink — so a generic
@@ -487,11 +468,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     e,
                 );
             }
-            let fault_evidence =
-                match handle_faults(&args, &mut machine.bus, &faults, require_fault_fired) {
-                    Ok(ev) => ev,
-                    Err(code) => return code,
-                };
+            let fault_evidence = handle_faults(&mut machine.bus, &faults);
             execute_test_loop(
                 &args,
                 &mut machine,
@@ -502,7 +479,9 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 &metrics,
                 &firmware_path,
                 system_path.as_ref(),
-                &fault_evidence,
+                &faults,
+                require_fault_fired,
+                fault_evidence,
             )
         }};
     }

--- a/crates/cli/src/faults.rs
+++ b/crates/cli/src/faults.rs
@@ -48,6 +48,15 @@ fn apply_one(bus: &mut SystemBus, f: &FaultSpec) -> FaultEvidence {
                 ),
             }
         }
+        FaultKind::MissingClock => match f.target.peripheral.as_deref() {
+            // fired is provisional here — it is finalised after the run, since
+            // missing_clock only fires if the firmware accessed the peripheral.
+            Some(p) => match bus.inject_missing_clock(p) {
+                Ok(()) => (false, None),
+                Err(e) => (false, Some(e)),
+            },
+            None => (false, Some("missing target.peripheral".to_string())),
+        },
         other => (
             false,
             Some(format!("fault kind {other:?} not yet implemented")),
@@ -58,6 +67,30 @@ fn apply_one(bus: &mut SystemBus, f: &FaultSpec) -> FaultEvidence {
         kind,
         fired,
         error,
+    }
+}
+
+/// Finalise runtime-observed fault outcomes after the run. For `missing_clock`,
+/// the fault fired only if the firmware actually accessed the unclocked
+/// peripheral (an access was suppressed). Apply-time-known kinds are left as-is.
+pub fn finalize_fault_evidence(
+    bus: &SystemBus,
+    faults: &[FaultSpec],
+    evidence: &mut [FaultEvidence],
+) {
+    for f in faults {
+        if !matches!(f.kind, FaultKind::MissingClock) {
+            continue;
+        }
+        let Some(ev) = evidence.iter_mut().find(|e| e.id == f.id) else {
+            continue;
+        };
+        if ev.error.is_some() {
+            continue; // could not be applied; keep it not-fired with its reason
+        }
+        if let Some(p) = f.target.peripheral.as_deref() {
+            ev.fired = bus.missing_clock_suppressed(p) > 0;
+        }
     }
 }
 
@@ -123,5 +156,59 @@ mod tests {
             .as_ref()
             .unwrap()
             .contains("not yet implemented"));
+    }
+
+    #[test]
+    fn missing_clock_apply_then_finalize_on_access() {
+        use labwired_config::{Access, PeripheralDescriptor, RegisterDescriptor};
+        use labwired_core::peripherals::declarative::GenericPeripheral;
+
+        let desc = PeripheralDescriptor {
+            peripheral: "t".to_string(),
+            version: "1.0".to_string(),
+            registers: vec![RegisterDescriptor {
+                id: "r".to_string(),
+                address_offset: 0,
+                size: 32,
+                access: Access::ReadWrite,
+                reset_value: 0xAB,
+                fields: vec![],
+                side_effects: None,
+            }],
+            interrupts: None,
+            timing: None,
+        };
+        let mut bus = SystemBus::new();
+        bus.add_peripheral(
+            "usart1",
+            0x4000_0000,
+            0x400,
+            None,
+            Box::new(GenericPeripheral::new(desc)),
+        );
+
+        let f = spec(
+            "mc",
+            FaultKind::MissingClock,
+            FaultTarget {
+                peripheral: Some("usart1".to_string()),
+                ..Default::default()
+            },
+            None,
+        );
+        let mut ev = apply_faults(&mut bus, std::slice::from_ref(&f));
+        assert!(!ev[0].fired, "fired is provisional before the run");
+
+        // No access yet: still not fired.
+        finalize_fault_evidence(&bus, std::slice::from_ref(&f), &mut ev);
+        assert!(!ev[0].fired);
+
+        // The firmware accesses the unclocked peripheral: now it fires.
+        let _ = bus.read_u32(0x4000_0000);
+        finalize_fault_evidence(&bus, std::slice::from_ref(&f), &mut ev);
+        assert!(
+            ev[0].fired,
+            "missing_clock fires once the peripheral is accessed"
+        );
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1521,7 +1521,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     metrics: &Arc<labwired_core::metrics::PerformanceMetrics>,
     firmware_path: &Path,
     system_path: Option<&PathBuf>,
-    fault_evidence: &[labwired_cli::faults::FaultEvidence],
+    faults: &[labwired_config::FaultSpec],
+    require_fault_fired: bool,
+    mut fault_evidence: Vec<labwired_cli::faults::FaultEvidence>,
 ) -> ExitCode {
     let max_steps = resolved_limits.max_steps;
     let max_cycles = resolved_limits.max_cycles;
@@ -1866,6 +1868,17 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         duration,
         0, // vcd_bytes - will be updated below
     );
+    // Finalise runtime-observed fault outcomes (e.g. missing_clock fires only
+    // when the firmware actually accessed the unclocked peripheral) and enforce
+    // the require_fault_fired gate: a fault that never took effect makes the run
+    // invalid, not a firmware pass.
+    labwired_cli::faults::finalize_fault_evidence(&machine.bus, faults, &mut fault_evidence);
+    let fault_gate_failed = require_fault_fired && fault_evidence.iter().any(|e| !e.fired);
+    if fault_gate_failed {
+        let n = fault_evidence.iter().filter(|e| !e.fired).count();
+        error!("require_fault_fired: {n} fault(s) did not fire; run is invalid");
+    }
+
     write_outputs(
         args,
         status,
@@ -1883,10 +1896,13 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         duration,
         &trace_observer,
         &coverage_observer,
-        fault_evidence,
+        &fault_evidence,
     );
 
-    if !all_passed || (stop_requires_assertion && !expected_stop_reason_matched) {
+    if !all_passed
+        || fault_gate_failed
+        || (stop_requires_assertion && !expected_stop_reason_matched)
+    {
         ExitCode::from(EXIT_ASSERT_FAIL)
     } else if sim_error_happened && !expected_stop_reason_matched {
         ExitCode::from(EXIT_RUNTIME_ERROR)
@@ -1966,6 +1982,19 @@ fn write_outputs<C: labwired_core::Cpu>(
                         }
                     }
                     Err(e) => error!("Failed to create trace.json: {}", e),
+                }
+            }
+
+            // fault-evidence.json (per-fault verdicts; also folded into the manifest)
+            if !fault_evidence.is_empty() {
+                let fault_path = output_dir.join("fault-evidence.json");
+                match std::fs::File::create(&fault_path) {
+                    Ok(f) => {
+                        if let Err(e) = serde_json::to_writer_pretty(f, fault_evidence) {
+                            error!("Failed to write fault-evidence.json: {}", e);
+                        }
+                    }
+                    Err(e) => error!("Failed to create fault-evidence.json: {}", e),
                 }
             }
 


### PR DESCRIPTION
Wires `missing_clock` end to end and introduces post-run fired-finalisation, on
top of the engine primitive (#368).

- `missing_clock` is applied from the script (the target peripheral is forced
  unclocked). Unlike `wrong_reset_value`, its "fired" is runtime-observed: it
  only fires if the firmware actually accessed the unclocked peripheral.
- Fault evidence and the `require_fault_fired` gate are now finalised after the
  run inside `execute_test_loop`, so runtime-observed kinds are judged correctly.
  Finalised evidence is written to `fault-evidence.json` and folded into the
  signed manifest.
- `handle_faults` now only applies faults pre-run and returns provisional
  evidence; the gate moved post-run.

Verified end to end: `missing_clock` on a peripheral the firmware drives fires
(suppressed accesses observed) and appears in the manifest `fault_injections`. A
unit test covers the apply → finalise-on-access cycle. `clippy --all-targets -D
warnings` clean.
