### PR TITLE
Fault injection: lower stuck_at_bit (Phase 2)

### DIFF
--- a/crates/cli/src/faults.rs
+++ b/crates/cli/src/faults.rs
@@ -48,6 +48,25 @@ fn apply_one(bus: &mut SystemBus, f: &FaultSpec) -> FaultEvidence {
                 ),
             }
         }
+        FaultKind::StuckAtBit => {
+            match (
+                f.target.peripheral.as_deref(),
+                f.target.register.as_deref(),
+                f.target.bit,
+                f.level,
+            ) {
+                (Some(p), Some(r), Some(bit), Some(level)) => {
+                    match bus.inject_stuck_bit(p, r, bit, level) {
+                        Ok(()) => (true, None),
+                        Err(e) => (false, Some(e)),
+                    }
+                }
+                _ => (
+                    false,
+                    Some("stuck_at_bit needs target.register, target.bit and level".to_string()),
+                ),
+            }
+        }
         FaultKind::MissingClock => match f.target.peripheral.as_deref() {
             // fired is provisional here — it is finalised after the run, since
             // missing_clock only fires if the firmware accessed the peripheral.
@@ -210,5 +229,60 @@ mod tests {
             ev[0].fired,
             "missing_clock fires once the peripheral is accessed"
         );
+    }
+
+    #[test]
+    fn stuck_at_bit_applies_and_reads_stuck() {
+        use labwired_config::{Access, PeripheralDescriptor, RegisterDescriptor};
+        use labwired_core::peripherals::declarative::GenericPeripheral;
+
+        let desc = PeripheralDescriptor {
+            peripheral: "t".to_string(),
+            version: "1.0".to_string(),
+            registers: vec![RegisterDescriptor {
+                id: "sr".to_string(),
+                address_offset: 0,
+                size: 32,
+                access: Access::ReadWrite,
+                reset_value: 0,
+                fields: vec![],
+                side_effects: None,
+            }],
+            interrupts: None,
+            timing: None,
+        };
+        let mut bus = SystemBus::new();
+        bus.add_peripheral(
+            "usart1",
+            0x4000_0000,
+            0x400,
+            None,
+            Box::new(GenericPeripheral::new(desc)),
+        );
+
+        let f = FaultSpec {
+            id: "s".to_string(),
+            kind: FaultKind::StuckAtBit,
+            target: FaultTarget {
+                peripheral: Some("usart1".to_string()),
+                register: Some("sr".to_string()),
+                bit: Some(7),
+                address: None,
+            },
+            trigger: FaultTrigger::AtStart,
+            level: Some(1),
+            value: None,
+            xor: None,
+            to: None,
+            deny: None,
+            delay_cycles: None,
+            interrupt: None,
+            bits: None,
+            size: None,
+        };
+        let ev = apply_faults(&mut bus, std::slice::from_ref(&f));
+        assert!(ev[0].fired);
+        assert!(ev[0].error.is_none());
+        assert_eq!(bus.read_u32(0x4000_0000).unwrap() & (1 << 7), 1 << 7);
     }
 }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1289,6 +1289,36 @@ impl SystemBus {
             .unwrap_or(0)
     }
 
+    /// Inject a `stuck_at_bit` fault: hold `bit` of `register` on the
+    /// declarative peripheral `peripheral` at `level` (0/1) — the CPU always
+    /// reads that level regardless of writes. Returns an error if the peripheral
+    /// or register is absent, the bit is out of range, or the peripheral is not
+    /// a declarative `GenericPeripheral`.
+    pub fn inject_stuck_bit(
+        &mut self,
+        peripheral: &str,
+        register: &str,
+        bit: u8,
+        level: u8,
+    ) -> Result<(), String> {
+        let idx = self
+            .find_peripheral_index_by_name(peripheral)
+            .ok_or_else(|| format!("fault target peripheral '{peripheral}' not found"))?;
+        let any = self.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .ok_or_else(|| format!("peripheral '{peripheral}' is not introspectable for faults"))?;
+        let generic = any
+            .downcast_mut::<crate::peripherals::declarative::GenericPeripheral>()
+            .ok_or_else(|| format!("peripheral '{peripheral}' is not a declarative peripheral"))?;
+        if !generic.force_stuck_bit(register, bit, level) {
+            return Err(format!(
+                "register '{register}' bit {bit} invalid on peripheral '{peripheral}'"
+            ));
+        }
+        Ok(())
+    }
+
     /// Inject a `wrong_reset_value` fault: force `register` on the declarative
     /// peripheral `peripheral` to `value`. Returns an error (never a silent
     /// no-op) if the peripheral or register is absent, or the peripheral is not

--- a/crates/core/src/peripherals/declarative.rs
+++ b/crates/core/src/peripherals/declarative.rs
@@ -20,6 +20,15 @@ struct InflightEvent {
     periodic_interval: Option<u64>,
 }
 
+/// A bit held at a fixed level by a `stuck_at_bit` fault. Applied to every read
+/// so the CPU always observes the stuck level regardless of writes.
+#[derive(Debug)]
+struct StuckBit {
+    byte_offset: u64,
+    bit_in_byte: u8,
+    level: u8,
+}
+
 /// A generic peripheral implementation that uses a `PeripheralDescriptor` to define its
 /// register layout and access permissions.
 ///
@@ -29,6 +38,7 @@ pub struct GenericPeripheral {
     descriptor: PeripheralDescriptor,
     data: RefCell<Vec<u8>>,
     inflight_events: RefCell<Vec<InflightEvent>>,
+    stuck_bits: RefCell<Vec<StuckBit>>,
 }
 
 impl GenericPeripheral {
@@ -71,6 +81,7 @@ impl GenericPeripheral {
             descriptor,
             data: RefCell::new(data),
             inflight_events: RefCell::new(Vec::new()),
+            stuck_bits: RefCell::new(Vec::new()),
         };
 
         // Initialize periodic events
@@ -126,6 +137,53 @@ impl GenericPeripheral {
             _ => {}
         }
         true
+    }
+
+    /// Hold `bit` of `reg_id` at `level` (the `stuck_at_bit` fault). The bit is
+    /// forced on every read, so writes never change what the CPU observes.
+    /// Returns false if the register is absent or the bit is out of range.
+    pub fn force_stuck_bit(&mut self, reg_id: &str, bit: u8, level: u8) -> bool {
+        let Some(reg) = self.descriptor.registers.iter().find(|r| r.id == reg_id) else {
+            return false;
+        };
+        if (bit as u32) >= reg.size as u32 {
+            return false;
+        }
+        self.stuck_bits.borrow_mut().push(StuckBit {
+            byte_offset: reg.address_offset + (bit / 8) as u64,
+            bit_in_byte: bit % 8,
+            level: level & 1,
+        });
+        true
+    }
+
+    /// Apply any stuck bits that fall on the byte at `offset` to a read value.
+    fn apply_stuck_byte(&self, offset: u64, mut byte: u8) -> u8 {
+        for s in self.stuck_bits.borrow().iter() {
+            if s.byte_offset == offset {
+                if s.level == 1 {
+                    byte |= 1 << s.bit_in_byte;
+                } else {
+                    byte &= !(1 << s.bit_in_byte);
+                }
+            }
+        }
+        byte
+    }
+
+    /// Apply any stuck bits within the 4 bytes at `offset` to a read value.
+    fn apply_stuck_u32(&self, offset: u64, mut val: u32) -> u32 {
+        for s in self.stuck_bits.borrow().iter() {
+            if s.byte_offset >= offset && s.byte_offset < offset + 4 {
+                let pos = ((s.byte_offset - offset) as u32) * 8 + s.bit_in_byte as u32;
+                if s.level == 1 {
+                    val |= 1 << pos;
+                } else {
+                    val &= !(1 << pos);
+                }
+            }
+        }
+        val
     }
 
     fn check_triggers(&self, register_id: &str, is_write: bool, value: Option<u32>) {
@@ -239,7 +297,7 @@ impl Peripheral for GenericPeripheral {
 
                 self.check_triggers(&reg.id, false, None);
 
-                return Ok(val);
+                return Ok(self.apply_stuck_byte(offset, val));
             }
         }
         Ok(0)
@@ -318,7 +376,7 @@ impl Peripheral for GenericPeripheral {
 
                 self.check_triggers(&reg.id, false, None);
 
-                return Ok(val);
+                return Ok(self.apply_stuck_u32(offset, val));
             }
         }
         let b0 = self.read(offset)? as u32;
@@ -529,6 +587,33 @@ mod tests {
 
         // An unknown register is reported, not silently ignored.
         assert!(!p.force_register_value("NOPE", 1));
+    }
+
+    #[test]
+    fn stuck_at_bit_holds_bit_through_writes() {
+        let mut p = GenericPeripheral::new(mock_descriptor());
+
+        // Force REG1 bit 5 stuck high; a write of 0 cannot clear it.
+        assert!(p.force_stuck_bit("REG1", 5, 1));
+        assert_eq!(p.read_u32(0).unwrap() & (1 << 5), 1 << 5);
+        p.write_u32(0, 0).unwrap();
+        assert_eq!(
+            p.read_u32(0).unwrap() & (1 << 5),
+            1 << 5,
+            "stuck-high bit survives a zero write"
+        );
+
+        // Force REG1 bit 3 stuck low (reset 0x12345678 has bit 3 set).
+        assert!(p.force_stuck_bit("REG1", 3, 0));
+        assert_eq!(
+            p.read_u32(0).unwrap() & (1 << 3),
+            0,
+            "stuck-low bit reads 0 despite a set reset value"
+        );
+
+        // Out-of-range bit and unknown register are rejected.
+        assert!(!p.force_stuck_bit("REG1", 32, 1));
+        assert!(!p.force_stuck_bit("NOPE", 0, 1));
     }
 
     #[test]


### PR DESCRIPTION
Lowers the `stuck_at_bit` fault — the first Phase-2 kind needing new engine code.

- `GenericPeripheral::force_stuck_bit` pins a register bit at a level that every
  read applies (in `read` and `read_u32`), so firmware writes can never change
  what the CPU observes.
- `SystemBus::inject_stuck_bit` resolves the declarative peripheral and applies
  it, erroring (never silently) on an absent peripheral/register or an
  out-of-range bit.
- The CLI lowers the `stuck_at_bit` kind onto it. fired is structural (the bit is
  pinned from injection), so no post-run finalisation is needed.

Tests: a bit held stuck-high survives a zero write; a stuck-low bit reads 0
despite a set reset value; the bus apply path reads the bit stuck. `clippy
--all-targets -D warnings` clean.

Three fault kinds are now lowered: wrong_reset_value, missing_clock, stuck_at_bit.
