### PR TITLE
fix(cli): write tracing logs to stderr, keep UART on stdout

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -843,10 +843,12 @@ fn main() -> ExitCode {
     // Initialize tracing with appropriate level based on --trace flag
     if cli.trace {
         tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
             .with_max_level(tracing::Level::DEBUG)
             .init();
     } else {
         tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
             .with_max_level(tracing::Level::INFO)
             .init();
     }


### PR DESCRIPTION
The tracing subscriber defaulted to **stdout**, where the firmware's UART console echo is also written. The two interleaved, so a multi-character console string (e.g. `Hello World! nrf52840dk/nrf52840`) was split by INFO progress lines and stopped appearing as a contiguous substring. Any tool capturing stdout to assert on console output — the Zephyr board matrix, CI smoke tests — saw **false negatives** even though the firmware printed correctly.

This routes logs to **stderr** so stdout carries only the firmware UART output (and the opt-in `--json` summary). Diagnostics already use `eprintln!`, so this unifies the log stream.

### Before
```
$ labwired --firmware zephyr.elf --system nrf52840-dk.yaml | grep "Hello World"
# (no match — "Hello World! nrf52840dk/nrf52840" was split by an interleaved INFO line)
```
### After
```
$ labwired --firmware zephyr.elf --system nrf52840-dk.yaml 2>/dev/null
*** Booting Zephyr OS build c66235fb7346 ***
Hello World! nrf52840dk/nrf52840
```

No test asserts on log lines via stdout. `cargo fmt --check` clean.