### PR TITLE
fix: repair IO-Link debug and analyzer flow

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -28,6 +28,7 @@ pub(crate) fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode 
         memory_overrides: Default::default(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         walk_deleted: false,
     };

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -7,6 +7,7 @@
 //! `labwired test` subcommand: run the Tier-1 protocol suite.
 
 use crate::*;
+use tracing::warn;
 
 /// Apply the script's faults to the built bus before the run, logging any that
 /// could not be applied. Returns the provisional evidence; runtime-observed
@@ -425,7 +426,21 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     };
 
     let uart_tx = Arc::new(Mutex::new(Vec::new()));
-    bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+    let debug_uart = system_path
+        .as_ref()
+        .and_then(|path| labwired_config::SystemManifest::from_file(path).ok())
+        .and_then(|manifest| manifest.debug_uart);
+    if let Some(debug_uart) = debug_uart.as_deref() {
+        if !bus.attach_uart_tx_sink_named(debug_uart, uart_tx.clone(), !args.no_uart_stdout) {
+            warn!(
+                "debug_uart '{}' did not resolve to a UART peripheral; falling back to all UARTs",
+                debug_uart
+            );
+            bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+        }
+    } else {
+        bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+    }
     // Let any attached IO-Link master record what it received over IO-Link into
     // the same captured buffer, so `uart_contains` can assert on the MASTER
     // side (MASTER PD= / MASTER VERDICT / MASTER EVENT), not just the device

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -195,6 +195,8 @@ pub struct SystemManifest {
     pub external_devices: Vec<ExternalDevice>,
     #[serde(default)]
     pub board_io: Vec<BoardIoBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debug_uart: Option<String>,
     #[serde(default)]
     pub peripherals: Vec<PeripheralConfig>,
     /// Opt-in: delete the per-cycle peripheral walk for this config (only takes

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1658,6 +1658,39 @@ impl SystemBus {
         }
     }
 
+    /// Attach a UART TX capture sink to one named UART peripheral.
+    /// Returns false when no matching UART peripheral exists.
+    pub fn attach_uart_tx_sink_named(
+        &mut self,
+        name: &str,
+        sink: Arc<Mutex<Vec<u8>>>,
+        echo_stdout: bool,
+    ) -> bool {
+        for p in &mut self.peripherals {
+            let Some(any) = p.dev.as_any_mut() else {
+                continue;
+            };
+            if let Some(uart) = any.downcast_mut::<Uart>() {
+                uart.set_sink(None, false);
+            }
+        }
+
+        for p in &mut self.peripherals {
+            if p.name != name {
+                continue;
+            }
+            let Some(any) = p.dev.as_any_mut() else {
+                return false;
+            };
+            let Some(uart) = any.downcast_mut::<Uart>() else {
+                return false;
+            };
+            uart.set_sink(Some(sink), echo_stdout);
+            return true;
+        }
+        false
+    }
+
     /// Collect shared RX buffer handles from all UART peripherals on this bus.
     /// The caller can push bytes into these buffers to inject serial input.
     pub fn attach_uart_rx_source(&self) -> Vec<Arc<Mutex<VecDeque<u8>>>> {
@@ -2168,6 +2201,7 @@ mod tests {
                 config,
             }],
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -2233,6 +2267,7 @@ mod tests {
                 config,
             }],
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -2336,6 +2371,7 @@ mod tests {
                 config,
             }],
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -2993,6 +3029,7 @@ peripherals:
             memory_overrides: std::collections::HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         }
     }
@@ -3131,6 +3168,7 @@ peripherals:
                 config,
             }],
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         }
     }

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -973,6 +973,19 @@ pub fn decode_thumb_16(opcode: u16) -> Instruction {
 
     // 8.1 Misc (T1) (0xBxxx)
     if (opcode & 0xF000) == 0xB000 {
+        // REV/REV16/REVSH (T1): 1011 1010 op mmm ddd.
+        // newlib strlen emits REV after its word-at-a-time zero-byte scan.
+        if (opcode & 0xFF00) == 0xBA00 {
+            let rm = ((opcode >> 3) & 0x7) as u8;
+            let rd = (opcode & 0x7) as u8;
+            return match (opcode >> 6) & 0x3 {
+                0b00 => Instruction::Rev { rd, rm },
+                0b01 => Instruction::Rev16 { rd, rm },
+                0b11 => Instruction::RevSh { rd, rm },
+                _ => Instruction::Unknown(opcode),
+            };
+        }
+
         // SXTH/SXTB/UXTH/UXTB (T1): 1011 0010 [op2] mmm ddd
         //   op2 = 00 -> SXTH (0xB200..0xB23F)
         //   op2 = 01 -> SXTB (0xB240..0xB27F)
@@ -2164,6 +2177,14 @@ mod tests {
         assert_eq!(decode_thumb_16(0xB281), Instruction::Uxth { rd: 1, rm: 0 });
         // UXTB R5, R4 -> 0xB2E5 (preserves existing behavior)
         assert_eq!(decode_thumb_16(0xB2E5), Instruction::Uxtb { rd: 5, rm: 4 });
+    }
+
+    #[test]
+    fn test_decode_rev_t1() {
+        // REV r2, r2 = 0xBA12, emitted by newlib strlen.
+        assert_eq!(decode_thumb_16(0xBA12), Instruction::Rev { rd: 2, rm: 2 });
+        assert_eq!(decode_thumb_16(0xBA52), Instruction::Rev16 { rd: 2, rm: 2 });
+        assert_eq!(decode_thumb_16(0xBAD2), Instruction::RevSh { rd: 2, rm: 2 });
     }
 
     #[test]

--- a/crates/core/src/peripherals/components/iolink_master.rs
+++ b/crates/core/src/peripherals/components/iolink_master.rs
@@ -376,7 +376,7 @@ impl IolinkMaster {
                 let r = decode_operate(&p.raw_device[..n], self.pd_in_len, self.od_len);
                 (r.pd, Some(r.checksum_ok), Some(r.pd_valid))
             } else {
-                (Vec::new(), Some(false), Some(false))
+                (Vec::new(), None, Some(false))
             }
         } else {
             (Vec::new(), None, None)
@@ -670,6 +670,23 @@ mod tests {
         let x = m.finalize_xfer(p);
         assert_eq!(x.ck_ok, None);
         assert_eq!(x.pd_valid, None);
+        assert!(x.pd_in.is_empty());
+    }
+
+    #[test]
+    fn finalize_incomplete_cyclic_frame_has_no_crc_verdict() {
+        let m = IolinkMaster::new(1, 1, IolinkComSpeed::Com2);
+        let p = PendingXfer {
+            seq: 1,
+            kind: IolinkFrameKind::Cyclic,
+            pd_out: vec![0],
+            link_state: IolinkLinkState::Operate,
+            raw_master: encode_type1_cycle(&[0]),
+            raw_device: vec![0x20],
+        };
+        let x = m.finalize_xfer(p);
+        assert_eq!(x.ck_ok, None);
+        assert_eq!(x.pd_valid, Some(false));
         assert!(x.pd_in.is_empty());
     }
 

--- a/crates/core/src/system/xtensa/mod.rs
+++ b/crates/core/src/system/xtensa/mod.rs
@@ -532,6 +532,7 @@ mod tests {
                 config,
             }],
             board_io: vec![],
+            debug_uart: None,
         };
 
         let mut bus = SystemBus::new();
@@ -603,6 +604,7 @@ mod tests {
                 config,
             }],
             board_io: vec![],
+            debug_uart: None,
         };
 
         // Register spi3_s3 exactly as the production S3 bring-up does
@@ -654,6 +656,7 @@ mod tests {
                 config: std::collections::HashMap::new(),
             }],
             board_io: vec![],
+            debug_uart: None,
         };
 
         let mut bus = SystemBus::new();

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -441,6 +441,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -546,6 +547,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -605,6 +607,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -659,6 +662,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -719,6 +723,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -733,6 +738,67 @@ pub mod integration_tests {
 
         let data = sink.lock().unwrap().clone();
         assert_eq!(data, vec![b'Y']);
+    }
+
+    #[test]
+    fn test_attach_uart_tx_sink_named_captures_only_selected_uart() {
+        let chip = ChipDescriptor {
+            schema_version: "1.0".to_string(),
+            name: "test-chip-two-uarts".to_string(),
+            arch: Arch::Arm,
+            core: None,
+            flash: MemoryRange {
+                base: 0x0,
+                size: "128KB".to_string(),
+            },
+            ram: MemoryRange {
+                base: 0x2000_0000,
+                size: "20KB".to_string(),
+            },
+            memory_regions: Vec::new(),
+            peripherals: vec![
+                PeripheralConfig {
+                    id: "uart1".to_string(),
+                    r#type: "uart".to_string(),
+                    base_address: 0x4000_C000,
+                    size: Some("1KB".to_string()),
+                    irq: Some(37),
+                    config: HashMap::new(),
+                    clock: None,
+                },
+                PeripheralConfig {
+                    id: "uart2".to_string(),
+                    r#type: "uart".to_string(),
+                    base_address: 0x4000_D000,
+                    size: Some("1KB".to_string()),
+                    irq: Some(38),
+                    config: HashMap::new(),
+                    clock: None,
+                },
+            ],
+        };
+
+        let manifest = SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "test-system-two-uarts".to_string(),
+            chip: "test-chip-two-uarts".to_string(),
+            memory_overrides: HashMap::new(),
+            external_devices: Vec::new(),
+            board_io: Vec::new(),
+            debug_uart: Some("uart1".to_string()),
+            peripherals: Vec::new(),
+        };
+
+        let mut bus = crate::bus::SystemBus::from_config(&chip, &manifest).unwrap();
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        assert!(bus.attach_uart_tx_sink_named("uart1", sink.clone(), false));
+
+        bus.write_u8(0x4000_D004, b'P').unwrap();
+        bus.write_u8(0x4000_C004, b'D').unwrap();
+
+        let data = sink.lock().unwrap().clone();
+        assert_eq!(data, vec![b'D']);
     }
 
     #[test]
@@ -776,6 +842,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -833,6 +900,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -890,6 +958,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -2062,6 +2131,7 @@ pub mod integration_tests {
             memory_overrides: HashMap::new(),
             external_devices: Vec::new(),
             board_io: Vec::new(),
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 

--- a/crates/core/tests/chip_conformance.rs
+++ b/crates/core/tests/chip_conformance.rs
@@ -255,6 +255,7 @@ fn dummy_manifest(path: &str) -> SystemManifest {
         chip: path.to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     }

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -31,6 +31,7 @@ fn h563_machine() -> Machine<labwired_core::cpu::CortexM> {
         chip: path.to_string_lossy().to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/h563_conformance.rs
+++ b/crates/core/tests/h563_conformance.rs
@@ -28,6 +28,7 @@ fn h563_bus() -> labwired_core::bus::SystemBus {
         chip: path.to_string_lossy().to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -52,6 +52,7 @@ fn validate_chip(path: &PathBuf) -> anyhow::Result<()> {
         chip: path.to_string_lossy().to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -130,6 +130,7 @@ fn dummy_manifest(path: &str) -> labwired_config::SystemManifest {
         chip: path.to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     }

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1140,6 +1140,7 @@ mod tests {
                 device_type: None,
                 i2c_address: None,
             }],
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -1206,6 +1207,7 @@ mod tests {
                     i2c_address: None,
                 },
             ],
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 
@@ -1261,6 +1263,7 @@ mod tests {
                 device_type: None,
                 i2c_address: None,
             }],
+            debug_uart: None,
             peripherals: Vec::new(),
         };
 

--- a/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
@@ -190,6 +190,7 @@ fn build_sim_bus() -> SystemBus {
         chip: chip_path.to_string_lossy().to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/foreign_firmware_probe.rs
+++ b/crates/hw-oracle/tests/foreign_firmware_probe.rs
@@ -33,6 +33,7 @@ fn probe_foreign_firmware() {
         chip: chip_path.to_string_lossy().to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/h563_mmio_diff.rs
+++ b/crates/hw-oracle/tests/h563_mmio_diff.rs
@@ -993,6 +993,7 @@ fn build_sim_bus() -> SystemBus {
         chip: chip_path.to_string_lossy().to_string(),
         external_devices: vec![],
         board_io: vec![],
+        debug_uart: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -147,7 +147,13 @@ impl WasmSimulator {
             .map_err(|e| JsValue::from_str(&format!("Bus config error: {:#}", e)))?;
 
         let uart_sink = Arc::new(Mutex::new(Vec::new()));
-        bus.attach_uart_tx_sink(uart_sink.clone(), false);
+        if let Some(debug_uart) = manifest.debug_uart.as_deref() {
+            if !bus.attach_uart_tx_sink_named(debug_uart, uart_sink.clone(), false) {
+                bus.attach_uart_tx_sink(uart_sink.clone(), false);
+            }
+        } else {
+            bus.attach_uart_tx_sink(uart_sink.clone(), false);
+        }
         let uart_rx_bufs = bus.attach_uart_rx_source();
 
         let (cpu, _nvic) = configure_cortex_m(&mut bus);

--- a/examples/iolink-dido/system.yaml
+++ b/examples/iolink-dido/system.yaml
@@ -3,6 +3,7 @@
 # 74HC165 input shifter are attached in M3/M4.
 name: "iolink-dido"
 chip: "../../configs/chips/stm32l476.yaml"
+debug_uart: "uart1"
 external_devices:
   # Native IO-Link master peer driving the device firmware over USART2.
   - id: "iolink_master"


### PR DESCRIPTION
## Summary
- route IO-Link example debug UART separately from protocol UART
- add named UART TX sink support for simulator capture
- avoid CRC verdicts for incomplete IO-Link cyclic frames and keep decoder fixes on current main

## Verification
- cargo fmt --check
- cargo test -p labwired-core test_attach_uart_tx_sink_named_captures_only_selected_uart -- --nocapture
- cargo test -p labwired-core finalize_incomplete_cyclic_frame_has_no_crc_verdict -- --nocapture
- cargo test -p labwired-core test_decode_rev_t1 -- --nocapture
- cargo test -p labwired-core test_thumb2_pld_is_nop_not_pc_load -- --nocapture
- cargo test -p labwired-core test_decode_dataproc32_adc_sbc_rsb -- --nocapture
- cargo test -p labwired-core test_dataproc32_adc_carry_in -- --nocapture
- cargo test -p labwired-core test_dataproc32_sbc_borrow -- --nocapture
- cargo test -p labwired-core test_dataproc32_rsb -- --nocapture
- cargo check -p labwired-wasm
- cargo build -p labwired-cli --bin labwired
- make -C examples/iolink-dido/firmware clean all STM32CUBE_L4_DIR=/home/andrii/projects/STM32CubeL4
- cargo run -p labwired-cli -- test --script examples/iolink-dido/test.yaml --no-uart-stdout --max-steps 3000000 --output-dir /tmp/labwired-iolink-clean-output
