### PR TITLE
fix(cortex-m): SysTick fires only on count-down to zero

### DIFF
--- a/crates/core/src/peripherals/systick.rs
+++ b/crates/core/src/peripherals/systick.rs
@@ -10,10 +10,18 @@ use crate::SimResult;
 /// Standard address: 0xE000_E010
 #[derive(Debug, Default, serde::Serialize)]
 pub struct Systick {
+    /// SYST_CSR config bits (ENABLE/TICKINT/CLKSOURCE). COUNTFLAG (bit 16) is
+    /// NOT stored here — it is held in `countflag` so a read of CSR can clear
+    /// it (the ARMv7-M "reads clear COUNTFLAG" rule, which `cortex_m_systick`
+    /// relies on; see `read_u32`).
     csr: u32,
     rvr: u32,
     cvr: u32,
     calib: u32,
+    /// SYST_CSR.COUNTFLAG. Set when the counter wraps to 0; cleared on a read
+    /// of SYST_CSR or a write of SYST_CVR. `Cell` so the `&self` read path can
+    /// clear it.
+    countflag: std::cell::Cell<bool>,
 }
 
 impl Systick {
@@ -23,6 +31,7 @@ impl Systick {
             rvr: 0,
             cvr: 0,
             calib: 0x4000_0000, // No reference clock, no skew
+            countflag: std::cell::Cell::new(false),
         }
     }
 
@@ -37,7 +46,10 @@ impl Systick {
 
     fn read_reg(&self, offset: u64) -> u32 {
         match offset {
-            0x00 => self.csr,
+            // COUNTFLAG (bit 16) folded in from `countflag`. Byte reads do not
+            // clear it; the word read (`read_u32`) does, matching how the
+            // driver accesses CSR.
+            0x00 => self.csr | if self.countflag.get() { 0x1_0000 } else { 0 },
             0x04 => self.rvr,
             0x08 => self.cvr,
             0x0C => self.calib,
@@ -70,8 +82,9 @@ impl Systick {
                 }
             }
             0x08 => {
+                // Writing SYST_CVR clears the counter and COUNTFLAG.
                 self.cvr = 0;
-                self.csr &= !0x10000;
+                self.countflag.set(false);
             }
             _ => {}
         }
@@ -84,6 +97,17 @@ impl crate::Peripheral for Systick {
         let byte_offset = (offset % 4) as u32;
         let reg_val = self.read_reg(reg_offset);
         Ok(((reg_val >> (byte_offset * 8)) & 0xFF) as u8)
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        let val = self.read_reg(offset);
+        // ARMv7-M: a read of SYST_CSR returns COUNTFLAG and then clears it.
+        // `cortex_m_systick`'s elapsed() depends on this to detect a wrap, so
+        // it must happen on the word read the driver issues.
+        if offset == 0x00 {
+            self.countflag.set(false);
+        }
+        Ok(val)
     }
 
     fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
@@ -108,35 +132,145 @@ impl crate::Peripheral for Systick {
             };
         }
 
+        // ARMv7-M SysTick is EDGE-triggered: COUNTFLAG/interrupt are raised only
+        // when the counter COUNTS DOWN to zero, never when it merely holds zero.
+        // A zero counter (after reset, or after software writes SYST_CVR — which
+        // hardware clears to 0) reloads from RVR on the next clock WITHOUT firing.
+        // Modelling "cvr == 0 ⇒ fire" instead would make every `SYST_CVR <- 0`
+        // the tickless-idle path issues each ISR re-pend SysTick immediately, so
+        // the handler is re-entered before the interrupted thread can run.
         if self.cvr == 0 {
+            // Reload only; the previous wrap already fired (or this is the
+            // initial/software-cleared zero).
             self.cvr = self.rvr;
-            self.csr |= 0x10000;
-            // SysTick raises system exception 15 — NOT an NVIC IRQ.
-            // The bus dispatches `system_exception` directly to the
-            // CPU's pending_exceptions bitmap, bypassing NVIC ISER/ISPR.
-            // (Routing through NVIC would interpret 15 as NVIC IRQ 15
-            // = exception 31, which doesn't have a vector in standard
-            // STM32 firmware.)
-            let fire = (self.csr & 0x2) != 0;
-            crate::PeripheralTickResult {
+            return crate::PeripheralTickResult {
                 irq: false,
                 cycles: 1,
-                dma_requests: None,
-                system_exception: if fire { Some(15) } else { None },
                 ..Default::default()
-            }
-        } else {
-            self.cvr -= 1;
-            crate::PeripheralTickResult {
-                irq: false, // IRQ is only true when counter reaches 0
+            };
+        }
+
+        self.cvr -= 1;
+        if self.cvr != 0 {
+            return crate::PeripheralTickResult {
+                irq: false,
                 cycles: 1,
-                dma_requests: None,
                 ..Default::default()
-            }
+            };
+        }
+
+        // Counter just transitioned to zero: set COUNTFLAG and raise the tick.
+        self.countflag.set(true);
+        // SysTick raises system exception 15 — NOT an NVIC IRQ. The bus
+        // dispatches `system_exception` directly to the CPU's pending_exceptions
+        // bitmap, bypassing NVIC ISER/ISPR. (Routing through NVIC would interpret
+        // 15 as NVIC IRQ 15 = exception 31, which has no vector in standard
+        // STM32 firmware.)
+        let fire = (self.csr & 0x2) != 0;
+        crate::PeripheralTickResult {
+            irq: false,
+            cycles: 1,
+            dma_requests: None,
+            system_exception: if fire { Some(15) } else { None },
+            ..Default::default()
         }
     }
 
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Peripheral;
+
+    /// Enable SysTick with the given reload, leaving the counter cleared to 0
+    /// (as hardware does on a SYST_CVR write).
+    fn armed(reload: u8) -> Systick {
+        let mut st = Systick::new();
+        st.write(0x04, reload).unwrap(); // RVR
+        st.write(0x08, 0x00).unwrap(); // CVR write → clears counter to 0
+        st.write(0x00, 0x07).unwrap(); // CSR: ENABLE | TICKINT | CLKSOURCE
+        st
+    }
+
+    /// Regression: a counter sitting at zero (freshly reloaded, or just cleared
+    /// by a software SYST_CVR write) must RELOAD without firing. Only a count-
+    /// down transition to zero raises the tick. Modelling "cvr == 0 ⇒ fire"
+    /// makes the tickless-idle SYST_CVR write re-pend SysTick every step, so the
+    /// ISR is re-entered before the interrupted thread can run (STM32 + Zephyr
+    /// never reached main).
+    #[test]
+    fn fires_only_on_countdown_to_zero_not_on_loaded_zero() {
+        let mut st = armed(4);
+
+        // tick 1: counter is 0 (software-cleared) → reload to RVR, NO fire.
+        assert_eq!(
+            st.tick().system_exception,
+            None,
+            "reload tick must not fire"
+        );
+        // ticks 2..=4: 4→3→2→1, no fire yet.
+        for _ in 0..3 {
+            assert_eq!(st.tick().system_exception, None);
+        }
+        // tick 5: 1→0, the count-down edge → fire SysTick (exception 15).
+        assert_eq!(
+            st.tick().system_exception,
+            Some(15),
+            "count-down to zero must raise SysTick"
+        );
+        // tick 6: counter is 0 again → reload, NO fire.
+        assert_eq!(
+            st.tick().system_exception,
+            None,
+            "post-fire reload must not fire"
+        );
+    }
+
+    /// A software write to SYST_CVR clears the counter; the immediately following
+    /// tick must reload from RVR rather than fire (the exact path the Zephyr
+    /// tickless idle exercises on every ISR).
+    #[test]
+    fn software_cvr_write_does_not_fire() {
+        let mut st = armed(3);
+        // Let it run partway down.
+        st.tick(); // reload to 3
+        st.tick(); // 3→2
+                   // Software clears the counter.
+        st.write(0x08, 0x00).unwrap();
+        // Next tick reloads, does not fire.
+        assert_eq!(st.tick().system_exception, None);
+    }
+
+    /// COUNTFLAG (SYST_CSR bit 16) reads as set after a wrap and is cleared by
+    /// the word read, per ARMv7-M. `cortex_m_systick`'s elapsed() relies on this.
+    #[test]
+    fn countflag_sets_on_wrap_and_clears_on_read() {
+        let mut st = armed(2);
+        st.tick(); // reload to 2
+        st.tick(); // 2→1
+        assert_eq!(st.tick().system_exception, Some(15)); // 1→0, fire
+
+        let csr = st.read_u32(0x00).unwrap();
+        assert_eq!(csr & 0x1_0000, 0x1_0000, "COUNTFLAG set after wrap");
+        let csr2 = st.read_u32(0x00).unwrap();
+        assert_eq!(csr2 & 0x1_0000, 0, "COUNTFLAG cleared by the read");
+    }
+
+    /// A disabled SysTick (ENABLE=0) never ticks down or fires.
+    #[test]
+    fn disabled_systick_is_inert() {
+        let mut st = Systick::new();
+        st.write(0x04, 1).unwrap();
+        st.write(0x08, 0x00).unwrap();
+        // ENABLE not set.
+        for _ in 0..10 {
+            let r = st.tick();
+            assert_eq!(r.system_exception, None);
+            assert_eq!(r.cycles, 0);
+        }
     }
 }

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1175,12 +1175,16 @@ pub mod integration_tests {
         machine.bus.write_u32(0xE000_E014, 1).unwrap();
         machine.bus.write_u32(0xE000_E010, 3).unwrap();
 
-        // Step 1: PC=0x2000_0000. Ticks SysTick.
-        // SysTick wrap triggers exception 15.
+        // Reload step: writing SYST_CVR cleared the counter to 0, so the first
+        // tick reloads RVR (=1) without firing — SysTick is edge-triggered on a
+        // count-down to zero, not on a held zero.
         let _ = machine.step();
 
-        // Step 2: Next step should detect pending exception AND handle it.
-        // It should perform stacking and jump to 0x1000.
+        // Step 1: counter 1->0, SysTick wrap pends exception 15.
+        let _ = machine.step();
+
+        // Step 2: next step detects the pending exception AND handles it —
+        // stacking and jumping to 0x1000.
         let _ = machine.step();
 
         assert_eq!(machine.cpu.pc, 0x1000);
@@ -1206,11 +1210,15 @@ pub mod integration_tests {
         machine.cpu.r0 = 10;
         machine.cpu.r7 = 20;
 
-        // 3. Trigger SysTick
-        machine.bus.write_u32(0xE000_E014, 100).unwrap();
+        // 3. Trigger SysTick (Reload=1 so the wrap is one count-down away).
+        machine.bus.write_u32(0xE000_E014, 1).unwrap();
         machine.bus.write_u32(0xE000_E010, 3).unwrap();
 
-        // Step 1: Wrap SysTick
+        // Reload step: writing SYST_CVR cleared the counter to 0; the first tick
+        // reloads RVR without firing (edge-triggered on count-down to zero).
+        machine.step().unwrap();
+
+        // Step 1: counter 1->0, SysTick wraps and pends exception 15.
         machine.step().unwrap();
 
         // Step 2: Handle Exception (Entry)
@@ -1233,8 +1241,10 @@ pub mod integration_tests {
         // Step 4: Execute BX LR (Exception Return)
         machine.step().unwrap();
 
-        // 5. Verify restored state
-        assert_eq!(machine.cpu.pc, 0x2000_0002); // Back at original PC + 2
+        // 5. Verify restored state. Two instructions ran at the (zeroed) reset
+        // PC before the wrap — the reload tick step and the count-down step —
+        // each a 2-byte NOP, so the interrupted/restored PC is original + 4.
+        assert_eq!(machine.cpu.pc, 0x2000_0004);
         assert_eq!(machine.cpu.r0, 10); // Original R0 restored!
         assert_eq!(machine.cpu.sp, 0x2002_0000); // SP restored
         assert_eq!(machine.cpu.r7, 20); // R7 was untouched


### PR DESCRIPTION
## Problem

The SysTick model raised COUNTFLAG and the tick exception whenever the current-value register (`SYST_CVR`) held zero. That conflated two distinct hardware states:

- a counter that **counted down** to zero — must fire
- a counter **loaded as zero** (at reset, or when software writes `SYST_CVR`, which hardware clears to 0) — must only reload from `SYST_RVR`, never fire

Zephyr's tickless idle writes `SYST_CVR` on every tick ISR to restart the counter. Under the old model each of those writes re-pended SysTick on the next step, so the handler was re-entered before the interrupted thread could run. On nRF (RTC-driven tick) this path was never exercised; on STM32, which drives the kernel from Cortex SysTick, the boot thread never reached `main` and nothing printed.

## Fix

`tick()` is now edge-triggered:

- a zero counter reloads from `RVR` **without firing**
- the tick exception is raised only on the `1 -> 0` count-down transition

`COUNTFLAG` moves into its own cell so a word read of `SYST_CSR` returns it and then clears it, per ARMv7-M — `cortex_m_systick`'s `elapsed()` depends on that read-clear.

## Tests

Adds unit tests for the count-down edge, the software-`CVR`-write reload (the exact Zephyr tickless path), `COUNTFLAG` read-clear, and the disabled-timer case. Full `firmware_survival` matrix stays green (the pre-existing `nrf52840_demo` failure is unrelated and reproduces on `main`).

## Why it matters

This is a silicon-fidelity / false-pass-prevention fix: a SysTick that fires on a loaded zero silently distorts every timing- and tick-driven behaviour. It also unblocks driving Zephyr from real SysTick on RP2040, whose bring-up (#371) had to stub the timer to work around this bug, and is a prerequisite for the STM32 family Zephyr bring-up.