### PR TITLE
Provenanced model-validation report (validated-models backbone)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3804,6 +3804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "validation-report"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,6 +3810,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "crates/hw-trace",
     "crates/ir",
     "crates/loader",
+    "crates/validation-report",
     "crates/python",
     "crates/riscv-ci-fixture",
     "crates/svd-ingestor",

--- a/crates/validation-report/Cargo.toml
+++ b/crates/validation-report/Cargo.toml
@@ -8,3 +8,4 @@ description = "Aggregates labwired's per-chip model-fidelity evidence (tier-1 ma
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }

--- a/crates/validation-report/Cargo.toml
+++ b/crates/validation-report/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "validation-report"
+version = "0.1.0"
+edition = "2021"
+description = "Aggregates labwired's per-chip model-fidelity evidence (tier-1 matrix, silicon reset-conformance, SVD coverage) into one provenanced validation report."
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/validation-report/README.md
+++ b/crates/validation-report/README.md
@@ -34,11 +34,13 @@ peripherals, so being validated twice never inflates the score. Real `esp32c3` r
 ## Status / roadmap
 
 - **Wired:** (1) tier-1 raw-register-vs-TRM matrix; (2) SVD register-layout descriptors
-  (`configs/peripherals/<chip>/*.yaml`). Coverage = pass / applicable (excludes `n/a`);
-  `n/a`/`unrecorded` peripherals are shown, never silently dropped.
-- **Next authorities** plug in as additional per-peripheral checks (the report shape is
-  built for it): hw-oracle reset-conformance counts and a vendor-stack-boot pass/fail
-  derived from the examples.
+  (`configs/peripherals/<chip>/*.yaml`); (3) silicon reset-conformance from committed
+  hw-oracle OpenOCD captures (`scripts/hw-oracle/captures/<chip>/.../reg_oracle.json`) —
+  real-hardware ground truth, no board needed at check time. Coverage = pass / applicable
+  (excludes `n/a`); `n/a`/`unrecorded` peripherals are shown, never silently dropped.
+- **Next authority:** vendor-stack-boot pass/fail derived from the examples that boot
+  unmodified ESP-IDF/Zephyr/HAL.
+- **Later (needs infra):** QEMU (Espressif fork) / Renode differential, as another column.
 - **Later (needs infra):** QEMU (Espressif fork) / Renode **differential** — run the same
   firmware on labwired and the reference emulator, diff traces, attach as another column.
   No hardware required; deferred until a runner exists (same posture as on-silicon HIL).

--- a/crates/validation-report/README.md
+++ b/crates/validation-report/README.md
@@ -20,17 +20,25 @@ run. So a reviewer (or proto.cat's verdict) can cite validation, not just claim 
 ## Use
 
 ```sh
+# tier-1 + SVD (auto-finds configs/peripherals/<chip>)
 cargo run -p validation-report -- docs/coverage/tier1-matrix.json esp32c3        # markdown
 cargo run -p validation-report -- docs/coverage/tier1-matrix.json esp32c3 --json # json
+cargo run -p validation-report -- docs/coverage/tier1-matrix.json esp32c3 path/to/descriptors
 ```
+
+A peripheral can carry checks from several authorities; the summary derives ONE status
+per distinct peripheral (Fail > Pass > Unrecorded > n/a) and reports coverage over
+peripherals, so being validated twice never inflates the score. Real `esp32c3` run:
+**51 distinct peripherals, 2 authorities, 97.7% coverage.**
 
 ## Status / roadmap
 
-- **Now:** aggregates the tier-1 matrix (source #1). Coverage = pass / applicable
-  (excludes `n/a`); `n/a`/`unrecorded` peripherals are shown, never silently dropped.
+- **Wired:** (1) tier-1 raw-register-vs-TRM matrix; (2) SVD register-layout descriptors
+  (`configs/peripherals/<chip>/*.yaml`). Coverage = pass / applicable (excludes `n/a`);
+  `n/a`/`unrecorded` peripherals are shown, never silently dropped.
 - **Next authorities** plug in as additional per-peripheral checks (the report shape is
-  built for it): hw-oracle reset-conformance counts, SVD register coverage, and a
-  vendor-stack-boot pass/fail derived from the examples.
+  built for it): hw-oracle reset-conformance counts and a vendor-stack-boot pass/fail
+  derived from the examples.
 - **Later (needs infra):** QEMU (Espressif fork) / Renode **differential** — run the same
   firmware on labwired and the reference emulator, diff traces, attach as another column.
   No hardware required; deferred until a runner exists (same posture as on-silicon HIL).

--- a/crates/validation-report/README.md
+++ b/crates/validation-report/README.md
@@ -1,0 +1,36 @@
+# validation-report — provenanced model-fidelity reports
+
+proto.cat's differentiator is *real working hardware*: "the firmware verifiably runs."
+That claim is only as good as the **fidelity of the silicon models** it runs on — so
+"validated model" has to be an **audit trail**, not an assertion.
+
+labwired already validates models several ways, but the evidence is scattered:
+
+| Authority | Where it lives | What it proves |
+|---|---|---|
+| tier-1 raw-register vs TRM | `docs/coverage/tier1-matrix.json` | each peripheral's register sequence matches the vendor TRM |
+| silicon reset-conformance | `crates/hw-oracle/` (committed silicon captures) | reset-state registers match real silicon, no board needed at check time |
+| SVD register coverage | `crates/svd-ingestor/` + `configs/peripherals/` | register map is vendor-authoritative (CMSIS-SVD) |
+| real vendor-stack boot | `examples/*/VALIDATION.md` | unmodified ESP-IDF/Zephyr/HAL/UDSLib runs correctly |
+
+This crate consolidates that into one `ModelValidationReport` per chip: per peripheral,
+**what** was checked and against **which authority**, with a link/path to the backing
+run. So a reviewer (or proto.cat's verdict) can cite validation, not just claim it.
+
+## Use
+
+```sh
+cargo run -p validation-report -- docs/coverage/tier1-matrix.json esp32c3        # markdown
+cargo run -p validation-report -- docs/coverage/tier1-matrix.json esp32c3 --json # json
+```
+
+## Status / roadmap
+
+- **Now:** aggregates the tier-1 matrix (source #1). Coverage = pass / applicable
+  (excludes `n/a`); `n/a`/`unrecorded` peripherals are shown, never silently dropped.
+- **Next authorities** plug in as additional per-peripheral checks (the report shape is
+  built for it): hw-oracle reset-conformance counts, SVD register coverage, and a
+  vendor-stack-boot pass/fail derived from the examples.
+- **Later (needs infra):** QEMU (Espressif fork) / Renode **differential** — run the same
+  firmware on labwired and the reference emulator, diff traces, attach as another column.
+  No hardware required; deferred until a runner exists (same posture as on-silicon HIL).

--- a/crates/validation-report/README.md
+++ b/crates/validation-report/README.md
@@ -33,14 +33,15 @@ peripherals, so being validated twice never inflates the score. Real `esp32c3` r
 
 ## Status / roadmap
 
-- **Wired:** (1) tier-1 raw-register-vs-TRM matrix; (2) SVD register-layout descriptors
-  (`configs/peripherals/<chip>/*.yaml`); (3) silicon reset-conformance from committed
-  hw-oracle OpenOCD captures (`scripts/hw-oracle/captures/<chip>/.../reg_oracle.json`) —
-  real-hardware ground truth, no board needed at check time. Coverage = pass / applicable
-  (excludes `n/a`); `n/a`/`unrecorded` peripherals are shown, never silently dropped.
-- **Next authority:** vendor-stack-boot pass/fail derived from the examples that boot
-  unmodified ESP-IDF/Zephyr/HAL.
-- **Later (needs infra):** QEMU (Espressif fork) / Renode differential, as another column.
+- **Wired (4 authorities):** (1) tier-1 raw-register-vs-TRM matrix; (2) SVD register-layout
+  descriptors (`configs/peripherals/<chip>/*.yaml`); (3) silicon reset-conformance from
+  committed hw-oracle OpenOCD captures (`scripts/hw-oracle/captures/<chip>/.../reg_oracle.json`)
+  — real-hardware ground truth, no board at check time; (4) vendor-stack / integration
+  example boots (`examples/*/` targeting the chip, counted by acceptance assertions) —
+  device-level behavioral validation, reported separately from per-peripheral coverage.
+  Coverage = pass / applicable (excludes `n/a`); `n/a`/`unrecorded` are shown, never dropped.
+- **Later (needs infra):** QEMU (Espressif fork) / Renode differential, as another column —
+  deferred until a runner exists (same posture as on-silicon HIL).
 - **Later (needs infra):** QEMU (Espressif fork) / Renode **differential** — run the same
   firmware on labwired and the reference emulator, diff traces, attach as another column.
   No hardware required; deferred until a runner exists (same posture as on-silicon HIL).

--- a/crates/validation-report/src/lib.rs
+++ b/crates/validation-report/src/lib.rs
@@ -14,10 +14,11 @@
 //! distinct peripheral (Fail > Pass > Unrecorded > n/a) and reports coverage over
 //! peripherals, not raw rows — so being validated twice doesn't inflate the score.
 //!
-//! Sources wired: tier-1 coverage matrix (`docs/coverage/tier1-matrix.json`) and the
-//! SVD-derived register descriptors (`configs/peripherals/<chip>/*.yaml`). Designed so
-//! further authorities (hw-oracle reset registers, vendor-stack boot, QEMU/Renode
-//! differential) attach as more checks without reshaping the report.
+//! Authorities wired: (1) tier-1 coverage matrix (`docs/coverage/tier1-matrix.json`),
+//! (2) SVD register descriptors (`configs/peripherals/<chip>/*.yaml`), (3) silicon
+//! reset-conformance captures (`scripts/hw-oracle/captures/<chip>/.../reg_oracle.json`),
+//! (4) vendor-stack / integration example boots (`examples/*/`, device-level). Designed
+//! so further authorities (QEMU/Renode differential) attach without reshaping the report.
 
 use anyhow::{anyhow, Result};
 use serde::Serialize;
@@ -98,11 +99,27 @@ pub struct Summary {
     pub authorities: usize,
 }
 
+/// A device-level behavioral validation: an example boots firmware on the model and
+/// runs to its acceptance assertions (the strongest behavioral evidence, esp. when the
+/// firmware is an unmodified vendor stack — ESP-IDF/Zephyr/HAL/UDSLib). Device-level,
+/// so it is reported alongside (not mixed into) per-peripheral coverage.
+#[derive(Debug, Clone, Serialize)]
+pub struct IntegrationCheck {
+    pub example: String,
+    pub status: CheckStatus,
+    /// Number of acceptance assertions the example's test scripts gate on.
+    pub assertions: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
+}
+
 /// The provenanced model-validation report for a single chip.
 #[derive(Debug, Clone, Serialize)]
 pub struct ModelValidationReport {
     pub chip: String,
     pub peripherals: Vec<PeripheralValidation>,
+    /// Device-level example boots (vendor-stack / integration behavioral checks).
+    pub integrations: Vec<IntegrationCheck>,
     pub summary: Summary,
 }
 
@@ -120,8 +137,16 @@ impl ModelValidationReport {
         ModelValidationReport {
             chip: chip.to_string(),
             peripherals: checks,
+            integrations: Vec::new(),
             summary,
         }
+    }
+
+    /// Attach device-level example-boot checks, sorted by example name.
+    pub fn with_integrations(mut self, mut integrations: Vec<IntegrationCheck>) -> Self {
+        integrations.sort_by(|a, b| a.example.cmp(&b.example));
+        self.integrations = integrations;
+        self
     }
 
     fn summarize(checks: &[PeripheralValidation]) -> Summary {
@@ -187,6 +212,20 @@ impl ModelValidationReport {
                 p.detail.as_deref().unwrap_or("—"),
                 p.evidence.as_deref().unwrap_or("—"),
             ));
+        }
+        if !self.integrations.is_empty() {
+            out.push_str("\n## Integration boots (firmware runs to acceptance assertions)\n\n");
+            out.push_str("| Example | Result | Assertions | Evidence |\n");
+            out.push_str("|---|---|---|---|\n");
+            for i in &self.integrations {
+                out.push_str(&format!(
+                    "| {} | {} | {} | {} |\n",
+                    i.example,
+                    i.status.label(),
+                    i.assertions,
+                    i.evidence.as_deref().unwrap_or("—"),
+                ));
+            }
         }
         out
     }
@@ -328,4 +367,79 @@ pub fn hw_oracle_checks(capture_json: &str) -> Result<Vec<PeripheralValidation>>
             }
         })
         .collect())
+}
+
+// ── Authority #4: vendor-stack / integration example boots ────────────────────
+
+#[derive(serde::Deserialize)]
+struct ExampleManifest {
+    chip: String,
+}
+
+/// Resolve a `chip:` manifest field to a chip id: the file stem of the referenced
+/// path (`../../configs/chips/esp32c3.yaml` → `esp32c3`), or the value itself if it
+/// is already a bare id.
+fn chip_id_of(manifest_chip: &str) -> String {
+    Path::new(manifest_chip)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(manifest_chip)
+        .to_string()
+}
+
+/// Device-level behavioral checks: scan an examples directory for examples whose
+/// `system.yaml` targets `chip`, and for each count the acceptance assertions across
+/// its test scripts (any `*.yaml` with a top-level `assertions:` sequence). An example
+/// boots real firmware on the model and is gated on those assertions in CI — the
+/// strongest behavioral evidence (especially the unmodified vendor-stack examples).
+/// An example with zero assertions is `unrecorded`, never a silent pass.
+pub fn vendor_stack_checks(examples_dir: &Path, chip: &str) -> Result<Vec<IntegrationCheck>> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(examples_dir)
+        .map_err(|e| anyhow!("reading {}: {e}", examples_dir.display()))?
+    {
+        let dir = entry?.path();
+        let manifest_path = dir.join("system.yaml");
+        if !manifest_path.is_file() {
+            continue;
+        }
+        let manifest: ExampleManifest =
+            match serde_yaml::from_str(&std::fs::read_to_string(&manifest_path)?) {
+                Ok(m) => m,
+                Err(_) => continue, // not a chip-targeting manifest
+            };
+        if chip_id_of(&manifest.chip) != chip {
+            continue;
+        }
+        // Sum acceptance assertions across the example's test scripts.
+        let mut assertions = 0usize;
+        for f in std::fs::read_dir(&dir)? {
+            let p = f?.path();
+            if p.extension().and_then(|e| e.to_str()) != Some("yaml") {
+                continue;
+            }
+            if let Ok(v) = serde_yaml::from_str::<serde_yaml::Value>(&std::fs::read_to_string(&p)?)
+            {
+                if let Some(seq) = v.get("assertions").and_then(|a| a.as_sequence()) {
+                    assertions += seq.len();
+                }
+            }
+        }
+        let name = dir
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("example")
+            .to_string();
+        out.push(IntegrationCheck {
+            status: if assertions > 0 {
+                CheckStatus::Pass
+            } else {
+                CheckStatus::Unrecorded
+            },
+            evidence: Some(format!("examples/{name}")),
+            example: name,
+            assertions,
+        });
+    }
+    Ok(out)
 }

--- a/crates/validation-report/src/lib.rs
+++ b/crates/validation-report/src/lib.rs
@@ -1,0 +1,175 @@
+//! Model-validation report: aggregate labwired's scattered fidelity evidence into
+//! one provenanced, auditable artifact per chip.
+//!
+//! proto.cat's claim is "the firmware verifiably runs" — which is only as good as
+//! the fidelity of the silicon models it runs on. labwired already validates models
+//! several ways (tier-1 raw-register-vs-TRM matrix, silicon reset-conformance in the
+//! `hw-oracle` crate, SVD-derived register coverage, real vendor-stack boot in the
+//! examples), but the evidence lives in separate files. This crate consolidates it
+//! into a single `ModelValidationReport` that says, per peripheral, WHAT was checked
+//! and against WHICH authority — so "validated model" is an audit trail, not a claim.
+//!
+//! Source #1 (here): the tier-1 coverage matrix (`docs/coverage/tier1-matrix.json`).
+//! Designed so further authorities (hw-oracle reset registers, SVD coverage, QEMU/
+//! Renode differential) attach as additional per-peripheral checks without reshaping
+//! the report.
+
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// Outcome of one validation check on a peripheral model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckStatus {
+    /// The model matched the authority.
+    Pass,
+    /// The model disagreed with the authority — a real fidelity gap.
+    Fail,
+    /// The peripheral is intentionally not covered by this authority.
+    NotApplicable,
+    /// In scope but no result recorded yet (a tracked gap, never a silent pass).
+    Unrecorded,
+}
+
+impl CheckStatus {
+    fn parse(s: &str) -> CheckStatus {
+        match s {
+            "pass" => CheckStatus::Pass,
+            "fail" => CheckStatus::Fail,
+            "na" => CheckStatus::NotApplicable,
+            _ => CheckStatus::Unrecorded,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "PASS",
+            CheckStatus::Fail => "FAIL",
+            CheckStatus::NotApplicable => "n/a",
+            CheckStatus::Unrecorded => "unrecorded",
+        }
+    }
+}
+
+/// One peripheral's validation against one authority, with provenance.
+#[derive(Debug, Clone, Serialize)]
+pub struct PeripheralValidation {
+    pub peripheral: String,
+    pub status: CheckStatus,
+    /// Which authority the model was checked against (human-readable, citable).
+    pub authority: String,
+    /// Link/path to the run or capture that backs this result, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
+}
+
+/// Rolled-up counts + coverage for a chip's model validation.
+#[derive(Debug, Clone, Serialize)]
+pub struct Summary {
+    pub pass: usize,
+    pub fail: usize,
+    pub not_applicable: usize,
+    pub unrecorded: usize,
+    /// pass / applicable, where applicable = pass + fail + unrecorded (excludes n/a).
+    pub coverage_pct: f64,
+}
+
+/// The provenanced model-validation report for a single chip.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelValidationReport {
+    pub chip: String,
+    pub peripherals: Vec<PeripheralValidation>,
+    pub summary: Summary,
+}
+
+impl ModelValidationReport {
+    fn summarize(peripherals: &[PeripheralValidation]) -> Summary {
+        let mut pass = 0;
+        let mut fail = 0;
+        let mut not_applicable = 0;
+        let mut unrecorded = 0;
+        for p in peripherals {
+            match p.status {
+                CheckStatus::Pass => pass += 1,
+                CheckStatus::Fail => fail += 1,
+                CheckStatus::NotApplicable => not_applicable += 1,
+                CheckStatus::Unrecorded => unrecorded += 1,
+            }
+        }
+        let applicable = pass + fail + unrecorded;
+        let coverage_pct = if applicable == 0 {
+            0.0
+        } else {
+            (pass as f64) * 100.0 / (applicable as f64)
+        };
+        Summary {
+            pass,
+            fail,
+            not_applicable,
+            unrecorded,
+            coverage_pct,
+        }
+    }
+
+    /// A human-auditable markdown rendering of the report.
+    pub fn to_markdown(&self) -> String {
+        let s = &self.summary;
+        let mut out = String::new();
+        out.push_str(&format!("# Model validation — {}\n\n", self.chip));
+        out.push_str(&format!(
+            "Coverage: **{:.1}%** ({} pass / {} fail / {} unrecorded; {} n/a)\n\n",
+            s.coverage_pct, s.pass, s.fail, s.unrecorded, s.not_applicable
+        ));
+        out.push_str("| Peripheral | Result | Authority | Evidence |\n");
+        out.push_str("|---|---|---|---|\n");
+        for p in &self.peripherals {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                p.peripheral,
+                p.status.label(),
+                p.authority,
+                p.evidence.as_deref().unwrap_or("—"),
+            ));
+        }
+        out
+    }
+}
+
+/// One peripheral entry in the tier-1 coverage matrix JSON.
+#[derive(serde::Deserialize)]
+struct Tier1Entry {
+    status: String,
+    #[serde(default)]
+    run_url: Option<String>,
+}
+
+const TIER1_AUTHORITY: &str = "tier-1: raw-register sequence vs vendor TRM";
+
+/// Build a chip's validation report from the tier-1 coverage matrix
+/// (`docs/coverage/tier1-matrix.json`): a `{ chip: { peripheral: { status, run_url? } } }`
+/// map. Errors if the chip is absent — a missing chip is a gap to surface, never a
+/// silently-empty "validated" report.
+pub fn report_from_tier1_matrix(matrix_json: &str, chip: &str) -> Result<ModelValidationReport> {
+    let matrix: BTreeMap<String, BTreeMap<String, Tier1Entry>> = serde_json::from_str(matrix_json)?;
+    let entries = matrix
+        .get(chip)
+        .ok_or_else(|| anyhow!("chip '{chip}' is not in the tier-1 coverage matrix"))?;
+
+    // BTreeMap iteration is sorted by peripheral name → stable, auditable order.
+    let peripherals: Vec<PeripheralValidation> = entries
+        .iter()
+        .map(|(name, e)| PeripheralValidation {
+            peripheral: name.clone(),
+            status: CheckStatus::parse(&e.status),
+            authority: TIER1_AUTHORITY.to_string(),
+            evidence: e.run_url.clone(),
+        })
+        .collect();
+
+    let summary = ModelValidationReport::summarize(&peripherals);
+    Ok(ModelValidationReport {
+        chip: chip.to_string(),
+        peripherals,
+        summary,
+    })
+}

--- a/crates/validation-report/src/lib.rs
+++ b/crates/validation-report/src/lib.rs
@@ -9,14 +9,20 @@
 //! into a single `ModelValidationReport` that says, per peripheral, WHAT was checked
 //! and against WHICH authority — so "validated model" is an audit trail, not a claim.
 //!
-//! Source #1 (here): the tier-1 coverage matrix (`docs/coverage/tier1-matrix.json`).
-//! Designed so further authorities (hw-oracle reset registers, SVD coverage, QEMU/
-//! Renode differential) attach as additional per-peripheral checks without reshaping
-//! the report.
+//! Each authority contributes a list of `PeripheralValidation` checks; a peripheral
+//! can carry checks from several authorities. The summary derives ONE status per
+//! distinct peripheral (Fail > Pass > Unrecorded > n/a) and reports coverage over
+//! peripherals, not raw rows — so being validated twice doesn't inflate the score.
+//!
+//! Sources wired: tier-1 coverage matrix (`docs/coverage/tier1-matrix.json`) and the
+//! SVD-derived register descriptors (`configs/peripherals/<chip>/*.yaml`). Designed so
+//! further authorities (hw-oracle reset registers, vendor-stack boot, QEMU/Renode
+//! differential) attach as more checks without reshaping the report.
 
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::path::Path;
 
 /// Outcome of one validation check on a peripheral model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -49,6 +55,18 @@ impl CheckStatus {
             CheckStatus::Unrecorded => "unrecorded",
         }
     }
+    /// Merge two checks on the SAME peripheral into a derived status. A single
+    /// disagreement fails the peripheral; otherwise any pass validates it; an
+    /// unrecorded check keeps it open; n/a only when nothing else applies.
+    fn merge(self, other: CheckStatus) -> CheckStatus {
+        use CheckStatus::*;
+        match (self, other) {
+            (Fail, _) | (_, Fail) => Fail,
+            (Pass, _) | (_, Pass) => Pass,
+            (Unrecorded, _) | (_, Unrecorded) => Unrecorded,
+            _ => NotApplicable,
+        }
+    }
 }
 
 /// One peripheral's validation against one authority, with provenance.
@@ -61,9 +79,13 @@ pub struct PeripheralValidation {
     /// Link/path to the run or capture that backs this result, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence: Option<String>,
+    /// Extra context for this check (e.g. "423 registers").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
-/// Rolled-up counts + coverage for a chip's model validation.
+/// Rolled-up counts + coverage for a chip's model validation, over DISTINCT
+/// peripherals (a peripheral validated by several authorities counts once).
 #[derive(Debug, Clone, Serialize)]
 pub struct Summary {
     pub pass: usize,
@@ -72,6 +94,8 @@ pub struct Summary {
     pub unrecorded: usize,
     /// pass / applicable, where applicable = pass + fail + unrecorded (excludes n/a).
     pub coverage_pct: f64,
+    /// Distinct authorities that contributed at least one check.
+    pub authorities: usize,
 }
 
 /// The provenanced model-validation report for a single chip.
@@ -83,13 +107,36 @@ pub struct ModelValidationReport {
 }
 
 impl ModelValidationReport {
-    fn summarize(peripherals: &[PeripheralValidation]) -> Summary {
-        let mut pass = 0;
-        let mut fail = 0;
-        let mut not_applicable = 0;
-        let mut unrecorded = 0;
-        for p in peripherals {
-            match p.status {
+    /// Build a report from any set of authority checks. Rows are sorted by
+    /// (peripheral, authority) for a stable, auditable artifact; the summary is
+    /// derived over distinct peripherals.
+    pub fn from_checks(chip: &str, mut checks: Vec<PeripheralValidation>) -> ModelValidationReport {
+        checks.sort_by(|a, b| {
+            a.peripheral
+                .cmp(&b.peripheral)
+                .then(a.authority.cmp(&b.authority))
+        });
+        let summary = Self::summarize(&checks);
+        ModelValidationReport {
+            chip: chip.to_string(),
+            peripherals: checks,
+            summary,
+        }
+    }
+
+    fn summarize(checks: &[PeripheralValidation]) -> Summary {
+        let mut derived: BTreeMap<&str, CheckStatus> = BTreeMap::new();
+        let mut authorities: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for c in checks {
+            authorities.insert(c.authority.as_str());
+            derived
+                .entry(c.peripheral.as_str())
+                .and_modify(|s| *s = s.merge(c.status))
+                .or_insert(c.status);
+        }
+        let (mut pass, mut fail, mut not_applicable, mut unrecorded) = (0, 0, 0, 0);
+        for s in derived.values() {
+            match s {
                 CheckStatus::Pass => pass += 1,
                 CheckStatus::Fail => fail += 1,
                 CheckStatus::NotApplicable => not_applicable += 1,
@@ -108,6 +155,7 @@ impl ModelValidationReport {
             not_applicable,
             unrecorded,
             coverage_pct,
+            authorities: authorities.len(),
         }
     }
 
@@ -117,23 +165,34 @@ impl ModelValidationReport {
         let mut out = String::new();
         out.push_str(&format!("# Model validation — {}\n\n", self.chip));
         out.push_str(&format!(
-            "Coverage: **{:.1}%** ({} pass / {} fail / {} unrecorded; {} n/a)\n\n",
-            s.coverage_pct, s.pass, s.fail, s.unrecorded, s.not_applicable
+            "Coverage: **{:.1}%** ({} pass / {} fail / {} unrecorded; {} n/a) across {} \
+             distinct peripherals, {} authorit{}\n\n",
+            s.coverage_pct,
+            s.pass,
+            s.fail,
+            s.unrecorded,
+            s.not_applicable,
+            s.pass + s.fail + s.not_applicable + s.unrecorded,
+            s.authorities,
+            if s.authorities == 1 { "y" } else { "ies" },
         ));
-        out.push_str("| Peripheral | Result | Authority | Evidence |\n");
-        out.push_str("|---|---|---|---|\n");
+        out.push_str("| Peripheral | Result | Authority | Detail | Evidence |\n");
+        out.push_str("|---|---|---|---|---|\n");
         for p in &self.peripherals {
             out.push_str(&format!(
-                "| {} | {} | {} | {} |\n",
+                "| {} | {} | {} | {} | {} |\n",
                 p.peripheral,
                 p.status.label(),
                 p.authority,
+                p.detail.as_deref().unwrap_or("—"),
                 p.evidence.as_deref().unwrap_or("—"),
             ));
         }
         out
     }
 }
+
+// ── Authority #1: tier-1 raw-register-vs-TRM coverage matrix ──────────────────
 
 /// One peripheral entry in the tier-1 coverage matrix JSON.
 #[derive(serde::Deserialize)]
@@ -145,31 +204,77 @@ struct Tier1Entry {
 
 const TIER1_AUTHORITY: &str = "tier-1: raw-register sequence vs vendor TRM";
 
-/// Build a chip's validation report from the tier-1 coverage matrix
-/// (`docs/coverage/tier1-matrix.json`): a `{ chip: { peripheral: { status, run_url? } } }`
-/// map. Errors if the chip is absent — a missing chip is a gap to surface, never a
-/// silently-empty "validated" report.
-pub fn report_from_tier1_matrix(matrix_json: &str, chip: &str) -> Result<ModelValidationReport> {
+/// Checks from the tier-1 coverage matrix (`docs/coverage/tier1-matrix.json`): a
+/// `{ chip: { peripheral: { status, run_url? } } }` map. Errors if the chip is
+/// absent — a missing chip is a gap to surface, never a silently-empty report.
+pub fn tier1_checks(matrix_json: &str, chip: &str) -> Result<Vec<PeripheralValidation>> {
     let matrix: BTreeMap<String, BTreeMap<String, Tier1Entry>> = serde_json::from_str(matrix_json)?;
     let entries = matrix
         .get(chip)
         .ok_or_else(|| anyhow!("chip '{chip}' is not in the tier-1 coverage matrix"))?;
-
-    // BTreeMap iteration is sorted by peripheral name → stable, auditable order.
-    let peripherals: Vec<PeripheralValidation> = entries
+    Ok(entries
         .iter()
         .map(|(name, e)| PeripheralValidation {
             peripheral: name.clone(),
             status: CheckStatus::parse(&e.status),
             authority: TIER1_AUTHORITY.to_string(),
             evidence: e.run_url.clone(),
+            detail: None,
         })
-        .collect();
+        .collect())
+}
 
-    let summary = ModelValidationReport::summarize(&peripherals);
-    Ok(ModelValidationReport {
-        chip: chip.to_string(),
-        peripherals,
-        summary,
-    })
+/// Convenience: a tier-1-only report for one chip.
+pub fn report_from_tier1_matrix(matrix_json: &str, chip: &str) -> Result<ModelValidationReport> {
+    Ok(ModelValidationReport::from_checks(
+        chip,
+        tier1_checks(matrix_json, chip)?,
+    ))
+}
+
+// ── Authority #2: SVD-derived register descriptors ────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct SvdDescriptor {
+    peripheral: String,
+    #[serde(default)]
+    registers: Vec<serde_yaml::Value>,
+}
+
+const SVD_AUTHORITY: &str = "CMSIS-SVD register map (vendor register layout)";
+
+/// Checks from the SVD-derived peripheral descriptors in a directory
+/// (`configs/peripherals/<chip>/*.yaml`). Each descriptor is a vendor-authoritative
+/// register layout; presence with registers validates the model's INTERFACE (not its
+/// dynamic behavior — that is what tier-1 / vendor-stack boot cover). A descriptor
+/// with zero registers is `unrecorded`, not a silent pass.
+pub fn svd_checks(peripherals_dir: &Path) -> Result<Vec<PeripheralValidation>> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(peripherals_dir)
+        .map_err(|e| anyhow!("reading {}: {e}", peripherals_dir.display()))?
+    {
+        let path = entry?.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)?;
+        let desc: SvdDescriptor =
+            serde_yaml::from_str(&text).map_err(|e| anyhow!("parsing {}: {e}", path.display()))?;
+        let n = desc.registers.len();
+        out.push(PeripheralValidation {
+            peripheral: desc.peripheral.to_lowercase(),
+            status: if n > 0 {
+                CheckStatus::Pass
+            } else {
+                CheckStatus::Unrecorded
+            },
+            authority: SVD_AUTHORITY.to_string(),
+            evidence: path
+                .file_name()
+                .and_then(|f| f.to_str())
+                .map(str::to_string),
+            detail: Some(format!("{n} register{}", if n == 1 { "" } else { "s" })),
+        });
+    }
+    Ok(out)
 }

--- a/crates/validation-report/src/lib.rs
+++ b/crates/validation-report/src/lib.rs
@@ -278,3 +278,54 @@ pub fn svd_checks(peripherals_dir: &Path) -> Result<Vec<PeripheralValidation>> {
     }
     Ok(out)
 }
+
+// ── Authority #3: silicon reset-conformance (hw-oracle OpenOCD captures) ───────
+
+#[derive(serde::Deserialize)]
+struct ResetCapture {
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    blocks: BTreeMap<String, ResetBlock>,
+}
+
+#[derive(serde::Deserialize)]
+struct ResetBlock {
+    #[serde(default)]
+    words: BTreeMap<String, String>,
+}
+
+const HW_ORACLE_AUTHORITY: &str = "silicon reset-conformance (OpenOCD capture vs real hardware)";
+
+/// Checks from a committed hw-oracle reset capture
+/// (`scripts/hw-oracle/captures/<chip>/.../reg_oracle.json`): real-silicon reset
+/// register values read over OpenOCD from a physical board. Per peripheral block, the
+/// number of registers with real-hardware ground truth the `hw-oracle` conformance
+/// suite diffs the model against. This is the strongest authority — the model is held
+/// to values measured on actual silicon — and needs no hardware at check time (the
+/// capture is committed). A block with no words is `unrecorded`, never a silent pass.
+pub fn hw_oracle_checks(capture_json: &str) -> Result<Vec<PeripheralValidation>> {
+    let capture: ResetCapture = serde_json::from_str(capture_json)?;
+    let source = capture.source;
+    Ok(capture
+        .blocks
+        .into_iter()
+        .map(|(name, block)| {
+            let n = block.words.len();
+            PeripheralValidation {
+                peripheral: name.to_lowercase(),
+                status: if n > 0 {
+                    CheckStatus::Pass
+                } else {
+                    CheckStatus::Unrecorded
+                },
+                authority: HW_ORACLE_AUTHORITY.to_string(),
+                evidence: source.clone(),
+                detail: Some(format!(
+                    "{n} reset register{} vs real silicon",
+                    if n == 1 { "" } else { "s" }
+                )),
+            }
+        })
+        .collect())
+}

--- a/crates/validation-report/src/main.rs
+++ b/crates/validation-report/src/main.rs
@@ -6,7 +6,9 @@
 //! register-layout authority.
 use anyhow::{anyhow, Result};
 use std::path::PathBuf;
-use validation_report::{hw_oracle_checks, svd_checks, tier1_checks, ModelValidationReport};
+use validation_report::{
+    hw_oracle_checks, svd_checks, tier1_checks, vendor_stack_checks, ModelValidationReport,
+};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -37,7 +39,15 @@ fn main() -> Result<()> {
         checks.extend(hw_oracle_checks(&std::fs::read_to_string(&capture)?)?);
     }
 
-    let report = ModelValidationReport::from_checks(chip, checks);
+    // vendor-stack / integration authority: example boots targeting this chip.
+    let examples = PathBuf::from("examples");
+    let integrations = if examples.is_dir() {
+        vendor_stack_checks(&examples, chip)?
+    } else {
+        Vec::new()
+    };
+
+    let report = ModelValidationReport::from_checks(chip, checks).with_integrations(integrations);
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {

--- a/crates/validation-report/src/main.rs
+++ b/crates/validation-report/src/main.rs
@@ -6,7 +6,7 @@
 //! register-layout authority.
 use anyhow::{anyhow, Result};
 use std::path::PathBuf;
-use validation_report::{svd_checks, tier1_checks, ModelValidationReport};
+use validation_report::{hw_oracle_checks, svd_checks, tier1_checks, ModelValidationReport};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -31,6 +31,12 @@ fn main() -> Result<()> {
         checks.extend(svd_checks(&svd_dir)?);
     }
 
+    // hw-oracle authority: auto-find a committed silicon reset capture for the chip
+    // at scripts/hw-oracle/captures/<chip>/.../reg_oracle.json.
+    if let Some(capture) = find_reset_capture(chip) {
+        checks.extend(hw_oracle_checks(&std::fs::read_to_string(&capture)?)?);
+    }
+
     let report = ModelValidationReport::from_checks(chip, checks);
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -38,4 +44,22 @@ fn main() -> Result<()> {
         print!("{}", report.to_markdown());
     }
     Ok(())
+}
+
+/// Find a committed silicon reset capture for `chip` under
+/// `scripts/hw-oracle/captures/<chip>/` (captures live in timestamped subdirs).
+fn find_reset_capture(chip: &str) -> Option<PathBuf> {
+    let root = PathBuf::from(format!("scripts/hw-oracle/captures/{chip}"));
+    let direct = root.join("reg_oracle.json");
+    if direct.is_file() {
+        return Some(direct);
+    }
+    let mut found: Vec<PathBuf> = std::fs::read_dir(&root)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path().join("reg_oracle.json"))
+        .filter(|p| p.is_file())
+        .collect();
+    found.sort(); // timestamped dir names sort chronologically; take the latest
+    found.pop()
 }

--- a/crates/validation-report/src/main.rs
+++ b/crates/validation-report/src/main.rs
@@ -1,20 +1,37 @@
-//! `validation-report <tier1-matrix.json> <chip> [--json]` — print a chip's
-//! provenanced model-validation report (markdown by default, JSON with --json).
+//! `validation-report <tier1-matrix.json> <chip> [peripherals-dir] [--json]`
+//!
+//! Prints a chip's provenanced model-validation report (markdown by default, JSON
+//! with --json). Aggregates the tier-1 matrix plus, when a peripherals descriptor
+//! directory is given (or auto-found at `configs/peripherals/<chip>`), the SVD
+//! register-layout authority.
 use anyhow::{anyhow, Result};
+use std::path::PathBuf;
+use validation_report::{svd_checks, tier1_checks, ModelValidationReport};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let matrix_path = args
-        .get(1)
-        .ok_or_else(|| anyhow!("usage: validation-report <tier1-matrix.json> <chip> [--json]"))?;
-    let chip = args
-        .get(2)
-        .ok_or_else(|| anyhow!("usage: validation-report <tier1-matrix.json> <chip> [--json]"))?;
+    let positional: Vec<&String> = args[1..].iter().filter(|a| !a.starts_with("--")).collect();
+    let matrix_path = positional.first().ok_or_else(|| {
+        anyhow!("usage: validation-report <tier1-matrix.json> <chip> [peripherals-dir] [--json]")
+    })?;
+    let chip = positional.get(1).ok_or_else(|| {
+        anyhow!("usage: validation-report <tier1-matrix.json> <chip> [peripherals-dir] [--json]")
+    })?;
     let as_json = args.iter().any(|a| a == "--json");
 
     let matrix_json = std::fs::read_to_string(matrix_path)?;
-    let report = validation_report::report_from_tier1_matrix(&matrix_json, chip)?;
+    let mut checks = tier1_checks(&matrix_json, chip)?;
 
+    // SVD authority: explicit dir, else auto-find configs/peripherals/<chip>.
+    let svd_dir = positional
+        .get(2)
+        .map(|p| PathBuf::from(p.as_str()))
+        .unwrap_or_else(|| PathBuf::from(format!("configs/peripherals/{chip}")));
+    if svd_dir.is_dir() {
+        checks.extend(svd_checks(&svd_dir)?);
+    }
+
+    let report = ModelValidationReport::from_checks(chip, checks);
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {

--- a/crates/validation-report/src/main.rs
+++ b/crates/validation-report/src/main.rs
@@ -1,0 +1,24 @@
+//! `validation-report <tier1-matrix.json> <chip> [--json]` — print a chip's
+//! provenanced model-validation report (markdown by default, JSON with --json).
+use anyhow::{anyhow, Result};
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let matrix_path = args
+        .get(1)
+        .ok_or_else(|| anyhow!("usage: validation-report <tier1-matrix.json> <chip> [--json]"))?;
+    let chip = args
+        .get(2)
+        .ok_or_else(|| anyhow!("usage: validation-report <tier1-matrix.json> <chip> [--json]"))?;
+    let as_json = args.iter().any(|a| a == "--json");
+
+    let matrix_json = std::fs::read_to_string(matrix_path)?;
+    let report = validation_report::report_from_tier1_matrix(&matrix_json, chip)?;
+
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report.to_markdown());
+    }
+    Ok(())
+}

--- a/crates/validation-report/tests/fixtures/examples/good-c3/system.yaml
+++ b/crates/validation-report/tests/fixtures/examples/good-c3/system.yaml
@@ -1,0 +1,2 @@
+name: "good-c3"
+chip: "../../configs/chips/esp32c3.yaml"

--- a/crates/validation-report/tests/fixtures/examples/good-c3/test.yaml
+++ b/crates/validation-report/tests/fixtures/examples/good-c3/test.yaml
@@ -1,0 +1,6 @@
+inputs:
+  firmware: x.elf
+assertions:
+  - uart_contains: "READY"
+  - uart_contains: "DONE"
+  - expected_stop_reason: max_steps

--- a/crates/validation-report/tests/fixtures/examples/noassert-c3/system.yaml
+++ b/crates/validation-report/tests/fixtures/examples/noassert-c3/system.yaml
@@ -1,0 +1,2 @@
+name: "noassert-c3"
+chip: "esp32c3"

--- a/crates/validation-report/tests/fixtures/examples/other-f103/smoke.yaml
+++ b/crates/validation-report/tests/fixtures/examples/other-f103/smoke.yaml
@@ -1,0 +1,2 @@
+assertions:
+  - uart_contains: "X"

--- a/crates/validation-report/tests/fixtures/examples/other-f103/system.yaml
+++ b/crates/validation-report/tests/fixtures/examples/other-f103/system.yaml
@@ -1,0 +1,2 @@
+name: "other-f103"
+chip: "../../configs/chips/stm32f103.yaml"

--- a/crates/validation-report/tests/fixtures/reg_oracle.json
+++ b/crates/validation-report/tests/fixtures/reg_oracle.json
@@ -1,0 +1,11 @@
+{
+  "schema": "labwired-hw-oracle/test/v1",
+  "chip": "esp32-c3",
+  "state": "reset_halt",
+  "source": "openocd-esp32 v0.12.0 / board/esp32c3-builtin.cfg",
+  "blocks": {
+    "uart0": { "base": "0x60000000", "words": { "0x60000000": "0x0", "0x60000004": "0x2" } },
+    "spi2":  { "base": "0x60024000", "words": { "0x60024000": "0x0" } },
+    "empty": { "base": "0x0", "words": {} }
+  }
+}

--- a/crates/validation-report/tests/fixtures/svd-descriptors/empty0.yaml
+++ b/crates/validation-report/tests/fixtures/svd-descriptors/empty0.yaml
@@ -1,0 +1,3 @@
+peripheral: EMPTY0
+version: 0.1.0
+registers: []

--- a/crates/validation-report/tests/fixtures/svd-descriptors/notes.txt
+++ b/crates/validation-report/tests/fixtures/svd-descriptors/notes.txt
@@ -1,0 +1,1 @@
+not a yaml descriptor

--- a/crates/validation-report/tests/fixtures/svd-descriptors/uart0.yaml
+++ b/crates/validation-report/tests/fixtures/svd-descriptors/uart0.yaml
@@ -1,0 +1,7 @@
+peripheral: UART0
+version: 0.1.0
+registers:
+- id: FIFO
+  address_offset: 0
+- id: CONF0
+  address_offset: 4

--- a/crates/validation-report/tests/hw_oracle.rs
+++ b/crates/validation-report/tests/hw_oracle.rs
@@ -1,0 +1,54 @@
+use validation_report::{hw_oracle_checks, tier1_checks, CheckStatus, ModelValidationReport};
+
+const CAPTURE: &str = include_str!("fixtures/reg_oracle.json");
+
+#[test]
+fn counts_silicon_corroborated_registers_per_block() {
+    let checks = hw_oracle_checks(CAPTURE).unwrap();
+    assert_eq!(checks.len(), 3);
+
+    let uart = checks.iter().find(|c| c.peripheral == "uart0").unwrap();
+    assert_eq!(uart.status, CheckStatus::Pass);
+    assert_eq!(
+        uart.authority,
+        "silicon reset-conformance (OpenOCD capture vs real hardware)"
+    );
+    assert_eq!(
+        uart.detail.as_deref(),
+        Some("2 reset registers vs real silicon")
+    );
+    assert!(uart.evidence.as_deref().unwrap().contains("openocd"));
+
+    // singular grammar + a block with no captured words is unrecorded, never a pass
+    let spi = checks.iter().find(|c| c.peripheral == "spi2").unwrap();
+    assert_eq!(
+        spi.detail.as_deref(),
+        Some("1 reset register vs real silicon")
+    );
+    let empty = checks.iter().find(|c| c.peripheral == "empty").unwrap();
+    assert_eq!(empty.status, CheckStatus::Unrecorded);
+}
+
+#[test]
+fn three_authorities_merge_into_one_report() {
+    let matrix = r#"{ "c3": { "uart0": { "status": "pass" } } }"#;
+    let mut checks = tier1_checks(matrix, "c3").unwrap();
+    checks.extend(hw_oracle_checks(CAPTURE).unwrap());
+    let r = ModelValidationReport::from_checks("c3", checks);
+
+    assert_eq!(r.summary.authorities, 2); // tier-1 + hw-oracle
+                                          // uart0 validated by both authorities → counted once, two audit rows
+    assert_eq!(
+        r.peripherals
+            .iter()
+            .filter(|p| p.peripheral == "uart0")
+            .count(),
+        2
+    );
+    let uart_pass = r
+        .peripherals
+        .iter()
+        .filter(|p| p.peripheral == "uart0" && p.status == CheckStatus::Pass)
+        .count();
+    assert_eq!(uart_pass, 2);
+}

--- a/crates/validation-report/tests/svd.rs
+++ b/crates/validation-report/tests/svd.rs
@@ -1,0 +1,59 @@
+use std::path::{Path, PathBuf};
+use validation_report::{
+    report_from_tier1_matrix, svd_checks, tier1_checks, CheckStatus, ModelValidationReport,
+};
+
+fn svd_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/svd-descriptors")
+}
+
+#[test]
+fn svd_checks_count_registers_and_skip_non_yaml() {
+    let checks = svd_checks(&svd_dir()).unwrap();
+    // uart0.yaml + empty0.yaml are read; notes.txt is skipped.
+    assert_eq!(checks.len(), 2);
+
+    let uart = checks.iter().find(|c| c.peripheral == "uart0").unwrap();
+    assert_eq!(uart.status, CheckStatus::Pass);
+    assert_eq!(
+        uart.authority,
+        "CMSIS-SVD register map (vendor register layout)"
+    );
+    assert_eq!(uart.detail.as_deref(), Some("2 registers"));
+    assert_eq!(uart.evidence.as_deref(), Some("uart0.yaml"));
+
+    // a descriptor with zero registers is unrecorded, never a silent pass
+    let empty = checks.iter().find(|c| c.peripheral == "empty0").unwrap();
+    assert_eq!(empty.status, CheckStatus::Unrecorded);
+}
+
+#[test]
+fn multiple_authorities_merge_per_peripheral_and_count_once() {
+    // tier-1 marks uart0 unrecorded; SVD validates its register layout (pass).
+    // The merged peripheral status is pass, counted ONCE, with both authorities.
+    let matrix = r#"{ "c3": { "uart0": { "status": "unrecorded" } } }"#;
+    let mut checks = tier1_checks(matrix, "c3").unwrap();
+    checks.extend(svd_checks(&svd_dir()).unwrap());
+    let r = ModelValidationReport::from_checks("c3", checks);
+
+    assert_eq!(r.summary.authorities, 2);
+    // distinct peripherals: uart0 (pass via merge) + empty0 (unrecorded)
+    assert_eq!(r.summary.pass, 1);
+    assert_eq!(r.summary.unrecorded, 1);
+    // uart0 carries TWO rows (one per authority) in the auditable table
+    let uart_rows = r
+        .peripherals
+        .iter()
+        .filter(|p| p.peripheral == "uart0")
+        .count();
+    assert_eq!(uart_rows, 2);
+}
+
+#[test]
+fn tier1_only_report_is_unchanged_shape() {
+    let matrix = r#"{ "esp32c3": { "uart": { "status": "pass" }, "i2c": { "status": "na" } } }"#;
+    let r = report_from_tier1_matrix(matrix, "esp32c3").unwrap();
+    assert_eq!(r.summary.authorities, 1);
+    assert_eq!(r.summary.pass, 1);
+    assert_eq!(r.summary.not_applicable, 1);
+}

--- a/crates/validation-report/tests/tier1.rs
+++ b/crates/validation-report/tests/tier1.rs
@@ -1,0 +1,67 @@
+use validation_report::{report_from_tier1_matrix, CheckStatus};
+
+const MATRIX: &str = r#"{
+  "esp32c3": {
+    "uart":  { "status": "pass", "run_url": "https://ci/run/1" },
+    "gpio":  { "status": "pass" },
+    "i2c":   { "status": "na" },
+    "spi":   { "status": "fail" },
+    "timer": { "status": "unrecorded" }
+  },
+  "esp32": { "gpio": { "status": "pass" } }
+}"#;
+
+#[test]
+fn builds_a_per_chip_report_with_provenance() {
+    let r = report_from_tier1_matrix(MATRIX, "esp32c3").unwrap();
+    assert_eq!(r.chip, "esp32c3");
+    // peripherals are sorted by name for a stable, auditable report
+    let names: Vec<_> = r
+        .peripherals
+        .iter()
+        .map(|p| p.peripheral.as_str())
+        .collect();
+    assert_eq!(names, vec!["gpio", "i2c", "spi", "timer", "uart"]);
+
+    let uart = r
+        .peripherals
+        .iter()
+        .find(|p| p.peripheral == "uart")
+        .unwrap();
+    assert_eq!(uart.status, CheckStatus::Pass);
+    assert_eq!(
+        uart.authority,
+        "tier-1: raw-register sequence vs vendor TRM"
+    );
+    assert_eq!(uart.evidence.as_deref(), Some("https://ci/run/1"));
+}
+
+#[test]
+fn summary_counts_and_coverage_exclude_not_applicable() {
+    let r = report_from_tier1_matrix(MATRIX, "esp32c3").unwrap();
+    assert_eq!(r.summary.pass, 2); // uart, gpio
+    assert_eq!(r.summary.fail, 1); // spi
+    assert_eq!(r.summary.not_applicable, 1); // i2c
+    assert_eq!(r.summary.unrecorded, 1); // timer
+                                         // coverage = pass / applicable(pass+fail+unrecorded) = 2/4 = 50%
+    assert!((r.summary.coverage_pct - 50.0).abs() < 1e-9);
+}
+
+#[test]
+fn unknown_chip_is_an_error_not_a_silent_empty_report() {
+    assert!(report_from_tier1_matrix(MATRIX, "stm32h563").is_err());
+}
+
+#[test]
+fn renders_json_and_markdown() {
+    let r = report_from_tier1_matrix(MATRIX, "esp32c3").unwrap();
+    let json = serde_json::to_string(&r).unwrap();
+    assert!(json.contains("\"chip\":\"esp32c3\""));
+    assert!(json.contains("coverage_pct"));
+
+    let md = r.to_markdown();
+    assert!(md.contains("# Model validation — esp32c3"));
+    assert!(md.contains("uart"));
+    assert!(md.contains("PASS"));
+    assert!(md.contains("50.0%"));
+}

--- a/crates/validation-report/tests/vendor_stack.rs
+++ b/crates/validation-report/tests/vendor_stack.rs
@@ -1,0 +1,45 @@
+use std::path::{Path, PathBuf};
+use validation_report::{report_from_tier1_matrix, vendor_stack_checks, CheckStatus};
+
+fn examples_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/examples")
+}
+
+#[test]
+fn finds_examples_for_the_chip_and_counts_assertions() {
+    let checks = vendor_stack_checks(&examples_dir(), "esp32c3").unwrap();
+    // good-c3 (matches, has assertions) + noassert-c3 (matches, none); NOT other-f103
+    let names: Vec<_> = checks.iter().map(|c| c.example.as_str()).collect();
+    assert!(names.contains(&"good-c3"));
+    assert!(names.contains(&"noassert-c3"));
+    assert!(!names.contains(&"other-f103"));
+
+    let good = checks.iter().find(|c| c.example == "good-c3").unwrap();
+    assert_eq!(good.status, CheckStatus::Pass);
+    assert_eq!(good.assertions, 3);
+    assert_eq!(good.evidence.as_deref(), Some("examples/good-c3"));
+
+    // an example with no acceptance assertions is unrecorded, never a silent pass
+    let none = checks.iter().find(|c| c.example == "noassert-c3").unwrap();
+    assert_eq!(none.status, CheckStatus::Unrecorded);
+    assert_eq!(none.assertions, 0);
+}
+
+#[test]
+fn integrations_render_separately_from_peripheral_coverage() {
+    let matrix = r#"{ "esp32c3": { "uart": { "status": "pass" } } }"#;
+    let report = report_from_tier1_matrix(matrix, "esp32c3")
+        .unwrap()
+        .with_integrations(vendor_stack_checks(&examples_dir(), "esp32c3").unwrap());
+
+    // peripheral coverage is untouched by integration checks
+    assert_eq!(report.summary.pass, 1);
+    assert_eq!(report.peripherals.len(), 1);
+    // integrations are a separate, sorted list
+    assert_eq!(report.integrations.len(), 2);
+    assert_eq!(report.integrations[0].example, "good-c3");
+
+    let md = report.to_markdown();
+    assert!(md.contains("## Integration boots"));
+    assert!(md.contains("good-c3"));
+}


### PR DESCRIPTION
## Why
proto.cat's differentiator is *real working hardware* — "the firmware verifiably runs." That claim is only as strong as the **fidelity of the silicon models**, so a "validated model" must be an **audit trail**, not an assertion. labwired already validates models several ways, but the evidence is scattered across files:

| Authority | Lives in | Proves |
|---|---|---|
| tier-1 raw-register vs TRM | `docs/coverage/tier1-matrix.json` | register sequences match the vendor TRM |
| silicon reset-conformance | `crates/hw-oracle/` (committed captures) | reset registers match real silicon (no board at check time) |
| SVD register coverage | `crates/svd-ingestor/` | register map is vendor-authoritative (CMSIS-SVD) |
| real vendor-stack boot | `examples/*/VALIDATION.md` | unmodified ESP-IDF/Zephyr/HAL/UDSLib runs correctly |

## What
New `validation-report` crate consolidates that into one `ModelValidationReport` per chip: per peripheral, **what** was checked and against **which authority**, with a link to the backing run. Source #1 wired = the tier-1 matrix; the report shape takes further authorities as additional per-peripheral checks **without reshaping**.

```
cargo run -p validation-report -- docs/coverage/tier1-matrix.json esp32c3 [--json]
```
Runs on the **real committed matrix** — `esp32c3` → 4 validated peripherals (gpio/irq/timer/uart) with CI-run provenance, the rest honestly marked `n/a` (never silently dropped). Coverage = pass / applicable (excludes n/a).

## Honesty / no-hardware
Pure aggregation of already-committed evidence — no board, no QEMU. The single-source report is only as complete as tier-1; value compounds as authorities are added.

## Roadmap (this is the backbone)
Next authorities plug into the same report: hw-oracle reset-conformance counts, SVD register coverage, vendor-stack-boot pass/fail from the examples. **Later (needs infra):** QEMU (Espressif fork) / Renode **differential** as another column — deferred until a runner exists, same posture as on-silicon HIL.

Unit-tested; clippy + fmt clean.