### PR TITLE
fix(uart): persist STM32 USARTv2 BRR for read-back fidelity

### DIFF
--- a/crates/core/src/peripherals/uart.rs
+++ b/crates/core/src/peripherals/uart.rs
@@ -989,6 +989,17 @@ impl crate::Peripheral for Uart {
                 return Ok(b);
             }
         }
+        // V2 (USARTv2: L4/F7/G0/H7…) BRR read-back. The USART exposes USARTDIV
+        // at 0x0C, and Zephyr's uart_stm32_set_baudrate writes it then reads it
+        // back to `__ASSERT(BRR >= 16)`. The divisor has no behavioural effect in
+        // this instruction-level model (byte timing is not simulated), but the
+        // register must read what firmware wrote or the assert panics at boot.
+        if matches!(self.layout, UartRegisterLayout::Stm32V2) {
+            let bo = offset.wrapping_sub(0x0C);
+            if bo < 4 {
+                return Ok((((self.brr & 0x0000_FFFF) >> (bo * 8)) & 0xFF) as u8);
+            }
+        }
         if offset == self.cr3_offset() {
             return Ok(self.cr3 as u8);
         }
@@ -1020,6 +1031,13 @@ impl crate::Peripheral for Uart {
             if (self.cr3 & (1 << 7)) != 0 {
                 self.dma_tx_pending = true;
             }
+        } else if matches!(self.layout, UartRegisterLayout::Stm32V2)
+            && offset.wrapping_sub(0x0C) < 4
+        {
+            // V2 BRR@0x0C: capture the written USARTDIV byte so the driver's
+            // read-back assert (BRR >= 16) sees what it wrote. Read-back only.
+            let shift = (offset - 0x0C) * 8;
+            self.brr = (self.brr & !(0xFF << shift)) | ((value as u32) << shift);
         } else if offset == self.cr3_offset() {
             self.cr3 = value as u32;
             if (self.cr3 & (1 << 7)) != 0 {
@@ -1185,6 +1203,36 @@ mod tests {
         assert_ne!(isr & (1 << 21), 0, "TEACK set once UE+TE");
         assert_ne!(isr & (1 << 22), 0, "REACK set once UE+RE");
         assert_eq!(isr & 0xC0, 0xC0, "TXE/TC still present");
+    }
+
+    /// Modern-USART BRR (USARTDIV) lives at 0x0C and must read back what
+    /// firmware wrote: Zephyr's uart_stm32_set_baudrate writes BRR then
+    /// `__ASSERT(BRR >= 16)`. A model that dropped the write returned 0 and
+    /// panicked the kernel before the console banner (silent boot hang).
+    /// BRR is read-back-only here — it has no behavioural effect on the
+    /// instruction-level TX path (byte timing is not simulated).
+    #[test]
+    fn test_uart_v2_brr_readback() {
+        let mut uart = Uart::new_with_layout(UartRegisterLayout::Stm32V2);
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        uart.set_sink(Some(sink.clone()), false);
+
+        // Reset BRR reads 0; the driver's assert would fire here.
+        assert_eq!(uart.read_u32(0x0C).unwrap(), 0);
+
+        // 80 MHz PCLK1 / 115200 baud, oversampling 16 → USARTDIV = 694 (0x2B6).
+        uart.write_u32(0x0C, 0x2B6).unwrap();
+        assert_eq!(uart.read_u32(0x0C).unwrap(), 0x2B6, "BRR reads back");
+        assert!(
+            uart.read_u32(0x0C).unwrap() >= 16,
+            "passes BRR >= 16 assert"
+        );
+
+        // Writing BRR must not transmit (TDR is 0x28).
+        assert!(sink.lock().unwrap().is_empty(), "BRR write is not a TX");
+        // Only the upper 16 bits are reserved; the divisor is 16-bit.
+        uart.write_u32(0x0C, 0xFFFF_FFFF).unwrap();
+        assert_eq!(uart.read_u32(0x0C).unwrap(), 0x0000_FFFF, "BRR is 16-bit");
     }
 
     #[test]

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-23 | ⚠ drift acked 2026-06-23 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-23 | ⚠ drift acked 2026-06-23 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-20 | ⚠ drift acked 2026-06-20 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-26 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-26 | no silicon capture |
@@ -43,7 +43,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-06-26 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -60,7 +60,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-06-26 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -69,7 +69,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-06-26 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -78,7 +78,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-06-26 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -87,7 +87,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-06-26 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -105,7 +105,11 @@ boards:
     # hardcoded behaviour byte-for-byte (ISR@0x1C, TDR@0x28, RDR@0x24, status_idle
     # 0xC0=TXE|TC, RXNE 1<<5, TXEIE 1<<7/TCIE 1<<6); h563_mmio_diff/parity pass
     # unchanged, so no behavioural change to this board's pinned registers.
-    drift_ack: 2026-06-26
+    # 2026-06-27: Stm32V2 USART now persists BRR (USARTDIV @ 0x0C) for read-back
+    # fidelity (was dropped → read 0). Additive and read-back only — no byte-path
+    # or reset-value change; h563_mmio_diff/parity (which don't write-then-read BRR)
+    # pass unchanged. No live re-capture this session.
+    drift_ack: 2026-06-27
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -165,7 +169,13 @@ boards:
     # byte-for-byte (status_idle 0xC0=TXE|TC, RXNE 1<<5, same ISR/TDR/RDR offsets);
     # l476_mmio_diff + l476_parity_diff pass unchanged → no behavioural change to
     # this board's pinned registers. No live re-capture this session.
-    drift_ack: 2026-06-26
+    # 2026-06-27: Stm32V2 USART now persists BRR (USARTDIV @ 0x0C) for read-back
+    # fidelity (was dropped → read 0). This fix lets unmodified Zephyr ztest run on
+    # this board: uart_stm32_set_baudrate writes BRR then __ASSERT(BRR >= 16), which
+    # previously panicked at PRE_KERNEL boot. Additive, read-back only — no byte-path
+    # change; l476_mmio_diff/parity (no BRR write-then-read) pass unchanged. tests/
+    # ztest/base now reaches PROJECT EXECUTION SUCCESSFUL. No live re-capture.
+    drift_ack: 2026-06-27
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -198,7 +208,11 @@ boards:
     # (status_idle 0xC0, RXNE 1<<5, same offsets); l0_mmio_diff passes unchanged →
     # no behavioural change to this board's pinned registers. No live re-capture
     # this session.
-    drift_ack: 2026-06-26
+    # 2026-06-27: Stm32V2 USART now persists BRR (USARTDIV @ 0x0C) for read-back
+    # fidelity (was dropped → read 0). Additive, read-back only — no byte-path or
+    # reset-value change; l0_mmio_diff (no BRR write-then-read) passes unchanged.
+    # No live re-capture this session.
+    drift_ack: 2026-06-27
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -227,7 +241,10 @@ boards:
     # (SR@0x00, DR@0x04, status_idle 0xC0=TXE|TC, RXNE 1<<5, TXEIE 1<<7/TCIE 1<<6);
     # stm32f1_mmio_diff + f103_conformance digest pass unchanged → no behavioural
     # change to this board's pinned registers. No live re-capture this session.
-    drift_ack: 2026-06-26
+    # 2026-06-27: uart.rs BRR read-back fix is gated to the Stm32V2 layout; the F1
+    # USART arm (this board) is untouched — purely a shared-file hash drift, zero
+    # behavioural change. stm32f1_mmio_diff + f103_conformance pass unchanged.
+    drift_ack: 2026-06-27
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -262,7 +279,10 @@ boards:
     # DR@0x04, status_idle 0xC0, RXNE 1<<5). UART was already smoke-tier here (not
     # in the mmio diff), so this board's silicon-pinned set is unaffected. No live
     # re-capture this session.
-    drift_ack: 2026-06-26
+    # 2026-06-27: uart.rs BRR read-back fix is gated to the Stm32V2 layout; the F1
+    # USART arm (this board) is untouched — purely a shared-file hash drift, zero
+    # behavioural change. stm32f4_mmio_diff passes unchanged.
+    drift_ack: 2026-06-27
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
## What

The modern STM32 USART (USARTv2 — L4/F7/G0/H7…, the `Stm32V2` layout) exposes the baud-rate divisor **BRR at offset 0x0C**, but the UART model only captured config registers for the F1 layout. A write to BRR was dropped and the read-back returned 0.

## Why it mattered

Zephyr's `uart_stm32_set_baudrate` writes BRR then `__ASSERT(LL_USART_ReadReg(usart, BRR) >= 16)`. With the read-back stuck at 0, the assert tripped `k_panic` during **PRE_KERNEL** UART init — *before* the console banner. So:

- **`CONFIG_ASSERT=y` images** (every ztest kernel suite) hung **silently at boot** on a V2-USART chip.
- **`CONFIG_ASSERT=n` images** (e.g. the console `hello_world` sample) ran fine, because the byte path ignores BRR and the dropped read-back was never checked.

That asymmetry is why a board could pass the console harness but hang the kernel suites — a real silicon-model fidelity gap, surfaced by running unmodified Zephyr ztest through the simulator.

## Fix

Capture the V2 BRR write (16-bit USARTDIV) and serve it back, mirroring the existing F1 read-back fidelity. BRR has **no behavioural effect** in this instruction-level model (byte timing is not simulated) — it is read-back only, exactly like the F1 `BRR/CR2/GTPR` capture.

## Verification

- New regression test `test_uart_v2_brr_readback` (BRR read-back + the `>= 16` assert condition).
- Full core lib suite: **1561 passed, 0 failed**; fmt + clippy clean.
- On NUCLEO-L476RG (`stm32l476`, V2 USART): unmodified Zephyr `tests/ztest/base` now boots and runs to **PROJECT EXECUTION SUCCESSFUL** (8 suites), where it previously hung before the banner. The console `hello_world` path is unaffected.

This unblocks the second-vendor (ST) board on the Zephyr→LabWired twister bridge so its kernel ztest suites — not just the console harness — run green.