### PR TITLE
Green up non-gating CI: rp2040-pio UART + iolinki frame.c submodule bump

### DIFF
--- a/crates/firmware-rp2040-pio-onboarding/src/main.rs
+++ b/crates/firmware-rp2040-pio-onboarding/src/main.rs
@@ -8,9 +8,9 @@ use panic_halt as _;
 const UART0_BASE: u32 = 0x40034000;
 const PIO0_BASE: u32 = 0x50200000;
 
-// UART Registers — labwired's rp2040.yaml models UART0 with the stm32v2
-// profile (TDR at offset 0x28), matching firmware-rp2040-demo.
-const UART0_TDR: *mut u32 = (UART0_BASE + 0x28) as *mut u32;
+// UART data register (PL011 UARTDR at offset 0x00 — the RP2040's real UART,
+// matching firmware-rp2040-demo and configs/chips/rp2040.yaml profile: pl011).
+const UART0_TDR: *mut u32 = UART0_BASE as *mut u32;
 
 // PIO Registers
 const PIO0_CTRL: *mut u32 = PIO0_BASE as *mut u32;


### PR DESCRIPTION
Fixes the two pre-existing red (non-gating) checks on `main`:

**onboarding-rp2040-pio** — the onboarding firmware wrote UART chars to `UART0_BASE+0x28` (a stale stm32v2 TDR offset), but `configs/chips/rp2040.yaml` models UART0 as PL011 (DR at 0x00). Output landed in FBRD and nothing reached the console, so the smoke captured zero bytes. Now writes to the PL011 data register like `firmware-rp2040-demo`; smoke prints `PIO_OK` and passes.

**core-iolink-station** — the station Makefiles compile `third_party/iolinki/src/frame.c`, but the v1.1.2 submodule pin lacked the file (`No rule to make target frame.c`). Bumps the pin to **iolinki v1.1.3**, which adds the shared frame helpers (frame.c/frame.h + tests, cppcheck/clang-format clean).

Verified locally: all three station ELFs build against the CubeL4 pack and `world_multichip` passes 3/3; rp2040-pio onboarding smoke passes (status: pass).