### PR TITLE
fix(i2c): don't assert L4 ISR.TXIS on CR2.START write

### DIFF
--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -451,9 +451,14 @@ impl L4I2c {
                         self.state = I2cState::AddressPending;
                         self.cycles_remaining = 20;
                         self.start_armed = false;
-                    } else {
-                        self.isr |= 1 << 1; // TXIS: hardware requests the byte
                     }
+                    // For a write, TXIS is NOT asserted here: on real STM32 L4
+                    // silicon TXIS only sets once the address phase has been
+                    // clocked out and ACKed (hardware then requests the first
+                    // byte). Firmware reading ISR immediately after setting
+                    // CR2.START sees only BUSY|TXE (0x8001), not TXIS. The byte
+                    // request is modelled by the engine consuming TXDR after the
+                    // address ACK (see `tick`), so no premature TXIS is needed.
                 }
                 if (value & (1 << 14)) != 0 {
                     // STOP: release the bus and tear down any armed/in-flight


### PR DESCRIPTION
## Problem

`test_nucleo_l476rg_i2c_survival` regressed after the L4/V2 I2C transaction engine landed (#394). The survival firmware reads `ISR` immediately after writing `CR2.START` and expects `0x8001` (BUSY bit15 | TXE bit0), but the model returned `0x8003` — an extra `ISR.TXIS` (bit1).

## Root cause

`L4I2c::write_reg` set `ISR.TXIS` synchronously on the `CR2.START` write for a write transfer. On real STM32 L4 silicon `TXIS` is only asserted once the address phase has been clocked out on the bus and ACKed — at that point hardware requests the first data byte. A read of `ISR` in the instant right after `CR2.START` (before any byte is on the wire) sees only BUSY|TXE, never TXIS.

## Fix

Drop the premature `TXIS` assertion. The first-byte request is already modelled by the engine consuming `TXDR` after the address ACK in `tick()`, so nothing depends on the early flag:

- the 6 L4 tier-1 fixtures (l073/l476/g474re/wb55/wba52/h563) write `TXDR` directly and assert `ISR.NACKF` on an absent device — that path is untouched and still PASSes
- the L4 unit tests (`test_l4_i2c_nack_on_no_device`, `test_l4_i2c_ack_delivers_byte_to_device`) never poll TXIS

## Verification

- `cargo test --release -p labwired-core --test firmware_survival` → `test_nucleo_l476rg_i2c_survival` green (38 passed)
- `cargo test --release -p labwired-core i2c` → 91 i2c tests green incl. both L4 NACK/ACK tests
- `cargo test --release -p labwired-core l476`/`l073` conformance + mmio → green
- tier-1: all 6 L4 chips report `TIER1 i2c PASS` + `done` (NACK-backed)
- `cargo test --release -p labwired-cli --test tier1_matrix_ratchet` → green
- `generate_validation_status.py --check --drift` → clean (no board drift; i2c.rs change is silicon-faithful, no drift_ack bump needed)
- `cargo fmt --all` clean; `cargo clippy -p labwired-core --all-targets -- -D warnings` clean

Pre-existing unrelated red: `chip_conformance_ratchet` flags `esp32c3: reg match 354 < baseline 364` — confirmed present on clean origin/main, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)