### PR TITLE
fix(esp32c3): seed silicon reset values in behavioral LEDC + APB_SARADC

### DIFF
--- a/crates/core/src/peripherals/esp32c3/apb_saradc.rs
+++ b/crates/core/src/peripherals/esp32c3/apb_saradc.rs
@@ -81,6 +81,23 @@ const DATA_MASK: u32 = 0x0001_FFFF;
 /// into bits [16:13] (the IDF `ADC_GET_CHANNEL`/`ADC_GET_DATA` layout).
 const DATA_CHANNEL_SHIFT: u32 = 13;
 
+/// Silicon cold-reset values of the register-backed `APB_SARADC` config
+/// registers (`(offset, reset_value)`), corroborated against a live ESP32-C3
+/// (rev v0.4) in `crates/hw-oracle/tests/esp32c3_reset_conformance.rs`. These
+/// power up non-zero; seeding them keeps the behavioral model's cold-reset
+/// readback identical to the demoted declarative descriptor. The behavioral
+/// one-shot logic only reacts to writes, so these defaults do not affect it.
+const RESET_REGS: &[(u64, u32)] = &[
+    (0x00, 0x4003_8240), // CTRL
+    (0x04, 0x0000_A1FE), // CTRL2
+    (0x0C, 0x00FF_0808), // FSM_WAIT
+    (0x20, 0x1A00_0000), // ONETIME_SAMPLE
+    (0x24, 0x0000_0900), // ARB_CTRL
+    (0x50, 0x0000_00FF), // DMA_CONF
+    (0x54, 0x0000_0004), // CLKM_CONF
+    (0x60, 0x0000_8000), // CALI
+];
+
 /// Deterministic fixed 12-bit source code for `channel`. The ramp is injective
 /// over the C3's five ADC1 channels so a reader can prove the result tracks the
 /// SELECTED channel, not a constant.
@@ -122,9 +139,16 @@ impl std::fmt::Debug for Esp32c3ApbSarAdc {
 
 impl Esp32c3ApbSarAdc {
     pub fn new(source_id: u32) -> Self {
+        // Seed the register-backed window with the silicon cold-reset state so
+        // the model's reset readback matches the captured oracle; the remaining
+        // registers power up at 0.
+        let mut regs = vec![0u32; (APB_SARADC_SIZE / 4) as usize];
+        for &(off, val) in RESET_REGS {
+            regs[(off / 4) as usize] = val;
+        }
         Self {
             source_id,
-            regs: vec![0u32; (APB_SARADC_SIZE / 4) as usize],
+            regs,
             int_raw: Cell::new(0),
             sar1_data: 0,
             sar2_data: 0,

--- a/crates/core/src/peripherals/esp32c3/ledc.rs
+++ b/crates/core/src/peripherals/esp32c3/ledc.rs
@@ -59,6 +59,21 @@ pub const LEDC_INTR_SOURCE_ID: u32 = 23;
 /// Number of low-speed timers in the C3 LEDC block.
 const NUM_TIMERS: usize = 4;
 
+/// Number of channels in the C3 LEDC block.
+const NUM_CHANNELS: usize = 6;
+
+/// Silicon reset value of each `LEDC_CHn_CONF1` register (offset `0x0C + n*0x14`):
+/// the channel's `DUTY_START`/duty-increment defaults latched at power-on. These
+/// registers are pure register-backed state in this model, so seeding the reset
+/// value matches the silicon capture without changing timer behavior.
+const CH_CONF1_RESET: u32 = 0x4000_0000;
+
+/// Silicon reset value of each `LEDC_TIMERx_CONF` register (offset `0xA0 + x*8`):
+/// the `RST` bit (bit 23) is set at power-on, i.e. every timer is held in reset
+/// until firmware configures and releases it. The behavioral counter already
+/// honors `RST` (held at 0 while set), so this is the correct cold-reset seed.
+const TIMER_CONF_RESET: u32 = 1 << 23;
+
 /// First timer-config register offset (`TIMER0_CONF`); the four configs are
 /// 8 bytes apart (`TIMERx_VALUE` sits between them).
 const TIMER0_CONF: u64 = 0xA0;
@@ -186,10 +201,23 @@ impl std::fmt::Debug for Esp32c3Ledc {
 
 impl Esp32c3Ledc {
     pub fn new(source_id: u32) -> Self {
+        // Seed the register-backed window with the silicon reset state so the
+        // cold-reset readback matches the captured oracle. Channel CONF1
+        // registers carry a non-zero reset value; the rest power up at 0.
+        let mut regs = vec![0u32; (LEDC_SIZE / 4) as usize];
+        for n in 0..NUM_CHANNELS {
+            let off = 0x0C + n * 0x14;
+            regs[off / 4] = CH_CONF1_RESET;
+        }
+        // Every timer's CONF reset value holds RST (bit 23) set, matching silicon.
+        let timers = core::array::from_fn(|_| Timer {
+            conf: TIMER_CONF_RESET,
+            ..Default::default()
+        });
         Self {
             source_id,
-            regs: vec![0u32; (LEDC_SIZE / 4) as usize],
-            timers: Default::default(),
+            regs,
+            timers,
             int_raw: 0,
             int_ena: 0,
         }

--- a/docs/coverage/chip-conformance.md
+++ b/docs/coverage/chip-conformance.md
@@ -7,21 +7,21 @@ Reg match = verifiable cold-reset registers reproduced. "Excluded" = registers a
 | Chip | Level | Estate | Peripherals | Reg match (verifiable) | Excluded | Behavior gate |
 |------|-------|--------|-------------|------------------------|----------|---------------|
 | esp32c3 | **L2** | ✓ | 39 | 364/402 (90%) | 190 | firmware_survival::test_esp32c3_demo_survival |
-| esp32 | **L0** | ✓ | 10 | — | — | — |
+| esp32 | **L0** | ✓ | 14 | — | — | — |
 | esp32s3 | **L0** | ✓ | 10 | — | — | — |
 | esp32s3-zero | **L0** | ✓ | 17 | — | — | — |
 | stm32f401cdu6 | **L1** | ✓ | 45 | — | — | onboarding-stm32f401cdu6 |
-| nrf52832 | **L1** | ✓ | 1 | — | — | firmware_survival::test_nrf52832_demo_survival |
+| nrf52832 | **L1** | ✓ | 10 | — | — | firmware_survival::test_nrf52832_demo_survival |
 | nrf52840 | **L1** | ✓ | 49 | — | — | firmware_survival::test_nrf52840_demo_survival |
 | nrf5340 | **L1** | ✓ | 20 | — | — | firmware_survival::test_nrf5340_zephyr_survival |
-| rp2040 | **L1** | ✓ | 8 | — | — | firmware_survival::test_rp2040_demo_survival |
+| rp2040 | **L1** | ✓ | 10 | — | — | firmware_survival::test_rp2040_demo_survival |
 | stm32f103 | **L1** | ✓ | 31 | — | — | stm32f1_exec_oracle |
-| stm32f401 | **L1** | ✓ | 10 | — | — | firmware_survival::test_stm32f401_blinky_survival |
-| stm32f407 | **L1** | ✓ | 25 | — | — | firmware_survival::test_nucleo_f407_smoke_survival |
-| stm32g474re | **L0** | ✓ | 11 | — | — | — |
+| stm32f401 | **L1** | ✓ | 15 | — | — | firmware_survival::test_stm32f401_blinky_survival |
+| stm32f407 | **L1** | ✓ | 27 | — | — | firmware_survival::test_nucleo_f407_smoke_survival |
+| stm32g474re | **L0** | ✓ | 20 | — | — | — |
 | stm32h563 | **L1** | ✓ | 37 | — | — | firmware_survival::test_stm32h563_demo_survival |
 | stm32l073 | **L2** | ✓ | 42 | 55/55 (100%) | 5 | firmware_survival::test_nucleo_l073rz_smoke_survival |
 | stm32l476 | **L1** | ✓ | 58 | — | — | firmware_survival::test_nucleo_l476rg_demo_survival |
-| stm32wb55 | **L0** | ✓ | 11 | — | — | — |
-| stm32wba52 | **L0** | ✓ | 11 | — | — | — |
+| stm32wb55 | **L0** | ✓ | 20 | — | — | — |
+| stm32wba52 | **L0** | ✓ | 19 | — | — | — |
 | mkw41z4 | **L1** | ✓ | 18 | — | — | firmware_survival::test_kw41z_smoke_survival |


### PR DESCRIPTION
## Problem

`cargo test --release -p labwired-core chip_conformance` was failing:

```
chip_conformance_ratchet ... FAILED — esp32c3: reg match 354 < baseline 364
```

Recent PRs replaced the esp32c3 `ledc` and `apb_saradc` declarative register-file stubs (which replayed the captured silicon reset values exactly) with behavioral models. Those models constructed their register windows all-zero, so the cold-reset readback diverged from the ESP32-C3 silicon corpus on 10 registers, dropping reg-match 364 -> 354. The deeper `esp32c3_reset_conformance` oracle also went red on 8 APB_SARADC reset values.

## Fix (truthful — baseline NOT lowered)

Seed the silicon cold-reset state at construction:

- **LEDC** (`ledc.rs`): 6x `CHn_CONF1` (`0x0C + n*0x14`) = `0x40000000`; 4x `TIMERx_CONF` (`0xA0 + x*8`) = `0x00800000` (RST bit held set, matching power-on — the counter already honors RST so behavior is unchanged).
- **APB_SARADC** (`apb_saradc.rs`): CTRL `0x40038240`, CTRL2 `0x0000A1FE`, FSM_WAIT `0x00FF0808`, ONETIME_SAMPLE `0x1A000000`, ARB_CTRL `0x00000900`, DMA_CONF `0x000000FF`, CLKM_CONF `0x00000004`, CALI `0x00008000`.

The behavioral logic reacts only to writes, so seeding the reset defaults restores byte-exact reset fidelity without altering timer/conversion behavior. spi2 already seeded its CTRL/CLOCK reset values correctly and needed no change.

## Verification (all green)

- `chip_conformance` ratchet: esp32c3 reg match restored to **364/402** (baseline json untouched).
- `cargo test -p labwired-core esp32c3` (ledc/spi/saradc behavioral unit tests): green.
- `esp32c3_reset_conformance`: green.
- esp32c3 tier1 fixture: `gpio/timer/irq/i2c/spi/adc/ledc PASS`, `done` present.
- `tier1_matrix_ratchet`: green (matrix unchanged, fixture ELF untouched).
- `generate_validation_status.py --check --drift`: clean.
- `cargo fmt --all` + clippy `-D warnings` on labwired-core: clean.

Only core-integrity is required here.