### PR TITLE
Fix: aggregate must refresh matrix when evidence presence changes

### DIFF
--- a/scripts/ci/test_tier1_status_equal.py
+++ b/scripts/ci/test_tier1_status_equal.py
@@ -33,6 +33,18 @@ def test_differs_when_cell_removed(tmp_path):
     assert _run(a, b) == 1
 
 
+def test_differs_when_evidence_gained(tmp_path):
+    # committed has status but no run_url; fresh adds the run_url -> must refresh
+    a = _write(tmp_path, "a.json", {"esp32": {"adc": {"status": "pass"}}})
+    b = _write(tmp_path, "b.json", {"esp32": {"adc": {"status": "pass", "run_url": "https://x/1"}}})
+    assert _run(a, b) == 1
+
+def test_differs_when_evidence_lost(tmp_path):
+    a = _write(tmp_path, "a.json", {"esp32": {"adc": {"status": "pass", "run_url": "https://x/1"}}})
+    b = _write(tmp_path, "b.json", {"esp32": {"adc": {"status": "pass"}}})
+    assert _run(a, b) == 1
+
+
 def test_error_exit_on_malformed(tmp_path):
     good = _write(tmp_path, "g.json", {"esp32": {"adc": {"status": "pass"}}})
     bad = tmp_path / "bad.json"

--- a/scripts/ci/tier1_status_equal.py
+++ b/scripts/ci/tier1_status_equal.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Exit 0 if two tier1 matrices have identical per-cell statuses (ignoring run_url)."""
+"""Exit 0 if two tier1 matrices are equivalent for refresh purposes.
+
+Two matrices are "equal" (exit 0, skip the refresh) iff every cell has the same
+status AND the same evidence PRESENCE (whether a run_url exists). The run_url
+*value* is ignored, so a re-run that only restamps fresh URLs does not churn
+main — but GAINING or LOSING evidence (e.g. a status-only cell that now has a
+run_url) IS a change and triggers a refresh. Without the presence check, a
+committed matrix with statuses but no run_urls would compare equal to a freshly
+stamped one and never get its evidence, leaving the /validation grid all-dots.
+"""
 import json
 import sys
 
@@ -7,7 +16,10 @@ import sys
 def statuses(path: str) -> dict:
     d = json.loads(open(path).read())
     return {
-        chip: {cls: cell.get("status") for cls, cell in row.items()}
+        chip: {
+            cls: (cell.get("status"), bool(cell.get("run_url")))
+            for cls, cell in row.items()
+        }
         for chip, row in d.items()
     }
 


### PR DESCRIPTION
The Phase 4 aggregate skipped refreshing when per-cell STATUS was unchanged, comparing statuses only. But the committed matrix had statuses with NO run_urls, while a fresh run has the same statuses WITH run_urls — so the comparator saw them as equal and never committed the evidence. The /validation grid could never escape all-dots, because adding run_urls doesn't change any status.

Fix: tier1_status_equal.py now compares (status, has_run_url) per cell — gaining/losing evidence triggers a refresh, while run_url VALUE churn is still ignored (no per-merge thrash). Adds tests for evidence gained/lost.