### PR TITLE
ci: add canonical pin-integrity.sh (single source for pinned-core health checks)

### DIFF
--- a/scripts/ci/pin-integrity.sh
+++ b/scripts/ci/pin-integrity.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Canonical "is this core checkout healthy" checks — one source of truth so
+# consumers (e.g. the app repo's pinned-submodule integrity gate) reference
+# these instead of re-hardcoding the commands in their own workflows.
+#   smoke        — run the CLI against a deterministic CI script
+#   determinism  — prove repeated runs match (result + trace)
+#   all          — both (default)
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+run_smoke() {
+  cargo run -q -p labwired-cli -- test \
+    --script examples/ci/dummy-max-uart-bytes.yaml \
+    --output-dir out/integration-smoke --no-uart-stdout
+}
+run_determinism() {
+  cargo test -p labwired-cli --test determinism -- --nocapture
+}
+
+case "${1:-all}" in
+  smoke) run_smoke ;;
+  determinism) run_determinism ;;
+  all) run_smoke; run_determinism ;;
+  *) echo "usage: pin-integrity.sh [smoke|determinism|all]" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
Phase 5 (core side). The app repo's Core Integration CI hardcodes the integration-smoke + determinism commands to verify its pinned core submodule is healthy. This adds `scripts/ci/pin-integrity.sh` (smoke | determinism | all) in core — next to the code it tests — so the app can call it instead of re-hardcoding the commands, keeping one source of truth.

App-side change (app's core-ci.yml calling this) follows in a w1ne/labwired PR once this merges and the app bumps its core pin.