### PR TITLE
chore: bump labwired-core to 0.17.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
 ]
@@ -1681,7 +1681,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1835,11 +1835,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.3"
+version = "0.17.4"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3295,7 +3295,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.3"
+version = "0.17.4"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
Bump version to 0.17.4 to release UARTE EasyDMA TX support merged since v0.17.3 (PR #340).