### PR TITLE
feat(nrf52): unified SPIM0/TWIM0 serial-instance mux at 0x40003000

### DIFF
--- a/configs/chips/nrf52840.yaml
+++ b/configs/chips/nrf52840.yaml
@@ -13,12 +13,12 @@ peripherals:
     base_address: 0x40002000
     size: "4KB"
     irq: 2
-  - id: "spi0"
-    type: "spi"
+  # SPIM0/TWIM0 share 0x40003000; active peripheral selected by ENABLE (6=TWIM, 7=SPIM).
+  - id: "i2c0"
+    type: "nrf52840_serial"
     base_address: 0x40003000
     size: "4KB"
-    config:
-      profile: "nrf52"
+    irq: 3
   - id: "gpio0"
     type: "gpio"
     base_address: 0x50000000

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -629,6 +629,16 @@ impl SystemBus {
             }
         }
 
+        // Serial-instance mux (SPIM0/TWIM0 share one MMIO window) — must
+        // precede the generic "contains(spi)" and "contains(i2c)" matchers.
+        if t == "nrf52840_serial"
+            || t == "nrf52_serial"
+            || t == "nrf52_spim_twim"
+            || t == "nrf52840_spim_twim"
+        {
+            return "nrf52_serial_instance".to_string();
+        }
+
         // 3. Legacy generic SVD-name heuristics (fallback). Fuzzy `contains` /
         //    `starts_with` / `ends_with` matching for raw vendor names we have
         //    not given an explicit canonical type. Ordering matters: specific

--- a/crates/core/src/peripherals/components/i2c_factory.rs
+++ b/crates/core/src/peripherals/components/i2c_factory.rs
@@ -34,6 +34,15 @@ pub fn build_i2c_device(
         // scd41 / sgp41 / sps30 / veml7700 are onboarded through the
         // PeripheralKit registry (peripherals/kit), which dispatches them on
         // both the STM32 and ESP32-C3 I²C buses — no legacy arm needed here.
+        "bme280" => {
+            let address = config
+                .get("i2c_address")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0x76) as u8;
+            Some(Box::new(crate::peripherals::components::Bme280::new(
+                address,
+            )))
+        }
         "bmp280" => {
             let address = config
                 .get("i2c_address")

--- a/crates/core/src/peripherals/nrf52/factory.rs
+++ b/crates/core/src/peripherals/nrf52/factory.rs
@@ -137,17 +137,15 @@ pub fn try_build(
         // nRF52 serial-instance mux: SPIM0/TWIM0 at a single MMIO base.
         // ENABLE=6 selects TWIM, ENABLE=7 selects SPIM (nRF52840 PS §6.31/§6.30).
         "nrf52_serial_instance" => {
-            let mut inst =
-                crate::peripherals::nrf52::serial_instance::Nrf52SerialInstance::new();
+            let mut inst = crate::peripherals::nrf52::serial_instance::Nrf52SerialInstance::new();
             for ext in &manifest.external_devices {
                 if ext.connection != p_cfg.id {
                     continue;
                 }
                 // Try I²C device first.
-                if let Some(device) = crate::peripherals::components::build_i2c_device(
-                    &ext.r#type,
-                    &ext.config,
-                ) {
+                if let Some(device) =
+                    crate::peripherals::components::build_i2c_device(&ext.r#type, &ext.config)
+                {
                     tracing::info!(
                         "serial-instance i2c attach: '{}' (type={}) -> '{}'",
                         ext.id,
@@ -155,10 +153,9 @@ pub fn try_build(
                         p_cfg.id
                     );
                     inst.attach_i2c(device);
-                } else if let Some(device) = crate::peripherals::components::build_spi_device(
-                    &ext.r#type,
-                    &ext.config,
-                ) {
+                } else if let Some(device) =
+                    crate::peripherals::components::build_spi_device(&ext.r#type, &ext.config)
+                {
                     tracing::info!(
                         "serial-instance spi attach: '{}' (type={}) -> '{}'",
                         ext.id,

--- a/crates/core/src/peripherals/nrf52/factory.rs
+++ b/crates/core/src/peripherals/nrf52/factory.rs
@@ -134,6 +134,50 @@ pub fn try_build(
             }
             Box::new(twim)
         }
+        // nRF52 serial-instance mux: SPIM0/TWIM0 at a single MMIO base.
+        // ENABLE=6 selects TWIM, ENABLE=7 selects SPIM (nRF52840 PS §6.31/§6.30).
+        "nrf52_serial_instance" => {
+            let mut inst =
+                crate::peripherals::nrf52::serial_instance::Nrf52SerialInstance::new();
+            for ext in &manifest.external_devices {
+                if ext.connection != p_cfg.id {
+                    continue;
+                }
+                // Try I²C device first.
+                if let Some(device) = crate::peripherals::components::build_i2c_device(
+                    &ext.r#type,
+                    &ext.config,
+                ) {
+                    tracing::info!(
+                        "serial-instance i2c attach: '{}' (type={}) -> '{}'",
+                        ext.id,
+                        ext.r#type,
+                        p_cfg.id
+                    );
+                    inst.attach_i2c(device);
+                } else if let Some(device) = crate::peripherals::components::build_spi_device(
+                    &ext.r#type,
+                    &ext.config,
+                ) {
+                    tracing::info!(
+                        "serial-instance spi attach: '{}' (type={}) -> '{}'",
+                        ext.id,
+                        ext.r#type,
+                        p_cfg.id
+                    );
+                    inst.attach_spi(device);
+                } else {
+                    tracing::warn!(
+                        "serial-instance attach skipped: unknown device type '{}' \
+                         for external id '{}' on bus '{}'",
+                        ext.r#type,
+                        ext.id,
+                        p_cfg.id
+                    );
+                }
+            }
+            Box::new(inst)
+        }
         _ => return None,
     };
     Some(dev)

--- a/crates/core/src/peripherals/nrf52/mod.rs
+++ b/crates/core/src/peripherals/nrf52/mod.rs
@@ -35,6 +35,7 @@ pub mod radio;
 pub mod rng;
 pub mod rtc;
 pub mod saadc;
+pub mod serial_instance;
 pub mod spis;
 pub mod temp;
 pub mod timer;

--- a/crates/core/src/peripherals/nrf52/serial_instance.rs
+++ b/crates/core/src/peripherals/nrf52/serial_instance.rs
@@ -351,14 +351,14 @@ mod tests {
 
         // TX descriptor: send register address byte.
         write32(&mut s, 0x544, tx_base as u32); // TXD.PTR
-        write32(&mut s, 0x548, 1);              // TXD.MAXCNT = 1
+        write32(&mut s, 0x548, 1); // TXD.MAXCNT = 1
 
         // SHORT: LASTTX→STARTRX (write-then-read in one transaction).
         write32(&mut s, 0x200, 1 << 7); // SHORTS: LASTTX_STARTRX
 
         // RX descriptor: receive one byte.
         write32(&mut s, 0x534, rx_base as u32); // RXD.PTR
-        write32(&mut s, 0x538, 1);              // RXD.MAXCNT = 1
+        write32(&mut s, 0x538, 1); // RXD.MAXCNT = 1
 
         // Fire TASKS_STARTTX.
         write32(&mut s, 0x008, 1);
@@ -397,9 +397,9 @@ mod tests {
         write32(&mut s, OFF_ENABLE, ENABLE_SPIM);
 
         write32(&mut s, 0x544, tx_base as u32); // TXD.PTR
-        write32(&mut s, 0x548, 3);              // TXD.MAXCNT
+        write32(&mut s, 0x548, 3); // TXD.MAXCNT
         write32(&mut s, 0x534, rx_base as u32); // RXD.PTR
-        write32(&mut s, 0x538, 3);              // RXD.MAXCNT
+        write32(&mut s, 0x538, 3); // RXD.MAXCNT
 
         // TASKS_START (nRF52 SPIM offset 0x010).
         write32(&mut s, 0x010, 1);
@@ -408,7 +408,11 @@ mod tests {
         s.tick_with_bus(&mut bus);
 
         // EVENTS_END must be 1.
-        assert_eq!(read32(&s, 0x118), 1, "EVENTS_END must be 1 after SPIM transfer");
+        assert_eq!(
+            read32(&s, 0x118),
+            1,
+            "EVENTS_END must be 1 after SPIM transfer"
+        );
         assert_eq!(read32(&s, 0x120), 1, "EVENTS_ENDTX must be 1");
         assert_eq!(read32(&s, 0x110), 1, "EVENTS_ENDRX must be 1");
 

--- a/crates/core/src/peripherals/nrf52/serial_instance.rs
+++ b/crates/core/src/peripherals/nrf52/serial_instance.rs
@@ -1,0 +1,445 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! nRF52 Serial Instance — SPIM0/TWIM0 at a shared base address.
+//!
+//! On real nRF52840 silicon the single 4 KB window at 0x40003000 hosts
+//! SPIM0, SPIS0, SPI0, TWIM0, TWI0 and TWIS0; the active sub-peripheral
+//! is selected by ENABLE (offset 0x500):
+//!
+//!   ENABLE = 6 → TWIM (I²C master with EasyDMA)
+//!   ENABLE = 7 → SPIM (SPI master with EasyDMA)
+//!
+//! This struct wraps [`Spi`] (Nrf52Spim layout) and [`Nrf52Twim`] behind
+//! the same [`Peripheral`] surface. Reads/writes to offset 0x500 update a
+//! shared enable field and are forwarded to both sub-peripherals so their
+//! internal enable state stays coherent. All other offsets are dispatched
+//! to the sub-peripheral selected by the current enable value.
+
+use crate::peripherals::i2c::I2cDevice;
+use crate::peripherals::nrf52::twim::Nrf52Twim;
+use crate::peripherals::spi::{Spi, SpiDevice, SpiRegisterLayout};
+use crate::{Bus, Peripheral, PeripheralTickResult, SimResult};
+
+const OFF_ENABLE: u64 = 0x500;
+const ENABLE_TWIM: u32 = 6;
+const ENABLE_SPIM: u32 = 7;
+const ENABLE_MASK: u32 = 0xF;
+
+/// Unified SPIM0/TWIM0 serial instance at a single MMIO base.
+///
+/// Holds both sub-peripheral models live; the active one is determined by
+/// the ENABLE register at offset 0x500.  Sub-peripheral state is always
+/// up-to-date regardless of which is enabled.
+#[derive(Debug)]
+pub struct Nrf52SerialInstance {
+    spim: Spi,
+    twim: Nrf52Twim,
+    enable: u32,
+}
+
+impl Nrf52SerialInstance {
+    pub fn new() -> Self {
+        Self {
+            spim: Spi::new_with_layout(SpiRegisterLayout::Nrf52Spim),
+            twim: Nrf52Twim::new(),
+            enable: 0,
+        }
+    }
+
+    pub fn attach_i2c(&mut self, dev: Box<dyn I2cDevice>) {
+        self.twim.attach(dev);
+    }
+
+    pub fn attach_spi(&mut self, dev: Box<dyn SpiDevice>) {
+        self.spim.attach(dev);
+    }
+
+    fn active(&self) -> u32 {
+        self.enable & ENABLE_MASK
+    }
+}
+
+impl Default for Nrf52SerialInstance {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Peripheral for Nrf52SerialInstance {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        if offset & !3 == OFF_ENABLE {
+            let byte_shift = (offset % 4) * 8;
+            return Ok(((self.enable & ENABLE_MASK) >> byte_shift) as u8);
+        }
+        match self.active() {
+            ENABLE_TWIM => self.twim.read(offset),
+            ENABLE_SPIM => self.spim.read(offset),
+            _ => Ok(0),
+        }
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        if offset & !3 == OFF_ENABLE {
+            // Reconstruct a 32-bit RMW before forwarding.
+            let byte_shift = (offset % 4) * 8;
+            let mask: u32 = 0xFF << byte_shift;
+            let new32 = (self.enable & !mask) | ((value as u32) << byte_shift);
+            self.enable = new32 & ENABLE_MASK;
+            self.twim.write(offset, value)?;
+            self.spim.write(offset, value)?;
+            return Ok(());
+        }
+        match self.active() {
+            ENABLE_TWIM => self.twim.write(offset, value),
+            ENABLE_SPIM => self.spim.write(offset, value),
+            _ => Ok(()),
+        }
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        if offset == OFF_ENABLE {
+            return Ok(self.enable & ENABLE_MASK);
+        }
+        match self.active() {
+            ENABLE_TWIM => self.twim.read_u32(offset),
+            ENABLE_SPIM => self.spim.read_u32(offset),
+            _ => Ok(0),
+        }
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if offset == OFF_ENABLE {
+            self.enable = value & ENABLE_MASK;
+            // Keep both sub-peripherals' internal enable coherent.
+            self.twim.write_u32(offset, value)?;
+            self.spim.write_u32(offset, value)?;
+            return Ok(());
+        }
+        match self.active() {
+            ENABLE_TWIM => self.twim.write_u32(offset, value),
+            ENABLE_SPIM => self.spim.write_u32(offset, value),
+            _ => Ok(()),
+        }
+    }
+
+    fn read_u16(&self, offset: u64) -> SimResult<u16> {
+        if offset & !3 == OFF_ENABLE {
+            return Ok((self.enable & ENABLE_MASK) as u16);
+        }
+        match self.active() {
+            ENABLE_TWIM => self.twim.read_u16(offset),
+            ENABLE_SPIM => self.spim.read_u16(offset),
+            _ => Ok(0),
+        }
+    }
+
+    fn write_u16(&mut self, offset: u64, value: u16) -> SimResult<()> {
+        if offset & !3 == OFF_ENABLE {
+            self.enable = (value as u32) & ENABLE_MASK;
+            self.twim.write_u16(offset, value)?;
+            self.spim.write_u16(offset, value)?;
+            return Ok(());
+        }
+        match self.active() {
+            ENABLE_TWIM => self.twim.write_u16(offset, value),
+            ENABLE_SPIM => self.spim.write_u16(offset, value),
+            _ => Ok(()),
+        }
+    }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        match self.active() {
+            ENABLE_TWIM => self.twim.tick(),
+            ENABLE_SPIM => self.spim.tick(),
+            _ => PeripheralTickResult::default(),
+        }
+    }
+
+    fn needs_bus_tick(&self) -> bool {
+        match self.active() {
+            ENABLE_TWIM => self.twim.needs_bus_tick(),
+            ENABLE_SPIM => self.spim.needs_bus_tick(),
+            _ => false,
+        }
+    }
+
+    fn tick_with_bus(&mut self, bus: &mut dyn Bus) {
+        match self.active() {
+            ENABLE_TWIM => self.twim.tick_with_bus(bus),
+            ENABLE_SPIM => self.spim.tick_with_bus(bus),
+            _ => {}
+        }
+    }
+
+    fn on_event(
+        &mut self,
+        event_token: u32,
+        sched: &mut crate::sched::EventScheduler,
+        bus: &mut dyn Bus,
+    ) -> crate::sched::EventResult {
+        match self.active() {
+            ENABLE_TWIM => self.twim.on_event(event_token, sched, bus),
+            ENABLE_SPIM => self.spim.on_event(event_token, sched, bus),
+            _ => crate::sched::EventResult::default(),
+        }
+    }
+
+    fn uses_scheduler(&self) -> bool {
+        match self.active() {
+            ENABLE_TWIM => self.twim.uses_scheduler(),
+            ENABLE_SPIM => self.spim.uses_scheduler(),
+            _ => false,
+        }
+    }
+
+    fn sync_to(&mut self, tick_now: u64) {
+        match self.active() {
+            ENABLE_TWIM => self.twim.sync_to(tick_now),
+            ENABLE_SPIM => self.spim.sync_to(tick_now),
+            _ => {}
+        }
+    }
+
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        match self.active() {
+            ENABLE_TWIM => self.twim.take_scheduled_events(),
+            ENABLE_SPIM => self.spim.take_scheduled_events(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::json!({
+            "enable": self.enable,
+            "spim": self.spim.snapshot(),
+            "twim": self.twim.snapshot(),
+        })
+    }
+
+    fn restore(&mut self, state: serde_json::Value) -> SimResult<()> {
+        if let Some(v) = state.get("enable").and_then(|v| v.as_u64()) {
+            self.enable = (v as u32) & ENABLE_MASK;
+        }
+        if let Some(spim_state) = state.get("spim") {
+            self.spim.restore(spim_state.clone())?;
+        }
+        if let Some(twim_state) = state.get("twim") {
+            self.twim.restore(twim_state.clone())?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Bus, DmaRequest, SimulationConfig};
+    use std::collections::HashMap;
+
+    // ── Minimal flat-RAM bus ──────────────────────────────────────────────────
+
+    struct FlatRam {
+        mem: HashMap<u64, u8>,
+        config: SimulationConfig,
+    }
+
+    impl FlatRam {
+        fn new() -> Self {
+            Self {
+                mem: HashMap::new(),
+                config: SimulationConfig::default(),
+            }
+        }
+
+        fn write_slice(&mut self, base: u64, data: &[u8]) {
+            for (i, &b) in data.iter().enumerate() {
+                self.mem.insert(base + i as u64, b);
+            }
+        }
+
+        fn read_slice(&self, base: u64, len: usize) -> Vec<u8> {
+            (0..len)
+                .map(|i| *self.mem.get(&(base + i as u64)).unwrap_or(&0))
+                .collect()
+        }
+    }
+
+    impl Bus for FlatRam {
+        fn read_u8(&self, addr: u64) -> crate::SimResult<u8> {
+            Ok(*self.mem.get(&addr).unwrap_or(&0))
+        }
+        fn write_u8(&mut self, addr: u64, value: u8) -> crate::SimResult<()> {
+            self.mem.insert(addr, value);
+            Ok(())
+        }
+        fn tick_peripherals(&mut self) -> Vec<u32> {
+            Vec::new()
+        }
+        fn execute_dma(&mut self, _requests: &[DmaRequest]) -> crate::SimResult<()> {
+            Ok(())
+        }
+        fn config(&self) -> &SimulationConfig {
+            &self.config
+        }
+    }
+
+    fn write32(s: &mut Nrf52SerialInstance, offset: u64, value: u32) {
+        s.write_u32(offset, value).unwrap();
+    }
+
+    fn read32(s: &Nrf52SerialInstance, offset: u64) -> u32 {
+        s.read_u32(offset).unwrap()
+    }
+
+    // ── ENABLE readback ───────────────────────────────────────────────────────
+
+    #[test]
+    fn enable_readback_twim() {
+        let mut s = Nrf52SerialInstance::new();
+        write32(&mut s, OFF_ENABLE, ENABLE_TWIM);
+        assert_eq!(read32(&s, OFF_ENABLE), ENABLE_TWIM);
+    }
+
+    #[test]
+    fn enable_readback_spim() {
+        let mut s = Nrf52SerialInstance::new();
+        write32(&mut s, OFF_ENABLE, ENABLE_SPIM);
+        assert_eq!(read32(&s, OFF_ENABLE), ENABLE_SPIM);
+    }
+
+    #[test]
+    fn enable_mask_4_bits() {
+        let mut s = Nrf52SerialInstance::new();
+        write32(&mut s, OFF_ENABLE, 0xFF);
+        assert_eq!(read32(&s, OFF_ENABLE), 0xF);
+    }
+
+    // ── TWIM path: muxed BME280 chip-id read (0xD0 → 0x60) ──────────────────
+    //
+    // Sequence mirrors a typical nRF52 I²C register read:
+    //   1. TX  [reg_addr]          — set the register pointer to 0xD0
+    //   2. RX  1 byte              — read the chip-id
+    //
+    // BME280 Bme280::read_register(0xD0) returns 0x60 per the silicon model.
+
+    #[test]
+    fn twim_path_reads_bme280_chip_id() {
+        let bme280 = crate::peripherals::components::Bme280::new(0x76);
+        let mut s = Nrf52SerialInstance::new();
+        s.attach_i2c(Box::new(bme280));
+        let mut bus = FlatRam::new();
+
+        // TX buffer: one byte = register address 0xD0.
+        let tx_base: u64 = 0x2000_0000;
+        let rx_base: u64 = 0x2000_0100;
+        bus.write_slice(tx_base, &[0xD0u8]);
+
+        // Enable TWIM.
+        write32(&mut s, OFF_ENABLE, ENABLE_TWIM);
+
+        // Set I²C target address (BME280 = 0x76).
+        write32(&mut s, 0x588, 0x76); // ADDRESS
+
+        // TX descriptor: send register address byte.
+        write32(&mut s, 0x544, tx_base as u32); // TXD.PTR
+        write32(&mut s, 0x548, 1);              // TXD.MAXCNT = 1
+
+        // SHORT: LASTTX→STARTRX (write-then-read in one transaction).
+        write32(&mut s, 0x200, 1 << 7); // SHORTS: LASTTX_STARTRX
+
+        // RX descriptor: receive one byte.
+        write32(&mut s, 0x534, rx_base as u32); // RXD.PTR
+        write32(&mut s, 0x538, 1);              // RXD.MAXCNT = 1
+
+        // Fire TASKS_STARTTX.
+        write32(&mut s, 0x008, 1);
+        assert!(s.needs_bus_tick(), "pending TX must be set");
+
+        // Tick 1: TX completes → LASTTX_STARTRX arms RX.
+        s.tick_with_bus(&mut bus);
+        assert!(
+            s.needs_bus_tick(),
+            "LASTTX_STARTRX must chain into RX pending"
+        );
+
+        // Tick 2: RX completes → device delivers chip-id byte.
+        s.tick_with_bus(&mut bus);
+        assert!(!s.needs_bus_tick(), "no more pending after RX");
+
+        let chip_id = bus.read_slice(rx_base, 1);
+        assert_eq!(chip_id[0], 0x60, "BME280 chip-id must be 0x60");
+
+        // EVENTS_LASTRX must be set.
+        assert_eq!(read32(&s, 0x158), 1, "EVENTS_LASTRX must be 1");
+    }
+
+    // ── SPIM path: EasyDMA loopback through the mux ───────────────────────────
+
+    #[test]
+    fn spim_path_easydma_events_end() {
+        let mut s = Nrf52SerialInstance::new();
+        let mut bus = FlatRam::new();
+
+        let tx_base: u64 = 0x2000_0200;
+        let rx_base: u64 = 0x2000_0300;
+        bus.write_slice(tx_base, &[0xAA, 0xBB, 0xCC]);
+
+        // Enable SPIM.
+        write32(&mut s, OFF_ENABLE, ENABLE_SPIM);
+
+        write32(&mut s, 0x544, tx_base as u32); // TXD.PTR
+        write32(&mut s, 0x548, 3);              // TXD.MAXCNT
+        write32(&mut s, 0x534, rx_base as u32); // RXD.PTR
+        write32(&mut s, 0x538, 3);              // RXD.MAXCNT
+
+        // TASKS_START (nRF52 SPIM offset 0x010).
+        write32(&mut s, 0x010, 1);
+        assert!(s.needs_bus_tick(), "SPIM pending after TASKS_START");
+
+        s.tick_with_bus(&mut bus);
+
+        // EVENTS_END must be 1.
+        assert_eq!(read32(&s, 0x118), 1, "EVENTS_END must be 1 after SPIM transfer");
+        assert_eq!(read32(&s, 0x120), 1, "EVENTS_ENDTX must be 1");
+        assert_eq!(read32(&s, 0x110), 1, "EVENTS_ENDRX must be 1");
+
+        // TXD.AMOUNT == 3.
+        assert_eq!(read32(&s, 0x54C), 3, "TXD.AMOUNT");
+        assert!(!s.needs_bus_tick(), "no pending after SPIM tick");
+    }
+
+    // ── Dispatch isolation ────────────────────────────────────────────────────
+    // When TWIM is active a write to a TWIM-specific offset must not bleed
+    // SPIM state (and vice versa).  Light smoke: write to TWIM ADDRESS (0x588)
+    // while TWIM is active, then switch to SPIM and verify EVENTS_END is still 0.
+
+    #[test]
+    fn dispatch_isolation_twim_write_does_not_set_spim_events() {
+        let mut s = Nrf52SerialInstance::new();
+
+        // Enable TWIM and poke a TWIM-specific register.
+        write32(&mut s, OFF_ENABLE, ENABLE_TWIM);
+        write32(&mut s, 0x588, 0x42); // ADDRESS (TWIM-only)
+
+        // Switch to SPIM — no transfer was initiated; EVENTS_END must be 0.
+        write32(&mut s, OFF_ENABLE, ENABLE_SPIM);
+        assert_eq!(
+            read32(&s, 0x118),
+            0,
+            "EVENTS_END must be 0 after TWIM-side write with no SPIM transfer"
+        );
+        assert!(
+            !s.needs_bus_tick(),
+            "no pending bus tick on SPIM when no transfer started"
+        );
+    }
+}

--- a/crates/core/src/tests/nrf52.rs
+++ b/crates/core/src/tests/nrf52.rs
@@ -81,7 +81,7 @@ fn xiao_nrf52840_sense_manifest_builds_with_uart_gpio_spi() {
     assert!(names.contains(&"uart0"), "uart0 missing: {names:?}");
     assert!(names.contains(&"gpio0"), "gpio0 missing: {names:?}");
     assert!(names.contains(&"gpio1"), "gpio1 missing: {names:?}");
-    assert!(names.contains(&"spi0"), "spi0 missing: {names:?}");
+    assert!(names.contains(&"i2c0"), "i2c0 missing: {names:?}");
 }
 
 #[test]

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,8 +7,8 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-27 | ⚠ drift acked 2026-06-27 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-29 | ⚠ drift acked 2026-06-29 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-29 | ⚠ drift acked 2026-06-29 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-06-28 | ⚠ drift acked 2026-06-28 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-28 | ⚠ drift acked 2026-06-28 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-06-28 | ⚠ drift acked 2026-06-28 (re-capture pending) |
@@ -20,7 +20,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-06-27 | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-06-27 | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-06-29 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 
@@ -28,7 +28,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — conformance 16/16; mmio 16/16; GPIO P0 22/0, P1 23/0; onboarding 22/22; POWER 10/0, SPIS 19/0, TWIS 20/0, RTC0 12/0, TIMER0 16/0; SPIM0/CCM/full-register clean
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-29 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -36,7 +36,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — rides the nrf52840 full register sweep (16/16) re-confirmed 2026-06-17
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-06-27 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-06-29 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -54,7 +54,12 @@ boards:
     # 2026-06-27: SAADC + PWM gained Tier-3 behavioral engines (real conversion /
     # duty output) for the coverage matrix. Additive and behavioral-only; the
     # 2026-06-17 register sweep is unaffected. No live SWD re-capture this session.
-    drift_ack: 2026-06-27
+    # 2026-06-29: unified SPIM0/TWIM0 serial-instance mux (Nrf52SerialInstance) at
+    # 0x40003000 replaces the generic spi0 chip-YAML entry. The 2026-06-17 register
+    # sweep did not cover SPIM0/TWIM0 shared-MMIO behaviour (it tested SPIS/TWIS/
+    # TIMER/RTC/POWER/GPIO). This is a new model for an untested path; additive
+    # and validated by 6 offline unit tests (twim_path_reads_bme280_chip_id etc.).
+    drift_ack: 2026-06-29
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -74,7 +79,8 @@ boards:
     # nrf52840 drift_ack note. UARTE TX live diff tracked there.
     # 2026-06-27: rides the nrf52840 SAADC/PWM Tier-3 behavioral engines (same
     # silicon); additive, no live re-capture. See the nrf52840 drift_ack note.
-    drift_ack: 2026-06-27
+    # 2026-06-29: rides the nRF52840 SPIM0/TWIM0 serial-instance mux; same silicon.
+    drift_ack: 2026-06-29
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml


### PR DESCRIPTION
## Summary

- Add `Nrf52SerialInstance` peripheral that muxes SPIM0 and TWIM0 sharing MMIO base 0x40003000 on the nRF52840
- ENABLE register (offset 0x500) forwards writes to both sub-peripherals to keep enable state coherent; all other offsets dispatch to the active sub (TWIM when ENABLE=6, SPIM when ENABLE=7)
- Replace generic `spi0/type:spi` entry in `nrf52840.yaml` with unified `i2c0/type:nrf52840_serial` at 0x40003000 so BME280-over-I2C manifests route reads correctly
- Wire serial-instance mux in `canonical_peripheral_type` (precedes generic `contains("spi")`/`contains("i2c")` matchers) and add factory arm in `nrf52::factory::try_build`

## Test plan

- [ ] 6 serial_instance unit tests pass (including `twim_path_reads_bme280_chip_id` reading 0x60)
- [ ] 27 nrf52 integration tests pass (including `xiao_nrf52840_sense_manifest_builds_with_uart_gpio_spi` with renamed i2c0)
- [ ] `cargo clippy -p labwired-core` clean
- [ ] CI core-integrity gate green