### PR TITLE
chore: bump labwired-core to 0.17.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.17.4 to 0.17.5
- Includes: feat(nrf52) unified SPIM0/TWIM0 serial-instance mux (#416)