### PR TITLE
fix(nrf52): mark serial-instance ext devices as attached before kit pass

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -132,6 +132,18 @@ impl SystemBus {
                 crate::peripherals::nrf52::factory::try_build(&canonical_type, p_cfg, manifest)
             });
             if let Some(dev) = family_dev {
+                // The nRF52 serial-instance mux (SPIM0/TWIM0) attaches all
+                // external devices connected to the shared MMIO window itself,
+                // so mark them here so the kit registry pass below does not
+                // try to attach them a second time (which would fail because
+                // Nrf52SerialInstance is not an I2c/Esp32c3I2c).
+                if canonical_type == "nrf52_serial_instance" {
+                    for ext in &manifest.external_devices {
+                        if ext.connection == p_cfg.id {
+                            attached_i2c_ext_ids.insert(ext.id.as_str());
+                        }
+                    }
+                }
                 bus.push_peripheral(p_cfg, dev)?;
                 continue;
             }


### PR DESCRIPTION
## Summary

- The nRF52 SPIM0/TWIM0 serial-instance factory attaches external devices inline
- Without tracking, the outer PeripheralKit registry pass retried the same devices
- BME280 kit failed: cannot downcast Nrf52SerialInstance to I2c/Esp32c3I2c
- Fix: add connected devices to attached_i2c_ext_ids before push_peripheral
- Same pattern used for STM32 I2c and ESP32-C3 I2c paths

## Test plan

- [ ] 6 serial_instance tests pass
- [ ] 27 nrf52 integration tests pass
- [ ] core-integrity green
- [ ] Zephyr proof CI executes the BME280 read test