### PR TITLE
chore: bump labwired-core to 0.17.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.5"
+version = "0.17.6"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"


### PR DESCRIPTION
Version bump to include nRF52 serial-instance kit-conflict fix (#418).