### PR TITLE
fix(nrf52): shadow pre-enable PSEL writes to TWIM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.7] - 2026-06-29
+
+### Fixed
+- **nRF52 SerialInstance pre-enable PSEL shadow**: Zephyr pinctrl writes PSEL.SCL/SDA (offsets 0x508/0x50C) before the ENABLE register is set. The SPIM0/TWIM0 mux was silently dropping those writes (falling to the no-op `_ => {}` arm), leaving PSEL at 0xFFFF_FFFF. `nrfx_twim_init` then called `nrfx_twi_twim_bus_recover(0x7FFFFFFF, 0x7FFFFFFF)` → `nrf_gpio_pin_present_check(0x7FFFFFFF)` → assertion failure at boot. Fix: route pre-enable writes/reads to the TWIM model so pinctrl's PSEL setup is preserved.
+
 ## [0.17.1] - 2026-06-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
 ]
@@ -1681,7 +1681,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1835,11 +1835,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.4"
+version = "0.17.7"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3295,7 +3295,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.4"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.6"
+version = "0.17.7"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/crates/core/src/peripherals/nrf52/serial_instance.rs
+++ b/crates/core/src/peripherals/nrf52/serial_instance.rs
@@ -75,7 +75,8 @@ impl Peripheral for Nrf52SerialInstance {
         match self.active() {
             ENABLE_TWIM => self.twim.read(offset),
             ENABLE_SPIM => self.spim.read(offset),
-            _ => Ok(0),
+            // ENABLE=0: pinctrl writes PSEL before ENABLE is set; shadow to TWIM.
+            _ => self.twim.read(offset),
         }
     }
 
@@ -93,7 +94,8 @@ impl Peripheral for Nrf52SerialInstance {
         match self.active() {
             ENABLE_TWIM => self.twim.write(offset, value),
             ENABLE_SPIM => self.spim.write(offset, value),
-            _ => Ok(()),
+            // ENABLE=0: pinctrl writes PSEL before ENABLE is set; shadow to TWIM.
+            _ => self.twim.write(offset, value),
         }
     }
 
@@ -104,7 +106,8 @@ impl Peripheral for Nrf52SerialInstance {
         match self.active() {
             ENABLE_TWIM => self.twim.read_u32(offset),
             ENABLE_SPIM => self.spim.read_u32(offset),
-            _ => Ok(0),
+            // ENABLE=0: pinctrl writes PSEL before ENABLE is set; shadow to TWIM.
+            _ => self.twim.read_u32(offset),
         }
     }
 
@@ -119,7 +122,8 @@ impl Peripheral for Nrf52SerialInstance {
         match self.active() {
             ENABLE_TWIM => self.twim.write_u32(offset, value),
             ENABLE_SPIM => self.spim.write_u32(offset, value),
-            _ => Ok(()),
+            // ENABLE=0: pinctrl writes PSEL before ENABLE is set; shadow to TWIM.
+            _ => self.twim.write_u32(offset, value),
         }
     }
 
@@ -130,7 +134,7 @@ impl Peripheral for Nrf52SerialInstance {
         match self.active() {
             ENABLE_TWIM => self.twim.read_u16(offset),
             ENABLE_SPIM => self.spim.read_u16(offset),
-            _ => Ok(0),
+            _ => self.twim.read_u16(offset),
         }
     }
 
@@ -144,7 +148,7 @@ impl Peripheral for Nrf52SerialInstance {
         match self.active() {
             ENABLE_TWIM => self.twim.write_u16(offset, value),
             ENABLE_SPIM => self.spim.write_u16(offset, value),
-            _ => Ok(()),
+            _ => self.twim.write_u16(offset, value),
         }
     }
 
@@ -425,6 +429,35 @@ mod tests {
     // When TWIM is active a write to a TWIM-specific offset must not bleed
     // SPIM state (and vice versa).  Light smoke: write to TWIM ADDRESS (0x588)
     // while TWIM is active, then switch to SPIM and verify EVENTS_END is still 0.
+
+    // ── Pre-enable PSEL shadow ────────────────────────────────────────────────
+    // nrfx / Zephyr pinctrl writes PSEL.SCL and PSEL.SDA _before_ ENABLE is
+    // written (they share offset space 0x508/0x50C with SPIM PSEL).  The mux
+    // must shadow those writes to the TWIM model so nrfx_twim_init can read
+    // them back without calling nrf_gpio_pin_present_check on 0x7FFFFFFF.
+
+    #[test]
+    fn psel_writes_before_enable_are_shadowed_to_twim() {
+        let mut s = Nrf52SerialInstance::new();
+
+        // ENABLE=0 at construction; write PSEL.SCL (P0.27) and PSEL.SDA (P0.26)
+        // the way Zephyr pinctrl does before writing ENABLE.
+        write32(&mut s, 0x508, 27); // PSEL.SCL
+        write32(&mut s, 0x50C, 26); // PSEL.SDA
+
+        // Now enable TWIM; the stored PSEL values must be readable.
+        write32(&mut s, OFF_ENABLE, ENABLE_TWIM);
+        assert_eq!(
+            read32(&s, 0x508),
+            27,
+            "PSEL.SCL written before ENABLE must survive into TWIM mode"
+        );
+        assert_eq!(
+            read32(&s, 0x50C),
+            26,
+            "PSEL.SDA written before ENABLE must survive into TWIM mode"
+        );
+    }
 
     #[test]
     fn dispatch_isolation_twim_write_does_not_set_spim_events() {


### PR DESCRIPTION
## Summary

- Zephyr pinctrl writes PSEL.SCL/SDA before ENABLE is set; the mux was dropping those writes (no-op `_ => {}` arm)
- PSEL stayed at 0xFFFF_FFFF, causing `nrfx_twim_init` → `nrfx_twi_twim_bus_recover(0x7FFFFFFF, ...)` → `nrf_gpio_pin_present_check(0x7FFFFFFF)` → assertion failure at boot
- Fix: route pre-enable reads/writes to the TWIM model; add regression test `psel_writes_before_enable_are_shadowed_to_twim`
- Bump to v0.17.7

## Test plan

- [ ] All 7 serial_instance tests pass (including new regression)
- [ ] All 206 nrf52 peripheral tests pass
- [ ] CI on labwired-core passes
- [ ] Zephyr BME280 proof CI passes after binary update