### PR TITLE
fix(nrf52): handle TASKS_RESUME in TWIM model for write-read transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.9] - 2026-06-29
+
+### Fixed
+- **nRF52 TWIM TASKS_RESUME handling**: `nrfx` issues `TASKS_RESUME` (not `TASKS_STARTRX`) to restart the bus after `EVENTS_SUSPENDED` in the TX_NO_STOP (write-then-read) path. The model previously treated `TASKS_RESUME` as a no-op, causing the follow-on RX transfer to never start. The bus would hang waiting for `EVENTS_STOPPED` (from `LASTRX_STOP`), producing a simulation timeout for every I2C `write_read_dt` call. Fixed by routing `TASKS_RESUME` to `PENDING_RX` when the driver has already set up `RXD.PTR`/`RXD.MAXCNT`.
+
 ## [0.17.8] - 2026-06-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
 ]
@@ -1681,7 +1681,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1835,11 +1835,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.8"
+version = "0.17.9"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3295,7 +3295,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.8"
+version = "0.17.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.8"
+version = "0.17.9"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/crates/cli/tests/config_validation.rs
+++ b/crates/cli/tests/config_validation.rs
@@ -29,6 +29,13 @@ fn test_chip_config_validation() {
     let val = bus.read_u32(0x4001100C).expect("Failed to read from GPIOC");
     assert_eq!(val, 0x1234);
 
+    // I2C1 is clock-gated on STM32F103: RCC_APB1ENR.I2C1EN = bit 21.
+    // RCC base is 0x40021000, APB1ENR is at offset 0x1C.
+    // Enable the clock before accessing I2C1 registers, mirroring what
+    // firmware does at boot.
+    bus.write_u32(0x4002101C, 1 << 21)
+        .expect("Failed to enable I2C1 clock in RCC_APB1ENR");
+
     // Try writing to I2C1_OAR1 (offset 0x08) which is a simple data register.
     // Bits 13:10 are reserved on F1 silicon and read back as 0, so the
     // silicon-faithful model echoes 0x55AA as 0x41AA.

--- a/crates/core/src/peripherals/nrf52/twim.rs
+++ b/crates/core/src/peripherals/nrf52/twim.rs
@@ -400,6 +400,13 @@ impl Peripheral for Nrf52Twim {
             OFF_TASKS_STOP if value != 0 && self.pending == PENDING_NONE => {
                 self.pending = PENDING_STOP;
             }
+            // TASKS_RESUME: nrfx uses this after EVENTS_SUSPENDED (TX_NO_STOP path) to
+            // restart the bus and begin the follow-on RX transfer.  The driver sets up
+            // RXD.PTR / RXD.MAXCNT / SHORTS before writing TASKS_RESUME, so routing to
+            // PENDING_RX here is correct and sufficient.
+            OFF_TASKS_RESUME if value != 0 && self.rxd_maxcnt > 0 => {
+                self.pending = PENDING_RX;
+            }
             OFF_TASKS_RESUME | OFF_TASKS_SUSPEND => {}
             OFF_TASKS_STARTRX | OFF_TASKS_STARTTX | OFF_TASKS_STOP => {
                 // value == 0: no-op (tasks are level-triggered on non-zero)


### PR DESCRIPTION
## Summary

- `nrfx` issues `TASKS_RESUME` (not `TASKS_STARTRX`) to restart the bus after `EVENTS_SUSPENDED` in the TX_NO_STOP path used by combined `write_read_dt` calls
- The TWIM model previously treated `TASKS_RESUME` as a no-op → follow-on RX never started → simulation timed out after 20M steps with no output
- Fix: route `TASKS_RESUME` to `PENDING_RX` when `RXD.MAXCNT > 0` (driver sets up DMA before writing RESUME)
- Bump to v0.17.9

## Test plan

- [ ] Local `cargo build --release` passes (verified)
- [ ] Release CI builds and uploads linux-x86_64, linux-aarch64, darwin-aarch64, darwin-x86_64
- [ ] `w1ne/zephyr-bme280-proof` CI with v0.17.9 shows `test_device_ready` PASS + `test_fetch_temperature_in_range` PASS