### PR TITLE
fix(nrf52-twim): correct EVENTS_SUSPENDED/LASTRX/LASTTX register offsets (v0.17.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.10] - 2026-06-29
+
+### Fixed
+- **nRF52 TWIM event register offsets**: Three event registers had wrong peripheral offsets in the model, making them invisible to firmware. The nrfx driver computes bit positions via `(offset - 0x100) / 4`, so the register at bit 18 must live at `0x100 + 18*4 = 0x148`, bit 23 at `0x15C`, bit 24 at `0x160`. The model had `EVENTS_SUSPENDED` at `0x128` (hardware: `0x148`), `EVENTS_LASTRX` at `0x158` (hardware: `0x15C`), `EVENTS_LASTTX` at `0x15C` (hardware: `0x160`). Consequences: (1) the ISR/polling loop never saw `EVENTS_SUSPENDED`, so `nrfx` never wrote `TASKS_RESUME` and the RX phase never started; (2) `EVENTS_LASTRX` was never seen at the correct offset, so completion was never acknowledged; (3) stale events at wrong offsets were never cleared by firmware, causing spurious IRQ loops that ate all simulation steps without producing UART output. Fixes Zephyr BME280 `i2c_write_read` hanging and simulation timeout.
+
 ## [0.17.9] - 2026-06-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1009,56 +1009,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
 ]
@@ -1681,7 +1681,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1835,11 +1835,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.9"
+version = "0.17.10"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3295,7 +3295,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.9"
+version = "0.17.10"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/crates/core/src/peripherals/nrf52/serial_instance.rs
+++ b/crates/core/src/peripherals/nrf52/serial_instance.rs
@@ -382,8 +382,8 @@ mod tests {
         let chip_id = bus.read_slice(rx_base, 1);
         assert_eq!(chip_id[0], 0x60, "BME280 chip-id must be 0x60");
 
-        // EVENTS_LASTRX must be set.
-        assert_eq!(read32(&s, 0x158), 1, "EVENTS_LASTRX must be 1");
+        // EVENTS_LASTRX must be set (nRF52840 TWIM offset 0x15C = bit-23).
+        assert_eq!(read32(&s, 0x15C), 1, "EVENTS_LASTRX must be 1");
     }
 
     // ── SPIM path: EasyDMA loopback through the mux ───────────────────────────

--- a/crates/core/src/peripherals/nrf52/twim.rs
+++ b/crates/core/src/peripherals/nrf52/twim.rs
@@ -14,12 +14,12 @@
 //!
 //! **TASKS_STARTTX (0x008):** reads TXD.MAXCNT bytes from RAM at TXD.PTR,
 //! delivers them to the attached I2C device (or consumes them if no device
-//! is attached), sets TXD.AMOUNT, fires EVENTS_LASTTX (0x15C). Then,
+//! is attached), sets TXD.AMOUNT, fires EVENTS_LASTTX (0x160). Then,
 //! depending on SHORTS, may fire EVENTS_STOPPED (0x104) or chain to STARTRX.
 //!
 //! **TASKS_STARTRX (0x000):** reads RXD.MAXCNT bytes from the device (or
 //! fills with 0xFF if no device), writes them to RAM at RXD.PTR, sets
-//! RXD.AMOUNT, fires EVENTS_LASTRX (0x158). Then, depending on SHORTS, may
+//! RXD.AMOUNT, fires EVENTS_LASTRX (0x15C). Then, depending on SHORTS, may
 //! fire EVENTS_STOPPED (0x104) or chain to STARTTX.
 //!
 //! **TASKS_STOP (0x014):** fires EVENTS_STOPPED (0x104).
@@ -59,11 +59,11 @@ const OFF_TASKS_SUSPEND: u64 = 0x01C;
 // ── Event offsets ─────────────────────────────────────────────────────────────
 const OFF_EVENTS_STOPPED: u64 = 0x104;
 const OFF_EVENTS_ERROR: u64 = 0x124;
-const OFF_EVENTS_SUSPENDED: u64 = 0x128;
+const OFF_EVENTS_SUSPENDED: u64 = 0x148;
 const OFF_EVENTS_RXSTARTED: u64 = 0x14C;
 const OFF_EVENTS_TXSTARTED: u64 = 0x150;
-const OFF_EVENTS_LASTRX: u64 = 0x158;
-const OFF_EVENTS_LASTTX: u64 = 0x15C;
+const OFF_EVENTS_LASTRX: u64 = 0x15C;
+const OFF_EVENTS_LASTTX: u64 = 0x160;
 
 // ── Control registers ─────────────────────────────────────────────────────────
 const OFF_SHORTS: u64 = 0x200;


### PR DESCRIPTION
## Root cause

Three TWIM event registers had wrong peripheral offsets. The nrfx driver computes INTEN bit positions via `(offset - 0x100) / 4`, so:

| Event | INTEN bit | Required offset | Was |
|-------|-----------|-----------------|-----|
| EVENTS_SUSPENDED | 18 | 0x148 | 0x128 |
| EVENTS_LASTRX | 23 | 0x15C | 0x158 |
| EVENTS_LASTTX | 24 | 0x160 | 0x15C |

Confirmed by disassembling the Zephyr BME280 ELF: `__nrfy_internal_twim_events_process` queries 0x148, 0x15C, 0x160.

## Impact

- ISR/polling loop never saw `EVENTS_SUSPENDED` → `nrfx` never wrote `TASKS_RESUME` → RX phase never started → every `i2c_write_read` timed out
- Stale events at wrong offsets were never cleared by firmware → spurious IRQ loop eating all simulation steps → no UART output → twister timeout

## Changes

- `crates/core/src/peripherals/nrf52/twim.rs`: fix three `OFF_EVENTS_*` constants
- `crates/core/src/peripherals/nrf52/serial_instance.rs`: update unit test assertion to correct 0x15C offset
- Bump to v0.17.10

## Tests

1658 core lib tests pass. Config-validation tests pass.