### PR TITLE
fix(kw41z): embed mkw41z4 declarative descriptors for the wasm playground

### DIFF
--- a/crates/core/src/bus/embedded_descriptors.rs
+++ b/crates/core/src/bus/embedded_descriptors.rs
@@ -137,6 +137,59 @@ pub fn lookup(descriptor_path: &str) -> Option<&'static str> {
         "esp32c3/xts_aes.yaml" => Some(include_str!(
             "../../../../configs/peripherals/esp32c3/xts_aes.yaml"
         )),
+        // NXP KW41Z (mkw41z4) declarative descriptors — embedded so the chip's
+        // declarative peripherals load in the wasm playground (no std::fs).
+        "mkw41z4/gpioa.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/gpioa.yaml"
+        )),
+        "mkw41z4/gpiob.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/gpiob.yaml"
+        )),
+        "mkw41z4/gpioc.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/gpioc.yaml"
+        )),
+        "mkw41z4/i2c0.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/i2c0.yaml"
+        )),
+        "mkw41z4/lpuart0.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/lpuart0.yaml"
+        )),
+        "mkw41z4/mcg.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/mcg.yaml"
+        )),
+        "mkw41z4/pit.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/pit.yaml"
+        )),
+        "mkw41z4/pmc.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/pmc.yaml"
+        )),
+        "mkw41z4/porta.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/porta.yaml"
+        )),
+        "mkw41z4/portb.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/portb.yaml"
+        )),
+        "mkw41z4/portc.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/portc.yaml"
+        )),
+        "mkw41z4/rcm.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/rcm.yaml"
+        )),
+        "mkw41z4/sim.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/sim.yaml"
+        )),
+        "mkw41z4/smc.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/smc.yaml"
+        )),
+        "mkw41z4/spi0.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/spi0.yaml"
+        )),
+        "mkw41z4/tpm0.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/tpm0.yaml"
+        )),
+        "mkw41z4/trng0.yaml" => Some(include_str!(
+            "../../../../configs/peripherals/mkw41z4/trng0.yaml"
+        )),
         _ => None,
     }
 }


### PR DESCRIPTION
The KW41Z (`mkw41z4`) chip's declarative peripherals (`sim`/`pmc`/`smc`/`porta`…/`i2c0`/`tpm0`/…) load their register descriptors from `configs/peripherals/mkw41z4/*.yaml` via `std::fs`, which doesn't exist in the wasm32 playground. So the simulator failed to init in-browser:

```
Simulator init failed: Failed to load declarative descriptor for 'sim' from
'../peripherals/mkw41z4/sim.yaml': operation not supported on this platform
```

Fix: embed the descriptors via `include_str!` in `embedded_descriptors::lookup` (the same mechanism already used for esp32c3), so the wasm build resolves them without the filesystem. Native loads are unchanged (the loader prefers the embedded copy, falls back to `std::fs`).

This unblocks **any** KW41Z playground demo (the FXOS8700 sensor node + the Nokia-5110 activity display). Without it, a clean deploy from main regresses to the init error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)