### PR TITLE
Pin thumbv6m smoke linker script

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -97,7 +97,7 @@ jobs:
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi
           cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
           cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
-          cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
+          RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
           # Debug build: dap/e2e and loader/test_location_to_pc look for the debug path.
           cargo build -p firmware-ci-fixture --target thumbv7m-none-eabi
 

--- a/.github/workflows/core-coverage.yml
+++ b/.github/workflows/core-coverage.yml
@@ -44,7 +44,7 @@ jobs:
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi
           cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
           cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
-          cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
+          RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
 
       - name: Run coverage
         run: |

--- a/crates/core/tests/strict_onboarding.rs
+++ b/crates/core/tests/strict_onboarding.rs
@@ -255,6 +255,7 @@ fn ensure_smoke_firmware_exists(project_root: &Path, smoke_test: &Path) -> anyho
     let target = parts[target_idx + 1].clone();
     let profile = parts[target_idx + 2].clone();
     let package = parts[target_idx + 3].clone();
+    let needs_thumbv6m_link_arg = target == "thumbv6m-none-eabi";
 
     let mut args = vec![
         "build".to_string(),
@@ -278,12 +279,17 @@ fn ensure_smoke_firmware_exists(project_root: &Path, smoke_test: &Path) -> anyho
         project_root.to_path_buf()
     };
 
-    let status = Command::new("cargo")
+    let mut command = Command::new("cargo");
+    command
         .current_dir(&build_dir)
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("RUSTFLAGS")
-        .args(args)
-        .status()?;
+        .args(args);
+    if needs_thumbv6m_link_arg {
+        command.env("RUSTFLAGS", "-C link-arg=-Tlink.x");
+    }
+
+    let status = command.status()?;
 
     Ok(status.success())
 }

--- a/scripts/onboarding_smoke.sh
+++ b/scripts/onboarding_smoke.sh
@@ -165,16 +165,21 @@ infer_failure_hint() {
 run_smoke_output_dir="${OUT_DIR}/simulation-output"
 mkdir -p "${run_smoke_output_dir}"
 
+firmware_build_env=()
+if [[ "${TARGET}" == "thumbv6m-none-eabi" ]]; then
+  firmware_build_env=(env RUSTFLAGS="-C link-arg=-Tlink.x")
+fi
+
 if ! run_stage build_cli cargo build -p labwired-cli; then
   :
 elif [[ "${PROFILE}" == "release" ]]; then
-  if ! run_stage build_firmware cargo build -p "${CRATE}" --release --target "${TARGET}"; then
+  if ! run_stage build_firmware "${firmware_build_env[@]}" cargo build -p "${CRATE}" --release --target "${TARGET}"; then
     :
   elif ! run_stage run_smoke cargo run -q -p labwired-cli -- test --script "${SCRIPT}" --output-dir "${run_smoke_output_dir}" --no-uart-stdout; then
     :
   fi
 else
-  if ! run_stage build_firmware cargo build -p "${CRATE}" --target "${TARGET}"; then
+  if ! run_stage build_firmware "${firmware_build_env[@]}" cargo build -p "${CRATE}" --target "${TARGET}"; then
     :
   elif ! run_stage run_smoke cargo run -q -p labwired-cli -- test --script "${SCRIPT}" --output-dir "${run_smoke_output_dir}" --no-uart-stdout; then
     :


### PR DESCRIPTION
## Summary
- set explicit RUSTFLAGS=-C link-arg=-Tlink.x for thumbv6m smoke firmware builds
- apply it in strict onboarding, the onboarding smoke script, and direct CI fixture builds
- fixes CI-built L073/RP2040 ELFs entering at 0x0 with empty UART output

## Verification
- scripts/onboarding_smoke.sh --target-id rp2040-pio --crate firmware-rp2040-pio-onboarding --target thumbv6m-none-eabi --script examples/rp2040-pio/io-smoke.yaml --system examples/rp2040-pio/system.yaml --out-dir /tmp/labwired-onboarding-rp2040-linkarg-2 --threshold-seconds 3600
- cargo test -p labwired-core --test strict_onboarding -- --nocapture
- cargo test -p labwired-cli --test stop_conditions test_stop_when_assertions_pass -- --nocapture
- cargo fmt --check
- git diff --check