### PR TITLE
fix(gpio): no silent STM32F1 fallback for vendor-neutral type: gpio (fixes KW41Z LCD)

### DIFF
--- a/configs/chips/esp32s3-zero.yaml
+++ b/configs/chips/esp32s3-zero.yaml
@@ -69,6 +69,13 @@ peripherals:
     type: "gpio"
     base_address: 0x60004000
     size: "2KiB"
+    # Placeholder layout: the ESP32-S3 GPIO matrix has no dedicated GpioPort
+    # model yet, and this chip boots via the Xtensa system builder (not the
+    # from_config GPIO path). Pinned explicitly to the classic STM32F1 map it
+    # historically resolved to, so the profile is a visible choice rather than
+    # an omission-driven silent default (see SystemBus::gpio_layout_for).
+    config:
+      profile: "stm32f1"
   - id: "timg0"
     type: "timer_group"
     base_address: 0x6001F000

--- a/configs/chips/onboarding/stm32f401cdu6-blackpill.yaml
+++ b/configs/chips/onboarding/stm32f401cdu6-blackpill.yaml
@@ -168,26 +168,38 @@ peripherals:
     type: "gpio"
     base_address: 0x40020000
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpiob"
     type: "gpio"
     base_address: 0x40020400
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpioc"
     type: "gpio"
     base_address: 0x40020800
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpiod"
     type: "gpio"
     base_address: 0x40020C00
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpioe"
     type: "gpio"
     base_address: 0x40021000
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpioh"
     type: "gpio"
     base_address: 0x40021C00
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "otg_fs_global"
     type: "stub"
     base_address: 0x50000000

--- a/configs/chips/stm32f103.yaml
+++ b/configs/chips/stm32f103.yaml
@@ -30,14 +30,20 @@ peripherals:
     # firmware that forgets to enable it has its register writes dropped on real
     # silicon — modelled here so the sim fails the same way (RM0008 §7.3.7).
     clock: { reg: "apb2enr", bit: 2 }
+    config:
+      profile: "stm32f1"
   - id: "gpiob"
     type: "gpio"
     base_address: 0x40010C00
     size: "1KB"
+    config:
+      profile: "stm32f1"
   - id: "gpioc"
     type: "gpio"
     base_address: 0x40011000
     size: "1KB"
+    config:
+      profile: "stm32f1"
   - id: "systick"
     type: "systick"
     base_address: 0xE000E010

--- a/configs/chips/stm32f401cdu6.yaml
+++ b/configs/chips/stm32f401cdu6.yaml
@@ -175,26 +175,38 @@ peripherals:
     type: "gpio"
     base_address: 0x40020000
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpiob"
     type: "gpio"
     base_address: 0x40020400
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpioc"
     type: "gpio"
     base_address: 0x40020800
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpiod"
     type: "gpio"
     base_address: 0x40020C00
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpioe"
     type: "gpio"
     base_address: 0x40021000
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "gpioh"
     type: "gpio"
     base_address: 0x40021C00
     size: "1KB"
+    config:
+      profile: "stm32v2"
   - id: "otg_fs_global"
     type: "stub"
     base_address: 0x50000000

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -178,13 +178,11 @@ impl SystemBus {
                 }
                 "gpio" | "stm32_gpioport" | "stm32f4_gpio" | "efmgpioport" | "npcx_gpio"
                 | "imxrt_gpio" => {
-                    let layout: GpioRegisterLayout = if p_cfg.r#type.contains("nrf") {
-                        GpioRegisterLayout::Nrf52
-                    } else if p_cfg.r#type.contains("stm32f4") || p_cfg.r#type.contains("h5") {
-                        GpioRegisterLayout::Stm32V2
-                    } else {
-                        Self::parse_profile_or_default(p_cfg, "GPIO")?
-                    };
+                    // Deterministic, type-driven layout resolution. The bare
+                    // vendor-neutral `gpio` type MUST name a profile; it is never
+                    // silently defaulted onto STM32F1 (which would move the ODR
+                    // offset and blank a display's D/C line — the KW41Z "cow" bug).
+                    let layout: GpioRegisterLayout = Self::gpio_layout_for(p_cfg)?;
                     // For nRF52 ports, an optional `num_pins` config key caps the
                     // valid-pin range (e.g. 16 for nRF52840 P1 which has P1.0–P1.15).
                     // Writes outside that range are discarded; reads return 0.

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -883,6 +883,91 @@ impl SystemBus {
         Ok(layout)
     }
 
+    /// Resolve the GPIO register layout for a peripheral **deterministically**
+    /// from its declared type, mirroring [`Self::uart_layout_for`]. There is NO
+    /// path that silently mismodels a GPIO port onto STM32F1 by omission — a
+    /// wrong GPIO layout moves the output-data-register offset, and anything
+    /// that latches a pin level from that register (e.g. a SPI display's D/C
+    /// line via [`Self::resolve_pin_odr`]) then samples the wrong address and
+    /// silently misbehaves. The FRDM-KW41Z "cow" LCD blanked exactly this way:
+    /// a `type: gpio` port with no `profile` fell back to Stm32F1 (ODR @0x0C),
+    /// so the D/C line resolved to an address the Kinetis firmware (PDOR @0x00)
+    /// never drives, D/C stayed low, and every pixel byte decoded as a command.
+    ///
+    ///   1. An explicit `config.profile` always wins (author's deliberate choice).
+    ///   2. A type whose silicon layout the *name* pins down routes to it:
+    ///      `*nrf*` → Nordic; `stm32f4`/`*h5*`/`*v2*` → modern STM32;
+    ///      `stm32_gpioport`/`stm32f1`/`stm32f2` and the legacy placeholder
+    ///      ports (`efmgpioport`/`npcx_gpio`/`imxrt_gpio`, historically run on
+    ///      the F1 map) → classic STM32F1.
+    ///   3. The bare vendor-neutral `"gpio"` type (or any other gpio-ish type we
+    ///      do not model) with NO `profile` ERRORS. It is never silently mapped
+    ///      onto STM32F1 by omission.
+    pub(crate) fn gpio_layout_for(
+        p_cfg: &PeripheralConfig,
+    ) -> anyhow::Result<crate::peripherals::gpio::GpioRegisterLayout> {
+        use crate::peripherals::gpio::GpioRegisterLayout;
+
+        // 1. Explicit author override wins, for any GPIO type.
+        if let Some(name) = Self::profile_name(p_cfg)? {
+            return GpioRegisterLayout::from_str(name).map_err(|e| {
+                anyhow::anyhow!(
+                    "Peripheral '{}' has invalid GPIO profile '{}': {}",
+                    p_cfg.id,
+                    name,
+                    e
+                )
+            });
+        }
+
+        // 2. Route the families whose declared type pins down the layout.
+        let raw = p_cfg.r#type.to_ascii_lowercase();
+        let has = |needle: &str| raw.contains(needle);
+        let layout = if has("nrf") {
+            GpioRegisterLayout::Nrf52
+        } else if has("stm32f4") || has("h5") || has("stm32v2") {
+            GpioRegisterLayout::Stm32V2
+        } else if raw == "stm32_gpioport" || has("stm32f1") || has("stm32f2") {
+            GpioRegisterLayout::Stm32F1
+        } else if raw == "efmgpioport" || raw == "npcx_gpio" || raw == "imxrt_gpio" {
+            // Not yet modelled with a dedicated register map; historically ran
+            // on the STM32F1 layout. Kept explicit (by type) so the choice is
+            // visible rather than an omission-driven silent default.
+            GpioRegisterLayout::Stm32F1
+        } else if raw == "gpio" {
+            // 3a. The bare vendor-neutral "gpio" type with no profile is the
+            //     dangerous case (real product chips: KW41Z / STM32 / nRF /
+            //     ESP32) — the author meant a *specific* silicon layout and
+            //     omitting it silently picked STM32F1, corrupting D/C
+            //     resolution (the FRDM-KW41Z "cow" blank). REFUSE to guess.
+            anyhow::bail!(
+                "GPIO peripheral '{}' is declared with the vendor-neutral `type: gpio` but no \
+                 `config.profile`; it will NOT be silently mapped onto STM32F1 (a wrong layout \
+                 moves the output register and blanks a display's D/C line). Choose a layout \
+                 explicitly with `config: {{ profile: <stm32f1|stm32v2|nrf52|kinetis> }}`.",
+                p_cfg.id
+            );
+        } else {
+            // 3b. A vendor-named gpio type we do not model yet (e.g.
+            //     `gaisler_gpio`, `cc2538_gpio`, `mpfs_gpio`, `gpio_esp32`, …),
+            //     used by the strict-onboarding chip ramp. These historically
+            //     ran on the STM32F1 placeholder layout. Keep them loadable so
+            //     onboarding isn't blocked, but WARN loudly instead of failing
+            //     silently — the placeholder is a known-incomplete model, not a
+            //     faithful one. Pin it with `config.profile` (or add a real
+            //     model) to silence this and get correct register behaviour.
+            tracing::warn!(
+                "GPIO type '{}' (peripheral '{}') has no dedicated register model; falling back \
+                 to the STM32F1 placeholder layout. This is a known-incomplete onboarding model — \
+                 set `config.profile` or add a real model for correct behaviour.",
+                p_cfg.r#type,
+                p_cfg.id
+            );
+            GpioRegisterLayout::Stm32F1
+        };
+        Ok(layout)
+    }
+
     fn resolve_peripheral_path(manifest: &SystemManifest, descriptor_path: &str) -> PathBuf {
         let raw = PathBuf::from(descriptor_path);
         if raw.is_absolute() {

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -597,7 +597,14 @@ pub mod integration_tests {
                     size: None,
                     irq: None,
                     clock: None,
-                    config: HashMap::new(),
+                    // A bare `type: gpio` must name its layout explicitly — the
+                    // factory no longer silently defaults to STM32F1 (see
+                    // SystemBus::gpio_layout_for). This test only checks the
+                    // size/irq/base defaults, so any valid profile works.
+                    config: HashMap::from([(
+                        "profile".to_string(),
+                        serde_yaml::Value::from("stm32f1"),
+                    )]),
                 },
             ],
         };

--- a/crates/core/tests/firmware_survival.rs
+++ b/crates/core/tests/firmware_survival.rs
@@ -1287,6 +1287,83 @@ fn test_kw41z_lcd_renders_screen() {
     }
 }
 
+/// Regression (browser "cow" blank via the wasm `new_from_config` path):
+///
+/// The FRDM-KW41Z LCD blanked in the deployed browser while the native test
+/// rendered the cow. Root cause was NOT the display model but the GPIO factory:
+/// a `type: gpio` port with no `config.profile` silently defaulted to STM32F1
+/// (ODR @0x0C), so the PCD8544 D/C line — which the bus latches from the
+/// driving GPIO's output register — resolved to an address the Kinetis firmware
+/// (PDOR @0x00) never drives. D/C stayed low, every pixel byte decoded as a
+/// command, and the panel rendered blank. Critically the display attach did
+/// NOT error, because `resolve_pin_odr` DID find a `GpioPort` (just the wrong
+/// family) and returned a valid-but-wrong offset — bypassing the pcd8544
+/// fail-loud guard.
+///
+/// This test locks in BOTH halves of the fix, on the same `SystemBus::from_config`
+/// path the wasm `WasmSimulator::new_from_config` browser entry uses:
+///   1. The real KW41Z config builds gpioc as a *behavioural* Kinetis `GpioPort`
+///      (ODR/PDOR @0x00), and D/C ("PC0") resolves to `gpioc_base + 0x00`.
+///   2. Stripping gpioc's `profile` makes `from_config` FAIL LOUD (no silent
+///      STM32F1 fallback), instead of building a bus that renders a blank panel.
+#[test]
+fn kw41z_gpioc_is_behavioural_kinetis_and_profileless_gpio_errors() {
+    use labwired_core::peripherals::gpio::GpioPort;
+
+    let (chip, manifest) = load_system("mkw41z4", "frdm-kw41z-lcd");
+
+    // --- Half 1: the shipped config yields a behavioural Kinetis GPIOC. ---
+    let bus = SystemBus::from_config(&chip, &manifest).expect("bus builds from real config");
+    let idx = bus
+        .find_peripheral_index_by_name("gpioc")
+        .expect("gpioc peripheral present");
+    let base = bus.peripherals[idx].base;
+    let gpioc = bus.peripherals[idx]
+        .dev
+        .as_any()
+        .and_then(|a| a.downcast_ref::<GpioPort>())
+        .expect("gpioc must be a behavioural GpioPort, not a passive declarative bank");
+    assert_eq!(
+        gpioc.odr_offset(),
+        0x00,
+        "gpioc must use the Kinetis layout (PDOR/output @0x00), not STM32F1 (@0x0C)"
+    );
+    // D/C pin (PC0) must resolve to the Kinetis output register @ base + 0x00.
+    let dc = SystemBus::resolve_pin_odr_pub(&bus, "PC0")
+        .expect("PC0 must resolve to a driveable GPIO output");
+    assert_eq!(
+        dc,
+        (base, 0),
+        "PCD8544 D/C (PC0) must latch from the Kinetis output register at gpioc base + 0x00"
+    );
+
+    // --- Half 2: a profileless bare `type: gpio` must fail loudly. ---
+    let mut broken = chip.clone();
+    let gpioc_cfg = broken
+        .peripherals
+        .iter_mut()
+        .find(|p| p.id == "gpioc")
+        .expect("gpioc in chip descriptor");
+    assert_eq!(gpioc_cfg.r#type, "gpio");
+    gpioc_cfg.config.remove("profile");
+    gpioc_cfg.config.remove("register_layout");
+    let err = match SystemBus::from_config(&broken, &manifest) {
+        Ok(_) => panic!("profileless bare `type: gpio` must NOT silently default to STM32F1"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("gpioc") && msg.contains("profile"),
+        "error must name the peripheral and demand an explicit profile, got: {msg}"
+    );
+    // The error must surface at bus-construction time (from_config), not after
+    // the machine has run and quietly rendered a blank panel.
+    assert!(
+        msg.contains("STM32F1"),
+        "error should explain it refuses the silent STM32F1 fallback, got: {msg}"
+    );
+}
+
 /// End-to-end proof that the universal bus-trace logic analyzer (Tasks 1-2)
 /// captures REAL transactions from the unmodified KW41Z-LCD demo firmware:
 /// an I2C address frame for the FXOS8700 accelerometer and at least one SPI

--- a/examples/f103-fidelity-bench/stm32f103-nogate.yaml
+++ b/examples/f103-fidelity-bench/stm32f103-nogate.yaml
@@ -33,14 +33,20 @@ peripherals:
     # GPIOA is clocked from RCC_APB2ENR.IOPAEN (bit 2). Unclocked out of reset:
     # firmware that forgets to enable it has its register writes dropped on real
     # silicon — modelled here so the sim fails the same way (RM0008 §7.3.7).
+    config:
+      profile: "stm32f1"
   - id: "gpiob"
     type: "gpio"
     base_address: 0x40010C00
     size: "1KB"
+    config:
+      profile: "stm32f1"
   - id: "gpioc"
     type: "gpio"
     base_address: 0x40011000
     size: "1KB"
+    config:
+      profile: "stm32f1"
   - id: "systick"
     type: "systick"
     base_address: 0xE000E010


### PR DESCRIPTION
## Summary
Fixes the KW41Z-LCD demo rendering blank in the browser, and closes the silent-fallback class that caused it.

**Root cause:** \`parse_profile_or_default\` silently defaulted a vendor-neutral \`type: gpio\` (no \`config.profile\`) to \`GpioRegisterLayout::Stm32F1\` (ODR@0x0C). In the wasm \`new_from_config\` browser path, KW41Z \`gpioc\` became an STM32 bank instead of Kinetis → the PCD8544 D/C pin resolved to an output register the Kinetis firmware (PDOR@0x00) never drives → D/C stuck low → every pixel byte decoded as a command → blank LCD. The native \`std::fs\` path honored the profile and rendered, which is why offline harnesses didn't reproduce it.

**Fix:** new \`SystemBus::gpio_layout_for\` (mirrors \`uart_layout_for\`): honors \`config.profile\`; a bare \`type: gpio\` with no profile is now a **hard, actionable error at construction** — never silently mapped onto STM32F1. Pinned explicit profiles on the product chips that relied on the old default (stm32f103/f103-nogate/esp32s3-zero → stm32f1; stm32f401cdu6 + blackpill → stm32v2, also fixing a latent F4-as-F1 mismodel). Vendor-named onboarding gpio types are unchanged.

## Testing
- New regression test \`kw41z_gpioc_is_behavioural_kinetis_and_profileless_gpio_errors\` (both halves, real from_config path).
- Reproduced the blank via a wasm-nodejs harness on the exact browser \`new_from_config\` path; the shipped config renders the cow (301 lit).
- Full enumeration confirms every \`type: gpio\` in configs/examples carries a profile — no board fails to load.
- cargo test -p labwired-core + labwired-cli green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)