### PR TITLE
feat: authoritative chip-driven pin map (single source of truth)

### DIFF
--- a/configs/chips/mkw41z4.yaml
+++ b/configs/chips/mkw41z4.yaml
@@ -21,6 +21,15 @@ flash:
 ram:
   base: 0x1FFF8000
   size: "128KB"
+pins:
+  PA5: { gpio: gpioc, bit: 16, functions: [{ type: spi, peripheral: spi0, role: sck }] }
+  PA6: { gpio: gpioc, bit: 18, functions: [{ type: spi, peripheral: spi0, role: miso }] }
+  PA7: { gpio: gpioc, bit: 17, functions: [{ type: spi, peripheral: spi0, role: mosi }] }
+  PB1: { gpio: gpioc, bit: 4,  functions: [{ type: spi, peripheral: spi0, role: nss }] }
+  PB2: { gpio: gpioc, bit: 1,  functions: [{ type: gpio, peripheral: gpioc }] }
+  PB6: { gpio: gpioc, bit: 2,  functions: [{ type: i2c, peripheral: i2c1, role: scl }] }
+  PB7: { gpio: gpioc, bit: 3,  functions: [{ type: i2c, peripheral: i2c1, role: sda }] }
+  PC0: { gpio: gpioc, bit: 0,  functions: [{ type: gpio, peripheral: gpioc }] }
 peripherals:
   # --- Console / serial ---
   # Behavioural LPUART (Kinetis layout): DATA writes hit the TX sink, STAT

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -112,6 +112,18 @@ pub struct PeripheralConfig {
     pub config: HashMap<String, serde_yaml::Value>,
 }
 
+/// One entry in a chip's authoritative pin map: which GPIO peripheral this pin's
+/// output register lives on, and the bit within that port's data register. This
+/// is silicon truth (from the SVD / board pinmux) — the pin *label* no longer
+/// implies a port, so a board whose silkscreen labels a `gpioc` pin "PB0" resolves
+/// correctly. Extra YAML fields (e.g. `functions:`, consumed by the app codegen)
+/// are ignored here.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PinLoc {
+    pub gpio: String,
+    pub bit: u8,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChipDescriptor {
     #[serde(default = "default_schema_version")]
@@ -151,6 +163,11 @@ pub struct ChipDescriptor {
     #[serde(default)]
     pub memory_regions: Vec<NamedMemoryRange>,
     pub peripherals: Vec<PeripheralConfig>,
+    /// Authoritative pin → GPIO map. When present, pin resolution uses this map
+    /// instead of parsing the label letter; an undeclared pin fails to resolve
+    /// (no silent standard-layout fallback). Absent → standard STM32/Nordic parse.
+    #[serde(default)]
+    pub pins: std::collections::BTreeMap<String, PinLoc>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -560,6 +577,7 @@ impl From<labwired_ir::IrDevice> for ChipDescriptor {
                     }
                 })
                 .collect(),
+            pins: std::collections::BTreeMap::new(),
         }
     }
 }
@@ -1360,5 +1378,44 @@ registers:
             }
             other => panic!("expected UdsTester variant, got {:?}", other),
         }
+    }
+}
+
+#[cfg(test)]
+mod pin_map_tests {
+    use super::*;
+
+    #[test]
+    fn chip_descriptor_parses_pins_and_ignores_extra_fields() {
+        let yaml = r#"
+name: "test-chip"
+arch: "arm"
+flash: { base: 0, size: "64K" }
+ram: { base: 0x20000000, size: "16K" }
+peripherals: []
+pins:
+  PC0: { gpio: gpioc, bit: 0, functions: [{ type: gpio, peripheral: gpioc }] }
+  PB6: { gpio: gpioc, bit: 2 }
+"#;
+        let chip: ChipDescriptor = serde_yaml::from_str(yaml).expect("parse chip with pins");
+        assert_eq!(chip.pins.len(), 2);
+        assert_eq!(chip.pins["PC0"].gpio, "gpioc");
+        assert_eq!(chip.pins["PC0"].bit, 0);
+        // `functions:` in the YAML is ignored by PinLoc (serde ignores unknown fields).
+        assert_eq!(chip.pins["PB6"].gpio, "gpioc");
+        assert_eq!(chip.pins["PB6"].bit, 2);
+    }
+
+    #[test]
+    fn chip_without_pins_defaults_to_empty() {
+        let yaml = r#"
+name: "no-pins"
+arch: "arm"
+flash: { base: 0, size: "64K" }
+ram: { base: 0x20000000, size: "16K" }
+peripherals: []
+"#;
+        let chip: ChipDescriptor = serde_yaml::from_str(yaml).expect("parse");
+        assert!(chip.pins.is_empty());
     }
 }

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -78,7 +78,15 @@ impl SystemBus {
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
+
+        // Authoritative pin map (silicon truth) — resolution prefers this over the
+        // label-letter parse; see routing::resolve_pin_odr.
+        for (label, loc) in &chip.pins {
+            bus.pin_map
+                .insert(label.to_ascii_uppercase(), (loc.gpio.clone(), loc.bit));
+        }
 
         let mut merged_peripherals = chip.peripherals.clone();
         for m_p in &manifest.peripherals {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -2487,6 +2487,7 @@ mod tests {
                 clock: None,
                 config: HashMap::new(),
             }],
+            pins: Default::default(),
         };
 
         let mut config = HashMap::new();
@@ -2555,6 +2556,7 @@ mod tests {
                 config: HashMap::new(),
                 clock: None,
             }],
+            pins: Default::default(),
         };
 
         let mut config = HashMap::new();
@@ -2657,6 +2659,7 @@ mod tests {
                 config: HashMap::new(),
                 clock: None,
             }],
+            pins: Default::default(),
         };
 
         let mut config = HashMap::new();
@@ -3459,6 +3462,7 @@ peripherals:
                     config: HashMap::new(),
                 },
             ],
+            pins: Default::default(),
         }
     }
 

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -215,6 +215,9 @@ pub struct SystemBus {
     /// present (never `None`) — empty until at least one peripheral is wired
     /// to it in `from_config`.
     pub bus_trace: bus_trace::BusTraceLog,
+    /// Authoritative pin → (gpio peripheral, bit) map, built from the chip
+    /// config's `pins:`. Empty when the chip declares none (→ label parse).
+    pub(crate) pin_map: std::collections::HashMap<String, (String, u8)>,
 }
 
 pub struct CanDiagnosticTester {
@@ -1675,6 +1678,7 @@ impl SystemBus {
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -1717,6 +1721,7 @@ impl SystemBus {
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -3654,6 +3659,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
 
         bus.flash.write_u8(0x0800_0000, 0x12);
@@ -3720,6 +3726,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -3937,6 +3944,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
         bus
@@ -4153,6 +4161,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
 
         bus.rebuild_peripheral_ranges();
@@ -4223,6 +4232,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
 
@@ -4862,5 +4872,38 @@ board_io: []
         inject_ecu_reply(&mut bus, 0x222, &[0x03, 0x7F, 0x2E, 0x31]);
         bus.service_can_uds_testers();
         assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+    }
+}
+
+#[cfg(test)]
+mod pin_map_tests {
+    use super::*;
+    use labwired_config::{ChipDescriptor, SystemManifest};
+
+    fn mkw41z4_bus() -> SystemBus {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../configs/chips/mkw41z4.yaml");
+        let chip = ChipDescriptor::from_file(&path).expect("load mkw41z4");
+        let manifest = SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "pinmap-test".to_string(),
+            chip: path.to_string_lossy().to_string(),
+            external_devices: vec![],
+            board_io: vec![],
+            debug_uart: None,
+            peripherals: vec![],
+            memory_overrides: Default::default(),
+        };
+        SystemBus::from_config(&chip, &manifest).expect("assemble bus")
+    }
+
+    #[test]
+    fn pin_map_populated_from_chip_pins() {
+        let bus = mkw41z4_bus();
+        assert_eq!(bus.pin_map.get("PC0"), Some(&("gpioc".to_string(), 0u8)));
+        // KW41Z remap: "PB6" labels a gpioc pin, not gpiob.
+        assert_eq!(bus.pin_map.get("PB6"), Some(&("gpioc".to_string(), 2u8)));
+        assert_eq!(bus.pin_map.len(), 8);
     }
 }

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -46,6 +46,21 @@ impl SystemBus {
     }
 
     pub(crate) fn resolve_pin_odr(bus: &SystemBus, pin: &str) -> Option<(u64, u8)> {
+        // 1. Chip-declared pin map is authoritative silicon truth. When a chip
+        //    declares any pins, resolution goes THROUGH the map — an undeclared pin
+        //    returns None rather than silently letter-parsing onto a wrong port.
+        if !bus.pin_map.is_empty() {
+            let (gpio_name, bit) = bus.pin_map.get(&pin.to_ascii_uppercase())?;
+            let idx = bus.find_peripheral_index_by_name(gpio_name)?;
+            let base = bus.peripherals[idx].base;
+            let odr_off = bus.peripherals[idx]
+                .dev
+                .as_any()
+                .and_then(|a| a.downcast_ref::<crate::peripherals::gpio::GpioPort>())
+                .map(|g| g.odr_offset())?;
+            return Some((base + odr_off, *bit));
+        }
+        // 2. No chip pin map → standard STM32/Nordic label parse.
         // STM32/Nordic: "PA5" / "P0.13" → per-port GpioPort with an ODR offset.
         if let Some((port_name, bit)) = Self::parse_stm32_pin(pin) {
             if let Some(idx) = bus.find_peripheral_index_by_name(&port_name) {
@@ -98,6 +113,17 @@ impl SystemBus {
     /// Resolve an STM32 pin label to its `(IDR address, bit)` so a sensor can
     /// drive an MCU input line (e.g. the HC-SR04 ECHO pin).
     pub(crate) fn resolve_pin_idr(bus: &SystemBus, pin: &str) -> Option<(u64, u8)> {
+        if !bus.pin_map.is_empty() {
+            let (gpio_name, bit) = bus.pin_map.get(&pin.to_ascii_uppercase())?;
+            let idx = bus.find_peripheral_index_by_name(gpio_name)?;
+            let base = bus.peripherals[idx].base;
+            let idr_off = bus.peripherals[idx]
+                .dev
+                .as_any()
+                .and_then(|a| a.downcast_ref::<crate::peripherals::gpio::GpioPort>())
+                .map(|g| g.idr_offset())?;
+            return Some((base + idr_off, *bit));
+        }
         let (port_name, bit) = Self::parse_stm32_pin(pin)?;
         let idx = bus.find_peripheral_index_by_name(&port_name)?;
         let base = bus.peripherals[idx].base;

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -433,6 +433,7 @@ pub mod integration_tests {
                     config: HashMap::new(),
                 },
             ],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -607,6 +608,7 @@ pub mod integration_tests {
                     )]),
                 },
             ],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -669,6 +671,7 @@ pub mod integration_tests {
                 clock: None,
                 config: HashMap::new(),
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -726,6 +729,7 @@ pub mod integration_tests {
                 clock: None,
                 config: gpio_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -789,6 +793,7 @@ pub mod integration_tests {
                 clock: None,
                 config: uart_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -938,6 +943,7 @@ pub mod integration_tests {
                     clock: None,
                 },
             ],
+            pins: Default::default(),
             reset_vector_offset: 0,
             atomic_register_aliases: false,
         };
@@ -998,6 +1004,7 @@ pub mod integration_tests {
                 clock: None,
                 config: rcc_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -1058,6 +1065,7 @@ pub mod integration_tests {
                 clock: None,
                 config: rcc_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -1118,6 +1126,7 @@ pub mod integration_tests {
                 clock: None,
                 config: gpio_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {
@@ -2303,6 +2312,7 @@ pub mod integration_tests {
                 clock: None,
                 config: HashMap::new(),
             }],
+            pins: Default::default(),
         };
 
         let manifest = SystemManifest {

--- a/crates/core/tests/pin_map_resolution.rs
+++ b/crates/core/tests/pin_map_resolution.rs
@@ -1,0 +1,60 @@
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+
+fn bus_for(chip_file: &str) -> SystemBus {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../configs/chips")
+        .join(chip_file);
+    let chip = ChipDescriptor::from_file(&path).expect("load chip");
+    let manifest = SystemManifest {
+        walk_deleted: false,
+        schema_version: "1.0".to_string(),
+        name: "pinmap".to_string(),
+        chip: path.to_string_lossy().to_string(),
+        external_devices: vec![],
+        board_io: vec![],
+        debug_uart: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    SystemBus::from_config(&chip, &manifest).expect("assemble bus")
+}
+
+#[test]
+fn mkw41z4_pc0_resolves_via_pin_map() {
+    let bus = bus_for("mkw41z4.yaml");
+    // PC0 → gpioc (base 0x400FF080) + Kinetis PDOR offset 0x00, bit 0.
+    let (addr, bit) = SystemBus::resolve_pin_odr_pub(&bus, "PC0").expect("PC0 resolves");
+    assert_eq!(addr, 0x400F_F080);
+    assert_eq!(bit, 0);
+}
+
+#[test]
+fn mkw41z4_pb6_maps_to_gpioc_not_gpiob() {
+    // The disagreement this whole change fixes: label letter 'B' would parse to
+    // gpiob, but the chip map says PB6 is gpioc bit 2.
+    let bus = bus_for("mkw41z4.yaml");
+    let (addr, bit) = SystemBus::resolve_pin_odr_pub(&bus, "PB6").expect("PB6 resolves");
+    assert_eq!(addr, 0x400F_F080); // gpioc, NOT gpiob (0x400FF040)
+    assert_eq!(bit, 2);
+}
+
+#[test]
+fn mkw41z4_undeclared_pin_fails_loudly_no_letter_parse() {
+    // PB0 is not in mkw41z4 `pins:`. With a declared map, resolution must NOT
+    // fall back to parsing 'B' → gpiob. It returns None (caller errors).
+    let bus = bus_for("mkw41z4.yaml");
+    assert!(SystemBus::resolve_pin_odr_pub(&bus, "PB0").is_none());
+}
+
+#[test]
+fn chip_without_pin_map_still_letter_parses() {
+    // Regression: stm32f103 declares no `pins:`, so the standard-layout parse
+    // still resolves PC13 → gpioc.
+    let bus = bus_for("stm32f103.yaml");
+    let resolved = SystemBus::resolve_pin_odr_pub(&bus, "PC13");
+    assert!(
+        resolved.is_some(),
+        "PC13 must resolve on stm32f103 via label parse"
+    );
+}

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1128,6 +1128,7 @@ mod tests {
                 clock: None,
                 config: HashMap::new(),
             }],
+            pins: Default::default(),
         };
 
         let manifest = labwired_config::SystemManifest {
@@ -1185,6 +1186,7 @@ mod tests {
                 clock: None,
                 config: gpio_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = labwired_config::SystemManifest {
@@ -1255,6 +1257,7 @@ mod tests {
                 clock: None,
                 config: gpio_config,
             }],
+            pins: Default::default(),
         };
 
         let manifest = labwired_config::SystemManifest {


### PR DESCRIPTION
Makes the chip config the single source of truth for pin→GPIO resolution, eliminating the four-way disagreement (core letter-parse vs app hand table vs validator vs component pins) that blanked the KW41Z LCD.

## What
- `ChipDescriptor.pins: BTreeMap<String, PinLoc{gpio,bit}>` — optional authoritative pin map.
- `SystemBus.pin_map` built from `chip.pins` in `from_config`.
- `resolve_pin_odr`/`resolve_pin_idr` resolve **through the map** when a chip declares one; undeclared pin → `None`, **no silent letter-parse fallback**.
- `mkw41z4.yaml` declares its pins (all physically `gpioc`).

Chips without `pins:` keep the existing label-parse unchanged.

## Tests
- New `crates/core/tests/pin_map_resolution.rs` (4): PC0→(0x400FF080,0); PB6→gpioc bit2 (remap, not gpiob); undeclared PB0→None; stm32f103 still letter-parses PC13.
- Config: parses `pins:`, ignores extra `functions:`, defaults empty.
- Regressions: kw41z_clock_boot 5/5, firmware_survival 44/44, e2e_spi3_dc_epaper 2/2.

App pin map will be code-generated from this `pins:` in a follow-up, gated by a drift test + submodule-freshness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)