### PR TITLE
fix(esp32c3-mlx90640-thermal): port firmware to the reentrant iolinki device API + CI build smoke

### DIFF
--- a/.github/workflows/core-iolink-native.yml
+++ b/.github/workflows/core-iolink-native.yml
@@ -16,6 +16,7 @@ on:
       - "crates/core/tests/world_multichip.rs"
       - "examples/iolink-dido/**"
       - "examples/iolink-station/**"
+      - "examples/esp32c3-mlx90640-thermal/**"
       - "third_party/iolinki"
       - "third_party/iolinki-master/**"
   pull_request:
@@ -35,6 +36,7 @@ on:
       - "crates/core/tests/world_multichip.rs"
       - "examples/iolink-dido/**"
       - "examples/iolink-station/**"
+      - "examples/esp32c3-mlx90640-thermal/**"
       - "third_party/iolinki"
       - "third_party/iolinki-master/**"
   workflow_dispatch:
@@ -84,3 +86,34 @@ jobs:
         with:
           name: labwired-iolink-native
           path: out/iolink
+
+  # Build smoke for the ESP32-C3 thermal-fingerprint firmware, which links the
+  # iolinki DEVICE stack for riscv32. This is the firmware an iolinki submodule
+  # pin bump silently broke (issue #445: iolink_core.c removed by the reentrant
+  # device-context line) — building it here makes the next API-breaking pin
+  # bump fail this workflow instead of the example.
+  thermal-firmware-build:
+    name: esp32c3-mlx90640-thermal firmware build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout LabWired core
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Configure private submodule auth
+        run: git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
+
+      - name: Checkout iolinki device submodule
+        run: git submodule update --init --depth 1 third_party/iolinki
+
+      # The Espressif riscv32 GCC the example's Makefile auto-discovers under
+      # ~/.platformio/packages/toolchain-riscv32-esp (pipx ships on the runner).
+      - name: Install riscv32-esp toolchain via PlatformIO
+        run: |
+          pipx install platformio
+          pio pkg install --global --tool "platformio/toolchain-riscv32-esp"
+          "$HOME/.platformio/packages/toolchain-riscv32-esp/bin/riscv32-esp-elf-gcc" --version
+
+      - name: Build thermal-fingerprint firmware against the pinned iolinki
+        run: make -C examples/esp32c3-mlx90640-thermal/firmware

--- a/examples/esp32c3-mlx90640-thermal/firmware/Makefile
+++ b/examples/esp32c3-mlx90640-thermal/firmware/Makefile
@@ -35,9 +35,11 @@ LDFLAGS := -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostartfiles \
 
 # iolinki IO-Link DEVICE-stack sources compiled ON-TARGET for rv32imc (the CMake
 # IOLINKI_SOURCES list, minus the POSIX phy_virtual.c / linux platform, plus the
-# baremetal time source) — the same set the iolink-dido ARM build uses.
+# baremetal time source) — the same set the iolink-dido ARM build uses. The
+# reentrant stack's device-context entry point is src/device.c (iolink_core.c
+# is gone from the pinned submodule).
 IOLINKI_SRC := \
-  $(IOLINKI_DIR)/src/iolink_core.c \
+  $(IOLINKI_DIR)/src/device.c \
   $(IOLINKI_DIR)/src/phy_generic.c \
   $(IOLINKI_DIR)/src/crc.c \
   $(IOLINKI_DIR)/src/dll.c \

--- a/examples/esp32c3-mlx90640-thermal/firmware/main.c
+++ b/examples/esp32c3-mlx90640-thermal/firmware/main.c
@@ -25,10 +25,17 @@
 #include "fingerprint.h"
 #include "iolinki/iolink.h"
 #include "iolinki/application.h"
+#include "iolinki/device.h"
 #include "iolinki/events.h"
 #include "phy_c3_iolink.h"
 
 #define MLX_ADDR 0x33
+
+/* Reentrant iolinki device context + config. File-scope statics: the helpers
+ * below service the link, and iolink_device_init() keeps a pointer to the
+ * config, so both must outlive main()'s init block. */
+static iolink_device_ctx_t g_iol_device;
+static iolink_device_config_t g_iol_cfg;
 
 /* How many times to pump iolink_process() after each verdict so the IO-Link
  * master (paced per UART tick in the sim, ~frame_gap_ticks between frames) can
@@ -113,7 +120,7 @@ static void print_verdict(const tfs_verdict_t *v) {
  * so the device-side test can confirm the link reached OPERATE. */
 static iolink_dll_state_t g_last_iol_state = (iolink_dll_state_t)0xFF;
 static void trace_iolink_state(void) {
-    iolink_dll_state_t s = iolink_get_state();
+    iolink_dll_state_t s = iolink_device_get_state(&g_iol_device);
     if (s != g_last_iol_state) {
         g_last_iol_state = s;
         uart_puts("STATE=");
@@ -133,9 +140,9 @@ static void trace_iolink_state(void) {
 static void iolink_service(uint32_t iters, uint32_t settle) {
     uint32_t operate_run = 0;
     for (uint32_t i = 0; i < iters; i++) {
-        iolink_process();
+        iolink_device_process(&g_iol_device);
         trace_iolink_state();
-        if (iolink_get_state() == IOLINK_DLL_STATE_OPERATE) {
+        if (iolink_device_get_state(&g_iol_device) == IOLINK_DLL_STATE_OPERATE) {
             if (++operate_run >= settle) {
                 return;
             }
@@ -177,26 +184,29 @@ int main(void) {
 
     /* ── Bring up the iolinki IO-Link DEVICE stack on UART1 (the C/Q line) ──
      * The 9-byte thermal verdict is published as IO-Link process data; a native
-     * master attached to uart1 cyclically reads it. memset the config first (the
-     * iolink-dido lesson: a designated-init can leave t_pd_us garbage and arm a bogus
-     * power-on delay). pd_in_len=9 matches the verdict frame; m_seq_type 1_1
-     * (PD + 1-byte OD) matches the master's `m_seq_type: 1`. */
-    iolink_config_t cfg;
-    memset(&cfg, 0, sizeof(cfg));
-    cfg.m_seq_type = IOLINK_M_SEQ_TYPE_1_1;
-    cfg.min_cycle_time = 0;
-    cfg.pd_in_len = 9;
-    cfg.pd_out_len = 0;
-    cfg.t_pd_us = 0;
-    if (iolink_init(iolink_phy_c3_get(), &cfg) != 0) {
+     * master attached to uart1 cyclically reads it. Reentrant API: the stack
+     * lives in an explicit device context (g_iol_device) instead of a singleton.
+     * memset the config first (the iolink-dido lesson: a designated-init can
+     * leave t_pd_us garbage and arm a bogus power-on delay). pd_in_len=9 matches
+     * the verdict frame; m_seq_type 1_1 (PD + 1-byte OD) matches the master's
+     * `m_seq_type: 1`. */
+    memset(&g_iol_device, 0, sizeof(g_iol_device));
+    memset(&g_iol_cfg, 0, sizeof(g_iol_cfg));
+    g_iol_cfg.phy = *iolink_phy_c3_get();
+    g_iol_cfg.stack.m_seq_type = IOLINK_M_SEQ_TYPE_1_1;
+    g_iol_cfg.stack.min_cycle_time = 0;
+    g_iol_cfg.stack.pd_in_len = 9;
+    g_iol_cfg.stack.pd_out_len = 0;
+    g_iol_cfg.stack.t_pd_us = 0;
+    if (iolink_device_init(&g_iol_device, &g_iol_cfg) != 0) {
         uart_puts("IOLINK INIT FAIL\r\n");
         for (;;) {
         }
     }
     /* Clock frozen + timing enforcement off: the handshake is driven purely by
      * byte arrival, which is what the cycle-stepped simulator models. */
-    iolink_set_timing_enforcement(false);
-    iolink_events_ctx_t *events = iolink_get_events_ctx();
+    iolink_device_set_timing_enforcement(&g_iol_device, false);
+    iolink_events_ctx_t *events = iolink_device_get_events_ctx(&g_iol_device);
     uart_puts("IOLINK INIT OK\r\n");
 
     tfs_ctx_t ctx;
@@ -212,7 +222,7 @@ int main(void) {
     {
         uint8_t pd0[9];
         memset(pd0, 0, sizeof(pd0));
-        iolink_pd_input_update(pd0, 9, true);
+        iolink_device_pd_input_update(&g_iol_device, pd0, 9, true);
         /* Pump until OPERATE is reached (then a short settle), capped. */
         iolink_service(IOLINK_SERVICE_ITERS, IOLINK_SETTLE_PUMPS);
     }
@@ -239,7 +249,7 @@ int main(void) {
         /* Publish the verdict as IO-Link process data the master reads cyclically. */
         uint8_t pd[9];
         pack_pd(&v, pd);
-        iolink_pd_input_update(pd, 9, true);
+        iolink_device_pd_input_update(&g_iol_device, pd, 9, true);
 
         /* On the first fault, raise an IO-Link TEMPERATURE diagnostic event. The
          * iolinki DLL sets the operate-status EVENT bit while events are pending,

--- a/examples/esp32c3-mlx90640-thermal/firmware/phy_c3_iolink.c
+++ b/examples/esp32c3-mlx90640-thermal/firmware/phy_c3_iolink.c
@@ -8,8 +8,9 @@
  * The IO-Link line speed is irrelevant in the cycle-stepped sim, so set_baudrate
  * is a no-op. detect_wakeup scans for the 0x55 wake-up byte the master sends
  * first (mirrors the iolink-dido phy_labwired / iolinki phy_virtual). No timing is
- * enforced here — the device firmware calls iolink_set_timing_enforcement(false)
- * and the handshake is driven purely by byte arrival. */
+ * enforced here — the device firmware calls
+ * iolink_device_set_timing_enforcement(false) and the handshake is driven purely
+ * by byte arrival. */
 #include "phy_c3_iolink.h"
 #include <stdint.h>
 
@@ -18,23 +19,32 @@
 #define U1_DR (*(volatile uint32_t *)(UART1_BASE + 0x04u))
 #define SR_RXNE (1u << 5)
 
-static int phy_init(void) {
+static int phy_init(void *user) {
+    (void)user;
     /* The generic UART model needs no explicit enable to TX/RX in the sim. */
     return 0;
 }
 
-static void phy_set_mode(iolink_phy_mode_t mode) { (void)mode; }
+static void phy_set_mode(void *user, iolink_phy_mode_t mode) {
+    (void)user;
+    (void)mode;
+}
 
-static void phy_set_baudrate(iolink_baudrate_t baudrate) { (void)baudrate; }
+static void phy_set_baudrate(void *user, iolink_baudrate_t baudrate) {
+    (void)user;
+    (void)baudrate;
+}
 
-static int phy_send(const uint8_t *data, size_t len) {
+static int phy_send(void *user, const uint8_t *data, size_t len) {
+    (void)user;
     for (size_t i = 0; i < len; i++) {
         U1_DR = (uint32_t)data[i];
     }
     return (int)len;
 }
 
-static int phy_recv_byte(uint8_t *byte) {
+static int phy_recv_byte(void *user, uint8_t *byte) {
+    (void)user;
     if (U1_SR & SR_RXNE) {
         *byte = (uint8_t)U1_DR;
         return 1;
@@ -42,9 +52,9 @@ static int phy_recv_byte(uint8_t *byte) {
     return 0;
 }
 
-static int phy_detect_wakeup(void) {
+static int phy_detect_wakeup(void *user) {
     uint8_t b;
-    while (phy_recv_byte(&b) > 0) {
+    while (phy_recv_byte(user, &b) > 0) {
         if (b == 0x55u) {
             return 1;
         }
@@ -53,6 +63,7 @@ static int phy_detect_wakeup(void) {
 }
 
 static const iolink_phy_api_t PHY = {
+    .user = 0,
     .init = phy_init,
     .set_mode = phy_set_mode,
     .set_baudrate = phy_set_baudrate,


### PR DESCRIPTION
Fixes #445

## Problem

The `third_party/iolinki` submodule bump to the reentrant device-context line (merge `3712db1d`) removed `src/iolink_core.c` and the old singleton device API. The ESP32-C3 thermal-fingerprint example still referenced both, so its firmware no longer built:

```
make: *** No rule to make target '../../../third_party/iolinki/src/iolink_core.c', needed by 'thermal_fingerprint.elf'.
```

Nothing in CI builds this firmware, so the pin bump broke it silently.

## Port (old singleton API → reentrant device-context API)

Mirrors the `examples/iolink-dido` firmware, which already uses the reentrant stack. Submodule pin is **unchanged**.

| Old (singleton) | New (reentrant) |
|---|---|
| `src/iolink_core.c` in `IOLINKI_SRC` | `src/device.c` |
| `iolink_config_t cfg` + `iolink_init(phy, &cfg)` | `iolink_device_config_t` (`.phy` embedded by value, stack config nested under `.stack`) + `iolink_device_init(&ctx, &cfg)` on an explicit static `iolink_device_ctx_t` |
| `iolink_process()` | `iolink_device_process(&ctx)` |
| `iolink_get_state()` | `iolink_device_get_state(&ctx)` |
| `iolink_pd_input_update(pd, 9, true)` | `iolink_device_pd_input_update(&ctx, pd, 9, true)` |
| `iolink_set_timing_enforcement(false)` | `iolink_device_set_timing_enforcement(&ctx, false)` |
| `iolink_get_events_ctx()` | `iolink_device_get_events_ctx(&ctx)` |
| PHY callbacks `init(void)`, `send(data, len)`, … | gain a leading `void *user` parameter; `iolink_phy_api_t` gains `.user` |

`iolink_event_trigger(events, code, type)` is unchanged (already ctx-based). Behavior is identical: same console lines (`TFS BOOT`, `MLX90640 READY`, `STATE=04 OPERATE`, per-frame verdict lines, `IOLINK EVENT TRIGGERED code=5130`) and the same 9-byte PD frames the test yamls assert.

## Verification

Firmware builds clean (riscv32-esp-elf-gcc, `-Wall -Wextra`, no warnings). Real simulator runs with a locally built `labwired-cli`:

- `labwired test --script examples/esp32c3-mlx90640-thermal/test-iolink.yaml` → **EXIT 0**
- `labwired test --script examples/esp32c3-mlx90640-thermal/test-iolink-fault.yaml` → **EXIT 0**

RED-check (assertions actually bite): temporarily mutated the fault yaml's `fault=COOLING_FAILURE` master-verdict assertion → **EXIT 1**; restored → **EXIT 0** again.

Repo gates: `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` both pass (no Rust code touched).

## CI smoke

New `thermal-firmware-build` job in `core-iolink-native.yml` — the workflow that already triggers on the `third_party/iolinki` pin path (plus new `examples/esp32c3-mlx90640-thermal/**` path filters). It installs the Espressif riscv32 GCC via PlatformIO (`pipx install platformio` + `pio pkg install --global --tool platformio/toolchain-riscv32-esp`, the exact path the example Makefile auto-discovers) and runs `make -C examples/esp32c3-mlx90640-thermal/firmware`. The next API-breaking iolinki pin bump fails this job instead of silently breaking the example.