### PR TITLE
fix(world): readable multi-node console output (per-node line prefixes)

### DIFF
--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -151,6 +151,19 @@ impl World {
             machine
                 .reset()
                 .map_err(|e| anyhow::anyhow!("node '{}': reset: {e:?}", node.id))?;
+            // Label each node's UART console with its id so the shared stdout
+            // stays readable (line-buffered per node instead of byte-interleaved
+            // across all nodes).
+            let prefix = format!("[{}] ", node.id);
+            for p in machine.bus.peripherals.iter_mut() {
+                if let Some(uart) = p
+                    .dev
+                    .as_any_mut()
+                    .and_then(|any| any.downcast_mut::<crate::peripherals::uart::Uart>())
+                {
+                    uart.set_stdout_prefix(prefix.clone());
+                }
+            }
             world.add_machine(node.id.clone(), Box::new(machine));
         }
 


### PR DESCRIPTION
Multi-chip worlds built via `World::from_manifest` echoed all nodes' UART consoles to one stdout character-by-character, so the IO-Link station multiport CI log was unreadable interleaved soup. This labels each node's UART console with `[node-id]` using the existing line-buffered `set_stdout_prefix` mechanism (same as the CLI dual-station path).

Before: `IIIIOOOOLLLLIIIINNNNKKKK IIIINNNNIIIITTTT OOOOKKKK` / `STATE=04 OPSSERTTATAAE TTPDEE=A==5`
After: `[sensor2] IOLINK INIT OK` / `[master] STATE=04 OPERATE PD=A5`

Verified locally: `world_multichip` (3/3, LABWIRED_REQUIRE_IOLINK_ELFS=1, real CubeL4 firmwares) + `e2e_iolink_dido` (1/1) + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)