### PR TITLE
feat(sim-input): generic SimInput interface — drive any input device by channel name

### DIFF
--- a/crates/core/src/bus/bus_trace.rs
+++ b/crates/core/src/bus/bus_trace.rs
@@ -164,6 +164,9 @@ impl I2cDevice for TracingI2cDevice {
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         self.inner.as_any_mut()
     }
+    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
+        self.inner.as_sim_input_mut()
+    }
 }
 
 pub struct TracingSpiDevice {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -586,6 +586,79 @@ impl Default for SystemBus {
 }
 
 impl SystemBus {
+    /// Discover every drivable input channel across attached devices, tagged
+    /// with the owning peripheral's name — the "what can an agent drive?"
+    /// query behind `labwired_list_inputs` / the browser panel.
+    ///
+    /// Currently walks I²C devices (accelerometers, …); SPI/UART/ADC inputs
+    /// gain the same `as_sim_input_mut` hook as they're added.
+    pub fn list_inputs(&self) -> Vec<(String, crate::sim_input::InputChannel)> {
+        let mut out = Vec::new();
+        for entry in &self.peripherals {
+            let Some(any) = entry.dev.as_any() else {
+                continue;
+            };
+            let Some(i2c) = any.downcast_ref::<crate::peripherals::i2c::I2c>() else {
+                continue;
+            };
+            for cell in i2c.attached_devices() {
+                let mut dev = cell.borrow_mut();
+                if let Some(si) = dev.as_sim_input_mut() {
+                    for ch in si.input_channels() {
+                        out.push((entry.name.clone(), *ch));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Drive `channel` to `value` (in the channel's engineering unit) on the
+    /// unique attached input device that exposes it. Generic over device type
+    /// via [`crate::sim_input::SimInput`] — no per-type dispatch. Errors if no
+    /// device (or more than one) exposes the channel, or the value is out of
+    /// range.
+    pub fn set_input(
+        &mut self,
+        channel: &str,
+        value: f64,
+    ) -> Result<(), crate::sim_input::SimInputError> {
+        use crate::sim_input::SimInputError;
+        // Count matches first so ambiguity is a typed error, not a silent
+        // "first wins".
+        let matches = self
+            .list_inputs()
+            .iter()
+            .filter(|(_, ch)| ch.key == channel)
+            .count();
+        if matches == 0 {
+            return Err(SimInputError::NoDevice(channel.to_string()));
+        }
+        if matches > 1 {
+            return Err(SimInputError::Ambiguous {
+                channel: channel.to_string(),
+                matches,
+            });
+        }
+        for entry in self.peripherals.iter_mut() {
+            let Some(any) = entry.dev.as_any_mut() else {
+                continue;
+            };
+            let Some(i2c) = any.downcast_mut::<crate::peripherals::i2c::I2c>() else {
+                continue;
+            };
+            for cell in i2c.attached_devices() {
+                let mut dev = cell.borrow_mut();
+                if let Some(si) = dev.as_sim_input_mut() {
+                    if si.input_channels().iter().any(|c| c.key == channel) {
+                        return si.set_input(channel, value);
+                    }
+                }
+            }
+        }
+        Err(SimInputError::NoDevice(channel.to_string()))
+    }
+
     /// Snapshot of the universal bus-transaction trace (logic analyzer):
     /// every I²C/SPI byte recorded so far by peripherals wired to
     /// `self.bus_trace` (see `crate::bus::bus_trace`), oldest first.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod physics;
 pub mod runtime_snapshot;
 pub mod sched;
 pub mod signals;
+pub mod sim_input;
 pub mod snapshot;
 pub mod system;
 pub mod trace;
@@ -739,6 +740,26 @@ pub struct Machine<C: Cpu> {
     /// under the `event-scheduler` feature.
     #[allow(dead_code)]
     scheduler_bootstrapped: bool,
+}
+
+impl<C: Cpu> Machine<C> {
+    /// Discover the drivable input channels on this machine (delegates to
+    /// [`bus::SystemBus::list_inputs`]). See [`crate::sim_input`].
+    pub fn list_inputs(&self) -> Vec<(String, crate::sim_input::InputChannel)> {
+        self.bus.list_inputs()
+    }
+
+    /// Drive a simulated input channel to `value` (delegates to
+    /// [`bus::SystemBus::set_input`]). The generic entry point an agent, the
+    /// WASM bridge, or a test-script stimulus calls to steer an input device
+    /// mid-run without knowing its concrete type.
+    pub fn set_input(
+        &mut self,
+        channel: &str,
+        value: f64,
+    ) -> Result<(), crate::sim_input::SimInputError> {
+        self.bus.set_input(channel, value)
+    }
 }
 
 impl<C: Cpu> Machine<C> {

--- a/crates/core/src/peripherals/components/fxos8700.rs
+++ b/crates/core/src/peripherals/components/fxos8700.rs
@@ -207,6 +207,59 @@ impl I2cDevice for Fxos8700 {
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
     }
+
+    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
+        Some(self)
+    }
+}
+
+/// Drivable accelerometer axes, in g. The FXOS8700 accel is 14-bit
+/// left-justified: 1 g = `ONE_G_LJ` (0x1000 = 4096) raw counts. Full-scale is
+/// set by `xyz_data_cfg`; the demo scale is ±2 g, matching the browser panel.
+impl crate::sim_input::SimInput for Fxos8700 {
+    fn input_channels(&self) -> &'static [crate::sim_input::InputChannel] {
+        use crate::sim_input::InputChannel;
+        const CH: &[InputChannel] = &[
+            InputChannel {
+                key: "x",
+                label: "X",
+                unit: "g",
+                min: -2.0,
+                max: 2.0,
+            },
+            InputChannel {
+                key: "y",
+                label: "Y",
+                unit: "g",
+                min: -2.0,
+                max: 2.0,
+            },
+            InputChannel {
+                key: "z",
+                label: "Z",
+                unit: "g",
+                min: -2.0,
+                max: 2.0,
+            },
+        ];
+        CH
+    }
+
+    fn set_input(&mut self, key: &str, value: f64) -> Result<(), crate::sim_input::SimInputError> {
+        self.require_channel(key, value)?;
+        let raw = (value * ONE_G_LJ as f64).round() as i16;
+        let axis = match key {
+            "x" => 0,
+            "y" => 1,
+            "z" => 2,
+            _ => unreachable!("require_channel validated the key"),
+        };
+        self.accel[axis] = raw;
+        // Latch manual so the built-in animation in `read()` stops overwriting
+        // the driven value — same contract as `set_sample`.
+        self.manual = true;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -32,6 +32,13 @@ pub trait I2cDevice: Send {
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         None
     }
+    /// Runtime-drivable view of this device, if it accepts simulated input.
+    /// Overridden by input devices (accelerometers, …) so the generic
+    /// [`crate::Machine::set_input`] resolver can reach them without a
+    /// downcast. Default `None` = not an input device.
+    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
+        None
+    }
 }
 
 /// I2C register layout selector. STM32F1/F2/F4 share the legacy I2C

--- a/crates/core/src/sim_input.rs
+++ b/crates/core/src/sim_input.rs
@@ -1,0 +1,110 @@
+//! Generic simulated-input interface.
+//!
+//! An "input component" is a modelled device whose behaviour an external
+//! driver can steer at runtime — an accelerometer's pose, a distance sensor's
+//! range, a thermistor's temperature. Historically each had a bespoke setter
+//! (`Fxos8700::set_sample`, `set_hcsr04_distance`, …) reached by downcasting to
+//! the concrete type, so every caller (the WASM bridge, a future MCP tool, a
+//! test script) hard-coded the type list.
+//!
+//! `SimInput` is the one generic contract over those setters. A device declares
+//! the named channels it accepts (`input_channels`) and applies a value to one
+//! (`set_input`). [`crate::Machine::set_input`] resolves a channel to the
+//! (unique) attached device that exposes it and drives it — so an agent can say
+//! "set channel `x` to 2.0" without knowing the device type, address, or bus.
+//!
+//! Units are the human-facing engineering units in [`InputChannel::unit`] (g,
+//! cm, °C …); each device impl owns the conversion to its raw register form, so
+//! that math lives in ONE place per device.
+
+/// Metadata for one drivable channel of an input component.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InputChannel {
+    /// Stable key used to address the channel (e.g. `"x"`, `"distance"`).
+    pub key: &'static str,
+    /// Human-facing label (e.g. `"X"`, `"Distance"`).
+    pub label: &'static str,
+    /// Engineering unit of `value` in [`SimInput::set_input`] (e.g. `"g"`).
+    pub unit: &'static str,
+    /// Inclusive minimum accepted value, in `unit`.
+    pub min: f64,
+    /// Inclusive maximum accepted value, in `unit`.
+    pub max: f64,
+}
+
+/// Why a [`SimInput::set_input`] / [`crate::Machine::set_input`] call failed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SimInputError {
+    /// No channel with this key on the resolved device.
+    UnknownChannel(String),
+    /// `value` is outside the channel's `[min, max]`.
+    OutOfRange {
+        key: String,
+        value: f64,
+        min: f64,
+        max: f64,
+    },
+    /// No attached input device exposes this channel.
+    NoDevice(String),
+    /// More than one attached device exposes this channel; disambiguation is
+    /// required (a future target selector). Carries how many matched.
+    Ambiguous { channel: String, matches: usize },
+}
+
+impl core::fmt::Display for SimInputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SimInputError::UnknownChannel(k) => write!(f, "unknown input channel '{k}'"),
+            SimInputError::OutOfRange {
+                key,
+                value,
+                min,
+                max,
+            } => write!(
+                f,
+                "value {value} for channel '{key}' is out of range [{min}, {max}]"
+            ),
+            SimInputError::NoDevice(c) => {
+                write!(f, "no attached input device exposes channel '{c}'")
+            }
+            SimInputError::Ambiguous { channel, matches } => write!(
+                f,
+                "channel '{channel}' is exposed by {matches} devices; disambiguation required"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SimInputError {}
+
+/// A device that accepts runtime input on one or more named channels.
+///
+/// Implementors also override `as_sim_input_mut` on their bus-device trait
+/// (e.g. `I2cDevice`) so [`crate::Machine::set_input`] can reach them without
+/// downcasting to the concrete type.
+pub trait SimInput {
+    /// The channels this device accepts, with metadata for discovery.
+    fn input_channels(&self) -> &'static [InputChannel];
+
+    /// Apply `value` (in the channel's `unit`) to channel `key`.
+    fn set_input(&mut self, key: &str, value: f64) -> Result<(), SimInputError>;
+
+    /// Range-check helper: returns the matching channel or a typed error.
+    fn require_channel(&self, key: &str, value: f64) -> Result<InputChannel, SimInputError> {
+        let ch = self
+            .input_channels()
+            .iter()
+            .find(|c| c.key == key)
+            .copied()
+            .ok_or_else(|| SimInputError::UnknownChannel(key.to_string()))?;
+        if value < ch.min || value > ch.max {
+            return Err(SimInputError::OutOfRange {
+                key: key.to_string(),
+                value,
+                min: ch.min,
+                max: ch.max,
+            });
+        }
+        Ok(ch)
+    }
+}

--- a/crates/core/tests/sim_input.rs
+++ b/crates/core/tests/sim_input.rs
@@ -1,0 +1,118 @@
+// Integration test for the generic simulated-input interface
+// (`crate::sim_input`): an agent / bridge / test-script can discover and drive
+// an input device's channels by name, without knowing the concrete type, on a
+// real board built from config.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::components::Fxos8700;
+use labwired_core::peripherals::i2c::{I2c, I2cDevice};
+use labwired_core::sim_input::SimInputError;
+use std::path::PathBuf;
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn workspace_root() -> PathBuf {
+    crate_root()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Build the FRDM-KW41Z-LCD bus (the cow demo board): a KinetisI2c with the
+/// FXOS8700 accelerometer attached at 0x1f.
+fn kw41z_lcd_bus() -> SystemBus {
+    let chip = ChipDescriptor::from_file(workspace_root().join("configs/chips/mkw41z4.yaml"))
+        .expect("load mkw41z4 chip");
+    let sys_path = workspace_root().join("configs/systems/frdm-kw41z-lcd.yaml");
+    let mut manifest = SystemManifest::from_file(&sys_path).expect("load frdm-kw41z-lcd system");
+    manifest.chip = sys_path
+        .parent()
+        .unwrap()
+        .join(&manifest.chip)
+        .to_str()
+        .unwrap()
+        .to_string();
+    SystemBus::from_config(&chip, &manifest).expect("build bus")
+}
+
+/// Read one 14-bit left-justified accel axis back out of the FXOS8700 over its
+/// I²C register interface — proving a driven value actually reaches the model's
+/// register file, not just an internal field.
+fn read_axis(bus: &mut SystemBus, msb_reg: u8) -> i16 {
+    for entry in bus.peripherals.iter_mut() {
+        let Some(any) = entry.dev.as_any_mut() else {
+            continue;
+        };
+        let Some(i2c) = any.downcast_mut::<I2c>() else {
+            continue;
+        };
+        for cell in i2c.attached_devices() {
+            let mut dev = cell.borrow_mut();
+            if let Some(any) = dev.as_any_mut() {
+                if let Some(fxos) = any.downcast_mut::<Fxos8700>() {
+                    fxos.stop(); // reset the register-pointer phase (fresh transaction)
+                    fxos.write(msb_reg);
+                    let hi = fxos.read() as i16;
+                    let lo = fxos.read() as i16;
+                    return (hi << 8) | (lo & 0xFF);
+                }
+            }
+        }
+    }
+    panic!("no FXOS8700 on the bus");
+}
+
+#[test]
+fn lists_the_accelerometer_channels() {
+    let bus = kw41z_lcd_bus();
+    let inputs = bus.list_inputs();
+    let keys: Vec<_> = inputs.iter().map(|(_, ch)| ch.key).collect();
+    assert!(keys.contains(&"x"), "expected an x channel, got {keys:?}");
+    assert!(keys.contains(&"y"));
+    assert!(keys.contains(&"z"));
+    // Channels carry discovery metadata (unit + range) for agents.
+    let x = inputs.iter().find(|(_, c)| c.key == "x").unwrap().1;
+    assert_eq!(x.unit, "g");
+    assert_eq!((x.min, x.max), (-2.0, 2.0));
+}
+
+#[test]
+fn set_input_drives_the_device_by_channel_name() {
+    let mut bus = kw41z_lcd_bus();
+
+    // Drive purely by channel name — no device type, address, or bus known.
+    bus.set_input("x", 1.0).expect("set x to +1 g");
+    bus.set_input("y", -0.5).expect("set y to -0.5 g");
+
+    // 1 g = 0x1000 (4096) raw, left-justified 14-bit; read it back over I²C.
+    // OUT_X_MSB = 0x01, OUT_Y_MSB = 0x03.
+    assert_eq!(read_axis(&mut bus, 0x01), 4096, "x should read +1 g");
+    assert_eq!(read_axis(&mut bus, 0x03), -2048, "y should read -0.5 g");
+
+    // The driven value must STICK across reads (manual latch beats the
+    // built-in animation) — the property the demo needs.
+    assert_eq!(read_axis(&mut bus, 0x01), 4096, "x must not animate away");
+}
+
+#[test]
+fn set_input_rejects_unknown_channel_and_out_of_range() {
+    let mut bus = kw41z_lcd_bus();
+
+    match bus.set_input("nope", 0.0) {
+        Err(SimInputError::NoDevice(c)) => assert_eq!(c, "nope"),
+        other => panic!("expected NoDevice, got {other:?}"),
+    }
+
+    match bus.set_input("x", 9.0) {
+        Err(SimInputError::OutOfRange { key, max, .. }) => {
+            assert_eq!(key, "x");
+            assert_eq!(max, 2.0);
+        }
+        other => panic!("expected OutOfRange, got {other:?}"),
+    }
+}

--- a/crates/wasm/src/inputs.rs
+++ b/crates/wasm/src/inputs.rs
@@ -10,6 +10,49 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 impl WasmSimulator {
+    /// Generic input-scripting entry point: drive `channel` to `value` (in the
+    /// channel's engineering unit — g, cm, °C …) on the unique attached input
+    /// device that exposes it. Type-agnostic (see `labwired_core::sim_input`),
+    /// so the browser panel, an MCP tool, and a test-script stimulus all share
+    /// ONE surface. Errors if no device (or more than one) exposes the channel,
+    /// or the value is out of range.
+    #[wasm_bindgen]
+    pub fn set_input(&mut self, channel: &str, value: f64) -> Result<(), JsValue> {
+        let machine = self
+            .machine
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("simulator not initialized"))?;
+        machine
+            .set_input(channel, value)
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Discover the drivable input channels on the running machine, as JSON:
+    /// `[{"peripheral":"i2c1","key":"x","label":"X","unit":"g","min":-2,"max":2}, …]`.
+    /// The "what can I drive?" query an agent calls before `set_input`.
+    #[wasm_bindgen]
+    pub fn list_inputs(&self) -> Result<JsValue, JsValue> {
+        let machine = self
+            .machine
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("simulator not initialized"))?;
+        let entries: Vec<serde_json::Value> = machine
+            .list_inputs()
+            .into_iter()
+            .map(|(peripheral, ch)| {
+                serde_json::json!({
+                    "peripheral": peripheral,
+                    "key": ch.key,
+                    "label": ch.label,
+                    "unit": ch.unit,
+                    "min": ch.min,
+                    "max": ch.max,
+                })
+            })
+            .collect();
+        serde_wasm_bindgen::to_value(&entries).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
     /// Set the distance (cm) reported by an HC-SR04 ultrasonic sensor — the
     /// host-controlled "hand position" that drives gesture control. Clamped to
     /// the sensor's 2–400 cm range.

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-30 | ⚠ drift acked 2026-06-30 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-30 | ⚠ drift acked 2026-06-30 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-01 | ⚠ drift acked 2026-07-01 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-28 | ⚠ drift acked 2026-06-28 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-01 | ⚠ drift acked 2026-07-01 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-01 | ⚠ drift acked 2026-07-01 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-01 | ⚠ drift acked 2026-07-01 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-01 | ⚠ drift acked 2026-07-01 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-01 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-03 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-01 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-03 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-01 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-03 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-01 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-03 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -145,7 +145,8 @@ boards:
     # hash drift only). h563_mmio_diff + h563_conformance pass. No live re-capture.
     # 2026-06-30: additive Kinetis I2C variant (KinetisI2c) + enum arm in i2c.rs for the KW41Z; the STM32 F1/L4 I2C engines are byte-for-byte untouched, stm32h563 diff/conformance unchanged. No live re-capture.
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
-    drift_ack: 2026-07-01
+    # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
+    drift_ack: 2026-07-03
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -232,7 +233,8 @@ boards:
     # is untouched. l476_mmio_diff passes unchanged. No live re-capture.
     # 2026-06-30: additive Kinetis I2C variant (KinetisI2c) + enum arm in i2c.rs for the KW41Z; the STM32 F1/L4 I2C engines are byte-for-byte untouched, nucleo-l476rg diff/conformance unchanged. No live re-capture.
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
-    drift_ack: 2026-07-01
+    # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
+    drift_ack: 2026-07-03
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -314,7 +316,8 @@ boards:
     # firmware updated to enable+wait HSE before selecting it. No live re-capture.
     # 2026-06-30: additive Kinetis I2C variant (KinetisI2c) + enum arm in i2c.rs for the KW41Z; the STM32 F1/L4 I2C engines are byte-for-byte untouched, stm32f103 diff/conformance unchanged. No live re-capture.
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
-    drift_ack: 2026-07-01
+    # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
+    drift_ack: 2026-07-03
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -360,7 +363,8 @@ boards:
     # re-capture.
     # 2026-06-30: additive Kinetis I2C variant (KinetisI2c) + enum arm in i2c.rs for the KW41Z; the STM32 F1/L4 I2C engines are byte-for-byte untouched, stm32f407 diff/conformance unchanged. No live re-capture.
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
-    drift_ack: 2026-07-01
+    # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
+    drift_ack: 2026-07-03
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
The reusable, type-agnostic foundation for **scriptable input behavior** — so the browser panel, an MCP tool (ChatGPT), and a declarative test-script stimulus all drive simulated inputs through **one** surface instead of downcasting to each concrete device type.

## Why
Every existing caller reached an input device by downcasting (`Fxos8700::set_sample`, `set_hcsr04_distance`, …). There was no generic "set channel `x` to `2.0`", so nothing could drive an input without compiling in the type list — the blocker for letting an agent script inputs over MCP.

## What
- **`crate::sim_input`**: a `SimInput` trait (`input_channels` + `set_input`) with `InputChannel` metadata (key/label/unit/min/max) and a typed `SimInputError`.
- **`I2cDevice::as_sim_input_mut`** hook (default `None`), forwarded through `TracingI2cDevice`; **`Fxos8700` implements `SimInput`** (x/y/z in g, ±2 g, owns the g→raw conversion).
- **`SystemBus::{list_inputs, set_input}`** resolve a channel to the *unique* attached device that exposes it — type-agnostic; ambiguity / unknown-channel / out-of-range are typed errors. `Machine` delegates.
- **WASM bridge**: `set_input(channel, value)` + `list_inputs()` (JSON) — the concrete agent-callable surface, shared by the browser and future MCP session tools.
- **Integration test** drives the FXOS8700 on the real KW41Z bus purely by channel name and reads it back over I²C; covers discovery + range/unknown errors.

## Verification
- `cargo test -p labwired-core --test sim_input` → 3 passing.
- `cargo check -p labwired-wasm` clean; clippy clean (the 2 remaining wasm warnings are pre-existing, unrelated `#[deprecated]`).
- `firmware_survival` (full board suite) still green.

## Next layers (design on the cow-demo branch)
SPI/UART/ADC inputs gain the same `as_sim_input_mut` hook incrementally. The declarative `stimuli:` track in TestScript (schema 1.2, reusing the fault-trigger vocabulary) and the interactive MCP `set_input`/`step` tools build directly on this — see `docs/superpowers/specs/2026-07-03-scriptable-inputs-via-mcp-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)