### PR TITLE
feat(test): declarative input stimuli (schema 1.2)

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -103,6 +103,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
         assertions,
         faults,
         verdict,
+        stimuli,
     ) = match loaded {
         LoadedTestScript::V1_0(script) => (
             Some(script.inputs.firmware),
@@ -117,6 +118,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             script.assertions,
             script.faults,
             script.verdict,
+            script.stimuli,
         ),
         LoadedTestScript::LegacyV1(script) => {
             tracing::warn!(
@@ -135,6 +137,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 script.assertions,
                 Vec::new(),
                 None,
+                Vec::new(),
             )
         }
     };
@@ -360,6 +363,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 &faults,
                 require_fault_fired,
                 fault_evidence,
+                &stimuli,
             );
             // Device-block render readout. Surfaces the attached panel block's
             // REAL render state — refresh_gen AND black-plane ink — so a generic
@@ -497,6 +501,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 &faults,
                 require_fault_fired,
                 fault_evidence,
+                &stimuli,
             )
         }};
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1632,6 +1632,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     faults: &[labwired_config::FaultSpec],
     require_fault_fired: bool,
     mut fault_evidence: Vec<labwired_cli::faults::FaultEvidence>,
+    stimuli: &[labwired_config::StimulusSpec],
 ) -> ExitCode {
     let max_steps = resolved_limits.max_steps;
     let max_cycles = resolved_limits.max_cycles;
@@ -1683,8 +1684,50 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         1
     };
 
+    // Declarative input stimuli (schema_version 1.2). Applied via the generic
+    // `Machine::set_input` path (see `labwired_core::sim_input`), so no per-type
+    // wiring. `at_start` fires now; `after_cycles` fires the first loop
+    // iteration at or past its cycle threshold. The closure takes `machine` as
+    // an argument (captures nothing) so it can be called both here and mid-loop.
+    let apply_stimulus =
+        |machine: &mut labwired_core::Machine<C>, s: &labwired_config::StimulusSpec| {
+            match machine.set_input(&s.target.channel, s.value) {
+                Ok(()) => info!("stimulus: {} = {} applied", s.target.channel, s.value),
+                Err(e) => error!(
+                    "stimulus '{}' = {} could not be applied: {:?}",
+                    s.target.channel, s.value, e
+                ),
+            }
+        };
+    for s in stimuli {
+        if matches!(s.trigger, labwired_config::FaultTrigger::AtStart) {
+            apply_stimulus(machine, s);
+        }
+    }
+    // Time-triggered stimuli, each tagged with whether it has fired yet.
+    let mut pending_stimuli: Vec<(&labwired_config::StimulusSpec, bool)> = stimuli
+        .iter()
+        .filter(|s| matches!(s.trigger, labwired_config::FaultTrigger::AfterCycles { .. }))
+        .map(|s| (s, false))
+        .collect();
+
     let mut step = 0;
     while step < max_steps {
+        // Fire any `after_cycles` stimulus whose threshold the run has reached.
+        if !pending_stimuli.is_empty() {
+            let cycles = metrics.get_cycles();
+            for (s, fired) in pending_stimuli.iter_mut() {
+                if *fired {
+                    continue;
+                }
+                if let labwired_config::FaultTrigger::AfterCycles { cycles: threshold } = s.trigger {
+                    if cycles >= threshold {
+                        apply_stimulus(machine, s);
+                        *fired = true;
+                    }
+                }
+            }
+        }
         if !args.breakpoint.is_empty() && args.breakpoint.contains(&machine.cpu.get_pc()) {
             stop_reason = StopReason::Halt;
             steps_executed = step;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1689,16 +1689,16 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     // wiring. `at_start` fires now; `after_cycles` fires the first loop
     // iteration at or past its cycle threshold. The closure takes `machine` as
     // an argument (captures nothing) so it can be called both here and mid-loop.
-    let apply_stimulus =
-        |machine: &mut labwired_core::Machine<C>, s: &labwired_config::StimulusSpec| {
-            match machine.set_input(&s.target.channel, s.value) {
-                Ok(()) => info!("stimulus: {} = {} applied", s.target.channel, s.value),
-                Err(e) => error!(
-                    "stimulus '{}' = {} could not be applied: {:?}",
-                    s.target.channel, s.value, e
-                ),
-            }
-        };
+    let apply_stimulus = |machine: &mut labwired_core::Machine<C>,
+                          s: &labwired_config::StimulusSpec| {
+        match machine.set_input(&s.target.channel, s.value) {
+            Ok(()) => info!("stimulus: {} = {} applied", s.target.channel, s.value),
+            Err(e) => error!(
+                "stimulus '{}' = {} could not be applied: {:?}",
+                s.target.channel, s.value, e
+            ),
+        }
+    };
     for s in stimuli {
         if matches!(s.trigger, labwired_config::FaultTrigger::AtStart) {
             apply_stimulus(machine, s);
@@ -1720,7 +1720,8 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                 if *fired {
                     continue;
                 }
-                if let labwired_config::FaultTrigger::AfterCycles { cycles: threshold } = s.trigger {
+                if let labwired_config::FaultTrigger::AfterCycles { cycles: threshold } = s.trigger
+                {
                     if cycles >= threshold {
                         apply_stimulus(machine, s);
                         *fired = true;

--- a/crates/cli/tests/e2e_kw41z_cow_stimulus.rs
+++ b/crates/cli/tests/e2e_kw41z_cow_stimulus.rs
@@ -1,0 +1,144 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+//
+// End-to-end coverage for declarative input stimuli (test-script schema 1.2)
+// via the examples/kw41z-cow-activity demo.
+//
+// The FRDM-KW41Z + FXOS8700 + Nokia-5110 "cow" firmware reads the accelerometer
+// live and prints `MOOD=CALM|ACTIVE`. These tests run the committed ELF through
+// the committed scenario scripts with `labwired test`, exercising the exact
+// path an author (or an agent over MCP) runs:
+//
+//   • calm.yaml           — no stimulus; the cow grazes (CALM) the whole run.
+//   • stimulus-shake.yaml — an `after_cycles` stimulus drives X to +2 g partway
+//                           through, flipping the cow to ACTIVE.
+//
+// This is what keeps the scriptable-input path honest: a regression in the
+// generic `Machine::set_input` dispatch, the FXOS8700 `SimInput` impl, the
+// cow firmware, or the schema-1.2 runner wiring fails the merge gate here.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+struct CowRun {
+    exit_code: Option<i32>,
+    stderr: String,
+    uart: String,
+    status: String,
+}
+
+/// Run one cow scenario script (relative to the repo root) through the
+/// `labwired test` CLI and collect its result + UART log.
+fn run_cow(script_rel: &str) -> CowRun {
+    let root = repo_root();
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let out_dir = std::env::temp_dir().join(format!("labwired-cow-{nonce}"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(&root)
+        .args([
+            "test",
+            "--script",
+            script_rel,
+            "--no-uart-stdout",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("execute labwired");
+
+    let uart = std::fs::read_to_string(out_dir.join("uart.log")).unwrap_or_default();
+    let result_json =
+        std::fs::read_to_string(out_dir.join("result.json")).expect("read result.json");
+    let result: serde_json::Value = serde_json::from_str(&result_json).expect("parse result.json");
+    let status = result["status"].as_str().unwrap_or("").to_string();
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+    CowRun {
+        exit_code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        uart,
+        status,
+    }
+}
+
+#[test]
+fn cow_grazes_calm_without_a_stimulus() {
+    let run = run_cow("examples/kw41z-cow-activity/calm.yaml");
+    assert_eq!(
+        run.exit_code,
+        Some(0),
+        "expected exit 0 (assertions pass); stderr: {}",
+        run.stderr
+    );
+    assert_eq!(run.status, "pass", "expected result.json status=pass");
+
+    assert!(
+        run.uart.contains("MOOD=CALM"),
+        "baseline should report CALM\n--- uart ---\n{}",
+        run.uart
+    );
+    // The control case: with nothing driving the accelerometer the cow never
+    // pops its head up. If this starts printing ACTIVE, the idle pose drifted.
+    assert!(
+        !run.uart.contains("MOOD=ACTIVE"),
+        "baseline (no stimulus) must never go ACTIVE\n--- uart ---\n{}",
+        run.uart
+    );
+}
+
+#[test]
+fn stimulus_flips_the_cow_active_mid_run() {
+    let run = run_cow("examples/kw41z-cow-activity/stimulus-shake.yaml");
+    assert_eq!(
+        run.exit_code,
+        Some(0),
+        "expected exit 0 (both MOOD assertions pass); stderr: {}",
+        run.stderr
+    );
+    assert_eq!(run.status, "pass", "expected result.json status=pass");
+
+    // The stimulus was actually applied (logged by the runner), not silently
+    // swallowed by a bad channel name.
+    assert!(
+        run.stderr.contains("stimulus: x = 2"),
+        "expected the runner to log the applied stimulus\n--- stderr ---\n{}",
+        run.stderr
+    );
+
+    // The headline: grazing before the shake, head up after it.
+    assert!(
+        run.uart.contains("MOOD=CALM"),
+        "expected CALM before the stimulus\n--- uart ---\n{}",
+        run.uart
+    );
+    assert!(
+        run.uart.contains("MOOD=ACTIVE"),
+        "expected ACTIVE after the X=+2 g stimulus\n--- uart ---\n{}",
+        run.uart
+    );
+
+    // Ordering: the first CALM precedes the first ACTIVE — the cow started calm
+    // and the stimulus is what drove it active, not the reverse.
+    let first_calm = run.uart.find("MOOD=CALM").unwrap();
+    let first_active = run.uart.find("MOOD=ACTIVE").unwrap();
+    assert!(
+        first_calm < first_active,
+        "CALM should appear before ACTIVE (stimulus drove the transition)"
+    );
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -817,6 +817,37 @@ pub struct Verdict {
     pub require_fault_fired: bool,
 }
 
+/// Which input channel a stimulus drives. `channel` is the [`crate::sim_input`]
+/// channel key (e.g. `x` on an accelerometer); `component` is an optional,
+/// advisory hint naming the device for readability. Resolution is by unique
+/// channel key today (the same rule as `Machine::set_input`), so an ambiguous
+/// channel is a run-time error rather than silently picking one.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct StimulusTarget {
+    /// Optional device name, for documentation/disambiguation of the YAML.
+    #[serde(default)]
+    pub component: Option<String>,
+    /// The input channel key to drive.
+    pub channel: String,
+}
+
+/// A declarative input stimulus (schema_version 1.2+): drive `target` to
+/// `value` (in the channel's engineering unit) when `trigger` fires. Reuses the
+/// [`FaultTrigger`] vocabulary; the first cut supports `at_start` and
+/// `after_cycles` (the time-based triggers). The runner applies each stimulus
+/// via the generic `Machine::set_input` path, so it works for any input device
+/// without per-type wiring.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct StimulusSpec {
+    pub target: StimulusTarget,
+    #[serde(default)]
+    pub trigger: FaultTrigger,
+    /// The value to set the channel to, in its engineering unit.
+    pub value: f64,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TestScript {
@@ -831,6 +862,9 @@ pub struct TestScript {
     /// The safe-behaviour verdict for a fault-injection run (schema_version 1.1+).
     #[serde(default)]
     pub verdict: Option<Verdict>,
+    /// Input stimuli to drive during the run (schema_version 1.2+).
+    #[serde(default)]
+    pub stimuli: Vec<StimulusSpec>,
 }
 
 impl TestScript {
@@ -844,9 +878,9 @@ impl TestScript {
     }
 
     pub fn validate(&self) -> Result<()> {
-        if self.schema_version != "1.0" && self.schema_version != "1.1" {
+        if !matches!(self.schema_version.as_str(), "1.0" | "1.1" | "1.2") {
             anyhow::bail!(
-                "Unsupported schema_version '{}'. Supported versions: '1.0', '1.1'",
+                "Unsupported schema_version '{}'. Supported versions: '1.0', '1.1', '1.2'",
                 self.schema_version
             );
         }
@@ -865,6 +899,34 @@ impl TestScript {
                 "'faults'/'verdict' require schema_version '1.1' (got '{}')",
                 self.schema_version
             );
+        }
+
+        // Input stimuli require schema_version 1.2+.
+        if !self.stimuli.is_empty() && matches!(self.schema_version.as_str(), "1.0" | "1.1") {
+            anyhow::bail!(
+                "'stimuli' require schema_version '1.2' (got '{}')",
+                self.schema_version
+            );
+        }
+        for (i, s) in self.stimuli.iter().enumerate() {
+            if s.target.channel.trim().is_empty() {
+                anyhow::bail!("stimuli[{}]: target.channel cannot be empty", i);
+            }
+            // Only the time-based triggers are wired for stimuli today; the
+            // register-access triggers need a write/read hook we haven't added
+            // for the input path. Fail loud rather than silently never firing.
+            match &s.trigger {
+                FaultTrigger::AtStart | FaultTrigger::AfterCycles { .. } => {}
+                other => anyhow::bail!(
+                    "stimuli[{}]: trigger {:?} is not yet supported for stimuli \
+                     (use at_start or after_cycles)",
+                    i,
+                    other
+                ),
+            }
+            if !s.value.is_finite() {
+                anyhow::bail!("stimuli[{}]: value must be a finite number", i);
+            }
         }
 
         // Structural fault-compiler guardrails. Deeper checks that need the
@@ -1108,6 +1170,89 @@ mod parse_size_tests {
     #[test]
     fn garbage_still_errors() {
         assert!(parse_size("not-a-size").is_err());
+    }
+}
+
+#[cfg(test)]
+mod stimuli_tests {
+    use super::*;
+
+    fn script(schema: &str, stimuli_block: &str) -> String {
+        format!(
+            r#"
+schema_version: "{schema}"
+inputs:
+  firmware: "cow.elf"
+  system: "sys.yaml"
+limits:
+  max_steps: 1000
+{stimuli_block}
+"#
+        )
+    }
+
+    #[test]
+    fn stimuli_parse_and_validate_on_1_2() {
+        let yaml = script(
+            "1.2",
+            r#"stimuli:
+  - target: { component: fxos8700, channel: x }
+    trigger: !after_cycles { cycles: 800000 }
+    value: 2.0
+  - target: { channel: z }
+    value: 1.0
+"#,
+        );
+        let s: TestScript = serde_yaml::from_str(&yaml).unwrap();
+        s.validate().unwrap();
+        assert_eq!(s.stimuli.len(), 2);
+        assert_eq!(s.stimuli[0].target.channel, "x");
+        assert_eq!(s.stimuli[0].target.component.as_deref(), Some("fxos8700"));
+        assert_eq!(s.stimuli[0].value, 2.0);
+        // Default trigger is at_start.
+        assert!(matches!(s.stimuli[1].trigger, FaultTrigger::AtStart));
+    }
+
+    #[test]
+    fn stimuli_require_schema_1_2() {
+        for schema in ["1.0", "1.1"] {
+            let yaml = script(
+                schema,
+                "stimuli:\n  - target: { channel: x }\n    value: 1.0\n",
+            );
+            let s: TestScript = serde_yaml::from_str(&yaml).unwrap();
+            let err = s.validate().unwrap_err().to_string();
+            assert!(err.contains("require schema_version '1.2'"), "{err}");
+        }
+    }
+
+    #[test]
+    fn empty_channel_rejected() {
+        let yaml = script("1.2", "stimuli:\n  - target: { channel: \"\" }\n    value: 1.0\n");
+        let s: TestScript = serde_yaml::from_str(&yaml).unwrap();
+        assert!(s
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("channel cannot be empty"));
+    }
+
+    #[test]
+    fn register_triggers_rejected_for_stimuli() {
+        let yaml = script(
+            "1.2",
+            r#"stimuli:
+  - target: { channel: x }
+    trigger: !on_write { register: "FOO" }
+    value: 1.0
+"#,
+        );
+        let s: TestScript = serde_yaml::from_str(&yaml).unwrap();
+        assert!(s
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("not yet supported for stimuli"));
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1228,7 +1228,10 @@ limits:
 
     #[test]
     fn empty_channel_rejected() {
-        let yaml = script("1.2", "stimuli:\n  - target: { channel: \"\" }\n    value: 1.0\n");
+        let yaml = script(
+            "1.2",
+            "stimuli:\n  - target: { channel: \"\" }\n    value: 1.0\n",
+        );
         let s: TestScript = serde_yaml::from_str(&yaml).unwrap();
         assert!(s
             .validate()

--- a/examples/kw41z-cow-activity/README.md
+++ b/examples/kw41z-cow-activity/README.md
@@ -1,0 +1,49 @@
+# KW41Z CowManager — scriptable input stimulus
+
+The FRDM-KW41Z + FXOS8700 accelerometer + Nokia-5110 LCD "cow" demo, driven by
+a **declarative input stimulus** instead of a one-shot seeded pose.
+
+`labwired test` schema **1.2** adds a `stimuli:` track: drive a component's
+input channel to a value when a trigger fires, then keep running. It's the
+declarative, CI-reproducible sibling of the browser's live input sliders and
+of the generic `Machine::set_input` an agent calls over MCP — all three reach
+the sensor through the one `SimInput` path in `crates/core/src/sim_input.rs`,
+so there is no cow- or FXOS-specific code in the runner.
+
+## Run
+
+```sh
+# Grazing baseline — no input driven, stays CALM.
+labwired test --script examples/kw41z-cow-activity/calm.yaml
+
+# Shake it mid-run — CALM until 3 M cycles, then X=+2 g flips it to ACTIVE.
+labwired test --script examples/kw41z-cow-activity/stimulus-shake.yaml
+```
+
+## The `stimuli` block
+
+```yaml
+schema_version: "1.2"
+stimuli:
+  - target: { component: fxos8700, channel: x }   # component is advisory;
+    trigger: !after_cycles { cycles: 3000000 }     # resolution is by channel key
+    value: 2.0                                      # engineering unit (g here)
+```
+
+- `target.channel` — the `SimInput` channel key (`x`/`y`/`z` on an accel,
+  `distance` on an HC-SR04, `temperature` on an NTC …). `target.component` is
+  an advisory hint; a stimulus resolves to the **unique** device exposing the
+  channel, and an ambiguous channel is a run error rather than a silent guess.
+- `trigger` — reuses the fault-trigger vocabulary. Wired today: `at_start`
+  (default) and `!after_cycles { cycles: N }`. The register-access triggers
+  (`on_write` / `on_read`) are rejected at validation for stimuli until the
+  input path grows a write hook.
+- `value` — the value in the channel's engineering unit; each device owns its
+  unit→raw conversion, so the YAML is silicon-agnostic.
+
+## Why it matters
+
+The same script is three things at once: a demo an author can read, a
+regression the merge gate runs, and the payload an agent (e.g. ChatGPT via the
+LabWired MCP server) hands over to steer a run — "boot, run to steady state,
+shake the sensor, confirm the cow went ACTIVE."

--- a/examples/kw41z-cow-activity/calm.yaml
+++ b/examples/kw41z-cow-activity/calm.yaml
@@ -1,0 +1,15 @@
+## KW41Z CowManager — idle baseline (no stimulus).
+##
+## The FRDM-KW41Z + FXOS8700 + Nokia-5110 "cow" demo left to graze. With no
+## input driven, the accelerometer sits near rest and the firmware keeps the
+## cow CALM the whole run. This is the control case for `stimulus-shake.yaml`,
+## which drives the same firmware ACTIVE by injecting a tilt mid-run.
+schema_version: "1.2"
+inputs:
+  firmware: "../../tests/fixtures/kw41z-lcd-activity.elf"
+  system: "../../configs/systems/frdm-kw41z-lcd.yaml"
+limits:
+  max_steps: 6000000
+  max_uart_bytes: 8000
+assertions:
+  - uart_regex: "MOOD=CALM"

--- a/examples/kw41z-cow-activity/stimulus-shake.yaml
+++ b/examples/kw41z-cow-activity/stimulus-shake.yaml
@@ -1,0 +1,29 @@
+## KW41Z CowManager — declarative input stimulus (schema_version 1.2).
+##
+## Boot the cow demo, let it graze for a few million cycles (MOOD=CALM), then
+## drive the FXOS8700 accelerometer's X axis to +2 g partway through the run.
+## The firmware's activity metric crosses its threshold and the cow pops its
+## head up: MOOD=ACTIVE. The whole thing is deterministic and replayable — the
+## same YAML an agent hands to `labwired test` (or drives over MCP) is a CI
+## regression.
+##
+## `stimuli` reuse the fault-trigger vocabulary; today `at_start` and
+## `after_cycles` are wired. The stimulus reaches the sensor through the generic
+## `Machine::set_input` path (crates/core/src/sim_input.rs) — no cow- or
+## FXOS-specific plumbing in the runner.
+schema_version: "1.2"
+inputs:
+  firmware: "../../tests/fixtures/kw41z-lcd-activity.elf"
+  system: "../../configs/systems/frdm-kw41z-lcd.yaml"
+limits:
+  max_steps: 6000000
+  max_uart_bytes: 8000
+stimuli:
+  - target: { component: fxos8700, channel: x }
+    trigger: !after_cycles { cycles: 3000000 }
+    value: 2.0
+assertions:
+  # Grazing before the shake …
+  - uart_regex: "MOOD=CALM"
+  # … head up after it.
+  - uart_regex: "MOOD=ACTIVE"


### PR DESCRIPTION
## What

Adds a **`stimuli:`** track to the `labwired test` script format (schema_version **1.2**): drive a component's input channel to a value when a trigger fires, then keep running. This is **Layer 2b** of the [scriptable-inputs design](../blob/main/docs) — the CI-reproducible sibling of the browser input sliders and the generic `Machine::set_input` an agent drives over MCP. All three reach the sensor through the single `SimInput` path landed in #451, so the runner carries **no** per-device code.

```yaml
schema_version: "1.2"
stimuli:
  - target: { component: fxos8700, channel: x }   # component advisory; resolves by unique channel key
    trigger: !after_cycles { cycles: 3000000 }      # at_start | after_cycles
    value: 2.0                                       # engineering unit (g)
assertions:
  - uart_regex: "MOOD=ACTIVE"
```

## Changes

- **config**: `StimulusSpec`/`StimulusTarget`, `TestScript.stimuli`, schema `"1.2"`. Reuses the `FaultTrigger` vocab; `at_start` + `after_cycles` wired, register-access triggers rejected at validation (no input write-hook yet). Validates finite value + non-empty channel.
- **cli**: `execute_test_loop` applies `at_start` stimuli before the loop and fires `after_cycles` ones as the run crosses each threshold, via `set_input`. Logs each applied stimulus.
- **examples/kw41z-cow-activity**: `calm.yaml` (control) + `stimulus-shake.yaml` (X=+2 g at 3 M cycles flips the cow **CALM→ACTIVE**) + README.
- **e2e** (`e2e_kw41z_cow_stimulus.rs`): baseline never goes ACTIVE; the stimulus drives an *ordered* CALM→ACTIVE transition. Plus config validation unit tests.

## Verification

- `cargo test -p labwired-config stimuli` → 4/4
- `cargo test -p labwired-cli --test e2e_kw41z_cow_stimulus` → 2/2 (runs the committed ELF through the real `labwired test` path)
- `cargo clippy -p labwired-config -p labwired-cli` clean

Layer 2a (interactive MCP `set_input`/`step` in the TS server) is the remaining piece; designed, not yet built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)