### PR TITLE
fix(wasm): read SSD1306 framebuffer from the ESP32-C3 I2C controller

### DIFF
--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -212,6 +212,16 @@ impl Esp32c3I2c {
         self.slaves.push(slave);
     }
 
+    /// Borrow the attached I²C slaves. Mirrors the generic `I2c::attached_devices`
+    /// accessor so UI/inspection paths (e.g. the SSD1306 framebuffer readback)
+    /// can enumerate devices on the ESP32-C3 command-list controller the same way
+    /// they do on the STM32 controller. Unlike the generic `I2c`, slaves here are
+    /// held directly (no `RefCell`) because the C3 engine never hands out interior
+    /// mutable references during a transaction.
+    pub fn attached_slaves(&self) -> &[Box<dyn I2cDevice>] {
+        &self.slaves
+    }
+
     fn fifo_status(&self) -> u32 {
         // FIFO_ST (C3 i2c0.yaml): TXFIFO_RADDR at bits 10..14 — esp-hal's
         // estimate_ack_failed_reason reads it to tell address-NACK (raddr <= 1)

--- a/crates/core/tests/leo_oled_i2c_readback.rs
+++ b/crates/core/tests/leo_oled_i2c_readback.rs
@@ -1,0 +1,66 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// Regression guard for the OLED-blank-in-embed bug: the ESP32-C3 leo
+// air-quality lab attaches its SSD1306 to the command-list `Esp32c3I2c`
+// controller (not the generic STM32 `I2c`). The playground/embed reads the
+// framebuffer through `WasmSimulator::get_ssd1306_framebuffer`, which enumerates
+// I²C slaves on the named peripheral. That accessor originally only understood
+// the generic `I2c`, so on the C3 it returned "not an I2C controller" and the
+// OLED rendered blank even though the device was present and being drawn to.
+//
+// This test locks in the two facts the fix depends on:
+//   1. Building the leo bus from its committed system.yaml attaches an SSD1306
+//      slave (address 0x3C) to the C3 I²C0 controller.
+//   2. The `Esp32c3I2c::attached_slaves()` accessor surfaces it and its
+//      framebuffer is readable via the same downcast chain `inspect.rs` uses.
+// The existing `e2e_leo_airquality` test proves the firmware renders a
+// non-blank frame into that same SSD1306 instance.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
+use std::path::PathBuf;
+
+#[test]
+fn leo_oled_is_readable_through_esp32c3_i2c() {
+    let system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/esp32c3-leo-airquality/system.yaml");
+    let manifest = SystemManifest::from_file(&system_path).expect("load leo manifest");
+    let chip_path = system_path.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load esp32c3 chip");
+    let bus = SystemBus::from_config(&chip, &manifest).expect("build leo bus");
+
+    let idx = bus
+        .find_peripheral_index_by_name("i2c0")
+        .expect("leo config must expose an 'i2c0' peripheral");
+    let any = bus.peripherals[idx]
+        .dev
+        .as_any()
+        .expect("i2c0 peripheral must support downcasting");
+
+    // On the C3 the controller is Esp32c3I2c, NOT the generic I2c — this is the
+    // whole point of the readback bug.
+    let c3 = any
+        .downcast_ref::<Esp32c3I2c>()
+        .expect("leo i2c0 must be the ESP32-C3 command-list controller");
+
+    // The exact enumeration path `get_ssd1306_framebuffer` now uses for the C3.
+    let oled = c3
+        .attached_slaves()
+        .iter()
+        .filter(|d| d.address() == 0x3C)
+        .find_map(|d| d.as_any().and_then(|a| a.downcast_ref::<Ssd1306>()))
+        .expect("an SSD1306 must be attached at 0x3C on the C3 i2c0 bus");
+
+    // Framebuffer is readable (128x64 -> 1024 bytes, page-major). Blank at boot
+    // is fine here; e2e_leo_airquality asserts the firmware fills it.
+    let fb = oled.framebuffer();
+    assert_eq!(
+        fb.len(),
+        1024,
+        "SSD1306 GDDRAM framebuffer must be 128x64/8 = 1024 bytes"
+    );
+}

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -203,9 +203,7 @@ impl WasmSimulator {
         // so both must be enumerable here — otherwise `get_ssd1306_framebuffer`
         // returns "not an I2C controller" and the OLED renders blank in the
         // playground/embed even though the device is present and being drawn to.
-        if let Some(i2c) =
-            any.downcast_ref::<labwired_core::peripherals::i2c::I2c>()
-        {
+        if let Some(i2c) = any.downcast_ref::<labwired_core::peripherals::i2c::I2c>() {
             for device in i2c.attached_devices() {
                 let device = device.borrow();
                 if device.address() != address {

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -194,27 +194,47 @@ impl WasmSimulator {
             .as_any()
             .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
 
-        let i2c = any
-            .downcast_ref::<labwired_core::peripherals::i2c::I2c>()
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "Peripheral '{}' is not an I2C controller",
-                    binding.peripheral
-                ))
-            })?;
-
         let address = binding.i2c_address.unwrap_or(0x3C);
-        for device in i2c.attached_devices() {
-            let device = device.borrow();
-            if device.address() != address {
-                continue;
+
+        // The framebuffer readback has to understand every I²C controller a
+        // supported board can attach an SSD1306 to. STM32 boards use the generic
+        // `I2c`; the ESP32-C3 (leo air-quality lab) uses the command-list
+        // `Esp32c3I2c`. Both attach the OLED via `AttachCtx::attach_i2c_device`,
+        // so both must be enumerable here — otherwise `get_ssd1306_framebuffer`
+        // returns "not an I2C controller" and the OLED renders blank in the
+        // playground/embed even though the device is present and being drawn to.
+        if let Some(i2c) =
+            any.downcast_ref::<labwired_core::peripherals::i2c::I2c>()
+        {
+            for device in i2c.attached_devices() {
+                let device = device.borrow();
+                if device.address() != address {
+                    continue;
+                }
+                if let Some(oled) = device.as_any().and_then(|any| {
+                    any.downcast_ref::<labwired_core::peripherals::components::Ssd1306>()
+                }) {
+                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
+                }
             }
-            if let Some(oled) = device.as_any().and_then(|any| {
-                any.downcast_ref::<labwired_core::peripherals::components::Ssd1306>()
-            }) {
-                let fb = oled.framebuffer().to_vec().into_boxed_slice();
-                return Ok(fb);
+        } else if let Some(c3) =
+            any.downcast_ref::<labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c>()
+        {
+            for device in c3.attached_slaves() {
+                if device.address() != address {
+                    continue;
+                }
+                if let Some(oled) = device.as_any().and_then(|any| {
+                    any.downcast_ref::<labwired_core::peripherals::components::Ssd1306>()
+                }) {
+                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
+                }
             }
+        } else {
+            return Err(JsValue::from_str(&format!(
+                "Peripheral '{}' is not an I2C controller",
+                binding.peripheral
+            )));
         }
 
         Err(JsValue::from_str(&format!(

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,7 +10,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-06-30 | ⚠ drift acked 2026-06-30 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-06-30 | ⚠ drift acked 2026-06-30 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-06-28 | ⚠ drift acked 2026-06-28 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-01 | ⚠ drift acked 2026-07-01 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-03 | ⚠ drift acked 2026-07-03 (re-capture pending) |
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-06-28 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-03 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -199,7 +199,12 @@ boards:
     # and latch LSTIMERx_OVF (TIMERx_CONF/VALUE + INT_* layout diffed against the
     # committed ledc.yaml SVD descriptor). It does not touch the asserted reset-oracle
     # set; this ack covers the new model file until the next full live re-capture.
-    drift_ack: 2026-06-28
+    # 2026-07-03: added Esp32c3I2c::attached_slaves() (esp32c3/i2c.rs) — a pure read
+    # accessor exposing the attached I2C devices so the wasm framebuffer readback
+    # (get_ssd1306_framebuffer) can reach an OLED on the C3 controller. No register,
+    # timing, state, or reset-value change; purely additive getter. This ack covers
+    # the model-file touch; no live re-capture warranted.
+    drift_ack: 2026-07-03
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md


### PR DESCRIPTION
## Why
ESP32-C3 OLED labs render **blank** — the OLED framebuffer accessor `get_ssd1306_framebuffer` only downcast the I²C peripheral to the generic STM32 `I2c`. On the C3 the OLED is attached to `Esp32c3I2c` (the command-list engine), so the downcast failed → `null` → the display poll's try/catch swallowed it → `displayBuffers = {}` → blank. (The STM32 `ssd1306-hello-lab` masked this — it uses the generic `I2c`.)

## Fix
- `esp32c3/i2c.rs`: expose `attached_slaves()` (mirrors `I2c::attached_devices`).
- `inspect.rs`: `get_ssd1306_framebuffer` tries the generic `I2c`, then `Esp32c3I2c::attached_slaves()`.
- New test `leo_oled_i2c_readback`: builds the leo-airquality bus from its `system.yaml`, asserts the `Ssd1306` @0x3C is reachable through `Esp32c3I2c`.

## Verified
`cargo test --test leo_oled_i2c_readback` passes; `cargo check -p labwired-wasm --target wasm32-unknown-unknown` clean; the leo e2e (asserts a **non-blank** OLED) passes.

Follow-up (no lab hits it today): the SPI accessors (`ili9341`/`pcd8544`) and an OLED on an ESP32-S3/classic controller need the same multi-controller readback.