### PR TITLE
fix(iolink-station): scope example consoles to USART1

### DIFF
--- a/examples/iolink-station/master/system.yaml
+++ b/examples/iolink-station/master/system.yaml
@@ -5,5 +5,8 @@
 # chip over the wire, not a host model.
 name: "iolink-master"
 chip: "../../../configs/chips/stm32l476.yaml"
+# Console on USART1 only; the IO-Link C/Q ports live on USART2-5, so without this
+# the simulator merges the raw C/Q bus (0x55 wake preamble) into the serial view.
+debug_uart: "uart1"
 external_devices: []
 board_io: []

--- a/examples/iolink-station/sensor/system.yaml
+++ b/examples/iolink-station/sensor/system.yaml
@@ -5,6 +5,8 @@
 # is its own chip. A 74HC165 on SPI1 supplies the digital-input process data.
 name: "iolink-sensor"
 chip: "../../../configs/chips/stm32l476.yaml"
+# Console on USART1 only; C/Q is on USART2 (keep the raw bus out of the serial view).
+debug_uart: "uart1"
 external_devices:
   - id: "di_shifter"
     type: "sn74hc165"

--- a/examples/iolink-station/sensor2/system.yaml
+++ b/examples/iolink-station/sensor2/system.yaml
@@ -3,6 +3,8 @@
 # verifiable (bit-order-invariant). C/Q (USART2) cross-linked to a master port.
 name: "iolink-sensor2"
 chip: "../../../configs/chips/stm32l476.yaml"
+# Console on USART1 only; C/Q is on USART2 (keep the raw bus out of the serial view).
+debug_uart: "uart1"
 external_devices:
   - id: "di_shifter"
     type: "sn74hc165"

--- a/examples/iolink-station/sensor3/system.yaml
+++ b/examples/iolink-station/sensor3/system.yaml
@@ -3,6 +3,8 @@
 # verifiable (bit-order-invariant). C/Q (USART2) cross-linked to a master port.
 name: "iolink-sensor3"
 chip: "../../../configs/chips/stm32l476.yaml"
+# Console on USART1 only; C/Q is on USART2 (keep the raw bus out of the serial view).
+debug_uart: "uart1"
 external_devices:
   - id: "di_shifter"
     type: "sn74hc165"

--- a/examples/iolink-station/sensor4/system.yaml
+++ b/examples/iolink-station/sensor4/system.yaml
@@ -3,6 +3,8 @@
 # verifiable (bit-order-invariant). C/Q (USART2) cross-linked to a master port.
 name: "iolink-sensor4"
 chip: "../../../configs/chips/stm32l476.yaml"
+# Console on USART1 only; C/Q is on USART2 (keep the raw bus out of the serial view).
+debug_uart: "uart1"
 external_devices:
   - id: "di_shifter"
     type: "sn74hc165"


### PR DESCRIPTION
The station master prints its console on USART1 while the IO-Link C/Q bus runs on USART2-5; the sensors print on USART1 with C/Q on USART2. Without a `debug_uart` filter the browser sim merges every UART into one serial stream, so the raw C/Q wake preamble (`0x55` = `'U'`) drowns the console and the serial view reads as jibberish (`UU?…`).

Set `debug_uart: "uart1"` on the master and all four sensor nodes so the serial view shows only the real console, matching the `al2205-iolink-dido` example which already reads clean.

YAML-only; no firmware/ELF change. This is the core half of the IO-Link master-station embed fix — the app side adds the logic-analyzer C/Q tap, deep UART-trace normalization, and the labelled multi-CPU view.