### PR TITLE
feat(wasm): faithful ESP32-S3 arch in the playground engine

### DIFF
--- a/crates/core/src/boot/esp32s3_rom.rs
+++ b/crates/core/src/boot/esp32s3_rom.rs
@@ -315,9 +315,12 @@ pub fn provision_rom_images() -> Option<RomImages> {
 /// Vendored flat ROM images, embedded at build time. Extracted from
 /// Espressif's published `esp32s3_rev0_rom.elf` by
 /// `scripts/make_esp32s3_rom_bins.py` — see `crates/core/roms/esp32s3/`.
-/// Not compiled into wasm builds (the playground uses the fast-boot path and
-/// must not carry the 512 KiB of ROM in its bundle).
-#[cfg(not(target_arch = "wasm32"))]
+///
+/// Shipped in wasm too (the +512 KiB is the price of a FAITHFUL S3 widget demo:
+/// the playground fast-boots esp-hal apps on the real ROM with zero thunks —
+/// see `system::xtensa::configure_xtensa_esp32s3` + the ROM `.data` init). On
+/// wasm `discover_rom_elf`/the cache path are inert (no fs), so this vendored
+/// blob is the only ROM source there.
 fn vendored_rom_images() -> Option<RomImages> {
     static VENDORED_IROM: &[u8] = include_bytes!("../../roms/esp32s3/esp32s3_rom.bin");
     static VENDORED_DROM: &[u8] = include_bytes!("../../roms/esp32s3/esp32s3_drom.bin");
@@ -327,11 +330,6 @@ fn vendored_rom_images() -> Option<RomImages> {
         irom: VENDORED_IROM.to_vec(),
         drom: VENDORED_DROM.to_vec(),
     })
-}
-
-#[cfg(target_arch = "wasm32")]
-fn vendored_rom_images() -> Option<RomImages> {
-    None
 }
 
 /// Cache directory for extracted ROM images (`$XDG_CACHE_HOME` or `~/.cache`).

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -133,6 +133,9 @@ impl WasmSimulator {
         match chip.arch {
             Arch::Arm | Arch::Unknown => Self::new_from_config_arm(&chip, &manifest, firmware),
             Arch::RiscV => Self::new_from_config_riscv(&chip, &manifest, firmware),
+            Arch::Xtensa if chip.name.starts_with("esp32s3") => {
+                Self::new_from_config_xtensa_esp32s3(&manifest, firmware)
+            }
             Arch::Xtensa => Self::new_from_config_xtensa_esp32(&manifest, firmware),
         }
     }
@@ -280,6 +283,73 @@ impl WasmSimulator {
         Ok(WasmSimulator {
             machine: Some(machine),
             board_io,
+            uart_sink,
+            uart_rx_bufs,
+            arch: Arch::Xtensa,
+            esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
+        })
+    }
+
+    /// ESP32-S3 (Xtensa LX7) bus setup — the FAITHFUL fast-boot path.
+    ///
+    /// `configure_xtensa_esp32s3` installs IRAM/DRAM/RTC/flash-XIP plus the
+    /// real vendored boot ROM (zero thunks; the ROM `.data` init lands
+    /// `rom_cache_internal_table_ptr` so esp-hal's ROM cache calls run for
+    /// real). `fast_boot` then loads the app ELF's segments (identity XIP)
+    /// and synthesises post-bootloader CPU state. Serial output on the S3
+    /// esp-hal apps goes through USB_SERIAL_JTAG, so we route that peripheral's
+    /// sink into the same `uart_sink` the widget's Serial tab reads.
+    fn new_from_config_xtensa_esp32s3(
+        manifest: &SystemManifest,
+        firmware: &[u8],
+    ) -> Result<WasmSimulator, JsValue> {
+        use labwired_core::boot::esp32s3::{fast_boot, BootOpts};
+        use labwired_core::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag;
+        use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
+
+        let mut bus = SystemBus::new();
+        // Default opts → fast-boot identity XIP + faithful ROM (real_reset_boot
+        // is false; --rom-boot's MMU model is native-CLI only).
+        let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+        let mut cpu = wiring.cpu;
+
+        // Route USB-serial-JTAG bytes into the widget's serial sink. esp-hal's
+        // `esp_println`/`println!` on the S3 targets USB_SERIAL_JTAG, not UART0.
+        let uart_sink = Arc::new(Mutex::new(Vec::new()));
+        for p in bus.peripherals.iter_mut() {
+            if p.name == "usb_serial_jtag" {
+                if let Some(any_mut) = p.dev.as_any_mut() {
+                    if let Some(jtag) = any_mut.downcast_mut::<UsbSerialJtag>() {
+                        jtag.set_sink(Some(uart_sink.clone()), false);
+                    }
+                }
+            }
+        }
+        // Also capture UART0 in case a sketch uses the classic UART path.
+        bus.attach_uart_tx_sink(uart_sink.clone(), false);
+        let uart_rx_bufs = bus.attach_uart_rx_source();
+        bus.refresh_peripheral_index();
+
+        fast_boot(
+            firmware,
+            &mut bus,
+            &mut cpu,
+            &BootOpts {
+                stack_top_fallback: 0x3FCD_FFF0,
+                icache_backing: Some(wiring.icache_backing),
+                dcache_backing: Some(wiring.dcache_backing),
+            },
+        )
+        .map_err(|e| JsValue::from_str(&format!("ESP32-S3 fast_boot: {e}")))?;
+
+        let boxed: Box<dyn Cpu> = Box::new(cpu);
+        let machine = Machine::new(boxed, bus);
+
+        Ok(WasmSimulator {
+            machine: Some(machine),
+            board_io: manifest.board_io.clone(),
             uart_sink,
             uart_rx_bufs,
             arch: Arch::Xtensa,


### PR DESCRIPTION
Builds on #456 (faithful S3 real-ROM boot, already merged).

## What
Exposes the faithful ESP32-S3 path to the wasm playground engine so S3 esp-hal apps run **in the widget with zero thunks**:
- New `new_from_config_xtensa_esp32s3`: configures the S3 bus (real vendored ROM + ROM `.data` init), fast-boots the app ELF (identity XIP), and routes the **USB_SERIAL_JTAG** sink (where esp-hal's `println!` lands on the S3, not UART0) into the widget's `uart_sink`.
- Dispatch: `Arch::Xtensa` chips whose `name` starts with `esp32s3` route here; classic ESP32 (LX6) keeps its existing path.
- The vendored S3 ROM (512 KiB) now **ships in wasm** — previously `#[cfg(not(wasm32))]`, which would have silently dropped the widget to the thunk harness. On wasm the fs-discovery/cache paths are inert, so the vendored blob is the only ROM source.

## Verification
`wasm-pack build --release --target web` locally, then a node smoke run of `esp32s3-hello-world` through `new_from_config`:
```
instantiating S3 sim via new_from_config...
ok. pc=0x40378e20
FOUND after ~2M cycles
SERIAL OUTPUT: "Hello world!\n"
RESULT: PASS
```
Real boot ROM, zero thunks, in the actual wasm engine.

## Cost
+512 KiB in the wasm bundle (the price of a faithful S3 widget demo — consistent with the "no thunks" line).