### PR TITLE
Egress bridge hardening + browser WS relay (fixed-target MVP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +772,12 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "demo-blinky"
@@ -1465,6 +1477,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "human-size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1813,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "labwired-egress-relay"
+version = "0.17.10"
+dependencies = [
+ "anyhow",
+ "labwired-core",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tungstenite",
+]
+
+[[package]]
 name = "labwired-fuzz"
 version = "0.17.10"
 dependencies = [
@@ -2011,7 +2051,7 @@ dependencies = [
  "num_enum 0.7.6",
  "once_cell",
  "postcard",
- "rand_core",
+ "rand_core 0.9.5",
  "rustversion",
  "serde",
  "serial_test",
@@ -2608,8 +2648,8 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.10",
  "rusty-fork",
@@ -2741,12 +2781,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2756,7 +2817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2774,7 +2844,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3201,6 +3271,17 @@ dependencies = [
  "scopeguard",
  "unescaper",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3638,6 +3719,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "tuple_list"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,6 +3885,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/config",
     "crates/core",
     "crates/dap",
+    "crates/egress-relay",
     "crates/firmware",
     "crates/firmware-ci-fixture",
     "crates/firmware-comparative-benchmark",

--- a/crates/core/src/network/egress/bus.rs
+++ b/crates/core/src/network/egress/bus.rs
@@ -24,9 +24,16 @@ pub struct EgressBus {
     rx: Receiver<EgressItem>,
     can_sources: Vec<Receiver<CanFrame>>,
     buffer: VecDeque<EgressItem>,
+    /// A payload already encoded but not yet accepted by the worker (endpoint
+    /// backed up). Retried before encoding new items, so each item is encoded
+    /// exactly once regardless of backpressure.
+    pending: Option<Vec<u8>>,
     policy: BufferPolicy,
     encoding: EncodingKind,
     dropped: u64,
+    /// Value of `dropped` at the last emitted warning, so we log on change
+    /// rather than every tick.
+    warned_dropped: u64,
     worker_tx: Option<SyncSender<Vec<u8>>>,
     worker: Option<JoinHandle<()>>,
 }
@@ -48,9 +55,11 @@ impl EgressBus {
             rx,
             can_sources: Vec::new(),
             buffer: VecDeque::new(),
+            pending: None,
             policy,
             encoding,
             dropped: 0,
+            warned_dropped: 0,
             worker_tx: Some(worker_tx),
             worker: Some(worker),
         }
@@ -79,27 +88,46 @@ impl EgressBus {
             self.buffer.pop_front();
             self.dropped += 1;
         }
+        // Surface backpressure loss once per burst instead of dropping silently.
+        if self.dropped > self.warned_dropped {
+            tracing::warn!(
+                dropped = self.dropped,
+                "egress endpoint can't keep up; dropped oldest buffered items"
+            );
+            self.warned_dropped = self.dropped;
+        }
+    }
+
+    /// Try to hand `payload` to the worker. On a full queue the payload is
+    /// stashed in `pending` (never re-encoded); on disconnect it is discarded.
+    fn try_send(&mut self, payload: Vec<u8>) {
+        let Some(tx) = &self.worker_tx else { return };
+        match tx.try_send(payload) {
+            Ok(()) => {}
+            Err(TrySendError::Full(p)) => self.pending = Some(p),
+            Err(TrySendError::Disconnected(_)) => {}
+        }
     }
 }
 
 impl Interconnect for EgressBus {
     fn tick(&mut self) -> SimResult<()> {
         self.drain_sources();
+        // Flush a previously-rejected payload before encoding anything new, so
+        // ordering holds and the worker queue drains in FIFO order.
+        if let Some(pending) = self.pending.take() {
+            self.try_send(pending);
+            if self.pending.is_some() {
+                return Ok(()); // still backed up; don't pile on more work
+            }
+        }
         if self.buffer.is_empty() {
             return Ok(());
         }
-        let items: Vec<EgressItem> = self.buffer.iter().cloned().collect();
+        let items: Vec<EgressItem> = self.buffer.drain(..).collect();
         let payload = encode(self.encoding, &items);
-        if payload.is_empty() {
-            self.buffer.clear();
-            return Ok(());
-        }
-        if let Some(tx) = &self.worker_tx {
-            match tx.try_send(payload) {
-                Ok(()) => self.buffer.clear(),
-                Err(TrySendError::Full(_)) => { /* keep buffered, retry next tick */ }
-                Err(TrySendError::Disconnected(_)) => self.buffer.clear(),
-            }
+        if !payload.is_empty() {
+            self.try_send(payload);
         }
         Ok(())
     }

--- a/crates/core/src/network/egress/transport/http.rs
+++ b/crates/core/src/network/egress/transport/http.rs
@@ -15,13 +15,12 @@ pub struct HttpPoster {
     host: String,
     port: u16,
     path: String,
-    #[allow(dead_code)]
-    flush_interval_ms: u64,
 }
 
 impl HttpPoster {
     /// `url` like `http://host:8080/ingest`. Only plain HTTP is supported.
-    pub fn new(url: String, flush_interval_ms: u64) -> anyhow::Result<Self> {
+    /// One POST per flushed payload (Connection: close); no batching.
+    pub fn new(url: String) -> anyhow::Result<Self> {
         let rest = url
             .strip_prefix("http://")
             .ok_or_else(|| anyhow::anyhow!("only http:// URLs supported: {url}"))?;
@@ -37,7 +36,6 @@ impl HttpPoster {
             host,
             port,
             path: path.to_string(),
-            flush_interval_ms,
         })
     }
 }
@@ -88,7 +86,7 @@ mod tests {
             line
         });
         let mut poster =
-            HttpPoster::new(format!("http://{}:{}/ingest", addr.ip(), addr.port()), 0).unwrap();
+            HttpPoster::new(format!("http://{}:{}/ingest", addr.ip(), addr.port())).unwrap();
         poster.send(b"body").unwrap();
         assert!(handle.join().unwrap().starts_with("POST /ingest"));
     }

--- a/crates/core/src/network/egress/transport/mqtt.rs
+++ b/crates/core/src/network/egress/transport/mqtt.rs
@@ -59,14 +59,16 @@ impl EgressTransport for MqttPublisher {
     }
 }
 
-/// MQTT 3.1.1 CONNECT with clean session, keep-alive 60s, no will/auth.
+/// MQTT 3.1.1 CONNECT with clean session, no will/auth. Keep-alive is 0
+/// (disabled): this QoS-0 fire-and-forget publisher never sends PINGREQ, so
+/// advertising a non-zero interval would be a promise it can't keep.
 fn connect_packet(client_id: &str) -> Vec<u8> {
     let mut var = Vec::new();
     var.extend_from_slice(&[0x00, 0x04]); // "MQTT" length
     var.extend_from_slice(b"MQTT");
     var.push(0x04); // protocol level 4 (3.1.1)
     var.push(0x02); // connect flags: clean session
-    var.extend_from_slice(&[0x00, 0x3C]); // keep-alive 60s
+    var.extend_from_slice(&[0x00, 0x00]); // keep-alive disabled
     let id = client_id.as_bytes();
     var.extend_from_slice(&(id.len() as u16).to_be_bytes());
     var.extend_from_slice(id);

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -285,7 +285,7 @@ fn build_egress(
                 .to_string();
             Box::new(MqttPublisher::lazy(host, port, topic))
         }
-        "http" => Box::new(HttpPoster::new(url, 0)?),
+        "http" => Box::new(HttpPoster::new(url)?),
         other => anyhow::bail!("egress: unknown transport '{other}'"),
     };
     let policy = BufferPolicy {

--- a/crates/egress-relay/Cargo.toml
+++ b/crates/egress-relay/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "labwired-egress-relay"
+version.workspace = true
+edition = "2021"
+license.workspace = true
+publish = false
+
+[dependencies]
+labwired-core = { path = "../core" }
+tungstenite = "0.24"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+tracing = "0.1"
+
+[features]
+net-tests = []
+
+[[bin]]
+name = "labwired-egress-relay"
+path = "src/main.rs"

--- a/crates/egress-relay/relay.example.toml
+++ b/crates/egress-relay/relay.example.toml
@@ -1,0 +1,7 @@
+# Fixed egress allowlist. The relay forwards ONLY to these targets.
+# Never add caller-supplied hosts — that turns the relay into an open proxy.
+bind = "0.0.0.0:8090"
+
+[[allow]]
+transport = "mqtt"
+url = "mqtt://demo-broker.labwired.internal:1883"

--- a/crates/egress-relay/src/build.rs
+++ b/crates/egress-relay/src/build.rs
@@ -1,0 +1,54 @@
+use crate::hello::Hello;
+use anyhow::Context;
+use labwired_core::network::egress::transport::{
+    EgressTransport, HttpPoster, MqttPublisher, TcpSink,
+};
+
+/// Map a validated hello to a native (blocking) egress transport. Transports
+/// connect lazily on first send, so this never touches the network.
+pub fn build_transport(h: &Hello) -> anyhow::Result<Box<dyn EgressTransport>> {
+    match h.transport.as_str() {
+        "tcp" => Ok(Box::new(TcpSink::new(h.url.clone()))),
+        "mqtt" => {
+            let (host, port) = parse_mqtt_url(&h.url)?;
+            let topic = h.topic.clone().context("mqtt hello needs 'topic'")?;
+            Ok(Box::new(MqttPublisher::lazy(host, port, topic)))
+        }
+        "http" => Ok(Box::new(HttpPoster::new(h.url.clone())?)),
+        other => anyhow::bail!("unknown transport '{other}'"),
+    }
+}
+
+/// `mqtt://host:port` -> (host, port). Duplicated from world.rs deliberately —
+/// the relay must not depend on the World wiring.
+fn parse_mqtt_url(url: &str) -> anyhow::Result<(String, u16)> {
+    let rest = url.strip_prefix("mqtt://").unwrap_or(url);
+    let (host, port) = rest
+        .rsplit_once(':')
+        .context("mqtt url must be mqtt://host:port")?;
+    Ok((host.to_string(), port.parse()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hello::parse_hello;
+
+    #[test]
+    fn builds_tcp_transport() {
+        let h = parse_hello(r#"{"transport":"tcp","url":"127.0.0.1:9000","encoding":"raw"}"#).unwrap();
+        assert!(build_transport(&h).is_ok());
+    }
+
+    #[test]
+    fn mqtt_requires_topic() {
+        let h = parse_hello(r#"{"transport":"mqtt","url":"mqtt://h:1883","encoding":"raw"}"#).unwrap();
+        assert!(build_transport(&h).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_transport() {
+        let h = parse_hello(r#"{"transport":"carrier-pigeon","url":"x","encoding":"raw"}"#).unwrap();
+        assert!(build_transport(&h).is_err());
+    }
+}

--- a/crates/egress-relay/src/build.rs
+++ b/crates/egress-relay/src/build.rs
@@ -36,19 +36,22 @@ mod tests {
 
     #[test]
     fn builds_tcp_transport() {
-        let h = parse_hello(r#"{"transport":"tcp","url":"127.0.0.1:9000","encoding":"raw"}"#).unwrap();
+        let h =
+            parse_hello(r#"{"transport":"tcp","url":"127.0.0.1:9000","encoding":"raw"}"#).unwrap();
         assert!(build_transport(&h).is_ok());
     }
 
     #[test]
     fn mqtt_requires_topic() {
-        let h = parse_hello(r#"{"transport":"mqtt","url":"mqtt://h:1883","encoding":"raw"}"#).unwrap();
+        let h =
+            parse_hello(r#"{"transport":"mqtt","url":"mqtt://h:1883","encoding":"raw"}"#).unwrap();
         assert!(build_transport(&h).is_err());
     }
 
     #[test]
     fn rejects_unknown_transport() {
-        let h = parse_hello(r#"{"transport":"carrier-pigeon","url":"x","encoding":"raw"}"#).unwrap();
+        let h =
+            parse_hello(r#"{"transport":"carrier-pigeon","url":"x","encoding":"raw"}"#).unwrap();
         assert!(build_transport(&h).is_err());
     }
 }

--- a/crates/egress-relay/src/conn.rs
+++ b/crates/egress-relay/src/conn.rs
@@ -1,0 +1,94 @@
+use crate::build::build_transport;
+use crate::hello::{parse_hello, Allowlist};
+use std::io::{Read, Write};
+use tungstenite::{Message, WebSocket};
+
+/// Handle one browser connection: first Text frame is the hello (validated
+/// against the fixed allowlist), every subsequent Binary frame is forwarded to
+/// the backend transport. A rejected hello closes the socket.
+pub fn serve_connection<S: Read + Write>(
+    ws: &mut WebSocket<S>,
+    allow: &Allowlist,
+) -> anyhow::Result<()> {
+    // 1. Hello.
+    let hello = loop {
+        match ws.read()? {
+            Message::Text(t) => break parse_hello(&t)?,
+            Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(_) => return Ok(()),
+            _ => anyhow::bail!("expected hello text frame first"),
+        }
+    };
+    if !allow.permits(&hello) {
+        tracing::warn!(target = %hello.url, "rejected egress target (not allowlisted)");
+        let _ = ws.close(None);
+        anyhow::bail!("target not allowlisted");
+    }
+    let mut transport = build_transport(&hello)?;
+
+    // 2. Forward payload frames.
+    loop {
+        match ws.read()? {
+            Message::Binary(b) => {
+                if let Err(e) = transport.send(&b) {
+                    tracing::warn!("backend send failed: {e:?}");
+                    break;
+                }
+            }
+            Message::Text(_) => { /* ignore post-hello text */ }
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Close(_) => break,
+            Message::Frame(_) => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, feature = "net-tests"))]
+mod tests {
+    use super::*;
+    use crate::hello::{AllowEntry, Allowlist};
+    use std::io::Read;
+    use std::net::TcpListener;
+
+    #[test]
+    fn forwards_ws_payload_to_allowed_tcp_backend() {
+        // Fake customer backend.
+        let backend = TcpListener::bind("127.0.0.1:0").unwrap();
+        let backend_addr = backend.local_addr().unwrap().to_string();
+        let backend_reader = std::thread::spawn(move || {
+            let (mut s, _) = backend.accept().unwrap();
+            let mut buf = [0u8; 5];
+            s.read_exact(&mut buf).unwrap();
+            buf
+        });
+
+        // Relay WS listener.
+        let relay = TcpListener::bind("127.0.0.1:0").unwrap();
+        let relay_addr = relay.local_addr().unwrap();
+        let allow = Allowlist {
+            entries: vec![AllowEntry {
+                transport: "tcp".into(),
+                url: backend_addr.clone(),
+            }],
+        };
+        let relay_thread = std::thread::spawn(move || {
+            let (stream, _) = relay.accept().unwrap();
+            let mut ws = tungstenite::accept(stream).unwrap();
+            let _ = serve_connection(&mut ws, &allow);
+        });
+
+        // Browser side.
+        let (mut ws, _) = tungstenite::connect(format!("ws://{relay_addr}/")).unwrap();
+        ws.send(tungstenite::Message::Text(format!(
+            r#"{{"transport":"tcp","url":"{backend_addr}","encoding":"raw"}}"#
+        )))
+        .unwrap();
+        ws.send(tungstenite::Message::Binary(b"hello".to_vec()))
+            .unwrap();
+        ws.close(None).ok();
+
+        assert_eq!(&backend_reader.join().unwrap(), b"hello");
+        relay_thread.join().unwrap();
+    }
+}

--- a/crates/egress-relay/src/hello.rs
+++ b/crates/egress-relay/src/hello.rs
@@ -1,0 +1,64 @@
+use serde::Deserialize;
+
+/// The first frame a browser sends: what backend it wants to reach.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Hello {
+    pub transport: String,
+    pub url: String,
+    #[serde(default)]
+    pub topic: Option<String>,
+    #[serde(default = "default_encoding")]
+    pub encoding: String,
+}
+
+fn default_encoding() -> String {
+    "raw".to_string()
+}
+
+pub fn parse_hello(text: &str) -> anyhow::Result<Hello> {
+    Ok(serde_json::from_str(text)?)
+}
+
+/// One permitted (transport, url) target. Fixed at deploy time; never derived
+/// from caller input.
+#[derive(Debug, Clone)]
+pub struct AllowEntry {
+    pub transport: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Allowlist {
+    pub entries: Vec<AllowEntry>,
+}
+
+impl Allowlist {
+    pub fn permits(&self, h: &Hello) -> bool {
+        self.entries
+            .iter()
+            .any(|e| e.transport == h.transport && e.url == h.url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_valid_mqtt_hello() {
+        let h = parse_hello(r#"{"v":1,"transport":"mqtt","url":"mqtt://demo.internal:1883","topic":"demo/temp","encoding":"raw"}"#).unwrap();
+        assert_eq!(h.transport, "mqtt");
+        assert_eq!(h.topic.as_deref(), Some("demo/temp"));
+    }
+
+    #[test]
+    fn allowlist_permits_only_listed_target() {
+        let allow = Allowlist { entries: vec![AllowEntry {
+            transport: "mqtt".into(), url: "mqtt://demo.internal:1883".into(),
+        }] };
+        let ok = parse_hello(r#"{"transport":"mqtt","url":"mqtt://demo.internal:1883","topic":"t","encoding":"raw"}"#).unwrap();
+        let bad = parse_hello(r#"{"transport":"mqtt","url":"mqtt://evil.example:1883","topic":"t","encoding":"raw"}"#).unwrap();
+        assert!(allow.permits(&ok));
+        assert!(!allow.permits(&bad));
+    }
+}

--- a/crates/egress-relay/src/hello.rs
+++ b/crates/egress-relay/src/hello.rs
@@ -53,11 +53,17 @@ mod tests {
 
     #[test]
     fn allowlist_permits_only_listed_target() {
-        let allow = Allowlist { entries: vec![AllowEntry {
-            transport: "mqtt".into(), url: "mqtt://demo.internal:1883".into(),
-        }] };
+        let allow = Allowlist {
+            entries: vec![AllowEntry {
+                transport: "mqtt".into(),
+                url: "mqtt://demo.internal:1883".into(),
+            }],
+        };
         let ok = parse_hello(r#"{"transport":"mqtt","url":"mqtt://demo.internal:1883","topic":"t","encoding":"raw"}"#).unwrap();
-        let bad = parse_hello(r#"{"transport":"mqtt","url":"mqtt://evil.example:1883","topic":"t","encoding":"raw"}"#).unwrap();
+        let bad = parse_hello(
+            r#"{"transport":"mqtt","url":"mqtt://evil.example:1883","topic":"t","encoding":"raw"}"#,
+        )
+        .unwrap();
         assert!(allow.permits(&ok));
         assert!(!allow.permits(&bad));
     }

--- a/crates/egress-relay/src/lib.rs
+++ b/crates/egress-relay/src/lib.rs
@@ -1,3 +1,4 @@
 //! Fixed-target WebSocket egress relay. See
 //! `docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md`.
 pub mod hello;
+pub mod build;

--- a/crates/egress-relay/src/lib.rs
+++ b/crates/egress-relay/src/lib.rs
@@ -1,0 +1,3 @@
+//! Fixed-target WebSocket egress relay. See
+//! `docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md`.
+pub mod hello;

--- a/crates/egress-relay/src/lib.rs
+++ b/crates/egress-relay/src/lib.rs
@@ -2,3 +2,4 @@
 //! `docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md`.
 pub mod hello;
 pub mod build;
+pub mod conn;

--- a/crates/egress-relay/src/lib.rs
+++ b/crates/egress-relay/src/lib.rs
@@ -1,5 +1,5 @@
 //! Fixed-target WebSocket egress relay. See
 //! `docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md`.
-pub mod hello;
 pub mod build;
 pub mod conn;
+pub mod hello;

--- a/crates/egress-relay/src/main.rs
+++ b/crates/egress-relay/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("labwired-egress-relay");
+}

--- a/crates/egress-relay/src/main.rs
+++ b/crates/egress-relay/src/main.rs
@@ -1,3 +1,67 @@
-fn main() {
-    println!("labwired-egress-relay");
+use labwired_egress_relay::hello::{AllowEntry, Allowlist};
+use labwired_egress_relay::conn::serve_connection;
+use std::net::TcpListener;
+
+/// Build the fixed allowlist from environment (injectable `get` for tests).
+/// MVP: a single demo target; extend the vec to allowlist more fixed backends.
+fn allow_from_env(get: impl Fn(&str) -> Option<String>) -> Allowlist {
+    Allowlist {
+        entries: vec![AllowEntry {
+            transport: get("RELAY_ALLOW_TRANSPORT").unwrap_or_else(|| "mqtt".into()),
+            url: get("RELAY_ALLOW_URL").unwrap_or_else(|| "mqtt://127.0.0.1:1883".into()),
+        }],
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber_init();
+    // MVP: fixed allowlist from env. Point at the demo broker only.
+    let allow = allow_from_env(|k| std::env::var(k).ok());
+    let bind = std::env::var("RELAY_BIND").unwrap_or_else(|_| "127.0.0.1:8090".into());
+    let listener = TcpListener::bind(&bind)?;
+    tracing::info!(%bind, "egress relay listening");
+
+    for stream in listener.incoming() {
+        let stream = match stream { Ok(s) => s, Err(_) => continue };
+        let allow = allow.clone();
+        std::thread::spawn(move || {
+            let mut ws = match tungstenite::accept(stream) { Ok(w) => w, Err(_) => return };
+            if let Err(e) = serve_connection(&mut ws, &allow) {
+                tracing::debug!("connection ended: {e:?}");
+            }
+        });
+    }
+    Ok(())
+}
+
+fn tracing_subscriber_init() {
+    // Best-effort; ignore if a global subscriber already exists.
+    let _ = tracing::subscriber::set_global_default(
+        tracing::subscriber::NoSubscriber::default(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn env_builds_single_allowlist_entry() {
+        let env: HashMap<&str, &str> = [
+            ("RELAY_ALLOW_TRANSPORT", "mqtt"),
+            ("RELAY_ALLOW_URL", "mqtt://demo.internal:1883"),
+        ].into_iter().collect();
+        let allow = allow_from_env(|k| env.get(k).map(|s| s.to_string()));
+        assert_eq!(allow.entries.len(), 1);
+        assert_eq!(allow.entries[0].transport, "mqtt");
+        assert_eq!(allow.entries[0].url, "mqtt://demo.internal:1883");
+    }
+
+    #[test]
+    fn env_falls_back_to_local_defaults() {
+        let allow = allow_from_env(|_| None);
+        assert_eq!(allow.entries.len(), 1);
+        assert!(allow.entries[0].url.starts_with("mqtt://127.0.0.1"));
+    }
 }

--- a/crates/egress-relay/src/main.rs
+++ b/crates/egress-relay/src/main.rs
@@ -1,5 +1,5 @@
-use labwired_egress_relay::hello::{AllowEntry, Allowlist};
 use labwired_egress_relay::conn::serve_connection;
+use labwired_egress_relay::hello::{AllowEntry, Allowlist};
 use std::net::TcpListener;
 
 /// Build the fixed allowlist from environment (injectable `get` for tests).
@@ -22,10 +22,16 @@ fn main() -> anyhow::Result<()> {
     tracing::info!(%bind, "egress relay listening");
 
     for stream in listener.incoming() {
-        let stream = match stream { Ok(s) => s, Err(_) => continue };
+        let stream = match stream {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
         let allow = allow.clone();
         std::thread::spawn(move || {
-            let mut ws = match tungstenite::accept(stream) { Ok(w) => w, Err(_) => return };
+            let mut ws = match tungstenite::accept(stream) {
+                Ok(w) => w,
+                Err(_) => return,
+            };
             if let Err(e) = serve_connection(&mut ws, &allow) {
                 tracing::debug!("connection ended: {e:?}");
             }
@@ -36,9 +42,7 @@ fn main() -> anyhow::Result<()> {
 
 fn tracing_subscriber_init() {
     // Best-effort; ignore if a global subscriber already exists.
-    let _ = tracing::subscriber::set_global_default(
-        tracing::subscriber::NoSubscriber::default(),
-    );
+    let _ = tracing::subscriber::set_global_default(tracing::subscriber::NoSubscriber::default());
 }
 
 #[cfg(test)]
@@ -51,7 +55,9 @@ mod tests {
         let env: HashMap<&str, &str> = [
             ("RELAY_ALLOW_TRANSPORT", "mqtt"),
             ("RELAY_ALLOW_URL", "mqtt://demo.internal:1883"),
-        ].into_iter().collect();
+        ]
+        .into_iter()
+        .collect();
         let allow = allow_from_env(|k| env.get(k).map(|s| s.to_string()));
         assert_eq!(allow.entries.len(), 1);
         assert_eq!(allow.entries[0].transport, "mqtt");

--- a/docs/superpowers/plans/2026-07-04-browser-egress-ws-relay.md
+++ b/docs/superpowers/plans/2026-07-04-browser-egress-ws-relay.md
@@ -1,0 +1,546 @@
+# Browser Egress WS Relay — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a fixed-target WebSocket relay so a firmware image running in the in-browser playground can stream its UART output to a live demo backend, powering a "simulated device → dashboard" homepage demo.
+
+**Architecture:** New sync (thread-per-connection) `tungstenite` relay bin crate in this workspace. Each connection: read a JSON *hello*, validate `transport`+`url`+`topic` against a **fixed allowlist**, build the existing native egress transport (`TcpSink`/`MqttPublisher`/`HttpPoster`), then forward each binary WS frame to it. The browser side needs no new WASM code — it already exposes `drain_uart_output() -> Vec<u8>` (`crates/wasm/src/traces.rs`); JS forwards those bytes over the WS.
+
+**Tech Stack:** Rust, `tungstenite` (sync WebSocket), `serde`/`serde_json`, `anyhow`, reused `labwired-core` egress transports. No tokio (matches the existing std-thread egress worker style).
+
+## Global Constraints
+
+- No `Claude`/`AI`/`assistant` references in commit messages or PR bodies; no `Co-Authored-By` AI footer.
+- Commit identity: `user.name = w1ne`, email `14119286+w1ne@users.noreply.github.com` (already set in the worktree).
+- Reuse the native transports verbatim — do **not** reimplement TCP/MQTT/HTTP.
+- MVP forwards to a **fixed allowlist only**; arbitrary user targets are out of scope (SSRF). Never widen the allowlist to accept caller-supplied hosts in this plan.
+- Net-touching tests gate behind the existing `net-tests` cargo feature pattern.
+
+---
+
+### Task 1: Scaffold `crates/egress-relay` + hello parsing & allowlist
+
+**Files:**
+- Create: `crates/egress-relay/Cargo.toml`
+- Create: `crates/egress-relay/src/hello.rs`
+- Create: `crates/egress-relay/src/lib.rs`
+- Modify: `Cargo.toml` (workspace `members`, add `"crates/egress-relay"`)
+
+**Interfaces:**
+- Produces: `Hello { transport: String, url: String, topic: Option<String>, encoding: String }` (serde `Deserialize`); `Allowlist { entries: Vec<AllowEntry> }` with `fn permits(&self, h: &Hello) -> bool`; `fn parse_hello(text: &str) -> anyhow::Result<Hello>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// crates/egress-relay/src/hello.rs  (bottom)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_valid_mqtt_hello() {
+        let h = parse_hello(r#"{"v":1,"transport":"mqtt","url":"mqtt://demo.internal:1883","topic":"demo/temp","encoding":"raw"}"#).unwrap();
+        assert_eq!(h.transport, "mqtt");
+        assert_eq!(h.topic.as_deref(), Some("demo/temp"));
+    }
+
+    #[test]
+    fn allowlist_permits_only_listed_target() {
+        let allow = Allowlist { entries: vec![AllowEntry {
+            transport: "mqtt".into(), url: "mqtt://demo.internal:1883".into(),
+        }] };
+        let ok = parse_hello(r#"{"transport":"mqtt","url":"mqtt://demo.internal:1883","topic":"t","encoding":"raw"}"#).unwrap();
+        let bad = parse_hello(r#"{"transport":"mqtt","url":"mqtt://evil.example:1883","topic":"t","encoding":"raw"}"#).unwrap();
+        assert!(allow.permits(&ok));
+        assert!(!allow.permits(&bad));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-egress-relay hello`
+Expected: FAIL to compile (`parse_hello`/`Hello`/`Allowlist` not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`crates/egress-relay/Cargo.toml`:
+```toml
+[package]
+name = "labwired-egress-relay"
+version.workspace = true
+edition = "2021"
+license.workspace = true
+publish = false
+
+[dependencies]
+labwired-core = { path = "../core" }
+tungstenite = "0.24"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+tracing = "0.1"
+
+[features]
+net-tests = []
+
+[[bin]]
+name = "labwired-egress-relay"
+path = "src/main.rs"
+```
+
+`crates/egress-relay/src/hello.rs`:
+```rust
+use serde::Deserialize;
+
+/// The first frame a browser sends: what backend it wants to reach.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Hello {
+    pub transport: String,
+    pub url: String,
+    #[serde(default)]
+    pub topic: Option<String>,
+    #[serde(default = "default_encoding")]
+    pub encoding: String,
+}
+
+fn default_encoding() -> String {
+    "raw".to_string()
+}
+
+pub fn parse_hello(text: &str) -> anyhow::Result<Hello> {
+    Ok(serde_json::from_str(text)?)
+}
+
+/// One permitted (transport, url) target. Fixed at deploy time; never derived
+/// from caller input.
+#[derive(Debug, Clone)]
+pub struct AllowEntry {
+    pub transport: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Allowlist {
+    pub entries: Vec<AllowEntry>,
+}
+
+impl Allowlist {
+    pub fn permits(&self, h: &Hello) -> bool {
+        self.entries
+            .iter()
+            .any(|e| e.transport == h.transport && e.url == h.url)
+    }
+}
+```
+
+`crates/egress-relay/src/lib.rs`:
+```rust
+//! Fixed-target WebSocket egress relay. See
+//! `docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md`.
+pub mod hello;
+```
+
+Add `"crates/egress-relay",` to the workspace `members` list in the root `Cargo.toml`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-egress-relay hello`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/egress-relay Cargo.toml
+git commit -m "feat(egress-relay): scaffold relay crate with hello parse + allowlist"
+```
+
+---
+
+### Task 2: Build a native transport from a validated hello
+
+**Files:**
+- Create: `crates/egress-relay/src/build.rs`
+- Modify: `crates/egress-relay/src/lib.rs` (add `pub mod build;`)
+
+**Interfaces:**
+- Consumes: `Hello` (Task 1); `labwired_core::network::egress::transport::{EgressTransport, TcpSink, MqttPublisher, HttpPoster}`.
+- Produces: `fn build_transport(h: &Hello) -> anyhow::Result<Box<dyn EgressTransport>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// crates/egress-relay/src/build.rs (bottom)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hello::parse_hello;
+
+    #[test]
+    fn builds_tcp_transport() {
+        let h = parse_hello(r#"{"transport":"tcp","url":"127.0.0.1:9000","encoding":"raw"}"#).unwrap();
+        assert!(build_transport(&h).is_ok());
+    }
+
+    #[test]
+    fn mqtt_requires_topic() {
+        let h = parse_hello(r#"{"transport":"mqtt","url":"mqtt://h:1883","encoding":"raw"}"#).unwrap();
+        assert!(build_transport(&h).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_transport() {
+        let h = parse_hello(r#"{"transport":"carrier-pigeon","url":"x","encoding":"raw"}"#).unwrap();
+        assert!(build_transport(&h).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-egress-relay build`
+Expected: FAIL (`build_transport` not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+// crates/egress-relay/src/build.rs
+use crate::hello::Hello;
+use anyhow::Context;
+use labwired_core::network::egress::transport::{
+    EgressTransport, HttpPoster, MqttPublisher, TcpSink,
+};
+
+/// Map a validated hello to a native (blocking) egress transport. Transports
+/// connect lazily on first send, so this never touches the network.
+pub fn build_transport(h: &Hello) -> anyhow::Result<Box<dyn EgressTransport>> {
+    match h.transport.as_str() {
+        "tcp" => Ok(Box::new(TcpSink::new(h.url.clone()))),
+        "mqtt" => {
+            let (host, port) = parse_mqtt_url(&h.url)?;
+            let topic = h.topic.clone().context("mqtt hello needs 'topic'")?;
+            Ok(Box::new(MqttPublisher::lazy(host, port, topic)))
+        }
+        "http" => Ok(Box::new(HttpPoster::new(h.url.clone())?)),
+        other => anyhow::bail!("unknown transport '{other}'"),
+    }
+}
+
+/// `mqtt://host:port` -> (host, port). Duplicated from world.rs deliberately —
+/// the relay must not depend on the World wiring.
+fn parse_mqtt_url(url: &str) -> anyhow::Result<(String, u16)> {
+    let rest = url.strip_prefix("mqtt://").unwrap_or(url);
+    let (host, port) = rest
+        .rsplit_once(':')
+        .context("mqtt url must be mqtt://host:port")?;
+    Ok((host.to_string(), port.parse()?))
+}
+```
+
+Add `pub mod build;` to `lib.rs`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-egress-relay build`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/egress-relay/src
+git commit -m "feat(egress-relay): build native transport from validated hello"
+```
+
+---
+
+### Task 3: Per-connection handler (hello → validate → forward frames)
+
+**Files:**
+- Create: `crates/egress-relay/src/conn.rs`
+- Modify: `crates/egress-relay/src/lib.rs` (add `pub mod conn;`)
+
+**Interfaces:**
+- Consumes: `Allowlist` (Task 1), `build_transport` (Task 2), `tungstenite::WebSocket`.
+- Produces: `fn serve_connection<S: Read + Write>(ws: &mut WebSocket<S>, allow: &Allowlist) -> anyhow::Result<()>`.
+
+- [ ] **Step 1: Write the failing test (net-gated: real localhost WS + fake TCP backend)**
+
+```rust
+// crates/egress-relay/src/conn.rs (bottom)
+#[cfg(all(test, feature = "net-tests"))]
+mod tests {
+    use super::*;
+    use crate::hello::{AllowEntry, Allowlist};
+    use std::io::Read;
+    use std::net::{TcpListener, TcpStream};
+
+    #[test]
+    fn forwards_ws_payload_to_allowed_tcp_backend() {
+        // Fake customer backend.
+        let backend = TcpListener::bind("127.0.0.1:0").unwrap();
+        let backend_addr = backend.local_addr().unwrap().to_string();
+        let backend_reader = std::thread::spawn(move || {
+            let (mut s, _) = backend.accept().unwrap();
+            let mut buf = [0u8; 5];
+            s.read_exact(&mut buf).unwrap();
+            buf
+        });
+
+        // Relay WS listener.
+        let relay = TcpListener::bind("127.0.0.1:0").unwrap();
+        let relay_addr = relay.local_addr().unwrap();
+        let allow = Allowlist { entries: vec![AllowEntry {
+            transport: "tcp".into(), url: backend_addr.clone(),
+        }] };
+        let relay_thread = std::thread::spawn(move || {
+            let (stream, _) = relay.accept().unwrap();
+            let mut ws = tungstenite::accept(stream).unwrap();
+            let _ = serve_connection(&mut ws, &allow);
+        });
+
+        // Browser side.
+        let (mut ws, _) =
+            tungstenite::client::connect(format!("ws://{relay_addr}/")).unwrap();
+        ws.send(tungstenite::Message::Text(
+            format!(r#"{{"transport":"tcp","url":"{backend_addr}","encoding":"raw"}}"#),
+        )).unwrap();
+        ws.send(tungstenite::Message::Binary(b"hello".to_vec())).unwrap();
+        ws.close(None).ok();
+
+        assert_eq!(&backend_reader.join().unwrap(), b"hello");
+        relay_thread.join().unwrap();
+    }
+}
+```
+(Client `connect` needs a `TcpStream`; if the tungstenite version in use wants an explicit stream, adapt to `tungstenite::client(url, TcpStream::connect(relay_addr)?)` — keep the assertion identical.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-egress-relay --features net-tests conn`
+Expected: FAIL (`serve_connection` not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+// crates/egress-relay/src/conn.rs
+use crate::build::build_transport;
+use crate::hello::{parse_hello, Allowlist};
+use std::io::{Read, Write};
+use tungstenite::{Message, WebSocket};
+
+/// Handle one browser connection: first Text frame is the hello (validated
+/// against the fixed allowlist), every subsequent Binary frame is forwarded to
+/// the backend transport. A rejected hello closes the socket.
+pub fn serve_connection<S: Read + Write>(
+    ws: &mut WebSocket<S>,
+    allow: &Allowlist,
+) -> anyhow::Result<()> {
+    // 1. Hello.
+    let hello = loop {
+        match ws.read()? {
+            Message::Text(t) => break parse_hello(&t)?,
+            Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(_) => return Ok(()),
+            _ => anyhow::bail!("expected hello text frame first"),
+        }
+    };
+    if !allow.permits(&hello) {
+        tracing::warn!(target = %hello.url, "rejected egress target (not allowlisted)");
+        let _ = ws.close(None);
+        anyhow::bail!("target not allowlisted");
+    }
+    let mut transport = build_transport(&hello)?;
+
+    // 2. Forward payload frames.
+    loop {
+        match ws.read()? {
+            Message::Binary(b) => {
+                if let Err(e) = transport.send(&b) {
+                    tracing::warn!("backend send failed: {e:?}");
+                    break;
+                }
+            }
+            Message::Text(_) => { /* ignore post-hello text */ }
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Close(_) => break,
+            Message::Frame(_) => {}
+        }
+    }
+    Ok(())
+}
+```
+
+Add `pub mod conn;` to `lib.rs`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p labwired-egress-relay --features net-tests conn`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/egress-relay/src
+git commit -m "feat(egress-relay): per-connection hello validation + frame forwarding"
+```
+
+---
+
+### Task 4: Server binary (bind, thread-per-connection, config)
+
+**Files:**
+- Create: `crates/egress-relay/src/main.rs`
+- Create: `crates/egress-relay/relay.example.toml`
+
+**Interfaces:**
+- Consumes: `serve_connection` (Task 3), `Allowlist`/`AllowEntry` (Task 1).
+- Produces: `fn allow_from_env(get: impl Fn(&str) -> Option<String>) -> Allowlist` in `main.rs` (injectable env lookup so it is unit-testable without touching process env).
+
+- [ ] **Step 1: Write the failing test (env → allowlist builder)**
+
+```rust
+// crates/egress-relay/src/main.rs (bottom) — note: bin crates can host #[cfg(test)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn env_builds_single_allowlist_entry() {
+        let env: HashMap<&str, &str> = [
+            ("RELAY_ALLOW_TRANSPORT", "mqtt"),
+            ("RELAY_ALLOW_URL", "mqtt://demo.internal:1883"),
+        ].into_iter().collect();
+        let allow = allow_from_env(|k| env.get(k).map(|s| s.to_string()));
+        assert_eq!(allow.entries.len(), 1);
+        assert_eq!(allow.entries[0].transport, "mqtt");
+        assert_eq!(allow.entries[0].url, "mqtt://demo.internal:1883");
+    }
+
+    #[test]
+    fn env_falls_back_to_local_defaults() {
+        let allow = allow_from_env(|_| None);
+        assert_eq!(allow.entries.len(), 1);
+        assert!(allow.entries[0].url.starts_with("mqtt://127.0.0.1"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p labwired-egress-relay env_`
+Expected: FAIL (`allow_from_env` not defined).
+
+- [ ] **Step 3: Write the binary**
+
+```rust
+// crates/egress-relay/src/main.rs
+use labwired_egress_relay::hello::{AllowEntry, Allowlist};
+use labwired_egress_relay::conn::serve_connection;
+use std::net::TcpListener;
+
+/// Build the fixed allowlist from environment (injectable `get` for tests).
+/// MVP: a single demo target; extend the vec to allowlist more fixed backends.
+fn allow_from_env(get: impl Fn(&str) -> Option<String>) -> Allowlist {
+    Allowlist {
+        entries: vec![AllowEntry {
+            transport: get("RELAY_ALLOW_TRANSPORT").unwrap_or_else(|| "mqtt".into()),
+            url: get("RELAY_ALLOW_URL").unwrap_or_else(|| "mqtt://127.0.0.1:1883".into()),
+        }],
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber_init();
+    // MVP: fixed allowlist from env. Point at the demo broker only.
+    let allow = allow_from_env(|k| std::env::var(k).ok());
+    let bind = std::env::var("RELAY_BIND").unwrap_or_else(|_| "127.0.0.1:8090".into());
+    let listener = TcpListener::bind(&bind)?;
+    tracing::info!(%bind, "egress relay listening");
+
+    for stream in listener.incoming() {
+        let stream = match stream { Ok(s) => s, Err(_) => continue };
+        let allow = allow.clone();
+        std::thread::spawn(move || {
+            let mut ws = match tungstenite::accept(stream) { Ok(w) => w, Err(_) => return };
+            if let Err(e) = serve_connection(&mut ws, &allow) {
+                tracing::debug!("connection ended: {e:?}");
+            }
+        });
+    }
+    Ok(())
+}
+
+fn tracing_subscriber_init() {
+    // Best-effort; ignore if a global subscriber already exists.
+    let _ = tracing::subscriber::set_global_default(
+        tracing::subscriber::NoSubscriber::default(),
+    );
+}
+```
+(If the workspace already has a standard `tracing_subscriber` setup, use it instead of the `NoSubscriber` stub — match sibling bins in `crates/cli`.)
+
+`crates/egress-relay/relay.example.toml`:
+```toml
+# Fixed egress allowlist. The relay forwards ONLY to these targets.
+# Never add caller-supplied hosts — that turns the relay into an open proxy.
+bind = "0.0.0.0:8090"
+
+[[allow]]
+transport = "mqtt"
+url = "mqtt://demo-broker.labwired.internal:1883"
+```
+
+- [ ] **Step 4: Build + run the suite**
+
+Run: `cargo build -p labwired-egress-relay && cargo test -p labwired-egress-relay --features net-tests`
+Expected: binary builds; all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/egress-relay
+git commit -m "feat(egress-relay): server binary with fixed allowlist + example config"
+```
+
+---
+
+### Task 5: Browser JS glue (CROSS-REPO — playground/landing repo)
+
+> **Repo boundary:** This task lives in the playground/embed frontend (`app.labwired.com` / the landing repo's playground), NOT in this workspace. No Rust code or test here. The WASM contract already exists: `WasmSimulator.drain_uart_output(): Uint8Array` (`crates/wasm/src/traces.rs`). Ship it as a separate PR in that repo.
+
+**Contract to implement in JS:**
+- On demo start, open `const ws = new WebSocket(RELAY_URL)` (RELAY_URL = the deployed relay).
+- On `ws.onopen`, send the hello (must exactly match an allowlist entry):
+  `ws.send(JSON.stringify({v:1, transport:"mqtt", url:DEMO_URL, topic:DEMO_TOPIC, encoding:"raw"}))`.
+- Each animation frame (alongside the existing `drain_uart_output()` poll that feeds the console), if `ws.readyState === WebSocket.OPEN`, forward the same bytes: `const b = sim.drain_uart_output(); if (b.length) ws.send(b)`.
+  - **Do not double-drain:** `drain_uart_output` clears the buffer, so read once per frame and fan out to both the console and the WS.
+- On demo stop / unload: `ws.close()`.
+- Surface `ws.onerror`/`onclose` in the embed status line (reuse the existing affordance).
+
+- [ ] **Step 1:** Implement the above in the playground's sim-driver module.
+- [ ] **Step 2:** Manually verify against a locally-run relay (`RELAY_BIND=127.0.0.1:8090`, allowlist pointing at a local mosquitto) that bytes reach the broker (`mosquitto_sub`).
+- [ ] **Step 3:** Commit in the frontend repo (same identity/no-AI-footer rules).
+
+---
+
+### Task 6: Live demo lab + chart page (CROSS-REPO — landing repo)
+
+> **Repo boundary:** landing/playground repo + a deployed relay + demo broker. Depends on Tasks 1–5. This is the payoff artifact.
+
+**Deliverable:** A homepage/embed demo where a real firmware image boots in-browser and its UART readings render on a live chart, end to end.
+
+- [ ] **Step 1:** Stand up the demo backend: a mosquitto (or existing dashboard) + a small chart page subscribing to `DEMO_TOPIC` over MQTT-over-WebSocket.
+- [ ] **Step 2:** Deploy the relay (Task 4 binary) with the allowlist fixed to that broker; set `RELAY_URL` in the frontend.
+- [ ] **Step 3:** Pick/point a demo firmware that emits periodic `KEY=VALUE\n` UART readings; wire the embed to stream via Task 5.
+- [ ] **Step 4:** Verify end to end in a browser: boot → chart moves. Capture the promo-grade recording per the repo's demo-video convention.
+- [ ] **Step 5:** Update the egress blog post ("Where it's going" → "shipped") once live. (User will handle blog copy.)
+
+---
+
+## Deferred (explicitly not in this plan)
+- Arbitrary user backend / self-hosted relay with per-user allowlist + auth (the SSRF-bearing dev path) — separate spec.
+- MQTT auth/TLS/reconnect, keep-alive (inherited native-bridge gap).
+- Per-connection bounded drop-oldest queue in the relay (MVP forwards synchronously; a slow backend backpressures that one WS).
+- Browser CAN/other-source egress; ingress/bidirectional.
+- Per-IP connection caps / idle timeout hardening (add before any public deploy).

--- a/docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md
+++ b/docs/superpowers/specs/2026-07-04-browser-egress-ws-relay-design.md
@@ -1,0 +1,111 @@
+# Browser Egress via WebSocket Relay — Design / Scope
+
+**Status:** SCOPE (not yet planned/implemented). Origin: post-roast tightening of
+the egress bridge — the browser is LabWired's primary product surface, and the
+native egress path can't run there. See `2026-07-03-egress-bridge-design.md`.
+
+**Goal:** Let a simulated device running in the *in-browser* playground (WASM)
+stream its output to a real backend, since WASM has no raw sockets. Ship the
+lowest-risk, highest-payoff slice first: a **fixed-target hosted relay** that
+powers a live "simulated device → dashboard" demo on the homepage.
+
+---
+
+## Why a relay at all
+
+WASM in the browser cannot open TCP/MQTT/HTTP sockets and has no worker thread
+doing blocking I/O. The native architecture (sim enqueues → worker thread →
+socket) therefore stops at the sandbox boundary. Something outside the browser
+must own the real socket. The browser reaches it over the one transport WASM
+*does* have: a WebSocket.
+
+## Architecture
+
+```
+WASM sim → EgressBus (enqueue) → WsRelayTransport → [JS WebSocket] → relay → backend
+          (deterministic core)   (payload → JS)      (browser)       (real socket)
+```
+
+The determinism boundary is unchanged: the sim core still only *enqueues*, and
+the bounded drop-oldest buffer still absorbs a slow/dead link. Only the last hop
+is new. `EgressBus`, `EgressTap`, `encoding`, and `BufferPolicy` are reused
+verbatim — the transport seam already isolates exactly this.
+
+### Component 1 — WASM side: **already done**
+The browser build already captures every UART TX byte into a shared
+`uart_sink: Arc<Mutex<Vec<u8>>>` and exposes `drain_uart_output() -> Vec<u8>`
+(`crates/wasm/src/traces.rs`), which the playground already polls. So browser
+egress needs **no new WASM code and no `EgressBus`/worker/`EgressTransport` in
+WASM at all** — the determinism boundary is trivially preserved (the sim writes
+an in-memory Vec; JS drains it and owns the WebSocket). Component 1 collapses to
+"JS forwards the bytes it already drains." (CAN/other-source egress from the
+browser is a later concern; MVP is UART, matching the native bridge's manifest
+wiring today.)
+
+### Component 2 — JS glue (playground)
+- Opens one WebSocket to the relay URL (compile-time/config constant for the
+  hosted demo).
+- Sends a **hello frame** (JSON) first: `{v:1, transport, url, topic, encoding}`.
+- Then streams **payload frames** (binary WS messages) from `egress_drain()`.
+- Surfaces relay errors/drops in the playground UI (reuses the existing embed
+  status affordance).
+
+### Component 3 — relay server (the only genuinely new service)
+- Small async server (Rust/`tokio` + `tokio-tungstenite`, or reuse whatever the
+  egress bridge / app backend already runs — TBD in planning).
+- Per connection: read hello → **validate against a fixed allowlist** → open the
+  real backend socket (reusing the *native* `TcpSink`/`MqttPublisher`/
+  `HttpPoster` transports directly — same code, server-side) → forward each
+  payload frame.
+- Backpressure: bounded per-connection queue, drop-oldest, same semantics as the
+  in-sim bus; report drop count back over the WS for UI display.
+- Lifecycle: close backend socket on WS close; idle timeout; per-IP connection
+  cap.
+
+## MVP scope — Fixed demo target (hosted)
+
+The relay forwards **only** to a LabWired-controlled demo broker/endpoint. The
+`url`/`topic` in the hello are validated against a hardcoded allowlist; anything
+else is rejected. This removes the entire SSRF / open-proxy risk class (see
+Non-goals) and is the exact shape the homepage demo needs.
+
+Deliverable: a homepage/embed demo where a real firmware image boots in the
+browser and its UART output appears on a live chart, end to end, no hardware.
+
+**In scope:**
+- `WsRelayTransport` + WASM boundary drain API.
+- JS WebSocket glue in the playground/embed.
+- Relay server with a **fixed allowlist** (demo target only), reusing native
+  transports server-side.
+- One live demo lab wired end to end (real firmware → chart).
+- Wire protocol: `{v, transport, url, topic, encoding}` hello + binary payload
+  frames; versioned (`v:1`).
+
+**Explicitly deferred (Phase 2+):**
+- **Arbitrary user backend / self-hosted relay** (`labwired-egress-relay
+  --allow …`) — the real dev use case, but carries the SSRF liability and needs
+  auth; separate spec.
+- MQTT auth/TLS/reconnect (inherited gap from the native bridge).
+- Ingress / bidirectional (RX injection from the backend).
+- Manifest CAN wiring for browser egress.
+
+## Non-goals / risks
+
+- **Open-proxy / SSRF (the load-bearing risk):** a hosted relay that forwards
+  arbitrary user bytes to an arbitrary `host:port` is an open proxy into
+  internal networks. The fixed-allowlist MVP sidesteps this entirely; the
+  Phase-2 arbitrary-target path MUST NOT ship hosted without egress allowlisting
+  + auth + rate limits (or ship self-host-only so the user owns the blast
+  radius).
+- **Cost/abuse:** even fixed-target, a public WS endpoint needs per-IP caps and
+  idle timeouts. In MVP scope.
+- **Determinism:** unchanged and preserved — the WS hop is off the deterministic
+  path exactly like the native socket. The egress *stream* remains non-replayable
+  (already stated honestly in the tightened blog copy).
+
+## Open questions for planning
+1. Relay hosting: standalone service vs. a route on the existing app backend?
+2. WASM boundary: wasm-bindgen exports vs. the playground's current JS↔WASM
+   bridge — match whatever `app.labwired.com` already uses.
+3. Demo target: dedicated mosquitto + a tiny chart page, or an existing
+   dashboard we already run?

--- a/examples/egress-demo/README.md
+++ b/examples/egress-demo/README.md
@@ -12,7 +12,9 @@ firmware TX  →  UART push_tx  →  EgressTap  →  EgressBus  →  worker thre
 
 The sim core only *enqueues*; a worker thread owns the socket. A slow or dead
 endpoint back-pressures into a bounded drop-oldest buffer and **never stalls the
-simulation**, so runs stay deterministic and replayable.
+simulation**, so the *simulation run* stays deterministic and replayable. (What
+reaches the wire is not itself replayable — a slow endpoint drops items, and the
+bus logs a warning with the running drop count rather than losing data silently.)
 
 ## The manifest
 
@@ -37,7 +39,7 @@ interconnects:
 | Transport | `url` | Notes |
 |-----------|-------|-------|
 | `tcp`  | `"127.0.0.1:9000"` | raw bytes to any TCP listener (virtual serial gateway) |
-| `mqtt` | `"mqtt://broker:1883"` | MQTT 3.1.1 QoS 0 PUBLISH to `topic` |
+| `mqtt` | `"mqtt://broker:1883"` | MQTT 3.1.1 QoS 0 PUBLISH to `topic`; unauthenticated, no TLS/keep-alive — point at a broker you control. Prefer `ndjson-trace` (one framed message per reading) over `raw` |
 | `http` | `"http://host:8080/ingest"` | HTTP/1.1 POST per flush |
 
 Encodings: `raw` (bytes verbatim), `ndjson-trace` (one JSON line per byte/frame),


### PR DESCRIPTION
## What

**1. Tighten the native egress bridge**
- `EgressBus::tick` drains + encodes once into a retried `pending` payload instead of re-encoding the whole buffer every tick (removes O(n²) work under backpressure).
- Throttled warning on each increase of the drop counter — no more silent loss.
- MQTT keep-alive advertised as 0/disabled: the QoS-0 publisher never sends PINGREQ, so a non-zero interval was a promise it couldn't keep.
- Remove the dead `HttpPoster::flush_interval_ms` field (`new(url)` is now 1-arg).
- README/demo copy: reproducibility scoped to the simulation run, not the egress stream.

**2. New `crates/egress-relay`** — fixed-target WebSocket egress relay
Lets the in-browser (WASM) playground stream firmware UART output to a demo backend, since WASM has no raw sockets. Sync `tungstenite`, thread-per-connection: reads a JSON hello, validates it against a **fixed allowlist**, and forwards WS binary frames into the reused native transports. The browser side needs no new WASM code — it already exposes `drain_uart_output()`.

## Security
The allowlist is validated (exact transport+url match, deploy-fixed, never caller-derived) **before** any transport is built — no path reaches a non-allowlisted host. Arbitrary-target / self-host is out of scope (separate spec).

⚠️ Not for public deployment yet — see #463 (unbounded thread-per-connection + no idle/read timeout). Must be closed before the live demo.

## Tests
- Relay: unit (hello/build/env) + net-gated E2E (WS → real TCP backend).
- Native egress: 11 lib unit tests green; fmt + clippy clean.

Design + plan under `docs/superpowers/specs|plans/2026-07-04-browser-egress-ws-relay*`.