### PR TITLE
feat(wasm): inject ESP32-S3 ROM on demand (stop baking it into the bundle)

### DIFF
--- a/crates/core/src/boot/esp32s3_rom.rs
+++ b/crates/core/src/boot/esp32s3_rom.rs
@@ -35,9 +35,19 @@ const DRAM_LO: u32 = 0x3FC8_8000;
 const DRAM_HI: u32 = 0x3FD0_0000;
 
 /// Flat ROM images ready to load as `RamPeripheral`s at their window bases.
+#[derive(Clone)]
 pub struct RomImages {
     pub irom: Vec<u8>,
     pub drom: Vec<u8>,
+}
+
+impl std::fmt::Debug for RomImages {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RomImages")
+            .field("irom_len", &self.irom.len())
+            .field("drom_len", &self.drom.len())
+            .finish()
+    }
 }
 
 /// The DRAM window the copy-table reconstruction targets — where the boot
@@ -316,11 +326,11 @@ pub fn provision_rom_images() -> Option<RomImages> {
 /// Espressif's published `esp32s3_rev0_rom.elf` by
 /// `scripts/make_esp32s3_rom_bins.py` — see `crates/core/roms/esp32s3/`.
 ///
-/// Shipped in wasm too (the +512 KiB is the price of a FAITHFUL S3 widget demo:
-/// the playground fast-boots esp-hal apps on the real ROM with zero thunks —
-/// see `system::xtensa::configure_xtensa_esp32s3` + the ROM `.data` init). On
-/// wasm `discover_rom_elf`/the cache path are inert (no fs), so this vendored
-/// blob is the only ROM source there.
+/// Native only — the 512 KiB is NOT baked into wasm bundles. The playground
+/// fetches the ROM as an on-demand asset and injects it via
+/// `Esp32s3Opts.rom_images` (see `configure_esp32s3_memmap`), so the shared
+/// wasm engine stays lean for every non-S3 board.
+#[cfg(not(target_arch = "wasm32"))]
 fn vendored_rom_images() -> Option<RomImages> {
     static VENDORED_IROM: &[u8] = include_bytes!("../../roms/esp32s3/esp32s3_rom.bin");
     static VENDORED_DROM: &[u8] = include_bytes!("../../roms/esp32s3/esp32s3_drom.bin");
@@ -330,6 +340,12 @@ fn vendored_rom_images() -> Option<RomImages> {
         irom: VENDORED_IROM.to_vec(),
         drom: VENDORED_DROM.to_vec(),
     })
+}
+
+/// On wasm the ROM is never baked in; it arrives via `Esp32s3Opts.rom_images`.
+#[cfg(target_arch = "wasm32")]
+fn vendored_rom_images() -> Option<RomImages> {
+    None
 }
 
 /// Cache directory for extracted ROM images (`$XDG_CACHE_HOME` or `~/.cache`).

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -33,6 +33,13 @@ pub struct Esp32s3Opts {
     /// ROM-image choice: a real ROM is still loaded for its function calls in
     /// both modes.
     pub real_reset_boot: bool,
+    /// Caller-injected boot ROM images. When `Some`, used directly instead of
+    /// `provision_rom_images()`. This is how wasm gets the faithful ROM: the
+    /// 512 KiB is NOT baked into the bundle (see
+    /// `esp32s3_rom::vendored_rom_images`, wasm → None) — the playground
+    /// fetches it as an on-demand asset and injects it here. `None` (default)
+    /// → the native provision chain (env pins / toolchain / vendored blob).
+    pub rom_images: Option<crate::boot::esp32s3_rom::RomImages>,
 }
 
 impl Default for Esp32s3Opts {
@@ -43,6 +50,7 @@ impl Default for Esp32s3Opts {
             flash_size: 4 * 1024 * 1024,
             cpu_clock_hz: 80_000_000,
             real_reset_boot: false,
+            rom_images: None,
         }
     }
 }
@@ -172,7 +180,12 @@ fn configure_esp32s3_memmap(bus: &mut SystemBus, opts: &Esp32s3Opts) -> Esp32s3M
     // fast-booted app still calls the real ROM (see the ROM block below), it
     // just reaches its own `.rodata`/`.text` through identity XIP rather than a
     // table the skipped bootloader never wrote.
-    let rom_images = crate::boot::esp32s3_rom::provision_rom_images();
+    // Caller-injected ROM (wasm's on-demand asset) wins; else the native
+    // provision chain (env pins / toolchain / vendored blob — None on wasm).
+    let rom_images = opts
+        .rom_images
+        .clone()
+        .or_else(crate::boot::esp32s3_rom::provision_rom_images);
     let mmu_model = opts.real_reset_boot;
     // Shared flash backing for the proper-model path, loaded from the real
     // flash image so XIP reads (and the SPI-flash controller below) return real

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -124,6 +124,7 @@ impl WasmSimulator {
         system_yaml: &str,
         chip_yaml: &str,
         firmware: &[u8],
+        blobs: JsValue,
     ) -> Result<WasmSimulator, JsValue> {
         let manifest: SystemManifest = serde_yaml::from_str(system_yaml)
             .map_err(|e| JsValue::from_str(&format!("System YAML error: {}", e)))?;
@@ -134,7 +135,8 @@ impl WasmSimulator {
             Arch::Arm | Arch::Unknown => Self::new_from_config_arm(&chip, &manifest, firmware),
             Arch::RiscV => Self::new_from_config_riscv(&chip, &manifest, firmware),
             Arch::Xtensa if chip.name.starts_with("esp32s3") => {
-                Self::new_from_config_xtensa_esp32s3(&manifest, firmware)
+                let blob_map = parse_named_blobs(&blobs);
+                Self::new_from_config_xtensa_esp32s3(&manifest, firmware, &blob_map)
             }
             Arch::Xtensa => Self::new_from_config_xtensa_esp32(&manifest, firmware),
         }
@@ -295,24 +297,42 @@ impl WasmSimulator {
     /// ESP32-S3 (Xtensa LX7) bus setup — the FAITHFUL fast-boot path.
     ///
     /// `configure_xtensa_esp32s3` installs IRAM/DRAM/RTC/flash-XIP plus the
-    /// real vendored boot ROM (zero thunks; the ROM `.data` init lands
+    /// real boot ROM (zero thunks; the ROM `.data` init lands
     /// `rom_cache_internal_table_ptr` so esp-hal's ROM cache calls run for
-    /// real). `fast_boot` then loads the app ELF's segments (identity XIP)
-    /// and synthesises post-bootloader CPU state. Serial output on the S3
-    /// esp-hal apps goes through USB_SERIAL_JTAG, so we route that peripheral's
-    /// sink into the same `uart_sink` the widget's Serial tab reads.
+    /// real). The ROM is NOT baked into the wasm bundle — it is fetched on
+    /// demand and passed in `blobs` under `esp32s3_irom`/`esp32s3_drom`, then
+    /// injected via `Esp32s3Opts.rom_images`. `fast_boot` then loads the app
+    /// ELF's segments (identity XIP) and synthesises post-bootloader CPU state.
+    /// Serial output on the S3 esp-hal apps goes through USB_SERIAL_JTAG, so we
+    /// route that peripheral's sink into the `uart_sink` the widget reads.
     fn new_from_config_xtensa_esp32s3(
         manifest: &SystemManifest,
         firmware: &[u8],
+        blobs: &std::collections::HashMap<String, Vec<u8>>,
     ) -> Result<WasmSimulator, JsValue> {
         use labwired_core::boot::esp32s3::{fast_boot, BootOpts};
+        use labwired_core::boot::esp32s3_rom::RomImages;
         use labwired_core::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag;
         use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
 
+        // Inject the on-demand ROM blobs (None → configure falls back to the
+        // native provision chain, which is None on wasm → thunk harness).
+        let rom_images = match (blobs.get("esp32s3_irom"), blobs.get("esp32s3_drom")) {
+            (Some(irom), Some(drom)) => Some(RomImages {
+                irom: irom.clone(),
+                drom: drom.clone(),
+            }),
+            _ => None,
+        };
+
         let mut bus = SystemBus::new();
-        // Default opts → fast-boot identity XIP + faithful ROM (real_reset_boot
-        // is false; --rom-boot's MMU model is native-CLI only).
-        let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+        // Default XIP model (fast-boot identity; --rom-boot's MMU model is
+        // native-CLI only) + the injected faithful ROM.
+        let opts = Esp32s3Opts {
+            rom_images,
+            ..Esp32s3Opts::default()
+        };
+        let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
         let mut cpu = wiring.cpu;
 
         // Route USB-serial-JTAG bytes into the widget's serial sink. esp-hal's
@@ -718,6 +738,33 @@ extern "C" {
 #[wasm_bindgen]
 pub fn clear_uart_wires() {
     labwired_core::network::virtual_uart_wire::clear_virtual_uart_wires();
+}
+
+/// Parse a JS `{ name: Uint8Array }` object into a `name → bytes` map. Values
+/// that aren't `Uint8Array` are skipped; `null`/`undefined` → empty map.
+///
+/// This is the generic on-demand binary-blob channel: a board fetches only the
+/// assets it needs (e.g. the ESP32-S3 boot ROM) and passes them through
+/// `new_from_config`, so no per-board blob is baked into the shared wasm bundle.
+fn parse_named_blobs(blobs: &JsValue) -> std::collections::HashMap<String, Vec<u8>> {
+    use wasm_bindgen::JsCast;
+    let mut map = std::collections::HashMap::new();
+    if blobs.is_undefined() || blobs.is_null() {
+        return map;
+    }
+    if let Ok(obj) = blobs.clone().dyn_into::<js_sys::Object>() {
+        for entry in js_sys::Object::entries(&obj).iter() {
+            if let Ok(pair) = entry.dyn_into::<js_sys::Array>() {
+                if let (Some(key), Ok(arr)) = (
+                    pair.get(0).as_string(),
+                    pair.get(1).dyn_into::<js_sys::Uint8Array>(),
+                ) {
+                    map.insert(key, arr.to_vec());
+                }
+            }
+        }
+    }
+    map
 }
 
 // WasmGdbEventLoop removed — see `gdb_process_packet` above for the rationale.


### PR DESCRIPTION
Follow-up to #460. The 512 KiB S3 boot ROM was baked into `labwired_wasm_bg.wasm`, taxing **every** board load (STM32, RP2040, nRF…) for an S3-only asset. Now it's fetched on demand and injected.

## Changes
- `vendored_rom_images()` is native-only again (`#[cfg(not(wasm32))]`; wasm → `None`).
- `Esp32s3Opts.rom_images: Option<RomImages>` — injected ROM wins; else the native provision chain.
- `new_from_config` gains a **generic** `blobs: { name: Uint8Array }` param (`parse_named_blobs`). The S3 path pulls `esp32s3_irom`/`esp32s3_drom` into `rom_images`. Any future per-board blob rides the same channel — nothing baked in.

## Result
Bundle: **5.19 MB → 4.71 MB (−479 KiB)**.

## Verification
`wasm-pack build --release --target web` + node run injecting the ROM as **separate blobs**:
```
injecting ROM blobs: irom=393216B drom=131072B
pc=0x40378e20
FOUND ~2M cyc
OUT: "Hello world!\n"
INJECTED-ROM: PASS
no-blobs instantiation ok (harness fallback)
```
Faithful, zero thunks. Native provision path unchanged (`rom_images` defaults `None` → vendored).

## Note
Requires the paired playground change (fetch the ROM asset + pass it as blobs, ship the ROM bins as public assets). Merging this alone leaves S3 in harness mode in the widget until that lands — they deploy together.