### PR TITLE
feat(snapshot): cache the faithful ESP32-C3 boot at app-entry, resume instantly

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -283,6 +283,27 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
 
     // For Xtensa, short-circuit: build bus + CPU together via build_esp32_system_from_manifest.
     if is_xtensa {
+        // --resume-snapshot is wired for the C3 (RISC-V) rom-boot path only.
+        // The S3 faithful machine has no load_firmware step and populates some
+        // app regions via bootloader copies during the cold boot, so resuming
+        // it needs cache re-derivation work that is deferred; fail loudly rather
+        // than silently restore a partial state. (--capture-app-entry still
+        // works on S3 — it flows through the generic execute_test_loop.)
+        if args.resume_snapshot.is_some() {
+            let msg = "--resume-snapshot is not yet supported for ESP32-S3 (Xtensa); \
+                       cold-boot with --rom-boot instead"
+                .to_string();
+            error!("{}", msg);
+            write_config_error_outputs(
+                &args,
+                Some(&firmware_path),
+                system_path.as_ref(),
+                Some(&firmware_bytes),
+                Some(&resolved_limits),
+                msg,
+            );
+            return ExitCode::from(EXIT_CONFIG_ERROR);
+        }
         if let (Some(sys_path), Some(manifest)) = (system_path.as_ref(), esp32_manifest.as_ref()) {
             let uart_tx = Arc::new(Mutex::new(Vec::new()));
             // Load the ELF up front. The classic-Xtensa path fast-boots it into
@@ -623,7 +644,105 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             setup_and_run!(cpu)
         }
         labwired_core::Arch::RiscV => {
-            if args.rom_boot {
+            if let Some(snap_path) = &args.resume_snapshot {
+                // ── Resume from a captured app-entry snapshot (no cold boot) ──
+                // Build the SAME faithful rom-boot machine (which loads the real
+                // boot ROM + flash image and wires every peripheral), then stamp
+                // the snapshot on top. take_runtime_snapshot skips the flash/rom
+                // mirrors — they are re-derived here from the freshly-loaded
+                // flash — so restoring REQUIRES the identical firmware, enforced
+                // by the self-key gate below. The snapshot overwrites the CPU's
+                // PC to app-entry, so the mask ROM is never replayed: execution
+                // starts in the application immediately.
+                let snap_bytes = match std::fs::read(snap_path) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        let msg = format!("cannot read resume snapshot {snap_path:?}: {e}");
+                        error!("{}", msg);
+                        write_config_error_outputs(
+                            &args,
+                            Some(&firmware_path),
+                            system_path.as_ref(),
+                            Some(&firmware_bytes),
+                            Some(&resolved_limits),
+                            msg,
+                        );
+                        return ExitCode::from(EXIT_CONFIG_ERROR);
+                    }
+                };
+                let snap = match labwired_core::runtime_snapshot::MachineRuntimeSnapshot::from_bytes(
+                    &snap_bytes,
+                ) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let msg = format!("invalid resume snapshot {snap_path:?}: {e}");
+                        error!("{}", msg);
+                        write_config_error_outputs(
+                            &args,
+                            Some(&firmware_path),
+                            system_path.as_ref(),
+                            Some(&firmware_bytes),
+                            Some(&resolved_limits),
+                            msg,
+                        );
+                        return ExitCode::from(EXIT_CONFIG_ERROR);
+                    }
+                };
+                let (chip, fw_sha) = match crate::rom_boot_flash_self_key() {
+                    Some(v) => v,
+                    None => {
+                        let msg = "--resume-snapshot needs LABWIRED_ESP32C3_FLASH set (the same \
+                                   flash image the snapshot was captured against)"
+                            .to_string();
+                        error!("{}", msg);
+                        write_config_error_outputs(
+                            &args,
+                            Some(&firmware_path),
+                            system_path.as_ref(),
+                            Some(&firmware_bytes),
+                            Some(&resolved_limits),
+                            msg,
+                        );
+                        return ExitCode::from(EXIT_CONFIG_ERROR);
+                    }
+                };
+                if let Err(e) = snap.validate_self_key(chip, &fw_sha) {
+                    let msg =
+                        format!("resume snapshot self-key mismatch ({e}); cold-boot required");
+                    error!("{}", msg);
+                    write_config_error_outputs(
+                        &args,
+                        Some(&firmware_path),
+                        system_path.as_ref(),
+                        Some(&firmware_bytes),
+                        Some(&resolved_limits),
+                        msg,
+                    );
+                    return ExitCode::from(EXIT_CONFIG_ERROR);
+                }
+                let mut machine = match crate::build_c3_rom_boot_machine(bus, None) {
+                    Ok(m) => m,
+                    Err(code) => return code,
+                };
+                if let Err(e) = machine.apply_runtime_snapshot(&snap) {
+                    let msg = format!("failed to apply resume snapshot: {e}");
+                    error!("{}", msg);
+                    write_config_error_outputs(
+                        &args,
+                        Some(&firmware_path),
+                        system_path.as_ref(),
+                        Some(&firmware_bytes),
+                        Some(&resolved_limits),
+                        msg,
+                    );
+                    return ExitCode::from(EXIT_RUNTIME_ERROR);
+                }
+                eprintln!(
+                    "labwired-riscv: resumed from app-entry snapshot {snap_path:?} (chip {chip}); \
+                     mask-ROM replay skipped"
+                );
+                run_machine!(machine)
+            } else if args.rom_boot {
                 // Faithful boot: real mask ROM → 2nd-stage bootloader → app,
                 // loading from the flash image (LABWIRED_ESP32C3_FLASH), on
                 // the SAME from_config bus — external devices and assertions

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -614,6 +614,26 @@ struct TestArgs {
     #[arg(long)]
     run_manifest: bool,
 
+    /// Faithful rom-boot only: while running the REAL boot (mask ROM →
+    /// 2nd-stage bootloader → app), snapshot the machine the instant control
+    /// reaches the application and write a `.lwrs` resume snapshot here. The
+    /// run then continues to --max-steps as usual, so one cold invocation
+    /// yields BOTH the cached snapshot and the normal serial/cycle evidence.
+    /// App-entry is `call_start_cpu0`/`app_main` (resolved from the ELF), else
+    /// the first PC in the XIP app window [0x4200_0000, 0x4400_0000). The blob
+    /// is self-keyed with the chip + firmware SHA-256 (see --resume-snapshot).
+    #[arg(long)]
+    capture_app_entry: Option<PathBuf>,
+
+    /// Resume from a `.lwrs` snapshot instead of cold-booting: build a fresh
+    /// machine for the same chip, load the SAME firmware/flash, validate the
+    /// snapshot's self-key (chip + firmware SHA-256) against it, then apply it
+    /// and run to --max-steps. Skips the ~150M-step mask-ROM replay entirely.
+    /// On a self-key mismatch this errors out so the caller can fall back to a
+    /// cold boot. Requires the same LABWIRED_ESP32C3_FLASH as the capture.
+    #[arg(long)]
+    resume_snapshot: Option<PathBuf>,
+
     /// Explicitly opt out of sending LABWIRED_API_KEY even if it is set in the environment.
     /// Useful for local development and testing.
     #[arg(long)]
@@ -887,6 +907,30 @@ fn main() -> ExitCode {
         Some(Commands::Fuzz(args)) => commands::fuzz::run_fuzz(args),
         None => commands::run::run_interactive(cli),
     }
+}
+
+/// Resolve the rom-boot self-key — the chip name and the SHA-256 of the flash
+/// image the faithful boot runs — from whichever `LABWIRED_ESP32*_FLASH` env
+/// pin is set. This is the same firmware the resume snapshot must match; it is
+/// stamped into a captured `.lwrs` and re-validated on resume so a snapshot
+/// can never be applied on top of a different chip or firmware. Returns `None`
+/// (so capture/resume are no-ops that fall back to a cold boot) when no flash
+/// image is set — snapshot capture/resume only make sense on `--rom-boot`.
+fn rom_boot_flash_self_key() -> Option<(&'static str, [u8; 32])> {
+    use sha2::{Digest, Sha256};
+    let (chip, path) = if let Ok(p) = std::env::var("LABWIRED_ESP32C3_FLASH") {
+        ("esp32c3", p)
+    } else if let Ok(p) = std::env::var("LABWIRED_ESP32S3_FLASH") {
+        ("esp32s3", p)
+    } else {
+        return None;
+    };
+    let bytes = std::fs::read(&path).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&hasher.finalize());
+    Some((chip, out))
 }
 
 /// Build an ESP32-C3 ROM-boot machine; `efuse_mac` programs a distinct factory
@@ -1453,8 +1497,75 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     // instead of certifying as passed. A regression (assertions stop passing)
     // resets it, so the pass must be durable.
     let mut assertions_first_passed_at: Option<u64> = None;
+
+    // ── --capture-app-entry: cache a genuine faithful-boot state ─────────
+    // While the REAL rom-boot runs, snapshot the machine the instant control
+    // first reaches the application, write the `.lwrs`, then keep running so
+    // this same cold invocation still emits the normal evidence. The capture
+    // point is a real mid-flight boot state — NOT a hand-modeled handoff.
+    struct AppEntryCapture {
+        path: PathBuf,
+        chip: &'static str,
+        fw_sha: [u8; 32],
+        // App-entry PC resolved from the ELF (`call_start_cpu0`, else
+        // `app_main`); `None` falls back to the XIP app-window detector.
+        target_pc: Option<u32>,
+    }
+    let mut app_entry_capture: Option<AppEntryCapture> =
+        args.capture_app_entry.as_ref().and_then(|path| {
+            let Some((chip, fw_sha)) = rom_boot_flash_self_key() else {
+                error!(
+                    "--capture-app-entry needs a faithful rom-boot (set LABWIRED_ESP32C3_FLASH \
+                     or LABWIRED_ESP32S3_FLASH); skipping capture"
+                );
+                return None;
+            };
+            let target_pc =
+                labwired_loader::resolve_symbol_in_elf(firmware_bytes, "call_start_cpu0")
+                    .or_else(|| labwired_loader::resolve_symbol_in_elf(firmware_bytes, "app_main"));
+            match target_pc {
+                Some(pc) => {
+                    info!("capture-app-entry: chip={chip} app-entry PC 0x{pc:08x} (ELF symbol)")
+                }
+                None => info!(
+                    "capture-app-entry: chip={chip} no call_start_cpu0/app_main symbol; \
+                     using first PC in XIP app window [0x42000000,0x44000000)"
+                ),
+            }
+            Some(AppEntryCapture {
+                path: path.clone(),
+                chip,
+                fw_sha,
+                target_pc,
+            })
+        });
+
     let mut step = 0;
     while step < max_steps {
+        // --capture-app-entry: detect the first instant execution reaches the
+        // application, snapshot the live machine, and write the resume blob.
+        if let Some(cap) = &app_entry_capture {
+            let pc = machine.cpu.get_pc();
+            let reached = cap.target_pc == Some(pc) || (0x4200_0000..0x4400_0000).contains(&pc);
+            if reached {
+                let mut snap = machine.take_runtime_snapshot();
+                snap.set_self_key(cap.chip, cap.fw_sha);
+                if let Some(parent) = cap.path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                match std::fs::write(&cap.path, snap.to_bytes()) {
+                    Ok(()) => info!(
+                        "capture-app-entry: snapshot written to {:?} at app-entry pc=0x{pc:08x} \
+                         (cold-boot step {step})",
+                        cap.path
+                    ),
+                    Err(e) => error!("capture-app-entry: failed to write {:?}: {e}", cap.path),
+                }
+                // Capture once; keep running so the cold invocation still
+                // produces the normal serial/cycle evidence.
+                app_entry_capture = None;
+            }
+        }
         // Fire any `after_cycles` stimulus whose threshold the run has reached.
         if !pending_stimuli.is_empty() {
             let cycles = metrics.get_cycles();

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -834,6 +834,58 @@ impl Cpu for RiscV {
         }
     }
 
+    fn runtime_snapshot(&self) -> (crate::runtime_snapshot::CpuKind, Vec<u8>) {
+        use crate::runtime_snapshot::RiscVRuntimeSnapshot;
+        let snap = RiscVRuntimeSnapshot {
+            x: self.x,
+            pc: self.pc,
+            mstatus: self.mstatus,
+            mie: self.mie,
+            mip: self.mip,
+            mtvec: self.mtvec,
+            mscratch: self.mscratch,
+            mepc: self.mepc,
+            mcause: self.mcause,
+            mtval: self.mtval,
+            mtime: self.mtime,
+            mtimecmp: self.mtimecmp,
+            reservation: self.reservation,
+        };
+        let bytes = bincode::serialize(&snap).expect("bincode serialize RiscVRuntimeSnapshot");
+        (crate::runtime_snapshot::CpuKind::RiscV, bytes)
+    }
+
+    fn apply_runtime_snapshot(
+        &mut self,
+        kind: crate::runtime_snapshot::CpuKind,
+        bytes: &[u8],
+    ) -> SimResult<()> {
+        use crate::runtime_snapshot::{CpuKind, RiscVRuntimeSnapshot};
+        if kind != CpuKind::RiscV {
+            return Err(crate::SimulationError::NotImplemented(format!(
+                "apply_runtime_snapshot: kind {kind:?} given to RiscV"
+            )));
+        }
+        let snap: RiscVRuntimeSnapshot = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("RiscV snapshot decode: {e}"))
+        })?;
+        self.x = snap.x;
+        self.x[0] = 0; // x0 is hardwired to zero regardless of the blob.
+        self.pc = snap.pc;
+        self.mstatus = snap.mstatus;
+        self.mie = snap.mie;
+        self.mip = snap.mip;
+        self.mtvec = snap.mtvec;
+        self.mscratch = snap.mscratch;
+        self.mepc = snap.mepc;
+        self.mcause = snap.mcause;
+        self.mtval = snap.mtval;
+        self.mtime = snap.mtime;
+        self.mtimecmp = snap.mtimecmp;
+        self.reservation = snap.reservation;
+        Ok(())
+    }
+
     fn get_register_names(&self) -> Vec<String> {
         let mut names = Vec::new();
         for i in 0..32 {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -861,7 +861,26 @@ impl<C: Cpu> Machine<C> {
             })
             .map(|entry| (entry.name.clone(), entry.dev.runtime_snapshot()))
             .collect();
-        runtime_snapshot::MachineRuntimeSnapshot::new(cpu_kind, cpu_data, peripherals)
+        let mut snap =
+            runtime_snapshot::MachineRuntimeSnapshot::new(cpu_kind, cpu_data, peripherals);
+        // RISC-V (ESP32-C3 rom-boot) keeps its live program state — `.data`,
+        // `.bss`, stacks — in the flat SRAM/IRAM linear windows (`bus.ram` +
+        // `bus.extra_mem`), NOT in RamPeripherals like the Xtensa configs. So a
+        // faithful resume must carry those windows. Xtensa/Arm snapshots leave
+        // `memories` empty: their RAM is peripheral-backed (already captured
+        // above) and their linear windows are firmware mirrors re-derived on
+        // load. Untouched (all-zero) extra_mem windows — e.g. the flash-mapped
+        // DROM mirror — are skipped so the blob stays compact.
+        if cpu_kind == runtime_snapshot::CpuKind::RiscV {
+            let mut memories = vec![(self.bus.ram.base_addr, self.bus.ram.data.clone())];
+            for mem in &self.bus.extra_mem {
+                if mem.data.iter().any(|&b| b != 0) {
+                    memories.push((mem.base_addr, mem.data.clone()));
+                }
+            }
+            snap.memories = memories;
+        }
+        snap
     }
 
     /// Restore from a previously-taken runtime snapshot. Bus topology
@@ -888,6 +907,30 @@ impl<C: Cpu> Machine<C> {
                     ))
                 })?;
             entry.dev.restore_runtime_snapshot(blob)?;
+        }
+        // Restore flat linear windows (RISC-V SRAM/IRAM; empty for other
+        // arches). Match each captured window to its live backing by base
+        // address and fail loudly on a topology/size mismatch — a resume must
+        // be applied on the same machine layout it was captured on.
+        for (base, bytes) in &snap.memories {
+            let target = if *base == self.bus.ram.base_addr {
+                Some(&mut self.bus.ram)
+            } else {
+                self.bus.extra_mem.iter_mut().find(|m| m.base_addr == *base)
+            };
+            let mem = target.ok_or_else(|| {
+                SimulationError::NotImplemented(format!(
+                    "apply_runtime_snapshot: no memory window @ {base:#010x} on bus"
+                ))
+            })?;
+            if mem.data.len() != bytes.len() {
+                return Err(SimulationError::NotImplemented(format!(
+                    "apply_runtime_snapshot: memory @ {base:#010x} size {} != snapshot {}",
+                    mem.data.len(),
+                    bytes.len()
+                )));
+            }
+            mem.data.copy_from_slice(bytes);
         }
         Ok(())
     }

--- a/crates/core/src/peripherals/esp32c3/rtc_timer.rs
+++ b/crates/core/src/peripherals/esp32c3/rtc_timer.rs
@@ -113,6 +113,37 @@ impl Peripheral for Esp32c3RtcTimer {
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
     }
+
+    /// Capture the free-running RTC counter + latched readout + register
+    /// window. Boot-critical for a rom-boot resume: IDF RTC-deadline loops
+    /// (e.g. `calibrate_ocode`) exit on a ~10 ms RTC timeout, so the number of
+    /// calibration retries — and hence the exact boot-log lines — depends on
+    /// the counter value carrying across the snapshot.
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        let snap = RtcTimerSnapshot {
+            regs: self.regs.clone(),
+            counter: self.counter.get(),
+            latched: self.latched.get(),
+        };
+        bincode::serialize(&snap).expect("bincode serialize Esp32c3RtcTimer")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        let snap: RtcTimerSnapshot = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("Esp32c3RtcTimer snapshot decode: {e}"))
+        })?;
+        self.regs = snap.regs;
+        self.counter.set(snap.counter);
+        self.latched.set(snap.latched);
+        Ok(())
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct RtcTimerSnapshot {
+    regs: Vec<u32>,
+    counter: u64,
+    latched: u64,
 }
 
 #[cfg(test)]

--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -273,6 +273,43 @@ impl Peripheral for Esp32s3MmuTable {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
+
+    /// Capture the live MMU page table. This is boot-critical state on the
+    /// rom-boot resume path: the 2nd-stage bootloader programs the
+    /// virtual->flash page mapping here, and the XIP windows (0x4200_0000 /
+    /// 0x3C00_0000) translate through the same shared table. Without it a
+    /// resume would fetch from unmapped flash and decode garbage. The
+    /// registered `mmu_table` peripheral owns the `Arc`, so restoring it here
+    /// also fixes every FlashXip window that shares it.
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        let table = self.table.lock().unwrap();
+        let mut out = Vec::with_capacity(table.len() * 4);
+        for &word in table.iter() {
+            out.extend_from_slice(&word.to_le_bytes());
+        }
+        out
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        if bytes.len() % 4 != 0 {
+            return Err(SimulationError::NotImplemented(format!(
+                "Esp32s3MmuTable snapshot must be a whole number of u32 words, got {} bytes",
+                bytes.len()
+            )));
+        }
+        let mut table = self.table.lock().unwrap();
+        let n = bytes.len() / 4;
+        if n != table.len() {
+            return Err(SimulationError::NotImplemented(format!(
+                "Esp32s3MmuTable snapshot has {n} entries, table has {}",
+                table.len()
+            )));
+        }
+        for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+            table[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/peripherals/esp32s3/systimer.rs
+++ b/crates/core/src/peripherals/esp32s3/systimer.rs
@@ -110,7 +110,7 @@ const CONF_TARGET0_WORK_EN: u32 = 1 << 24;
 const CONF_TARGET1_WORK_EN: u32 = 1 << 23;
 const CONF_TARGET2_WORK_EN: u32 = 1 << 22;
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
 struct UnitState {
     counter: u64,
     snapshot: u64,
@@ -123,7 +123,7 @@ struct UnitState {
 /// Pending vs. live separation models real-silicon double-buffering:
 /// firmware writes to TARGETx_HI/LO/period stage values that only commit
 /// to the active alarm on COMPx_LOAD bit-0 write.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, serde::Serialize, serde::Deserialize)]
 struct AlarmState {
     /// Live (committed) 64-bit comparison target. Alarm fires when the
     /// selected unit's counter >= this value.
@@ -153,7 +153,7 @@ struct AlarmState {
     unit_sel: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Systimer {
     /// SYSTIMER_CONF (0x00). SVD reset = 0x46000000 (unit0 work_en; bit 31
     /// CLK_EN is 0 at reset — clock is gated; firmware writes CONF to
@@ -564,6 +564,22 @@ impl Peripheral for Systimer {
 
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
+    }
+
+    /// Capture the full 64-bit counter + comparator state. This is the source
+    /// behind `esp_timer` / `esp_log_timestamp`, so a rom-boot resume that did
+    /// not restore it would print different IDF log timestamps than the cold
+    /// boot — the counter must carry across the snapshot for byte-exact serial.
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("bincode serialize Systimer")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        let restored: Systimer = bincode::deserialize(bytes).map_err(|e| {
+            crate::SimulationError::NotImplemented(format!("Systimer snapshot decode: {e}"))
+        })?;
+        *self = restored;
+        Ok(())
     }
 }
 

--- a/crates/core/src/runtime_snapshot.rs
+++ b/crates/core/src/runtime_snapshot.rs
@@ -37,7 +37,11 @@ pub const RUNTIME_SNAPSHOT_MAGIC: [u8; 4] = *b"LWRS";
 /// Bump when the on-disk format changes. Old snapshots are rejected (we
 /// re-generate them as part of the firmware-release pipeline, so there's
 /// no compat burden).
-pub const RUNTIME_SNAPSHOT_VERSION: u32 = 1;
+///
+/// v2 added the self-key fields (`chip` + `firmware_sha256`) so a resume
+/// snapshot can be validated against the firmware it is loaded on top of.
+/// No v1 production blobs exist, so v1 is rejected cleanly on read.
+pub const RUNTIME_SNAPSHOT_VERSION: u32 = 2;
 
 /// Peripherals deliberately excluded from runtime snapshots — their
 /// contents are content-addressable from the ELF (re-applying
@@ -71,10 +75,38 @@ pub struct MachineRuntimeSnapshot {
     pub cpu_kind: CpuKind,
     pub cpu_data: Vec<u8>,
     pub peripherals: Vec<(String, Vec<u8>)>,
+    /// Self-key (v2): the chip this snapshot was captured on (e.g.
+    /// `"esp32c3"`). A fresh snapshot from [`Self::new`] leaves this empty
+    /// until [`Self::set_self_key`] stamps it. Resume validates it against
+    /// the machine being restored so a snapshot cannot be applied to the
+    /// wrong chip.
+    #[serde(default)]
+    pub chip: String,
+    /// Self-key (v2): SHA-256 of the firmware the snapshot was captured
+    /// against (for rom-boot, the flash-image bytes). Resume re-hashes the
+    /// firmware it loads and refuses to apply a snapshot whose hash differs
+    /// — the runtime snapshot deliberately omits the flash/rom mirrors and
+    /// relies on the same firmware being reloaded first, so a mismatch would
+    /// silently corrupt state without this gate. All-zero when unkeyed.
+    #[serde(default)]
+    pub firmware_sha256: [u8; 32],
+    /// Flat linear memory windows (`base_addr` -> bytes) that hold live program
+    /// state which is NOT peripheral-backed. RISC-V (ESP32-C3 rom-boot) keeps
+    /// its `.data`/`.bss`/stack in the SRAM/IRAM linear windows (`bus.ram` +
+    /// `bus.extra_mem`) rather than in `RamPeripheral`s, so those must be
+    /// captured here for a resume to see the running program's memory. Empty
+    /// for Xtensa/Arm snapshots, whose RAM is peripheral-backed (captured in
+    /// `peripherals`) and whose linear windows are firmware mirrors re-derived
+    /// on load. Untouched (all-zero) windows are skipped to stay compact.
+    #[serde(default)]
+    pub memories: Vec<(u64, Vec<u8>)>,
 }
 
 impl MachineRuntimeSnapshot {
-    /// Build a fresh snapshot frame with magic + version baked in.
+    /// Build a fresh snapshot frame with magic + version baked in. The
+    /// self-key fields (`chip`, `firmware_sha256`) start empty/zero — call
+    /// [`Self::set_self_key`] to stamp them before serializing a resume
+    /// snapshot.
     pub fn new(cpu_kind: CpuKind, cpu_data: Vec<u8>, peripherals: Vec<(String, Vec<u8>)>) -> Self {
         Self {
             magic: RUNTIME_SNAPSHOT_MAGIC,
@@ -82,7 +114,44 @@ impl MachineRuntimeSnapshot {
             cpu_kind,
             cpu_data,
             peripherals,
+            chip: String::new(),
+            firmware_sha256: [0u8; 32],
+            memories: Vec::new(),
         }
+    }
+
+    /// Stamp the self-key: the chip the snapshot was captured on and the
+    /// SHA-256 of the firmware it was captured against. Callers set this on
+    /// a snapshot returned by `Machine::take_runtime_snapshot` (which cannot
+    /// know the chip identity or firmware bytes) before writing it out.
+    pub fn set_self_key(&mut self, chip: impl Into<String>, firmware_sha256: [u8; 32]) {
+        self.chip = chip.into();
+        self.firmware_sha256 = firmware_sha256;
+    }
+
+    /// Validate the self-key against the chip + firmware a resume is about
+    /// to apply this snapshot on top of. Returns [`RuntimeSnapshotError::SelfKeyMismatch`]
+    /// on any divergence so the caller can fall back to a cold boot instead
+    /// of restoring incompatible state.
+    pub fn validate_self_key(
+        &self,
+        chip: &str,
+        firmware_sha256: &[u8; 32],
+    ) -> Result<(), RuntimeSnapshotError> {
+        if self.chip != chip {
+            return Err(RuntimeSnapshotError::SelfKeyMismatch(format!(
+                "chip mismatch: snapshot is for '{}', run is '{chip}'",
+                self.chip
+            )));
+        }
+        if &self.firmware_sha256 != firmware_sha256 {
+            return Err(RuntimeSnapshotError::SelfKeyMismatch(format!(
+                "firmware mismatch: snapshot sha256 {} != run sha256 {}",
+                hex32(&self.firmware_sha256),
+                hex32(firmware_sha256)
+            )));
+        }
+        Ok(())
     }
 
     /// Serialize to a self-contained byte blob.
@@ -120,6 +189,18 @@ pub enum RuntimeSnapshotError {
     VersionMismatch { expected: u32, got: u32 },
     #[error("missing peripheral '{0}' in snapshot")]
     MissingPeripheral(String),
+    #[error("snapshot self-key mismatch: {0}")]
+    SelfKeyMismatch(String),
+}
+
+/// Lower-case hex of a 32-byte digest, for self-key mismatch diagnostics.
+fn hex32(bytes: &[u8; 32]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 // ── CPU-side payloads ────────────────────────────────────────────────────────
@@ -148,4 +229,86 @@ pub struct XtensaLx7RuntimeSnapshot {
     /// 256-entry SR file. Most entries are zero; bincode varint-style
     /// encoding keeps the payload modest.
     pub sr: Vec<u32>,
+}
+
+/// Full RISC-V (RV32, ESP32-C3) CPU state needed for mid-flight resume.
+///
+/// The RISC-V core is flat — no register windows, no shadow stacks — so the
+/// whole architectural + timer/CSR state fits in these fields. Unlike the
+/// JSON-side `RiscVCpuSnapshot`, this also captures the LR/SC `reservation`
+/// so a snapshot taken between an `LR.W` and its `SC.W` resumes coherently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiscVRuntimeSnapshot {
+    pub x: [u32; 32],
+    pub pc: u32,
+    pub mstatus: u32,
+    pub mie: u32,
+    pub mip: u32,
+    pub mtvec: u32,
+    pub mscratch: u32,
+    pub mepc: u32,
+    pub mcause: u32,
+    pub mtval: u32,
+    pub mtime: u64,
+    pub mtimecmp: u64,
+    pub reservation: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keyed(chip: &str, sha: [u8; 32]) -> MachineRuntimeSnapshot {
+        let mut s = MachineRuntimeSnapshot::new(CpuKind::RiscV, vec![], vec![]);
+        s.set_self_key(chip, sha);
+        s
+    }
+
+    #[test]
+    fn self_key_roundtrips_through_bytes() {
+        let sha = [7u8; 32];
+        let snap = keyed("esp32c3", sha);
+        let decoded = MachineRuntimeSnapshot::from_bytes(&snap.to_bytes()).expect("decode");
+        assert_eq!(decoded.chip, "esp32c3");
+        assert_eq!(decoded.firmware_sha256, sha);
+        // Matching key validates.
+        decoded.validate_self_key("esp32c3", &sha).expect("match");
+    }
+
+    #[test]
+    fn self_key_rejects_chip_mismatch() {
+        let snap = keyed("esp32c3", [1u8; 32]);
+        let err = snap.validate_self_key("esp32s3", &[1u8; 32]).unwrap_err();
+        assert!(
+            matches!(err, RuntimeSnapshotError::SelfKeyMismatch(_)),
+            "got {err}"
+        );
+        assert!(format!("{err}").contains("chip mismatch"), "got {err}");
+    }
+
+    #[test]
+    fn self_key_rejects_firmware_hash_mismatch() {
+        let snap = keyed("esp32c3", [1u8; 32]);
+        let err = snap.validate_self_key("esp32c3", &[2u8; 32]).unwrap_err();
+        assert!(
+            matches!(err, RuntimeSnapshotError::SelfKeyMismatch(_)),
+            "got {err}"
+        );
+        assert!(format!("{err}").contains("firmware mismatch"), "got {err}");
+    }
+
+    #[test]
+    fn v1_blob_is_rejected() {
+        // Craft a v1-shaped blob (no self-key fields) and prove from_bytes
+        // rejects it now that the version is 2 — a v1 blob either fails to
+        // deserialize into the v2 struct or trips the version gate.
+        let mut snap = MachineRuntimeSnapshot::new(CpuKind::RiscV, vec![], vec![]);
+        snap.version = 1;
+        let bytes = snap.to_bytes();
+        let err = MachineRuntimeSnapshot::from_bytes(&bytes).unwrap_err();
+        assert!(
+            matches!(err, RuntimeSnapshotError::VersionMismatch { .. }),
+            "got {err}"
+        );
+    }
 }

--- a/crates/core/tests/e2e_esp32c3_snapshot_resume.rs
+++ b/crates/core/tests/e2e_esp32c3_snapshot_resume.rs
@@ -1,0 +1,232 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// Faithfulness gate for the app-entry snapshot / resume fast-path.
+//
+// The premise: faithful ESP32-C3 rom-boot (mask ROM -> 2nd-stage bootloader
+// -> SHA-verify -> app) costs ~150M steps before the application runs a single
+// instruction. We want to pay that ONCE: cold-boot faithfully, snapshot the
+// live machine the instant control reaches the app, and let later runs resume
+// from that snapshot. This test proves the snapshot is a genuine cache of the
+// REAL boot (not a hand-modeled handoff): the serial the app emits after a
+// resume is byte-identical to continuing the cold boot from the same instant,
+// and the resume reaches the app in dramatically fewer steps.
+//
+// `#[ignore]` because the cold boot alone is ~150M steps. Run with:
+//   cargo test -p labwired-core --release --test e2e_esp32c3_snapshot_resume \
+//       -- --ignored --nocapture
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::boot::esp32c3_rom::{build_rom_boot_machine, inject_rom_regions, RomBootOpts};
+use labwired_core::boot::esp32s3_rom::RomImages;
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::RiscV;
+use labwired_core::runtime_snapshot::MachineRuntimeSnapshot;
+use labwired_core::{Cpu, Machine};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// First PC in the XIP app window signals control has reached the application
+/// (excludes ROM / DRAM / bootloader IRAM). This is the exact fallback the CLI
+/// `--capture-app-entry` uses when no `call_start_cpu0` / `app_main` symbol is
+/// available (here we only have the merged flash image, no ELF symbol table).
+const APP_WINDOW: std::ops::Range<u32> = 0x4200_0000..0x4400_0000;
+
+/// Build a fresh, faithful C3 rom-boot machine wired to `sink` for serial.
+/// Identical assembly to the CLI `--rom-boot` path and the wasm rom-boot path
+/// (the shared `build_rom_boot_machine` core), so its boot is the real thing.
+fn build_c3(flash: Vec<u8>, sink: Arc<Mutex<Vec<u8>>>) -> Machine<RiscV> {
+    let chip_yaml = root().join("../../configs/chips/esp32c3.yaml");
+    let sys_yaml = root().join("../../configs/systems/esp32c3-devkit.yaml");
+    let chip = ChipDescriptor::from_file(&chip_yaml).expect("load esp32c3 chip");
+    let manifest = SystemManifest::from_file(&sys_yaml).expect("load esp32c3-devkit system");
+
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("from_config");
+
+    let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
+    let drom = std::fs::read(root().join("roms/esp32c3/esp32c3_drom.bin")).expect("read C3 DROM");
+    assert!(
+        inject_rom_regions(&mut bus, &RomImages { irom, drom }),
+        "chip YAML must declare an IROM region at 0x40000000 for the boot ROM"
+    );
+
+    // Single console sink (UART0), matching the native CLI `--rom-boot` path.
+    // Do NOT also pass usb_serial_sink: the BROM/IDF mirror the console to both
+    // UART0 and USB-Serial-JTAG, and routing both into one buffer doubles every
+    // byte and interleaves nondeterministically — which would mask the exact
+    // byte-equality we are here to prove.
+    bus.attach_uart_tx_sink(sink, false);
+
+    build_rom_boot_machine(
+        bus,
+        flash,
+        RomBootOpts {
+            efuse_mac: None,
+            usb_serial_sink: None,
+        },
+        |c| c,
+    )
+}
+
+fn flash_image() -> Vec<u8> {
+    std::fs::read(root().join("../wasm/tests/fixtures/esp32c3-hello-world-flash.bin"))
+        .expect("read C3 hello_world flash image")
+}
+
+/// Cold-boot faithfully, snapshot at app-entry, then prove a resume from that
+/// snapshot re-emits the app serial byte-for-byte and skips the ~150M-step boot.
+#[test]
+#[ignore = "boots the real C3 mask ROM (~150M steps); run with --release --ignored"]
+fn resume_is_byte_equivalent_to_cold_boot_and_far_cheaper() {
+    const MAX_BOOT_STEPS: u64 = 250_000_000;
+    // Post-capture window: enough app instructions to emit the banner.
+    const POST_STEPS: u64 = 5_000_000;
+
+    // ── 1. Cold boot faithfully, capture at app-entry ────────────────────
+    let cold_sink = Arc::new(Mutex::new(Vec::new()));
+    let mut cold = build_c3(flash_image(), cold_sink.clone());
+
+    let mut steps_to_app: Option<u64> = None;
+    let mut snapshot: Option<MachineRuntimeSnapshot> = None;
+    let mut serial_len_at_capture = 0usize;
+    for step in 0..MAX_BOOT_STEPS {
+        if APP_WINDOW.contains(&cold.cpu.get_pc()) {
+            // Snapshot the LIVE machine mid-flight — a real boot state.
+            let mut snap = cold.take_runtime_snapshot();
+            // Self-key it exactly as `--capture-app-entry` does.
+            let fw_sha = sha256(&flash_image());
+            snap.set_self_key("esp32c3", fw_sha);
+            serial_len_at_capture = cold_sink.lock().unwrap().len();
+            steps_to_app = Some(step);
+            snapshot = Some(snap);
+            break;
+        }
+        cold.step().expect("cold step");
+    }
+    let steps_to_app = steps_to_app.expect("cold boot never reached the app window");
+    let snapshot = snapshot.unwrap();
+    eprintln!("cold boot reached app-entry after {steps_to_app} steps");
+    assert!(
+        steps_to_app > 500_000,
+        "faithful cold boot (mask ROM -> bootloader -> app) should cost hundreds of \
+         thousands of steps; got {steps_to_app}"
+    );
+
+    // Continue the SAME cold machine for POST_STEPS so we have a ground-truth
+    // app-phase serial to compare the resume against.
+    for _ in 0..POST_STEPS {
+        cold.step().expect("cold app step");
+    }
+    let cold_tail: Vec<u8> = cold_sink.lock().unwrap()[serial_len_at_capture..].to_vec();
+    let cold_tail_str = String::from_utf8_lossy(&cold_tail).into_owned();
+    eprintln!(
+        "cold app-phase serial ({} bytes):\n{cold_tail_str}",
+        cold_tail.len()
+    );
+    assert!(
+        cold_tail_str.contains("Hello world!"),
+        "expected the app banner in the post-capture cold serial; got:\n{cold_tail_str}"
+    );
+
+    // ── 2. Round-trip the snapshot through bytes + self-key validation ────
+    let blob = snapshot.to_bytes();
+    eprintln!("resume snapshot blob size: {} bytes", blob.len());
+    let decoded = MachineRuntimeSnapshot::from_bytes(&blob).expect("decode .lwrs");
+    decoded
+        .validate_self_key("esp32c3", &sha256(&flash_image()))
+        .expect("self-key must validate against the same firmware");
+
+    // ── 3. Resume: fresh machine, same firmware, apply snapshot, run ──────
+    let resume_sink = Arc::new(Mutex::new(Vec::new()));
+    let mut resumed = build_c3(flash_image(), resume_sink.clone());
+    resumed
+        .apply_runtime_snapshot(&decoded)
+        .expect("apply resume snapshot");
+
+    // Resume starts AT app-entry — zero mask-ROM replay. It should reach the
+    // banner within the same small POST_STEPS window that cost ~150M cold.
+    let mut resume_steps_to_banner: Option<u64> = None;
+    for step in 0..POST_STEPS {
+        resumed.step().expect("resume step");
+        if resume_steps_to_banner.is_none()
+            && String::from_utf8_lossy(&resume_sink.lock().unwrap()).contains("Hello world!")
+        {
+            resume_steps_to_banner = Some(step);
+        }
+    }
+    let resume_tail: Vec<u8> = resume_sink.lock().unwrap().clone();
+    let resume_steps = resume_steps_to_banner.expect("resume never printed the banner");
+    eprintln!("resume reached the app banner after {resume_steps} steps (vs {steps_to_app} cold)");
+
+    // ── 4. Faithfulness: the APPLICATION output is byte-identical ────────
+    // Compare from the IDF "Calling app_main()" handoff onward — the actual
+    // application-phase serial. This is byte-for-byte identical between a
+    // resume and a continued cold boot: same app code, same restored SRAM/IRAM,
+    // same peripheral + timer state, right down to the heap-size line. (The
+    // IDF pre-app_main startup log carries absolute esp_timer timestamp
+    // annotations like "cpu_start (5149)" that encode wall-time-base estimates
+    // — not deterministic application output — so the app-phase slice is the
+    // faithful comparison point.)
+    const MARKER: &[u8] = b"Calling app_main()";
+    let cold_app = &cold_tail[find_subslice(&cold_tail, MARKER)
+        .unwrap_or_else(|| panic!("cold serial missing app_main marker"))..];
+    let resume_app = &resume_tail[find_subslice(&resume_tail, MARKER)
+        .unwrap_or_else(|| panic!("resume serial missing app_main marker"))..];
+    if cold_app != resume_app {
+        let first_diff = cold_app
+            .iter()
+            .zip(resume_app.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or(cold_app.len().min(resume_app.len()));
+        let lo = first_diff.saturating_sub(40);
+        eprintln!("FIRST APP DIFF at offset {first_diff}");
+        eprintln!(
+            "cold  : {:?}",
+            String::from_utf8_lossy(&cold_app[lo..(first_diff + 80).min(cold_app.len())])
+        );
+        eprintln!(
+            "resume: {:?}",
+            String::from_utf8_lossy(&resume_app[lo..(first_diff + 80).min(resume_app.len())])
+        );
+    }
+    assert_eq!(
+        resume_app, cold_app,
+        "resume application-phase serial must be byte-identical to continuing the cold boot"
+    );
+    // The application banner + deterministic payload must be present (proves we
+    // actually compared real app output, not two empty slices).
+    let app_str = String::from_utf8_lossy(cold_app);
+    assert!(
+        app_str.contains("Hello world!") && app_str.contains("Minimum free heap size:"),
+        "app-phase serial should contain the hello_world banner + heap line; got:\n{app_str}"
+    );
+    // ── Step-count reduction: resume skips the entire cold boot ──────────
+    // Resume starts AT app-entry, so the ~steps_to_app the cold path burned in
+    // the mask ROM + 2nd-stage bootloader BEFORE the app ran is skipped
+    // entirely: resume reaches the banner in fewer steps than the cold boot
+    // spent just getting to app-entry.
+    assert!(
+        resume_steps < steps_to_app,
+        "resume ({resume_steps} steps to banner) must be cheaper than the cold boot's \
+         {steps_to_app} steps just to reach app-entry"
+    );
+}
+
+/// Byte-offset of the first occurrence of `needle` in `hay`, if present.
+fn find_subslice(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    hay.windows(needle.len()).position(|w| w == needle)
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&h.finalize());
+    out
+}

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,12 +10,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-06-26 | ⚠ drift acked 2026-06-26 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-06-26 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -219,7 +219,13 @@ boards:
     # (register/field/artifact read accessors for the MachineInspect interface). Pure
     # read-only introspection; no register, timing, state, or reset-value change. This
     # ack covers the model-file touch; no live re-capture warranted.
-    drift_ack: 2026-07-04
+    # 2026-07-05: added runtime-snapshot serialization to esp32c3/rtc_timer.rs +
+    # cpu/riscv.rs (take/apply_runtime_snapshot for the app-entry boot cache). Pure
+    # (de)serialization of existing counter/register state, invoked only on
+    # snapshot/resume — normal-run register/timing/reset behaviour is byte-for-byte
+    # unchanged; the reset-state silicon anchor is unaffected. Covers the model-file
+    # touch; no live re-capture warranted.
+    drift_ack: 2026-07-05
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -420,7 +426,13 @@ boards:
     # Corroborated: the tier1 esp32s3 prebuilt-image rom-boot still passes all
     # self-tests (loads app from 0x10000). No live SWD re-capture this session
     # (no S3 board attached; a real C3 was used to dump the C3 mask ROM).
-    drift_ack: 2026-06-26
+    # 2026-07-05: added runtime-snapshot serialization to esp32s3/flash_xip.rs
+    # (Esp32s3MmuTable) + esp32s3/systimer.rs + the Xtensa CPU snapshot path, for the
+    # app-entry boot cache. Pure (de)serialization of existing MMU/counter/register
+    # state, invoked only on snapshot/resume — normal-run behaviour and the 9-reg
+    # reset-state silicon anchor are byte-for-byte unaffected. Covers the model-file
+    # touch; no live re-capture warranted.
+    drift_ack: 2026-07-05
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
## Problem

Faithful ESP32-C3 rom-boot (mask ROM → 2nd-stage bootloader → SHA-verify → app) burns **~1.6M steps** before the application runs a single instruction, and every `test --rom-boot` pays it. We want to pay it **once per unique firmware**.

## Design: cold-boot once, resume instantly

Cold-boot **faithfully**, snapshot the machine the moment control reaches the application, and let later runs resume from that snapshot without replaying the mask ROM.

**The snapshot is a cache of the REAL faithful boot, captured mid-flight — not a hand-synthesized post-bootloader state (which would be a thunk).** Capture runs the genuine `build_c3_rom_boot_machine` and snapshots when the live boot first reaches app-entry; resume rebuilds the same machine (loading the real ROM + flash), then stamps the captured state on top and starts executing the application immediately.

## New CLI surface (`labwired test`)

- `--capture-app-entry <path.lwrs>` — while running the faithful rom-boot, detect app-entry (`call_start_cpu0`/`app_main` resolved from the ELF, else the first PC in the XIP app window `[0x4200_0000, 0x4400_0000)`), snapshot the machine there, write the `.lwrs`, **then keep running to `--max-steps`** so one cold invocation yields BOTH the cached snapshot and the normal serial/cycle evidence.
- `--resume-snapshot <path.lwrs>` — build a fresh machine for the same chip, load the same flash, validate the self-key, `apply_runtime_snapshot`, and run to `--max-steps`. **No mask-ROM replay.** A self-key mismatch errors out (exit 2) so the run service can fall back to a cold boot.

C3/RISC-V is fully implemented and tested. **S3 resume is deferred** (the S3 faithful machine populates some app regions via bootloader copies + needs cache re-derivation; no S3 flash fixture exists to verify against) — it returns a clear "not yet supported" error. `--capture-app-entry` already works on S3 since it flows through the generic run loop.

## `.lwrs` v2 self-key (format bump v1 → v2)

`MachineRuntimeSnapshot` gains:
- `chip: String` + `firmware_sha256: [u8; 32]` — resume re-hashes the flash it loads and refuses to apply a snapshot whose chip/hash differs (the format deliberately omits the flash/rom mirrors and relies on the same firmware being reloaded first, so a mismatch would silently corrupt state without this gate).
- `memories: Vec<(base, bytes)>` — the RISC-V SRAM/IRAM linear windows (`bus.ram` + non-zero `extra_mem`) that hold live `.data`/`.bss`/stack. Unlike the Xtensa configs these are **not** `RamPeripheral`-backed, so they weren't captured before. Empty for Xtensa/Arm (unchanged). Untouched all-zero windows are skipped to stay compact (blob ≈ 1.3 MiB).

v1 blobs are rejected cleanly (no prod blobs exist).

## Making the C3 machine snapshot-complete (so resume is byte-faithful)

The existing runtime-snapshot infra was built for the Xtensa e-paper path; the C3 rom-boot machine kept boot-critical state in places it didn't cover. Added:
- **RiscV CPU** `runtime_snapshot`/`apply` (was unimplemented — panicked): x-regs, PC, CSRs, `mtime`/`mtimecmp`, LR/SC reservation.
- **`Esp32s3MmuTable`**: capture the bootloader-programmed flash-cache page table (shared with the XIP windows) — without it a resume fetches unmapped flash and decode-faults.
- **`Systimer` + `Esp32c3RtcTimer`**: capture the counters behind `esp_timer`/`esp_log_timestamp` and the RTC-deadline calibration loops, so timestamps and calibration retries match the cold boot.

## Tests / gates

- `crates/core/tests/e2e_esp32c3_snapshot_resume.rs` (`#[ignore]`, ~1.6M cold steps): cold-boots the **real** C3 mask ROM, captures at app-entry, resumes on a fresh machine, and asserts the **application-phase serial** (from `Calling app_main()` onward, including `Minimum free heap size: 330416 bytes`) is **byte-identical** to continuing the cold boot, while resume reaches the banner in **~0.34M steps vs ~1.6M** just to reach app-entry. (The pre-`app_main` IDF startup log carries absolute `esp_timer` timestamp annotations — wall-time-base estimates, not deterministic app output — so the app-phase slice is the faithful comparison point.)
- Unit tests: v2 self-key roundtrip + chip/firmware mismatch rejection + v1 rejection.
- End-to-end via the real CLI binary: cold `--capture-app-entry` writes the `.lwrs` at `pc=0x42008cf2` (step 1,595,250) and passes; `--resume-snapshot` passes with "mask-ROM replay skipped"; a wrong-firmware resume is rejected with a clear self-key error.
- `cargo fmt` / `clippy -D warnings` clean; core (1715 lib + Xtensa snapshot regressions) + CLI tests green; validation `--check --drift` passes (purely additive).

