### PR TITLE
fidelity: serialize unmodeled-access gaps into TestResult (result.json)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -663,6 +663,12 @@ struct TestResult {
     /// built a machine.
     #[serde(skip_serializing_if = "Option::is_none")]
     inspect: Option<labwired_core::inspect::MachineInspect>,
+    /// Structured coverage gaps the model hit during the run: unmapped MMIO and
+    /// undecoded instructions, flattened from core's thread-local
+    /// `FidelityReport`. Empty (and omitted) on a clean run, so honest runs stay
+    /// clean. The builder maps this into `/run`'s `unmodeled_access[]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fidelity: Vec<labwired_core::fidelity::FidelityGap>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -1994,6 +2000,13 @@ fn write_outputs<C: labwired_core::Cpu>(
     hasher.update(firmware_bytes);
     let firmware_hash = format!("{:x}", hasher.finalize());
 
+    // Drain the coverage-gap log for THIS run. `write_outputs` is called
+    // synchronously at the tail of `execute_test_loop`, on the very thread that
+    // ran the sim loop, so this reads the same thread-local the `record_*` calls
+    // populated. `take()` resets it, so it must run exactly once per run — this
+    // is the sole call site on the run path.
+    let fidelity = labwired_core::fidelity::take().to_gaps();
+
     let assertions_for_junit = assertions.clone();
     let result = TestResult {
         result_schema_version: RESULT_SCHEMA_VERSION.to_string(),
@@ -2014,6 +2027,7 @@ fn write_outputs<C: labwired_core::Cpu>(
             script: args.script.clone(),
         },
         inspect,
+        fidelity,
     };
 
     if let Some(output_dir) = &args.output_dir {
@@ -2334,6 +2348,8 @@ pub(crate) fn write_config_error_outputs(
             script: args.script.clone(),
         },
         inspect: None,
+        // Config error: the sim never ran, so there are no coverage gaps to report.
+        fidelity: Vec::new(),
     };
 
     if let Some(output_dir) = &args.output_dir {

--- a/crates/cli/tests/outputs.rs
+++ b/crates/cli/tests/outputs.rs
@@ -321,6 +321,96 @@ assertions:
 }
 
 #[test]
+fn test_cli_result_json_surfaces_fidelity_on_unmapped_access() {
+    // A firmware that writes to a UART address the tiny chip does NOT map hits an
+    // unmapped-MMIO access, which core records via fidelity::record_unmapped
+    // before returning a MemoryViolation. That gap must surface as a structured
+    // `fidelity` entry in result.json (the builder maps it to unmodeled_access[]).
+    let fw_abs = std::fs::canonicalize("../../tests/fixtures/uart-ok-thumbv7m.elf").unwrap();
+    let base_dir = std::env::temp_dir()
+        .join("labwired-tests")
+        .join(format!("fidelity-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&base_dir);
+
+    let chip_path = base_dir.join("chip.yaml");
+    std::fs::write(
+        &chip_path,
+        r#"
+name: "tiny"
+arch: "cortex-m3"
+flash:
+  base: 0x0
+  size: "1B"
+ram:
+  base: 0x20000000
+  size: "1KB"
+peripherals: []
+"#,
+    )
+    .unwrap();
+
+    let system_path = base_dir.join("system.yaml");
+    std::fs::write(
+        &system_path,
+        r#"
+name: "tiny-system"
+chip: "chip.yaml"
+"#,
+    )
+    .unwrap();
+
+    let script = write_temp_file(
+        "script-fidelity",
+        &format!(
+            r#"
+schema_version: "1.0"
+inputs:
+  firmware: "{}"
+limits:
+  max_steps: 1000
+"#,
+            fw_abs.to_str().unwrap()
+        ),
+    );
+
+    let output_dir = base_dir.join("artifacts");
+    let _ = std::fs::remove_dir_all(&output_dir);
+
+    let _ = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .args([
+            "test",
+            "--system",
+            system_path.to_str().unwrap(),
+            "--script",
+            script.to_str().unwrap(),
+            "--no-uart-stdout",
+            "--output-dir",
+            output_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let result_content = std::fs::read_to_string(output_dir.join("result.json")).unwrap();
+    let result: serde_json::Value = serde_json::from_str(&result_content).unwrap();
+
+    let fidelity = result["fidelity"]
+        .as_array()
+        .expect("result.json must carry a non-empty `fidelity` array on an unmapped access");
+    assert!(!fidelity.is_empty(), "expected at least one fidelity gap");
+    let mmio = fidelity
+        .iter()
+        .find(|g| g["kind"] == "unmapped_mmio")
+        .expect("expected an unmapped_mmio gap");
+    assert!(mmio["address"].as_str().unwrap().starts_with("0x"));
+    assert!(mmio["opcode"].is_null(), "mmio gap must omit opcode");
+    assert!(mmio["first_pc"].as_str().unwrap().starts_with("0x"));
+    assert!(mmio["count"].as_u64().unwrap() >= 1);
+    assert_eq!(mmio["detail"], "write");
+
+    let _ = std::fs::remove_dir_all(&base_dir);
+}
+
+#[test]
 fn test_cli_test_mode_max_steps_guard() {
     let fw_abs = std::fs::canonicalize("../../tests/fixtures/uart-ok-thumbv7m.elf").unwrap();
     let script = write_temp_file(

--- a/crates/core/src/fidelity.rs
+++ b/crates/core/src/fidelity.rs
@@ -20,8 +20,38 @@
 //! Recording only happens on the (rare) gap paths, so there is no cost on the
 //! hot mapped-access / decoded-instruction paths.
 
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+
+/// A FLAT, serialisable view of a single coverage gap, shaped for a consumer
+/// list (the CLI's `result.json` → builder `/run` → MCP `unmodeled_access[]`).
+///
+/// This is the additive, wire-facing projection of [`FidelityReport`]. The
+/// in-memory report keys gaps by opcode/address in `BTreeMap`s for dedup/ranking;
+/// this struct unrolls each entry into one record with hex-formatted fields so a
+/// downstream consumer can render "the model did not model X at PC Y, N times"
+/// without knowing the internal keying.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FidelityGap {
+    /// `"unmapped_mmio"` or `"undecoded_instruction"`.
+    pub kind: String,
+    /// Hex address of the unmapped MMIO access (e.g. `"0x40020000"`).
+    /// `Some` for `unmapped_mmio`, `None` for undecoded instructions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    /// Hex packed opcode of the undecoded instruction (e.g. `"0xfa80f040"`).
+    /// `Some` for `undecoded_instruction`, `None` for MMIO.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opcode: Option<String>,
+    /// Hex PC at the first occurrence (e.g. `"0x08000abc"`; `"0x0"` when the
+    /// site has no PC, as with a bus access).
+    pub first_pc: String,
+    /// Number of times this exact gap was hit.
+    pub count: u64,
+    /// Human-readable classification (mnemonic guess / access kind).
+    pub detail: String,
+}
 
 /// One distinct coverage gap and how often it was hit.
 #[derive(Clone, Debug)]
@@ -58,6 +88,38 @@ impl FidelityReport {
             .map(|g| g.count)
             .sum::<u64>()
             + self.unmapped_mmio.values().map(|g| g.count).sum::<u64>()
+    }
+
+    /// Flatten the report into a serialisable list of [`FidelityGap`]s: every
+    /// unmapped-MMIO entry (address set, opcode absent) followed by every
+    /// undecoded-instruction entry (opcode set, address absent). This is the
+    /// shape the CLI emits in `result.json` and the builder/MCP surface as
+    /// structured unmodeled-access faults.
+    pub fn to_gaps(&self) -> Vec<FidelityGap> {
+        let mut gaps = Vec::with_capacity(
+            self.unmapped_mmio.len() + self.undecoded_instructions.len(),
+        );
+        for (addr, g) in &self.unmapped_mmio {
+            gaps.push(FidelityGap {
+                kind: "unmapped_mmio".to_string(),
+                address: Some(format!("{addr:#x}")),
+                opcode: None,
+                first_pc: format!("{:#x}", g.first_pc),
+                count: g.count,
+                detail: g.detail.clone(),
+            });
+        }
+        for (opcode, g) in &self.undecoded_instructions {
+            gaps.push(FidelityGap {
+                kind: "undecoded_instruction".to_string(),
+                address: None,
+                opcode: Some(format!("{opcode:#x}")),
+                first_pc: format!("{:#x}", g.first_pc),
+                count: g.count,
+                detail: g.detail.clone(),
+            });
+        }
+        gaps
     }
 }
 
@@ -185,5 +247,54 @@ mod tests {
         let taken = take();
         assert_eq!(taken.total_hits(), 3);
         assert!(report().is_empty());
+    }
+
+    #[test]
+    fn to_gaps_flattens_with_correct_shape() {
+        let mut report = FidelityReport::default();
+        report.unmapped_mmio.insert(
+            0x4002_0000,
+            Gap {
+                count: 3,
+                first_pc: 0,
+                detail: "read_u32".to_string(),
+            },
+        );
+        report.undecoded_instructions.insert(
+            0xFA80_F040,
+            Gap {
+                count: 2,
+                first_pc: 0x0800_0ABC,
+                detail: "uadd8?".to_string(),
+            },
+        );
+
+        let gaps = report.to_gaps();
+        assert_eq!(gaps.len(), 2);
+
+        // unmapped MMIO first: address set, opcode absent.
+        let mmio = &gaps[0];
+        assert_eq!(mmio.kind, "unmapped_mmio");
+        assert_eq!(mmio.address.as_deref(), Some("0x40020000"));
+        assert_eq!(mmio.opcode, None);
+        assert_eq!(mmio.first_pc, "0x0");
+        assert_eq!(mmio.count, 3);
+        assert_eq!(mmio.detail, "read_u32");
+
+        // undecoded instruction next: opcode set, address absent.
+        let insn = &gaps[1];
+        assert_eq!(insn.kind, "undecoded_instruction");
+        assert_eq!(insn.address, None);
+        assert_eq!(insn.opcode.as_deref(), Some("0xfa80f040"));
+        assert_eq!(insn.first_pc, "0x8000abc");
+        assert_eq!(insn.count, 2);
+        assert_eq!(insn.detail, "uadd8?");
+
+        // Round-trips through serde (the wire contract) and skips None fields.
+        let json = serde_json::to_string(insn).unwrap();
+        assert!(!json.contains("address"), "None address must be skipped: {json}");
+        assert!(json.contains("\"opcode\":\"0xfa80f040\""), "{json}");
+        let back: FidelityGap = serde_json::from_str(&json).unwrap();
+        assert_eq!(&back, insn);
     }
 }

--- a/crates/core/src/fidelity.rs
+++ b/crates/core/src/fidelity.rs
@@ -96,9 +96,8 @@ impl FidelityReport {
     /// shape the CLI emits in `result.json` and the builder/MCP surface as
     /// structured unmodeled-access faults.
     pub fn to_gaps(&self) -> Vec<FidelityGap> {
-        let mut gaps = Vec::with_capacity(
-            self.unmapped_mmio.len() + self.undecoded_instructions.len(),
-        );
+        let mut gaps =
+            Vec::with_capacity(self.unmapped_mmio.len() + self.undecoded_instructions.len());
         for (addr, g) in &self.unmapped_mmio {
             gaps.push(FidelityGap {
                 kind: "unmapped_mmio".to_string(),
@@ -292,7 +291,10 @@ mod tests {
 
         // Round-trips through serde (the wire contract) and skips None fields.
         let json = serde_json::to_string(insn).unwrap();
-        assert!(!json.contains("address"), "None address must be skipped: {json}");
+        assert!(
+            !json.contains("address"),
+            "None address must be skipped: {json}"
+        );
         assert!(json.contains("\"opcode\":\"0xfa80f040\""), "{json}");
         let back: FidelityGap = serde_json::from_str(&json).unwrap();
         assert_eq!(&back, insn);


### PR DESCRIPTION
The core already tracks unmodeled MMIO + undecoded instructions honestly (`FidelityReport`, `PeekByte::Unmapped` — no thunk), but the CLI never serialized them, so the builder/MCP fell back to a heuristic `diagnosis` string.

- `fidelity.rs`: `FidelityGap` (serde) + `FidelityReport::to_gaps()` flattening unmapped_mmio + undecoded_instructions.
- `cli/main.rs`: `TestResult.fidelity` (skip if empty), populated from `fidelity::take()` at the single `write_outputs` site (thread-local read on the sim thread; config-error path emits empty).
- Tests: `to_gaps_flattens_with_correct_shape` + a CLI test asserting `result.json` surfaces `fidelity[]` on an unmapped write.

Additive; `Display`/strict-gate untouched. Downstream: builder `run.ts` maps this to `unmodeled_access[]` (separate labwired PR), which the MCP `run`/`verify` already consume.