### PR TITLE
fix esp32c3 oled i2c transactions

### DIFF
--- a/crates/core/src/peripherals/components/ssd1306.rs
+++ b/crates/core/src/peripherals/components/ssd1306.rs
@@ -77,6 +77,16 @@ impl Ssd1306 {
         &self.gddram
     }
 
+    /// Count framebuffer bytes that contain at least one lit OLED pixel.
+    pub fn ink_bytes(&self) -> usize {
+        self.gddram.iter().filter(|b| **b != 0).count()
+    }
+
+    /// Count lit OLED pixels across the page-major GDDRAM framebuffer.
+    pub fn lit_pixels(&self) -> usize {
+        self.gddram.iter().map(|b| b.count_ones() as usize).sum()
+    }
+
     /// Panel width in pixels (128).
     pub fn width(&self) -> usize {
         WIDTH

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -99,6 +99,8 @@ const REG_SCL_STRETCH_CONF: u64 = 0x84;
 const REG_DATE: u64 = 0xF8;
 
 const CTR_TRANS_START_BIT: u32 = 1 << 5;
+/// CTR bit 10: FSM_RST — write-trigger master FSM reset.
+const CTR_FSM_RST: u32 = 1 << 10;
 /// CTR bit 11: CONF_UPGATE — self-clearing config-sync trigger.
 const CTR_CONF_UPGATE: u32 = 1 << 11;
 
@@ -113,6 +115,7 @@ const CMD_DONE_BIT: u32 = 1 << 31;
 pub const INT_END_DETECT: u32 = 1 << 3;
 pub const INT_TRANS_COMPLETE: u32 = 1 << 7;
 pub const INT_NACK: u32 = 1 << 10;
+const SCL_RST_SLV_EN: u32 = 1 << 0;
 
 /// ESP32-C3 has 8 COMD slots at offsets 0x58..0x78 (COMD0..COMD7 in the yaml).
 const NUM_CMDS: usize = 8;
@@ -136,6 +139,8 @@ pub struct Esp32c3I2c {
     irq_pending: bool,
     /// Interrupt-matrix source this instance asserts (29 for I2C0).
     intr_source_id: u32,
+    active_slave: Option<usize>,
+    expects_addr: bool,
 
     // Config / timing registers — masked storage (reset values per C3 i2c0.yaml).
     reg_scl_low_period: u32,   // 0x00  reset 0x0000_0000  mask 0x0000_01FF
@@ -178,6 +183,8 @@ impl Esp32c3I2c {
             slaves: Vec::new(),
             irq_pending: false,
             intr_source_id: I2C0_INTR_SOURCE_ID,
+            active_slave: None,
+            expects_addr: true,
 
             reg_scl_low_period: 0x0000_0000,
             reg_to: 0x0000_0010,
@@ -242,6 +249,17 @@ impl Esp32c3I2c {
         let rx = (self.rx_fifo.borrow().len() as u32) & 0x3F;
         let tx = (self.tx_fifo.len() as u32) & 0x3F;
         (self.sr & SR_RESP_REC) | SR_STRETCH_CAUSE_RESET | (rx << 8) | (tx << 18)
+    }
+
+    fn find_slave_from_slave_addr_register(&self) -> Option<usize> {
+        let raw = self.slave_addr & 0x7FFF;
+        if raw <= 0x7F {
+            if let Some(idx) = self.slaves.iter().position(|s| s.address() == raw as u8) {
+                return Some(idx);
+            }
+        }
+        let shifted = ((raw >> 1) & 0x7F) as u8;
+        self.slaves.iter().position(|s| s.address() == shifted)
     }
 }
 
@@ -338,8 +356,9 @@ impl Peripheral for Esp32c3I2c {
                     // Auto-clear TRANS_START like real silicon.
                     self.ctr &= !CTR_TRANS_START_BIT;
                 }
-                // CONF_UPGATE (bit 11) is a self-clearing sync trigger.
-                self.ctr &= !CTR_CONF_UPGATE;
+                // One-shot control bits self-clear after the write-triggered
+                // operation is accepted.
+                self.ctr &= !(CTR_FSM_RST | CTR_CONF_UPGATE);
             }
             REG_TO => masked_write(&mut self.reg_to, value, 0x0000_003F),
             REG_SLAVE_ADDR => self.slave_addr = value,
@@ -382,7 +401,12 @@ impl Peripheral for Esp32c3I2c {
             REG_SCL_MAIN_ST_TIME_OUT => {
                 masked_write(&mut self.reg_scl_main_st_time_out, value, 0x0000_001F)
             }
-            REG_SCL_SP_CONF => masked_write(&mut self.reg_scl_sp_conf, value, 0x0000_00FF),
+            REG_SCL_SP_CONF => {
+                masked_write(&mut self.reg_scl_sp_conf, value, 0x0000_00FF);
+                // SCL_RST_SLV_EN is R/W/SC. Arduino's C3 bus-clear helper
+                // writes it and then polls until hardware clears it.
+                self.reg_scl_sp_conf &= !SCL_RST_SLV_EN;
+            }
             REG_SCL_STRETCH_CONF => {
                 masked_write(&mut self.reg_scl_stretch_conf, value, 0x0000_3FFF)
             }
@@ -446,6 +470,8 @@ impl Peripheral for Esp32c3I2c {
                         "h": oled.height(),
                         "format": "ssd1306_page",
                         "generation": crate::inspect::artifact_generation(fb),
+                        "ink_bytes": oled.ink_bytes(),
+                        "lit_pixels": oled.lit_pixels(),
                     }),
                     bytes: if opts.include_bytes {
                         Some(fb.to_vec())
@@ -474,8 +500,8 @@ impl Esp32c3I2c {
         const OP_END: u32 = 4;
         const OP_RSTART: u32 = 6;
 
-        let mut active: Option<usize> = None;
-        let mut expects_addr = true;
+        let mut active = self.active_slave;
+        let mut expects_addr = self.expects_addr;
         let mut last_op_was_end = false;
 
         // Reset RESP_REC and the TX-FIFO read pointer at the start of a new
@@ -504,15 +530,26 @@ impl Esp32c3I2c {
                             // First byte of a WRITE following RSTART is addr+R/W.
                             let addr = b >> 1;
                             active = self.slaves.iter().position(|s| s.address() == addr);
-                            if active.is_none() {
-                                self.int_raw |= INT_NACK;
-                            } else {
+                            if active.is_some() {
                                 // Slave acknowledged its address.
                                 self.sr |= SR_RESP_REC;
+                                expects_addr = false;
+                                // Don't deliver the addr byte to the slave's write().
+                                continue;
+                            }
+
+                            // ESP-IDF/Arduino can program the address in
+                            // SLAVE_ADDR and put only payload bytes in TXFIFO.
+                            // In that shape the first FIFO byte is real data.
+                            active = self.find_slave_from_slave_addr_register();
+                            if active.is_some() {
+                                self.sr |= SR_RESP_REC;
+                            } else {
+                                self.int_raw |= INT_NACK;
+                                expects_addr = false;
+                                continue;
                             }
                             expects_addr = false;
-                            // Don't deliver the addr byte to the slave's write().
-                            continue;
                         }
                         if let Some(slave_idx) = active {
                             self.slaves[slave_idx].write(b);
@@ -542,6 +579,8 @@ impl Esp32c3I2c {
                     if let Some(slave_idx) = active {
                         self.slaves[slave_idx].stop();
                     }
+                    active = None;
+                    expects_addr = true;
                     self.cmds[idx] |= CMD_DONE_BIT;
                     break;
                 }
@@ -557,8 +596,12 @@ impl Esp32c3I2c {
         // list that runs out without an explicit END) completes the transaction
         // and raises TRANS_COMPLETE (bit 7).
         if last_op_was_end {
+            self.active_slave = active;
+            self.expects_addr = expects_addr;
             self.int_raw |= INT_END_DETECT;
         } else {
+            self.active_slave = None;
+            self.expects_addr = true;
             self.int_raw |= INT_TRANS_COMPLETE;
         }
         if self.int_ena & (INT_TRANS_COMPLETE | INT_END_DETECT | INT_NACK) != 0 {
@@ -691,6 +734,29 @@ mod tests {
         p.write_u32(REG_CMD0, cmd(CMD_END, 0)).unwrap();
         p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
         assert_eq!(p.read_u32(REG_CTR).unwrap() & CTR_TRANS_START_BIT, 0);
+    }
+
+    #[test]
+    fn one_shot_control_bits_auto_clear() {
+        let mut p = Esp32c3I2c::new();
+        p.write_u32(REG_CTR, CTR_FSM_RST | CTR_CONF_UPGATE).unwrap();
+        assert_eq!(
+            p.read_u32(REG_CTR).unwrap() & (CTR_FSM_RST | CTR_CONF_UPGATE),
+            0
+        );
+    }
+
+    #[test]
+    fn scl_reset_slave_enable_self_clears() {
+        let mut p = Esp32c3I2c::new();
+        // Exact value observed in Arduino's i2c_ll_master_clr_bus(): enable
+        // plus 9 SCL pulses encoded in SCL_RST_SLV_NUM bits [5:1].
+        p.write_u32(REG_SCL_SP_CONF, 0x13).unwrap();
+        assert_eq!(
+            p.read_u32(REG_SCL_SP_CONF).unwrap(),
+            0x12,
+            "SCL_RST_SLV_EN must self-clear while preserving pulse count"
+        );
     }
 
     #[test]
@@ -829,6 +895,103 @@ mod tests {
             p.read_u32(REG_INT_RAW).unwrap() & INT_TRANS_COMPLETE,
             INT_TRANS_COMPLETE
         );
+    }
+
+    #[test]
+    fn inspect_ssd1306_framebuffer_reports_ink_metrics() {
+        use crate::inspect::InspectOpts;
+        use crate::peripherals::components::Ssd1306;
+
+        let mut p = Esp32c3I2c::new();
+        p.attach_slave(Box::new(Ssd1306::new(0x3C)));
+
+        // Same transaction shape as the C3 OLED firmware:
+        // RSTART; WRITE 3 (addr+W, control=0x40, one framebuffer byte); STOP.
+        p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
+        p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 3)).unwrap();
+        p.write_u32(REG_CMD0 + 8, cmd(CMD_STOP, 0)).unwrap();
+        p.write_u32(REG_DATA, 0x78).unwrap(); // 0x3C << 1, write
+        p.write_u32(REG_DATA, 0x40).unwrap(); // SSD1306 data stream
+        p.write_u32(REG_DATA, 0xAA).unwrap(); // four lit pixels in byte 0
+        p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
+
+        let pi = p.inspect(0x6001_3000, "i2c0", &InspectOpts::default());
+        let fb = pi
+            .artifacts
+            .iter()
+            .find(|a| a.kind == "framebuffer")
+            .expect("framebuffer artifact present");
+        assert_eq!(fb.meta["ink_bytes"], 1);
+        assert_eq!(fb.meta["lit_pixels"], 4);
+    }
+
+    #[test]
+    fn register_addressed_write_delivers_payload_to_ssd1306() {
+        use crate::inspect::InspectOpts;
+        use crate::peripherals::components::Ssd1306;
+
+        let mut p = Esp32c3I2c::new();
+        p.attach_slave(Box::new(Ssd1306::new(0x3C)));
+
+        // Arduino-ESP32 / ESP-IDF may program SLAVE_ADDR with addr<<1 and
+        // write only the SSD1306 payload bytes to TXFIFO: control byte 0x40,
+        // then data 0xAA.
+        p.write_u32(REG_SLAVE_ADDR, 0x3C << 1).unwrap();
+        p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
+        p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 2)).unwrap();
+        p.write_u32(REG_CMD0 + 8, cmd(CMD_STOP, 0)).unwrap();
+        p.write_u32(REG_DATA, 0x40).unwrap();
+        p.write_u32(REG_DATA, 0xAA).unwrap();
+        p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
+
+        assert_eq!(p.read_u32(REG_INT_RAW).unwrap() & INT_NACK, 0);
+        let pi = p.inspect(0x6001_3000, "i2c0", &InspectOpts::default());
+        let fb = pi
+            .artifacts
+            .iter()
+            .find(|a| a.kind == "framebuffer")
+            .expect("framebuffer artifact present");
+        assert_eq!(fb.meta["ink_bytes"], 1);
+        assert_eq!(fb.meta["lit_pixels"], 4);
+    }
+
+    #[test]
+    fn end_paused_address_phase_carries_active_slave() {
+        use crate::inspect::InspectOpts;
+        use crate::peripherals::components::Ssd1306;
+
+        let mut p = Esp32c3I2c::new();
+        p.attach_slave(Box::new(Ssd1306::new(0x3C)));
+
+        // Arduino-ESP32 splits a write: address phase ends with END_DETECT,
+        // then payload bytes are sent by a second command-list run.
+        p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
+        p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 1)).unwrap();
+        p.write_u32(REG_CMD0 + 8, cmd(CMD_END, 0)).unwrap();
+        p.write_u32(REG_DATA, 0x78).unwrap();
+        p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
+        assert_eq!(
+            p.read_u32(REG_INT_RAW).unwrap() & INT_END_DETECT,
+            INT_END_DETECT
+        );
+        p.write_u32(REG_INT_CLR, INT_END_DETECT).unwrap();
+
+        p.write_u32(REG_CMD0, cmd(CMD_WRITE, 2)).unwrap();
+        p.write_u32(REG_CMD0 + 4, cmd(CMD_STOP, 0)).unwrap();
+        p.write_u32(REG_CMD0 + 8, 0).unwrap();
+        p.write_u32(REG_DATA, 0x40).unwrap();
+        p.write_u32(REG_DATA, 0xAA).unwrap();
+        p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
+
+        assert_eq!(p.read_u32(REG_INT_RAW).unwrap() & INT_NACK, 0);
+        let pi = p.inspect(0x6001_3000, "i2c0", &InspectOpts::default());
+        let fb = pi
+            .artifacts
+            .iter()
+            .find(|a| a.kind == "framebuffer")
+            .expect("framebuffer artifact present");
+        assert_eq!(fb.meta["ink_bytes"], 1);
+        assert_eq!(fb.meta["lit_pixels"], 4);
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32s3/i2c.rs
+++ b/crates/core/src/peripherals/esp32s3/i2c.rs
@@ -98,6 +98,8 @@ const REG_SCL_STRETCH_CONF: u64 = 0x84;
 const REG_DATE: u64 = 0xF8;
 
 const CTR_TRANS_START_BIT: u32 = 1 << 5;
+/// CTR bit 10: FSM_RST — write-trigger master FSM reset.
+const CTR_FSM_RST: u32 = 1 << 10;
 /// CTR bit 11: CONF_UPGATE — self-clearing config-sync trigger.
 const CTR_CONF_UPGATE: u32 = 1 << 11;
 
@@ -114,6 +116,7 @@ const CMD_DONE_BIT: u32 = 1 << 31;
 pub const INT_END_DETECT: u32 = 1 << 3;
 pub const INT_TRANS_COMPLETE: u32 = 1 << 7;
 pub const INT_NACK: u32 = 1 << 10;
+const SCL_RST_SLV_EN: u32 = 1 << 0;
 
 /// ESP32-S3 has 8 COMD slots at offsets 0x58..0x78. Higher offsets are
 /// SCL/SP timing registers that we accept-and-ignore.
@@ -136,6 +139,8 @@ pub struct Esp32s3I2c {
     irq_pending: bool,
     /// Interrupt-matrix source this instance asserts: 42 for I2C0, 43 for I2C1.
     intr_source_id: u32,
+    active_slave: Option<usize>,
+    expects_addr: bool,
 
     // Config / timing registers — masked storage (SVD-accurate reset values).
     // On write: stored = (stored & !mask) | (value & mask).  Reserved bits
@@ -178,6 +183,8 @@ impl Esp32s3I2c {
             slaves: Vec::new(),
             irq_pending: false,
             intr_source_id: I2C0_INTR_SOURCE_ID,
+            active_slave: None,
+            expects_addr: true,
 
             // Config / timing registers initialised to SVD reset values.
             reg_scl_low_period: 0x0000_0000,
@@ -237,6 +244,17 @@ impl Esp32s3I2c {
         let rx = (self.rx_fifo.borrow().len() as u32) & 0x3F;
         let tx = (self.tx_fifo.len() as u32) & 0x3F;
         (self.sr & SR_RESP_REC) | SR_STRETCH_CAUSE_RESET | (rx << 8) | (tx << 18)
+    }
+
+    fn find_slave_from_slave_addr_register(&self) -> Option<usize> {
+        let raw = self.slave_addr & 0x7FFF;
+        if raw <= 0x7F {
+            if let Some(idx) = self.slaves.iter().position(|s| s.address() == raw as u8) {
+                return Some(idx);
+            }
+        }
+        let shifted = ((raw >> 1) & 0x7F) as u8;
+        self.slaves.iter().position(|s| s.address() == shifted)
     }
 }
 
@@ -339,7 +357,7 @@ impl Peripheral for Esp32s3I2c {
                 // driver writes it and polls for it to clear; if it stays set the
                 // driver concludes the controller is wedged and aborts the
                 // transfer (ESP_ERR_INVALID_STATE). esp-hal never sets it.
-                self.ctr &= !CTR_CONF_UPGATE;
+                self.ctr &= !(CTR_FSM_RST | CTR_CONF_UPGATE);
             }
             REG_TO => masked_write(&mut self.reg_to, value, 0x0000_003F),
             REG_SLAVE_ADDR => self.slave_addr = value,
@@ -384,7 +402,12 @@ impl Peripheral for Esp32s3I2c {
             REG_SCL_MAIN_ST_TIME_OUT => {
                 masked_write(&mut self.reg_scl_main_st_time_out, value, 0x0000_001F)
             }
-            REG_SCL_SP_CONF => masked_write(&mut self.reg_scl_sp_conf, value, 0x0000_00FF),
+            REG_SCL_SP_CONF => {
+                masked_write(&mut self.reg_scl_sp_conf, value, 0x0000_00FF);
+                // SCL_RST_SLV_EN is R/W/SC. Arduino's S3 bus-clear helper
+                // writes it and then polls until hardware clears it.
+                self.reg_scl_sp_conf &= !SCL_RST_SLV_EN;
+            }
             REG_SCL_STRETCH_CONF => {
                 masked_write(&mut self.reg_scl_stretch_conf, value, 0x0000_3FFF)
             }
@@ -444,10 +467,10 @@ impl Esp32s3I2c {
         const OP_END: u32 = 4;
         const OP_RSTART: u32 = 6;
 
-        // Index into self.slaves of the currently-selected device, or
-        // None if no address has been latched yet (or just after RSTART).
-        let mut active: Option<usize> = None;
-        let mut expects_addr = true;
+        // Index into self.slaves of the currently-selected device. END pauses
+        // the command list, so the selected slave can carry into the next run.
+        let mut active = self.active_slave;
+        let mut expects_addr = self.expects_addr;
         let mut last_op_was_end = false;
         let mut hit_stop = false;
 
@@ -475,15 +498,26 @@ impl Esp32s3I2c {
                             // First byte of a WRITE following RSTART is addr+R/W.
                             let addr = b >> 1;
                             active = self.slaves.iter().position(|s| s.address() == addr);
-                            if active.is_none() {
-                                self.int_raw |= INT_NACK;
-                            } else {
+                            if active.is_some() {
                                 // Slave acknowledged its address.
                                 self.sr |= SR_RESP_REC;
+                                expects_addr = false;
+                                // Don't deliver the addr byte to the slave's write().
+                                continue;
+                            }
+
+                            // ESP-IDF/Arduino can program the address in
+                            // SLAVE_ADDR and put only payload bytes in TXFIFO.
+                            // In that shape the first FIFO byte is real data.
+                            active = self.find_slave_from_slave_addr_register();
+                            if active.is_some() {
+                                self.sr |= SR_RESP_REC;
+                            } else {
+                                self.int_raw |= INT_NACK;
+                                expects_addr = false;
+                                continue;
                             }
                             expects_addr = false;
-                            // Don't deliver the addr byte to the slave's write().
-                            continue;
                         }
                         if let Some(slave_idx) = active {
                             self.slaves[slave_idx].write(b);
@@ -514,6 +548,8 @@ impl Esp32s3I2c {
                     if let Some(slave_idx) = active {
                         self.slaves[slave_idx].stop();
                     }
+                    active = None;
+                    expects_addr = true;
                     self.cmds[idx] |= CMD_DONE_BIT;
                     hit_stop = true;
                     break;
@@ -531,12 +567,18 @@ impl Esp32s3I2c {
         // TRANS_COMPLETE (bit 7). esp-hal blocks on (END_DETECT | TX_COMPLETE)
         // and uses END_DETECT to chain phase 2 of a write_read.
         if last_op_was_end {
+            self.active_slave = active;
+            self.expects_addr = expects_addr;
             self.int_raw |= INT_END_DETECT;
         } else if hit_stop {
+            self.active_slave = None;
+            self.expects_addr = true;
             self.int_raw |= INT_TRANS_COMPLETE;
         } else {
             // Empty cmd list or reserved opcode — set TRANS_COMPLETE so the
             // driver's wait loop unblocks rather than hanging.
+            self.active_slave = None;
+            self.expects_addr = true;
             self.int_raw |= INT_TRANS_COMPLETE;
         }
         if self.int_ena & (INT_TRANS_COMPLETE | INT_END_DETECT | INT_NACK) != 0 {
@@ -920,9 +962,9 @@ mod tests {
         p.write_u32(REG_FILTER_CFG, 0xFFFF_FFFF).unwrap();
         assert_eq!(p.read_u32(REG_FILTER_CFG).unwrap(), 0x0000_03FF);
 
-        // SCL_SP_CONF: mask 0xFF.
+        // SCL_SP_CONF: mask 0xFF, with SCL_RST_SLV_EN bit 0 self-clearing.
         p.write_u32(REG_SCL_SP_CONF, 0xFFFF_FFFF).unwrap();
-        assert_eq!(p.read_u32(REG_SCL_SP_CONF).unwrap(), 0x0000_00FF);
+        assert_eq!(p.read_u32(REG_SCL_SP_CONF).unwrap(), 0x0000_00FE);
 
         // TO: mask 0x3F — bits 6..31 are reserved, read back reset (0x10 & ~0x3F == 0,
         // so reserved bits are 0; full write reads back 0x3F only).

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -1031,6 +1031,8 @@ impl crate::Peripheral for I2c {
                         "h": oled.height(),
                         "format": "ssd1306_page",
                         "generation": crate::inspect::artifact_generation(fb),
+                        "ink_bytes": oled.ink_bytes(),
+                        "lit_pixels": oled.lit_pixels(),
                     }),
                     bytes: if opts.include_bytes {
                         Some(fb.to_vec())

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -157,7 +157,11 @@ boards:
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
     # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
     # 2026-07-04: drift is the file-hash of the additive L4 PLLSAI1/2 ready-bit change in rcc.rs (L4Rcc::ready); this board's RCC engine (H5Rcc) is byte-for-byte untouched, h563_mmio_diff + h563_conformance unchanged, no live re-capture.
-    drift_ack: 2026-07-04
+    # 2026-07-05: shared i2c.rs gained SSD1306 inspect artifact metadata
+    # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
+    # STM32 H5 I2C register/transaction engines are untouched; h563_mmio_diff +
+    # h563_conformance remain the pinned coverage. No live re-capture.
+    drift_ack: 2026-07-05
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -261,7 +265,11 @@ boards:
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
     # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
     # 2026-07-04: modeled RCC_CR PLLSAI1RDY(bit27)←PLLSAI1ON, PLLSAI2RDY(bit29)←PLLSAI2ON (RM0351 §6.4.1) so STM32 Arduino HAL PLLSAI1 (48 MHz domain) bring-up completes instead of HAL_TIMEOUT. Additive ready-bit behavior; pending live HW re-capture.
-    drift_ack: 2026-07-04
+    # 2026-07-05: shared i2c.rs gained SSD1306 inspect artifact metadata
+    # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
+    # STM32 L4 I2C register/transaction engines are untouched; l476_mmio_diff +
+    # l476_parity_diff remain the pinned coverage. No live re-capture.
+    drift_ack: 2026-07-05
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -346,7 +354,11 @@ boards:
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
     # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
     # 2026-07-04: drift is the file-hash of the additive L4 PLLSAI1/2 ready-bit change in rcc.rs (L4Rcc::ready); this board's RCC engine (F1Rcc) is byte-for-byte untouched, stm32f1_mmio_diff + f103_conformance unchanged, no live re-capture.
-    drift_ack: 2026-07-04
+    # 2026-07-05: shared i2c.rs gained SSD1306 inspect artifact metadata
+    # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
+    # STM32 F1 I2C register/transaction engines are untouched; stm32f1_mmio_diff +
+    # f103_conformance remain the pinned coverage. No live re-capture.
+    drift_ack: 2026-07-05
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -394,7 +406,11 @@ boards:
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
     # 2026-07-03: additive `as_sim_input_mut` default method on the I2cDevice trait (generic SimInput hook) + new SystemBus set_input/list_inputs; STM32 register engines byte-for-byte untouched, the default returns None for all STM32 devices. Diff/conformance unchanged; no live re-capture.
     # 2026-07-04: drift is the file-hash of the additive L4 PLLSAI1/2 ready-bit change in rcc.rs (L4Rcc::ready); this board's RCC engine (F4Rcc) is byte-for-byte untouched, stm32f4_mmio_diff + stm32f4_exec_oracle unchanged, no live re-capture.
-    drift_ack: 2026-07-04
+    # 2026-07-05: shared i2c.rs gained SSD1306 inspect artifact metadata
+    # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
+    # STM32 F4 I2C register/transaction engines are untouched; stm32f4_mmio_diff +
+    # stm32f4_exec_oracle remain the pinned coverage. No live re-capture.
+    drift_ack: 2026-07-05
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
Fixes ESP32-C3/S3 I2C command handling so reset bits self-clear and END-paused OLED transactions retain the active slave across command-list runs. Also reports SSD1306 ink/lit-pixel metadata for inspection. Verified with cargo fmt --all -- --check and targeted labwired-core I2C/OLED/BMP280 tests.