### PR TITLE
Merge C3 fixes after ESP32 tick optimization

### DIFF
--- a/crates/config/src/canonical.rs
+++ b/crates/config/src/canonical.rs
@@ -260,83 +260,87 @@ impl CanonicalConfig {
         // Non-MCU parts, in original order (mirrors `diagram.parts`, which
         // `canonicalToDiagramV1` builds by filtering out the MCU).
         let non_mcu = || self.parts.iter().filter(|p| p.id != mcu.id);
-        let mut push = |ext: Option<String>, bio: Option<String>| {
-            if let Some(e) = ext {
-                external_devices.push(e);
-            }
-            if let Some(b) = bio {
-                board_io.push(b);
-            }
-        };
 
         // The dedicated-emitter loops run in the SAME order as `diagramToConfig`,
         // because both the `external_devices` and `board_io` lists are emitted in
         // this order (byte-order matters).
-
-        // 1. Ultrasonic (HC-SR04).
-        for part in non_mcu() {
-            if part.r#type == "ultrasonic" {
-                let (ext, bio) = emit_ultrasonic(&board, &wires, mcu_id, part);
-                push(ext, bio);
-            }
-        }
-        // 2. PCD8544 (Nokia 5110).
-        for part in non_mcu() {
-            if part.r#type == "pcd8544" {
-                let (ext, bio) = emit_pcd8544(&board, &wires, mcu_id, &part.id);
-                push(ext, bio);
-            }
-        }
-        // 3. SN74HC165 shift register.
-        for part in non_mcu() {
-            if part.r#type == "sn74hc165" {
-                let (ext, bio) = emit_sn74hc165(&board, &wires, mcu_id, part);
-                push(ext, bio);
-            }
-        }
-        // 4. IO-Link master.
-        for part in non_mcu() {
-            if part.r#type == "iolink-master" {
-                let (ext, bio) = emit_iolink_master(&board, &wires, mcu_id, &self.parts, &part.id);
-                push(ext, bio);
-            }
-        }
-        // 5. Legacy I²C devices (adxl345, mpu6050, bme280, oled-ssd1306, …).
-        for part in non_mcu() {
-            let Some(address) = i2c_device_address(&part.r#type) else {
-                continue;
+        {
+            let mut push = |ext: Option<String>, bio: Option<String>| {
+                if let Some(e) = ext {
+                    external_devices.push(e);
+                }
+                if let Some(b) = bio {
+                    board_io.push(b);
+                }
             };
-            let Some(connection) = i2c_peripheral_for_part_wire(&board, &wires, mcu_id, &part.id)
-            else {
-                continue;
-            };
-            let (ed, bio) = emit_legacy_i2c_device(&part.id, &part.r#type, &connection, address);
-            push(Some(ed), Some(bio));
-        }
-        // 6. SPI devices (ili9341, max31855, ssd1680_tricolor_290).
-        for part in non_mcu() {
-            if SPI_DEVICE_TYPES.contains(&part.r#type.as_str()) {
-                let (ext, bio) = emit_spi_device(&board, &wires, mcu_id, &part.id, &part.r#type);
-                push(ext, bio);
-            }
-        }
-        // 7. NEO-6M GPS.
-        for part in non_mcu() {
-            if part.r#type == "neo6m-gps" {
-                let (ext, bio) = emit_neo6m_gps(&board, &wires, mcu_id, &part.id);
-                push(ext, bio);
-            }
-        }
-        // 8. CAN diagnostic tester.
-        for part in non_mcu() {
-            if part.r#type == "can-diagnostic-tool" {
-                let (ext, bio) =
-                    emit_can_diagnostic_tool(&board, &wires, mcu_id, &self.parts, part);
-                push(ext, bio);
-            }
-        }
 
-        drop(push);
+            // 1. Ultrasonic (HC-SR04).
+            for part in non_mcu() {
+                if part.r#type == "ultrasonic" {
+                    let (ext, bio) = emit_ultrasonic(&board, &wires, mcu_id, part);
+                    push(ext, bio);
+                }
+            }
+            // 2. PCD8544 (Nokia 5110).
+            for part in non_mcu() {
+                if part.r#type == "pcd8544" {
+                    let (ext, bio) = emit_pcd8544(&board, &wires, mcu_id, &part.id);
+                    push(ext, bio);
+                }
+            }
+            // 3. SN74HC165 shift register.
+            for part in non_mcu() {
+                if part.r#type == "sn74hc165" {
+                    let (ext, bio) = emit_sn74hc165(&board, &wires, mcu_id, part);
+                    push(ext, bio);
+                }
+            }
+            // 4. IO-Link master.
+            for part in non_mcu() {
+                if part.r#type == "iolink-master" {
+                    let (ext, bio) =
+                        emit_iolink_master(&board, &wires, mcu_id, &self.parts, &part.id);
+                    push(ext, bio);
+                }
+            }
+            // 5. Legacy I²C devices (adxl345, mpu6050, bme280, oled-ssd1306, …).
+            for part in non_mcu() {
+                let Some(address) = i2c_device_address(&part.r#type) else {
+                    continue;
+                };
+                let Some(connection) =
+                    i2c_peripheral_for_part_wire(&board, &wires, mcu_id, &part.id)
+                else {
+                    continue;
+                };
+                let (ed, bio) =
+                    emit_legacy_i2c_device(&part.id, &part.r#type, &connection, address);
+                push(Some(ed), Some(bio));
+            }
+            // 6. SPI devices (ili9341, max31855, ssd1680_tricolor_290).
+            for part in non_mcu() {
+                if SPI_DEVICE_TYPES.contains(&part.r#type.as_str()) {
+                    let (ext, bio) =
+                        emit_spi_device(&board, &wires, mcu_id, &part.id, &part.r#type);
+                    push(ext, bio);
+                }
+            }
+            // 7. NEO-6M GPS.
+            for part in non_mcu() {
+                if part.r#type == "neo6m-gps" {
+                    let (ext, bio) = emit_neo6m_gps(&board, &wires, mcu_id, &part.id);
+                    push(ext, bio);
+                }
+            }
+            // 8. CAN diagnostic tester.
+            for part in non_mcu() {
+                if part.r#type == "can-diagnostic-tool" {
+                    let (ext, bio) =
+                        emit_can_diagnostic_tool(&board, &wires, mcu_id, &self.parts, part);
+                    push(ext, bio);
+                }
+            }
+        }
 
         // 9. Wire-based board_io for all remaining (GPIO/ADC) part types.
         board_io.extend(emit_board_io_from_wires(

--- a/crates/config/src/canonical.rs
+++ b/crates/config/src/canonical.rs
@@ -103,13 +103,6 @@ pub enum CanonicalError {
     /// today (mirrors the TS `canonicalToDiagramV1`).
     #[error("multiple MCU parts ({0}); the resolver models a single MCU")]
     MultipleMcuParts(String),
-
-    /// A part `type` is handled by a TS emitter that Phase 2a did NOT port
-    /// (SPI devices, ultrasonic, pcd8544, sn74hc165, iolink-master, neo6m-gps,
-    /// can-diagnostic-tool, …) — or is otherwise outside the Phase 2a subset.
-    /// Phase 2b must port the remaining emitters; see the module TODO.
-    #[error("part type '{0}' is not supported by the Phase 2a resolver (Phase 2b TODO)")]
-    UnsupportedInPhase2a(String),
 }
 
 /// Parse a canonical config from JSON. Rejects unknown keys and malformed
@@ -181,33 +174,41 @@ impl CanonicalConfig {
     /// string — the Rust port of the TS oracle `diagramToConfig`
     /// (`packages/board-config/src/diagram-to-config.ts` + `compile/emitters.ts`).
     ///
-    /// # Phase 2a scope
+    /// The MCU part (the one whose `type` is a known MCU) becomes the board; the
+    /// TS `canonicalToDiagramV1` throws on zero or >1 MCU parts, so this returns
+    /// [`CanonicalError::NoMcuPart`] / [`CanonicalError::MultipleMcuParts`] to
+    /// match. Every `connection`'s MCU pin is resolved to its peripheral via the
+    /// ported pin maps ([`parse_mcu_pin`] / [`mcu_pin_for_part_pin`] / the
+    /// `find_*_peripheral` lookups).
     ///
-    /// This ports the subset of the TS emitters the Phase 1 parity fixtures need:
-    /// legacy I²C devices ([`emit_legacy_i2c_device`], keyed by
-    /// [`i2c_device_address`]) and GPIO `board_io` from point-to-point wires
-    /// ([`emit_board_io_from_wires`]), assembled by [`build_system_yaml`] in the
-    /// oracle's exact byte format. The MCU part (the one whose `type` is a known
-    /// MCU) becomes the board; each connection's MCU pin is resolved to its
-    /// peripheral ([`parse_mcu_pin`] / [`mcu_pin_for_part_pin`] /
-    /// [`i2c_peripheral_for_part_wire`]).
+    /// # Ported emitters (Phase 2a + 2b)
     ///
-    /// Part types handled by an emitter Phase 2a did NOT port (SPI devices,
-    /// ultrasonic, pcd8544, sn74hc165, iolink-master, neo6m-gps,
-    /// can-diagnostic-tool) — and any other type outside the subset — yield
-    /// [`CanonicalError::UnsupportedInPhase2a`] rather than a partial result.
+    /// All TS emitters are ported: legacy I²C devices ([`emit_legacy_i2c_device`]),
+    /// GPIO/ADC `board_io` from point-to-point wires ([`emit_board_io_from_wires`]),
+    /// SPI devices ([`emit_spi_device`]), ultrasonic ([`emit_ultrasonic`]),
+    /// pcd8544 ([`emit_pcd8544`]), sn74hc165 ([`emit_sn74hc165`]), iolink-master
+    /// ([`emit_iolink_master`]), neo6m-gps ([`emit_neo6m_gps`]) and the CAN
+    /// diagnostic tester ([`emit_can_diagnostic_tool`]). They are invoked in the
+    /// exact order `diagramToConfig` uses (the output is byte-order-sensitive) and
+    /// assembled by [`build_system_yaml`].
+    ///
+    /// Like the TS oracle, `resolve()` is total over part types: a part no emitter
+    /// claims (a passive/tool bridge part such as `can-transceiver`, or an unknown
+    /// type) simply contributes nothing — it is never an error.
+    ///
+    /// # Bus pin-map coverage
+    ///
+    /// The bus lookups ([`find_i2c_peripheral`], [`find_spi_peripheral`],
+    /// [`find_uart_peripheral`], [`find_can_function`], [`find_adc_peripheral`])
+    /// cover the STM32 F103/F401/L476/H563 pin maps — the only chips the TS oracle
+    /// can actually resolve, since `diagramToConfig` throws for any board absent
+    /// from `CHIP_YAMLS` (currently `stm32f103`/`stm32f401`/`stm32l476`). Non-STM32
+    /// boards resolve GPIO `board_io` (via [`parse_mcu_pin`]) but return `None`
+    /// from the bus lookups, so a bus device on them stays unbound — faithful to
+    /// `findPinFunction` returning null for an unmapped board.
     ///
     /// The output is gated byte-for-byte against the TS oracle snapshots by
     /// `resolve_matches_ts_oracle` in this module's tests.
-    ///
-    /// ## Phase 2b TODO (unported emitters)
-    ///
-    /// `emitSpiDevice` (`ili9341`, `max31855`, `ssd1680_tricolor_290`),
-    /// `emitUltrasonic` (`ultrasonic`), `emitPcd8544` (`pcd8544`),
-    /// `emitSn74hc165` (`sn74hc165`), `emitIolinkMaster` (`iolink-master`),
-    /// `emitNeo6mGps` (`neo6m-gps`), `emitCanDiagnosticTool`
-    /// (`can-diagnostic-tool`), plus the ADC-input `board_io` branch (needs the
-    /// per-chip ADC pin map) and non-STM32 I²C/pin maps.
     pub fn resolve(&self) -> Result<String, CanonicalError> {
         self.validate_structure()?;
 
@@ -253,31 +254,55 @@ impl CanonicalConfig {
             })
             .collect::<Result<_, CanonicalError>>()?;
 
-        // Fail fast on any non-MCU part outside the Phase 2a subset, rather than
-        // silently dropping it (which would diverge from the oracle invisibly).
-        for part in &self.parts {
-            if part.id == mcu.id {
-                continue;
-            }
-            let t = part.r#type.as_str();
-            if i2c_device_address(t).is_some() {
-                continue; // legacy I²C device — ported
-            }
-            if board_io_kind(t).is_some() {
-                continue; // GPIO board_io — ported
-            }
-            return Err(CanonicalError::UnsupportedInPhase2a(t.to_string()));
-        }
-
         let mut external_devices: Vec<String> = Vec::new();
         let mut board_io: Vec<String> = Vec::new();
 
-        // Legacy I²C devices (mirrors the I2C_DEVICE_ADDRESSES loop in
-        // diagramToConfig): iterate parts in order, skipping the MCU.
-        for part in &self.parts {
-            if part.id == mcu.id {
-                continue;
+        // Non-MCU parts, in original order (mirrors `diagram.parts`, which
+        // `canonicalToDiagramV1` builds by filtering out the MCU).
+        let non_mcu = || self.parts.iter().filter(|p| p.id != mcu.id);
+        let mut push = |ext: Option<String>, bio: Option<String>| {
+            if let Some(e) = ext {
+                external_devices.push(e);
             }
+            if let Some(b) = bio {
+                board_io.push(b);
+            }
+        };
+
+        // The dedicated-emitter loops run in the SAME order as `diagramToConfig`,
+        // because both the `external_devices` and `board_io` lists are emitted in
+        // this order (byte-order matters).
+
+        // 1. Ultrasonic (HC-SR04).
+        for part in non_mcu() {
+            if part.r#type == "ultrasonic" {
+                let (ext, bio) = emit_ultrasonic(&board, &wires, mcu_id, part);
+                push(ext, bio);
+            }
+        }
+        // 2. PCD8544 (Nokia 5110).
+        for part in non_mcu() {
+            if part.r#type == "pcd8544" {
+                let (ext, bio) = emit_pcd8544(&board, &wires, mcu_id, &part.id);
+                push(ext, bio);
+            }
+        }
+        // 3. SN74HC165 shift register.
+        for part in non_mcu() {
+            if part.r#type == "sn74hc165" {
+                let (ext, bio) = emit_sn74hc165(&board, &wires, mcu_id, part);
+                push(ext, bio);
+            }
+        }
+        // 4. IO-Link master.
+        for part in non_mcu() {
+            if part.r#type == "iolink-master" {
+                let (ext, bio) = emit_iolink_master(&board, &wires, mcu_id, &self.parts, &part.id);
+                push(ext, bio);
+            }
+        }
+        // 5. Legacy I²C devices (adxl345, mpu6050, bme280, oled-ssd1306, …).
+        for part in non_mcu() {
             let Some(address) = i2c_device_address(&part.r#type) else {
                 continue;
             };
@@ -286,11 +311,34 @@ impl CanonicalConfig {
                 continue;
             };
             let (ed, bio) = emit_legacy_i2c_device(&part.id, &part.r#type, &connection, address);
-            external_devices.push(ed);
-            board_io.push(bio);
+            push(Some(ed), Some(bio));
+        }
+        // 6. SPI devices (ili9341, max31855, ssd1680_tricolor_290).
+        for part in non_mcu() {
+            if SPI_DEVICE_TYPES.contains(&part.r#type.as_str()) {
+                let (ext, bio) = emit_spi_device(&board, &wires, mcu_id, &part.id, &part.r#type);
+                push(ext, bio);
+            }
+        }
+        // 7. NEO-6M GPS.
+        for part in non_mcu() {
+            if part.r#type == "neo6m-gps" {
+                let (ext, bio) = emit_neo6m_gps(&board, &wires, mcu_id, &part.id);
+                push(ext, bio);
+            }
+        }
+        // 8. CAN diagnostic tester.
+        for part in non_mcu() {
+            if part.r#type == "can-diagnostic-tool" {
+                let (ext, bio) =
+                    emit_can_diagnostic_tool(&board, &wires, mcu_id, &self.parts, part);
+                push(ext, bio);
+            }
         }
 
-        // Wire-based board_io for the remaining (GPIO) part types.
+        drop(push);
+
+        // 9. Wire-based board_io for all remaining (GPIO/ADC) part types.
         board_io.extend(emit_board_io_from_wires(
             &board,
             &wires,
@@ -336,15 +384,24 @@ const MCU_TYPES: &[&str] = &[
     "nrf52840-dk",
 ];
 
-/// STM32 board keys whose pin map carries the F103/L476 I²C pin functions
-/// (PB6–PB9 → I2C1, PB10/PB11 → I2C2). Non-STM32 I²C maps are a Phase 2b TODO.
-const STM32_I2C_BOARDS: &[&str] = &[
+/// STM32 board keys whose pin map carries the F103/L476/F401/H563 bus pin
+/// functions (I²C on PB6–PB11, SPI on PA/PB/PC, UART on PA/PB/PC, CAN on
+/// PA11/PA12, ADC on PA/PB/PC). All five share the F103 baseline for the pins
+/// the emitters resolve (L476 differs only in ADC *channel* numbers, which the
+/// emitters never emit — only the peripheral name). Non-STM32 boards have no
+/// bus pin map here, so the `find_*_peripheral` lookups return `None` for them
+/// (faithful to `findPinFunction` returning null for an unmapped board).
+const STM32_BOARDS: &[&str] = &[
     "stm32f103",
     "stm32f401",
     "stm32f401cdu6",
     "stm32l476",
     "stm32h563",
 ];
+
+/// SPI display/sensor devices addressed by their own emitter
+/// (port of the TS `SPI_DEVICE_TYPES` set).
+const SPI_DEVICE_TYPES: &[&str] = &["ili9341", "max31855", "ssd1680_tricolor_290"];
 
 /// Map an MCU part `type` to the chip-family key the pin map is keyed by.
 /// Ported from `BOARDS` (`mcuComponentType` → `chip`); falls back to the type
@@ -379,15 +436,36 @@ fn i2c_device_address(part_type: &str) -> Option<u32> {
     }
 }
 
-/// `board_io` kind for a GPIO part type (ported subset of `COMPONENT_META`,
-/// itself derived from `CATALOG.boardIoKind`). Only the kinds the Phase 2a
-/// wire-based emitter fully supports are returned; ADC-input parts are a Phase
-/// 2b TODO (they need the per-chip ADC pin map) and are rejected upstream.
+/// `board_io` kind for a part type — a faithful, TOTAL port of `COMPONENT_META`
+/// (itself `CATALOG.boardIoKind` for every part). Returns the CATALOG kind
+/// verbatim, including the `i2c_device`/`spi_device`/`uart_device` kinds:
+/// [`emit_board_io_from_wires`] mirrors the TS emitter, which skips the legacy
+/// I²C set, the [`SPI_DEVICE_TYPES`] set and the dedicated-emitter parts, then
+/// emits whatever kind remains for any other wired part (e.g. a `pca9685` or
+/// `seven-segment` wired straight to GPIO). `adc_input` remaps its peripheral to
+/// the pin's ADC controller in that emitter.
 fn board_io_kind(part_type: &str) -> Option<&'static str> {
     match part_type {
         "led" | "rgb-led" => Some("led"),
-        "button" => Some("button"),
-        "pwm_output" | "servo" => Some("pwm_output"),
+        "button" | "dht22" | "dip-switch" | "keypad" | "pir-sensor" | "rotary-encoder"
+        | "slide-switch" | "ultrasonic" => Some("button"),
+        "buzzer" | "l293d" | "servo" => Some("pwm_output"),
+        "adxl345" | "bme280" | "fxos8700" | "ir" | "lcd1602" | "mlx90614" | "mpu6050"
+        | "oled-ssd1306" | "pca9685" | "scd41" | "sgp41" | "sps30" | "veml7700" => {
+            Some("i2c_device")
+        }
+        "74hc595"
+        | "ili9341"
+        | "led-matrix"
+        | "max31855"
+        | "neopixel"
+        | "pcd8544"
+        | "seven-segment"
+        | "sn74hc165"
+        | "ssd1680_tricolor_290"
+        | "uc8151d_tricolor_290" => Some("spi_device"),
+        "ldr" | "ntc-thermistor" | "potentiometer" => Some("adc_input"),
+        "iolink-master" | "neo6m-gps" => Some("uart_device"),
         _ => None,
     }
 }
@@ -497,11 +575,11 @@ fn i2c_peripheral_for_part_wire(
 }
 
 /// STM32 `findPinFunction(board, pin, 'i2c')` — the first I²C function on the
-/// pin. Ported for the STM32 F103/L476 pin maps the fixtures use; other boards
-/// return `None` (faithful to `findPinFunction` returning null for an unmapped
-/// board), leaving the device unbound.
+/// pin. Ported from the STM32F103 base pin map (shared by F401/L476/H563); other
+/// boards return `None` (faithful to `findPinFunction` returning null for an
+/// unmapped board), leaving the device unbound.
 fn find_i2c_peripheral(board: &str, pin_label: &str) -> Option<&'static str> {
-    if !STM32_I2C_BOARDS.contains(&board) {
+    if !STM32_BOARDS.contains(&board) {
         return None;
     }
     match pin_label.to_ascii_uppercase().as_str() {
@@ -509,6 +587,283 @@ fn find_i2c_peripheral(board: &str, pin_label: &str) -> Option<&'static str> {
         "PB10" | "PB11" => Some("i2c2"),
         _ => None,
     }
+}
+
+/// STM32 `findPinFunction(board, pin, 'spi')` — the SPI peripheral on the pin,
+/// from the STM32F103 base pin map (SPI1 on PA4–PA7/PA15/PB3–PB5, SPI2 on
+/// PB12–PB15, SPI3 on PC10–PC12). `None` for a non-STM32 board or an unmapped
+/// pin.
+fn find_spi_peripheral(board: &str, pin_label: &str) -> Option<&'static str> {
+    if !STM32_BOARDS.contains(&board) {
+        return None;
+    }
+    match pin_label.to_ascii_uppercase().as_str() {
+        "PA4" | "PA5" | "PA6" | "PA7" | "PA15" | "PB3" | "PB4" | "PB5" => Some("spi1"),
+        "PB12" | "PB13" | "PB14" | "PB15" => Some("spi2"),
+        "PC10" | "PC11" | "PC12" => Some("spi3"),
+        _ => None,
+    }
+}
+
+/// STM32 `findPinFunction(board, pin, 'uart')` — the UART peripheral on the pin,
+/// from the STM32F103 base pin map (USART1 on PA9/PA10, USART2 on PA2/PA3,
+/// USART3 on PB10/PB11 & PC10/PC11). `None` for a non-STM32 board or an unmapped
+/// pin.
+fn find_uart_peripheral(board: &str, pin_label: &str) -> Option<&'static str> {
+    if !STM32_BOARDS.contains(&board) {
+        return None;
+    }
+    match pin_label.to_ascii_uppercase().as_str() {
+        "PA9" | "PA10" => Some("uart1"),
+        "PA2" | "PA3" => Some("uart2"),
+        "PB10" | "PB11" | "PC10" | "PC11" => Some("uart3"),
+        _ => None,
+    }
+}
+
+/// STM32 `findPinFunction(board, pin, 'can')` → `(peripheral, role)` — the CAN
+/// function on the pin, from the STM32F103 base pin map (bxCAN1 RX on PA11, TX
+/// on PA12). `None` for a non-STM32 board or an unmapped pin.
+fn find_can_function(board: &str, pin_label: &str) -> Option<(&'static str, &'static str)> {
+    if !STM32_BOARDS.contains(&board) {
+        return None;
+    }
+    match pin_label.to_ascii_uppercase().as_str() {
+        "PA11" => Some(("bxcan1", "rx")),
+        "PA12" => Some(("bxcan1", "tx")),
+        _ => None,
+    }
+}
+
+/// STM32 `findPinFunction(board, pin, 'adc')` — the ADC controller on the pin,
+/// from the STM32F103 base pin map (ADC1 on PA0–PA7, PB0/PB1, PC0–PC5). The
+/// emitter only needs the peripheral name; L476's differing ADC *channel*
+/// numbers are irrelevant here. `None` for a non-STM32 board or an unmapped pin.
+fn find_adc_peripheral(board: &str, pin_label: &str) -> Option<&'static str> {
+    if !STM32_BOARDS.contains(&board) {
+        return None;
+    }
+    match pin_label.to_ascii_uppercase().as_str() {
+        "PA0" | "PA1" | "PA2" | "PA3" | "PA4" | "PA5" | "PA6" | "PA7" | "PB0" | "PB1" | "PC0"
+        | "PC1" | "PC2" | "PC3" | "PC4" | "PC5" => Some("adc1"),
+        _ => None,
+    }
+}
+
+/// The SPI peripheral for a device's clock wire (port of `spiPeripheralForPart`):
+/// the first of `CLK`/`SCK`/`DIN`/`MOSI` whose wired MCU pin has an SPI function.
+fn spi_peripheral_for_part(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+) -> Option<String> {
+    for pin_id in ["CLK", "SCK", "DIN", "MOSI"] {
+        if let Some(mcu_pin) = mcu_pin_for_part_pin(wires, mcu_id, part_id, pin_id) {
+            if let Some(p) = find_spi_peripheral(board, mcu_pin) {
+                return Some(p.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// The UART peripheral for a device's RX/TX wire (port of `uartPeripheralForPart`).
+fn uart_peripheral_for_part(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+) -> Option<String> {
+    for pin_id in ["RX", "TX"] {
+        if let Some(mcu_pin) = mcu_pin_for_part_pin(wires, mcu_id, part_id, pin_id) {
+            if let Some(p) = find_uart_peripheral(board, mcu_pin) {
+                return Some(p.to_string());
+            }
+        }
+    }
+    None
+}
+
+// --- Net-based traversal (port of the wire-graph helpers in emitters.ts) -----
+
+/// Every endpoint reachable from `start` over the undirected wire graph,
+/// including `start` itself (port of `connectedEndpoints` — a BFS over both wire
+/// directions). Endpoints are `(part, pin)` pairs; visitation order matches the
+/// TS BFS (FIFO queue, adjacency lists built in wire order, `from→to` then
+/// `to→from` per wire).
+fn connected_endpoints(wires: &[Wire], start_part: &str, start_pin: &str) -> Vec<(String, String)> {
+    let key = |part: &str, pin: &str| format!("{part}:{pin}");
+    let mut by_key: std::collections::HashMap<String, Vec<(String, String)>> =
+        std::collections::HashMap::new();
+    let mut add_edge = |a: (&str, &str), b: (&str, &str)| {
+        by_key
+            .entry(key(a.0, a.1))
+            .or_default()
+            .push((b.0.to_string(), b.1.to_string()));
+    };
+    for w in wires {
+        add_edge((&w.from_part, &w.from_pin), (&w.to_part, &w.to_pin));
+        add_edge((&w.to_part, &w.to_pin), (&w.from_part, &w.from_pin));
+    }
+
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut queue: std::collections::VecDeque<(String, String)> = std::collections::VecDeque::new();
+    queue.push_back((start_part.to_string(), start_pin.to_string()));
+    while let Some(endpoint) = queue.pop_front() {
+        let k = key(&endpoint.0, &endpoint.1);
+        if seen.contains(&k) {
+            continue;
+        }
+        seen.insert(k.clone());
+        if let Some(neighbours) = by_key.get(&k) {
+            for n in neighbours {
+                if !seen.contains(&key(&n.0, &n.1)) {
+                    queue.push_back(n.clone());
+                }
+            }
+        }
+        out.push(endpoint);
+    }
+    out
+}
+
+/// MCU pins on the same net as `part_id:pin_id` (port of `mcuPinsOnNet`).
+fn mcu_pins_on_net(wires: &[Wire], mcu_id: &str, part_id: &str, pin_id: &str) -> Vec<String> {
+    connected_endpoints(wires, part_id, pin_id)
+        .into_iter()
+        .filter(|(part, _)| part == mcu_id)
+        .map(|(_, pin)| pin)
+        .collect()
+}
+
+/// The CAN peripheral bridged by a `can-transceiver` (port of
+/// `canPeripheralForTransceiver`): TXD must reach exactly one CAN-`tx` peripheral
+/// and RXD exactly one CAN-`rx`, and they must agree.
+fn can_peripheral_for_transceiver(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+) -> Option<String> {
+    let peripheral_for = |pin_id: &str, role: &str| -> Option<String> {
+        let mut matches: HashSet<String> = HashSet::new();
+        for mcu_pin in mcu_pins_on_net(wires, mcu_id, part_id, pin_id) {
+            if let Some((periph, r)) = find_can_function(board, &mcu_pin) {
+                if r == role {
+                    matches.insert(periph.to_string());
+                }
+            }
+        }
+        if matches.len() == 1 {
+            matches.into_iter().next()
+        } else {
+            None
+        }
+    };
+    let tx = peripheral_for("TXD", "tx");
+    let rx = peripheral_for("RXD", "rx");
+    match (tx, rx) {
+        (Some(tx), Some(rx)) if tx == rx => Some(tx),
+        _ => None,
+    }
+}
+
+/// The CAN peripheral a diagnostic tool observes, via a wired `can-transceiver`
+/// (port of `canPeripheralForDiagnosticTool`).
+fn can_peripheral_for_diagnostic_tool(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    parts: &[CanonicalPart],
+    part_id: &str,
+) -> Option<String> {
+    for pin_id in ["CAN_H", "CAN_L"] {
+        for (ep_part, ep_pin) in connected_endpoints(wires, part_id, pin_id) {
+            let Some(part) = parts.iter().find(|p| p.id == ep_part) else {
+                continue;
+            };
+            if part.r#type != "can-transceiver" {
+                continue;
+            }
+            if ep_pin != "CAN_H" && ep_pin != "CAN_L" {
+                continue;
+            }
+            if let Some(p) = can_peripheral_for_transceiver(board, wires, mcu_id, &ep_part) {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// The UART peripheral an `iolink-transceiver`'s TXD/RXD reach (port of
+/// `uartPeripheralForIolinkTransceiver`): exactly one UART across both pins.
+fn uart_peripheral_for_iolink_transceiver(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+) -> Option<String> {
+    let mut matches: HashSet<String> = HashSet::new();
+    for pin_id in ["TXD", "RXD"] {
+        for mcu_pin in mcu_pins_on_net(wires, mcu_id, part_id, pin_id) {
+            if let Some(u) = find_uart_peripheral(board, &mcu_pin) {
+                matches.insert(u.to_string());
+            }
+        }
+    }
+    if matches.len() == 1 {
+        matches.into_iter().next()
+    } else {
+        None
+    }
+}
+
+/// The UART peripheral for an `iolink-master` (port of
+/// `uartPeripheralForIolinkMaster`): a direct RX/TX wire, else via a wired
+/// `iolink-transceiver`'s CQ line.
+fn uart_peripheral_for_iolink_master(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    parts: &[CanonicalPart],
+    part_id: &str,
+) -> Option<String> {
+    if let Some(direct) = uart_peripheral_for_part(board, wires, mcu_id, part_id) {
+        return Some(direct);
+    }
+    for pin_id in ["TX", "RX"] {
+        for (ep_part, ep_pin) in connected_endpoints(wires, part_id, pin_id) {
+            let Some(part) = parts.iter().find(|p| p.id == ep_part) else {
+                continue;
+            };
+            if part.r#type != "iolink-transceiver" {
+                continue;
+            }
+            if ep_pin != "CQ" {
+                continue;
+            }
+            if let Some(u) = uart_peripheral_for_iolink_transceiver(board, wires, mcu_id, &ep_part)
+            {
+                return Some(u);
+            }
+        }
+    }
+    None
+}
+
+/// `String(attrs[key])`-style lookup: a string attr verbatim, any other JSON
+/// value stringified (mirrors `attrsToStringMap` + `String(v)`). `None` when
+/// absent.
+fn attr_string(part: &CanonicalPart, key: &str) -> Option<String> {
+    let v = part.attrs.as_ref()?.get(key)?;
+    Some(match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        other => other.to_string(),
+    })
 }
 
 /// Emit the `external_devices` + `board_io` fragments for a legacy I²C device
@@ -529,10 +884,217 @@ fn emit_legacy_i2c_device(
     (external_device, board_io)
 }
 
-/// Emit `board_io` entries for point-to-point GPIO wires (port of
-/// `emitBoardIoFromWires`). Skips parts owned by the special/I²C/SPI emitters,
-/// and parts with no `board_io` kind. ADC-input peripheral remapping is a Phase
-/// 2b TODO (rejected upstream), so `signal` is `input` only for buttons.
+/// Format a numeric attr value the way the TS `${n}` template literal does:
+/// integers without a decimal point, non-integers via Rust's default `f64`
+/// formatting (adequate for the values these emitters produce).
+fn format_js_number(n: f64) -> String {
+    if n.fract() == 0.0 && n.is_finite() {
+        format!("{}", n as i64)
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Emit the `external_devices` fragment for an ultrasonic part (port of
+/// `emitUltrasonic`). `distance_cm` defaults to 100; `cpu_hz` is 250000 on
+/// stm32l476, else 80000000. Never emits `board_io` (ultrasonic is in the
+/// wire-emitter skip set).
+fn emit_ultrasonic(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part: &CanonicalPart,
+) -> (Option<String>, Option<String>) {
+    let trig = mcu_pin_for_part_pin(wires, mcu_id, &part.id, "TRIG");
+    let echo = mcu_pin_for_part_pin(wires, mcu_id, &part.id, "ECHO");
+    let (Some(trig), Some(echo)) = (trig, echo) else {
+        return (None, None);
+    };
+    let distance_cm = attr_string(part, "distance")
+        .and_then(|s| s.trim().parse::<f64>().ok())
+        .filter(|d| d.is_finite())
+        .unwrap_or(100.0);
+    let cpu_hz = if board == "stm32l476" {
+        250_000
+    } else {
+        80_000_000
+    };
+    let ext = format!(
+        "  - id: \"{}\"\n    type: \"hc-sr04\"\n    connection: \"gpio\"\n    config:\n      trig_pin: \"{trig}\"\n      echo_pin: \"{echo}\"\n      distance_cm: {}\n      cpu_hz: {cpu_hz}",
+        part.id,
+        format_js_number(distance_cm)
+    );
+    (Some(ext), None)
+}
+
+/// Emit the `external_devices` + `board_io` fragments for a pcd8544 part (port of
+/// `emitPcd8544`).
+fn emit_pcd8544(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+) -> (Option<String>, Option<String>) {
+    let connection = spi_peripheral_for_part(board, wires, mcu_id, part_id);
+    let cs_pin = mcu_pin_for_part_pin(wires, mcu_id, part_id, "CE");
+    let dc_pin = mcu_pin_for_part_pin(wires, mcu_id, part_id, "DC");
+    let (Some(connection), Some(cs_pin), Some(dc_pin)) = (connection, cs_pin, dc_pin) else {
+        return (None, None);
+    };
+    let ext = format!(
+        "  - id: \"{part_id}\"\n    type: \"pcd8544\"\n    connection: \"{connection}\"\n    config:\n      cs_pin: \"{cs_pin}\"\n      dc_pin: \"{dc_pin}\""
+    );
+    let bio = parse_mcu_pin(cs_pin).map(|(_, pin)| {
+        format!(
+            "  - id: \"{part_id}\"\n    kind: \"spi_device\"\n    peripheral: \"{connection}\"\n    pin: {pin}\n    signal: \"input\"\n    active_high: true\n    device_type: \"pcd8544\""
+        )
+    });
+    (Some(ext), bio)
+}
+
+/// Emit the `external_devices` fragment for a sn74hc165 part (port of
+/// `emitSn74hc165`). `inputs` defaults to 165.
+fn emit_sn74hc165(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part: &CanonicalPart,
+) -> (Option<String>, Option<String>) {
+    let connection = spi_peripheral_for_part(board, wires, mcu_id, &part.id);
+    let cs_pin = mcu_pin_for_part_pin(wires, mcu_id, &part.id, "SH_LD");
+    let (Some(connection), Some(cs_pin)) = (connection, cs_pin) else {
+        return (None, None);
+    };
+    // Number.parseInt(attrs.inputs ?? '165', 10) || 165: a 0/NaN parse falls
+    // back to 165.
+    let inputs = attr_string(part, "inputs")
+        .and_then(|s| parse_int_prefix(&s))
+        .filter(|&n| n != 0)
+        .unwrap_or(165);
+    let ext = format!(
+        "  - id: \"{}\"\n    type: \"sn74hc165\"\n    connection: \"{connection}\"\n    config:\n      cs_pin: \"{cs_pin}\"\n      inputs: {inputs}",
+        part.id
+    );
+    (Some(ext), None)
+}
+
+/// Emit the `external_devices` fragment for an iolink-master part (port of
+/// `emitIolinkMaster`).
+fn emit_iolink_master(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    parts: &[CanonicalPart],
+    part_id: &str,
+) -> (Option<String>, Option<String>) {
+    let Some(connection) = uart_peripheral_for_iolink_master(board, wires, mcu_id, parts, part_id)
+    else {
+        return (None, None);
+    };
+    let ext = format!(
+        "  - id: \"{part_id}\"\n    type: \"iolink-master\"\n    connection: \"{connection}\"\n    config:\n      pd_in_len: 1\n      m_seq_type: 1\n      com: \"COM2\""
+    );
+    (Some(ext), None)
+}
+
+/// Emit the `external_devices` + `board_io` fragments for an SPI device from the
+/// [`SPI_DEVICE_TYPES`] set (port of `emitSpiDevice`).
+fn emit_spi_device(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+    part_type: &str,
+) -> (Option<String>, Option<String>) {
+    let connection = spi_peripheral_for_part(board, wires, mcu_id, part_id);
+    let cs_pin = mcu_pin_for_part_pin(wires, mcu_id, part_id, "CS");
+    let (Some(connection), Some(cs_pin)) = (connection, cs_pin) else {
+        return (None, None);
+    };
+    let ext = format!(
+        "  - id: \"{part_id}\"\n    type: \"{part_type}\"\n    connection: \"{connection}\"\n    config:\n      cs_pin: \"{cs_pin}\""
+    );
+    let bio = parse_mcu_pin(cs_pin).map(|(_, pin)| {
+        format!(
+            "  - id: \"{part_id}\"\n    kind: \"spi_device\"\n    peripheral: \"{connection}\"\n    pin: {pin}\n    signal: \"input\"\n    active_high: true\n    device_type: \"{part_type}\""
+        )
+    });
+    (Some(ext), bio)
+}
+
+/// Emit the `external_devices` + `board_io` fragments for a neo6m-gps part (port
+/// of `emitNeo6mGps`).
+fn emit_neo6m_gps(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    part_id: &str,
+) -> (Option<String>, Option<String>) {
+    let Some(connection) = uart_peripheral_for_part(board, wires, mcu_id, part_id) else {
+        return (None, None);
+    };
+    let ext = format!(
+        "  - id: \"{part_id}\"\n    type: \"neo6m-gps\"\n    connection: \"{connection}\"\n    config: {{}}"
+    );
+    let bio = format!(
+        "  - id: \"{part_id}\"\n    kind: \"uart_device\"\n    peripheral: \"{connection}\"\n    pin: 0\n    signal: \"input\"\n    active_high: true\n    device_type: \"neo6m-gps\""
+    );
+    (Some(ext), Some(bio))
+}
+
+/// Emit the `external_devices` fragment for an off-board CAN diagnostic tester
+/// (port of `emitCanDiagnosticTool`). `request_id`/`request_data` default to
+/// `0x7E0` / `03 22 F1 90`.
+fn emit_can_diagnostic_tool(
+    board: &str,
+    wires: &[Wire],
+    mcu_id: &str,
+    parts: &[CanonicalPart],
+    part: &CanonicalPart,
+) -> (Option<String>, Option<String>) {
+    let Some(connection) =
+        can_peripheral_for_diagnostic_tool(board, wires, mcu_id, parts, &part.id)
+    else {
+        return (None, None);
+    };
+    let request_id = attr_string(part, "request_id").unwrap_or_else(|| "0x7E0".to_string());
+    let request_data =
+        attr_string(part, "request_data").unwrap_or_else(|| "03 22 F1 90".to_string());
+    let ext = format!(
+        "  - id: \"{}\"\n    type: \"can-diagnostic-tester\"\n    connection: \"{connection}\"\n    config:\n      request_id: \"{request_id}\"\n      request_data: \"{request_data}\"",
+        part.id
+    );
+    (Some(ext), None)
+}
+
+/// JS `Number.parseInt(s, 10)`-style leading-integer parse: reads an optional
+/// sign then the leading decimal digits, ignoring trailing junk. `None` when no
+/// digits lead (JS `NaN`).
+fn parse_int_prefix(s: &str) -> Option<i64> {
+    let s = s.trim_start();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut neg = false;
+    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+        neg = bytes[i] == b'-';
+        i += 1;
+    }
+    let start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == start {
+        return None;
+    }
+    let n: i64 = s[start..i].parse().ok()?;
+    Some(if neg { -n } else { n })
+}
+
+/// Emit `board_io` entries for point-to-point wires (port of
+/// `emitBoardIoFromWires`). Skips parts owned by the dedicated emitters, the
+/// legacy I²C set and the [`SPI_DEVICE_TYPES`] set, then emits whatever
+/// `board_io_kind` remains for any other wired part. For an `adc_input` part the
+/// peripheral is remapped to the pin's ADC controller when the pin has one.
 fn emit_board_io_from_wires(
     board: &str,
     wires: &[Wire],
@@ -549,10 +1111,7 @@ fn emit_board_io_from_wires(
         "can-transceiver",
         "can-diagnostic-tool",
     ];
-    // SPI devices addressed by their own emitter (port of `SPI_DEVICE_TYPES`).
-    const SPI_DEVICE_TYPES: &[&str] = &["ili9341", "max31855", "ssd1680_tricolor_290"];
 
-    let _ = board; // ADC remap (the only board-dependent branch) is Phase 2b.
     let mut entries = Vec::new();
 
     for wire in wires {
@@ -580,10 +1139,19 @@ fn emit_board_io_from_wires(
         let Some(kind) = board_io_kind(t) else {
             continue;
         };
-        let Some((peripheral, pin)) = parse_mcu_pin(mcu_pin) else {
+        let Some((mut peripheral, pin)) = parse_mcu_pin(mcu_pin) else {
             continue;
         };
-        let signal = if kind == "button" { "input" } else { "output" };
+        let signal = if kind == "button" || kind == "adc_input" {
+            "input"
+        } else {
+            "output"
+        };
+        if kind == "adc_input" {
+            if let Some(adc) = find_adc_peripheral(board, mcu_pin) {
+                peripheral = adc.to_string();
+            }
+        }
         entries.push(format!(
             "  - id: \"{}\"\n    kind: \"{kind}\"\n    peripheral: \"{peripheral}\"\n    pin: {pin}\n    signal: \"{signal}\"\n    active_high: true",
             part.id
@@ -840,8 +1408,323 @@ board_io:
     active_high: true
 "#;
 
-    /// THE Phase 2a parity gate: for each Phase 1 fixture, the Rust `resolve()`
-    /// must produce the exact `systemYaml` the TS oracle emits (byte-for-byte).
+    // -----------------------------------------------------------------------
+    // Phase 2b fixtures: one per newly-ported emitter. Each FIXTURE_* is the
+    // verbatim JSON from packages/board-config/test/fixtures/canonical/*.json and
+    // each EXPECTED_* the verbatim oracle snapshot from that package's
+    // test/__snapshots__/canonical.test.ts.snap.
+    // -----------------------------------------------------------------------
+
+    const FIXTURE_SPI_ILI9341: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "disp", "type": "ili9341" }
+      ],
+      "connections": [
+        ["mcu:PA5", "disp:SCK"],
+        ["mcu:PA7", "disp:MOSI"],
+        ["mcu:PA4", "disp:CS"],
+        ["mcu:3V3", "disp:VCC"],
+        ["mcu:GND", "disp:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_SPI_ILI9341: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "disp"
+    type: "ili9341"
+    connection: "spi1"
+    config:
+      cs_pin: "PA4"
+board_io:
+  - id: "disp"
+    kind: "spi_device"
+    peripheral: "spi1"
+    pin: 4
+    signal: "input"
+    active_high: true
+    device_type: "ili9341"
+"#;
+
+    const FIXTURE_SPI_MAX31855: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "tc", "type": "max31855" }
+      ],
+      "connections": [
+        ["mcu:PA5", "tc:SCK"],
+        ["mcu:PA6", "tc:MISO"],
+        ["mcu:PA4", "tc:CS"],
+        ["mcu:3V3", "tc:VCC"],
+        ["mcu:GND", "tc:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_SPI_MAX31855: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "tc"
+    type: "max31855"
+    connection: "spi1"
+    config:
+      cs_pin: "PA4"
+board_io:
+  - id: "tc"
+    kind: "spi_device"
+    peripheral: "spi1"
+    pin: 4
+    signal: "input"
+    active_high: true
+    device_type: "max31855"
+"#;
+
+    const FIXTURE_SPI_SSD1680: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "epd", "type": "ssd1680_tricolor_290" }
+      ],
+      "connections": [
+        ["mcu:PA5", "epd:CLK"],
+        ["mcu:PA7", "epd:DIN"],
+        ["mcu:PA4", "epd:CS"],
+        ["mcu:3V3", "epd:VCC"],
+        ["mcu:GND", "epd:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_SPI_SSD1680: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "epd"
+    type: "ssd1680_tricolor_290"
+    connection: "spi1"
+    config:
+      cs_pin: "PA4"
+board_io:
+  - id: "epd"
+    kind: "spi_device"
+    peripheral: "spi1"
+    pin: 4
+    signal: "input"
+    active_high: true
+    device_type: "ssd1680_tricolor_290"
+"#;
+
+    const FIXTURE_ULTRASONIC: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "dist", "type": "ultrasonic" }
+      ],
+      "connections": [
+        ["mcu:PA0", "dist:TRIG"],
+        ["mcu:PA1", "dist:ECHO"],
+        ["mcu:3V3", "dist:VCC"],
+        ["mcu:GND", "dist:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_ULTRASONIC: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "dist"
+    type: "hc-sr04"
+    connection: "gpio"
+    config:
+      trig_pin: "PA0"
+      echo_pin: "PA1"
+      distance_cm: 100
+      cpu_hz: 80000000
+board_io:
+  []
+"#;
+
+    const FIXTURE_PCD8544: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "lcd", "type": "pcd8544" }
+      ],
+      "connections": [
+        ["mcu:PA5", "lcd:CLK"],
+        ["mcu:PA7", "lcd:DIN"],
+        ["mcu:PA4", "lcd:CE"],
+        ["mcu:PA3", "lcd:DC"],
+        ["mcu:3V3", "lcd:VCC"],
+        ["mcu:GND", "lcd:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_PCD8544: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "lcd"
+    type: "pcd8544"
+    connection: "spi1"
+    config:
+      cs_pin: "PA4"
+      dc_pin: "PA3"
+board_io:
+  - id: "lcd"
+    kind: "spi_device"
+    peripheral: "spi1"
+    pin: 4
+    signal: "input"
+    active_high: true
+    device_type: "pcd8544"
+"#;
+
+    const FIXTURE_SN74HC165: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "sr", "type": "sn74hc165" }
+      ],
+      "connections": [
+        ["mcu:PA5", "sr:CLK"],
+        ["mcu:PA6", "sr:QH"],
+        ["mcu:PA4", "sr:SH_LD"],
+        ["mcu:3V3", "sr:VCC"],
+        ["mcu:GND", "sr:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_SN74HC165: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "sr"
+    type: "sn74hc165"
+    connection: "spi1"
+    config:
+      cs_pin: "PA4"
+      inputs: 165
+board_io:
+  []
+"#;
+
+    const FIXTURE_IOLINK_MASTER: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "iol", "type": "iolink-master" }
+      ],
+      "connections": [
+        ["mcu:PA3", "iol:RX"],
+        ["mcu:PA2", "iol:TX"],
+        ["mcu:3V3", "iol:VCC"],
+        ["mcu:GND", "iol:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_IOLINK_MASTER: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "iol"
+    type: "iolink-master"
+    connection: "uart2"
+    config:
+      pd_in_len: 1
+      m_seq_type: 1
+      com: "COM2"
+board_io:
+  []
+"#;
+
+    const FIXTURE_NEO6M_GPS: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "gps", "type": "neo6m-gps" }
+      ],
+      "connections": [
+        ["mcu:PA3", "gps:RX"],
+        ["mcu:PA2", "gps:TX"],
+        ["mcu:3V3", "gps:VCC"],
+        ["mcu:GND", "gps:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_NEO6M_GPS: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "gps"
+    type: "neo6m-gps"
+    connection: "uart2"
+    config: {}
+board_io:
+  - id: "gps"
+    kind: "uart_device"
+    peripheral: "uart2"
+    pin: 0
+    signal: "input"
+    active_high: true
+    device_type: "neo6m-gps"
+"#;
+
+    const FIXTURE_CAN_DIAGNOSTIC_TOOL: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "tc", "type": "can-transceiver" },
+        { "id": "diag", "type": "can-diagnostic-tool" }
+      ],
+      "connections": [
+        ["mcu:PA12", "tc:TXD"],
+        ["mcu:PA11", "tc:RXD"],
+        ["tc:CAN_H", "diag:CAN_H"],
+        ["tc:CAN_L", "diag:CAN_L"],
+        ["mcu:3V3", "tc:VCC"],
+        ["mcu:GND", "tc:GND"]
+      ]
+    }"#;
+
+    const EXPECTED_CAN_DIAGNOSTIC_TOOL: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  - id: "diag"
+    type: "can-diagnostic-tester"
+    connection: "bxcan1"
+    config:
+      request_id: "0x7E0"
+      request_data: "03 22 F1 90"
+board_io:
+  []
+"#;
+
+    const FIXTURE_ADC_INPUT: &str = r#"{
+      "version": 1,
+      "parts": [
+        { "id": "mcu", "type": "nucleo-f401re" },
+        { "id": "pot", "type": "potentiometer" }
+      ],
+      "connections": [
+        ["mcu:PA0", "pot:W"],
+        ["mcu:3V3", "pot:1"],
+        ["mcu:GND", "pot:2"]
+      ]
+    }"#;
+
+    const EXPECTED_ADC_INPUT: &str = r#"name: "playground-board"
+chip: "inline"
+external_devices:
+  []
+board_io:
+  - id: "pot"
+    kind: "adc_input"
+    peripheral: "adc1"
+    pin: 0
+    signal: "input"
+    active_high: true
+"#;
+
+    /// THE parity gate: for each fixture, the Rust `resolve()` must produce the
+    /// exact `systemYaml` the TS oracle emits (byte-for-byte). Every fixture
+    /// under packages/board-config/test/fixtures/canonical/*.json that has a
+    /// board in CHIP_YAMLS (so the oracle can resolve it) is covered here.
     #[test]
     fn resolve_matches_ts_oracle() {
         for (name, fixture, expected) in [
@@ -852,6 +1735,24 @@ board_io:
                 FIXTURE_I2C_OLED_AND_LED,
                 EXPECTED_I2C_OLED_AND_LED,
             ),
+            ("spi-ili9341", FIXTURE_SPI_ILI9341, EXPECTED_SPI_ILI9341),
+            ("spi-max31855", FIXTURE_SPI_MAX31855, EXPECTED_SPI_MAX31855),
+            ("spi-ssd1680", FIXTURE_SPI_SSD1680, EXPECTED_SPI_SSD1680),
+            ("ultrasonic", FIXTURE_ULTRASONIC, EXPECTED_ULTRASONIC),
+            ("pcd8544", FIXTURE_PCD8544, EXPECTED_PCD8544),
+            ("sn74hc165", FIXTURE_SN74HC165, EXPECTED_SN74HC165),
+            (
+                "iolink-master",
+                FIXTURE_IOLINK_MASTER,
+                EXPECTED_IOLINK_MASTER,
+            ),
+            ("neo6m-gps", FIXTURE_NEO6M_GPS, EXPECTED_NEO6M_GPS),
+            (
+                "can-diagnostic-tool",
+                FIXTURE_CAN_DIAGNOSTIC_TOOL,
+                EXPECTED_CAN_DIAGNOSTIC_TOOL,
+            ),
+            ("adc-input", FIXTURE_ADC_INPUT, EXPECTED_ADC_INPUT),
         ] {
             let cfg = CanonicalConfig::from_json(fixture)
                 .unwrap_or_else(|e| panic!("{name}: fixture failed to parse/validate: {e}"));
@@ -862,10 +1763,29 @@ board_io:
         }
     }
 
-    /// Part types handled by an unported Phase 2b emitter (or otherwise outside
-    /// the subset) must surface a clear error, not a silently-wrong config.
+    /// Like the TS oracle, `resolve()` is total over part types: a passive/tool
+    /// bridge part (here `can-transceiver`) contributes nothing on its own and is
+    /// never an error, and a bus device whose clock pin has no SPI function on the
+    /// board stays unbound (emits nothing) rather than erroring.
     #[test]
-    fn resolve_rejects_unported_part_types() {
+    fn resolve_ignores_unhandled_and_unbound_parts() {
+        // A lone can-transceiver: no MCU-side CAN wiring, so it yields an empty
+        // config — not an error.
+        let json = r#"{
+          "version": 1,
+          "parts": [
+            { "id": "mcu", "type": "nucleo-f401re" },
+            { "id": "tc", "type": "can-transceiver" }
+          ],
+          "connections": [["mcu:PB9", "tc:TXD"]]
+        }"#;
+        let cfg = CanonicalConfig::from_json(json).unwrap();
+        let yaml = cfg.resolve().expect("should resolve, not error");
+        assert!(yaml.contains("external_devices:\n  []"), "got {yaml:?}");
+        assert!(yaml.contains("board_io:\n  []"), "got {yaml:?}");
+
+        // An ili9341 whose only wire is CS (no SPI clock pin) → spiPeripheralForPart
+        // returns null → emitSpiDevice emits nothing. Faithful to the oracle.
         let json = r#"{
           "version": 1,
           "parts": [
@@ -875,11 +1795,8 @@ board_io:
           "connections": [["mcu:PB9", "disp:CS"]]
         }"#;
         let cfg = CanonicalConfig::from_json(json).unwrap();
-        let err = cfg.resolve().unwrap_err();
-        assert!(
-            matches!(err, CanonicalError::UnsupportedInPhase2a(ref t) if t == "ili9341"),
-            "got {err:?}"
-        );
+        let yaml = cfg.resolve().expect("should resolve, not error");
+        assert!(yaml.contains("external_devices:\n  []"), "got {yaml:?}");
     }
 
     /// A config with no MCU part is rejected (mirrors `canonicalToDiagramV1`).

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -18,7 +18,15 @@ use std::sync::Arc;
 /// drops from ~380M instructions to a few million.
 const CYCLE_SCALE: u64 = 256;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Copy)]
+pub struct RiscVDecodeCacheEntry {
+    pub tag: u32,
+    pub opcode: u32,
+    pub instruction: Instruction,
+    pub inst_len: u8,
+}
+
+#[derive(Debug)]
 pub struct RiscV {
     pub x: [u32; 32], // x0..x31. x0 is correctly hardwired to 0 in logic.
     pub pc: u32,
@@ -42,6 +50,29 @@ pub struct RiscV {
     /// hart any intervening store (including any AMO*) invalidates the
     /// reservation per RISC-V ISA §8.2.
     pub reservation: Option<u32>,
+
+    decode_cache: Box<[Option<RiscVDecodeCacheEntry>; 4096]>,
+}
+
+impl Default for RiscV {
+    fn default() -> Self {
+        Self {
+            x: [0; 32],
+            pc: 0,
+            mstatus: 0,
+            mie: 0,
+            mip: 0,
+            mtvec: 0,
+            mscratch: 0,
+            mepc: 0,
+            mcause: 0,
+            mtval: 0,
+            mtime: 0,
+            mtimecmp: 0,
+            reservation: None,
+            decode_cache: Box::new([None; 4096]),
+        }
+    }
 }
 
 impl RiscV {
@@ -162,8 +193,28 @@ impl Cpu for RiscV {
             observer.on_step_start(self.pc, opcode);
         }
 
-        let instruction = decode_rv32(opcode);
-        let inst_len = if (opcode & 0x3) == 0x3 { 4 } else { 2 };
+        let cache_idx = ((self.pc >> 1) & 0xFFF) as usize;
+        let cached = if _config.decode_cache_enabled {
+            self.decode_cache[cache_idx]
+                .filter(|entry| entry.tag == self.pc && entry.opcode == opcode)
+        } else {
+            None
+        };
+        let (instruction, inst_len) = if let Some(entry) = cached {
+            (entry.instruction, entry.inst_len as u32)
+        } else {
+            let instruction = decode_rv32(opcode);
+            let inst_len = if (opcode & 0x3) == 0x3 { 4 } else { 2 };
+            if _config.decode_cache_enabled {
+                self.decode_cache[cache_idx] = Some(RiscVDecodeCacheEntry {
+                    tag: self.pc,
+                    opcode,
+                    instruction,
+                    inst_len: inst_len as u8,
+                });
+            }
+            (instruction, inst_len)
+        };
         tracing::debug!(
             "PC={:#x}, Op={:#08x}, Instr={:?}, Len={}",
             self.pc,
@@ -1342,5 +1393,35 @@ mod tests {
 
         assert_eq!(machine.cpu.read_reg(10), 42);
         assert_eq!(machine.cpu.pc, 12); // 4 + 4 + 2 + 2 = 12
+    }
+
+    #[test]
+    fn riscv_decode_cache_uses_opcode_tag_for_same_pc_changes() {
+        let mut bus = SystemBus::new();
+        let mut cpu = RiscV::new();
+        bus.flash.data = vec![
+            0x93, 0x00, 0x10, 0x00, // ADDI x1, x0, 1
+        ];
+
+        cpu.pc = 0;
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.decode_cache_enabled = true;
+        machine.step().unwrap();
+
+        let cache_idx = ((0u32 >> 1) & 0xFFF) as usize;
+        let entry = machine.cpu.decode_cache[cache_idx].expect("first step caches decode");
+        assert_eq!(entry.tag, 0);
+        assert_eq!(entry.opcode, 0x0010_0093);
+        assert_eq!(machine.cpu.read_reg(1), 1);
+
+        machine.bus.flash.data = vec![
+            0x93, 0x00, 0x20, 0x00, // ADDI x1, x0, 2
+        ];
+        machine.cpu.pc = 0;
+        machine.step().unwrap();
+
+        let entry = machine.cpu.decode_cache[cache_idx].expect("second step refreshes decode");
+        assert_eq!(entry.opcode, 0x0020_0093);
+        assert_eq!(machine.cpu.read_reg(1), 2);
     }
 }

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -1406,9 +1406,10 @@ mod tests {
         cpu.pc = 0;
         let mut machine = Machine::new(cpu, bus);
         machine.config.decode_cache_enabled = true;
+        let initial_pc = machine.cpu.pc;
         machine.step().unwrap();
 
-        let cache_idx = ((0u32 >> 1) & 0xFFF) as usize;
+        let cache_idx = ((initial_pc >> 1) & 0xFFF) as usize;
         let entry = machine.cpu.decode_cache[cache_idx].expect("first step caches decode");
         assert_eq!(entry.tag, 0);
         assert_eq!(entry.opcode, 0x0010_0093);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -422,6 +422,24 @@ pub trait Peripheral: std::fmt::Debug + Send {
     /// polarity. Default no-op.
     fn observe_gpio_change(&mut self, _changes: &[(u8, u8, u8)]) {}
 
+    /// GPIO capability: read the firmware-visible input level for `pin`.
+    /// Non-GPIO peripherals return `None`.
+    fn read_gpio_input(&self, _pin: u8) -> Option<bool> {
+        None
+    }
+
+    /// GPIO capability: read the firmware-visible output latch for `pin`.
+    /// Non-GPIO peripherals return `None`.
+    fn read_gpio_output(&self, _pin: u8) -> Option<bool> {
+        None
+    }
+
+    /// GPIO capability: drive an externally controlled input level for `pin`
+    /// (e.g. browser button press). Returns `false` if unsupported.
+    fn set_gpio_input(&mut self, _pin: u8, _level: bool) -> bool {
+        false
+    }
+
     /// Bus-aware tick hook for peripherals that need to read or write the
     /// bus themselves (e.g. Easy DMA on RADIO). Default no-op.
     fn tick_with_bus(&mut self, _bus: &mut dyn Bus) {}

--- a/crates/core/src/peripherals/declarative.rs
+++ b/crates/core/src/peripherals/declarative.rs
@@ -171,6 +171,42 @@ impl GenericPeripheral {
         true
     }
 
+    fn gpio_reg_offset(&self, id: &str) -> Option<usize> {
+        if !self.descriptor.peripheral.eq_ignore_ascii_case("GPIO") {
+            return None;
+        }
+        self.descriptor
+            .registers
+            .iter()
+            .find(|r| r.id == id && r.size == 32)
+            .map(|r| r.address_offset as usize)
+    }
+
+    fn read_register_storage_u32(&self, offset: usize) -> Option<u32> {
+        let data = self.data.borrow();
+        if offset + 3 >= data.len() {
+            return None;
+        }
+        Some(
+            (data[offset] as u32)
+                | ((data[offset + 1] as u32) << 8)
+                | ((data[offset + 2] as u32) << 16)
+                | ((data[offset + 3] as u32) << 24),
+        )
+    }
+
+    fn write_register_storage_u32(&self, offset: usize, value: u32) -> bool {
+        let mut data = self.data.borrow_mut();
+        if offset + 3 >= data.len() {
+            return false;
+        }
+        data[offset] = (value & 0xFF) as u8;
+        data[offset + 1] = ((value >> 8) & 0xFF) as u8;
+        data[offset + 2] = ((value >> 16) & 0xFF) as u8;
+        data[offset + 3] = ((value >> 24) & 0xFF) as u8;
+        true
+    }
+
     /// Apply any stuck bits that fall on the byte at `offset` to a read value.
     fn apply_stuck_byte(&self, offset: u64, mut byte: u8) -> u8 {
         for s in self.stuck_bits.borrow().iter() {
@@ -547,6 +583,42 @@ impl Peripheral for GenericPeripheral {
             "peripheral": self.descriptor.peripheral,
             "data": *self.data.borrow()
         })
+    }
+
+    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let offset = self.gpio_reg_offset("IN")?;
+        let value = self.read_register_storage_u32(offset)?;
+        Some((value & (1u32 << pin)) != 0)
+    }
+
+    fn read_gpio_output(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let offset = self.gpio_reg_offset("OUT")?;
+        let value = self.read_register_storage_u32(offset)?;
+        Some((value & (1u32 << pin)) != 0)
+    }
+
+    fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
+        if pin >= 32 {
+            return false;
+        }
+        let Some(offset) = self.gpio_reg_offset("IN") else {
+            return false;
+        };
+        let Some(mut value) = self.read_register_storage_u32(offset) else {
+            return false;
+        };
+        if level {
+            value |= 1u32 << pin;
+        } else {
+            value &= !(1u32 << pin);
+        }
+        self.write_register_storage_u32(offset, value)
     }
 
     /// Expose the descriptor's register layout to the universal inspect

--- a/crates/core/src/peripherals/esp32/gpio.rs
+++ b/crates/core/src/peripherals/esp32/gpio.rs
@@ -245,15 +245,36 @@ impl Peripheral for Esp32Gpio {
     }
 
     fn snapshot(&self) -> serde_json::Value {
-        // ODR-shaped snapshot lets the WasmSimulator board_io polling path
-        // read GPIO output state via the same {"odr": <bits>} contract used
-        // by STM32 GPIO ports — no special-casing in JS.
+        // Keep the public snapshot compact and human-readable. Browser board_io
+        // uses the GPIO capability methods below, not these field names.
         serde_json::json!({
             "layout": "esp32_classic",
             "odr": self.out,
             "idr": self.in_data,
             "enable": self.enable,
         })
+    }
+
+    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        Some((self.in_data & (1u32 << pin)) != 0)
+    }
+
+    fn read_gpio_output(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        Some((self.out & (1u32 << pin)) != 0)
+    }
+
+    fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
+        if pin >= 32 {
+            return false;
+        }
+        self.set_pin_input(pin, level);
+        true
     }
 
     fn tick(&mut self) -> PeripheralTickResult {

--- a/crates/core/src/peripherals/esp32s3/gpio.rs
+++ b/crates/core/src/peripherals/esp32s3/gpio.rs
@@ -356,6 +356,28 @@ impl Peripheral for Esp32s3Gpio {
         PeripheralTickResult::default()
     }
 
+    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        Some((self.in_data & (1u32 << pin)) != 0)
+    }
+
+    fn read_gpio_output(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        Some((self.out & (1u32 << pin)) != 0)
+    }
+
+    fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
+        if pin >= 32 {
+            return false;
+        }
+        self.set_pin_input(pin, level);
+        true
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -401,6 +401,37 @@ impl crate::Peripheral for GpioPort {
         Ok(())
     }
 
+    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let reg = self.read_reg(self.idr_offset());
+        Some((reg & (1u32 << pin)) != 0)
+    }
+
+    fn read_gpio_output(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let reg = self.read_reg(self.odr_offset());
+        Some((reg & (1u32 << pin)) != 0)
+    }
+
+    fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
+        if pin >= 32 {
+            return false;
+        }
+        let offset = self.idr_offset();
+        let mut reg = self.read_reg(offset);
+        if level {
+            reg |= 1u32 << pin;
+        } else {
+            reg &= !(1u32 << pin);
+        }
+        self.write_reg(offset, reg);
+        true
+    }
+
     fn snapshot(&self) -> serde_json::Value {
         // Serialize the active family's register struct directly (flat), so the
         // snapshot keeps registers like `odr` at top level (no variant tag) —

--- a/crates/wasm/src/inputs.rs
+++ b/crates/wasm/src/inputs.rs
@@ -90,23 +90,16 @@ impl WasmSimulator {
                 JsValue::from_str(&format!("Peripheral '{}' not found", binding.peripheral))
             })?;
 
-        // Read the IDR via snapshot, modify the bit, write back via bus
-        let snapshot = machine.bus.peripherals[idx].dev.snapshot();
-        let current_idr = snapshot["idr"].as_u64().unwrap_or(0) as u32;
-
         let pin_high = if binding.active_high { active } else { !active };
-        let new_idr = if pin_high {
-            current_idr | (1 << binding.pin)
-        } else {
-            current_idr & !(1 << binding.pin)
-        };
-
-        // Write IDR through the peripheral's write interface.
-        // Determine IDR offset from layout in snapshot.
-        let layout = snapshot["layout"].as_str().unwrap_or("stm32_f1");
-        let idr_offset: u64 = if layout.contains("v2") { 0x10 } else { 0x08 };
-        let base = machine.bus.peripherals[idx].base;
-        let _ = machine.bus.write_u32(base + idr_offset, new_idr);
+        if !machine.bus.peripherals[idx]
+            .dev
+            .set_gpio_input(binding.pin, pin_high)
+        {
+            return Err(JsValue::from_str(&format!(
+                "Peripheral '{}' does not expose GPIO input control",
+                binding.peripheral
+            )));
+        }
 
         Ok(())
     }
@@ -689,5 +682,69 @@ impl WasmSimulator {
             }
         }
         Err(JsValue::from_str("no 74HC165 shift register attached"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use labwired_core::cpu::riscv::RiscV;
+
+    fn c3_button_sim() -> WasmSimulator {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip_yaml = std::fs::read_to_string(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let chip: ChipDescriptor = serde_yaml::from_str(&chip_yaml).expect("parse chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-button-test"
+chip: "../chips/esp32c3.yaml"
+board_io:
+  - id: "left"
+    kind: "button"
+    peripheral: "gpio"
+    pin: 2
+    signal: "input"
+    active_high: true
+"#,
+        )
+        .expect("parse system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("construct C3 bus");
+        bus.refresh_peripheral_index();
+        let machine = Machine::new(Box::new(RiscV::new()) as Box<dyn Cpu>, bus);
+
+        WasmSimulator {
+            machine: Some(machine),
+            board_io: manifest.board_io,
+            uart_sink: Arc::new(Mutex::new(Vec::new())),
+            uart_rx_bufs: Vec::new(),
+            arch: Arch::RiscV,
+            esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
+        }
+    }
+
+    fn button_active(sim: &WasmSimulator) -> bool {
+        let machine = sim.machine.as_ref().expect("machine");
+        let binding = sim
+            .board_io
+            .iter()
+            .find(|b| b.id == "left")
+            .expect("left binding");
+        sim.read_board_io_state(machine, binding)
+    }
+
+    #[test]
+    fn esp32c3_board_io_button_press_updates_gpio_input_state() {
+        let mut sim = c3_button_sim();
+
+        assert!(!button_active(&sim));
+
+        sim.set_board_io_input("left", true).expect("press left");
+        assert!(button_active(&sim));
+
+        sim.set_board_io_input("left", false).expect("release left");
+        assert!(!button_active(&sim));
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -390,18 +390,28 @@ impl WasmSimulator {
             .expect("esp32c3_flash presence checked by caller")
             .clone();
 
-        // Capture console output for the widget's Serial tab. The IDF default
-        // console is UART0; esp-hal / jtag-serial apps print through
-        // USB_SERIAL_JTAG. The BROM prints to BOTH, so route both into the same
-        // sink: attach UART0's tx sink here, and hand the sink to the shared
-        // builder so its USB_SERIAL_JTAG model mirrors into it too.
+        // Capture one console for the widget's Serial tab. The C3 boot ROM
+        // prints the same banner to UART0 and USB_SERIAL_JTAG; wiring both into
+        // one browser buffer renders every ROM character twice. Default to
+        // UART0 (Arduino/IDF Serial in hosted labs). A manifest can explicitly
+        // request the USB console with debug_uart: usb_serial_jtag.
         let uart_sink = Arc::new(Mutex::new(Vec::new()));
-        if let Some(debug_uart) = manifest.debug_uart.as_deref() {
-            if !bus.attach_uart_tx_sink_named(debug_uart, uart_sink.clone(), false) {
+        let capture_usb_serial = manifest
+            .debug_uart
+            .as_deref()
+            .map(|debug_uart| {
+                debug_uart.eq_ignore_ascii_case("usb_serial_jtag")
+                    || debug_uart.eq_ignore_ascii_case("usb-serial-jtag")
+            })
+            .unwrap_or(false);
+        if !capture_usb_serial {
+            if let Some(debug_uart) = manifest.debug_uart.as_deref() {
+                if !bus.attach_uart_tx_sink_named(debug_uart, uart_sink.clone(), false) {
+                    bus.attach_uart_tx_sink(uart_sink.clone(), false);
+                }
+            } else {
                 bus.attach_uart_tx_sink(uart_sink.clone(), false);
             }
-        } else {
-            bus.attach_uart_tx_sink(uart_sink.clone(), false);
         }
         let uart_rx_bufs = bus.attach_uart_rx_source();
 
@@ -410,7 +420,7 @@ impl WasmSimulator {
             flash_bytes,
             RomBootOpts {
                 efuse_mac: None,
-                usb_serial_sink: Some(uart_sink.clone()),
+                usb_serial_sink: capture_usb_serial.then(|| uart_sink.clone()),
             },
             // WasmSimulator holds Machine<Box<dyn Cpu>>; box the concrete RiscV.
             |c| Box::new(c) as Box<dyn Cpu>,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -603,11 +603,15 @@ impl WasmSimulator {
             None => return false,
         };
 
-        let snapshot = machine.bus.peripherals[idx].dev.snapshot();
-
-        let register = match binding.kind {
-            BoardIoKind::Led | BoardIoKind::PwmOutput => "odr",
-            BoardIoKind::Button => "idr",
+        let pin_high = match binding.kind {
+            BoardIoKind::Led | BoardIoKind::PwmOutput => machine.bus.peripherals[idx]
+                .dev
+                .read_gpio_output(binding.pin)
+                .unwrap_or(false),
+            BoardIoKind::Button => machine.bus.peripherals[idx]
+                .dev
+                .read_gpio_input(binding.pin)
+                .unwrap_or(false),
             // Analog/bus kinds are not boolean and are exposed through typed state accessors.
             BoardIoKind::AdcInput
             | BoardIoKind::I2cDevice
@@ -616,8 +620,6 @@ impl WasmSimulator {
                 return false;
             }
         };
-        let reg_val = snapshot[register].as_u64().unwrap_or(0) as u32;
-        let pin_high = (reg_val >> binding.pin) & 1 == 1;
 
         if binding.active_high {
             pin_high

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -12,7 +12,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
@@ -70,7 +70,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -313,7 +313,11 @@ boards:
     # 2026-06-30: additive Kinetis GPIO + DSPI variants in gpio.rs/spi.rs for the KW41Z; the STM32 GPIO/SPI engines are untouched, l073 diff unchanged. No live re-capture.
     # 2026-07-01: additive bus-trace device wrappers at I2c/Spi attach + shared BusTraceLog on SystemBus (universal bus analyzer); STM32 register engines byte-for-byte untouched, wrappers only forward (transparent as_any) and activate only when a device+log is attached. Diff/conformance unchanged; no live re-capture.
     # 2026-07-04: drift is the file-hash of the additive L4 PLLSAI1/2 ready-bit change in rcc.rs (L4Rcc::ready); this board's RCC engine (L0Rcc) is byte-for-byte untouched, stm32l0_mmio_diff unchanged, no live re-capture.
-    drift_ack: 2026-07-04
+    # 2026-07-05: GPIO gained generic board-input capability for simulator UI
+    # controls. L0 GPIO register layout/reset and the pinned l073 mmio paths are
+    # unchanged; input injection is additive and only active when a board IO source
+    # drives a pin. No live re-capture this session.
+    drift_ack: 2026-07-05
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
This rebases the canonical config, C3 serial/GPIO input, and RISC-V decode-cache fixes on top of the merged ESP32 tick optimization so the parent repo can advance the core submodule without dropping those changes.\n\nVerification:\n- cargo clippy --all-targets -- -D warnings\n- cargo test -p labwired-core --lib