### PR TITLE
Add switchable idle fast-forward

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -16,6 +16,11 @@ pub struct SimulationConfig {
     pub optimized_bus_access: bool,
     /// Enable high-throughput batch execution for the CPU.
     pub batch_mode_enabled: bool,
+    /// Enable scheduler-safe CPU idle fast-forwarding.
+    ///
+    /// Off by default so existing runners keep instruction-for-instruction
+    /// behavior unless they explicitly opt in.
+    pub idle_fast_forward_enabled: bool,
 }
 
 impl Default for SimulationConfig {
@@ -25,6 +30,7 @@ impl Default for SimulationConfig {
             peripheral_tick_interval: 1, // Correctness by default
             optimized_bus_access: true,
             batch_mode_enabled: true,
+            idle_fast_forward_enabled: false,
         }
     }
 }

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -51,6 +51,7 @@ pub struct RiscV {
     /// reservation per RISC-V ISA §8.2.
     pub reservation: Option<u32>,
 
+    waiting_for_interrupt: bool,
     decode_cache: Box<[Option<RiscVDecodeCacheEntry>; 4096]>,
 }
 
@@ -70,6 +71,7 @@ impl Default for RiscV {
             mtime: 0,
             mtimecmp: 0,
             reservation: None,
+            waiting_for_interrupt: false,
             decode_cache: Box::new([None; 4096]),
         }
     }
@@ -78,6 +80,15 @@ impl Default for RiscV {
 impl RiscV {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn update_mtime_after_elapsed_cycles(&mut self, cycles: u64) {
+        self.mtime = self.mtime.wrapping_add(cycles);
+        if self.mtime >= self.mtimecmp {
+            self.mip |= 1 << 7; // MTIP
+        } else {
+            self.mip &= !(1 << 7);
+        }
     }
 
     fn read_reg(&self, n: u8) -> u32 {
@@ -186,6 +197,7 @@ impl Cpu for RiscV {
         observers: &[Arc<dyn SimulationObserver>],
         _config: &crate::SimulationConfig,
     ) -> SimResult<()> {
+        self.waiting_for_interrupt = false;
         let opcode = bus.read_u32(self.pc as u64)?;
 
         let retired_pc = self.pc;
@@ -423,6 +435,7 @@ impl Cpu for RiscV {
                 // Wait-for-interrupt: implemented as a no-op busy-wait. The step
                 // loop already polls pending interrupts every instruction, so
                 // the idle task's WFI spin wakes as soon as a line asserts.
+                self.waiting_for_interrupt = true;
             }
             Instruction::Ecall | Instruction::Ebreak => {
                 // Should trap. For now, we can just log or halt.
@@ -737,12 +750,7 @@ impl Cpu for RiscV {
         }
 
         // Timer update (Internal minimal CLINT)
-        self.mtime = self.mtime.wrapping_add(1);
-        if self.mtime >= self.mtimecmp {
-            self.mip |= 1 << 7; // MTIP
-        } else {
-            self.mip &= !(1 << 7);
-        }
+        self.update_mtime_after_elapsed_cycles(1);
 
         // Check for interrupts. On the ESP32-C3 the custom interrupt controller
         // exposes its 31 sources as CPU interrupt lines 1..31 directly in
@@ -830,6 +838,26 @@ impl Cpu for RiscV {
         // The specific 'exception_num' (IRQ) would be tracked by a PLIC.
         // Since we don't have a PLIC yet, we pend a generic external interrupt.
         self.mip |= 1 << 11;
+    }
+
+    fn idle_fast_forward_budget(&self, bus: &dyn Bus) -> Option<u64> {
+        if !self.waiting_for_interrupt {
+            return None;
+        }
+        if ((self.mip & self.mie) | bus.external_irq_lines()) != 0 {
+            return None;
+        }
+        if self.mtimecmp == u64::MAX {
+            return Some(u64::MAX);
+        }
+        if self.mtime + 1 >= self.mtimecmp {
+            return None;
+        }
+        Some(self.mtimecmp - self.mtime - 1)
+    }
+
+    fn fast_forward_idle_cycles(&mut self, cycles: u64) {
+        self.update_mtime_after_elapsed_cycles(cycles);
     }
 
     fn get_register(&self, id: u8) -> u32 {
@@ -961,6 +989,7 @@ impl Cpu for RiscV {
 mod tests {
     use super::*;
     use crate::bus::SystemBus;
+    use crate::DebugControl;
     use crate::Machine;
 
     #[test]
@@ -1225,6 +1254,46 @@ mod tests {
         let mut machine = Machine::new(cpu, bus);
         machine.step().unwrap();
         assert_eq!(machine.cpu.pc, 0x4, "WFI advances PC like a NOP");
+    }
+
+    #[test]
+    fn test_riscv_wfi_fast_forward_is_off_by_default() {
+        let mut bus = SystemBus::new();
+        let mut cpu = RiscV::new();
+        bus.flash.data = vec![0; 0x100];
+        bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
+        bus.write_u32(0x4, 0x0000_006f).unwrap(); // JAL x0, 0
+        cpu.pc = 0x0;
+        cpu.mtimecmp = u64::MAX;
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.bus.legacy_walk_disabled = true;
+        machine.run(Some(10)).unwrap();
+
+        assert_eq!(machine.total_cycles, 10);
+        assert_eq!(machine.step_profile().cpu_instructions, 10);
+    }
+
+    #[test]
+    fn test_riscv_wfi_fast_forward_skips_cpu_work_when_enabled() {
+        let mut bus = SystemBus::new();
+        let mut cpu = RiscV::new();
+        bus.flash.data = vec![0; 0x100];
+        bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
+        bus.write_u32(0x4, 0x0000_006f).unwrap(); // JAL x0, 0
+        cpu.pc = 0x0;
+        cpu.mtimecmp = u64::MAX;
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.idle_fast_forward_enabled = true;
+        machine.bus.legacy_walk_disabled = true;
+        machine.run(Some(10)).unwrap();
+
+        assert_eq!(machine.total_cycles, 10);
+        assert!(
+            machine.step_profile().cpu_instructions < 10,
+            "fast-forwarded cycles should not retire CPU instructions"
+        );
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -258,6 +258,18 @@ pub trait Cpu: Send {
         0
     }
 
+    /// Return the maximum number of idle cycles this CPU may skip now, or
+    /// `None` when it is not architecturally waiting or an interrupt is already
+    /// observable. Machine-level guards decide whether the bus/peripheral side
+    /// is also safe to skip.
+    fn idle_fast_forward_budget(&self, _bus: &dyn Bus) -> Option<u64> {
+        None
+    }
+
+    /// Advance CPU-local time/counters for cycles skipped while idle. The
+    /// default is a no-op for CPUs that do not opt into idle fast-forwarding.
+    fn fast_forward_idle_cycles(&mut self, _cycles: u64) {}
+
     /// Phase 3.2 JIT pilot (issue #124): total number of times any
     /// JIT-compiled block on this CPU has been invoked. Default 0 for
     /// CPUs/builds without JIT support so callers can unconditionally
@@ -357,6 +369,12 @@ impl Cpu for Box<dyn Cpu> {
     }
     fn intlevel(&self) -> u8 {
         (**self).intlevel()
+    }
+    fn idle_fast_forward_budget(&self, bus: &dyn Bus) -> Option<u64> {
+        (**self).idle_fast_forward_budget(bus)
+    }
+    fn fast_forward_idle_cycles(&mut self, cycles: u64) {
+        (**self).fast_forward_idle_cycles(cycles)
     }
     fn jit_hit_count(&self) -> u64 {
         (**self).jit_hit_count()
@@ -903,6 +921,64 @@ impl<C: Cpu> Machine<C> {
         self.step_profile.peripheral_ticked_entries += cost_entries as u64;
         self.step_profile.bus_tick_entries += bus_tick_entries as u64;
         self.step_profile.legacy_tick_entries += legacy_tick_entries as u64;
+    }
+
+    fn try_idle_fast_forward(&mut self, _max_steps: Option<u32>, _steps: u32) -> u32 {
+        if !self.config.idle_fast_forward_enabled
+            || !self.breakpoints.is_empty()
+            || self.bus.requires_cycle_accurate()
+        {
+            return 0;
+        }
+
+        #[cfg(not(feature = "event-scheduler"))]
+        {
+            0
+        }
+
+        #[cfg(feature = "event-scheduler")]
+        {
+            if !self.bus.legacy_walk_disabled {
+                return 0;
+            }
+
+            // Drain first: a due scheduler event may assert an interrupt, in
+            // which case the CPU must resume normally instead of skipping.
+            self.drain_scheduler_events();
+
+            let mut budget = match self.cpu.idle_fast_forward_budget(&self.bus) {
+                Some(budget) if budget > 0 => budget,
+                _ => return 0,
+            };
+            let remaining = _max_steps
+                .map(|limit| limit.saturating_sub(_steps) as u64)
+                .unwrap_or(1_000_000);
+            if remaining == 0 {
+                return 0;
+            }
+            budget = budget.min(remaining);
+
+            let interval = (self.config.peripheral_tick_interval as u64).max(1);
+            let generations = self.bus.peripheral_generations();
+            if let Some(deadline_tick) = self.sched.next_event_deadline(&generations) {
+                let deadline_cycle = deadline_tick.saturating_mul(interval);
+                if deadline_cycle <= self.total_cycles {
+                    return 0;
+                }
+                budget = budget.min(deadline_cycle - self.total_cycles);
+            }
+
+            if budget == 0 {
+                return 0;
+            }
+            let skipped = budget.min(u32::MAX as u64) as u32;
+            self.cpu.fast_forward_idle_cycles(skipped as u64);
+            self.total_cycles += skipped as u64;
+            self.bus.current_cycle = self.total_cycles;
+            self.sched.advance_to(self.total_cycles / interval);
+            self.drain_scheduler_events();
+            skipped
+        }
     }
 
     /// Take a binary mid-flight runtime snapshot of the entire machine —
@@ -1594,6 +1670,12 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 if steps >= limit {
                     return Ok(StopReason::MaxStepsReached);
                 }
+            }
+
+            let skipped = self.try_idle_fast_forward(max_steps, steps);
+            if skipped > 0 {
+                steps += skipped;
+                continue;
             }
 
             // Execute in batch until next peripheral tick or breakpoint/limit

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -836,6 +836,14 @@ impl WasmSimulator {
         }
     }
 
+    /// Enable/disable scheduler-safe CPU idle fast-forwarding. Off by default;
+    /// browser callers opt in explicitly after comparing accelerated and
+    /// non-accelerated traces for the target firmware.
+    #[wasm_bindgen]
+    pub fn set_idle_fast_forward_enabled(&mut self, enabled: bool) {
+        self.machine().config.idle_fast_forward_enabled = enabled;
+    }
+
     /// Total number of times the browser JIT has dispatched a
     /// compiled block. Useful for confirming the JIT path actually
     /// fired during a benchmark.

--- a/docs/superpowers/plans/2026-07-06-idle-fast-forward.md
+++ b/docs/superpowers/plans/2026-07-06-idle-fast-forward.md
@@ -1,0 +1,99 @@
+# Idle Fast-Forward Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a switchable idle fast-forward path that accelerates RISC-V WFI waits without changing default emulator behavior.
+
+**Architecture:** Add a `SimulationConfig` boolean that defaults off. RISC-V marks itself as waiting after WFI, and the `Machine::run` loop fast-forwards only when that flag is set, no breakpoint/cycle-accurate service is active, the scheduler-backed bus can safely skip legacy ticks, and no interrupt is already pending.
+
+**Tech Stack:** Rust core crate, existing `SimulationConfig`, `Cpu` trait, `Machine::run`, and event-scheduler hooks.
+
+---
+
+### Task 1: Switchable WFI Fast-Forward Contract
+
+**Files:**
+- Modify: `crates/core/src/config.rs`
+- Modify: `crates/core/src/lib.rs`
+- Modify: `crates/core/src/cpu/riscv.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests in `crates/core/src/cpu/riscv.rs`:
+
+```rust
+#[test]
+fn test_riscv_wfi_fast_forward_is_off_by_default() {
+    let mut bus = SystemBus::new();
+    let mut cpu = RiscV::new();
+    bus.flash.data = vec![0; 0x100];
+    bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
+    bus.write_u32(0x4, 0x0000_006f).unwrap(); // JAL x0, 0
+    cpu.pc = 0x0;
+    let mut machine = Machine::new(cpu, bus);
+    machine.bus.legacy_walk_disabled = true;
+    machine.run(Some(10)).unwrap();
+    assert_eq!(machine.total_cycles, 10);
+    assert_eq!(machine.step_profile().cpu_instructions, 10);
+}
+```
+
+```rust
+#[test]
+fn test_riscv_wfi_fast_forward_skips_cpu_work_when_enabled() {
+    let mut bus = SystemBus::new();
+    let mut cpu = RiscV::new();
+    bus.flash.data = vec![0; 0x100];
+    bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
+    bus.write_u32(0x4, 0x0000_006f).unwrap(); // JAL x0, 0
+    cpu.pc = 0x0;
+    let mut machine = Machine::new(cpu, bus);
+    machine.config.idle_fast_forward_enabled = true;
+    machine.bus.legacy_walk_disabled = true;
+    machine.run(Some(10)).unwrap();
+    assert_eq!(machine.total_cycles, 10);
+    assert!(machine.step_profile().cpu_instructions < 10);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p labwired-core test_riscv_wfi_fast_forward --features event-scheduler`
+
+Expected: FAIL because `idle_fast_forward_enabled` and CPU waiting-state hooks do not exist yet.
+
+- [ ] **Step 3: Add minimal switch and CPU hook**
+
+Add `idle_fast_forward_enabled: bool` to `SimulationConfig`, default `false`. Add CPU trait hooks for idle waiting and fast-forwarding elapsed cycles. Implement them only for `RiscV`, setting the waiting flag on `Instruction::Wfi` and advancing `mtime`/`mip` during skipped cycles.
+
+- [ ] **Step 4: Add minimal run-loop skip**
+
+At the top of `Machine::run`, if enabled and safe, advance by the smaller of remaining requested steps and next scheduler deadline or batch limit. Update `total_cycles`, `steps`, and scheduler time; leave `cpu_instructions` unchanged for skipped cycles.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `cargo test -p labwired-core test_riscv_wfi_fast_forward --features event-scheduler`
+
+Expected: PASS.
+
+### Task 2: Regression Coverage
+
+**Files:**
+- Modify: `crates/core/src/cpu/riscv.rs`
+- Modify: `crates/core/src/config.rs`
+
+- [ ] **Step 1: Confirm existing WFI behavior still passes**
+
+Run: `cargo test -p labwired-core test_riscv_wfi_is_nop`
+
+Expected: PASS.
+
+- [ ] **Step 2: Confirm default config is unchanged except explicit field**
+
+Add a small assertion that `SimulationConfig::default().idle_fast_forward_enabled` is false.
+
+- [ ] **Step 3: Run core tests touched by this path**
+
+Run: `cargo test -p labwired-core test_riscv_timer_interrupt test_riscv_wfi --features event-scheduler`
+
+Expected: PASS.


### PR DESCRIPTION
## Summary
- add default-off `idle_fast_forward_enabled` to `SimulationConfig`
- add CPU idle fast-forward hooks and implement them for RISC-V WFI
- expose a WASM setter so browser callers can opt in explicitly

## Fidelity guardrails
- disabled by default
- only skips after decoded WFI
- refuses to skip when an interrupt is already observable
- refuses to cross the RISC-V timer interrupt edge
- machine run-loop only activates it when the scheduler-backed bus has disabled the legacy per-cycle walk

## Test Plan
- cargo fmt --check
- cargo test -p labwired-core --lib --features event-scheduler
- cargo test -p labwired-core --test event_scheduler --features event-scheduler
- cargo check -p labwired-wasm --features labwired-core/event-scheduler

Note: I also started `cargo test -p labwired-core --features event-scheduler`; it was interrupted after several slow e2e binaries had passed, so I am not counting it as a completed full-suite pass.