### PR TITLE
Fast-forward ESP32-C3 idle timers

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -26,7 +26,22 @@ mod tick;
 
 pub use bus_trace::{new_log, BusPayload, BusTraceEvent, BusTraceLog, I2cSym};
 
-impl SystemBus {}
+impl SystemBus {
+    /// True when CPU idle fast-forward can skip the legacy peripheral walk for
+    /// the skipped window without dropping observable work. Scheduler-driven
+    /// peripherals are safe because the machine clamps to their next deadline;
+    /// inert or currently-inactive legacy peripherals have no tick output to
+    /// lose. Active non-scheduler legacy work blocks fast-forward until the
+    /// normal tick path drains it.
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn idle_fast_forward_legacy_safe(&self) -> bool {
+        self.legacy_walk_disabled
+            || self
+                .peripherals
+                .iter()
+                .all(|p| p.dev.uses_scheduler() || !p.dev.legacy_tick_active())
+    }
+}
 
 /// A peripheral's RCC clock-gate, resolved to a concrete RCC register offset +
 /// bit at bus-build time (the symbolic `reg` name from the yaml is mapped to the

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -1262,7 +1262,7 @@ mod tests {
         let mut cpu = RiscV::new();
         bus.flash.data = vec![0; 0x100];
         bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
-        bus.write_u32(0x4, 0x0000_006f).unwrap(); // JAL x0, 0
+        bus.write_u32(0x4, 0xffdf_f06f).unwrap(); // JAL x0, -4
         cpu.pc = 0x0;
         cpu.mtimecmp = u64::MAX;
 
@@ -1280,7 +1280,7 @@ mod tests {
         let mut cpu = RiscV::new();
         bus.flash.data = vec![0; 0x100];
         bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
-        bus.write_u32(0x4, 0x0000_006f).unwrap(); // JAL x0, 0
+        bus.write_u32(0x4, 0xffdf_f06f).unwrap(); // JAL x0, -4
         cpu.pc = 0x0;
         cpu.mtimecmp = u64::MAX;
 
@@ -1293,6 +1293,54 @@ mod tests {
         assert!(
             machine.step_profile().cpu_instructions < 10,
             "fast-forwarded cycles should not retire CPU instructions"
+        );
+    }
+
+    #[test]
+    fn test_riscv_wfi_fast_forward_wakes_on_systimer_event() {
+        let mut bus = SystemBus::empty();
+        let mut cpu = RiscV::new();
+        bus.flash.data = vec![0; 0x3000];
+        bus.write_u32(0x0, 0x1050_0073).unwrap(); // WFI
+        bus.write_u32(0x4, 0xffdf_f06f).unwrap(); // JAL x0, -4
+        bus.write_u32(0x2000 + 11 * 4, 0x3020_0073).unwrap(); // MRET at machine external IRQ vector
+
+        bus.add_peripheral(
+            "systimer",
+            0x6002_3000,
+            0x100,
+            None,
+            Box::new(
+                crate::peripherals::esp32s3::systimer::Systimer::new_with_source(160_000_000, 11),
+            ),
+        );
+        bus.write_u32(0x6002_3064, 1).unwrap(); // INT_ENA TARGET0
+        bus.write_u32(0x6002_301C, 0).unwrap(); // TARGET0_HI
+        bus.write_u32(0x6002_3020, 3).unwrap(); // TARGET0_LO: 3 SYSTIMER ticks
+        bus.write_u32(0x6002_3050, 1).unwrap(); // COMP0_LOAD
+        let conf = bus.read_u32(0x6002_3000).unwrap();
+        bus.write_u32(0x6002_3000, conf | (1 << 24)).unwrap(); // TARGET0_WORK_EN
+
+        cpu.pc = 0x0;
+        cpu.mtvec = 0x2000 | 1; // vectored machine interrupts
+        cpu.mie = 1 << 11; // MEIE
+        cpu.mstatus = 1 << 3; // MIE
+        cpu.mtimecmp = u64::MAX;
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.idle_fast_forward_enabled = true;
+        machine.run(Some(40)).unwrap();
+
+        assert!(
+            machine.step_profile().cpu_instructions < machine.total_cycles,
+            "WFI should skip idle cycles until the SYSTIMER event; retired {} over {} cycles",
+            machine.step_profile().cpu_instructions,
+            machine.total_cycles
+        );
+        assert_ne!(
+            machine.cpu.mcause & 0x8000_0000,
+            0,
+            "the scheduled SYSTIMER event should become an observable interrupt"
         );
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -192,8 +192,11 @@ pub trait Cpu: Send {
         config: &SimulationConfig,
         max_count: u32,
     ) -> SimResult<u32> {
-        for _ in 0..max_count {
+        for i in 0..max_count {
             self.step(bus, observers, config)?;
+            if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
+                return Ok(i + 1);
+            }
         }
         Ok(max_count)
     }
@@ -938,7 +941,7 @@ impl<C: Cpu> Machine<C> {
 
         #[cfg(feature = "event-scheduler")]
         {
-            if !self.bus.legacy_walk_disabled {
+            if !self.bus.idle_fast_forward_legacy_safe() {
                 return 0;
             }
 

--- a/crates/core/src/peripherals/esp32c3/ana_i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/ana_i2c.rs
@@ -81,6 +81,10 @@ impl Peripheral for Esp32c3AnaI2c {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32c3/cache.rs
+++ b/crates/core/src/peripherals/esp32c3/cache.rs
@@ -114,6 +114,10 @@ impl Peripheral for Esp32c3Cache {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32c3/forced_status.rs
+++ b/crates/core/src/peripherals/esp32c3/forced_status.rs
@@ -71,6 +71,10 @@ impl Peripheral for Esp32c3ForcedStatus {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32c3/ledc.rs
+++ b/crates/core/src/peripherals/esp32c3/ledc.rs
@@ -137,9 +137,9 @@ impl Timer {
         self.conf & RST_BIT != 0
     }
 
-    /// Advance by one CPU cycle. Returns true if the counter wrapped past its
-    /// period this cycle (an overflow edge).
-    fn advance(&mut self) -> bool {
+    /// Advance by `cycles` CPU cycles. Returns true if the counter wrapped past
+    /// its period at least once during this elapsed window.
+    fn advance_cycles(&mut self, cycles: u64) -> bool {
         if self.in_reset() {
             self.counter = 0;
             self.accum = 0;
@@ -148,17 +148,17 @@ impl Timer {
         if self.paused() {
             return false;
         }
-        self.accum += 1;
+        self.accum = self.accum.saturating_add(cycles);
         let per_count = self.divider();
-        let mut overflowed = false;
-        while self.accum >= per_count {
-            self.accum -= per_count;
-            self.counter += 1;
-            if self.counter >= self.period() {
-                self.counter = 0;
-                overflowed = true;
-            }
+        let counts = self.accum / per_count;
+        self.accum %= per_count;
+        if counts == 0 {
+            return false;
         }
+        let period = self.period() as u64;
+        let next = self.counter as u64 + counts;
+        let overflowed = next >= period;
+        self.counter = (next % period) as u32;
         overflowed
     }
 }
@@ -309,8 +309,12 @@ impl Peripheral for Esp32c3Ledc {
     }
 
     fn tick(&mut self) -> PeripheralTickResult {
+        self.tick_elapsed(1)
+    }
+
+    fn tick_elapsed(&mut self, cycles: u64) -> PeripheralTickResult {
         for (i, timer) in self.timers.iter_mut().enumerate() {
-            if timer.advance() {
+            if timer.advance_cycles(cycles) {
                 self.int_raw |= 1 << i;
             }
         }
@@ -322,6 +326,18 @@ impl Peripheral for Esp32c3Ledc {
             },
             ..PeripheralTickResult::default()
         }
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        self.int_st() != 0
+            || self
+                .timers
+                .iter()
+                .any(|timer| !timer.in_reset() && !timer.paused())
+    }
+
+    fn legacy_tick_dynamic(&self) -> bool {
+        true
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -371,6 +387,32 @@ mod tests {
         // 100 cycles / divider 10 ≈ 10 counts (not 100).
         let v = l.read_u32(TIMER0_VALUE_OFF).unwrap();
         assert_eq!(v, 10, "integer divider gates the count rate");
+    }
+
+    #[test]
+    fn tick_elapsed_matches_repeated_tick() {
+        let mut repeated = Esp32c3Ledc::new(LEDC_INTR_SOURCE_ID);
+        let mut elapsed = Esp32c3Ledc::new(LEDC_INTR_SOURCE_ID);
+        repeated.write_u32(TIMER0_CONF_OFF, conf(4, 2)).unwrap();
+        elapsed.write_u32(TIMER0_CONF_OFF, conf(4, 2)).unwrap();
+        repeated.write_u32(INT_ENA, 1).unwrap();
+        elapsed.write_u32(INT_ENA, 1).unwrap();
+
+        let mut repeated_irq = None;
+        for _ in 0..40 {
+            repeated_irq = repeated.tick().explicit_irqs;
+        }
+        let elapsed_irq = elapsed.tick_elapsed(40).explicit_irqs;
+
+        assert_eq!(
+            elapsed.read_u32(TIMER0_VALUE_OFF).unwrap(),
+            repeated.read_u32(TIMER0_VALUE_OFF).unwrap()
+        );
+        assert_eq!(
+            elapsed.read_u32(INT_RAW).unwrap(),
+            repeated.read_u32(INT_RAW).unwrap()
+        );
+        assert_eq!(elapsed_irq, repeated_irq);
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32c3/reg_block.rs
+++ b/crates/core/src/peripherals/esp32c3/reg_block.rs
@@ -52,6 +52,10 @@ impl Peripheral for Esp32c3RegBlock {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32c3/rng.rs
+++ b/crates/core/src/peripherals/esp32c3/rng.rs
@@ -62,6 +62,10 @@ impl Peripheral for Esp32c3Rng {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32c3/rtc_timer.rs
+++ b/crates/core/src/peripherals/esp32c3/rtc_timer.rs
@@ -45,6 +45,8 @@ pub struct Esp32c3RtcTimer {
     /// Counter value latched by the most recent TIME_UPDATE write; what the
     /// TIME0/TIME1 readout registers return.
     latched: Cell<u64>,
+    /// Scheduler/elapsed-mode anchor in peripheral-tick units.
+    anchor_tick: Cell<u64>,
 }
 
 impl Default for Esp32c3RtcTimer {
@@ -60,6 +62,7 @@ impl Esp32c3RtcTimer {
             regs: vec![0u32; size_bytes.div_ceil(4)],
             counter: Cell::new(0),
             latched: Cell::new(0),
+            anchor_tick: Cell::new(0),
         }
     }
 
@@ -101,9 +104,28 @@ impl Peripheral for Esp32c3RtcTimer {
     }
 
     fn tick(&mut self) -> crate::PeripheralTickResult {
+        self.tick_elapsed(1)
+    }
+
+    fn tick_elapsed(&mut self, cycles: u64) -> crate::PeripheralTickResult {
         // One slow-clock tick per simulated step — time advances monotonically.
-        self.counter.set(self.counter.get().wrapping_add(1));
+        self.counter.set(self.counter.get().wrapping_add(cycles));
+        self.anchor_tick
+            .set(self.anchor_tick.get().wrapping_add(cycles));
         crate::PeripheralTickResult::default()
+    }
+
+    fn uses_scheduler(&self) -> bool {
+        true
+    }
+
+    fn sync_to(&mut self, tick_now: u64) {
+        if tick_now <= self.anchor_tick.get() {
+            return;
+        }
+        let delta = tick_now - self.anchor_tick.get();
+        self.counter.set(self.counter.get().wrapping_add(delta));
+        self.anchor_tick.set(tick_now);
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -124,6 +146,7 @@ impl Peripheral for Esp32c3RtcTimer {
             regs: self.regs.clone(),
             counter: self.counter.get(),
             latched: self.latched.get(),
+            anchor_tick: self.anchor_tick.get(),
         };
         bincode::serialize(&snap).expect("bincode serialize Esp32c3RtcTimer")
     }
@@ -135,6 +158,7 @@ impl Peripheral for Esp32c3RtcTimer {
         self.regs = snap.regs;
         self.counter.set(snap.counter);
         self.latched.set(snap.latched);
+        self.anchor_tick.set(snap.anchor_tick);
         Ok(())
     }
 }
@@ -144,6 +168,8 @@ struct RtcTimerSnapshot {
     regs: Vec<u32>,
     counter: u64,
     latched: u64,
+    #[serde(default)]
+    anchor_tick: u64,
 }
 
 #[cfg(test)]
@@ -182,6 +208,19 @@ mod tests {
         assert_eq!(t.read_u32(TIME_LOW).unwrap(), snap);
         t.write_u32(TIME_UPDATE, TIME_UPDATE_BIT).unwrap();
         assert_eq!(t.read_u32(TIME_LOW).unwrap(), snap + 50);
+    }
+
+    #[test]
+    fn tick_elapsed_matches_repeated_tick() {
+        let mut repeated = Esp32c3RtcTimer::new();
+        let mut elapsed = Esp32c3RtcTimer::new();
+
+        for _ in 0..1000 {
+            repeated.tick();
+        }
+        elapsed.tick_elapsed(1000);
+
+        assert_eq!(rtc_time_get(&mut elapsed), rtc_time_get(&mut repeated));
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32c3/sar_adc.rs
+++ b/crates/core/src/peripherals/esp32c3/sar_adc.rs
@@ -80,6 +80,10 @@ impl Peripheral for Esp32c3SarAdc {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32c3/sha.rs
+++ b/crates/core/src/peripherals/esp32c3/sha.rs
@@ -160,6 +160,10 @@ impl Peripheral for Esp32c3Sha {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -206,6 +206,10 @@ impl Peripheral for FlashXipPeripheral {
         Err(SimulationError::MemoryViolation(self.base as u64 + offset))
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }
@@ -268,6 +272,10 @@ impl Peripheral for Esp32s3MmuTable {
             self.table.lock().unwrap()[i] = value;
         }
         Ok(())
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/crates/core/src/peripherals/esp32s3/spi_mem_flash.rs
+++ b/crates/core/src/peripherals/esp32s3/spi_mem_flash.rs
@@ -290,6 +290,10 @@ impl Peripheral for SpiMemFlash {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/esp32s3/systimer.rs
+++ b/crates/core/src/peripherals/esp32s3/systimer.rs
@@ -97,6 +97,7 @@ const SYSTIMER_CLOCK_HZ: u64 = 16_000_000;
 /// SYSTIMER interrupt-matrix source ID for TARGET0 (per esp32s3-pac
 /// `Interrupt::SYSTIMER_TARGET0 = 57`).  TARGET1/2 follow at +1/+2.
 const SYSTIMER_TARGET0_SOURCE: u32 = 57;
+const SYSTIMER_WAKE_TOKEN: u32 = 0;
 
 /// Mask for the 26-bit `period` field in TARGETx_CONF.
 const ALARM_PERIOD_MASK: u32 = 0x03FF_FFFF;
@@ -181,6 +182,85 @@ pub struct Systimer {
     /// this same IP but its matrix source IDs are 37/38/39, so the C3 wiring
     /// constructs the model with `new_with_source(_, 37)`.
     target0_source: u32,
+    /// Scheduler/elapsed-mode anchor in peripheral-tick units. The C3 ROM path
+    /// uses the default one CPU cycle per peripheral tick.
+    last_tick: u64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct SystimerSnapshotV2 {
+    conf: u32,
+    unit0: UnitState,
+    unit1: UnitState,
+    cpu_clock_hz: u32,
+    cpu_cycle_accum: u64,
+    unit0_alarms: [AlarmState; 3],
+    int_ena: u32,
+    date: u32,
+    target0_source: u32,
+    last_tick: u64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct SystimerSnapshotV1 {
+    conf: u32,
+    unit0: UnitState,
+    unit1: UnitState,
+    cpu_clock_hz: u32,
+    cpu_cycle_accum: u64,
+    unit0_alarms: [AlarmState; 3],
+    int_ena: u32,
+    date: u32,
+    target0_source: u32,
+}
+
+impl SystimerSnapshotV2 {
+    fn from_systimer(s: &Systimer) -> Self {
+        Self {
+            conf: s.conf,
+            unit0: s.unit0,
+            unit1: s.unit1,
+            cpu_clock_hz: s.cpu_clock_hz,
+            cpu_cycle_accum: s.cpu_cycle_accum,
+            unit0_alarms: s.unit0_alarms,
+            int_ena: s.int_ena,
+            date: s.date,
+            target0_source: s.target0_source,
+            last_tick: s.last_tick,
+        }
+    }
+
+    fn into_systimer(self) -> Systimer {
+        Systimer {
+            conf: self.conf,
+            unit0: self.unit0,
+            unit1: self.unit1,
+            cpu_clock_hz: self.cpu_clock_hz,
+            cpu_cycle_accum: self.cpu_cycle_accum,
+            unit0_alarms: self.unit0_alarms,
+            int_ena: self.int_ena,
+            date: self.date,
+            target0_source: self.target0_source,
+            last_tick: self.last_tick,
+        }
+    }
+}
+
+impl SystimerSnapshotV1 {
+    fn into_systimer(self) -> Systimer {
+        Systimer {
+            conf: self.conf,
+            unit0: self.unit0,
+            unit1: self.unit1,
+            cpu_clock_hz: self.cpu_clock_hz,
+            cpu_cycle_accum: self.cpu_cycle_accum,
+            unit0_alarms: self.unit0_alarms,
+            int_ena: self.int_ena,
+            date: self.date,
+            target0_source: self.target0_source,
+            last_tick: 0,
+        }
+    }
 }
 
 impl Systimer {
@@ -215,6 +295,7 @@ impl Systimer {
             // Silicon-validated date/revision register (read via OpenOCD).
             date: 0x0201_2251,
             target0_source,
+            last_tick: 0,
         }
     }
 
@@ -224,6 +305,109 @@ impl Systimer {
 
     fn unit1_running(&self) -> bool {
         self.conf & (1 << 29) != 0
+    }
+
+    fn cpu_per_systimer(&self) -> u64 {
+        (self.cpu_clock_hz as u64)
+            .saturating_div(SYSTIMER_CLOCK_HZ)
+            .max(1)
+    }
+
+    fn advance_cycles(&mut self, cycles: u64) {
+        if cycles == 0 {
+            return;
+        }
+        self.cpu_cycle_accum = self.cpu_cycle_accum.saturating_add(cycles);
+        let cpu_per_systimer = self.cpu_per_systimer();
+        if self.cpu_cycle_accum < cpu_per_systimer {
+            return;
+        }
+        let ticks = self.cpu_cycle_accum / cpu_per_systimer;
+        self.cpu_cycle_accum %= cpu_per_systimer;
+        if self.unit0_running() {
+            self.unit0.counter = self.unit0.counter.wrapping_add(ticks);
+        }
+        if self.unit1_running() {
+            self.unit1.counter = self.unit1.counter.wrapping_add(ticks);
+        }
+    }
+
+    fn evaluate_alarms(&mut self) -> Vec<u32> {
+        // ── Alarm checks ──
+        // For each enabled alarm, on the rising edge from `counter < target` to
+        // `counter >= target` we set the pending bit and bump the target for
+        // period-mode alarms. IRQ delivery is level-sensitive while
+        // `pending && int_ena`, matching the legacy tick path.
+        let mut explicit_irqs = Vec::new();
+        let unit0_counter = self.unit0.counter;
+        let unit1_counter = self.unit1.counter;
+        for (i, alarm) in self.unit0_alarms.iter_mut().enumerate() {
+            if !alarm.enabled {
+                continue;
+            }
+            let counter = if alarm.unit_sel {
+                unit1_counter
+            } else {
+                unit0_counter
+            };
+            if alarm.period_mode && alarm.period > 0 {
+                if counter >= alarm.target {
+                    alarm.pending = true;
+                    alarm.target = counter.saturating_add(alarm.period);
+                }
+            } else if counter >= alarm.target && !alarm.edge_latched {
+                alarm.edge_latched = true;
+                alarm.pending = true;
+            }
+            if alarm.pending && (self.int_ena & (1 << i) != 0) {
+                explicit_irqs.push(self.target0_source + i as u32);
+            }
+        }
+        explicit_irqs
+    }
+
+    fn sync_to_tick(&mut self, tick_now: u64) -> Vec<u32> {
+        if tick_now > self.last_tick {
+            self.advance_cycles(tick_now - self.last_tick);
+            self.last_tick = tick_now;
+        }
+        self.evaluate_alarms()
+    }
+
+    fn next_alarm_delay_cycles(&self) -> Option<u64> {
+        let cpu_per_systimer = self.cpu_per_systimer();
+        let mut best: Option<u64> = None;
+        for (i, alarm) in self.unit0_alarms.iter().enumerate() {
+            if alarm.pending && (self.int_ena & (1 << i) != 0) {
+                return Some(0);
+            }
+            if !alarm.enabled || alarm.pending {
+                continue;
+            }
+            let running = if alarm.unit_sel {
+                self.unit1_running()
+            } else {
+                self.unit0_running()
+            };
+            if !running {
+                continue;
+            }
+            let counter = if alarm.unit_sel {
+                self.unit1.counter
+            } else {
+                self.unit0.counter
+            };
+            let systimer_ticks = alarm.target.saturating_sub(counter);
+            let cycles = if systimer_ticks == 0 {
+                0
+            } else {
+                systimer_ticks
+                    .saturating_mul(cpu_per_systimer)
+                    .saturating_sub(self.cpu_cycle_accum.min(cpu_per_systimer - 1))
+            };
+            best = Some(best.map_or(cycles, |cur| cur.min(cycles)));
+        }
+        best
     }
 
     fn read_word(&self, offset: u64) -> u32 {
@@ -472,82 +656,11 @@ impl Peripheral for Systimer {
     /// One CPU cycle elapses per `tick`. Convert to SYSTIMER ticks at 16 MHz.
     /// At 80 MHz CPU clock, 5 CPU cycles == 1 SYSTIMER tick.
     fn tick(&mut self) -> PeripheralTickResult {
-        self.cpu_cycle_accum += 1;
-        let cpu_per_systimer = (self.cpu_clock_hz as u64)
-            .saturating_div(SYSTIMER_CLOCK_HZ)
-            .max(1);
-        if self.cpu_cycle_accum >= cpu_per_systimer {
-            let ticks = self.cpu_cycle_accum / cpu_per_systimer;
-            self.cpu_cycle_accum %= cpu_per_systimer;
-            if self.unit0_running() {
-                self.unit0.counter = self.unit0.counter.wrapping_add(ticks);
-            }
-            if self.unit1_running() {
-                self.unit1.counter = self.unit1.counter.wrapping_add(ticks);
-            }
-        }
+        self.tick_elapsed(1)
+    }
 
-        // ── Alarm checks ──
-        // For each enabled alarm, on the rising edge from
-        // `counter < target` to `counter >= target` we set the pending bit
-        // and bump the target for period-mode alarms.
-        //
-        // IRQ delivery is *level-sensitive*: as long as `pending && int_ena`,
-        // we keep emitting the SYSTIMER source ID on every tick. This
-        // matches real-silicon behaviour where the peripheral's IRQ line
-        // stays asserted until firmware writes INT_CLR. Without this,
-        // dispatch_irq's one-shot clear of `bus.pending_cpu_irqs` would
-        // race the firmware's own INTERRUPT-SR read inside the ISR — by
-        // the time __level_1_interrupt iterates through pending sources,
-        // both the bus aggregator bit and the SR bit are 0, so the ISR
-        // exits without invoking the user handler. (Plan 3 Task 10 case
-        // study — the ISR ran but never called alarm_isr; INT_RAW stayed
-        // sticky, and the LED never toggled.)
-        let mut explicit_irqs = Vec::new();
-        let unit0_counter = self.unit0.counter;
-        let unit1_counter = self.unit1.counter;
-        for (i, alarm) in self.unit0_alarms.iter_mut().enumerate() {
-            if !alarm.enabled {
-                continue;
-            }
-            let counter = if alarm.unit_sel {
-                unit1_counter
-            } else {
-                unit0_counter
-            };
-            // Fire when the counter reaches the target.
-            //
-            // PERIOD (auto-reload) mode is handled INDEPENDENTLY of
-            // `edge_latched`: real silicon re-arms automatically every
-            // `period` counts with no firmware intervention (no COMP_LOAD).
-            // We must not gate it behind `edge_latched`, because the FreeRTOS
-            // tick first arms the alarm one-shot, lets it fire once (latching
-            // edge_latched), THEN flips it to period mode via
-            // `systimer_ll_enable_alarm_period` with no COMP_LOAD — leaving a
-            // stale `edge_latched=true` and `target=0` that would wedge the
-            // alarm forever (one tick, then silence → idle cores never wake).
-            // On each period fire we rebase `target = counter + period`, which
-            // both keeps it periodic and repairs a stale/zero initial target.
-            if alarm.period_mode && alarm.period > 0 {
-                if counter >= alarm.target {
-                    alarm.pending = true;
-                    alarm.target = counter.saturating_add(alarm.period);
-                }
-            } else if counter >= alarm.target && !alarm.edge_latched {
-                // One-shot: fire once, latch until firmware re-arms (COMP_LOAD).
-                alarm.edge_latched = true;
-                alarm.pending = true;
-            }
-            // Level-sensitive IRQ: while pending && int_ena, emit the
-            // source on every tick. The bus aggregator OR's into
-            // pending_cpu_irqs, which dispatch_irq clears on entry — but
-            // because we re-emit each tick, the firmware sees a stable
-            // pending_cpu_irqs/INTERRUPT bit while it iterates handlers.
-            if alarm.pending && (self.int_ena & (1 << i) != 0) {
-                explicit_irqs.push(self.target0_source + i as u32);
-            }
-        }
-
+    fn tick_elapsed(&mut self, cycles: u64) -> PeripheralTickResult {
+        let explicit_irqs = self.sync_to_tick(self.last_tick.saturating_add(cycles));
         PeripheralTickResult {
             explicit_irqs: if explicit_irqs.is_empty() {
                 None
@@ -555,6 +668,34 @@ impl Peripheral for Systimer {
                 Some(explicit_irqs)
             },
             ..PeripheralTickResult::default()
+        }
+    }
+
+    fn uses_scheduler(&self) -> bool {
+        true
+    }
+
+    fn sync_to(&mut self, tick_now: u64) {
+        self.sync_to_tick(tick_now);
+    }
+
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        self.next_alarm_delay_cycles()
+            .map(|delay| vec![(delay, SYSTIMER_WAKE_TOKEN)])
+            .unwrap_or_default()
+    }
+
+    fn on_event(
+        &mut self,
+        _event_token: u32,
+        sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        let explicit_irqs = self.sync_to_tick(sched.now());
+        crate::sched::EventResult {
+            explicit_irqs,
+            reschedule_delay: self.next_alarm_delay_cycles(),
+            ..Default::default()
         }
     }
 
@@ -571,14 +712,19 @@ impl Peripheral for Systimer {
     /// not restore it would print different IDF log timestamps than the cold
     /// boot — the counter must carry across the snapshot for byte-exact serial.
     fn runtime_snapshot(&self) -> Vec<u8> {
-        bincode::serialize(self).expect("bincode serialize Systimer")
+        bincode::serialize(&SystimerSnapshotV2::from_systimer(self))
+            .expect("bincode serialize Systimer")
     }
 
     fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
-        let restored: Systimer = bincode::deserialize(bytes).map_err(|e| {
+        if let Ok(restored) = bincode::deserialize::<SystimerSnapshotV2>(bytes) {
+            *self = restored.into_systimer();
+            return Ok(());
+        }
+        let restored = bincode::deserialize::<SystimerSnapshotV1>(bytes).map_err(|e| {
             crate::SimulationError::NotImplemented(format!("Systimer snapshot decode: {e}"))
         })?;
-        *self = restored;
+        *self = restored.into_systimer();
         Ok(())
     }
 }
@@ -630,6 +776,74 @@ mod tests {
             s.tick();
         }
         assert_eq!(s.unit0.counter, 1);
+    }
+
+    #[test]
+    fn tick_elapsed_matches_repeated_tick_for_counter_and_alarm() {
+        let mut repeated = Systimer::new_with_source(160_000_000, 37);
+        let mut elapsed = Systimer::new_with_source(160_000_000, 37);
+
+        repeated.write_word(0x64, 1);
+        elapsed.write_word(0x64, 1);
+
+        repeated.write_word(0x1C, 0);
+        repeated.write_word(0x20, 2);
+        repeated.write_word(0x50, 1);
+        repeated.write_word(0x00, repeated.read_word(0x00) | (1 << 24));
+
+        elapsed.write_word(0x1C, 0);
+        elapsed.write_word(0x20, 2);
+        elapsed.write_word(0x50, 1);
+        elapsed.write_word(0x00, elapsed.read_word(0x00) | (1 << 24));
+
+        let mut repeated_irq = None;
+        for _ in 0..30 {
+            repeated_irq = repeated.tick().explicit_irqs;
+        }
+        let elapsed_irq = elapsed.tick_elapsed(30).explicit_irqs;
+
+        assert_eq!(elapsed.unit0.counter, repeated.unit0.counter);
+        assert_eq!(elapsed.read_word(0x68), repeated.read_word(0x68));
+        assert_eq!(elapsed_irq, repeated_irq);
+    }
+
+    #[test]
+    fn alarm_arm_schedules_next_deadline() {
+        let mut s = Systimer::new_with_source(160_000_000, 37);
+        s.write_word(0x64, 1);
+        s.write_word(0x1C, 0);
+        s.write_word(0x20, 3);
+        s.write_word(0x50, 1);
+        s.write_word(0x00, s.read_word(0x00) | (1 << 24));
+
+        assert!(s.uses_scheduler());
+        assert_eq!(s.take_scheduled_events(), vec![(30, 0)]);
+    }
+
+    #[test]
+    fn restore_accepts_pre_scheduler_snapshot() {
+        let mut original = Systimer::new_with_source(160_000_000, 37);
+        original.tick_elapsed(25);
+        let old = SystimerSnapshotV1 {
+            conf: original.conf,
+            unit0: original.unit0,
+            unit1: original.unit1,
+            cpu_clock_hz: original.cpu_clock_hz,
+            cpu_cycle_accum: original.cpu_cycle_accum,
+            unit0_alarms: original.unit0_alarms,
+            int_ena: original.int_ena,
+            date: original.date,
+            target0_source: original.target0_source,
+        };
+        let bytes = bincode::serialize(&old).unwrap();
+
+        let mut restored = Systimer::new_with_source(80_000_000, 57);
+        restored.restore_runtime_snapshot(&bytes).unwrap();
+
+        assert_eq!(restored.unit0.counter, original.unit0.counter);
+        assert_eq!(restored.cpu_cycle_accum, original.cpu_cycle_accum);
+        assert_eq!(restored.target0_source, 37);
+        assert_eq!(restored.last_tick, 0);
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
+++ b/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
@@ -93,6 +93,10 @@ impl Peripheral for UsbSerialJtag {
         Ok(())
     }
 
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-06 | ⚠ drift acked 2026-07-06 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-06 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -461,7 +461,12 @@ boards:
     # state, invoked only on snapshot/resume — normal-run behaviour and the 9-reg
     # reset-state silicon anchor are byte-for-byte unaffected. Covers the model-file
     # touch; no live re-capture warranted.
-    drift_ack: 2026-07-05
+    # 2026-07-06: SYSTIMER gained scheduler/elapsed-cycle execution so C3/S3 idle
+    # fast-forward can jump directly to alarm deadlines instead of polling every
+    # CPU cycle. The register layout, reset values (including CONF=0x46000000),
+    # level IRQ semantics, and one-cycle tick equivalence are preserved by offline
+    # elapsed-vs-repeated-tick tests; no live USB-JTAG re-capture this session.
+    drift_ack: 2026-07-06
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
## Summary
- allow idle fast-forward when legacy peripherals are dynamically safe instead of requiring the whole legacy walk to be disabled
- make ESP32-C3/S3 SYSTIMER scheduler-driven with elapsed-cycle alarm deadlines
- add elapsed paths for C3 RTC timer and LEDC, and mark inert C3/S3 helper peripherals inactive for legacy ticks
- stop CPU batches at WFI when idle fast-forward is enabled so the machine can skip the idle window
- keep SYSTIMER runtime snapshots backward-compatible with pre-scheduler snapshots

## Verification
- cargo fmt --check
- cargo clippy -p labwired-core --all-targets --features event-scheduler -- -D warnings
- cargo test -p labwired-core --lib --features event-scheduler
- cargo test -p labwired-core --test event_scheduler --features event-scheduler
- cargo test -p labwired-core esp32c3 --features event-scheduler
- focused WFI/SYSTIMER/elapsed equivalence tests
