### PR TITLE
Reduce GitHub Actions usage

### DIFF
--- a/.github/workflows/core-board-ci.yml
+++ b/.github/workflows/core-board-ci.yml
@@ -3,15 +3,38 @@ name: Core Board CI
 on:
   push:
     branches: [main]
+    paths:
+      - "configs/**"
+      - "examples/**"
+      - "hil/**"
+      - "platformio/**"
+      - "scripts/ci/board_matrix.py"
+      - "scripts/generate_tier1_scoreboard.py"
+      - "docs/coverage/tier1-matrix.json"
+      - ".github/workflows/core-board-ci.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "configs/**"
+      - "examples/**"
+      - "hil/**"
+      - "platformio/**"
+      - "scripts/ci/board_matrix.py"
+      - "scripts/generate_tier1_scoreboard.py"
+      - "docs/coverage/tier1-matrix.json"
+      - ".github/workflows/core-board-ci.yml"
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * 0"
   workflow_dispatch:
+
+concurrency:
+  group: core-board-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   setup:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
@@ -30,6 +53,7 @@ jobs:
   board:
     needs: setup
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
@@ -94,6 +118,7 @@ jobs:
   # whoever changed the matrix must commit the regenerated scoreboard.
   coverage-staleness:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -9,14 +9,20 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: core-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Fast PR gate (REQUIRED) ────────────────────────────────────────────────
   # Formatting, lints, and unit tests only — no firmware cross-builds, no
   # fixture-dependent integration tests, no Tier-1 sims. Target a few minutes so
-  # PRs merge fast. The complete suite runs post-merge in `core-full` below.
+  # PRs merge fast. The complete suite is now opt-in via manual dispatch or a
+  # `[full-ci]` marker on a main-branch commit while Actions quota is tight.
   integrity:
     name: core-integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,18 +65,21 @@ jobs:
       # Library unit tests across the workspace. `--lib` skips the no_std
       # firmware bin crates (which only build for thumb targets) and the
       # integration tests under tests/ that need pre-built firmware fixtures —
-      # both run in core-full post-merge.
+      # both run in core-full when explicitly requested.
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
 
   # ── Full suite (NOT a PR gate) ─────────────────────────────────────────────
-  # Runs after merge on main (and on manual dispatch). Builds firmware fixtures,
-  # runs the complete workspace tests, the host-only feature lanes, and the
-  # Tier-1 matrix + ratchet. A regression caught here is fixed forward on main.
+  # Builds firmware fixtures, runs the complete workspace tests, the host-only
+  # feature lanes, and the Tier-1 matrix + ratchet. This is expensive, so keep it
+  # manual/opt-in instead of running it after every merge to main.
   full:
     name: core-full
-    if: github.event_name != 'pull_request'
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.event.head_commit.message, '[full-ci]'))
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -1,12 +1,15 @@
 name: Core Coverage Matrix Smoke
 
 on:
-  # Post-merge: run the full matrix on every push to main so all tests run
-  # after merge even when a PR only touched core crates (the fast PR gate does
-  # not block on this).
   push:
     branches:
       - main
+    paths:
+      - "configs/chips/**"
+      - "configs/systems/**"
+      - "examples/**"
+      - "crates/labwired-models-**"
+      - ".github/workflows/core-coverage-matrix-smoke.yml"
   pull_request:
     branches:
       - main
@@ -18,11 +21,15 @@ on:
       - ".github/workflows/core-coverage-matrix-smoke.yml"
   workflow_dispatch:
 
+concurrency:
+  group: core-coverage-matrix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   coverage-matrix-smoke:
     name: coverage-matrix-${{ matrix.id }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -171,6 +178,7 @@ jobs:
   coverage-matrix-scoreboard:
     name: coverage-matrix-scoreboard
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: coverage-matrix-smoke
     if: always()
     steps:

--- a/.github/workflows/core-coverage.yml
+++ b/.github/workflows/core-coverage.yml
@@ -2,13 +2,17 @@ name: Core Coverage Gate
 
 on:
   schedule:
-    - cron: "20 2 * * *"
+    - cron: "20 2 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: core-coverage
+  cancel-in-progress: true
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -2,16 +2,21 @@ name: Rust Core Nightly
 
 on:
   schedule:
-    - cron: '0 2 * * *' # 2 AM UTC
+    - cron: '0 2 * * 0' # Sundays 02:00 UTC
   workflow_dispatch:
 
 permissions:
   contents: write
 
+concurrency:
+  group: core-nightly
+  cancel-in-progress: true
+
 jobs:
   validation:
     name: Advanced Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -69,6 +74,7 @@ jobs:
   example-smokes:
     name: Example Smokes (real-output autochecks)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -112,6 +118,7 @@ jobs:
   esp32s3-fixtures-e2e:
     name: ESP32-S3 Fixtures E2E (espup)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -180,6 +187,7 @@ jobs:
   tier1-fixture-drift:
     name: Tier-1 Fixture Drift Check
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       # Gate to Sundays only for scheduled runs; workflow_dispatch always proceeds.
       - name: Set drift-skip flag on non-Sunday scheduled runs

--- a/.github/workflows/core-onboarding-smoke.yml
+++ b/.github/workflows/core-onboarding-smoke.yml
@@ -1,12 +1,15 @@
 name: Core Onboarding Smoke
 
 on:
-  # Post-merge: run the full matrix on every push to main so all tests run
-  # after merge even when a PR only touched core crates (the fast PR gate does
-  # not block on this).
   push:
     branches:
       - main
+    paths:
+      - "configs/chips/**"
+      - "configs/systems/**"
+      - "examples/**"
+      - "crates/labwired-models-**"
+      - ".github/workflows/core-onboarding-smoke.yml"
   pull_request:
     branches:
       - main
@@ -18,11 +21,15 @@ on:
       - ".github/workflows/core-onboarding-smoke.yml"
   workflow_dispatch:
 
+concurrency:
+  group: core-onboarding-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   onboarding-smoke:
     name: onboarding-${{ matrix.id }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -86,6 +93,7 @@ jobs:
   onboarding-scoreboard:
     name: onboarding-scoreboard
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: onboarding-smoke
     if: always()
     steps:


### PR DESCRIPTION
## Summary
- keep the required fast core PR gate, but make the expensive `core-full` suite manual/opt-in via `[full-ci]`
- reduce daily heavy scheduled workflows to weekly and add cancellation/timeouts
- narrow board, coverage-matrix, and onboarding workflows to relevant paths on push/PR

## Context
July billing showed `labwired-core` as the top Actions consumer. Recent runs were dominated by `Rust Core CI`, `Core Board CI`, `Rust Core Nightly`, and post-merge matrix workflows.

## Verification
- Connector compare confirms this branch changes only `.github/workflows/*.yml`
- Local YAML parsing was run for the local workflow edits in related repos; remote workflow syntax still needs GitHub Actions to validate on this PR branch.