### PR TITLE
fix: keep scheduler peripherals out of legacy tick walk

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -27,6 +27,14 @@ mod tick;
 pub use bus_trace::{new_log, BusPayload, BusTraceEvent, BusTraceLog, I2cSym};
 
 impl SystemBus {
+    #[inline]
+    fn legacy_tick_index_active(p: &PeripheralEntry) -> bool {
+        if cfg!(feature = "event-scheduler") && p.dev.uses_scheduler() {
+            return false;
+        }
+        p.dev.legacy_tick_active()
+    }
+
     /// True when CPU idle fast-forward can skip the legacy peripheral walk for
     /// the skipped window without dropping observable work. Scheduler-driven
     /// peripherals are safe because the machine clamps to their next deadline;
@@ -2650,6 +2658,43 @@ mod tests {
         assert!(
             bus.legacy_tick_indices.is_empty(),
             "one-shot declarative timing should leave the hot tick set after it drains"
+        );
+    }
+
+    #[cfg(feature = "event-scheduler")]
+    #[test]
+    fn scheduler_peripherals_do_not_enter_legacy_tick_index() {
+        #[derive(Debug)]
+        struct SchedulerPeripheral;
+        impl crate::Peripheral for SchedulerPeripheral {
+            fn read(&self, _offset: u64) -> SimResult<u8> {
+                Ok(0)
+            }
+
+            fn write(&mut self, _offset: u64, _value: u8) -> SimResult<()> {
+                Ok(())
+            }
+
+            fn legacy_tick_active(&self) -> bool {
+                true
+            }
+
+            fn uses_scheduler(&self) -> bool {
+                true
+            }
+        }
+
+        let mut bus = SystemBus::empty();
+        bus.add_peripheral("sched", 0x1000, 0x100, None, Box::new(SchedulerPeripheral));
+
+        assert!(
+            bus.legacy_tick_indices.is_empty(),
+            "scheduler-owned peripherals are advanced by the event scheduler, not the legacy tick walk"
+        );
+        assert!(!bus.refresh_legacy_tick_index(0));
+        assert!(
+            bus.legacy_tick_indices.is_empty(),
+            "refresh must not reinsert scheduler-owned peripherals into the legacy tick walk"
         );
     }
 

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -155,7 +155,7 @@ impl SystemBus {
             .peripherals
             .iter()
             .enumerate()
-            .filter_map(|(index, p)| p.dev.legacy_tick_active().then_some(index))
+            .filter_map(|(index, p)| Self::legacy_tick_index_active(p).then_some(index))
             .collect();
         self.bus_tick_indices = self
             .peripherals
@@ -315,7 +315,7 @@ impl SystemBus {
         let active = self
             .peripherals
             .get(idx)
-            .is_some_and(|p| p.dev.legacy_tick_active());
+            .is_some_and(Self::legacy_tick_index_active);
         let pos = self.legacy_tick_indices.iter().position(|&i| i == idx);
         match (active, pos) {
             (true, None) => {

--- a/crates/core/src/tests/test_cycles.rs
+++ b/crates/core/src/tests/test_cycles.rs
@@ -89,7 +89,12 @@ fn machine_run_records_step_profile_counters() {
     assert_eq!(profile.peripheral_ticks, 2);
     assert_eq!(profile.peripheral_ticked_entries, 0);
     assert_eq!(profile.bus_tick_entries, 0);
-    assert_eq!(profile.legacy_tick_entries, 8);
+    let expected_legacy_tick_entries = if cfg!(feature = "event-scheduler") {
+        6
+    } else {
+        8
+    };
+    assert_eq!(profile.legacy_tick_entries, expected_legacy_tick_entries);
 }
 
 /// A peripheral that reports a fixed byte from the side-effect-free `peek`.


### PR DESCRIPTION
## Summary
- exclude event-scheduler owned peripherals from the legacy tick index
- keep non-event-scheduler builds on the existing conservative path
- add a regression test covering scheduler-owned peripherals that still report legacy_tick_active

## Safety
This does not skip emulated time or bypass ROM boot. In event-scheduler builds these peripherals were already skipped inside the legacy tick loop; this removes the dead hot-path iteration and leaves their sync/event handling on the scheduler path.

## Tests
- cargo test -p labwired-core scheduler_peripherals_do_not_enter_legacy_tick_index --features event-scheduler
- cargo test -p labwired-core declarative_peripherals_enter_legacy_tick_set_only_while_events_are_pending --features event-scheduler
- cargo test -p labwired-wasm esp32c3_ -- --nocapture
- cargo test -p labwired-wasm --release wasm_romboot_oled_paints -- --ignored --nocapture