### PR TITLE
fix: keep C3 romboot timers read-fresh in wasm

### DIFF
--- a/crates/core/src/boot/esp32c3_rom.rs
+++ b/crates/core/src/boot/esp32c3_rom.rs
@@ -439,7 +439,12 @@ pub fn build_rom_boot_machine<C: crate::Cpu, F: FnOnce(crate::cpu::RiscV) -> C>(
         // C3 SYSTIMER_TARGET0 routes through the interrupt matrix on source
         // 37 (TARGET1/2 at 38/39), unlike the S3's 57; the FreeRTOS tick
         // alarm fires on that source.
-        Box::new(crate::peripherals::esp32s3::systimer::Systimer::new_with_source(160_000_000, 37)),
+        Box::new(
+            crate::peripherals::esp32s3::systimer::Systimer::new_with_source_legacy_tick(
+                160_000_000,
+                37,
+            ),
+        ),
     );
     // RTC_CNTL main timer (0x6000_8000): the free-running slow-clock counter
     // the IDF reads via rtc_time_get (set TIME_UPDATE @0x0C bit31 to latch,

--- a/crates/core/src/peripherals/esp32c3/rtc_timer.rs
+++ b/crates/core/src/peripherals/esp32c3/rtc_timer.rs
@@ -116,7 +116,11 @@ impl Peripheral for Esp32c3RtcTimer {
     }
 
     fn uses_scheduler(&self) -> bool {
-        true
+        // The bus read API is intentionally `&self`; until it can sync
+        // scheduler-driven peripherals before reads, this read-driven RTC must
+        // stay on the legacy tick path or firmware delay loops observe stale
+        // time and spin forever.
+        false
     }
 
     fn sync_to(&mut self, tick_now: u64) {
@@ -221,6 +225,17 @@ mod tests {
         elapsed.tick_elapsed(1000);
 
         assert_eq!(rtc_time_get(&mut elapsed), rtc_time_get(&mut repeated));
+    }
+
+    #[test]
+    fn rtc_timer_stays_on_legacy_tick_path() {
+        let t = Esp32c3RtcTimer::new();
+
+        assert!(
+            !t.uses_scheduler(),
+            "RTC timer reads are time-sensitive; until bus reads can sync scheduler-driven \
+             peripherals, the C3 RTC must stay on the legacy tick path"
+        );
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32s3/systimer.rs
+++ b/crates/core/src/peripherals/esp32s3/systimer.rs
@@ -185,6 +185,13 @@ pub struct Systimer {
     /// Scheduler/elapsed-mode anchor in peripheral-tick units. The C3 ROM path
     /// uses the default one CPU cycle per peripheral tick.
     last_tick: u64,
+    /// Whether this instance participates in the event scheduler.
+    ///
+    /// C3 firmware commonly reads SYSTIMER through write-UPDATE/read-snapshot
+    /// sequences. The current bus read API cannot sync scheduler-driven
+    /// peripherals before reads, so C3 ROM boot keeps this false and uses the
+    /// legacy per-cycle tick path for fidelity.
+    scheduler_enabled: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -242,6 +249,7 @@ impl SystimerSnapshotV2 {
             date: self.date,
             target0_source: self.target0_source,
             last_tick: self.last_tick,
+            scheduler_enabled: true,
         }
     }
 }
@@ -259,6 +267,7 @@ impl SystimerSnapshotV1 {
             date: self.date,
             target0_source: self.target0_source,
             last_tick: 0,
+            scheduler_enabled: true,
         }
     }
 }
@@ -296,7 +305,18 @@ impl Systimer {
             date: 0x0201_2251,
             target0_source,
             last_tick: 0,
+            scheduler_enabled: true,
         }
+    }
+
+    /// Construct a SYSTIMER that stays on the legacy per-cycle tick path.
+    ///
+    /// This is used by ESP32-C3 ROM boot until scheduler-driven peripherals can
+    /// be synchronized before MMIO reads as well as before writes.
+    pub fn new_with_source_legacy_tick(cpu_clock_hz: u32, target0_source: u32) -> Self {
+        let mut timer = Self::new_with_source(cpu_clock_hz, target0_source);
+        timer.scheduler_enabled = false;
+        timer
     }
 
     fn unit0_running(&self) -> bool {
@@ -672,7 +692,7 @@ impl Peripheral for Systimer {
     }
 
     fn uses_scheduler(&self) -> bool {
-        true
+        self.scheduler_enabled
     }
 
     fn sync_to(&mut self, tick_now: u64) {
@@ -680,6 +700,9 @@ impl Peripheral for Systimer {
     }
 
     fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if !self.scheduler_enabled {
+            return Vec::new();
+        }
         self.next_alarm_delay_cycles()
             .map(|delay| vec![(delay, SYSTIMER_WAKE_TOKEN)])
             .unwrap_or_default()
@@ -717,14 +740,17 @@ impl Peripheral for Systimer {
     }
 
     fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        let scheduler_enabled = self.scheduler_enabled;
         if let Ok(restored) = bincode::deserialize::<SystimerSnapshotV2>(bytes) {
             *self = restored.into_systimer();
+            self.scheduler_enabled = scheduler_enabled;
             return Ok(());
         }
         let restored = bincode::deserialize::<SystimerSnapshotV1>(bytes).map_err(|e| {
             crate::SimulationError::NotImplemented(format!("Systimer snapshot decode: {e}"))
         })?;
         *self = restored.into_systimer();
+        self.scheduler_enabled = scheduler_enabled;
         Ok(())
     }
 }
@@ -818,6 +844,36 @@ mod tests {
 
         assert!(s.uses_scheduler());
         assert_eq!(s.take_scheduled_events(), vec![(30, 0)]);
+    }
+
+    #[test]
+    fn c3_legacy_constructor_stays_off_scheduler() {
+        let mut s = Systimer::new_with_source_legacy_tick(160_000_000, 37);
+
+        assert!(!s.uses_scheduler());
+        assert!(s.take_scheduled_events().is_empty());
+
+        s.tick_elapsed(10);
+        assert_eq!(
+            s.unit0.counter, 1,
+            "legacy mode must still advance the live counter through ticks"
+        );
+    }
+
+    #[test]
+    fn restore_preserves_current_scheduler_mode() {
+        let mut original = Systimer::new_with_source(160_000_000, 37);
+        original.tick_elapsed(25);
+        let bytes = original.runtime_snapshot();
+
+        let mut restored = Systimer::new_with_source_legacy_tick(160_000_000, 37);
+        restored.restore_runtime_snapshot(&bytes).unwrap();
+
+        assert_eq!(restored.unit0.counter, original.unit0.counter);
+        assert!(
+            !restored.uses_scheduler(),
+            "restore must not flip a C3 legacy-tick instance back to scheduler mode"
+        );
     }
 
     #[test]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -383,7 +383,7 @@ impl WasmSimulator {
                 debug_uart.eq_ignore_ascii_case("usb_serial_jtag")
                     || debug_uart.eq_ignore_ascii_case("usb-serial-jtag")
             })
-            .unwrap_or(true);
+            .unwrap_or(false);
         if !capture_usb_serial {
             if let Some(debug_uart) = manifest.debug_uart.as_deref() {
                 if !bus.attach_uart_tx_sink_named(debug_uart, uart_sink.clone(), false) {
@@ -1042,6 +1042,17 @@ impl WasmSimulator {
         self.machine().config.idle_fast_forward_enabled = enabled;
     }
 
+    /// Set the peripheral tick interval used by `Machine::run`.
+    ///
+    /// `1` is the exact default: tick orchestration runs after every executed
+    /// instruction. Larger values are a bounded browser acceleration knob for
+    /// firmware bring-up paths whose active peripherals are scheduler-driven or
+    /// inactive.
+    #[wasm_bindgen]
+    pub fn set_peripheral_tick_interval(&mut self, interval: u32) {
+        self.machine().config.peripheral_tick_interval = interval.max(1);
+    }
+
     /// Total number of times the browser JIT has dispatched a
     /// compiled block. Useful for confirming the JIT path actually
     /// fired during a benchmark.
@@ -1455,6 +1466,67 @@ mod romboot_tests {
             painted,
             "C3 OLED lab did not paint (>= {MIN_LIT} lit pixels) within {MAX_STEPS} steps; \
              last count = {lit}.\n--- captured serial ---\n{out}"
+        );
+    }
+
+    /// Accelerated C3 flash shares must still run the real app image and paint
+    /// attached devices. This skips the mask-ROM replay, but does not fake the
+    /// OLED: pixels must come from firmware I2C writes into the SSD1306 model.
+    #[test]
+    fn wasm_c3_flash_fast_start_oled_paints_quickly() {
+        let manifest_dir = root();
+        let chip_yaml =
+            std::fs::read_to_string(manifest_dir.join("../../configs/chips/esp32c3.yaml"))
+                .expect("read esp32c3 chip yaml");
+        let system_yaml = std::fs::read_to_string(
+            manifest_dir.join("../../configs/systems/esp32c3-oled-demo.yaml"),
+        )
+        .expect("read esp32c3-oled-demo system yaml");
+        let chip: ChipDescriptor = serde_yaml::from_str(&chip_yaml).expect("parse chip yaml");
+        let manifest: SystemManifest =
+            serde_yaml::from_str(&system_yaml).expect("parse system yaml");
+
+        let irom = std::fs::read(manifest_dir.join("../core/roms/esp32c3/esp32c3_rom.bin"))
+            .expect("read vendored C3 IROM");
+        let drom = std::fs::read(manifest_dir.join("../core/roms/esp32c3/esp32c3_drom.bin"))
+            .expect("read vendored C3 DROM");
+        let flash = std::fs::read(manifest_dir.join("tests/fixtures/esp32c3-oled-demo-flash.bin"))
+            .expect("read C3 OLED demo flash image");
+
+        let mut blobs: HashMap<String, Vec<u8>> = HashMap::new();
+        blobs.insert("esp32c3_irom".into(), irom);
+        blobs.insert("esp32c3_drom".into(), drom);
+        blobs.insert("esp32c3_flash".into(), flash);
+
+        let mut sim = WasmSimulator::new_from_config_riscv_flash_fastboot(&chip, &manifest, &blobs)
+            .expect("construct C3 flash fast-start WasmSimulator");
+
+        const BATCH: u32 = 1_000_000;
+        const MAX_STEPS: u64 = 40_000_000;
+        const MIN_LIT: usize = 400;
+        let mut steps: u64 = 0;
+        let mut lit = 0usize;
+        while steps < MAX_STEPS {
+            sim.step(BATCH).expect("step");
+            steps += BATCH as u64;
+            if let Ok(fb) = sim.get_ssd1306_framebuffer("oled") {
+                lit = fb.iter().map(|b| b.count_ones() as usize).sum();
+                if lit >= MIN_LIT {
+                    let out = String::from_utf8_lossy(&sim.uart_sink.lock().unwrap()).into_owned();
+                    assert!(
+                        out.contains("oled-lab"),
+                        "C3 flash fast-start painted but did not capture UART0 app logs; \
+                         captured serial:\n{out}"
+                    );
+                    return;
+                }
+            }
+        }
+
+        let out = String::from_utf8_lossy(&sim.uart_sink.lock().unwrap()).into_owned();
+        panic!(
+            "C3 flash fast-start did not paint OLED (>= {MIN_LIT} lit pixels) within \
+             {MAX_STEPS} steps; last count = {lit}.\n--- captured serial ---\n{out}"
         );
     }
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,12 +10,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-06 | ⚠ drift acked 2026-07-06 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-07 | ⚠ drift acked 2026-07-07 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-06 | ⚠ drift acked 2026-07-06 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-07 | ⚠ drift acked 2026-07-07 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-06 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-07 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-06 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-07 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -238,7 +238,12 @@ boards:
     # parameters, matching Arduino/Wire traffic; this is an attached device model,
     # not an ESP32-C3 silicon register/reset change. No live USB-JTAG re-capture
     # this session; re-capture remains pending.
-    drift_ack: 2026-07-06
+    # 2026-07-07: C3 ROM-boot RTC and SYSTIMER stay on the legacy tick path under
+    # event-scheduler because the current bus read API cannot sync scheduler-driven
+    # peripherals before read-driven timer snapshots. This restores the same
+    # per-cycle timer freshness as the non-scheduler path and is covered by the
+    # generated Arduino OLED ROM-boot regression; no reset-register silicon change.
+    drift_ack: 2026-07-07
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -466,7 +471,11 @@ boards:
     # CPU cycle. The register layout, reset values (including CONF=0x46000000),
     # level IRQ semantics, and one-cycle tick equivalence are preserved by offline
     # elapsed-vs-repeated-tick tests; no live USB-JTAG re-capture this session.
-    drift_ack: 2026-07-06
+    # 2026-07-07: SYSTIMER gained a per-instance scheduler-mode flag so C3 ROM boot
+    # can force legacy ticking while the default S3 constructor remains
+    # scheduler-driven. S3 reset values/MMIO semantics are unchanged; unit coverage
+    # asserts default scheduler behaviour and snapshot compatibility.
+    drift_ack: 2026-07-07
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
## Summary\n- Keep ESP32-C3 RTC and C3 ROM-boot SYSTIMER on the legacy tick path under event-scheduler so read-driven timer code sees fresh time.\n- Preserve S3 SYSTIMER scheduler behavior and add snapshot-mode/unit coverage.\n- Align C3 flash fast-start serial capture with faithful ROM boot and assert UART + OLED in wasm regression.\n\n## Test Plan\n- cargo test -p labwired-core --features event-scheduler systimer::tests -- --nocapture\n- cargo test -p labwired-core --features event-scheduler rtc_timer_stays_on_legacy_tick_path -- --nocapture\n- cargo test -p labwired-wasm --release wasm_c3_flash_fast_start_oled_paints_quickly --features labwired-core/event-scheduler -- --nocapture\n- LABWIRED_ESP32C3_FLASH=/tmp/labwired-yl8hCaEuWkpd-flash.bin cargo run --release -p labwired-cli --features labwired-core/event-scheduler -- test --rom-boot --script /tmp/labwired-share-stop-fast.yaml --max-steps 20000000 --json