### PR TITLE
feat: add ESP32-C3 display workshop labs

### DIFF
--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -53,10 +53,9 @@ peripherals:
     base_address: 0x60000000
     size: "512B"
   - id: "gpio"
-    type: "declarative"
+    type: "esp32c3_gpio"
     base_address: 0x60004000
-    config:
-      path: "../peripherals/esp32c3/gpio.yaml"
+    size: "4KB"
   - id: "timg0"
     type: "esp32_timg"
     base_address: 0x6001F000

--- a/configs/systems/esp32c3-epaper-workshop.yaml
+++ b/configs/systems/esp32c3-epaper-workshop.yaml
@@ -1,0 +1,19 @@
+name: "esp32c3-epaper-workshop"
+chip: "../chips/esp32c3.yaml"
+
+external_devices:
+  - id: "epaper"
+    type: "ssd1680_tricolor_290"
+    connection: "spi2"
+    config:
+      cs_pin: "GPIO10"
+      dc_pin: "GPIO2"
+
+board_io:
+  - id: "epaper"
+    kind: "spi_device"
+    peripheral: "spi2"
+    pin: 10
+    signal: "input"
+    active_high: true
+    device_type: "ssd1680_tricolor_290"

--- a/configs/systems/esp32c3-nokia5110-workshop.yaml
+++ b/configs/systems/esp32c3-nokia5110-workshop.yaml
@@ -1,0 +1,19 @@
+name: "esp32c3-nokia5110-workshop"
+chip: "../chips/esp32c3.yaml"
+
+external_devices:
+  - id: "lcd"
+    type: "pcd8544"
+    connection: "spi2"
+    config:
+      cs_pin: "GPIO10"
+      dc_pin: "GPIO2"
+
+board_io:
+  - id: "lcd"
+    kind: "spi_device"
+    peripheral: "spi2"
+    pin: 10
+    signal: "input"
+    active_high: true
+    device_type: "pcd8544"

--- a/configs/systems/esp32c3-oled-128x32-workshop.yaml
+++ b/configs/systems/esp32c3-oled-128x32-workshop.yaml
@@ -1,0 +1,19 @@
+name: "esp32c3-oled-128x32-workshop"
+chip: "../chips/esp32c3.yaml"
+
+external_devices:
+  - id: "oled"
+    type: "oled-ssd1306-128x32"
+    connection: "i2c0"
+    config:
+      i2c_address: 0x3C
+
+board_io:
+  - id: "oled"
+    kind: "i2c_device"
+    peripheral: "i2c0"
+    pin: 4
+    signal: "input"
+    active_high: true
+    i2c_address: 0x3C
+    device_type: "oled-ssd1306-128x32"

--- a/configs/systems/esp32c3-tm1637-clock-workshop.yaml
+++ b/configs/systems/esp32c3-tm1637-clock-workshop.yaml
@@ -1,0 +1,10 @@
+name: "esp32c3-tm1637-clock-workshop"
+chip: "../chips/esp32c3.yaml"
+
+external_devices:
+  - id: "seg"
+    type: "tm1637-7seg"
+    connection: "gpio"
+    config:
+      clk_pin: "GPIO0"
+      dio_pin: "GPIO1"

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -142,13 +142,18 @@ impl SystemBus {
             // Per-family factories own their peripheral arms in their own modules,
             // so this central match stops growing (and shrinks as families migrate
             // out). Try them first; unmigrated families fall through to the match.
-            let family_dev = crate::peripherals::esp32s3::factory::try_build(
-                &canonical_type,
-                p_cfg,
-            )
-            .or_else(|| {
-                crate::peripherals::nrf52::factory::try_build(&canonical_type, p_cfg, manifest)
-            });
+            let family_dev =
+                crate::peripherals::esp32s3::factory::try_build(&canonical_type, p_cfg)
+                    .or_else(|| {
+                        crate::peripherals::esp32c3::factory::try_build(&canonical_type, p_cfg)
+                    })
+                    .or_else(|| {
+                        crate::peripherals::nrf52::factory::try_build(
+                            &canonical_type,
+                            p_cfg,
+                            manifest,
+                        )
+                    });
             if let Some(dev) = family_dev {
                 // The nRF52 serial-instance mux (SPIM0/TWIM0) attaches all
                 // external devices connected to the shared MMIO window itself,

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1705,15 +1705,19 @@ impl SystemBus {
     /// for SPI peripherals with no D/C-observing device (one cheap downcast).
     fn maybe_latch_dc(&mut self, idx: usize) {
         use crate::peripherals::esp32::spi::Esp32Spi;
+        use crate::peripherals::esp32c3::spi::Esp32c3Spi;
         use crate::peripherals::spi::{Spi, SpiDevice};
 
         // Borrow the attached-device list off whichever SPI peripheral kind
-        // this is (generic `Spi` for STM32/Nordic, `Esp32Spi` for ESP32).
+        // this is (generic `Spi` for STM32/Nordic, ESP32-family SPI variants).
         fn attached_ref(any: &dyn std::any::Any) -> Option<&Vec<Box<dyn SpiDevice>>> {
             if let Some(s) = any.downcast_ref::<Spi>() {
                 return Some(&s.attached_devices);
             }
             if let Some(s) = any.downcast_ref::<Esp32Spi>() {
+                return Some(&s.attached_devices);
+            }
+            if let Some(s) = any.downcast_ref::<Esp32c3Spi>() {
                 return Some(&s.attached_devices);
             }
             None
@@ -1725,6 +1729,11 @@ impl SystemBus {
             if any.is::<Esp32Spi>() {
                 return any
                     .downcast_mut::<Esp32Spi>()
+                    .map(|s| &mut s.attached_devices);
+            }
+            if any.is::<Esp32c3Spi>() {
+                return any
+                    .downcast_mut::<Esp32c3Spi>()
                     .map(|s| &mut s.attached_devices);
             }
             None

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -85,6 +85,8 @@ impl SystemBus {
                 .map(|a| {
                     a.downcast_ref::<crate::peripherals::esp32::gpio::Esp32Gpio>()
                         .is_some()
+                        || a.downcast_ref::<crate::peripherals::esp32c3::gpio::Esp32c3Gpio>()
+                            .is_some()
                 })
                 .unwrap_or(false);
             if is_esp32 {

--- a/crates/core/src/peripherals/components/ili9341.rs
+++ b/crates/core/src/peripherals/components/ili9341.rs
@@ -365,8 +365,7 @@ impl PeripheralKit for Ili9341Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
-        let spi = ctx.spi()?;
-        spi.attach(Box::new(Ili9341::new(cs_pin)));
+        ctx.attach_spi_device(Box::new(Ili9341::new(cs_pin)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -284,11 +284,10 @@ impl PeripheralKit for Pcd8544Kit {
                 dc_pin,
             )
         })?;
-        let spi = ctx.spi()?;
         let mut dev = Pcd8544::new(cs_pin, dc_pin);
         let (odr_addr, bit) = dc_src;
         crate::peripherals::spi::SpiDevice::set_dc_source(&mut dev, odr_addr, bit);
-        spi.attach(Box::new(dev));
+        ctx.attach_spi_device(Box::new(dev))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
@@ -565,8 +565,19 @@ impl PeripheralKit for Ssd1680Tricolor290Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
-        let spi = ctx.spi()?;
-        spi.attach(Box::new(Ssd1680Tricolor290::new(cs_pin)));
+        let mut panel = Ssd1680Tricolor290::new(cs_pin);
+        if let Some(dc_pin) = ctx.config_str("dc_pin") {
+            let (odr_addr, bit) = ctx.resolve_pin_odr(dc_pin).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "ssd1680_tricolor_290 '{}' dc_pin '{}' could not be resolved to a GPIO output",
+                    ctx.device_id(),
+                    dc_pin
+                )
+            })?;
+            panel = panel.with_dc_pin(dc_pin.to_string());
+            crate::peripherals::spi::SpiDevice::set_dc_source(&mut panel, odr_addr, bit);
+        }
+        ctx.attach_spi_device(Box::new(panel))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/esp32c3/factory.rs
+++ b/crates/core/src/peripherals/esp32c3/factory.rs
@@ -1,0 +1,18 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Data-driven factory for ESP32-C3 peripheral models.
+
+use crate::Peripheral;
+use labwired_config::PeripheralConfig;
+
+pub fn try_build(canonical_type: &str, _p_cfg: &PeripheralConfig) -> Option<Box<dyn Peripheral>> {
+    let dev: Box<dyn Peripheral> = match canonical_type {
+        "esp32c3_gpio" => Box::new(super::gpio::Esp32c3Gpio::new()),
+        _ => return None,
+    };
+    Some(dev)
+}
+
+pub const SUPPORTED_TYPES: &[&str] = &["esp32c3_gpio"];

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -1,0 +1,279 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 GPIO peripheral model.
+//!
+//! This follows the C3 GPIO register offsets from
+//! `configs/peripherals/esp32c3/gpio.yaml`. The important behavioral delta from
+//! the declarative descriptor is W1TS/W1TC side effects: Arduino/ESP-IDF GPIO
+//! writes use those set/clear registers, and display peripherals read GPIO
+//! output back for CS/DC/bit-banged buses.
+
+use crate::{Peripheral, PeripheralTickResult, SimResult};
+
+const PIN_COUNT: u8 = 26;
+const PIN_MASK: u32 = (1u32 << PIN_COUNT) - 1;
+
+const BT_SELECT: u64 = 0x00;
+const OUT: u64 = 0x04;
+const OUT_W1TS: u64 = 0x08;
+const OUT_W1TC: u64 = 0x0C;
+const SDIO_SELECT: u64 = 0x1C;
+const ENABLE: u64 = 0x20;
+const ENABLE_W1TS: u64 = 0x24;
+const ENABLE_W1TC: u64 = 0x28;
+const STRAP: u64 = 0x38;
+const IN: u64 = 0x3C;
+const STATUS: u64 = 0x44;
+const STATUS_W1TS: u64 = 0x48;
+const STATUS_W1TC: u64 = 0x4C;
+const PCPU_INT: u64 = 0x5C;
+const PCPU_NMI_INT: u64 = 0x60;
+const CPUSDIO_INT: u64 = 0x64;
+const PIN0: u64 = 0x74;
+
+#[derive(Debug)]
+pub struct Esp32c3Gpio {
+    bt_select: u32,
+    out: u32,
+    sdio_select: u32,
+    enable: u32,
+    in_data: u32,
+    status: u32,
+    pin_cfg: [u32; PIN_COUNT as usize],
+    cycle: u64,
+    anchor_tick: u64,
+}
+
+impl Esp32c3Gpio {
+    pub fn new() -> Self {
+        Self {
+            bt_select: 0,
+            out: 0,
+            sdio_select: 0,
+            enable: 0,
+            in_data: 0,
+            status: 0,
+            pin_cfg: [0; PIN_COUNT as usize],
+            cycle: 0,
+            anchor_tick: 0,
+        }
+    }
+
+    pub fn out_value(&self) -> u32 {
+        self.out
+    }
+
+    pub fn enable_value(&self) -> u32 {
+        self.enable
+    }
+
+    pub fn set_pin_input(&mut self, pin: u8, level: bool) {
+        assert!(pin < PIN_COUNT, "set_pin_input: pin {pin} >= {PIN_COUNT}");
+        if level {
+            self.in_data |= 1u32 << pin;
+        } else {
+            self.in_data &= !(1u32 << pin);
+        }
+    }
+
+    fn pin_cfg_index(off: u64) -> Option<usize> {
+        if (PIN0..PIN0 + (PIN_COUNT as u64) * 4).contains(&off) {
+            Some(((off - PIN0) / 4) as usize)
+        } else {
+            None
+        }
+    }
+
+    fn read_word(&self, word_off: u64) -> u32 {
+        match word_off {
+            BT_SELECT => self.bt_select,
+            OUT | OUT_W1TS | OUT_W1TC => self.out,
+            SDIO_SELECT => self.sdio_select,
+            ENABLE | ENABLE_W1TS | ENABLE_W1TC => self.enable,
+            STRAP => 0,
+            IN => self.in_data,
+            STATUS | STATUS_W1TS | STATUS_W1TC => self.status,
+            PCPU_INT | PCPU_NMI_INT | CPUSDIO_INT => self.status,
+            off => Self::pin_cfg_index(off)
+                .map(|idx| self.pin_cfg[idx])
+                .unwrap_or(0),
+        }
+    }
+
+    fn write_word(&mut self, word_off: u64, value: u32) {
+        let value = value & PIN_MASK;
+        match word_off {
+            BT_SELECT => self.bt_select = value,
+            OUT => self.out = value,
+            OUT_W1TS => self.out |= value,
+            OUT_W1TC => self.out &= !value,
+            SDIO_SELECT => self.sdio_select = value,
+            ENABLE => self.enable = value,
+            ENABLE_W1TS => self.enable |= value,
+            ENABLE_W1TC => self.enable &= !value,
+            STRAP | IN => {}
+            STATUS => self.status = value,
+            STATUS_W1TS => self.status |= value,
+            STATUS_W1TC => self.status &= !value,
+            PCPU_INT | PCPU_NMI_INT | CPUSDIO_INT => {}
+            off => {
+                if let Some(idx) = Self::pin_cfg_index(off) {
+                    self.pin_cfg[idx] = value;
+                }
+            }
+        }
+    }
+
+    fn write_byte_special(&mut self, word_off: u64, byte_off: u64, value: u8) -> bool {
+        let mask = (value as u32) << (byte_off * 8);
+        match word_off {
+            OUT_W1TS => self.out |= mask & PIN_MASK,
+            OUT_W1TC => self.out &= !(mask & PIN_MASK),
+            ENABLE_W1TS => self.enable |= mask & PIN_MASK,
+            ENABLE_W1TC => self.enable &= !(mask & PIN_MASK),
+            STATUS_W1TS => self.status |= mask & PIN_MASK,
+            STATUS_W1TC => self.status &= !(mask & PIN_MASK),
+            _ => return false,
+        }
+        true
+    }
+}
+
+impl Default for Esp32c3Gpio {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Peripheral for Esp32c3Gpio {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word_off = offset & !3;
+        let byte_off = (offset & 3) * 8;
+        let word = self.read_word(word_off);
+        Ok(((word >> byte_off) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let word_off = offset & !3;
+        let byte_off = offset & 3;
+        if self.write_byte_special(word_off, byte_off, value) {
+            return Ok(());
+        }
+        let shift = byte_off * 8;
+        let mut word = self.read_word(word_off);
+        word &= !(0xFFu32 << shift);
+        word |= (value as u32) << shift;
+        self.write_word(word_off, word);
+        Ok(())
+    }
+
+    fn write_u16(&mut self, offset: u64, value: u16) -> SimResult<()> {
+        if offset & 1 == 0 {
+            let word_off = offset & !3;
+            let shift = (offset & 3) * 8;
+            if matches!(
+                word_off,
+                OUT_W1TS | OUT_W1TC | ENABLE_W1TS | ENABLE_W1TC | STATUS_W1TS | STATUS_W1TC
+            ) {
+                self.write_word(word_off, (value as u32) << shift);
+                return Ok(());
+            }
+        }
+        self.write(offset, (value & 0xFF) as u8)?;
+        self.write(offset + 1, (value >> 8) as u8)
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if offset & 3 == 0 {
+            self.write_word(offset, value);
+            Ok(())
+        } else {
+            for i in 0..4 {
+                self.write(offset + i, ((value >> (i * 8)) & 0xFF) as u8)?;
+            }
+            Ok(())
+        }
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::json!({
+            "layout": "esp32c3",
+            "odr": self.out,
+            "idr": self.in_data,
+            "enable": self.enable,
+            "status": self.status,
+        })
+    }
+
+    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
+        if pin >= PIN_COUNT {
+            return None;
+        }
+        Some((self.in_data & (1u32 << pin)) != 0)
+    }
+
+    fn read_gpio_output(&self, pin: u8) -> Option<bool> {
+        if pin >= PIN_COUNT {
+            return None;
+        }
+        Some((self.out & (1u32 << pin)) != 0)
+    }
+
+    fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
+        if pin >= PIN_COUNT {
+            return false;
+        }
+        self.set_pin_input(pin, level);
+        true
+    }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        self.cycle = self.cycle.wrapping_add(1);
+        PeripheralTickResult::default()
+    }
+
+    fn uses_scheduler(&self) -> bool {
+        true
+    }
+
+    fn sync_to(&mut self, tick_now: u64) {
+        if tick_now <= self.anchor_tick {
+            return;
+        }
+        self.cycle = self.cycle.wrapping_add(tick_now - self.anchor_tick);
+        self.anchor_tick = tick_now;
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn w1ts_and_w1tc_update_output_register() {
+        let mut gpio = Esp32c3Gpio::new();
+        gpio.write_u32(OUT_W1TS, (1 << 4) | (1 << 5)).unwrap();
+        assert_eq!(gpio.out_value(), (1 << 4) | (1 << 5));
+
+        gpio.write_u32(OUT_W1TC, 1 << 4).unwrap();
+        assert_eq!(gpio.out_value(), 1 << 5);
+    }
+
+    #[test]
+    fn c3_pin_config_uses_c3_pin0_offset() {
+        let mut gpio = Esp32c3Gpio::new();
+        gpio.write_u32(PIN0 + 3 * 4, 0x2 << 7).unwrap();
+        assert_eq!(gpio.read_word(PIN0 + 3 * 4), 0x2 << 7);
+        assert_eq!(gpio.read_word(0x88), 0);
+    }
+}

--- a/crates/core/src/peripherals/esp32c3/mod.rs
+++ b/crates/core/src/peripherals/esp32c3/mod.rs
@@ -7,7 +7,9 @@
 pub mod ana_i2c;
 pub mod apb_saradc;
 pub mod cache;
+pub mod factory;
 pub mod forced_status;
+pub mod gpio;
 pub mod i2c;
 pub mod ledc;
 pub mod reg_block;

--- a/crates/core/src/peripherals/esp32c3/spi.rs
+++ b/crates/core/src/peripherals/esp32c3/spi.rs
@@ -142,7 +142,7 @@ pub struct Esp32c3Spi {
     int_raw: u32,
     /// Devices on this controller's bus: MOSI bytes broadcast to every device,
     /// first non-zero MISO byte wins (single-device labs in practice).
-    attached_devices: Vec<Box<dyn SpiDevice>>,
+    pub(crate) attached_devices: Vec<Box<dyn SpiDevice>>,
 }
 
 impl std::fmt::Debug for Esp32c3Spi {
@@ -181,6 +181,10 @@ impl Esp32c3Spi {
     /// Attach a simulated device to this controller's bus.
     pub fn attach_device(&mut self, device: Box<dyn SpiDevice>) {
         self.attached_devices.push(device);
+    }
+
+    pub fn attached_devices(&self) -> &[Box<dyn SpiDevice>] {
+        &self.attached_devices
     }
 
     fn reg(&self, off: u64) -> u32 {

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -83,6 +83,7 @@ pub const MODEL_TYPES: &[&str] = &[
     // ESP32-C3 behavioral models (esp32 factory).
     "esp32c3_i2c",
     "esp32c3_spi",
+    "esp32c3_gpio",
     "esp32c3_apb_saradc",
     "esp32c3_ledc",
     // nRF52 behavioral models (nrf52 factory).

--- a/crates/core/src/peripherals/kit/ctx.rs
+++ b/crates/core/src/peripherals/kit/ctx.rs
@@ -18,8 +18,9 @@ use labwired_config::ExternalDevice;
 use crate::bus::SystemBus;
 use crate::peripherals::adc::Adc;
 use crate::peripherals::esp32c3::i2c::Esp32c3I2c;
+use crate::peripherals::esp32c3::spi::Esp32c3Spi;
 use crate::peripherals::i2c::{I2c, I2cDevice};
-use crate::peripherals::spi::Spi;
+use crate::peripherals::spi::{Spi, SpiDevice};
 use crate::peripherals::uart::Uart;
 
 pub struct AttachCtx<'a> {
@@ -123,6 +124,31 @@ impl<'a> AttachCtx<'a> {
             return Ok(());
         }
         Err(wrong_transport_err(ext, "I2C"))
+    }
+
+    /// Attach an [`SpiDevice`] to whichever SPI controller the `connection:`
+    /// field resolves to: the generic STM32-style [`Spi`] or the ESP32-C3 GP-SPI
+    /// model. This mirrors [`Self::attach_i2c_device`] for mixed-controller
+    /// systems.
+    pub fn attach_spi_device(&mut self, device: Box<dyn SpiDevice>) -> Result<()> {
+        let ext = self.ext;
+        let idx = self
+            .bus
+            .find_peripheral_index_by_name(&ext.connection)
+            .ok_or_else(|| missing_connection_err(ext))?;
+        let any = self.bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .ok_or_else(|| downcast_err(ext))?;
+        if let Some(spi) = any.downcast_mut::<Spi>() {
+            spi.attach(device);
+            return Ok(());
+        }
+        if let Some(c3) = any.downcast_mut::<Esp32c3Spi>() {
+            c3.attach_device(device);
+            return Ok(());
+        }
+        Err(wrong_transport_err(ext, "SPI"))
     }
 
     /// Acquire the ADC peripheral declared in the system.yaml `connection:`

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2373,6 +2373,173 @@ pub mod integration_tests {
     }
 
     #[test]
+    fn test_esp32c3_gpio_w1ts_w1tc_drive_output_readback() {
+        let chip = ChipDescriptor {
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-gpio-test".to_string(),
+            arch: Arch::RiscV,
+            core: None,
+            flash: MemoryRange {
+                base: 0x4200_0000,
+                size: "4MB".to_string(),
+            },
+            ram: MemoryRange {
+                base: 0x3FC8_0000,
+                size: "400KB".to_string(),
+            },
+            reset_vector_offset: 0,
+            atomic_register_aliases: false,
+            memory_regions: Vec::new(),
+            peripherals: vec![PeripheralConfig {
+                id: "gpio".to_string(),
+                r#type: "esp32c3_gpio".to_string(),
+                base_address: 0x6000_4000,
+                size: Some("4KB".to_string()),
+                irq: None,
+                clock: None,
+                config: HashMap::new(),
+            }],
+            pins: Default::default(),
+        };
+
+        let manifest = SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-gpio-test".to_string(),
+            chip: "esp32c3-gpio-test".to_string(),
+            memory_overrides: HashMap::new(),
+            external_devices: Vec::new(),
+            board_io: Vec::new(),
+            debug_uart: None,
+            peripherals: Vec::new(),
+        };
+
+        let mut bus = crate::bus::SystemBus::from_config(&chip, &manifest).unwrap();
+        const GPIO_BASE: u64 = 0x6000_4000;
+        const GPIO_OUT: u64 = 0x04;
+        const GPIO_OUT_W1TS: u64 = 0x08;
+        const GPIO_OUT_W1TC: u64 = 0x0C;
+
+        bus.write_u32(GPIO_BASE + GPIO_OUT_W1TS, (1 << 4) | (1 << 5))
+            .unwrap();
+        assert_eq!(
+            bus.read_u32(GPIO_BASE + GPIO_OUT).unwrap() & ((1 << 4) | (1 << 5)),
+            (1 << 4) | (1 << 5)
+        );
+
+        bus.write_u32(GPIO_BASE + GPIO_OUT_W1TC, 1 << 4).unwrap();
+        let out = bus.read_u32(GPIO_BASE + GPIO_OUT).unwrap();
+        assert_eq!(out & (1 << 4), 0, "target pin should clear");
+        assert_eq!(out & (1 << 5), 1 << 5, "other output pins must survive");
+    }
+
+    #[test]
+    fn test_esp32c3_spi_latches_pcd8544_dc_from_gpio_output() {
+        let chip = ChipDescriptor {
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-spi-dc-test".to_string(),
+            arch: Arch::RiscV,
+            core: None,
+            flash: MemoryRange {
+                base: 0x4200_0000,
+                size: "4MB".to_string(),
+            },
+            ram: MemoryRange {
+                base: 0x3FC8_0000,
+                size: "400KB".to_string(),
+            },
+            reset_vector_offset: 0,
+            atomic_register_aliases: false,
+            memory_regions: Vec::new(),
+            peripherals: vec![
+                PeripheralConfig {
+                    id: "gpio".to_string(),
+                    r#type: "esp32c3_gpio".to_string(),
+                    base_address: 0x6000_4000,
+                    size: Some("4KB".to_string()),
+                    irq: None,
+                    clock: None,
+                    config: HashMap::new(),
+                },
+                PeripheralConfig {
+                    id: "spi2".to_string(),
+                    r#type: "esp32c3_spi".to_string(),
+                    base_address: 0x6002_4000,
+                    size: Some("4KB".to_string()),
+                    irq: None,
+                    clock: None,
+                    config: HashMap::new(),
+                },
+            ],
+            pins: Default::default(),
+        };
+
+        let manifest = SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-spi-dc-test".to_string(),
+            chip: "esp32c3-spi-dc-test".to_string(),
+            memory_overrides: HashMap::new(),
+            external_devices: Vec::new(),
+            board_io: Vec::new(),
+            debug_uart: None,
+            peripherals: Vec::new(),
+        };
+
+        let mut bus = crate::bus::SystemBus::from_config(&chip, &manifest).unwrap();
+        let (odr_addr, bit) =
+            crate::bus::SystemBus::resolve_pin_odr_pub(&bus, "GPIO2").expect("GPIO2 ODR");
+        let mut lcd = crate::peripherals::components::Pcd8544::new("GPIO10".into(), "GPIO2".into());
+        crate::peripherals::spi::SpiDevice::set_dc_source(&mut lcd, odr_addr, bit);
+
+        let spi_idx = bus
+            .find_peripheral_index_by_name("spi2")
+            .expect("spi2 peripheral");
+        {
+            let spi = bus.peripherals[spi_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<crate::peripherals::esp32c3::spi::Esp32c3Spi>())
+                .expect("esp32c3 spi2");
+            spi.attach_device(Box::new(lcd));
+        }
+
+        const GPIO_BASE: u64 = 0x6000_4000;
+        const GPIO_OUT_W1TS: u64 = 0x08;
+        const SPI2_BASE: u64 = 0x6002_4000;
+        const SPI_CMD: u64 = 0x00;
+        const SPI_MS_DLEN: u64 = 0x1C;
+        const SPI_W0: u64 = 0x98;
+        const SPI_USR: u32 = 1 << 24;
+
+        // D/C high means the following SPI byte is display RAM data.
+        bus.write_u32(GPIO_BASE + GPIO_OUT_W1TS, 1 << 2).unwrap();
+        bus.write_u32(SPI2_BASE + SPI_W0, 0xFF).unwrap();
+        bus.write_u32(SPI2_BASE + SPI_MS_DLEN, 8 - 1).unwrap();
+        bus.write_u32(SPI2_BASE + SPI_CMD, SPI_USR).unwrap();
+
+        let spi = bus.peripherals[spi_idx]
+            .dev
+            .as_any()
+            .and_then(|any| any.downcast_ref::<crate::peripherals::esp32c3::spi::Esp32c3Spi>())
+            .expect("esp32c3 spi2");
+        let lcd = spi
+            .attached_devices()
+            .iter()
+            .find_map(|device| {
+                device
+                    .as_any()
+                    .and_then(|any| any.downcast_ref::<crate::peripherals::components::Pcd8544>())
+            })
+            .expect("attached pcd8544");
+        assert_eq!(
+            lcd.framebuffer()[0],
+            0xFF,
+            "C3 SPI must latch PCD8544 D/C from GPIO2 before transfer"
+        );
+    }
+
+    #[test]
     fn test_breakpoint_sticky_step_over() {
         let mut machine = create_machine();
         let pc = 0x2000_0000;

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -282,23 +282,31 @@ impl WasmSimulator {
             .as_any()
             .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
 
-        let spi = any
-            .downcast_ref::<labwired_core::peripherals::spi::Spi>()
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "Peripheral '{}' is not an SPI controller",
-                    binding.peripheral
-                ))
-            })?;
-
-        for device in &spi.attached_devices {
-            if let Some(tft) = device
-                .as_any()
-                .and_then(|a| a.downcast_ref::<labwired_core::peripherals::components::Ili9341>())
-            {
-                let fb = tft.framebuffer().to_vec().into_boxed_slice();
-                return Ok(fb);
+        if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
+            for device in &spi.attached_devices {
+                if let Some(tft) = device.as_any().and_then(|a| {
+                    a.downcast_ref::<labwired_core::peripherals::components::Ili9341>()
+                }) {
+                    let fb = tft.framebuffer().to_vec().into_boxed_slice();
+                    return Ok(fb);
+                }
             }
+        } else if let Some(spi) =
+            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
+        {
+            for device in spi.attached_devices() {
+                if let Some(tft) = device.as_any().and_then(|a| {
+                    a.downcast_ref::<labwired_core::peripherals::components::Ili9341>()
+                }) {
+                    let fb = tft.framebuffer().to_vec().into_boxed_slice();
+                    return Ok(fb);
+                }
+            }
+        } else {
+            return Err(JsValue::from_str(&format!(
+                "Peripheral '{}' is not an SPI controller",
+                binding.peripheral
+            )));
         }
 
         Err(JsValue::from_str(&format!(
@@ -340,28 +348,59 @@ impl WasmSimulator {
             .as_any()
             .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
 
-        let spi = any
-            .downcast_ref::<labwired_core::peripherals::spi::Spi>()
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "Peripheral '{}' is not an SPI controller",
-                    binding.peripheral
-                ))
-            })?;
-
-        for device in &spi.attached_devices {
-            if let Some(lcd) = device
-                .as_any()
-                .and_then(|a| a.downcast_ref::<labwired_core::peripherals::components::Pcd8544>())
-            {
-                return Ok(lcd.framebuffer().to_vec().into_boxed_slice());
+        if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
+            for device in &spi.attached_devices {
+                if let Some(lcd) = device.as_any().and_then(|a| {
+                    a.downcast_ref::<labwired_core::peripherals::components::Pcd8544>()
+                }) {
+                    return Ok(lcd.framebuffer().to_vec().into_boxed_slice());
+                }
             }
+        } else if let Some(spi) =
+            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
+        {
+            for device in spi.attached_devices() {
+                if let Some(lcd) = device.as_any().and_then(|a| {
+                    a.downcast_ref::<labwired_core::peripherals::components::Pcd8544>()
+                }) {
+                    return Ok(lcd.framebuffer().to_vec().into_boxed_slice());
+                }
+            }
+        } else {
+            return Err(JsValue::from_str(&format!(
+                "Peripheral '{}' is not an SPI controller",
+                binding.peripheral
+            )));
         }
 
         Err(JsValue::from_str(&format!(
             "PCD8544 device not found on SPI peripheral '{}'",
             binding.peripheral
         )))
+    }
+
+    /// Return the decoded four-character text currently latched into a TM1637
+    /// 4-digit display. The TM1637 is GPIO bit-banged, so it is stored on the
+    /// bus side rather than inside a hardware bus peripheral.
+    #[wasm_bindgen]
+    pub fn get_tm1637_text(&self, device_id: &str) -> Result<String, JsValue> {
+        let machine = self.machine.as_ref().unwrap();
+        machine
+            .bus
+            .tm1637
+            .iter()
+            .find(|dev| dev.id == device_id)
+            .map(|dev| {
+                let mut text = dev.text();
+                if dev.colon() && text.len() >= 2 {
+                    text.insert(2, ':');
+                }
+                if !dev.display_on() {
+                    text.clear();
+                }
+                text
+            })
+            .ok_or_else(|| JsValue::from_str(&format!("TM1637 device '{}' not found", device_id)))
     }
 
     /// Return the SSD1680 tri-color e-paper framebuffer for the device identified by `device_id`.
@@ -422,6 +461,14 @@ impl WasmSimulator {
                 any.downcast_ref::<labwired_core::peripherals::esp32::spi::Esp32Spi>()
             {
                 spi.attached_devices.iter().find_map(|dev| {
+                    dev.as_any().and_then(|a| {
+                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
+                }).map(|panel| (panel.black_plane().to_vec(), panel.red_plane().to_vec()))
+                })
+            } else if let Some(spi) =
+                any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
+            {
+                spi.attached_devices().iter().find_map(|dev| {
                     dev.as_any().and_then(|a| {
                     a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
                 }).map(|panel| (panel.black_plane().to_vec(), panel.red_plane().to_vec()))
@@ -493,6 +540,14 @@ impl WasmSimulator {
             any.downcast_ref::<labwired_core::peripherals::esp32::spi::Esp32Spi>()
         {
             spi.attached_devices.iter().find_map(|dev| {
+                dev.as_any().and_then(|a| {
+                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
+                }).map(|panel| panel.refresh_generation())
+            })
+        } else if let Some(spi) =
+            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
+        {
+            spi.attached_devices().iter().find_map(|dev| {
                 dev.as_any().and_then(|a| {
                     a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
                 }).map(|panel| panel.refresh_generation())

--- a/examples/esp32c3-display-workshop-arduino/esp32c3-display-workshop.ino
+++ b/examples/esp32c3-display-workshop-arduino/esp32c3-display-workshop.ino
@@ -1,0 +1,253 @@
+// ESP32-C3 Display Workshop
+//
+// One Arduino sketch drives the workshop display set:
+// - SSD1306 OLED 128x64 / 128x32 on I2C SDA=GPIO4, SCL=GPIO5
+// - Nokia 5110 / PCD8544 on SPI SCK=GPIO6, MOSI=GPIO7, DC=GPIO2, CS=GPIO10, RST=GPIO3
+// - TM1637 4-digit LED clock on CLK=GPIO0, DIO=GPIO1
+// - 2.9" tri-color e-paper on SPI SCK=GPIO6, MOSI=GPIO7, DC=GPIO2, CS=GPIO10, RST=GPIO3, BUSY=GPIO4
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <Wire.h>
+
+static constexpr int PIN_TM_CLK = 0;
+static constexpr int PIN_TM_DIO = 1;
+static constexpr int PIN_DC = 2;
+static constexpr int PIN_RST = 3;
+static constexpr int PIN_BUSY = 4;
+static constexpr int PIN_I2C_SDA = 4;
+static constexpr int PIN_I2C_SCL = 5;
+static constexpr int PIN_SPI_SCK = 6;
+static constexpr int PIN_SPI_MOSI = 7;
+static constexpr int PIN_SPI_MISO_UNUSED = 8;
+static constexpr int PIN_CS = 10;
+
+static uint8_t oled[128 * 4];
+static uint8_t nokia[84 * 6];
+static uint32_t lastSecond = 0;
+static bool epaperDone = false;
+
+static const uint8_t SEG_DIGITS[10] = {
+  0x3F, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F
+};
+
+static const uint8_t SEG_BITS[10][7] = {
+  {1,1,1,1,1,1,0}, {0,1,1,0,0,0,0}, {1,1,0,1,1,0,1}, {1,1,1,1,0,0,1},
+  {0,1,1,0,0,1,1}, {1,0,1,1,0,1,1}, {1,0,1,1,1,1,1}, {1,1,1,0,0,0,0},
+  {1,1,1,1,1,1,1}, {1,1,1,1,0,1,1}
+};
+
+static void tmDelay() { delayMicroseconds(5); }
+static void tmClk(bool high) { digitalWrite(PIN_TM_CLK, high ? HIGH : LOW); tmDelay(); }
+static void tmDio(bool high) { digitalWrite(PIN_TM_DIO, high ? HIGH : LOW); tmDelay(); }
+static void tmStart() { tmDio(HIGH); tmClk(HIGH); tmDio(LOW); tmClk(LOW); }
+static void tmStop() { tmClk(LOW); tmDio(LOW); tmClk(HIGH); tmDio(HIGH); }
+static void tmWrite(uint8_t b) {
+  for (int i = 0; i < 8; i++) {
+    tmClk(LOW);
+    tmDio((b >> i) & 1);
+    tmClk(HIGH);
+  }
+  tmClk(LOW);
+  tmDio(HIGH);
+  tmClk(HIGH);
+  tmClk(LOW);
+}
+
+static void tmDisplay(uint8_t h, uint8_t m, bool colon) {
+  uint8_t data[4] = {
+    SEG_DIGITS[(h / 10) % 10],
+    static_cast<uint8_t>(SEG_DIGITS[h % 10] | (colon ? 0x80 : 0)),
+    SEG_DIGITS[(m / 10) % 10],
+    SEG_DIGITS[m % 10],
+  };
+  tmStart(); tmWrite(0x40); tmStop();
+  tmStart(); tmWrite(0xC0);
+  for (uint8_t b : data) tmWrite(b);
+  tmStop();
+  tmStart(); tmWrite(0x8F); tmStop();
+}
+
+static void oledCmd(uint8_t c) {
+  Wire.beginTransmission(0x3C);
+  Wire.write(0x00);
+  Wire.write(c);
+  Wire.endTransmission();
+}
+
+static void oledData(const uint8_t *data, size_t n) {
+  while (n) {
+    size_t chunk = n > 16 ? 16 : n;
+    Wire.beginTransmission(0x3C);
+    Wire.write(0x40);
+    for (size_t i = 0; i < chunk; i++) Wire.write(data[i]);
+    Wire.endTransmission();
+    data += chunk;
+    n -= chunk;
+  }
+}
+
+static void oledInit() {
+  Wire.begin(PIN_I2C_SDA, PIN_I2C_SCL);
+  delay(20);
+  const uint8_t init[] = {
+    0xAE, 0xD5, 0x80, 0xA8, 0x1F, 0xD3, 0x00, 0x40, 0x8D, 0x14, 0x20, 0x00,
+    0xA1, 0xC8, 0xDA, 0x02, 0x81, 0x8F, 0xD9, 0xF1, 0xDB, 0x40, 0xA4, 0xA6, 0xAF
+  };
+  for (uint8_t c : init) oledCmd(c);
+}
+
+static void setPixel(uint8_t *buf, int w, int h, int x, int y) {
+  if (x < 0 || y < 0 || x >= w || y >= h) return;
+  buf[(y >> 3) * w + x] |= 1 << (y & 7);
+}
+
+static void hLine(uint8_t *buf, int w, int h, int x, int y, int len) {
+  for (int i = 0; i < len; i++) setPixel(buf, w, h, x + i, y);
+}
+
+static void vLine(uint8_t *buf, int w, int h, int x, int y, int len) {
+  for (int i = 0; i < len; i++) setPixel(buf, w, h, x, y + i);
+}
+
+static void drawDigit(uint8_t *buf, int w, int h, int x, int y, int s, int digit) {
+  const uint8_t *seg = SEG_BITS[digit % 10];
+  int sw = 4 * s, vh = 5 * s;
+  if (seg[0]) hLine(buf, w, h, x + s, y, sw);
+  if (seg[1]) vLine(buf, w, h, x + sw + s, y + s, vh);
+  if (seg[2]) vLine(buf, w, h, x + sw + s, y + vh + 2 * s, vh);
+  if (seg[3]) hLine(buf, w, h, x + s, y + 2 * vh + 2 * s, sw);
+  if (seg[4]) vLine(buf, w, h, x, y + vh + 2 * s, vh);
+  if (seg[5]) vLine(buf, w, h, x, y + s, vh);
+  if (seg[6]) hLine(buf, w, h, x + s, y + vh + s, sw);
+}
+
+static void drawClock(uint8_t *buf, int w, int h, int hh, int mm) {
+  memset(buf, 0, (w * h) / 8);
+  int s = (w >= 100) ? 3 : 2;
+  int y = (h >= 48) ? 8 : 4;
+  int x = (w >= 100) ? 7 : 3;
+  int step = 6 * s + 4;
+  drawDigit(buf, w, h, x, y, s, hh / 10);
+  drawDigit(buf, w, h, x + step, y, s, hh % 10);
+  setPixel(buf, w, h, x + 2 * step - 1, y + 5 * s);
+  setPixel(buf, w, h, x + 2 * step - 1, y + 8 * s);
+  drawDigit(buf, w, h, x + 2 * step + 3, y, s, mm / 10);
+  drawDigit(buf, w, h, x + 3 * step + 3, y, s, mm % 10);
+}
+
+static void oledFlush() {
+  for (uint8_t page = 0; page < 4; page++) {
+    oledCmd(0xB0 | page);
+    oledCmd(0x00);
+    oledCmd(0x10);
+    oledData(&oled[page * 128], 128);
+  }
+}
+
+static void spiSelect(bool active) {
+  digitalWrite(PIN_CS, active ? LOW : HIGH);
+}
+
+static void spiCommand(uint8_t c) {
+  digitalWrite(PIN_DC, LOW);
+  spiSelect(true);
+  SPI.transfer(c);
+  spiSelect(false);
+}
+
+static void spiData(uint8_t d) {
+  digitalWrite(PIN_DC, HIGH);
+  spiSelect(true);
+  SPI.transfer(d);
+  spiSelect(false);
+}
+
+static void nokiaInit() {
+  digitalWrite(PIN_RST, LOW);
+  delay(5);
+  digitalWrite(PIN_RST, HIGH);
+  spiCommand(0x21);
+  spiCommand(0xB8);
+  spiCommand(0x14);
+  spiCommand(0x20);
+  spiCommand(0x0C);
+}
+
+static void nokiaFlush() {
+  spiCommand(0x40);
+  spiCommand(0x80);
+  digitalWrite(PIN_DC, HIGH);
+  spiSelect(true);
+  for (uint8_t b : nokia) SPI.transfer(b);
+  spiSelect(false);
+}
+
+static void epaperPaintOnce() {
+  if (epaperDone) return;
+  epaperDone = true;
+  spiCommand(0x12);
+  delay(5);
+  spiCommand(0x24);
+  digitalWrite(PIN_DC, HIGH);
+  spiSelect(true);
+  for (int i = 0; i < 4736; i++) SPI.transfer((i % 17) < 8 ? 0x00 : 0xFF);
+  spiSelect(false);
+  spiCommand(0x26);
+  digitalWrite(PIN_DC, HIGH);
+  spiSelect(true);
+  for (int i = 0; i < 4736; i++) SPI.transfer(0xFF);
+  spiSelect(false);
+  spiCommand(0x22);
+  spiData(0xF7);
+  spiCommand(0x20);
+}
+
+static void drawSpiDisplays(uint8_t hh, uint8_t mm, bool includeEpaper) {
+  drawClock(nokia, 84, 48, hh, mm);
+  nokiaFlush();
+  if (includeEpaper) {
+    epaperPaintOnce();
+    nokiaFlush();
+  }
+}
+
+static void drawI2cDisplays(uint8_t hh, uint8_t mm) {
+  drawClock(oled, 128, 32, hh, mm);
+  oledFlush();
+}
+
+static void drawAllDisplays(uint8_t hh, uint8_t mm, bool colon) {
+  tmDisplay(hh, mm, colon);
+  drawSpiDisplays(hh, mm, false);
+  drawI2cDisplays(hh, mm);
+}
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("ESP32-C3 Display Workshop");
+  pinMode(PIN_TM_CLK, OUTPUT);
+  pinMode(PIN_TM_DIO, OUTPUT);
+  pinMode(PIN_DC, OUTPUT);
+  pinMode(PIN_RST, OUTPUT);
+  pinMode(PIN_CS, OUTPUT);
+  pinMode(PIN_BUSY, INPUT);
+  digitalWrite(PIN_CS, HIGH);
+  tmDisplay(12, 34, true);
+  SPI.begin(PIN_SPI_SCK, PIN_SPI_MISO_UNUSED, PIN_SPI_MOSI, PIN_CS);
+  SPI.beginTransaction(SPISettings(2000000, MSBFIRST, SPI_MODE0));
+  nokiaInit();
+  drawSpiDisplays(12, 34, true);
+  oledInit();
+  drawI2cDisplays(12, 34);
+  lastSecond = millis() / 1000;
+}
+
+void loop() {
+  uint32_t seconds = millis() / 1000;
+  if (seconds == lastSecond) return;
+  lastSecond = seconds;
+  uint8_t hh = (seconds / 3600) % 24;
+  uint8_t mm = (seconds / 60) % 60;
+  drawAllDisplays(hh, mm, seconds & 1);
+}


### PR DESCRIPTION
## Summary
- Add ESP32-C3 GPIO behavior and C3 SPI D/C latching for display peripherals.
- Add C3 workshop system YAMLs and Arduino display workshop sketch.
- Extend wasm display readback for OLED, Nokia/PCD8544, e-paper, and TM1637 paths.

## Test Plan
- `cargo test -p labwired-core esp32c3 -- --nocapture`
- `cargo test -p labwired-wasm --lib --quiet`
- Browser acceptance probe for TM1637, Nokia 5110, e-paper, OLED 128x64, OLED 128x32: all nonblank and no wiring errors.
