### PR TITLE
fix: simplify ESP32-C3 workshop OLED sketch

### DIFF
--- a/examples/esp32c3-display-workshop-arduino/esp32c3-display-workshop.ino
+++ b/examples/esp32c3-display-workshop-arduino/esp32c3-display-workshop.ino
@@ -1,112 +1,31 @@
 // ESP32-C3 Display Workshop
 //
-// One Arduino sketch drives the workshop display set:
-// - SSD1306 OLED 128x64 / 128x32 on I2C SDA=GPIO4, SCL=GPIO5
-// - Nokia 5110 / PCD8544 on SPI SCK=GPIO6, MOSI=GPIO7, DC=GPIO2, CS=GPIO10, RST=GPIO3
-// - TM1637 4-digit LED clock on CLK=GPIO0, DIO=GPIO1
-// - 2.9" tri-color e-paper on SPI SCK=GPIO6, MOSI=GPIO7, DC=GPIO2, CS=GPIO10, RST=GPIO3, BUSY=GPIO4
+// Arduino clock sketch for the workshop OLED modules:
+// - 0.96" SSD1306 OLED 128x64 on I2C SDA=GPIO4, SCL=GPIO5
+// - 0.91" SSD1306 OLED 128x32 on I2C SDA=GPIO4, SCL=GPIO5
 
 #include <Arduino.h>
-#include <SPI.h>
 #include <Wire.h>
 
-static constexpr int PIN_TM_CLK = 0;
-static constexpr int PIN_TM_DIO = 1;
-static constexpr int PIN_DC = 2;
-static constexpr int PIN_RST = 3;
-static constexpr int PIN_BUSY = 4;
 static constexpr int PIN_I2C_SDA = 4;
 static constexpr int PIN_I2C_SCL = 5;
-static constexpr int PIN_SPI_SCK = 6;
-static constexpr int PIN_SPI_MOSI = 7;
-static constexpr int PIN_SPI_MISO_UNUSED = 8;
-static constexpr int PIN_CS = 10;
 
 #ifndef WORKSHOP_OLED_HEIGHT
 #define WORKSHOP_OLED_HEIGHT 64
 #endif
 
-#define WORKSHOP_TARGET_ALL 0
-#define WORKSHOP_TARGET_OLED 1
-#define WORKSHOP_TARGET_NOKIA5110 2
-#define WORKSHOP_TARGET_TM1637 3
-#define WORKSHOP_TARGET_EPAPER 4
-
-#ifndef WORKSHOP_DISPLAY_TARGET
-#define WORKSHOP_DISPLAY_TARGET WORKSHOP_TARGET_ALL
-#endif
-
 static constexpr uint8_t OLED_HEIGHT = WORKSHOP_OLED_HEIGHT;
 static constexpr uint8_t OLED_PAGES = OLED_HEIGHT / 8;
 static_assert(OLED_HEIGHT == 32 || OLED_HEIGHT == 64, "WORKSHOP_OLED_HEIGHT must be 32 or 64");
-static_assert(
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_ALL ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_OLED ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_NOKIA5110 ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_TM1637 ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_EPAPER,
-  "WORKSHOP_DISPLAY_TARGET must be one of the WORKSHOP_TARGET_* constants"
-);
-
-static constexpr bool USE_OLED =
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_ALL ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_OLED;
-static constexpr bool USE_NOKIA =
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_ALL ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_NOKIA5110;
-static constexpr bool USE_TM1637 =
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_ALL ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_TM1637;
-static constexpr bool USE_EPAPER =
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_ALL ||
-  WORKSHOP_DISPLAY_TARGET == WORKSHOP_TARGET_EPAPER;
-static constexpr bool USE_SPI = USE_NOKIA || USE_EPAPER;
 
 static uint8_t oled[128 * OLED_PAGES];
-static uint8_t nokia[84 * 6];
 static uint32_t lastSecond = 0;
-static bool epaperDone = false;
-
-static const uint8_t SEG_DIGITS[10] = {
-  0x3F, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F
-};
 
 static const uint8_t SEG_BITS[10][7] = {
   {1,1,1,1,1,1,0}, {0,1,1,0,0,0,0}, {1,1,0,1,1,0,1}, {1,1,1,1,0,0,1},
   {0,1,1,0,0,1,1}, {1,0,1,1,0,1,1}, {1,0,1,1,1,1,1}, {1,1,1,0,0,0,0},
   {1,1,1,1,1,1,1}, {1,1,1,1,0,1,1}
 };
-
-static void tmDelay() { delayMicroseconds(5); }
-static void tmClk(bool high) { digitalWrite(PIN_TM_CLK, high ? HIGH : LOW); tmDelay(); }
-static void tmDio(bool high) { digitalWrite(PIN_TM_DIO, high ? HIGH : LOW); tmDelay(); }
-static void tmStart() { tmDio(HIGH); tmClk(HIGH); tmDio(LOW); tmClk(LOW); }
-static void tmStop() { tmClk(LOW); tmDio(LOW); tmClk(HIGH); tmDio(HIGH); }
-static void tmWrite(uint8_t b) {
-  for (int i = 0; i < 8; i++) {
-    tmClk(LOW);
-    tmDio((b >> i) & 1);
-    tmClk(HIGH);
-  }
-  tmClk(LOW);
-  tmDio(HIGH);
-  tmClk(HIGH);
-  tmClk(LOW);
-}
-
-static void tmDisplay(uint8_t h, uint8_t m, bool colon) {
-  uint8_t data[4] = {
-    SEG_DIGITS[(h / 10) % 10],
-    static_cast<uint8_t>(SEG_DIGITS[h % 10] | (colon ? 0x80 : 0)),
-    SEG_DIGITS[(m / 10) % 10],
-    SEG_DIGITS[m % 10],
-  };
-  tmStart(); tmWrite(0x40); tmStop();
-  tmStart(); tmWrite(0xC0);
-  for (uint8_t b : data) tmWrite(b);
-  tmStop();
-  tmStart(); tmWrite(0x8F); tmStop();
-}
 
 static void oledCmd(uint8_t c) {
   Wire.beginTransmission(0x3C);
@@ -151,30 +70,48 @@ static void vLine(uint8_t *buf, int w, int h, int x, int y, int len) {
   for (int i = 0; i < len; i++) setPixel(buf, w, h, x, y + i);
 }
 
-static void drawDigit(uint8_t *buf, int w, int h, int x, int y, int s, int digit) {
+static void fillRect(uint8_t *buf, int w, int h, int x, int y, int rw, int rh) {
+  for (int yy = 0; yy < rh; yy++) {
+    hLine(buf, w, h, x, y + yy, rw);
+  }
+}
+
+static void drawDigit(uint8_t *buf, int w, int h, int x, int y, int digitW, int digitH, int t, int digit) {
   const uint8_t *seg = SEG_BITS[digit % 10];
-  int sw = 4 * s, vh = 5 * s;
-  if (seg[0]) hLine(buf, w, h, x + s, y, sw);
-  if (seg[1]) vLine(buf, w, h, x + sw + s, y + s, vh);
-  if (seg[2]) vLine(buf, w, h, x + sw + s, y + vh + 2 * s, vh);
-  if (seg[3]) hLine(buf, w, h, x + s, y + 2 * vh + 2 * s, sw);
-  if (seg[4]) vLine(buf, w, h, x, y + vh + 2 * s, vh);
-  if (seg[5]) vLine(buf, w, h, x, y + s, vh);
-  if (seg[6]) hLine(buf, w, h, x + s, y + vh + s, sw);
+  const int mid = y + digitH / 2;
+  const int middleY = mid - t / 2;
+  const int topVertH = middleY - (y + t);
+  const int bottomVertH = (y + digitH - t) - (middleY + t);
+  if (seg[0]) fillRect(buf, w, h, x + t, y, digitW - 2 * t, t);
+  if (seg[1]) fillRect(buf, w, h, x + digitW - t, y + t, t, topVertH);
+  if (seg[2]) fillRect(buf, w, h, x + digitW - t, middleY + t, t, bottomVertH);
+  if (seg[3]) fillRect(buf, w, h, x + t, y + digitH - t, digitW - 2 * t, t);
+  if (seg[4]) fillRect(buf, w, h, x, middleY + t, t, bottomVertH);
+  if (seg[5]) fillRect(buf, w, h, x, y + t, t, topVertH);
+  if (seg[6]) fillRect(buf, w, h, x + t, middleY, digitW - 2 * t, t);
 }
 
 static void drawClock(uint8_t *buf, int w, int h, int hh, int mm) {
   memset(buf, 0, (w * h) / 8);
-  int s = (w >= 100) ? 3 : 2;
-  int y = (h >= 48) ? 8 : 4;
-  int x = (w >= 100) ? 7 : 3;
-  int step = 6 * s + 4;
-  drawDigit(buf, w, h, x, y, s, hh / 10);
-  drawDigit(buf, w, h, x + step, y, s, hh % 10);
-  setPixel(buf, w, h, x + 2 * step - 1, y + 5 * s);
-  setPixel(buf, w, h, x + 2 * step - 1, y + 8 * s);
-  drawDigit(buf, w, h, x + 2 * step + 3, y, s, mm / 10);
-  drawDigit(buf, w, h, x + 3 * step + 3, y, s, mm % 10);
+  const int digitW = (h >= 48) ? 22 : 18;
+  const int digitH = (h >= 48) ? 44 : 24;
+  const int t = (h >= 48) ? 4 : 2;
+  const int gap = (h >= 48) ? 5 : 4;
+  const int colonGap = (h >= 48) ? 10 : 8;
+  const int totalW = 4 * digitW + 3 * gap + colonGap;
+  const int x = (w - totalW) / 2;
+  const int y = (h - digitH) / 2;
+  const int d0 = x;
+  const int d1 = d0 + digitW + gap;
+  const int colonX = d1 + digitW + gap;
+  const int d2 = colonX + colonGap;
+  const int d3 = d2 + digitW + gap;
+  drawDigit(buf, w, h, d0, y, digitW, digitH, t, hh / 10);
+  drawDigit(buf, w, h, d1, y, digitW, digitH, t, hh % 10);
+  fillRect(buf, w, h, colonX, y + digitH / 3, t, t);
+  fillRect(buf, w, h, colonX, y + (2 * digitH) / 3, t, t);
+  drawDigit(buf, w, h, d2, y, digitW, digitH, t, mm / 10);
+  drawDigit(buf, w, h, d3, y, digitW, digitH, t, mm % 10);
 }
 
 static void oledFlush() {
@@ -186,86 +123,9 @@ static void oledFlush() {
   }
 }
 
-static void spiSelect(bool active) {
-  digitalWrite(PIN_CS, active ? LOW : HIGH);
-}
-
-static void spiCommand(uint8_t c) {
-  digitalWrite(PIN_DC, LOW);
-  spiSelect(true);
-  SPI.transfer(c);
-  spiSelect(false);
-}
-
-static void spiData(uint8_t d) {
-  digitalWrite(PIN_DC, HIGH);
-  spiSelect(true);
-  SPI.transfer(d);
-  spiSelect(false);
-}
-
-static void spiPanelReset() {
-  digitalWrite(PIN_RST, LOW);
-  delay(5);
-  digitalWrite(PIN_RST, HIGH);
-}
-
-static void nokiaInit() {
-  spiPanelReset();
-  spiCommand(0x21);
-  spiCommand(0xB8);
-  spiCommand(0x14);
-  spiCommand(0x20);
-  spiCommand(0x0C);
-}
-
-static void nokiaFlush() {
-  spiCommand(0x40);
-  spiCommand(0x80);
-  digitalWrite(PIN_DC, HIGH);
-  spiSelect(true);
-  for (uint8_t b : nokia) SPI.transfer(b);
-  spiSelect(false);
-}
-
-static void epaperPaintOnce() {
-  if (epaperDone) return;
-  epaperDone = true;
-  spiCommand(0x12);
-  delay(5);
-  spiCommand(0x24);
-  digitalWrite(PIN_DC, HIGH);
-  spiSelect(true);
-  for (int i = 0; i < 4736; i++) SPI.transfer((i % 17) < 8 ? 0x00 : 0xFF);
-  spiSelect(false);
-  spiCommand(0x26);
-  digitalWrite(PIN_DC, HIGH);
-  spiSelect(true);
-  for (int i = 0; i < 4736; i++) SPI.transfer(0xFF);
-  spiSelect(false);
-  spiCommand(0x22);
-  spiData(0xF7);
-  spiCommand(0x20);
-}
-
-static void drawSpiDisplays(uint8_t hh, uint8_t mm, bool includeEpaper) {
-  drawClock(nokia, 84, 48, hh, mm);
-  nokiaFlush();
-  if (includeEpaper) {
-    epaperPaintOnce();
-    nokiaFlush();
-  }
-}
-
-static void drawI2cDisplays(uint8_t hh, uint8_t mm) {
+static void drawOled(uint8_t hh, uint8_t mm) {
   drawClock(oled, 128, OLED_HEIGHT, hh, mm);
   oledFlush();
-}
-
-static void drawAllDisplays(uint8_t hh, uint8_t mm, bool colon) {
-  if (USE_TM1637) tmDisplay(hh, mm, colon);
-  if (USE_NOKIA) drawSpiDisplays(hh, mm, false);
-  if (USE_OLED) drawI2cDisplays(hh, mm);
 }
 
 static void workshopSerialBegin() {
@@ -286,32 +146,8 @@ static void workshopSerialPrintln(const char *line) {
 void setup() {
   workshopSerialBegin();
   workshopSerialPrintln("ESP32-C3 Display Workshop");
-  if (USE_TM1637) {
-    pinMode(PIN_TM_CLK, OUTPUT);
-    pinMode(PIN_TM_DIO, OUTPUT);
-    tmDisplay(12, 34, true);
-  }
-  if (USE_OLED) {
-    oledInit();
-    drawI2cDisplays(12, 34);
-  }
-  if (USE_SPI) {
-    pinMode(PIN_DC, OUTPUT);
-    pinMode(PIN_RST, OUTPUT);
-    pinMode(PIN_CS, OUTPUT);
-    if (USE_EPAPER) pinMode(PIN_BUSY, INPUT);
-    digitalWrite(PIN_CS, HIGH);
-    SPI.begin(PIN_SPI_SCK, PIN_SPI_MISO_UNUSED, PIN_SPI_MOSI, PIN_CS);
-    SPI.beginTransaction(SPISettings(2000000, MSBFIRST, SPI_MODE0));
-    if (USE_NOKIA) {
-      nokiaInit();
-      drawSpiDisplays(12, 34, false);
-    }
-    if (USE_EPAPER) {
-      spiPanelReset();
-      epaperPaintOnce();
-    }
-  }
+  oledInit();
+  drawOled(12, 34);
   workshopSerialPrintln("WORKSHOP_TICK 00:00");
   lastSecond = millis() / 1000;
 }
@@ -322,7 +158,7 @@ void loop() {
   lastSecond = seconds;
   uint8_t hh = (seconds / 3600) % 24;
   uint8_t mm = (seconds / 60) % 60;
-  drawAllDisplays(hh, mm, seconds & 1);
+  drawOled(hh, mm);
   char line[24];
   snprintf(line, sizeof(line), "WORKSHOP_TICK %02u:%02u", hh, mm);
   workshopSerialPrintln(line);


### PR DESCRIPTION
## Summary
- simplify the ESP32-C3 workshop sketch to the two SSD1306 OLED modules only
- keep one Arduino source with WORKSHOP_OLED_HEIGHT selecting 128x64 vs 128x32 init/geometry
- replace thin one-pixel segment strokes with filled seven-segment clock digits

## Verification
- PlatformIO build: WORKSHOP_OLED_HEIGHT=64
- PlatformIO build: WORKSHOP_OLED_HEIGHT=32
- flashed rebuilt 0.96 OLED image to /dev/cu.usbmodem21201 with esptool; hash verified
- serial capture from real ESP32-C3: ESP32-C3 Display Workshop + WORKSHOP_TICK at 1.000s cadence