### PR TITLE
docs: align LabWired action failure policy

### DIFF
--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -23,7 +23,14 @@ jobs:
         uses: w1ne/labwired/.github/actions/labwired-test@main
         with:
           script: tests/basic_boot.yaml
-          artifact_name: test-results
+          output_dir: test-results
+
+      - name: Upload LabWired artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: labwired-results
+          path: test-results/
 ```
 
 ### GitLab CI
@@ -93,7 +100,8 @@ steps:
 
 ## 4. Artifacts and Reporting
 
-The test runner produces machine-readable outputs for integration with CI reporting tools.
+The test runner produces machine-readable outputs for integration with CI reporting tools. The
+`labwired-test` GitHub Action fails when assertions fail, after writing these artifacts.
 
 - **`result.json`**: Detailed execution statistics (cycles, instructions, assertion results).
 - **`junit.xml`**: Standard JUnit format for test result visualization in GitHub/GitLab UI.

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -335,6 +335,7 @@ This repo includes a minimal composite action wrapper at `.github/actions/labwir
 - runs `labwired test`
 - emits artifact paths as outputs
 - writes a small summary into the GitHub Actions step summary
+- fails the action when `labwired test` exits nonzero, after writing artifacts and the summary
 
 Copy-paste this workflow into `.github/workflows/labwired-test.yml`:
 
@@ -368,12 +369,6 @@ jobs:
           name: labwired-artifacts
           path: ${{ steps.labwired.outputs.artifacts_dir }}
           if-no-files-found: warn
-
-      - name: Fail job if test failed
-        if: ${{ steps.labwired.outputs.exit_code != '0' }}
-        run: |
-          echo "labwired test failed with exit_code=${{ steps.labwired.outputs.exit_code }}"
-          exit ${{ steps.labwired.outputs.exit_code }}
 ```
 
 ## Local vs CI Parity

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -45,7 +45,8 @@ jobs:
           profile: release
           no_uart_stdout: true
 
-      # Upload test artifacts
+      # Upload test artifacts. The LabWired action fails on failed assertions
+      # after writing result.json, uart.log, junit.xml, and summary.md.
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- document that the LabWired composite action now fails internally when labwired test exits nonzero
- remove the stale extra workflow failure step from CI docs
- fix the CI integration example to use output_dir and upload artifacts

## Verification
- git diff --check
