### PR TITLE
Release v0.18.0

### DIFF
--- a/.github/workflows/core-board-ci.yml
+++ b/.github/workflows/core-board-ci.yml
@@ -76,10 +76,11 @@ jobs:
       - name: Install apt packages
         if: matrix.apt != ''
         env:
+          DEBIAN_FRONTEND: noninteractive
           APT: ${{ matrix.apt }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y $APT
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $APT
 
       - name: Add rust targets
         if: matrix.rust_targets != ''

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -103,7 +103,7 @@ jobs:
             Or with a specific version:
 
             ```sh
-            LABWIRED_VERSION=${{ github.ref_name }} curl -fsSL https://labwired.com/install.sh | sh
+            curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=${{ github.ref_name }} sh
             ```
 
             See the [full changelog](CHANGELOG.md) for what's new.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-09
+
+### Added
+- **Bus-agnostic Component IR**: Declarative component models can now share one
+  engine across I2C and read-only SPI devices.
+- **One-step SVD ingestion**: `labwired asset ingest-svd` converts vendor SVD
+  input into a runnable declarative chip path.
+- **Native IO-Link simulation path**: LabWired can bridge to the native C
+  IO-Link master, run cyclic PD-out frames, isolate multiple device contexts,
+  and execute multi-node IO-Link worlds in CI.
+- **Firmware exercise matrix**: Added an explicit matrix for which real
+  firmware paths exercise each modeled board/peripheral capability, backed by
+  generated tier-1 scoreboards.
+- **KW41Z Zephyr and display coverage**: Added unmodified Zephyr hello,
+  FXOS8700 activity, Nokia 5110 display, and visible activity-display examples.
+- **Generic input and stimuli flow**: Added `SimInput` channels and declarative
+  input stimuli so tests can drive modeled sensors and inputs mid-run.
+- **Bus trace and analyzer exports**: Added a shared trace event stream,
+  universal tracing wrappers for attached I2C/SPI devices, WASM trace draining,
+  and CLI JSON/VCD export via `--bus-trace-out`.
+- **Peripheral egress bridge and relay**: Simulated peripheral output can be
+  forwarded through validated MQTT/TCP/HTTP-style egress flows.
+- **Faithful ESP32-C3 / ESP32-S3 browser paths**: Added lazy ROM injection,
+  flash-image ROM boot in WASM, ESP32-C3 SSD1306/OLED paint proof, and
+  `labwired test --rom-boot` coverage for faithful ESP targets.
+- **Universal peripheral inspect interface**: Added a common inspection surface
+  for machine/peripheral state, including ESP32-C3 inspect integration.
+- **Snapshot app-entry cache**: Faithful ESP32-C3 boot can be cached at app
+  entry and resumed for faster interactive startup.
+- **Additional examples and devices**: Added RP2040 Arduino Mbed-OS USB CDC,
+  CAN player replay, F103 J1939 monitor, CANmod GPS simulation, display catalog
+  devices, and ESP32-C3 display workshop labs.
+
+### Changed
+- **Unified pin mapping**: Chip descriptors now carry an authoritative `pins`
+  map; runtime routing resolves through that map instead of parsing pin names or
+  falling back silently.
+- **Canonical config loading**: Rust `resolve()` now follows the TypeScript
+  oracle for byte-identical canonical config behavior.
+- **IO-Link wire conformance**: Device and master pins were aligned to the
+  V1.1.5 spec-conformant wire mapping.
+- **Browser runtime performance**: WASM builds use smaller/faster settings,
+  lazy ROM loading, idle fast-forward, cached C3 tick/IRQ routing, and batched
+  RISC-V stepping.
+- **Test runner stop semantics**: Assertion-pass stop handling now supports a
+  settle window and minimum-step floor for more stable scripted runs.
+- **Release-facing README**: Rewrote the project README around concrete
+  capabilities, examples, validation scope, and a verified smoke command.
+
+### Fixed
+- **IO-Link correctness and observability**: Repaired IO-Link debug/analyzer
+  flow, native stack routing, multi-device state isolation, station console
+  labeling, station USART scoping, and the four-port master PHY ABI.
+- **nRF52 firmware fidelity**: Modeled TWIM transfer latency, both write-read
+  paths, RTC LFCLK timing, and legacy UART TXD behavior for Arduino output.
+- **Cortex-M and instruction fidelity**: Cleared stale pending exception bits
+  after NVIC ICPR, fixed LDM T1 writeback when the base register is in the
+  register list, and covered CPU arithmetic behavior used by IO-Link flows.
+- **ESP32-C3 / SSD1306 paths**: Fixed OLED I2C transactions, split-command
+  SSD1306 state, dynamic bus tick caching, GPIO flash boot strap values,
+  read-fresh ROM-boot timers, scheduler tick walking, and workshop firmware
+  display/serial behavior.
+- **STM32 and RP2040 bring-up**: Modeled STM32L476 PLLSAI ready bits for
+  Arduino HAL boot and RP2040 XIP_SSI for boot2/XIP completion.
+- **Modeling failures become explicit**: PCD8544 D/C pin resolution and
+  vendor-neutral GPIO routing now fail loudly instead of guessing a fallback.
+- **CI and packaging stability**: Restored strict onboarding smoke gates, pinned
+  the thumbv6m smoke linker path, reduced unnecessary GitHub Actions usage, and
+  aligned the published LabWired action failure policy.
+
 ## [0.17.10] - 2026-06-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1021,56 +1021,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1717,7 +1717,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-egress-relay"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "labwired-core",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1884,11 +1884,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.17.10"
+version = "0.18.0"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3385,7 +3385,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.17.10"
+version = "0.18.0"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,65 +1,81 @@
 # LabWired Core
 
-Deterministic firmware simulator for ARM Cortex-M, RISC-V, and Xtensa (ESP32 / ESP32-S3) — the same ELF runs on hardware and in the simulator.
+LabWired Core runs embedded firmware in a deterministic simulated hardware lab.
+
+It loads real firmware ELFs and executes them against modeled chips, boards,
+peripherals, buses, sensors, displays, and protocol devices. The goal is not to
+replace every hardware test. The goal is to move the fast, repeatable part of
+firmware bring-up and regression testing into a local and CI-friendly simulator.
 
 [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://labwired.com/docs/)
 
-## Why this exists
+## What You Can Do
 
-Most firmware simulators let you boot a binary and stop there. LabWired goes further:
+| Use case | Where to start | What LabWired provides |
+| --- | --- | --- |
+| Run firmware without a board | [`labwired run`](docs/cli_reference.md) | ELF loading, system manifests, UART/GPIO output, traces, snapshots |
+| Gate firmware behavior in CI | [`labwired test`](docs/ci_test_runner.md) | YAML test scripts, assertions, exit codes, artifacts, JUnit output |
+| Debug firmware without hardware | [Debugging](docs/debugging.md), [GDB](docs/gdb_integration.md) | GDB RSP and VS Code DAP support for breakpoints and register inspection |
+| Model board-level I/O | [`examples/demo-blinky`](examples/demo-blinky/README.md) | External I2C/SPI-style device attachment, board I/O mapping, deterministic checks |
+| Validate simulator behavior against hardware | [`examples/nucleo-h563zi`](examples/nucleo-h563zi/README.md) | Hardware and simulator traces, UART logs, reproducible validation reports |
+| Add or audit chip support | [Board onboarding](docs/board_onboarding_playbook.md), [coverage](docs/coverage_scoreboard.md) | Chip/system YAML, target support rubric, smoke coverage, catalog metadata |
 
-- **Hardware-validated reset + UART parity.** A real NUCLEO-H563ZI board is captured via OpenOCD+GDB and diffed against the simulator running the same firmware ELF. The committed report — [`determinism_report_h563.json`](examples/nucleo-h563zi/golden-reference/determinism_report_h563.json) — documents the verified scope (post-reset architectural alignment + UART byte parity over the smoke run) and explicitly notes what isn't verified (step-by-step PC sequence past reset — OpenOCD's sampling can't resolve every executed instruction on real silicon). For deeper byte-parity evidence under continuous execution, see the NUCLEO-L476RG survival traces (`firmware-l476-demo/`).
-- **Deterministic by construction.** Same firmware → same trace, byte-for-byte, across runs and machines. Trace SHA-256 hashes are CI-gated.
-- **Production-grade debug.** GDB Remote Serial Protocol stub *and* a native VS Code Debug Adapter Protocol server — breakpoints, register inspect, expression evaluation, all without hardware.
-- **Silicon-validated fidelity.** Peripheral models continuously diffed against real hardware; high-MIPS host execution when iteration speed matters. See [`docs/architecture.md`](docs/architecture.md) for the perf gates.
-
-## Featured demo: NUCLEO-H563ZI
-
-Same firmware ELF runs on a real STM32H563ZI Nucleo and on the simulator. UART output matches. Reset-state architectural alignment verified. The captured artifacts (HW trace, sim trace, sim run result, UART log, determinism report) are committed alongside the firmware that produced them: [`examples/nucleo-h563zi/`](examples/nucleo-h563zi/).
-
-## What this repo owns
-
-- Simulation engine correctness and determinism.
-- Chip/system model execution (`configs/chips`, `configs/systems`).
-- Hardware-target validation metadata for catalog consumers.
+Supported targets are intentionally uneven. ARM Cortex-M and RISC-V have the
+deepest CI coverage today; selected ESP32/Xtensa paths exist for specific
+examples. Check the per-board docs before assuming a peripheral is modeled:
+[docs/boards](docs/boards/).
 
 ## Quick Start
 
-### Install
+### Install the CLI
 
-Pinned release (recommended):
+Pinned release:
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.16.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.18.0 sh
 labwired --version
 ```
 
-Prefer to read the script first:
+Prefer to inspect the installer first:
 
 ```sh
 curl -fsSL https://labwired.com/install.sh -o install.sh
 # review install.sh, then:
-LABWIRED_VERSION=v0.16.0 sh install.sh
+LABWIRED_VERSION=v0.18.0 sh install.sh
 ```
 
 Supported host environments:
+
 - Linux
 - macOS
 - Windows via WSL2
 
 Install options:
 
-- `LABWIRED_VERSION=v0.16.0` pins a release (omit for latest).
-- `LABWIRED_FROM_SOURCE=1` forces source build.
-- `LABWIRED_INSTALL_DIR=~/.local/bin` overrides install dir.
+- `LABWIRED_VERSION=v0.18.0` pins a release. Omit it to install the latest
+  published version.
+- `LABWIRED_FROM_SOURCE=1` forces a source build.
+- `LABWIRED_INSTALL_DIR=~/.local/bin` changes the install directory.
 
-### Run a deterministic test script
+### Run the CI smoke example from a source checkout
+
+The bundled smoke script expects the fixture firmware to exist in `target/`.
+From the repository root:
 
 ```sh
-labwired test --script examples/ci/uart-ok.yaml --output-dir results
+rustup target add thumbv6m-none-eabi
+cargo build -p firmware-ci-fixture --release --target thumbv6m-none-eabi
+cargo run -q -p labwired-cli -- test \
+  --script examples/ci/uart-ok.yaml \
+  --output-dir /tmp/labwired-readme-smoke \
+  --no-uart-stdout
 ```
 
-### Build from source
+That script runs the fixture firmware against
+[`configs/systems/ci-fixture-uart1.yaml`](configs/systems/ci-fixture-uart1.yaml)
+and asserts that UART output contains `OK`.
+
+### Build the simulator from source
 
 ```sh
 rustup target add thumbv6m-none-eabi thumbv7m-none-eabi riscv32i-unknown-none-elf
@@ -67,46 +83,104 @@ cargo build --release -p labwired-cli
 ./target/release/labwired --version
 ```
 
-## CI At A Glance
+## Examples
 
-### Required merge gate
+Start with examples that have a clear system manifest, firmware path, and smoke
+test:
 
-- `.github/workflows/core-ci.yml`: fmt, clippy, build, and integration tests on every PR to `main`.
+- [CI UART smoke](examples/ci/README.md): minimal `labwired test` scripts for
+  deterministic pass/fail behavior.
+- [Blinky + TMP102](examples/demo-blinky/README.md): STM32F103 firmware talking
+  to a virtual TMP102 sensor over I2C.
+- [NUCLEO-H563ZI](examples/nucleo-h563zi/README.md): same demo story on the
+  simulator and a physical STM32H563ZI Nucleo board, with committed validation
+  artifacts.
+- [NUCLEO-L476RG](examples/nucleo-l476rg/README.md): survival and validation
+  traces for an STM32 Nucleo target.
+- [Seeed XIAO nRF52840 Sense](examples/seeed-xiao-nrf52840-sense/README.md):
+  nRF52840 board coverage with UART/GPIO/SPI smoke paths.
+- [UDS on STM32F103](examples/f103-uds-ecu/README.md) and
+  [UDS on STM32H563](examples/h563-uds-ecu/README.md): CAN/UDS-oriented
+  firmware examples.
+- [IO-Link DIDO](examples/iolink-dido/README.md): IO-Link device-oriented
+  system wiring and smoke test.
 
-### Quality signals
+For the broader list, see [docs/demos.md](docs/demos.md). Treat each example's
+README and validation file as the source of truth for what is actually modeled.
 
-- `core-coverage.yml`: coverage verification.
-- `core-unsupported-audit.yml`: unsupported instruction audits.
-- `core-nightly.yml`: broader nightly validation.
-- `core-validate-hw-targets.yml`: full onboarding target sweep, emits `out/hw-target-validation/summary.{json,md}`, and refreshes onboarding validation metadata.
+## Validation Model
 
-### Board model signals
+LabWired distinguishes between three levels of confidence:
 
-- `core-board-ci-fixture-arm.yml`: ARM fixture smoke coverage.
-- `core-board-ci-fixture-riscv.yml`: RISC-V fixture smoke coverage.
-- `core-board-nucleo-h563zi.yml`: H563 io-smoke and fullchip-smoke.
+- **Modeled**: a chip, peripheral, bus, or external device has simulator logic
+  behind it and can execute firmware behavior.
+- **Smoke-tested**: a repository test or example script exercises that model
+  and checks observable output.
+- **Hardware-compared**: captured hardware behavior is compared with simulator
+  behavior for a documented scope.
 
-## Validation Structure
+The H563 example is the best place to inspect hardware-comparison artifacts:
 
-- PR smoke and scoreboard: `core-onboarding-smoke.yml`.
-- Full target sweep for catalog metadata: `core-validate-hw-targets.yml`.
-- Policy and downstream contract: [docs/catalog_validation.md](./docs/catalog_validation.md).
+- [`examples/nucleo-h563zi/golden-reference/determinism_report_h563.json`](examples/nucleo-h563zi/golden-reference/determinism_report_h563.json)
+- [`examples/nucleo-h563zi/VALIDATION.md`](examples/nucleo-h563zi/VALIDATION.md)
+- [`docs/golden_reference.md`](docs/golden_reference.md)
 
-## Key Docs
+Those reports are evidence for the scope they describe. They are not a blanket
+claim that every instruction, peripheral, or timing path matches hardware.
 
-- [Docs Index](./docs/index.md)
-- [Architecture](./docs/architecture.md)
-- [Board Onboarding Playbook](./docs/board_onboarding_playbook.md)
-- [CI Integration Guide](./docs/ci_integration.md)
-- [Release Strategy](./docs/release_strategy.md)
-- [Agents Manual](./docs/agents.md)
+## Repository Scope
 
-## Other demos
+This repository owns the core simulator and its validation assets:
 
-- [Blinky + I2C Sensor Demo](examples/demo-blinky/README.md) — STM32F103 + virtual TMP102 over I2C.
-- [STM32 Case Study](docs/case_study_stm32.md) — debugging firmware without hardware, end-to-end.
-- [Demo Index](docs/demos.md) — full list of bundled examples.
+- CPU, bus, memory, peripheral, and external device execution.
+- Chip and system descriptors in [`configs/chips`](configs/chips/) and
+  [`configs/systems`](configs/systems/).
+- CLI, test runner, debug adapters, and snapshot/trace tooling.
+- Hardware-target validation metadata consumed by catalog and app surfaces.
+
+Application UI, hosted playground behavior, and product-specific surfaces live
+outside this core package.
+
+## CI and Release Signals
+
+The main merge gate is [`.github/workflows/core-ci.yml`](.github/workflows/core-ci.yml):
+formatting, linting, build, and integration tests.
+
+Additional workflows publish narrower signals:
+
+- [`core-board-ci.yml`](.github/workflows/core-board-ci.yml): board/example
+  smoke coverage.
+- [`core-coverage.yml`](.github/workflows/core-coverage.yml): coverage checks.
+- [`core-unsupported-audit.yml`](.github/workflows/core-unsupported-audit.yml):
+  unsupported instruction audits.
+- [`core-nightly.yml`](.github/workflows/core-nightly.yml): broader scheduled
+  validation.
+- [`core-validate-hw-targets.yml`](.github/workflows/core-validate-hw-targets.yml):
+  onboarding target sweep and catalog metadata.
+
+For release mechanics, see [RELEASE_PROCESS.md](RELEASE_PROCESS.md) and
+[RELEASE_READINESS_CHECKLIST.md](RELEASE_READINESS_CHECKLIST.md).
+
+## Documentation
+
+- [Docs index](docs/index.md)
+- [Architecture overview](docs/architecture_overview.md)
+- [Engine architecture](docs/architecture.md)
+- [CLI reference](docs/cli_reference.md)
+- [CI test runner](docs/ci_test_runner.md)
+- [Configuration reference](docs/configuration_reference.md)
+- [Board onboarding playbook](docs/board_onboarding_playbook.md)
+- [Target support rubric](docs/target_support_rubric.md)
+- [Debugging](docs/debugging.md)
+- [PlatformIO integration](docs/platformio_integration.md)
+- [Agents manual](docs/agents.md)
+
+## Contributing
+
+Use [CONTRIBUTING.md](CONTRIBUTING.md) for repository workflow and
+[docs/agents.md](docs/agents.md) for AI-agent-specific guidance. For security
+issues, see [SECURITY.md](SECURITY.md).
 
 ## License
 
-MIT
+MIT. See [LICENSE](LICENSE).

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -65,12 +65,16 @@ This document outlines the standardized process for releasing new versions of La
   - **Title**: `vX.Y.Z: <Key Highlight/Theme>`
   - **Description**: Copy contents from `.github/RELEASE_TEMPLATE.md` and fill it in with details from `CHANGELOG.md`.
 
-### Artifacts (Manual Step until CI is fully automated)
-- [ ] **Build Binaries**:
-  ```bash
-  cargo build --release --bin labwired
-  ```
-- [ ] **Upload Assets**: Attach the binary (and signature if available) to the GitHub Release.
+### Artifacts
+- [ ] **Release Workflow**: Pushing `vX.Y.Z` triggers
+  [`.github/workflows/core-release.yml`](.github/workflows/core-release.yml),
+  which builds CLI archives for Linux and macOS targets and uploads them to the
+  GitHub Release.
+- [ ] **Workflow Verification**: Confirm the release workflow completed and the
+  expected `labwired-vX.Y.Z-<platform>.tar.gz` assets are attached.
+- [ ] **Manual Fallback**: If the release workflow fails, build the CLI locally
+  with `cargo build -p labwired-cli --release`, package the `labwired` binary,
+  and attach the archive manually with a note in the release description.
 
 ## 4. Post-Release
 - [ ] **Announce**: Share the release notes on relevant channels (Discord, Twitter, Internal).

--- a/RELEASE_READINESS_CHECKLIST.md
+++ b/RELEASE_READINESS_CHECKLIST.md
@@ -1,34 +1,51 @@
-# Release Readiness Checklist (v0.16.0)
+# Release Readiness Checklist (v0.18.0)
 
-**Date**: 2026-06-18
-**Version**: 0.16.0
+**Date**: 2026-07-09
+**Version**: 0.18.0
 **Coordinator**: @w1ne
 
 ## 1. Documentation Audit
-- [ ] **Changelog Updated**: `CHANGELOG.md` captures major changes since the previous release.
-- [ ] **Install Docs Updated**: `README.md` pinned install examples reference `v0.16.0`.
-- [ ] **Process Docs Updated**: `RELEASE_PROCESS.md` uses neutral version examples.
-- [ ] **Roadmap Updated**: `ROADMAP.md` has a `v0.16.0` section reflecting what shipped, and the previous version is no longer marked `(Current)`.
+- [x] **Changelog Updated**: `CHANGELOG.md` captures major changes since `v0.17.10`.
+- [x] **Install Docs Updated**: `README.md` pinned install examples reference `v0.18.0`.
+- [x] **Process Docs Reviewed**: `RELEASE_PROCESS.md` and release workflow instructions match the tag-triggered automation.
+- [x] **Roadmap Updated**: `ROADMAP.md` has a `v0.18.0` section reflecting what shipped, and stale sections are no longer marked `(Current)`.
+- [x] **Relative Links Checked**: Release-facing Markdown links in `README.md`, `CHANGELOG.md`, `RELEASE_PROCESS.md`, `RELEASE_READINESS_CHECKLIST.md`, and `ROADMAP.md` resolve locally.
 
 ## 2. Codebase Integrity
-- [ ] **Cargo Check**: `cargo check --workspace` passes after the workspace version bump.
-- [ ] **Tests Passing**: `cargo test --workspace` passes.
-- [ ] **Formatting**: `cargo fmt --all -- --check` passes.
-- [ ] **Lints**: `cargo clippy --workspace --all-targets -- -D warnings` passes.
-- [ ] **Diff Hygiene**: `git diff --check` reports no whitespace errors.
+- [x] **Cargo Check**: `cargo check --workspace` passes after the workspace version bump.
+- [x] **Tests Passing**: Workspace tests were verified in split lanes; the monolithic `cargo test --workspace` run was interrupted by the local environment and is recorded below.
+- [x] **Formatting**: `cargo fmt --all -- --check` passes.
+- [x] **Lints**: `cargo clippy --workspace --all-targets -- -D warnings` passes.
+- [x] **Diff Hygiene**: `git diff --check` reports no whitespace errors.
 
 ## 3. Artifacts & Packaging
-- [ ] **Version Bump**: `[workspace.package].version` in root `Cargo.toml` updated; `Cargo.lock` regenerated.
-- [ ] **Generated Output Cleanup**: Tracked `out/**` run artifacts and accidental build products are removed; committed test fixtures remain.
-- [ ] **Release Notes Prepared**: `CHANGELOG.md` `0.16.0` section is ready to publish as the GitHub release body.
+- [x] **Version Bump**: `[workspace.package].version` in root `Cargo.toml` is `0.18.0`; `Cargo.lock` regenerated.
+- [x] **Generated Output Cleanup**: No tracked `out/**` run artifacts or accidental build products are part of the release-prep diff.
+- [x] **Release Notes Prepared**: `CHANGELOG.md` `0.18.0` section is ready to publish as the GitHub release body.
+- [x] **Release Workflow Checked**: `.github/workflows/core-release.yml` creates the release and uploads CLI archives from the pushed tag.
+- [x] **Generated UI Manifest Refreshed**: `packages/ui/src/peripherals/manifest.json` in the parent repo was regenerated from the v0.18.0 CLI.
 
 ## 4. Final Review
-- [ ] **Working Tree Reviewed**: Release-prep diff contains expected metadata, documentation, generated-output cleanup, formatter changes.
-- [ ] **Release Notes Reviewed**: GitHub release body matches the `CHANGELOG.md` `0.16.0` section.
+- [x] **Working Tree Reviewed**: Release-prep diff contains expected metadata, documentation, lint fixes, one test-harness fix, and generated lockfile changes.
+- [x] **Release Notes Reviewed**: GitHub release body should use the `CHANGELOG.md` `0.18.0` section.
+- [ ] **Release Branch Ready**: Release prep is committed on `release/v0.18.0` and ready for PR review.
+- [ ] **CI Green**: Pushed release branch passes GitHub Actions.
+- [ ] **Release Tagged**: `v0.18.0` tag is created and pushed only after review/CI.
 
 ---
-**Status**: [ ] READY FOR RELEASE
+**Status**: [x] LOCAL RELEASE PREP COMPLETE; [ ] READY TO TAG
 
-## Known Issues (v0.16.0)
-- `crates/core/tests/e2e_agentdeck_in_sim.rs` remains `#[ignore]`-gated on a 22 MB external firmware ELF that lives outside the repo. Regression assertions are present but only fire when invoked explicitly with `cargo test -- --ignored`.
-- The Arduino-ESP32 / FreeRTOS path uses stub mutexes (`return_pd_true`) that unconditionally succeed; a future release should wire real queue semantics. The stub emits a one-time `tracing::warn!` on first call.
+## Known Issues (v0.18.0)
+- Full release confidence still depends on the CI matrix for hardware-backed and
+  toolchain-specific lanes that are not practical to reproduce in this local
+  checkout.
+- A monolithic `cargo test --workspace` run reached the long e-paper E2E path
+  and was terminated by the local environment. The suite was then verified in
+  split lanes:
+  - `cargo test -p labwired-core --test intmatrix_alarm`
+  - focused core continuation lanes through `xtensa_regs`
+  - `cargo test -p labwired-cli --test breakpoints`
+  - `cargo test --workspace --exclude labwired-core --exclude labwired-cli --exclude labwired-dap --exclude labwired-gdbstub`
+  - `cargo test -p labwired-dap --test e2e` after building `firmware-ci-fixture`
+  - `cargo test -p labwired-gdbstub --test gdb_e2e` outside the sandbox because
+    the test binds a local TCP port.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,33 @@
 
 This roadmap outlines the planned evolution of LabWired Core as we move towards a production-ready ecosystem for professional firmware simulation.
 
-## 🟢 v0.16.0: SoC Factory, Faithful ESP32 Boot & Module Refactor (Current)
+## v0.18.0: Analyzer, IO-Link, Browser Firmware Fidelity & Pin Routing (Current)
+- **Analyzer foundations**: shared trace event stream, attached-device tracing
+  wrappers, JSON/VCD bus trace export, and a universal peripheral inspect
+  interface.
+- **IO-Link execution depth**: native C master bridge, multi-device isolation,
+  cyclic PD-out, real-stack conformance, multi-node worlds, and clearer station
+  observability.
+- **Faithful browser firmware paths**: lazy ESP32-S3/C3 ROM injection, ESP32-C3
+  flash-image ROM boot in WASM, OLED/display workshop labs, and app-entry
+  snapshot resume.
+- **Config and routing hardening**: canonical config resolution ported to Rust,
+  authoritative chip pin maps, and fail-loud routing for GPIO/display pins.
+- **Expanded real-firmware coverage**: KW41Z Zephyr/display labs, RP2040
+  Arduino USB CDC, CAN/J1939 examples, display catalog devices, and a firmware
+  exercise matrix tied to tier-1 scoreboards.
+
+## v0.17.x: CAN, Clock Gating, nRF52 I2C Fidelity & Patch Train
+- **Classical CAN and UDS**: STM32F1 bxCAN loopback/frame trace and a real
+  two-node UDS-oriented CAN bus.
+- **Clock-gated STM32 models**: RCC-gated access for F1/L4 peripherals and
+  improved register-coverage measurement independent of runtime gating.
+- **nRF52 TWIM fixes**: PSEL shadowing, SHORTS bit positions, task resume, event
+  offsets, stop handling, and combined write-read behavior.
+- **Live validation refreshes**: silicon-tier captures and drift acknowledgments
+  for STM32, ESP32-S3, and nRF52 paths.
+
+## v0.16.0: SoC Factory, Faithful ESP32 Boot & Module Refactor
 - **SoC Factory architecture**: per-family peripheral factories + const peripheral table with a thin `from_config` match (generic, nRF52, ESP32 LX6/LX7); adding a chip is a table entry plus a factory hook.
 - **Faithful ESP32 boot**: ESP32-S3 ROM auto-provisioning from the toolchain (loaded by default) and ESP32 (LX6) real-boot de-thunk; `Esp32s3BootMode` telemetry distinguishes Faithful vs Harness.
 - **Silicon-validation & drift gate**: CI compares the model against silicon-derived expectations and fails on drift; auto-generated board status and a data-driven coverage matrix.

--- a/configs/ci/boards.yml
+++ b/configs/ci/boards.yml
@@ -9,7 +9,7 @@ boards:
   - id: iolink-station-l476
     kind: firmware-gate
     path: examples/iolink-station
-    apt: [gcc-arm-none-eabi]
+    apt: [gcc-arm-none-eabi, libnewlib-arm-none-eabi]
     packs: [stm32cubel4@v1.18.2]
     submodules: recursive
     gate: true

--- a/crates/core/tests/intmatrix_alarm.rs
+++ b/crates/core/tests/intmatrix_alarm.rs
@@ -13,7 +13,7 @@
 use labwired_core::bus::SystemBus;
 use labwired_core::peripherals::esp32s3::gpio::GpioObserver;
 use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
-use labwired_core::{Bus, Cpu};
+use labwired_core::{Bus, Cpu, Machine};
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Default)]
@@ -135,21 +135,16 @@ fn intmatrix_alarm_full_irq_chain() {
 
     cpu.set_pc(IRAM_BASE);
 
-    let observers: Vec<std::sync::Arc<dyn labwired_core::SimulationObserver>> = Vec::new();
+    let mut machine = Machine::new(cpu, bus);
     const MAX_STEPS: u64 = 100_000;
     for _step in 0..MAX_STEPS {
-        if let Err(e) = cpu.step(
-            &mut bus,
-            &observers,
-            &labwired_core::SimulationConfig::default(),
-        ) {
+        if let Err(e) = machine.step() {
             let events = obs.events.lock().unwrap();
             panic!(
                 "CPU step failed at pc=0x{:08x}: {e}; events: {events:?}",
-                cpu.get_pc(),
+                machine.cpu.get_pc(),
             );
         }
-        bus.tick_peripherals_with_costs();
 
         let events = obs.events.lock().unwrap();
         let pin2_count = events.iter().filter(|&&(p, _, _, _)| p == 2).count();
@@ -162,6 +157,6 @@ fn intmatrix_alarm_full_irq_chain() {
     panic!(
         "did not see 3+ transitions on GPIO2 in {MAX_STEPS} steps; \
          events: {events:?}, final PC=0x{:08x}",
-        cpu.get_pc(),
+        machine.cpu.get_pc(),
     );
 }

--- a/crates/firmware-f103-conformance/src/main.rs
+++ b/crates/firmware-f103-conformance/src/main.rs
@@ -90,14 +90,22 @@ const FAULT_MAGIC: u32 = 0xDEAD_FA17;
 #[no_mangle]
 pub extern "C" fn HardFaultHandler() -> ! {
     unsafe { digest(IDX_DONE, FAULT_MAGIC) };
-    loop {}
+    halt_forever()
 }
 
 #[no_mangle]
 pub extern "C" fn DefaultHandler() -> ! {
     unsafe { digest(IDX_DONE, FAULT_MAGIC) };
-    loop {}
+    halt_forever()
 }
+
+#[inline(never)]
+fn halt_forever() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
 #[inline(always)]
 unsafe fn digest(idx: usize, val: u32) {
     wr(VERDICT + (idx as u32) * 4, val);
@@ -120,7 +128,7 @@ fn main() -> ! {
         test_dma();
         digest(IDX_DONE, DONE_MAGIC); // sentinel — must be last
     }
-    loop {}
+    halt_forever()
 }
 
 /// GPIOA atomic set/reset (BSRR/BRR with BS-over-BR priority) → ODR = 0x001C.
@@ -151,9 +159,9 @@ unsafe fn test_crc() {
     enable_clock(RCC_AHBENR, 1 << 6); // CRCEN
     wr(CRC + 0x08, 1); // CR.RESET
     settle();
-    wr(CRC + 0x00, 0x1234_5678); // DR
-    wr(CRC + 0x00, 0x9ABC_DEF0);
-    digest(IDX_CRC, rd(CRC + 0x00));
+    wr(CRC, 0x1234_5678); // DR
+    wr(CRC, 0x9ABC_DEF0);
+    digest(IDX_CRC, rd(CRC));
 }
 
 /// EXTI software-trigger lines 0+2, then clear line 0 → PR=0x4, SWIER=0x4.
@@ -164,7 +172,7 @@ unsafe fn test_exti() {
     wr(EXTI + 0x0C, 0); // FTSR = 0
     wr(EXTI + 0x14, 0x000F_FFFF); // PR rc_w1: clear all lines
     settle();
-    wr(EXTI + 0x00, 0x5); // IMR lines 0,2
+    wr(EXTI, 0x5); // IMR lines 0,2
     wr(EXTI + 0x10, 0x5); // SWIER -> PR
     wr(EXTI + 0x14, 0x1); // PR rc_w1: clear line 0
     settle();
@@ -190,16 +198,16 @@ unsafe fn test_dma() {
     );
     // Poll TCIF1 (ISR bit 1) with a bounded timeout.
     let mut guard: u32 = 0;
-    while (rd(DMA1 + 0x00) & (1 << 1)) == 0 && guard < 1_000_000 {
+    while (rd(DMA1) & (1 << 1)) == 0 && guard < 1_000_000 {
         guard += 1;
     }
     digest(IDX_DMA_D0, rd(DMA_DST));
     digest(IDX_DMA_D1, rd(DMA_DST + 4));
     digest(IDX_DMA_CNDTR, rd(DMA1 + 0x0C));
-    digest(IDX_DMA_ISR, rd(DMA1 + 0x00));
+    digest(IDX_DMA_ISR, rd(DMA1));
 }
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
+    halt_forever()
 }

--- a/crates/firmware-f103-fuzztarget/src/main.rs
+++ b/crates/firmware-f103-fuzztarget/src/main.rs
@@ -43,15 +43,22 @@ unsafe fn rd8(addr: u32) -> u8 {
     read_volatile(addr as *const u8)
 }
 
+#[inline(never)]
+fn halt_forever() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn HardFaultHandler() -> ! {
     unsafe { wr(VERDICT, FAULT_MAGIC) };
-    loop {}
+    halt_forever()
 }
 #[no_mangle]
 pub extern "C" fn DefaultHandler() -> ! {
     unsafe { wr(VERDICT, FAULT_MAGIC) };
-    loop {}
+    halt_forever()
 }
 
 #[no_mangle]
@@ -66,7 +73,7 @@ fn main() -> ! {
         parse(len);
         wr(VERDICT, DONE_MAGIC);
     }
-    loop {}
+    halt_forever()
 }
 
 /// Walk the frame stream. Bounds the per-frame data read to the remaining input

--- a/crates/firmware-hal-test/Cargo.toml
+++ b/crates/firmware-hal-test/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "firmware-hal-test"
-version = "0.11.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/firmware-kw41z-lcd/src/main.rs
+++ b/crates/firmware-kw41z-lcd/src/main.rs
@@ -564,7 +564,7 @@ unsafe fn i2c_read(addr: u8, reg: u8, buf: &mut [u8]) {
     }
     let _ = read_volatile(I2C1_D); // dummy read kicks the first byte
     i2c_wait_clear();
-    for i in 0..n {
+    for (i, byte) in buf.iter_mut().enumerate().take(n) {
         if i == n - 1 {
             // STOP before the final byte read.
             write_volatile(I2C1_C1, C1_IICEN);
@@ -572,7 +572,7 @@ unsafe fn i2c_read(addr: u8, reg: u8, buf: &mut [u8]) {
             // NAK the byte after this one (the last).
             write_volatile(I2C1_C1, C1_IICEN | C1_MST | C1_TXAK);
         }
-        buf[i] = read_volatile(I2C1_D);
+        *byte = read_volatile(I2C1_D);
         if i != n - 1 {
             i2c_wait_clear();
         }

--- a/crates/firmware-nrf52840-conformance/src/main.rs
+++ b/crates/firmware-nrf52840-conformance/src/main.rs
@@ -113,7 +113,14 @@ fn main() -> ! {
         // Sentinel written LAST so the harness knows all tests ran.
         digest(IDX_DONE, DONE_MAGIC);
     }
-    loop {}
+    halt_forever()
+}
+
+#[inline(never)]
+fn halt_forever() -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 // ── Test: GPIO0 ───────────────────────────────────────────────────────────────
@@ -155,7 +162,7 @@ unsafe fn test_timer0() {
     wr(TIMER0_BASE + 0x508, 3); // BITMODE = 32-bit
     wr(TIMER0_BASE + 0x00C, 1); // TASKS_CLEAR
     settle();
-    wr(TIMER0_BASE + 0x000, 1); // TASKS_START (required even in counter mode)
+    wr(TIMER0_BASE, 1); // TASKS_START (required even in counter mode)
     settle();
     // Pulse TASKS_COUNT 7 times.
     for _ in 0..7u32 {
@@ -185,8 +192,8 @@ unsafe fn test_ecb() {
     let ptr = &raw const ECB_BUF as u32;
     wr(ECB_BASE + 0x504, ptr); // ECBDATAPTR
     wr(ECB_BASE + 0x100, 0); // clear EVENTS_ENDECB
-    wr(ECB_BASE + 0x000, 1); // TASKS_STARTECB
-                             // Bounded wait on EVENTS_ENDECB.
+    wr(ECB_BASE, 1); // TASKS_STARTECB
+                     // Bounded wait on EVENTS_ENDECB.
     let mut guard: u32 = 0;
     while rd(ECB_BASE + 0x100) == 0 && guard < 2_000_000 {
         guard += 1;
@@ -224,11 +231,8 @@ unsafe fn test_gpiote() {
     // GPIOTE CONFIG[0]: MODE=Task(3), PSEL=8, PORT=0(GPIO0), POLARITY=LoToHi(1), OUTINIT=0
     // bit pattern: bits[1:0]=3, bits[12:8]=8, bit[13]=0, bits[17:16]=1, bit[20]=0
     // = 0x0001_0803
-    let config: u32 = (3 << 0)  // MODE = Task
-        | (8 << 8)               // PSEL = pin 8
-        | (0 << 13)              // PORT = GPIO0
-        | (1 << 16)              // POLARITY = LoToHi (SET task → pin high)
-        | (0 << 20); // OUTINIT = low
+    // MODE=Task, PSEL=8, PORT=GPIO0, POLARITY=LoToHi, OUTINIT=low.
+    let config: u32 = 3 | (8 << 8) | (1 << 16);
     wr(GPIOTE_BASE + 0x510, config); // CONFIG[0]
     settle();
 
@@ -251,14 +255,14 @@ unsafe fn test_gpiote() {
 // -50°C..100°C → raw [-200, 400]. Liveness + sanity only.
 unsafe fn test_temp() {
     wr(TEMP_BASE + 0x100, 0); // clear EVENTS_DATARDY
-    wr(TEMP_BASE + 0x000, 1); // TASKS_START
+    wr(TEMP_BASE, 1); // TASKS_START
     let mut guard: u32 = 0;
     while rd(TEMP_BASE + 0x100) == 0 && guard < 2_000_000 {
         guard += 1;
     }
     let in_range: u32 = if rd(TEMP_BASE + 0x100) != 0 {
         let raw = rd(TEMP_BASE + 0x508) as i32;
-        if raw >= -200 && raw <= 400 {
+        if (-200..=400).contains(&raw) {
             1
         } else {
             0
@@ -281,7 +285,7 @@ unsafe fn test_temp() {
 // (non-deterministic). IDX_RNG_LIVE = 1 if VALRDY fired, else 0.
 unsafe fn test_rng() {
     wr(RNG_BASE + 0x100, 0); // clear EVENTS_VALRDY
-    wr(RNG_BASE + 0x000, 1); // TASKS_START
+    wr(RNG_BASE, 1); // TASKS_START
     let mut guard: u32 = 0;
     while rd(RNG_BASE + 0x100) == 0 && guard < 2_000_000 {
         guard += 1;

--- a/crates/firmware-nrf52840-cpu-conformance/src/main.rs
+++ b/crates/firmware-nrf52840-cpu-conformance/src/main.rs
@@ -34,6 +34,7 @@
 //! digest words. The harness polls `VERDICT[0]` then diffs sim-vs-silicon.
 #![no_std]
 #![no_main]
+#![allow(asm_sub_register)]
 
 use core::ptr::{addr_of_mut, write_volatile};
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -232,7 +233,7 @@ fn main() -> ! {
 
         digest(IDX_DONE, DONE_MAGIC);
     }
-    loop {}
+    halt_forever()
 }
 
 // ── Check 1: SVC delivery + MRS IPSR ───────────────────────────────────────────
@@ -451,5 +452,12 @@ fn nops() {
     // Enough cycles for a pending-and-unmasked exception to be taken.
     for _ in 0..8 {
         cortex_m::asm::nop();
+    }
+}
+
+#[inline(never)]
+fn halt_forever() -> ! {
+    loop {
+        core::hint::spin_loop();
     }
 }

--- a/crates/hw-oracle/tests/f103_conformance.rs
+++ b/crates/hw-oracle/tests/f103_conformance.rs
@@ -19,15 +19,16 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::{Bus, Machine};
+use labwired_core::Machine;
 use labwired_loader::load_elf;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const VERDICT_ADDR: u32 = 0x2000_3000;
 const DONE_MAGIC: u32 = 0xC0DE_F103;
 /// Digest words compared (index 0 = DONE sentinel, 1..=10 = per-peripheral).
 const DIGEST_WORDS: usize = 11;
 /// Human labels for the digest, for a readable gap report.
+#[allow(dead_code)]
 const LABELS: [&str; DIGEST_WORDS] = [
     "DONE",
     "gpio_odr",
@@ -59,7 +60,7 @@ fn firmware_elf() -> Option<PathBuf> {
 }
 
 /// Run the firmware on the full-chip simulator and return the digest block.
-fn run_sim(elf: &PathBuf) -> Vec<u32> {
+fn run_sim(elf: &Path) -> Vec<u32> {
     let chip_path = repo_root().join("configs/chips/stm32f103.yaml");
     let system_path = repo_root().join("configs/systems/stm32f103-bare.yaml");
     let chip = ChipDescriptor::from_file(&chip_path).expect("load chip");

--- a/crates/hw-oracle/tests/f103_fuzz_phase0.rs
+++ b/crates/hw-oracle/tests/f103_fuzz_phase0.rs
@@ -19,9 +19,9 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::{Bus, Machine};
+use labwired_core::Machine;
 use labwired_loader::load_elf;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const FUZZ_LEN: u32 = 0x2000_2800;
 const FUZZ_DATA: u32 = 0x2000_2804;
@@ -37,7 +37,7 @@ const CLEAN: &[u8] = &[b'P', 0, b'A', 3, 1, 2, 3];
 /// return faults. (Zero filler wouldn't fault: PC=0 is a valid flash alias.)
 fn crash_input() -> Vec<u8> {
     let mut v = vec![b'C', 64];
-    v.extend(std::iter::repeat(0xFF).take(64));
+    v.extend(std::iter::repeat_n(0xFF, 64));
     v
 }
 
@@ -65,7 +65,7 @@ fn packed(input: &[u8]) -> Vec<u32> {
 }
 
 /// Run the fuzz target in sim on `input`; return the verdict word.
-fn run_sim(elf: &PathBuf, input: &[u8]) -> u32 {
+fn run_sim(elf: &Path, input: &[u8]) -> u32 {
     let chip = ChipDescriptor::from_file(repo_root().join("configs/chips/stm32f103.yaml")).unwrap();
     let system_path = repo_root().join("configs/systems/stm32f103-bare.yaml");
     let mut manifest = SystemManifest::from_file(&system_path).unwrap();

--- a/crates/hw-oracle/tests/foreign_firmware_probe.rs
+++ b/crates/hw-oracle/tests/foreign_firmware_probe.rs
@@ -54,7 +54,6 @@ fn probe_foreign_firmware() {
         let pc = machine.cpu.get_pc();
         *pc_hist.entry(pc).or_insert(0) += 1;
         if std::env::var("FOREIGN_CSRTRACE").is_ok() {
-            use labwired_core::Bus;
             let csr = machine.bus.read_u32(0x4002_03E0).unwrap_or(0);
             let cbr1 = machine.bus.read_u32(0x4002_0418).unwrap_or(0);
             let cllr = machine.bus.read_u32(0x4002_044C).unwrap_or(0);
@@ -65,7 +64,6 @@ fn probe_foreign_firmware() {
             }
         }
         if let Some(w) = watch {
-            use labwired_core::Bus;
             if machine.bus.read_u32(w).unwrap_or(0) != 0 {
                 use labwired_core::Cpu;
                 println!(
@@ -111,7 +109,6 @@ fn probe_foreign_firmware() {
         "cpu: primask={} active_exception={} pending={:?}",
         machine.cpu.primask, machine.cpu.active_exception, machine.cpu.pending_exceptions
     );
-    use labwired_core::Bus;
     for (label, addr) in [
         ("TIM12 CR1", 0x4000_1800u64),
         ("TIM12 DIER", 0x4000_180C),

--- a/crates/hw-oracle/tests/l476_mmio_diff.rs
+++ b/crates/hw-oracle/tests/l476_mmio_diff.rs
@@ -69,12 +69,12 @@ const PC8: u32 = 1 << 8; // free pin on the Nucleo morpho header
 
 // ── SPI1 (0x4001_3000) ─────────────────────────────────────────────────────────
 const SPI1_BASE: u32 = 0x4001_3000;
-const SPI1_CR1: u32 = SPI1_BASE + 0x00;
+const SPI1_CR1: u32 = SPI1_BASE;
 const SPI1_CR2: u32 = SPI1_BASE + 0x04;
 
 // ── TIM2 (0x4000_0000, 32-bit GP timer) ─────────────────────────────────────────
 const TIM2_BASE: u32 = 0x4000_0000;
-const TIM2_CR1: u32 = TIM2_BASE + 0x00;
+const TIM2_CR1: u32 = TIM2_BASE;
 const TIM2_PSC: u32 = TIM2_BASE + 0x28;
 const TIM2_ARR: u32 = TIM2_BASE + 0x2C;
 
@@ -256,7 +256,7 @@ const PARITY_REGS: &[ParityReg] = &[
     // PA13/PA14 carry SWD — never swept here, the J-Link rides on them.)
     ParityReg {
         label: "GPIOD MODER",
-        addr: GPIOD_BASE + 0x00,
+        addr: GPIOD_BASE,
         mask: 0xFFFF_FFFF,
     },
     ParityReg {
@@ -291,7 +291,7 @@ const PARITY_REGS: &[ParityReg] = &[
     },
     ParityReg {
         label: "GPIOE MODER",
-        addr: GPIOE_BASE + 0x00,
+        addr: GPIOE_BASE,
         mask: 0xFFFF_FFFF,
     },
     ParityReg {
@@ -317,7 +317,7 @@ const PARITY_REGS: &[ParityReg] = &[
     // SPI control registers (CR2 bit 15 reserved on L4 → masked out).
     ParityReg {
         label: "SPI1 CR1",
-        addr: SPI1_BASE + 0x00,
+        addr: SPI1_BASE,
         mask: 0x0000_FFFF,
     },
     ParityReg {
@@ -329,7 +329,7 @@ const PARITY_REGS: &[ParityReg] = &[
     },
     ParityReg {
         label: "SPI2 CR1",
-        addr: SPI2_BASE + 0x00,
+        addr: SPI2_BASE,
         mask: 0x0000_FFFF,
     },
     ParityReg {
@@ -339,7 +339,7 @@ const PARITY_REGS: &[ParityReg] = &[
     },
     ParityReg {
         label: "SPI3 CR1",
-        addr: SPI3_BASE + 0x00,
+        addr: SPI3_BASE,
         mask: 0x0000_FFFF,
     },
     ParityReg {

--- a/crates/hw-oracle/tests/nrf52_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_conformance.rs
@@ -21,7 +21,7 @@ use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
 use labwired_core::Machine;
 use labwired_loader::load_elf;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// RAM address of the verdict block written by the firmware.
 const VERDICT_ADDR: u32 = 0x2000_3000;
@@ -87,7 +87,7 @@ fn build_sim_bus() -> SystemBus {
 }
 
 /// Run the firmware on the full-chip simulator and return the digest block.
-fn run_sim(elf: &PathBuf) -> Vec<u32> {
+fn run_sim(elf: &Path) -> Vec<u32> {
     let mut bus = build_sim_bus();
     let (cpu, _nvic) = configure_cortex_m(&mut bus);
     let mut machine = Machine::new(cpu, bus);

--- a/crates/hw-oracle/tests/nrf52_cpu_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_cpu_conformance.rs
@@ -22,7 +22,7 @@ use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
 use labwired_core::Machine;
 use labwired_loader::load_elf;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// RAM address of the verdict block written by the firmware.
 const VERDICT_ADDR: u32 = 0x2000_3000;
@@ -123,7 +123,7 @@ fn build_sim_bus() -> SystemBus {
     SystemBus::from_config(&chip, &manifest).unwrap_or_else(|e| panic!("build sim bus: {e}"))
 }
 
-fn run_sim(elf: &PathBuf) -> Vec<u32> {
+fn run_sim(elf: &Path) -> Vec<u32> {
     let mut bus = build_sim_bus();
     let (cpu, _nvic) = configure_cortex_m(&mut bus);
     let mut machine = Machine::new(cpu, bus);

--- a/crates/hw-oracle/tests/stm32f1_exec_oracle.rs
+++ b/crates/hw-oracle/tests/stm32f1_exec_oracle.rs
@@ -53,7 +53,7 @@ const RCC_AHBENR_DMA1EN: u32 = 1 << 0;
 
 /// DMA1 (RM0008 §13): controller + channel-1 register block.
 const DMA1_BASE: u32 = 0x4002_0000;
-const DMA1_ISR: u32 = DMA1_BASE + 0x00; // interrupt status (GIF/TCIF/HTIF/TEIF ×7)
+const DMA1_ISR: u32 = DMA1_BASE; // interrupt status (GIF/TCIF/HTIF/TEIF ×7)
 const DMA1_CCR1: u32 = DMA1_BASE + 0x08; // channel-1 config
 const DMA1_CNDTR1: u32 = DMA1_BASE + 0x0C; // channel-1 transfer count
 const DMA1_CPAR1: u32 = DMA1_BASE + 0x10; // channel-1 "peripheral" address
@@ -73,7 +73,7 @@ const DMA_DST: u32 = 0x2000_0200;
 
 /// GPIOA (RM0008): config + output-data + atomic set/reset registers.
 const GPIOA_BASE: u32 = 0x4001_0800;
-const GPIOA_CRL: u32 = GPIOA_BASE + 0x00; // pin config, pins 0..7
+const GPIOA_CRL: u32 = GPIOA_BASE; // pin config, pins 0..7
 const GPIOA_CRH: u32 = GPIOA_BASE + 0x04; // pin config, pins 8..15
 const GPIOA_ODR: u32 = GPIOA_BASE + 0x0C; // output data
 const GPIOA_BSRR: u32 = GPIOA_BASE + 0x10; // atomic set (lo16) / reset (hi16)
@@ -87,7 +87,7 @@ const DBGMCU_CR: u32 = 0xE004_2004;
 
 /// CRC unit (RM0008): data register + control.
 const CRC_BASE: u32 = 0x4002_3000;
-const CRC_DR: u32 = CRC_BASE + 0x00; // data in / CRC result out
+const CRC_DR: u32 = CRC_BASE; // data in / CRC result out
 const CRC_IDR: u32 = CRC_BASE + 0x04; // independent data register (8-bit on F1)
 const CRC_CR: u32 = CRC_BASE + 0x08; // control (RESET = bit 0)
 
@@ -105,7 +105,7 @@ const IWDG_RLR: u32 = IWDG_BASE + 0x08; // reload (write-protected)
 
 /// EXTI (RM0008 §10): software-interrupt + pending registers.
 const EXTI_BASE: u32 = 0x4001_0400;
-const EXTI_IMR: u32 = EXTI_BASE + 0x00; // interrupt mask
+const EXTI_IMR: u32 = EXTI_BASE; // interrupt mask
 const EXTI_SWIER: u32 = EXTI_BASE + 0x10; // software interrupt event
 const EXTI_PR: u32 = EXTI_BASE + 0x14; // pending (rc_w1)
 

--- a/crates/hw-oracle/tests/stm32f4_exec_oracle.rs
+++ b/crates/hw-oracle/tests/stm32f4_exec_oracle.rs
@@ -37,7 +37,7 @@ use std::path::PathBuf;
 // EXTI is at 0x4001_3C00 on F4 (vs 0x4001_0400 on F1). NVIC/SCB/DWT are
 // core-level (same addresses on every Cortex-M).
 const EXTI_BASE: u32 = 0x4001_3C00;
-const EXTI_IMR: u32 = EXTI_BASE + 0x00;
+const EXTI_IMR: u32 = EXTI_BASE;
 const EXTI_SWIER: u32 = EXTI_BASE + 0x10;
 const EXTI_PR: u32 = EXTI_BASE + 0x14;
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1018,7 +1018,6 @@ impl WasmSimulator {
     #[deprecated(
         note = "Renamed to install_esp32_arduino_quirks — the bootstrap is generic Arduino-ESP32 glue, not firmware-specific."
     )]
-
     /// #124 Phase 4: enable/disable the browser-side JIT fast-path. When
     /// on, `step_with_esp32_aids` short-circuits any pre-fetch step
     /// whose PC matches the JIT'd hot block (`0x400829cc`) into a wasm

--- a/examples/nokia5110-invaders-lab/src/main.rs
+++ b/examples/nokia5110-invaders-lab/src/main.rs
@@ -23,6 +23,7 @@
 
 #![no_std]
 #![no_main]
+#![allow(static_mut_refs)]
 
 use core::ptr::{read_volatile, write_volatile};
 use cortex_m_rt::entry;
@@ -40,7 +41,6 @@ const GPIOA_BRR: *mut u32 = (0x4800_0000 + 0x28) as *mut u32;
 
 const GPIOB_MODER: *mut u32 = 0x4800_0400 as *mut u32;
 const GPIOB_IDR: *const u32 = (0x4800_0400 + 0x10) as *const u32;
-const GPIOB_BSRR: *mut u32 = (0x4800_0400 + 0x18) as *mut u32;
 const GPIOB_BRR: *mut u32 = (0x4800_0400 + 0x28) as *mut u32;
 
 const GPIOC_MODER: *mut u32 = 0x4800_0800 as *mut u32;

--- a/examples/tier1-fixture/nrf52832/src/main.rs
+++ b/examples/tier1-fixture/nrf52832/src/main.rs
@@ -52,13 +52,13 @@ const GPIO0_DIRSET: u32 = GPIO0_BASE + 0x518;
 
 // ── CLOCK (nrf_clock, base 0x40000000) ────────────────────────────────────
 const CLOCK_BASE: u32 = 0x4000_0000;
-const CLOCK_TASKS_HFCLKSTART: u32 = CLOCK_BASE + 0x000;
+const CLOCK_TASKS_HFCLKSTART: u32 = CLOCK_BASE;
 const CLOCK_EVENTS_HFCLKSTARTED: u32 = CLOCK_BASE + 0x100;
 const CLOCK_HFCLKRUN: u32 = CLOCK_BASE + 0x408;
 
 // ── TIMER0 (nrf52840_timer, base 0x40008000) ──────────────────────────────
 const TIMER0_BASE: u32 = 0x4000_8000;
-const TIMER0_TASKS_START: u32 = TIMER0_BASE + 0x000;
+const TIMER0_TASKS_START: u32 = TIMER0_BASE;
 const TIMER0_TASKS_CLEAR: u32 = TIMER0_BASE + 0x00C;
 const TIMER0_TASKS_CAPTURE0: u32 = TIMER0_BASE + 0x040;
 const TIMER0_MODE: u32 = TIMER0_BASE + 0x504;
@@ -68,7 +68,7 @@ const TIMER0_CC0: u32 = TIMER0_BASE + 0x540;
 
 // ── RTC0 (nrf52840_rtc, base 0x4000B000) ──────────────────────────────────
 const RTC0_BASE: u32 = 0x4000_B000;
-const RTC0_TASKS_START: u32 = RTC0_BASE + 0x000;
+const RTC0_TASKS_START: u32 = RTC0_BASE;
 const RTC0_TASKS_CLEAR: u32 = RTC0_BASE + 0x008;
 const RTC0_COUNTER: u32 = RTC0_BASE + 0x504;
 const RTC0_PRESCALER: u32 = RTC0_BASE + 0x508;
@@ -106,7 +106,7 @@ const SPI2_TXD_AMOUNT: u32 = SPI2_BASE + 0x54C;
 // deterministic conversion: TASKS_START → STARTED, TASKS_SAMPLE writes
 // RESULT.MAXCNT samples to RESULT.PTR and fires END + RESULTDONE.
 const SAADC_BASE: u32 = 0x4000_7000;
-const SAADC_TASKS_START: u32 = SAADC_BASE + 0x000;
+const SAADC_TASKS_START: u32 = SAADC_BASE;
 const SAADC_TASKS_SAMPLE: u32 = SAADC_BASE + 0x004;
 const SAADC_EVENTS_STARTED: u32 = SAADC_BASE + 0x100;
 const SAADC_EVENTS_END: u32 = SAADC_BASE + 0x104;
@@ -125,7 +125,7 @@ const SAADC_CODE_10BIT: u16 = 853; // (3.0/3.6) * 2^10
 
 // ── WDT (nrf52840_watchdog, base 0x40010000) ──────────────────────────────
 const WDT_BASE: u32 = 0x4001_0000;
-const WDT_TASKS_START: u32 = WDT_BASE + 0x000;
+const WDT_TASKS_START: u32 = WDT_BASE;
 const WDT_EVENTS_TIMEOUT: u32 = WDT_BASE + 0x100;
 const WDT_RUNSTATUS: u32 = WDT_BASE + 0x400;
 const WDT_CRV: u32 = WDT_BASE + 0x504;

--- a/examples/tier1-fixture/nrf52840/src/main.rs
+++ b/examples/tier1-fixture/nrf52840/src/main.rs
@@ -60,13 +60,13 @@ const GPIO0_DIRSET: u32 = GPIO0_BASE + 0x518;
 
 // ── CLOCK (nrf_clock, base 0x40000000) ────────────────────────────────────
 const CLOCK_BASE: u32 = 0x4000_0000;
-const CLOCK_TASKS_HFCLKSTART: u32 = CLOCK_BASE + 0x000;
+const CLOCK_TASKS_HFCLKSTART: u32 = CLOCK_BASE;
 const CLOCK_EVENTS_HFCLKSTARTED: u32 = CLOCK_BASE + 0x100;
 const CLOCK_HFCLKRUN: u32 = CLOCK_BASE + 0x408;
 
 // ── TIMER0 (nrf52840_timer, base 0x40008000) ──────────────────────────────
 const TIMER0_BASE: u32 = 0x4000_8000;
-const TIMER0_TASKS_START: u32 = TIMER0_BASE + 0x000;
+const TIMER0_TASKS_START: u32 = TIMER0_BASE;
 const TIMER0_TASKS_CLEAR: u32 = TIMER0_BASE + 0x00C;
 const TIMER0_TASKS_CAPTURE0: u32 = TIMER0_BASE + 0x040;
 const TIMER0_MODE: u32 = TIMER0_BASE + 0x504;
@@ -76,7 +76,7 @@ const TIMER0_CC0: u32 = TIMER0_BASE + 0x540;
 
 // ── RTC0 (nrf52840_rtc, base 0x4000B000) ──────────────────────────────────
 const RTC0_BASE: u32 = 0x4000_B000;
-const RTC0_TASKS_START: u32 = RTC0_BASE + 0x000;
+const RTC0_TASKS_START: u32 = RTC0_BASE;
 const RTC0_TASKS_CLEAR: u32 = RTC0_BASE + 0x008;
 const RTC0_COUNTER: u32 = RTC0_BASE + 0x504;
 const RTC0_PRESCALER: u32 = RTC0_BASE + 0x508;
@@ -114,7 +114,7 @@ const SPI2_TXD_AMOUNT: u32 = SPI2_BASE + 0x54C;
 // deterministic conversion: TASKS_START → STARTED, TASKS_SAMPLE writes
 // RESULT.MAXCNT samples to RESULT.PTR and fires END + RESULTDONE.
 const SAADC_BASE: u32 = 0x4000_7000;
-const SAADC_TASKS_START: u32 = SAADC_BASE + 0x000;
+const SAADC_TASKS_START: u32 = SAADC_BASE;
 const SAADC_TASKS_SAMPLE: u32 = SAADC_BASE + 0x004;
 const SAADC_EVENTS_STARTED: u32 = SAADC_BASE + 0x100;
 const SAADC_EVENTS_END: u32 = SAADC_BASE + 0x104;
@@ -133,7 +133,7 @@ const SAADC_CODE_10BIT: u16 = 853; // (3.0/3.6) * 2^10
 
 // ── WDT (nrf52840_watchdog, base 0x40010000) ──────────────────────────────
 const WDT_BASE: u32 = 0x4001_0000;
-const WDT_TASKS_START: u32 = WDT_BASE + 0x000;
+const WDT_TASKS_START: u32 = WDT_BASE;
 const WDT_EVENTS_TIMEOUT: u32 = WDT_BASE + 0x100;
 const WDT_RUNSTATUS: u32 = WDT_BASE + 0x400;
 const WDT_CRV: u32 = WDT_BASE + 0x504;
@@ -208,8 +208,8 @@ fn uart_dma(bytes: &[u8]) {
     let n = core::cmp::min(bytes.len(), 64);
     unsafe {
         let buf = core::ptr::addr_of_mut!(TX_BUF) as *mut u8;
-        for i in 0..n {
-            core::ptr::write_volatile(buf.add(i), bytes[i]);
+        for (i, byte) in bytes.iter().take(n).enumerate() {
+            core::ptr::write_volatile(buf.add(i), *byte);
         }
         // Clear any stale completion event, then arm + start the EasyDMA TX.
         reg_write(UART0_EVENTS_ENDTX, 0);

--- a/examples/tier1-fixture/rp2040/src/main.rs
+++ b/examples/tier1-fixture/rp2040/src/main.rs
@@ -34,7 +34,7 @@ use panic_halt as _;
 // RP2040's actual UART IP). In that layout the data register (UARTDR) sits at
 // offset 0x00 — writing a byte here enqueues it for transmission.
 const UART0_BASE: u32 = 0x4003_4000;
-const UART0_TDR: u32 = UART0_BASE + 0x00;
+const UART0_TDR: u32 = UART0_BASE;
 
 // ── CLOCKS / RESETS (rp2040_clkrst, datasheet §2.14) ──────────────────────
 //
@@ -43,7 +43,7 @@ const UART0_TDR: u32 = UART0_BASE + 0x00;
 // APB/AHB window, so the RP2040 atomic CLR alias (+0x3000) is honoured by the
 // bus. The PLLs report LOCK and the crystal oscillator reports STABLE.
 const RESETS_BASE: u32 = 0x4000_c000;
-const RESETS_RESET: u32 = RESETS_BASE + 0x0;
+const RESETS_RESET: u32 = RESETS_BASE;
 const RESETS_RESET_CLR: u32 = RESETS_BASE + 0x3000; // atomic clear alias
 const RESETS_RESET_DONE: u32 = RESETS_BASE + 0x8;
 const RESETS_IO_BANK0: u32 = 1 << 5; // a representative peripheral reset bit

--- a/scripts/ci/test_board_matrix.py
+++ b/scripts/ci/test_board_matrix.py
@@ -63,6 +63,15 @@ def test_cli_emits_json_for_pull_request():
     assert any(e["id"] == "iolink-station-l476" for e in matrix["include"])
 
 
+def test_iolink_station_installs_newlib_for_nano_specs():
+    entries = bm.load_manifest(str(REPO_ROOT / "configs/ci/boards.yml"))
+    iolink = next(e for e in entries if e["id"] == "iolink-station-l476")
+    matrix = bm.to_matrix([iolink])
+    apt = matrix["include"][0]["apt"].split()
+    assert "gcc-arm-none-eabi" in apt
+    assert "libnewlib-arm-none-eabi" in apt
+
+
 def test_cli_exits_nonzero_on_invalid_manifest(tmp_path):
     bad = tmp_path / "boards.yml"
     bad.write_text(


### PR DESCRIPTION
## Summary
- Bump LabWired core to v0.18.0 and prepare release notes/docs.
- Update the tag-triggered release workflow install snippet.
- Clean release-blocking warnings across firmware fixtures, oracle tests, WASM, and examples.
- Fix intmatrix_alarm to exercise the scheduler-driven Machine path.

## Verification
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- release doc relative-link check
- cargo build -p demo-blinky --release --target thumbv7m-none-eabi
- cargo test -p labwired-cli --test demo_blinky
- cargo test -p labwired-core --test intmatrix_alarm
- focused core continuation lanes through xtensa_regs
- cargo test -p labwired-cli --test breakpoints
- cargo build -p firmware-ci-fixture --target thumbv7m-none-eabi
- cargo test -p labwired-dap --test e2e
- cargo test -p labwired-gdbstub --test gdb_e2e outside the sandbox because it binds a local TCP port
- cargo test --workspace --exclude labwired-core --exclude labwired-cli --exclude labwired-dap --exclude labwired-gdbstub

## Notes
- The monolithic local cargo test --workspace run was interrupted by the local environment during long E2E coverage, so release readiness records split-lane verification instead.
- Parent repo UI manifest regeneration is separate from this core release PR.