### PR TITLE
Universal logic-analyzer engine support: pad sampler + ESP32 I2C bus tracing

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -299,6 +299,11 @@ impl SystemBus {
                 // than a hand-wired system builder.
                 "esp32c3_i2c" => {
                     let mut i2c = crate::peripherals::esp32c3::i2c::Esp32c3I2c::new();
+                    // Wire the shared bus-trace log (universal logic analyzer)
+                    // BEFORE any device is attached below, so every attach call
+                    // wraps its device into the log — same contract as the
+                    // generic `i2c` arm above.
+                    i2c.set_bus_trace(p_cfg.id.clone(), bus.bus_trace.clone());
                     for ext in &manifest.external_devices {
                         if ext.connection != p_cfg.id {
                             continue;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -462,6 +462,17 @@ pub trait Peripheral: std::fmt::Debug + Send {
         None
     }
 
+    /// GPIO capability: the pad level a logic probe clipped to `pin` would
+    /// see — output-driven pins report the output latch, input pins report
+    /// the input level, pins routed to a peripheral (alternate function)
+    /// report `None` when the model can't know the wire state. GPIO models
+    /// with a direction register override this; the default prefers the
+    /// output latch.
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        self.read_gpio_output(pin)
+            .or_else(|| self.read_gpio_input(pin))
+    }
+
     /// GPIO capability: drive an externally controlled input level for `pin`
     /// (e.g. browser button press). Returns `false` if unsupported.
     fn set_gpio_input(&mut self, _pin: u8, _level: bool) -> bool {

--- a/crates/core/src/peripherals/esp32/gpio.rs
+++ b/crates/core/src/peripherals/esp32/gpio.rs
@@ -269,6 +269,20 @@ impl Peripheral for Esp32Gpio {
         Some((self.out & (1u32 << pin)) != 0)
     }
 
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let mask = 1u32 << pin;
+        // ENABLE is the output driver: enabled pins show the OUT latch,
+        // everything else shows the (externally driven) input level.
+        Some(if (self.enable & mask) != 0 {
+            (self.out & mask) != 0
+        } else {
+            (self.in_data & mask) != 0
+        })
+    }
+
     fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
         if pin >= 32 {
             return false;

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -227,6 +227,20 @@ impl Peripheral for Esp32c3Gpio {
         Some((self.out & (1u32 << pin)) != 0)
     }
 
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        if pin >= PIN_COUNT {
+            return None;
+        }
+        let mask = 1u32 << pin;
+        // ENABLE is the output driver: enabled pins show the OUT latch,
+        // everything else shows the (externally driven) input level.
+        Some(if (self.enable & mask) != 0 {
+            (self.out & mask) != 0
+        } else {
+            (self.in_data & mask) != 0
+        })
+    }
+
     fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
         if pin >= PIN_COUNT {
             return false;

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -135,6 +135,11 @@ pub struct Esp32c3I2c {
     tx_pop_count: usize,
     rx_fifo: RefCell<std::collections::VecDeque<u8>>,
     slaves: Vec<Box<dyn I2cDevice>>,
+    /// Bus-trace identity + shared log; when set, `attach_slave` wraps slaves
+    /// in `TracingI2cDevice` so this controller feeds the same bus trace the
+    /// generic `I2c` does (analyzer waveforms, I²C decoder).
+    bus_name: String,
+    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
     /// Set when a command-list run sets TRANS_COMPLETE & INT_ENA has it.
     irq_pending: bool,
     /// Interrupt-matrix source this instance asserts (29 for I2C0).
@@ -181,6 +186,8 @@ impl Esp32c3I2c {
             tx_pop_count: 0,
             rx_fifo: RefCell::new(std::collections::VecDeque::with_capacity(FIFO_CAPACITY)),
             slaves: Vec::new(),
+            bus_name: "i2c0".to_string(),
+            bus_log: None,
             irq_pending: false,
             intr_source_id: I2C0_INTR_SOURCE_ID,
             active_slave: None,
@@ -213,9 +220,25 @@ impl Esp32c3I2c {
         }
     }
 
+    /// Route this controller's transactions into the shared bus-trace log.
+    /// Must be called before `attach_slave` — already-attached slaves are
+    /// not retroactively wrapped.
+    pub fn set_bus_trace(&mut self, name: String, log: crate::bus::bus_trace::BusTraceLog) {
+        self.bus_name = name;
+        self.bus_log = Some(log);
+    }
+
     /// Attach an `I2cDevice` slave. Slaves are matched by address bits at
     /// transaction time; later additions take precedence on duplicate addresses.
     pub fn attach_slave(&mut self, slave: Box<dyn I2cDevice>) {
+        let slave: Box<dyn I2cDevice> = match &self.bus_log {
+            Some(log) => Box::new(crate::bus::bus_trace::TracingI2cDevice::new(
+                self.bus_name.clone(),
+                log.clone(),
+                slave,
+            )),
+            None => slave,
+        };
         self.slaves.push(slave);
     }
 
@@ -538,8 +561,13 @@ impl Esp32c3I2c {
                             // First byte of a WRITE following RSTART is addr+R/W.
                             let addr = b >> 1;
                             active = self.slaves.iter().position(|s| s.address() == addr);
-                            if active.is_some() {
-                                // Slave acknowledged its address.
+                            if let Some(slave_idx) = active {
+                                // Slave acknowledged its address. Signal START
+                                // to the selected device — on the wire the
+                                // START + address frame precedes the data, and
+                                // the bus-trace wrapper reconstructs the
+                                // address frame from this call.
+                                self.slaves[slave_idx].start();
                                 self.sr |= SR_RESP_REC;
                                 expects_addr = false;
                                 // Don't deliver the addr byte to the slave's write().
@@ -550,7 +578,8 @@ impl Esp32c3I2c {
                             // SLAVE_ADDR and put only payload bytes in TXFIFO.
                             // In that shape the first FIFO byte is real data.
                             active = self.find_slave_from_slave_addr_register();
-                            if active.is_some() {
+                            if let Some(slave_idx) = active {
+                                self.slaves[slave_idx].start();
                                 self.sr |= SR_RESP_REC;
                             } else {
                                 self.int_raw |= INT_NACK;
@@ -1044,5 +1073,43 @@ mod tests {
         assert_eq!(p.read_u32(REG_DATA).unwrap(), 0x6B);
         assert_eq!(p.read_u32(REG_DATA).unwrap(), 0x43);
         assert_eq!(p.read_u32(REG_DATA).unwrap(), 0x67);
+    }
+
+    #[test]
+    fn set_bus_trace_records_transactions_for_attached_slaves() {
+        use crate::peripherals::components::Bmp280;
+
+        let log = crate::bus::bus_trace::new_log();
+        let mut p = Esp32c3I2c::new();
+        p.set_bus_trace("i2c0".to_string(), log.clone());
+        p.attach_slave(Box::new(Bmp280::new(0x76)));
+
+        // Same canonical pointer-write transaction as
+        // write_read_drives_attached_bmp280: RSTART; WRITE 2; STOP.
+        p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
+        p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 2)).unwrap();
+        p.write_u32(REG_CMD0 + 8, cmd(CMD_STOP, 0)).unwrap();
+        p.write_u32(REG_DATA, 0xEC).unwrap(); // addr+W
+        p.write_u32(REG_DATA, 0xD0).unwrap(); // pointer
+        p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
+
+        let events = log.lock().unwrap().snapshot();
+        assert!(
+            !events.is_empty(),
+            "tracing wrapper must record I2C traffic on the C3 controller"
+        );
+        assert!(events.iter().all(|e| e.bus == "i2c0"));
+        // The controller must signal START at address match so the trace
+        // carries a decodable address frame, not just raw data bytes.
+        assert!(
+            events.iter().any(|e| matches!(
+                &e.payload,
+                crate::bus::bus_trace::BusPayload::I2c {
+                    kind: crate::bus::bus_trace::I2cSym::AddrWrite,
+                    ..
+                }
+            )),
+            "trace must contain an address frame for transaction decode"
+        );
     }
 }

--- a/crates/core/src/peripherals/esp32s3/gpio.rs
+++ b/crates/core/src/peripherals/esp32s3/gpio.rs
@@ -370,6 +370,20 @@ impl Peripheral for Esp32s3Gpio {
         Some((self.out & (1u32 << pin)) != 0)
     }
 
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let mask = 1u32 << pin;
+        // ENABLE is the output driver: enabled pins show the OUT latch,
+        // everything else shows the (externally driven) input level.
+        Some(if (self.enable & mask) != 0 {
+            (self.out & mask) != 0
+        } else {
+            (self.in_data & mask) != 0
+        })
+    }
+
     fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
         if pin >= 32 {
             return false;

--- a/crates/core/src/peripherals/esp32s3/i2c.rs
+++ b/crates/core/src/peripherals/esp32s3/i2c.rs
@@ -134,6 +134,11 @@ pub struct Esp32s3I2c {
     tx_fifo: std::collections::VecDeque<u8>,
     rx_fifo: RefCell<std::collections::VecDeque<u8>>,
     slaves: Vec<Box<dyn I2cDevice>>,
+    /// Bus-trace identity + shared log; when set, `attach_slave` wraps slaves
+    /// in `TracingI2cDevice` so this controller feeds the same bus trace the
+    /// generic `I2c` does (analyzer waveforms, I²C decoder).
+    bus_name: String,
+    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
     /// Set when a command-list run sets TRANS_COMPLETE & INT_ENA has it.
     /// Drained by `tick()` into the interrupt-matrix source aggregation.
     irq_pending: bool,
@@ -181,6 +186,8 @@ impl Esp32s3I2c {
             tx_fifo: std::collections::VecDeque::with_capacity(FIFO_CAPACITY),
             rx_fifo: RefCell::new(std::collections::VecDeque::with_capacity(FIFO_CAPACITY)),
             slaves: Vec::new(),
+            bus_name: "i2c0".to_string(),
+            bus_log: None,
             irq_pending: false,
             intr_source_id: I2C0_INTR_SOURCE_ID,
             active_slave: None,
@@ -215,9 +222,25 @@ impl Esp32s3I2c {
         }
     }
 
+    /// Route this controller's transactions into the shared bus-trace log.
+    /// Must be called before `attach_slave` — already-attached slaves are
+    /// not retroactively wrapped.
+    pub fn set_bus_trace(&mut self, name: String, log: crate::bus::bus_trace::BusTraceLog) {
+        self.bus_name = name;
+        self.bus_log = Some(log);
+    }
+
     /// Attach an `I2cDevice` slave. Slaves are matched by address bits at
     /// transaction time; later additions take precedence on duplicate addresses.
     pub fn attach_slave(&mut self, slave: Box<dyn I2cDevice>) {
+        let slave: Box<dyn I2cDevice> = match &self.bus_log {
+            Some(log) => Box::new(crate::bus::bus_trace::TracingI2cDevice::new(
+                self.bus_name.clone(),
+                log.clone(),
+                slave,
+            )),
+            None => slave,
+        };
         self.slaves.push(slave);
     }
 
@@ -498,8 +521,13 @@ impl Esp32s3I2c {
                             // First byte of a WRITE following RSTART is addr+R/W.
                             let addr = b >> 1;
                             active = self.slaves.iter().position(|s| s.address() == addr);
-                            if active.is_some() {
-                                // Slave acknowledged its address.
+                            if let Some(slave_idx) = active {
+                                // Slave acknowledged its address. Signal START
+                                // to the selected device — on the wire the
+                                // START + address frame precedes the data, and
+                                // the bus-trace wrapper reconstructs the
+                                // address frame from this call.
+                                self.slaves[slave_idx].start();
                                 self.sr |= SR_RESP_REC;
                                 expects_addr = false;
                                 // Don't deliver the addr byte to the slave's write().
@@ -510,7 +538,8 @@ impl Esp32s3I2c {
                             // SLAVE_ADDR and put only payload bytes in TXFIFO.
                             // In that shape the first FIFO byte is real data.
                             active = self.find_slave_from_slave_addr_register();
-                            if active.is_some() {
+                            if let Some(slave_idx) = active {
+                                self.slaves[slave_idx].start();
                                 self.sr |= SR_RESP_REC;
                             } else {
                                 self.int_raw |= INT_NACK;

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -409,6 +409,52 @@ impl crate::Peripheral for GpioPort {
         Some((reg & (1u32 << pin)) != 0)
     }
 
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let bit = |reg: u32| (reg & (1u32 << pin)) != 0;
+        match self {
+            Self::Stm32F1(g) => {
+                // CRL/CRH: 4 bits per pin — MODE!=0 is an output; CNF 10/11 on
+                // an output pin hands the pad to a peripheral (AF), which this
+                // model doesn't track at wire level.
+                let cr = g.read_reg(if pin < 8 { 0x00 } else { 0x04 });
+                let shift = ((pin % 8) * 4) as u32;
+                let mode = (cr >> shift) & 0b11;
+                let cnf = (cr >> (shift + 2)) & 0b11;
+                if mode == 0 {
+                    Some(bit(g.read_reg(0x08)))
+                } else if cnf >= 0b10 {
+                    None
+                } else {
+                    Some(bit(g.read_reg(0x0C)))
+                }
+            }
+            Self::Stm32V2(g) => {
+                // MODER: 00 input, 01 output, 10 alternate function (wire state
+                // owned by the peripheral — unknown here), 11 analog.
+                let mode = (g.read_reg(0x00) >> (pin * 2)) & 0b11;
+                match mode {
+                    0b01 => Some(bit(g.read_reg(0x14))),
+                    0b10 => None,
+                    _ => Some(bit(g.read_reg(0x10))),
+                }
+            }
+            // The nRF IN read already mixes OUT-through-DIR with latched
+            // inputs — it IS the pad view.
+            Self::Nrf52(g) => Some(bit(g.read_reg(0x510))),
+            Self::Kinetis(g) => {
+                let dir = g.read_reg(0x14);
+                Some(if (dir & (1u32 << pin)) != 0 {
+                    bit(g.read_reg(0x00))
+                } else {
+                    bit(g.read_reg(0x10))
+                })
+            }
+        }
+    }
+
     fn read_gpio_output(&self, pin: u8) -> Option<bool> {
         if pin >= 32 {
             return None;

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -629,6 +629,9 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
     // always, plus an opt-in PCA9685 (LABWIRED_ESP32S3_PCA9685) for the
     // SpiceDispenser servos. Built directly so the slaves are attached.
     let mut i2c0 = Esp32s3I2c::new();
+    // Feed the shared bus-trace log (universal logic analyzer) before any
+    // attach, so every slave below is wrapped into the trace.
+    i2c0.set_bus_trace("i2c0".to_string(), bus.bus_trace.clone());
     i2c0.attach_slave(Box::new(Tmp102::new()));
     if std::env::var("LABWIRED_ESP32S3_PCA9685").is_ok() {
         i2c0.attach_slave(Box::new(

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2641,4 +2641,84 @@ pub mod integration_tests {
             "straight-line code takes no branch edges"
         );
     }
+
+    /// The browser C3 labs build through `from_config` and attach the OLED via
+    /// the kit pass — the whole chain must land in the shared bus trace or the
+    /// logic analyzer's I²C decoder is blind on ESP32-C3.
+    #[test]
+    fn test_esp32c3_i2c_from_config_kit_attach_records_bus_trace() {
+        let chip = ChipDescriptor {
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-i2c-trace-test".to_string(),
+            arch: Arch::RiscV,
+            core: None,
+            flash: MemoryRange {
+                base: 0x4200_0000,
+                size: "4MB".to_string(),
+            },
+            ram: MemoryRange {
+                base: 0x3FC8_0000,
+                size: "400KB".to_string(),
+            },
+            reset_vector_offset: 0,
+            atomic_register_aliases: false,
+            memory_regions: Vec::new(),
+            peripherals: vec![PeripheralConfig {
+                id: "i2c0".to_string(),
+                r#type: "esp32c3_i2c".to_string(),
+                base_address: 0x6001_3000,
+                size: Some("4KB".to_string()),
+                irq: None,
+                clock: None,
+                config: HashMap::new(),
+            }],
+            pins: Default::default(),
+        };
+
+        let mut oled_config = HashMap::new();
+        oled_config.insert(
+            "i2c_address".to_string(),
+            serde_yaml::Value::Number(0x3C.into()),
+        );
+        let manifest = SystemManifest {
+            walk_deleted: false,
+            schema_version: "1.0".to_string(),
+            name: "esp32c3-i2c-trace-test".to_string(),
+            chip: "esp32c3-i2c-trace-test".to_string(),
+            memory_overrides: HashMap::new(),
+            external_devices: vec![labwired_config::ExternalDevice {
+                id: "oled".to_string(),
+                r#type: "oled-ssd1306-128x32".to_string(),
+                connection: "i2c0".to_string(),
+                config: oled_config,
+            }],
+            board_io: Vec::new(),
+            debug_uart: None,
+            peripherals: Vec::new(),
+        };
+
+        let mut bus = crate::bus::SystemBus::from_config(&chip, &manifest).unwrap();
+
+        // Drive one command-list transaction: RSTART; WRITE 2 (addr+W 0x78,
+        // control byte 0x00); STOP — the canonical SSD1306 command prologue.
+        const I2C_BASE: u64 = 0x6001_3000;
+        const REG_CTR: u64 = 0x04;
+        const REG_DATA: u64 = 0x1C;
+        const REG_CMD0: u64 = 0x58;
+        const CTR_TRANS_START: u32 = 1 << 5;
+        let cmd = |opcode: u32, byte_num: u32| (opcode << 11) | byte_num;
+        bus.write_u32(I2C_BASE + REG_CMD0, cmd(6, 0)).unwrap(); // RSTART
+        bus.write_u32(I2C_BASE + REG_CMD0 + 4, cmd(1, 2)).unwrap(); // WRITE 2
+        bus.write_u32(I2C_BASE + REG_CMD0 + 8, cmd(2, 0)).unwrap(); // STOP
+        bus.write_u32(I2C_BASE + REG_DATA, 0x78).unwrap(); // 0x3C << 1
+        bus.write_u32(I2C_BASE + REG_DATA, 0x00).unwrap(); // control byte
+        bus.write_u32(I2C_BASE + REG_CTR, CTR_TRANS_START).unwrap();
+
+        let events = bus.bus_trace_snapshot();
+        assert!(
+            !events.is_empty(),
+            "kit-attached OLED traffic on the C3 controller must reach the bus trace"
+        );
+        assert!(events.iter().all(|event| event.bus == "i2c0"));
+    }
 }

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -44,6 +44,50 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&states).unwrap_or(JsValue::NULL)
     }
 
+    /// Sample the pad level of GPIO pins for the logic analyzer.
+    /// Input: `[{ kind: "gpio", peripheral, pin }]`.
+    /// Output: the same refs each extended with `value: bool | null` —
+    /// `null` when the pin's wire state is unknown (missing peripheral,
+    /// out-of-range pin, or a pad handed to a bus controller the GPIO
+    /// model doesn't track). Cheap enough to call every UI frame.
+    #[wasm_bindgen]
+    pub fn sample_logic_signals(&self, refs: JsValue) -> JsValue {
+        #[derive(serde::Deserialize)]
+        struct Ref {
+            kind: String,
+            peripheral: String,
+            pin: u8,
+        }
+
+        let machine = self.machine.as_ref().unwrap();
+        let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
+            Ok(r) => r,
+            Err(_) => return JsValue::NULL,
+        };
+
+        let samples: Vec<serde_json::Value> = refs
+            .iter()
+            .map(|r| {
+                let value = if r.kind == "gpio" {
+                    machine
+                        .bus
+                        .find_peripheral_index_by_name(&r.peripheral)
+                        .and_then(|idx| machine.bus.peripherals[idx].dev.read_gpio_pad(r.pin))
+                } else {
+                    None
+                };
+                serde_json::json!({
+                    "kind": r.kind,
+                    "peripheral": r.peripheral,
+                    "pin": r.pin,
+                    "value": value,
+                })
+            })
+            .collect();
+
+        serde_wasm_bindgen::to_value(&samples).unwrap_or(JsValue::NULL)
+    }
+
     /// Get a peripheral's full state snapshot as JSON.
     #[wasm_bindgen]
     pub fn get_peripheral_snapshot(&self, name: &str) -> JsValue {

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,13 +9,13 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-07 | ⚠ drift acked 2026-07-07 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-05 | ⚠ drift acked 2026-07-05 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-07 | ⚠ drift acked 2026-07-07 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-07 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -70,7 +70,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-07 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -161,7 +161,8 @@ boards:
     # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
     # STM32 H5 I2C register/transaction engines are untouched; h563_mmio_diff +
     # h563_conformance remain the pinned coverage. No live re-capture.
-    drift_ack: 2026-07-05
+    # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
+    drift_ack: 2026-07-09
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -243,7 +244,8 @@ boards:
     # peripherals before read-driven timer snapshots. This restores the same
     # per-cycle timer freshness as the non-scheduler path and is covered by the
     # generated Arduino OLED ROM-boot regression; no reset-register silicon change.
-    drift_ack: 2026-07-07
+    # 2026-07-09: universal logic analyzer — additive read_gpio_pad pad probe (ENABLE-mask direction) + I2C controller wraps attached slaves in TracingI2cDevice (shared bus trace) and signals START to the selected slave at address match so traces carry decodable address frames. Register map/reset values byte-for-byte untouched; conformance/e2e unchanged. No live re-capture.
+    drift_ack: 2026-07-09
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -283,7 +285,8 @@ boards:
     # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
     # STM32 L4 I2C register/transaction engines are untouched; l476_mmio_diff +
     # l476_parity_diff remain the pinned coverage. No live re-capture.
-    drift_ack: 2026-07-05
+    # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
+    drift_ack: 2026-07-09
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -331,7 +334,8 @@ boards:
     # controls. L0 GPIO register layout/reset and the pinned l073 mmio paths are
     # unchanged; input injection is additive and only active when a board IO source
     # drives a pin. No live re-capture this session.
-    drift_ack: 2026-07-05
+    # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
+    drift_ack: 2026-07-09
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -376,7 +380,8 @@ boards:
     # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
     # STM32 F1 I2C register/transaction engines are untouched; stm32f1_mmio_diff +
     # f103_conformance remain the pinned coverage. No live re-capture.
-    drift_ack: 2026-07-05
+    # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
+    drift_ack: 2026-07-09
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -428,7 +433,8 @@ boards:
     # (`ink_bytes`/`lit_pixels`) so browser/OLED proof paths can detect drawn ink.
     # STM32 F4 I2C register/transaction engines are untouched; stm32f4_mmio_diff +
     # stm32f4_exec_oracle remain the pinned coverage. No live re-capture.
-    drift_ack: 2026-07-05
+    # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
+    drift_ack: 2026-07-09
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -475,7 +481,8 @@ boards:
     # can force legacy ticking while the default S3 constructor remains
     # scheduler-driven. S3 reset values/MMIO semantics are unchanged; unit coverage
     # asserts default scheduler behaviour and snapshot compatibility.
-    drift_ack: 2026-07-07
+    # 2026-07-09: universal logic analyzer — additive read_gpio_pad pad probe (ENABLE-mask direction) + I2C controller wraps attached slaves in TracingI2cDevice (shared bus trace) and signals START to the selected slave at address match so traces carry decodable address frames. Register map/reset values byte-for-byte untouched; conformance/e2e unchanged. No live re-capture.
+    drift_ack: 2026-07-09
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Engine half of the universal logic analyzer:

- `sample_logic_signals` wasm export — sample any GPIO pad through one trait method (`read_gpio_pad`), direction-aware per family (STM32 F1/V2, nRF52, Kinetis, ESP32/C3/S3). AF-routed pads report unknown instead of a stale latch.
- ESP32-C3/S3 I2C controllers wrap attached slaves in `TracingI2cDevice` (both from_config external-device and kit attach paths), so C3/S3 labs feed the shared bus trace like every other chip.
- C3/S3 command-list engines signal START at address match — traces now carry decodable address frames (the I²C decoder was seeing raw data bytes only).

Verified live in the playground: ESP32-C3 OLED workshop paints waveforms with edge/duty/frequency measurements and decodes 74 I²C transactions while the sim runs at full speed.

Note: 3 pre-existing `cpu::riscv::tests` WFI failures on macOS are unrelated (fail on clean main too).