### PR TITLE
Logic analyzer v2 engine: in-loop edge capture, choke-point bus tracing, cycle stamps, pin routing

### DIFF
--- a/crates/cli/tests/bus_trace_export.rs
+++ b/crates/cli/tests/bus_trace_export.rs
@@ -16,6 +16,7 @@ fn vcd_export_emits_one_signal_per_bus_with_byte_values() {
     let events = vec![
         BusTraceEvent {
             seq: 1,
+            cycle: 100,
             bus: "i2c1".into(),
             payload: BusPayload::I2c {
                 kind: I2cSym::AddrWrite,
@@ -25,6 +26,7 @@ fn vcd_export_emits_one_signal_per_bus_with_byte_values() {
         },
         BusTraceEvent {
             seq: 2,
+            cycle: 200,
             bus: "i2c1".into(),
             payload: BusPayload::I2c {
                 kind: I2cSym::Data,
@@ -49,6 +51,7 @@ fn json_export_round_trips_events() {
     use labwired_core::bus::bus_trace::{BusPayload, BusTraceEvent};
     let events = vec![BusTraceEvent {
         seq: 1,
+        cycle: 100,
         bus: "spi0".into(),
         payload: BusPayload::Spi {
             mosi: 0x10,

--- a/crates/core/src/bus/bus_trace.rs
+++ b/crates/core/src/bus/bus_trace.rs
@@ -2,11 +2,22 @@
 //!
 //! A wrapper sits between any I²C/SPI master and its attached device, forwards
 //! every trait call (so behaviour is unchanged, including `as_any` downcasts),
-//! and records each transacted byte into a shared `BusTraceLog`. Because every
-//! family attaches through `I2c::attach` / `Spi::attach`, one wrapper covers
-//! all chips.
+//! and records each transacted byte into a shared [`BusTrace`].
+//!
+//! ## One choke point (no per-callsite `set_bus_trace`)
+//!
+//! A slave is wrapped in exactly ONE place — the free functions [`wrap_i2c`] /
+//! [`wrap_spi`] below — and those are reached through a single funnel:
+//! [`crate::bus::SystemBus::attach_i2c_slave`] /
+//! [`crate::bus::SystemBus::attach_spi_device`]. Controllers no longer carry a
+//! trace handle and their raw `push_slave` / `push_device` methods do NOT wrap;
+//! the only way to hand a controller a slave is through the bus funnel, which
+//! always wraps. That makes it impossible to attach a device that bypasses the
+//! trace: a controller family the funnel does not recognise is a hard error, not
+//! a silently untraced bus (the failure mode that once shipped on ESP32-C3).
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::peripherals::i2c::I2cDevice;
@@ -32,6 +43,11 @@ pub enum BusPayload {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct BusTraceEvent {
     pub seq: u64,
+    /// Engine cycle counter at the moment the byte transacted, mirrored from the
+    /// bus's `current_cycle` via the shared clock (see [`BusTrace::set_cycle`]).
+    /// Lets the UI time-align protocol decode with sampled waveforms on one
+    /// cycle axis. `0` until the machine has stepped at least once.
+    pub cycle: u64,
     pub bus: String,
     pub payload: BusPayload,
 }
@@ -43,13 +59,14 @@ pub struct BusTraceRing {
 }
 
 impl BusTraceRing {
-    pub fn push(&mut self, bus: &str, payload: BusPayload) {
+    fn push(&mut self, cycle: u64, bus: &str, payload: BusPayload) {
         self.seq = self.seq.wrapping_add(1);
         if self.events.len() >= BUS_TRACE_LIMIT {
             self.events.pop_front();
         }
         self.events.push_back(BusTraceEvent {
             seq: self.seq,
+            cycle,
             bus: bus.to_string(),
             payload,
         });
@@ -59,23 +76,79 @@ impl BusTraceRing {
     }
 }
 
-pub type BusTraceLog = Arc<Mutex<BusTraceRing>>;
-pub fn new_log() -> BusTraceLog {
-    Arc::new(Mutex::new(BusTraceRing::default()))
+/// Shared bus-trace handle: a ring-buffered event log plus a shared cycle clock
+/// the bus advances once per step. Cloning shares both (Arc), so every wrapper
+/// stamping into the log reads the same "now". Cheap to clone.
+#[derive(Clone)]
+pub struct BusTrace {
+    ring: Arc<Mutex<BusTraceRing>>,
+    clock: Arc<AtomicU64>,
+}
+
+impl Default for BusTrace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BusTrace {
+    pub fn new() -> Self {
+        Self {
+            ring: Arc::new(Mutex::new(BusTraceRing::default())),
+            clock: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Publish the current engine cycle so subsequent trace events are stamped
+    /// with it. Called by the bus once per step from `current_cycle`; a plain
+    /// atomic store, no lock.
+    pub fn set_cycle(&self, cycle: u64) {
+        self.clock.store(cycle, Ordering::Relaxed);
+    }
+
+    /// Record one transacted symbol, stamped with the shared clock's "now".
+    pub fn push(&self, bus: &str, payload: BusPayload) {
+        let cycle = self.clock.load(Ordering::Relaxed);
+        self.ring.lock().unwrap().push(cycle, bus, payload);
+    }
+
+    pub fn snapshot(&self) -> Vec<BusTraceEvent> {
+        self.ring.lock().unwrap().snapshot()
+    }
+}
+
+/// Retained name for the shared handle type; every reference means [`BusTrace`].
+pub type BusTraceLog = BusTrace;
+
+pub fn new_log() -> BusTrace {
+    BusTrace::new()
+}
+
+/// The single point at which an I²C slave is wrapped for tracing. Reached only
+/// through [`crate::bus::SystemBus::attach_i2c_slave`] (and the nRF52 serial mux,
+/// which must attach at build time) — never from a controller's own attach.
+pub fn wrap_i2c(bus: &str, trace: &BusTrace, dev: Box<dyn I2cDevice>) -> Box<dyn I2cDevice> {
+    Box::new(TracingI2cDevice::new(bus.to_string(), trace.clone(), dev))
+}
+
+/// The single point at which a SPI device is wrapped for tracing (see
+/// [`wrap_i2c`]).
+pub fn wrap_spi(bus: &str, trace: &BusTrace, dev: Box<dyn SpiDevice>) -> Box<dyn SpiDevice> {
+    Box::new(TracingSpiDevice::new(bus.to_string(), trace.clone(), dev))
 }
 
 pub struct TracingI2cDevice {
     bus: String,
-    log: BusTraceLog,
+    trace: BusTrace,
     inner: Box<dyn I2cDevice>,
     expect_address: bool, // next write is the address byte (set on start())
 }
 
 impl TracingI2cDevice {
-    pub fn new(bus: String, log: BusTraceLog, inner: Box<dyn I2cDevice>) -> Self {
+    pub fn new(bus: String, trace: BusTrace, inner: Box<dyn I2cDevice>) -> Self {
         Self {
             bus,
-            log,
+            trace,
             inner,
             expect_address: false,
         }
@@ -112,7 +185,7 @@ impl I2cDevice for TracingI2cDevice {
         } else {
             data
         };
-        self.log.lock().unwrap().push(
+        self.trace.push(
             &self.bus,
             BusPayload::I2c {
                 kind,
@@ -123,7 +196,7 @@ impl I2cDevice for TracingI2cDevice {
         // When the first write IS the address frame, the data byte still flows to the
         // device; emit it as a following Data event so no payload byte is lost.
         if matches!(kind, I2cSym::AddrWrite) {
-            self.log.lock().unwrap().push(
+            self.trace.push(
                 &self.bus,
                 BusPayload::I2c {
                     kind: I2cSym::Data,
@@ -138,7 +211,7 @@ impl I2cDevice for TracingI2cDevice {
             // A read transaction: synthesize the address frame (R) before the first byte.
             self.expect_address = false;
             let addr_byte = (self.inner.address() << 1) | 1; // read
-            self.log.lock().unwrap().push(
+            self.trace.push(
                 &self.bus,
                 BusPayload::I2c {
                     kind: I2cSym::AddrRead,
@@ -148,7 +221,7 @@ impl I2cDevice for TracingI2cDevice {
             );
         }
         let b = self.inner.read();
-        self.log.lock().unwrap().push(
+        self.trace.push(
             &self.bus,
             BusPayload::I2c {
                 kind: I2cSym::Data,
@@ -171,13 +244,13 @@ impl I2cDevice for TracingI2cDevice {
 
 pub struct TracingSpiDevice {
     bus: String,
-    log: BusTraceLog,
+    trace: BusTrace,
     inner: Box<dyn SpiDevice>,
 }
 
 impl TracingSpiDevice {
-    pub fn new(bus: String, log: BusTraceLog, inner: Box<dyn SpiDevice>) -> Self {
-        Self { bus, log, inner }
+    pub fn new(bus: String, trace: BusTrace, inner: Box<dyn SpiDevice>) -> Self {
+        Self { bus, trace, inner }
     }
 }
 
@@ -190,9 +263,7 @@ impl SpiDevice for TracingSpiDevice {
     }
     fn transfer(&mut self, mosi: u8) -> u8 {
         let miso = self.inner.transfer(mosi);
-        self.log
-            .lock()
-            .unwrap()
+        self.trace
             .push(&self.bus, BusPayload::Spi { mosi, miso });
         miso
     }
@@ -252,7 +323,7 @@ mod tests {
         let mut w = TracingI2cDevice::new("i2c1".into(), log.clone(), Box::new(Dev { addr: 0x1E }));
         // simulate a master write of one data byte
         I2cDevice::write(&mut w, 0xAF);
-        let snap = log.lock().unwrap().snapshot();
+        let snap = log.snapshot();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].bus, "i2c1");
         match &snap[0].payload {
@@ -265,5 +336,20 @@ mod tests {
             any.downcast_ref::<Dev>().is_some(),
             "as_any must forward to inner"
         );
+    }
+
+    #[test]
+    fn events_are_stamped_with_the_shared_clock_cycle() {
+        let log = new_log();
+        let mut w = TracingI2cDevice::new("i2c1".into(), log.clone(), Box::new(Dev { addr: 0x1E }));
+        // First byte transacts at cycle 0 (clock never advanced).
+        I2cDevice::write(&mut w, 0x01);
+        // Advance the shared clock, then transact again.
+        log.set_cycle(4242);
+        I2cDevice::write(&mut w, 0x02);
+        let snap = log.snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].cycle, 0, "first event predates any step");
+        assert_eq!(snap[1].cycle, 4242, "second event carries the advanced cycle");
     }
 }

--- a/crates/core/src/bus/bus_trace.rs
+++ b/crates/core/src/bus/bus_trace.rs
@@ -263,8 +263,7 @@ impl SpiDevice for TracingSpiDevice {
     }
     fn transfer(&mut self, mosi: u8) -> u8 {
         let miso = self.inner.transfer(mosi);
-        self.trace
-            .push(&self.bus, BusPayload::Spi { mosi, miso });
+        self.trace.push(&self.bus, BusPayload::Spi { mosi, miso });
         miso
     }
     fn cs_pin(&self) -> &str {
@@ -350,6 +349,9 @@ mod tests {
         let snap = log.snapshot();
         assert_eq!(snap.len(), 2);
         assert_eq!(snap[0].cycle, 0, "first event predates any step");
-        assert_eq!(snap[1].cycle, 4242, "second event carries the advanced cycle");
+        assert_eq!(
+            snap[1].cycle, 4242,
+            "second event carries the advanced cycle"
+        );
     }
 }

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -152,6 +152,7 @@ impl SystemBus {
                             &canonical_type,
                             p_cfg,
                             manifest,
+                            &bus.bus_trace,
                         )
                     });
             if let Some(dev) = family_dev {
@@ -172,9 +173,76 @@ impl SystemBus {
             }
             // Cross-vendor / generic peripherals (fallible: size + profile parsing).
             if let Some(dev) =
-                crate::peripherals::generic_factory::try_build(&canonical_type, p_cfg, manifest)?
+                crate::peripherals::generic_factory::try_build(
+                    &canonical_type,
+                    p_cfg,
+                    manifest,
+                    &bus.bus_trace,
+                )?
             {
                 bus.push_peripheral(p_cfg, dev)?;
+                continue;
+            }
+
+            // I²C controllers that carry external slaves. Build the controller,
+            // REGISTER it, then attach every wired slave through the single bus
+            // choke point `attach_i2c_slave`, which wraps each device into the
+            // shared bus trace. There is no per-controller `set_bus_trace` and no
+            // inline wrapping — a family that reaches the bus this way cannot be
+            // silently untraced (the ESP32-C3 blind-bus bug that motivated this).
+            if matches!(
+                canonical_type.as_str(),
+                "i2c" | "stm32f1_i2c"
+                    | "stm32f2_i2c"
+                    | "stm32f4_i2c"
+                    | "stm32f7_i2c"
+                    | "efm32ggi2ccontroller"
+                    | "esp32c3_i2c"
+            ) {
+                let controller: Box<dyn Peripheral> = if canonical_type == "esp32c3_i2c" {
+                    // ESP32-C3 behavioral I²C0 controller (command-list engine);
+                    // the C3 (RISC-V) reaches it through this config loader rather
+                    // than a hand-wired system builder.
+                    Box::new(crate::peripherals::esp32c3::i2c::Esp32c3I2c::new())
+                } else {
+                    let layout: crate::peripherals::i2c::I2cRegisterLayout =
+                        Self::parse_profile_or_default(p_cfg, "I2C")?;
+                    Box::new(crate::peripherals::i2c::I2c::new_with_layout(layout))
+                };
+                bus.push_peripheral(p_cfg, controller)?;
+                for ext in &manifest.external_devices {
+                    if ext.connection != p_cfg.id {
+                        continue;
+                    }
+                    match crate::peripherals::components::build_i2c_device(
+                        &ext.r#type,
+                        &ext.config,
+                    ) {
+                        Some(device) => {
+                            tracing::info!(
+                                "i2c attach: '{}' (type={}) -> '{}'",
+                                ext.id,
+                                ext.r#type,
+                                p_cfg.id
+                            );
+                            bus.attach_i2c_slave(&p_cfg.id, device)?;
+                            attached_i2c_ext_ids.insert(ext.id.as_str());
+                        }
+                        None => {
+                            // Devices migrated to the PeripheralKit contract are
+                            // attached by the kit pass below; their absence here
+                            // is expected. Only warn for types no path handles.
+                            if crate::peripherals::kit::registry::lookup(&ext.r#type).is_none() {
+                                tracing::warn!(
+                                    "i2c attach skipped: unknown device type '{}' for external id '{}' on bus '{}'",
+                                    ext.r#type,
+                                    ext.id,
+                                    p_cfg.id
+                                );
+                            }
+                        }
+                    }
+                }
                 continue;
             }
 
@@ -237,107 +305,6 @@ impl SystemBus {
                     } else {
                         Box::new(crate::peripherals::gpio::GpioPort::new_with_layout(layout))
                     }
-                }
-                "i2c"
-                | "stm32f1_i2c"
-                | "stm32f2_i2c"
-                | "stm32f4_i2c"
-                | "stm32f7_i2c"
-                | "efm32ggi2ccontroller" => {
-                    let layout: crate::peripherals::i2c::I2cRegisterLayout =
-                        Self::parse_profile_or_default(p_cfg, "I2C")?;
-                    let mut i2c = crate::peripherals::i2c::I2c::new_with_layout(layout);
-                    // Wire the shared bus-trace log (universal logic analyzer)
-                    // BEFORE any device is attached below, so every attach call
-                    // wraps its device into the log (see `I2c::attach`).
-                    i2c.set_bus_trace(p_cfg.id.clone(), bus.bus_trace.clone());
-                    for ext in &manifest.external_devices {
-                        if ext.connection != p_cfg.id {
-                            continue;
-                        }
-                        match crate::peripherals::components::build_i2c_device(
-                            &ext.r#type,
-                            &ext.config,
-                        ) {
-                            Some(device) => {
-                                tracing::info!(
-                                    "i2c attach: '{}' (type={}) -> '{}'",
-                                    ext.id,
-                                    ext.r#type,
-                                    p_cfg.id
-                                );
-                                i2c.attach(device);
-                                attached_i2c_ext_ids.insert(ext.id.as_str());
-                            }
-                            None => {
-                                // Devices migrated to the PeripheralKit contract
-                                // are attached by the kit pass below (see the
-                                // `registry::lookup` loop), not by this legacy
-                                // inline factory — so their absence here is
-                                // expected, not an error. Only warn for types
-                                // that no path will handle.
-                                if crate::peripherals::kit::registry::lookup(&ext.r#type).is_none()
-                                {
-                                    tracing::warn!(
-                                        "i2c attach skipped: unknown device type '{}' for external id '{}' on bus '{}'",
-                                        ext.r#type,
-                                        ext.id,
-                                        p_cfg.id
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Box::new(i2c)
-                }
-                // ESP32-C3 behavioral I²C0 controller (command-list engine).
-                // Same Espressif I²C IP family as the S3; the C3 chip yaml
-                // selects this type for `i2c0` so a slave declared in
-                // `external_devices` (connection: "i2c0") attaches here via the
-                // same `build_i2c_device` factory the STM32 path uses. The C3
-                // (RISC-V) reaches this through the from_config bus loader rather
-                // than a hand-wired system builder.
-                "esp32c3_i2c" => {
-                    let mut i2c = crate::peripherals::esp32c3::i2c::Esp32c3I2c::new();
-                    // Wire the shared bus-trace log (universal logic analyzer)
-                    // BEFORE any device is attached below, so every attach call
-                    // wraps its device into the log — same contract as the
-                    // generic `i2c` arm above.
-                    i2c.set_bus_trace(p_cfg.id.clone(), bus.bus_trace.clone());
-                    for ext in &manifest.external_devices {
-                        if ext.connection != p_cfg.id {
-                            continue;
-                        }
-                        match crate::peripherals::components::build_i2c_device(
-                            &ext.r#type,
-                            &ext.config,
-                        ) {
-                            Some(device) => {
-                                tracing::info!(
-                                    "esp32c3 i2c attach: '{}' (type={}) -> '{}'",
-                                    ext.id,
-                                    ext.r#type,
-                                    p_cfg.id
-                                );
-                                i2c.attach_slave(device);
-                                attached_i2c_ext_ids.insert(ext.id.as_str());
-                            }
-                            None => {
-                                // Kit-contract devices attach via the kit pass
-                                // below; only warn for types no path handles.
-                                if crate::peripherals::kit::registry::lookup(&ext.r#type).is_none()
-                                {
-                                    tracing::warn!(
-                                        "esp32c3 i2c attach skipped: unknown device type '{}' for external id '{}' on bus '{}'",
-                                        ext.r#type,
-                                        ext.id,
-                                        p_cfg.id
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Box::new(i2c)
                 }
                 // ESP32-C3 behavioral GP-SPI2 controller (CPU/W-buffer
                 // transaction engine). Same Espressif GP-SPI IP family as the
@@ -519,26 +486,9 @@ impl SystemBus {
             bus.push_peripheral(p_cfg, dev)?;
         }
 
-        // Wire the shared bus-trace log (universal logic analyzer) into every
-        // I2C/SPI peripheral built above, by name, BEFORE the PeripheralKit
-        // registry pass below attaches its devices — so those attaches also
-        // wrap into the log. The inline I²C arm above already does this for
-        // itself (so its own attach loop, which runs before this point, is
-        // covered too); this pass additionally covers `Spi` peripherals built
-        // by `generic_factory::try_build` (which has no direct access to
-        // `bus.bus_trace`) and any I²C peripheral re-touched here is a no-op
-        // (same name + same log already set).
-        let trace_log = bus.bus_trace.clone();
-        for entry in &mut bus.peripherals {
-            if let Some(any) = entry.dev.as_any_mut() {
-                if let Some(i2c) = any.downcast_mut::<crate::peripherals::i2c::I2c>() {
-                    i2c.set_bus_trace(entry.name.clone(), trace_log.clone());
-                } else if let Some(spi) = any.downcast_mut::<crate::peripherals::spi::Spi>() {
-                    spi.set_bus_trace(entry.name.clone(), trace_log.clone());
-                }
-            }
-        }
-
+        // Bus-trace wiring is no longer a per-peripheral property: the shared
+        // trace is applied at the single attach choke point (`attach_i2c_slave`
+        // / `attach_spi_device`), so there is nothing to wire here.
         for ext in &manifest.external_devices {
             // Already attached as an I²C slave by a chip-specific i2c path
             // (the `i2c` / `esp32c3_i2c` arms above). Don't let it fall through

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -172,14 +172,12 @@ impl SystemBus {
                 continue;
             }
             // Cross-vendor / generic peripherals (fallible: size + profile parsing).
-            if let Some(dev) =
-                crate::peripherals::generic_factory::try_build(
-                    &canonical_type,
-                    p_cfg,
-                    manifest,
-                    &bus.bus_trace,
-                )?
-            {
+            if let Some(dev) = crate::peripherals::generic_factory::try_build(
+                &canonical_type,
+                p_cfg,
+                manifest,
+                &bus.bus_trace,
+            )? {
                 bus.push_peripheral(p_cfg, dev)?;
                 continue;
             }
@@ -192,7 +190,8 @@ impl SystemBus {
             // silently untraced (the ESP32-C3 blind-bus bug that motivated this).
             if matches!(
                 canonical_type.as_str(),
-                "i2c" | "stm32f1_i2c"
+                "i2c"
+                    | "stm32f1_i2c"
                     | "stm32f2_i2c"
                     | "stm32f4_i2c"
                     | "stm32f7_i2c"
@@ -214,10 +213,8 @@ impl SystemBus {
                     if ext.connection != p_cfg.id {
                         continue;
                     }
-                    match crate::peripherals::components::build_i2c_device(
-                        &ext.r#type,
-                        &ext.config,
-                    ) {
+                    match crate::peripherals::components::build_i2c_device(&ext.r#type, &ext.config)
+                    {
                         Some(device) => {
                             tracing::info!(
                                 "i2c attach: '{}' (type={}) -> '{}'",

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -784,7 +784,71 @@ impl SystemBus {
     /// every I²C/SPI byte recorded so far by peripherals wired to
     /// `self.bus_trace` (see `crate::bus::bus_trace`), oldest first.
     pub fn bus_trace_snapshot(&self) -> Vec<bus_trace::BusTraceEvent> {
-        self.bus_trace.lock().unwrap().snapshot()
+        self.bus_trace.snapshot()
+    }
+
+    /// The single funnel through which every I²C slave reaches a controller.
+    /// Wraps `dev` in the shared bus trace (via [`bus_trace::wrap_i2c`]) and
+    /// hands the wrapped device to the named controller's raw `push_slave`.
+    /// Because the wrap happens here — before any family dispatch — there is no
+    /// path that attaches a slave untraced: a controller family this dispatch
+    /// does not recognise is a hard error, not a silently invisible bus.
+    pub fn attach_i2c_slave(
+        &mut self,
+        controller: &str,
+        dev: Box<dyn crate::peripherals::i2c::I2cDevice>,
+    ) -> anyhow::Result<()> {
+        let wrapped = bus_trace::wrap_i2c(controller, &self.bus_trace, dev);
+        let idx = self
+            .find_peripheral_index_by_name(controller)
+            .ok_or_else(|| anyhow::anyhow!("attach_i2c_slave: no peripheral '{controller}'"))?;
+        let any = self.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .ok_or_else(|| anyhow::anyhow!("attach_i2c_slave: '{controller}' is not downcastable"))?;
+        if let Some(c) = any.downcast_mut::<crate::peripherals::i2c::I2c>() {
+            c.push_slave(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32c3::i2c::Esp32c3I2c>() {
+            c.push_slave(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32s3::i2c::Esp32s3I2c>() {
+            c.push_slave(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32::i2c::Esp32I2c>() {
+            c.push_slave(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::nrf52::twim::Nrf52Twim>() {
+            c.push_slave(wrapped);
+        } else {
+            anyhow::bail!("attach_i2c_slave: '{controller}' is not an I2C controller");
+        }
+        Ok(())
+    }
+
+    /// The single funnel through which every SPI device reaches a controller —
+    /// the SPI counterpart of [`Self::attach_i2c_slave`]. Wraps then dispatches.
+    pub fn attach_spi_device(
+        &mut self,
+        controller: &str,
+        dev: Box<dyn crate::peripherals::spi::SpiDevice>,
+    ) -> anyhow::Result<()> {
+        let wrapped = bus_trace::wrap_spi(controller, &self.bus_trace, dev);
+        let idx = self
+            .find_peripheral_index_by_name(controller)
+            .ok_or_else(|| anyhow::anyhow!("attach_spi_device: no peripheral '{controller}'"))?;
+        let any = self.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .ok_or_else(|| anyhow::anyhow!("attach_spi_device: '{controller}' is not downcastable"))?;
+        if let Some(c) = any.downcast_mut::<crate::peripherals::spi::Spi>() {
+            c.push_device(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32c3::spi::Esp32c3Spi>() {
+            c.push_device(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>() {
+            c.push_device(wrapped);
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32s3::gpspi::Esp32s3Spi>() {
+            c.push_device(wrapped);
+        } else {
+            anyhow::bail!("attach_spi_device: '{controller}' is not a SPI controller");
+        }
+        Ok(())
     }
 
     pub(crate) fn canonical_peripheral_type(raw_type: &str) -> String {

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -802,10 +802,9 @@ impl SystemBus {
         let idx = self
             .find_peripheral_index_by_name(controller)
             .ok_or_else(|| anyhow::anyhow!("attach_i2c_slave: no peripheral '{controller}'"))?;
-        let any = self.peripherals[idx]
-            .dev
-            .as_any_mut()
-            .ok_or_else(|| anyhow::anyhow!("attach_i2c_slave: '{controller}' is not downcastable"))?;
+        let any = self.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
+            anyhow::anyhow!("attach_i2c_slave: '{controller}' is not downcastable")
+        })?;
         if let Some(c) = any.downcast_mut::<crate::peripherals::i2c::I2c>() {
             c.push_slave(wrapped);
         } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32c3::i2c::Esp32c3I2c>() {
@@ -833,17 +832,17 @@ impl SystemBus {
         let idx = self
             .find_peripheral_index_by_name(controller)
             .ok_or_else(|| anyhow::anyhow!("attach_spi_device: no peripheral '{controller}'"))?;
-        let any = self.peripherals[idx]
-            .dev
-            .as_any_mut()
-            .ok_or_else(|| anyhow::anyhow!("attach_spi_device: '{controller}' is not downcastable"))?;
+        let any = self.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
+            anyhow::anyhow!("attach_spi_device: '{controller}' is not downcastable")
+        })?;
         if let Some(c) = any.downcast_mut::<crate::peripherals::spi::Spi>() {
             c.push_device(wrapped);
         } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32c3::spi::Esp32c3Spi>() {
             c.push_device(wrapped);
         } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>() {
             c.push_device(wrapped);
-        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32s3::gpspi::Esp32s3Spi>() {
+        } else if let Some(c) = any.downcast_mut::<crate::peripherals::esp32s3::gpspi::Esp32s3Spi>()
+        {
             c.push_device(wrapped);
         } else {
             anyhow::bail!("attach_spi_device: '{controller}' is not a SPI controller");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -903,7 +903,9 @@ impl<C: Cpu> Machine<C> {
             .iter()
             .map(|r| {
                 r.and_then(|(idx, pin)| {
-                    bus.peripherals.get(idx).and_then(|p| p.dev.read_gpio_pad(pin))
+                    bus.peripherals
+                        .get(idx)
+                        .and_then(|p| p.dev.read_gpio_pad(pin))
                 })
             })
             .collect();
@@ -933,7 +935,9 @@ impl<C: Cpu> Machine<C> {
         let now = self.total_cycles;
         let bus = &self.bus;
         self.logic_capture.sample(now, |idx, pin| {
-            bus.peripherals.get(idx).and_then(|p| p.dev.read_gpio_pad(pin))
+            bus.peripherals
+                .get(idx)
+                .and_then(|p| p.dev.read_gpio_pad(pin))
         });
     }
 }
@@ -1809,8 +1813,7 @@ impl<C: Cpu> DebugControl for Machine<C> {
             // stride past intermediate edges we can only read at batch
             // boundaries. Cost is paid ONLY while a watch set is active.
             if self.logic_capture.is_active() {
-                current_batch =
-                    current_batch.min(logic_capture::LOGIC_SAMPLE_INTERVAL as u32);
+                current_batch = current_batch.min(logic_capture::LOGIC_SAMPLE_INTERVAL as u32);
             }
 
             let executed =

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod decoder;
 pub mod fidelity;
 pub mod inspect;
 pub mod interrupt;
+pub mod logic_capture;
 pub mod memory;
 pub mod metrics;
 pub mod multi_core;
@@ -851,6 +852,13 @@ pub struct Machine<C: Cpu> {
     /// under the `event-scheduler` feature.
     #[allow(dead_code)]
     scheduler_bootstrapped: bool,
+
+    /// In-engine logic-analyzer edge capture (see [`crate::logic_capture`]).
+    /// Empty/inactive by default — the step loop pays a single `is_active`
+    /// check per step and nothing more until `logic_watch` installs a watch
+    /// set. Not part of snapshot/restore: capture is a UI observation stream,
+    /// re-armed by the frontend after a resume.
+    logic_capture: logic_capture::LogicCapture,
 }
 
 impl<C: Cpu> Machine<C> {
@@ -870,6 +878,52 @@ impl<C: Cpu> Machine<C> {
         value: f64,
     ) -> Result<(), crate::sim_input::SimInputError> {
         self.bus.set_input(channel, value)
+    }
+
+    /// Install a logic-analyzer watch set, resetting the capture buffer and
+    /// cursor. `resolved[i]` is `Some((peripheral_index, pin))` for a
+    /// resolvable GPIO ref or `None` for an unresolvable one (never sampled).
+    /// Returns each channel's initial pad level (`None` = unknown), same order
+    /// as `resolved`, so the caller can seed the waveform before the first
+    /// edge. Passing an empty slice disarms capture.
+    pub fn logic_watch(&mut self, resolved: &[Option<(usize, u8)>]) -> Vec<Option<bool>> {
+        let bus = &self.bus;
+        let initial: Vec<Option<bool>> = resolved
+            .iter()
+            .map(|r| {
+                r.and_then(|(idx, pin)| {
+                    bus.peripherals.get(idx).and_then(|p| p.dev.read_gpio_pad(pin))
+                })
+            })
+            .collect();
+        self.logic_capture.install(resolved, &initial);
+        initial
+    }
+
+    /// Drain logic edges newer than `cursor` (see
+    /// [`logic_capture::LogicCapture::read_edges`]).
+    pub fn logic_read_edges(&self, cursor: u64) -> logic_capture::LogicEdgeBatch {
+        self.logic_capture.read_edges(cursor)
+    }
+
+    /// Current engine cycle — the `nowCycle` reported alongside a logic-edge
+    /// read so the UI can extend flat traces to "now".
+    pub fn logic_now_cycle(&self) -> u64 {
+        self.total_cycles
+    }
+
+    /// Sample the watched pads at the current cycle. Hooked into the step loop;
+    /// the leading `is_active` guard is the entire cost when nothing is watched.
+    #[inline]
+    fn logic_sample(&mut self) {
+        if !self.logic_capture.is_active() {
+            return;
+        }
+        let now = self.total_cycles;
+        let bus = &self.bus;
+        self.logic_capture.sample(now, |idx, pin| {
+            bus.peripherals.get(idx).and_then(|p| p.dev.read_gpio_pad(pin))
+        });
     }
 }
 
@@ -909,6 +963,7 @@ impl<C: Cpu> Machine<C> {
             flash_index,
             scb_index,
             scheduler_bootstrapped: false,
+            logic_capture: logic_capture::LogicCapture::new(),
         }
     }
 
@@ -1281,6 +1336,12 @@ impl<C: Cpu> Machine<C> {
         // batch/CLI run path (`Machine::run`), which executes cycle-accurately
         // when an H5 op-modeling FLASH is present so this fires per instruction.
         self.apply_pending_flash_op()?;
+
+        // Logic-analyzer edge capture. No-op (one `is_active` check) unless a
+        // watch set is installed. Sampled after the instruction + peripheral
+        // effects of this cycle have landed, so pad levels are the committed
+        // state at `total_cycles`.
+        self.logic_sample();
 
         Ok(())
     }
@@ -1729,6 +1790,15 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 current_batch = current_batch.min(1);
             }
 
+            // Logic-analyzer capture: clamp the batch so pad state is observed
+            // at least once per sample interval — otherwise a large batch would
+            // stride past intermediate edges we can only read at batch
+            // boundaries. Cost is paid ONLY while a watch set is active.
+            if self.logic_capture.is_active() {
+                current_batch =
+                    current_batch.min(logic_capture::LOGIC_SAMPLE_INTERVAL as u32);
+            }
+
             let executed =
                 self.cpu
                     .step_batch(&mut self.bus, &self.observers, &self.config, current_batch)?;
@@ -1773,6 +1843,11 @@ impl<C: Cpu> DebugControl for Machine<C> {
             if self.drain_scb_reset_request() {
                 self.reset()?;
             }
+
+            // Logic-analyzer edge capture at the batch boundary (no-op unless a
+            // watch set is installed; the batch was clamped above so this fires
+            // at least once per sample interval).
+            self.logic_sample();
 
             // If we executed less than requested, it means the CPU wanted to exit early (e.g. branch/exception)
             // or we just finished the batch naturally. The loop will continue and check breakpoints/limits.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -473,6 +473,17 @@ pub trait Peripheral: std::fmt::Debug + Send {
             .or_else(|| self.read_gpio_input(pin))
     }
 
+    /// GPIO capability: the routing of `pin` — its direction/`mode` and, when
+    /// resolvable, the peripheral signal `func` it is wired to — derived from the
+    /// SAME register truth [`read_gpio_pad`](Self::read_gpio_pad) reads (no
+    /// fabrication). This is the honest source the UI logic analyzer uses instead
+    /// of guessing signal roles from pin NAMES. `None` for non-GPIO peripherals
+    /// or out-of-range pins; a returned routing may still carry
+    /// `mode = Unknown` / `func = None` where a family cannot say.
+    fn gpio_routing(&self, _pin: u8) -> Option<crate::peripherals::gpio::GpioRouting> {
+        None
+    }
+
     /// GPIO capability: drive an externally controlled input level for `pin`
     /// (e.g. browser button press). Returns `false` if unsupported.
     fn set_gpio_input(&mut self, _pin: u8, _level: bool) -> bool {
@@ -989,6 +1000,7 @@ impl<C: Cpu> Machine<C> {
             self.cpu.fast_forward_idle_cycles(skipped as u64);
             self.total_cycles += skipped as u64;
             self.bus.current_cycle = self.total_cycles;
+            self.bus.bus_trace.set_cycle(self.total_cycles);
             self.sched.advance_to(self.total_cycles / interval);
             self.drain_scheduler_events();
             skipped
@@ -1195,6 +1207,7 @@ impl<C: Cpu> Machine<C> {
         // (event-scheduler) and the HC-SR04 echo-window timing (always). O(1) —
         // a single field write, not the per-peripheral walk this phase removed.
         self.bus.current_cycle = self.total_cycles;
+        self.bus.bus_trace.set_cycle(self.total_cycles);
         self.cpu
             .step(&mut self.bus, &self.observers, &self.config)?;
         self.step_profile.cpu_instructions += 1;
@@ -1698,6 +1711,7 @@ impl<C: Cpu> DebugControl for Machine<C> {
             // (and tick-time services) can read "now". The batch is bounded by
             // `peripheral_tick_interval`, so intra-batch staleness is < one tick.
             self.bus.current_cycle = current_cycles;
+            self.bus.bus_trace.set_cycle(current_cycles);
             let tick_interval = self.config.peripheral_tick_interval as u64;
             let remaining_until_tick = (tick_interval - (current_cycles % tick_interval)) as u32;
 

--- a/crates/core/src/logic_capture.rs
+++ b/crates/core/src/logic_capture.rs
@@ -1,0 +1,184 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Deterministic, in-engine logic-analyzer edge capture.
+//!
+//! The browser logic analyzer used to sample GPIO pads from the UI thread on
+//! `requestAnimationFrame` ticks (via `sample_logic_signals`). Sample spacing
+//! therefore depended on host frame timing, so the waveforms aliased and were
+//! nondeterministic even though the simulator itself is fully deterministic.
+//!
+//! This module moves capture INSIDE the simulation loop: while a watch set is
+//! active, [`Machine`](crate::Machine) samples the watched pads on a fixed
+//! engine-cycle cadence ([`LOGIC_SAMPLE_INTERVAL`]) and records a `{ch, cycle,
+//! value}` edge ONLY on a transition. Timestamps are engine cycles, so
+//! identical firmware + identical watch config produce byte-identical edge
+//! streams regardless of how the host drives stepping.
+//!
+//! Everything here is host-frame-independent and allocation-free on the hot
+//! path — the single per-step cost when nothing is watched is one `is_empty`
+//! check on the channel list.
+
+use std::collections::VecDeque;
+
+/// Cycle spacing between logic samples.
+///
+/// A 100 kHz signal on a 40 MHz core has a period of 40e6 / 100e3 = 400 engine
+/// cycles. Sampling every 16 cycles yields 400 / 16 = 25 samples per period
+/// (>= 20, the fidelity target for reconstructing a 100 kHz waveform), while
+/// keeping the sample count — and therefore the per-sample cost when a watch is
+/// active — an order of magnitude below one-sample-per-cycle. It is a power of
+/// two so the bucket division is a shift. A fixed internal constant on purpose:
+/// no config knob to keep the capture contract simple and deterministic.
+pub const LOGIC_SAMPLE_INTERVAL: u64 = 16;
+
+/// Maximum number of edges retained in the ring buffer. On overflow the oldest
+/// edge is dropped (and counted) so capture never grows without bound. 64k
+/// edges is ~10 s of a steadily toggling 100 kHz signal on a single channel
+/// before the UI must drain — far more than any interactive poll interval.
+pub const LOGIC_RING_CAPACITY: usize = 64 * 1024;
+
+/// A single recorded logic transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct LogicEdge {
+    /// Channel index — the position of the ref in the watch set passed to
+    /// `watch_logic_signals`.
+    pub ch: u32,
+    /// Engine cycle (`Machine::total_cycles`) at which the transition was
+    /// observed.
+    pub cycle: u64,
+    /// The new pad level after the transition.
+    pub value: bool,
+}
+
+/// One resolved watch channel. Resolution (peripheral index + pin) happens once
+/// at `watch` time so the sampling hot path never does a string lookup.
+#[derive(Debug, Clone, Copy)]
+struct LogicChannel {
+    /// `Some((peripheral_index, pin))` for a resolvable GPIO ref, `None` for an
+    /// unresolvable ref (unknown peripheral / non-gpio kind). Unresolvable
+    /// channels are never sampled and never emit edges.
+    resolved: Option<(usize, u8)>,
+    /// Last known pad level, or `None` if never known (initial, or the pad has
+    /// only ever read back as unknown). A transition is emitted when a `Some(v)`
+    /// read differs from this.
+    last: Option<bool>,
+}
+
+/// Result of draining the edge ring from a caller cursor.
+pub struct LogicEdgeBatch {
+    /// Monotonic edge sequence number to pass back on the next read to receive
+    /// only newer edges.
+    pub cursor: u64,
+    /// Cumulative count of edges dropped to ring-buffer overflow since the watch
+    /// set was installed.
+    pub dropped: u64,
+    /// New edges since the caller's cursor, oldest first.
+    pub edges: Vec<LogicEdge>,
+}
+
+/// In-engine logic-analyzer capture buffer. Owned by [`Machine`](crate::Machine).
+#[derive(Default)]
+pub struct LogicCapture {
+    channels: Vec<LogicChannel>,
+    ring: VecDeque<LogicEdge>,
+    /// Total edges ever pushed since the watch set was installed. Also the
+    /// exclusive upper bound of the cursor space; the oldest retained edge has
+    /// sequence `next_seq - ring.len()`.
+    next_seq: u64,
+    dropped: u64,
+    /// Last sampled cycle bucket (`cycle / LOGIC_SAMPLE_INTERVAL`), so a bucket
+    /// is sampled at most once even if the step loop revisits the same cycle
+    /// window across a batch boundary.
+    last_bucket: u64,
+    sampled_once: bool,
+}
+
+impl LogicCapture {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `true` while a watch set is installed. The step loop checks this and
+    /// does nothing further when it is `false` — the entire zero-overhead path.
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        !self.channels.is_empty()
+    }
+
+    /// Install a fresh watch set from pre-resolved channels and their initial
+    /// pad levels, clearing the ring, cursor and drop count. `resolved[i]` and
+    /// `initial[i]` describe channel `i`; they must be the same length.
+    pub fn install(&mut self, resolved: &[Option<(usize, u8)>], initial: &[Option<bool>]) {
+        debug_assert_eq!(resolved.len(), initial.len());
+        self.channels = resolved
+            .iter()
+            .zip(initial.iter())
+            .map(|(&resolved, &last)| LogicChannel { resolved, last })
+            .collect();
+        self.ring.clear();
+        self.next_seq = 0;
+        self.dropped = 0;
+        self.last_bucket = 0;
+        self.sampled_once = false;
+    }
+
+    /// Sample every watched pad at engine cycle `now`, recording a transition
+    /// for any channel whose known level changed. `read` maps a resolved
+    /// `(peripheral_index, pin)` to the direction-aware pad level (the same
+    /// truth as `Peripheral::read_gpio_pad`); a `None` read records nothing.
+    ///
+    /// Caller guarantees this is only invoked when [`is_active`](Self::is_active).
+    /// At most one sample is taken per `LOGIC_SAMPLE_INTERVAL`-cycle bucket.
+    pub fn sample(&mut self, now: u64, read: impl Fn(usize, u8) -> Option<bool>) {
+        let bucket = now / LOGIC_SAMPLE_INTERVAL;
+        if self.sampled_once && bucket == self.last_bucket {
+            return;
+        }
+        self.last_bucket = bucket;
+        self.sampled_once = true;
+
+        for i in 0..self.channels.len() {
+            let Some((idx, pin)) = self.channels[i].resolved else {
+                continue;
+            };
+            let Some(level) = read(idx, pin) else {
+                continue;
+            };
+            if self.channels[i].last != Some(level) {
+                self.channels[i].last = Some(level);
+                self.push_edge(LogicEdge {
+                    ch: i as u32,
+                    cycle: now,
+                    value: level,
+                });
+            }
+        }
+    }
+
+    fn push_edge(&mut self, edge: LogicEdge) {
+        if self.ring.len() == LOGIC_RING_CAPACITY {
+            self.ring.pop_front();
+            self.dropped += 1;
+        }
+        self.ring.push_back(edge);
+        self.next_seq += 1;
+    }
+
+    /// Drain edges newer than `cursor`. Pass `0` on the first read (right after
+    /// `watch`); pass back the returned `cursor` thereafter. Edges older than
+    /// the retained window (dropped to overflow) are silently skipped — the
+    /// `dropped` count reflects the loss.
+    pub fn read_edges(&self, cursor: u64) -> LogicEdgeBatch {
+        let base = self.next_seq - self.ring.len() as u64;
+        let start = cursor.max(base);
+        let skip = (start - base) as usize;
+        let edges = self.ring.iter().skip(skip).copied().collect();
+        LogicEdgeBatch {
+            cursor: self.next_seq,
+            dropped: self.dropped,
+            edges,
+        }
+    }
+}

--- a/crates/core/src/peripherals/components/adxl345.rs
+++ b/crates/core/src/peripherals/components/adxl345.rs
@@ -148,8 +148,7 @@ impl PeripheralKit for Adxl345Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let address = ctx.i2c_address_or(0x53)?;
-        let i2c = ctx.i2c()?;
-        i2c.attach(Box::new(Adxl345::new(address)));
+        ctx.attach_i2c_device(Box::new(Adxl345::new(address)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/bme280.rs
+++ b/crates/core/src/peripherals/components/bme280.rs
@@ -190,8 +190,7 @@ impl PeripheralKit for Bme280Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let address = ctx.i2c_address_or(0x76)?;
-        let i2c = ctx.i2c()?;
-        i2c.attach(Box::new(Bme280::new(address)));
+        ctx.attach_i2c_device(Box::new(Bme280::new(address)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/hc595_7seg.rs
+++ b/crates/core/src/peripherals/components/hc595_7seg.rs
@@ -223,8 +223,7 @@ impl PeripheralKit for Hc5957SegKit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
-        let spi = ctx.spi()?;
-        spi.attach(Box::new(Hc5957Seg::new(cs_pin)));
+        ctx.attach_spi_device(Box::new(Hc5957Seg::new(cs_pin)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/max31855.rs
+++ b/crates/core/src/peripherals/components/max31855.rs
@@ -144,8 +144,7 @@ impl PeripheralKit for Max31855Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
-        let spi = ctx.spi()?;
-        spi.attach(Box::new(Max31855::new(cs_pin)));
+        ctx.attach_spi_device(Box::new(Max31855::new(cs_pin)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/mpu6050.rs
+++ b/crates/core/src/peripherals/components/mpu6050.rs
@@ -182,8 +182,7 @@ impl PeripheralKit for Mpu6050Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let address = ctx.i2c_address_or(0x68)?;
-        let i2c = ctx.i2c()?;
-        i2c.attach(Box::new(Mpu6050::new(address)));
+        ctx.attach_i2c_device(Box::new(Mpu6050::new(address)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -368,7 +368,7 @@ mod tests {
         let mut lcd = Pcd8544::new("PB6".into(), "PC7".into());
         // D/C resolves to GPIOC ODR bit 7 (PC7) — exactly what bus install does.
         SpiDevice::set_dc_source(&mut lcd, GPIOC + ODR, 7);
-        spi.attach(Box::new(lcd));
+        spi.push_device(Box::new(lcd));
         bus.add_peripheral("spi1", SPI1, 0x400, None, Box::new(spi));
 
         // Enable SPE so DR writes kick off transfers.

--- a/crates/core/src/peripherals/components/sn74hc165.rs
+++ b/crates/core/src/peripherals/components/sn74hc165.rs
@@ -127,12 +127,11 @@ impl PeripheralKit for Sn74hc165Kit {
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
         let inputs = ctx.config_i64("inputs");
-        let spi = ctx.spi()?;
         let mut shifter = Sn74hc165::new(cs_pin);
         if let Some(v) = inputs {
             shifter.set_inputs(v as u8);
         }
-        spi.attach(Box::new(shifter));
+        ctx.attach_spi_device(Box::new(shifter))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/components/vl53l1x.rs
+++ b/crates/core/src/peripherals/components/vl53l1x.rs
@@ -225,8 +225,7 @@ impl PeripheralKit for Vl53l1xKit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let address = ctx.i2c_address_or(0x29)?;
-        let i2c = ctx.i2c()?;
-        i2c.attach(Box::new(Vl53l1x::new(address)));
+        ctx.attach_i2c_device(Box::new(Vl53l1x::new(address)))?;
         Ok(())
     }
 }

--- a/crates/core/src/peripherals/esp32/gpio.rs
+++ b/crates/core/src/peripherals/esp32/gpio.rs
@@ -283,6 +283,23 @@ impl Peripheral for Esp32Gpio {
         })
     }
 
+    fn gpio_routing(&self, pin: u8) -> Option<crate::peripherals::gpio::GpioRouting> {
+        use crate::peripherals::gpio::{GpioMode, GpioRouting};
+        if pin >= 32 {
+            return None;
+        }
+        // ENABLE is the output driver. The classic ESP32 GPIO model does not
+        // track the output matrix (FUNCn_OUT_SEL), so it can report direction but
+        // cannot distinguish a plain-GPIO output from a peripheral-routed one, nor
+        // name the signal — func stays None (honest "can't say").
+        let mode = if (self.enable & (1u32 << pin)) != 0 {
+            GpioMode::Output
+        } else {
+            GpioMode::Input
+        };
+        Some(GpioRouting { mode, func: None })
+    }
+
     fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
         if pin >= 32 {
             return false;

--- a/crates/core/src/peripherals/esp32/i2c.rs
+++ b/crates/core/src/peripherals/esp32/i2c.rs
@@ -150,9 +150,11 @@ impl Esp32I2c {
         }
     }
 
-    /// Attach an `I2cDevice` slave. Slaves are matched by 7-bit address at
-    /// transaction time; later additions take precedence on duplicate addresses.
-    pub fn attach_slave(&mut self, slave: Box<dyn I2cDevice>) {
+    /// Raw slave push — does NOT wrap for tracing. The only production caller is
+    /// the bus choke point [`crate::bus::SystemBus::attach_i2c_slave`], which
+    /// wraps first. Slaves are matched by 7-bit address at transaction time;
+    /// later additions take precedence on duplicate addresses.
+    pub(crate) fn push_slave(&mut self, slave: Box<dyn I2cDevice>) {
         self.slaves.push(slave);
     }
 
@@ -547,7 +549,7 @@ mod tests {
         // A WRITE of 2 bytes following RSTART consumes 2 TX-FIFO bytes; the
         // FIFO_ST TXFIFO_START_ADDR field (bits 14..10) reports that pointer.
         let mut p = Esp32I2c::new();
-        p.attach_slave(Box::new(crate::peripherals::components::Bmp280::new(0x76)));
+        p.push_slave(Box::new(crate::peripherals::components::Bmp280::new(0x76)));
         p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
         p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 2)).unwrap();
         p.write_u32(REG_CMD0 + 8, cmd(CMD_STOP, 0)).unwrap();
@@ -567,7 +569,7 @@ mod tests {
     fn write_read_drives_attached_bmp280() {
         let mut p = Esp32I2c::new();
         // Default address 0x76.
-        p.attach_slave(Box::new(Bmp280::new(0x76)));
+        p.push_slave(Box::new(Bmp280::new(0x76)));
 
         // Canonical register-pointer read: set pointer to 0xD0 (chip-id), then
         // repeated-start and read one byte. CHIP_ID for BMP280 is 0x58.

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -84,7 +84,10 @@ impl Esp32Spi {
         Self::default()
     }
 
-    pub fn attach(&mut self, device: Box<dyn SpiDevice>) {
+    /// Raw device push — does NOT wrap for tracing. The only production caller
+    /// is the bus choke point [`crate::bus::SystemBus::attach_spi_device`],
+    /// which wraps first.
+    pub(crate) fn push_device(&mut self, device: Box<dyn SpiDevice>) {
         self.attached_devices.push(device);
     }
 
@@ -369,7 +372,7 @@ mod tests {
     #[test]
     fn cmd_usr_streams_mosi_bytes_to_attached_device() {
         let mut spi = Esp32Spi::new();
-        spi.attach(Box::new(Recorder::default()));
+        spi.push_device(Box::new(Recorder::default()));
 
         // Stream 5 bytes: 0x12, 0x34, 0x56, 0x78, 0x9A.
         write32(&mut spi, FIFO_START, 0x78_56_34_12); // bytes 0..3
@@ -396,7 +399,7 @@ mod tests {
     #[test]
     fn cmd_usr_without_usr_mosi_bit_does_not_send_bytes() {
         let mut spi = Esp32Spi::new();
-        spi.attach(Box::new(Recorder::default()));
+        spi.push_device(Box::new(Recorder::default()));
 
         write32(&mut spi, FIFO_START, 0xDE_AD_BE_EF);
         write32(&mut spi, REG_USER, 0); // USR_MOSI cleared

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -10,10 +10,35 @@
 //! writes use those set/clear registers, and display peripherals read GPIO
 //! output back for CS/DC/bit-banged buses.
 
+use crate::peripherals::gpio::{GpioMode, GpioRouting};
 use crate::{Peripheral, PeripheralTickResult, SimResult};
 
 const PIN_COUNT: u8 = 26;
 const PIN_MASK: u32 = (1u32 << PIN_COUNT) - 1;
+
+/// `GPIO_FUNCn_OUT_SEL_CFG_REG` base (C3 TRM §5.12): per-PAD output routing.
+/// Bits [8:0] select which peripheral output signal drives pad `n`; the sentinel
+/// `SIG_GPIO_OUT` (128) means the pad is a plain GPIO output (GPIO_OUT latch).
+const FUNC_OUT_SEL: u64 = 0x554;
+const SIG_GPIO_OUT: u32 = 128;
+
+/// ESP32-C3 GPIO-matrix OUTPUT signal index → signal name, for the I²C / SPI /
+/// UART signals the logic analyzer cares about (from esp-idf
+/// `soc/esp32c3/include/soc/gpio_sig_map.h`). Unmapped indices → `None` (null,
+/// never a guess).
+fn c3_out_signal_name(idx: u32) -> Option<&'static str> {
+    Some(match idx {
+        6 => "U0TXD",
+        9 => "U1TXD",
+        53 => "I2CEXT0_SCL",
+        54 => "I2CEXT0_SDA",
+        63 => "FSPICLK",
+        64 => "FSPIQ", // FSPI MISO
+        65 => "FSPID", // FSPI MOSI
+        68 => "FSPICS0",
+        _ => return None,
+    })
+}
 
 const BT_SELECT: u64 = 0x00;
 const OUT: u64 = 0x04;
@@ -46,6 +71,9 @@ pub struct Esp32c3Gpio {
     in_data: u32,
     status: u32,
     pin_cfg: [u32; PIN_COUNT as usize],
+    /// `GPIO_FUNCn_OUT_SEL_CFG` per pad — the output-matrix selector read by
+    /// `gpio_routing` to name the signal a pad is wired to.
+    out_sel: [u32; PIN_COUNT as usize],
     cycle: u64,
     anchor_tick: u64,
 }
@@ -61,8 +89,17 @@ impl Esp32c3Gpio {
             in_data: 0,
             status: 0,
             pin_cfg: [0; PIN_COUNT as usize],
+            out_sel: [0; PIN_COUNT as usize],
             cycle: 0,
             anchor_tick: 0,
+        }
+    }
+
+    fn out_sel_index(off: u64) -> Option<usize> {
+        if (FUNC_OUT_SEL..FUNC_OUT_SEL + (PIN_COUNT as u64) * 4).contains(&off) {
+            Some(((off - FUNC_OUT_SEL) / 4) as usize)
+        } else {
+            None
         }
     }
 
@@ -101,9 +138,15 @@ impl Esp32c3Gpio {
             IN => self.in_data,
             STATUS | STATUS_W1TS | STATUS_W1TC => self.status,
             PCPU_INT | PCPU_NMI_INT | CPUSDIO_INT => self.status,
-            off => Self::pin_cfg_index(off)
-                .map(|idx| self.pin_cfg[idx])
-                .unwrap_or(0),
+            off => {
+                if let Some(idx) = Self::out_sel_index(off) {
+                    self.out_sel[idx]
+                } else {
+                    Self::pin_cfg_index(off)
+                        .map(|idx| self.pin_cfg[idx])
+                        .unwrap_or(0)
+                }
+            }
         }
     }
 
@@ -124,7 +167,9 @@ impl Esp32c3Gpio {
             STATUS_W1TC => self.status &= !value,
             PCPU_INT | PCPU_NMI_INT | CPUSDIO_INT => {}
             off => {
-                if let Some(idx) = Self::pin_cfg_index(off) {
+                if let Some(idx) = Self::out_sel_index(off) {
+                    self.out_sel[idx] = value;
+                } else if let Some(idx) = Self::pin_cfg_index(off) {
                     self.pin_cfg[idx] = value;
                 }
             }
@@ -241,6 +286,37 @@ impl Peripheral for Esp32c3Gpio {
         })
     }
 
+    fn gpio_routing(&self, pin: u8) -> Option<GpioRouting> {
+        if pin >= PIN_COUNT {
+            return None;
+        }
+        let mask = 1u32 << pin;
+        if (self.enable & mask) == 0 {
+            // Output driver disabled → the pad is an input. The input matrix
+            // (FUNCn_IN_SEL, indexed by signal) is not tracked, so we cannot name
+            // the signal — func stays None rather than a guess.
+            return Some(GpioRouting {
+                mode: GpioMode::Input,
+                func: None,
+            });
+        }
+        // Output driver enabled: consult the per-pad output-matrix selector.
+        let sig = self.out_sel[pin as usize] & 0x1FF;
+        if sig == SIG_GPIO_OUT {
+            // Pad driven directly by the GPIO_OUT latch — a plain GPIO output.
+            Some(GpioRouting {
+                mode: GpioMode::Output,
+                func: None,
+            })
+        } else {
+            // Pad routed to a peripheral output signal (alternate function).
+            Some(GpioRouting {
+                mode: GpioMode::Af,
+                func: c3_out_signal_name(sig).map(String::from),
+            })
+        }
+    }
+
     fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
         if pin >= PIN_COUNT {
             return false;
@@ -304,5 +380,44 @@ mod tests {
 
         gpio.write_u32(STRAP, 0).unwrap();
         assert_eq!(gpio.read_word(STRAP), STRAP_SPI_FAST_FLASH_BOOT);
+    }
+
+    #[test]
+    fn gpio_routing_resolves_the_output_matrix() {
+        use crate::peripherals::gpio::GpioMode;
+        let mut g = Esp32c3Gpio::new();
+
+        // pin5: output driver on + routed to I2CEXT0_SDA (signal index 54) → AF.
+        g.write_u32(ENABLE_W1TS, 1 << 5).unwrap();
+        g.write_u32(FUNC_OUT_SEL + 5 * 4, 54).unwrap();
+        let r5 = g.gpio_routing(5).unwrap();
+        assert_eq!(r5.mode, GpioMode::Af);
+        assert_eq!(r5.func.as_deref(), Some("I2CEXT0_SDA"));
+
+        // pin6: output driver on + GPIO_OUT sentinel (128) → plain output, no func.
+        g.write_u32(ENABLE_W1TS, 1 << 6).unwrap();
+        g.write_u32(FUNC_OUT_SEL + 6 * 4, SIG_GPIO_OUT).unwrap();
+        let r6 = g.gpio_routing(6).unwrap();
+        assert_eq!(r6.mode, GpioMode::Output);
+        assert!(r6.func.is_none());
+
+        // pin7: routed to FSPICLK (index 63).
+        g.write_u32(ENABLE_W1TS, 1 << 7).unwrap();
+        g.write_u32(FUNC_OUT_SEL + 7 * 4, 63).unwrap();
+        assert_eq!(g.gpio_routing(7).unwrap().func.as_deref(), Some("FSPICLK"));
+
+        // pin8: output driver off → input, func unknown (input matrix not tracked).
+        let r8 = g.gpio_routing(8).unwrap();
+        assert_eq!(r8.mode, GpioMode::Input);
+        assert!(r8.func.is_none());
+
+        // pin9: enabled but an unmapped signal index → AF with func null (no guess).
+        g.write_u32(ENABLE_W1TS, 1 << 9).unwrap();
+        g.write_u32(FUNC_OUT_SEL + 9 * 4, 200).unwrap();
+        let r9 = g.gpio_routing(9).unwrap();
+        assert_eq!(r9.mode, GpioMode::Af);
+        assert!(r9.func.is_none());
+
+        assert!(g.gpio_routing(PIN_COUNT).is_none(), "out-of-range pin");
     }
 }

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -135,11 +135,6 @@ pub struct Esp32c3I2c {
     tx_pop_count: usize,
     rx_fifo: RefCell<std::collections::VecDeque<u8>>,
     slaves: Vec<Box<dyn I2cDevice>>,
-    /// Bus-trace identity + shared log; when set, `attach_slave` wraps slaves
-    /// in `TracingI2cDevice` so this controller feeds the same bus trace the
-    /// generic `I2c` does (analyzer waveforms, I²C decoder).
-    bus_name: String,
-    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
     /// Set when a command-list run sets TRANS_COMPLETE & INT_ENA has it.
     irq_pending: bool,
     /// Interrupt-matrix source this instance asserts (29 for I2C0).
@@ -186,8 +181,6 @@ impl Esp32c3I2c {
             tx_pop_count: 0,
             rx_fifo: RefCell::new(std::collections::VecDeque::with_capacity(FIFO_CAPACITY)),
             slaves: Vec::new(),
-            bus_name: "i2c0".to_string(),
-            bus_log: None,
             irq_pending: false,
             intr_source_id: I2C0_INTR_SOURCE_ID,
             active_slave: None,
@@ -220,25 +213,11 @@ impl Esp32c3I2c {
         }
     }
 
-    /// Route this controller's transactions into the shared bus-trace log.
-    /// Must be called before `attach_slave` — already-attached slaves are
-    /// not retroactively wrapped.
-    pub fn set_bus_trace(&mut self, name: String, log: crate::bus::bus_trace::BusTraceLog) {
-        self.bus_name = name;
-        self.bus_log = Some(log);
-    }
-
-    /// Attach an `I2cDevice` slave. Slaves are matched by address bits at
-    /// transaction time; later additions take precedence on duplicate addresses.
-    pub fn attach_slave(&mut self, slave: Box<dyn I2cDevice>) {
-        let slave: Box<dyn I2cDevice> = match &self.bus_log {
-            Some(log) => Box::new(crate::bus::bus_trace::TracingI2cDevice::new(
-                self.bus_name.clone(),
-                log.clone(),
-                slave,
-            )),
-            None => slave,
-        };
+    /// Raw slave push — does NOT wrap for tracing. The only production caller is
+    /// the bus choke point [`crate::bus::SystemBus::attach_i2c_slave`], which
+    /// wraps first. Slaves are matched by address bits at transaction time;
+    /// later additions take precedence on duplicate addresses.
+    pub(crate) fn push_slave(&mut self, slave: Box<dyn I2cDevice>) {
         self.slaves.push(slave);
     }
 
@@ -906,7 +885,7 @@ mod tests {
     fn write_read_drives_attached_bmp280() {
         let mut p = Esp32c3I2c::new();
         // Default address 0x76.
-        p.attach_slave(Box::new(Bmp280::new(0x76)));
+        p.push_slave(Box::new(Bmp280::new(0x76)));
 
         // Canonical register-pointer read: set pointer to 0xD0 (chip-id), then
         // repeated-start and read one byte. CHIP_ID for BMP280 is 0x58.
@@ -957,7 +936,7 @@ mod tests {
         use crate::peripherals::components::Ssd1306;
 
         let mut p = Esp32c3I2c::new();
-        p.attach_slave(Box::new(Ssd1306::new(0x3C)));
+        p.push_slave(Box::new(Ssd1306::new(0x3C)));
 
         // Same transaction shape as the C3 OLED firmware:
         // RSTART; WRITE 3 (addr+W, control=0x40, one framebuffer byte); STOP.
@@ -985,7 +964,7 @@ mod tests {
         use crate::peripherals::components::Ssd1306;
 
         let mut p = Esp32c3I2c::new();
-        p.attach_slave(Box::new(Ssd1306::new(0x3C)));
+        p.push_slave(Box::new(Ssd1306::new(0x3C)));
 
         // Arduino-ESP32 / ESP-IDF may program SLAVE_ADDR with addr<<1 and
         // write only the SSD1306 payload bytes to TXFIFO: control byte 0x40,
@@ -1015,7 +994,7 @@ mod tests {
         use crate::peripherals::components::Ssd1306;
 
         let mut p = Esp32c3I2c::new();
-        p.attach_slave(Box::new(Ssd1306::new(0x3C)));
+        p.push_slave(Box::new(Ssd1306::new(0x3C)));
 
         // Arduino-ESP32 splits a write: address phase ends with END_DETECT,
         // then payload bytes are sent by a second command-list run.
@@ -1054,7 +1033,7 @@ mod tests {
         // multi-byte READ pulling sequential register-pointer data through the
         // RX FIFO.
         let mut p = Esp32c3I2c::new();
-        p.attach_slave(Box::new(Bmp280::new(0x76)));
+        p.push_slave(Box::new(Bmp280::new(0x76)));
 
         p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
         p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 2)).unwrap();
@@ -1081,8 +1060,12 @@ mod tests {
 
         let log = crate::bus::bus_trace::new_log();
         let mut p = Esp32c3I2c::new();
-        p.set_bus_trace("i2c0".to_string(), log.clone());
-        p.attach_slave(Box::new(Bmp280::new(0x76)));
+        // The bus choke point wraps before push; emulate it here.
+        p.push_slave(crate::bus::bus_trace::wrap_i2c(
+            "i2c0",
+            &log,
+            Box::new(Bmp280::new(0x76)),
+        ));
 
         // Same canonical pointer-write transaction as
         // write_read_drives_attached_bmp280: RSTART; WRITE 2; STOP.
@@ -1093,7 +1076,7 @@ mod tests {
         p.write_u32(REG_DATA, 0xD0).unwrap(); // pointer
         p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
 
-        let events = log.lock().unwrap().snapshot();
+        let events = log.snapshot();
         assert!(
             !events.is_empty(),
             "tracing wrapper must record I2C traffic on the C3 controller"

--- a/crates/core/src/peripherals/esp32c3/spi.rs
+++ b/crates/core/src/peripherals/esp32c3/spi.rs
@@ -178,8 +178,10 @@ impl Esp32c3Spi {
         }
     }
 
-    /// Attach a simulated device to this controller's bus.
-    pub fn attach_device(&mut self, device: Box<dyn SpiDevice>) {
+    /// Raw device push — does NOT wrap for tracing. The only production caller
+    /// is the bus choke point [`crate::bus::SystemBus::attach_spi_device`],
+    /// which wraps first.
+    pub(crate) fn push_device(&mut self, device: Box<dyn SpiDevice>) {
         self.attached_devices.push(device);
     }
 
@@ -516,7 +518,7 @@ mod tests {
             }
         }
         let mut s = Esp32c3Spi::new(SPI2_INTR_SOURCE_ID);
-        s.attach_device(Box::new(Xor(Vec::new())));
+        s.push_device(Box::new(Xor(Vec::new())));
         // MOSI = 0xEFBE_ADDE little-endian → bytes DE AD BE EF.
         s.write_u32(W0, 0xEFBE_ADDE).unwrap();
         s.write_u32(MS_DLEN, 32 - 1).unwrap();

--- a/crates/core/src/peripherals/esp32s3/gdma.rs
+++ b/crates/core/src/peripherals/esp32s3/gdma.rs
@@ -2930,7 +2930,7 @@ mod tests {
         let mut spi = Esp32s3Spi::new(22);
         let log = if with_device {
             let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-            spi.attach(Box::new(XorDevice { seen: seen.clone() }));
+            spi.push_device(Box::new(XorDevice { seen: seen.clone() }));
             Some(seen)
         } else {
             None

--- a/crates/core/src/peripherals/esp32s3/gpio.rs
+++ b/crates/core/src/peripherals/esp32s3/gpio.rs
@@ -384,6 +384,22 @@ impl Peripheral for Esp32s3Gpio {
         })
     }
 
+    fn gpio_routing(&self, pin: u8) -> Option<crate::peripherals::gpio::GpioRouting> {
+        use crate::peripherals::gpio::{GpioMode, GpioRouting};
+        if pin >= 32 {
+            return None;
+        }
+        // ENABLE is the output driver. The S3 GPIO model does not track the
+        // output matrix (FUNCn_OUT_SEL arrays are documented-but-unmodeled), so it
+        // reports direction only; func stays None (honest "can't say").
+        let mode = if (self.enable & (1u32 << pin)) != 0 {
+            GpioMode::Output
+        } else {
+            GpioMode::Input
+        };
+        Some(GpioRouting { mode, func: None })
+    }
+
     fn set_gpio_input(&mut self, pin: u8, level: bool) -> bool {
         if pin >= 32 {
             return false;

--- a/crates/core/src/peripherals/esp32s3/gpspi.rs
+++ b/crates/core/src/peripherals/esp32s3/gpspi.rs
@@ -243,11 +243,12 @@ impl Esp32s3Spi {
         }
     }
 
-    /// Attach a simulated device to this controller's bus (same surface as
-    /// `Esp32Spi::attach`; reachable from config-level external-device
-    /// wiring via `attach_esp32_external_devices` in `system/xtensa.rs`,
-    /// which downcasts to either SPI model).
-    pub fn attach(&mut self, device: Box<dyn SpiDevice>) {
+    /// Raw device push — does NOT wrap for tracing. The only production caller
+    /// is the bus choke point [`crate::bus::SystemBus::attach_spi_device`],
+    /// which wraps first. Reachable from config-level external-device wiring via
+    /// `attach_esp32_external_devices` in `system/xtensa.rs`, which downcasts to
+    /// either SPI model.
+    pub(crate) fn push_device(&mut self, device: Box<dyn SpiDevice>) {
         self.attached_devices.push(device);
     }
 
@@ -800,7 +801,7 @@ mod tests {
             }
         }
         let mut s = Esp32s3Spi::new(SPI3_SOURCE);
-        s.attach(Box::new(Xor(Vec::new())));
+        s.push_device(Box::new(Xor(Vec::new())));
         s.write_u32(DMA_CONF, SPI_DMA_TX_ENA | SPI_DMA_RX_ENA)
             .unwrap();
         s.write_u32(MS_DLEN, 4 * 8 - 1).unwrap();

--- a/crates/core/src/peripherals/esp32s3/i2c.rs
+++ b/crates/core/src/peripherals/esp32s3/i2c.rs
@@ -134,11 +134,6 @@ pub struct Esp32s3I2c {
     tx_fifo: std::collections::VecDeque<u8>,
     rx_fifo: RefCell<std::collections::VecDeque<u8>>,
     slaves: Vec<Box<dyn I2cDevice>>,
-    /// Bus-trace identity + shared log; when set, `attach_slave` wraps slaves
-    /// in `TracingI2cDevice` so this controller feeds the same bus trace the
-    /// generic `I2c` does (analyzer waveforms, I²C decoder).
-    bus_name: String,
-    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
     /// Set when a command-list run sets TRANS_COMPLETE & INT_ENA has it.
     /// Drained by `tick()` into the interrupt-matrix source aggregation.
     irq_pending: bool,
@@ -186,8 +181,6 @@ impl Esp32s3I2c {
             tx_fifo: std::collections::VecDeque::with_capacity(FIFO_CAPACITY),
             rx_fifo: RefCell::new(std::collections::VecDeque::with_capacity(FIFO_CAPACITY)),
             slaves: Vec::new(),
-            bus_name: "i2c0".to_string(),
-            bus_log: None,
             irq_pending: false,
             intr_source_id: I2C0_INTR_SOURCE_ID,
             active_slave: None,
@@ -222,25 +215,11 @@ impl Esp32s3I2c {
         }
     }
 
-    /// Route this controller's transactions into the shared bus-trace log.
-    /// Must be called before `attach_slave` — already-attached slaves are
-    /// not retroactively wrapped.
-    pub fn set_bus_trace(&mut self, name: String, log: crate::bus::bus_trace::BusTraceLog) {
-        self.bus_name = name;
-        self.bus_log = Some(log);
-    }
-
-    /// Attach an `I2cDevice` slave. Slaves are matched by address bits at
-    /// transaction time; later additions take precedence on duplicate addresses.
-    pub fn attach_slave(&mut self, slave: Box<dyn I2cDevice>) {
-        let slave: Box<dyn I2cDevice> = match &self.bus_log {
-            Some(log) => Box::new(crate::bus::bus_trace::TracingI2cDevice::new(
-                self.bus_name.clone(),
-                log.clone(),
-                slave,
-            )),
-            None => slave,
-        };
+    /// Raw slave push — does NOT wrap for tracing. The only production caller is
+    /// the bus choke point [`crate::bus::SystemBus::attach_i2c_slave`], which
+    /// wraps first. Slaves are matched by address bits at transaction time;
+    /// later additions take precedence on duplicate addresses.
+    pub(crate) fn push_slave(&mut self, slave: Box<dyn I2cDevice>) {
         self.slaves.push(slave);
     }
 
@@ -841,7 +820,7 @@ mod tests {
     #[test]
     fn write_read_drives_attached_tmp102() {
         let mut p = Esp32s3I2c::new();
-        p.attach_slave(Box::new(Tmp102::new()));
+        p.push_slave(Box::new(Tmp102::new()));
 
         // Build the canonical TMP102 read sequence:
         //   RSTART; WRITE 2 (addr+W, pointer=0); RSTART;
@@ -890,7 +869,7 @@ mod tests {
         // Set pointer to CONFIG (0x01) via WRITE, then READ should return
         // CONFIG canned value 0x60A0 high byte then low byte.
         let mut p = Esp32s3I2c::new();
-        p.attach_slave(Box::new(Tmp102::new()));
+        p.push_slave(Box::new(Tmp102::new()));
 
         p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
         p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, 2)).unwrap();

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -107,6 +107,7 @@ pub fn try_build(
     canonical_type: &str,
     p_cfg: &PeripheralConfig,
     manifest: &SystemManifest,
+    bus_trace: &crate::bus::bus_trace::BusTrace,
 ) -> anyhow::Result<Option<Box<dyn Peripheral>>> {
     let dev: Box<dyn Peripheral> = match canonical_type {
         "systick" | "arm_generictimer" => {
@@ -245,7 +246,11 @@ pub fn try_build(
                 match crate::peripherals::components::build_spi_device(&ext.r#type, &ext.config) {
                     Some(device) => {
                         tracing::info!("spi attach: '{}' (type=ir) -> '{}'", ext.id, p_cfg.id);
-                        spi.attach(device);
+                        // Wrap through the single trace helper (this factory
+                        // attaches before the peripheral is on the bus).
+                        spi.push_device(crate::bus::bus_trace::wrap_spi(
+                            &p_cfg.id, bus_trace, device,
+                        ));
                     }
                     None => {
                         tracing::warn!(

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -15,6 +15,29 @@
 use crate::SimResult;
 use std::str::FromStr;
 
+/// A pad's electrical role, derived from the GPIO model's direction/mode
+/// registers (never fabricated). `Unknown` is returned where a family's model
+/// cannot decide. Serialized lowercase for the `pin_routing` wasm export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GpioMode {
+    Input,
+    Output,
+    /// Pad handed to a peripheral (alternate function / routed via a GPIO matrix).
+    Af,
+    Analog,
+    Unknown,
+}
+
+/// Routing metadata for one GPIO pad: its [`GpioMode`] plus, when the model can
+/// resolve it, the peripheral signal `func` name (`"I2CEXT0_SDA"`, `"AF4"`, …).
+/// `func` is `None` when the model cannot name the signal — null over a guess.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct GpioRouting {
+    pub mode: GpioMode,
+    pub func: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GpioRegisterLayout {
@@ -455,6 +478,74 @@ impl crate::Peripheral for GpioPort {
         }
     }
 
+    fn gpio_routing(&self, pin: u8) -> Option<GpioRouting> {
+        if pin >= 32 {
+            return None;
+        }
+        // Mode from the SAME register truth read_gpio_pad reads.
+        let mode = match self {
+            Self::Stm32F1(g) => {
+                // CRL/CRH: 4 bits/pin. MODE==0 → input (CNF 00 = analog, else
+                // digital input); MODE!=0 → output, CNF 10/11 = alternate function.
+                let cr = g.read_reg(if pin < 8 { 0x00 } else { 0x04 });
+                let shift = ((pin % 8) * 4) as u32;
+                let m = (cr >> shift) & 0b11;
+                let cnf = (cr >> (shift + 2)) & 0b11;
+                if m == 0 {
+                    if cnf == 0b00 {
+                        GpioMode::Analog
+                    } else {
+                        GpioMode::Input
+                    }
+                } else if cnf >= 0b10 {
+                    GpioMode::Af
+                } else {
+                    GpioMode::Output
+                }
+            }
+            Self::Stm32V2(g) => {
+                // MODER: 00 input, 01 output, 10 alternate function, 11 analog.
+                match (g.read_reg(0x00) >> (pin * 2)) & 0b11 {
+                    0b00 => GpioMode::Input,
+                    0b01 => GpioMode::Output,
+                    0b10 => GpioMode::Af,
+                    _ => GpioMode::Analog,
+                }
+            }
+            // nRF52 / Kinetis: a plain DIR register (nRF DIR @0x514, Kinetis PDDR
+            // @0x14) — bit set = output, clear = input. No AF concept at the GPIO
+            // port (peripheral routing is elsewhere), so func stays None.
+            Self::Nrf52(g) => {
+                if (g.read_reg(0x514) & (1u32 << pin)) != 0 {
+                    GpioMode::Output
+                } else {
+                    GpioMode::Input
+                }
+            }
+            Self::Kinetis(g) => {
+                if (g.read_reg(0x14) & (1u32 << pin)) != 0 {
+                    GpioMode::Output
+                } else {
+                    GpioMode::Input
+                }
+            }
+        };
+        // func: STM32 V2 exposes an AFR nibble per AF pad → "AF<n>" (no full
+        // AF→signal table; that is out of scope). Everything else: None.
+        let func = match self {
+            Self::Stm32V2(g) if mode == GpioMode::Af => {
+                let (afr_off, sh) = if pin < 8 {
+                    (0x20, (pin * 4) as u32)
+                } else {
+                    (0x24, ((pin - 8) * 4) as u32)
+                };
+                Some(format!("AF{}", (g.read_reg(afr_off) >> sh) & 0xF))
+            }
+            _ => None,
+        };
+        Some(GpioRouting { mode, func })
+    }
+
     fn read_gpio_output(&self, pin: u8) -> Option<bool> {
         if pin >= 32 {
             return None;
@@ -497,6 +588,61 @@ impl crate::Peripheral for GpioPort {
 
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
+    }
+}
+
+#[cfg(test)]
+mod routing_tests {
+    use super::{GpioMode, GpioPort, GpioRegisterLayout};
+    use crate::Peripheral;
+
+    #[test]
+    fn stm32f1_routing_modes() {
+        let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Stm32F1);
+        // CRL nibbles: pin0 = MODE01/CNF00 (output), pin1 = MODE01/CNF10 (AF),
+        // pin2 = MODE00/CNF00 (analog input), pin3 = MODE00/CNF01 (float input).
+        let crl = 0b0001 | (0b1001 << 4) | (0b0000 << 8) | (0b0100 << 12);
+        g.write_u32(0x00, crl).unwrap();
+        assert_eq!(g.gpio_routing(0).unwrap().mode, GpioMode::Output);
+        let af = g.gpio_routing(1).unwrap();
+        assert_eq!(af.mode, GpioMode::Af);
+        assert!(af.func.is_none(), "F1 has no AF→signal index table");
+        assert_eq!(g.gpio_routing(2).unwrap().mode, GpioMode::Analog);
+        assert_eq!(g.gpio_routing(3).unwrap().mode, GpioMode::Input);
+        assert!(g.gpio_routing(32).is_none(), "out-of-range pin");
+    }
+
+    #[test]
+    fn stm32v2_routing_modes_and_af_number() {
+        let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2);
+        // MODER: pin0=01 output, pin1=10 AF, pin2=00 input, pin3=11 analog.
+        g.write_u32(0x00, 0b01 | (0b10 << 2) | (0b00 << 4) | (0b11 << 6))
+            .unwrap();
+        // AFRL: pin1 nibble (bits 4..8) = 4 → "AF4".
+        g.write_u32(0x20, 4 << 4).unwrap();
+        assert_eq!(g.gpio_routing(0).unwrap().mode, GpioMode::Output);
+        let af = g.gpio_routing(1).unwrap();
+        assert_eq!(af.mode, GpioMode::Af);
+        assert_eq!(af.func.as_deref(), Some("AF4"));
+        assert_eq!(g.gpio_routing(2).unwrap().mode, GpioMode::Input);
+        assert_eq!(g.gpio_routing(3).unwrap().mode, GpioMode::Analog);
+    }
+
+    #[test]
+    fn nrf52_routing_from_dir() {
+        let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Nrf52);
+        g.write_u32(0x514, 1 << 5).unwrap(); // DIR: pin5 output
+        assert_eq!(g.gpio_routing(5).unwrap().mode, GpioMode::Output);
+        assert!(g.gpio_routing(5).unwrap().func.is_none());
+        assert_eq!(g.gpio_routing(6).unwrap().mode, GpioMode::Input);
+    }
+
+    #[test]
+    fn kinetis_routing_from_pddr() {
+        let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Kinetis);
+        g.write_u32(0x14, 1 << 3).unwrap(); // PDDR: pin3 output
+        assert_eq!(g.gpio_routing(3).unwrap().mode, GpioMode::Output);
+        assert_eq!(g.gpio_routing(4).unwrap().mode, GpioMode::Input);
     }
 }
 

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -597,6 +597,9 @@ mod routing_tests {
     use crate::Peripheral;
 
     #[test]
+    // Zero-valued nibbles are kept explicit: each term documents one pin's slot
+    // in the register layout the assertions below depend on.
+    #[allow(clippy::identity_op)]
     fn stm32f1_routing_modes() {
         let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Stm32F1);
         // CRL nibbles: pin0 = MODE01/CNF00 (output), pin1 = MODE01/CNF10 (AF),
@@ -613,6 +616,8 @@ mod routing_tests {
     }
 
     #[test]
+    // Zero-valued fields kept explicit — same rationale as stm32f1_routing_modes.
+    #[allow(clippy::identity_op)]
     fn stm32v2_routing_modes_and_af_number() {
         let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2);
         // MODER: pin0=01 output, pin1=10 AF, pin2=00 input, pin3=11 analog.

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -111,13 +111,6 @@ pub struct F1I2c {
     rxne_consumed: Cell<bool>,
     #[serde(skip)]
     read_dr_consumed: Cell<bool>,
-    /// Bus name + shared trace log for the universal logic-analyzer (set via
-    /// `I2c::set_bus_trace`). `None` (default) keeps `attach` unwrapped —
-    /// existing behaviour for every caller that doesn't opt in.
-    #[serde(skip)]
-    bus_name: String,
-    #[serde(skip)]
-    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
 }
 
 impl Default for F1I2c {
@@ -143,8 +136,6 @@ impl Default for F1I2c {
             stop_requested: false,
             rxne_consumed: Cell::new(false),
             read_dr_consumed: Cell::new(true),
-            bus_name: String::new(),
-            bus_log: None,
         }
     }
 }
@@ -398,13 +389,6 @@ pub struct L4I2c {
     /// data byte is loaded into TXDR (write) — mirrors F1's START→DR ordering.
     #[serde(skip)]
     start_armed: bool,
-    /// Bus name + shared trace log for the universal logic-analyzer (set via
-    /// `I2c::set_bus_trace`). `None` (default) keeps `attach` unwrapped —
-    /// existing behaviour for every caller that doesn't opt in.
-    #[serde(skip)]
-    bus_name: String,
-    #[serde(skip)]
-    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
 }
 
 impl Default for L4I2c {
@@ -428,8 +412,6 @@ impl Default for L4I2c {
             is_reading: false,
             autoend: false,
             start_armed: false,
-            bus_name: String::new(),
-            bus_log: None,
         }
     }
 }
@@ -673,13 +655,6 @@ pub struct KinetisI2c {
     attached_devices: Vec<RefCell<Box<dyn I2cDevice>>>,
     #[serde(skip)]
     current_target: Option<usize>,
-    /// Bus name + shared trace log for the universal logic-analyzer (set via
-    /// `I2c::set_bus_trace`). `None` (default) keeps `attach` unwrapped —
-    /// existing behaviour for every caller that doesn't opt in.
-    #[serde(skip)]
-    bus_name: String,
-    #[serde(skip)]
-    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
 }
 
 impl Default for KinetisI2c {
@@ -703,8 +678,6 @@ impl Default for KinetisI2c {
             is_reading: false,
             attached_devices: Vec::new(),
             current_target: None,
-            bus_name: String::new(),
-            bus_log: None,
         }
     }
 }
@@ -884,54 +857,30 @@ impl I2c {
         }
     }
 
-    /// Set the bus name + a clone of the shared bus-trace log (universal logic
-    /// analyzer, see `crate::bus::bus_trace`). Must be called before `attach`
-    /// for an attached device to be wrapped into the log — devices already
-    /// attached are unaffected.
-    pub fn set_bus_trace(&mut self, name: String, log: crate::bus::bus_trace::BusTraceLog) {
-        match self {
-            I2c::Stm32F1(i) => {
-                i.bus_name = name;
-                i.bus_log = Some(log);
-            }
-            I2c::Stm32L4(i) => {
-                i.bus_name = name;
-                i.bus_log = Some(log);
-            }
-            I2c::Kinetis(i) => {
-                i.bus_name = name;
-                i.bus_log = Some(log);
-            }
-        }
+    /// Attach a slave to a bare (off-bus) controller, wrapping it into `trace`.
+    /// The trace handle is mandatory, so there is no untraced attach — this is
+    /// the off-bus counterpart of the on-bus choke point
+    /// [`crate::bus::SystemBus::attach_i2c_slave`], and both funnel through the
+    /// one wrap helper `bus_trace::wrap_i2c`. Used by standalone tests that
+    /// drive an `I2c` directly (no `SystemBus`).
+    pub fn attach_traced(
+        &mut self,
+        bus_name: &str,
+        trace: &crate::bus::bus_trace::BusTrace,
+        device: Box<dyn I2cDevice>,
+    ) {
+        self.push_slave(crate::bus::bus_trace::wrap_i2c(bus_name, trace, device));
     }
 
-    pub fn attach(&mut self, device: Box<dyn I2cDevice>) {
-        let wrap = |name: &str,
-                    log: &Option<crate::bus::bus_trace::BusTraceLog>,
-                    d: Box<dyn I2cDevice>|
-         -> Box<dyn I2cDevice> {
-            match log {
-                Some(l) => Box::new(crate::bus::bus_trace::TracingI2cDevice::new(
-                    name.to_string(),
-                    l.clone(),
-                    d,
-                )),
-                None => d,
-            }
-        };
+    /// Raw slave push — does NOT wrap for tracing. The only caller is the bus
+    /// choke point [`crate::bus::SystemBus::attach_i2c_slave`], which wraps the
+    /// device first; nothing else should attach directly (that would bypass the
+    /// universal bus trace).
+    pub(crate) fn push_slave(&mut self, device: Box<dyn I2cDevice>) {
         match self {
-            Self::Stm32F1(i) => {
-                let d = wrap(&i.bus_name, &i.bus_log, device);
-                i.attached_devices.push(RefCell::new(d));
-            }
-            Self::Stm32L4(i) => {
-                let d = wrap(&i.bus_name, &i.bus_log, device);
-                i.attached_devices.push(RefCell::new(d));
-            }
-            Self::Kinetis(i) => {
-                let d = wrap(&i.bus_name, &i.bus_log, device);
-                i.attached_devices.push(RefCell::new(d));
-            }
+            Self::Stm32F1(i) => i.attached_devices.push(RefCell::new(device)),
+            Self::Stm32L4(i) => i.attached_devices.push(RefCell::new(device)),
+            Self::Kinetis(i) => i.attached_devices.push(RefCell::new(device)),
         }
     }
 
@@ -1074,7 +1023,7 @@ mod tests {
         use crate::peripherals::components::Ssd1306;
 
         let mut i2c = I2c::new();
-        i2c.attach(Box::new(Ssd1306::new(0x3C)));
+        i2c.push_slave(Box::new(Ssd1306::new(0x3C)));
 
         // Summary mode: metadata present, bytes omitted.
         let summary = i2c.inspect(0x4000_5400, "i2c1", &InspectOpts::default());
@@ -1158,7 +1107,7 @@ mod tests {
     fn test_i2c_full_transfer_flow() {
         use crate::peripherals::components::Mpu6050;
         let mut i2c = I2c::new();
-        i2c.attach(Box::new(Mpu6050::new(0x50)));
+        i2c.push_slave(Box::new(Mpu6050::new(0x50)));
 
         i2c.write(0x01, 0x01).unwrap(); // START
         for _ in 0..10 {
@@ -1199,7 +1148,7 @@ mod tests {
         let mut i2c = I2c::new();
         let mut sensor = Adxl345::new(0x53);
         sensor.set_sample(256, -128, 64);
-        i2c.attach(Box::new(sensor));
+        i2c.push_slave(Box::new(sensor));
 
         i2c.write(0x00, 0x01).unwrap();
         i2c.write(0x01, 0x01).unwrap();
@@ -1267,7 +1216,7 @@ mod tests {
     fn test_i2c_single_byte_read_advances_device_once() {
         let reads = Arc::new(AtomicUsize::new(0));
         let mut i2c = I2c::new();
-        i2c.attach(Box::new(CountingDevice::new(0x42, reads.clone())));
+        i2c.push_slave(Box::new(CountingDevice::new(0x42, reads.clone())));
 
         i2c.write(0x01, 0x01).unwrap();
         for _ in 0..10 {
@@ -1356,7 +1305,7 @@ mod tests {
         }
 
         let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
-        i2c.attach(Box::new(WriteCounter {
+        i2c.push_slave(Box::new(WriteCounter {
             address: 0x3C,
             writes: writes.clone(),
         }));
@@ -1381,12 +1330,11 @@ mod tests {
 
     #[test]
     fn i2c_attach_wraps_device_into_shared_log() {
-        use crate::bus::bus_trace::{new_log, BusPayload};
+        use crate::bus::bus_trace::{new_log, wrap_i2c, BusPayload};
         use crate::Peripheral;
 
         let log = new_log();
         let mut i2c = I2c::Kinetis(KinetisI2c::default());
-        i2c.set_bus_trace("i2c1".into(), log.clone());
 
         // device at 0x1E
         struct D;
@@ -1399,7 +1347,8 @@ mod tests {
             }
             fn write(&mut self, _: u8) {}
         }
-        i2c.attach(Box::new(D));
+        // The bus choke point wraps before push; emulate it here.
+        i2c.push_slave(wrap_i2c("i2c1", &log, Box::new(D)));
 
         // Drive START + addr(W) + one data byte through the Kinetis register
         // model via the public `Peripheral::write` MMIO path (the same path
@@ -1409,7 +1358,7 @@ mod tests {
         i2c.write(0x04, 0x3C).unwrap(); // addr 0x1E + W -> selects device, start()
         i2c.write(0x04, 0xAF).unwrap(); // data -> device.write -> wrapper records
 
-        let snap = log.lock().unwrap().snapshot();
+        let snap = log.snapshot();
         assert!(snap
             .iter()
             .any(|e| matches!(&e.payload, BusPayload::I2c { byte, .. } if *byte == 0xAF)));

--- a/crates/core/src/peripherals/kit/ctx.rs
+++ b/crates/core/src/peripherals/kit/ctx.rs
@@ -17,8 +17,6 @@ use labwired_config::ExternalDevice;
 
 use crate::bus::SystemBus;
 use crate::peripherals::adc::Adc;
-use crate::peripherals::esp32c3::i2c::Esp32c3I2c;
-use crate::peripherals::esp32c3::spi::Esp32c3Spi;
 use crate::peripherals::i2c::{I2c, I2cDevice};
 use crate::peripherals::spi::{Spi, SpiDevice};
 use crate::peripherals::uart::Uart;
@@ -106,24 +104,13 @@ impl<'a> AttachCtx<'a> {
     /// buses. Going through this method lets one kit serve a sensor on either
     /// family without caring which bus the system.yaml wired it to.
     pub fn attach_i2c_device(&mut self, device: Box<dyn I2cDevice>) -> Result<()> {
-        let ext = self.ext;
-        let idx = self
-            .bus
-            .find_peripheral_index_by_name(&ext.connection)
-            .ok_or_else(|| missing_connection_err(ext))?;
-        let any = self.bus.peripherals[idx]
-            .dev
-            .as_any_mut()
-            .ok_or_else(|| downcast_err(ext))?;
-        if let Some(i2c) = any.downcast_mut::<I2c>() {
-            i2c.attach(device);
-            return Ok(());
-        }
-        if let Some(c3) = any.downcast_mut::<Esp32c3I2c>() {
-            c3.attach_slave(device);
-            return Ok(());
-        }
-        Err(wrong_transport_err(ext, "I2C"))
+        // Funnel through the single bus choke point, which wraps the device in
+        // the shared bus trace before handing it to whichever I²C controller the
+        // `connection:` resolves to. There is no untraced attach path.
+        let connection = self.ext.connection.clone();
+        self.bus
+            .attach_i2c_slave(&connection, device)
+            .map_err(|_| wrong_transport_err(self.ext, "I2C"))
     }
 
     /// Attach an [`SpiDevice`] to whichever SPI controller the `connection:`
@@ -131,24 +118,11 @@ impl<'a> AttachCtx<'a> {
     /// model. This mirrors [`Self::attach_i2c_device`] for mixed-controller
     /// systems.
     pub fn attach_spi_device(&mut self, device: Box<dyn SpiDevice>) -> Result<()> {
-        let ext = self.ext;
-        let idx = self
-            .bus
-            .find_peripheral_index_by_name(&ext.connection)
-            .ok_or_else(|| missing_connection_err(ext))?;
-        let any = self.bus.peripherals[idx]
-            .dev
-            .as_any_mut()
-            .ok_or_else(|| downcast_err(ext))?;
-        if let Some(spi) = any.downcast_mut::<Spi>() {
-            spi.attach(device);
-            return Ok(());
-        }
-        if let Some(c3) = any.downcast_mut::<Esp32c3Spi>() {
-            c3.attach_device(device);
-            return Ok(());
-        }
-        Err(wrong_transport_err(ext, "SPI"))
+        // Funnel through the single bus choke point (see `attach_i2c_device`).
+        let connection = self.ext.connection.clone();
+        self.bus
+            .attach_spi_device(&connection, device)
+            .map_err(|_| wrong_transport_err(self.ext, "SPI"))
     }
 
     /// Acquire the ADC peripheral declared in the system.yaml `connection:`

--- a/crates/core/src/peripherals/nrf52/factory.rs
+++ b/crates/core/src/peripherals/nrf52/factory.rs
@@ -158,7 +158,9 @@ pub fn try_build(
                         ext.r#type,
                         p_cfg.id
                     );
-                    inst.attach_i2c(crate::bus::bus_trace::wrap_i2c(&p_cfg.id, bus_trace, device));
+                    inst.attach_i2c(crate::bus::bus_trace::wrap_i2c(
+                        &p_cfg.id, bus_trace, device,
+                    ));
                 } else if let Some(device) =
                     crate::peripherals::components::build_spi_device(&ext.r#type, &ext.config)
                 {
@@ -168,7 +170,9 @@ pub fn try_build(
                         ext.r#type,
                         p_cfg.id
                     );
-                    inst.attach_spi(crate::bus::bus_trace::wrap_spi(&p_cfg.id, bus_trace, device));
+                    inst.attach_spi(crate::bus::bus_trace::wrap_spi(
+                        &p_cfg.id, bus_trace, device,
+                    ));
                 } else {
                     tracing::warn!(
                         "serial-instance attach skipped: unknown device type '{}' \

--- a/crates/core/src/peripherals/nrf52/factory.rs
+++ b/crates/core/src/peripherals/nrf52/factory.rs
@@ -21,6 +21,7 @@ pub fn try_build(
     canonical_type: &str,
     p_cfg: &PeripheralConfig,
     manifest: &SystemManifest,
+    bus_trace: &crate::bus::bus_trace::BusTrace,
 ) -> Option<Box<dyn Peripheral>> {
     let dev: Box<dyn Peripheral> = match canonical_type {
         "nrf52840_uart" => Box::new(crate::peripherals::nrf52::uarte::Nrf52Uarte::new()),
@@ -119,7 +120,12 @@ pub fn try_build(
                             ext.r#type,
                             p_cfg.id
                         );
-                        twim.attach(device);
+                        // Wrap through the single trace helper before the raw
+                        // push — same contract as the bus choke point, since the
+                        // factory attaches before the peripheral is on the bus.
+                        twim.push_slave(crate::bus::bus_trace::wrap_i2c(
+                            &p_cfg.id, bus_trace, device,
+                        ));
                     }
                     None => {
                         tracing::warn!(
@@ -152,7 +158,7 @@ pub fn try_build(
                         ext.r#type,
                         p_cfg.id
                     );
-                    inst.attach_i2c(device);
+                    inst.attach_i2c(crate::bus::bus_trace::wrap_i2c(&p_cfg.id, bus_trace, device));
                 } else if let Some(device) =
                     crate::peripherals::components::build_spi_device(&ext.r#type, &ext.config)
                 {
@@ -162,7 +168,7 @@ pub fn try_build(
                         ext.r#type,
                         p_cfg.id
                     );
-                    inst.attach_spi(device);
+                    inst.attach_spi(crate::bus::bus_trace::wrap_spi(&p_cfg.id, bus_trace, device));
                 } else {
                     tracing::warn!(
                         "serial-instance attach skipped: unknown device type '{}' \

--- a/crates/core/src/peripherals/nrf52/serial_instance.rs
+++ b/crates/core/src/peripherals/nrf52/serial_instance.rs
@@ -47,12 +47,17 @@ impl Nrf52SerialInstance {
         }
     }
 
+    /// Attach an I²C slave. `dev` is expected to already be trace-wrapped by the
+    /// caller (the nRF52 factory wraps via `bus_trace::wrap_i2c`); this only
+    /// forwards to the TWIM's raw push.
     pub fn attach_i2c(&mut self, dev: Box<dyn I2cDevice>) {
-        self.twim.attach(dev);
+        self.twim.push_slave(dev);
     }
 
+    /// Attach a SPI device (already trace-wrapped by the caller); forwards to the
+    /// SPIM's raw push.
     pub fn attach_spi(&mut self, dev: Box<dyn SpiDevice>) {
-        self.spim.attach(dev);
+        self.spim.push_device(dev);
     }
 
     fn active(&self) -> u32 {

--- a/crates/core/src/peripherals/nrf52/twim.rs
+++ b/crates/core/src/peripherals/nrf52/twim.rs
@@ -238,9 +238,11 @@ impl Nrf52Twim {
         Self::default()
     }
 
-    /// Attach an I2C device.  The device is matched by its 7-bit address when
-    /// `ADDRESS` is set and a STARTTX/STARTRX task fires.
-    pub fn attach(&mut self, device: Box<dyn I2cDevice>) {
+    /// Raw slave push — does NOT wrap for tracing. Callers are the bus choke
+    /// point [`crate::bus::SystemBus::attach_i2c_slave`] and the nRF52 serial
+    /// mux, both of which wrap first. The device is matched by its 7-bit address
+    /// when `ADDRESS` is set and a STARTTX/STARTRX task fires.
+    pub(crate) fn push_slave(&mut self, device: Box<dyn I2cDevice>) {
         self.attached_devices.push(RefCell::new(device));
     }
 
@@ -916,7 +918,7 @@ mod tests {
     #[test]
     fn twim_tx_reads_ram_and_sets_amount() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x48, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x48, vec![])));
         let mut bus = FlatRam::new();
 
         let tx_base: u64 = 0x2000_0000;
@@ -988,7 +990,7 @@ mod tests {
     fn twim_tx_delivers_correct_bytes_to_device() {
         let tx_data: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x10, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x10, vec![])));
         let mut bus = FlatRam::new();
         let tx_base: u64 = 0x2000_0200;
         bus.write_slice(tx_base, &tx_data);
@@ -1016,7 +1018,7 @@ mod tests {
     fn twim_rx_fills_ram_and_sets_amount() {
         let read_seq: Vec<u8> = vec![0x11, 0x22, 0x33, 0x44];
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x68, read_seq.clone())));
+        t.push_slave(Box::new(RecordingDevice::new(0x68, read_seq.clone())));
         let mut bus = FlatRam::new();
 
         let rx_base: u64 = 0x2000_0300;
@@ -1088,7 +1090,7 @@ mod tests {
     #[test]
     fn short_lasttx_stop_fires_stopped() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x20, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x20, vec![])));
         let mut bus = FlatRam::new();
         let tx_base: u64 = 0x2000_0500;
         bus.write_slice(tx_base, &[0x01, 0x02]);
@@ -1115,7 +1117,7 @@ mod tests {
     #[test]
     fn short_lasttx_suspend_fires_suspended() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x76, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x76, vec![])));
         let mut bus = FlatRam::new();
         let tx_base: u64 = 0x2000_0500;
         bus.write_slice(tx_base, &[0xD0]); // register address byte
@@ -1153,7 +1155,7 @@ mod tests {
     fn twim_resume_after_suspend_starts_followon_rx() {
         let read_seq: Vec<u8> = vec![0x60]; // BME280 chip-id
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x76, read_seq.clone())));
+        t.push_slave(Box::new(RecordingDevice::new(0x76, read_seq.clone())));
         let mut bus = FlatRam::new();
         let tx_base: u64 = 0x2000_0500;
         let rx_base: u64 = 0x2000_0600;
@@ -1204,7 +1206,7 @@ mod tests {
     #[test]
     fn short_lastrx_stop_fires_stopped() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x21, vec![0xAA, 0xBB])));
+        t.push_slave(Box::new(RecordingDevice::new(0x21, vec![0xAA, 0xBB])));
         let mut bus = FlatRam::new();
         let rx_base: u64 = 0x2000_0600;
 
@@ -1230,7 +1232,7 @@ mod tests {
     fn short_lasttx_startrx_chains_into_rx() {
         let read_seq: Vec<u8> = vec![0x55, 0x66];
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x30, read_seq.clone())));
+        t.push_slave(Box::new(RecordingDevice::new(0x30, read_seq.clone())));
         let mut bus = FlatRam::new();
 
         let tx_base: u64 = 0x2000_0700;
@@ -1275,7 +1277,7 @@ mod tests {
     #[test]
     fn short_lastrx_starttx_chains_into_tx() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x31, vec![0xAA])));
+        t.push_slave(Box::new(RecordingDevice::new(0x31, vec![0xAA])));
         let mut bus = FlatRam::new();
 
         let tx_base: u64 = 0x2000_0900;
@@ -1335,7 +1337,7 @@ mod tests {
         write32(&mut t, OFF_ADDRESS, 0x48);
         write32(&mut t, OFF_TXD_PTR, tx_base as u32);
         write32(&mut t, OFF_TXD_MAXCNT, 1);
-        t.attach(Box::new(RecordingDevice::new(0x48, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x48, vec![])));
         write32(&mut t, OFF_TASKS_STARTTX, 1);
         run_leg(&mut t, &mut bus);
 
@@ -1359,7 +1361,7 @@ mod tests {
     #[test]
     fn twim_tx_zero_length() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x48, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x48, vec![])));
         let mut bus = FlatRam::new();
 
         write32(&mut t, OFF_ENABLE, 6);
@@ -1385,7 +1387,7 @@ mod tests {
     #[test]
     fn twim_rx_zero_length() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x48, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x48, vec![])));
         let mut bus = FlatRam::new();
 
         write32(&mut t, OFF_ENABLE, 6);
@@ -1411,7 +1413,7 @@ mod tests {
     #[test]
     fn irq_raised_when_inten_set_and_event_fires() {
         let mut t = Nrf52Twim::new();
-        t.attach(Box::new(RecordingDevice::new(0x48, vec![])));
+        t.push_slave(Box::new(RecordingDevice::new(0x48, vec![])));
         let mut bus = FlatRam::new();
         let tx_base: u64 = 0x2000_0C00;
         bus.write_slice(tx_base, &[0xAB]);

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -540,14 +540,6 @@ pub struct Spi {
 
     #[serde(skip)]
     pub attached_devices: Vec<Box<dyn SpiDevice>>,
-
-    /// Bus name + shared trace log for the universal logic-analyzer (set via
-    /// `Spi::set_bus_trace`). `None` (default) keeps `attach` unwrapped —
-    /// existing behaviour for every caller that doesn't opt in.
-    #[serde(skip)]
-    bus_name: String,
-    #[serde(skip)]
-    bus_log: Option<crate::bus::bus_trace::BusTraceLog>,
 }
 
 impl core::fmt::Debug for Spi {
@@ -610,24 +602,11 @@ impl Spi {
         self.cr1_mask = Some(mask);
     }
 
-    /// Set the bus name + a clone of the shared bus-trace log (universal logic
-    /// analyzer, see `crate::bus::bus_trace`). Must be called before `attach`
-    /// for an attached device to be wrapped into the log — devices already
-    /// attached are unaffected.
-    pub fn set_bus_trace(&mut self, name: String, log: crate::bus::bus_trace::BusTraceLog) {
-        self.bus_name = name;
-        self.bus_log = Some(log);
-    }
-
-    pub fn attach(&mut self, device: Box<dyn SpiDevice>) {
-        let device = match &self.bus_log {
-            Some(log) => Box::new(crate::bus::bus_trace::TracingSpiDevice::new(
-                self.bus_name.clone(),
-                log.clone(),
-                device,
-            )) as Box<dyn SpiDevice>,
-            None => device,
-        };
+    /// Raw device push — does NOT wrap for tracing. The only caller is the bus
+    /// choke point [`crate::bus::SystemBus::attach_spi_device`], which wraps the
+    /// device first; nothing else should attach directly (that would bypass the
+    /// universal bus trace).
+    pub(crate) fn push_device(&mut self, device: Box<dyn SpiDevice>) {
         self.attached_devices.push(device);
     }
 
@@ -1340,7 +1319,7 @@ mod tests {
     #[test]
     fn fifo_packs_u16_dr_write_into_two_frames() {
         let mut spi = Spi::new_with_layout(SpiRegisterLayout::Stm32Fifo);
-        spi.attach(Box::new(Capture { rx: Vec::new() }));
+        spi.push_device(Box::new(Capture { rx: Vec::new() }));
         spi.write(0x00, 0x40).unwrap(); // CR1: SPE
         spi.write_u16(0x0C, 0x00AB).unwrap(); // 16-bit DR write, DS=8 (reset 0x0700)
         assert_eq!(
@@ -1354,7 +1333,7 @@ mod tests {
     #[test]
     fn fifo_u8_dr_write_is_one_frame() {
         let mut spi = Spi::new_with_layout(SpiRegisterLayout::Stm32Fifo);
-        spi.attach(Box::new(Capture { rx: Vec::new() }));
+        spi.push_device(Box::new(Capture { rx: Vec::new() }));
         spi.write(0x00, 0x40).unwrap();
         spi.write(0x0C, 0xAB).unwrap(); // 8-bit DR write
         assert_eq!(captured(&spi), vec![0xAB], "8-bit DR ⇒ 1 frame");
@@ -1365,7 +1344,7 @@ mod tests {
     #[test]
     fn plain_stm32_does_not_pack() {
         let mut spi = Spi::new_with_layout(SpiRegisterLayout::Stm32);
-        spi.attach(Box::new(Capture { rx: Vec::new() }));
+        spi.push_device(Box::new(Capture { rx: Vec::new() }));
         spi.write(0x00, 0x40).unwrap();
         spi.write_u16(0x0C, 0x00AB).unwrap();
         assert_eq!(captured(&spi), vec![0xAB], "non-FIFO ⇒ 1 frame");
@@ -1570,7 +1549,7 @@ mod tests {
         }
 
         let mut spi = Spi::new_with_layout(SpiRegisterLayout::Nrf52Spim);
-        spi.attach(Box::new(EchoSlave));
+        spi.push_device(Box::new(EchoSlave));
         let mut bus = FlatRamBus::new();
 
         let tx_base: u64 = 0x2000_0400;
@@ -2007,7 +1986,7 @@ mod tests {
     #[test]
     fn stm32h5_tx_engine_transmits_and_completes() {
         let mut spi = h5_master(2);
-        spi.attach(Box::new(Capture { rx: Vec::new() }));
+        spi.push_device(Box::new(Capture { rx: Vec::new() }));
         h5_write(&mut spi, 0x00, (1 << 0) | (1 << 9) | (1 << 12)); // SPE|CSTART|SSI
         h5_write(&mut spi, 0x20, 0x11);
         assert_eq!(h5_read(&spi, 0x14), 0x0001_0012, "CTSIZE 2→1, TXP|TXTF");
@@ -2022,7 +2001,7 @@ mod tests {
     #[test]
     fn stm32h5_txdr_ignored_when_disabled() {
         let mut spi = h5_master(2);
-        spi.attach(Box::new(Capture { rx: Vec::new() }));
+        spi.push_device(Box::new(Capture { rx: Vec::new() }));
         h5_write(&mut spi, 0x20, 0xAB);
         assert_eq!(h5_read(&spi, 0x14), 0x0000_1002, "SR untouched");
         assert!(captured(&spi).is_empty(), "nothing transmitted");
@@ -2034,7 +2013,7 @@ mod tests {
     #[test]
     fn stm32h5_byte_and_halfword_txdr_access_is_one_frame() {
         let mut spi = h5_master(0); // TSIZE=0: endless
-        spi.attach(Box::new(Capture { rx: Vec::new() }));
+        spi.push_device(Box::new(Capture { rx: Vec::new() }));
         h5_write(&mut spi, 0x00, (1 << 0) | (1 << 9) | (1 << 12));
         spi.write(0x20, 0x5A).unwrap(); // byte access → one 8-bit frame
         spi.write_u16(0x20, 0x1234).unwrap(); // halfword access → one frame

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -88,39 +88,17 @@ pub fn attach_esp32_external_devices(
             }
         }
 
-        let idx = bus
-            .find_peripheral_index_by_name(&ext.connection)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "External device '{}' references missing connection '{}'",
-                    ext.id,
-                    ext.connection
-                )
-            })?;
-        let any = bus.peripherals[idx].dev.as_any_mut().ok_or_else(|| {
+        // Funnel through the single bus choke point, which wraps `panel` in the
+        // shared bus trace and dispatches to whichever SPI controller the
+        // `connection:` resolves to (classic `Esp32Spi` spi2/spi3 or the GP-SPI
+        // `Esp32s3Spi` spi2_s3/spi3_s3). No untraced attach path.
+        bus.attach_spi_device(&ext.connection, panel).map_err(|_| {
             anyhow::anyhow!(
-                "External device '{}' connection '{}' cannot be downcast",
+                "External device '{}' connection '{}' is not an ESP32 SPI peripheral",
                 ext.id,
                 ext.connection
             )
         })?;
-        // ESP32-classic buses register `Esp32Spi` controllers (spi2/spi3);
-        // ESP32-S3 buses register the GP-SPI model `Esp32s3Spi`
-        // (spi2_s3/spi3_s3). Both expose the same `attach` surface, so a
-        // manifest can wire an external device to either family's SPI.
-        if let Some(spi) = any.downcast_mut::<crate::peripherals::esp32::spi::Esp32Spi>() {
-            spi.attach(panel);
-        } else if let Some(spi) =
-            any.downcast_mut::<crate::peripherals::esp32s3::gpspi::Esp32s3Spi>()
-        {
-            spi.attach(panel);
-        } else {
-            anyhow::bail!(
-                "External device '{}' connection '{}' is not an ESP32 SPI peripheral",
-                ext.id,
-                ext.connection
-            );
-        }
     }
     Ok(())
 }
@@ -525,9 +503,15 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     // canonical register-pointer device, lets firmware drive a full
     // write-pointer / repeated-start / read transaction and read back genuine
     // device data (CHIP_ID 0x58). Source 49 = ETS_I2C_EXT0_INTR_SOURCE.
-    let mut i2c0 = crate::peripherals::esp32::i2c::Esp32I2c::new();
-    i2c0.attach_slave(Box::new(crate::peripherals::components::Bmp280::new(0x76)));
+    let i2c0 = crate::peripherals::esp32::i2c::Esp32I2c::new();
     bus.add_peripheral("i2c0", 0x3FF5_3000, 0x1000, None, Box::new(i2c0));
+    // Register first, then attach through the single bus choke point so the
+    // slave is wrapped into the shared bus trace (universal logic analyzer).
+    bus.attach_i2c_slave(
+        "i2c0",
+        Box::new(crate::peripherals::components::Bmp280::new(0x76)),
+    )
+    .expect("i2c0 just registered as Esp32I2c");
 
     // SYSCON (TRM §13.2) — system controller. Owns SYSCLK_CONF, TICK_CONF,
     // SARADC_CTRL, FRONT_END_MEM_PD, and the RND_DATA TRNG output the BROM

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -628,18 +628,21 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
     // I2C0 carries board-specific I2C slaves the factory does not model: TMP102
     // always, plus an opt-in PCA9685 (LABWIRED_ESP32S3_PCA9685) for the
     // SpiceDispenser servos. Built directly so the slaves are attached.
-    let mut i2c0 = Esp32s3I2c::new();
-    // Feed the shared bus-trace log (universal logic analyzer) before any
-    // attach, so every slave below is wrapped into the trace.
-    i2c0.set_bus_trace("i2c0".to_string(), bus.bus_trace.clone());
-    i2c0.attach_slave(Box::new(Tmp102::new()));
+    let i2c0 = Esp32s3I2c::new();
+    // Register first, then attach every slave through the single bus choke point
+    // so each is wrapped into the shared bus trace (universal logic analyzer) —
+    // no per-callsite set_bus_trace ordering to get wrong.
+    bus.add_peripheral("i2c0", I2C0_BASE as u64, I2C0_SIZE, None, Box::new(i2c0));
+    bus.attach_i2c_slave("i2c0", Box::new(Tmp102::new()))
+        .expect("i2c0 just registered as Esp32s3I2c");
     if std::env::var("LABWIRED_ESP32S3_PCA9685").is_ok() {
-        i2c0.attach_slave(Box::new(
-            crate::peripherals::components::pca9685::Pca9685::new(),
-        ));
+        bus.attach_i2c_slave(
+            "i2c0",
+            Box::new(crate::peripherals::components::pca9685::Pca9685::new()),
+        )
+        .expect("i2c0 just registered as Esp32s3I2c");
         eprintln!("configure_xtensa_esp32s3: attached PCA9685 @ 0x40 on I2C0");
     }
-    bus.add_peripheral("i2c0", I2C0_BASE as u64, I2C0_SIZE, None, Box::new(i2c0));
 }
 
 /// Register the default thunk set for esp-hal hello-world boot.

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2492,17 +2492,8 @@ pub mod integration_tests {
         let mut lcd = crate::peripherals::components::Pcd8544::new("GPIO10".into(), "GPIO2".into());
         crate::peripherals::spi::SpiDevice::set_dc_source(&mut lcd, odr_addr, bit);
 
-        let spi_idx = bus
-            .find_peripheral_index_by_name("spi2")
-            .expect("spi2 peripheral");
-        {
-            let spi = bus.peripherals[spi_idx]
-                .dev
-                .as_any_mut()
-                .and_then(|any| any.downcast_mut::<crate::peripherals::esp32c3::spi::Esp32c3Spi>())
-                .expect("esp32c3 spi2");
-            spi.attach_device(Box::new(lcd));
-        }
+        bus.attach_spi_device("spi2", Box::new(lcd))
+            .expect("spi2 is an esp32c3 SPI controller");
 
         const GPIO_BASE: u64 = 0x6000_4000;
         const GPIO_OUT_W1TS: u64 = 0x08;
@@ -2518,6 +2509,9 @@ pub mod integration_tests {
         bus.write_u32(SPI2_BASE + SPI_MS_DLEN, 8 - 1).unwrap();
         bus.write_u32(SPI2_BASE + SPI_CMD, SPI_USR).unwrap();
 
+        let spi_idx = bus
+            .find_peripheral_index_by_name("spi2")
+            .expect("spi2 peripheral");
         let spi = bus.peripherals[spi_idx]
             .dev
             .as_any()
@@ -2720,5 +2714,108 @@ pub mod integration_tests {
             "kit-attached OLED traffic on the C3 controller must reach the bus trace"
         );
         assert!(events.iter().all(|event| event.bus == "i2c0"));
+    }
+
+    /// The choke point, not the callsites: a config-built system records bus
+    /// traffic for TWO different controller families (the generic STM32 `I2c`
+    /// and the ESP32-C3 command-list `Esp32c3I2c`) with no per-family
+    /// `set_bus_trace` anywhere. Both attach their OLED through the single
+    /// `attach_i2c_slave` funnel; if either family's dispatch arm were missing,
+    /// `attach_i2c_slave` would have returned `Err` at build time — never a
+    /// silently untraced bus.
+    #[test]
+    fn test_bus_trace_choke_point_covers_two_families() {
+        fn build_with_oled(i2c_type: &str, profile: Option<&str>) -> crate::bus::SystemBus {
+            let mut i2c_cfg = HashMap::new();
+            if let Some(p) = profile {
+                i2c_cfg.insert(
+                    "profile".to_string(),
+                    serde_yaml::Value::String(p.to_string()),
+                );
+            }
+            let chip = ChipDescriptor {
+                schema_version: "1.0".to_string(),
+                name: "two-family-trace".to_string(),
+                arch: Arch::RiscV,
+                core: None,
+                flash: MemoryRange {
+                    base: 0x4200_0000,
+                    size: "4MB".to_string(),
+                },
+                ram: MemoryRange {
+                    base: 0x3FC8_0000,
+                    size: "400KB".to_string(),
+                },
+                reset_vector_offset: 0,
+                atomic_register_aliases: false,
+                memory_regions: Vec::new(),
+                peripherals: vec![PeripheralConfig {
+                    id: "i2c0".to_string(),
+                    r#type: i2c_type.to_string(),
+                    base_address: 0x4000_5400,
+                    size: Some("4KB".to_string()),
+                    irq: None,
+                    clock: None,
+                    config: i2c_cfg,
+                }],
+                pins: Default::default(),
+            };
+            let mut oled_config = HashMap::new();
+            oled_config.insert(
+                "i2c_address".to_string(),
+                serde_yaml::Value::Number(0x3C.into()),
+            );
+            let manifest = SystemManifest {
+                walk_deleted: false,
+                schema_version: "1.0".to_string(),
+                name: "two-family-trace".to_string(),
+                chip: "two-family-trace".to_string(),
+                memory_overrides: HashMap::new(),
+                external_devices: vec![labwired_config::ExternalDevice {
+                    id: "oled".to_string(),
+                    r#type: "oled-ssd1306-128x32".to_string(),
+                    connection: "i2c0".to_string(),
+                    config: oled_config,
+                }],
+                board_io: Vec::new(),
+                debug_uart: None,
+                peripherals: Vec::new(),
+            };
+            crate::bus::SystemBus::from_config(&chip, &manifest).unwrap()
+        }
+
+        // Family A: ESP32-C3 command-list controller — drive the canonical
+        // SSD1306 command prologue (RSTART; WRITE 2; STOP).
+        let mut c3 = build_with_oled("esp32c3_i2c", None);
+        const BASE: u64 = 0x4000_5400;
+        let cmd = |opcode: u32, byte_num: u32| (opcode << 11) | byte_num;
+        c3.write_u32(BASE + 0x58, cmd(6, 0)).unwrap(); // RSTART
+        c3.write_u32(BASE + 0x58 + 4, cmd(1, 2)).unwrap(); // WRITE 2
+        c3.write_u32(BASE + 0x58 + 8, cmd(2, 0)).unwrap(); // STOP
+        c3.write_u32(BASE + 0x1C, 0x78).unwrap(); // addr 0x3C<<1
+        c3.write_u32(BASE + 0x1C, 0x00).unwrap(); // control byte
+        c3.write_u32(BASE + 0x04, 1 << 5).unwrap(); // CTR.TRANS_START
+        let c3_events = c3.bus_trace_snapshot();
+
+        // Family B: generic STM32 `I2c` (Kinetis byte-oriented layout) — drive
+        // START, address, one data byte through the MMIO register path.
+        let mut km = build_with_oled("i2c", Some("kinetis"));
+        km.write_u8(BASE + 0x02, 0x30).unwrap(); // C1 = MST|TX (START)
+        km.write_u8(BASE + 0x04, 0x78).unwrap(); // D = addr 0x3C<<1 (select+start)
+        km.write_u8(BASE + 0x04, 0x00).unwrap(); // D = data → device.write → trace
+        let km_events = km.bus_trace_snapshot();
+
+        assert!(
+            !c3_events.is_empty(),
+            "ESP32-C3 family must record bus trace through the choke point"
+        );
+        assert!(
+            !km_events.is_empty(),
+            "generic STM32 I2c family must record bus trace through the choke point"
+        );
+        assert!(c3_events.iter().all(|e| e.bus == "i2c0"));
+        assert!(km_events.iter().all(|e| e.bus == "i2c0"));
+        // Every event carries the additive cycle stamp (0 here — no machine step).
+        assert!(c3_events.iter().all(|e| e.cycle == 0));
     }
 }

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -163,7 +163,7 @@ mod logic_capture_tests {
         step_n(&mut machine, gap);
         let second = machine.logic_read_edges(first.cursor);
         assert_eq!(second.edges.len(), 1, "only the new edge since the cursor");
-        assert_eq!(second.edges[0].value, false);
+        assert!(!second.edges[0].value);
 
         // Re-reading with the same cursor yields nothing.
         let again = machine.logic_read_edges(second.cursor);

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -1,0 +1,201 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Tests for in-engine logic-analyzer edge capture (`crate::logic_capture`).
+
+#[cfg(test)]
+mod logic_capture_tests {
+    use crate::cpu::CortexM;
+    use crate::logic_capture::{LogicCapture, LogicEdge, LOGIC_RING_CAPACITY, LOGIC_SAMPLE_INTERVAL};
+    use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+    use crate::{Bus, Machine};
+
+    const GPIO_BASE: u64 = 0x5000_0000;
+    /// V2-layout register offsets used below.
+    const MODER: u64 = 0x00;
+    const ODR: u64 = 0x14;
+    /// A NOP-equivalent Thumb instruction (`movs r0, #0`, LE bytes 00 20) the
+    /// CPU chews through so `step()` advances cycles without side effects.
+    const RAM_BASE: u64 = 0x2000_0000;
+
+    /// Build a Cortex-M machine with a spare V2 GPIO wired at `GPIO_BASE`, its
+    /// pin 0 configured as a push-pull output, and the CPU pointed at a slab of
+    /// harmless instructions in RAM so `step()` makes deterministic progress.
+    fn machine_with_gpio() -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        bus.add_peripheral(
+            "gpio_test",
+            GPIO_BASE,
+            0x400,
+            None,
+            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2)),
+        );
+        let mut machine = Machine::new(cpu, bus);
+
+        // MODER pin0 = 0b01 (output) so read_gpio_pad(0) reflects ODR bit 0.
+        machine.bus.write_u32(GPIO_BASE + MODER, 0x0000_0001).unwrap();
+
+        // Fill a RAM window with `movs r0, #0` and run from it.
+        for i in 0..256u64 {
+            let byte = if i % 2 == 0 { 0x00 } else { 0x20 };
+            machine.bus.write_u8(RAM_BASE + i, byte).unwrap();
+        }
+        machine.cpu.pc = RAM_BASE as u32;
+        machine
+    }
+
+    fn set_pin0(machine: &mut Machine<CortexM>, level: bool) {
+        machine
+            .bus
+            .write_u32(GPIO_BASE + ODR, if level { 1 } else { 0 })
+            .unwrap();
+    }
+
+    fn step_n(machine: &mut Machine<CortexM>, n: usize) {
+        for _ in 0..n {
+            machine.step().unwrap();
+        }
+    }
+
+    /// Drive a toggle sequence through the step loop and collect the edges.
+    /// Returns `(edges, dropped, now_cycle)`.
+    fn run_scenario(machine: &mut Machine<CortexM>) -> (Vec<LogicEdge>, u64, u64) {
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        let initial = machine.logic_watch(&[Some((idx, 0))]);
+        assert_eq!(initial, vec![Some(false)], "pin starts low");
+
+        // Space each toggle well past one sample interval so a sample lands
+        // between transitions and each edge is captured exactly once.
+        let gap = (LOGIC_SAMPLE_INTERVAL as usize) * 3;
+        step_n(machine, gap); // low (== initial): no edge
+        set_pin0(machine, true);
+        step_n(machine, gap); // -> high
+        set_pin0(machine, false);
+        step_n(machine, gap); // -> low
+        set_pin0(machine, true);
+        step_n(machine, gap); // -> high
+
+        let batch = machine.logic_read_edges(0);
+        (batch.edges, batch.dropped, machine.logic_now_cycle())
+    }
+
+    #[test]
+    fn captures_gpio_transitions_with_monotonic_cycles() {
+        let mut machine = machine_with_gpio();
+        let (edges, dropped, now) = run_scenario(&mut machine);
+
+        assert_eq!(dropped, 0, "no overflow in this small scenario");
+        let values: Vec<bool> = edges.iter().map(|e| e.value).collect();
+        assert_eq!(values, vec![true, false, true], "high, low, high");
+
+        // All on channel 0, cycles strictly increasing and non-decreasing vs now.
+        for e in &edges {
+            assert_eq!(e.ch, 0);
+            assert!(e.cycle <= now);
+        }
+        for w in edges.windows(2) {
+            assert!(w[1].cycle > w[0].cycle, "cycles strictly increase");
+        }
+    }
+
+    #[test]
+    fn identical_runs_produce_byte_identical_edge_streams() {
+        let mut a = machine_with_gpio();
+        let mut b = machine_with_gpio();
+        let (edges_a, _, _) = run_scenario(&mut a);
+        let (edges_b, _, _) = run_scenario(&mut b);
+        assert_eq!(edges_a, edges_b, "determinism: same firmware + watch => same edges");
+    }
+
+    #[test]
+    fn unresolvable_refs_are_never_sampled() {
+        let mut machine = machine_with_gpio();
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        // Channel 0 unresolvable (None), channel 1 a real pad.
+        let initial = machine.logic_watch(&[None, Some((idx, 0))]);
+        assert_eq!(initial, vec![None, Some(false)]);
+
+        let gap = (LOGIC_SAMPLE_INTERVAL as usize) * 3;
+        step_n(&mut machine, gap);
+        set_pin0(&mut machine, true);
+        step_n(&mut machine, gap);
+
+        let batch = machine.logic_read_edges(0);
+        assert!(batch.edges.iter().all(|e| e.ch == 1), "only channel 1 emits");
+        assert_eq!(batch.edges.len(), 1);
+    }
+
+    #[test]
+    fn cursor_returns_only_new_edges() {
+        let mut machine = machine_with_gpio();
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        machine.logic_watch(&[Some((idx, 0))]);
+        let gap = (LOGIC_SAMPLE_INTERVAL as usize) * 3;
+
+        set_pin0(&mut machine, true);
+        step_n(&mut machine, gap);
+        let first = machine.logic_read_edges(0);
+        assert_eq!(first.edges.len(), 1);
+
+        set_pin0(&mut machine, false);
+        step_n(&mut machine, gap);
+        let second = machine.logic_read_edges(first.cursor);
+        assert_eq!(second.edges.len(), 1, "only the new edge since the cursor");
+        assert_eq!(second.edges[0].value, false);
+
+        // Re-reading with the same cursor yields nothing.
+        let again = machine.logic_read_edges(second.cursor);
+        assert!(again.edges.is_empty());
+    }
+
+    /// Ring-buffer overflow at the capture layer: push more edges than capacity,
+    /// assert some were dropped and the newest are retained.
+    #[test]
+    fn ring_buffer_drops_oldest_on_overflow() {
+        let mut cap = LogicCapture::new();
+        cap.install(&[Some((0, 0))], &[Some(false)]);
+
+        let overflow = 100usize;
+        let total = LOGIC_RING_CAPACITY + overflow;
+        // Toggle on every sample so each sample records exactly one edge; space
+        // samples one interval apart so each lands in a fresh cycle bucket.
+        for i in 0..total {
+            let cycle = (i as u64 + 1) * LOGIC_SAMPLE_INTERVAL;
+            let level = i % 2 == 0;
+            cap.sample(cycle, |_, _| Some(level));
+        }
+
+        let batch = cap.read_edges(0);
+        assert_eq!(batch.dropped, overflow as u64, "oldest edges dropped");
+        assert_eq!(batch.edges.len(), LOGIC_RING_CAPACITY, "ring is full, not larger");
+        // Newest edge is the last sample taken.
+        let last = batch.edges.last().unwrap();
+        assert_eq!(last.cycle, total as u64 * LOGIC_SAMPLE_INTERVAL);
+        assert_eq!(batch.cursor, total as u64);
+    }
+
+    /// A pad that reads back as unknown (`None`) records no edges for that
+    /// channel, even across many samples.
+    #[test]
+    fn unknown_pad_records_no_edges() {
+        let mut cap = LogicCapture::new();
+        cap.install(&[Some((0, 0))], &[None]);
+        for i in 0..10 {
+            cap.sample((i + 1) * LOGIC_SAMPLE_INTERVAL, |_, _| None);
+        }
+        let batch = cap.read_edges(0);
+        assert!(batch.edges.is_empty());
+        assert_eq!(batch.dropped, 0);
+    }
+}

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -7,7 +7,9 @@
 #[cfg(test)]
 mod logic_capture_tests {
     use crate::cpu::CortexM;
-    use crate::logic_capture::{LogicCapture, LogicEdge, LOGIC_RING_CAPACITY, LOGIC_SAMPLE_INTERVAL};
+    use crate::logic_capture::{
+        LogicCapture, LogicEdge, LOGIC_RING_CAPACITY, LOGIC_SAMPLE_INTERVAL,
+    };
     use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
     use crate::{Bus, Machine};
 
@@ -35,7 +37,10 @@ mod logic_capture_tests {
         let mut machine = Machine::new(cpu, bus);
 
         // MODER pin0 = 0b01 (output) so read_gpio_pad(0) reflects ODR bit 0.
-        machine.bus.write_u32(GPIO_BASE + MODER, 0x0000_0001).unwrap();
+        machine
+            .bus
+            .write_u32(GPIO_BASE + MODER, 0x0000_0001)
+            .unwrap();
 
         // Fill a RAM window with `movs r0, #0` and run from it.
         for i in 0..256u64 {
@@ -109,7 +114,10 @@ mod logic_capture_tests {
         let mut b = machine_with_gpio();
         let (edges_a, _, _) = run_scenario(&mut a);
         let (edges_b, _, _) = run_scenario(&mut b);
-        assert_eq!(edges_a, edges_b, "determinism: same firmware + watch => same edges");
+        assert_eq!(
+            edges_a, edges_b,
+            "determinism: same firmware + watch => same edges"
+        );
     }
 
     #[test]
@@ -129,7 +137,10 @@ mod logic_capture_tests {
         step_n(&mut machine, gap);
 
         let batch = machine.logic_read_edges(0);
-        assert!(batch.edges.iter().all(|e| e.ch == 1), "only channel 1 emits");
+        assert!(
+            batch.edges.iter().all(|e| e.ch == 1),
+            "only channel 1 emits"
+        );
         assert_eq!(batch.edges.len(), 1);
     }
 
@@ -178,7 +189,11 @@ mod logic_capture_tests {
 
         let batch = cap.read_edges(0);
         assert_eq!(batch.dropped, overflow as u64, "oldest edges dropped");
-        assert_eq!(batch.edges.len(), LOGIC_RING_CAPACITY, "ring is full, not larger");
+        assert_eq!(
+            batch.edges.len(),
+            LOGIC_RING_CAPACITY,
+            "ring is full, not larger"
+        );
         // Newest edge is the last sample taken.
         let last = batch.edges.last().unwrap();
         assert_eq!(last.cycle, total as u64 * LOGIC_SAMPLE_INTERVAL);

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -3,6 +3,8 @@ pub mod esp32;
 #[cfg(test)]
 pub mod integration;
 #[cfg(test)]
+pub mod logic_capture;
+#[cfg(test)]
 pub mod nrf52;
 #[cfg(test)]
 pub mod rp2040;

--- a/crates/core/tests/e2e_esp32_epaper.rs
+++ b/crates/core/tests/e2e_esp32_epaper.rs
@@ -76,15 +76,8 @@ fn firmware_drives_panel_to_ereader_bitmap() {
 
     // Attach SSD1680 panel to SPI3 — mirrors what
     // `WasmSimulator::attach_esp32_external_devices` does for the playground.
-    let spi3_idx = bus
-        .find_peripheral_index_by_name("spi3")
-        .expect("spi3 must be registered by configure_xtensa_esp32");
-    let any = bus.peripherals[spi3_idx]
-        .dev
-        .as_any_mut()
-        .expect("spi3 supports downcast");
-    let spi = any.downcast_mut::<Esp32Spi>().expect("spi3 is Esp32Spi");
-    spi.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+    bus.attach_spi_device("spi3", Box::new(Ssd1680Tricolor290::new("GPIO5")))
+        .expect("spi3 is an Esp32Spi controller");
 
     bus.refresh_peripheral_index();
 

--- a/crates/core/tests/e2e_external_arduino_esp32_in_sim.rs
+++ b/crates/core/tests/e2e_external_arduino_esp32_in_sim.rs
@@ -44,14 +44,16 @@ fn external_arduino_esp32_firmware_drives_panel_in_sim() {
     let cpu = configure_xtensa_esp32(&mut bus);
 
     // Wire the SSD1680 to spi3, same as the e-paper lab.
-    let spi3_idx = bus
-        .find_peripheral_index_by_name("spi3")
-        .expect("spi3 registered");
-    let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
-    let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
-    spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+    bus.attach_spi_device("spi3", Box::new(Ssd1680Tricolor290::new("GPIO5")))
+        .expect("spi3 is an Esp32Spi controller");
     // Capture every byte on the wire so we can diagnose missing panel state.
-    spi3.enable_byte_capture(256);
+    {
+        let spi3_idx = bus.find_peripheral_index_by_name("spi3").unwrap();
+        let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
+        any.downcast_mut::<Esp32Spi>()
+            .unwrap()
+            .enable_byte_capture(256);
+    }
 
     bus.refresh_peripheral_index();
     let mut machine = Machine::new(cpu, bus);

--- a/crates/core/tests/e2e_spi3_dc_epaper.rs
+++ b/crates/core/tests/e2e_spi3_dc_epaper.rs
@@ -60,9 +60,8 @@ fn attach_panel_with_dc(bus: &mut SystemBus, panel: Box<dyn SpiDevice>) -> usize
         .expect("configure_xtensa_esp32 registers spi3");
     let mut panel = panel;
     panel.set_dc_source(dc_src.0, dc_src.1);
-    let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
-    let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
-    spi3.attach(panel);
+    bus.attach_spi_device("spi3", panel)
+        .expect("spi3 is an Esp32Spi controller");
     bus.refresh_peripheral_index();
     spi3_idx
 }

--- a/crates/core/tests/hardware_fidelity.rs
+++ b/crates/core/tests/hardware_fidelity.rs
@@ -134,8 +134,7 @@ fn test_spi_fidelity_in_machine() {
 #[test]
 fn test_i2c_fidelity_in_machine() {
     let mut bus = SystemBus::new();
-    let mut i2c = I2c::new();
-    i2c.attach(Box::new(Mpu6050::new(0x50)));
+    let i2c = I2c::new();
     bus.peripherals.push(PeripheralEntry {
         name: "I2C1".to_string(),
         base: 0x40005400,
@@ -147,6 +146,9 @@ fn test_i2c_fidelity_in_machine() {
         clock_gate: None,
     });
     bus.refresh_peripheral_index();
+    // Attach through the single bus choke point (wraps into the shared trace).
+    bus.attach_i2c_slave("I2C1", Box::new(Mpu6050::new(0x50)))
+        .expect("I2C1 is a generic I2c controller");
 
     // 1. START
     bus.write_u8(0x40005401, 0x01).unwrap(); // CR1 START=1 (bit 8)

--- a/crates/core/tests/i2c_component.rs
+++ b/crates/core/tests/i2c_component.rs
@@ -12,7 +12,10 @@ use labwired_core::Peripheral;
 fn test_mpu6050_who_am_i() {
     let mut i2c = I2c::new();
     let mpu = Mpu6050::new(0x68);
-    i2c.attach(Box::new(mpu));
+    // Off-bus attach still goes through the mandatory-trace helper (no untraced
+    // attach path); the throwaway trace is unused by this model-level test.
+    let trace = labwired_core::bus::bus_trace::new_log();
+    i2c.attach_traced("i2c1", &trace, Box::new(mpu));
 
     // 1. START
     i2c.write(0x00, 0x01).unwrap(); // PE (Peripheral Enable)

--- a/crates/core/tests/runtime_snapshot.rs
+++ b/crates/core/tests/runtime_snapshot.rs
@@ -130,12 +130,8 @@ fn machine_runtime_snapshot_roundtrips_through_serialization() {
     let cpu = configure_xtensa_esp32(&mut bus);
 
     // Attach an SSD1680 to spi3 so the snapshot covers the SPI-device path.
-    let spi3_idx = bus
-        .find_peripheral_index_by_name("spi3")
-        .expect("spi3 registered");
-    let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
-    let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
-    spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+    bus.attach_spi_device("spi3", Box::new(Ssd1680Tricolor290::new("GPIO5")))
+        .expect("spi3 is an Esp32Spi controller");
     bus.refresh_peripheral_index();
 
     let mut machine = Machine::new(cpu, bus);
@@ -214,12 +210,8 @@ fn agentdeck_snapshot_file_restores_post_paint_panel() {
     // Build a fresh machine matching the the reference firmware topology.
     let mut bus = SystemBus::new();
     let cpu = configure_xtensa_esp32(&mut bus);
-    let spi3_idx = bus
-        .find_peripheral_index_by_name("spi3")
-        .expect("spi3 registered");
-    let any = bus.peripherals[spi3_idx].dev.as_any_mut().unwrap();
-    let spi3 = any.downcast_mut::<Esp32Spi>().unwrap();
-    spi3.attach(Box::new(Ssd1680Tricolor290::new("GPIO5")));
+    bus.attach_spi_device("spi3", Box::new(Ssd1680Tricolor290::new("GPIO5")))
+        .expect("spi3 is an Esp32Spi controller");
     bus.refresh_peripheral_index();
 
     let boxed: Box<dyn Cpu> = Box::new(cpu);

--- a/crates/hw-oracle/src/lib.rs
+++ b/crates/hw-oracle/src/lib.rs
@@ -730,8 +730,7 @@ fn capture_sim_state(case: &OracleCase) -> OracleState {
     {
         use labwired_core::peripherals::esp32s3::i2c::{Esp32s3I2c, I2C0_BASE, I2C0_SIZE};
         use labwired_core::peripherals::esp32s3::tmp102::Tmp102;
-        let mut i2c0 = Esp32s3I2c::new();
-        i2c0.attach_slave(Box::new(Tmp102::new()));
+        let i2c0 = Esp32s3I2c::new();
         bus.add_peripheral(
             "oracle_i2c0",
             I2C0_BASE as u64,
@@ -739,6 +738,9 @@ fn capture_sim_state(case: &OracleCase) -> OracleState {
             None,
             Box::new(i2c0),
         );
+        // Attach through the single bus choke point (wraps into the shared trace).
+        bus.attach_i2c_slave("oracle_i2c0", Box::new(Tmp102::new()))
+            .expect("oracle_i2c0 just registered as Esp32s3I2c");
     }
 
     let mut cpu = XtensaLx7::new();

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -88,6 +88,104 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&samples).unwrap_or(JsValue::NULL)
     }
 
+    /// Arm deterministic, in-engine logic-analyzer capture for a set of GPIO
+    /// pads. Same ref shape as [`sample_logic_signals`]:
+    /// `[{ kind: "gpio", peripheral, pin }]`.
+    ///
+    /// Each ref is resolved ONCE here (to a peripheral index + pin) so the
+    /// in-loop sampling path never does a string lookup. Unresolvable refs
+    /// (unknown peripheral / non-gpio kind) get `value: null` and are never
+    /// sampled. Installing a watch set resets the capture ring and cursor.
+    ///
+    /// Returns the initial state as `[{ ...ref, ch, value }]` where `ch` is the
+    /// channel index used in edge records (the ref's position) and `value` is
+    /// the current pad level (`bool | null`). Poll new edges with
+    /// [`read_logic_edges`]. Pass an empty array to disarm capture.
+    #[wasm_bindgen]
+    pub fn watch_logic_signals(&mut self, refs: JsValue) -> JsValue {
+        #[derive(serde::Deserialize)]
+        struct Ref {
+            kind: String,
+            peripheral: String,
+            pin: u8,
+        }
+
+        let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
+            Ok(r) => r,
+            Err(_) => return JsValue::NULL,
+        };
+
+        let machine = self.machine.as_mut().unwrap();
+        let resolved: Vec<Option<(usize, u8)>> = refs
+            .iter()
+            .map(|r| {
+                if r.kind == "gpio" {
+                    machine
+                        .bus
+                        .find_peripheral_index_by_name(&r.peripheral)
+                        .map(|idx| (idx, r.pin))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let initial = machine.logic_watch(&resolved);
+
+        let out: Vec<serde_json::Value> = refs
+            .iter()
+            .zip(initial)
+            .enumerate()
+            .map(|(ch, (r, value))| {
+                serde_json::json!({
+                    "kind": r.kind,
+                    "peripheral": r.peripheral,
+                    "pin": r.pin,
+                    "ch": ch,
+                    "value": value,
+                })
+            })
+            .collect();
+
+        serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
+    }
+
+    /// Drain logic edges captured since `cursor`. Pass `0` right after
+    /// [`watch_logic_signals`], then pass back the returned `cursor` to receive
+    /// only newer edges.
+    ///
+    /// Returns `{ cursor, dropped, nowCycle, edges: [{ ch, cycle, value }] }`:
+    /// - `cursor` — monotonic edge sequence number to pass back next time.
+    /// - `dropped` — edges lost to ring-buffer overflow since the watch armed.
+    /// - `nowCycle` — current engine cycle, to extend flat traces to "now".
+    /// - `edges` — transitions oldest-first; `cycle` is the engine cycle.
+    ///
+    /// Cycles are emitted as JS numbers (f64), matching the sub-2^53 engine
+    /// cycle counts the playground runs to.
+    #[wasm_bindgen]
+    pub fn read_logic_edges(&self, cursor: f64) -> JsValue {
+        let machine = self.machine.as_ref().unwrap();
+        let batch = machine.logic_read_edges(cursor as u64);
+        let edges: Vec<serde_json::Value> = batch
+            .edges
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "ch": e.ch,
+                    "cycle": e.cycle as f64,
+                    "value": e.value,
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "cursor": batch.cursor as f64,
+            "dropped": batch.dropped as f64,
+            "nowCycle": machine.logic_now_cycle() as f64,
+            "edges": edges,
+        });
+        serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
+    }
+
     /// Get a peripheral's full state snapshot as JSON.
     #[wasm_bindgen]
     pub fn get_peripheral_snapshot(&self, name: &str) -> JsValue {

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -88,6 +88,70 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&samples).unwrap_or(JsValue::NULL)
     }
 
+    /// Resolve the signal routing of GPIO pads for the logic analyzer — the
+    /// engine's honest answer to "what is this pad wired to?", replacing UI-side
+    /// pin-NAME regex guessing.
+    ///
+    /// Input: `[{ kind: "gpio", peripheral, pin }]`.
+    /// Output: the same refs each extended with:
+    ///   * `mode`: `"input" | "output" | "af" | "analog" | "unknown"` — derived
+    ///     from the same register truth `read_gpio_pad` reads (STM32 F1 CRL/CRH,
+    ///     V2 MODER+AFR, ESP32-family GPIO-matrix ENABLE + FUNCn_OUT_SEL, nRF52
+    ///     DIR, Kinetis PDDR). `"unknown"` where a family cannot say.
+    ///   * `func`: best-effort signal NAME (`"I2CEXT0_SDA"`, `"FSPICLK"`,
+    ///     `"AF4"`, …) or `null` — never a guess.
+    #[wasm_bindgen]
+    pub fn pin_routing(&self, refs: JsValue) -> JsValue {
+        #[derive(serde::Deserialize)]
+        struct Ref {
+            kind: String,
+            peripheral: String,
+            pin: u8,
+        }
+
+        let machine = self.machine.as_ref().unwrap();
+        let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
+            Ok(r) => r,
+            Err(_) => return JsValue::NULL,
+        };
+
+        let out: Vec<serde_json::Value> = refs
+            .iter()
+            .map(|r| {
+                let routing = if r.kind == "gpio" {
+                    machine
+                        .bus
+                        .find_peripheral_index_by_name(&r.peripheral)
+                        .and_then(|idx| machine.bus.peripherals[idx].dev.gpio_routing(r.pin))
+                } else {
+                    None
+                };
+                let (mode, func) = match routing {
+                    Some(rt) => (
+                        serde_json::to_value(rt.mode)
+                            .unwrap_or_else(|_| serde_json::Value::String("unknown".into())),
+                        rt.func
+                            .map(serde_json::Value::String)
+                            .unwrap_or(serde_json::Value::Null),
+                    ),
+                    None => (
+                        serde_json::Value::String("unknown".into()),
+                        serde_json::Value::Null,
+                    ),
+                };
+                serde_json::json!({
+                    "kind": r.kind,
+                    "peripheral": r.peripheral,
+                    "pin": r.pin,
+                    "mode": mode,
+                    "func": func,
+                })
+            })
+            .collect();
+
+        serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
+    }
+
     /// Get a peripheral's full state snapshot as JSON.
     #[wasm_bindgen]
     pub fn get_peripheral_snapshot(&self, name: &str) -> JsValue {

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,15 +7,15 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-04 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-09 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -28,7 +28,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — conformance 16/16; mmio 16/16; GPIO P0 22/0, P1 23/0; onboarding 22/22; POWER 10/0, SPIS 19/0, TWIS 20/0, RTC0 12/0, TIMER0 16/0; SPIM0/CCM/full-register clean
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -36,7 +36,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — rides the nrf52840 full register sweep (16/16) re-confirmed 2026-06-17
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-07-04 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -70,7 +70,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-09 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,20 +7,20 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-04 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-09 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-07-04 | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-04 | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-10 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -80,7 +80,8 @@ boards:
     # not cover (it exercised UARTE EasyDMA, not the legacy TXD shifter); the reset
     # sweep (conformance/mmio/GPIO/POWER/SPIS/TWIS/RTC/TIMER) is unaffected. No live
     # SWD re-capture of the legacy-UART TX sequence this session (no bench board).
-    drift_ack: 2026-07-04
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -106,7 +107,8 @@ boards:
     # drift_ack note — success-path live re-capture tracked there.
     # 2026-07-04: rides the nrf52840 legacy-UART (UART0/UARTE0) TXD/TXDRDY model;
     # same silicon. Additive, no live re-capture. See the nrf52840 drift_ack note.
-    drift_ack: 2026-07-04
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -162,7 +164,8 @@ boards:
     # STM32 H5 I2C register/transaction engines are untouched; h563_mmio_diff +
     # h563_conformance remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -245,7 +248,8 @@ boards:
     # per-cycle timer freshness as the non-scheduler path and is covered by the
     # generated Arduino OLED ROM-boot regression; no reset-register silicon change.
     # 2026-07-09: universal logic analyzer — additive read_gpio_pad pad probe (ENABLE-mask direction) + I2C controller wraps attached slaves in TracingI2cDevice (shared bus trace) and signals START to the selected slave at address match so traces carry decodable address frames. Register map/reset values byte-for-byte untouched; conformance/e2e unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -286,7 +290,8 @@ boards:
     # STM32 L4 I2C register/transaction engines are untouched; l476_mmio_diff +
     # l476_parity_diff remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -335,7 +340,8 @@ boards:
     # unchanged; input injection is additive and only active when a board IO source
     # drives a pin. No live re-capture this session.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -381,7 +387,8 @@ boards:
     # STM32 F1 I2C register/transaction engines are untouched; stm32f1_mmio_diff +
     # f103_conformance remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -434,7 +441,8 @@ boards:
     # STM32 F4 I2C register/transaction engines are untouched; stm32f4_mmio_diff +
     # stm32f4_exec_oracle remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -482,7 +490,8 @@ boards:
     # scheduler-driven. S3 reset values/MMIO semantics are unchanged; unit coverage
     # asserts default scheduler behaviour and snapshot compatibility.
     # 2026-07-09: universal logic analyzer — additive read_gpio_pad pad probe (ENABLE-mask direction) + I2C controller wraps attached slaves in TracingI2cDevice (shared bus trace) and signals START to the selected slave at address match so traces carry decodable address frames. Register map/reset values byte-for-byte untouched; conformance/e2e unchanged. No live re-capture.
-    drift_ack: 2026-07-09
+    # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
+    drift_ack: 2026-07-10
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Engine half of the logic-analyzer architecture overhaul (four defects fixed):

## In-engine edge capture (deterministic waveforms)
- New `logic_capture` module: while a watch set is armed, the machine samples watched pads every 16 cycles inside the step loop and records transitions only (`{ch, cycle, value}`) into a bounded 64k ring with a monotonic cursor and honest `dropped` counter.
- Wasm exports: `watch_logic_signals(refs)` (resolves refs once, returns initial levels + channel ids, resets capture) and `read_logic_edges(cursor)` (`{cursor, dropped, nowCycle, edges}`).
- Timestamps are engine cycles: identical firmware + watch config → byte-identical edge streams, regardless of host frame timing. Zero overhead when unarmed (single branch).
- `run()` clamps its inner batch to the sample interval only while watching, so no edge falls between batch boundaries.

## Bus tracing at ONE choke point
- Slaves are wrapped in tracing exactly once, in `SystemBus::attach_i2c_slave` / `attach_spi_device`; controllers lost `set_bus_trace` and their public attach — only a `pub(crate)` raw push remains. An unrecognized controller family is a hard error, not a silently untraced bus (the failure mode that shipped on ESP32-C3).
- Covers STM32, ESP32/C3/S3, nRF52 TWIM + serial mux, Kinetis, and the SPI equivalents.

## Cycle timestamps on bus trace events
- `BusTraceEvent` gains an additive `cycle` field, stamped from a shared atomic clock the bus advances with `current_cycle` — protocol decode and sampled waveforms now share one time axis.

## `pin_routing` wasm export
- `[{kind:'gpio', peripheral, pin}]` → `[{...ref, mode, func}]` from the same register truth `read_gpio_pad` uses (STM32 F1/V2, nRF52, Kinetis, ESP32-family). ESP32-C3 resolves GPIO-matrix out_sel to signal names (I2CEXT0_SDA/SCL, FSPI*, U0/U1TXD) — the C3 GPIO model now faithfully stores `FUNCn_OUT_SEL_CFG` (previously read 0). STM32 V2 reports `AF<n>`. Never a guess: unresolvable → `unknown`/`null`. `read_gpio_pad`'s honest `None` for AF pads is unchanged.

## Validation
- 1784 tests pass; the only failures are the 3 pre-existing macOS `cpu::riscv` WFI tests (fail on clean main).
- Silicon drift gate green: dated `drift_ack: 2026-07-10` + comments on the 9 affected boards, VALIDATION_STATUS.md regenerated.