### PR TITLE
Honest kit lab metadata: real board ids, no phantom demos

### DIFF
--- a/crates/core/src/peripherals/components/hc595_7seg.rs
+++ b/crates/core/src/peripherals/components/hc595_7seg.rs
@@ -186,7 +186,7 @@ impl SpiDevice for Hc5957Seg {
 // ─── PeripheralKit registration ────────────────────────────────────────────
 
 use crate::peripherals::kit::{
-    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
 };
 
 pub struct Hc5957SegKit;
@@ -210,12 +210,11 @@ static HC595_7SEG_METADATA: KitMetadata = KitMetadata {
         ty: ConfigType::Str,
         doc: "RCLK latch GPIO pin, wired as SPI chip-select (e.g. \"PA4\"). Defaults to PA4.",
     }],
-    labs: &[LabRef {
-        board_id: "hc595-7seg-lab",
-        chip: "stm32f103",
-        example_dir: "hc595-7seg-lab",
-        demo_elf: "demo-hc595-7seg-lab.elf",
-    }],
+    // No lab yet: examples/hc595-7seg-lab has only a README + system.yaml — no demo
+    // firmware/ELF is built or published. Declaring a LabRef would promise a
+    // one-click demo that 404s (the playground gate rightly rejects it).
+    // Re-add the LabRef when the demo firmware ships.
+    labs: &[],
 };
 
 impl PeripheralKit for Hc5957SegKit {

--- a/crates/core/src/peripherals/components/mlx90614.rs
+++ b/crates/core/src/peripherals/components/mlx90614.rs
@@ -229,7 +229,7 @@ static MLX90614_METADATA: KitMetadata = KitMetadata {
         },
     ],
     labs: &[LabRef {
-        board_id: "leo-airquality-lab",
+        board_id: "esp32c3-leo-airquality",
         chip: "esp32c3",
         example_dir: "esp32c3-leo-airquality",
         demo_elf: "demo-esp32c3-leo-airquality.elf",

--- a/crates/core/src/peripherals/components/scd41.rs
+++ b/crates/core/src/peripherals/components/scd41.rs
@@ -237,7 +237,7 @@ static SCD41_METADATA: KitMetadata = KitMetadata {
         },
     ],
     labs: &[LabRef {
-        board_id: "leo-airquality-lab",
+        board_id: "esp32c3-leo-airquality",
         chip: "esp32c3",
         example_dir: "esp32c3-leo-airquality",
         demo_elf: "demo-esp32c3-leo-airquality.elf",

--- a/crates/core/src/peripherals/components/sgp41.rs
+++ b/crates/core/src/peripherals/components/sgp41.rs
@@ -178,7 +178,7 @@ static SGP41_METADATA: KitMetadata = KitMetadata {
         },
     ],
     labs: &[LabRef {
-        board_id: "leo-airquality-lab",
+        board_id: "esp32c3-leo-airquality",
         chip: "esp32c3",
         example_dir: "esp32c3-leo-airquality",
         demo_elf: "demo-esp32c3-leo-airquality.elf",

--- a/crates/core/src/peripherals/components/sps30.rs
+++ b/crates/core/src/peripherals/components/sps30.rs
@@ -274,7 +274,7 @@ static SPS30_METADATA: KitMetadata = KitMetadata {
         },
     ],
     labs: &[LabRef {
-        board_id: "leo-airquality-lab",
+        board_id: "esp32c3-leo-airquality",
         chip: "esp32c3",
         example_dir: "esp32c3-leo-airquality",
         demo_elf: "demo-esp32c3-leo-airquality.elf",

--- a/crates/core/src/peripherals/components/ssd1306.rs
+++ b/crates/core/src/peripherals/components/ssd1306.rs
@@ -335,12 +335,11 @@ static SSD1306_128X32_METADATA: KitMetadata = KitMetadata {
         ty: ConfigType::Int,
         doc: "7-bit slave address. Defaults to 0x3C; 0x3D selects the SA0=high variant.",
     }],
-    labs: &[LabRef {
-        board_id: "ssd1306-128x32-lab",
-        chip: "stm32f103",
-        example_dir: "ssd1306-128x32-lab",
-        demo_elf: "demo-ssd1306-128x32-lab.elf",
-    }],
+    // No lab yet: examples/ssd1306-128x32-lab has only a README + system.yaml — no demo
+    // firmware/ELF is built or published. Declaring a LabRef would promise a
+    // one-click demo that 404s (the playground gate rightly rejects it).
+    // Re-add the LabRef when the demo firmware ships.
+    labs: &[],
 };
 
 impl PeripheralKit for Ssd1306Oled091Kit {

--- a/crates/core/src/peripherals/components/tm1637_7seg.rs
+++ b/crates/core/src/peripherals/components/tm1637_7seg.rs
@@ -258,7 +258,7 @@ impl Tm1637 {
 // ─── PeripheralKit registration ────────────────────────────────────────────
 
 use crate::peripherals::kit::{
-    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
 };
 
 pub struct Tm16377SegKit;
@@ -288,12 +288,11 @@ static TM1637_7SEG_METADATA: KitMetadata = KitMetadata {
             doc: "DIO GPIO pin the firmware bit-bangs (e.g. \"PA9\"). Defaults to PA9.",
         },
     ],
-    labs: &[LabRef {
-        board_id: "tm1637-7seg-lab",
-        chip: "stm32f103",
-        example_dir: "tm1637-7seg-lab",
-        demo_elf: "demo-tm1637-7seg-lab.elf",
-    }],
+    // No lab yet: examples/tm1637-7seg-lab has only a README + system.yaml — no demo
+    // firmware/ELF is built or published. Declaring a LabRef would promise a
+    // one-click demo that 404s (the playground gate rightly rejects it).
+    // Re-add the LabRef when the demo firmware ships.
+    labs: &[],
 };
 
 impl PeripheralKit for Tm16377SegKit {

--- a/crates/core/src/peripherals/components/veml7700.rs
+++ b/crates/core/src/peripherals/components/veml7700.rs
@@ -224,7 +224,7 @@ static VEML7700_METADATA: KitMetadata = KitMetadata {
         },
     ],
     labs: &[LabRef {
-        board_id: "leo-airquality-lab",
+        board_id: "esp32c3-leo-airquality",
         chip: "esp32c3",
         example_dir: "esp32c3-leo-airquality",
         demo_elf: "demo-esp32c3-leo-airquality.elf",

--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -271,14 +271,7 @@
           "doc": "7-bit slave address. Defaults to 0x3C; 0x3D selects the SA0=high variant."
         }
       ],
-      "labs": [
-        {
-          "board_id": "ssd1306-128x32-lab",
-          "chip": "stm32f103",
-          "example_dir": "ssd1306-128x32-lab",
-          "demo_elf": "demo-ssd1306-128x32-lab.elf"
-        }
-      ],
+      "labs": [],
       "inputs": []
     },
     {
@@ -474,14 +467,7 @@
           "doc": "RCLK latch GPIO pin, wired as SPI chip-select (e.g. \"PA4\"). Defaults to PA4."
         }
       ],
-      "labs": [
-        {
-          "board_id": "hc595-7seg-lab",
-          "chip": "stm32f103",
-          "example_dir": "hc595-7seg-lab",
-          "demo_elf": "demo-hc595-7seg-lab.elf"
-        }
-      ],
+      "labs": [],
       "inputs": []
     },
     {
@@ -503,14 +489,7 @@
           "doc": "DIO GPIO pin the firmware bit-bangs (e.g. \"PA9\"). Defaults to PA9."
         }
       ],
-      "labs": [
-        {
-          "board_id": "tm1637-7seg-lab",
-          "chip": "stm32f103",
-          "example_dir": "tm1637-7seg-lab",
-          "demo_elf": "demo-tm1637-7seg-lab.elf"
-        }
-      ],
+      "labs": [],
       "inputs": []
     },
     {
@@ -688,7 +667,7 @@
       ],
       "labs": [
         {
-          "board_id": "leo-airquality-lab",
+          "board_id": "esp32c3-leo-airquality",
           "chip": "esp32c3",
           "example_dir": "esp32c3-leo-airquality",
           "demo_elf": "demo-esp32c3-leo-airquality.elf"
@@ -732,7 +711,7 @@
       ],
       "labs": [
         {
-          "board_id": "leo-airquality-lab",
+          "board_id": "esp32c3-leo-airquality",
           "chip": "esp32c3",
           "example_dir": "esp32c3-leo-airquality",
           "demo_elf": "demo-esp32c3-leo-airquality.elf"
@@ -771,7 +750,7 @@
       ],
       "labs": [
         {
-          "board_id": "leo-airquality-lab",
+          "board_id": "esp32c3-leo-airquality",
           "chip": "esp32c3",
           "example_dir": "esp32c3-leo-airquality",
           "demo_elf": "demo-esp32c3-leo-airquality.elf"
@@ -810,7 +789,7 @@
       ],
       "labs": [
         {
-          "board_id": "leo-airquality-lab",
+          "board_id": "esp32c3-leo-airquality",
           "chip": "esp32c3",
           "example_dir": "esp32c3-leo-airquality",
           "demo_elf": "demo-esp32c3-leo-airquality.elf"
@@ -854,7 +833,7 @@
       ],
       "labs": [
         {
-          "board_id": "leo-airquality-lab",
+          "board_id": "esp32c3-leo-airquality",
           "chip": "esp32c3",
           "example_dir": "esp32c3-leo-airquality",
           "demo_elf": "demo-esp32c3-leo-airquality.elf"


### PR DESCRIPTION
Five air-quality kits pointed at a nonexistent board id ('leo-airquality-lab' → real board is 'esp32c3-leo-airquality'); three kits (oled-ssd1306-128x32, hc595-7seg, tm1637-7seg) declared labs with no demo firmware/ELF behind them — removed until the demos exist. Manifest fixture regenerated. Unblocks the superproject peripherals-manifest refresh (which carries the new per-device `inputs` schema).