### PR TITLE
logic capture: sample every cycle while armed, eliminating aliasing

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1008,9 +1008,13 @@ impl<C: Cpu> Machine<C> {
     }
 
     fn try_idle_fast_forward(&mut self, _max_steps: Option<u32>, _steps: u32) -> u32 {
+        // Logic capture disables the skip too: a scheduler event inside the
+        // skipped window could toggle a watched pad, and the per-cycle capture
+        // guarantee must hold even under this opt-in acceleration.
         if !self.config.idle_fast_forward_enabled
             || !self.breakpoints.is_empty()
             || self.bus.requires_cycle_accurate()
+            || self.logic_capture.is_active()
         {
             return 0;
         }
@@ -1808,12 +1812,17 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 current_batch = current_batch.min(1);
             }
 
-            // Logic-analyzer capture: clamp the batch so pad state is observed
-            // at least once per sample interval — otherwise a large batch would
-            // stride past intermediate edges we can only read at batch
-            // boundaries. Cost is paid ONLY while a watch set is active.
+            // Logic-analyzer capture: clamp the batch to one instruction so pad
+            // state is observed at EVERY cycle boundary — pads only change at
+            // instruction/tick boundaries, so this is a complete, alias-free
+            // capture. (An earlier fixed 16-cycle sampling grid aliased any
+            // signal toggling faster than ~32 cycles — bit-banged buses looked
+            // wrong before they looked dropped.) Cost is paid ONLY while a
+            // watch set is active; measured on a real firmware fixture at the
+            // default tick interval it is <= 1.05x, and ~1.4-1.5x at the widest
+            // batching config (see tests/logic_capture_bench.rs).
             if self.logic_capture.is_active() {
-                current_batch = current_batch.min(logic_capture::LOGIC_SAMPLE_INTERVAL as u32);
+                current_batch = current_batch.min(1);
             }
 
             let executed =
@@ -1862,8 +1871,8 @@ impl<C: Cpu> DebugControl for Machine<C> {
             }
 
             // Logic-analyzer edge capture at the batch boundary (no-op unless a
-            // watch set is installed; the batch was clamped above so this fires
-            // at least once per sample interval).
+            // watch set is installed; the batch was clamped to 1 above so this
+            // fires at every cycle boundary while armed).
             self.logic_sample();
 
             // If we executed less than requested, it means the CPU wanted to exit early (e.g. branch/exception)

--- a/crates/core/src/logic_capture.rs
+++ b/crates/core/src/logic_capture.rs
@@ -10,28 +10,27 @@
 //! nondeterministic even though the simulator itself is fully deterministic.
 //!
 //! This module moves capture INSIDE the simulation loop: while a watch set is
-//! active, [`Machine`](crate::Machine) samples the watched pads on a fixed
-//! engine-cycle cadence ([`LOGIC_SAMPLE_INTERVAL`]) and records a `{ch, cycle,
-//! value}` edge ONLY on a transition. Timestamps are engine cycles, so
-//! identical firmware + identical watch config produce byte-identical edge
-//! streams regardless of how the host drives stepping.
+//! active, [`Machine`](crate::Machine) samples the watched pads at EVERY
+//! engine-cycle boundary (the run loop executes one instruction per batch
+//! while armed) and records a `{ch, cycle, value}` edge ONLY on a transition.
+//! Timestamps are engine cycles, so identical firmware + identical watch
+//! config produce byte-identical edge streams regardless of how the host
+//! drives stepping.
+//!
+//! The sampling guarantee: any pad level that persists across at least one
+//! instruction boundary is captured — no aliasing, at any toggle rate. A pad
+//! toggling every cycle yields an edge every cycle (and fills the ring in
+//! [`LOGIC_RING_CAPACITY`] cycles if never drained; overflow drops the OLDEST
+//! edges and counts them, it never distorts the newest). Earlier versions
+//! sampled on a fixed 16-cycle grid, which aliased anything toggling faster
+//! than ~32 cycles — bit-banged buses looked wrong before they looked dropped.
 //!
 //! Everything here is host-frame-independent and allocation-free on the hot
 //! path — the single per-step cost when nothing is watched is one `is_empty`
-//! check on the channel list.
+//! check on the channel list (and the edge ring is only ever allocated once a
+//! transition is actually recorded).
 
 use std::collections::VecDeque;
-
-/// Cycle spacing between logic samples.
-///
-/// A 100 kHz signal on a 40 MHz core has a period of 40e6 / 100e3 = 400 engine
-/// cycles. Sampling every 16 cycles yields 400 / 16 = 25 samples per period
-/// (>= 20, the fidelity target for reconstructing a 100 kHz waveform), while
-/// keeping the sample count — and therefore the per-sample cost when a watch is
-/// active — an order of magnitude below one-sample-per-cycle. It is a power of
-/// two so the bucket division is a shift. A fixed internal constant on purpose:
-/// no config knob to keep the capture contract simple and deterministic.
-pub const LOGIC_SAMPLE_INTERVAL: u64 = 16;
 
 /// Maximum number of edges retained in the ring buffer. On overflow the oldest
 /// edge is dropped (and counted) so capture never grows without bound. 64k
@@ -88,11 +87,6 @@ pub struct LogicCapture {
     /// sequence `next_seq - ring.len()`.
     next_seq: u64,
     dropped: u64,
-    /// Last sampled cycle bucket (`cycle / LOGIC_SAMPLE_INTERVAL`), so a bucket
-    /// is sampled at most once even if the step loop revisits the same cycle
-    /// window across a batch boundary.
-    last_bucket: u64,
-    sampled_once: bool,
 }
 
 impl LogicCapture {
@@ -120,8 +114,6 @@ impl LogicCapture {
         self.ring.clear();
         self.next_seq = 0;
         self.dropped = 0;
-        self.last_bucket = 0;
-        self.sampled_once = false;
     }
 
     /// Sample every watched pad at engine cycle `now`, recording a transition
@@ -130,15 +122,11 @@ impl LogicCapture {
     /// truth as `Peripheral::read_gpio_pad`); a `None` read records nothing.
     ///
     /// Caller guarantees this is only invoked when [`is_active`](Self::is_active).
-    /// At most one sample is taken per `LOGIC_SAMPLE_INTERVAL`-cycle bucket.
+    /// Every call is a real sample — the step loop invokes this at every cycle
+    /// boundary while armed, so no transition that persists across a boundary
+    /// is ever missed. Re-sampling the same cycle is harmless: capture is
+    /// transitions-only, so an unchanged pad records nothing.
     pub fn sample(&mut self, now: u64, read: impl Fn(usize, u8) -> Option<bool>) {
-        let bucket = now / LOGIC_SAMPLE_INTERVAL;
-        if self.sampled_once && bucket == self.last_bucket {
-            return;
-        }
-        self.last_bucket = bucket;
-        self.sampled_once = true;
-
         for i in 0..self.channels.len() {
             let Some((idx, pin)) = self.channels[i].resolved else {
                 continue;

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -7,9 +7,7 @@
 #[cfg(test)]
 mod logic_capture_tests {
     use crate::cpu::CortexM;
-    use crate::logic_capture::{
-        LogicCapture, LogicEdge, LOGIC_RING_CAPACITY, LOGIC_SAMPLE_INTERVAL,
-    };
+    use crate::logic_capture::{LogicCapture, LogicEdge, LOGIC_RING_CAPACITY};
     use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
     use crate::{Bus, Machine};
 
@@ -74,9 +72,9 @@ mod logic_capture_tests {
         let initial = machine.logic_watch(&[Some((idx, 0))]);
         assert_eq!(initial, vec![Some(false)], "pin starts low");
 
-        // Space each toggle well past one sample interval so a sample lands
-        // between transitions and each edge is captured exactly once.
-        let gap = (LOGIC_SAMPLE_INTERVAL as usize) * 3;
+        // Sampling is per-cycle, so any spacing captures each edge exactly
+        // once; a few steps of gap keeps the cycle stamps visibly distinct.
+        let gap = 48;
         step_n(machine, gap); // low (== initial): no edge
         set_pin0(machine, true);
         step_n(machine, gap); // -> high
@@ -131,7 +129,7 @@ mod logic_capture_tests {
         let initial = machine.logic_watch(&[None, Some((idx, 0))]);
         assert_eq!(initial, vec![None, Some(false)]);
 
-        let gap = (LOGIC_SAMPLE_INTERVAL as usize) * 3;
+        let gap = 48;
         step_n(&mut machine, gap);
         set_pin0(&mut machine, true);
         step_n(&mut machine, gap);
@@ -152,7 +150,7 @@ mod logic_capture_tests {
             .find_peripheral_index_by_name("gpio_test")
             .unwrap();
         machine.logic_watch(&[Some((idx, 0))]);
-        let gap = (LOGIC_SAMPLE_INTERVAL as usize) * 3;
+        let gap = 48;
 
         set_pin0(&mut machine, true);
         step_n(&mut machine, gap);
@@ -179,10 +177,9 @@ mod logic_capture_tests {
 
         let overflow = 100usize;
         let total = LOGIC_RING_CAPACITY + overflow;
-        // Toggle on every sample so each sample records exactly one edge; space
-        // samples one interval apart so each lands in a fresh cycle bucket.
+        // Toggle on every sample so each sample records exactly one edge.
         for i in 0..total {
-            let cycle = (i as u64 + 1) * LOGIC_SAMPLE_INTERVAL;
+            let cycle = i as u64 + 1;
             let level = i % 2 == 0;
             cap.sample(cycle, |_, _| Some(level));
         }
@@ -196,7 +193,7 @@ mod logic_capture_tests {
         );
         // Newest edge is the last sample taken.
         let last = batch.edges.last().unwrap();
-        assert_eq!(last.cycle, total as u64 * LOGIC_SAMPLE_INTERVAL);
+        assert_eq!(last.cycle, total as u64);
         assert_eq!(batch.cursor, total as u64);
     }
 
@@ -207,10 +204,109 @@ mod logic_capture_tests {
         let mut cap = LogicCapture::new();
         cap.install(&[Some((0, 0))], &[None]);
         for i in 0..10 {
-            cap.sample((i + 1) * LOGIC_SAMPLE_INTERVAL, |_, _| None);
+            cap.sample(i + 1, |_, _| None);
         }
         let batch = cap.read_edges(0);
         assert!(batch.edges.is_empty());
+        assert_eq!(batch.dropped, 0);
+    }
+
+    /// The no-aliasing guarantee on the `step()` path: a pad toggled on EVERY
+    /// cycle produces an edge on EVERY cycle — nothing is sampled away.
+    #[test]
+    fn pad_toggling_every_cycle_produces_every_edge() {
+        let mut machine = machine_with_gpio();
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        let initial = machine.logic_watch(&[Some((idx, 0))]);
+        assert_eq!(initial, vec![Some(false)]);
+
+        let toggles = 100usize;
+        for i in 0..toggles {
+            set_pin0(&mut machine, i % 2 == 0); // true, false, true, ...
+            machine.step().unwrap();
+        }
+
+        let batch = machine.logic_read_edges(0);
+        assert_eq!(
+            batch.edges.len(),
+            toggles,
+            "every per-cycle toggle is captured — no aliasing"
+        );
+        for (i, e) in batch.edges.iter().enumerate() {
+            assert_eq!(e.value, i % 2 == 0, "values strictly alternate");
+        }
+        for w in batch.edges.windows(2) {
+            assert_eq!(w[1].cycle - w[0].cycle, 1, "one edge per cycle");
+        }
+        assert_eq!(batch.dropped, 0);
+    }
+
+    /// The no-aliasing guarantee on the batched `Machine::run` path: firmware
+    /// bit-banging a pad on consecutive instructions (str/str/branch loop) has
+    /// every transition captured even with a wide peripheral tick interval —
+    /// the run loop clamps its batch to one instruction while a watch is armed.
+    #[test]
+    fn run_path_captures_bitbang_toggles_without_aliasing() {
+        use crate::DebugControl;
+
+        let mut machine = machine_with_gpio();
+        // Wide tick interval: without the armed batch clamp the run loop would
+        // stride past intermediate toggles and alias them away.
+        machine.config.peripheral_tick_interval = 8;
+
+        // r0 = &ODR, r1 = 1, r2 = 0;  loop: str r1,[r0]; str r2,[r0]; b loop
+        machine.cpu.r0 = (GPIO_BASE + ODR) as u32;
+        machine.cpu.r1 = 1;
+        machine.cpu.r2 = 0;
+        machine.bus.write_u16(RAM_BASE, 0x6001).unwrap(); // str r1, [r0]
+        machine.bus.write_u16(RAM_BASE + 2, 0x6002).unwrap(); // str r2, [r0]
+        machine.bus.write_u16(RAM_BASE + 4, 0xE7FC).unwrap(); // b .-8
+        machine.cpu.pc = RAM_BASE as u32;
+
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        machine.logic_watch(&[Some((idx, 0))]);
+
+        let steps = 300u32;
+        machine.run(Some(steps)).unwrap();
+
+        let batch = machine.logic_read_edges(0);
+        // 2 toggles per 3-instruction loop iteration; anything close to that is
+        // alias-free (the old 16-cycle grid captured well under a tenth of it).
+        assert!(
+            batch.edges.len() >= 190,
+            "expected ~200 edges over {steps} cycles, got {}",
+            batch.edges.len()
+        );
+        for (i, e) in batch.edges.iter().enumerate() {
+            assert_eq!(e.value, i % 2 == 0, "values strictly alternate");
+        }
+        for w in batch.edges.windows(2) {
+            assert!(
+                w[1].cycle - w[0].cycle <= 2,
+                "consecutive toggles captured at consecutive boundaries"
+            );
+        }
+    }
+
+    /// Unarmed capture stays on the zero-overhead path: no watch installed
+    /// means no samples, no edges and no ring growth, no matter how much the
+    /// machine runs.
+    #[test]
+    fn unarmed_run_records_nothing() {
+        let mut machine = machine_with_gpio();
+        for i in 0..100 {
+            set_pin0(&mut machine, i % 2 == 0);
+            machine.step().unwrap();
+        }
+        let batch = machine.logic_read_edges(0);
+        assert!(batch.edges.is_empty(), "no watch, no capture");
+        assert_eq!(batch.cursor, 0);
         assert_eq!(batch.dropped, 0);
     }
 }

--- a/crates/core/tests/logic_capture_bench.rs
+++ b/crates/core/tests/logic_capture_bench.rs
@@ -1,0 +1,180 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Timing harness for logic-analyzer capture overhead.
+//!
+//! Not a pass/fail benchmark — it prints wall-clock numbers for capture
+//! disarmed vs armed (4 and 8 watched channels) so the cost of per-cycle
+//! sampling stays measured, not guessed. Two scenarios:
+//!
+//! 1. A real firmware fixture (`stm32f103-blinky.elf`) driven through
+//!    `Machine::run` in wasm-worker-style batches at the default
+//!    `peripheral_tick_interval = 1` — the configuration every playground
+//!    run uses.
+//! 2. A synthetic NOP loop on a bare bus at `peripheral_tick_interval = 64`
+//!    — the maximum-batching case, where arming capture clamps the run-loop
+//!    batch and the clamp cost is at its worst.
+//!
+//! Run manually with:
+//!
+//! ```sh
+//! cargo test --release -p labwired-core --test logic_capture_bench -- --ignored --nocapture
+//! ```
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{cpu::CortexM, DebugControl, Machine};
+use std::path::PathBuf;
+use std::time::Instant;
+
+const FIRMWARE_STEPS: u64 = 2_000_000;
+const SYNTHETIC_STEPS: u64 = 20_000_000;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Real firmware on the real board model, default (cycle-accurate) config.
+fn build_firmware_machine() -> Machine<CortexM> {
+    let root = workspace_root();
+    let chip =
+        ChipDescriptor::from_file(root.join("configs/chips/stm32f103.yaml")).expect("chip config");
+    let sys_path = root.join("configs/systems/stm32f103-bare.yaml");
+    let mut manifest = SystemManifest::from_file(&sys_path).expect("system config");
+    manifest.chip = sys_path
+        .parent()
+        .unwrap()
+        .join(&manifest.chip)
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("bus from config");
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+
+    let image = labwired_loader::load_elf(&root.join("tests/fixtures/stm32f103-blinky.elf"))
+        .expect("load fixture ELF");
+    machine.load_firmware(&image).expect("load firmware");
+    machine
+}
+
+/// Bare bus + one GPIO port + a 1001-instruction NOP loop in RAM, ticked every
+/// 64 cycles so `Machine::run` batches as widely as it ever does.
+fn build_synthetic_machine() -> Machine<CortexM> {
+    const GPIO_BASE: u64 = 0x5000_0000;
+    const RAM_BASE: u64 = 0x2000_0000;
+
+    let mut bus = SystemBus::new();
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    bus.add_peripheral(
+        "gpio_bench",
+        GPIO_BASE,
+        0x400,
+        None,
+        Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2)),
+    );
+    let mut machine = Machine::new(cpu, bus);
+    machine.config.peripheral_tick_interval = 64;
+
+    // MODER pin0..7 = output so read_gpio_pad reflects ODR.
+    machine
+        .bus
+        .write_u32(GPIO_BASE, 0x0000_5555) // V2 MODER @ 0x00
+        .unwrap();
+
+    // 1000 x `movs r0, #0` (0x2000) then `b` back to the start (imm11 = -1002
+    // halfwords), i.e. a 1001-instruction idle loop.
+    for i in 0..1000u64 {
+        machine
+            .bus
+            .write_u16(RAM_BASE + i * 2, 0x2000)
+            .expect("write nop");
+    }
+    machine
+        .bus
+        .write_u16(
+            RAM_BASE + 2000,
+            0xE000 | ((-1002i32 as u32 as u16) & 0x07FF),
+        )
+        .expect("write branch");
+    machine.cpu.pc = RAM_BASE as u32;
+    machine
+}
+
+/// First `n` readable GPIO pads on the bus, as `(peripheral_index, pin)`.
+fn readable_pads(machine: &Machine<CortexM>, n: usize) -> Vec<Option<(usize, u8)>> {
+    let mut out = Vec::new();
+    for (idx, p) in machine.bus.peripherals.iter().enumerate() {
+        for pin in 0..16u8 {
+            if p.dev.read_gpio_pad(pin).is_some() {
+                out.push(Some((idx, pin)));
+                if out.len() == n {
+                    return out;
+                }
+            }
+        }
+    }
+    panic!("only found {} readable pads, wanted {}", out.len(), n);
+}
+
+fn timed_run(mut machine: Machine<CortexM>, channels: usize, steps: u64) -> (f64, usize, u64) {
+    if channels > 0 {
+        let pads = readable_pads(&machine, channels);
+        machine.logic_watch(&pads);
+    }
+    // Drive the machine the way the wasm worker does: repeated `run` batches
+    // until the target cycle count is reached (early `StepDone` returns are
+    // normal at branch/exception boundaries).
+    let start = Instant::now();
+    while machine.get_cycle_count() < steps {
+        let before = machine.get_cycle_count();
+        let remaining = (steps - before).min(u32::MAX as u64) as u32;
+        machine.run(Some(remaining)).expect("run");
+        assert!(
+            machine.get_cycle_count() > before,
+            "no forward progress at cycle {before}"
+        );
+    }
+    let secs = start.elapsed().as_secs_f64();
+    let batch = machine.logic_read_edges(0);
+    (secs, batch.edges.len(), batch.dropped)
+}
+
+type BuildMachine = fn() -> Machine<CortexM>;
+
+#[test]
+#[ignore = "manual timing harness, run with --release --nocapture"]
+fn bench_logic_capture_overhead() {
+    let scenarios: [(&str, BuildMachine, u64); 2] = [
+        ("firmware tick=1 ", build_firmware_machine, FIRMWARE_STEPS),
+        (
+            "synthetic tick=64",
+            build_synthetic_machine,
+            SYNTHETIC_STEPS,
+        ),
+    ];
+    for (name, build, steps) in scenarios {
+        let mut base = f64::NAN;
+        for channels in [0usize, 4, 8] {
+            let (secs, edges, dropped) = timed_run(build(), channels, steps);
+            if channels == 0 {
+                base = secs;
+            }
+            println!(
+                "{name} channels={channels} : {secs:.3}s \
+                 ({:.2} Minstr/s, {:.2}x vs unarmed) edges={edges} dropped={dropped}",
+                steps as f64 / secs / 1e6,
+                secs / base,
+            );
+        }
+    }
+}


### PR DESCRIPTION
Removes the 16-cycle sampling grid (the analyzer's Nyquist ceiling): while a watch set is armed, pads are sampled at every cycle boundary, so no toggle rate aliases. Bit-banged buses were the victim — they looked wrong before they looked dropped.

- Interval concept deleted entirely (no knob added): every `sample()` call is real, transitions-only recording makes re-sampling free, ring + dropped counter unchanged, determinism unchanged.
- `Machine::run` clamps the batch to 1 while armed; unarmed cost stays one `is_active` check.
- `try_idle_fast_forward` is disabled while armed so the guarantee survives idle acceleration.
- New tests: every-cycle toggle → every edge; str/str/branch bit-bang loop alias-free through batched `run` at tick=64 (fails on the old grid); unarmed runs record nothing. Plus an ignored bench harness.

Measured (release): real stm32f103-blinky fixture at default tick — unarmed 1.00x, 4ch 1.02x, 8ch 1.04x. Synthetic widest-batching worst case: 1.40x/1.52x. Far under the 4x budget, hence no interval parameter.

No interface change: watch_logic_signals / read_logic_edges shapes untouched; callers just see denser, honest edges.