### PR TITLE
logic capture: event-driven push mode — no batch clamp, idle fast-forward stays on

### DIFF
--- a/crates/core/src/bus/accessors.rs
+++ b/crates/core/src/bus/accessors.rs
@@ -45,6 +45,10 @@ impl SystemBus {
 }
 
 impl crate::Bus for SystemBus {
+    fn logic_tap(&self) -> Option<crate::logic_capture::LogicTap> {
+        Some(self.logic_tap.clone())
+    }
+
     fn read_u8(&self, addr: u64) -> SimResult<u8> {
         // RAM is always first (hot path, never overlaps a peripheral window).
         if let Some(val) = self.ram.read_u8(addr) {

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -87,6 +87,7 @@ impl SystemBus {
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
 

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -280,6 +280,12 @@ pub struct SystemBus {
     /// present (never `None`) — empty until at least one peripheral is wired
     /// to it in `from_config`.
     pub bus_trace: bus_trace::BusTraceLog,
+    /// Push-mode logic-capture tap (see [`crate::logic_capture`]): the shared
+    /// handle instrumented peripherals report pad writes into, and whose
+    /// provisional cycle clock the CPU batch loops advance per retired
+    /// instruction while push capture is armed. Always present (cheap when
+    /// disarmed); wired to peripherals by `Machine::logic_watch`.
+    pub logic_tap: crate::logic_capture::LogicTap,
     /// Authoritative pin → (gpio peripheral, bit) map, built from the chip
     /// config's `pins:`. Empty when the chip declares none (→ label parse).
     pub(crate) pin_map: std::collections::HashMap<String, (String, u8)>,
@@ -2211,6 +2217,7 @@ impl SystemBus {
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
@@ -2263,6 +2270,7 @@ impl SystemBus {
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
@@ -4571,6 +4579,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
 
@@ -4647,6 +4656,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
@@ -4874,6 +4884,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();
@@ -5100,6 +5111,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
 
@@ -5180,6 +5192,7 @@ peripherals:
             flash_models_ops: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
+            logic_tap: crate::logic_capture::LogicTap::new(),
             pin_map: std::collections::HashMap::new(),
         };
         bus.rebuild_peripheral_ranges();

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -644,8 +644,17 @@ impl Cpu for CortexM {
         config: &SimulationConfig,
         max_count: u32,
     ) -> SimResult<u32> {
+        // Push-mode logic capture: while armed, the tap clock advances once
+        // per retired instruction (BEFORE executing it) so MMIO pad writes
+        // stamp with the cycle boundary they become observable at. One Arc
+        // clone + flag check per batch when disarmed.
+        let tap = bus.logic_tap().filter(|t| t.push_armed());
+
         if !config.batch_mode_enabled {
             for _ in 0..max_count {
+                if let Some(tap) = &tap {
+                    tap.bump_clock();
+                }
                 self.step(bus, observers, config)?;
             }
             return Ok(max_count);
@@ -671,6 +680,9 @@ impl Cpu for CortexM {
                     }
                 }
                 let old_pc = self.pc;
+                if let Some(tap) = &tap {
+                    tap.bump_clock();
+                }
                 self.step_internal(sysbus, observers, config)?;
                 executed += 1;
                 let pc_diff = self.pc.wrapping_sub(old_pc);
@@ -693,6 +705,9 @@ impl Cpu for CortexM {
                     }
                 }
                 let old_pc = self.pc;
+                if let Some(tap) = &tap {
+                    tap.bump_clock();
+                }
                 self.step_internal(bus, observers, config)?;
                 executed += 1;
                 let pc_diff = self.pc.wrapping_sub(old_pc);

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -831,7 +831,14 @@ impl Cpu for RiscV {
         config: &crate::SimulationConfig,
         max_count: u32,
     ) -> SimResult<u32> {
+        // Push-mode logic capture: advance the tap clock once per retired
+        // instruction while armed, so MMIO pad writes stamp with the cycle
+        // boundary they become observable at (see `crate::logic_capture`).
+        let tap = bus.logic_tap().filter(|t| t.push_armed());
         for i in 0..max_count {
+            if let Some(tap) = &tap {
+                tap.bump_clock();
+            }
             self.step(bus, observers, config)?;
             if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
                 return Ok(i + 1);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -193,7 +193,16 @@ pub trait Cpu: Send {
         config: &SimulationConfig,
         max_count: u32,
     ) -> SimResult<u32> {
+        // While push-mode logic capture is armed, the tap clock must advance
+        // once per retired instruction so pad writes stamp with the cycle
+        // boundary they become observable at (see `crate::logic_capture`).
+        // One Arc clone + flag check per batch when idle; a relaxed atomic
+        // increment per instruction while armed.
+        let tap = bus.logic_tap().filter(|t| t.push_armed());
         for i in 0..max_count {
+            if let Some(tap) = &tap {
+                tap.bump_clock();
+            }
             self.step(bus, observers, config)?;
             if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
                 return Ok(i + 1);
@@ -491,6 +500,29 @@ pub trait Peripheral: std::fmt::Debug + Send {
         false
     }
 
+    /// Logic-capture capability: install (or clear) a push-mode logic tap.
+    ///
+    /// `watched` is this peripheral's slice of the machine's watch set as
+    /// `(pin, channel)` pairs (empty ⇒ remove any installed tap). A
+    /// push-instrumented peripheral stores the tap and, from then on, reports
+    /// every watched pad-level change from its own write sites via
+    /// [`logic_capture::LogicTap::push`] — the same direction-aware level
+    /// truth [`read_gpio_pad`](Self::read_gpio_pad) reads.
+    ///
+    /// The return value DECLARES push capability: `true` means "I am
+    /// instrumented; my watched pads need no per-cycle polling" (returned for
+    /// empty `watched` too), `false` (the default) keeps the machine's
+    /// per-cycle poll fallback for channels resolved to this peripheral. This
+    /// is the single source of truth — the machine never keeps a hardcoded
+    /// list of push-capable peripherals.
+    fn install_logic_tap(
+        &mut self,
+        _tap: &logic_capture::LogicTap,
+        _watched: &[(u8, u32)],
+    ) -> bool {
+        false
+    }
+
     /// Bus-aware tick hook for peripherals that need to read or write the
     /// bus themselves (e.g. Easy DMA on RADIO). Default no-op.
     fn tick_with_bus(&mut self, _bus: &mut dyn Bus) {}
@@ -698,6 +730,14 @@ pub trait Bus {
         Ok(())
     }
 
+    /// The bus's shared push-mode logic tap, when it carries one (a cheap
+    /// `Arc` clone). CPU batch loops use it to advance the tap clock once per
+    /// retired instruction while push capture is armed; `None` (the default)
+    /// means no tap and no per-instruction work.
+    fn logic_tap(&self) -> Option<logic_capture::LogicTap> {
+        None
+    }
+
     /// Plan 3: look up a registered ROM thunk by absolute PC. Used by the
     /// Xtensa LX7 `BREAK 1, 14` dispatch to redirect calls into the simulated
     /// ESP32-S3 mask ROM. Default returns None for buses that don't model
@@ -870,6 +910,12 @@ pub struct Machine<C: Cpu> {
     /// set. Not part of snapshot/restore: capture is a UI observation stream,
     /// re-armed by the frontend after a resume.
     logic_capture: logic_capture::LogicCapture,
+    /// Test-only forcing knob (see [`Machine::logic_force_poll_capture`]):
+    /// when `true`, `logic_watch` keeps every channel on the per-cycle poll
+    /// path even for push-instrumented peripherals. This is what the
+    /// differential oracle tests use to compare the two capture modes; it is
+    /// NOT user-facing configuration.
+    logic_force_poll: bool,
 }
 
 impl<C: Cpu> Machine<C> {
@@ -923,7 +969,42 @@ impl<C: Cpu> Machine<C> {
     /// Returns each channel's initial pad level (`None` = unknown), same order
     /// as `resolved`, so the caller can seed the waveform before the first
     /// edge. Passing an empty slice disarms capture.
+    ///
+    /// Each resolvable channel is armed in one of two modes: push
+    /// (event-driven — the owning peripheral accepted
+    /// [`Peripheral::install_logic_tap`] and reports pad writes itself) or the
+    /// per-cycle poll fallback. See [`crate::logic_capture`].
     pub fn logic_watch(&mut self, resolved: &[Option<(usize, u8)>]) -> Vec<Option<bool>> {
+        // Group the watch set per owning peripheral as (pin, channel) pairs.
+        let mut per_peripheral: std::collections::HashMap<usize, Vec<(u8, u32)>> =
+            std::collections::HashMap::new();
+        if !self.logic_force_poll {
+            for (ch, r) in resolved.iter().enumerate() {
+                if let Some((idx, pin)) = *r {
+                    per_peripheral
+                        .entry(idx)
+                        .or_default()
+                        .push((pin, ch as u32));
+                }
+            }
+        }
+
+        // Offer every peripheral its slice of the watch set (empty ⇒ clears a
+        // previously installed tap). Whether a peripheral ACCEPTS is its own
+        // declaration of push capability — no hardcoded list here.
+        let tap = self.bus.logic_tap.clone();
+        let mut push = vec![false; resolved.len()];
+        static EMPTY: [(u8, u32); 0] = [];
+        for (idx, p) in self.bus.peripherals.iter_mut().enumerate() {
+            let watched: &[(u8, u32)] = per_peripheral.get(&idx).map_or(&EMPTY, |v| v.as_slice());
+            let accepted = p.dev.install_logic_tap(&tap, watched);
+            if accepted {
+                for &(_, ch) in watched {
+                    push[ch as usize] = true;
+                }
+            }
+        }
+
         let bus = &self.bus;
         let initial: Vec<Option<bool>> = resolved
             .iter()
@@ -935,8 +1016,27 @@ impl<C: Cpu> Machine<C> {
                 })
             })
             .collect();
-        self.logic_capture.install(resolved, &initial);
+        self.logic_capture.install(resolved, &initial, &push);
+
+        // Arm the tap clock at "the next observation boundary" so pushes that
+        // happen before any stepping (e.g. a paused-machine input change)
+        // stamp where the first post-watch sample would observe them.
+        tap.clear_events();
+        tap.set_clock(self.total_cycles + 1);
+        tap.set_armed(self.logic_capture.push_active());
         initial
+    }
+
+    /// Test-only forcing knob for the differential capture oracle: when
+    /// `true`, subsequent [`logic_watch`](Self::logic_watch) calls keep every
+    /// channel on the per-cycle poll path even where push instrumentation
+    /// exists (the batch clamp and idle-fast-forward disable apply again).
+    /// Takes effect at the next `logic_watch`. Not user-facing configuration —
+    /// it exists so tests can assert push and poll produce byte-identical
+    /// edge streams.
+    #[doc(hidden)]
+    pub fn logic_force_poll_capture(&mut self, force: bool) {
+        self.logic_force_poll = force;
     }
 
     /// Drain logic edges newer than `cursor` (see
@@ -951,20 +1051,39 @@ impl<C: Cpu> Machine<C> {
         self.total_cycles
     }
 
-    /// Sample the watched pads at the current cycle. Hooked into the step loop;
-    /// the leading `is_active` guard is the entire cost when nothing is watched.
+    /// Observe the watched channels at the current cycle boundary: drain the
+    /// push tap (event-driven channels) and sample the polled channels.
+    /// Hooked into the step loop; the leading `is_active` guard is the entire
+    /// cost when nothing is watched.
+    ///
+    /// `boundary` is the engine cycle at the end of the just-executed
+    /// instruction batch, BEFORE any peripheral tick-cost cycles were charged
+    /// — pushes stamped at it are finalised to `total_cycles` ("now"), which
+    /// is where a per-cycle poll would have seen them.
     #[inline]
-    fn logic_sample(&mut self) {
+    fn logic_observe(&mut self, boundary: u64) {
         if !self.logic_capture.is_active() {
             return;
         }
         let now = self.total_cycles;
-        let bus = &self.bus;
-        self.logic_capture.sample(now, |idx, pin| {
-            bus.peripherals
-                .get(idx)
-                .and_then(|p| p.dev.read_gpio_pad(pin))
-        });
+        if self.logic_capture.push_active() {
+            let events = self.bus.logic_tap.take_events();
+            if !events.is_empty() {
+                self.logic_capture.ingest_push(&events, boundary, now);
+            }
+            // Re-arm the provisional stamp at the NEXT boundary so pad writes
+            // arriving while the machine is paused (sim-input, button pushes)
+            // stamp where the first post-resume observation would see them.
+            self.bus.logic_tap.set_clock(now + 1);
+        }
+        if self.logic_capture.poll_active() {
+            let bus = &self.bus;
+            self.logic_capture.sample(now, |idx, pin| {
+                bus.peripherals
+                    .get(idx)
+                    .and_then(|p| p.dev.read_gpio_pad(pin))
+            });
+        }
     }
 }
 
@@ -1005,6 +1124,7 @@ impl<C: Cpu> Machine<C> {
             scb_index,
             scheduler_bootstrapped: false,
             logic_capture: logic_capture::LogicCapture::new(),
+            logic_force_poll: false,
         }
     }
 
@@ -1034,13 +1154,16 @@ impl<C: Cpu> Machine<C> {
     }
 
     fn try_idle_fast_forward(&mut self, _max_steps: Option<u32>, _steps: u32) -> u32 {
-        // Logic capture disables the skip too: a scheduler event inside the
-        // skipped window could toggle a watched pad, and the per-cycle capture
-        // guarantee must hold even under this opt-in acceleration.
+        // POLLED logic capture disables the skip: a scheduler event inside the
+        // skipped window could toggle a watched pad, and the per-cycle poll
+        // guarantee must hold even under this opt-in acceleration. Push-only
+        // watch sets keep the skip — a pad write inside the window happens in
+        // instrumented peripheral code, which pushes its own edge with the
+        // post-skip tap clock (seeded below before the scheduler drain).
         if !self.config.idle_fast_forward_enabled
             || !self.breakpoints.is_empty()
             || self.bus.requires_cycle_accurate()
-            || self.logic_capture.is_active()
+            || self.logic_capture.poll_active()
         {
             return 0;
         }
@@ -1090,6 +1213,14 @@ impl<C: Cpu> Machine<C> {
             self.total_cycles += skipped as u64;
             self.bus.current_cycle = self.total_cycles;
             self.bus.bus_trace.set_cycle(self.total_cycles);
+            // Push-mode logic capture: stamp any pad writes made by the
+            // scheduler events due at the end of the skipped window with the
+            // cycle we skipped to (the events' own deadline — the budget was
+            // clamped to it above), keeping edges deterministic and correctly
+            // placed inside what would otherwise be a silent window.
+            if self.logic_capture.push_active() {
+                self.bus.logic_tap.set_clock(self.total_cycles);
+            }
             self.sched.advance_to(self.total_cycles / interval);
             self.drain_scheduler_events();
             skipped
@@ -1297,6 +1428,13 @@ impl<C: Cpu> Machine<C> {
         // a single field write, not the per-peripheral walk this phase removed.
         self.bus.current_cycle = self.total_cycles;
         self.bus.bus_trace.set_cycle(self.total_cycles);
+        // The cycle boundary this instruction's effects become observable at —
+        // pad writes pushed through the logic tap stamp with it (single-step
+        // path: one instruction, no CPU-side clock bumps needed).
+        let logic_boundary = self.total_cycles;
+        if self.logic_capture.push_active() {
+            self.bus.logic_tap.set_clock(logic_boundary);
+        }
         self.cpu
             .step(&mut self.bus, &self.observers, &self.config)?;
         self.step_profile.cpu_instructions += 1;
@@ -1385,10 +1523,10 @@ impl<C: Cpu> Machine<C> {
         self.apply_pending_flash_op()?;
 
         // Logic-analyzer edge capture. No-op (one `is_active` check) unless a
-        // watch set is installed. Sampled after the instruction + peripheral
+        // watch set is installed. Observed after the instruction + peripheral
         // effects of this cycle have landed, so pad levels are the committed
         // state at `total_cycles`.
-        self.logic_sample();
+        self.logic_observe(logic_boundary);
 
         Ok(())
     }
@@ -1838,17 +1976,25 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 current_batch = current_batch.min(1);
             }
 
-            // Logic-analyzer capture: clamp the batch to one instruction so pad
-            // state is observed at EVERY cycle boundary — pads only change at
-            // instruction/tick boundaries, so this is a complete, alias-free
-            // capture. (An earlier fixed 16-cycle sampling grid aliased any
-            // signal toggling faster than ~32 cycles — bit-banged buses looked
-            // wrong before they looked dropped.) Cost is paid ONLY while a
-            // watch set is active; measured on a real firmware fixture at the
-            // default tick interval it is <= 1.05x, and ~1.4-1.5x at the widest
-            // batching config (see tests/logic_capture_bench.rs).
-            if self.logic_capture.is_active() {
+            // Logic-analyzer POLL fallback: clamp the batch to one instruction
+            // so polled pad state is observed at EVERY cycle boundary — pads
+            // only change at instruction/tick boundaries, so this is a
+            // complete, alias-free capture. (An earlier fixed 16-cycle
+            // sampling grid aliased any signal toggling faster than ~32 cycles
+            // — bit-banged buses looked wrong before they looked dropped.)
+            // Cost is paid ONLY while at least one polled (non-push) channel
+            // is armed; push-instrumented channels report their own edges from
+            // the write sites and keep the full batch width (see
+            // `crate::logic_capture` and tests/logic_capture_bench.rs).
+            if self.logic_capture.poll_active() {
                 current_batch = current_batch.min(1);
+            }
+
+            // Push-mode capture: seed the tap clock at the batch start; the
+            // CPU advances it once per retired instruction so pad writes stamp
+            // with the boundary they become observable at.
+            if self.logic_capture.push_active() {
+                self.bus.logic_tap.set_clock(current_cycles);
             }
 
             let executed =
@@ -1859,6 +2005,10 @@ impl<C: Cpu> DebugControl for Machine<C> {
             self.total_cycles += executed as u64;
             self.step_profile.cpu_instructions += executed as u64;
             self.step_profile.cpu_batches += 1;
+            // The cycle boundary the batch ended at, BEFORE peripheral tick
+            // costs — logic pushes stamped at it are finalised to the
+            // post-cost "now" (see `logic_observe`).
+            let logic_boundary = self.total_cycles;
 
             if self.total_cycles % (self.config.peripheral_tick_interval as u64) == 0 {
                 // Propagate peripherals
@@ -1896,10 +2046,11 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 self.reset()?;
             }
 
-            // Logic-analyzer edge capture at the batch boundary (no-op unless a
-            // watch set is installed; the batch was clamped to 1 above so this
-            // fires at every cycle boundary while armed).
-            self.logic_sample();
+            // Logic-analyzer edge capture at the batch boundary (no-op unless
+            // a watch set is installed): drain push events and, when a polled
+            // channel is armed, sample — the batch was clamped to 1 above in
+            // that case, so polling still fires at every cycle boundary.
+            self.logic_observe(logic_boundary);
 
             // If we executed less than requested, it means the CPU wanted to exit early (e.g. branch/exception)
             // or we just finished the batch naturally. The loop will continue and check breakpoints/limits.

--- a/crates/core/src/logic_capture.rs
+++ b/crates/core/src/logic_capture.rs
@@ -9,15 +9,48 @@
 //! therefore depended on host frame timing, so the waveforms aliased and were
 //! nondeterministic even though the simulator itself is fully deterministic.
 //!
-//! This module moves capture INSIDE the simulation loop: while a watch set is
-//! active, [`Machine`](crate::Machine) samples the watched pads at EVERY
-//! engine-cycle boundary (the run loop executes one instruction per batch
-//! while armed) and records a `{ch, cycle, value}` edge ONLY on a transition.
-//! Timestamps are engine cycles, so identical firmware + identical watch
-//! config produce byte-identical edge streams regardless of how the host
-//! drives stepping.
+//! This module moves capture INSIDE the simulation loop, with two per-channel
+//! capture modes that produce byte-identical edge streams:
 //!
-//! The sampling guarantee: any pad level that persists across at least one
+//! * **Push (event-driven)** — the default whenever the watched pad's owning
+//!   peripheral is instrumented for it (declared by accepting
+//!   [`Peripheral::install_logic_tap`](crate::Peripheral::install_logic_tap)).
+//!   Pad state only changes when code writes it, so the write sites themselves
+//!   report the new level into a shared [`LogicTap`]: GPIO out-latch /
+//!   direction / matrix updates, externally driven input-pad updates
+//!   (`set_gpio_input` / sim-input), and bit-engine line drivers (the ESP32-C3
+//!   I²C `I2cLineLevels` cell). The run loop keeps its full instruction batch
+//!   width and idle fast-forward stays available — probing costs (almost)
+//!   nothing.
+//! * **Poll (per-cycle sampling)** — the fallback for watched pads whose
+//!   peripheral is NOT push-instrumented. [`Machine`](crate::Machine) samples
+//!   those pads at EVERY engine-cycle boundary; while at least one polled
+//!   channel is armed the run loop clamps its batch to one instruction and
+//!   idle fast-forward is disabled (the pre-push behaviour, kept as the
+//!   honest fallback).
+//!
+//! Both modes record a `{ch, cycle, value}` edge ONLY on a transition, and
+//! timestamps are engine cycles, so identical firmware + identical watch
+//! config produce byte-identical edge streams regardless of how the host
+//! drives stepping — and regardless of the capture mode. The differential
+//! oracle test (`tests/logic_capture_differential.rs`) runs the same firmware
+//! under forced poll and under push and asserts the streams are byte-equal.
+//!
+//! ## Observation semantics (shared by both modes)
+//!
+//! An edge is *observed* at the first engine-cycle boundary at or after the
+//! write that caused it: a write during the instruction executing between
+//! cycles `c` and `c+1` yields an edge stamped `c+1` (plus any peripheral
+//! tick-cost cycles charged at that boundary — exactly where the poll loop
+//! samples). A pad that toggles more than once within one cycle records only
+//! the net transition (the last written level wins), matching what a
+//! boundary sampler can see. When several channels transition in the same
+//! cycle, edges are emitted in ascending channel order; if both push and poll
+//! channels transition in the same cycle, the push channels' edges are
+//! recorded first (again in ascending channel order). All of this is
+//! deterministic — no host timing leaks in.
+//!
+//! The capture guarantee: any pad level that persists across at least one
 //! instruction boundary is captured — no aliasing, at any toggle rate. A pad
 //! toggling every cycle yields an edge every cycle (and fills the ring in
 //! [`LOGIC_RING_CAPACITY`] cycles if never drained; overflow drops the OLDEST
@@ -31,6 +64,8 @@
 //! transition is actually recorded).
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 /// Maximum number of edges retained in the ring buffer. On overflow the oldest
 /// edge is dropped (and counted) so capture never grows without bound. 64k
@@ -63,6 +98,131 @@ struct LogicChannel {
     /// only ever read back as unknown). A transition is emitted when a `Some(v)`
     /// read differs from this.
     last: Option<bool>,
+    /// `true` when the owning peripheral pushes this channel's transitions
+    /// through the [`LogicTap`] (event-driven capture); `false` for the
+    /// per-cycle poll fallback. A channel is exactly one of the two.
+    push: bool,
+}
+
+/// A single pad-level report pushed by an instrumented peripheral through the
+/// [`LogicTap`]. `cycle` is the provisional stamp (the tap clock at write
+/// time); [`LogicCapture::ingest_push`] finalises boundary stamps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PadEvent {
+    /// Watch-channel index (see [`LogicEdge::ch`]).
+    pub ch: u32,
+    /// The pad level after the write.
+    pub value: bool,
+    /// Provisional engine-cycle stamp: the cycle boundary reached after the
+    /// instruction (or peripheral tick) performing the write.
+    pub cycle: u64,
+}
+
+#[derive(Default)]
+struct TapShared {
+    /// `true` while at least one push-mode channel is armed. Checked once per
+    /// CPU batch (to enable per-instruction clock bumps) and by instrumented
+    /// peripherals implicitly via their installed tap state.
+    armed: AtomicBool,
+    /// The provisional stamp for pushes happening "now": the engine-cycle
+    /// boundary reached once the currently-executing instruction retires.
+    /// Seeded by [`Machine`](crate::Machine) at batch/step start and advanced
+    /// once per retired instruction by the CPU while armed (see
+    /// `Cpu::step_batch`), so an MMIO pad write during instruction `k` of a
+    /// batch starting at cycle `C` is stamped `C + k + 1` — the same cycle the
+    /// per-cycle poll loop would observe it at.
+    clock: AtomicU64,
+    /// Number of events currently queued — lets the per-boundary drain skip
+    /// the mutex entirely on quiet boundaries (the common case), keeping the
+    /// armed hot path at one relaxed load per batch.
+    pending: AtomicUsize,
+    /// Pushed pad events, drained by the machine at observation boundaries.
+    /// Single-threaded in practice (everything runs on the machine thread);
+    /// the mutex exists because `Peripheral: Send` forces shared handles to be
+    /// `Send + Sync`, mirroring `bus_trace::BusTrace`.
+    queue: Mutex<Vec<PadEvent>>,
+}
+
+/// Shared push-capture tap: the handle instrumented peripherals report pad
+/// writes into, and whose clock the CPU advances per retired instruction while
+/// push capture is armed. Owned by the bus (one per machine); cloning shares
+/// the same underlying state, mirroring [`crate::bus::bus_trace::BusTrace`].
+#[derive(Clone, Default)]
+pub struct LogicTap {
+    shared: Arc<TapShared>,
+}
+
+impl std::fmt::Debug for LogicTap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogicTap")
+            .field("armed", &self.push_armed())
+            .finish()
+    }
+}
+
+impl LogicTap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `true` while at least one push-mode channel is armed.
+    #[inline]
+    pub fn push_armed(&self) -> bool {
+        self.shared.armed.load(Ordering::Relaxed)
+    }
+
+    /// Advance the provisional stamp by one retired instruction. Called by
+    /// CPU batch loops (only while [`push_armed`](Self::push_armed)) BEFORE
+    /// executing each instruction, so writes performed by that instruction
+    /// stamp with the boundary they become observable at.
+    #[inline]
+    pub fn bump_clock(&self) {
+        self.shared.clock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Seed the provisional stamp (machine-side, at batch/step start, after an
+    /// idle fast-forward skip, and to "next boundary" after each drain so
+    /// pause-time input pushes stamp where the first post-resume sample would
+    /// see them).
+    #[inline]
+    pub fn set_clock(&self, cycle: u64) {
+        self.shared.clock.store(cycle, Ordering::Relaxed);
+    }
+
+    /// Record a pad level for watched channel `ch`, stamped with the current
+    /// provisional clock. Called by instrumented peripherals from their pad
+    /// write sites; transitions-only dedup happens at ingest, so reporting an
+    /// unchanged level is harmless (but callers avoid it to keep the queue
+    /// small).
+    pub fn push(&self, ch: u32, value: bool) {
+        let cycle = self.shared.clock.load(Ordering::Relaxed);
+        self.shared
+            .queue
+            .lock()
+            .unwrap()
+            .push(PadEvent { ch, value, cycle });
+        self.shared.pending.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn set_armed(&self, armed: bool) {
+        self.shared.armed.store(armed, Ordering::Relaxed);
+    }
+
+    /// Drain all pushed events (machine-side, at observation boundaries).
+    /// A quiet boundary — the common case — costs one relaxed load, no lock,
+    /// no allocation.
+    pub(crate) fn take_events(&self) -> Vec<PadEvent> {
+        if self.shared.pending.load(Ordering::Relaxed) == 0 {
+            return Vec::new();
+        }
+        self.shared.pending.store(0, Ordering::Relaxed);
+        std::mem::take(&mut *self.shared.queue.lock().unwrap())
+    }
+
+    pub(crate) fn clear_events(&self) {
+        self.shared.pending.store(0, Ordering::Relaxed);
+        self.shared.queue.lock().unwrap().clear();
+    }
 }
 
 /// Result of draining the edge ring from a caller cursor.
@@ -101,15 +261,44 @@ impl LogicCapture {
         !self.channels.is_empty()
     }
 
-    /// Install a fresh watch set from pre-resolved channels and their initial
-    /// pad levels, clearing the ring, cursor and drop count. `resolved[i]` and
-    /// `initial[i]` describe channel `i`; they must be the same length.
-    pub fn install(&mut self, resolved: &[Option<(usize, u8)>], initial: &[Option<bool>]) {
+    /// `true` while at least one resolvable channel is on the per-cycle poll
+    /// fallback. Only then does the run loop clamp its batch to one
+    /// instruction and disable idle fast-forward; an all-push watch set pays
+    /// neither cost.
+    #[inline]
+    pub fn poll_active(&self) -> bool {
+        self.channels
+            .iter()
+            .any(|c| c.resolved.is_some() && !c.push)
+    }
+
+    /// `true` while at least one channel is push-mode (event-driven).
+    #[inline]
+    pub fn push_active(&self) -> bool {
+        self.channels.iter().any(|c| c.push)
+    }
+
+    /// Install a fresh watch set from pre-resolved channels, their initial
+    /// pad levels and their capture mode, clearing the ring, cursor and drop
+    /// count. `resolved[i]`, `initial[i]` and `push[i]` describe channel `i`;
+    /// they must be the same length.
+    pub fn install(
+        &mut self,
+        resolved: &[Option<(usize, u8)>],
+        initial: &[Option<bool>],
+        push: &[bool],
+    ) {
         debug_assert_eq!(resolved.len(), initial.len());
+        debug_assert_eq!(resolved.len(), push.len());
         self.channels = resolved
             .iter()
             .zip(initial.iter())
-            .map(|(&resolved, &last)| LogicChannel { resolved, last })
+            .zip(push.iter())
+            .map(|((&resolved, &last), &push)| LogicChannel {
+                resolved,
+                last,
+                push,
+            })
             .collect();
         self.ring.clear();
         self.next_seq = 0;
@@ -128,6 +317,9 @@ impl LogicCapture {
     /// transitions-only, so an unchanged pad records nothing.
     pub fn sample(&mut self, now: u64, read: impl Fn(usize, u8) -> Option<bool>) {
         for i in 0..self.channels.len() {
+            if self.channels[i].push {
+                continue; // event-driven channel: its peripheral pushes edges
+            }
             let Some((idx, pin)) = self.channels[i].resolved else {
                 continue;
             };
@@ -142,6 +334,55 @@ impl LogicCapture {
                     value: level,
                 });
             }
+        }
+    }
+
+    /// Ingest a drained batch of push events, recording transitions with
+    /// poll-identical semantics. `boundary` is the engine cycle at the end of
+    /// the just-executed instruction batch (before peripheral tick costs) and
+    /// `now` is the current engine cycle (after tick costs) — events stamped
+    /// AT the boundary are observed at `now`, exactly where the per-cycle poll
+    /// loop samples after charging tick costs.
+    ///
+    /// Semantics, matching a per-cycle boundary sampler bit for bit:
+    /// * events are grouped by finalised cycle (the queue is stamped in
+    ///   nondecreasing order by construction);
+    /// * within one cycle the LAST reported level per channel wins (a pad
+    ///   that toggles and returns within one cycle records nothing);
+    /// * a cycle's surviving transitions are emitted in ascending channel
+    ///   order.
+    pub fn ingest_push(&mut self, events: &[PadEvent], boundary: u64, now: u64) {
+        let mut i = 0;
+        while i < events.len() {
+            let cyc = events[i].cycle;
+            let mut j = i + 1;
+            while j < events.len() && events[j].cycle == cyc {
+                j += 1;
+            }
+            let stamp = if cyc >= boundary { now } else { cyc };
+            for ch in 0..self.channels.len() {
+                if !self.channels[ch].push {
+                    continue;
+                }
+                // Net level for this channel within the cycle: last write wins.
+                let mut level = None;
+                for e in &events[i..j] {
+                    if e.ch as usize == ch {
+                        level = Some(e.value);
+                    }
+                }
+                if let Some(level) = level {
+                    if self.channels[ch].last != Some(level) {
+                        self.channels[ch].last = Some(level);
+                        self.push_edge(LogicEdge {
+                            ch: ch as u32,
+                            cycle: stamp,
+                            value: level,
+                        });
+                    }
+                }
+            }
+            i = j;
         }
     }
 

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -65,6 +65,20 @@ const PCPU_NMI_INT: u64 = 0x60;
 const CPUSDIO_INT: u64 = 0x64;
 const PIN0: u64 = 0x74;
 
+/// Push-mode logic-capture state for the C3 GPIO (see
+/// [`crate::logic_capture`]): the shared tap, this port's watched
+/// `(pin, channel)` pairs, a pre-write level scratchpad, and the channel
+/// lists last registered with the shared I²C line cell (so registration is
+/// only re-synced when a write actually changes a watched pad's routing).
+#[derive(Debug)]
+struct C3Tap {
+    tap: crate::logic_capture::LogicTap,
+    watched: Vec<(u8, u32)>,
+    scratch: Vec<Option<bool>>,
+    line_scl_chs: Vec<u32>,
+    line_sda_chs: Vec<u32>,
+}
+
 #[derive(Debug)]
 pub struct Esp32c3Gpio {
     bt_select: u32,
@@ -83,6 +97,10 @@ pub struct Esp32c3Gpio {
     /// matrix routes I2CEXT0_SCL/SDA read the wire here instead of the
     /// GPIO_OUT latch.
     i2c_lines: Option<std::sync::Arc<super::i2c::I2cLineLevels>>,
+    /// `Some` while the logic analyzer watches pads on this port in push mode
+    /// (installed via `install_logic_tap`). Not snapshot state — the watch is
+    /// re-armed by the frontend after a resume.
+    tap: Option<C3Tap>,
     cycle: u64,
     anchor_tick: u64,
 }
@@ -100,6 +118,7 @@ impl Esp32c3Gpio {
             pin_cfg: [0; PIN_COUNT as usize],
             out_sel: [0; PIN_COUNT as usize],
             i2c_lines: None,
+            tap: None,
             cycle: 0,
             anchor_tick: 0,
         }
@@ -109,6 +128,103 @@ impl Esp32c3Gpio {
     /// engine drives) so matrix-routed pads carry the real waveform.
     pub(crate) fn set_i2c_lines(&mut self, lines: std::sync::Arc<super::i2c::I2cLineLevels>) {
         self.i2c_lines = Some(lines);
+    }
+
+    /// Direction-aware pad level — the single truth `read_gpio_pad` and the
+    /// push-capture tap both read.
+    fn pad_level(&self, pin: u8) -> Option<bool> {
+        if pin >= PIN_COUNT {
+            return None;
+        }
+        let mask = 1u32 << pin;
+        // ENABLE is the output driver: enabled pins show the driving signal,
+        // everything else shows the (externally driven) input level.
+        if (self.enable & mask) != 0 {
+            // Output matrix: pads routed to the I²C0 controller carry the live
+            // SDA/SCL wire the bit engine drives, not the GPIO_OUT latch.
+            if let Some(lines) = &self.i2c_lines {
+                match self.out_sel[pin as usize] & 0x1FF {
+                    SIG_I2CEXT0_SCL => return Some(lines.scl()),
+                    SIG_I2CEXT0_SDA => return Some(lines.sda()),
+                    _ => {}
+                }
+            }
+            return Some((self.out & mask) != 0);
+        }
+        Some((self.in_data & mask) != 0)
+    }
+
+    /// Record every watched pad's current level before a mutation. No-op (one
+    /// branch) while no tap is installed. The tap is briefly taken out of
+    /// `self` so `pad_level(&self)` can run while the scratchpad is written.
+    #[inline]
+    fn tap_snapshot(&mut self) {
+        let Some(mut t) = self.tap.take() else {
+            return;
+        };
+        for (k, &(pin, _)) in t.watched.iter().enumerate() {
+            t.scratch[k] = self.pad_level(pin);
+        }
+        self.tap = Some(t);
+    }
+
+    /// Report watched pads whose level became known-different since the
+    /// matching [`tap_snapshot`](Self::tap_snapshot), then re-sync the I²C
+    /// line-cell registration if the write changed a watched pad's routing —
+    /// so a pad handed to (or taken from) the I²C matrix keeps pushing edges
+    /// from the correct source afterwards.
+    #[inline]
+    fn tap_report(&mut self) {
+        let Some(t) = self.tap.take() else {
+            return;
+        };
+        for (k, &(pin, ch)) in t.watched.iter().enumerate() {
+            if let Some(level) = self.pad_level(pin) {
+                if t.scratch[k] != Some(level) {
+                    t.tap.push(ch, level);
+                }
+            }
+        }
+        self.tap = Some(t);
+        self.sync_line_tap();
+    }
+
+    /// Channels whose watched pads currently route to the I²C0 SCL / SDA
+    /// output-matrix signals (and are output-enabled) — the pads whose level
+    /// changes are driven by the I²C bit engine rather than GPIO writes.
+    fn routed_line_channels(&self) -> (Vec<u32>, Vec<u32>) {
+        let mut scl = Vec::new();
+        let mut sda = Vec::new();
+        if let Some(t) = &self.tap {
+            for &(pin, ch) in &t.watched {
+                if pin >= PIN_COUNT || (self.enable & (1u32 << pin)) == 0 {
+                    continue;
+                }
+                match self.out_sel[pin as usize] & 0x1FF {
+                    SIG_I2CEXT0_SCL => scl.push(ch),
+                    SIG_I2CEXT0_SDA => sda.push(ch),
+                    _ => {}
+                }
+            }
+        }
+        (scl, sda)
+    }
+
+    /// Push the current routed-channel lists into the shared I²C line cell,
+    /// but only when they changed (avoids mutex traffic on unrelated writes).
+    fn sync_line_tap(&mut self) {
+        let Some(lines) = self.i2c_lines.clone() else {
+            return;
+        };
+        let (scl, sda) = self.routed_line_channels();
+        let Some(t) = &mut self.tap else {
+            return;
+        };
+        if t.line_scl_chs != scl || t.line_sda_chs != sda {
+            t.line_scl_chs = scl.clone();
+            t.line_sda_chs = sda.clone();
+            lines.install_tap(Some(t.tap.clone()), scl, sda);
+        }
     }
 
     fn out_sel_index(off: u64) -> Option<usize> {
@@ -224,7 +340,9 @@ impl Peripheral for Esp32c3Gpio {
     fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
         let word_off = offset & !3;
         let byte_off = offset & 3;
+        self.tap_snapshot();
         if self.write_byte_special(word_off, byte_off, value) {
+            self.tap_report();
             return Ok(());
         }
         let shift = byte_off * 8;
@@ -232,6 +350,7 @@ impl Peripheral for Esp32c3Gpio {
         word &= !(0xFFu32 << shift);
         word |= (value as u32) << shift;
         self.write_word(word_off, word);
+        self.tap_report();
         Ok(())
     }
 
@@ -243,7 +362,9 @@ impl Peripheral for Esp32c3Gpio {
                 word_off,
                 OUT_W1TS | OUT_W1TC | ENABLE_W1TS | ENABLE_W1TC | STATUS_W1TS | STATUS_W1TC
             ) {
+                self.tap_snapshot();
                 self.write_word(word_off, (value as u32) << shift);
+                self.tap_report();
                 return Ok(());
             }
         }
@@ -253,7 +374,9 @@ impl Peripheral for Esp32c3Gpio {
 
     fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
         if offset & 3 == 0 {
+            self.tap_snapshot();
             self.write_word(offset, value);
+            self.tap_report();
             Ok(())
         } else {
             for i in 0..4 {
@@ -289,25 +412,7 @@ impl Peripheral for Esp32c3Gpio {
     }
 
     fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
-        if pin >= PIN_COUNT {
-            return None;
-        }
-        let mask = 1u32 << pin;
-        // ENABLE is the output driver: enabled pins show the driving signal,
-        // everything else shows the (externally driven) input level.
-        if (self.enable & mask) != 0 {
-            // Output matrix: pads routed to the I²C0 controller carry the live
-            // SDA/SCL wire the bit engine drives, not the GPIO_OUT latch.
-            if let Some(lines) = &self.i2c_lines {
-                match self.out_sel[pin as usize] & 0x1FF {
-                    SIG_I2CEXT0_SCL => return Some(lines.scl()),
-                    SIG_I2CEXT0_SDA => return Some(lines.sda()),
-                    _ => {}
-                }
-            }
-            return Some((self.out & mask) != 0);
-        }
-        Some((self.in_data & mask) != 0)
+        self.pad_level(pin)
     }
 
     fn gpio_routing(&self, pin: u8) -> Option<GpioRouting> {
@@ -345,7 +450,34 @@ impl Peripheral for Esp32c3Gpio {
         if pin >= PIN_COUNT {
             return false;
         }
+        self.tap_snapshot();
         self.set_pin_input(pin, level);
+        self.tap_report();
+        true
+    }
+
+    fn install_logic_tap(
+        &mut self,
+        tap: &crate::logic_capture::LogicTap,
+        watched: &[(u8, u32)],
+    ) -> bool {
+        if watched.is_empty() {
+            self.tap = None;
+            if let Some(lines) = &self.i2c_lines {
+                lines.install_tap(None, Vec::new(), Vec::new());
+            }
+        } else {
+            self.tap = Some(C3Tap {
+                tap: tap.clone(),
+                watched: watched.to_vec(),
+                scratch: vec![None; watched.len()],
+                // Seeded stale so the sync below always installs the current
+                // routing into the line cell.
+                line_scl_chs: vec![u32::MAX],
+                line_sda_chs: vec![u32::MAX],
+            });
+            self.sync_line_tap();
+        }
         true
     }
 

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -180,16 +180,31 @@ const CPU_CLK_HZ: u64 = 160_000_000;
 const XTAL_CLK_HZ: u64 = 40_000_000;
 const RC_FAST_CLK_HZ: u64 = 17_500_000;
 
+/// Push-mode logic-capture registration for the I²C line cell: which watch
+/// channels observe pads currently matrix-routed to SCL / SDA. Maintained by
+/// the C3 GPIO model (which owns the routing truth) via
+/// [`I2cLineLevels::install_tap`]; consulted by [`I2cLineLevels::set`] so the
+/// bit engine pushes an edge at the exact moment it drives a line transition.
+#[derive(Debug, Default)]
+struct LineTapState {
+    tap: Option<crate::logic_capture::LogicTap>,
+    scl_chs: Vec<u32>,
+    sda_chs: Vec<u32>,
+}
+
 /// Live SDA/SCL levels of the I²C0 bus (wired-AND of controller + slave drive,
 /// idle high — open-drain with pull-ups). The controller bit engine is the only
 /// writer; the C3 GPIO model reads it for pads whose GPIO output matrix
 /// (`FUNCn_OUT_SEL_CFG`) routes `I2CEXT0_SCL` / `I2CEXT0_SDA`, so
 /// `read_gpio_pad` — and the in-engine logic analyzer sampling through it —
-/// observes the real waveform on the routed pads.
+/// observes the real waveform on the routed pads. With push-mode capture
+/// armed on a routed pad, [`set`](Self::set) additionally reports each line
+/// transition into the shared logic tap (event-driven capture — no polling).
 #[derive(Debug)]
 pub struct I2cLineLevels {
     scl: AtomicBool,
     sda: AtomicBool,
+    tap: std::sync::Mutex<LineTapState>,
 }
 
 impl I2cLineLevels {
@@ -197,6 +212,7 @@ impl I2cLineLevels {
         Self {
             scl: AtomicBool::new(true),
             sda: AtomicBool::new(true),
+            tap: std::sync::Mutex::new(LineTapState::default()),
         }
     }
 
@@ -209,8 +225,43 @@ impl I2cLineLevels {
     }
 
     fn set(&self, scl: bool, sda: bool) {
-        self.scl.store(scl, Ordering::Relaxed);
-        self.sda.store(sda, Ordering::Relaxed);
+        let old_scl = self.scl.swap(scl, Ordering::Relaxed);
+        let old_sda = self.sda.swap(sda, Ordering::Relaxed);
+        if old_scl == scl && old_sda == sda {
+            return;
+        }
+        // A line actually transitioned: report it to any watch channels whose
+        // pads the GPIO matrix currently routes here. Lock taken only on
+        // transitions (module-tick rate, not per engine cycle).
+        let t = self.tap.lock().unwrap();
+        if let Some(tap) = &t.tap {
+            if old_scl != scl {
+                for &ch in &t.scl_chs {
+                    tap.push(ch, scl);
+                }
+            }
+            if old_sda != sda {
+                for &ch in &t.sda_chs {
+                    tap.push(ch, sda);
+                }
+            }
+        }
+    }
+
+    /// Install (or clear, with `tap = None`) the push-capture registration.
+    /// Called by the C3 GPIO model at watch install time and whenever a write
+    /// changes the routing of a watched pad, so the channel lists always
+    /// mirror the live GPIO matrix state.
+    pub(crate) fn install_tap(
+        &self,
+        tap: Option<crate::logic_capture::LogicTap>,
+        scl_chs: Vec<u32>,
+        sda_chs: Vec<u32>,
+    ) {
+        let mut t = self.tap.lock().unwrap();
+        t.tap = tap;
+        t.scl_chs = scl_chs;
+        t.sda_chs = sda_chs;
     }
 }
 

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -292,55 +292,17 @@ impl KinetisGpio {
     }
 }
 
-/// GPIO port — one variant per chip family. Register sets are fully isolated.
+/// The per-family register set of a [`GpioPort`]. Register sets are fully
+/// isolated — a register from one family cannot exist on another.
 #[derive(Debug, serde::Serialize)]
-pub enum GpioPort {
+pub enum GpioFamily {
     Stm32F1(F1Gpio),
     Stm32V2(V2Gpio),
     Nrf52(Nrf52Gpio),
     Kinetis(KinetisGpio),
 }
 
-impl Default for GpioPort {
-    fn default() -> Self {
-        Self::Stm32F1(F1Gpio::new())
-    }
-}
-
-impl GpioPort {
-    pub fn new() -> Self {
-        Self::new_with_layout(GpioRegisterLayout::Stm32F1)
-    }
-
-    pub fn new_with_layout(layout: GpioRegisterLayout) -> Self {
-        match layout {
-            GpioRegisterLayout::Stm32F1 => Self::Stm32F1(F1Gpio::new()),
-            GpioRegisterLayout::Stm32V2 => Self::Stm32V2(V2Gpio::default()),
-            GpioRegisterLayout::Nrf52 => Self::Nrf52(Nrf52Gpio::default()),
-            GpioRegisterLayout::Kinetis => Self::Kinetis(KinetisGpio::default()),
-        }
-    }
-
-    /// Build an nRF52-layout GPIO port with an explicit pin count.
-    /// Use this when the port has fewer than 32 physical pins (e.g. P1 = 16).
-    pub fn new_nrf52(num_pins: u32) -> Self {
-        Self::Nrf52(Nrf52Gpio::with_num_pins(num_pins))
-    }
-
-    /// Build a V2-layout GPIO port with explicit MODER/OSPEEDR/PUPDR reset
-    /// values. On real silicon these are per-port (debug pins keep port A off
-    /// the all-analog default; B carries the JTDO pull config; C..G reset to
-    /// 0xFFFFFFFF analog). The chip yaml supplies them via
-    /// `config: { reset_moder / reset_ospeedr / reset_pupdr }`.
-    pub fn new_stm32v2_with_resets(moder: u32, ospeedr: u32, pupdr: u32) -> Self {
-        Self::Stm32V2(V2Gpio {
-            moder,
-            ospeedr,
-            pupdr,
-            ..Default::default()
-        })
-    }
-
+impl GpioFamily {
     fn read_reg(&self, offset: u64) -> u32 {
         match self {
             Self::Stm32F1(g) => g.read_reg(offset),
@@ -359,80 +321,11 @@ impl GpioPort {
         }
     }
 
-    /// Register offset of the output data register (ODR) for this family.
-    /// Used by the bus to resolve a display's D/C line to a concrete address.
-    pub fn odr_offset(&self) -> u64 {
-        match self {
-            Self::Stm32F1(_) => 0x0C,
-            Self::Stm32V2(_) => 0x14,
-            Self::Nrf52(_) => 0x504,
-            Self::Kinetis(_) => 0x00,
-        }
-    }
-
-    /// Register offset of the input data register (IDR) for this family.
-    /// Used by the bus to resolve a sensor's input line (e.g. HC-SR04 ECHO).
-    pub fn idr_offset(&self) -> u64 {
-        match self {
-            Self::Stm32F1(_) => 0x08,
-            Self::Stm32V2(_) => 0x10,
-            Self::Nrf52(_) => 0x510,
-            Self::Kinetis(_) => 0x10,
-        }
-    }
-}
-
-impl crate::Peripheral for GpioPort {
-    fn read(&self, offset: u64) -> SimResult<u8> {
-        let reg_offset = offset & !3;
-        let byte_offset = (offset % 4) as u32;
-        let reg_val = self.read_reg(reg_offset);
-        Ok(((reg_val >> (byte_offset * 8)) & 0xFF) as u8)
-    }
-
-    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
-        let reg_offset = offset & !3;
-        let byte_offset = (offset % 4) as u32;
-
-        if reg_offset == 0x0C {
-            tracing::trace!("GPIO ODR Write: byte {} = {:#x}", byte_offset, value);
-        }
-
-        let mut reg_val = self.read_reg(reg_offset);
-        let mask = 0xFF << (byte_offset * 8);
-        reg_val &= !mask;
-        reg_val |= (value as u32) << (byte_offset * 8);
-
-        self.write_reg(reg_offset, reg_val);
-        Ok(())
-    }
-
-    fn read_u32(&self, offset: u64) -> SimResult<u32> {
-        Ok(self.read_reg(offset & !3))
-    }
-
-    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
-        // GPIO data registers are word-access. BSRR (atomic set/reset) only
-        // behaves correctly when the whole 32-bit word is presented at once:
-        // the default byte-decomposition would split BSRR's set half (low 16)
-        // from its reset half (high 16) into separate write_reg calls, so a
-        // pin named in both halves loses the BS-over-BR priority rule (set
-        // wins). Silicon performs the STR as one 32-bit transaction; mirror
-        // that by handing write_reg the full word. Silicon-verified on the
-        // bench STM32F103 (stm32f1_exec_oracle::gpioa_bsrr_set_reset).
-        self.write_reg(offset & !3, value);
-        Ok(())
-    }
-
-    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
-        if pin >= 32 {
-            return None;
-        }
-        let reg = self.read_reg(self.idr_offset());
-        Some((reg & (1u32 << pin)) != 0)
-    }
-
-    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+    /// Direction-aware pad level (the logic-probe truth). See
+    /// [`crate::Peripheral::read_gpio_pad`]; kept on the family so the
+    /// push-capture tap can read pre/post-write levels while the tap state is
+    /// mutably borrowed.
+    fn pad_level(&self, pin: u8) -> Option<bool> {
         if pin >= 32 {
             return None;
         }
@@ -477,14 +370,200 @@ impl crate::Peripheral for GpioPort {
             }
         }
     }
+}
+
+/// Push-mode logic-capture state for a [`GpioPort`]: the shared tap plus this
+/// port's watched `(pin, channel)` pairs and a pre-write level scratchpad
+/// (allocated once at install so the write hot path stays allocation-free).
+#[derive(Debug)]
+struct PortTap {
+    tap: crate::logic_capture::LogicTap,
+    watched: Vec<(u8, u32)>,
+    scratch: Vec<Option<bool>>,
+}
+
+/// GPIO port — a per-family register model (see [`GpioFamily`]) plus optional
+/// push-mode logic-capture instrumentation. The chip-yaml `profile` selects
+/// the family; the `Peripheral` impl and the `odr_offset`/`idr_offset` bus
+/// helpers dispatch to the active family.
+#[derive(Debug)]
+pub struct GpioPort {
+    family: GpioFamily,
+    /// `Some` while the logic analyzer watches pads on this port in push mode
+    /// (installed via `install_logic_tap`). Every register write then reports
+    /// watched pad-level changes into the tap. Not snapshot state — the watch
+    /// is re-armed by the frontend after a resume.
+    tap: Option<PortTap>,
+}
+
+impl Default for GpioPort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GpioPort {
+    fn from_family(family: GpioFamily) -> Self {
+        Self { family, tap: None }
+    }
+
+    pub fn new() -> Self {
+        Self::new_with_layout(GpioRegisterLayout::Stm32F1)
+    }
+
+    pub fn new_with_layout(layout: GpioRegisterLayout) -> Self {
+        Self::from_family(match layout {
+            GpioRegisterLayout::Stm32F1 => GpioFamily::Stm32F1(F1Gpio::new()),
+            GpioRegisterLayout::Stm32V2 => GpioFamily::Stm32V2(V2Gpio::default()),
+            GpioRegisterLayout::Nrf52 => GpioFamily::Nrf52(Nrf52Gpio::default()),
+            GpioRegisterLayout::Kinetis => GpioFamily::Kinetis(KinetisGpio::default()),
+        })
+    }
+
+    /// Build an nRF52-layout GPIO port with an explicit pin count.
+    /// Use this when the port has fewer than 32 physical pins (e.g. P1 = 16).
+    pub fn new_nrf52(num_pins: u32) -> Self {
+        Self::from_family(GpioFamily::Nrf52(Nrf52Gpio::with_num_pins(num_pins)))
+    }
+
+    /// Build a V2-layout GPIO port with explicit MODER/OSPEEDR/PUPDR reset
+    /// values. On real silicon these are per-port (debug pins keep port A off
+    /// the all-analog default; B carries the JTDO pull config; C..G reset to
+    /// 0xFFFFFFFF analog). The chip yaml supplies them via
+    /// `config: { reset_moder / reset_ospeedr / reset_pupdr }`.
+    pub fn new_stm32v2_with_resets(moder: u32, ospeedr: u32, pupdr: u32) -> Self {
+        Self::from_family(GpioFamily::Stm32V2(V2Gpio {
+            moder,
+            ospeedr,
+            pupdr,
+            ..Default::default()
+        }))
+    }
+
+    fn read_reg(&self, offset: u64) -> u32 {
+        self.family.read_reg(offset)
+    }
+
+    fn write_reg(&mut self, offset: u64, value: u32) {
+        self.family.write_reg(offset, value);
+    }
+
+    /// Register offset of the output data register (ODR) for this family.
+    /// Used by the bus to resolve a display's D/C line to a concrete address.
+    pub fn odr_offset(&self) -> u64 {
+        match &self.family {
+            GpioFamily::Stm32F1(_) => 0x0C,
+            GpioFamily::Stm32V2(_) => 0x14,
+            GpioFamily::Nrf52(_) => 0x504,
+            GpioFamily::Kinetis(_) => 0x00,
+        }
+    }
+
+    /// Register offset of the input data register (IDR) for this family.
+    /// Used by the bus to resolve a sensor's input line (e.g. HC-SR04 ECHO).
+    pub fn idr_offset(&self) -> u64 {
+        match &self.family {
+            GpioFamily::Stm32F1(_) => 0x08,
+            GpioFamily::Stm32V2(_) => 0x10,
+            GpioFamily::Nrf52(_) => 0x510,
+            GpioFamily::Kinetis(_) => 0x10,
+        }
+    }
+
+    /// Record every watched pad's current level before a mutation. No-op (one
+    /// branch) while no tap is installed.
+    #[inline]
+    fn tap_snapshot(&mut self) {
+        if let Some(t) = &mut self.tap {
+            for (k, &(pin, _)) in t.watched.iter().enumerate() {
+                t.scratch[k] = self.family.pad_level(pin);
+            }
+        }
+    }
+
+    /// Report watched pads whose level became known-different since the
+    /// matching [`tap_snapshot`](Self::tap_snapshot). A pad whose level became
+    /// UNknown (e.g. handed to a peripheral) reports nothing — same rule as
+    /// the poll path, which keeps the last known level.
+    #[inline]
+    fn tap_report(&mut self) {
+        if let Some(t) = &mut self.tap {
+            for (k, &(pin, ch)) in t.watched.iter().enumerate() {
+                if let Some(level) = self.family.pad_level(pin) {
+                    if t.scratch[k] != Some(level) {
+                        t.tap.push(ch, level);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl crate::Peripheral for GpioPort {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let reg_offset = offset & !3;
+        let byte_offset = (offset % 4) as u32;
+        let reg_val = self.read_reg(reg_offset);
+        Ok(((reg_val >> (byte_offset * 8)) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let reg_offset = offset & !3;
+        let byte_offset = (offset % 4) as u32;
+
+        if reg_offset == 0x0C {
+            tracing::trace!("GPIO ODR Write: byte {} = {:#x}", byte_offset, value);
+        }
+
+        let mut reg_val = self.read_reg(reg_offset);
+        let mask = 0xFF << (byte_offset * 8);
+        reg_val &= !mask;
+        reg_val |= (value as u32) << (byte_offset * 8);
+
+        self.tap_snapshot();
+        self.write_reg(reg_offset, reg_val);
+        self.tap_report();
+        Ok(())
+    }
+
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        Ok(self.read_reg(offset & !3))
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        // GPIO data registers are word-access. BSRR (atomic set/reset) only
+        // behaves correctly when the whole 32-bit word is presented at once:
+        // the default byte-decomposition would split BSRR's set half (low 16)
+        // from its reset half (high 16) into separate write_reg calls, so a
+        // pin named in both halves loses the BS-over-BR priority rule (set
+        // wins). Silicon performs the STR as one 32-bit transaction; mirror
+        // that by handing write_reg the full word. Silicon-verified on the
+        // bench STM32F103 (stm32f1_exec_oracle::gpioa_bsrr_set_reset).
+        self.tap_snapshot();
+        self.write_reg(offset & !3, value);
+        self.tap_report();
+        Ok(())
+    }
+
+    fn read_gpio_input(&self, pin: u8) -> Option<bool> {
+        if pin >= 32 {
+            return None;
+        }
+        let reg = self.read_reg(self.idr_offset());
+        Some((reg & (1u32 << pin)) != 0)
+    }
+
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        self.family.pad_level(pin)
+    }
 
     fn gpio_routing(&self, pin: u8) -> Option<GpioRouting> {
         if pin >= 32 {
             return None;
         }
         // Mode from the SAME register truth read_gpio_pad reads.
-        let mode = match self {
-            Self::Stm32F1(g) => {
+        let mode = match &self.family {
+            GpioFamily::Stm32F1(g) => {
                 // CRL/CRH: 4 bits/pin. MODE==0 → input (CNF 00 = analog, else
                 // digital input); MODE!=0 → output, CNF 10/11 = alternate function.
                 let cr = g.read_reg(if pin < 8 { 0x00 } else { 0x04 });
@@ -503,7 +582,7 @@ impl crate::Peripheral for GpioPort {
                     GpioMode::Output
                 }
             }
-            Self::Stm32V2(g) => {
+            GpioFamily::Stm32V2(g) => {
                 // MODER: 00 input, 01 output, 10 alternate function, 11 analog.
                 match (g.read_reg(0x00) >> (pin * 2)) & 0b11 {
                     0b00 => GpioMode::Input,
@@ -515,14 +594,14 @@ impl crate::Peripheral for GpioPort {
             // nRF52 / Kinetis: a plain DIR register (nRF DIR @0x514, Kinetis PDDR
             // @0x14) — bit set = output, clear = input. No AF concept at the GPIO
             // port (peripheral routing is elsewhere), so func stays None.
-            Self::Nrf52(g) => {
+            GpioFamily::Nrf52(g) => {
                 if (g.read_reg(0x514) & (1u32 << pin)) != 0 {
                     GpioMode::Output
                 } else {
                     GpioMode::Input
                 }
             }
-            Self::Kinetis(g) => {
+            GpioFamily::Kinetis(g) => {
                 if (g.read_reg(0x14) & (1u32 << pin)) != 0 {
                     GpioMode::Output
                 } else {
@@ -532,8 +611,8 @@ impl crate::Peripheral for GpioPort {
         };
         // func: STM32 V2 exposes an AFR nibble per AF pad → "AF<n>" (no full
         // AF→signal table; that is out of scope). Everything else: None.
-        let func = match self {
-            Self::Stm32V2(g) if mode == GpioMode::Af => {
+        let func = match &self.family {
+            GpioFamily::Stm32V2(g) if mode == GpioMode::Af => {
                 let (afr_off, sh) = if pin < 8 {
                     (0x20, (pin * 4) as u32)
                 } else {
@@ -565,7 +644,26 @@ impl crate::Peripheral for GpioPort {
         } else {
             reg &= !(1u32 << pin);
         }
+        self.tap_snapshot();
         self.write_reg(offset, reg);
+        self.tap_report();
+        true
+    }
+
+    fn install_logic_tap(
+        &mut self,
+        tap: &crate::logic_capture::LogicTap,
+        watched: &[(u8, u32)],
+    ) -> bool {
+        self.tap = if watched.is_empty() {
+            None
+        } else {
+            Some(PortTap {
+                tap: tap.clone(),
+                watched: watched.to_vec(),
+                scratch: vec![None; watched.len()],
+            })
+        };
         true
     }
 
@@ -573,11 +671,11 @@ impl crate::Peripheral for GpioPort {
         // Serialize the active family's register struct directly (flat), so the
         // snapshot keeps registers like `odr` at top level (no variant tag) —
         // matching the pre-split format the snapshot contract depends on.
-        match self {
-            Self::Stm32F1(g) => serde_json::to_value(g),
-            Self::Stm32V2(g) => serde_json::to_value(g),
-            Self::Nrf52(g) => serde_json::to_value(g),
-            Self::Kinetis(g) => serde_json::to_value(g),
+        match &self.family {
+            GpioFamily::Stm32F1(g) => serde_json::to_value(g),
+            GpioFamily::Stm32V2(g) => serde_json::to_value(g),
+            GpioFamily::Nrf52(g) => serde_json::to_value(g),
+            GpioFamily::Kinetis(g) => serde_json::to_value(g),
         }
         .unwrap_or(serde_json::Value::Null)
     }

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -173,7 +173,7 @@ mod logic_capture_tests {
     #[test]
     fn ring_buffer_drops_oldest_on_overflow() {
         let mut cap = LogicCapture::new();
-        cap.install(&[Some((0, 0))], &[Some(false)]);
+        cap.install(&[Some((0, 0))], &[Some(false)], &[false]);
 
         let overflow = 100usize;
         let total = LOGIC_RING_CAPACITY + overflow;
@@ -202,7 +202,7 @@ mod logic_capture_tests {
     #[test]
     fn unknown_pad_records_no_edges() {
         let mut cap = LogicCapture::new();
-        cap.install(&[Some((0, 0))], &[None]);
+        cap.install(&[Some((0, 0))], &[None], &[false]);
         for i in 0..10 {
             cap.sample(i + 1, |_, _| None);
         }
@@ -247,7 +247,9 @@ mod logic_capture_tests {
     /// The no-aliasing guarantee on the batched `Machine::run` path: firmware
     /// bit-banging a pad on consecutive instructions (str/str/branch loop) has
     /// every transition captured even with a wide peripheral tick interval —
-    /// the run loop clamps its batch to one instruction while a watch is armed.
+    /// push-instrumented pads report every write-site transition; polled pads
+    /// get the same guarantee from the armed one-instruction batch clamp (see
+    /// `tests/logic_capture_differential.rs` for the byte-equality oracle).
     #[test]
     fn run_path_captures_bitbang_toggles_without_aliasing() {
         use crate::DebugControl;

--- a/crates/core/src/tests/logic_capture_differential.rs
+++ b/crates/core/src/tests/logic_capture_differential.rs
@@ -1,0 +1,542 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential oracle for the two logic-capture modes (`crate::logic_capture`):
+//! run the SAME firmware twice — once forcing the per-cycle poll path
+//! (`Machine::logic_force_poll_capture`), once with event-driven push capture —
+//! and assert the edge streams are BYTE-IDENTICAL (same cycles, values,
+//! order). Poll is the reference semantics; if push disagrees, push is wrong.
+//!
+//! Also proves the two costs push removes are actually removed: the armed
+//! batch clamp (push runs keep multi-instruction batches) and — under the
+//! `event-scheduler` feature — the idle fast-forward disable (a WFI firmware
+//! skips idle cycles while probed, with an identical edge stream).
+
+#[cfg(test)]
+mod logic_capture_differential_tests {
+    use crate::cpu::CortexM;
+    use crate::logic_capture::LogicEdge;
+    use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+    use crate::{Bus, DebugControl, Machine, Peripheral, SimResult};
+
+    const GPIO_BASE: u64 = 0x5000_0000;
+    const RAM_BASE: u64 = 0x2000_0000;
+    /// V2-layout register offsets.
+    const MODER: u64 = 0x00;
+    const ODR: u64 = 0x14;
+
+    /// Build a Cortex-M machine with a V2 GPIO at `GPIO_BASE`, pins 0..2 as
+    /// outputs, and a str/str/branch bit-bang loop toggling pins 0+1 together
+    /// through one ODR word write per store.
+    fn bitbang_machine(tick_interval: u32) -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        bus.add_peripheral(
+            "gpio_test",
+            GPIO_BASE,
+            0x400,
+            None,
+            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2)),
+        );
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.peripheral_tick_interval = tick_interval;
+
+        // MODER pins 0..2 = output.
+        machine
+            .bus
+            .write_u32(GPIO_BASE + MODER, 0b01_01_01)
+            .unwrap();
+
+        // r0 = &ODR, r1 = 0b11, r2 = 0;  loop: str r1,[r0]; str r2,[r0]; b loop
+        machine.cpu.r0 = (GPIO_BASE + ODR) as u32;
+        machine.cpu.r1 = 0b11;
+        machine.cpu.r2 = 0;
+        machine.bus.write_u16(RAM_BASE, 0x6001).unwrap(); // str r1, [r0]
+        machine.bus.write_u16(RAM_BASE + 2, 0x6002).unwrap(); // str r2, [r0]
+        machine.bus.write_u16(RAM_BASE + 4, 0xE7FC).unwrap(); // b .-8
+        machine.cpu.pc = RAM_BASE as u32;
+        machine
+    }
+
+    /// Watch pins [1, 0] (reversed, so channel order != pin order — this is
+    /// what exercises the same-cycle cross-channel ordering rule), run
+    /// `steps`, and return the edge stream plus the (batches, instructions)
+    /// profile.
+    fn run_bitbang(mut machine: Machine<CortexM>, force_poll: bool, steps: u32) -> RunResult {
+        machine.logic_force_poll_capture(force_poll);
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        let initial = machine.logic_watch(&[Some((idx, 1)), Some((idx, 0))]);
+        assert_eq!(initial, vec![Some(false), Some(false)]);
+        machine.reset_step_profile();
+        machine.run(Some(steps)).unwrap();
+        let batch = machine.logic_read_edges(0);
+        RunResult {
+            edges: batch.edges,
+            dropped: batch.dropped,
+            batches: machine.step_profile().cpu_batches,
+            instructions: machine.step_profile().cpu_instructions,
+        }
+    }
+
+    struct RunResult {
+        edges: Vec<LogicEdge>,
+        dropped: u64,
+        batches: u64,
+        instructions: u64,
+    }
+
+    /// THE gate: bit-banged GPIO, wide tick interval. Poll (clamped, sampled
+    /// per cycle) and push (event-driven, full batches) must produce
+    /// byte-identical edge streams — and push must actually have kept its
+    /// batches wide (no armed clamp).
+    #[test]
+    fn stm32_bitbang_push_stream_is_byte_identical_to_poll() {
+        for tick_interval in [1u32, 8, 64] {
+            let steps = 600;
+            let poll = run_bitbang(bitbang_machine(tick_interval), true, steps);
+            let push = run_bitbang(bitbang_machine(tick_interval), false, steps);
+
+            assert!(
+                poll.edges.len() >= 300,
+                "tick={tick_interval}: expected a dense bit-bang stream, got {}",
+                poll.edges.len()
+            );
+            assert_eq!(
+                poll.edges, push.edges,
+                "tick={tick_interval}: push edges must be byte-identical to poll edges"
+            );
+            assert_eq!(poll.dropped, push.dropped);
+
+            // Poll clamps to one instruction per batch; push must not.
+            assert_eq!(
+                poll.batches, poll.instructions,
+                "tick={tick_interval}: poll fallback runs one instruction per batch"
+            );
+            if tick_interval > 1 {
+                assert!(
+                    push.batches < push.instructions,
+                    "tick={tick_interval}: push capture must keep multi-instruction \
+                     batches ({} batches for {} instructions)",
+                    push.batches,
+                    push.instructions
+                );
+            }
+        }
+    }
+
+    /// Peripheral tick-COST cycles (SysTick charges one cycle per tick while
+    /// enabled) shift the observation cycle past the batch boundary — the
+    /// poll loop samples only after costs are charged, so push stamps
+    /// finalised at the boundary must land on the same post-cost cycle. This
+    /// is the only fixture that exercises the boundary→now finalisation with
+    /// `now > boundary`.
+    #[test]
+    fn stm32_bitbang_with_tick_costs_push_stream_is_byte_identical_to_poll() {
+        const SYST_CSR: u64 = 0xE000_E010;
+        const SYST_RVR: u64 = 0xE000_E014;
+        let build = |tick_interval: u32| {
+            let mut machine = bitbang_machine(tick_interval);
+            machine.bus.write_u32(SYST_RVR, 9).unwrap();
+            machine.bus.write_u32(SYST_CSR, 1).unwrap(); // ENABLE, no interrupt
+            machine
+        };
+        for tick_interval in [1u32, 8] {
+            let poll = run_bitbang(build(tick_interval), true, 600);
+            let push = run_bitbang(build(tick_interval), false, 600);
+            assert!(poll.edges.len() >= 300);
+            // SysTick's per-tick cost must actually be in play: with it, some
+            // observation cycles exceed their instruction count.
+            assert!(
+                poll.edges.last().unwrap().cycle > 600,
+                "tick costs must push observation cycles past the step count"
+            );
+            assert_eq!(
+                poll.edges, push.edges,
+                "tick={tick_interval}: push edges must match poll under tick costs"
+            );
+        }
+    }
+
+    /// Externally driven input pads (sim-input / button path): levels set via
+    /// `set_gpio_input` while the machine is paused between run slices must
+    /// land on the same cycle in both modes.
+    #[test]
+    fn stm32_input_pad_push_stream_is_byte_identical_to_poll() {
+        let run = |force_poll: bool| {
+            let mut machine = bitbang_machine(8);
+            // Pin 3 stays MODER=input (00) — the externally driven channel.
+            machine.logic_force_poll_capture(force_poll);
+            let idx = machine
+                .bus
+                .find_peripheral_index_by_name("gpio_test")
+                .unwrap();
+            machine.logic_watch(&[Some((idx, 3)), Some((idx, 0))]);
+            for slice in 0..6 {
+                let level = slice % 2 == 0;
+                assert!(machine.bus.peripherals[idx].dev.set_gpio_input(3, level));
+                machine.run(Some(50)).unwrap();
+            }
+            machine.logic_read_edges(0).edges
+        };
+        let poll = run(true);
+        let push = run(false);
+        assert!(
+            poll.iter().filter(|e| e.ch == 0).count() >= 5,
+            "input channel must record the paused-machine level changes"
+        );
+        assert_eq!(poll, push, "input-pad edges must be byte-identical");
+    }
+
+    // ── ESP32-C3 I²C waveform (bit-engine push path) ────────────────────────
+
+    const C3_RAM_BASE: u64 = 0x2000_0000;
+    const I2C_BASE: u64 = 0x6001_3000;
+    const C3_GPIO_BASE: u64 = 0x6000_4000;
+    const SDA_PIN: u8 = 5;
+    const SCL_PIN: u8 = 6;
+    const SIG_I2CEXT0_SCL: u32 = 53;
+    const SIG_I2CEXT0_SDA: u32 = 54;
+    const ENABLE_W1TS: u64 = 0x24;
+    const FUNC_OUT_SEL: u64 = 0x554;
+    const REG_CTR: u64 = 0x04;
+    const REG_DATA: u64 = 0x1C;
+    const REG_CMD0: u64 = 0x58;
+    const WIRE_BYTES: [u8; 3] = [0x78, 0x40, 0xA5];
+
+    /// The ESP32-C3 SSD1306/I²C waveform fixture from
+    /// `tests/esp32c3_i2c_waveform.rs`, driven through `Machine::run` batches.
+    fn c3_i2c_machine(tick_interval: u32) -> Machine<CortexM> {
+        use crate::peripherals::components::Ssd1306;
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        bus.add_peripheral(
+            "gpio",
+            C3_GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(crate::peripherals::esp32c3::gpio::Esp32c3Gpio::new()),
+        );
+        bus.add_peripheral(
+            "i2c0",
+            I2C_BASE,
+            0x1000,
+            None,
+            Box::new(crate::peripherals::esp32c3::i2c::Esp32c3I2c::new()),
+        );
+        bus.attach_i2c_slave("i2c0", Box::new(Ssd1306::new(0x3C)))
+            .unwrap();
+        bus.wire_esp32c3_i2c_pads();
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.peripheral_tick_interval = tick_interval;
+        // The bus carries its own SimulationConfig copy; the peripheral walk
+        // hands `tick_elapsed` the BUS interval, so keep both in sync or the
+        // bit engine would advance slower than engine time.
+        machine.bus.config.peripheral_tick_interval = tick_interval;
+        for i in 0..1022u64 {
+            let byte = if i % 2 == 0 { 0x00 } else { 0x20 };
+            machine.bus.write_u8(C3_RAM_BASE + i, byte).unwrap();
+        }
+        machine.bus.write_u8(C3_RAM_BASE + 1022, 0xFF).unwrap();
+        machine.bus.write_u8(C3_RAM_BASE + 1023, 0xE5).unwrap();
+        machine.cpu.pc = C3_RAM_BASE as u32;
+
+        let bus = &mut machine.bus;
+        bus.write_u32(C3_GPIO_BASE + ENABLE_W1TS, (1 << SDA_PIN) | (1 << SCL_PIN))
+            .unwrap();
+        bus.write_u32(
+            C3_GPIO_BASE + FUNC_OUT_SEL + (SDA_PIN as u64) * 4,
+            SIG_I2CEXT0_SDA,
+        )
+        .unwrap();
+        bus.write_u32(
+            C3_GPIO_BASE + FUNC_OUT_SEL + (SCL_PIN as u64) * 4,
+            SIG_I2CEXT0_SCL,
+        )
+        .unwrap();
+        bus.write_u32(I2C_BASE, 199).unwrap(); // SCL_LOW_PERIOD
+        bus.write_u32(I2C_BASE + 0x38, 180 | (19 << 9)).unwrap(); // SCL_HIGH_PERIOD
+        bus.write_u32(I2C_BASE + 0x30, 29).unwrap(); // SDA_HOLD
+        bus.write_u32(I2C_BASE + 0x40, 199).unwrap(); // SCL_START_HOLD
+        bus.write_u32(I2C_BASE + 0x44, 199).unwrap(); // SCL_RSTART_SETUP
+        bus.write_u32(I2C_BASE + 0x4C, 199).unwrap(); // SCL_STOP_SETUP
+        bus.write_u32(I2C_BASE + 0x48, 199).unwrap(); // SCL_STOP_HOLD
+        machine
+    }
+
+    fn run_c3_i2c(tick_interval: u32, force_poll: bool) -> Vec<LogicEdge> {
+        let mut machine = c3_i2c_machine(tick_interval);
+        machine.logic_force_poll_capture(force_poll);
+        let gpio_idx = machine.bus.find_peripheral_index_by_name("gpio").unwrap();
+        let initial = machine.logic_watch(&[Some((gpio_idx, SDA_PIN)), Some((gpio_idx, SCL_PIN))]);
+        assert_eq!(initial, vec![Some(true), Some(true)]);
+
+        // Kick RSTART; WRITE 3 (addr, control, data); STOP.
+        let bus = &mut machine.bus;
+        let cmd = |opcode: u32, byte_num: u32| (opcode << 11) | byte_num;
+        bus.write_u32(I2C_BASE + REG_CMD0, cmd(6, 0)).unwrap();
+        bus.write_u32(I2C_BASE + REG_CMD0 + 4, cmd(1, 3)).unwrap();
+        bus.write_u32(I2C_BASE + REG_CMD0 + 8, cmd(2, 0)).unwrap();
+        for b in WIRE_BYTES {
+            bus.write_u32(I2C_BASE + REG_DATA, b as u32).unwrap();
+        }
+        bus.write_u32(I2C_BASE + REG_CTR, 1 << 5).unwrap();
+
+        // ~46k cycles of wire time at 100 kHz; run a fixed budget with
+        // headroom so both modes execute the identical cycle count.
+        for _ in 0..60 {
+            machine.run(Some(1_000)).unwrap();
+        }
+        machine.logic_read_edges(0).edges
+    }
+
+    /// THE gate, I²C flavour: the bit-level engine's SDA/SCL waveform on
+    /// matrix-routed pads, pushed from the `I2cLineLevels` cell, must be
+    /// byte-identical to the per-cycle poll of `read_gpio_pad`.
+    #[test]
+    fn esp32c3_i2c_waveform_push_stream_is_byte_identical_to_poll() {
+        for tick_interval in [1u32, 4] {
+            let poll = run_c3_i2c(tick_interval, true);
+            let push = run_c3_i2c(tick_interval, false);
+            let scl_rises = poll.iter().filter(|e| e.ch == 1 && e.value).count();
+            assert_eq!(
+                scl_rises,
+                WIRE_BYTES.len() * 9 + 1,
+                "tick={tick_interval}: full transaction on the wire (3 bytes x 9 bits + STOP rise)"
+            );
+            assert_eq!(
+                poll, push,
+                "tick={tick_interval}: push I2C waveform must be byte-identical to poll"
+            );
+        }
+    }
+
+    // ── Honest fallback: non-instrumented peripherals stay on poll ──────────
+
+    /// A minimal GPIO-ish peripheral that deliberately does NOT accept a
+    /// logic tap: one output latch word, every pin an output.
+    #[derive(Debug, Default)]
+    struct PollOnlyGpio {
+        latch: u32,
+    }
+
+    impl Peripheral for PollOnlyGpio {
+        fn read(&self, offset: u64) -> SimResult<u8> {
+            Ok(((self.latch >> ((offset & 3) * 8)) & 0xFF) as u8)
+        }
+        fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+            let shift = (offset & 3) * 8;
+            self.latch = (self.latch & !(0xFFu32 << shift)) | ((value as u32) << shift);
+            Ok(())
+        }
+        fn read_gpio_output(&self, pin: u8) -> Option<bool> {
+            (pin < 32).then(|| (self.latch >> pin) & 1 != 0)
+        }
+    }
+
+    /// Mixed watch set: one channel on a push-instrumented `GpioPort`, one on
+    /// a non-instrumented peripheral. The fallback channel must still capture
+    /// (per-cycle poll), the batch clamp must be back in force, and the whole
+    /// stream must equal the fully-forced-poll run.
+    #[test]
+    fn non_instrumented_peripheral_falls_back_to_poll() {
+        const POLL_GPIO_BASE: u64 = 0x5100_0000;
+        let build = || {
+            let mut machine = bitbang_machine(8);
+            machine.bus.add_peripheral(
+                "gpio_poll_only",
+                POLL_GPIO_BASE,
+                0x100,
+                None,
+                Box::<PollOnlyGpio>::default(),
+            );
+            // loop: str r1,[r0]; str r1,[r3]; str r2,[r0]; str r2,[r3]; b loop
+            machine.cpu.r3 = POLL_GPIO_BASE as u32;
+            machine.bus.write_u16(RAM_BASE, 0x6001).unwrap(); // str r1, [r0]
+            machine.bus.write_u16(RAM_BASE + 2, 0x6019).unwrap(); // str r1, [r3]
+            machine.bus.write_u16(RAM_BASE + 4, 0x6002).unwrap(); // str r2, [r0]
+            machine.bus.write_u16(RAM_BASE + 6, 0x601A).unwrap(); // str r2, [r3]
+            machine.bus.write_u16(RAM_BASE + 8, 0xE7FA).unwrap(); // b .-12
+            machine
+        };
+        let run = |force_poll: bool| {
+            let mut machine = build();
+            machine.logic_force_poll_capture(force_poll);
+            let push_idx = machine
+                .bus
+                .find_peripheral_index_by_name("gpio_test")
+                .unwrap();
+            let poll_idx = machine
+                .bus
+                .find_peripheral_index_by_name("gpio_poll_only")
+                .unwrap();
+            machine.logic_watch(&[Some((push_idx, 0)), Some((poll_idx, 0))]);
+            machine.reset_step_profile();
+            machine.run(Some(400)).unwrap();
+            let profile = machine.step_profile();
+            (
+                machine.logic_read_edges(0).edges,
+                profile.cpu_batches,
+                profile.cpu_instructions,
+            )
+        };
+        let (poll_edges, poll_batches, poll_instr) = run(true);
+        let (push_edges, push_batches, push_instr) = run(false);
+
+        assert!(
+            poll_edges.iter().filter(|e| e.ch == 1).count() >= 100,
+            "the non-instrumented channel must still record its toggles"
+        );
+        assert_eq!(poll_edges, push_edges, "mixed-mode stream must match poll");
+        // A polled channel is armed in BOTH runs, so both keep the clamp.
+        assert_eq!(poll_batches, poll_instr);
+        assert_eq!(push_batches, push_instr);
+    }
+
+    // ── ingest semantics units ───────────────────────────────────────────────
+
+    /// A pad that toggles and returns within one cycle records nothing (the
+    /// last written level wins) — matching what a per-cycle boundary sampler
+    /// can observe.
+    #[test]
+    fn intra_cycle_toggle_records_net_transition_only() {
+        use crate::logic_capture::{LogicCapture, PadEvent};
+        let mut cap = LogicCapture::new();
+        cap.install(&[Some((0, 0))], &[Some(false)], &[true]);
+        cap.ingest_push(
+            &[
+                PadEvent {
+                    ch: 0,
+                    value: true,
+                    cycle: 10,
+                },
+                PadEvent {
+                    ch: 0,
+                    value: false,
+                    cycle: 10,
+                },
+            ],
+            999,
+            999,
+        );
+        assert!(
+            cap.read_edges(0).edges.is_empty(),
+            "A->B->A inside one cycle is invisible to a boundary observer"
+        );
+    }
+
+    /// Same-cycle transitions on several channels are emitted in ascending
+    /// channel order regardless of write order — the documented deterministic
+    /// rule (and exactly what the poll sampler produces).
+    #[test]
+    fn same_cycle_edges_are_emitted_in_ascending_channel_order() {
+        use crate::logic_capture::{LogicCapture, PadEvent};
+        let mut cap = LogicCapture::new();
+        cap.install(
+            &[Some((0, 0)), Some((0, 1))],
+            &[Some(false), Some(false)],
+            &[true, true],
+        );
+        cap.ingest_push(
+            &[
+                PadEvent {
+                    ch: 1,
+                    value: true,
+                    cycle: 7,
+                },
+                PadEvent {
+                    ch: 0,
+                    value: true,
+                    cycle: 7,
+                },
+            ],
+            999,
+            999,
+        );
+        let edges = cap.read_edges(0).edges;
+        assert_eq!(edges.len(), 2);
+        assert_eq!((edges[0].ch, edges[0].cycle), (0, 7));
+        assert_eq!((edges[1].ch, edges[1].cycle), (1, 7));
+    }
+
+    // ── Idle fast-forward while probing (push-only watch sets) ──────────────
+
+    /// The product win: a WFI-idling RISC-V firmware keeps its idle skip while
+    /// its pads are probed through push capture, and the edge stream is still
+    /// byte-identical to the (clamped, non-skipping) poll reference. Gated on
+    /// `event-scheduler` because `try_idle_fast_forward` compiles to a no-op
+    /// without it.
+    #[cfg(feature = "event-scheduler")]
+    #[test]
+    fn idle_fast_forward_engages_while_probing_push_channels() {
+        use crate::cpu::RiscV;
+        let build = || {
+            let mut bus = crate::bus::SystemBus::new();
+            bus.flash.data = vec![0; 0x100];
+            bus.add_peripheral(
+                "gpio_test",
+                GPIO_BASE,
+                0x400,
+                None,
+                Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2)),
+            );
+            // MODER pin0 = output.
+            bus.write_u32(GPIO_BASE + MODER, 0b01).unwrap();
+            // lui x1, 0x50000; addi x2, x0, 1; sw x2, 0x14(x1); wfi; jal .-4
+            bus.write_u32(0x0, 0x5000_00B7).unwrap();
+            bus.write_u32(0x4, 0x0010_0113).unwrap();
+            bus.write_u32(0x8, 0x0020_AA23).unwrap();
+            bus.write_u32(0xC, 0x1050_0073).unwrap();
+            bus.write_u32(0x10, 0xFFDF_F06F).unwrap();
+            let mut cpu = RiscV::new();
+            cpu.pc = 0x0;
+            cpu.mtimecmp = u64::MAX;
+            let mut machine = Machine::new(cpu, bus);
+            machine.config.idle_fast_forward_enabled = true;
+            machine.bus.legacy_walk_disabled = true;
+            machine
+        };
+        let run = |force_poll: bool| {
+            let mut machine = build();
+            machine.logic_force_poll_capture(force_poll);
+            let idx = machine
+                .bus
+                .find_peripheral_index_by_name("gpio_test")
+                .unwrap();
+            machine.logic_watch(&[Some((idx, 0))]);
+            machine.reset_step_profile();
+            machine.run(Some(10_000)).unwrap();
+            (
+                machine.logic_read_edges(0).edges,
+                machine.step_profile().cpu_instructions,
+                machine.total_cycles,
+            )
+        };
+        let (poll_edges, poll_instr, poll_cycles) = run(true);
+        let (push_edges, push_instr, push_cycles) = run(false);
+
+        assert_eq!(poll_cycles, push_cycles, "identical simulated time");
+        assert_eq!(
+            poll_edges.len(),
+            1,
+            "one pad write before the firmware parks in WFI"
+        );
+        assert_eq!(
+            poll_edges, push_edges,
+            "edge stream must be exact under fast-forward"
+        );
+        assert_eq!(
+            poll_instr, poll_cycles,
+            "poll fallback chews every idle cycle (fast-forward disabled)"
+        );
+        assert!(
+            push_instr < push_cycles / 100,
+            "push capture must keep the idle skip: retired {push_instr} \
+             instructions over {push_cycles} cycles"
+        );
+    }
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -7,6 +7,8 @@ pub mod integration;
 #[cfg(test)]
 pub mod logic_capture;
 #[cfg(test)]
+pub mod logic_capture_differential;
+#[cfg(test)]
 pub mod nrf52;
 #[cfg(test)]
 pub mod rp2040;

--- a/crates/core/tests/logic_capture_bench.rs
+++ b/crates/core/tests/logic_capture_bench.rs
@@ -5,16 +5,19 @@
 //! Timing harness for logic-analyzer capture overhead.
 //!
 //! Not a pass/fail benchmark — it prints wall-clock numbers for capture
-//! disarmed vs armed (4 and 8 watched channels) so the cost of per-cycle
-//! sampling stays measured, not guessed. Two scenarios:
+//! disarmed vs armed (4 and 8 watched channels), in BOTH capture modes
+//! (event-driven push — the default for instrumented peripherals — and the
+//! forced per-cycle poll fallback via `Machine::logic_force_poll_capture`),
+//! so the cost of probing stays measured, not guessed. Two scenarios:
 //!
 //! 1. A real firmware fixture (`stm32f103-blinky.elf`) driven through
 //!    `Machine::run` in wasm-worker-style batches at the default
 //!    `peripheral_tick_interval = 1` — the configuration every playground
 //!    run uses.
 //! 2. A synthetic NOP loop on a bare bus at `peripheral_tick_interval = 64`
-//!    — the maximum-batching case, where arming capture clamps the run-loop
-//!    batch and the clamp cost is at its worst.
+//!    — the maximum-batching case, where arming POLL capture clamps the
+//!    run-loop batch and the clamp cost is at its worst; push capture keeps
+//!    the full batch width and should track the unarmed time.
 //!
 //! Run manually with:
 //!
@@ -126,8 +129,14 @@ fn readable_pads(machine: &Machine<CortexM>, n: usize) -> Vec<Option<(usize, u8)
     panic!("only found {} readable pads, wanted {}", out.len(), n);
 }
 
-fn timed_run(mut machine: Machine<CortexM>, channels: usize, steps: u64) -> (f64, usize, u64) {
+fn timed_run(
+    mut machine: Machine<CortexM>,
+    channels: usize,
+    steps: u64,
+    force_poll: bool,
+) -> (f64, usize, u64) {
     if channels > 0 {
+        machine.logic_force_poll_capture(force_poll);
         let pads = readable_pads(&machine, channels);
         machine.logic_watch(&pads);
     }
@@ -163,18 +172,22 @@ fn bench_logic_capture_overhead() {
         ),
     ];
     for (name, build, steps) in scenarios {
-        let mut base = f64::NAN;
-        for channels in [0usize, 4, 8] {
-            let (secs, edges, dropped) = timed_run(build(), channels, steps);
-            if channels == 0 {
-                base = secs;
+        let (base, edges, dropped) = timed_run(build(), 0, steps, false);
+        println!(
+            "{name} channels=0 (unarmed)   : {base:.3}s \
+             ({:.2} Minstr/s) edges={edges} dropped={dropped}",
+            steps as f64 / base / 1e6,
+        );
+        for channels in [4usize, 8] {
+            for (mode, force_poll) in [("push", false), ("poll", true)] {
+                let (secs, edges, dropped) = timed_run(build(), channels, steps, force_poll);
+                println!(
+                    "{name} channels={channels} mode={mode} : {secs:.3}s \
+                     ({:.2} Minstr/s, {:.2}x vs unarmed) edges={edges} dropped={dropped}",
+                    steps as f64 / secs / 1e6,
+                    secs / base,
+                );
             }
-            println!(
-                "{name} channels={channels} : {secs:.3}s \
-                 ({:.2} Minstr/s, {:.2}x vs unarmed) edges={edges} dropped={dropped}",
-                steps as f64 / secs / 1e6,
-                secs / base,
-            );
         }
     }
 }


### PR DESCRIPTION
Converts logic capture from poll-per-cycle to push-on-write for instrumented peripherals: the code that changes a pad records the edge at write time with the exact cycle. Poll remains the honest per-channel fallback for uninstrumented families.

- Armed overhead with push: ~1.00x in every benchmark scenario (the poll clamp cost 1.5–1.7x in the synthetic worst case). Disarmed: one predictable branch per batch.
- Idle fast-forward stays engaged while probing push-only channels — WFI firmware keeps its skip (poll retired every idle cycle; push retires <1%), with scheduler-event pad writes stamped at their deadline.
- Push capability is declared by the peripheral itself via `install_logic_tap` (no hardcoded list). Instrumented: shared GpioPort (STM32 F1/V2/H5, nRF52, Kinetis), ESP32-C3 GPIO, C3 I2cLineLevels (the bit engine pushes SDA/SCL itself). ESP32 classic/S3 + declarative models stay polled+clamped.
- Honesty gate: `logic_capture_differential.rs` runs the same firmware under forced poll and under push and asserts BYTE-IDENTICAL edge streams — STM32 bit-bang at tick 1/8/64 (incl. SysTick tick costs), paused-machine input drives, the C3 SSD1306 waveform fixture, mixed push+fallback sets, and the WFI/fast-forward case.
- wasm API and edge-stream shape unchanged; no new exports; only a doc-hidden test-only force-poll knob.

Gates: fmt + clippy --all-targets clean; workspace suite green; jit,event-scheduler lane green (known machine-local intmatrix_alarm failure reproduced on pristine base).