### PR TITLE
STM32 SPI: bit-level cycle-stretched wire engine (real SCK/MOSI/MISO waveforms)

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -702,6 +702,10 @@ impl SystemBus {
         // the C3 GPIO model so matrix-routed pads carry the real waveform.
         // No-op for every other chip.
         bus.wire_esp32c3_i2c_pads();
+        // STM32: share each classic/FIFO SPI bit engine's live SCK/MOSI/MISO
+        // line levels with the STM32 GPIO ports so AF-routed pads carry the
+        // real waveform. No-op for every other chip.
+        bus.wire_stm32_spi_pads();
         // Resolve declared per-peripheral RCC clock-gates now that every
         // peripheral (incl. the RCC, needed to map reg-name → offset) is on the
         // bus. Peripherals without a `clock:` field stay ungated.

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -977,6 +977,125 @@ impl SystemBus {
         }
     }
 
+    /// Wire the STM32 SPI bit engines' live SCK/MOSI/MISO levels into the
+    /// STM32 GPIO ports, so pads whose MODER/AFR (V2) or CRL/CRH CNF (F1)
+    /// route an SPI alternate function read the real waveform through
+    /// `read_gpio_pad` (which is what the in-engine logic analyzer samples).
+    /// The SPI counterpart of [`Self::wire_esp32c3_i2c_pads`]; no-op on buses
+    /// without a classic/FIFO STM32 SPI.
+    ///
+    /// Signal mapping comes from static per-family AF tables sourced from the
+    /// datasheet alternate-function maps:
+    /// * L4 (FIFO SPI + V2 GPIO): STM32L476 datasheet DS10198 Table 17 —
+    ///   SPI1/SPI2 on AF5, SPI3 on AF6.
+    /// * F4 (classic SPI + V2 GPIO): STM32F407 datasheet DS8626 Table 9 —
+    ///   SPI1/SPI2 on AF5.
+    /// * F1 (classic SPI + F1 GPIO): RM0008 §9.3 default pinout, no AFIO
+    ///   remap (remap is not modeled). F1 MISO pads are input-mode on real
+    ///   silicon and are intentionally not routed (see `GpioPort` docs).
+    pub(crate) fn wire_stm32_spi_pads(&mut self) {
+        use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+        use crate::peripherals::spi::{Spi, SpiSignal};
+        use SpiSignal::{Miso, Mosi, Sck};
+
+        // (spi, port, pin, AF, signal, func) — V2 ports, L4 parts (DS10198
+        // Table 17: SPI1-3).
+        const L4: &[(&str, char, u8, u8, SpiSignal, &str)] = &[
+            ("spi1", 'a', 5, 5, Sck, "SPI1_SCK"),
+            ("spi1", 'a', 6, 5, Miso, "SPI1_MISO"),
+            ("spi1", 'a', 7, 5, Mosi, "SPI1_MOSI"),
+            ("spi1", 'b', 3, 5, Sck, "SPI1_SCK"),
+            ("spi1", 'b', 4, 5, Miso, "SPI1_MISO"),
+            ("spi1", 'b', 5, 5, Mosi, "SPI1_MOSI"),
+            ("spi1", 'e', 13, 5, Sck, "SPI1_SCK"),
+            ("spi1", 'e', 14, 5, Miso, "SPI1_MISO"),
+            ("spi1", 'e', 15, 5, Mosi, "SPI1_MOSI"),
+            ("spi2", 'b', 10, 5, Sck, "SPI2_SCK"),
+            ("spi2", 'b', 13, 5, Sck, "SPI2_SCK"),
+            ("spi2", 'b', 14, 5, Miso, "SPI2_MISO"),
+            ("spi2", 'b', 15, 5, Mosi, "SPI2_MOSI"),
+            ("spi2", 'c', 2, 5, Miso, "SPI2_MISO"),
+            ("spi2", 'c', 3, 5, Mosi, "SPI2_MOSI"),
+            ("spi2", 'd', 1, 5, Sck, "SPI2_SCK"),
+            ("spi2", 'd', 3, 5, Miso, "SPI2_MISO"),
+            ("spi2", 'd', 4, 5, Mosi, "SPI2_MOSI"),
+            ("spi3", 'b', 3, 6, Sck, "SPI3_SCK"),
+            ("spi3", 'b', 4, 6, Miso, "SPI3_MISO"),
+            ("spi3", 'b', 5, 6, Mosi, "SPI3_MOSI"),
+            ("spi3", 'c', 10, 6, Sck, "SPI3_SCK"),
+            ("spi3", 'c', 11, 6, Miso, "SPI3_MISO"),
+            ("spi3", 'c', 12, 6, Mosi, "SPI3_MOSI"),
+        ];
+        // V2 ports, F4 parts (DS8626 Table 9: SPI1-2).
+        const F4: &[(&str, char, u8, u8, SpiSignal, &str)] = &[
+            ("spi1", 'a', 5, 5, Sck, "SPI1_SCK"),
+            ("spi1", 'a', 6, 5, Miso, "SPI1_MISO"),
+            ("spi1", 'a', 7, 5, Mosi, "SPI1_MOSI"),
+            ("spi1", 'b', 3, 5, Sck, "SPI1_SCK"),
+            ("spi1", 'b', 4, 5, Miso, "SPI1_MISO"),
+            ("spi1", 'b', 5, 5, Mosi, "SPI1_MOSI"),
+            ("spi2", 'b', 10, 5, Sck, "SPI2_SCK"),
+            ("spi2", 'b', 13, 5, Sck, "SPI2_SCK"),
+            ("spi2", 'b', 14, 5, Miso, "SPI2_MISO"),
+            ("spi2", 'b', 15, 5, Mosi, "SPI2_MOSI"),
+            ("spi2", 'c', 2, 5, Miso, "SPI2_MISO"),
+            ("spi2", 'c', 3, 5, Mosi, "SPI2_MOSI"),
+        ];
+        // F1 ports (RM0008 §9.3 default mapping, SPI1-2, SCK/MOSI only).
+        const F1: &[(&str, char, u8, SpiSignal, &str)] = &[
+            ("spi1", 'a', 5, Sck, "SPI1_SCK"),
+            ("spi1", 'a', 7, Mosi, "SPI1_MOSI"),
+            ("spi2", 'b', 13, Sck, "SPI2_SCK"),
+            ("spi2", 'b', 15, Mosi, "SPI2_MOSI"),
+        ];
+
+        for spi_name in ["spi1", "spi2", "spi3"] {
+            let Some(spi_idx) = self.find_peripheral_index_by_name(spi_name) else {
+                continue;
+            };
+            let Some((fifo, lines)) = self.peripherals[spi_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Spi>())
+                .filter(|s| s.is_stm32_wire_layout())
+                .map(|s| (s.is_fifo_layout(), s.line_levels_arc()))
+            else {
+                continue;
+            };
+            for port in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] {
+                let Some(gpio_idx) = self.find_peripheral_index_by_name(&format!("gpio{port}"))
+                else {
+                    continue;
+                };
+                let Some(gpio) = self.peripherals[gpio_idx]
+                    .dev
+                    .as_any_mut()
+                    .and_then(|a| a.downcast_mut::<GpioPort>())
+                else {
+                    continue;
+                };
+                match gpio.register_layout() {
+                    GpioRegisterLayout::Stm32V2 => {
+                        let table = if fifo { L4 } else { F4 };
+                        for &(spi, p, pin, af, sig, func) in table {
+                            if spi == spi_name && p == port {
+                                gpio.add_spi_pad_route(&lines, pin, Some(af), sig, func);
+                            }
+                        }
+                    }
+                    GpioRegisterLayout::Stm32F1 => {
+                        for &(spi, p, pin, sig, func) in F1 {
+                            if spi == spi_name && p == port {
+                                gpio.add_spi_pad_route(&lines, pin, None, sig, func);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     /// The single funnel through which every SPI device reaches a controller —
     /// the SPI counterpart of [`Self::attach_i2c_slave`]. Wraps then dispatches.
     pub fn attach_spi_device(

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -375,14 +375,37 @@ mod tests {
         // Enable SPE so DR writes kick off transfers.
         bus.write_u16(SPI1 + CR1, 1 << 6).unwrap();
 
+        // Clock the bit engine until the frame leaves the wire — the same
+        // wait-for-BSY a real driver performs between bytes (a DR write no
+        // longer completes instantly).
+        fn clock_out(bus: &mut SystemBus) {
+            let idx = bus.find_peripheral_index_by_name("spi1").unwrap();
+            for _ in 0..10_000 {
+                let spi = bus.peripherals[idx]
+                    .dev
+                    .as_any()
+                    .unwrap()
+                    .downcast_ref::<Spi>()
+                    .unwrap();
+                if !spi.transfer_active() {
+                    return;
+                }
+                bus.peripherals[idx].dev.tick_elapsed(1);
+            }
+            panic!("SPI frame never completed");
+        }
+
         // D/C low (PC7=0, the reset state): two command bytes position the
         // cursor at bank 2, column 5.
         bus.write_u16(SPI1 + DR, 0x40 | 2).unwrap(); // set Y (bank) = 2
+        clock_out(&mut bus);
         bus.write_u16(SPI1 + DR, 0x80 | 5).unwrap(); // set X (col)  = 5
+        clock_out(&mut bus);
 
         // Drive PC7 high (D/C = data) via BSRR, then stream a data byte.
         bus.write_u32(GPIOC + BSRR, 1 << 7).unwrap();
         bus.write_u16(SPI1 + DR, 0xAB).unwrap();
+        clock_out(&mut bus);
 
         // Inspect the attached panel's framebuffer through the bus.
         let idx = bus.find_peripheral_index_by_name("spi1").unwrap();

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -375,11 +375,31 @@ impl GpioFamily {
 /// Push-mode logic-capture state for a [`GpioPort`]: the shared tap plus this
 /// port's watched `(pin, channel)` pairs and a pre-write level scratchpad
 /// (allocated once at install so the write hot path stays allocation-free).
+/// `line_chs` caches, per wired SPI line cell, the channel lists last
+/// registered with that cell (so registration is only re-synced when a write
+/// actually changes a watched pad's routing) — the C3 GPIO pattern.
 #[derive(Debug)]
 struct PortTap {
     tap: crate::logic_capture::LogicTap,
     watched: Vec<(u8, u32)>,
     scratch: Vec<Option<bool>>,
+    line_chs: Vec<[Vec<u32>; 3]>,
+}
+
+/// One AF-routed SPI pad on this port, installed at config-build time by
+/// [`crate::bus::SystemBus::wire_stm32_spi_pads`] from the per-family static
+/// AF table (datasheet AF maps). `af` is the AFR nibble the pad must select
+/// (STM32 V2 ports); `None` on F1 ports, whose pin→signal mapping is fixed
+/// (default, no AFIO remap — remap is not modeled).
+#[derive(Debug, Clone)]
+pub(crate) struct SpiPadRoute {
+    pin: u8,
+    af: Option<u8>,
+    signal: crate::peripherals::spi::SpiSignal,
+    /// Signal name surfaced through `gpio_routing().func` (e.g. "SPI1_SCK").
+    func: &'static str,
+    /// Index into [`GpioPort::spi_cells`].
+    cell: usize,
 }
 
 /// GPIO port — a per-family register model (see [`GpioFamily`]) plus optional
@@ -394,6 +414,11 @@ pub struct GpioPort {
     /// watched pad-level changes into the tap. Not snapshot state — the watch
     /// is re-armed by the frontend after a resume.
     tap: Option<PortTap>,
+    /// SPI line-level cells wired to this port (deduplicated), plus the pads
+    /// routed to them. Installed once at config-build time; empty on buses
+    /// without a wired STM32 SPI.
+    spi_cells: Vec<std::sync::Arc<crate::peripherals::spi::SpiLineLevels>>,
+    spi_routes: Vec<SpiPadRoute>,
 }
 
 impl Default for GpioPort {
@@ -404,7 +429,12 @@ impl Default for GpioPort {
 
 impl GpioPort {
     fn from_family(family: GpioFamily) -> Self {
-        Self { family, tap: None }
+        Self {
+            family,
+            tap: None,
+            spi_cells: Vec::new(),
+            spi_routes: Vec::new(),
+        }
     }
 
     pub fn new() -> Self {
@@ -470,30 +500,180 @@ impl GpioPort {
         }
     }
 
+    /// Register layout of this port (used by the SPI pad-wiring helper to
+    /// select the matching AF table).
+    pub(crate) fn register_layout(&self) -> GpioRegisterLayout {
+        match &self.family {
+            GpioFamily::Stm32F1(_) => GpioRegisterLayout::Stm32F1,
+            GpioFamily::Stm32V2(_) => GpioRegisterLayout::Stm32V2,
+            GpioFamily::Nrf52(_) => GpioRegisterLayout::Nrf52,
+            GpioFamily::Kinetis(_) => GpioRegisterLayout::Kinetis,
+        }
+    }
+
+    /// Install one SPI AF pad route (config-build time; see
+    /// [`crate::bus::SystemBus::wire_stm32_spi_pads`]). Cells are deduplicated
+    /// by identity so several pads of one controller share one entry.
+    pub(crate) fn add_spi_pad_route(
+        &mut self,
+        cell: &std::sync::Arc<crate::peripherals::spi::SpiLineLevels>,
+        pin: u8,
+        af: Option<u8>,
+        signal: crate::peripherals::spi::SpiSignal,
+        func: &'static str,
+    ) {
+        let cell_idx = match self
+            .spi_cells
+            .iter()
+            .position(|c| std::sync::Arc::ptr_eq(c, cell))
+        {
+            Some(i) => i,
+            None => {
+                self.spi_cells.push(cell.clone());
+                self.spi_cells.len() - 1
+            }
+        };
+        self.spi_routes.push(SpiPadRoute {
+            pin,
+            af,
+            signal,
+            func,
+            cell: cell_idx,
+        });
+    }
+
+    /// The active SPI route for `pin`, if the family registers currently hand
+    /// the pad to that SPI signal: V2 = MODER selects AF and the AFR nibble
+    /// selects the route's AF number; F1 = the pin is an AF output (MODE!=0,
+    /// CNF 10/11) on the fixed default mapping. F1 MISO (an input-mode pad on
+    /// real silicon) is intentionally NOT routed — an honest limit, so a plain
+    /// GPIO input on that pin never silently reads the SPI wire.
+    fn active_spi_route<'a>(
+        family: &GpioFamily,
+        routes: &'a [SpiPadRoute],
+        pin: u8,
+    ) -> Option<&'a SpiPadRoute> {
+        routes.iter().find(|r| {
+            if r.pin != pin {
+                return false;
+            }
+            match (family, r.af) {
+                (GpioFamily::Stm32V2(g), Some(af)) => {
+                    if (g.read_reg(0x00) >> (pin * 2)) & 0b11 != 0b10 {
+                        return false;
+                    }
+                    let (afr_off, sh) = if pin < 8 {
+                        (0x20, (pin * 4) as u32)
+                    } else {
+                        (0x24, ((pin - 8) * 4) as u32)
+                    };
+                    ((g.read_reg(afr_off) >> sh) & 0xF) as u8 == af
+                }
+                (GpioFamily::Stm32F1(g), None) => {
+                    let cr = g.read_reg(if pin < 8 { 0x00 } else { 0x04 });
+                    let shift = ((pin % 8) * 4) as u32;
+                    let mode = (cr >> shift) & 0b11;
+                    let cnf = (cr >> (shift + 2)) & 0b11;
+                    mode != 0 && cnf >= 0b10
+                }
+                _ => false,
+            }
+        })
+    }
+
+    /// Direction-aware pad level — the single truth `read_gpio_pad` and the
+    /// push-capture tap both read. Pads whose MODER/AFR (or F1 CNF) route an
+    /// SPI alternate function report the live wire level from the shared
+    /// [`SpiLineLevels`](crate::peripherals::spi::SpiLineLevels) cell; every
+    /// other pad falls back to the family register truth.
+    fn pad_level(&self, pin: u8) -> Option<bool> {
+        if !self.spi_routes.is_empty() {
+            if let Some(r) = Self::active_spi_route(&self.family, &self.spi_routes, pin) {
+                return Some(self.spi_cells[r.cell].level(r.signal));
+            }
+        }
+        self.family.pad_level(pin)
+    }
+
     /// Record every watched pad's current level before a mutation. No-op (one
     /// branch) while no tap is installed.
     #[inline]
     fn tap_snapshot(&mut self) {
-        if let Some(t) = &mut self.tap {
-            for (k, &(pin, _)) in t.watched.iter().enumerate() {
-                t.scratch[k] = self.family.pad_level(pin);
-            }
+        let Some(mut t) = self.tap.take() else {
+            return;
+        };
+        for (k, &(pin, _)) in t.watched.iter().enumerate() {
+            t.scratch[k] = self.pad_level(pin);
         }
+        self.tap = Some(t);
     }
 
     /// Report watched pads whose level became known-different since the
-    /// matching [`tap_snapshot`](Self::tap_snapshot). A pad whose level became
-    /// UNknown (e.g. handed to a peripheral) reports nothing — same rule as
-    /// the poll path, which keeps the last known level.
+    /// matching [`tap_snapshot`](Self::tap_snapshot), then re-sync the SPI
+    /// line-cell registration if the write changed a watched pad's routing —
+    /// so a pad handed to (or taken from) an SPI keeps pushing edges from the
+    /// correct source afterwards. A pad whose level became UNknown reports
+    /// nothing — same rule as the poll path, which keeps the last known level.
     #[inline]
     fn tap_report(&mut self) {
-        if let Some(t) = &mut self.tap {
-            for (k, &(pin, ch)) in t.watched.iter().enumerate() {
-                if let Some(level) = self.family.pad_level(pin) {
-                    if t.scratch[k] != Some(level) {
-                        t.tap.push(ch, level);
-                    }
+        let Some(t) = self.tap.take() else {
+            return;
+        };
+        for (k, &(pin, ch)) in t.watched.iter().enumerate() {
+            if let Some(level) = self.pad_level(pin) {
+                if t.scratch[k] != Some(level) {
+                    t.tap.push(ch, level);
                 }
+            }
+        }
+        self.tap = Some(t);
+        self.sync_spi_line_taps();
+    }
+
+    /// Per-cell channel lists for watched pads currently routed to that
+    /// cell's SCK/MOSI/MISO — the pads whose level changes are driven by the
+    /// SPI bit engine rather than GPIO writes.
+    fn routed_spi_channels(&self) -> Vec<[Vec<u32>; 3]> {
+        use crate::peripherals::spi::SpiSignal;
+        let mut per_cell: Vec<[Vec<u32>; 3]> = self
+            .spi_cells
+            .iter()
+            .map(|_| [Vec::new(), Vec::new(), Vec::new()])
+            .collect();
+        if let Some(t) = &self.tap {
+            for &(pin, ch) in &t.watched {
+                if let Some(r) = Self::active_spi_route(&self.family, &self.spi_routes, pin) {
+                    let slot = match r.signal {
+                        SpiSignal::Sck => 0,
+                        SpiSignal::Mosi => 1,
+                        SpiSignal::Miso => 2,
+                    };
+                    per_cell[r.cell][slot].push(ch);
+                }
+            }
+        }
+        per_cell
+    }
+
+    /// Push the current routed-channel lists into the shared SPI line cells,
+    /// but only where they changed (avoids mutex traffic on unrelated writes).
+    fn sync_spi_line_taps(&mut self) {
+        if self.spi_cells.is_empty() {
+            return;
+        }
+        let per_cell = self.routed_spi_channels();
+        let Some(t) = &mut self.tap else {
+            return;
+        };
+        for (i, chs) in per_cell.into_iter().enumerate() {
+            if t.line_chs[i] != chs {
+                self.spi_cells[i].install_tap(
+                    Some(t.tap.clone()),
+                    chs[0].clone(),
+                    chs[1].clone(),
+                    chs[2].clone(),
+                );
+                t.line_chs[i] = chs;
             }
         }
     }
@@ -554,7 +734,7 @@ impl crate::Peripheral for GpioPort {
     }
 
     fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
-        self.family.pad_level(pin)
+        self.pad_level(pin)
     }
 
     fn gpio_routing(&self, pin: u8) -> Option<GpioRouting> {
@@ -609,18 +789,25 @@ impl crate::Peripheral for GpioPort {
                 }
             }
         };
-        // func: STM32 V2 exposes an AFR nibble per AF pad → "AF<n>" (no full
-        // AF→signal table; that is out of scope). Everything else: None.
-        let func = match &self.family {
-            GpioFamily::Stm32V2(g) if mode == GpioMode::Af => {
+        // func: a pad whose AF routing resolves to a wired SPI signal names it
+        // ("SPI1_SCK"); otherwise STM32 V2 exposes the raw AFR nibble → "AF<n>"
+        // (no full AF→signal table; that is out of scope). Everything else:
+        // None — null over a guess.
+        let func = if mode == GpioMode::Af {
+            if let Some(r) = Self::active_spi_route(&self.family, &self.spi_routes, pin) {
+                Some(r.func.to_string())
+            } else if let GpioFamily::Stm32V2(g) = &self.family {
                 let (afr_off, sh) = if pin < 8 {
                     (0x20, (pin * 4) as u32)
                 } else {
                     (0x24, ((pin - 8) * 4) as u32)
                 };
                 Some(format!("AF{}", (g.read_reg(afr_off) >> sh) & 0xF))
+            } else {
+                None
             }
-            _ => None,
+        } else {
+            None
         };
         Some(GpioRouting { mode, func })
     }
@@ -655,15 +842,26 @@ impl crate::Peripheral for GpioPort {
         tap: &crate::logic_capture::LogicTap,
         watched: &[(u8, u32)],
     ) -> bool {
-        self.tap = if watched.is_empty() {
-            None
+        if watched.is_empty() {
+            self.tap = None;
+            for cell in &self.spi_cells {
+                cell.install_tap(None, Vec::new(), Vec::new(), Vec::new());
+            }
         } else {
-            Some(PortTap {
+            self.tap = Some(PortTap {
                 tap: tap.clone(),
                 watched: watched.to_vec(),
                 scratch: vec![None; watched.len()],
-            })
-        };
+                // Seeded stale so the sync below always installs the current
+                // routing into every wired line cell.
+                line_chs: self
+                    .spi_cells
+                    .iter()
+                    .map(|_| [vec![u32::MAX], vec![u32::MAX], vec![u32::MAX]])
+                    .collect(),
+            });
+            self.sync_spi_line_taps();
+        }
         true
     }
 

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -15,6 +15,8 @@
 use crate::{Bus, SimResult};
 use std::any::Any;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 /// Trait implemented by simulated SPI devices (peripherals attached to an SPI bus).
 ///
@@ -131,9 +133,184 @@ impl FromStr for SpiRegisterLayout {
     }
 }
 
-/// Event token for the one-shot SPI transfer-completion event (the SPI has a
-/// single kind of scheduled wakeup, so the value is arbitrary).
+/// Event token for the SPI bit engine's next-wire-transition event (the SPI
+/// has a single kind of scheduled wakeup, so the value is arbitrary).
 const SPI_DONE_TOKEN: u32 = 0;
+
+// ── STM32 SPI wire (bit-level engine) ────────────────────────────────────────
+//
+// The classic/FIFO STM32 SPI no longer completes a DR write instantly: a bit
+// engine clocks the frame on the wire over simulated cycles, mirroring the
+// ESP32-C3 I²C bit-level engine (core#507). SCK timing derives from CR1
+// BR[2:0] against the peripheral clock (this simulator's cycle base models
+// PCLK, the same convention every other STM32 peripheral here uses):
+// f_SCK = f_PCLK / 2^(BR+1), so one SCK half-period is 2^BR peripheral-clock
+// cycles and a frame is `bits × 2^(BR+1)` cycles. CPOL sets the idle level,
+// CPHA selects the sample edge (data is driven for the whole bit period;
+// sample = leading edge at CPHA=0, trailing edge at CPHA=1), LSBFIRST picks
+// the shift direction, and the frame size comes from CR2.DS on FIFO ports
+// (L4/F7/G4) or CR1.DFF on classic ports (F1/F4) — datasheet reset values
+// apply when firmware never programs them.
+//
+// Slaves stay byte-level ([`SpiDevice`], behind the TracingSpiDevice choke
+// point): the engine consults them once per frame, at the frame boundary
+// where the frame starts clocking, and the byte the device answers is what
+// MISO carries bit-by-bit during that SAME frame — full duplex, like real
+// silicon exchanging shift registers. (Frames wider than 8 bits still
+// exchange one byte with the byte-level device; the wire carries the full
+// programmed frame — an honest limit of the byte-level device contract.)
+
+/// SPI signal roles on the wire, used by the GPIO AF pad routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpiSignal {
+    Sck,
+    Mosi,
+    Miso,
+}
+
+/// Push-mode logic-capture registration for the SPI line cell: which watch
+/// channels observe pads currently AF-routed to SCK / MOSI / MISO. Maintained
+/// by the STM32 GPIO model (which owns the routing truth) via
+/// [`SpiLineLevels::install_tap`]; consulted by [`SpiLineLevels::set`] so the
+/// bit engine pushes an edge at the exact moment it drives a line transition
+/// (event-driven capture, same pattern as the C3 `I2cLineLevels`).
+#[derive(Debug, Default)]
+struct SpiLineTapState {
+    tap: Option<crate::logic_capture::LogicTap>,
+    sck_chs: Vec<u32>,
+    mosi_chs: Vec<u32>,
+    miso_chs: Vec<u32>,
+}
+
+/// Live SCK/MOSI/MISO levels of one STM32 SPI controller's wire. The
+/// controller bit engine is the only writer; the STM32 `GpioPort` reads it for
+/// pads whose MODER/AFR (or F1 CRL/CRH CNF) route this SPI's alternate
+/// function, so `read_gpio_pad` — and the in-engine logic analyzer sampling
+/// through it — observes the real waveform on the routed pads. With push-mode
+/// capture armed on a routed pad, [`set`](Self::set) additionally reports each
+/// line transition into the shared logic tap at drive time.
+#[derive(Debug)]
+pub struct SpiLineLevels {
+    sck: AtomicBool,
+    mosi: AtomicBool,
+    miso: AtomicBool,
+    tap: std::sync::Mutex<SpiLineTapState>,
+}
+
+impl SpiLineLevels {
+    fn new(sck_idle: bool) -> Self {
+        Self {
+            sck: AtomicBool::new(sck_idle),
+            mosi: AtomicBool::new(false),
+            miso: AtomicBool::new(false),
+            tap: std::sync::Mutex::new(SpiLineTapState::default()),
+        }
+    }
+
+    pub fn sck(&self) -> bool {
+        self.sck.load(Ordering::Relaxed)
+    }
+
+    pub fn mosi(&self) -> bool {
+        self.mosi.load(Ordering::Relaxed)
+    }
+
+    pub fn miso(&self) -> bool {
+        self.miso.load(Ordering::Relaxed)
+    }
+
+    pub fn level(&self, signal: SpiSignal) -> bool {
+        match signal {
+            SpiSignal::Sck => self.sck(),
+            SpiSignal::Mosi => self.mosi(),
+            SpiSignal::Miso => self.miso(),
+        }
+    }
+
+    fn set(&self, sck: bool, mosi: bool, miso: bool) {
+        let old_sck = self.sck.swap(sck, Ordering::Relaxed);
+        let old_mosi = self.mosi.swap(mosi, Ordering::Relaxed);
+        let old_miso = self.miso.swap(miso, Ordering::Relaxed);
+        if old_sck == sck && old_mosi == mosi && old_miso == miso {
+            return;
+        }
+        // A line actually transitioned: report it to any watch channels whose
+        // pads the GPIO AF routing currently maps here. Lock taken only on
+        // transitions (segment-boundary rate, not per engine cycle).
+        let t = self.tap.lock().unwrap();
+        if let Some(tap) = &t.tap {
+            if old_sck != sck {
+                for &ch in &t.sck_chs {
+                    tap.push(ch, sck);
+                }
+            }
+            if old_mosi != mosi {
+                for &ch in &t.mosi_chs {
+                    tap.push(ch, mosi);
+                }
+            }
+            if old_miso != miso {
+                for &ch in &t.miso_chs {
+                    tap.push(ch, miso);
+                }
+            }
+        }
+    }
+
+    /// Install (or clear, with `tap = None`) the push-capture registration.
+    /// Called by the STM32 GPIO model at watch install time and whenever a
+    /// write changes the routing of a watched pad, so the channel lists always
+    /// mirror the live MODER/AFR state.
+    pub(crate) fn install_tap(
+        &self,
+        tap: Option<crate::logic_capture::LogicTap>,
+        sck_chs: Vec<u32>,
+        mosi_chs: Vec<u32>,
+        miso_chs: Vec<u32>,
+    ) {
+        let mut t = self.tap.lock().unwrap();
+        t.tap = tap;
+        t.sck_chs = sck_chs;
+        t.mosi_chs = mosi_chs;
+        t.miso_chs = miso_chs;
+    }
+}
+
+/// Wire timing snapshot, derived from the live CR1/CR2 registers at frame
+/// start (datasheet reset values apply when firmware never programs them —
+/// no invented constants).
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+struct FrameTiming {
+    /// SCK half-period in peripheral-clock cycles = `2^BR` (CR1 BR[5:3]).
+    half_ticks: u32,
+    /// Frame size in bits: CR2.DS+1 on FIFO ports, CR1.DFF ? 16 : 8 on
+    /// classic ports.
+    bits: u8,
+    /// CR1.CPOL — SCK idle level.
+    cpol: bool,
+    /// CR1.CPHA — sample on leading (0) or trailing (1) edge.
+    cpha: bool,
+    /// CR1.LSBFIRST — shift direction.
+    lsb_first: bool,
+}
+
+/// The frame currently shifting on the wire. Every bit period is two counted
+/// half-periods; the (SCK, MOSI, MISO) levels are a pure function of this
+/// state (see [`Spi::stm32_frame_levels`]).
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+struct ActiveFrame {
+    t: FrameTiming,
+    /// The full frame value clocked out on MOSI.
+    mosi: u16,
+    /// The full frame value clocked in on MISO (the slave's byte answer).
+    miso: u16,
+    /// Bit currently on the wire, 0-based in shift order.
+    bit_idx: u8,
+    /// Second half of the current bit period.
+    second_half: bool,
+    /// Peripheral-clock cycles left in the current half-period.
+    ticks_left: u32,
+}
 
 /// STM32 SPI register file (F1/F4/L0 classic and L4/F7/G4 FIFO share this map;
 /// `fifo` selects the FIFO DS/data-packing behaviour). H5/H7 use the separate
@@ -518,14 +695,31 @@ impl Default for SpiRegs {
 pub struct Spi {
     regs: SpiRegs,
 
-    // Shared transfer-engine state (architecture-independent).
-    transfer_in_progress: bool,
-    transfer_cycles_remaining: u32,
-    transfer_buffer: u8,
+    // STM32 bit-engine state (classic/FIFO layout only; the other register
+    // families keep their own transfer semantics).
+    /// The frame currently clocking on the wire, if any.
+    frame: Option<ActiveFrame>,
+    /// Frames queued behind the wire (FIFO data packing, back-to-back DR
+    /// writes). Each entry is one full frame value.
+    tx_queue: std::collections::VecDeque<u16>,
     #[serde(skip)]
     scheduled: bool,
-    /// When true, completed transfers also load `transfer_buffer` into the RX
-    /// path (`dr` + RXNE), as if MOSI were jumpered to MISO. Defaults false.
+    /// Event-scheduler path only: the absolute scheduler tick the engine's
+    /// wire state corresponds to. Anchored by `sync_to` (called by the bus
+    /// before every MMIO write, so a DR write pins the frame start to the
+    /// write tick — identically in clamped and batched runs) and advanced by
+    /// `on_event`. The legacy walk clocks the engine through `tick_elapsed`
+    /// instead and never touches this.
+    #[serde(skip)]
+    anchor_tick: u64,
+    /// Shared SCK/MOSI/MISO line levels, read by the STM32 GPIO model for
+    /// AF-routed pads. Created lazily by [`Self::line_levels_arc`] at bus
+    /// wiring time; `None` when no pads are wired (the engine still runs —
+    /// only the wire publication is skipped).
+    #[serde(skip)]
+    lines: Option<Arc<SpiLineLevels>>,
+    /// When true, completed transfers also load the transmitted frame into the
+    /// RX path (`dr` + RXNE), as if MOSI were jumpered to MISO. Defaults false.
     loopback: bool,
 
     /// nRF52 SPIM: set when TASKS_START is written; cleared after
@@ -553,7 +747,8 @@ impl core::fmt::Debug for Spi {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Spi")
             .field("regs", &self.regs)
-            .field("transfer_in_progress", &self.transfer_in_progress)
+            .field("frame", &self.frame)
+            .field("tx_queue_len", &self.tx_queue.len())
             .field("loopback", &self.loopback)
             .field("attached_devices", &self.attached_devices.len())
             .finish()
@@ -636,6 +831,15 @@ impl Spi {
                 if let SpiRegs::Stm32(r) = &mut self.regs {
                     r.cr1 = value & cr1_mask;
                 }
+                // A CPOL change while the wire is idle re-drives the SCK idle
+                // level (real silicon drives SCK = CPOL as soon as the pad is
+                // handed to the SPI).
+                if self.frame.is_none() {
+                    if let Some(lines) = &self.lines {
+                        let cpol = value & (1 << 1) != 0;
+                        lines.set(cpol, lines.mosi(), lines.miso());
+                    }
+                }
             }
             0x04 => {
                 // STM32L4/F7 SPI CR2: DS[3:0] (bits 11:8) select the data
@@ -673,33 +877,32 @@ impl Spi {
             }
             0x0C => {
                 // DR write goes to the TX path only. Starts a transfer iff SPE.
+                // The frame does NOT complete here: the bit engine clocks it on
+                // the wire over `bits × 2^(BR+1)` peripheral-clock cycles.
                 let cr1 = match &self.regs {
                     SpiRegs::Stm32(r) => r.cr1,
                     _ => 0,
                 };
                 if (cr1 & (1 << 6)) != 0 {
+                    let fifo = matches!(&self.regs, SpiRegs::Stm32(r) if r.fifo);
                     if let SpiRegs::Stm32(r) = &mut self.regs {
                         r.sr &= !0x0002; // Clear TXE
                         r.sr |= 0x0080; // Set BSY
                     }
-                    self.transfer_in_progress = true;
-                    let br = (cr1 >> 3) & 0x7;
-                    let divider = 1u32 << (br + 1);
-                    self.transfer_cycles_remaining = 8 * divider;
-                    self.transfer_buffer = (value & 0xFF) as u8;
-
-                    // v1 routing: broadcast to all attached devices, use last
-                    // non-zero response.
-                    if !self.attached_devices.is_empty() {
-                        let mosi = self.transfer_buffer;
-                        let mut miso: u8 = 0;
-                        for dev in &mut self.attached_devices {
-                            let resp = dev.transfer(mosi);
-                            if resp != 0 {
-                                miso = resp;
-                            }
-                        }
-                        self.transfer_buffer = miso;
+                    if self.frame.is_some() && !fifo && !self.tx_queue.is_empty() {
+                        // Classic single-buffer TX: a DR write while TXE=0
+                        // overwrites the waiting byte (RM0008 — the shifting
+                        // frame is unaffected).
+                        *self.tx_queue.back_mut().unwrap() = value;
+                    } else if fifo && self.tx_queue.len() >= 4 {
+                        // FIFO parts: the 32-bit TX FIFO is full — the write
+                        // is lost (RM0351 §40.4.9). Conservative frame-count
+                        // bound (4 × 8-bit frames).
+                    } else {
+                        self.tx_queue.push_back(value);
+                    }
+                    if self.frame.is_none() {
+                        self.stm32_start_next_frame();
                     }
                 }
             }
@@ -750,7 +953,6 @@ impl Spi {
                 // PUSHR: low 16 bits are the frame data. PCD8544 and most SPI
                 // peripherals here clock 8-bit frames, so deliver the low byte.
                 let mosi = (value & 0xFF) as u8;
-                self.transfer_buffer = mosi;
                 let mut miso: u8 = 0;
                 for dev in &mut self.attached_devices {
                     let resp = dev.transfer(mosi);
@@ -921,6 +1123,218 @@ impl Spi {
     }
 }
 
+// ── STM32 bit engine ─────────────────────────────────────────────────────────
+//
+// A frame executes on the wire as a chain of fixed-level half-period segments.
+// Slaves stay byte-level: the engine consults them exactly once per frame (at
+// the boundary where the frame starts clocking) and the answered byte is what
+// MISO carries bit-by-bit during that same frame.
+impl Spi {
+    /// `true` while a frame is clocking on the wire. Production code reads
+    /// SR.BSY instead; tests clock the engine against this directly.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn transfer_active(&self) -> bool {
+        self.frame.is_some()
+    }
+
+    /// `true` when this instance carries the classic/FIFO STM32 register file
+    /// (the layouts the bit engine drives). The H5 "SPI v3" IP and the other
+    /// vendor layouts are separate models.
+    pub(crate) fn is_stm32_wire_layout(&self) -> bool {
+        matches!(self.regs, SpiRegs::Stm32(_))
+    }
+
+    /// `true` for the FIFO (L4/F7/G4) flavour of the STM32 layout.
+    pub(crate) fn is_fifo_layout(&self) -> bool {
+        matches!(&self.regs, SpiRegs::Stm32(r) if r.fifo)
+    }
+
+    /// Get-or-create the shared line-level cell (bus wiring hands the same
+    /// `Arc` to the STM32 GPIO ports carrying this SPI's AF pads).
+    pub(crate) fn line_levels_arc(&mut self) -> Arc<SpiLineLevels> {
+        if self.lines.is_none() {
+            let cpol = matches!(&self.regs, SpiRegs::Stm32(r) if r.cr1 & (1 << 1) != 0);
+            self.lines = Some(Arc::new(SpiLineLevels::new(cpol)));
+        }
+        self.lines.as_ref().unwrap().clone()
+    }
+
+    /// Derive the wire timing from the live registers. Reset values (the
+    /// datasheet defaults: BR=0 → f_PCLK/2, CPOL=CPHA=0, MSB first, 8-bit
+    /// frames — CR2 reset 0x0700 on FIFO ports, CR1.DFF=0 on classic ports)
+    /// apply when firmware never programs them.
+    fn stm32_frame_timing(&self) -> FrameTiming {
+        let (cr1, cr2, fifo) = match &self.regs {
+            SpiRegs::Stm32(r) => (r.cr1, r.cr2, r.fifo),
+            _ => (0, 0, false),
+        };
+        let br = (cr1 >> 3) & 0x7;
+        let bits = if fifo {
+            // CR2.DS[3:0]: frame = DS+1 bits. Values below 0b0011 are reserved
+            // and forced to 0b0111 (8-bit) at write time; reset is 0x0700.
+            (((cr2 >> 8) & 0xF) as u8) + 1
+        } else if cr1 & (1 << 11) != 0 {
+            16 // CR1.DFF
+        } else {
+            8
+        };
+        FrameTiming {
+            half_ticks: 1u32 << br,
+            bits,
+            cpol: cr1 & (1 << 1) != 0,
+            cpha: cr1 & 1 != 0,
+            lsb_first: cr1 & (1 << 7) != 0,
+        }
+    }
+
+    /// The (SCK, MOSI, MISO) levels the wire carries in the current frame
+    /// state. SCK: idle = CPOL; the bit period's active half is the second
+    /// half at CPHA=0 (leading edge = sample) and the first half at CPHA=1
+    /// (leading edge = shift, trailing = sample). Data lines hold the bit
+    /// value for the whole bit period.
+    fn stm32_frame_levels(f: &ActiveFrame) -> (bool, bool, bool) {
+        let active_half = f.second_half != f.t.cpha;
+        let sck = if active_half { !f.t.cpol } else { f.t.cpol };
+        let bit = |v: u16| {
+            if f.t.lsb_first {
+                (v >> f.bit_idx) & 1 != 0
+            } else {
+                (v >> (f.t.bits - 1 - f.bit_idx)) & 1 != 0
+            }
+        };
+        (sck, bit(f.mosi), bit(f.miso))
+    }
+
+    /// Publish the current frame-state levels into the shared line cell (the
+    /// cell pushes any transition into the logic tap at this exact moment).
+    fn stm32_drive_levels(&self) {
+        let (Some(f), Some(lines)) = (&self.frame, &self.lines) else {
+            return;
+        };
+        let (sck, mosi, miso) = Self::stm32_frame_levels(f);
+        lines.set(sck, mosi, miso);
+    }
+
+    /// Dequeue the next pending frame onto the wire. Consults the byte-level
+    /// devices at this frame boundary: the broadcast answer (last non-zero
+    /// response, same routing rule as always) is the byte MISO clocks out
+    /// during this frame.
+    fn stm32_start_next_frame(&mut self) {
+        let Some(value) = self.tx_queue.pop_front() else {
+            return;
+        };
+        let t = self.stm32_frame_timing();
+        let mask = if t.bits >= 16 {
+            0xFFFF
+        } else {
+            (1u16 << t.bits) - 1
+        };
+        let mosi = value & mask;
+        let miso = if !self.attached_devices.is_empty() {
+            let mosi_byte = (mosi & 0xFF) as u8;
+            let mut miso_byte = 0u8;
+            for dev in &mut self.attached_devices {
+                let resp = dev.transfer(mosi_byte);
+                if resp != 0 {
+                    miso_byte = resp;
+                }
+            }
+            miso_byte as u16
+        } else if self.loopback {
+            mosi
+        } else {
+            0
+        };
+        self.frame = Some(ActiveFrame {
+            t,
+            mosi,
+            miso,
+            bit_idx: 0,
+            second_half: false,
+            ticks_left: t.half_ticks,
+        });
+        self.stm32_drive_levels();
+    }
+
+    /// Advance the wire by `units` peripheral-clock cycles. Returns `true`
+    /// when a completed frame wants the TXE interrupt raised (CR2.TXEIE).
+    fn stm32_advance_units(&mut self, mut units: u64) -> bool {
+        let mut irq = false;
+        while units > 0 {
+            let Some(f) = &mut self.frame else { break };
+            let step = (f.ticks_left as u64).min(units);
+            f.ticks_left -= step as u32;
+            units -= step;
+            if f.ticks_left == 0 {
+                self.stm32_segment_boundary(&mut irq);
+            }
+        }
+        irq
+    }
+
+    /// The current half-period expired: drive the next segment, or complete
+    /// the frame at derived wire time (RXNE/BSY/TXE flip HERE, not at the DR
+    /// write).
+    fn stm32_segment_boundary(&mut self, irq: &mut bool) {
+        let Some(mut f) = self.frame.take() else {
+            return;
+        };
+        if !f.second_half {
+            f.second_half = true;
+            f.ticks_left = f.t.half_ticks;
+            self.frame = Some(f);
+            self.stm32_drive_levels();
+            return;
+        }
+        if f.bit_idx + 1 < f.t.bits {
+            f.bit_idx += 1;
+            f.second_half = false;
+            f.ticks_left = f.t.half_ticks;
+            self.frame = Some(f);
+            self.stm32_drive_levels();
+            return;
+        }
+        // Frame complete: exchange lands in the RX path. A wired slave drove
+        // its byte onto MISO during the frame; loopback mirrors MOSI. Without
+        // either, RXNE stays clear (real silicon: no MISO data).
+        let deliver_rx = self.loopback || !self.attached_devices.is_empty();
+        if let SpiRegs::Stm32(r) = &mut self.regs {
+            if deliver_rx {
+                r.dr = f.miso;
+                r.sr |= 0x0001; // RXNE
+            }
+        }
+        if !self.tx_queue.is_empty() {
+            // Back-to-back: the next queued frame starts on the very next
+            // cycle (BSY stays set, TXE stays clear).
+            self.stm32_start_next_frame();
+            return;
+        }
+        self.frame = None;
+        if let SpiRegs::Stm32(r) = &mut self.regs {
+            r.sr &= !0x0080; // Clear BSY
+            r.sr |= 0x0002; // Set TXE
+            if (r.cr2 & (1 << 7)) != 0 {
+                *irq = true; // TXEIE
+            }
+        }
+        // Wire idles: SCK returns to CPOL (the trailing edge of the last
+        // bit); MOSI/MISO hold their last driven level, like real pads.
+        if let Some(lines) = &self.lines {
+            lines.set(f.t.cpol, lines.mosi(), lines.miso());
+        }
+    }
+
+    /// Peripheral-clock cycles until the engine's next wire transition (the
+    /// scheduling quantum for the event-driven path). 0 when idle.
+    fn stm32_next_transition_ticks(&self) -> u64 {
+        self.frame
+            .as_ref()
+            .map(|f| f.ticks_left.max(1) as u64)
+            .unwrap_or(0)
+    }
+}
+
 impl crate::Peripheral for Spi {
     fn read(&self, offset: u64) -> SimResult<u8> {
         let reg_offset = offset & !3;
@@ -1088,10 +1502,35 @@ impl crate::Peripheral for Spi {
         true
     }
 
+    /// Event-scheduler path: anchor the engine's wire state to the current
+    /// scheduler tick. The bus calls this before every MMIO write, so a DR
+    /// write pins the frame start to the write tick — and because CPU batches
+    /// never cross a peripheral-tick boundary, that tick is identical whether
+    /// the run loop is clamped (poll capture) or batched (push capture).
+    fn sync_to(&mut self, tick_now: u64) {
+        if tick_now <= self.anchor_tick {
+            return;
+        }
+        let delta = tick_now - self.anchor_tick;
+        self.anchor_tick = tick_now;
+        if self.frame.is_some() {
+            self.stm32_advance_units(delta);
+        }
+    }
+
+    /// Event-driven clocking (the walk-deleted path): while a frame is on the
+    /// wire, the engine keeps exactly one event armed at (or just before —
+    /// the drain harvesting this may already be one tick past the write tick)
+    /// its next wire transition. [`Self::on_event`] self-corrects against the
+    /// absolute anchor and re-arms via `reschedule_delay` until the frame
+    /// (and any queued frames) complete.
     fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
-        if self.transfer_in_progress && !self.scheduled {
+        if self.frame.is_some() && !self.scheduled {
             self.scheduled = true;
-            vec![(self.transfer_cycles_remaining as u64, SPI_DONE_TOKEN)]
+            vec![(
+                self.stm32_next_transition_ticks().saturating_sub(1),
+                SPI_DONE_TOKEN,
+            )]
         } else {
             Vec::new()
         }
@@ -1100,28 +1539,34 @@ impl crate::Peripheral for Spi {
     fn on_event(
         &mut self,
         _event_token: u32,
-        _sched: &mut crate::sched::EventScheduler,
+        sched: &mut crate::sched::EventScheduler,
         _bus: &mut dyn crate::Bus,
     ) -> crate::sched::EventResult {
         self.scheduled = false;
-        if !self.transfer_in_progress {
+        let Some(f) = &self.frame else {
             return crate::sched::EventResult::default();
-        }
-        self.transfer_in_progress = false;
-        self.transfer_cycles_remaining = 0;
-        let deliver_rx = self.loopback || !self.attached_devices.is_empty();
-        let buf = self.transfer_buffer;
+        };
         let mut res = crate::sched::EventResult::default();
-        if let SpiRegs::Stm32(r) = &mut self.regs {
-            r.sr &= !0x0080; // Clear BSY
-            r.sr |= 0x0002; // Set TXE
-            if deliver_rx {
-                r.dr = buf as u16;
-                r.sr |= 0x0001; // RXNE
-            }
-            if (r.cr2 & (1 << 7)) != 0 {
-                res.raise_own_irq = true; // TXEIE
-            }
+        let now = sched.now();
+        let target = self.anchor_tick + f.ticks_left as u64;
+        if now < target {
+            // Early wakeup (the arming drain ran past the write tick and the
+            // conservative delay undershot): re-arm at the exact boundary.
+            res.reschedule_delay = Some(target - now);
+            self.scheduled = true;
+            return res;
+        }
+        // Advance the wire to "now" — every segment boundary in the window
+        // lands exactly on its derived tick (drains run at least once per
+        // tick, so this is typically exactly one boundary).
+        let delta = now - self.anchor_tick;
+        self.anchor_tick = now;
+        if self.stm32_advance_units(delta) {
+            res.raise_own_irq = true; // TXEIE at frame completion
+        }
+        if self.frame.is_some() {
+            res.reschedule_delay = Some(self.stm32_next_transition_ticks());
+            self.scheduled = true;
         }
         res
     }
@@ -1213,6 +1658,14 @@ impl crate::Peripheral for Spi {
     }
 
     fn tick(&mut self) -> crate::PeripheralTickResult {
+        self.tick_elapsed(1)
+    }
+
+    /// Legacy-walk clocking (non-event-scheduler builds): advance the bit
+    /// engine by the elapsed peripheral-clock cycles. The event-scheduler
+    /// build never calls this for the SPI (the walk skips scheduler-driven
+    /// peripherals), so the two clocking paths cannot double-advance.
+    fn tick_elapsed(&mut self, cycles: u64) -> crate::PeripheralTickResult {
         let mut irq = false;
         let mut fired: Vec<u32> = Vec::new();
 
@@ -1242,28 +1695,9 @@ impl crate::Peripheral for Spi {
             };
         }
 
-        // ── STM32 SPI: cycle-counted shift-register transfer ─────────────────
-        if self.transfer_in_progress {
-            self.transfer_cycles_remaining = self.transfer_cycles_remaining.saturating_sub(1);
-            if self.transfer_cycles_remaining == 0 {
-                self.transfer_in_progress = false;
-                let deliver_rx = self.loopback || !self.attached_devices.is_empty();
-                let buf = self.transfer_buffer;
-                if let SpiRegs::Stm32(r) = &mut self.regs {
-                    r.sr &= !0x0080; // Clear BSY
-                    r.sr |= 0x0002; // Set TXE
-                    if deliver_rx {
-                        // A wired slave drove its byte onto MISO (already in
-                        // `transfer_buffer`); loopback mirrors MOSI. Either way
-                        // the firmware sees RXNE high with the received byte.
-                        r.dr = buf as u16;
-                        r.sr |= 0x0001; // RXNE
-                    }
-                    if (r.cr2 & (1 << 7)) != 0 {
-                        irq = true; // TXEIE
-                    }
-                }
-            }
+        // ── STM32 SPI: bit engine clocks the frame on the wire ───────────────
+        if self.frame.is_some() && self.stm32_advance_units(cycles) {
+            irq = true; // TXEIE at frame completion
         }
 
         crate::PeripheralTickResult {
@@ -1321,14 +1755,28 @@ mod tests {
             .clone()
     }
 
+    /// Clock the bit engine to completion (DR writes no longer complete
+    /// instantly — the frame is stretched over simulated cycles).
+    fn run_engine(spi: &mut Spi) {
+        for _ in 0..1_000_000 {
+            if !spi.transfer_active() {
+                return;
+            }
+            spi.tick_elapsed(8);
+        }
+        panic!("STM32 SPI bit engine did not complete");
+    }
+
     /// FIFO-family SPI: a 16-bit DR write at DS=8 packs TWO frames — the
-    /// silicon behaviour that broke the real Nokia 5110 panel.
+    /// silicon behaviour that broke the real Nokia 5110 panel. The second
+    /// frame clocks back-to-back after the first on the wire.
     #[test]
     fn fifo_packs_u16_dr_write_into_two_frames() {
         let mut spi = Spi::new_with_layout(SpiRegisterLayout::Stm32Fifo);
         spi.push_device(Box::new(Capture { rx: Vec::new() }));
         spi.write(0x00, 0x40).unwrap(); // CR1: SPE
         spi.write_u16(0x0C, 0x00AB).unwrap(); // 16-bit DR write, DS=8 (reset 0x0700)
+        run_engine(&mut spi);
         assert_eq!(
             captured(&spi),
             vec![0xAB, 0x00],
@@ -1343,6 +1791,7 @@ mod tests {
         spi.push_device(Box::new(Capture { rx: Vec::new() }));
         spi.write(0x00, 0x40).unwrap();
         spi.write(0x0C, 0xAB).unwrap(); // 8-bit DR write
+        run_engine(&mut spi);
         assert_eq!(captured(&spi), vec![0xAB], "8-bit DR ⇒ 1 frame");
     }
 
@@ -1354,6 +1803,7 @@ mod tests {
         spi.push_device(Box::new(Capture { rx: Vec::new() }));
         spi.write(0x00, 0x40).unwrap();
         spi.write_u16(0x0C, 0x00AB).unwrap();
+        run_engine(&mut spi);
         assert_eq!(captured(&spi), vec![0xAB], "non-FIFO ⇒ 1 frame");
     }
 
@@ -1385,6 +1835,109 @@ mod tests {
         // No slave wired → no MISO data → RXNE stays clear, DR reads 0.
         assert_eq!(sr & 0x01, 0, "RXNE NOT set without a slave");
         assert_eq!(spi.read(0x0C).unwrap(), 0x00, "DR=0 with no MISO data");
+    }
+
+    /// Analytic wire time: a frame completes at EXACTLY `bits × 2^(BR+1)`
+    /// peripheral-clock cycles, for two BR settings (and 16-bit DFF frames on
+    /// the classic port take twice the clocks of 8-bit ones).
+    #[test]
+    fn frame_completes_at_exact_derived_cycle_for_two_br_settings() {
+        // (CR1 BR bits, expected cycles for an 8-bit frame)
+        for (br, expected) in [(0u16, 8 * 2u64), (4u16, 8 * 32u64)] {
+            let mut spi = Spi::new();
+            spi.write_u16(0x00, (1 << 6) | (br << 3)).unwrap(); // SPE | BR
+            spi.write(0x0C, 0xA5).unwrap();
+            let mut cycles = 0u64;
+            while spi.transfer_active() {
+                spi.tick_elapsed(1);
+                cycles += 1;
+                assert!(cycles < 1_000_000, "engine never completed");
+            }
+            assert_eq!(
+                cycles, expected,
+                "BR={br}: 8-bit frame must complete at bits × 2^(BR+1) cycles"
+            );
+        }
+        // Classic 16-bit frames (CR1.DFF): twice the clocks at the same BR.
+        let mut spi = Spi::new();
+        spi.write_u16(0x00, (1 << 6) | (1 << 3) | (1 << 11))
+            .unwrap(); // SPE|BR=1|DFF
+        spi.write_u16(0x0C, 0xBEEF).unwrap();
+        let mut cycles = 0u64;
+        while spi.transfer_active() {
+            spi.tick_elapsed(1);
+            cycles += 1;
+            assert!(cycles < 1_000_000, "engine never completed");
+        }
+        assert_eq!(cycles, 16 * 4, "DFF frame = 16 bits × 2^(BR+1) cycles");
+    }
+
+    /// Mode-3 + LSBFIRST wire shape: SCK idles HIGH (CPOL=1), data is driven
+    /// on the leading (falling) edge and sampled on the trailing (rising)
+    /// edge (CPHA=1), and the bit order is LSB first. Decoding the MOSI line
+    /// at every SCK rising edge must reproduce the written byte.
+    #[test]
+    fn mode3_lsbfirst_waveform_samples_on_trailing_edge() {
+        let mut spi = Spi::new();
+        let lines = spi.line_levels_arc();
+        // CR1: SPE | CPOL | CPHA | LSBFIRST, BR=0 (half-period = 1 cycle).
+        spi.write_u16(0x00, (1 << 6) | (1 << 1) | 1 | (1 << 7))
+            .unwrap();
+        assert!(lines.sck(), "idle SCK level must be CPOL = 1");
+
+        spi.write(0x0C, 0xB4).unwrap();
+        let mut prev = lines.sck();
+        let mut bits = Vec::new();
+        for _ in 0..16 {
+            spi.tick_elapsed(1);
+            let sck = lines.sck();
+            if sck && !prev {
+                bits.push(lines.mosi()); // sample on the trailing (rising) edge
+            }
+            prev = sck;
+        }
+        assert!(!spi.transfer_active(), "16 half-periods complete the frame");
+        assert!(lines.sck(), "SCK returns to the CPOL idle level");
+        assert_eq!(bits.len(), 8, "8 trailing edges per 8-bit frame");
+        let byte = bits
+            .iter()
+            .enumerate()
+            .fold(0u8, |acc, (i, &b)| acc | (u8::from(b) << i));
+        assert_eq!(byte, 0xB4, "LSB-first decode at the mode-3 sample edges");
+    }
+
+    /// Full-duplex fidelity: the byte the slave answers at the frame boundary
+    /// is what lands in DR when the SAME frame finishes clocking — not a byte
+    /// from a previous frame, and not delivered before wire time.
+    #[test]
+    fn slave_answer_clocks_back_during_the_same_frame() {
+        struct Sequenced {
+            next: u8,
+        }
+        impl SpiDevice for Sequenced {
+            fn transfer(&mut self, _mosi: u8) -> u8 {
+                let out = self.next;
+                self.next = self.next.wrapping_add(1);
+                out
+            }
+            fn cs_pin(&self) -> &str {
+                ""
+            }
+        }
+        let mut spi = Spi::new();
+        spi.push_device(Box::new(Sequenced { next: 0x51 }));
+        spi.write(0x00, 0x48).unwrap(); // SPE | BR=1
+        spi.write(0x0C, 0x01).unwrap();
+        assert_eq!(
+            spi.read(0x08).unwrap() & 0x01,
+            0,
+            "RXNE must not assert before the frame finishes on the wire"
+        );
+        run_engine(&mut spi);
+        assert_eq!(spi.read(0x0C).unwrap(), 0x51, "first frame's answer");
+        spi.write(0x0C, 0x02).unwrap();
+        run_engine(&mut spi);
+        assert_eq!(spi.read(0x0C).unwrap(), 0x52, "second frame's answer");
     }
 
     // ── nRF52 SPIM EasyDMA unit tests ─────────────────────────────────────────

--- a/crates/core/src/tests/logic_capture_differential.rs
+++ b/crates/core/src/tests/logic_capture_differential.rs
@@ -315,6 +315,109 @@ mod logic_capture_differential_tests {
         }
     }
 
+    // ── STM32 SPI waveform (bit-engine push path) ────────────────────────────
+
+    const SPI1_BASE: u64 = 0x4001_3000;
+    const SPIA_GPIO_BASE: u64 = 0x5000_0000;
+    const SCK_PIN: u8 = 5;
+    const MOSI_PIN: u8 = 7;
+    const SPI_WIRE_BYTES: [u8; 3] = [0x21, 0x0C, 0xA5];
+
+    /// The STM32 SPI1/PA5/PA7 waveform fixture from
+    /// `tests/stm32_spi_waveform.rs`, driven through `Machine::run` batches.
+    /// BR=4 (half-period 16 cycles) keeps every wire transition on a
+    /// tick-interval multiple for all tested intervals.
+    fn stm32_spi_machine(tick_interval: u32) -> Machine<CortexM> {
+        use crate::peripherals::spi::{Spi, SpiRegisterLayout};
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        // A V2 GPIOA at a dedicated base (the default test-bus "gpioa" is F1).
+        let gpioa_idx = bus.find_peripheral_index_by_name("gpioa").unwrap();
+        bus.peripherals[gpioa_idx].dev =
+            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2));
+        bus.peripherals[gpioa_idx].base = SPIA_GPIO_BASE;
+        bus.rebuild_peripheral_ranges();
+        bus.add_peripheral(
+            "spi1",
+            SPI1_BASE,
+            0x400,
+            None,
+            Box::new(Spi::new_with_layout(SpiRegisterLayout::Stm32Fifo)),
+        );
+        bus.wire_stm32_spi_pads();
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.peripheral_tick_interval = tick_interval;
+        machine.bus.config.peripheral_tick_interval = tick_interval;
+        for i in 0..1022u64 {
+            let byte = if i % 2 == 0 { 0x00 } else { 0x20 };
+            machine.bus.write_u8(RAM_BASE + i, byte).unwrap();
+        }
+        machine.bus.write_u8(RAM_BASE + 1022, 0xFF).unwrap();
+        machine.bus.write_u8(RAM_BASE + 1023, 0xE5).unwrap();
+        machine.cpu.pc = RAM_BASE as u32;
+
+        let bus = &mut machine.bus;
+        bus.write_u32(
+            SPIA_GPIO_BASE + MODER,
+            (0b10 << (SCK_PIN * 2)) | (0b10 << (MOSI_PIN * 2)),
+        )
+        .unwrap();
+        bus.write_u32(
+            SPIA_GPIO_BASE + 0x20, // AFRL: AF5 on both pads
+            (5 << (SCK_PIN * 4)) | (5 << (MOSI_PIN * 4)),
+        )
+        .unwrap();
+        // CR1 = MSTR|SSM|SSI|BR=4 (/32)|SPE — mode 0, MSB first, 8-bit.
+        bus.write_u16(
+            SPI1_BASE,
+            (1 << 2) | (1 << 9) | (1 << 8) | (0x4 << 3) | (1 << 6),
+        )
+        .unwrap();
+        machine
+    }
+
+    fn run_stm32_spi(tick_interval: u32, force_poll: bool) -> Vec<LogicEdge> {
+        let mut machine = stm32_spi_machine(tick_interval);
+        machine.logic_force_poll_capture(force_poll);
+        let gpioa_idx = machine.bus.find_peripheral_index_by_name("gpioa").unwrap();
+        let initial =
+            machine.logic_watch(&[Some((gpioa_idx, MOSI_PIN)), Some((gpioa_idx, SCK_PIN))]);
+        assert_eq!(initial, vec![Some(false), Some(false)]);
+
+        // Three bytes back-to-back through the TX FIFO (3 × 8-bit fits the
+        // 4-frame FIFO), then a fixed cycle budget so both modes execute the
+        // identical cycle count. 3 frames × 8 bits × 32 cycles ≈ 768 cycles.
+        for b in SPI_WIRE_BYTES {
+            machine.bus.write_u8(SPI1_BASE + 0x0C, b).unwrap();
+        }
+        for _ in 0..40 {
+            machine.run(Some(100)).unwrap();
+        }
+        machine.logic_read_edges(0).edges
+    }
+
+    /// THE gate, SPI flavour: the bit-level engine's SCK/MOSI waveform on
+    /// AFR-routed pads, pushed from the `SpiLineLevels` cell, must be
+    /// byte-identical to the per-cycle poll of `read_gpio_pad`.
+    #[test]
+    fn stm32_spi_waveform_push_stream_is_byte_identical_to_poll() {
+        for tick_interval in [1u32, 4] {
+            let poll = run_stm32_spi(tick_interval, true);
+            let push = run_stm32_spi(tick_interval, false);
+            let sck_rises = poll.iter().filter(|e| e.ch == 1 && e.value).count();
+            assert_eq!(
+                sck_rises,
+                SPI_WIRE_BYTES.len() * 8,
+                "tick={tick_interval}: full byte stream on the wire (3 bytes x 8 SCK rises)"
+            );
+            assert_eq!(
+                poll, push,
+                "tick={tick_interval}: push SPI waveform must be byte-identical to poll"
+            );
+        }
+    }
+
     // ── Honest fallback: non-instrumented peripherals stay on poll ──────────
 
     /// A minimal GPIO-ish peripheral that deliberately does NOT accept a

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -15,4 +15,6 @@ pub mod rp2040;
 #[cfg(test)]
 pub mod scb_reset;
 #[cfg(test)]
+pub mod stm32_spi_waveform;
+#[cfg(test)]
 pub mod test_cycles;

--- a/crates/core/src/tests/stm32_spi_waveform.rs
+++ b/crates/core/src/tests/stm32_spi_waveform.rs
@@ -1,0 +1,302 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! End-to-end waveform test for the STM32 bit-level SPI engine: arm the
+//! in-engine logic analyzer on the AFR-routed L4 SPI1 SCK/MOSI pads (PA5/PA7
+//! on AF5, the nokia5110 lab wiring), run a PCD8544-style byte stream through
+//! the controller's registers exactly as the firmware driver does (poll TXE,
+//! write DR, poll BSY), and assert the captured edge stream is a valid mode-0
+//! SPI waveform whose decoded MOSI byte pattern matches the byte-level
+//! bus-trace monitor byte for byte. The waveform is sampled through the
+//! normal `read_gpio_pad` path — nothing is synthesized into the ring.
+
+#[cfg(test)]
+mod stm32_spi_waveform_tests {
+    use crate::bus::bus_trace::BusPayload;
+    use crate::cpu::CortexM;
+    use crate::logic_capture::LogicEdge;
+    use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+    use crate::peripherals::spi::{Spi, SpiDevice, SpiRegisterLayout};
+    use crate::{Bus, Machine};
+
+    const RAM_BASE: u64 = 0x2000_0000;
+    /// The default test-bus gpioa entry (its dev is swapped for a V2 port).
+    const GPIOA_BASE: u64 = 0x4001_0800;
+    const SPI1_BASE: u64 = 0x4001_3000;
+
+    const MODER: u64 = 0x00;
+    const AFRL: u64 = 0x20;
+    const CR1: u64 = SPI1_BASE;
+    const SR: u64 = SPI1_BASE + 0x08;
+    const DR: u64 = SPI1_BASE + 0x0C;
+
+    /// nokia5110-invaders-lab wiring: PA5 = SPI1_SCK, PA7 = SPI1_MOSI (AF5).
+    const SCK_PIN: u8 = 5;
+    const MOSI_PIN: u8 = 7;
+    const CH_MOSI: u32 = 0;
+    const CH_SCK: u32 = 1;
+
+    /// PCD8544-style stream: extended-mode init (0x21 0xBF 0x04 0x14),
+    /// basic mode + normal video (0x20 0x0C), one framebuffer byte.
+    const WIRE_BYTES: [u8; 7] = [0x21, 0xBF, 0x04, 0x14, 0x20, 0x0C, 0xA5];
+
+    /// Write-only display-style device (PCD8544 never drives MISO).
+    struct PanelSink;
+    impl SpiDevice for PanelSink {
+        fn transfer(&mut self, _mosi: u8) -> u8 {
+            0
+        }
+        fn cs_pin(&self) -> &str {
+            "PB6"
+        }
+    }
+
+    /// Build a machine whose bus carries an L4-style SPI1 (FIFO layout, with a
+    /// traced write-only panel) and a V2 GPIOA wired through
+    /// `wire_stm32_spi_pads`. The CPU chews a NOP loop so `step()` advances
+    /// cycles deterministically.
+    fn machine() -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        // The default test bus ships an F1-layout "gpioa"; this lab is an L4
+        // (V2 registers), so swap the device in place.
+        let gpioa_idx = bus.find_peripheral_index_by_name("gpioa").unwrap();
+        bus.peripherals[gpioa_idx].dev =
+            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2));
+        bus.add_peripheral(
+            "spi1",
+            SPI1_BASE,
+            0x400,
+            None,
+            Box::new(Spi::new_with_layout(SpiRegisterLayout::Stm32Fifo)),
+        );
+        // Through the single traced choke point, same as a config-built bus.
+        bus.attach_spi_device("spi1", Box::new(PanelSink)).unwrap();
+        bus.wire_stm32_spi_pads();
+
+        let mut machine = Machine::new(cpu, bus);
+        // NOP slab (`movs r0, #0`) with a Thumb `b` back to the start.
+        for i in 0..1022u64 {
+            let byte = if i % 2 == 0 { 0x00 } else { 0x20 };
+            machine.bus.write_u8(RAM_BASE + i, byte).unwrap();
+        }
+        machine.bus.write_u8(RAM_BASE + 1022, 0xFF).unwrap();
+        machine.bus.write_u8(RAM_BASE + 1023, 0xE5).unwrap();
+        machine.cpu.pc = RAM_BASE as u32;
+        machine
+    }
+
+    /// Route the pads and bring up SPI1 exactly as the nokia firmware does:
+    /// PA5/PA7 → AF mode, AFRL nibbles = 5; CR1 = MSTR|SSM|SSI|BR=/4|SPE
+    /// (mode 0, MSB first, 8-bit frames via the CR2 reset 0x0700).
+    fn configure(machine: &mut Machine<CortexM>) {
+        let bus = &mut machine.bus;
+        bus.write_u32(
+            GPIOA_BASE + MODER,
+            (0b10 << (SCK_PIN * 2)) | (0b10 << (MOSI_PIN * 2)),
+        )
+        .unwrap();
+        bus.write_u32(
+            GPIOA_BASE + AFRL,
+            (5 << (SCK_PIN * 4)) | (5 << (MOSI_PIN * 4)),
+        )
+        .unwrap();
+        bus.write_u16(CR1, (1 << 2) | (1 << 9) | (1 << 8) | (0x1 << 3) | (1 << 6))
+            .unwrap();
+    }
+
+    /// Drive one byte the way `spi_write` in the lab firmware does: wait TXE,
+    /// write DR (8-bit access — one frame on FIFO parts), wait BSY clear.
+    fn spi_write(machine: &mut Machine<CortexM>, byte: u8) {
+        for _ in 0..10_000 {
+            if machine.bus.read_u16(SR).unwrap() & (1 << 1) != 0 {
+                break;
+            }
+            machine.step().unwrap();
+        }
+        machine.bus.write_u8(DR, byte).unwrap();
+        for _ in 0..10_000 {
+            if machine.bus.read_u16(SR).unwrap() & (1 << 7) == 0 {
+                return;
+            }
+            machine.step().unwrap();
+        }
+        panic!("BSY never cleared — the bit engine's wire time is wrong");
+    }
+
+    /// Pad level of `ch` at engine cycle `cycle`, reconstructed from the
+    /// initial level and the recorded transitions.
+    fn level_at(initial: bool, edges: &[LogicEdge], ch: u32, cycle: u64) -> bool {
+        let mut level = initial;
+        for e in edges {
+            if e.ch == ch && e.cycle <= cycle {
+                level = e.value;
+            }
+        }
+        level
+    }
+
+    #[test]
+    fn logic_capture_sees_real_spi_waveform_matching_bus_trace() {
+        let mut machine = machine();
+        configure(&mut machine);
+
+        let gpioa_idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpioa")
+            .expect("gpioa registered");
+        let initial =
+            machine.logic_watch(&[Some((gpioa_idx, MOSI_PIN)), Some((gpioa_idx, SCK_PIN))]);
+        assert_eq!(
+            initial,
+            vec![Some(false), Some(false)],
+            "idle mode-0 wire reads low (SCK = CPOL = 0) on both AFR-routed pads"
+        );
+
+        for b in WIRE_BYTES {
+            spi_write(&mut machine, b);
+        }
+
+        let edges = machine.logic_read_edges(0).edges;
+        assert!(
+            !edges.is_empty(),
+            "hardware-SPI pads must carry edges, not a flat trace"
+        );
+        assert!(edges.iter().any(|e| e.ch == CH_SCK), "SCK edges present");
+        assert!(edges.iter().any(|e| e.ch == CH_MOSI), "MOSI edges present");
+
+        // ── Clock structure: mode 0 samples on the rising edge; 8 rises per
+        // byte, and SCK returns low (CPOL idle) after every frame.
+        let rising: Vec<u64> = edges
+            .iter()
+            .filter(|e| e.ch == CH_SCK && e.value)
+            .map(|e| e.cycle)
+            .collect();
+        assert_eq!(
+            rising.len(),
+            WIRE_BYTES.len() * 8,
+            "8 SCK rising edges per byte"
+        );
+        let falling = edges.iter().filter(|e| e.ch == CH_SCK && !e.value).count();
+        assert_eq!(
+            falling,
+            WIRE_BYTES.len() * 8,
+            "every SCK pulse returns to the CPOL idle level"
+        );
+
+        // ── Decode MOSI at the mode-0 sample edges, MSB first.
+        let bits: Vec<bool> = rising
+            .iter()
+            .map(|&c| level_at(false, &edges, CH_MOSI, c))
+            .collect();
+        let decoded: Vec<u8> = bits
+            .chunks(8)
+            .map(|chunk| chunk.iter().fold(0u8, |acc, &b| (acc << 1) | u8::from(b)))
+            .collect();
+        assert_eq!(
+            decoded,
+            WIRE_BYTES.to_vec(),
+            "the clocked MOSI byte pattern must be the programmed stream"
+        );
+
+        // ── Waveform and byte-level bus monitor must agree: the same bytes,
+        // in the same order, on the same bus.
+        let traced: Vec<u8> = machine
+            .bus
+            .bus_trace_snapshot()
+            .iter()
+            .filter(|e| e.bus == "spi1")
+            .filter_map(|e| match e.payload {
+                BusPayload::Spi { mosi, .. } => Some(mosi),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            traced,
+            WIRE_BYTES.to_vec(),
+            "bus monitor must record the same bytes the waveform clocked"
+        );
+        assert_eq!(
+            decoded, traced,
+            "waveform decode and bus-trace monitor must agree byte for byte"
+        );
+    }
+
+    /// Analytic wire time through the machine: with BR=/4 an 8-bit frame is
+    /// exactly 32 engine cycles on the wire — BSY reads busy for the whole
+    /// window and clear right after.
+    #[test]
+    fn frame_wire_time_is_exact_through_the_machine() {
+        let mut machine = machine();
+        configure(&mut machine);
+        machine.bus.write_u8(DR, 0xA5).unwrap();
+        let mut busy_cycles = 0u64;
+        while machine.bus.read_u16(SR).unwrap() & (1 << 7) != 0 {
+            machine.step().unwrap();
+            busy_cycles += 1;
+            assert!(busy_cycles < 10_000, "frame never completed");
+        }
+        assert_eq!(
+            busy_cycles, 32,
+            "8 bits × 2^(BR+1) = 32 cycles at BR=1 — firmware-visible wire time"
+        );
+    }
+
+    /// The pads report the SPI wire ONLY while MODER/AFR route it: flipping
+    /// PA5 back to a plain GPIO output detaches the pad from the engine.
+    #[test]
+    fn pad_follows_afr_routing() {
+        let mut machine = machine();
+        configure(&mut machine);
+        let gpioa_idx = machine.bus.find_peripheral_index_by_name("gpioa").unwrap();
+        let routing = machine.bus.peripherals[gpioa_idx]
+            .dev
+            .gpio_routing(SCK_PIN)
+            .unwrap();
+        assert_eq!(routing.func.as_deref(), Some("SPI1_SCK"));
+
+        // Re-route PA5 to plain output with ODR bit set: the pad must now
+        // read the GPIO latch (high), not the idle SPI clock (low).
+        machine
+            .bus
+            .write_u32(GPIOA_BASE + 0x14, 1 << SCK_PIN)
+            .unwrap();
+        machine
+            .bus
+            .write_u32(
+                GPIOA_BASE + MODER,
+                (0b01 << (SCK_PIN * 2)) | (0b10 << (MOSI_PIN * 2)),
+            )
+            .unwrap();
+        let pad = machine.bus.peripherals[gpioa_idx]
+            .dev
+            .read_gpio_pad(SCK_PIN);
+        assert_eq!(pad, Some(true), "output-mode pad reads the ODR latch");
+        let routing = machine.bus.peripherals[gpioa_idx]
+            .dev
+            .gpio_routing(SCK_PIN)
+            .unwrap();
+        assert!(routing.func.is_none(), "no SPI func on a plain output");
+    }
+
+    /// Determinism: identical run, identical edge stream.
+    #[test]
+    fn waveform_capture_is_deterministic() {
+        let run = || {
+            let mut machine = machine();
+            configure(&mut machine);
+            let gpioa_idx = machine.bus.find_peripheral_index_by_name("gpioa").unwrap();
+            machine.logic_watch(&[Some((gpioa_idx, MOSI_PIN)), Some((gpioa_idx, SCK_PIN))]);
+            for b in WIRE_BYTES {
+                spi_write(&mut machine, b);
+            }
+            machine.logic_read_edges(0).edges
+        };
+        assert_eq!(
+            run(),
+            run(),
+            "same firmware + watch => byte-identical edges"
+        );
+    }
+}

--- a/crates/core/tests/hardware_fidelity.rs
+++ b/crates/core/tests/hardware_fidelity.rs
@@ -93,10 +93,11 @@ fn test_spi_fidelity_in_machine() {
     assert_ne!(sr & 0x80, 0);
 
     // Advance the transfer to completion. Flag-off, the per-cycle walk drives
-    // the SPI countdown (8 bits × 4 divider = 32 ticks). Flag-on, the SPI is
-    // event-scheduled and the walk skips it, so fire its single completion
-    // event exactly as `Machine::drain_scheduler_events` does — swapping the
-    // peripheral out to satisfy the borrow checker.
+    // the SPI bit engine (8 bits × 4 divider = 32 ticks of wire time).
+    // Flag-on, the SPI is event-scheduled and the walk skips it, so drive the
+    // per-transition event chain exactly as `Machine::drain_scheduler_events`
+    // does — advancing scheduler time and re-firing while the engine keeps
+    // rescheduling — swapping the peripheral out to satisfy the borrow checker.
     #[cfg(not(feature = "event-scheduler"))]
     for _ in 0..32 {
         bus.tick_peripherals();
@@ -113,10 +114,19 @@ fn test_spi_fidelity_in_machine() {
             if !bus.peripherals[i].dev.uses_scheduler() {
                 continue;
             }
-            let placeholder: Box<dyn Peripheral> = Box::new(StubPeripheral::new(0));
-            let mut dev = std::mem::replace(&mut bus.peripherals[i].dev, placeholder);
-            dev.on_event(0, &mut sched, &mut bus);
-            bus.peripherals[i].dev = dev;
+            let mut tick = 0u64;
+            loop {
+                tick += 1;
+                sched.advance_to(tick);
+                let placeholder: Box<dyn Peripheral> = Box::new(StubPeripheral::new(0));
+                let mut dev = std::mem::replace(&mut bus.peripherals[i].dev, placeholder);
+                let result = dev.on_event(0, &mut sched, &mut bus);
+                bus.peripherals[i].dev = dev;
+                if result.reschedule_delay.is_none() {
+                    break;
+                }
+                assert!(tick < 10_000, "event chain never completed");
+            }
         }
     }
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -70,7 +70,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -165,7 +165,8 @@ boards:
     # h563_conformance remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
-    drift_ack: 2026-07-10
+    # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-11
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -292,7 +293,8 @@ boards:
     # l476_parity_diff remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
-    drift_ack: 2026-07-10
+    # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-11
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -342,7 +344,8 @@ boards:
     # drives a pin. No live re-capture this session.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
-    drift_ack: 2026-07-10
+    # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-11
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -389,7 +392,8 @@ boards:
     # f103_conformance remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
-    drift_ack: 2026-07-10
+    # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-11
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -443,7 +447,8 @@ boards:
     # stm32f4_exec_oracle remain the pinned coverage. No live re-capture.
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
-    drift_ack: 2026-07-10
+    # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-11
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
The STM32 SPI twin of #507's ESP32-C3 I²C bit engine: DR writes no longer complete instantly — the frame clocks on the wire over simulated cycles, and AF-routed GPIO pads carry the real waveform, so logic-analyzer raw lanes on SCK/MOSI/MISO show actual edges (previously flat: transaction-atomic model + AF pads read None).

## Wire engine
Classic/FIFO STM32 layouts gain a segment machine: per bit, two half-periods of `2^BR` PCLK cycles (CR1 BR[2:0]); CPOL idle level, CPHA sample edge, LSBFIRST shift order, frame width from CR2.DS (FIFO) / CR1.DFF (classic), datasheet resets when unprogrammed. Total frame time `bits × 2^(BR+1)` is numerically identical to the old countdown for 8-bit frames — firmware-visible timing did not move (nokia e2e step budgets unchanged, splash framebuffer byte-identical to base in both featureless and event-scheduler lanes).

Byte-level `SpiDevice`s stay behind the untouched `TracingSpiDevice` choke point, consulted once per frame at the boundary where it starts clocking; the answered byte is what MISO carries bit-by-bit during that same frame (full duplex). Flags flip at wire time: BSY/TXE at DR write, TXE+BSY clear at frame completion, RXNE only when a slave/loopback drove MISO. FIFO parts pack two 8-bit frames per u16 DR write (back-to-back on the wire) with a 4-frame TX FIFO bound (RM0351); classic parts model the single TX buffer overwrite (RM0008).

## Pads
The engine publishes into a shared `SpiLineLevels` cell (clone of `I2cLineLevels`, including push-capture tap registration at drive time). STM32 GPIO ports return cell levels from `read_gpio_pad` for pads whose live MODER+AFR (V2) or CRL/CRH CNF (F1) route the SPI AF; static AF tables sourced from DS10198 (L4), DS8626 (F4), RM0008 default map (F1). Wired at config-build time via `SystemBus::wire_stm32_spi_pads`. GPIO writes re-sync watched-channel registration so live re-routing keeps push capture honest. F1 MISO intentionally not routed (input-mode pad on silicon — a plain GPIO input must never silently read the SPI wire).

## Scheduling
Event-scheduler path: `sync_to` anchors the engine to the MMIO write tick; one event armed per wire transition; `on_event` self-corrects against `sched.now()` (early wakeups re-arm exactly). Legacy walk clocks via `tick_elapsed`. The two paths cannot double-advance.

## Tests
New `stm32_spi_waveform.rs` (PA5/PA7 AFR-routed watch driven like the lab firmware: 8 SCK rises/byte, MOSI decoded at mode-0 sample edges == programmed bytes == bus-trace monitor byte-for-byte; exact wire-time; BR=0/BR=4/16-bit analytic; mode-3+LSBFIRST; determinism; AFR re-route detach), a push-vs-poll differential SPI case (byte-identical, ticks 1 and 4, both feature lanes), PCD8544 D/C keystone updated to clock the engine, 6 new unit tests.

Honest limits (documented in code): slave mode/CRC/TI mode/I2S register-backed only; >8-bit frames exchange one byte with byte-level devices; AFIO remap not modeled; H5 "SPI v3" keeps its silicon-pinned model; mid-frame engine state not runtime-snapshotted (same as C3 I²C).

Validation: dated drift_acks for h563/l476/l073/f103/f407; `generate_validation_status.py --check --drift` passes. All lanes green locally (workspace, jit+event-scheduler, clippy -D warnings, fmt); known machine-local intmatrix/WFI-FF failures verified identical on unmodified base.