### PR TITLE
perf: event-migrate HC-SR04 echo + alloc-free per-cycle tick

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -85,6 +85,8 @@ impl SystemBus {
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -265,6 +265,17 @@ pub struct SystemBus {
     /// `requires_cycle_accurate` — called per run-loop iteration — never scans
     /// peripherals. `false` on every bus without an H5 op-modeling FLASH.
     flash_models_ops: bool,
+    /// Cached in `rebuild_peripheral_ranges`: true when a Nordic `gpio0`/`gpio1`
+    /// port is present, so the per-cycle tick runs the GPIO-edge/GPIOTE service
+    /// pass. Lets `tick_peripherals_fully` decide in O(1) whether the walk-free
+    /// per-cycle tick has any work at all (see `per_cycle_tick_is_trivial`)
+    /// instead of scanning peripherals by name every cycle.
+    nordic_gpio_service: bool,
+    /// Test/diagnostic override: force the legacy per-cycle HC-SR04 service path
+    /// even under the `event-scheduler` feature (disables the scheduled-edge
+    /// path). Set only by the differential determinism test; `false` in every
+    /// real config so the scheduled path is used whenever it is available.
+    pub hcsr04_scheduling_disabled: bool,
     /// Index of the FLASH register peripheral whose opt-in H5 program-error
     /// fidelity gate is enabled, if any. Cached in `rebuild_peripheral_ranges`
     /// (same staleness contract as `rcc_idx`). `None` on every bus where the
@@ -1535,7 +1546,57 @@ impl SystemBus {
     /// CLI/batch run path would record the op in the FLASH cell but never apply
     /// it (no 0xFF fill, no bank swap, no reset).
     pub fn requires_cycle_accurate(&self) -> bool {
-        !self.hcsr04.is_empty() || self.has_iolink_master() || self.flash_models_ops
+        let hcsr04_needs_cycle_accurate = !self.hcsr04.is_empty() && !self.hcsr04_event_scheduled();
+        hcsr04_needs_cycle_accurate || self.has_iolink_master() || self.flash_models_ops
+    }
+
+    /// True when the HC-SR04 echo waveform is driven by the event scheduler
+    /// (rise/fall edges scheduled at their exact cycles and drained by
+    /// `Machine::drain_scheduler_events`) rather than the per-cycle
+    /// `service_hcsr04` pass. Active only under the `event-scheduler` feature on
+    /// a walk-deleted bus (`legacy_walk_disabled`) — the same buses that already
+    /// route every migrated peripheral through the scheduler. On the legacy-walk
+    /// or feature-off path the sensor stays on the per-tick service path and
+    /// `requires_cycle_accurate` keeps batches at one instruction. The
+    /// `hcsr04_scheduling_disabled` override forces the legacy path (differential
+    /// determinism test only).
+    ///
+    /// Gated on `peripheral_tick_interval > 1`: at interval 1 there is no
+    /// instruction batching to unlock (batches are already one instruction), so
+    /// the scheduled path would only add per-cycle drain overhead for no win —
+    /// the proven per-tick service path is kept, byte-for-byte identical to the
+    /// pre-migration build. The scheduled path activates exactly when the browser
+    /// raises the interval to batch, which is when it pays off (see the throughput
+    /// numbers in the migration notes).
+    #[inline]
+    pub(crate) fn hcsr04_event_scheduled(&self) -> bool {
+        cfg!(feature = "event-scheduler")
+            && self.legacy_walk_disabled
+            && !self.hcsr04.is_empty()
+            && !self.hcsr04_scheduling_disabled
+            && self.config.peripheral_tick_interval > 1
+    }
+
+    /// True when the per-cycle tick (`tick_peripherals_fully`) has no orchestration
+    /// work beyond the NVIC scan: the legacy peripheral walk is deleted, no
+    /// bus-aware peripheral needs a pre-tick pass, no Nordic GPIO/GPIOTE service
+    /// is wired, no CAN synthetic testers are attached, and every HC-SR04 (if any)
+    /// is event-scheduled. On such a bus the tick early-outs to just the NVIC
+    /// aggregation, avoiding the phase-1 orchestration and its allocations every
+    /// cycle. Only meaningful under the `event-scheduler` feature (the walk is
+    /// never deleted otherwise).
+    #[cfg(feature = "event-scheduler")]
+    #[inline]
+    fn per_cycle_tick_is_trivial(&self) -> bool {
+        self.legacy_walk_disabled
+            && self.bus_tick_indices.is_empty()
+            && !self.nordic_gpio_service
+            && !self.esp32c3_irq_routing
+            && !self.esp32s3_irq_routing
+            && self.can_diagnostic_testers.is_empty()
+            && self.can_uds_testers.is_empty()
+            && self.can_log_players.is_empty()
+            && (self.hcsr04.is_empty() || self.hcsr04_event_scheduled())
     }
 
     /// True when an IO-Link master peer is attached to any UART. The master is
@@ -1572,28 +1633,90 @@ impl SystemBus {
         if self.hcsr04.is_empty() {
             return;
         }
-        let now = self.current_cycle;
         for i in 0..self.hcsr04.len() {
             // TRIG is no longer polled here — `maybe_arm_hcsr04` arms the window
             // on the GPIO write (cycle-exact, see the note in `Machine::step`).
             // The per-cycle work is two integer comparisons plus, only on a
             // transition, one read-modify-write of the ECHO input bit.
-            let echo_high = self.hcsr04[i].echo_high_at(now);
-            if echo_high == self.hcsr04[i].last_echo_high() {
-                continue;
+            self.drive_hcsr04_echo(i);
+        }
+    }
+
+    /// Drive sensor `i`'s ECHO input register to the level its armed window
+    /// implies at `self.current_cycle`, touching the bus only on a transition.
+    /// The single choke point shared by the per-cycle [`service_hcsr04`] pass and
+    /// the event-scheduler edge handler ([`apply_hcsr04_event`]) — routing both
+    /// through the same `write_u32` keeps logic-analyzer probe capture on the
+    /// ECHO pad byte-identical across the two paths.
+    ///
+    /// [`service_hcsr04`]: Self::service_hcsr04
+    /// [`apply_hcsr04_event`]: Self::apply_hcsr04_event
+    fn drive_hcsr04_echo(&mut self, i: usize) {
+        let now = self.current_cycle;
+        let echo_high = self.hcsr04[i].echo_high_at(now);
+        if echo_high == self.hcsr04[i].last_echo_high() {
+            return;
+        }
+        let echo_addr = self.hcsr04[i].echo_idr_addr;
+        let echo_bit = self.hcsr04[i].echo_bit;
+        let idr = self.read_u32(echo_addr).unwrap_or(0);
+        let new_idr = if echo_high {
+            idr | (1 << echo_bit)
+        } else {
+            idr & !(1 << echo_bit)
+        };
+        if new_idr != idr {
+            let _ = self.write_u32(echo_addr, new_idr);
+        }
+        self.hcsr04[i].set_last_echo_high(echo_high);
+    }
+
+    /// Event-scheduler edge handler: a scheduled ECHO rise/fall for sensor
+    /// `sensor` came due, so drive its ECHO input register to the current
+    /// window level. Recomputing from the window (rather than trusting a
+    /// hard-coded rise/fall) makes the handler idempotent and self-correcting
+    /// through the same choke point the per-cycle pass uses. Called by
+    /// `Machine::drain_scheduler_events` for [`crate::sched::SUBSYSTEM_PERIPHERAL_IDX`]
+    /// events. Out-of-range `sensor` (a sensor removed after scheduling) is a
+    /// no-op.
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn apply_hcsr04_event(&mut self, sensor: usize) {
+        if sensor < self.hcsr04.len() {
+            self.drive_hcsr04_echo(sensor);
+        }
+    }
+
+    /// Event-scheduler path: the earliest cycle at which any event-scheduled
+    /// HC-SR04 must next drive its ECHO pad, or `None` when no sensor has a
+    /// pending edge. The run loop clamps its batch to end exactly here so a
+    /// busy-polling firmware observes the edge on time. Scoped to HC-SR04 (not
+    /// every scheduled peripheral): the SPI wire engine self-corrects against
+    /// its anchor when its event fires a batch late, so clamping to it would only
+    /// shrink batches during framebuffer pushes for no correctness gain — HC-SR04
+    /// is the one device that is polled cycle-tight and must not be observed late.
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn next_hcsr04_deadline_cycle(&self) -> Option<u64> {
+        if !self.hcsr04_event_scheduled() {
+            return None;
+        }
+        let interval = (self.config.peripheral_tick_interval as u64).max(1);
+        let now = self.current_cycle;
+        self.hcsr04
+            .iter()
+            .filter_map(|s| s.next_edge_deadline_cycle(now, interval))
+            .min()
+    }
+
+    /// Event-scheduler path: harvest any sensor whose echo window was (re)armed
+    /// since the last harvest, returning `(sensor_idx, rise_tick, fall_tick)`
+    /// absolute peripheral-tick deadlines for `Machine::drain_scheduler_events`
+    /// to enqueue. No allocation when nothing was armed.
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn harvest_hcsr04_edges(&mut self, interval: u64, out: &mut Vec<(usize, u64, u64)>) {
+        for i in 0..self.hcsr04.len() {
+            if let Some((rise, fall)) = self.hcsr04[i].take_edge_schedule(interval) {
+                out.push((i, rise, fall));
             }
-            let echo_addr = self.hcsr04[i].echo_idr_addr;
-            let echo_bit = self.hcsr04[i].echo_bit;
-            let idr = self.read_u32(echo_addr).unwrap_or(0);
-            let new_idr = if echo_high {
-                idr | (1 << echo_bit)
-            } else {
-                idr & !(1 << echo_bit)
-            };
-            if new_idr != idr {
-                let _ = self.write_u32(echo_addr, new_idr);
-            }
-            self.hcsr04[i].set_last_echo_high(echo_high);
         }
     }
 
@@ -2334,6 +2457,8 @@ impl SystemBus {
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),
@@ -2387,6 +2512,8 @@ impl SystemBus {
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),
@@ -4696,6 +4823,8 @@ peripherals:
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),
@@ -4773,6 +4902,8 @@ peripherals:
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),
@@ -5001,6 +5132,8 @@ peripherals:
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),
@@ -5228,6 +5361,8 @@ peripherals:
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),
@@ -5309,6 +5444,8 @@ peripherals:
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
             flash_models_ops: false,
+            nordic_gpio_service: false,
+            hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
             bus_trace: bus_trace::new_log(),
             logic_tap: crate::logic_capture::LogicTap::new(),

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -216,6 +216,11 @@ impl SystemBus {
                 .is_some()
         });
         self.esp32s3_irq_routing = self.esp32s3_intmatrix_idx.is_some();
+        // Cache whether the per-cycle GPIO-edge/GPIOTE service pass has any
+        // Nordic port to scan, so `tick_peripherals_fully` can early-out on
+        // walk-free buses without scanning peripherals by name every cycle.
+        self.nordic_gpio_service = self.find_peripheral_index_by_name("gpio0").is_some()
+            || self.find_peripheral_index_by_name("gpio1").is_some();
     }
 
     pub(crate) fn rebuild_esp32c3_irq_cache(&mut self) {

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -361,7 +361,14 @@ impl SystemBus {
 
             // HC-SR04 and CAN synthetic services are not present on C3 ROM-boot
             // labs; keep them off the C3 high-frequency tick path.
-            self.service_hcsr04();
+            //
+            // When the sensor is event-scheduled, its ECHO edges are driven by
+            // `Machine::drain_scheduler_events` at their exact cycles instead —
+            // skip the per-cycle pass so the two paths don't both drive the pad
+            // (and so a walk-free bus can early-out of the tick entirely).
+            if !self.hcsr04_event_scheduled() {
+                self.service_hcsr04();
+            }
             self.service_can_diagnostic_testers();
             self.service_can_uds_testers();
             self.service_can_log_players();
@@ -643,6 +650,18 @@ impl SystemBus {
     }
 
     pub fn tick_peripherals_fully(&mut self) -> (Vec<u32>, Vec<PeripheralTickCost>) {
+        // Walk-free fast path: on a bus whose per-cycle tick has no orchestration
+        // work (walk deleted, no bus-tick/GPIO/CAN services, HC-SR04 event-
+        // scheduled), the only per-cycle duty left is aggregating enabled+pending
+        // NVIC interrupts. Returning here skips the whole phase-1 pass and its
+        // allocations. `Vec::new()` does not allocate until pushed, so the
+        // no-pending-IRQ case is allocation-free.
+        #[cfg(feature = "event-scheduler")]
+        if self.per_cycle_tick_is_trivial() {
+            let mut interrupts = Vec::new();
+            self.collect_enabled_nvic_interrupts(&mut interrupts);
+            return (interrupts, Vec::new());
+        }
         let (mut interrupts, costs, pending_dma, dma_signals, explicit_source_ids) =
             self.tick_peripherals_phase1();
         if self.esp32c3_irq_routing {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -903,6 +903,13 @@ pub struct Machine<C: Cpu> {
     /// under the `event-scheduler` feature.
     #[allow(dead_code)]
     scheduler_bootstrapped: bool,
+    /// Reusable scratch for `drain_scheduler_events`'s HC-SR04 edge harvest, so
+    /// the per-drain (per-cycle at tick interval 1) harvest allocates nothing on
+    /// the steady-state path. Holds `(sensor_idx, rise_tick, fall_tick)` and is
+    /// drained each call. Always present; only used under the `event-scheduler`
+    /// feature.
+    #[allow(dead_code)]
+    hcsr04_edge_scratch: Vec<(usize, u64, u64)>,
 
     /// In-engine logic-analyzer edge capture (see [`crate::logic_capture`]).
     /// Empty/inactive by default — the step loop pays a single `is_active`
@@ -1123,6 +1130,7 @@ impl<C: Cpu> Machine<C> {
             flash_index,
             scb_index,
             scheduler_bootstrapped: false,
+            hcsr04_edge_scratch: Vec::new(),
             logic_capture: logic_capture::LogicCapture::new(),
             logic_force_poll: false,
         }
@@ -1648,9 +1656,40 @@ impl<C: Cpu> Machine<C> {
                 .unwrap_or(0);
             self.sched.schedule(now + delay, idx as u32, token, gen);
         }
+        // HC-SR04: enqueue the ECHO rise/fall edges of any freshly-armed window
+        // as cycle-exact events under the reserved subsystem idx. The sensor is
+        // not a `peripherals[]` entry, so it can't ride the `pending_schedule`
+        // (peripheral-idx) path; it is dispatched below by idx match instead.
+        self.bus
+            .harvest_hcsr04_edges(interval, &mut self.hcsr04_edge_scratch);
+        for (sensor, rise_tick, fall_tick) in self.hcsr04_edge_scratch.drain(..) {
+            self.sched.schedule(
+                rise_tick.max(now),
+                sched::SUBSYSTEM_PERIPHERAL_IDX,
+                sensor as u32,
+                0,
+            );
+            self.sched.schedule(
+                fall_tick.max(now),
+                sched::SUBSYSTEM_PERIPHERAL_IDX,
+                sensor as u32,
+                0,
+            );
+        }
+        // Nothing queued (steady state between an SPI frame / HC-SR04 pulse):
+        // skip the generation snapshot + heap drain entirely — no allocation.
+        if self.sched.is_empty() {
+            return;
+        }
         let generations = self.bus.peripheral_generations();
         let due = self.sched.drain_due(&generations);
         for ev in due {
+            // Bus-subsystem pseudo-peripheral (HC-SR04): no `peripherals[]`
+            // entry — dispatch straight to the shared ECHO choke point.
+            if ev.peripheral_idx == sched::SUBSYSTEM_PERIPHERAL_IDX {
+                self.bus.apply_hcsr04_event(ev.event_token as usize);
+                continue;
+            }
             let idx = ev.peripheral_idx as usize;
             let Some(entry) = self.bus.peripherals.get_mut(idx) else {
                 continue;
@@ -1990,6 +2029,24 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 current_batch = current_batch.min(1);
             }
 
+            // Event-scheduler: end the batch exactly at the next event-scheduled
+            // HC-SR04 ECHO transition, so the post-batch `drain_scheduler_events`
+            // applies it at its exact cycle and a busy-polling firmware observes
+            // it that instruction — never a batch late. This is what lets HC-SR04
+            // drop out of `requires_cycle_accurate` (which pins the batch to one
+            // instruction) while staying correct. No-op at tick interval 1 (batch
+            // is already one instruction and the drain runs every cycle) and when
+            // no echo edge is pending, so the common paths pay nothing.
+            #[cfg(feature = "event-scheduler")]
+            if current_batch > 1 {
+                if let Some(deadline_cycle) = self.bus.next_hcsr04_deadline_cycle() {
+                    let until = deadline_cycle.saturating_sub(self.total_cycles);
+                    // `until == 0` means an edge is due at this exact cycle; take
+                    // one instruction so the drain applies it before advancing.
+                    current_batch = current_batch.min(until.clamp(1, u32::MAX as u64) as u32);
+                }
+            }
+
             // Push-mode capture: seed the tap clock at the batch start; the
             // CPU advances it once per retired instruction so pad writes stamp
             // with the boundary they become observable at.
@@ -2026,6 +2083,17 @@ impl<C: Cpu> DebugControl for Machine<C> {
                     self.cpu.set_exception_pending(irq);
                     tracing::debug!("Exception {} Pend", irq);
                 }
+            }
+
+            // Advance the bus's mirrored cycle to the batch-END cycle before the
+            // drain: scheduler event handlers that read `bus.current_cycle` (e.g.
+            // the HC-SR04 ECHO-edge handler recomputing its level from the window)
+            // must see "now", not the batch-start value seeded above — otherwise
+            // an edge due at the batch boundary is evaluated one batch stale (a
+            // fall would still read high and never transition).
+            #[cfg(feature = "event-scheduler")]
+            {
+                self.bus.current_cycle = self.total_cycles;
             }
 
             #[cfg(feature = "event-scheduler")]

--- a/crates/core/src/peripherals/hc_sr04.rs
+++ b/crates/core/src/peripherals/hc_sr04.rs
@@ -78,6 +78,13 @@ pub struct HcSr04 {
     /// a given peripheral write touches this sensor's TRIG line. `None` until
     /// resolved.
     trig_peripheral_idx: Option<usize>,
+    /// Event-scheduler path only: set true by [`observe_trig`](Self::observe_trig)
+    /// on a TRIG rising edge (a fresh echo window was just computed) and cleared
+    /// by [`take_edge_schedule`](Self::take_edge_schedule) once the bus has
+    /// scheduled the window's rise/fall edges as scheduler events. Unused by the
+    /// legacy per-tick service path.
+    #[cfg_attr(not(feature = "event-scheduler"), allow(dead_code))]
+    edge_reschedule_pending: bool,
 }
 
 impl HcSr04 {
@@ -103,6 +110,7 @@ impl HcSr04 {
             echo_end_cycle: 0,
             last_echo_high: false,
             trig_peripheral_idx: None,
+            edge_reschedule_pending: false,
         }
     }
 
@@ -198,8 +206,49 @@ impl HcSr04 {
             let pulse = ((self.distance_cm * US_PER_CM) as f64 * cpu) as u64;
             self.echo_start_cycle = now + delay;
             self.echo_end_cycle = self.echo_start_cycle + pulse.max(1);
+            // Event-scheduler path: flag the fresh window so the bus reschedules
+            // this sensor's ECHO rise/fall as scheduler events. Harmless (unread)
+            // on the legacy per-tick path.
+            self.edge_reschedule_pending = true;
         }
         self.last_trig = trig_high;
+    }
+
+    /// Event-scheduler path: if a fresh echo window was armed since the last
+    /// call, return the absolute peripheral-tick indices at which ECHO should
+    /// rise and fall, and clear the pending flag. The tick of a cycle `c` is
+    /// `ceil(c / interval)` — the first peripheral-tick boundary at or after the
+    /// exact cycle, which is precisely when the legacy per-tick `service_hcsr04`
+    /// (running only at tick boundaries) would first observe the level change.
+    /// At `interval == 1` this is the exact cycle, so the scheduled edges are
+    /// cycle-identical to the per-cycle path. Returns `None` when no new window
+    /// has been armed.
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn take_edge_schedule(&mut self, interval: u64) -> Option<(u64, u64)> {
+        if !self.edge_reschedule_pending {
+            return None;
+        }
+        self.edge_reschedule_pending = false;
+        let interval = interval.max(1);
+        Some((
+            self.echo_start_cycle.div_ceil(interval),
+            self.echo_end_cycle.div_ceil(interval),
+        ))
+    }
+
+    /// Event-scheduler path: the cycle of this sensor's next ECHO transition
+    /// strictly after `now`, quantised to the `interval` tick boundary its
+    /// scheduled event fires on (`ceil(edge / interval) * interval`) so the run
+    /// loop can end a batch exactly there. Returns `None` once the armed window
+    /// has fully elapsed (no pending transition) — matching the two edges
+    /// scheduled by [`take_edge_schedule`](Self::take_edge_schedule). Cheap: two
+    /// divides, no allocation.
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn next_edge_deadline_cycle(&self, now: u64, interval: u64) -> Option<u64> {
+        let interval = interval.max(1);
+        let rise = self.echo_start_cycle.div_ceil(interval) * interval;
+        let fall = self.echo_end_cycle.div_ceil(interval) * interval;
+        [rise, fall].into_iter().filter(|&c| c > now).min()
     }
 
     /// The ECHO input level for the current cycle: high while `now` is inside the

--- a/crates/core/src/sched/event_scheduler.rs
+++ b/crates/core/src/sched/event_scheduler.rs
@@ -27,6 +27,14 @@ use std::collections::BinaryHeap;
 
 pub type SimCycle = u64;
 
+/// Reserved `peripheral_idx` for bus-subsystem pseudo-peripherals that are NOT
+/// entries in `SystemBus::peripherals` and therefore have no generation slot —
+/// currently the HC-SR04 echo-edge scheduler (`SystemBus::hcsr04`). Events
+/// tagged with this idx are never generation-stale (there is nothing to cancel
+/// them against) and are dispatched by `Machine::drain_scheduler_events` to a
+/// dedicated bus handler rather than `peripherals[idx].on_event`.
+pub const SUBSYSTEM_PERIPHERAL_IDX: u32 = u32::MAX;
+
 #[derive(Debug, Default, Clone)]
 pub struct SchedulerStats {
     /// Count of `schedule()` calls in release mode whose `deadline < now`
@@ -162,7 +170,18 @@ impl EventScheduler {
         out
     }
 
+    /// True once no events remain queued. Lets the per-step drain skip its
+    /// generation snapshot + heap scan entirely when nothing is scheduled.
+    pub fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
     fn is_stale(ev: &ScheduledEvent, peripheral_generations: &[u32]) -> bool {
+        // Bus-subsystem pseudo-peripherals (e.g. HC-SR04) have no generation
+        // slot in `peripheral_generations`; they are never generation-cancelled.
+        if ev.peripheral_idx == SUBSYSTEM_PERIPHERAL_IDX {
+            return false;
+        }
         match peripheral_generations.get(ev.peripheral_idx as usize) {
             Some(cur) => *cur != ev.generation,
             // Out-of-range idx (peripheral removed) → treat as stale.

--- a/crates/core/src/sched/mod.rs
+++ b/crates/core/src/sched/mod.rs
@@ -14,5 +14,7 @@ pub mod event_scheduler;
 pub mod result;
 
 pub use clock::{ClockDomain, ClockGraph};
-pub use event_scheduler::{EventScheduler, ScheduledEvent, SchedulerStats, SimCycle};
+pub use event_scheduler::{
+    EventScheduler, ScheduledEvent, SchedulerStats, SimCycle, SUBSYSTEM_PERIPHERAL_IDX,
+};
 pub use result::EventResult;

--- a/crates/core/src/tests/hcsr04_event_tick_differential.rs
+++ b/crates/core/src/tests/hcsr04_event_tick_differential.rs
@@ -1,0 +1,197 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential oracle for the HC-SR04 echo-waveform migration
+//! (`perf/hcsr04-event-tick`): run the SAME busy-poll firmware twice — once on
+//! the legacy per-cycle `service_hcsr04` path (`hcsr04_scheduling_disabled =
+//! true`, which keeps `requires_cycle_accurate()` true and pins the batch to
+//! one instruction), once on the event-scheduled ECHO-edge path — and assert
+//! the two runs are BYTE-IDENTICAL: the ECHO input pad transitions at exactly
+//! the same cycles, and the full machine snapshot + cycle count agree.
+//!
+//! Per-tick is the reference semantics; if the scheduled path disagrees, the
+//! scheduled path is wrong. The firmware pulses TRIG, then busy-polls ECHO in
+//! a tight `ldr/tst/b` loop — precisely the "an edge landing mid-batch must not
+//! be observed late" case the migration has to preserve.
+//!
+//! The idle fast-forward is DISABLED here so the two paths execute the same
+//! instruction stream one cycle at a time and can be compared step-for-step —
+//! lifting the HC-SR04 cycle-accurate pin also re-enables idle fast-forward,
+//! which would otherwise let the scheduled path skip the busy-poll and diverge
+//! in instruction count (that optimisation is exercised by other tests).
+
+#![cfg(feature = "event-scheduler")]
+
+#[cfg(test)]
+mod hcsr04_event_tick_differential_tests {
+    use crate::cpu::CortexM;
+    use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+    use crate::peripherals::hc_sr04::HcSr04;
+    use crate::{DebugControl, Machine};
+
+    const GPIO_BASE: u64 = 0x4800_0000; // stm32v2: IDR @0x10, ODR @0x14
+    const IDR: u64 = 0x10;
+    const ODR: u64 = 0x14;
+    const RAM_BASE: u64 = 0x2000_0000;
+    const TRIG_BIT: u8 = 8; // PA8 (TRIG output)
+    const ECHO_BIT: u8 = 9; // PA9 (ECHO input)
+    const CPU_HZ: u64 = 1_000_000; // 1 cycle per µs → short, fast window
+
+    /// Build a Cortex-M machine with a V2 GPIO, one HC-SR04 wired TRIG=PA8 /
+    /// ECHO=PA9, on a walk-deleted bus (the config class the scheduled path
+    /// serves). `scheduling_disabled` selects the legacy per-tick path.
+    ///
+    /// Firmware (Thumb) at RAM_BASE, r0=&ODR r1=1<<TRIG r2=&IDR r3=1<<ECHO:
+    ///   str  r1,[r0]        ; TRIG high → arm the echo window
+    ///   poll_high: ldr r4,[r2]; tst r4,r3; beq poll_high   ; wait ECHO high
+    ///   poll_low:  ldr r4,[r2]; tst r4,r3; bne poll_low     ; wait ECHO low
+    ///   end: b end
+    fn build_machine(
+        tick_interval: u32,
+        scheduling_disabled: bool,
+        distance_cm: f32,
+    ) -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        bus.add_peripheral(
+            "gpioa",
+            GPIO_BASE,
+            0x400,
+            None,
+            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2)),
+        );
+        bus.hcsr04.push(HcSr04::new(
+            "dist".into(),
+            GPIO_BASE + ODR,
+            TRIG_BIT,
+            GPIO_BASE + IDR,
+            ECHO_BIT,
+            CPU_HZ,
+            distance_cm,
+        ));
+        // The scheduled ECHO-edge path is gated on a walk-deleted bus.
+        bus.legacy_walk_disabled = true;
+        bus.hcsr04_scheduling_disabled = scheduling_disabled;
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.config.peripheral_tick_interval = tick_interval;
+        // Fair A/B: keep both paths executing the same instruction stream (see
+        // module docs). Idle fast-forward is validated separately.
+        machine.config.idle_fast_forward_enabled = false;
+
+        machine.cpu.r0 = (GPIO_BASE + ODR) as u32;
+        machine.cpu.r1 = 1 << TRIG_BIT;
+        machine.cpu.r2 = (GPIO_BASE + IDR) as u32;
+        machine.cpu.r3 = 1 << ECHO_BIT;
+        // 0x00 str r1,[r0]
+        machine.bus.write_u16(RAM_BASE, 0x6001).unwrap();
+        // 0x02 ldr r4,[r2]  (poll_high)
+        machine.bus.write_u16(RAM_BASE + 2, 0x6814).unwrap();
+        // 0x04 tst r4,r3
+        machine.bus.write_u16(RAM_BASE + 4, 0x421C).unwrap();
+        // 0x06 beq poll_high  (target 0x02)
+        machine.bus.write_u16(RAM_BASE + 6, 0xD0FC).unwrap();
+        // 0x08 ldr r4,[r2]  (poll_low)
+        machine.bus.write_u16(RAM_BASE + 8, 0x6814).unwrap();
+        // 0x0A tst r4,r3
+        machine.bus.write_u16(RAM_BASE + 10, 0x421C).unwrap();
+        // 0x0C bne poll_low  (target 0x08)
+        machine.bus.write_u16(RAM_BASE + 12, 0xD1FC).unwrap();
+        // 0x0E b end  (self)
+        machine.bus.write_u16(RAM_BASE + 14, 0xE7FE).unwrap();
+        machine.cpu.pc = RAM_BASE as u32;
+        machine
+    }
+
+    fn echo_high(machine: &Machine<CortexM>) -> bool {
+        (machine.bus.read_u32(GPIO_BASE + IDR).unwrap() >> ECHO_BIT) & 1 != 0
+    }
+
+    /// Single-step the machine cycle-by-cycle, recording every `(cycle, level)`
+    /// transition of the ECHO input pad. The exact cycle each rise/fall is
+    /// driven — through the shared choke point on either path — is what this
+    /// pins. `step()` ticks/drains once per cycle, so both the per-tick service
+    /// and the event drain are exercised at their real cycle.
+    fn echo_edges(
+        mut machine: Machine<CortexM>,
+        cycles: u64,
+    ) -> (Vec<(u64, bool)>, serde_json::Value) {
+        let mut edges = Vec::new();
+        let mut prev = echo_high(&machine);
+        for _ in 0..cycles {
+            machine.step().unwrap();
+            let now = echo_high(&machine);
+            if now != prev {
+                edges.push((machine.total_cycles, now));
+                prev = now;
+            }
+        }
+        (edges, serde_json::to_value(machine.snapshot()).unwrap())
+    }
+
+    /// THE gate: legacy per-tick ECHO service vs event-scheduled ECHO edges must
+    /// be byte-identical — the ECHO pad transitions at exactly the same cycles
+    /// and the machine ends in an identical state. Runs at tick interval 2 (the
+    /// scheduled path activates only for interval > 1), cycle-stepped so the
+    /// edge cycle of every rise/fall is captured on both paths.
+    #[test]
+    fn scheduled_echo_edge_cycles_match_per_tick() {
+        for distance_cm in [2.0f32, 30.0, 100.0, 300.0] {
+            let cycles = 30_000;
+            let (per_tick, snap_a) = echo_edges(build_machine(2, true, distance_cm), cycles);
+            let (scheduled, snap_b) = echo_edges(build_machine(2, false, distance_cm), cycles);
+
+            assert_eq!(
+                per_tick.len(),
+                2,
+                "distance={distance_cm}: expected exactly one ECHO rise + one fall, got {per_tick:?}"
+            );
+            assert_eq!(
+                per_tick, scheduled,
+                "distance={distance_cm}: ECHO edge cycles must be byte-identical \
+                 (per-tick {per_tick:?} vs scheduled {scheduled:?})"
+            );
+            assert_eq!(
+                snap_a, snap_b,
+                "distance={distance_cm}: full machine snapshot must be byte-identical"
+            );
+        }
+    }
+
+    /// The batch-clamp path (tick interval > 1, where the scheduled path runs
+    /// multi-instruction batches ended exactly at the next ECHO edge) must stay
+    /// byte-identical to the per-tick reference, which quantises ECHO to the
+    /// same tick boundaries via its one-instruction batches.
+    #[test]
+    fn scheduled_echo_matches_per_tick_across_tick_intervals() {
+        for tick_interval in [2u32, 8, 64] {
+            let cycles = 30_000;
+            let (per_tick, snap_a) = run_state(build_machine(tick_interval, true, 30.0), cycles);
+            let (scheduled, snap_b) = run_state(build_machine(tick_interval, false, 30.0), cycles);
+            assert_eq!(
+                per_tick, scheduled,
+                "tick={tick_interval}: total_cycles must match after the ECHO window"
+            );
+            assert_eq!(
+                snap_a, snap_b,
+                "tick={tick_interval}: full machine snapshot must be byte-identical"
+            );
+        }
+    }
+
+    /// Run via the batched `Machine::run` to a cycle budget and return
+    /// `(total_cycles, snapshot)`. Exercises the batch clamp on the scheduled
+    /// path (wide batches ended at the ECHO edge) and the one-instruction clamp
+    /// on the per-tick path.
+    fn run_state(mut machine: Machine<CortexM>, cycles: u64) -> (u64, serde_json::Value) {
+        while machine.total_cycles < cycles {
+            let remaining = (cycles - machine.total_cycles).min(u32::MAX as u64) as u32;
+            machine.run(Some(remaining)).unwrap();
+        }
+        (
+            machine.total_cycles,
+            serde_json::to_value(machine.snapshot()).unwrap(),
+        )
+    }
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -3,6 +3,8 @@ pub mod esp32;
 #[cfg(test)]
 pub mod esp32c3_i2c_waveform;
 #[cfg(test)]
+pub mod hcsr04_event_tick_differential;
+#[cfg(test)]
 pub mod integration;
 #[cfg(test)]
 pub mod logic_capture;


### PR DESCRIPTION
Phase 1.5 of the Cortex-M speed plan. Profiling showed the invaders lab pinned to 1-instruction batches (HC-SR04 → `requires_cycle_accurate`) with `tick_peripherals_fully` firing every cycle and allocating two Vecs per call — together ~40-54% of wall time.

## HC-SR04 → scheduled events
On event-scheduler walk-deleted buses with `peripheral_tick_interval > 1`, the ECHO rise/fall edges (already computed at TRIG time) are scheduled as cycle-exact scheduler events under a reserved subsystem index and dispatched through the same ECHO choke point the per-tick pass uses (push-capture stays byte-identical). The run loop ends batches exactly at the next pending ECHO transition, so busy-polling firmware observes edges at the precise cycle — which is what lets HC-SR04 drop out of `requires_cycle_accurate`. Edge ticks are `ceil(cycle/interval)` — exactly when the legacy per-tick service would first observe the change at the same interval; exact at interval 1.

Deliberately gated on `interval > 1`: at interval 1 there is no batching to unlock and the always-on scheduled path measured ~15% slower (drain overhead, no win) — so the deployed default stays byte-for-byte identical to this PR's base. The acceleration activates when the frontend raises the interval (follow-up).

## Alloc-free tick
Walk-free buses whose per-cycle tick has no orchestration work (walk deleted, no bus-tick/GPIO/CAN services, HC-SR04 event-scheduled) early-out of `tick_peripherals_fully` to just the NVIC aggregation — allocation-free when no IRQ is pending. Plus a reusable edge-harvest scratch buffer and an empty-scheduler early-out in the drain.

## Bugfix found by the differential gate
`Machine::run` left `bus.current_cycle` at the batch-start value during the post-batch drain, so event handlers reading it (the ECHO edge handler recomputing its level) evaluated one batch stale — a fall edge would read high and never de-assert. Now refreshed to the batch-end cycle before draining.

## Verification
- Committed differential test: ECHO edge cycles byte-identical scheduled-vs-per-tick across intervals {2,8,64} × distances {2,30,100,300 cm}, plus full machine-snapshot equality.
- nokia5110-invaders e2e green in both feature lanes, framebuffer identical.
- clippy -D warnings + fmt clean in both lanes; workspace lib tests green.
- Throughput (invaders, 150M cycles, release, median of 3): interval 1 parity (7.03 vs 6.99 MIPS — no regression); interval 64: 13.85 MIPS cold / ~9.5 sustained-thermal vs 7.1 baseline.