### PR TITLE
sched: cycle-denominated event deadlines — honest peripheral_tick_interval > 1

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -64,6 +64,13 @@ pub struct ResolvedClockGate {
     pub bit: u8,
 }
 
+/// The `peripheral_tick_interval` recommended for a fully scheduler-driven
+/// (walk-deleted) bus — see [`SystemBus::max_safe_tick_interval`]. Native
+/// throughput plateaus from ~16 up (Phase 1.5 measurements); 64 sits on the
+/// plateau while keeping the worst-case event-observation quantisation (one
+/// interval) small.
+pub const RECOMMENDED_TICK_INTERVAL: u32 = 64;
+
 pub struct PeripheralEntry {
     pub name: String,
     pub base: u64,
@@ -203,9 +210,12 @@ pub struct SystemBus {
     /// Phase 2B.3a (issue #192): write-context schedule requests buffered
     /// during MMIO writes. A scheduler-driven peripheral can't reach the
     /// scheduler from `write`, so after the write the bus collects its
-    /// `take_scheduled_events()` here as `(peripheral_idx, delay_ticks,
-    /// token)`; `Machine::drain_scheduler_events` enqueues and clears them.
-    /// Only populated under the `event-scheduler` feature.
+    /// `take_scheduled_events()` here as `(peripheral_idx, deadline_cycle,
+    /// token)` — an ABSOLUTE CPU-cycle deadline, converted from the
+    /// peripheral's relative delay at collect time (see
+    /// `collect_scheduled_events`); `Machine::drain_scheduler_events` enqueues
+    /// (clamped to its `now`) and clears them. Only populated under the
+    /// `event-scheduler` feature.
     pub pending_schedule: Vec<(usize, u64, u32)>,
     /// Phase 2B.3c (issue #192): when true, `tick_peripherals_phase1` skips the
     /// entire per-cycle peripheral walk — the actual ~2.4x win. Set ONLY for a
@@ -1550,6 +1560,36 @@ impl SystemBus {
         hcsr04_needs_cycle_accurate || self.has_iolink_master() || self.flash_models_ops
     }
 
+    /// The largest `peripheral_tick_interval` this bus can run at without
+    /// losing fidelity: [`RECOMMENDED_TICK_INTERVAL`] when every peripheral is
+    /// scheduler-driven (cycle-exact event deadlines, observation quantised by
+    /// at most one interval), `1` when anything non-relaxable is present.
+    ///
+    /// Non-relaxable arms are checked directly rather than through
+    /// [`Self::requires_cycle_accurate`]: that predicate treats HC-SR04 as
+    /// cycle-accurate until the interval is ALREADY raised above 1
+    /// (`hcsr04_event_scheduled` gates on it), so consulting it at interval 1
+    /// would always answer "stay at 1". HC-SR04 itself is relaxable — its ECHO
+    /// edges become scheduler events (batch-clamped to the exact edge) the
+    /// moment the interval rises — except under the test-only
+    /// `hcsr04_scheduling_disabled` override, which pins the legacy per-tick
+    /// path. Callers (the wasm `recommended_tick_interval` getter) apply the
+    /// result via `set_peripheral_tick_interval` at engine init.
+    pub fn max_safe_tick_interval(&self) -> u32 {
+        #[cfg(feature = "event-scheduler")]
+        {
+            let hcsr04_forced_legacy = !self.hcsr04.is_empty() && self.hcsr04_scheduling_disabled;
+            if self.legacy_walk_disabled
+                && !self.has_iolink_master()
+                && !self.flash_models_ops
+                && !hcsr04_forced_legacy
+            {
+                return RECOMMENDED_TICK_INTERVAL;
+            }
+        }
+        1
+    }
+
     /// True when the HC-SR04 echo waveform is driven by the event scheduler
     /// (rise/fall edges scheduled at their exact cycles and drained by
     /// `Machine::drain_scheduler_events`) rather than the per-cycle
@@ -1708,8 +1748,9 @@ impl SystemBus {
     }
 
     /// Event-scheduler path: harvest any sensor whose echo window was (re)armed
-    /// since the last harvest, returning `(sensor_idx, rise_tick, fall_tick)`
-    /// absolute peripheral-tick deadlines for `Machine::drain_scheduler_events`
+    /// since the last harvest, returning `(sensor_idx, rise_cycle, fall_cycle)`
+    /// absolute cycle deadlines (quantised up to the tick grid — see
+    /// `HcSr04::take_edge_schedule`) for `Machine::drain_scheduler_events`
     /// to enqueue. No allocation when nothing was armed.
     #[cfg(feature = "event-scheduler")]
     pub(crate) fn harvest_hcsr04_edges(&mut self, interval: u64, out: &mut Vec<(usize, u64, u64)>) {
@@ -3096,6 +3137,44 @@ mod tests {
         TimingAction, TimingDescriptor, TimingTrigger,
     };
     use std::path::PathBuf;
+
+    /// `max_safe_tick_interval`: 1 while the legacy walk is live (the default
+    /// bus), the batching recommendation once the walk is deleted, and back to
+    /// 1 when a non-relaxable device (test-only HC-SR04 legacy pin) is present.
+    #[test]
+    fn max_safe_tick_interval_relaxes_only_walk_deleted_buses() {
+        let mut bus = SystemBus::new();
+        assert_eq!(bus.max_safe_tick_interval(), 1, "legacy walk → stay exact");
+
+        bus.legacy_walk_disabled = true;
+        let relaxed = bus.max_safe_tick_interval();
+        if cfg!(feature = "event-scheduler") {
+            assert_eq!(relaxed, RECOMMENDED_TICK_INTERVAL);
+        } else {
+            assert_eq!(relaxed, 1, "feature-off builds never batch");
+        }
+
+        bus.hcsr04.push(crate::peripherals::hc_sr04::HcSr04::new(
+            "dist".into(),
+            0x4800_0014,
+            0,
+            0x4800_0010,
+            1,
+            1_000_000,
+            100.0,
+        ));
+        assert_eq!(
+            bus.max_safe_tick_interval(),
+            relaxed,
+            "HC-SR04 is relaxable (its edges become scheduler events)"
+        );
+        bus.hcsr04_scheduling_disabled = true;
+        assert_eq!(
+            bus.max_safe_tick_interval(),
+            1,
+            "the test-only legacy-pin override must force interval 1"
+        );
+    }
 
     /// Minimal fixed-value peripheral for routing tests: reads return a
     /// constant tag byte, writes are ignored.

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -92,19 +92,17 @@ impl SystemBus {
     }
 
     /// Phase 2B.2 (issue #192): if the peripheral at `idx` is scheduler-driven,
-    /// advance its lazy state to the current peripheral-tick index before an
-    /// MMIO write observes it. The tick index is `current_cycle /
-    /// peripheral_tick_interval` — the same quantum the legacy walk advanced by
-    /// one per `tick()`. One virtual `uses_scheduler()` call for legacy
-    /// peripherals (false → return); the sync only runs for opted-in ones.
+    /// advance its lazy state to the current CPU cycle (`current_cycle`, the
+    /// batch-start cycle — the same cycle count the legacy walk advances by via
+    /// `tick_elapsed(interval)`) before an MMIO write observes it. One virtual
+    /// `uses_scheduler()` call for legacy peripherals (false → return); the
+    /// sync only runs for opted-in ones.
     #[cfg(feature = "event-scheduler")]
     #[inline]
     pub(crate) fn sync_scheduler_peripheral(&mut self, idx: usize) {
-        let interval = (self.config.peripheral_tick_interval as u64).max(1);
-        let tick_now = self.current_cycle / interval;
         let p = &mut self.peripherals[idx];
         if p.dev.uses_scheduler() {
-            p.dev.sync_to(tick_now);
+            p.dev.sync_to(self.current_cycle);
         }
     }
 
@@ -112,6 +110,17 @@ impl SystemBus {
     /// peripheral, harvest any events it wants scheduled (e.g. a just-armed
     /// TX interrupt) into `pending_schedule` for `Machine` to enqueue. One
     /// virtual `uses_scheduler()` call for legacy peripherals (false → return).
+    ///
+    /// The peripheral's `(delay_cycles, token)` is relative to its just-synced
+    /// state (`sync_to(current_cycle)` ran before the write), so it is
+    /// converted to the absolute cycle deadline `current_cycle + 1 + delay`
+    /// here — pinning the deadline to the write instead of to whenever the
+    /// next scheduler drain happens to run. The `+ 1` preserves the historical
+    /// contract exactly: delays were relative to the next drain, and at tick
+    /// interval 1 the next drain always runs one cycle after the write, so
+    /// interval-1 deadlines are byte-identical to the pre-conversion build. At
+    /// interval > 1 the deadline no longer stretches with the drain cadence —
+    /// an SPI half-period of N cycles stays N cycles.
     #[cfg(feature = "event-scheduler")]
     #[inline]
     pub(crate) fn collect_scheduled_events(&mut self, idx: usize) {
@@ -119,7 +128,8 @@ impl SystemBus {
             return;
         }
         for (delay, token) in self.peripherals[idx].dev.take_scheduled_events() {
-            self.pending_schedule.push((idx, delay, token));
+            self.pending_schedule
+                .push((idx, self.current_cycle + 1 + delay, token));
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -640,22 +640,27 @@ pub trait Peripheral: std::fmt::Debug + Send {
     }
 
     /// Phase 2B.2 (issue #192): advance a scheduler-driven peripheral's lazy
-    /// state to `tick_now` (the peripheral-tick index — CPU cycles divided by
-    /// `peripheral_tick_interval`, the same quantum the legacy walk advanced
-    /// one step per `tick()` call). Called by the bus immediately before an
-    /// MMIO write observes the peripheral, so a frozen-then-strobed counter
-    /// reads the up-to-date value. Default no-op; only peripherals that opt
-    /// into the scheduler implement it.
-    fn sync_to(&mut self, _tick_now: u64) {}
+    /// state to CPU cycle `now_cycle` (`SystemBus::current_cycle` — the same
+    /// cycle count the legacy walk advances by via `tick_elapsed(interval)`).
+    /// Called by the bus immediately before an MMIO write observes the
+    /// peripheral, so a frozen-then-strobed counter reads the up-to-date
+    /// value. During a CPU batch `current_cycle` holds the batch-start cycle,
+    /// so the sync point trails the true write cycle by less than one
+    /// `peripheral_tick_interval` (exact at interval 1). Default no-op; only
+    /// peripherals that opt into the scheduler implement it.
+    fn sync_to(&mut self, _now_cycle: u64) {}
 
     /// Phase 2B.3a (issue #192): hand the bus any events this peripheral wants
     /// scheduled as a result of the MMIO write that just completed (e.g. a
-    /// UART arming its TX interrupt). Each entry is `(delay_ticks, token)` —
-    /// a delay in peripheral-tick units from "now" and an opaque token the
-    /// peripheral interprets in its own `on_event`. The buffer is drained
-    /// (cleared) by this call. A peripheral can't reach the scheduler from
-    /// `write`, so this is the bootstrap path; `on_event` reschedules itself
-    /// thereafter. Default empty — only write-scheduling peripherals override.
+    /// UART arming its TX interrupt). Each entry is `(delay_cycles, token)` —
+    /// a delay in CPU cycles from the peripheral's just-synced state (the
+    /// `sync_to` cycle) and an opaque token the peripheral interprets in its
+    /// own `on_event`. The bus converts the delay to an absolute cycle
+    /// deadline (see `SystemBus::collect_scheduled_events`). The buffer is
+    /// drained (cleared) by this call. A peripheral can't reach the scheduler
+    /// from `write`, so this is the bootstrap path; `on_event` reschedules
+    /// itself thereafter. Default empty — only write-scheduling peripherals
+    /// override.
     fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
         Vec::new()
     }
@@ -1203,10 +1208,8 @@ impl<C: Cpu> Machine<C> {
             }
             budget = budget.min(remaining);
 
-            let interval = (self.config.peripheral_tick_interval as u64).max(1);
             let generations = self.bus.peripheral_generations();
-            if let Some(deadline_tick) = self.sched.next_event_deadline(&generations) {
-                let deadline_cycle = deadline_tick.saturating_mul(interval);
+            if let Some(deadline_cycle) = self.sched.next_event_deadline(&generations) {
                 if deadline_cycle <= self.total_cycles {
                     return 0;
                 }
@@ -1229,7 +1232,7 @@ impl<C: Cpu> Machine<C> {
             if self.logic_capture.push_active() {
                 self.bus.logic_tap.set_clock(self.total_cycles);
             }
-            self.sched.advance_to(self.total_cycles / interval);
+            self.sched.advance_to(self.total_cycles);
             self.drain_scheduler_events();
             skipped
         }
@@ -1622,55 +1625,69 @@ impl<C: Cpu> Machine<C> {
     /// peripheral event. Called from both `step()` and the batch run loop so
     /// neither path silently strands a scheduler-driven peripheral.
     ///
-    /// The scheduler runs in peripheral-tick units (`total_cycles /
-    /// peripheral_tick_interval`) — the same quantum the legacy walk and
-    /// `sync_to` use — so deadlines are interval-agnostic. Write-context
-    /// schedule requests the bus buffered during this step's MMIO writes
-    /// (`pending_schedule`) are enqueued first: a peripheral can't reach the
-    /// scheduler from `write`, so it hands `(delay_ticks, token)` to the bus
-    /// and we convert to an absolute deadline here.
+    /// The scheduler runs in absolute CPU cycles (`total_cycles`) — the same
+    /// quantum the legacy walk advances by (`tick_elapsed(interval)`) — so
+    /// cycle-denominated peripheral delays (an SPI half-period, a systimer
+    /// alarm) keep their exact meaning at any `peripheral_tick_interval`. An
+    /// event lands at the first drain at or after its exact cycle; drains run
+    /// at least once per CPU batch, so the observation error is bounded by one
+    /// tick interval (and is zero at interval 1, where drains run per cycle).
+    /// Write-context schedule requests the bus buffered during this step's
+    /// MMIO writes (`pending_schedule`) are enqueued first: a peripheral can't
+    /// reach the scheduler from `write`, so the bus buffers an absolute
+    /// cycle deadline (see `collect_scheduled_events`) which is clamped to
+    /// `now` here — a deadline that expired mid-batch fires on this drain.
     #[cfg(feature = "event-scheduler")]
     fn drain_scheduler_events(&mut self) {
         // One-time bootstrap: give every scheduler-driven peripheral a chance
         // to schedule events that arise from *setup* rather than an MMIO write
-        // (e.g. a UART with an RX stream attached before firmware runs).
+        // (e.g. a UART with an RX stream attached before firmware runs). The
+        // returned delays are relative to the peripheral's un-synced state at
+        // cycle `total_cycles`, so the absolute deadline is `total_cycles +
+        // delay` (no +1: unlike the write path there is no "next drain" skew —
+        // this drain is the one converting them).
         if !self.scheduler_bootstrapped {
             self.scheduler_bootstrapped = true;
             for idx in 0..self.bus.peripherals.len() {
                 if self.bus.peripherals[idx].dev.uses_scheduler() {
                     for (delay, token) in self.bus.peripherals[idx].dev.take_scheduled_events() {
-                        self.bus.pending_schedule.push((idx, delay, token));
+                        self.bus
+                            .pending_schedule
+                            .push((idx, self.total_cycles + delay, token));
                     }
                 }
             }
         }
         let interval = (self.config.peripheral_tick_interval as u64).max(1);
-        self.sched.advance_to(self.total_cycles / interval);
+        self.sched.advance_to(self.total_cycles);
         let now = self.sched.now();
-        for (idx, delay, token) in std::mem::take(&mut self.bus.pending_schedule) {
+        for (idx, deadline, token) in std::mem::take(&mut self.bus.pending_schedule) {
             let gen = self
                 .bus
                 .peripherals
                 .get(idx)
                 .map(|p| p.generation)
                 .unwrap_or(0);
-            self.sched.schedule(now + delay, idx as u32, token, gen);
+            self.sched
+                .schedule(deadline.max(now), idx as u32, token, gen);
         }
         // HC-SR04: enqueue the ECHO rise/fall edges of any freshly-armed window
-        // as cycle-exact events under the reserved subsystem idx. The sensor is
-        // not a `peripherals[]` entry, so it can't ride the `pending_schedule`
-        // (peripheral-idx) path; it is dispatched below by idx match instead.
+        // as events under the reserved subsystem idx, at their exact cycles
+        // quantised up to the tick grid (per-tick reference semantics — see
+        // `take_edge_schedule`). The sensor is not a `peripherals[]` entry, so
+        // it can't ride the `pending_schedule` (peripheral-idx) path; it is
+        // dispatched below by idx match instead.
         self.bus
             .harvest_hcsr04_edges(interval, &mut self.hcsr04_edge_scratch);
-        for (sensor, rise_tick, fall_tick) in self.hcsr04_edge_scratch.drain(..) {
+        for (sensor, rise_cycle, fall_cycle) in self.hcsr04_edge_scratch.drain(..) {
             self.sched.schedule(
-                rise_tick.max(now),
+                rise_cycle.max(now),
                 sched::SUBSYSTEM_PERIPHERAL_IDX,
                 sensor as u32,
                 0,
             );
             self.sched.schedule(
-                fall_tick.max(now),
+                fall_cycle.max(now),
                 sched::SUBSYSTEM_PERIPHERAL_IDX,
                 sensor as u32,
                 0,

--- a/crates/core/src/peripherals/hc_sr04.rs
+++ b/crates/core/src/peripherals/hc_sr04.rs
@@ -215,14 +215,16 @@ impl HcSr04 {
     }
 
     /// Event-scheduler path: if a fresh echo window was armed since the last
-    /// call, return the absolute peripheral-tick indices at which ECHO should
-    /// rise and fall, and clear the pending flag. The tick of a cycle `c` is
-    /// `ceil(c / interval)` — the first peripheral-tick boundary at or after the
-    /// exact cycle, which is precisely when the legacy per-tick `service_hcsr04`
-    /// (running only at tick boundaries) would first observe the level change.
-    /// At `interval == 1` this is the exact cycle, so the scheduled edges are
-    /// cycle-identical to the per-cycle path. Returns `None` when no new window
-    /// has been armed.
+    /// call, return the absolute CPU cycles at which ECHO should rise and
+    /// fall, quantised UP to the peripheral-tick grid
+    /// (`ceil(c / interval) * interval` — the first tick boundary at or after
+    /// the exact cycle), and clear the pending flag. That boundary is
+    /// precisely when the legacy per-tick `service_hcsr04` (running only at
+    /// tick boundaries) would first observe the level change, so the scheduled
+    /// path stays byte-identical to the per-tick reference (the differential
+    /// gate in `tests/hcsr04_event_tick_differential.rs`). At `interval == 1`
+    /// this is the exact cycle. Returns `None` when no new window has been
+    /// armed.
     #[cfg(feature = "event-scheduler")]
     pub(crate) fn take_edge_schedule(&mut self, interval: u64) -> Option<(u64, u64)> {
         if !self.edge_reschedule_pending {
@@ -231,8 +233,8 @@ impl HcSr04 {
         self.edge_reschedule_pending = false;
         let interval = interval.max(1);
         Some((
-            self.echo_start_cycle.div_ceil(interval),
-            self.echo_end_cycle.div_ceil(interval),
+            self.echo_start_cycle.div_ceil(interval) * interval,
+            self.echo_end_cycle.div_ceil(interval) * interval,
         ))
     }
 

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -704,12 +704,12 @@ pub struct Spi {
     tx_queue: std::collections::VecDeque<u16>,
     #[serde(skip)]
     scheduled: bool,
-    /// Event-scheduler path only: the absolute scheduler tick the engine's
-    /// wire state corresponds to. Anchored by `sync_to` (called by the bus
-    /// before every MMIO write, so a DR write pins the frame start to the
-    /// write tick — identically in clamped and batched runs) and advanced by
-    /// `on_event`. The legacy walk clocks the engine through `tick_elapsed`
-    /// instead and never touches this.
+    /// Event-scheduler path only: the absolute CPU cycle the engine's wire
+    /// state corresponds to. Anchored by `sync_to` (called by the bus with
+    /// `current_cycle` before every MMIO write, so a DR write pins the frame
+    /// start to the batch-start cycle — identically in clamped and batched
+    /// runs) and advanced by `on_event`. The legacy walk clocks the engine
+    /// through `tick_elapsed` instead and never touches this.
     #[serde(skip)]
     anchor_tick: u64,
     /// Shared SCK/MOSI/MISO line levels, read by the STM32 GPIO model for
@@ -1503,9 +1503,9 @@ impl crate::Peripheral for Spi {
     }
 
     /// Event-scheduler path: anchor the engine's wire state to the current
-    /// scheduler tick. The bus calls this before every MMIO write, so a DR
-    /// write pins the frame start to the write tick — and because CPU batches
-    /// never cross a peripheral-tick boundary, that tick is identical whether
+    /// CPU cycle. The bus calls this before every MMIO write, so a DR write
+    /// pins the frame start to the batch-start cycle — and because CPU batches
+    /// never cross a peripheral-tick boundary, that cycle is identical whether
     /// the run loop is clamped (poll capture) or batched (push capture).
     fn sync_to(&mut self, tick_now: u64) {
         if tick_now <= self.anchor_tick {
@@ -1519,11 +1519,14 @@ impl crate::Peripheral for Spi {
     }
 
     /// Event-driven clocking (the walk-deleted path): while a frame is on the
-    /// wire, the engine keeps exactly one event armed at (or just before —
-    /// the drain harvesting this may already be one tick past the write tick)
-    /// its next wire transition. [`Self::on_event`] self-corrects against the
-    /// absolute anchor and re-arms via `reschedule_delay` until the frame
-    /// (and any queued frames) complete.
+    /// wire, the engine keeps exactly one event armed at its next wire
+    /// transition. The returned delay is relative to the just-synced anchor;
+    /// the bus converts it to the absolute deadline `anchor + 1 + delay`, so
+    /// the `- 1` here lands the event exactly at `anchor + half_ticks` — the
+    /// first transition's true cycle at any tick interval. [`Self::on_event`]
+    /// self-corrects against the absolute anchor (a drain may run past the
+    /// deadline by up to one tick interval) and re-arms via `reschedule_delay`
+    /// until the frame (and any queued frames) complete.
     fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
         if self.frame.is_some() && !self.scheduled {
             self.scheduled = true;
@@ -1550,15 +1553,17 @@ impl crate::Peripheral for Spi {
         let now = sched.now();
         let target = self.anchor_tick + f.ticks_left as u64;
         if now < target {
-            // Early wakeup (the arming drain ran past the write tick and the
-            // conservative delay undershot): re-arm at the exact boundary.
+            // Early wakeup (a stale event from before a re-anchor): re-arm at
+            // the exact boundary.
             res.reschedule_delay = Some(target - now);
             self.scheduled = true;
             return res;
         }
-        // Advance the wire to "now" — every segment boundary in the window
-        // lands exactly on its derived tick (drains run at least once per
-        // tick, so this is typically exactly one boundary).
+        // Advance the wire to "now" — at tick interval 1 drains run every
+        // cycle, so this is exactly one boundary; at larger intervals a drain
+        // may arrive up to one interval late and cross several boundaries in
+        // one call, but the boundaries' derived cycles (and the frame's total
+        // wire time) are unchanged.
         let delta = now - self.anchor_tick;
         self.anchor_tick = now;
         if self.stm32_advance_units(delta) {

--- a/crates/core/src/tests/stm32_spi_waveform.rs
+++ b/crates/core/src/tests/stm32_spi_waveform.rs
@@ -18,6 +18,8 @@ mod stm32_spi_waveform_tests {
     use crate::logic_capture::LogicEdge;
     use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
     use crate::peripherals::spi::{Spi, SpiDevice, SpiRegisterLayout};
+    #[cfg(feature = "event-scheduler")]
+    use crate::DebugControl;
     use crate::{Bus, Machine};
 
     const RAM_BASE: u64 = 0x2000_0000;
@@ -240,6 +242,90 @@ mod stm32_spi_waveform_tests {
         assert_eq!(
             busy_cycles, 32,
             "8 bits × 2^(BR+1) = 32 cycles at BR=1 — firmware-visible wire time"
+        );
+    }
+
+    /// Phase 1.6 no-stretch gate, exact flavour: with the scheduler timebase
+    /// in absolute cycles, a 32-cycle frame is STILL exactly 32 firmware-
+    /// visible cycles at `peripheral_tick_interval = 64` when drains run per
+    /// cycle (`step()`). Before the cycle-exact conversion the tick-index
+    /// timebase reinterpreted the engine's cycle delays as tick counts and the
+    /// same frame took ~2048 cycles (×interval stretch).
+    #[cfg(feature = "event-scheduler")]
+    #[test]
+    fn frame_wire_time_does_not_stretch_at_interval_64() {
+        let mut machine = machine();
+        configure(&mut machine);
+        machine.config.peripheral_tick_interval = 64;
+        machine.bus.config.peripheral_tick_interval = 64;
+        machine.bus.write_u8(DR, 0xA5).unwrap();
+        let mut busy_cycles = 0u64;
+        while machine.bus.read_u16(SR).unwrap() & (1 << 7) != 0 {
+            machine.step().unwrap();
+            busy_cycles += 1;
+            assert!(busy_cycles < 10_000, "frame never completed");
+        }
+        assert_eq!(
+            busy_cycles, 32,
+            "cycle-denominated frame time must not scale with the tick interval"
+        );
+    }
+
+    /// Phase 1.6 no-stretch gate, batched flavour: through the real
+    /// `Machine::run` batch loop at interval 64, frame completion is applied
+    /// at the first scheduler drain at/after its exact cycle — the
+    /// firmware-visible wire time is within `N..N+interval` of the exact
+    /// 32-cycle time, never `N×interval`.
+    #[cfg(feature = "event-scheduler")]
+    #[test]
+    fn batched_frame_wire_time_within_one_interval_at_64() {
+        let mut machine = machine();
+        configure(&mut machine);
+        machine.config.peripheral_tick_interval = 64;
+        machine.bus.config.peripheral_tick_interval = 64;
+        machine.bus.write_u8(DR, 0xA5).unwrap();
+        let start = machine.total_cycles;
+        let observed = loop {
+            machine.run(Some(64)).unwrap();
+            if machine.bus.read_u16(SR).unwrap() & (1 << 7) == 0 {
+                break machine.total_cycles;
+            }
+            assert!(
+                machine.total_cycles - start < 10_000,
+                "frame never completed"
+            );
+        };
+        let busy = observed - start;
+        assert!(
+            (32..=32 + 64).contains(&busy),
+            "batched wire time must be the exact 32 cycles plus at most one \
+             interval of drain quantisation, got {busy}"
+        );
+    }
+
+    /// Phase 1.6: the captured SCK/MOSI waveform — every edge cycle — is
+    /// byte-identical at tick interval 64 and interval 1 when observed
+    /// per-cycle. Scheduled wire transitions land at their exact cycles at any
+    /// interval, so batching cannot move them.
+    #[cfg(feature = "event-scheduler")]
+    #[test]
+    fn waveform_edges_identical_across_tick_intervals() {
+        let run = |interval: u32| {
+            let mut machine = machine();
+            configure(&mut machine);
+            machine.config.peripheral_tick_interval = interval;
+            machine.bus.config.peripheral_tick_interval = interval;
+            let gpioa_idx = machine.bus.find_peripheral_index_by_name("gpioa").unwrap();
+            machine.logic_watch(&[Some((gpioa_idx, MOSI_PIN)), Some((gpioa_idx, SCK_PIN))]);
+            for b in WIRE_BYTES {
+                spi_write(&mut machine, b);
+            }
+            machine.logic_read_edges(0).edges
+        };
+        assert_eq!(
+            run(1),
+            run(64),
+            "per-cycle-observed SPI edges must not depend on the tick interval"
         );
     }
 

--- a/crates/core/tests/e2e_nokia5110_invaders.rs
+++ b/crates/core/tests/e2e_nokia5110_invaders.rs
@@ -13,7 +13,7 @@ use labwired_core::bus::SystemBus;
 use labwired_core::cpu::cortex_m::CortexM;
 use labwired_core::peripherals::components::Pcd8544;
 use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::Machine;
+use labwired_core::{DebugControl, Machine};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -147,6 +147,41 @@ fn firmware_draws_and_ship_tracks_distance() {
     assert!(
         far < near,
         "ship should move left as the target moves away: near_x={near}, far_x={far}"
+    );
+}
+
+/// Phase 1.6 gate: the splash framebuffer the panel receives over SPI must be
+/// byte-identical at `peripheral_tick_interval = 64` (the browser batching
+/// interval) and interval 1, through the real batched `Machine::run` loop.
+/// Before the cycle-exact scheduler conversion the tick-index timebase
+/// stretched every SPI frame ×interval, so the push was still in flight (or
+/// mis-clocked) at the same cycle budget.
+#[test]
+#[ignore = "slow: builds + runs the Space Invaders firmware in-sim"]
+fn splash_framebuffer_matches_across_tick_intervals() {
+    let elf = ensure_firmware_built();
+    let fb_at = |interval: u32| {
+        let mut machine = build_machine(&elf);
+        machine.config.peripheral_tick_interval = interval;
+        machine.bus.config.peripheral_tick_interval = interval;
+        // Into the splash hold via the batched run loop (see
+        // dump_splash_framebuffer for the budget rationale).
+        while machine.total_cycles < 800_000 {
+            let remaining = (800_000 - machine.total_cycles).min(u32::MAX as u64) as u32;
+            machine.run(Some(remaining)).expect("run");
+        }
+        framebuffer(&machine)
+    };
+    let fb1 = fb_at(1);
+    assert_eq!(fb1.len(), 504);
+    assert!(
+        fb1.iter().any(|&b| b != 0),
+        "splash must be drawn at interval 1"
+    );
+    assert_eq!(
+        fb1,
+        fb_at(64),
+        "splash framebuffer must be byte-identical at tick interval 64"
     );
 }
 

--- a/crates/core/tests/event_scheduler.rs
+++ b/crates/core/tests/event_scheduler.rs
@@ -297,16 +297,21 @@ mod write_context_scheduling {
         );
 
         // A non-arming-aware peripheral would leave this empty; ours queues
-        // exactly one (peripheral_idx=0, delay=0, ARM_TOKEN) on write.
+        // exactly one (peripheral_idx=0, deadline, ARM_TOKEN) on write. The
+        // peripheral's relative delay 0 becomes the absolute cycle deadline
+        // `current_cycle + 1 + 0` — the cycle the next per-cycle drain runs at
+        // (`current_cycle` is 0 here; no machine is stepping this bus).
         bus.write_u32(0x5000_0000, 1).unwrap();
-        assert_eq!(bus.pending_schedule, vec![(0usize, 0u64, ARM_TOKEN)]);
+        assert_eq!(bus.pending_schedule, vec![(0usize, 1u64, ARM_TOKEN)]);
 
         // A second write re-arms and appends another request (the harvest
-        // cleared `armed` the first time, so this isn't a stale duplicate).
+        // cleared `armed` the first time, so this isn't a stale duplicate),
+        // with the deadline pinned to the (advanced) write cycle.
+        bus.current_cycle = 5;
         bus.write_u32(0x5000_0000, 1).unwrap();
         assert_eq!(
             bus.pending_schedule,
-            vec![(0usize, 0u64, ARM_TOKEN), (0usize, 0u64, ARM_TOKEN)]
+            vec![(0usize, 1u64, ARM_TOKEN), (0usize, 6u64, ARM_TOKEN)]
         );
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1047,9 +1047,28 @@ impl WasmSimulator {
     /// instruction. Larger values are a bounded browser acceleration knob for
     /// firmware bring-up paths whose active peripherals are scheduler-driven or
     /// inactive.
+    ///
+    /// The machine and bus each hold a `SimulationConfig`; both are updated —
+    /// the run loop paces ticks off the machine's copy while the legacy-walk
+    /// quantum (`tick_elapsed(interval)`) and the HC-SR04 event-scheduling
+    /// gate read the bus's, and they must agree or walked peripherals run
+    /// `interval`× slow.
     #[wasm_bindgen]
     pub fn set_peripheral_tick_interval(&mut self, interval: u32) {
-        self.machine().config.peripheral_tick_interval = interval.max(1);
+        let machine = self.machine();
+        machine.config.peripheral_tick_interval = interval.max(1);
+        machine.bus.config.peripheral_tick_interval = interval.max(1);
+    }
+
+    /// The largest `peripheral_tick_interval` this machine's bus can run at
+    /// without losing fidelity (see `SystemBus::max_safe_tick_interval`): a
+    /// batching interval when every peripheral is scheduler-driven, `1` when
+    /// anything non-relaxable (IO-Link master, op-modeling FLASH, a live
+    /// legacy walk) is present. The TS side calls this once at engine init
+    /// and feeds the answer straight into `set_peripheral_tick_interval`.
+    #[wasm_bindgen]
+    pub fn recommended_tick_interval(&mut self) -> u32 {
+        self.machine().bus.max_safe_tick_interval()
     }
 
     /// Total number of times the browser JIT has dispatched a


### PR DESCRIPTION
Phase 1.6 of the Cortex-M speed plan. The event scheduler ran on the peripheral-tick index, so cycle-denominated peripheral delays (SPI half-periods, systimer alarms) were reinterpreted as ticks at interval > 1 — a 32-cycle SPI frame stretched to 2048 cycles at interval 64. This made the batching interval (and the Phase 1.5 speedups gated on it) unusable.

## Scheduler timebase → absolute CPU cycles
- `pending_schedule` now carries absolute cycle deadlines, converted at the collect site as `current_cycle + 1 + delay`. The `+1` preserves the historical contract exactly: delays were relative to the next drain, and at interval 1 the next drain runs one cycle after the write — interval-1 deadlines are value-identical to the pre-conversion build (differential-proven: total_cycles, framebuffer hash, canonical machine-snapshot hash byte-identical vs pristine main across batched-run and step paths, both feature lanes). Bootstrap entries convert without the +1 (this drain converts them itself); deadlines expired mid-batch clamp to now.
- `sync_to` receives raw `current_cycle` — fixing a second latent bug: the tick-index sync made every scheduler-driven counter (TIMG, RTC_CNTL, GPIO stamps, systimer, SPI anchor) run interval× slow at interval > 1.
- HC-SR04 edges (from #511) schedule at cycles quantised up to the tick grid — deliberately per-tick reference semantics, keeping the #511 differential gate byte-identical.
- Idle fast-forward budgets clamp to cycle deadlines directly (no ×interval). No batch clamping to SPI events (the engine's `on_event` self-corrects; exactness held without it).

## Safe-interval surface
`SystemBus::max_safe_tick_interval()` → 64 only when the walk is deleted and nothing non-relaxable is present (IO-Link master, op-modeling FLASH); else 1 (reasons from the non-relaxable arms directly — `requires_cycle_accurate()` can't be consulted at interval 1 due to the #511 gate). Wasm getter `recommended_tick_interval()` for the TS side, and `set_peripheral_tick_interval` now updates BOTH config copies (machine + bus) — previously only the machine copy, so the legacy-walk quantum and HC-SR04 gate disagreed (zero-caller latent bug).

## Committed proofs
- `frame_wire_time_does_not_stretch_at_interval_64`: 32-cycle SPI frame = exactly 32 firmware-visible cycles at interval 64 (~2048 before).
- `batched_frame_wire_time_within_one_interval_at_64`: real run() loop, busy ∈ 32..96.
- `waveform_edges_identical_across_tick_intervals`: edge stream at 64 == 1.
- `splash_framebuffer_matches_across_tick_intervals` (invaders e2e): panel framebuffer byte-identical at 64 vs 1.

## Numbers (invaders lab, native release, median of 3)
Interval 1: 7.08 MIPS (parity). Interval 64: **14.18 MIPS (2.0×)**.

Known bounded skews at interval > 1 (documented in code): push-capture stamps ≤ one interval late for off-grid transitions (poll capture exact); `sync_to` anchors to batch-start so a mid-batch frame starts ≤ interval−1 early (duration preserved). Interval 1 unaffected everywhere.

All lanes green: workspace lib 1995 passed; jit+event-scheduler 1836 passed; nokia e2e 4/4 both lanes; clippy -D warnings + fmt clean; wasm32 target check clean. Known machine-local failures verified identical on pristine main.