### PR TITLE
walk deletion: conservative auto-derivation + explicit pin escape hatch

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -70,7 +70,7 @@ pub(crate) fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode 
         board_io: vec![],
         debug_uart: None,
         peripherals: vec![],
-        walk_deleted: false,
+        walk_deleted: Some(false),
     };
 
     // Two-station WiFi run (env LABWIRED_WIFI_DUAL): boot two C3 instances with

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -240,13 +240,24 @@ pub struct SystemManifest {
     pub debug_uart: Option<String>,
     #[serde(default)]
     pub peripherals: Vec<PeripheralConfig>,
-    /// Opt-in: delete the per-cycle peripheral walk for this config (only takes
-    /// effect in `event-scheduler` builds; no-op otherwise). ONLY safe when
-    /// every peripheral the firmware actually drives is event-migrated (SPI,
-    /// UART) or inert for this firmware — the firmware MUST be verified
-    /// byte-identical walk-free first.
+    /// Per-cycle peripheral-walk deletion (only consulted in `event-scheduler`
+    /// builds; no-op otherwise). Three states:
+    ///
+    /// - **absent (`None`)** — the core auto-derives walk-deletability at
+    ///   `from_config` finalize time: the walk is deleted iff EVERY peripheral
+    ///   on the bus is provably walk-independent for all firmware states
+    ///   (scheduler-driven, or its `tick()` is a structural no-op — see the
+    ///   core's `Peripheral::needs_legacy_walk` contract). Conservative: any
+    ///   peripheral that could ever do walk work keeps the walk on.
+    /// - **`Some(true)`** — force the walk deleted (hand opt-in / escape hatch
+    ///   for configs the author verified byte-identical walk-free but that the
+    ///   conservative auto-derivation cannot prove — e.g. a firmware that never
+    ///   arms the timers/ADC/DMA the chip descriptor instantiates).
+    /// - **`Some(false)`** — pin the walk ON, overriding any auto-derivation.
+    ///
+    /// Deserializes from the YAML `walk_deleted:` key; omit it for auto-derive.
     #[serde(default)]
-    pub walk_deleted: bool,
+    pub walk_deleted: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -712,11 +712,25 @@ impl SystemBus {
         // peripheral (incl. the RCC, needed to map reg-name → offset) is on the
         // bus. Peripherals without a `clock:` field stay ungated.
         bus.resolve_clock_gates(&merged_peripherals)?;
-        // Per-config walk-deletion opt-in. The field is only consulted under the
-        // `event-scheduler` feature (the legacy build always walks), so this is a
-        // no-op there. Safe only because the manifest author verified the
-        // firmware runs byte-identical walk-free (see the walk-identity test).
-        bus.legacy_walk_disabled = manifest.walk_deleted;
+        // Walk-deletion decision (only consulted under the `event-scheduler`
+        // feature; the legacy build always walks, so this is inert there).
+        //
+        //   Some(true)  → force deleted (hand opt-in / escape hatch)
+        //   Some(false) → pin the walk ON, overriding auto-derivation
+        //   None        → auto-derive: delete iff EVERY peripheral is provably
+        //                 walk-independent for all firmware states.
+        //
+        // The auto-derivation is deliberately conservative — see
+        // `derive_walk_deletable`. It only fires when deleting the walk is
+        // byte-identical for ANY reachable firmware state, so it can never
+        // silently starve a peripheral of its per-cycle `tick()`. A hand
+        // `walk_deleted: true` stays honored for configs whose byte-identity is
+        // firmware-specific (the firmware never arms the timers/ADC/DMA the chip
+        // descriptor instantiates) and thus not config-derivable.
+        bus.legacy_walk_disabled = match manifest.walk_deleted {
+            Some(explicit) => explicit,
+            None => bus.derive_walk_deletable(),
+        };
         Ok(bus)
     }
 }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -3176,6 +3176,70 @@ mod tests {
         );
     }
 
+    /// `derive_walk_deletable`: an all-scheduler / inert bus derives deletion;
+    /// a single walk-dependent peripheral (native Timer, or an unknown model
+    /// keeping the conservative default) pins the walk on.
+    #[test]
+    fn derive_walk_deletable_is_conservative() {
+        use crate::peripherals::spi::{Spi, SpiRegisterLayout};
+        use crate::peripherals::stub::StubPeripheral;
+        use crate::peripherals::timer::Timer;
+
+        // Start from a truly empty peripheral set (`new()` pre-populates a few).
+        let mut bus = SystemBus::new();
+        bus.peripherals.clear();
+        assert!(bus.derive_walk_deletable(), "empty bus derives deletion");
+
+        // Scheduler-driven (SPI) + inert stub: still deletable.
+        bus.add_peripheral(
+            "spi1",
+            0x4001_3000,
+            0x400,
+            None,
+            Box::new(Spi::new_with_layout(SpiRegisterLayout::Stm32)),
+        );
+        bus.add_peripheral(
+            "syscfg",
+            0x4001_0000,
+            0x400,
+            None,
+            Box::new(StubPeripheral::new(0)),
+        );
+        assert!(
+            bus.derive_walk_deletable(),
+            "scheduler + inert-stub bus is walk-independent"
+        );
+
+        // Add a native Timer (its `tick()` counts once CEN is set — walk work
+        // reachable via MMIO). The bus must NOT derive deletion.
+        bus.add_peripheral("tim2", 0x4000_0000, 0x400, None, Box::new(Timer::new()));
+        assert!(
+            !bus.derive_walk_deletable(),
+            "a native timer is walk-dependent — walk must stay on"
+        );
+    }
+
+    /// The default `needs_legacy_walk() == true` makes an unknown/native model
+    /// (here the fixed-value `TagPeripheral`, which does not override it) pin the
+    /// walk on — the conservative default that prevents silently starving a
+    /// peripheral of ticks.
+    #[test]
+    fn derive_walk_deletable_defaults_conservative_for_unknown_models() {
+        let mut bus = SystemBus::new();
+        bus.peripherals.clear();
+        bus.add_peripheral(
+            "tag",
+            0x4002_0000,
+            0x400,
+            None,
+            Box::new(TagPeripheral(0xAB)),
+        );
+        assert!(
+            !bus.derive_walk_deletable(),
+            "a model that doesn't prove walk-independence keeps the walk"
+        );
+    }
+
     /// Minimal fixed-value peripheral for routing tests: reads return a
     /// constant tag byte, writes are ignored.
     #[derive(Debug)]
@@ -3592,7 +3656,7 @@ mod tests {
             serde_yaml::Value::Number(0x53.into()),
         );
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "adxl345-test".to_string(),
             chip: "../chips/stm32f103.yaml".to_string(),
@@ -3661,7 +3725,7 @@ mod tests {
             serde_yaml::Value::Number(0x76.into()),
         );
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "esp32c3-bmp280-test".to_string(),
             chip: "../chips/esp32c3.yaml".to_string(),
@@ -3778,7 +3842,7 @@ mod tests {
             serde_yaml::Value::Number(25.0.into()),
         );
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "esp32c3-mlx90640-test".to_string(),
             chip: "../chips/esp32c3.yaml".to_string(),
@@ -4576,7 +4640,7 @@ peripherals:
 
     fn empty_manifest() -> SystemManifest {
         SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "bit-band-test".to_string(),
             chip: "unused".to_string(),
@@ -4713,7 +4777,7 @@ peripherals:
         config: std::collections::HashMap<String, serde_yaml::Value>,
     ) -> labwired_config::SystemManifest {
         labwired_config::SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "adxl345-test".to_string(),
             chip: "../chips/stm32f103.yaml".to_string(),
@@ -6290,7 +6354,7 @@ mod pin_map_tests {
             .join("../../configs/chips/mkw41z4.yaml");
         let chip = ChipDescriptor::from_file(&path).expect("load mkw41z4");
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "pinmap-test".to_string(),
             chip: path.to_string_lossy().to_string(),

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -44,6 +44,41 @@ fn pend_nvic(
 }
 
 impl SystemBus {
+    /// Config-time derivation of walk-deletability (issue: browser-perf chain).
+    ///
+    /// Returns `true` iff EVERY peripheral currently on the bus is provably
+    /// *walk-independent for all reachable firmware states* — meaning deleting
+    /// the per-cycle legacy walk (`legacy_tick_indices` iteration in
+    /// `tick_peripherals_phase1`) cannot change any observable output no matter
+    /// what the firmware does. A peripheral qualifies when either:
+    ///
+    /// 1. `uses_scheduler()` — the walk loop already returns `default()` for it
+    ///    every cycle (it is driven by the event scheduler, not the walk), so
+    ///    skipping the whole loop changes nothing; or
+    /// 2. `!needs_legacy_walk()` — its `tick()`/`tick_elapsed()` is a structural
+    ///    no-op for ALL states (a pure register bank, a stub, or a
+    ///    lazily-evaluated model that never mutates observable state from the
+    ///    walk). See the `Peripheral::needs_legacy_walk` contract.
+    ///
+    /// CONSERVATIVE by construction: the default `needs_legacy_walk()` is
+    /// `true`, so any peripheral whose walk-independence is not *proven* (an
+    /// unknown native model, a timer/ADC/DMA/EXTI/SysTick whose `tick()` does
+    /// real work once firmware arms it, a declarative bank with timed inflight
+    /// events) forces `false` here and the walk stays on. Getting this wrong
+    /// would silently starve a peripheral of ticks, so the predicate errs
+    /// entirely toward keeping the walk.
+    ///
+    /// Note this is strictly weaker than a hand `walk_deleted: true`: the hand
+    /// flag can assert firmware-*specific* byte-identity (e.g. "this firmware
+    /// never touches the 11 timers the chip descriptor instantiates"), which no
+    /// config-time predicate can prove. Such configs must keep the explicit
+    /// opt-in.
+    pub(crate) fn derive_walk_deletable(&self) -> bool {
+        self.peripherals
+            .iter()
+            .all(|p| p.dev.uses_scheduler() || !p.dev.needs_legacy_walk())
+    }
+
     pub(crate) fn tick_profile_entry_counts(&self) -> (usize, usize) {
         let bus_tick_entries = self.bus_tick_indices.len();
         let legacy_tick_entries = if cfg!(feature = "event-scheduler") && self.legacy_walk_disabled

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -547,6 +547,33 @@ pub trait Peripheral: std::fmt::Debug + Send {
     fn legacy_tick_dynamic(&self) -> bool {
         false
     }
+    /// True if this peripheral's participation in the legacy per-cycle walk is
+    /// behaviorally significant for SOME reachable firmware state — i.e.
+    /// deleting the walk (`SystemBus::derive_walk_deletable`) could change
+    /// observable output. This is a static, firmware-independent property of
+    /// the model, distinct from [`Self::legacy_tick_active`] (a per-instant
+    /// state query the walk uses to skip inert entries cheaply).
+    ///
+    /// The conservative default is `true`: unless a model *proves* its
+    /// `tick()`/`tick_elapsed()` can never mutate observable state, it keeps the
+    /// walk on. Override to `false` ONLY when BOTH hold for every reachable
+    /// state:
+    ///
+    /// - the peripheral's `tick()`/`tick_elapsed()` is a genuine no-op
+    ///   (a pure register bank / stub, or a purely lazy model that advances its
+    ///   state on MMIO access rather than in `tick`), AND
+    /// - it never emits an IRQ, DMA request, mmio-write, or fired event from
+    ///   the walk.
+    ///
+    /// Scheduler-driven peripherals need NOT override this (they are handled by
+    /// `uses_scheduler()` in the derivation); overriding is only for models that
+    /// stay on the legacy path but do nothing there. Getting this wrong (a
+    /// `false` on a model that actually does walk work) silently starves the
+    /// peripheral of ticks once the bus derives walk-deletion — so the honest
+    /// direction under any doubt is to leave it `true`.
+    fn needs_legacy_walk(&self) -> bool {
+        true
+    }
     fn as_any(&self) -> Option<&dyn Any> {
         None
     }

--- a/crates/core/src/peripherals/declarative.rs
+++ b/crates/core/src/peripherals/declarative.rs
@@ -570,6 +570,18 @@ impl Peripheral for GenericPeripheral {
         !self.has_read_trigger() && self.has_write_trigger()
     }
 
+    /// A declarative register bank does walk work only when it can hold an
+    /// inflight timed event — which requires a read/write trigger in the
+    /// descriptor (or an event armed at construction). A trigger-free bank's
+    /// `tick()` loop body can never execute, so it is walk-independent for every
+    /// state. Mirrors the `legacy_tick_active`/`legacy_tick_dynamic` reachability
+    /// above: no trigger AND no live event ⇒ can never become tick-active.
+    fn needs_legacy_walk(&self) -> bool {
+        self.has_read_trigger()
+            || self.has_write_trigger()
+            || !self.inflight_events.borrow().is_empty()
+    }
+
     fn as_any(&self) -> Option<&dyn Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/stub.rs
+++ b/crates/core/src/peripherals/stub.rs
@@ -41,6 +41,12 @@ impl crate::Peripheral for StubPeripheral {
         Ok(())
     }
 
+    /// A stub never overrides `tick()` — it is a literal no-op on the legacy
+    /// walk for every state, so it can never be the reason a bus keeps the walk.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }

--- a/crates/core/src/system/xtensa/mod.rs
+++ b/crates/core/src/system/xtensa/mod.rs
@@ -519,7 +519,7 @@ mod tests {
             serde_yaml::Value::String("GPIO5".to_string()),
         );
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-esp32-epaper".to_string(),
             chip: "esp32.yaml".to_string(),
@@ -591,7 +591,7 @@ mod tests {
             serde_yaml::Value::String("GPIO10".to_string()),
         );
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-esp32s3-epaper".to_string(),
             chip: "esp32s3.yaml".to_string(),
@@ -643,7 +643,7 @@ mod tests {
         use labwired_config::{ExternalDevice, SystemManifest};
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test".to_string(),
             chip: "esp32.yaml".to_string(),

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -437,7 +437,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),
@@ -612,7 +612,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-2".to_string(),
             chip: "test-chip-2".to_string(),
@@ -675,7 +675,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-3".to_string(),
             chip: "test-chip-3".to_string(),
@@ -733,7 +733,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-gpio-v2".to_string(),
             chip: "test-chip-gpio-v2".to_string(),
@@ -797,7 +797,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-uart-v2".to_string(),
             chip: "test-chip-uart-v2".to_string(),
@@ -949,7 +949,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-two-uarts".to_string(),
             chip: "test-chip-two-uarts".to_string(),
@@ -1008,7 +1008,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-rcc-v2".to_string(),
             chip: "test-chip-rcc-v2".to_string(),
@@ -1069,7 +1069,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-rcc-f4".to_string(),
             chip: "test-chip-rcc-f4".to_string(),
@@ -1130,7 +1130,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-gpio-v2-alias".to_string(),
             chip: "test-chip-gpio-v2-alias".to_string(),
@@ -2316,7 +2316,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "esp32c3-timg-test".to_string(),
@@ -2403,7 +2403,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "esp32c3-gpio-test".to_string(),
             chip: "esp32c3-gpio-test".to_string(),
@@ -2475,7 +2475,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "esp32c3-spi-dc-test".to_string(),
             chip: "esp32c3-spi-dc-test".to_string(),
@@ -2675,7 +2675,7 @@ pub mod integration_tests {
             serde_yaml::Value::Number(0x3C.into()),
         );
         let manifest = SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "esp32c3-i2c-trace-test".to_string(),
             chip: "esp32c3-i2c-trace-test".to_string(),
@@ -2774,7 +2774,7 @@ pub mod integration_tests {
                 serde_yaml::Value::Number(0x3C.into()),
             );
             let manifest = SystemManifest {
-                walk_deleted: false,
+                walk_deleted: Some(false),
                 schema_version: "1.0".to_string(),
                 name: "two-family-trace".to_string(),
                 chip: "two-family-trace".to_string(),

--- a/crates/core/tests/chip_conformance.rs
+++ b/crates/core/tests/chip_conformance.rs
@@ -267,7 +267,7 @@ fn root(rel: &str) -> PathBuf {
 
 fn dummy_manifest(path: &str) -> SystemManifest {
     SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "chip-conformance".to_string(),
         chip: path.to_string(),

--- a/crates/core/tests/e2e_nokia5110_invaders.rs
+++ b/crates/core/tests/e2e_nokia5110_invaders.rs
@@ -53,9 +53,18 @@ fn ensure_firmware_built() -> PathBuf {
 }
 
 fn build_machine(elf: &Path) -> Cm {
+    build_machine_with(elf, None)
+}
+
+/// Build the invaders machine, optionally overriding the manifest's
+/// `walk_deleted` field (`None` keeps the yaml's explicit `Some(true)`).
+fn build_machine_with(elf: &Path, walk_deleted: Option<Option<bool>>) -> Cm {
     let system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../examples/nokia5110-invaders-lab/system.yaml");
-    let manifest = SystemManifest::from_file(&system_path).expect("load manifest");
+    let mut manifest = SystemManifest::from_file(&system_path).expect("load manifest");
+    if let Some(wd) = walk_deleted {
+        manifest.walk_deleted = wd;
+    }
     let chip_path = system_path.parent().unwrap().join(&manifest.chip);
     let chip = ChipDescriptor::from_file(&chip_path).expect("load chip");
     let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
@@ -182,6 +191,67 @@ fn splash_framebuffer_matches_across_tick_intervals() {
         fb1,
         fb_at(64),
         "splash framebuffer must be byte-identical at tick interval 64"
+    );
+}
+
+/// Walk-deletion output-safety differential: the machine built from the invaders
+/// config with the `walk_deleted:` line REMOVED (`None` ⇒ conservative
+/// auto-derivation, which for this config KEEPS the walk on because of the native
+/// timers/SysTick/ADC/DMA/EXTI the descriptor instantiates) must produce
+/// byte-identical observable output — framebuffer AND total_cycles — to the
+/// explicit-flag machine (`Some(true)` ⇒ walk deleted), over 20M+ cycles at the
+/// same tick interval. This proves the hand `walk_deleted: true` opt-in is
+/// output-equivalent to the derived decision (walk-on ≡ walk-off for THIS
+/// firmware), i.e. the flag is a pure performance opt-in, safe to keep or drop
+/// for correctness.
+///
+/// It ALSO documents the perf reality honestly: the explicit-flag bus unlocks
+/// `max_safe_tick_interval == 64` (browser batching), while the flag-removed
+/// (derived) bus stays at 1 — the conservative derivation cannot recover the
+/// firmware-specific batching win, so removing the flag is a throughput
+/// regression even though it is output-safe.
+#[test]
+#[ignore = "slow: builds + runs the Space Invaders firmware in-sim"]
+fn derived_and_explicit_walk_flag_are_output_identical() {
+    let elf = ensure_firmware_built();
+
+    // Explicit Some(true): walk deleted. Derived None: walk kept (conservative).
+    let mut explicit = build_machine_with(&elf, Some(Some(true)));
+    let mut derived = build_machine_with(&elf, Some(None));
+
+    // Honest perf reality: the flag unlocks batching, the derivation does not.
+    if cfg!(feature = "event-scheduler") {
+        assert_eq!(explicit.bus.max_safe_tick_interval(), 64);
+        assert_eq!(
+            derived.bus.max_safe_tick_interval(),
+            1,
+            "conservative derivation keeps the walk for a chip with native timers"
+        );
+    }
+
+    // Run both at interval 1 so the comparison isolates walk-on vs walk-off
+    // (not batching). 20M cycles well past the splash + several game frames.
+    let budget = 20_000_000u64;
+    for m in [&mut explicit, &mut derived] {
+        while m.total_cycles < budget {
+            let remaining = (budget - m.total_cycles).min(u32::MAX as u64) as u32;
+            m.run(Some(remaining)).expect("run");
+        }
+    }
+
+    assert_eq!(
+        explicit.total_cycles, derived.total_cycles,
+        "total_cycles must match walk-deleted vs walk-kept"
+    );
+    let fb_explicit = framebuffer(&explicit);
+    let fb_derived = framebuffer(&derived);
+    assert!(
+        fb_explicit.iter().any(|&b| b != 0),
+        "the firmware must have drawn to the framebuffer"
+    );
+    assert_eq!(
+        fb_explicit, fb_derived,
+        "framebuffer must be byte-identical: walk deletion is output-safe here"
     );
 }
 

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -25,7 +25,7 @@ fn h563_machine() -> Machine<labwired_core::cpu::CortexM> {
         .join("../../configs/chips/stm32h563.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load stm32h563.yaml");
     let manifest = labwired_config::SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "flash-h5-ops".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/h563_conformance.rs
+++ b/crates/core/tests/h563_conformance.rs
@@ -22,7 +22,7 @@ fn h563_bus() -> labwired_core::bus::SystemBus {
         .join("../../configs/chips/stm32h563.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load chip");
     let manifest = labwired_config::SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "h563-conformance".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/kw41z_clock_boot.rs
+++ b/crates/core/tests/kw41z_clock_boot.rs
@@ -37,7 +37,7 @@ fn kw41z_bus() -> SystemBus {
         .join("../../configs/chips/mkw41z4.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load mkw41z4 chip");
     let manifest = labwired_config::SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "kw41z-clock-boot".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/nrf5340_clock_boot.rs
+++ b/crates/core/tests/nrf5340_clock_boot.rs
@@ -41,7 +41,7 @@ fn nrf5340_bus() -> SystemBus {
         .join("../../configs/chips/nrf5340.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load nrf5340 chip");
     let manifest = labwired_config::SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "nrf5340-clock-boot".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/pin_map_resolution.rs
+++ b/crates/core/tests/pin_map_resolution.rs
@@ -7,7 +7,7 @@ fn bus_for(chip_file: &str) -> SystemBus {
         .join(chip_file);
     let chip = ChipDescriptor::from_file(&path).expect("load chip");
     let manifest = SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "pinmap".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -46,7 +46,7 @@ fn validate_chip(path: &PathBuf) -> anyhow::Result<()> {
 
     // Create Manual System Manifest
     let dummy_manifest = labwired_config::SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "test-bench".to_string(),
         chip: path.to_string_lossy().to_string(),

--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -124,7 +124,7 @@ fn root(rel: &str) -> PathBuf {
 
 fn dummy_manifest(path: &str) -> labwired_config::SystemManifest {
     labwired_config::SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "coverage".to_string(),
         chip: path.to_string(),

--- a/crates/core/tests/uart_parity_ratchet.rs
+++ b/crates/core/tests/uart_parity_ratchet.rs
@@ -28,7 +28,7 @@ const UNMODELLED_UART_TYPES: &[&str] = &[];
 
 fn dummy_manifest(path: &str) -> SystemManifest {
     SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".into(),
         name: "uart-parity".into(),
         chip: path.into(),

--- a/crates/core/tests/walk_deletion.rs
+++ b/crates/core/tests/walk_deletion.rs
@@ -1,7 +1,13 @@
-//! Guards for the per-config walk-deletion opt-in (`SystemManifest.walk_deleted`
-//! → `SystemBus.legacy_walk_disabled`). The flag is only *consulted* under the
-//! `event-scheduler` feature, but it is *plumbed* unconditionally, so these
-//! tests run in both flag states.
+//! Guards for the walk-deletion decision (`SystemManifest.walk_deleted:
+//! Option<bool>` → `SystemBus.legacy_walk_disabled`). The field is only
+//! *consulted* under the `event-scheduler` feature, but it is *plumbed*
+//! unconditionally, so these tests run in both flag states.
+//!
+//! Semantics:
+//!   Some(true)  → force walk deleted (hand opt-in / escape hatch)
+//!   Some(false) → pin the walk ON, overriding auto-derivation
+//!   None        → auto-derive (conservative: delete iff EVERY peripheral is
+//!                 provably walk-independent for all firmware states)
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
@@ -14,34 +20,69 @@ fn root(rel: &str) -> PathBuf {
     p
 }
 
-/// The Nokia 5110 lab opts into walk-deletion (its firmware was verified
-/// byte-identical walk-free with SPI event-migrated), and that opt-in must
-/// reach the bus.
-#[test]
-fn nokia_walk_deleted_flag_reaches_bus() {
+fn nokia() -> (ChipDescriptor, SystemManifest) {
     let chip = ChipDescriptor::from_file(root("configs/chips/stm32l476.yaml"))
         .expect("load stm32l476 chip");
     let manifest = SystemManifest::from_file(root("examples/nokia5110-invaders-lab/system.yaml"))
         .expect("load nokia manifest");
-    assert!(
+    (chip, manifest)
+}
+
+/// The Nokia 5110 lab carries an explicit `walk_deleted: true` (its firmware was
+/// hand-verified byte-identical walk-free), and that opt-in must reach the bus.
+#[test]
+fn nokia_explicit_flag_reaches_bus() {
+    let (chip, manifest) = nokia();
+    assert_eq!(
         manifest.walk_deleted,
+        Some(true),
         "the Nokia lab manifest must keep walk_deleted: true"
     );
     let bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
     assert!(
         bus.legacy_walk_disabled,
-        "walk_deleted manifest flag must set bus.legacy_walk_disabled"
+        "explicit walk_deleted: true must set bus.legacy_walk_disabled"
     );
 }
 
-/// Walk-deletion is strictly opt-in: a manifest without the field keeps the
-/// per-cycle walk (the safe default).
+/// Auto-derivation is CONSERVATIVE at the real-config level: with the Nokia lab's
+/// explicit flag REMOVED (`None`), the bus does NOT derive walk-deletion, because
+/// the stm32l476 descriptor instantiates native timers / SysTick / ADC / DMA /
+/// EXTI / CAN whose `tick()` does real work once firmware arms them. Their
+/// byte-identity walk-free is a *firmware-specific* fact (this firmware never arms
+/// them) that no config-time predicate can prove — so the walk stays on and the
+/// explicit flag remains load-bearing.
 #[test]
-fn walk_deletion_is_off_by_default() {
+fn nokia_without_flag_does_not_auto_derive_deletion() {
+    let (chip, mut manifest) = nokia();
+    manifest.walk_deleted = None; // simulate removing the yaml line
+    let bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+    assert!(
+        !bus.legacy_walk_disabled,
+        "conservative derivation must keep the walk (native timers are armable)"
+    );
+}
+
+/// An explicit `Some(false)` pins the walk ON — the escape hatch.
+#[test]
+fn explicit_false_pins_walk_on() {
+    let (chip, mut manifest) = nokia();
+    manifest.walk_deleted = Some(false);
+    let bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+    assert!(
+        !bus.legacy_walk_disabled,
+        "walk_deleted: false must pin the walk on"
+    );
+}
+
+/// A manifest without the field parses to `None` (auto-derive), not a hard-coded
+/// off.
+#[test]
+fn walk_deleted_defaults_to_none() {
     let yaml = "name: t\nchip: x\n";
     let manifest: SystemManifest = serde_yaml::from_str(yaml).expect("parse minimal manifest");
-    assert!(
-        !manifest.walk_deleted,
-        "walk_deleted must default to false (walk preserved)"
+    assert_eq!(
+        manifest.walk_deleted, None,
+        "walk_deleted must default to None (auto-derive)"
     );
 }

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1132,7 +1132,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),
@@ -1190,7 +1190,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),
@@ -1261,7 +1261,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
-            walk_deleted: false,
+            walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
             chip: "test-chip".to_string(),

--- a/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
@@ -184,7 +184,7 @@ fn build_sim_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "esp32c3-reset-conformance".to_string(),
         chip: chip_path.to_string_lossy().to_string(),

--- a/crates/hw-oracle/tests/foreign_firmware_probe.rs
+++ b/crates/hw-oracle/tests/foreign_firmware_probe.rs
@@ -27,7 +27,7 @@ fn probe_foreign_firmware() {
     let chip_path = root.join("configs/chips/stm32h563.yaml");
     let chip = ChipDescriptor::from_file(&chip_path).expect("load chip");
     let manifest = SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "foreign-probe".to_string(),
         chip: chip_path.to_string_lossy().to_string(),

--- a/crates/hw-oracle/tests/h563_mmio_diff.rs
+++ b/crates/hw-oracle/tests/h563_mmio_diff.rs
@@ -987,7 +987,7 @@ fn build_sim_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
-        walk_deleted: false,
+        walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "h563-mmio-diff".to_string(),
         chip: chip_path.to_string_lossy().to_string(),


### PR DESCRIPTION
Groundwork from the walk-deletion investigation. Finding first: a sound config-time derivation CANNOT delete the walk for real STM32 boards — the invaders bus carries 49 armable walker peripherals (SysTick, SCB, TIM1-17, ADC, DMA, EXTI, CAN, I2C) whose ticks are no-ops only in reset state; the hand `walk_deleted: true` asserts a firmware-specific inertness no static predicate can prove. This PR ships only what is sound:

- `Peripheral::needs_legacy_walk()` (default `true`, conservative) — override to `false` only for structural no-op ticks. Overridden on `StubPeripheral` and trigger-free declarative banks.
- `SystemBus::derive_walk_deletable()` — walk deleted iff every peripheral is `uses_scheduler() || !needs_legacy_walk()`.
- `SystemManifest.walk_deleted` → `Option<bool>`: `None` auto-derives, `Some(true)` forces deletion (hand opt-in, unchanged semantics), `Some(false)` pins the walk on (new escape hatch).

Correctness gates: 20M-cycle differential (derived vs explicit invaders machines — byte-identical framebuffer + total_cycles); a synthetic walk-dependent bus must NOT derive deletion; all walk-identity/hcsr04/SPI differentials green. Existing Rust `false` literals migrated to `Some(false)` (exact prior behavior).

Zero behavior change for every existing config. The browser-facing fix (carrying the authored flag through the playground's diagram regeneration, demo-firmware-gated) lands separately in the superproject.