### PR TITLE
walk-free: C3/ESP32 Class-A sweep — 21 verified-inert models unpinned

### DIFF
--- a/crates/core/src/peripherals/esp32/dport.rs
+++ b/crates/core/src/peripherals/esp32/dport.rs
@@ -258,6 +258,11 @@ impl Dport {
 }
 
 impl Peripheral for Dport {
+    // Inert walk: DPORT register bank (clock gating / intr-matrix mapping / cache plumbing, all write-settled); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = (offset & !3) as u32;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/efuse.rs
+++ b/crates/core/src/peripherals/esp32/efuse.rs
@@ -206,6 +206,11 @@ impl Efuse {
 }
 
 impl Peripheral for Efuse {
+    // Inert walk: eFuse register bank; the CMD handshake settles across the write/next-read pair, and tick() is an explicit no-op ("no time-varying state").
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = (offset & !3) as u32;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/ledc.rs
+++ b/crates/core/src/peripherals/esp32/ledc.rs
@@ -325,6 +325,11 @@ impl Ledc {
 }
 
 impl Peripheral for Ledc {
+    // Inert walk: classic-ESP32 LEDC is a config-introspection register bank — no PWM edges or timer-counter advance modeled (unlike the C3 LEDC, whose live up-counters DO real tick work); tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = offset & !3;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/mcpwm.rs
+++ b/crates/core/src/peripherals/esp32/mcpwm.rs
@@ -173,6 +173,11 @@ impl Mcpwm {
 }
 
 impl Peripheral for Mcpwm {
+    // Inert walk: MCPWM register bank (duty introspection, no waveform generation modeled); tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word = self.word(offset & !3);
         Ok(((word >> ((offset & 3) * 8)) & 0xFF) as u8)

--- a/crates/core/src/peripherals/esp32/sar_adc.rs
+++ b/crates/core/src/peripherals/esp32/sar_adc.rs
@@ -154,6 +154,11 @@ impl Esp32SarAdc {
 }
 
 impl Peripheral for Esp32SarAdc {
+    // Inert walk: conversions complete at the MEAS_START write (result latched there); tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32/sdio_stub.rs
+++ b/crates/core/src/peripherals/esp32/sdio_stub.rs
@@ -32,6 +32,11 @@ impl HostSlc {
 }
 
 impl Peripheral for HostSlc {
+    // Inert walk: register-backed SDIO stub (FSM-done forced on read); tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = (offset & !3) as u32;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/sha.rs
+++ b/crates/core/src/peripherals/esp32/sha.rs
@@ -461,6 +461,11 @@ impl Sha {
 }
 
 impl Peripheral for Sha {
+    // Inert walk: SHA ops run atomically at the command-register write (BUSY reads 0); tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = offset & !3;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -188,6 +188,11 @@ impl Esp32Spi {
 }
 
 impl Peripheral for Esp32Spi {
+    // Inert walk: SPI transactions run atomically at the launching CMD write (USR auto-clears there); tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = offset & !3;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/syscon.rs
+++ b/crates/core/src/peripherals/esp32/syscon.rs
@@ -140,6 +140,11 @@ impl Syscon {
 }
 
 impl Peripheral for Syscon {
+    // Inert walk: SYSCON register bank; the RNG word advances on read, never in the walk; tick() is an explicit no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = (offset & !3) as u32;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp32/twai.rs
+++ b/crates/core/src/peripherals/esp32/twai.rs
@@ -197,6 +197,11 @@ impl Esp32Twai {
 }
 
 impl crate::Peripheral for Esp32Twai {
+    // Inert walk: SJA1000-style controller whose transmits complete instantly at the CMD write; tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let reg = offset & !3;
         let byte = (offset % 4) as u32;

--- a/crates/core/src/peripherals/esp32c3/ana_i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/ana_i2c.rs
@@ -48,6 +48,11 @@ impl Esp32c3AnaI2c {
 }
 
 impl Peripheral for Esp32c3AnaI2c {
+    // Inert walk: register-backed analog-I²C master; transactions complete at the write (FSM-done forced on read); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32c3/cache.rs
+++ b/crates/core/src/peripherals/esp32c3/cache.rs
@@ -71,6 +71,11 @@ impl Esp32c3Cache {
 }
 
 impl Peripheral for Esp32c3Cache {
+    // Inert walk: cache ops complete atomically at the launching write (done bits forced on read); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32c3/forced_status.rs
+++ b/crates/core/src/peripherals/esp32c3/forced_status.rs
@@ -44,6 +44,11 @@ impl Esp32c3ForcedStatus {
 }
 
 impl Peripheral for Esp32c3ForcedStatus {
+    // Inert walk: register bank with read-forced status bits (RF air-gap cut); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32c3/reg_block.rs
+++ b/crates/core/src/peripherals/esp32c3/reg_block.rs
@@ -29,6 +29,11 @@ impl Esp32c3RegBlock {
 }
 
 impl Peripheral for Esp32c3RegBlock {
+    // Inert walk: plain register-backed MMIO block; tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32c3/rng.rs
+++ b/crates/core/src/peripherals/esp32c3/rng.rs
@@ -45,6 +45,11 @@ impl Esp32c3Rng {
 }
 
 impl Peripheral for Esp32c3Rng {
+    // Inert walk: xorshift state advances on read, never in the walk; tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.next_word();
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32c3/sar_adc.rs
+++ b/crates/core/src/peripherals/esp32c3/sar_adc.rs
@@ -50,6 +50,11 @@ impl Esp32c3SarAdc {
 }
 
 impl Peripheral for Esp32c3SarAdc {
+    // Inert walk: conversions are instantaneous (valid flags + mid-scale sample forced on read); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32c3/sha.rs
+++ b/crates/core/src/peripherals/esp32c3/sha.rs
@@ -113,6 +113,11 @@ impl Esp32c3Sha {
 }
 
 impl Peripheral for Esp32c3Sha {
+    // Inert walk: SHA-256 compression runs atomically at the START/CONTINUE write (BUSY reads 0); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let w = self.read_u32(offset & !3)?;
         Ok((w >> ((offset & 3) * 8)) as u8)

--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -184,6 +184,11 @@ impl FlashXipPeripheral {
 }
 
 impl Peripheral for FlashXipPeripheral {
+    // Inert walk: read-only XIP window translating through the shared MMU table on access; tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let r = match self.translate(offset) {
             Some(phys) => {
@@ -240,6 +245,11 @@ impl Esp32s3MmuTable {
 }
 
 impl Peripheral for Esp32s3MmuTable {
+    // Inert walk: MMU page-table register file (entries stored at the write); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word = match Self::entry_index(offset & !3) {
             Some(i) => self.table.lock().unwrap()[i],

--- a/crates/core/src/peripherals/esp32s3/spi_mem_flash.rs
+++ b/crates/core/src/peripherals/esp32s3/spi_mem_flash.rs
@@ -259,6 +259,11 @@ impl SpiMemFlash {
 }
 
 impl Peripheral for SpiMemFlash {
+    // Inert walk: flash commands execute atomically at the launching CMD write (trigger bits auto-clear there); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word = self.reg(offset & !3);
         Ok(((word >> ((offset & 3) * 8)) & 0xFF) as u8)

--- a/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
+++ b/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
@@ -64,6 +64,11 @@ impl UsbSerialJtag {
 }
 
 impl Peripheral for UsbSerialJtag {
+    // Inert walk: polling-based CDC byte sink (EP1_CONF always ready, no IRQs); tick() is the trait-default no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         match offset {
             // EP1_CONF (4 bytes, LE): always returns 0x0000_0003

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -27,8 +27,11 @@
 //!
 //! 4. `oled_lab_walk_pinners_after_rtc_migration` — the endgame ledger: on
 //!    the real OLED rom-boot bus, `rtc_cntl_timer` no longer pins the walk
-//!    (`uses_scheduler() == true`), and the remaining pinners are exactly the
-//!    known set (systimer / timg / i2c / …), printed for the campaign report.
+//!    (`uses_scheduler() == true`), and after the C3/ESP32 Class-A inert
+//!    sweep (`needs_legacy_walk() == false` on the verified-inert models) the
+//!    remaining pinners are EXACTLY the verified real workers
+//!    (systimer / i2c0 / ledc / spi2 / apb_saradc / wifi_mac), asserted as an
+//!    exact set so the campaign report stays honest.
 
 #![cfg(feature = "event-scheduler")]
 
@@ -363,28 +366,50 @@ fn oled_lab_native_mips_probe() {
     );
 }
 
-/// Endgame ledger: after the RTC migration, which peripherals still pin the
-/// per-cycle walk on the REAL OLED rom-boot bus? Locks in that
-/// `rtc_cntl_timer` is walk-independent and prints the remaining pinners
-/// (run with `--nocapture` for the list). `max_safe_tick_interval` stays 1
-/// until the ledger empties — asserted so the report stays honest.
+/// Endgame ledger: after the RTC migration + the C3/ESP32 Class-A inert
+/// sweep, which peripherals still pin the per-cycle walk on the REAL OLED
+/// rom-boot bus? Locks in that `rtc_cntl_timer` is walk-independent and that
+/// the remaining pinners are EXACTLY the verified real workers — models whose
+/// tick genuinely mutates state or asserts a level IRQ from the walk:
+///
+///   - `systimer` — free-running counter + FreeRTOS tick alarm, legacy-tick
+///     mode on the C3 (real per-tick counter/alarm work);
+///   - `i2c0` — bit-level wire engine advances mid-transfer in
+///     `tick_elapsed` (num/den module-clock fraction) + level IRQ;
+///   - `ledc` — the four low-speed timers run as live up-counters clocked by
+///     elapsed cycles (OVF latch) + level IRQ;
+///   - `spi2` — `tick()` re-asserts the level interrupt source while
+///     `int_raw & int_ena != 0` (reachable whenever firmware enables a
+///     TRANS_DONE/DMA int), so deleting the walk would starve the IRQ;
+///   - `apb_saradc` — same level-IRQ re-assert pattern from `tick()`
+///     (this is the chip-yaml `esp32c3_apb_saradc` controller; the rom-boot
+///     `apb_saradc` cal window at the same name is inert and no longer pins);
+///   - `wifi_mac` — `tick_with_bus` pumps TX/RX descriptor rings + `tick()`
+///     re-asserts the MAC level interrupt while events are pending.
+///
+/// Every other model on the bus now proves walk-independence itself
+/// (`uses_scheduler()` or a verified `needs_legacy_walk() == false`).
+/// `derive_walk_deletable()` stays false and `max_safe_tick_interval` stays 1
+/// until this set empties — asserted so the report stays honest (zero
+/// behavior change is the point of the Class-A sweep).
 #[test]
 #[ignore = "builds the full rom-boot bus (needs ROM blobs + flash fixture); run with --ignored"]
 fn oled_lab_walk_pinners_after_rtc_migration() {
+    /// The verified real workers still awaiting scheduler migration. A model
+    /// newly marked `needs_legacy_walk() == false` or migrated to the
+    /// scheduler must shrink this set; a model that starts pinning again is a
+    /// regression.
+    const EXPECTED_PINNERS: &[&str] =
+        &["apb_saradc", "i2c0", "ledc", "spi2", "systimer", "wifi_mac"];
+
     let lab = build_oled_lab(1, false);
     let bus = &lab.machine.bus;
 
-    let mut pinners: Vec<String> = Vec::new();
+    let mut pinners: Vec<&str> = Vec::new();
     for p in &bus.peripherals {
         let walk_independent = p.dev.uses_scheduler() || !p.dev.needs_legacy_walk();
         if !walk_independent {
-            pinners.push(format!(
-                "{} (uses_scheduler={}, needs_legacy_walk={}, legacy_tick_active={})",
-                p.name,
-                p.dev.uses_scheduler(),
-                p.dev.needs_legacy_walk(),
-                p.dev.legacy_tick_active()
-            ));
+            pinners.push(p.name.as_str());
         }
     }
     eprintln!("walk pinners on the esp32c3-oled-demo rom-boot bus:");
@@ -394,12 +419,37 @@ fn oled_lab_walk_pinners_after_rtc_migration() {
     eprintln!("max_safe_tick_interval = {}", bus.max_safe_tick_interval());
 
     assert!(
-        !pinners.iter().any(|p| p.starts_with("rtc_cntl_timer ")),
+        !pinners.contains(&"rtc_cntl_timer"),
         "rtc_cntl_timer must no longer pin the walk; pinners: {pinners:?}"
     );
+
+    let mut got = pinners.clone();
+    got.sort_unstable();
+    let mut expected: Vec<&str> = EXPECTED_PINNERS.to_vec();
+    expected.sort_unstable();
+    assert_eq!(
+        got,
+        expected,
+        "walk-pinning set (needs_legacy_walk && !uses_scheduler) drifted from the \
+         verified real-worker ledger on the esp32c3-oled-demo rom-boot bus.\n  \
+         got ({}):      {:?}\n  expected ({}): {:?}\n\
+         A model newly (un)marked `needs_legacy_walk()` or migrated to the scheduler \
+         must update EXPECTED_PINNERS to match the campaign's remaining surface.",
+        got.len(),
+        got,
+        expected.len(),
+        expected,
+    );
+
+    // Zero behavior change: the real workers above still force the walk, so
+    // the OLED bus must NOT flip walk-deletable and must stay on interval 1.
+    // `derive_walk_deletable()` (crate-private) is true iff every peripheral
+    // satisfies `uses_scheduler() || !needs_legacy_walk()` — i.e. iff this
+    // pinner set is empty — so a non-empty set IS the derivation staying
+    // false, and `max_safe_tick_interval() == 1` is its runtime effect.
     assert!(
         !pinners.is_empty(),
-        "ledger must stay honest: other pinners (systimer/timg/i2c/…) remain"
+        "OLED rom-boot bus must not derive walk-deletion while real workers remain"
     );
     assert_eq!(
         bus.max_safe_tick_interval(),

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-10 | ⚠ drift acked 2026-07-11 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -257,6 +257,14 @@ boards:
     # gate removal. Byte-identical to the walk path by committed differentials
     # (esp32c3_walk_differential, esp32c3_rtc_delay_loop); reset oracle unchanged.
     # No live re-capture this session.
+    # 2026-07-11 (Class-A sweep): asserted needs_legacy_walk()==false on the
+    # verified-inert C3 models (ana_i2c, cache, forced_status, reg_block, rng,
+    # sar_adc cal window, sha) — each one's tick() is the trait-default no-op and
+    # all work happens at the MMIO access, so the override is pure walk-scheduling
+    # metadata. i2c0/ledc/spi2/apb_saradc/wifi_mac verified as REAL walk workers
+    # and deliberately left pinning (endgame ledger asserts the exact set). No
+    # register, reset-value, timing or IRQ change; reset oracle unaffected. No
+    # live re-capture warranted.
     drift_ack: 2026-07-11
 
   - id: nucleo-l476rg
@@ -503,7 +511,13 @@ boards:
     # asserts default scheduler behaviour and snapshot compatibility.
     # 2026-07-09: universal logic analyzer — additive read_gpio_pad pad probe (ENABLE-mask direction) + I2C controller wraps attached slaves in TracingI2cDevice (shared bus trace) and signals START to the selected slave at address match so traces carry decodable address frames. Register map/reset values byte-for-byte untouched; conformance/e2e unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
-    drift_ack: 2026-07-10
+    # 2026-07-11: walk-free Class-A sweep — asserted needs_legacy_walk()==false on
+    # SpiMemFlash, FlashXipPeripheral, Esp32s3MmuTable and UsbSerialJtag (all
+    # verified structurally inert in the per-cycle walk: work happens at the MMIO
+    # access, tick() is the trait-default no-op). Pure walk-scheduling metadata —
+    # no register, reset-value, timing or IRQ change; the 9-reg reset-state
+    # silicon anchor is unaffected. No live re-capture warranted.
+    drift_ack: 2026-07-11
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
ESP32-C3/classic analogue of B0 (#515). Verify-then-override `needs_legacy_walk() = false` on 21 model types whose tick is structurally inert in all states (work happens at MMIO access): C3 ana_i2c/cache/forced_status/reg_block/rng/sar_adc/sha, shared spi_mem_flash/flash_xip×2/usb_serial_jtag, classic dport/twai/efuse/ledc/mcpwm/sar_adc/sdio_stub/sha/spi/syscon.

Conservative discipline caught four candidates the #516 summary list had wrong — all left pinned with evidence: `i2c0` (bit-level wire engine advances in tick_elapsed), C3 `ledc` (live up-counters latching LSTIMERx_OVF), and two new rejections: `spi2` and `apb_saradc` re-assert their level interrupt source from tick() while int_raw & int_ena != 0 — flipping them would starve the IRQ once a bus derives walk-deletion.

Endgame ledger updated: the C3 OLED rom-boot pinned set is now exactly {apb_saradc, i2c0, ledc, spi2, systimer, wifi_mac}, asserted with ids; walk-deletion still not derived, max_safe_tick_interval == 1 — zero behavior change by construction.

All lanes green (workspace lib, jit+event-scheduler 1845/1845, clippy -D warnings both, fmt, wasm32, C3 differentials + release-mode OLED boot suite, leo readback); drift gate green (dated acks, single trailing key); known machine-local intmatrix_alarm verified identical on unmodified main via stash A/B.