### PR TITLE
perf: walk-free STM32 timers — lazy CNT + scheduled update/compare events

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -3274,12 +3274,23 @@ mod tests {
             "scheduler + inert-stub bus is walk-independent"
         );
 
-        // Add a native Timer (its `tick()` counts once CEN is set — walk work
-        // reachable via MMIO). The bus must NOT derive deletion.
+        // Add a native Timer pinned to legacy mode (its `tick()` counts once
+        // CEN is set — walk work reachable via MMIO). The bus must NOT derive
+        // deletion. (`add_peripheral` attaches the cycle clock, which under
+        // `event-scheduler` migrates the timer to the scheduler — detach it
+        // so this test keeps pinning the conservative legacy-walker default.)
         bus.add_peripheral("tim2", 0x4000_0000, 0x400, None, Box::new(Timer::new()));
+        let tim_idx = bus.find_peripheral_index_by_name("tim2").unwrap();
+        bus.peripherals[tim_idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Timer>()
+            .unwrap()
+            .force_legacy_walk();
         assert!(
             !bus.derive_walk_deletable(),
-            "a native timer is walk-dependent — walk must stay on"
+            "a legacy-walk native timer is walk-dependent — walk must stay on"
         );
     }
 

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -103,8 +103,28 @@ impl SystemBus {
     /// handler. Mirrors the per-tick `pend_nvic` path but collects
     /// non-NVIC fallthroughs into the supplied vector for the caller to
     /// forward to `cpu.set_exception_pending`.
+    ///
+    /// Same-tick CPU visibility (walk-free B2/B3): the legacy walk pends
+    /// ISPR and scans ISPR&ISER into the CPU **in the same
+    /// `tick_peripherals` call**, so a walk-raised IRQ dispatches before the
+    /// very next instruction. The event drain runs after that scan, so an
+    /// event-raised IRQ left only in ISPR would become CPU-visible one tick
+    /// late. To keep event-path IRQ delivery cycle-identical to the walk,
+    /// an ISER-enabled pend is ALSO pushed into `fallthrough` as its
+    /// exception number (16 + position) for the caller's
+    /// `cpu.set_exception_pending` — exactly what the walk's same-tick NVIC
+    /// scan would have produced. A not-yet-enabled pend stays ISPR-only and
+    /// is picked up by the per-tick scan once firmware enables it (identical
+    /// to the walk).
     pub fn pend_irq_for_event(&self, irq: u32, fallthrough: &mut Vec<u32>) {
         pend_nvic(&self.nvic, fallthrough, irq);
+        if let Some(nvic) = &self.nvic {
+            let idx = (irq / 32) as usize;
+            let bit = irq % 32;
+            if idx < 8 && (nvic.iser[idx].load(Ordering::SeqCst) & (1 << bit)) != 0 {
+                fallthrough.push(16 + irq);
+            }
+        }
     }
 
     /// Route a peripheral DMA signal (`source_name` + `request_id`) to its
@@ -833,13 +853,13 @@ mod walk_free_campaign {
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;
 
-    /// Walk-forcing ids on the runtime invaders bus after B1 (event-scheduler
-    /// builds): B0's 22 minus `systick` + `scb` (scheduler-migrated) = 20 —
-    /// the plan's remaining Class-B: 11 timers + 2 dma + 3 i2c + adc + exti +
-    /// bxcan (19) + the core DWT.
+    /// Walk-forcing ids on the runtime invaders bus after B2/B3 (event-
+    /// scheduler builds): B1's 20 minus the 11 `tim*` (scheduler-migrated —
+    /// lazy CNT/SR + scheduled update/compare events) = 9 — the plan's
+    /// remaining Class-B: 2 dma + 3 i2c + adc + exti + bxcan (8) + the core
+    /// DWT.
     #[cfg(feature = "event-scheduler")]
     const EXPECTED_WALK_FORCING: &[&str] = &[
-        "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim15", "tim16", "tim17",
         "dma1", "dma2", "i2c1", "i2c2", "i2c3", "adc1", "exti", "can1", "dwt",
     ];
 
@@ -898,13 +918,13 @@ mod walk_free_campaign {
 
     #[test]
     fn remaining_class_b_walkers_still_pin_walk_deletion() {
-        // Timers/DMA/I2C/ADC/EXTI/bxCAN (+DWT) still force the walk, so
-        // B1 cannot flip the invaders bus yet: the derivation must stay
+        // DMA/I2C/ADC/EXTI/bxCAN (+DWT) still force the walk, so B2/B3
+        // cannot flip the invaders bus yet: the derivation must stay
         // conservative until every Class-B walker is migrated.
         let bus = invaders_bus_walk_stripped();
         assert!(
             !bus.derive_walk_deletable(),
-            "invaders bus became walk-deletable after B1, but Class-B walkers remain — \
+            "invaders bus became walk-deletable after B2/B3, but Class-B walkers remain — \
              each batch must be honest bookkeeping with no premature walk deletion"
         );
     }

--- a/crates/core/src/peripherals/timer.rs
+++ b/crates/core/src/peripherals/timer.rs
@@ -4,7 +4,8 @@
 // This software is released under the MIT License.
 // See the LICENSE file in the project root for full license information.
 
-use crate::SimResult;
+use crate::{CycleClock, SimResult};
+use std::cell::Cell;
 
 /// STM32 timer peripheral covering basic, general-purpose, and advanced-
 /// control variants:
@@ -21,18 +22,93 @@ use crate::SimResult;
 ///
 /// Counter / ARR width (16 or 32) is selectable via `width: 32` in the
 /// chip yaml's `config` block.
+///
+/// ## Drive modes (walk-free plan Part 2, batches B2/B3)
+///
+/// Two mutually exclusive time sources, selected by ONE predicate
+/// (`scheduler_mode`), following the SysTick (B1) exemplar:
+///
+/// * **Scheduler mode** (`event-scheduler` feature + a [`CycleClock`] attached
+///   at bus registration): `uses_scheduler()` is true, the per-cycle walk skips
+///   this peripheral entirely, and
+///   - `CNT` / `SR` are **derived lazily** from the bus-published cycle clock
+///     with exact closed-form replay of the walk (`advance_to`) — a `&self`
+///     read advances `Cell`-held state to "now", so firmware polling `CNT` or
+///     `SR` flags observes fresh time without any walk;
+///   - update events (UIF) and compare matches (CC1..4IF) that the walk would
+///     raise as NVIC interrupts are delivered by **scheduled events**: arming
+///     writes hand the bus a `(delay, token)` via `take_scheduled_events`
+///     computed in closed form from PSC/ARR/CNT/CCRx/DIER, and `on_event`
+///     claims the fire and perpetuates the chain (delay-1 while the legacy
+///     walk would hold the IRQ level) — `EventResult::raise_own_irq` pends the
+///     peripheral's configured NVIC line through the exact same
+///     `pend_irq_for_event` choke the legacy `tick()` path uses.
+///
+/// * **Legacy mode** (feature off, or no clock attached — hand-built test
+///   buses that bypass the bus registration chokes): the per-cycle walk drives
+///   `tick()` and the counter advances eagerly, byte-identical to the
+///   historical model.
+///
+/// ### Timing contract
+///
+/// At tick interval 1 on the batched `Machine::run` path, IRQ pend cycles,
+/// `CNT`/`SR` reads, `total_cycles` and register state are **byte-identical**
+/// to the walk-driven reference (see
+/// `crates/core/tests/stm32_timer_walk_differential.rs` and the in-module
+/// `scheduler_matches_walk_*` property gates). At interval N > 1 IRQ pends and
+/// lazy reads are quantised to the batch grid — at most one interval
+/// late/stale, the same documented bound the write-path `sync_to` ships (and
+/// strictly better than the legacy walk at interval N, which under the default
+/// `tick_elapsed` slows the count by a factor of N).
+///
+/// ### Preserved semantics (differentially pinned — including the model's
+/// known limitations, kept deliberately so the two drive modes are identical)
+///
+/// - **IRQ-level counter freeze**: while any enabled status flag is latched
+///   (`SR & DIER & 0x1F != 0`) the legacy `tick()` returns the held IRQ level
+///   *before* counting, so the counter does not advance until firmware clears
+///   the flag. The lazy replay freezes at exactly the same tick.
+/// - **Update-tick IRQ vs compare-latch IRQ timing**: an overflow with UIE
+///   pends on the overflow tick itself; a compare match latches CCxIF on the
+///   match tick and (via the level check) first pends on the **next** tick.
+/// - **PSC is applied immediately** (the model has no prescaler buffer;
+///   silicon buffers PSC until the next update event). `psc_cnt` keeps its
+///   phase across a PSC rewrite, including `psc_cnt > PSC` (next tick
+///   increments).
+/// - **ARR/CCRx are applied immediately** (no ARPE preload modeling); CR1
+///   bits other than CEN (DIR/CMS/OPM/…) are stored but do not affect
+///   counting — the model always up-counts, exactly like the walk.
+/// - **32-bit `ARR == 0xFFFF_FFFF` never wraps**: the walk's `cnt > arr`
+///   check can never fire (u32 wrapping_add), so the counter free-runs
+///   mod 2^32 with no UIF — reproduced exactly.
+/// - **SMCR (external clock / encoder modes) is a pure register bank bit**:
+///   the walk ignores it and always counts the CPU clock, so scheduler mode
+///   is exactly as expressive — no configuration needs to stay on the walk.
+///
+/// ### Tick-cost normalization (B2/B3)
+///
+/// The legacy model charged `cycles: 1` into the peripheral tick-cost channel
+/// on every overflow tick and on every held-IRQ-level tick, inflating
+/// `total_cycles` — a sim artifact (real TIMx consumes zero core cycles) that
+/// is structurally incompatible with deleting the walk. Both modes now charge
+/// zero cost, so the walk-on reference and the scheduler path agree
+/// cycle-for-cycle (the same normalization B1 applied to SysTick).
 #[derive(Debug, Default, serde::Serialize)]
 pub struct Timer {
     cr1: u32,
     cr2: u32,
     smcr: u32,
     dier: u32,
-    sr: u32,
+    /// Status flags. `Cell` so the scheduler-mode `&self` read path can
+    /// lazily latch UIF/CCxIF up to the bus-published clock. In legacy mode
+    /// only `tick()`/`write_reg` mutate it.
+    sr: Cell<u32>,
     egr: u32,
     ccmr1: u32,
     ccmr2: u32,
     ccer: u32,
-    cnt: u32,
+    /// Current counter value. `Cell` for the lazy `&self` advance.
+    cnt: Cell<u32>,
     psc: u32,
     arr: u32,
     rcr: u32,
@@ -63,8 +139,29 @@ pub struct Timer {
     basic: bool,
 
     // Internal state
-    psc_cnt: u32,
+    /// Prescaler phase counter. `Cell` for the lazy `&self` advance.
+    psc_cnt: Cell<u32>,
+
+    /// Lazy-path anchor: the absolute published cycle the counter state was
+    /// last advanced to. Owned exclusively by `advance_to` (scheduler mode);
+    /// the legacy walk never touches it.
+    #[serde(skip)]
+    anchor: Cell<u64>,
+    /// Arming-sequence token: bumped on every `take_scheduled_events` so an
+    /// in-flight event chain scheduled under an older configuration dies on
+    /// arrival (token mismatch) instead of racing the fresh chain.
+    #[serde(skip)]
+    arm_seq: u32,
+    /// Bus-published cycle clock (walk-free plan Part 1). `Some` once the bus
+    /// registration choke attaches it; `None` keeps the model on the legacy
+    /// walk path.
+    #[serde(skip)]
+    clock: Option<CycleClock>,
 }
+
+/// Full 32-bit ARR sentinel: the walk's `cnt > arr` overflow check can never
+/// fire, so the counter free-runs mod 2^32 with no update events.
+const ARR_NEVER_WRAPS: u32 = u32::MAX;
 
 impl Timer {
     pub fn new() -> Self {
@@ -82,12 +179,12 @@ impl Timer {
             cr2: 0,
             smcr: 0,
             dier: 0,
-            sr: 0,
+            sr: Cell::new(0),
             egr: 0,
             ccmr1: 0,
             ccmr2: 0,
             ccer: 0,
-            cnt: 0,
+            cnt: Cell::new(0),
             psc: 0,
             arr: arr_reset,
             rcr: 0,
@@ -108,7 +205,10 @@ impl Timer {
             width,
             advanced,
             basic: false,
-            psc_cnt: 0,
+            psc_cnt: Cell::new(0),
+            anchor: Cell::new(0),
+            arm_seq: 0,
+            clock: None,
         }
     }
 
@@ -120,6 +220,30 @@ impl Timer {
         self
     }
 
+    /// True when the event scheduler owns this timer's time base (feature on
+    /// AND bus clock attached). Everything time-related branches on this ONE
+    /// predicate so the two drive modes can never mix.
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Test/differential knob: detach the cycle clock, pinning the model to
+    /// the legacy walk path (`uses_scheduler() == false`). Used by the
+    /// walk-on-vs-scheduler differential gates to build the reference config
+    /// from the same bus assembly.
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
+    }
+
+    /// IRQ-level / counter-freeze predicate: the legacy `tick()` returns the
+    /// held IRQ level (and skips all counting) while any enabled status flag
+    /// among UIF/CC1..4IF is latched.
+    #[inline]
+    fn irq_level_held(&self) -> bool {
+        (self.sr.get() & self.dier & 0x1F) != 0
+    }
+
     /// Latch CCxIF for every output-compare channel whose CCRx currently
     /// equals CNT. Called at an update (UG) event, which reloads CNT and so
     /// re-evaluates the compare for all four channels. At reset (CCRx=0,
@@ -128,6 +252,7 @@ impl Timer {
     /// input-capture mode (CCxS != 0) don't compare and are skipped.
     fn latch_compare_match_flags(&mut self) {
         let mask = self.cnt_mask();
+        let cnt = self.cnt.get();
         let channels = [
             (self.ccr1, self.ccmr1 & 0x3, 1u32),
             (self.ccr2, (self.ccmr1 >> 8) & 0x3, 2),
@@ -135,8 +260,8 @@ impl Timer {
             (self.ccr4, (self.ccmr2 >> 8) & 0x3, 4),
         ];
         for (ccr, ccs, bit) in channels {
-            if ccs == 0 && (ccr & mask) == self.cnt {
-                self.sr |= 1 << bit;
+            if ccs == 0 && (ccr & mask) == cnt {
+                self.sr.set(self.sr.get() | (1 << bit));
             }
         }
         // Advanced timers carry the output-only internal channels 5/6 whose
@@ -145,8 +270,8 @@ impl Timer {
         // CC5IF|CC6IF set on top of the channel-1..4 latch.
         if self.advanced {
             for (ccr, bit) in [(self.ccr5, 16u32), (self.ccr6, 17)] {
-                if (ccr & mask) == self.cnt {
-                    self.sr |= 1 << bit;
+                if (ccr & mask) == cnt {
+                    self.sr.set(self.sr.get() | (1 << bit));
                 }
             }
         }
@@ -160,18 +285,252 @@ impl Timer {
         }
     }
 
+    // ── Closed-form walk replay (scheduler mode) ────────────────────────────
+    //
+    // The legacy walk applies, per tick:
+    //   if SR & DIER & 0x1F != 0 → held IRQ level, NO counting (freeze);
+    //   else if !CEN → nothing;
+    //   else psc_cnt += 1; if psc_cnt > PSC { psc_cnt = 0; cnt += 1;
+    //        if cnt > ARR { cnt = 0; UIF; latch compares } else { latch } }
+    //
+    // Counter *increments* therefore happen on a fixed tick grid derived from
+    // PSC (`k1` ticks to the first, then every `PSC+1`), and the value visited
+    // at increment j is a pure function of (CNT, ARR, j). All flag latches and
+    // IRQ fires are attached to increments, so a window of `e` ticks replays
+    // exactly in O(#channels).
+
+    /// Walk ticks until the first counter increment: `psc_cnt` starts at `c`,
+    /// increments each tick, and the counter bumps on the tick where it
+    /// exceeds PSC (then resets to 0). A stale `c > PSC` (PSC shrunk mid-run,
+    /// applied immediately — no buffering, like the walk) bumps on the next
+    /// tick.
+    #[inline]
+    fn ticks_to_first_increment(&self) -> u64 {
+        (self.psc as u64).saturating_sub(self.psc_cnt.get() as u64) + 1
+    }
+
+    /// Number of increments until the counter first *visits* value `w`
+    /// (post-increment compare, the walk's `latch_compare_match_flags` site),
+    /// or `None` if unreachable. Value sequence from `v`: `v+1, …, ARR, 0(U),
+    /// 1, …` (a stale `v > ARR` — CNT written above ARR — wraps to 0 on the
+    /// first increment, exactly like the walk's `cnt > arr` check).
+    fn increments_to_value(&self, v: u32, w: u32) -> Option<u64> {
+        let arr = self.arr;
+        if arr == ARR_NEVER_WRAPS {
+            // Free-running mod 2^32 (32-bit reset ARR): every value is
+            // visited; a match on the current value needs a full lap.
+            let d = w.wrapping_sub(v);
+            return Some(if d == 0 { 1u64 << 32 } else { d as u64 });
+        }
+        if w > arr {
+            return None; // never visited (walk resets past ARR before latch)
+        }
+        if v > arr {
+            // First increment wraps to 0, then counts 1, 2, …
+            Some(1 + w as u64)
+        } else if w > v {
+            Some((w - v) as u64)
+        } else {
+            // Wrap first (ARR - v + 1 increments), then count up to w.
+            // u64 math: arr - v + 1 + w can exceed u32 on 32-bit timers.
+            Some(arr as u64 - v as u64 + 1 + w as u64)
+        }
+    }
+
+    /// Number of increments until the first update event (wrap to 0 with
+    /// UIF), or `None` if ARR never wraps (32-bit 0xFFFF_FFFF).
+    fn increments_to_wrap(&self, v: u32) -> Option<u64> {
+        let arr = self.arr;
+        if arr == ARR_NEVER_WRAPS {
+            return None;
+        }
+        if v > arr {
+            Some(1)
+        } else {
+            Some((arr - v + 1) as u64)
+        }
+    }
+
+    /// Counter value after `m >= 1` increments from `v` (no freeze within).
+    fn value_after_increments(&self, v: u32, m: u64) -> u32 {
+        let arr = self.arr;
+        if arr == ARR_NEVER_WRAPS {
+            return v.wrapping_add((m & 0xFFFF_FFFF) as u32);
+        }
+        let period = arr as u64 + 1;
+        if v > arr {
+            // First increment wraps to 0.
+            ((m - 1) % period) as u32
+        } else if m <= (arr - v) as u64 {
+            v + m as u32
+        } else {
+            ((m - (arr - v) as u64 - 1) % period) as u32
+        }
+    }
+
+    /// The increment index of the first latch of an *enabled* flag (the walk
+    /// freezes counting from the next tick on, and pends the NVIC line), and
+    /// whether the pend lands on the SAME tick as the increment (update event
+    /// with UIE — the walk returns `irq` from the overflow tick itself) or on
+    /// the NEXT tick (compare match — latched on the match tick, first pended
+    /// by the level check one tick later).
+    fn first_enabled_event(&self) -> Option<(u64, bool)> {
+        if (self.cr1 & 0x1) == 0 {
+            return None;
+        }
+        let v = self.cnt.get();
+        let mut best: Option<(u64, bool)> = None;
+        if (self.dier & 0x1) != 0 {
+            if let Some(j) = self.increments_to_wrap(v) {
+                best = Some((j, true));
+            }
+        }
+        if !self.basic {
+            let mask = self.cnt_mask();
+            let channels = [
+                (self.ccr1, self.ccmr1 & 0x3, 1u32),
+                (self.ccr2, (self.ccmr1 >> 8) & 0x3, 2),
+                (self.ccr3, self.ccmr2 & 0x3, 3),
+                (self.ccr4, (self.ccmr2 >> 8) & 0x3, 4),
+            ];
+            for (ccr, ccs, bit) in channels {
+                if ccs != 0 || (self.dier >> bit) & 1 == 0 {
+                    continue;
+                }
+                if let Some(j) = self.increments_to_value(v, ccr & mask) {
+                    // Strict `<` keeps update-event precedence on a tie (the
+                    // walk pends the overflow tick itself when UIE is set).
+                    if best.map_or(true, |(b, _)| j < b) {
+                        best = Some((j, false));
+                    }
+                }
+            }
+        }
+        best
+    }
+
+    /// Lazy advance to absolute published cycle `now` — callable from `&self`
+    /// (all mutated state is in `Cell`). Idempotent; a `now` older than the
+    /// anchor is ignored. The advanced window always has constant
+    /// CR1/DIER/PSC/ARR/CCRx: every MMIO write syncs first (bus `sync_to`
+    /// choke), so settings changes never straddle a window. Replays the walk
+    /// EXACTLY, including the enabled-flag counter freeze.
+    fn advance_to(&self, now: u64) {
+        let anchor = self.anchor.get();
+        if now <= anchor {
+            return;
+        }
+        self.anchor.set(now);
+        if self.irq_level_held() || (self.cr1 & 0x1) == 0 {
+            // Frozen (held IRQ level) or not enabled: the window elapses with
+            // no counting — exactly the walk's early returns.
+            return;
+        }
+        let e = now - anchor;
+        let k1 = self.ticks_to_first_increment();
+        if e < k1 {
+            // No increment in the window: only the prescaler phase advances.
+            self.psc_cnt.set(self.psc_cnt.get() + e as u32);
+            return;
+        }
+        let period = self.psc as u64 + 1;
+        let n = 1 + (e - k1) / period; // increments the un-frozen walk would do
+        let freeze_j = self.first_enabled_event().map(|(j, _)| j);
+        // Increments actually applied: the walk stops counting after the
+        // increment that latches an enabled flag.
+        let m = match freeze_j {
+            Some(j) if j <= n => j,
+            _ => n,
+        };
+        let v = self.cnt.get();
+        // Latch every flag whose first occurrence lies within the applied
+        // window — disabled flags accumulate lazily without freezing, exactly
+        // like the walk.
+        let mut sr = self.sr.get();
+        if let Some(j) = self.increments_to_wrap(v) {
+            if j <= m {
+                sr |= 1; // UIF
+            }
+        }
+        if !self.basic {
+            let mask = self.cnt_mask();
+            let channels = [
+                (self.ccr1, self.ccmr1 & 0x3, 1u32),
+                (self.ccr2, (self.ccmr1 >> 8) & 0x3, 2),
+                (self.ccr3, self.ccmr2 & 0x3, 3),
+                (self.ccr4, (self.ccmr2 >> 8) & 0x3, 4),
+            ];
+            for (ccr, ccs, bit) in channels {
+                if ccs != 0 {
+                    continue;
+                }
+                if let Some(j) = self.increments_to_value(v, ccr & mask) {
+                    if j <= m {
+                        sr |= 1 << bit;
+                    }
+                }
+            }
+            if self.advanced {
+                let mask = self.cnt_mask();
+                for (ccr, bit) in [(self.ccr5, 16u32), (self.ccr6, 17)] {
+                    if let Some(j) = self.increments_to_value(v, ccr & mask) {
+                        if j <= m {
+                            sr |= 1 << bit;
+                        }
+                    }
+                }
+            }
+        }
+        self.sr.set(sr);
+        self.cnt.set(self.value_after_increments(v, m));
+        // Prescaler phase: an increment tick resets it to 0; if the walk
+        // froze at increment `m` it stays 0 for the rest of the window,
+        // otherwise the post-increment remainder ticks accumulate.
+        let frozen = matches!(freeze_j, Some(j) if j <= n);
+        self.psc_cnt.set(if frozen {
+            0
+        } else {
+            ((e - k1) % period) as u32
+        });
+    }
+
+    /// Pull "now" from the bus-published clock and advance. No-op without an
+    /// attached clock (legacy mode — the walk advances the counter instead).
+    fn sync_from_clock(&self) {
+        if let Some(clock) = &self.clock {
+            if self.scheduler_mode() {
+                self.advance_to(clock.now());
+            }
+        }
+    }
+
+    /// Walk ticks from the just-synced state until the tick on which the
+    /// legacy walk would FIRST pend the NVIC line, for the event chain:
+    /// `None` when nothing is armed (chain dies; the next relevant MMIO write
+    /// re-arms). The tick is `k1 + (j-1)*(PSC+1)` for the increment, plus one
+    /// for compare matches (level-pended one tick after the latch).
+    fn ticks_until_first_pend(&self) -> Option<u64> {
+        if self.irq_level_held() {
+            // Already held: the walk pends on the very next tick.
+            return Some(1);
+        }
+        let (j, same_tick) = self.first_enabled_event()?;
+        let t = self.ticks_to_first_increment() + (j - 1) * (self.psc as u64 + 1);
+        Some(if same_tick { t } else { t + 1 })
+    }
+
     fn read_reg(&self, offset: u64) -> u32 {
         match offset {
             0x00 => self.cr1,
             0x04 => self.cr2,
             0x08 => self.smcr,
             0x0C => self.dier,
-            0x10 => self.sr,
+            0x10 => self.sr.get(),
             0x14 => self.egr,
             0x18 => self.ccmr1,
             0x1C => self.ccmr2,
             0x20 => self.ccer,
-            0x24 => self.cnt,
+            0x24 => self.cnt.get(),
             0x28 => self.psc,
             0x2C => self.arr,
             0x30 if self.advanced => self.rcr,
@@ -216,7 +575,7 @@ impl Timer {
                 self.dier = value & mask;
             }
             // TIMx_SR is rc_w0 for status flags: writing 0 clears, writing 1 keeps current.
-            0x10 => self.sr &= value & 0x1FFFF,
+            0x10 => self.sr.set(self.sr.get() & (value & 0x1FFFF)),
             // TIMx_EGR: only UG (bit 0) drives state — but advanced timers
             // also have CC1G-CC4G, COMG, TG, BG. We accept all and treat
             // CC*G as also setting the corresponding CC*IF flags.
@@ -224,9 +583,9 @@ impl Timer {
                 self.egr = value & 0xFF;
                 if (self.egr & 0x01) != 0 {
                     // Update event: reload counter/prescaler and set UIF.
-                    self.cnt = 0;
-                    self.psc_cnt = 0;
-                    self.sr |= 1;
+                    self.cnt.set(0);
+                    self.psc_cnt.set(0);
+                    self.sr.set(self.sr.get() | 1);
                     // The UG reload re-evaluates every output-compare channel:
                     // on a general-purpose/advanced timer the channels whose
                     // CCRx now equals CNT latch their CCxIF (at reset, all of
@@ -238,19 +597,19 @@ impl Timer {
                 }
                 if self.advanced {
                     if (self.egr & 0x02) != 0 {
-                        self.sr |= 1 << 1;
+                        self.sr.set(self.sr.get() | (1 << 1));
                     } // CC1IF
                     if (self.egr & 0x04) != 0 {
-                        self.sr |= 1 << 2;
+                        self.sr.set(self.sr.get() | (1 << 2));
                     }
                     if (self.egr & 0x08) != 0 {
-                        self.sr |= 1 << 3;
+                        self.sr.set(self.sr.get() | (1 << 3));
                     }
                     if (self.egr & 0x10) != 0 {
-                        self.sr |= 1 << 4;
+                        self.sr.set(self.sr.get() | (1 << 4));
                     }
                     if (self.egr & 0x80) != 0 {
-                        self.sr |= 1 << 7;
+                        self.sr.set(self.sr.get() | (1 << 7));
                     } // BIF (break)
                 }
             }
@@ -266,7 +625,7 @@ impl Timer {
                 let mask = if self.advanced { 0xFFFF } else { 0x3333 };
                 self.ccer = value & mask;
             }
-            0x24 => self.cnt = value & self.cnt_mask(),
+            0x24 => self.cnt.set(value & self.cnt_mask()),
             0x28 => self.psc = value & 0xFFFF,
             0x2C => self.arr = value & self.cnt_mask(),
             0x30 if self.advanced => self.rcr = value & 0xFFFF,
@@ -292,6 +651,10 @@ impl Timer {
 
 impl crate::Peripheral for Timer {
     fn read(&self, offset: u64) -> SimResult<u8> {
+        // Scheduler mode: advance the lazy counter to the published "now"
+        // first, so polled CNT/SR reads observe fresh time (batch-boundary
+        // freshness; exact at interval 1 on the run path).
+        self.sync_from_clock();
         let reg_offset = offset & !3;
         let byte_offset = (offset % 4) as u32;
         let reg_val = self.read_reg(reg_offset);
@@ -312,16 +675,22 @@ impl crate::Peripheral for Timer {
     }
 
     fn tick(&mut self) -> crate::PeripheralTickResult {
+        // Never runs in scheduler mode (the walk skips `uses_scheduler()`
+        // peripherals; the guard keeps a stray direct call from corrupting
+        // the lazily-anchored state).
+        if self.scheduler_mode() {
+            return crate::PeripheralTickResult::default();
+        }
         // Keep the IRQ level high while any enabled status flag is latched:
         // UIF/UIE (bit 0) and the compare-match pairs CC1..4IF/CC1..4IE
         // (bits 1..4). Compare interrupts drive alarm-style time drivers
         // (CCR written ahead of CNT, CCxIE set, wake on match) — exercised
         // by foreign STM32H563 firmware and silicon-verified on the bench
         // TIM2 (2026-06-11): CC1IF pends the NVIC line with the CPU halted.
-        if (self.sr & self.dier & 0x1F) != 0 {
+        if self.irq_level_held() {
             return crate::PeripheralTickResult {
                 irq: true,
-                cycles: 1,
+                cycles: 0,
                 ..Default::default()
             };
         }
@@ -335,14 +704,14 @@ impl crate::Peripheral for Timer {
             };
         }
 
-        self.psc_cnt = self.psc_cnt.wrapping_add(1);
-        if self.psc_cnt > self.psc {
-            self.psc_cnt = 0;
-            self.cnt = self.cnt.wrapping_add(1);
+        self.psc_cnt.set(self.psc_cnt.get().wrapping_add(1));
+        if self.psc_cnt.get() > self.psc {
+            self.psc_cnt.set(0);
+            self.cnt.set(self.cnt.get().wrapping_add(1));
 
-            if self.cnt > self.arr {
-                self.cnt = 0;
-                self.sr |= 1; // Set UIF (Update Interrupt Flag)
+            if self.cnt.get() > self.arr {
+                self.cnt.set(0);
+                self.sr.set(self.sr.get() | 1); // Set UIF (Update Interrupt Flag)
                 if !self.basic {
                     self.latch_compare_match_flags();
                 }
@@ -350,7 +719,7 @@ impl crate::Peripheral for Timer {
                 // Return true if Update Interrupt Enable (UIE) is set
                 return crate::PeripheralTickResult {
                     irq: (self.dier & 1) != 0,
-                    cycles: 1,
+                    cycles: 0,
                     dma_signals: None,
                     ..Default::default()
                 };
@@ -372,7 +741,104 @@ impl crate::Peripheral for Timer {
         }
     }
 
+    fn uses_scheduler(&self) -> bool {
+        // True once the bus attached its cycle clock (event-scheduler builds):
+        // reads stay fresh through the lazy `advance_to` path and update/
+        // compare IRQs ride scheduled events, so the walk is unnecessary.
+        // Without a clock (feature off / hand-built buses) stay on the legacy
+        // walk with exact historical semantics.
+        self.scheduler_mode()
+    }
+
+    fn needs_legacy_walk(&self) -> bool {
+        // Everything this model's `tick()` can ever do (prescaled up-count,
+        // UIF/CCxIF latching, held-level NVIC pend) is event-expressible —
+        // SMCR external-clock/encoder modes are inert register bits the walk
+        // ignores identically, so no configuration needs a dynamic fallback.
+        // In legacy mode (no clock / feature off) the walk does real work and
+        // the conservative `true` stands.
+        !self.scheduler_mode()
+    }
+
+    fn sync_to(&mut self, now_cycle: u64) {
+        if self.scheduler_mode() {
+            self.advance_to(now_cycle);
+        }
+    }
+
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if !self.scheduler_mode() {
+            return Vec::new();
+        }
+        // Kill any in-flight chain: the configuration (or counter) may have
+        // just changed under this write, so its deadline is stale. The fresh
+        // chain below carries the new token.
+        self.arm_seq = self.arm_seq.wrapping_add(1);
+        // `collect_scheduled_events` converts to `current_cycle + 1 + delay`;
+        // the first pend lands `d` walk ticks after the just-synced state,
+        // i.e. at absolute cycle `current_cycle + d` — hence `d - 1`
+        // (d >= 1 always: a held level pends on the next tick, d == 1).
+        self.ticks_until_first_pend()
+            .map(|d| vec![(d - 1, self.arm_seq)])
+            .unwrap_or_default()
+    }
+
+    fn on_event(
+        &mut self,
+        event_token: u32,
+        sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if !self.scheduler_mode() || event_token != self.arm_seq {
+            // Stale chain (re-armed since this event was scheduled): die.
+            return crate::sched::EventResult::default();
+        }
+        // Bring the lazy counter up to the drain cycle; this is what
+        // materialises the update/compare latch this event was scheduled for.
+        self.advance_to(sched.now());
+        if self.irq_level_held() {
+            // The walk would return `irq: true` on this tick (overflow with
+            // UIE, or the held level after a compare latch) and on every tick
+            // after until firmware clears SR/DIER — perpetuate at delay 1,
+            // pending the peripheral's own NVIC line through the same
+            // `pend_irq_for_event` choke the legacy walk uses. Re-pends merge
+            // in ISPR exactly as the walk's per-tick pends do.
+            crate::sched::EventResult {
+                raise_own_irq: true,
+                reschedule_delay: Some(1),
+                ..Default::default()
+            }
+        } else {
+            // Not (yet) pending — defensively re-arm at the next computed
+            // fire so the chain never silently dies while events are armed.
+            crate::sched::EventResult {
+                reschedule_delay: self.ticks_until_first_pend(),
+                ..Default::default()
+            }
+        }
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        // Anchor at the clock's current value so cycles that elapsed before
+        // attach (normally zero — attach happens at bus assembly) are not
+        // retroactively replayed into the counter.
+        self.anchor.set(clock.now());
+        self.clock = Some(clock);
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
     fn snapshot(&self) -> serde_json::Value {
+        // Sync first so the serialized CNT/SR reflect "now" (scheduler mode);
+        // no-op in legacy mode. Keeps the snapshot shape identical across
+        // drive modes for the determinism gates.
+        self.sync_from_clock();
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }
 }
@@ -479,5 +945,407 @@ mod tests {
         assert_eq!(tim.read(0x44).unwrap(), 0x00);
         tim.write(0x30, 0x05).unwrap(); // RCR — should no-op
         assert_eq!(tim.read(0x30).unwrap(), 0x00);
+    }
+
+    #[test]
+    fn without_clock_stays_on_legacy_tick_path() {
+        let tim = Timer::new();
+        assert!(
+            !tim.uses_scheduler(),
+            "no cycle clock attached → the model must stay on the legacy walk \
+             (hand-built buses that bypass the registration chokes keep exact semantics)"
+        );
+        assert!(tim.needs_legacy_walk());
+    }
+
+    /// The legacy tick charges ZERO cycle cost in every state (B2/B3 tick-cost
+    /// normalization): an armed, overflowing, and held-level timer must never
+    /// inflate `total_cycles`, so the walk-on reference and the scheduler path
+    /// agree cycle-for-cycle.
+    #[test]
+    fn legacy_tick_charges_zero_cost_in_every_state() {
+        let mut tim = Timer::new();
+        tim.write_reg(0x2C, 1); // ARR = 1
+        tim.write_reg(0x0C, 1); // DIER = UIE
+        tim.write_reg(0x00, 1); // CR1 = CEN
+        for _ in 0..10 {
+            // Covers counting ticks, the overflow tick, and held-level ticks.
+            assert_eq!(tim.tick().cycles, 0);
+        }
+    }
+
+    #[cfg(feature = "event-scheduler")]
+    mod scheduler_mode {
+        use super::*;
+        use crate::CycleClock;
+
+        /// Mirror of the legacy per-tick walk semantics, kept in the test as
+        /// an independent oracle: returns whether the walk pends the NVIC
+        /// line on this tick.
+        fn walk_tick_oracle(t: &mut Timer) -> bool {
+            t.tick().irq
+        }
+
+        /// Drive a scheduler-mode timer exactly the way `Machine` +
+        /// `SystemBus` do at tick interval 1: publish the clock each cycle,
+        /// convert write-armed events at `cycle + 1 + delay`, drain due
+        /// events through `on_event` (rescheduling at `now + delay`), and
+        /// record the cycles on which the event chain pends the own-IRQ.
+        struct SchedHarness {
+            tim: Timer,
+            clock: CycleClock,
+            sched: crate::sched::EventScheduler,
+            bus: crate::bus::SystemBus,
+            /// (deadline, token) — at most one live chain plus stale tokens.
+            events: Vec<(u64, u32)>,
+            now: u64,
+        }
+
+        impl SchedHarness {
+            fn new(tim: Timer) -> Self {
+                let clock = CycleClock::default();
+                let mut tim = tim;
+                tim.attach_cycle_clock(clock.clone());
+                Self {
+                    tim,
+                    clock,
+                    sched: crate::sched::EventScheduler::new(),
+                    bus: crate::bus::SystemBus::new(),
+                    events: Vec::new(),
+                    now: 0,
+                }
+            }
+
+            /// MMIO write at the current cycle, through the bus chokes'
+            /// contract: sync first, write, then harvest `(delay, token)`
+            /// as `now + 1 + delay` (the `collect_scheduled_events` identity).
+            fn write(&mut self, offset: u64, value: u32) {
+                self.tim.sync_to(self.now);
+                self.tim.write_reg(offset, value);
+                for (delay, token) in self.tim.take_scheduled_events() {
+                    self.events.push((self.now + 1 + delay, token));
+                }
+            }
+
+            /// Advance one cycle and drain due events; returns true if the
+            /// chain pended the own-IRQ this cycle.
+            fn step(&mut self) -> bool {
+                self.now += 1;
+                self.clock.publish(self.now);
+                self.sched.advance_to(self.now);
+                let mut pended = false;
+                let due: Vec<(u64, u32)> = self
+                    .events
+                    .iter()
+                    .copied()
+                    .filter(|(d, _)| *d <= self.now)
+                    .collect();
+                self.events.retain(|(d, _)| *d > self.now);
+                for (_, token) in due {
+                    let res = self.tim.on_event(token, &mut self.sched, &mut self.bus);
+                    if res.raise_own_irq {
+                        pended = true;
+                    }
+                    if let Some(delay) = res.reschedule_delay {
+                        self.events.push((self.now + delay, token));
+                    }
+                }
+                pended
+            }
+
+            fn state(&self) -> (u32, u32, u32) {
+                // Reads sync lazily, exactly like the MMIO read path.
+                self.tim.sync_from_clock();
+                (
+                    self.tim.cnt.get(),
+                    self.tim.sr.get(),
+                    self.tim.psc_cnt.get(),
+                )
+            }
+        }
+
+        /// The heart of the fidelity gate: replay the SAME register-write
+        /// script against (a) the legacy per-tick walk and (b) the lazy
+        /// closed-form + event-chain scheduler path, comparing full counter
+        /// state at EVERY cycle and the exact set of IRQ-pend cycles.
+        fn assert_walk_identical(
+            tim_factory: impl Fn() -> Timer,
+            script: &[(u64, u64, u32)], // (cycle, offset, value) — applied before that cycle's tick
+            cycles: u64,
+            what: &str,
+        ) {
+            let mut walk = tim_factory();
+            let mut sched = SchedHarness::new(tim_factory());
+
+            let mut walk_pends: Vec<u64> = Vec::new();
+            let mut sched_pends: Vec<u64> = Vec::new();
+
+            for c in 1..=cycles {
+                for &(sc, off, val) in script {
+                    // A write during the instruction ending at cycle `c`
+                    // syncs to `c - 1` (batch-start) — the harness models
+                    // that; the walk applies it before tick `c`.
+                    if sc == c {
+                        walk.write_reg(off, val);
+                        sched.now = c - 1;
+                        sched.write(off, val);
+                        sched.now = c - 1; // step() re-increments
+                    }
+                }
+                if walk_tick_oracle(&mut walk) {
+                    walk_pends.push(c);
+                }
+                sched.now = c - 1;
+                if sched.step() {
+                    sched_pends.push(c);
+                }
+                let (s_cnt, s_sr, s_psc) = sched.state();
+                assert_eq!(
+                    (walk.cnt.get(), walk.sr.get(), walk.psc_cnt.get()),
+                    (s_cnt, s_sr, s_psc),
+                    "{what}: state diverged at cycle {c}"
+                );
+            }
+            assert_eq!(
+                walk_pends, sched_pends,
+                "{what}: IRQ pend cycles diverged"
+            );
+        }
+
+        fn gp32() -> Timer {
+            Timer::new_with_layout(32, false)
+        }
+
+        #[test]
+        fn clock_attach_flips_to_scheduler_and_walk_tick_is_inert() {
+            let mut tim = Timer::new();
+            tim.attach_cycle_clock(CycleClock::default());
+            assert!(tim.uses_scheduler(), "clock attached → walk-independent");
+            assert!(!tim.needs_legacy_walk());
+            tim.write_reg(0x2C, 3);
+            tim.write_reg(0x00, 1);
+            let r = tim.tick();
+            assert!(!r.irq);
+            assert_eq!(tim.cnt.get(), 0, "tick inert in scheduler mode");
+        }
+
+        #[test]
+        fn update_event_walk_identity_across_psc_arr_grid() {
+            for psc in [0u32, 1, 2, 7] {
+                for arr in [1u32, 3, 10, 50] {
+                    let script = [
+                        (1u64, 0x28u64, psc), // PSC
+                        (1, 0x2C, arr),       // ARR
+                        (1, 0x0C, 1),         // DIER = UIE
+                        (1, 0x00, 1),         // CR1 = CEN
+                        // ISR-style SR clear a while after the first fire.
+                        (((psc as u64 + 1) * (arr as u64 + 1)) + 8, 0x10, 0),
+                    ];
+                    assert_walk_identical(
+                        Timer::new,
+                        &script,
+                        3 * (psc as u64 + 1) * (arr as u64 + 1) + 40,
+                        &format!("UIE psc={psc} arr={arr}"),
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn compare_match_walk_identity() {
+            for (psc, arr, ccr) in [(0u32, 20u32, 7u32), (2, 50, 0), (1, 10, 10), (0, 5, 9)] {
+                // ccr=9 > arr=5: unreachable compare — no event may ever fire.
+                let script = [
+                    (1u64, 0x28u64, psc),
+                    (1, 0x2C, arr),
+                    (1, 0x34, ccr),  // CCR1
+                    (1, 0x0C, 0x02), // DIER = CC1IE
+                    (1, 0x00, 1),
+                    ((psc as u64 + 1) * (arr as u64 + 2) + 15, 0x10, 0), // SR clear
+                ];
+                assert_walk_identical(
+                    Timer::new,
+                    &script,
+                    4 * (psc as u64 + 1) * (arr as u64 + 1) + 60,
+                    &format!("CC1IE psc={psc} arr={arr} ccr={ccr}"),
+                );
+            }
+        }
+
+        #[test]
+        fn polling_mode_walk_identity_no_dier() {
+            // DIER=0: pure lazy counting + flag latching, no freeze, no IRQs.
+            let script = [
+                (1u64, 0x28u64, 1u32),
+                (1, 0x2C, 6),
+                (1, 0x34, 3),
+                (1, 0x00, 1),
+                (40, 0x10, 0), // poll-loop style SR clear
+            ];
+            assert_walk_identical(Timer::new, &script, 120, "polling DIER=0");
+        }
+
+        #[test]
+        fn mid_run_reconfiguration_walk_identity() {
+            // PSC/ARR/CNT/CCR rewrites mid-count (immediate-apply semantics,
+            // no update-event buffering — the model's pinned behaviour),
+            // EGR.UG software update, DIER enable of an already-latched flag.
+            let script = [
+                (1u64, 0x28u64, 1u32), // PSC=1
+                (1, 0x2C, 30),         // ARR=30
+                (1, 0x0C, 1),          // UIE
+                (1, 0x00, 1),          // CEN
+                (20, 0x28, 5),         // PSC shrink/grow mid-count (immediate)
+                (35, 0x2C, 8),         // ARR below current CNT → wrap path
+                (50, 0x10, 0),         // clear SR
+                (60, 0x24, 100),       // CNT write above ARR
+                (70, 0x14, 1),         // EGR.UG software update
+                (90, 0x10, 0),
+                (95, 0x0C, 0x03), // DIER: UIE|CC1IE with CCR1 latched?
+                (110, 0x10, 0),
+            ];
+            assert_walk_identical(Timer::new, &script, 200, "mid-run reconfig");
+        }
+
+        #[test]
+        fn psc_rewrite_keeps_phase_walk_identity() {
+            // "PSC-buffered reload" honesty check: the model applies PSC
+            // immediately (no buffer register) and keeps the prescaler phase,
+            // including psc_cnt > PSC after a shrink — the scheduler path must
+            // reproduce the walk's exact phase, not silicon's buffered reload.
+            let script = [
+                (1u64, 0x28u64, 9u32), // PSC=9
+                (1, 0x2C, 100),
+                (1, 0x00, 1),
+                (7, 0x28, 2),  // shrink mid-phase (psc_cnt=6 > 2 → next tick bumps)
+                (30, 0x28, 0), // PSC=0: every tick increments
+            ];
+            assert_walk_identical(Timer::new, &script, 80, "psc rewrite phase");
+        }
+
+        #[test]
+        fn basic_timer_walk_identity() {
+            let script = [
+                (1u64, 0x28u64, 0u32),
+                (1, 0x2C, 4),
+                (1, 0x0C, 1),
+                (1, 0x00, 1),
+                (12, 0x10, 0),
+            ];
+            assert_walk_identical(|| Timer::new().basic(true), &script, 40, "basic TIM6/7");
+        }
+
+        #[test]
+        fn advanced_timer_cc5_cc6_lazy_latch_walk_identity() {
+            let script = [
+                (1u64, 0x28u64, 0u32),
+                (1, 0x2C, 10),
+                (1, 0x58, 4), // CCR5
+                (1, 0x5C, 7), // CCR6
+                (1, 0x00, 1),
+            ];
+            assert_walk_identical(
+                || Timer::new_with_layout(16, true),
+                &script,
+                40,
+                "advanced CC5/6 lazy latch",
+            );
+        }
+
+        #[test]
+        fn arr_max_32bit_never_wraps_walk_identity() {
+            // 32-bit reset ARR (0xFFFF_FFFF): the walk's `cnt > arr` can never
+            // fire — free-run with no UIF. UIE armed must produce NO pends.
+            let script = [(1u64, 0x0Cu64, 1u32), (1, 0x00, 1)];
+            assert_walk_identical(gp32, &script, 100, "32-bit ARR=MAX free-run");
+        }
+
+        #[test]
+        fn input_capture_channel_never_latches_or_fires() {
+            // CCMR1.CC1S != 0 (input capture): the walk skips the channel in
+            // latch_compare_match_flags; CC1IE must not schedule anything.
+            let script = [
+                (1u64, 0x18u64, 0x01u32), // CCMR1.CC1S = 01 (input)
+                (1, 0x28, 0),
+                (1, 0x2C, 6),
+                (1, 0x34, 3),
+                (1, 0x0C, 0x02), // CC1IE
+                (1, 0x00, 1),
+            ];
+            assert_walk_identical(Timer::new, &script, 50, "input-capture CC1S!=0");
+        }
+
+        #[test]
+        fn lazy_cnt_read_tracks_published_clock_exactly() {
+            let clock = CycleClock::default();
+            let mut tim = Timer::new();
+            tim.attach_cycle_clock(clock.clone());
+            // PSC=1 (increment every 2 ticks), ARR=5.
+            tim.sync_to(0);
+            tim.write_reg(0x28, 1);
+            tim.write_reg(0x2C, 5);
+            tim.write_reg(0x00, 1);
+            let _ = tim.take_scheduled_events();
+            clock.publish(4);
+            assert_eq!(tim.read_u32(0x24).unwrap(), 2, "2 increments in 4 ticks");
+            clock.publish(12);
+            // 6 increments: values 1..5 then wrap to 0 at j=6 → CNT=0, UIF.
+            assert_eq!(tim.read_u32(0x24).unwrap(), 0);
+            assert_eq!(tim.read_u32(0x10).unwrap() & 1, 1, "UIF latched lazily");
+        }
+
+        #[test]
+        fn take_scheduled_events_computes_exact_update_deadline() {
+            let clock = CycleClock::default();
+            let mut tim = Timer::new();
+            tim.attach_cycle_clock(clock.clone());
+            tim.sync_to(0);
+            tim.write_reg(0x28, 2); // PSC=2 → period 3
+            tim.write_reg(0x2C, 9); // ARR=9 → wrap at increment 10
+            tim.write_reg(0x0C, 1); // UIE
+            tim.write_reg(0x00, 1); // CEN
+            let evs = tim.take_scheduled_events();
+            // Fire at tick 3*10 = 30 after the synced state; bus adds
+            // current_cycle + 1 + delay → delay = 29.
+            assert_eq!(evs.len(), 1);
+            assert_eq!(evs[0].0, 29, "update-event delay must be exact");
+        }
+
+        #[test]
+        fn stale_event_chain_dies_on_token_mismatch() {
+            let clock = CycleClock::default();
+            let mut tim = Timer::new();
+            tim.attach_cycle_clock(clock.clone());
+            tim.sync_to(0);
+            tim.write_reg(0x2C, 4);
+            tim.write_reg(0x0C, 1);
+            tim.write_reg(0x00, 1);
+            let old_token = tim.take_scheduled_events()[0].1;
+            // Re-arm (e.g. CNT rewrite): kills the old chain.
+            tim.write_reg(0x24, 0);
+            let new_token = tim.take_scheduled_events()[0].1;
+            assert_ne!(old_token, new_token);
+            clock.publish(500);
+            let mut sched = crate::sched::EventScheduler::new();
+            sched.advance_to(500);
+            let mut bus = crate::bus::SystemBus::new();
+            let res = tim.on_event(old_token, &mut sched, &mut bus);
+            assert!(!res.raise_own_irq, "stale chain must be inert");
+            assert_eq!(res.reschedule_delay, None, "stale chain must not respawn");
+        }
+
+        #[test]
+        fn snapshot_shape_matches_legacy_mode() {
+            let legacy = Timer::new();
+            let mut sched = Timer::new();
+            sched.attach_cycle_clock(CycleClock::default());
+            let a = legacy.snapshot();
+            let b = sched.snapshot();
+            assert_eq!(
+                a.as_object().unwrap().keys().collect::<Vec<_>>(),
+                b.as_object().unwrap().keys().collect::<Vec<_>>(),
+                "snapshot shape must be identical across drive modes"
+            );
+        }
     }
 }

--- a/crates/core/src/peripherals/timer.rs
+++ b/crates/core/src/peripherals/timer.rs
@@ -400,7 +400,7 @@ impl Timer {
                 if let Some(j) = self.increments_to_value(v, ccr & mask) {
                     // Strict `<` keeps update-event precedence on a tie (the
                     // walk pends the overflow tick itself when UIE is set).
-                    if best.map_or(true, |(b, _)| j < b) {
+                    if best.is_none_or(|(b, _)| j < b) {
                         best = Some((j, false));
                     }
                 }
@@ -1106,10 +1106,7 @@ mod tests {
                     "{what}: state diverged at cycle {c}"
                 );
             }
-            assert_eq!(
-                walk_pends, sched_pends,
-                "{what}: IRQ pend cycles diverged"
-            );
+            assert_eq!(walk_pends, sched_pends, "{what}: IRQ pend cycles diverged");
         }
 
         fn gp32() -> Timer {

--- a/crates/core/tests/stm32_timer_walk_differential.rs
+++ b/crates/core/tests/stm32_timer_walk_differential.rs
@@ -1,0 +1,538 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential gates for walk-free batches **B2/B3** (STM32 TIMx → event
+//! scheduler), in the `systick_walk_differential` (B1) style: the SAME
+//! hand-built Cortex-M machine and hand-assembled Thumb firmware run twice —
+//! once with the timer pinned back onto the per-cycle walk
+//! (`force_legacy_walk`, the reference) and once scheduler-driven — and every
+//! observable is compared.
+//!
+//! 1. `update_irq_firmware_is_byte_identical_at_interval_1` — a firmware that
+//!    arms TIM (PSC/ARR/DIER.UIE/CR1.CEN), polls `CNT` from its main loop
+//!    (the lazy-read surface), and takes the update IRQ through the NVIC
+//!    (line 28 → exception 44). Probed after EVERY instruction: total_cycles,
+//!    PC, all 16 core registers and both RAM counters must be byte-identical
+//!    at tick interval 1 — which pins the NVIC IRQ delivery cycles (including
+//!    the legacy level-repend double-entry artifact), the held-level counter
+//!    freeze, and the lazy CNT reads exactly.
+//!
+//! 2. `compare_match_irq_firmware_is_byte_identical_at_interval_1` — the CCR1
+//!    compare-match leg (DIER.CC1IE): the CCxIF latch lands on the match tick
+//!    and the level pend on the NEXT tick, exactly like the walk.
+//!
+//! 3. `mid_run_reconfig_firmware_is_byte_identical_at_interval_1` — firmware
+//!    rewrites PSC and ARR mid-count and issues a software update (EGR.UG):
+//!    the model's immediate-apply prescaler semantics (NO buffered reload —
+//!    a pinned limitation, silicon buffers PSC until the update event) and
+//!    the pending-event cancel/re-arm on every write are held identical.
+//!
+//! 4. `cnt_sr_poll_firmware_is_byte_identical_at_interval_1` — the DIER=0
+//!    polling shape (no freeze, no IRQs): raw CNT + lazily-latched SR reads
+//!    every loop pass.
+//!
+//! 5. `wrap_count_is_exact_at_interval_64` — the scheduler lane at tick
+//!    interval 64 vs the walk-on interval-1 golden reference, on the DIER=0
+//!    UIF-poll-and-clear shape: lazy reads are quantised to the batch grid
+//!    (documented, ≤ one interval), but the latched UIF can never be missed,
+//!    so the observed update-event count over a fixed instruction window is
+//!    EXACT (absolute closed-form deadlines — no cumulative drift), provided
+//!    no wrap lands within one interval of the window edge (asserted from the
+//!    reference's own trace).
+//!
+//!    The IRQ-enabled (UIE) shape is deliberately NOT count-compared at
+//!    interval 64: the legacy level-repend during the ISR's flag-clear window
+//!    (a faithful NVIC artifact, pinned byte-exact at interval 1 by gate 1)
+//!    is sampled on the tick grid, so at interval 64 the mid-interval
+//!    re-pends legitimately collapse — the same ≤-one-interval quantisation
+//!    the write-path `sync_to` documents, and strictly better than the
+//!    pre-migration walk at interval 64 (which slowed the whole counter 64×).
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::CortexM;
+use labwired_core::peripherals::timer::Timer;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{DebugControl, Machine};
+
+/// ISR increment target.
+const ISR_COUNT_ADDR: u64 = 0x2000_0000;
+/// Main-loop increment target.
+const MAIN_COUNT_ADDR: u64 = 0x2000_0004;
+const INITIAL_SP: u32 = 0x2000_8000;
+
+const TIM_BASE: u32 = 0x4000_0000;
+/// NVIC position for the hand-built TIM entry (TIM2 on STM32L4/F1) —
+/// exception number 16 + 28 = 44, vector at 44*4 = 0xB0.
+const TIM_IRQ: u32 = 28;
+const NVIC_ISER0: u32 = 0xE000_E100;
+
+fn load_thumb(bus: &mut SystemBus, base: u64, halfwords: &[u16]) {
+    for (i, hw) in halfwords.iter().enumerate() {
+        bus.write_u16(base + (i as u64) * 2, *hw).unwrap();
+    }
+}
+
+fn write_word(bus: &mut SystemBus, addr: u64, word: u32) {
+    bus.write_u32(addr, word).unwrap();
+}
+
+/// Build the shared machine assembly: `SystemBus::new()` +
+/// `configure_cortex_m` (real SCB/NVIC/DWT) + a native `Timer` registered at
+/// `TIM_BASE` with NVIC line 28 through `add_peripheral` — which attaches the
+/// bus cycle clock exactly as the production `from_config` choke would.
+/// `scheduler = false` then pins the timer back onto the legacy walk
+/// (`force_legacy_walk`) to form the reference lane from the same assembly.
+fn build_machine(scheduler: bool, tick_interval: u32) -> Machine<CortexM> {
+    let mut bus = SystemBus::new();
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+
+    bus.add_peripheral(
+        "tim2",
+        TIM_BASE as u64,
+        0x400,
+        Some(TIM_IRQ),
+        Box::new(Timer::new()),
+    );
+
+    if !scheduler {
+        let idx = bus.find_peripheral_index_by_name("tim2").unwrap();
+        bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Timer>()
+            .unwrap()
+            .force_legacy_walk();
+    }
+
+    let mut machine = Machine::new(cpu, bus);
+    machine.config.peripheral_tick_interval = tick_interval;
+    machine.bus.config.peripheral_tick_interval = tick_interval;
+    machine.cpu.sp = INITIAL_SP;
+    machine
+}
+
+/// The shared ISR at 0x80: clear TIM SR (all flags), then increment the word
+/// at `ISR_COUNT_ADDR` and return.
+///
+///   0x80: 4803  ldr r0, [pc, #12]   ; = TIM_BASE (pool at 0x90)
+///   0x82: 2100  movs r1, #0
+///   0x84: 6101  str r1, [r0, #0x10] ; SR = 0 (rc_w0 clears every flag)
+///   0x86: 4803  ldr r0, [pc, #12]   ; = ISR_COUNT_ADDR (pool at 0x94)
+///   0x88: 6801  ldr r1, [r0]
+///   0x8A: 3101  adds r1, #1
+///   0x8C: 6001  str r1, [r0]
+///   0x8E: 4770  bx lr
+///   0x90: .word TIM_BASE
+///   0x94: .word ISR_COUNT_ADDR
+const ISR_BASE: u64 = 0x80;
+fn load_isr(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        ISR_BASE,
+        &[
+            0x4803, 0x2100, 0x6101, 0x4803, 0x6801, 0x3101, 0x6001, 0x4770,
+        ],
+    );
+    write_word(bus, ISR_BASE + 0x10, TIM_BASE);
+    write_word(bus, ISR_BASE + 0x14, ISR_COUNT_ADDR as u32);
+    // Vector for exception 16 + TIM_IRQ = 44 → offset 0xB0.
+    write_word(bus, (16 + TIM_IRQ) as u64 * 4, (ISR_BASE as u32) | 1);
+}
+
+/// Firmware A — arm the update interrupt: NVIC enable line 28, PSC=2, ARR=50,
+/// DIER=UIE, CR1=CEN; then spin incrementing the main counter while polling
+/// `CNT` (the lazy-read surface).
+///
+///   0x40: 4808  ldr r0, [pc, #32]   ; = NVIC_ISER0 (pool at 0x64)
+///   0x42: 4909  ldr r1, [pc, #36]   ; = 1 << 28    (pool at 0x68)
+///   0x44: 6001  str r1, [r0]
+///   0x46: 4809  ldr r0, [pc, #36]   ; = TIM_BASE   (pool at 0x6C)
+///   0x48: 2102  movs r1, #2
+///   0x4A: 6281  str r1, [r0, #0x28] ; PSC = 2
+///   0x4C: 2132  movs r1, #50
+///   0x4E: 62C1  str r1, [r0, #0x2C] ; ARR = 50
+///   0x50: 2101  movs r1, #1
+///   0x52: 60C1  str r1, [r0, #0x0C] ; DIER = UIE
+///   0x54: 6001  str r1, [r0, #0x00] ; CR1 = CEN
+///   0x56: 4A06  ldr r2, [pc, #24]   ; = MAIN_COUNT_ADDR (pool at 0x70)
+///   0x58: 2300  movs r3, #0
+///   loop:
+///   0x5A: 3301  adds r3, #1
+///   0x5C: 6013  str r3, [r2]
+///   0x5E: 6A44  ldr r4, [r0, #0x24] ; poll CNT (lazy read)
+///   0x60: E7FB  b loop
+///   0x62: BF00  nop (pool align)
+fn load_firmware_update_irq(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x4808, 0x4909, 0x6001, 0x4809, 0x2102, 0x6281, 0x2132, 0x62C1, 0x2101, 0x60C1, 0x6001,
+            0x4A06, 0x2300, 0x3301, 0x6013, 0x6A44, 0xE7FB, 0xBF00,
+        ],
+    );
+    write_word(bus, 0x64, NVIC_ISER0);
+    write_word(bus, 0x68, 1 << TIM_IRQ);
+    write_word(bus, 0x6C, TIM_BASE);
+    write_word(bus, 0x70, MAIN_COUNT_ADDR as u32);
+    load_isr(bus);
+}
+
+/// Firmware B — the compare-match leg: CCR1=30, DIER=CC1IE, ARR=50, PSC=2.
+///
+///   0x40: 4809  ldr r0, [pc, #36]   ; = NVIC_ISER0 (pool at 0x68)
+///   0x42: 490A  ldr r1, [pc, #40]   ; = 1 << 28    (pool at 0x6C)
+///   0x44: 6001  str r1, [r0]
+///   0x46: 480A  ldr r0, [pc, #40]   ; = TIM_BASE   (pool at 0x70)
+///   0x48: 2102  movs r1, #2
+///   0x4A: 6281  str r1, [r0, #0x28] ; PSC = 2
+///   0x4C: 2132  movs r1, #50
+///   0x4E: 62C1  str r1, [r0, #0x2C] ; ARR = 50
+///   0x50: 211E  movs r1, #30
+///   0x52: 6341  str r1, [r0, #0x34] ; CCR1 = 30
+///   0x54: 2102  movs r1, #2
+///   0x56: 60C1  str r1, [r0, #0x0C] ; DIER = CC1IE
+///   0x58: 2101  movs r1, #1
+///   0x5A: 6001  str r1, [r0, #0x00] ; CR1 = CEN
+///   0x5C: 4A05  ldr r2, [pc, #20]   ; = MAIN_COUNT_ADDR (pool at 0x74)
+///   0x5E: 2300  movs r3, #0
+///   loop:
+///   0x60: 3301  adds r3, #1
+///   0x62: 6013  str r3, [r2]
+///   0x64: 6A44  ldr r4, [r0, #0x24] ; poll CNT
+///   0x66: E7FB  b loop
+fn load_firmware_compare_irq(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x4809, 0x490A, 0x6001, 0x480A, 0x2102, 0x6281, 0x2132, 0x62C1, 0x211E, 0x6341, 0x2102,
+            0x60C1, 0x2101, 0x6001, 0x4A05, 0x2300, 0x3301, 0x6013, 0x6A44, 0xE7FB,
+        ],
+    );
+    write_word(bus, 0x68, NVIC_ISER0);
+    write_word(bus, 0x6C, 1 << TIM_IRQ);
+    write_word(bus, 0x70, TIM_BASE);
+    write_word(bus, 0x74, MAIN_COUNT_ADDR as u32);
+    load_isr(bus);
+}
+
+/// Firmware C — mid-run reconfiguration: arm PSC=1/ARR=30/UIE, poll CNT for
+/// 200 loop passes (several update IRQs land), then rewrite PSC=5, ARR=20 and
+/// fire a software update (EGR.UG); spin polling after.
+///
+///   0x40: 480B  ldr r0, [pc, #44]   ; = NVIC_ISER0 (pool at 0x70)
+///   0x42: 490C  ldr r1, [pc, #48]   ; = 1 << 28    (pool at 0x74)
+///   0x44: 6001  str r1, [r0]
+///   0x46: 480C  ldr r0, [pc, #48]   ; = TIM_BASE   (pool at 0x78)
+///   0x48: 2101  movs r1, #1
+///   0x4A: 6281  str r1, [r0, #0x28] ; PSC = 1
+///   0x4C: 211E  movs r1, #30
+///   0x4E: 62C1  str r1, [r0, #0x2C] ; ARR = 30
+///   0x50: 2101  movs r1, #1
+///   0x52: 60C1  str r1, [r0, #0x0C] ; DIER = UIE
+///   0x54: 6001  str r1, [r0, #0x00] ; CR1 = CEN
+///   0x56: 25C8  movs r5, #200
+///   d1:
+///   0x58: 6A44  ldr r4, [r0, #0x24] ; poll CNT
+///   0x5A: 3D01  subs r5, #1
+///   0x5C: D1FC  bne d1
+///   0x5E: 2105  movs r1, #5
+///   0x60: 6281  str r1, [r0, #0x28] ; PSC = 5 (immediate-apply, mid-phase)
+///   0x62: 2114  movs r1, #20
+///   0x64: 62C1  str r1, [r0, #0x2C] ; ARR = 20
+///   0x66: 2101  movs r1, #1
+///   0x68: 6141  str r1, [r0, #0x14] ; EGR.UG (software update)
+///   loop:
+///   0x6A: 3301  adds r3, #1
+///   0x6C: 6A44  ldr r4, [r0, #0x24]
+///   0x6E: E7FC  b loop
+fn load_firmware_reconfig(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x480B, 0x490C, 0x6001, 0x480C, 0x2101, 0x6281, 0x211E, 0x62C1, 0x2101, 0x60C1, 0x6001,
+            0x25C8, 0x6A44, 0x3D01, 0xD1FC, 0x2105, 0x6281, 0x2114, 0x62C1, 0x2101, 0x6141, 0x3301,
+            0x6A44, 0xE7FC,
+        ],
+    );
+    write_word(bus, 0x70, NVIC_ISER0);
+    write_word(bus, 0x74, 1 << TIM_IRQ);
+    write_word(bus, 0x78, TIM_BASE);
+    load_isr(bus);
+}
+
+/// Firmware D — the DIER=0 polling shape: PSC=3, ARR=9, no interrupts; every
+/// loop pass stores raw CNT and SR to RAM (the lazily-latched-flag surface).
+///
+///   0x40: 4807  ldr r0, [pc, #28]   ; = TIM_BASE (pool at 0x60)
+///   0x42: 2103  movs r1, #3
+///   0x44: 6281  str r1, [r0, #0x28] ; PSC = 3
+///   0x46: 2109  movs r1, #9
+///   0x48: 62C1  str r1, [r0, #0x2C] ; ARR = 9
+///   0x4A: 2101  movs r1, #1
+///   0x4C: 6001  str r1, [r0, #0x00] ; CR1 = CEN
+///   0x4E: 4A05  ldr r2, [pc, #20]   ; = 0x2000_0008 (pool at 0x64)
+///   loop:
+///   0x50: 6A44  ldr r4, [r0, #0x24] ; CNT
+///   0x52: 6014  str r4, [r2]
+///   0x54: 6905  ldr r5, [r0, #0x10] ; SR (lazy latch surface)
+///   0x56: 6055  str r5, [r2, #4]
+///   0x58: E7FA  b loop
+///   0x5A: BF00  nop
+///   0x5C: BF00  nop (pool align)
+fn load_firmware_poll(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x4807, 0x2103, 0x6281, 0x2109, 0x62C1, 0x2101, 0x6001, 0x4A05, 0x6A44, 0x6014, 0x6905,
+            0x6055, 0xE7FA, 0xBF00, 0xBF00,
+        ],
+    );
+    write_word(bus, 0x60, TIM_BASE);
+    write_word(bus, 0x64, 0x2000_0008);
+}
+
+/// Firmware E — the interval-64 count gate: DIER=0, PSC=3, ARR=99 (update
+/// every 400 cycles); the main loop polls SR, and on UIF clears SR and
+/// increments the wrap counter at `MAIN_COUNT_ADDR`. The latched flag cannot
+/// be missed at any tick interval, so the wrap count is exact.
+///
+///   0x40: 4809  ldr r0, [pc, #36]   ; = TIM_BASE (pool at 0x68)
+///   0x42: 2103  movs r1, #3
+///   0x44: 6281  str r1, [r0, #0x28] ; PSC = 3
+///   0x46: 2163  movs r1, #99
+///   0x48: 62C1  str r1, [r0, #0x2C] ; ARR = 99
+///   0x4A: 2101  movs r1, #1
+///   0x4C: 6001  str r1, [r0, #0x00] ; CR1 = CEN (DIER stays 0)
+///   0x4E: 4A07  ldr r2, [pc, #28]   ; = MAIN_COUNT_ADDR (pool at 0x6C)
+///   loop:
+///   0x50: 6905  ldr r5, [r0, #0x10] ; SR (lazy latch surface)
+///   0x52: 07ED  lsls r5, r5, #31    ; UIF → bit 31, sets Z
+///   0x54: D004  beq skip
+///   0x56: 2100  movs r1, #0
+///   0x58: 6101  str r1, [r0, #0x10] ; clear SR
+///   0x5A: 6813  ldr r3, [r2]
+///   0x5C: 3301  adds r3, #1
+///   0x5E: 6013  str r3, [r2]        ; wrap_count++
+///   skip:
+///   0x60: E7F6  b loop
+///   0x62: BF00  nop
+///   0x64: BF00  nop (pool align)
+fn load_firmware_wrap_poll(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x4809, 0x2103, 0x6281, 0x2163, 0x62C1, 0x2101, 0x6001, 0x4A07, 0x6905, 0x07ED, 0xD004,
+            0x2100, 0x6101, 0x6813, 0x3301, 0x6013, 0xE7F6, 0xBF00, 0xBF00,
+        ],
+    );
+    write_word(bus, 0x68, TIM_BASE);
+    write_word(bus, 0x6C, MAIN_COUNT_ADDR as u32);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Probe {
+    step: u64,
+    total_cycles: u64,
+    pc: u32,
+    regs: [u32; 16],
+    isr_count: u32,
+    main_count: u32,
+    poll_out: [u32; 2],
+}
+
+fn probe(machine: &Machine<CortexM>, step: u64) -> Probe {
+    let mut regs = [0u32; 16];
+    for (i, r) in regs.iter_mut().enumerate() {
+        *r = machine.read_core_reg(i as u8);
+    }
+    Probe {
+        step,
+        total_cycles: machine.total_cycles,
+        pc: machine.get_pc(),
+        regs,
+        isr_count: machine.bus.read_u32(ISR_COUNT_ADDR).unwrap(),
+        main_count: machine.bus.read_u32(MAIN_COUNT_ADDR).unwrap(),
+        poll_out: [
+            machine.bus.read_u32(0x2000_0008).unwrap(),
+            machine.bus.read_u32(0x2000_000C).unwrap(),
+        ],
+    }
+}
+
+/// Run `steps` instructions one at a time through the batched `Machine::run`
+/// path (the production path the scheduler timing convention is calibrated
+/// to), probing the full architectural state after every instruction.
+fn run_probed(machine: &mut Machine<CortexM>, entry: u32, steps: u64) -> Vec<Probe> {
+    machine.cpu.pc = entry;
+    let mut probes = Vec::with_capacity(steps as usize);
+    for s in 0..steps {
+        machine.run(Some(1)).unwrap();
+        probes.push(probe(machine, s + 1));
+    }
+    probes
+}
+
+fn assert_probes_identical(reference: &[Probe], candidate: &[Probe], what: &str) {
+    assert_eq!(reference.len(), candidate.len());
+    for (r, c) in reference.iter().zip(candidate.iter()) {
+        assert_eq!(
+            r, c,
+            "{what}: first divergence at step {} (walk-reference vs scheduler)",
+            r.step
+        );
+    }
+}
+
+fn run_differential(
+    load: fn(&mut SystemBus),
+    steps: u64,
+    what: &str,
+) -> (Vec<Probe>, Vec<Probe>) {
+    let mut walk = build_machine(false, 1);
+    load(&mut walk.bus);
+    let walk_probes = run_probed(&mut walk, 0x40, steps);
+
+    let mut sched = build_machine(true, 1);
+    load(&mut sched.bus);
+    let sched_probes = run_probed(&mut sched, 0x40, steps);
+
+    assert_probes_identical(&walk_probes, &sched_probes, what);
+    (walk_probes, sched_probes)
+}
+
+/// Gate 1: update-event (UIF/UIE) NVIC IRQ + lazy CNT polling — walk-on vs
+/// scheduler at tick interval 1, every instruction-boundary observable
+/// byte-identical (IRQ delivery cycles including the level-repend artifact,
+/// held-level counter freeze, ISR execution count, total_cycles, registers —
+/// r4 carries the raw CNT poll).
+#[test]
+fn update_irq_firmware_is_byte_identical_at_interval_1() {
+    const STEPS: u64 = 4_000;
+    let (walk_probes, _) = run_differential(
+        load_firmware_update_irq,
+        STEPS,
+        "timer update-IRQ firmware",
+    );
+    let last = walk_probes.last().unwrap();
+    assert!(
+        last.isr_count >= 15,
+        "reference must take repeated update ISRs (got {})",
+        last.isr_count
+    );
+    assert!(last.main_count > 300, "main loop must run");
+}
+
+/// Gate 2: compare-match (CC1IF/CC1IE) — the latch lands on the match tick,
+/// the level pend one tick later; byte-identity pins both.
+#[test]
+fn compare_match_irq_firmware_is_byte_identical_at_interval_1() {
+    const STEPS: u64 = 4_000;
+    let (walk_probes, _) = run_differential(
+        load_firmware_compare_irq,
+        STEPS,
+        "timer compare-IRQ firmware",
+    );
+    let last = walk_probes.last().unwrap();
+    assert!(
+        last.isr_count >= 15,
+        "reference must take repeated compare ISRs (got {})",
+        last.isr_count
+    );
+}
+
+/// Gate 3: mid-run PSC/ARR rewrite + EGR.UG — reconfiguration must cancel and
+/// re-arm the event chain at the exact walk cycles (immediate-apply PSC
+/// phase, the model's pinned no-buffered-reload semantics).
+#[test]
+fn mid_run_reconfig_firmware_is_byte_identical_at_interval_1() {
+    const STEPS: u64 = 4_000;
+    let (walk_probes, _) = run_differential(
+        load_firmware_reconfig,
+        STEPS,
+        "timer mid-run-reconfig firmware",
+    );
+    let last = walk_probes.last().unwrap();
+    assert!(
+        last.isr_count >= 5,
+        "reference must take ISRs across the reconfiguration (got {})",
+        last.isr_count
+    );
+}
+
+/// Gate 4: DIER=0 polling — lazy CNT and lazily-latched SR flag reads with no
+/// freeze and no IRQs, byte-identical every instruction.
+#[test]
+fn cnt_sr_poll_firmware_is_byte_identical_at_interval_1() {
+    const STEPS: u64 = 2_000;
+    let (walk_probes, _) =
+        run_differential(load_firmware_poll, STEPS, "timer CNT/SR poll firmware");
+    let last = walk_probes.last().unwrap();
+    assert!(
+        last.poll_out[1] & 1 == 1 || walk_probes.iter().any(|p| p.poll_out[1] & 1 == 1),
+        "the poll loop must observe a lazily-latched UIF"
+    );
+}
+
+/// Gate 5: scheduler @ interval 64 vs the walk-on interval-1 golden
+/// reference, on the DIER=0 UIF-poll-and-clear shape. Lazy reads quantise to
+/// the batch grid (≤ one interval, documented), so per-instruction state is
+/// NOT compared — but the latched UIF can never be missed, so the observed
+/// update-event count over the fixed window must be EXACT (absolute
+/// closed-form deadlines — no cumulative drift), with the window edge
+/// verified to be more than one interval + poll-loop length away from any
+/// wrap observation in the reference.
+#[test]
+fn wrap_count_is_exact_at_interval_64() {
+    const STEPS: u64 = 6_000;
+
+    let mut walk = build_machine(false, 1);
+    load_firmware_wrap_poll(&mut walk.bus);
+    let walk_probes = run_probed(&mut walk, 0x40, STEPS);
+
+    let mut sched = build_machine(true, 64);
+    load_firmware_wrap_poll(&mut sched.bus);
+    sched.cpu.pc = 0x40;
+    sched.run(Some(STEPS as u32)).unwrap();
+
+    let reference = walk_probes.last().unwrap();
+    let sched_count = sched.bus.read_u32(MAIN_COUNT_ADDR).unwrap();
+
+    // Quantisation can only DELAY an observation (lazy reads trail by < one
+    // interval; the poll loop adds a bounded lag). The count can only differ
+    // if the last wrap observation sits within ~(64 + loop length) cycles of
+    // the window edge — verify the fixture stays clear (wrap period is 400).
+    let last_observation_step = walk_probes
+        .iter()
+        .zip(walk_probes.iter().skip(1))
+        .filter(|(a, b)| b.main_count > a.main_count)
+        .map(|(_, b)| b.step)
+        .next_back()
+        .expect("reference observes at least one wrap");
+    assert!(
+        STEPS - last_observation_step > 100,
+        "fixture must keep the window edge > interval + poll lag from the last \
+         wrap observation (last at step {last_observation_step})"
+    );
+
+    assert!(
+        reference.main_count >= 10,
+        "reference must observe repeated update events (got {})",
+        reference.main_count
+    );
+    assert_eq!(
+        sched_count, reference.main_count,
+        "update-event count over the fixed window must be exact at interval 64"
+    );
+    // total_cycles advances one per instruction in both lanes (B2/B3 removed
+    // the legacy timer tick-cost artifact), so the window length matches.
+    assert_eq!(sched.total_cycles, reference.total_cycles);
+}

--- a/crates/core/tests/stm32_timer_walk_differential.rs
+++ b/crates/core/tests/stm32_timer_walk_differential.rs
@@ -392,11 +392,7 @@ fn assert_probes_identical(reference: &[Probe], candidate: &[Probe], what: &str)
     }
 }
 
-fn run_differential(
-    load: fn(&mut SystemBus),
-    steps: u64,
-    what: &str,
-) -> (Vec<Probe>, Vec<Probe>) {
+fn run_differential(load: fn(&mut SystemBus), steps: u64, what: &str) -> (Vec<Probe>, Vec<Probe>) {
     let mut walk = build_machine(false, 1);
     load(&mut walk.bus);
     let walk_probes = run_probed(&mut walk, 0x40, steps);
@@ -417,11 +413,8 @@ fn run_differential(
 #[test]
 fn update_irq_firmware_is_byte_identical_at_interval_1() {
     const STEPS: u64 = 4_000;
-    let (walk_probes, _) = run_differential(
-        load_firmware_update_irq,
-        STEPS,
-        "timer update-IRQ firmware",
-    );
+    let (walk_probes, _) =
+        run_differential(load_firmware_update_irq, STEPS, "timer update-IRQ firmware");
     let last = walk_probes.last().unwrap();
     assert!(
         last.isr_count >= 15,

--- a/crates/hw-oracle/tests/h563_mmio_diff.rs
+++ b/crates/hw-oracle/tests/h563_mmio_diff.rs
@@ -1019,6 +1019,12 @@ fn sim_masked_read(sim: &mut SystemBus, case: &MmioCase) -> u32 {
             )
         });
     for _ in 0..case.settle_ticks {
+        // Advance the bus cycle clock alongside the walk (one cycle per
+        // tick), exactly as the Machine run loop does at tick interval 1:
+        // scheduler-driven models (the walk-free timers) derive their state
+        // lazily from the published clock instead of the walk.
+        let now = sim.current_cycle + 1;
+        sim.set_current_cycle(now);
         sim.tick_peripherals_fully();
     }
     let v = sim
@@ -1151,8 +1157,12 @@ mod hw {
         write_both(sim, oc, case.write.0, case.write.1);
         // Settle: the sim ticks its peripheral engines; silicon has been
         // running free since the write (each TCL round-trip is ~ms), so a
-        // matching settle on the hardware side is implicit.
+        // matching settle on the hardware side is implicit. The cycle clock
+        // advances alongside the walk (one cycle per tick) so scheduler-
+        // driven models (the walk-free timers) elapse the same time lazily.
         for _ in 0..case.settle_ticks {
+            let now = sim.current_cycle + 1;
+            sim.set_current_cycle(now);
             sim.tick_peripherals_fully();
         }
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -70,7 +70,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -166,7 +166,8 @@ boards:
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
     # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
-    drift_ack: 2026-07-11
+    # 2026-07-12: STM32 TIMx walk-free migration (timer.rs) — event-scheduler builds now derive CNT/SR lazily from the bus cycle clock (exact closed-form walk replay incl. the enabled-flag counter freeze) and deliver update/compare IRQs via scheduled events; the legacy walk path is byte-identical, pinned by committed differentials (stm32_timer_walk_differential + in-module walk-identity gates). The tick-cost sim artifact (cycles:1 charged on overflow/held-level ticks) is removed in both modes. Register layout, reset values and MMIO byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-12
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -308,7 +309,8 @@ boards:
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
     # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
-    drift_ack: 2026-07-11
+    # 2026-07-12: STM32 TIMx walk-free migration (timer.rs) — event-scheduler builds now derive CNT/SR lazily from the bus cycle clock (exact closed-form walk replay incl. the enabled-flag counter freeze) and deliver update/compare IRQs via scheduled events; the legacy walk path is byte-identical, pinned by committed differentials (stm32_timer_walk_differential + in-module walk-identity gates). The tick-cost sim artifact (cycles:1 charged on overflow/held-level ticks) is removed in both modes. Register layout, reset values and MMIO byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-12
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -359,7 +361,8 @@ boards:
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
     # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
-    drift_ack: 2026-07-11
+    # 2026-07-12: STM32 TIMx walk-free migration (timer.rs) — event-scheduler builds now derive CNT/SR lazily from the bus cycle clock (exact closed-form walk replay incl. the enabled-flag counter freeze) and deliver update/compare IRQs via scheduled events; the legacy walk path is byte-identical, pinned by committed differentials (stm32_timer_walk_differential + in-module walk-identity gates). The tick-cost sim artifact (cycles:1 charged on overflow/held-level ticks) is removed in both modes. Register layout, reset values and MMIO byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-12
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -407,7 +410,8 @@ boards:
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
     # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
-    drift_ack: 2026-07-11
+    # 2026-07-12: STM32 TIMx walk-free migration (timer.rs) — event-scheduler builds now derive CNT/SR lazily from the bus cycle clock (exact closed-form walk replay incl. the enabled-flag counter freeze) and deliver update/compare IRQs via scheduled events; the legacy walk path is byte-identical, pinned by committed differentials (stm32_timer_walk_differential + in-module walk-identity gates). The tick-cost sim artifact (cycles:1 charged on overflow/held-level ticks) is removed in both modes. Register layout, reset values and MMIO byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-12
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -462,7 +466,8 @@ boards:
     # 2026-07-09: read_gpio_pad — additive, READ-ONLY direction-aware pad probe accessor on the Peripheral trait + GpioPort (universal logic analyzer sampling). No register read/write path, reset value, or byte-path changed; mmio diffs/conformance unchanged. No live re-capture.
     # 2026-07-10: bus-trace single-choke-point refactor (attach wraps at SystemBus::attach_i2c_slave/attach_spi_device; no per-callsite set_bus_trace) + cycle stamp on trace events + gpio_routing/pin_routing metadata. Additive; oracle output unchanged.
     # 2026-07-11: STM32 SPI bit-level wire engine — classic/FIFO `Spi` DR writes now clock frames over derived wire time (CR1 BR/CPOL/CPHA/LSBFIRST + CR2.DS/CR1.DFF; SR flags flip at wire time — same firmware-visible completion timing, bits x 2^(BR+1) PCLK cycles, as the previous countdown) and GPIO ports gained read-only SPI AF pad routing (read_gpio_pad reads the live SCK/MOSI/MISO wire per the datasheet AF maps; H5's SPI-v3 model untouched). Register layouts, reset values and byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
-    drift_ack: 2026-07-11
+    # 2026-07-12: STM32 TIMx walk-free migration (timer.rs) — event-scheduler builds now derive CNT/SR lazily from the bus cycle clock (exact closed-form walk replay incl. the enabled-flag counter freeze) and deliver update/compare IRQs via scheduled events; the legacy walk path is byte-identical, pinned by committed differentials (stm32_timer_walk_differential + in-module walk-identity gates). The tick-cost sim artifact (cycles:1 charged on overflow/held-level ticks) is removed in both modes. Register layout, reset values and MMIO byte paths unchanged; mmio diffs/conformance unaffected. No live re-capture.
+    drift_ack: 2026-07-12
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
Walk-free plan batches **B2/B3**: migrate the shared STM32 TIMx model (all 11 instances on the L476 invaders bus) off the per-cycle legacy walk, following the B1 SysTick exemplar.

## Design

**Lazy CNT/SR (closed-form walk replay).** `cnt`/`sr`/`psc_cnt` move into `Cell`s; `advance_to(now)` replays the walk exactly in O(#channels) from the bus-published `CycleClock`: prescaler phase (`k1 = PSC − psc_cnt + 1`, then every `PSC+1`), counter trajectory, UIF + CC1..4IF (+ CC5/6IF on advanced) latching, and — critically — the **enabled-flag counter freeze**: the legacy `tick()` returns the held IRQ level *before* counting, so the counter stops on the tick an enabled flag latches and stays frozen until firmware clears SR/DIER. The replay freezes at exactly the same tick. `&self` reads sync first, so polled CNT/SR observe fresh time with no walk.

**Scheduled update/compare events.** Every MMIO write (bus sync+collect chokes) cancels the in-flight chain (`arm_seq` token) and re-arms at the exact first-pend tick computed in closed form: an overflow with UIE pends **on the overflow tick**; a compare match latches on the match tick and first pends **one tick later** (the walk's level check); a held level pends **every tick** via a delay-1 reschedule chain that dies when SR/DIER clears — reproducing the walk's per-tick level re-pend (including the faithful NVIC double-entry artifact when firmware clears the flag late in the ISR). Deadlines use the `current_cycle + 1 + delay` write identity / `now + delay` reschedule identity from #511.

**NVIC routing: reused, with one timing fix.** Events pend via the existing `EventResult::raise_own_irq` → `pend_irq_for_event` choke (no new mechanism). One real skew fixed in that choke: the legacy walk pends ISPR **and** scans ISPR&ISER into the CPU in the same `tick_peripherals` call, while the event drain runs after that scan — an event-raised IRQ left only in ISPR became CPU-visible one tick late. `pend_irq_for_event` now also pushes ISER-enabled pends as their exception number into the caller's `set_exception_pending` fan-out (ISPR-only when not enabled, picked up by the per-tick scan exactly like the walk). This aligns uart/spi event IRQs too; full suite is green.

**Tick-cost normalization (same as B1).** The legacy tick charged `cycles: 1` on overflow ticks and on *every* held-level tick — a sim artifact incompatible with walk deletion. Both modes now charge zero.

**Preserved limitations (deliberately, bit-for-bit):** PSC applies immediately (no buffered reload — silicon buffers until the update event; the walk did not, and the phase across a mid-count PSC rewrite, incl. `psc_cnt > PSC`, is reproduced); no ARPE preload; always up-counts (CR1 DIR/CMS/OPM inert); 32-bit `ARR == 0xFFFF_FFFF` never wraps (the walk's `cnt > arr` u32 check can never fire — free-run mod 2^32, no UIF); input-capture channels (CCxS≠0) never latch/fire; EGR/SR write quirks (persistent EGR readback, SR write clearing bit 17 unconditionally) untouched.

**No config kept on the walk:** SMCR (external clock/encoder) is an inert register bit the walk equally ignores, so scheduler mode is exactly as expressive as the walk for everything this model implements. `needs_legacy_walk()` is `false` only in scheduler mode; without a clock (featureless / hand-built buses) the model stays on the legacy walk with exact historical semantics (`force_legacy_walk()` test knob, as B1).

## Fidelity evidence

- **Model-level per-cycle identity** (unit, `timer.rs::scheduler_mode`): a harness drives the scheduler path exactly like `Machine` at interval 1 (publish/drain/write-choke identities) against the legacy `tick()` oracle, comparing **full state every cycle and the exact IRQ-pend cycle set** across a PSC×ARR grid, compare matches (incl. unreachable CCR > ARR), DIER=0 polling, mid-run PSC/ARR/CNT/CCR rewrites, EGR.UG, PSC-phase rewrites, basic timers, advanced CC5/6, 32-bit ARR=MAX free-run, input-capture gating.
- **Machine-level differentials** (`tests/stm32_timer_walk_differential.rs`, B1 style — hand-built Cortex-M + real NVIC + hand-assembled Thumb): update-IRQ, compare-IRQ, mid-run reconfig, CNT/SR-poll firmwares probed after **every instruction** at interval 1 — total_cycles, PC, all 16 registers, RAM counters byte-identical walk vs scheduler. At interval 64: update-event count exact over a fixed window (UIF-poll shape), total_cycles equal.
- **Invaders lab**: `splash_framebuffer_matches_across_tick_intervals` and `derived_and_explicit_walk_flag_are_output_identical` (20M cycles, walk-on vs walk-deleted) pass on the branch.
- **Silicon-anchored oracle**: h563 TIM1 PWM settle case passes; the harness now advances the bus cycle clock alongside its walk loop (one cycle per tick — the Machine interval-1 contract), keeping it honest for both drive modes.
- Full `cargo test -p labwired-core --features jit,event-scheduler`: green except the known machine-local `intmatrix_alarm` flake. Featureless lanes: green (3 known WFI-FF feature-unification failures in a bare `-p labwired-core --lib` run only).

## Honest quantization notes (interval > 1)

- Lazy CNT/SR reads and IRQ pends quantise to the batch grid — ≤ one interval, the same documented `sync_to` bound (and strictly better than the pre-migration walk at interval 64, which slowed the whole counter 64×).
- The level re-pend chain is sampled on the grid, so mid-interval re-pends that vanish before the boundary (flag cleared inside the ISR) collapse at interval 64 — the double-entry artifact is an interval-1 behaviour, pinned byte-exact there. The interval-64 count gate therefore uses the latched-flag (UIF-poll) shape, which cannot miss events.

## Numbers (invaders lab firmware, release, native, 40M cycles)

| config | before (47bc9432) | after |
|---|---|---|
| hand `walk_deleted: true`, interval 64 | 14.34 MIPS | 14.09 MIPS (unchanged, noise) |
| hand `walk_deleted: true`, interval 1 | 7.18 MIPS | 7.26 MIPS |
| walk-stripped (derived), interval 1 | 2.08 MIPS | **2.47 MIPS (+19%)** |

The remaining pinned walkers (dma1/2, i2c1-3, adc1, exti, can1, dwt) still hold `derive_walk_deletable() == false`, so the derived bus stays clamped at interval 1 — the batching unlock lands only when the remaining Class-B batches (B4+) migrate. The pinned-surface test now expects exactly that 9-walker set.

## Validation drift

`timer.rs` is tracked by 5 silicon-tier boards (stm32h563, nucleo-l476rg, nucleo-l073rz, stm32f103, stm32f407): register layout/reset/MMIO byte paths are unchanged, dated `drift_ack: 2026-07-12` added per entry, VALIDATION_STATUS.md regenerated (`--check --drift` green).
