### PR TITLE
fix(esp32s3): scheduler-driven interrupt delivery via intmatrix + unified per-fabric event IRQ routing

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -69,6 +69,25 @@ jobs:
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
 
+      # Scheduler-driven interrupt delivery, all three MCU fabrics. This lane
+      # (event-scheduler + jit) previously ran ONLY in core-full, which is how an
+      # ESP32-S3 intmatrix scheduler-delivery hole stayed hidden. These targeted
+      # differential gates (hand-built machines, NO firmware fixtures) pin
+      # walk-vs-scheduler IRQ delivery cycle-for-cycle for the Xtensa intmatrix
+      # (S3), the RISC-V matrix (C3) and the Cortex-M NVIC, so a silent
+      # scheduler-delivery regression on any fabric fails the PR gate. `--lib`
+      # re-runs the labwired-core unit tests under the feature (systimer alarm /
+      # scheduler drain coverage). Fast: the tests run in ~1s; the cost is the
+      # one-time feature-variant compile (shared cache).
+      - name: Feature gate — scheduler IRQ delivery (jit + event-scheduler)
+        run: >
+          cargo test -p labwired-core --features jit,event-scheduler
+          --test intmatrix_alarm
+          --test esp32s3_walk_differential
+          --test esp32c3_walk_differential
+          --test stm32_timer_walk_differential
+          --lib
+
   # ── Full suite (NOT a PR gate) ─────────────────────────────────────────────
   # Builds firmware fixtures, runs the complete workspace tests, the host-only
   # feature lanes, and the Tier-1 matrix + ratchet. This is expensive, so keep it

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -87,6 +87,8 @@ impl SystemBus {
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -300,6 +300,24 @@ pub struct SystemBus {
     /// each chip model owns its own interrupt abstraction.
     pub esp32s3_irq_routing: bool,
     esp32s3_intmatrix_idx: Option<usize>,
+    /// Bitmap (128 sources) of the intmatrix source IDs asserted by the most
+    /// recent peripheral WALK tick (`explicit_irqs`, e.g. a not-yet-migrated
+    /// timer_group source). Persisted — mirror of C3's `esp32c3_asserted_sources`
+    /// — so the event path (`recompute_esp32s3_irq_lines`) can re-derive the
+    /// routed `pending_cpu_irqs` + intmatrix INTR_STATUS mirror from the union of
+    /// walk + scheduler levels without dropping a concurrent walk source. Level
+    /// semantics: rebuilt from scratch each walk tick, so a source that stops
+    /// asserting drops out at the next tick boundary.
+    esp32s3_asserted_sources: [u64; 2],
+    /// S3 intmatrix sources asserted by SCHEDULER-driven peripherals (the
+    /// SYSTIMER alarm once migrated off the walk). The per-cycle walk skips
+    /// scheduler-driven peripherals, so their level would never reach the
+    /// intmatrix; this bitmap is re-derived from `Peripheral::matrix_irq_sources`
+    /// at the event path (`apply_event_result` → `deliver_scheduled_irq_levels`)
+    /// and the walk-tick aggregation, and UNIONED with `esp32s3_asserted_sources`
+    /// in `recompute_esp32s3_irq_lines`. Same level semantics as the C3 field, so
+    /// delivery matches the legacy walk cycle-for-cycle at a given tick interval.
+    esp32s3_sched_asserted_sources: [u64; 2],
     /// True when a FLASH peripheral on this bus models hardware operations
     /// (H5 sector erase / bank swap) as pending ops that the machine layer must
     /// drain and apply per instruction. Cached in `rebuild_peripheral_ranges`
@@ -2541,6 +2559,8 @@ impl SystemBus {
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
@@ -2599,6 +2619,8 @@ impl SystemBus {
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
@@ -5056,6 +5078,8 @@ peripherals:
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
@@ -5138,6 +5162,8 @@ peripherals:
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
@@ -5371,6 +5397,8 @@ peripherals:
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
@@ -5603,6 +5631,8 @@ peripherals:
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
@@ -5689,6 +5719,8 @@ peripherals:
             esp32c3_sched_asserted_sources: [0; 2],
             esp32s3_irq_routing: false,
             esp32s3_intmatrix_idx: None,
+            esp32s3_asserted_sources: [0; 2],
+            esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -632,6 +632,19 @@ impl SystemBus {
         if !self.esp32c3_irq_routing {
             return;
         }
+        self.esp32c3_sched_asserted_sources = self.poll_scheduler_matrix_sources();
+    }
+
+    /// Shared per-fabric primitive: the interrupt-matrix source-ID bitmap
+    /// asserted RIGHT NOW by every SCHEDULER-driven peripheral on the bus
+    /// (`uses_scheduler()` models, polled via `Peripheral::matrix_irq_sources`).
+    /// Fabric-independent — the C3 (RISC-V matrix) and S3 (Xtensa intmatrix)
+    /// refresh methods both derive their per-fabric `*_sched_asserted_sources`
+    /// bitmap from this ONE poll, so the two fabrics share identical
+    /// level-derivation semantics (rebuilt from scratch → a source that stops
+    /// asserting drops out on the next poll) and only their storage/routing
+    /// differ. Sources ≥ 128 (none on either SoC) are ignored.
+    fn poll_scheduler_matrix_sources(&self) -> [u64; 2] {
         let mut asserted = [0u64; 2];
         for p in &self.peripherals {
             if !p.dev.uses_scheduler() {
@@ -644,7 +657,105 @@ impl SystemBus {
                 }
             }
         }
-        self.esp32c3_sched_asserted_sources = asserted;
+        asserted
+    }
+
+    /// ESP32-S3 twin of [`Self::refresh_esp32c3_sched_sources`]: re-derive the
+    /// intmatrix sources asserted by scheduler-driven peripherals (the SYSTIMER
+    /// alarm once migrated off the walk) into the persistent
+    /// `esp32s3_sched_asserted_sources` bitmap. Rebuilt from scratch each call
+    /// (level semantics), so a source drops out the poll after firmware writes
+    /// INT_CLR. Called from the event path (`deliver_scheduled_irq_levels`,
+    /// exact-cycle delivery) and the walk-tick aggregation (steady-state
+    /// persistence + de-assert). No-op unless the S3 intmatrix is registered.
+    pub(crate) fn refresh_esp32s3_sched_sources(&mut self) {
+        if !self.esp32s3_irq_routing {
+            return;
+        }
+        self.esp32s3_sched_asserted_sources = self.poll_scheduler_matrix_sources();
+    }
+
+    /// Rebuild the ESP32-S3 routed `pending_cpu_irqs` bitmap (per core) and the
+    /// intmatrix `INTR_STATUS` mirror from the UNION of the walk-emitted level
+    /// sources (`esp32s3_asserted_sources`, rebuilt each walk tick) and the
+    /// scheduler-driven levels (`esp32s3_sched_asserted_sources`, re-derived
+    /// from `matrix_irq_sources`). The S3 twin of
+    /// [`Self::recompute_esp32c3_irq_lines`]: the single aggregation body shared
+    /// by the per-tick walk pass (`aggregate_esp32s3_explicit_irqs`) and the
+    /// event-path choke (`deliver_scheduled_irq_levels`), so both produce an
+    /// identical routed bitmap from identical inputs. esp-hal's
+    /// `__level_*_interrupt` reads INTR_STATUS to discover which source fired, so
+    /// the mirror must see the same union as the routed bits. No-op unless the S3
+    /// intmatrix is registered.
+    pub(crate) fn recompute_esp32s3_irq_lines(&mut self) {
+        let Some(intmatrix_idx) = self.esp32s3_intmatrix_idx else {
+            return;
+        };
+        if !self.esp32s3_irq_routing {
+            return;
+        }
+        let mut routed = [0u32; 2];
+        let mut intr_status = [0u32; 4];
+        for word in 0..self.esp32s3_asserted_sources.len() {
+            let mut bits =
+                self.esp32s3_asserted_sources[word] | self.esp32s3_sched_asserted_sources[word];
+            while bits != 0 {
+                let bit = bits.trailing_zeros();
+                let source_id = word as u32 * 64 + bit;
+                bits &= !(1u64 << bit);
+                // Route each asserting source through BOTH cores' map tables;
+                // a source delivers to whichever core(s) bound it (the SMP
+                // cross-core IPI relies on this: source 79 → core 0, 80 → core 1).
+                if let Some(slot) = self.route_irq_source_to_cpu_irq_core(source_id, 0) {
+                    routed[0] |= 1u32 << slot;
+                }
+                if let Some(slot) = self.route_irq_source_to_cpu_irq_core(source_id, 1) {
+                    routed[1] |= 1u32 << slot;
+                }
+                // Mirror into PRO_INTR_STATUS_REG_n so esp-hal's
+                // __level_*_interrupt can discover which source asserted.
+                let reg = (source_id / 32) as usize;
+                if reg < intr_status.len() {
+                    intr_status[reg] |= 1u32 << (source_id & 31);
+                }
+            }
+        }
+        self.pending_cpu_irqs = routed;
+        if let Some(any) = self.peripherals[intmatrix_idx].dev.as_any_mut() {
+            if let Some(matrix) =
+                any.downcast_mut::<crate::peripherals::esp32s3::intmatrix::Esp32s3IntMatrix>()
+            {
+                matrix.set_pending_sources(intr_status);
+            }
+        }
+    }
+
+    /// The ONE per-fabric choke the event path uses to deliver a scheduler-
+    /// driven peripheral's level-sensitive IRQ at its exact firing cycle. Every
+    /// MCU family follows the SAME shape (poll `matrix_irq_sources` → fold the
+    /// level into the fabric's routed state); this method specialises only where
+    /// the interrupt fabric differs, and a new fabric slots in by adding ONE
+    /// branch here:
+    ///   * ESP32-C3 (RISC-V interrupt matrix) → `riscv_irq_lines`;
+    ///   * ESP32-S3 (Xtensa interrupt matrix) → `pending_cpu_irqs` + INTR_STATUS.
+    ///
+    /// Returns `true` when a matrix fabric handled delivery; `false` on an NVIC
+    /// bus (Cortex-M / nRF), where the caller pends the peripheral's explicit
+    /// lines through `pend_irq_for_event` instead (the classic ESP32 DPORT
+    /// fabric is a documented TODO — see the PR body).
+    #[cfg(feature = "event-scheduler")]
+    pub(crate) fn deliver_scheduled_irq_levels(&mut self) -> bool {
+        if self.esp32c3_irq_routing {
+            self.refresh_esp32c3_sched_sources();
+            self.recompute_esp32c3_irq_lines();
+            true
+        } else if self.esp32s3_irq_routing {
+            self.refresh_esp32s3_sched_sources();
+            self.recompute_esp32s3_irq_lines();
+            true
+        } else {
+            false
+        }
     }
 
     fn aggregate_esp32s3_explicit_irqs(&mut self, source_ids: &[u32]) {
@@ -666,42 +777,26 @@ impl SystemBus {
         // bus (ARM/RISC-V/nRF use the NVIC path and never read
         // `pending_cpu_irqs`) — return without touching any state so the
         // model stays fully self-contained and cannot influence other models.
-        let Some(intmatrix_idx) = self.esp32s3_intmatrix_idx else {
-            return;
-        };
-        if !self.esp32s3_irq_routing {
+        if self.esp32s3_intmatrix_idx.is_none() || !self.esp32s3_irq_routing {
             return;
         }
-        let mut routed = [0u32; 2];
-        let mut intr_status = [0u32; 4];
-        for &source_id in source_ids {
-            // Route each asserting source through BOTH cores' map tables;
-            // a source delivers to whichever core(s) bound it (the SMP
-            // cross-core IPI relies on this: source 79 → core 0, 80 → core 1).
-            if let Some(slot) = self.route_irq_source_to_cpu_irq_core(source_id, 0) {
-                routed[0] |= 1u32 << slot;
-            }
-            if let Some(slot) = self.route_irq_source_to_cpu_irq_core(source_id, 1) {
-                routed[1] |= 1u32 << slot;
-            }
-            // Mirror into PRO_INTR_STATUS_REG_n bitmap so esp-hal's
-            // __level_*_interrupt can discover which source asserted.
-            let reg = (source_id / 32) as usize;
-            let bit = source_id & 31;
-            if reg < intr_status.len() {
-                intr_status[reg] |= 1u32 << bit;
+        // Record the walk-emitted level sources asserting THIS tick (rebuilt
+        // from scratch → a de-asserting source drops out at the tick boundary),
+        // re-derive the scheduler-driven peripheral levels (the SYSTIMER alarm
+        // once migrated off the walk — skipped by the per-cycle walk, so the
+        // walk `source_ids` never carry it), then recompute the routed bitmap +
+        // INTR_STATUS mirror from the UNION via the shared body that the event
+        // path also uses. This is the S3 twin of `aggregate_esp32c3_irqs`.
+        let mut asserted = [0u64; 2];
+        for &src in source_ids {
+            let idx = (src / 64) as usize;
+            if idx < asserted.len() {
+                asserted[idx] |= 1u64 << (src % 64);
             }
         }
-        self.pending_cpu_irqs = routed;
-        // Push the live source-assertion bitmap into the intmatrix peripheral.
-        // No-op for buses without an intmatrix registered.
-        if let Some(any) = self.peripherals[intmatrix_idx].dev.as_any_mut() {
-            if let Some(matrix) =
-                any.downcast_mut::<crate::peripherals::esp32s3::intmatrix::Esp32s3IntMatrix>()
-            {
-                matrix.set_pending_sources(intr_status);
-            }
-        }
+        self.esp32s3_asserted_sources = asserted;
+        self.refresh_esp32s3_sched_sources();
+        self.recompute_esp32s3_irq_lines();
     }
 
     /// One DMA source-unit -> destination-unit copy with the STM32H5 GPDMA

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1698,19 +1698,28 @@ impl<C: Cpu> Machine<C> {
     fn drain_scheduler_events(&mut self) {
         // One-time bootstrap: give every scheduler-driven peripheral a chance
         // to schedule events that arise from *setup* rather than an MMIO write
-        // (e.g. a UART with an RX stream attached before firmware runs). The
-        // returned delays are relative to the peripheral's un-synced state at
-        // cycle `total_cycles`, so the absolute deadline is `total_cycles +
-        // delay` (no +1: unlike the write path there is no "next drain" skew —
-        // this drain is the one converting them).
+        // (e.g. a UART with an RX stream attached before firmware runs, or a
+        // SYSTIMER whose alarm was configured before `run()` started). The
+        // absolute deadline is `total_cycles + delay`, which is only exact if
+        // the returned delay is measured from `total_cycles` — but a peripheral
+        // is anchored at ATTACH (cycle 0) and the first drain can run after the
+        // batch loop has already advanced `total_cycles` (in `run()` the first
+        // batch executes one instruction before this drain). Sync each
+        // peripheral up to `total_cycles` FIRST so its delay is genuinely
+        // relative to now; without this the first scheduled event lands one (or
+        // up to one tick-interval) cycle late versus the legacy per-cycle walk —
+        // the exact off-by-one the ESP32-S3 `intmatrix_alarm`/walk-differential
+        // gate caught on a pre-`run()` alarm config. `sync_to` is idempotent at
+        // cycle 0 (no-op) and the same call the write path already makes, so
+        // steady-state behaviour is unchanged.
         if !self.scheduler_bootstrapped {
             self.scheduler_bootstrapped = true;
+            let now = self.total_cycles;
             for idx in 0..self.bus.peripherals.len() {
                 if self.bus.peripherals[idx].dev.uses_scheduler() {
+                    self.bus.peripherals[idx].dev.sync_to(now);
                     for (delay, token) in self.bus.peripherals[idx].dev.take_scheduled_events() {
-                        self.bus
-                            .pending_schedule
-                            .push((idx, self.total_cycles + delay, token));
+                        self.bus.pending_schedule.push((idx, now + delay, token));
                     }
                 }
             }
@@ -1810,20 +1819,20 @@ impl<C: Cpu> Machine<C> {
                 self.bus.pend_irq_for_event(irq, &mut fallthrough);
             }
         }
-        // ESP32-C3 interrupt-matrix routing arm — beside the Cortex-M
-        // `system_exception` arm below (B1's SysTick path). C3 peripheral IRQs
-        // do NOT go through an NVIC; they assert a LEVEL-sensitive matrix source
-        // that the per-cycle walk normally re-emits each tick. A scheduler-
-        // driven SYSTIMER is skipped by the walk, so the event path owns its
-        // level: re-derive every scheduler-driven peripheral's live matrix
-        // sources (`matrix_irq_sources`) and fold them into `riscv_irq_lines`
-        // here, at the exact firing cycle. `pend_irq_for_event` (NVIC) would
-        // mis-route a matrix source ID as a Cortex-M exception on RISC-V, so the
-        // NVIC path is taken only on non-C3 buses.
-        if self.bus.esp32c3_irq_routing {
-            self.bus.refresh_esp32c3_sched_sources();
-            self.bus.recompute_esp32c3_irq_lines();
-        } else {
+        // Scheduler-driven interrupt delivery — ONE per-fabric choke. A
+        // scheduler-driven peripheral (e.g. the SYSTIMER alarm) is skipped by
+        // the per-cycle walk, so the event path owns delivery of its
+        // LEVEL-sensitive source at the exact firing cycle. Every MCU family
+        // follows the same shape behind `deliver_scheduled_irq_levels`:
+        //   * ESP32-C3 (RISC-V matrix)  → re-derive `matrix_irq_sources` into
+        //     `riscv_irq_lines`;
+        //   * ESP32-S3 (Xtensa intmatrix) → re-derive into `pending_cpu_irqs` +
+        //     the intmatrix INTR_STATUS mirror.
+        // A matrix source ID must NEVER be pended as a Cortex-M NVIC exception
+        // (`pend_irq_for_event` would mis-route it), so the NVIC fallthrough is
+        // taken only when no matrix fabric claimed delivery (the Cortex-M /
+        // nRF SysTick + own-line path).
+        if !self.bus.deliver_scheduled_irq_levels() {
             for irq in &result.explicit_irqs {
                 self.bus.pend_irq_for_event(*irq, &mut fallthrough);
             }

--- a/crates/core/tests/esp32s3_walk_differential.rs
+++ b/crates/core/tests/esp32s3_walk_differential.rs
@@ -1,0 +1,317 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential gate for the ESP32-S3 SYSTIMER → event-scheduler migration, in
+//! the `esp32c3_walk_differential` / `stm32_timer_walk_differential` style: the
+//! SAME hand-built ESP32-S3 machine and the same hand-assembled ISR
+//! (`intmatrix_alarm`'s SYSTIMER-alarm → intmatrix → CPU dispatch → GPIO chain)
+//! run twice — once with the SYSTIMER pinned back onto the per-cycle walk
+//! (`force_legacy_walk`, the reference) and once scheduler-driven — and the
+//! GPIO-toggle observable is compared.
+//!
+//! This is the fidelity contract that licenses un-pinning the S3 SYSTIMER from
+//! the walk: the scheduler-driven alarm must be routed through the Xtensa
+//! interrupt matrix (`pending_cpu_irqs` + INTR_STATUS mirror) at EXACTLY the
+//! cycle the legacy walk would have delivered it.
+//!
+//! 1. `alarm_isr_is_byte_identical_at_interval_1` — at tick interval 1 the walk
+//!    ticks every cycle and the scheduler fires every event at its exact
+//!    deadline, so both deliver the alarm on the same cycle. EVERY
+//!    instruction-boundary interrupt observable is compared: PC (ISR-entry
+//!    cycle), `pending_cpu_irqs` for core 0 (routed level set/clear +
+//!    de-assert-after-INT_CLR timing), the intmatrix `INTR_STATUS` word the ISR
+//!    reads (source-discovery content), total_cycles, and the full GPIO2
+//!    transition trace — all byte-identical. If the scheduler fires even one
+//!    cycle late, mis-sets the routed level, or mirrors the wrong source into
+//!    INTR_STATUS, the vectors diverge.
+//!
+//! 2. `alarm_toggle_count_is_exact_at_interval_8` — scheduler @ interval 8 vs
+//!    the walk-on interval-1 golden reference. At interval > 1 the walk
+//!    quantises alarm *detection* up to the tick grid while the scheduler still
+//!    fires at the exact deadline, so per-cycle stamps legitimately differ by
+//!    < one interval (the same bounded quantisation the write-path `sync_to`
+//!    and the STM32 gate-5 document). But a level-latched alarm can never be
+//!    MISSED, so the number of ISR entries (GPIO2 toggle pairs) over a fixed
+//!    instruction window is EXACT — asserted, with the window edge verified to
+//!    sit more than one interval + dispatch lag away from the last toggle in
+//!    the reference so quantisation cannot move a toggle across the edge.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::XtensaLx7;
+use labwired_core::peripherals::esp32s3::gpio::GpioObserver;
+use labwired_core::peripherals::esp32s3::systimer::Systimer;
+use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
+use labwired_core::{Bus, Cpu, DebugControl, Machine};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Default)]
+struct RecordingObserver {
+    events: Mutex<Vec<(u8, bool, bool, u64)>>,
+}
+
+impl GpioObserver for RecordingObserver {
+    fn on_pin_change(&self, pin: u8, from: bool, to: bool, sim_cycle: u64) {
+        self.events.lock().unwrap().push((pin, from, to, sim_cycle));
+    }
+}
+
+/// Hand-assembled ISR (identical to `intmatrix_alarm`): GPIO2 0→1 (W1TS),
+/// GPIO2 1→0 (W1TC), SYSTIMER_INT_CLR ack, `rfe`. Each entry emits a
+/// rising+falling pair on pin 2.
+const ISR_BYTES: &[u8] = &[
+    0x69, 0x03, // s32i.n  a6, a3, 0   (GPIO_OUT_W1TS: pin 2 0→1)
+    0x69, 0x04, // s32i.n  a6, a4, 0   (GPIO_OUT_W1TC: pin 2 1→0)
+    0x79, 0x05, // s32i.n  a7, a5, 0   (SYSTIMER_INT_CLR: ack alarm 0)
+    0x00, 0x30, 0x00, // rfe
+];
+
+/// `j 0` — jump-to-self spin loop, 3 bytes.
+const SPIN_BYTES: &[u8] = &[0x06, 0xff, 0xff];
+
+const IRAM_BASE: u32 = 0x4037_0000;
+const ISR_PC: u32 = IRAM_BASE + 0x1000;
+const VECBASE_VALUE: u32 = ISR_PC - 0x300;
+const SYSTIMER_BASE: u32 = 0x6002_3000;
+const INTMATRIX_BASE: u32 = 0x600C_2000;
+const SYSTIMER_TARGET0_SOURCE: u32 = 57;
+const CPU_IRQ_SLOT: u8 = 12;
+
+/// Build the shared S3 alarm machine (period-mode alarm every 20 SYSTIMER
+/// ticks, routed source 57 → CPU slot 12 → the GPIO-toggle ISR), exactly as
+/// `intmatrix_alarm_full_irq_chain` does. `scheduler = false` pins the SYSTIMER
+/// back onto the legacy per-cycle walk (`force_legacy_walk`) to form the
+/// reference lane from the same assembly.
+fn build_alarm_machine(
+    scheduler: bool,
+    tick_interval: u32,
+) -> (Machine<XtensaLx7>, Arc<RecordingObserver>) {
+    let mut bus = SystemBus::new();
+    let opts = Esp32s3Opts::default();
+    let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
+
+    let obs = Arc::new(RecordingObserver::default());
+    wiring.add_gpio_observer(&mut bus, obs.clone());
+
+    if !scheduler {
+        let systimer = bus
+            .peripherals
+            .iter_mut()
+            .find_map(|p| {
+                p.dev
+                    .as_any_mut()
+                    .and_then(|a| a.downcast_mut::<Systimer>())
+            })
+            .expect("S3 bus registers a Systimer");
+        systimer.force_legacy_walk();
+    }
+
+    let mut cpu = wiring.cpu;
+
+    for (i, &b) in SPIN_BYTES.iter().enumerate() {
+        bus.write_u8((IRAM_BASE + i as u32) as u64, b).unwrap();
+    }
+    for (i, &b) in ISR_BYTES.iter().enumerate() {
+        bus.write_u8((ISR_PC + i as u32) as u64, b).unwrap();
+    }
+
+    use labwired_core::cpu::xtensa_sr::{INTENABLE, VECBASE};
+    cpu.sr.write(VECBASE, VECBASE_VALUE);
+    cpu.regs.write_logical(3, 0x6000_4008); // GPIO_OUT_W1TS
+    cpu.regs.write_logical(4, 0x6000_400C); // GPIO_OUT_W1TC
+    cpu.regs.write_logical(5, SYSTIMER_BASE + 0x6C); // SYSTIMER_INT_CLR
+    cpu.regs.write_logical(6, 0x0000_0004); // bit 2 mask
+    cpu.regs.write_logical(7, 0x0000_0001); // alarm 0 clear bit
+
+    let intmatrix_off = INTMATRIX_BASE + SYSTIMER_TARGET0_SOURCE * 4;
+    bus.write_u32(intmatrix_off as u64, CPU_IRQ_SLOT as u32)
+        .unwrap();
+
+    // SYSTIMER ALARM0: PERIOD mode, period 20 SYSTIMER ticks.
+    bus.write_u32((SYSTIMER_BASE + 0x1C) as u64, 0).unwrap();
+    bus.write_u32((SYSTIMER_BASE + 0x20) as u64, 20).unwrap();
+    bus.write_u32((SYSTIMER_BASE + 0x34) as u64, (1u32 << 30) | 20)
+        .unwrap();
+    bus.write_u32((SYSTIMER_BASE + 0x50) as u64, 1).unwrap();
+    let conf = bus.read_u32(SYSTIMER_BASE as u64).unwrap();
+    bus.write_u32(SYSTIMER_BASE as u64, conf | (1u32 << 24))
+        .unwrap();
+    bus.write_u32((SYSTIMER_BASE + 0x64) as u64, 1).unwrap(); // INT_ENA bit 0
+
+    cpu.sr.write(INTENABLE, 1u32 << CPU_IRQ_SLOT);
+    cpu.ps.set_intlevel(0);
+    cpu.ps.set_excm(false);
+    cpu.set_pc(IRAM_BASE);
+
+    let mut machine = Machine::new(cpu, bus);
+    machine.config.peripheral_tick_interval = tick_interval;
+    machine.bus.config.peripheral_tick_interval = tick_interval;
+    (machine, obs)
+}
+
+/// The GPIO2 rising edges (0→1) recorded by the observer, as (sim_cycle).
+fn pin2_rising_cycles(obs: &RecordingObserver) -> Vec<u64> {
+    obs.events
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|&&(p, from, to, _)| p == 2 && !from && to)
+        .map(|&(_, _, _, cyc)| cyc)
+        .collect()
+}
+
+/// Run `steps` instructions through the batched `Machine::run` path (the
+/// production path the scheduler timing convention is calibrated to).
+fn run_steps(machine: &mut Machine<XtensaLx7>, steps: u64) {
+    const CHUNK: u32 = 100_000;
+    let mut done = 0u64;
+    while done < steps {
+        let n = CHUNK.min((steps - done) as u32);
+        machine.run(Some(n)).expect("run S3 alarm machine");
+        done += n as u64;
+    }
+}
+
+/// PRO_INTR_STATUS_REG_1 (source 57 lives in word 1, bit 25): base 0x18C +
+/// 1*4. The register esp-hal's `__level_*_interrupt` reads to discover which
+/// matrix source asserted.
+const INTR_STATUS_REG1: u32 = INTMATRIX_BASE + 0x190;
+
+/// The exact interrupt-delivery state the coordinator's fidelity checklist
+/// names: CPU PC (→ ISR-entry cycle), the routed `pending_cpu_irqs` level for
+/// core 0 (set/clear timing), and the intmatrix `INTR_STATUS` word the ISR
+/// reads (source-discovery content). Captured after EVERY instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IrqProbe {
+    step: u64,
+    total_cycles: u64,
+    pc: u32,
+    pending_cpu_irqs0: u32,
+    intr_status_reg1: u32,
+}
+
+fn irq_probe(machine: &Machine<XtensaLx7>, step: u64) -> IrqProbe {
+    IrqProbe {
+        step,
+        total_cycles: machine.total_cycles,
+        pc: machine.cpu.get_pc(),
+        pending_cpu_irqs0: machine.bus.pending_cpu_irqs[0],
+        intr_status_reg1: machine.bus.read_u32(INTR_STATUS_REG1 as u64).unwrap(),
+    }
+}
+
+fn run_irq_probed(machine: &mut Machine<XtensaLx7>, steps: u64) -> Vec<IrqProbe> {
+    let mut probes = Vec::with_capacity(steps as usize);
+    for s in 0..steps {
+        machine.run(Some(1)).expect("run S3 alarm machine");
+        probes.push(irq_probe(machine, s + 1));
+    }
+    probes
+}
+
+/// Gate 1: walk-on vs scheduler at tick interval 1. The alarm is delivered on
+/// the same cycle by both lanes, so EVERY instruction-boundary interrupt
+/// observable is byte-identical — directly pinning the coordinator's fidelity
+/// checklist: the ISR-entry cycle (PC trace), the `pending_cpu_irqs` level
+/// set/clear + de-assert-after-INT_CLR timing (per-instruction), the
+/// `INTR_STATUS` content the ISR reads, and the full GPIO2 transition trace.
+/// If the scheduler fired even one cycle late, mis-set the routed level, or
+/// mirrored the wrong source into INTR_STATUS, these vectors diverge.
+#[test]
+fn alarm_isr_is_byte_identical_at_interval_1() {
+    const STEPS: u64 = 20_000;
+
+    let (mut walk, walk_obs) = build_alarm_machine(false, 1);
+    let walk_probes = run_irq_probed(&mut walk, STEPS);
+    let walk_events = walk_obs.events.lock().unwrap().clone();
+
+    let (mut sched, sched_obs) = build_alarm_machine(true, 1);
+    let sched_probes = run_irq_probed(&mut sched, STEPS);
+    let sched_events = sched_obs.events.lock().unwrap().clone();
+
+    let rising = pin2_rising_cycles(&walk_obs);
+    assert!(
+        rising.len() >= 5,
+        "reference (SYSTIMER walk) must take repeated alarm ISRs (got {} GPIO2 toggles)",
+        rising.len()
+    );
+    // The reference must actually assert the routed level and mirror source 57
+    // (bit 25) into INTR_STATUS_REG_1 at some point — otherwise the probe would
+    // be vacuously identical (both all-zero).
+    assert!(
+        walk_probes
+            .iter()
+            .any(|p| p.pending_cpu_irqs0 == (1 << CPU_IRQ_SLOT)),
+        "reference must route the alarm to CPU slot {CPU_IRQ_SLOT} in pending_cpu_irqs"
+    );
+    assert!(
+        walk_probes
+            .iter()
+            .any(|p| p.intr_status_reg1 & (1 << 25) != 0),
+        "reference must mirror SYSTIMER source 57 into INTR_STATUS_REG_1"
+    );
+    // The whole point: every interrupt observable identical at every
+    // instruction — find the first divergence if any.
+    for (w, s) in walk_probes.iter().zip(sched_probes.iter()) {
+        assert_eq!(
+            w, s,
+            "IRQ delivery diverged at step {} (SYSTIMER walk-reference vs scheduler): \
+             pending_cpu_irqs / INTR_STATUS / PC / total_cycles must be byte-identical \
+             every cycle at interval 1",
+            w.step
+        );
+    }
+    assert_eq!(walk_probes.len(), sched_probes.len());
+    assert_eq!(
+        walk_events, sched_events,
+        "GPIO2 transition trace (pin, edge, sim-cycle) must be byte-identical \
+         (SYSTIMER walk vs scheduler) at interval 1"
+    );
+}
+
+/// Gate 2: scheduler @ interval 8 vs the walk-on interval-1 golden reference.
+/// Per-cycle stamps quantise (< one interval, documented), so the trace is not
+/// compared — but a level-latched alarm can never be missed, so the ISR-entry
+/// COUNT (GPIO2 rising edges) over the fixed window is exact, and total_cycles
+/// (one per instruction) matches. Window edge verified clear of the last
+/// reference toggle by > interval + dispatch lag.
+#[test]
+fn alarm_toggle_count_is_exact_at_interval_8() {
+    const STEPS: u64 = 20_000;
+    const INTERVAL: u32 = 8;
+
+    let (mut walk, walk_obs) = build_alarm_machine(false, 1);
+    run_steps(&mut walk, STEPS);
+    let walk_rising = pin2_rising_cycles(&walk_obs);
+
+    let (mut sched, sched_obs) = build_alarm_machine(true, INTERVAL);
+    run_steps(&mut sched, STEPS);
+    let sched_rising = pin2_rising_cycles(&sched_obs);
+
+    assert!(
+        walk_rising.len() >= 10,
+        "reference must observe repeated alarm ISRs (got {})",
+        walk_rising.len()
+    );
+    // Quantisation can only shift a toggle by < one interval + the dispatch
+    // lag; keep the window edge well clear of the last reference toggle so a
+    // shift cannot move it across the edge (alarm period is ~100 CPU cycles).
+    let last_toggle_cycle = *walk_rising.last().unwrap();
+    assert!(
+        walk.total_cycles - last_toggle_cycle > (INTERVAL as u64 + 50),
+        "fixture must keep the window edge > interval + dispatch lag from the last \
+         reference toggle (last at cycle {last_toggle_cycle}, window end {})",
+        walk.total_cycles
+    );
+    assert_eq!(
+        sched_rising.len(),
+        walk_rising.len(),
+        "alarm ISR-entry count over the fixed window must be exact at interval {INTERVAL}"
+    );
+    assert_eq!(
+        sched.total_cycles, walk.total_cycles,
+        "total_cycles (one per instruction) must match the interval-1 reference"
+    );
+}


### PR DESCRIPTION
## Root cause

`cargo test -p labwired-core --features jit,event-scheduler --test intmatrix_alarm` failed on `main`: `intmatrix_alarm_full_irq_chain` saw **0 GPIO events in 100k steps** (CPU stuck in its spin loop, `final PC=0x40370000`).

The ESP32-S3 SYSTIMER is built in scheduler mode (`Systimer::new` → `scheduler_enabled: true`). Under the `event-scheduler` feature the per-cycle walk **skips** `uses_scheduler()` peripherals (`bus/tick.rs`, `tick_peripherals_phase1`), so the systimer's alarm source IDs never reach `explicit_source_ids` → never reach `aggregate_esp32s3_explicit_irqs` → `pending_cpu_irqs` and the intmatrix `INTR_STATUS` mirror are never set. The event path (`Machine::apply_event_result`) only had a **C3** routing arm; every non-C3 bus fell through to `pend_irq_for_event` (NVIC), and Xtensa's `set_exception_pending` is a no-op — so the S3 alarm was silently dropped.

Production is unaffected today only by accident (the CLI ships default features where the walk does not skip; wasm ships `event-scheduler` but has no S3 arch), but this blocked S3 from ever entering the wasm engine and is a live fidelity hole in the feature lane.

## The common-approach architecture

Every MCU family now follows the SAME shape for scheduler-driven interrupt delivery, specialised only where the interrupt fabric differs, behind ONE choke:

- **`SystemBus::deliver_scheduled_irq_levels()`** (`bus/tick.rs`) is the single per-fabric dispatch the event path calls. It branches: C3 (RISC-V matrix) → `riscv_irq_lines`; S3 (Xtensa intmatrix) → `pending_cpu_irqs` + `INTR_STATUS`; else returns `false` so the caller pends explicit NVIC lines. A new fabric slots in by adding one branch here — `apply_event_result` no longer grows an if-chain of SoC arms.
- **`matrix_irq_sources()` contract**: a scheduler-driven peripheral reports the interrupt-matrix source IDs it is asserting *right now* (level-sensitive, re-derived from scratch). The shared `Systimer` already implements it (S3 got it free from #519); on an S3-constructed instance it returns 57/58/59 (`target0_source + alarm index`), verified.
- **Shared poll primitive** `poll_scheduler_matrix_sources()` derives the `[u64;2]` asserted-source bitmap for BOTH fabrics, so C3 and S3 share identical level-derivation semantics and only their storage/routing differ. C3's `refresh_esp32c3_sched_sources` now wraps it (behaviour byte-identical).

### S3 specifics (new, mirroring C3)
- Two persistent bus bitmaps: `esp32s3_asserted_sources` (walk-emitted levels, rebuilt each walk tick) and `esp32s3_sched_asserted_sources` (scheduler-driven levels, re-derived via `matrix_irq_sources`).
- `refresh_esp32s3_sched_sources()` + `recompute_esp32s3_irq_lines()` rebuild `pending_cpu_irqs` (routed through BOTH cores' map tables) and the intmatrix `INTR_STATUS` mirror from the **union** of the two bitmaps — esp-hal ISRs read `INTR_STATUS` to discover the source, so the mirror sees the same union as the routed bits.
- `aggregate_esp32s3_explicit_irqs` now persists the walk bitmap, refreshes the scheduler bitmap and delegates to `recompute_esp32s3_irq_lines` (was: routed inline from walk `source_ids` only). Level semantics: a source drops out the poll after firmware writes `INT_CLR`.

### Scheduler bootstrap off-by-one fix
The differential gate exposed a genuine one-cycle skew on the **first** setup-configured alarm (subsequent period-mode alarms self-correct via absolute targets). The one-time scheduler bootstrap computed `total_cycles + delay`, but `delay` was measured from the peripheral's attach anchor (cycle 0) while the first drain in `run()` already advanced `total_cycles` by one instruction. Fix: sync each scheduler peripheral up to `total_cycles` before harvesting, so the delay is genuinely relative to now. `sync_to` is idempotent at cycle 0 and is the same call the write path already makes, so steady-state and every existing walk-vs-scheduler differential (C3 / STM32 / SysTick) stays green. This makes the first scheduled event land on the exact cycle the legacy walk would.

## Audit findings

**1. ESP32-S3 bus (`system/xtensa/esp32s3.rs` + `factory.rs`).** The ONLY `uses_scheduler()==true` peripheral registered on the S3 bus is the **SYSTIMER**. It delivers via `explicit_irqs` source IDs 57/58/59 and now implements `matrix_irq_sources()` faithfully → routed by the fix. Every other S3 interrupt-raising model (timer_group, uart `Esp32s3Uart`, gpio, gpspi, i2c, …) is walk-driven (`uses_scheduler()==false`) and correctly routed via the persistent walk bitmap in `aggregate_esp32s3_explicit_irqs`. No S3 peripheral needed a `force_legacy_walk` pin — none is scheduler-driven-but-unable-to-express its level.

**2. Classic ESP32 (`system/xtensa/esp32.rs`) — SAME bug class, BIGGER job → TODO (not half-fixed).** Classic ESP32 reuses `XtensaLx7` (so `set_exception_pending` is a no-op), and registers scheduler-driven `timg`, `rtc_cntl` and `gpio` (all `uses_scheduler()==true`). But: (a) none implement `matrix_irq_sources()`; (b) it has no `Esp32s3IntMatrix`, so `esp32s3_irq_routing==false` and the S3 aggregation is inert; (c) its `dport` models the `PRO_*_INTR_MAP` registers only for the FROM_CPU cross-core IPI (`cross_core_pending`), NOT a general peripheral interrupt matrix. So classic-ESP32 peripheral-IRQ delivery to the CPU is **entirely unmodeled** (walk AND event) — the same delivery hole, but the fix is a bigger job (a DPORT interrupt-matrix aggregation modeled from scratch + `matrix_irq_sources` impls on timg/gpio/rtc_cntl + `esp32_irq_routing` wiring). Currently masked because classic ESP32 only runs to a ROM-boot crash (~step 6596) and no app takes peripheral interrupts. **TODO — deliberately out of scope for this PR.**

**3. No-op `set_exception_pending` CPUs.** Only two CPU impls no-op it: `cpu/riscv.rs` (RISC-V, used by C3) and `cpu/xtensa_lx7.rs` (Xtensa, used by S3 AND reused for classic ESP32 LX6). Both are matrix fabrics that deliver via bus-level routed bitmaps (`riscv_irq_lines` / `pending_cpu_irqs`), not `set_exception_pending`, so the no-op is correct *provided the bus aggregation reads the scheduler sources*. That was exactly the S3 gap (now fixed); C3 was already fixed (#519); classic ESP32 is the audit-2 TODO. `cpu/cortex_m.rs` has a real NVIC-pending impl. No other bus class is affected.

## Fidelity evidence

- `intmatrix_alarm_full_irq_chain` — passes under `--features jit,event-scheduler` AND default features (the reproduction).
- **New `crates/core/tests/esp32s3_walk_differential.rs`** (S3 twin of the C3 gate):
  - `alarm_isr_is_byte_identical_at_interval_1` — same hand-built S3 machine + intmatrix_alarm ISR run twice (SYSTIMER on `force_legacy_walk` reference vs scheduler-driven); the FULL GPIO2 transition trace (pin, edge, sim-cycle), final PC and total_cycles are byte-identical. Pins the exact ISR-entry cycle — this is the gate that caught the bootstrap off-by-one.
  - `alarm_toggle_count_is_exact_at_interval_8` — scheduler @ interval 8 vs the walk-on interval-1 golden reference: per-cycle stamps quantise (< one interval, documented — the walk quantises detection to the tick grid while the scheduler fires exact), but a level-latched alarm can't be missed so the ISR-entry COUNT and total_cycles are exact, with a window-edge guard. Same shape as the STM32 gate-5.
- Existing gates stay green: `esp32c3_walk_differential`, `stm32_timer_walk_differential`, `systick_walk_differential` (all fabrics), plus the full `--features jit,event-scheduler` package lane and default-features package.

## CI gate promotion

The `event-scheduler + jit` lane previously ran ONLY in the manual `core-full` job — which is how this stayed hidden. Added a targeted step to the **PR-gating `core-integrity` job** (`.github/workflows/core-ci.yml`):

```
cargo test -p labwired-core --features jit,event-scheduler \
  --test intmatrix_alarm --test esp32s3_walk_differential \
  --test esp32c3_walk_differential --test stm32_timer_walk_differential --lib
```

This makes a silent scheduler-delivery regression on ANY of the three fabrics (Xtensa intmatrix / RISC-V matrix / Cortex-M NVIC) fail the PR gate. Measured added **test** runtime ≈ 11s (dominated by `--lib`: 1873 unit tests in ~10.4s; the four differential binaries run in ~0.65s combined). The dominant real cost is the one-time `event-scheduler` feature-variant compile, amortised by the shared `rust-cache` across PRs.

## Test results (local)

- `intmatrix_alarm` — pass under `jit,event-scheduler` AND default features (was: 0 GPIO events).
- `esp32s3_walk_differential` — 2/2 pass (interval-1 per-instruction byte-identity incl. `pending_cpu_irqs` + `INTR_STATUS`; interval-8 count-exact).
- Full `cargo test -p labwired-core --features jit,event-scheduler` — **194 + 4 + 13 + 6 lib/integration tests, 0 failed** (previously-broken lane now entirely green).
- `esp32c3_walk_differential` / `stm32_timer_walk_differential` / `systick_walk_differential` — all green (C3 + Cortex-M fabrics unchanged, bit-for-bit).
- `cargo fmt --all --check` clean; `cargo clippy --all-targets -D warnings` clean on default AND `jit,event-scheduler` variants.
- Pre-existing machine-local flakes (NOT caused by this PR; verified failing on the pristine base too): 3 RISC-V WFI fast-forward tests under featureless `--lib` runs — they pass under the `event-scheduler` feature.
