### PR TITLE
perf: walk-free kw41z — mcg/rsim/dwt (cycle-exact), staging the first derive_walk_deletable board

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -86,6 +86,7 @@ jobs:
           --test esp32s3_walk_differential
           --test esp32c3_walk_differential
           --test stm32_timer_walk_differential
+          --test kw41z_walk_free_differential
           --lib
 
   # ── Full suite (NOT a PR gate) ─────────────────────────────────────────────

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -972,18 +972,21 @@ mod walk_free_campaign {
     //!
     //! Why `configure_cortex_m`: the Cortex-M core installs the *real* SCB and
     //! NVIC (the chip descriptor only carries inert placeholders for those ids)
-    //! and appends DWT (CYCCNT), which is not in the descriptor at all. SCB's
-    //! `tick()` drains software-pended exceptions and DWT's advances CYCCNT — both
-    //! real walk work. Omitting this step would hide SCB's real tick and DWT
-    //! entirely and under-report the surface, so the runtime-faithful bus is the
-    //! honest one to pin.
+    //! and appends DWT (CYCCNT), which is not in the descriptor at all. In a
+    //! featureless build SCB's `tick()` drains software-pended exceptions and
+    //! DWT's advances CYCCNT — both real walk work. Omitting this step would hide
+    //! SCB's real tick and DWT entirely and under-report the surface, so the
+    //! runtime-faithful bus is the honest one to pin. (Under `event-scheduler`,
+    //! `configure_cortex_m` attaches the bus cycle clock to DWT, migrating it to
+    //! the lazy-read scheduler path — see the cfg-split lists below.)
     //!
     //! After batch **B0** (Class-A inert sweep) the forcing set is the plan's 21
     //! Class-B instances still awaiting scheduler migration, PLUS the core DWT
     //! (a lazy-read CYCCNT counter the plan calls out separately as the purest
-    //! read-sync case). Each later batch (SysTick+SCB, timers, DMA, …) migrates a
-    //! slice onto the scheduler, flipping its `uses_scheduler()`, so this expected
-    //! set shrinks batch by batch. Keep it in lockstep with the plan's inventory.
+    //! read-sync case). Each later batch (SysTick+SCB, timers, DMA, the DWT
+    //! lazy-CYCCNT migration, …) moves a slice onto the scheduler, flipping its
+    //! `uses_scheduler()`, so this expected set shrinks batch by batch. Keep it
+    //! in lockstep with the plan's inventory.
     //!
     //! Batch **B1** (SysTick + SCB → scheduler) removes `systick` and `scb`
     //! from the forcing set — but only in `event-scheduler` builds:
@@ -996,14 +999,15 @@ mod walk_free_campaign {
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;
 
-    /// Walk-forcing ids on the runtime invaders bus after B2/B3 (event-
-    /// scheduler builds): B1's 20 minus the 11 `tim*` (scheduler-migrated —
-    /// lazy CNT/SR + scheduled update/compare events) = 9 — the plan's
-    /// remaining Class-B: 2 dma + 3 i2c + adc + exti + bxcan (8) + the core
-    /// DWT.
+    /// Walk-forcing ids on the runtime invaders bus after B2/B3 + the DWT
+    /// lazy-CYCCNT migration (event-scheduler builds): B1's 20 minus the 11
+    /// `tim*` (scheduler-migrated — lazy CNT/SR + scheduled update/compare
+    /// events) minus the core DWT (now a scheduler-driven lazy-read CYCCNT
+    /// counter — `configure_cortex_m` attaches the bus cycle clock) = 8 — the
+    /// plan's remaining Class-B: 2 dma + 3 i2c + adc + exti + bxcan.
     #[cfg(feature = "event-scheduler")]
     const EXPECTED_WALK_FORCING: &[&str] = &[
-        "dma1", "dma2", "i2c1", "i2c2", "i2c3", "adc1", "exti", "can1", "dwt",
+        "dma1", "dma2", "i2c1", "i2c2", "i2c3", "adc1", "exti", "can1",
     ];
 
     /// Featureless builds: the scheduler does not exist, so SysTick and SCB

--- a/crates/core/src/peripherals/dwt.rs
+++ b/crates/core/src/peripherals/dwt.rs
@@ -4,23 +4,147 @@
 // This software is released under the MIT License.
 // See the LICENSE file in the project root for full license information.
 
-use crate::{Peripheral, PeripheralTickResult, SimResult};
-use std::sync::atomic::{AtomicU32, Ordering};
+//! ARMv7-M DWT (Data Watchpoint & Trace) — the free-running cycle counter
+//! `CYCCNT` at `DWT_CYCCNT` (offset 0x04), gated by `DWT_CTRL.CYCCNTENA`
+//! (offset 0x00, bit 0).
+//!
+//! ## Drive modes (walk-free plan Part 1, the purest lazy-read case)
+//!
+//! `CYCCNT` is a linear function of elapsed CPU cycles while `CYCCNTENA` is
+//! set — no IRQ, no DMA, no compare (the comparators / CPI-LSU counters are
+//! not modelled), so it is the simplest possible scheduler-migrated peripheral:
+//! a bare lazily-derived counter with NO scheduled events. Two mutually
+//! exclusive time sources, selected by ONE predicate (`scheduler_mode`),
+//! exactly like [`crate::peripherals::systick::Systick`]'s lazy `SYST_CVR`:
+//!
+//! * **Scheduler mode** (`event-scheduler` feature + a [`CycleClock`] attached
+//!   at bus registration): `uses_scheduler()` is true, the per-cycle walk skips
+//!   this peripheral entirely, and `CYCCNT` is **derived lazily** from the
+//!   bus-published cycle clock — a `&self` read advances the `Cell`-held counter
+//!   to "now" (`advance_to`), so firmware polling `CYCCNT` for a busy-wait /
+//!   micro-delay / cycle-profiling loop observes fresh cycles with NO walk. The
+//!   counter counts TRUE CPU cycles (a frozen `CYCCNT` under walk-deletion would
+//!   be a fidelity bug — this keeps it live).
+//!
+//! * **Legacy mode** (feature off, or no clock attached — hand-built test buses
+//!   that bypass the bus registration chokes): the per-cycle walk drives
+//!   `tick()` and the counter advances eagerly by one per enabled cycle,
+//!   byte-identical to the historical model.
+//!
+//! ### Timing contract
+//!
+//! On the batched `Machine::run` path at tick interval 1, a `CYCCNT` read is
+//! **byte-identical** to the walk-driven reference at every instruction
+//! boundary: the batch is one instruction, so the bus-published clock is the
+//! exact current cycle. At interval N > 1 lazy reads quantise to the batch-start
+//! grid (≤ one interval stale, never frozen, no cumulative drift) — the same
+//! documented bound the write-path [`Peripheral::sync_to`] ships, and strictly
+//! better than the legacy walk at interval N (which under the default
+//! `tick_elapsed` would slow the count by a factor of N).
+//!
+//! ### Preserved semantics (differentially pinned)
+//!
+//! - `CYCCNTENA` (CTRL bit 0) gates counting; clearing it freezes `CYCCNT`
+//!   exactly where it stood. The window between any two MMIO writes has a
+//!   constant CTRL (every write syncs first via the bus `sync_to` choke), so a
+//!   settings change never straddles a lazy window.
+//! - A software write to `CYCCNT` sets it verbatim; from then it advances from
+//!   the written value (used by delay/profiling code that resets the counter).
+//! - `CYCCNT` is 32-bit and wraps modulo 2^32, matching silicon.
+
+use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
+use std::cell::Cell;
 
 const DWT_CTRL: u64 = 0x00;
 const DWT_CYCCNT: u64 = 0x04;
 
+/// CTRL.CYCCNTENA — enables the cycle counter.
+const CTRL_CYCCNTENA: u32 = 1 << 0;
+
 #[derive(Debug)]
 pub struct Dwt {
-    ctrl: AtomicU32,
-    cyccnt: AtomicU32,
+    /// DWT_CTRL. Plain `u32`: only the `&mut self` write path mutates it, and
+    /// the lazy `&self` read path merely reads it (the window between writes has
+    /// constant CTRL, so `advance_to` can safely apply it across the window).
+    ctrl: u32,
+    /// `CYCCNT` as of `anchor`. `Cell` so the scheduler-mode `&self` read path
+    /// can lazily advance it to the bus-published clock (walk-free plan Part 1
+    /// read-side freshness). In legacy mode only `tick()` mutates it.
+    cyccnt: Cell<u32>,
+    /// Lazy-path anchor: the absolute published cycle `cyccnt` was last advanced
+    /// to. Owned exclusively by `advance_to` (scheduler mode); the legacy walk
+    /// never touches it.
+    anchor: Cell<u64>,
+    /// Bus-published cycle clock (walk-free plan Part 1). `Some` once the bus
+    /// registration choke attaches it; `None` keeps the model on the legacy
+    /// walk path.
+    clock: Option<CycleClock>,
 }
 
 impl Dwt {
     pub fn new() -> Self {
         Self {
-            ctrl: AtomicU32::new(0),
-            cyccnt: AtomicU32::new(0),
+            ctrl: 0,
+            cyccnt: Cell::new(0),
+            anchor: Cell::new(0),
+            clock: None,
+        }
+    }
+
+    /// True when the event scheduler owns this counter's time base (feature on
+    /// AND bus clock attached). Everything time-related branches on this ONE
+    /// predicate so the two drive modes can never mix.
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Test/differential knob: detach the cycle clock, pinning the model to the
+    /// legacy walk path (`uses_scheduler() == false`). Used by the
+    /// walk-on-vs-scheduler differential gate to build the reference lane from
+    /// the same bus assembly.
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
+    }
+
+    /// Lazily advance `cyccnt` to absolute published cycle `now` — callable from
+    /// `&self` (all mutated state is in `Cell`). Idempotent; a `now` older than
+    /// the anchor is ignored (the clock is monotonic within a run; a stale read
+    /// must never rewind). `CYCCNT += (now - anchor)` while `CYCCNTENA` is set,
+    /// wrapping modulo 2^32 exactly as the per-cycle walk's `fetch_add(1)` chain
+    /// does. The advanced window always has a constant CTRL: every MMIO write
+    /// syncs first (bus `sync_to` choke), so an enable/disable never straddles a
+    /// window.
+    fn advance_to(&self, now: u64) {
+        let anchor = self.anchor.get();
+        if now <= anchor {
+            return;
+        }
+        let elapsed = now - anchor;
+        self.anchor.set(now);
+        if (self.ctrl & CTRL_CYCCNTENA) != 0 {
+            self.cyccnt
+                .set(self.cyccnt.get().wrapping_add(elapsed as u32));
+        }
+    }
+
+    /// Pull "now" from the bus-published clock and advance. No-op without an
+    /// attached clock (legacy mode — the walk advances the counter instead).
+    fn sync_from_clock(&self) {
+        if self.scheduler_mode() {
+            if let Some(clock) = &self.clock {
+                self.advance_to(clock.now());
+            }
+        }
+    }
+
+    /// The current register word, folding in the lazily-advanced `CYCCNT`.
+    /// Assumes the counter has already been synced.
+    fn read_reg(&self, aligned_offset: u64) -> u32 {
+        match aligned_offset {
+            DWT_CTRL => self.ctrl,
+            DWT_CYCCNT => self.cyccnt.get(),
+            _ => 0,
         }
     }
 }
@@ -33,91 +157,298 @@ impl Default for Dwt {
 
 impl Peripheral for Dwt {
     fn read(&self, offset: u64) -> SimResult<u8> {
-        let val = match offset & !3 {
-            DWT_CTRL => self.ctrl.load(Ordering::SeqCst),
-            DWT_CYCCNT => self.cyccnt.load(Ordering::SeqCst),
-            _ => 0,
-        };
-
+        // Scheduler mode: advance the lazy counter to the published "now" first,
+        // so polled CYCCNT reads observe fresh cycles (batch-boundary freshness;
+        // exact at interval 1 on the run path). No-op in legacy mode.
+        self.sync_from_clock();
+        let val = self.read_reg(offset & !3);
         let byte_offset = (offset & 3) as u32;
         Ok(((val >> (byte_offset * 8)) & 0xFF) as u8)
     }
 
-    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
-        // We only support word-aligned writes for simplicity in this MVP,
-        // or we need a read-modify-write buffer.
-        // For DWT, usually 32-bit access is used.
-        // But `write` takes u8.
-        // To properly support byte writes we need either internal state or
-        // we can implement `write_u32` if the trait supported it directly/optimally,
-        // but `Peripheral` trait is byte-oriented.
-        //
-        // However, `Bus` breaks down u32 writes into 4 u8 writes.
-        // We can use a simplified approach: just update the byte in the atomic.
-        // But Atomically updating a single byte in a U32 is tricky without CAS loop.
-        //
-        // Simplification: Load, modify, store.
+    fn read_u32(&self, offset: u64) -> SimResult<u32> {
+        self.sync_from_clock();
+        Ok(self.read_reg(offset & !3))
+    }
 
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        // `Bus` decomposes a u32 write into 4 byte writes; load-modify-store the
+        // target register. In scheduler mode the bus `sync_to` choke has already
+        // advanced the counter to the write cycle and re-anchored, so the
+        // load-modify-store operates on the fresh value (and the post-write
+        // anchor stays at the write cycle).
         let aligned_offset = offset & !3;
         let byte_shift = (offset & 3) * 8;
+        let mask = 0xFF_u32 << byte_shift;
+        let inserted = (value as u32) << byte_shift;
 
-        let (atom, _is_cyccnt) = match aligned_offset {
-            DWT_CTRL => (&self.ctrl, false),
-            DWT_CYCCNT => (&self.cyccnt, true),
-            _ => return Ok(()),
-        };
-
-        let mut current = atom.load(Ordering::SeqCst);
-        let mask = 0xFF << byte_shift;
-        current &= !mask;
-        current |= (value as u32) << byte_shift;
-        atom.store(current, Ordering::SeqCst);
-
+        match aligned_offset {
+            DWT_CTRL => {
+                self.ctrl = (self.ctrl & !mask) | inserted;
+            }
+            DWT_CYCCNT => {
+                let cur = self.cyccnt.get();
+                self.cyccnt.set((cur & !mask) | inserted);
+            }
+            _ => {}
+        }
         Ok(())
     }
 
     fn tick(&mut self) -> PeripheralTickResult {
-        // Check CYCCNTENA bit (bit 0) in CTRL
-        let ctrl = self.ctrl.load(Ordering::Relaxed);
-        if (ctrl & 1) != 0 {
-            self.cyccnt.fetch_add(1, Ordering::Relaxed);
+        // Never runs in scheduler mode (the walk skips `uses_scheduler()`
+        // peripherals; the guard keeps a stray direct call from corrupting the
+        // lazily-anchored state).
+        if self.scheduler_mode() {
+            return PeripheralTickResult::default();
         }
+        if (self.ctrl & CTRL_CYCCNTENA) != 0 {
+            self.cyccnt.set(self.cyccnt.get().wrapping_add(1));
+        }
+        PeripheralTickResult::default()
+    }
 
-        PeripheralTickResult {
-            cycles: 0,
-            irq: false,
-            dma_requests: None,
-            ticks_until_next: None,
-            ..Default::default()
+    fn uses_scheduler(&self) -> bool {
+        // True once the bus attached its cycle clock (event-scheduler builds):
+        // reads stay fresh through the lazy `advance_to` path, so the walk is
+        // unnecessary. Without a clock (feature off / hand-built buses) stay on
+        // the legacy walk with exact historical semantics.
+        self.scheduler_mode()
+    }
+
+    fn sync_to(&mut self, now_cycle: u64) {
+        if self.scheduler_mode() {
+            self.advance_to(now_cycle);
         }
     }
 
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        // Anchor at the clock's current value so cycles that elapsed before
+        // attach (normally zero — attach happens at bus assembly) are not
+        // retroactively replayed into the counter.
+        self.anchor.set(clock.now());
+        self.clock = Some(clock);
+    }
+
     fn peek(&self, offset: u64) -> Option<u8> {
+        // Side-effect-free: fold in the lazily-advanced counter WITHOUT mutating
+        // the anchor, so a debug probe never perturbs the lazy state. Reads the
+        // published clock directly.
+        let cyccnt = if self.scheduler_mode() {
+            match &self.clock {
+                Some(clock) => {
+                    let now = clock.now();
+                    let anchor = self.anchor.get();
+                    let base = self.cyccnt.get();
+                    if now > anchor && (self.ctrl & CTRL_CYCCNTENA) != 0 {
+                        base.wrapping_add((now - anchor) as u32)
+                    } else {
+                        base
+                    }
+                }
+                None => self.cyccnt.get(),
+            }
+        } else {
+            self.cyccnt.get()
+        };
         let val = match offset & !3 {
-            DWT_CTRL => self.ctrl.load(Ordering::Relaxed),
-            DWT_CYCCNT => self.cyccnt.load(Ordering::Relaxed),
+            DWT_CTRL => self.ctrl,
+            DWT_CYCCNT => cyccnt,
             _ => return None,
         };
         let byte_offset = (offset & 3) as u32;
         Some(((val >> (byte_offset * 8)) & 0xFF) as u8)
     }
 
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
     fn snapshot(&self) -> serde_json::Value {
+        // Sync first so the serialized CYCCNT reflects "now" (scheduler mode);
+        // no-op in legacy mode. Keeps the snapshot shape identical across drive
+        // modes for the determinism gates.
+        self.sync_from_clock();
         serde_json::json!({
-            "ctrl": self.ctrl.load(Ordering::Relaxed),
-            "cyccnt": self.cyccnt.load(Ordering::Relaxed),
+            "ctrl": self.ctrl,
+            "cyccnt": self.cyccnt.get(),
         })
     }
 
     fn restore(&mut self, state: serde_json::Value) -> SimResult<()> {
         if let Some(obj) = state.as_object() {
             if let Some(ctrl) = obj.get("ctrl").and_then(|v| v.as_u64()) {
-                self.ctrl.store(ctrl as u32, Ordering::Relaxed);
+                self.ctrl = ctrl as u32;
             }
             if let Some(cyccnt) = obj.get("cyccnt").and_then(|v| v.as_u64()) {
-                self.cyccnt.store(cyccnt as u32, Ordering::Relaxed);
+                self.cyccnt.set(cyccnt as u32);
             }
         }
+        // Re-anchor to "now" so a restored counter advances from the restored
+        // value rather than replaying the pre-restore window.
+        if let Some(clock) = &self.clock {
+            self.anchor.set(clock.now());
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_tick_counts_only_when_enabled() {
+        let mut dwt = Dwt::new();
+        // Disabled: no counting.
+        for _ in 0..10 {
+            dwt.tick();
+        }
+        assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 0);
+        // Enable CYCCNTENA.
+        dwt.write(DWT_CTRL, 0x01).unwrap();
+        for _ in 0..5 {
+            dwt.tick();
+        }
+        assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 5);
+    }
+
+    #[test]
+    fn software_cyccnt_write_sets_value() {
+        let mut dwt = Dwt::new();
+        dwt.write(DWT_CTRL, 0x01).unwrap();
+        // Byte-decomposed word write of 0x0000_1234.
+        dwt.write(DWT_CYCCNT, 0x34).unwrap();
+        dwt.write(DWT_CYCCNT + 1, 0x12).unwrap();
+        dwt.write(DWT_CYCCNT + 2, 0x00).unwrap();
+        dwt.write(DWT_CYCCNT + 3, 0x00).unwrap();
+        assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 0x1234);
+        dwt.tick();
+        assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 0x1235);
+    }
+
+    #[test]
+    fn without_clock_stays_on_legacy_tick_path() {
+        let dwt = Dwt::new();
+        assert!(
+            !dwt.uses_scheduler(),
+            "no cycle clock attached → the model must stay on the legacy walk \
+             (hand-built buses that bypass the registration chokes keep exact semantics)"
+        );
+    }
+
+    #[cfg(feature = "event-scheduler")]
+    mod scheduler_mode {
+        use super::*;
+        use crate::CycleClock;
+
+        fn enabled_scheduler() -> (Dwt, CycleClock) {
+            let clock = CycleClock::default();
+            let mut dwt = Dwt::new();
+            dwt.attach_cycle_clock(clock.clone());
+            dwt.write(DWT_CTRL, 0x01).unwrap(); // CYCCNTENA
+            (dwt, clock)
+        }
+
+        #[test]
+        fn clock_attach_flips_to_scheduler_and_walk_tick_is_inert() {
+            let (mut dwt, _clock) = enabled_scheduler();
+            assert!(dwt.uses_scheduler(), "clock attached → walk-independent");
+            // A stray walk tick must not double-count against the lazy anchor.
+            dwt.tick();
+            assert_eq!(
+                dwt.read_u32(DWT_CYCCNT).unwrap(),
+                0,
+                "tick inert in scheduler mode (clock still at 0)"
+            );
+        }
+
+        #[test]
+        fn lazy_cyccnt_read_tracks_published_clock_exactly() {
+            let (dwt, clock) = enabled_scheduler();
+            // CYCCNT == published cycle (enabled from cycle 0, base 0).
+            for c in [1u64, 7, 8, 100, 12345] {
+                clock.publish(c);
+                assert_eq!(
+                    dwt.read_u32(DWT_CYCCNT).unwrap() as u64,
+                    c,
+                    "CYCCNT must equal elapsed cycles at c={c}"
+                );
+            }
+        }
+
+        #[test]
+        fn disable_freezes_the_counter() {
+            let (mut dwt, clock) = enabled_scheduler();
+            clock.publish(50);
+            assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 50);
+            // Disable CYCCNTENA (bus syncs to 50 before the write).
+            dwt.sync_to(50);
+            dwt.write(DWT_CTRL, 0x00).unwrap();
+            clock.publish(1000);
+            assert_eq!(
+                dwt.read_u32(DWT_CYCCNT).unwrap(),
+                50,
+                "frozen while CYCCNTENA=0"
+            );
+            // Re-enable; counting resumes from the frozen value.
+            dwt.sync_to(1000);
+            dwt.write(DWT_CTRL, 0x01).unwrap();
+            clock.publish(1005);
+            assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 55);
+        }
+
+        #[test]
+        fn software_write_reanchors_and_advances_from_written_value() {
+            let (mut dwt, clock) = enabled_scheduler();
+            clock.publish(100);
+            assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 100);
+            // Reset CYCCNT to 0 (bus syncs to 100 first).
+            dwt.sync_to(100);
+            dwt.write(DWT_CYCCNT, 0).unwrap();
+            dwt.write(DWT_CYCCNT + 1, 0).unwrap();
+            dwt.write(DWT_CYCCNT + 2, 0).unwrap();
+            dwt.write(DWT_CYCCNT + 3, 0).unwrap();
+            clock.publish(130);
+            assert_eq!(
+                dwt.read_u32(DWT_CYCCNT).unwrap(),
+                30,
+                "counts from the written value"
+            );
+        }
+
+        #[test]
+        fn peek_is_side_effect_free() {
+            let (dwt, clock) = enabled_scheduler();
+            clock.publish(42);
+            assert_eq!(dwt.peek(DWT_CYCCNT).unwrap(), 42);
+            // Peek must not have advanced the anchor: a later real read at the
+            // same clock still returns the same value.
+            assert_eq!(dwt.read_u32(DWT_CYCCNT).unwrap(), 42);
+        }
+
+        #[test]
+        fn wraps_modulo_2_32_like_the_walk() {
+            let clock = CycleClock::default();
+            let mut dwt = Dwt::new();
+            dwt.attach_cycle_clock(clock.clone());
+            dwt.write(DWT_CTRL, 0x01).unwrap();
+            // Preset near the 32-bit boundary.
+            dwt.sync_to(0);
+            dwt.write(DWT_CYCCNT, 0xFF).unwrap();
+            dwt.write(DWT_CYCCNT + 1, 0xFF).unwrap();
+            dwt.write(DWT_CYCCNT + 2, 0xFF).unwrap();
+            dwt.write(DWT_CYCCNT + 3, 0xFF).unwrap(); // 0xFFFF_FFFF
+            clock.publish(5);
+            assert_eq!(
+                dwt.read_u32(DWT_CYCCNT).unwrap(),
+                4,
+                "0xFFFF_FFFF + 5 wraps to 4"
+            );
+        }
     }
 }

--- a/crates/core/src/peripherals/mcg.rs
+++ b/crates/core/src/peripherals/mcg.rs
@@ -144,6 +144,17 @@ impl Peripheral for Mcg {
         self.regs.get(offset as usize).copied()
     }
 
+    /// Walk-free (kw41z): the MCG is purely combinational — `MCG_S` is
+    /// recomputed from the control bits on every write (`recompute_status`) and
+    /// there is NO `tick()`/`tick_elapsed()` override, so the model has zero
+    /// time-dependent state. The clock modes settle instantaneously (no PLL, no
+    /// lock counter), so the per-cycle walk can never change any observable
+    /// output. Proven inert (`needs_legacy_walk() == false`) by the differential
+    /// gate `crates/core/tests/kw41z_walk_free_differential.rs`.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/rsim.rs
+++ b/crates/core/src/peripherals/rsim.rs
@@ -138,6 +138,18 @@ impl Peripheral for Rsim {
         self.data.get(offset as usize).copied()
     }
 
+    /// Walk-free (kw41z): the RSIM is purely combinational — `RF_OSC_READY` is
+    /// recomputed from the enable/override bits on every CONTROL write
+    /// (`refresh_control`), every other register is plain storage, and there is
+    /// NO `tick()`/`tick_elapsed()` override. The crystal start-up is modelled
+    /// as instantaneous (no timed handshake), so the model has zero
+    /// time-dependent state and the per-cycle walk can never change any
+    /// observable output. Proven inert (`needs_legacy_walk() == false`) by the
+    /// differential gate `crates/core/tests/kw41z_walk_free_differential.rs`.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn Any> {
         Some(self)
     }

--- a/crates/core/src/system/cortex_m.rs
+++ b/crates/core/src/system/cortex_m.rs
@@ -9,6 +9,7 @@ use crate::cpu::CortexM;
 use crate::peripherals::dwt::Dwt;
 use crate::peripherals::nvic::{Nvic, NvicState};
 use crate::peripherals::scb::{Scb, SharedScbState};
+use crate::Peripheral;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
@@ -97,7 +98,14 @@ pub fn configure_cortex_m(bus: &mut SystemBus) -> (CortexM, Arc<NvicState>) {
     // Ensure DWT exists. Size 0x1000 covers the full CoreSight DWT register space,
     // including the CYCCNT enable bit at offset 0 and CYCCNT at offset 4, as well as
     // extended offsets accessed by some HAL dwt_init routines (e.g. offset 0xfc).
-    let dwt = Dwt::new();
+    // Attach the bus cycle clock so CYCCNT can be derived lazily (walk-free
+    // plan Part 1). DWT is registered by directly manipulating `bus.peripherals`
+    // (not `add_peripheral`), so the attach choke is replicated here — without
+    // it the model stays on the legacy walk. The clone happens before the
+    // `iter_mut` borrow below.
+    let dwt_clock = bus.cycle_clock.clone();
+    let mut dwt = Dwt::new();
+    dwt.attach_cycle_clock(dwt_clock);
     if let Some(p) = bus
         .peripherals
         .iter_mut()

--- a/crates/core/tests/kw41z_walk_free_differential.rs
+++ b/crates/core/tests/kw41z_walk_free_differential.rs
@@ -1,0 +1,479 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Walk-free **kw41z** batch (mcg / rsim / dwt → walk-independent), in the
+//! `stm32_timer_walk_differential` (B2/B3) style: the SAME hand-built Cortex-M
+//! machine and hand-assembled Thumb firmware run twice — once with DWT pinned
+//! back onto the per-cycle walk (`force_legacy_walk`, the reference) and once
+//! scheduler-driven (lazy CYCCNT) — and every observable is compared. Plus the
+//! inertness proof for the two combinational Kinetis models and the
+//! board-config flip status.
+//!
+//! ## Gates
+//!
+//! 1. `dwt_cyccnt_is_byte_identical_at_interval_1` — firmware enables
+//!    `DWT_CTRL.CYCCNTENA`, then polls `DWT_CYCCNT` from its main loop (the
+//!    lazy-read surface) at many distinct, unaligned cycle counts. Probed after
+//!    EVERY instruction: `total_cycles`, PC, all 16 core registers, and the
+//!    stored CYCCNT sample must be byte-identical between the walk reference and
+//!    the walk-deleted scheduler lane. This is the "a read at any cycle returns
+//!    exactly what the walk would have produced" proof (the CYCCNT reads land at
+//!    arbitrary unaligned cycles and every one is exact).
+//!
+//! 2. `dwt_cyccnt_reads_are_bounded_and_live_at_interval_64` — the same firmware
+//!    with the scheduler lane batched at tick interval 64 vs the walk-on
+//!    interval-1 golden reference. A mid-batch CYCCNT read quantises to the
+//!    batch-start grid (the documented ≤ one-interval bound the write-path
+//!    `sync_to` ships), so per-instruction state is NOT byte-compared — instead
+//!    every read is proven to (a) never run AHEAD of the true walk, (b) trail it
+//!    by strictly less than one interval, and (c) stay LIVE (a frozen CYCCNT
+//!    under walk-deletion would be a fidelity bug). `total_cycles` is identical,
+//!    proving the migration introduced no timing artifact.
+//!
+//! 3. `mcg_tick_is_a_genuine_no_op` / `rsim_tick_is_a_genuine_no_op` — the two
+//!    combinational Kinetis models are driven through their real boot register
+//!    sequences and then ticked; the snapshot is byte-identical before and after
+//!    any number of ticks and the tick result is `default()`. This is the
+//!    inertness proof behind their `needs_legacy_walk() == false`.
+//!
+//! 4. `kw41z_board_walk_forcing_set_is_only_i2c1` /
+//!    `kw41z_board_derive_walk_deletable_flips` — the board-config flip status
+//!    on the honestly-assembled FRDM-KW41Z bus (`from_config` +
+//!    `configure_cortex_m`, exactly how the run path builds it). After this
+//!    batch the sole remaining walker is `i2c1` (the shared Kinetis/STM32 I2C
+//!    model, migrated on a parallel branch); the flip assertion is `#[ignore]`d
+//!    until that lands.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::CortexM;
+use labwired_core::peripherals::dwt::Dwt;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{DebugControl, Machine, Peripheral};
+
+// ── DWT differential (hand-built Cortex-M) ──────────────────────────────────
+
+const DWT_BASE: u64 = 0xE000_1000;
+const MAIN_COUNT_ADDR: u64 = 0x2000_0004;
+const CYCCNT_STORE_ADDR: u64 = 0x2000_0008;
+const INITIAL_SP: u32 = 0x2000_8000;
+
+fn load_thumb(bus: &mut SystemBus, base: u64, halfwords: &[u16]) {
+    for (i, hw) in halfwords.iter().enumerate() {
+        bus.write_u16(base + (i as u64) * 2, *hw).unwrap();
+    }
+}
+
+/// Firmware — enable CYCCNT (DWT_CTRL.CYCCNTENA), then spin: increment the main
+/// counter, poll `DWT_CYCCNT` (the lazy-read surface), and store the sample.
+///
+///   0x40: 4806  ldr r0, [pc, #24]   ; = DWT_BASE          (pool at 0x5C)
+///   0x42: 2101  movs r1, #1
+///   0x44: 6001  str r1, [r0, #0]    ; DWT_CTRL = CYCCNTENA
+///   0x46: 4A06  ldr r2, [pc, #24]   ; = MAIN_COUNT_ADDR   (pool at 0x60)
+///   0x48: 4D06  ldr r5, [pc, #24]   ; = CYCCNT_STORE_ADDR (pool at 0x64)
+///   0x4A: 2300  movs r3, #0
+///   loop:
+///   0x4C: 3301  adds r3, #1
+///   0x4E: 6013  str r3, [r2]        ; main_count++
+///   0x50: 6844  ldr r4, [r0, #4]    ; poll CYCCNT (lazy read)
+///   0x52: 602C  str r4, [r5]        ; store last sample
+///   0x54: E7FA  b loop
+fn load_firmware_cyccnt_poll(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x4806, 0x2101, 0x6001, 0x4A06, 0x4D06, 0x2300, 0x3301, 0x6013, 0x6844, 0x602C, 0xE7FA,
+            0xBF00, 0xBF00, 0xBF00,
+        ],
+    );
+    bus.write_u32(0x5C, DWT_BASE as u32).unwrap();
+    bus.write_u32(0x60, MAIN_COUNT_ADDR as u32).unwrap();
+    bus.write_u32(0x64, CYCCNT_STORE_ADDR as u32).unwrap();
+}
+
+/// Base of the CYCCNT sample buffer written by `load_firmware_cyccnt_buffer`.
+const BUFFER_BASE: u64 = 0x2000_0100;
+
+/// Firmware variant for the batched interval-64 gate — same enable, but stores
+/// each `DWT_CYCCNT` sample into a rolling buffer (`r5` bumped by 4 each pass)
+/// so a single batched run leaves a full trace of mid-batch reads to inspect.
+///
+///   0x40: 4804  ldr r0, [pc, #16]   ; = DWT_BASE     (pool at 0x54)
+///   0x42: 2101  movs r1, #1
+///   0x44: 6001  str r1, [r0, #0]    ; DWT_CTRL = CYCCNTENA
+///   0x46: 4D04  ldr r5, [pc, #16]   ; = BUFFER_BASE  (pool at 0x58)
+///   loop:
+///   0x48: 6844  ldr r4, [r0, #4]    ; poll CYCCNT (lazy read)
+///   0x4A: 602C  str r4, [r5]        ; *r5 = CYCCNT
+///   0x4C: 3504  adds r5, #4         ; r5 += 4
+///   0x4E: E7FB  b loop
+fn load_firmware_cyccnt_buffer(bus: &mut SystemBus) {
+    load_thumb(
+        bus,
+        0x40,
+        &[
+            0x4804, 0x2101, 0x6001, 0x4D04, 0x6844, 0x602C, 0x3504, 0xE7FB, 0xBF00, 0xBF00,
+        ],
+    );
+    bus.write_u32(0x54, DWT_BASE as u32).unwrap();
+    bus.write_u32(0x58, BUFFER_BASE as u32).unwrap();
+}
+
+/// `SystemBus::new()` + `configure_cortex_m` (real SCB/NVIC/DWT, DWT with the
+/// bus cycle clock attached). `scheduler = false` pins DWT back onto the legacy
+/// walk (`force_legacy_walk`) to form the reference lane from the same assembly.
+fn build_machine(scheduler: bool, tick_interval: u32) -> Machine<CortexM> {
+    let mut bus = SystemBus::new();
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+
+    if !scheduler {
+        let idx = bus.find_peripheral_index_by_name("dwt").unwrap();
+        bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Dwt>()
+            .unwrap()
+            .force_legacy_walk();
+    }
+
+    let mut machine = Machine::new(cpu, bus);
+    machine.config.peripheral_tick_interval = tick_interval;
+    machine.bus.config.peripheral_tick_interval = tick_interval;
+    machine.cpu.sp = INITIAL_SP;
+    machine
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Probe {
+    step: u64,
+    total_cycles: u64,
+    pc: u32,
+    regs: [u32; 16],
+    main_count: u32,
+    cyccnt_sample: u32,
+}
+
+fn probe(machine: &Machine<CortexM>, step: u64) -> Probe {
+    let mut regs = [0u32; 16];
+    for (i, r) in regs.iter_mut().enumerate() {
+        *r = machine.read_core_reg(i as u8);
+    }
+    Probe {
+        step,
+        total_cycles: machine.total_cycles,
+        pc: machine.get_pc(),
+        regs,
+        main_count: machine.bus.read_u32(MAIN_COUNT_ADDR).unwrap(),
+        cyccnt_sample: machine.bus.read_u32(CYCCNT_STORE_ADDR).unwrap(),
+    }
+}
+
+/// Run `steps` instructions one at a time through the batched `Machine::run`
+/// path, probing the full architectural state after every instruction.
+fn run_probed(machine: &mut Machine<CortexM>, entry: u32, steps: u64) -> Vec<Probe> {
+    machine.cpu.pc = entry;
+    let mut probes = Vec::with_capacity(steps as usize);
+    for s in 0..steps {
+        machine.run(Some(1)).unwrap();
+        probes.push(probe(machine, s + 1));
+    }
+    probes
+}
+
+/// Gate 1: lazy CYCCNT reads at unaligned cycles, walk-on vs walk-deleted
+/// scheduler at tick interval 1 — every instruction-boundary observable
+/// byte-identical (r4 carries the raw CYCCNT poll, stored to RAM).
+#[test]
+fn dwt_cyccnt_is_byte_identical_at_interval_1() {
+    const STEPS: u64 = 3_000;
+
+    let mut walk = build_machine(false, 1);
+    load_firmware_cyccnt_poll(&mut walk.bus);
+    let walk_probes = run_probed(&mut walk, 0x40, STEPS);
+
+    let mut sched = build_machine(true, 1);
+    load_firmware_cyccnt_poll(&mut sched.bus);
+    let sched_probes = run_probed(&mut sched, 0x40, STEPS);
+
+    assert_eq!(walk_probes.len(), sched_probes.len());
+    for (r, c) in walk_probes.iter().zip(sched_probes.iter()) {
+        assert_eq!(
+            r, c,
+            "DWT CYCCNT firmware: first divergence at step {} (walk-reference vs scheduler)",
+            r.step
+        );
+    }
+
+    let last = walk_probes.last().unwrap();
+    assert!(
+        last.cyccnt_sample > 1_000,
+        "reference must observe a live, advancing CYCCNT (got {})",
+        last.cyccnt_sample
+    );
+    // The reads land at many distinct cycle values (unaligned), so this is the
+    // "exact at arbitrary cycles" proof, not just at a single point.
+    let distinct: std::collections::BTreeSet<u32> =
+        walk_probes.iter().map(|p| p.cyccnt_sample).collect();
+    assert!(
+        distinct.len() > 100,
+        "CYCCNT must be sampled at many distinct cycle values (got {})",
+        distinct.len()
+    );
+}
+
+/// Gate 2: scheduler @ interval 64 vs walk-on interval-1 golden reference, run
+/// as a SINGLE batched call each (so 64-wide batches actually form). Both lanes
+/// execute the same instruction stream, so the CYCCNT sample at buffer index `i`
+/// is read at the same true cycle in both. The walk trace is a smooth ramp; the
+/// scheduler trace is a staircase (each 64-cycle batch reads the batch-start
+/// value), proving: (a) batching engaged (plateaus), (b) every read differs from
+/// the true walk by strictly less than one interval in EITHER direction (the
+/// documented batch-boundary freshness bound — reads quantise to batch-start and
+/// the enabling CTRL write is likewise synced to batch-start, so a read may sit
+/// slightly ahead near a batch edge; interval 1 is byte-exact, gate 1), and
+/// (c) CYCCNT stays LIVE — a frozen CYCCNT under walk-deletion would be a
+/// fidelity bug. `total_cycles` is identical, proving no timing artifact.
+#[test]
+fn dwt_cyccnt_reads_are_bounded_and_live_at_interval_64() {
+    const STEPS: u64 = 4_000;
+    const INTERVAL: u64 = 64;
+    // Well under the ~999 samples STEPS produces (loop is 4 instructions), so
+    // both lanes have written every slot we read.
+    const N_SAMPLES: u64 = 800;
+
+    let mut walk = build_machine(false, 1);
+    load_firmware_cyccnt_buffer(&mut walk.bus);
+    walk.cpu.pc = 0x40;
+    walk.run(Some(STEPS as u32)).unwrap();
+
+    let mut sched = build_machine(true, INTERVAL as u32);
+    load_firmware_cyccnt_buffer(&mut sched.bus);
+    sched.cpu.pc = 0x40;
+    sched.run(Some(STEPS as u32)).unwrap();
+
+    assert_eq!(
+        walk.total_cycles, sched.total_cycles,
+        "total_cycles must match (no timing artifact from the migration)"
+    );
+
+    let read_buf = |m: &Machine<CortexM>| -> Vec<u32> {
+        (0..N_SAMPLES)
+            .map(|i| m.bus.read_u32(BUFFER_BASE + i * 4).unwrap())
+            .collect()
+    };
+    let w = read_buf(&walk);
+    let s = read_buf(&sched);
+
+    let mut saw_plateau = false;
+    for i in 0..N_SAMPLES as usize {
+        // Both traces are monotone non-decreasing (CYCCNT never rewinds).
+        if i > 0 {
+            assert!(w[i] >= w[i - 1], "walk CYCCNT rewound at sample {i}");
+            assert!(s[i] >= s[i - 1], "scheduler CYCCNT rewound at sample {i}");
+            // The walk (interval 1) is a strict ramp — no plateaus.
+            assert!(
+                w[i] > w[i - 1],
+                "walk CYCCNT must strictly advance at sample {i}"
+            );
+            // The scheduler quantises: a batch of reads shares the batch-start
+            // value → at least one plateau across the run.
+            if s[i] == s[i - 1] {
+                saw_plateau = true;
+            }
+        }
+        // Bounded by strictly less than one interval in either direction
+        // (reads quantise to batch-start; the enabling CTRL write is synced to
+        // batch-start too, so a read can sit slightly ahead near a batch edge).
+        let diff = (w[i] as i64 - s[i] as i64).unsigned_abs();
+        assert!(
+            diff < INTERVAL,
+            "sample {i}: |walk {} - sched {}| = {} exceeds interval {}",
+            w[i],
+            s[i],
+            diff,
+            INTERVAL
+        );
+    }
+
+    assert!(
+        saw_plateau,
+        "interval-64 batching did not engage (no CYCCNT plateau — was the batch clamped to 1?)"
+    );
+    // Live, not frozen: the scheduler counter climbs well past zero.
+    assert!(
+        *s.last().unwrap() > 1_000,
+        "scheduler CYCCNT must keep counting true cycles (got {})",
+        s.last().unwrap()
+    );
+}
+
+// ── mcg / rsim inertness (the walk contributes nothing) ─────────────────────
+
+/// Assert a tick result carries no side effect (no IRQ / DMA / exception / mmio
+/// write / fired event / tick cost) — a genuine walk no-op. (`PeripheralTickResult`
+/// does not derive `PartialEq`, so the fields are checked individually.)
+fn assert_tick_is_inert(r: &labwired_core::PeripheralTickResult, what: &str) {
+    assert!(!r.irq, "{what}: tick raised an IRQ");
+    assert_eq!(r.cycles, 0, "{what}: tick charged cycles");
+    assert!(
+        r.dma_requests.is_none(),
+        "{what}: tick emitted a DMA request"
+    );
+    assert!(
+        r.explicit_irqs.is_none(),
+        "{what}: tick raised explicit IRQs"
+    );
+    assert!(
+        r.system_exception.is_none(),
+        "{what}: tick raised a system exception"
+    );
+    assert!(r.dma_signals.is_none(), "{what}: tick emitted a DMA signal");
+    assert!(
+        r.mmio_writes.is_empty(),
+        "{what}: tick requested an mmio write"
+    );
+    assert!(r.fired_events.is_empty(), "{what}: tick fired an event");
+}
+
+/// Drive the MCG through the NXP `CLOCK_SetFeeMode` control writes, then prove
+/// its `tick()` is a genuine no-op: the snapshot is byte-identical before and
+/// after any number of ticks, and the tick result is `default()`. This is the
+/// evidence behind `Mcg::needs_legacy_walk() == false`.
+#[test]
+fn mcg_tick_is_a_genuine_no_op() {
+    use labwired_core::peripherals::mcg::Mcg;
+
+    let mut mcg = Mcg::new();
+    // A representative spread of reachable control states (reset, FEE, external
+    // clock select, crystal-osc enable).
+    for &(off, val) in &[(0x00u64, 0x28u8), (0x01, 0xC4), (0x03, 0x20), (0x00, 0x80)] {
+        mcg.write(off, val).unwrap();
+        let before = mcg.snapshot();
+        for _ in 0..1000 {
+            assert_tick_is_inert(&mcg.tick(), "MCG");
+        }
+        // `tick_elapsed(N)` is the interval-batched walk entry — also inert.
+        let _ = mcg.tick_elapsed(64);
+        let after = mcg.snapshot();
+        assert_eq!(
+            before, after,
+            "MCG state changed under the walk (state after write off={off:#x} val={val:#x})"
+        );
+    }
+}
+
+/// Drive the RSIM through `BOARD_RfOscInit` (enable the RF oscillator), then
+/// prove its `tick()` is a genuine no-op — the evidence behind
+/// `Rsim::needs_legacy_walk() == false`.
+#[test]
+fn rsim_tick_is_a_genuine_no_op() {
+    use labwired_core::peripherals::rsim::Rsim;
+
+    let mut rsim = Rsim::new();
+    // Not-yet-enabled and enabled states both must be walk-inert.
+    for enable in [false, true] {
+        if enable {
+            let ctrl = rsim.read_u32(0x000).unwrap();
+            rsim.write_u32(0x000, (ctrl & !(0xF << 8)) | (1 << 8))
+                .unwrap();
+        }
+        let before = rsim.snapshot();
+        for _ in 0..1000 {
+            assert_tick_is_inert(&rsim.tick(), "RSIM");
+        }
+        let _ = rsim.tick_elapsed(64);
+        let after = rsim.snapshot();
+        assert_eq!(
+            before, after,
+            "RSIM state changed under the walk (enable={enable})"
+        );
+    }
+}
+
+// ── kw41z board-config flip status ──────────────────────────────────────────
+
+/// Assemble the FRDM-KW41Z bus exactly as the run path builds it: `from_config`
+/// (chip + system manifest, any hand `walk_deleted` stripped) + the real
+/// Cortex-M SCB / NVIC / DWT via `configure_cortex_m`.
+fn frdm_kw41z_runtime_bus() -> SystemBus {
+    use labwired_config::{ChipDescriptor, SystemManifest};
+    use std::path::PathBuf;
+
+    let system_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../configs/systems/frdm-kw41z.yaml");
+    let mut manifest = SystemManifest::from_file(&system_path).expect("load frdm-kw41z manifest");
+    // Derive from the models, not the manifest escape hatch.
+    manifest.walk_deleted = None;
+    let chip_path = system_path.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load mkw41z4 chip");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build frdm-kw41z bus");
+    let _ = configure_cortex_m(&mut bus);
+    bus
+}
+
+/// The exact `SystemBus::derive_walk_deletable` predicate (which is `pub(crate)`),
+/// recomputed here from PUBLIC trait methods over the PUBLIC `peripherals` list:
+/// walk-deletable iff EVERY peripheral is scheduler-driven or walk-independent.
+fn is_walk_deletable(bus: &SystemBus) -> bool {
+    bus.peripherals
+        .iter()
+        .all(|p| p.dev.uses_scheduler() || !p.dev.needs_legacy_walk())
+}
+
+fn walk_forcing_set(bus: &SystemBus) -> Vec<String> {
+    let mut forcing: Vec<String> = bus
+        .peripherals
+        .iter()
+        .filter(|p| p.dev.needs_legacy_walk() && !p.dev.uses_scheduler())
+        .map(|p| p.name.clone())
+        .collect();
+    forcing.sort();
+    forcing
+}
+
+/// After the mcg/rsim/dwt batch, the ONLY peripheral still forcing the walk on
+/// the kw41z bus is `i2c1` (the shared Kinetis/STM32 I2C model migrated on a
+/// parallel branch). mcg, rsim and dwt are now walk-independent.
+#[test]
+fn kw41z_board_walk_forcing_set_is_only_i2c1() {
+    let bus = frdm_kw41z_runtime_bus();
+    let forcing = walk_forcing_set(&bus);
+    assert_eq!(
+        forcing,
+        vec!["i2c1".to_string()],
+        "expected i2c1 as the sole remaining walk-forcer after the mcg/rsim/dwt batch; \
+         got {forcing:?}"
+    );
+    // The mcg/rsim/dwt models this batch cleared are genuinely gone from the set.
+    for cleared in ["mcg", "rsim", "dwt"] {
+        assert!(
+            !forcing.iter().any(|n| n == cleared),
+            "{cleared} must no longer force the walk"
+        );
+    }
+}
+
+/// The board flip: once `i2c1` migrates, `derive_walk_deletable()` returns true
+/// for the FRDM-KW41Z bus with no hand flag, making it the FIRST board where the
+/// per-cycle walk is deleted for arbitrary firmware.
+///
+/// `#[ignore]`d pending the shared I2C migration (branch
+/// `perf/walk-free-stm32-dma-i2c`): `i2c1` is the last blocker. After both PRs
+/// merge, remove `#[ignore]` to activate the flip gate.
+#[test]
+#[ignore = "blocked on i2c1 (shared Kinetis/STM32 I2C migration, parallel branch); \
+            activate once that lands and i2c1 leaves the walk-forcing set"]
+fn kw41z_board_derive_walk_deletable_flips() {
+    let bus = frdm_kw41z_runtime_bus();
+    assert!(
+        is_walk_deletable(&bus),
+        "FRDM-KW41Z bus must derive walk-deletion once every walker (incl. i2c1) is \
+         migrated; remaining forcing set: {:?}",
+        walk_forcing_set(&bus)
+    );
+}


### PR DESCRIPTION
## Summary

Migrates the last three non-I2C walkers on the **Kinetis KW41Z** (Cortex-M) bus off the per-cycle peripheral walk — **mcg**, **rsim**, **dwt** — so the KW41Z becomes the board closest to `derive_walk_deletable()` flipping true for arbitrary firmware. After this batch the **sole remaining walk-forcer on the FRDM-KW41Z bus is `i2c1`** (the shared Kinetis/STM32 I2C model, migrated on the parallel branch `perf/walk-free-stm32-dma-i2c`). Once that lands, the board flips with no hand `walk_deleted` flag.

**Fidelity is preserved exactly.** DWT follows the SysTick lazy-CVR pattern: byte-identical to the legacy walk at tick interval 1, bounded batch-boundary quantisation at interval 64 — never frozen. mcg/rsim are proven inert (their `tick()` is a genuine no-op).

## Per-model inventory & classification

| Model | Walk behaviour today | Classification | Migration |
|---|---|---|---|
| **mcg** (Kinetis MCG clock gen) | No `tick()` override; `MCG_S` recomputed from control bits on every write (`recompute_status`); modes settle instantaneously (no PLL/lock counter) — zero time-dependent state | **INERT** | `needs_legacy_walk() = false` |
| **rsim** (Radio System Integration Module) | No `tick()` override; `RF_OSC_READY` recomputed on CONTROL write (`refresh_control`); instantaneous crystal start-up; rest is plain storage | **INERT** | `needs_legacy_walk() = false` |
| **dwt** (CYCCNT) | `tick()` increments CYCCNT +1/cycle while `CTRL.CYCCNTENA`; free-running, read-polled, no IRQ | **LAZY read-derived** | scheduler-mode lazy `advance_to` from the bus `CycleClock`; `uses_scheduler() = true` |

**Evidence** — each classification is pinned by a committed differential (see below), not asserted.

## DWT lazy-CYCCNT design

CYCCNT is a linear function of elapsed cycles while enabled, so it is the purest lazy-read case (no scheduled events). Two mutually-exclusive drive modes, one predicate (`scheduler_mode = event-scheduler feature && CycleClock attached`), mirroring `systick.rs`:

- **Scheduler mode**: `CYCCNT` derived closed-form on read — `advance_to(now)` adds `(now − anchor)` to a `Cell`-held counter while `CYCCNTENA` is set (wrapping mod 2³²), from the bus-published cycle clock. A `&self` read syncs to "now" first, so a poll at any cycle returns exactly what the walk would have produced. The walk skips DWT entirely.
- **Legacy mode** (feature off / no clock — hand-built buses): the per-cycle `tick()` advances eagerly, byte-identical to the historical model.

`configure_cortex_m` now attaches the bus `CycleClock` to DWT. DWT is registered by directly manipulating `bus.peripherals` (it bypasses the `add_peripheral` attach choke), so the attach is replicated explicitly — exactly as the sibling SCB install already does. The window between any two MMIO writes has a constant CTRL (every write syncs first via the bus `sync_to` choke), so an enable/disable never straddles a lazy window. Byte writes to CYCCNT/CTRL are preserved (load-modify-store on the fresh value); `peek` is side-effect-free (never advances the anchor).

## Fidelity evidence

New: `crates/core/tests/kw41z_walk_free_differential.rs` (added to the core-ci "scheduler IRQ delivery" gate).

1. **`dwt_cyccnt_is_byte_identical_at_interval_1`** — hand-built Cortex-M + hand-assembled Thumb firmware enables CYCCNT and polls it from its loop at many distinct **unaligned** cycle counts. Run twice — DWT `force_legacy_walk()` (reference) vs scheduler-driven — and every instruction-boundary observable (`total_cycles`, PC, all 16 regs, the stored CYCCNT sample) is **byte-identical**. This is the "exact at arbitrary cycles" proof.
2. **`dwt_cyccnt_reads_are_bounded_and_live_at_interval_64`** — scheduler @ interval 64 vs walk-on interval-1 golden ref, run as a single batched call so 64-wide batches actually form. The walk trace is a smooth ramp; the scheduler trace is a **staircase** (batching engaged). Every read differs from the true walk by strictly less than one interval in either direction (reads and the enabling CTRL write both quantise to batch-start — the documented `sync_to` bound), CYCCNT stays **live** (never frozen), and `total_cycles` is identical (no timing artifact).
3. **`mcg_tick_is_a_genuine_no_op` / `rsim_tick_is_a_genuine_no_op`** — driven through their real NXP boot register sequences (`CLOCK_SetFeeMode` / `BOARD_RfOscInit`), then ticked 1000× + `tick_elapsed(64)`: snapshot byte-identical before/after, tick result carries no side effect.
4. **Unit tests** in `dwt.rs` (9): legacy tick counting, software CYCCNT write, lazy read tracks clock exactly, disable freezes, re-anchor on write, wrap mod 2³², side-effect-free peek.
5. **Real-firmware e2e** (`firmware_survival` kw41z, 9 tests): NXP-vendor, Zephyr hello, Zephyr fxos8700 (I²C sensor over i2c1), LCD cow-tilt — all boot and run correctly with lazy DWT + inert mcg/rsim. `kw41z_clock_boot` (5) green.

Full `cargo test -p labwired-core --features jit,event-scheduler` green (44 result groups, 0 failures); default-features dwt + campaign tests green; clippy clean.

## Flip-test status

`kw41z_board_walk_forcing_set_is_only_i2c1` (**active**) asserts the FRDM-KW41Z runtime bus (`from_config` + `configure_cortex_m`) walk-forcing set is exactly `{i2c1}` and mcg/rsim/dwt are cleared. `kw41z_board_derive_walk_deletable_flips` (**`#[ignore]`d**, naming i2c1 as the last blocker) asserts the full flip; un-ignore it after the i2c1 PR merges. Production activation is honest: `from_config` derives `legacy_walk_disabled` over the chip-descriptor peripherals; SCB/NVIC/DWT added later by `configure_cortex_m` are all walk-independent under event-scheduler (absent from the invaders forcing set), so once i2c1 leaves the set the derive flips true.

## Perf

The flip does **not** activate in this PR (i2c1 pins it), so the KW41Z bus still runs the per-cycle walk at interval 1 — this batch is correctness/staging. Baseline native release throughput (kw41z-zephyr-hello on FRDM-KW41Z, interval 1, this machine): **≈5.0 MIPS** (20M steps / 3.97s user; linear — 5M/0.94s). At interval 1 the change removes 3 of ~20 walker instances from the per-cycle loop, and in a build where the flip has not engaged the walk still runs identically (DWT only goes lazy under event-scheduler; mcg/rsim are only skipped once the walk is deleted), so the interval-1 before/after delta is nil-to-noise — the honest expectation. The real win — interval-64 batching (~64× fewer peripheral-tick passes) — unlocks when i2c1 merges and the flip engages; gate 2 already demonstrates that batching stays cycle-honest for DWT.

## Remaining pinned set (KW41Z, event-scheduler)

`{ i2c1 }` — shared Kinetis/STM32 I2C model, parallel branch. Everything else (lpuart0, systick, spi0, declarative banks, gpioc, scb, nvic, dwt, mcg, rsim) is walk-independent.

Does **not** touch the shared I2C model (`i2c.rs`) or the STM32 DMA model (parallel agent's ownership).
