### PR TITLE
perf: walk-free ESP32-C3 I2C0 via self-perpetuating module-tick events

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -3859,6 +3859,11 @@ mod tests {
         let i2c = any
             .downcast_mut::<crate::peripherals::esp32c3::i2c::Esp32c3I2c>()
             .expect("i2c0 must be the behavioral Esp32c3I2c controller");
+        // This test drives the bit engine directly via `tick_elapsed` (the
+        // legacy walk path) with no Machine event loop; pin it off the scheduler
+        // so the direct drive advances the engine (byte-identical to the
+        // scheduler path, which a Machine drives via `drain_scheduler_events`).
+        i2c.force_legacy_walk();
 
         // Drive the canonical register-pointer read of the BMP280 chip-id
         // (0xD0 → 0x58), exactly as C3 firmware would, through the controller's
@@ -3976,6 +3981,9 @@ mod tests {
         let i2c = any
             .downcast_mut::<crate::peripherals::esp32c3::i2c::Esp32c3I2c>()
             .expect("i2c0 must be the behavioral Esp32c3I2c controller");
+        // Direct `tick_elapsed` drive (legacy walk path), no Machine event loop:
+        // pin off the scheduler so the direct drive advances the engine.
+        i2c.force_legacy_walk();
 
         // 16-bit-addressed read of EEPROM word 0x2430: write the 2-byte big-
         // endian register address (0x24, 0x30), repeated-start, read 2 bytes

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -80,7 +80,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::peripherals::i2c::I2cDevice;
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
 
 pub const I2C0_BASE: u32 = 0x6001_3000;
 pub const I2C0_SIZE: u64 = 0x1000;
@@ -153,6 +153,13 @@ pub const INT_END_DETECT: u32 = 1 << 3;
 pub const INT_TRANS_COMPLETE: u32 = 1 << 7;
 pub const INT_NACK: u32 = 1 << 10;
 const SCL_RST_SLV_EN: u32 = 1 << 0;
+
+/// Event-scheduler token: advance the bit engine by one I²C module-clock tick.
+/// The engine keeps exactly one such event in flight while a transaction is
+/// active (walk-free plan): `take_scheduled_events` bootstraps it from the
+/// `TRANS_START` write and `on_event` re-arms it at the next module tick until
+/// the engine parks. Opaque to the scheduler.
+const I2C_MODULE_TICK_TOKEN: u32 = 0;
 
 /// ESP32-C3 has 8 COMD slots at offsets 0x58..0x78 (COMD0..COMD7 in the yaml).
 const NUM_CMDS: usize = 8;
@@ -409,6 +416,26 @@ pub struct Esp32c3I2c {
     /// pads. Created lazily by [`Self::line_levels_arc`] at bus wiring time.
     lines: Option<Arc<I2cLineLevels>>,
 
+    /// Bus-published cycle clock (walk-free plan). `Some` once
+    /// `SystemBus::add_peripheral` attaches it. Its presence (under the
+    /// `event-scheduler` feature) flips the model onto the event scheduler:
+    /// the per-cycle walk skips it and the bit engine is driven by
+    /// self-perpetuating module-tick events instead. `None` (feature off, a
+    /// hand-built bus, or the differential's `force_legacy_walk`) keeps the
+    /// legacy per-cycle walk. Not serialized — re-attached by the bus.
+    clock: Option<CycleClock>,
+    /// CPU cycle the bit engine has been advanced to (scheduler mode anchor).
+    /// The write path (`sync_to`) and the module-tick event (`on_event`) both
+    /// advance the engine by `now - last_synced` and bump this, so the two
+    /// paths compose without double-counting elapsed cycles.
+    last_synced: u64,
+    /// `true` while exactly one module-tick event is in flight for this engine
+    /// (walk-free plan). Guards against re-bootstrapping a second event on a
+    /// later MMIO write while a transaction is already clocking: only
+    /// `take_scheduled_events` (no event in flight) may arm one, and `on_event`
+    /// re-arms the single successor. Mirrors the generic SPI `scheduled` gate.
+    scheduled: bool,
+
     // Config / timing registers — masked storage (reset values per C3 i2c0.yaml).
     reg_scl_low_period: u32,   // 0x00  reset 0x0000_0000  mask 0x0000_01FF
     reg_to: u32,               // 0x0C  reset 0x0000_0010  mask 0x0000_003F
@@ -453,6 +480,9 @@ impl Esp32c3I2c {
             expects_addr: true,
             engine: BitEngine::new(),
             lines: None,
+            clock: None,
+            last_synced: 0,
+            scheduled: false,
 
             reg_scl_low_period: 0x0000_0000,
             reg_to: 0x0000_0010,
@@ -705,17 +735,14 @@ impl Peripheral for Esp32c3I2c {
     /// module-clock ticks through the exact `num/den` fraction snapshotted at
     /// `TRANS_START`, so wire timing is independent of the peripheral tick
     /// interval the host chose.
+    ///
+    /// This is the LEGACY per-cycle walk path. In scheduler mode
+    /// ([`Self::uses_scheduler`] true) the walk skips this peripheral entirely
+    /// and the engine is driven by module-tick events instead; the guard keeps
+    /// a stray direct call from advancing the engine twice.
     fn tick_elapsed(&mut self, cycles: u64) -> PeripheralTickResult {
-        if self.engine_active() {
-            self.engine.acc += cycles.saturating_mul(self.engine.timing.den);
-            while self.engine.acc >= self.engine.timing.num {
-                self.engine.acc -= self.engine.timing.num;
-                self.module_tick();
-                if !self.engine_active() {
-                    self.engine.acc = 0;
-                    break;
-                }
-            }
+        if !self.uses_scheduler() {
+            self.advance_engine(cycles);
         }
         // LEVEL interrupt: assert the I2C0 source every tick while any enabled
         // INT bit is set, mirroring real silicon (INT_RAW stays asserted until
@@ -740,6 +767,98 @@ impl Peripheral for Esp32c3I2c {
 
     fn legacy_tick_dynamic(&self) -> bool {
         true
+    }
+
+    /// Walk-free plan: driven by the event scheduler once the bus has attached
+    /// its cycle clock (production `add_peripheral` always does, under the
+    /// `event-scheduler` feature). The per-cycle walk then skips this
+    /// peripheral; the bit engine advances via `sync_to` (write path) and
+    /// self-perpetuating module-tick events (`on_event`). Without a clock
+    /// (feature off, a hand-built bus, or `force_legacy_walk`) it stays on the
+    /// legacy walk so those callers keep the old exact semantics.
+    fn uses_scheduler(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Anchor the bit engine to CPU cycle `now`, advancing it over the cycles
+    /// elapsed since the last sync. The bus calls this before every MMIO write
+    /// (so a `TRANS_START` / config / `INT_CLR` write observes the up-to-date
+    /// engine) and it composes with `on_event` through the shared `last_synced`
+    /// anchor without double-counting.
+    fn sync_to(&mut self, now: u64) {
+        if now > self.last_synced {
+            self.advance_engine(now - self.last_synced);
+            self.last_synced = now;
+        }
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        // Anchor at the clock's current value so cycles elapsed before attach
+        // (normally zero — attach happens at bus assembly) are not retroactively
+        // credited to the engine (mirrors the rtc_timer #516 re-anchor contract).
+        self.last_synced = clock.now();
+        self.clock = Some(clock);
+    }
+
+    /// C3 interrupt-matrix level: the I2C0 source while any enabled INT bit is
+    /// set — the exact condition `tick_elapsed` pushes on the legacy walk. In
+    /// scheduler mode the walk no longer re-emits it, so the bus re-derives the
+    /// level from here (`refresh_esp32c3_sched_sources`, polled on the event
+    /// path and the walk-tick aggregation) so the level-sensitive IRQ stays
+    /// routed and de-asserts the tick after firmware writes INT_CLR.
+    fn matrix_irq_sources(&self) -> Vec<u32> {
+        if self.int_raw & self.int_ena != 0 {
+            vec![self.intr_source_id]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Bootstrap the single module-tick event when a transaction begins clocking
+    /// and none is in flight. The delay is relative to the just-synced anchor;
+    /// the bus converts it to the absolute deadline `anchor + 1 + delay`, so the
+    /// `- 1` here lands the first module tick exactly at `anchor +
+    /// cycles_to_next_module_tick` — the cycle the walk would fire it, at any
+    /// tick interval (the same anchor calibration the generic SPI engine uses).
+    /// `on_event` re-arms every subsequent tick.
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if self.engine_active() && !self.scheduled {
+            self.scheduled = true;
+            vec![(
+                self.cycles_to_next_module_tick().saturating_sub(1),
+                I2C_MODULE_TICK_TOKEN,
+            )]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Fire one module tick at its exact cycle, then re-arm the successor while
+    /// the engine keeps clocking. Advancing to `sched.now()` via the shared
+    /// anchor is delta-based, so a drain that arrives a few cycles late (tick
+    /// interval > 1) or early (a stale event after an intervening write
+    /// re-anchored the engine) self-corrects — the accumulator only ever
+    /// consumes the true elapsed cycles. The reschedule delay carries no `- 1`:
+    /// the event path uses `sched.now() + delay` directly (no `+ 1` anchor
+    /// offset, unlike the write path).
+    fn on_event(
+        &mut self,
+        _event_token: u32,
+        sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        self.scheduled = false;
+        let now = sched.now();
+        if now > self.last_synced {
+            self.advance_engine(now - self.last_synced);
+            self.last_synced = now;
+        }
+        let mut res = crate::sched::EventResult::default();
+        if self.engine_active() {
+            res.reschedule_delay = Some(self.cycles_to_next_module_tick());
+            self.scheduled = true;
+        }
+        res
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -889,6 +1008,52 @@ impl Esp32c3I2c {
         self.set_lines(scl, sda);
         self.engine.state = state;
         self.engine.ticks_left = ticks;
+    }
+
+    /// Advance the bit engine by `cycles` engine cycles, firing module ticks as
+    /// the `num/den` accumulator crosses. Shared by BOTH drive paths: the
+    /// legacy per-cycle walk ([`Self::tick_elapsed`]) and the scheduler
+    /// (`sync_to`/`on_event`). The accumulator is in units of `1/den` engine
+    /// cycles; the invariant `acc < num` holds on entry and exit (the `while`
+    /// drains it), so the same cycle→module-tick mapping applies whether one
+    /// cycle or a whole batch is advanced in a single call — the source of the
+    /// walk-vs-scheduler byte-identity.
+    fn advance_engine(&mut self, cycles: u64) {
+        if !self.engine_active() {
+            return;
+        }
+        self.engine.acc += cycles.saturating_mul(self.engine.timing.den);
+        while self.engine.acc >= self.engine.timing.num {
+            self.engine.acc -= self.engine.timing.num;
+            self.module_tick();
+            if !self.engine_active() {
+                self.engine.acc = 0;
+                break;
+            }
+        }
+    }
+
+    /// Engine cycles until the accumulator next reaches `num` — i.e. until the
+    /// next module tick fires, from the current (post-`advance_engine`,
+    /// `acc < num`) state. `ceil((num - acc) / den)`, always ≥ 1 while the
+    /// engine is active (`num/den` ≥ 4). Undefined (returns 0) when parked; only
+    /// called while `engine_active()`.
+    fn cycles_to_next_module_tick(&self) -> u64 {
+        if !self.engine_active() {
+            return 0;
+        }
+        let num = self.engine.timing.num;
+        let den = self.engine.timing.den.max(1);
+        // acc < num invariant → num - acc ≥ 1.
+        (num - self.engine.acc).div_ceil(den)
+    }
+
+    /// Test/differential knob: detach the cycle clock, pinning the model to the
+    /// legacy per-cycle walk (`uses_scheduler() == false`). Used by the
+    /// walk-on-vs-scheduler differential gate to build the reference config from
+    /// the same bus assembly (mirrors `Esp32c3RtcTimer::force_legacy_walk`).
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
     }
 
     /// One I²C module-clock tick.

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2723,6 +2723,20 @@ pub mod integration_tests {
         };
 
         let mut bus = crate::bus::SystemBus::from_config(&chip, &manifest).unwrap();
+        // This test drives the engine through the raw per-cycle bus walk
+        // (`tick_peripherals_fully`) with no Machine `drain_scheduler_events`
+        // loop; the walk skips scheduler-driven peripherals, so pin i2c0 to the
+        // legacy walk path (byte-identical) for the direct drive to advance it.
+        {
+            let idx = bus.find_peripheral_index_by_name("i2c0").unwrap();
+            bus.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<crate::peripherals::esp32c3::i2c::Esp32c3I2c>()
+                .unwrap()
+                .force_legacy_walk();
+        }
 
         // Drive one command-list transaction: RSTART; WRITE 2 (addr+W 0x78,
         // control byte 0x00); STOP — the canonical SSD1306 command prologue.
@@ -2827,6 +2841,18 @@ pub mod integration_tests {
         // SSD1306 command prologue (RSTART; WRITE 2; STOP).
         let mut c3 = build_with_oled("esp32c3_i2c", None);
         const BASE: u64 = 0x4000_5400;
+        // Direct raw-bus-walk drive (no Machine scheduler drain): pin i2c0 to the
+        // legacy walk path so `tick_peripherals_fully` advances the engine.
+        {
+            let idx = c3.find_peripheral_index_by_name("i2c0").unwrap();
+            c3.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .unwrap()
+                .downcast_mut::<crate::peripherals::esp32c3::i2c::Esp32c3I2c>()
+                .unwrap()
+                .force_legacy_walk();
+        }
         let cmd = |opcode: u32, byte_num: u32| (opcode << 11) | byte_num;
         c3.write_u32(BASE + 0x58, cmd(6, 0)).unwrap(); // RSTART
         c3.write_u32(BASE + 0x58 + 4, cmd(1, 2)).unwrap(); // WRITE 2

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -30,9 +30,9 @@
 //!    (`uses_scheduler() == true`), and after the C3/ESP32 Class-A inert
 //!    sweep (`needs_legacy_walk() == false` on the verified-inert models) the
 //!    remaining pinners are EXACTLY the verified real workers
-//!    (i2c0 / ledc / spi2 / apb_saradc / wifi_mac), asserted as an
-//!    exact set so the campaign report stays honest. SYSTIMER is now
-//!    scheduler-driven (walk-free C3 SYSTIMER batch) and no longer pins.
+//!    (ledc / spi2 / apb_saradc / wifi_mac), asserted as an
+//!    exact set so the campaign report stays honest. SYSTIMER and I²C0 are now
+//!    scheduler-driven (walk-free C3 SYSTIMER + I²C0 batches) and no longer pin.
 
 #![cfg(feature = "event-scheduler")]
 
@@ -90,9 +90,15 @@ struct OledLab {
 /// Build the OLED lab exactly as the browser fast-start does. `rtc_legacy`
 /// selects the reference config (RTC main timer pinned back onto the
 /// per-cycle walk via `force_legacy_walk`); `systimer_legacy` does the same for
-/// the SYSTIMER (the FreeRTOS-tick source), so a walk-on-vs-scheduler
-/// differential can isolate the SYSTIMER migration.
-fn build_oled_lab(tick_interval: u32, rtc_legacy: bool, systimer_legacy: bool) -> OledLab {
+/// the SYSTIMER (the FreeRTOS-tick source) and `i2c0_legacy` for the I²C0
+/// bit-engine (the OLED bus master), so a walk-on-vs-scheduler differential can
+/// isolate each migration in turn.
+fn build_oled_lab(
+    tick_interval: u32,
+    rtc_legacy: bool,
+    systimer_legacy: bool,
+    i2c0_legacy: bool,
+) -> OledLab {
     let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
         .expect("load esp32c3 chip yaml");
     let manifest =
@@ -192,6 +198,20 @@ fn build_oled_lab(tick_interval: u32, rtc_legacy: bool, systimer_legacy: bool) -
         systimer.force_legacy_walk();
     }
 
+    if i2c0_legacy {
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("i2c0")
+            .expect("oled bus registers i2c0");
+        machine.bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Esp32c3I2c>()
+            .expect("i2c0 is the C3 command-list controller")
+            .force_legacy_walk();
+    }
+
     machine.config.peripheral_tick_interval = tick_interval;
     machine.bus.config.peripheral_tick_interval = tick_interval;
 
@@ -247,9 +267,10 @@ const MIN_LIT: usize = 400;
 #[test]
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
-    let (walk_cycles, walk_fb, walk_serial) = run_lab(build_oled_lab(1, true, false), PAINT_BUDGET);
+    let (walk_cycles, walk_fb, walk_serial) =
+        run_lab(build_oled_lab(1, true, false, false), PAINT_BUDGET);
     let (sched_cycles, sched_fb, sched_serial) =
-        run_lab(build_oled_lab(1, false, false), PAINT_BUDGET);
+        run_lab(build_oled_lab(1, false, false, false), PAINT_BUDGET);
 
     assert!(
         lit_pixels(&walk_fb) >= MIN_LIT,
@@ -280,8 +301,8 @@ fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
 #[test]
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_framebuffer_is_byte_identical_across_tick_intervals() {
-    let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false), PAINT_BUDGET);
-    let (_, fb_64, serial_64) = run_lab(build_oled_lab(64, false, false), PAINT_BUDGET);
+    let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false, false), PAINT_BUDGET);
+    let (_, fb_64, serial_64) = run_lab(build_oled_lab(64, false, false, false), PAINT_BUDGET);
 
     assert!(
         lit_pixels(&fb_1) >= MIN_LIT,
@@ -314,9 +335,9 @@ fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
     for interval in [1u32, 64] {
         // reference: SYSTIMER on the legacy walk; test: SYSTIMER scheduler.
         let (walk_cycles, walk_fb, walk_serial) =
-            run_lab(build_oled_lab(interval, false, true), PAINT_BUDGET);
+            run_lab(build_oled_lab(interval, false, true, false), PAINT_BUDGET);
         let (sched_cycles, sched_fb, sched_serial) =
-            run_lab(build_oled_lab(interval, false, false), PAINT_BUDGET);
+            run_lab(build_oled_lab(interval, false, false, false), PAINT_BUDGET);
 
         assert!(
             lit_pixels(&walk_fb) >= MIN_LIT,
@@ -342,6 +363,67 @@ fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
              interval {interval}"
         );
     }
+}
+
+/// I²C0 walk-free gate (the fidelity contract for THIS batch): I²C0 is the OLED
+/// bus master — the SSD1306 GDDRAM is painted entirely through its bit-level
+/// command-list engine, so the framebuffer is the direct downstream observable
+/// of every module tick. Run the REAL demo with I²C0 on the legacy per-cycle
+/// walk (reference) vs scheduler-driven (self-perpetuating module-tick events
+/// routed through the C3 interrupt matrix), RTC + SYSTIMER scheduler in both so
+/// I²C0 is the only variable.
+///
+/// At interval 1 every observable must be BYTE-IDENTICAL: the module ticks fire
+/// at the same cycles, the slave sees the same byte boundaries and the same
+/// SDA/SCL waveform, so serial + total_cycles + framebuffer cannot differ. At
+/// interval 64 the framebuffer must ALSO be byte-identical: I²C0's bounded-stale
+/// `&self` register reads (SR.BUS_BUSY / INT_RAW polled between module-tick
+/// events) never change what the engine actually clocks onto the wire, so the
+/// painted OLED output is interval-independent. This is the cycle-exact identity
+/// that licenses un-pinning I²C0 from the walk.
+#[test]
+#[ignore = "runs the real C3 bootloader + app (~4x30M steps); run with --release --ignored"]
+fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
+    // interval 1: full byte-identity (serial + total_cycles + framebuffer).
+    let (walk_cycles, walk_fb, walk_serial) =
+        run_lab(build_oled_lab(1, false, false, true), PAINT_BUDGET);
+    let (sched_cycles, sched_fb, sched_serial) =
+        run_lab(build_oled_lab(1, false, false, false), PAINT_BUDGET);
+
+    assert!(
+        lit_pixels(&walk_fb) >= MIN_LIT,
+        "reference (I²C0 walk) must paint the OLED at interval 1 (lit={}); serial:\n{}",
+        lit_pixels(&walk_fb),
+        String::from_utf8_lossy(&walk_serial)
+    );
+    assert_eq!(
+        walk_cycles, sched_cycles,
+        "total_cycles must be byte-identical (I²C0 walk vs scheduler) at interval 1"
+    );
+    assert!(
+        walk_serial == sched_serial,
+        "serial stream must be byte-identical (I²C0 walk vs scheduler) at interval 1\n\
+         --- walk ---\n{}\n--- sched ---\n{}",
+        String::from_utf8_lossy(&walk_serial),
+        String::from_utf8_lossy(&sched_serial)
+    );
+    assert!(
+        walk_fb == sched_fb,
+        "SSD1306 framebuffer must be byte-identical (I²C0 walk vs scheduler) at interval 1"
+    );
+
+    // interval 64: bounded-stale reads must leave the painted OLED unchanged.
+    let (_, walk_fb_64, _) = run_lab(build_oled_lab(64, false, false, true), PAINT_BUDGET);
+    let (_, sched_fb_64, _) = run_lab(build_oled_lab(64, false, false, false), PAINT_BUDGET);
+    assert!(
+        walk_fb_64 == sched_fb_64,
+        "SSD1306 framebuffer must be byte-identical (I²C0 walk vs scheduler) at interval 64 \
+         (bounded-stale reads must not change the painted OLED)"
+    );
+    assert!(
+        sched_fb_64 == sched_fb,
+        "I²C0 scheduler framebuffer must be interval-independent (interval 64 == interval 1)"
+    );
 }
 
 /// Task C gate: FROM_CPU IPI + INTC config writes re-aggregate the routed
@@ -420,7 +502,7 @@ fn oled_lab_native_mips_probe() {
         .unwrap_or(1);
     let systimer_legacy = std::env::var("LABWIRED_MIPS_SYSTIMER_LEGACY").as_deref() == Ok("1");
     const STEPS: u64 = 50_000_000;
-    let mut lab = build_oled_lab(interval, false, systimer_legacy);
+    let mut lab = build_oled_lab(interval, false, systimer_legacy, false);
     let start = std::time::Instant::now();
     let mut steps = 0u64;
     while steps < STEPS {
@@ -444,10 +526,9 @@ fn oled_lab_native_mips_probe() {
 /// the remaining pinners are EXACTLY the verified real workers — models whose
 /// tick genuinely mutates state or asserts a level IRQ from the walk:
 ///
-///   (`systimer` — the free-running counter + FreeRTOS tick alarm — is now
-///   scheduler-driven and no longer here.)
-///   - `i2c0` — bit-level wire engine advances mid-transfer in
-///     `tick_elapsed` (num/den module-clock fraction) + level IRQ;
+///   (`systimer` — the free-running counter + FreeRTOS tick alarm — and `i2c0`
+///   — the OLED bit-level wire engine — are now scheduler-driven and no longer
+///   here.)
 ///   - `ledc` — the four low-speed timers run as live up-counters clocked by
 ///     elapsed cycles (OVF latch) + level IRQ;
 ///   - `spi2` — `tick()` re-asserts the level interrupt source while
@@ -471,9 +552,9 @@ fn oled_lab_walk_pinners_after_rtc_migration() {
     /// newly marked `needs_legacy_walk() == false` or migrated to the
     /// scheduler must shrink this set; a model that starts pinning again is a
     /// regression.
-    const EXPECTED_PINNERS: &[&str] = &["apb_saradc", "i2c0", "ledc", "spi2", "wifi_mac"];
+    const EXPECTED_PINNERS: &[&str] = &["apb_saradc", "ledc", "spi2", "wifi_mac"];
 
-    let lab = build_oled_lab(1, false, false);
+    let lab = build_oled_lab(1, false, false, false);
     let bus = &lab.machine.bus;
 
     let mut pinners: Vec<&str> = Vec::new();

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,7 +10,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-11 | ⚠ drift acked 2026-07-11 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-11 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -267,7 +267,16 @@ boards:
     # and deliberately left pinning (endgame ledger asserts the exact set). No
     # register, reset-value, timing or IRQ change; reset oracle unaffected. No
     # live re-capture warranted.
-    drift_ack: 2026-07-11
+    # 2026-07-12: I2C0 (esp32c3/i2c.rs) walk-free migration — the bit-level engine
+    # now advances via the event scheduler (uses_scheduler + a single self-perpetuating
+    # module-tick event + matrix_irq_sources level export) instead of the per-cycle
+    # walk; the shared advance_engine keeps the num/den module-tick cadence intact so
+    # wire timing stays interval-independent. Byte-identical to the walk path by the
+    # committed differential (oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical:
+    # serial + total_cycles + SSD1306 framebuffer at interval 1, framebuffer at
+    # interval 64). Register map, reset values, FIFO semantics unchanged; reset oracle
+    # unaffected. No live re-capture this session.
+    drift_ack: 2026-07-12
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md


### PR DESCRIPTION
## What

Migrate the ESP32-C3 **I2C0** bit-level command-list engine off the per-cycle legacy walk onto the event scheduler. Mirrors the shipped SYSTIMER #519 and the generic STM32 SPI bit-engine. Step 1 of the campaign to make the C3 OLED lab batchable (delete the bus walk → raise the tick interval).

## Mechanism (all in `peripherals/esp32c3/i2c.rs`, bus unchanged)

- `advance_engine(cycles)` is split out of the old `tick_elapsed` acc-loop and shared by BOTH drive paths, so the `num/den` module-tick cadence is byte-identical however cycles are batched.
- `uses_scheduler()` is true once the bus attaches its `CycleClock` (feature-gated); `attach_cycle_clock`/`sync_to` anchor the engine to `last_synced` and advance it before every MMIO write, keeping `&self` reads of SR/FIFO_ST/INT_RAW fresh at the write choke.
- `matrix_irq_sources()` exposes the I2C0 level (`int_raw & int_ena`) — the C3 interrupt matrix re-derives it, replacing the walk's `explicit_irqs` push.
- **Arm/event mechanism:** exactly ONE module-tick event stays in flight, guarded by a `scheduled` flag (mirrors the generic SPI engine). `take_scheduled_events` bootstraps it from the `TRANS_START` write (`delay - 1` to offset the bus write-path `+1` anchor); `on_event` fires one module tick and re-arms its successor at `cycles_to_next_module_tick()` until the engine parks. The self-perpetuating per-tick event tracks `timing_from_regs()` exactly, so wire timing stays tick-interval-independent (the multi-phase chase/transition/begin_byte NACK-abort state machine is preserved — no whole-transaction alarm is precomputed).
- `force_legacy_walk()` detaches the clock for the differential reference and the direct-drive unit tests (which have no Machine scheduler loop).

## Fidelity gate

New `oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical` (real C3 bootloader+app) asserts:
- **interval 1:** byte-identical serial + `total_cycles` + SSD1306 framebuffer (walk vs scheduler)
- **interval 64:** framebuffer byte-identical (bounded-stale reads leave the OLED output unchanged)

I2C0 drops from the C3 walk-pinner ledger (`EXPECTED_PINNERS` 5→4: `apb_saradc, ledc, spi2, wifi_mac`); `derive_walk_deletable()` stays **false** (4 real workers remain) so the OLED bus stays on interval 1 — zero behavior change.

## Tests

- Full core suite `--features jit,event-scheduler`: **2391 passed / 0 failed / 35 ignored**.
- All 6 esp32c3 `--ignored` differentials pass (i2c0 byte-identity, RTC, SYSTIMER, framebuffer-across-intervals).
- 4 direct-drive I2C0 unit tests (bmp280/mlx90640 register round-trip, two bus-trace tests) now pin `force_legacy_walk` — they drive the engine via the raw walk with no Machine event loop; the legacy path is byte-identical.

Please review before merging — bit-engine port. Auto-merge intentionally not armed.