### PR TITLE
perf: walk-free ESP32-C3 spi2 + apb_saradc (level-only matrix export)

### DIFF
--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1283,7 +1283,8 @@ mod c3_level_peripheral_matrix_routing {
         let mut bus = SystemBus::from_config(&chip, &manifest).expect("build c3 devkit bus");
         bus.esp32c3_irq_routing = true;
         bus.refresh_peripheral_index();
-        bus.write_u32(INTMATRIX + (source as u64) * 4, LINE).unwrap();
+        bus.write_u32(INTMATRIX + (source as u64) * 4, LINE)
+            .unwrap();
         bus.write_u32(INTMATRIX + 0x114 + (LINE as u64) * 4, 1)
             .unwrap();
         bus.write_u32(INTMATRIX + 0x194, 1).unwrap();

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1231,3 +1231,209 @@ mod c3_systimer_matrix_routing {
         );
     }
 }
+
+/// Walk-free C3 level-only peripheral batch (`spi2` + `apb_saradc`) — the
+/// interrupt-matrix ROUTING identity.
+///
+/// Both are one-shot LEVEL re-emitters: `int_raw` is write-armed by a
+/// transaction / conversion (no free-running counter), and the model re-asserts
+/// its matrix source while `int_raw & int_ena != 0`. On the legacy walk that
+/// level is re-emitted every tick via `tick()`'s `explicit_irqs`; migrated off
+/// the walk it is exported through `matrix_irq_sources` and re-derived by the
+/// bus (`refresh_esp32c3_sched_sources` inside `aggregate_esp32c3_irqs`). This
+/// gate proves the two paths deliver the routed CPU line IDENTICALLY — the
+/// end-to-end fidelity contract the OLED differential can't exercise (spi2 /
+/// apb_saradc never fire in that lab). Same trigger, armed on two buses; one
+/// left scheduler-driven, one pinned back to the walk with `force_legacy_walk`.
+#[cfg(all(test, feature = "event-scheduler"))]
+mod c3_level_peripheral_matrix_routing {
+    use crate::bus::SystemBus;
+    use crate::peripherals::esp32c3::apb_saradc::{Esp32c3ApbSarAdc, APB_SARADC_INTR_SOURCE_ID};
+    use crate::peripherals::esp32c3::spi::{Esp32c3Spi, SPI2_INTR_SOURCE_ID, TRANS_DONE};
+    use labwired_config::{ChipDescriptor, SystemManifest};
+    use std::path::PathBuf;
+
+    const INTMATRIX: u64 = 0x600C_2000;
+    const LINE: u32 = 7;
+
+    // spi2 register offsets + bits (private in spi.rs; mirrored for the test).
+    const SPI_CMD: u64 = 0x00;
+    const SPI_DMA_INT_ENA: u64 = 0x34;
+    const SPI_DMA_INT_CLR: u64 = 0x38;
+    const SPI_USR_BIT: u32 = 1 << 24;
+
+    // apb_saradc register offsets + bits (private in apb_saradc.rs; mirrored).
+    const SARADC_ONETIME_SAMPLE: u64 = 0x20;
+    const SARADC_INT_ENA: u64 = 0x40;
+    const SARADC_INT_CLR: u64 = 0x4C;
+    const SAR1_DONE_INT: u32 = 1 << 31;
+    const SAR1_ONETIME_SAMPLE: u32 = 1 << 31;
+    const ONETIME_START: u32 = 1 << 29;
+
+    /// Build a devkit C3 bus (real `interrupt_core0` → INTC cache), enable C3
+    /// routing, and route `source` → CPU line 7 (priority 1, threshold 1,
+    /// enabled) — the same wiring the SYSTIMER routing gate uses.
+    fn routed_bus(source: u32) -> SystemBus {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("load esp32c3 chip yaml");
+        let manifest =
+            SystemManifest::from_file(root.join("../../configs/systems/esp32c3-devkit.yaml"))
+                .expect("load esp32c3-devkit system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("build c3 devkit bus");
+        bus.esp32c3_irq_routing = true;
+        bus.refresh_peripheral_index();
+        bus.write_u32(INTMATRIX + (source as u64) * 4, LINE).unwrap();
+        bus.write_u32(INTMATRIX + 0x114 + (LINE as u64) * 4, 1)
+            .unwrap();
+        bus.write_u32(INTMATRIX + 0x194, 1).unwrap();
+        bus.write_u32(INTMATRIX + 0x104, 1 << LINE).unwrap();
+        bus
+    }
+
+    fn idx(bus: &SystemBus, name: &str) -> usize {
+        bus.find_peripheral_index_by_name(name)
+            .unwrap_or_else(|| panic!("c3 devkit bus carries {name}"))
+    }
+
+    /// Drive the level directly on the peripheral's own register write path (the
+    /// same effect an MMIO write has on the device), bypassing any bus-side
+    /// clock gate so the test is about the routing, not RCC bring-up. Refreshes
+    /// the legacy walk tick-set membership afterwards exactly as the real MMIO
+    /// write choke (`SystemBus::write_u32`) does, so a walk-pinned peripheral
+    /// that just asserted its level is actually ticked.
+    fn write_dev(bus: &mut SystemBus, name: &str, off: u64, val: u32) {
+        let i = idx(bus, name);
+        bus.peripherals[i].dev.write_u32(off, val).unwrap();
+        bus.refresh_legacy_tick_index(i);
+    }
+
+    fn arm_spi2(bus: &mut SystemBus) {
+        write_dev(bus, "spi2", SPI_DMA_INT_ENA, TRANS_DONE); // enable TRANS_DONE
+        write_dev(bus, "spi2", SPI_CMD, SPI_USR_BIT); // launch → latches TRANS_DONE
+    }
+
+    fn arm_saradc(bus: &mut SystemBus) {
+        write_dev(bus, "apb_saradc", SARADC_INT_ENA, SAR1_DONE_INT); // enable
+        write_dev(
+            bus,
+            "apb_saradc",
+            SARADC_ONETIME_SAMPLE,
+            SAR1_ONETIME_SAMPLE | ONETIME_START | (3 << 25), // one-shot ch3 → DONE
+        );
+    }
+
+    fn pin_to_walk(bus: &mut SystemBus, name: &str) {
+        let i = idx(bus, name);
+        let dev = bus.peripherals[i].dev.as_any_mut().unwrap();
+        if let Some(spi) = dev.downcast_mut::<Esp32c3Spi>() {
+            spi.force_legacy_walk();
+        } else if let Some(adc) = dev.downcast_mut::<Esp32c3ApbSarAdc>() {
+            adc.force_legacy_walk();
+        } else {
+            panic!("{name} is not a known C3 level peripheral");
+        }
+        // Flipping uses_scheduler false changes walk-set membership; refresh it
+        // so an already-armed peripheral joins the walk (the arm's own refresh
+        // ran while it was still scheduler-driven and thus excluded).
+        bus.refresh_legacy_tick_index(i);
+    }
+
+    /// Shared body: arm `name` on a scheduler bus and a walk bus, tick each, and
+    /// assert the routed CPU line is delivered identically; then clear the level
+    /// and assert both de-assert. `source` is the peripheral's matrix source ID,
+    /// `int_clr`/`clr_bit` the W1C acknowledge.
+    fn assert_walk_scheduler_identical(
+        name: &str,
+        source: u32,
+        int_clr: u64,
+        clr_bit: u32,
+        arm: fn(&mut SystemBus),
+    ) {
+        let mut sched = routed_bus(source);
+        let mut walk = routed_bus(source);
+        arm(&mut sched);
+        arm(&mut walk);
+        pin_to_walk(&mut walk, name);
+
+        // Scheduler bus: the peripheral is walk-skipped and exports its level.
+        let si = idx(&sched, name);
+        assert!(
+            sched.peripherals[si].dev.uses_scheduler(),
+            "{name} must be scheduler-driven once the bus attached its clock"
+        );
+        assert_eq!(
+            sched.peripherals[si].dev.matrix_irq_sources(),
+            vec![source],
+            "{name} must export its matrix source while armed+enabled"
+        );
+        // Walk bus: pinned back, so it re-emits via the walk (`tick`), not the
+        // scheduler export. (`matrix_irq_sources` still reflects the raw level,
+        // but the bus never polls it for a non-`uses_scheduler` peripheral.)
+        let wi = idx(&walk, name);
+        assert!(
+            !walk.peripherals[wi].dev.uses_scheduler(),
+            "force_legacy_walk must pin {name} back onto the per-cycle walk"
+        );
+        assert_eq!(
+            walk.peripherals[wi].dev.tick().explicit_irqs,
+            Some(vec![source]),
+            "a walk-pinned {name} must re-emit its level source from the walk tick"
+        );
+
+        // One walk tick on each aggregates the routed line mask.
+        sched.tick_peripherals_with_costs();
+        walk.tick_peripherals_with_costs();
+        assert_eq!(
+            sched.riscv_irq_lines,
+            1 << LINE,
+            "scheduler path must route {name} source {source} to CPU line {LINE}"
+        );
+        assert_eq!(
+            walk.riscv_irq_lines,
+            1 << LINE,
+            "walk path must route {name} source {source} to CPU line {LINE}"
+        );
+        assert_eq!(
+            sched.riscv_irq_lines, walk.riscv_irq_lines,
+            "walk vs scheduler IRQ delivery for {name} must be byte-identical"
+        );
+
+        // Acknowledge the level on both; the routed line must de-assert on the
+        // next tick — same level semantics on either path.
+        write_dev(&mut sched, name, int_clr, clr_bit);
+        write_dev(&mut walk, name, int_clr, clr_bit);
+        sched.tick_peripherals_with_costs();
+        walk.tick_peripherals_with_costs();
+        assert_eq!(
+            sched.riscv_irq_lines, 0,
+            "scheduler path must de-assert {name} after INT_CLR"
+        );
+        assert_eq!(
+            walk.riscv_irq_lines, 0,
+            "walk path must de-assert {name} after INT_CLR"
+        );
+    }
+
+    #[test]
+    fn spi2_irq_delivered_identically_walk_and_scheduler() {
+        assert_walk_scheduler_identical(
+            "spi2",
+            SPI2_INTR_SOURCE_ID,
+            SPI_DMA_INT_CLR,
+            TRANS_DONE,
+            arm_spi2,
+        );
+    }
+
+    #[test]
+    fn apb_saradc_irq_delivered_identically_walk_and_scheduler() {
+        assert_walk_scheduler_identical(
+            "apb_saradc",
+            APB_SARADC_INTR_SOURCE_ID,
+            SARADC_INT_CLR,
+            SAR1_DONE_INT,
+            arm_saradc,
+        );
+    }
+}

--- a/crates/core/src/peripherals/esp32c3/apb_saradc.rs
+++ b/crates/core/src/peripherals/esp32c3/apb_saradc.rs
@@ -41,7 +41,7 @@
 
 use std::cell::Cell;
 
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
 
 pub const APB_SARADC_BASE: u32 = 0x6004_0000;
 pub const APB_SARADC_SIZE: u64 = 0x1000;
@@ -116,6 +116,18 @@ pub struct Esp32c3ApbSarAdc {
     /// Latched conversion results for SAR1 / SAR2 (the `*DATA_STATUS` regs).
     sar1_data: u32,
     sar2_data: u32,
+    /// Bus-published cycle clock (walk-free plan). `Some` once
+    /// `SystemBus::push_peripheral`/`add_peripheral` attaches it. Its presence
+    /// (under the `event-scheduler` feature) flips the model onto the event
+    /// scheduler: the per-cycle walk skips this peripheral and the bus derives
+    /// its level-sensitive matrix IRQ from [`Self::matrix_irq_sources`] instead
+    /// of the walk's `explicit_irqs`. This one-shot controller has NO
+    /// free-running counter — `int_raw` is write-armed by `convert()` on the
+    /// ONETIME_START strobe — so there are no scheduled events: the migration is
+    /// level-export only. `None` (feature off, a hand-built bus, or the
+    /// differential's `force_legacy_walk`) keeps the legacy per-cycle walk. Not
+    /// serialized — re-attached by the bus.
+    clock: Option<CycleClock>,
 }
 
 impl Default for Esp32c3ApbSarAdc {
@@ -152,7 +164,16 @@ impl Esp32c3ApbSarAdc {
             int_raw: Cell::new(0),
             sar1_data: 0,
             sar2_data: 0,
+            clock: None,
         }
+    }
+
+    /// Test/differential knob: detach the cycle clock, pinning the model to the
+    /// legacy per-cycle walk (`uses_scheduler() == false`). Used by the
+    /// walk-on-vs-scheduler differential gate to build the reference config from
+    /// the same bus assembly (mirrors `Esp32c3I2c::force_legacy_walk`).
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
     }
 
     fn int_st(&self) -> u32 {
@@ -242,6 +263,11 @@ impl Peripheral for Esp32c3ApbSarAdc {
         Ok(())
     }
 
+    /// LEGACY per-cycle walk path: re-assert the level interrupt source while
+    /// any enabled INT bit is set. In scheduler mode ([`Self::uses_scheduler`]
+    /// true) the walk skips this peripheral entirely and the bus re-derives the
+    /// level from [`Self::matrix_irq_sources`] instead; this reporter is a pure
+    /// no-op on state, so a stray call is harmless.
     fn tick(&mut self) -> PeripheralTickResult {
         PeripheralTickResult {
             explicit_irqs: if self.int_st() != 0 {
@@ -259,6 +285,37 @@ impl Peripheral for Esp32c3ApbSarAdc {
 
     fn legacy_tick_dynamic(&self) -> bool {
         true
+    }
+
+    /// Walk-free plan: driven by the event scheduler once the bus has attached
+    /// its cycle clock (production `push_peripheral`/`add_peripheral` always do,
+    /// under the `event-scheduler` feature). The per-cycle walk then skips this
+    /// peripheral; its `int_raw` is write-armed by `convert()` on the
+    /// ONETIME_START strobe (no free-running counter), so there is nothing to
+    /// advance and no event to schedule — only the level export via
+    /// `matrix_irq_sources` is needed. Without a clock (feature off, a
+    /// hand-built bus, or `force_legacy_walk`) it stays on the legacy walk so
+    /// those callers keep the old exact semantics.
+    fn uses_scheduler(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        self.clock = Some(clock);
+    }
+
+    /// C3 interrupt-matrix level: the `APB_SARADC` source while any enabled INT
+    /// bit is set — the exact condition `tick` pushes on the legacy walk. In
+    /// scheduler mode the walk no longer re-emits it, so the bus re-derives the
+    /// level from here (`refresh_esp32c3_sched_sources`, polled on the event
+    /// path and the walk-tick aggregation) so the level-sensitive IRQ stays
+    /// routed and de-asserts the tick after firmware writes INT_CLR.
+    fn matrix_irq_sources(&self) -> Vec<u32> {
+        if self.int_st() != 0 {
+            vec![self.source_id]
+        } else {
+            Vec::new()
+        }
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/crates/core/src/peripherals/esp32c3/spi.rs
+++ b/crates/core/src/peripherals/esp32c3/spi.rs
@@ -45,7 +45,7 @@
 //! interrupt matrix.
 
 use crate::peripherals::spi::SpiDevice;
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
 
 pub const SPI2_BASE: u32 = 0x6002_4000;
 pub const SPI2_SIZE: u64 = 0x1000;
@@ -143,6 +143,17 @@ pub struct Esp32c3Spi {
     /// Devices on this controller's bus: MOSI bytes broadcast to every device,
     /// first non-zero MISO byte wins (single-device labs in practice).
     pub(crate) attached_devices: Vec<Box<dyn SpiDevice>>,
+    /// Bus-published cycle clock (walk-free plan). `Some` once
+    /// `SystemBus::push_peripheral`/`add_peripheral` attaches it. Its presence
+    /// (under the `event-scheduler` feature) flips the model onto the event
+    /// scheduler: the per-cycle walk skips this peripheral and the bus derives
+    /// its level-sensitive matrix IRQ from [`Self::matrix_irq_sources`] instead
+    /// of the walk's `explicit_irqs`. This controller has NO free-running
+    /// counter — `int_raw` is write-armed by the transaction launch — so there
+    /// are no scheduled events: the migration is level-export only. `None`
+    /// (feature off, a hand-built bus, or the differential's `force_legacy_walk`)
+    /// keeps the legacy per-cycle walk. Not serialized — re-attached by the bus.
+    clock: Option<CycleClock>,
 }
 
 impl std::fmt::Debug for Esp32c3Spi {
@@ -175,7 +186,16 @@ impl Esp32c3Spi {
             regs,
             int_raw: 0,
             attached_devices: Vec::new(),
+            clock: None,
         }
+    }
+
+    /// Test/differential knob: detach the cycle clock, pinning the model to the
+    /// legacy per-cycle walk (`uses_scheduler() == false`). Used by the
+    /// walk-on-vs-scheduler differential gate to build the reference config from
+    /// the same bus assembly (mirrors `Esp32c3I2c::force_legacy_walk`).
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
     }
 
     /// Raw device push — does NOT wrap for tracing. The only production caller
@@ -342,6 +362,11 @@ impl Peripheral for Esp32c3Spi {
         Ok(())
     }
 
+    /// LEGACY per-cycle walk path: re-assert the level interrupt source while
+    /// any enabled INT bit is set. In scheduler mode ([`Self::uses_scheduler`]
+    /// true) the walk skips this peripheral entirely and the bus re-derives the
+    /// level from [`Self::matrix_irq_sources`] instead; this reporter is a pure
+    /// no-op on state, so a stray call is harmless.
     fn tick(&mut self) -> PeripheralTickResult {
         PeripheralTickResult {
             explicit_irqs: if self.int_st() != 0 {
@@ -359,6 +384,37 @@ impl Peripheral for Esp32c3Spi {
 
     fn legacy_tick_dynamic(&self) -> bool {
         true
+    }
+
+    /// Walk-free plan: driven by the event scheduler once the bus has attached
+    /// its cycle clock (production `push_peripheral`/`add_peripheral` always do,
+    /// under the `event-scheduler` feature). The per-cycle walk then skips this
+    /// peripheral; its `int_raw` is write-armed by the transaction launch (no
+    /// free-running counter), so there is nothing to advance and no event to
+    /// schedule — only the level export via `matrix_irq_sources` is needed.
+    /// Without a clock (feature off, a hand-built bus, or `force_legacy_walk`)
+    /// it stays on the legacy walk so those callers keep the old exact
+    /// semantics.
+    fn uses_scheduler(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        self.clock = Some(clock);
+    }
+
+    /// C3 interrupt-matrix level: the GP-SPI2 source while any enabled INT bit
+    /// is set — the exact condition `tick` pushes on the legacy walk. In
+    /// scheduler mode the walk no longer re-emits it, so the bus re-derives the
+    /// level from here (`refresh_esp32c3_sched_sources`, polled on the event
+    /// path and the walk-tick aggregation) so the level-sensitive IRQ stays
+    /// routed and de-asserts the tick after firmware writes INT_CLR.
+    fn matrix_irq_sources(&self) -> Vec<u32> {
+        if self.int_st() != 0 {
+            vec![self.source_id]
+        } else {
+            Vec::new()
+        }
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -335,7 +335,8 @@ fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_framebuffer_is_byte_identical_across_tick_intervals() {
     let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
-    let (_, fb_64, serial_64) = run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
+    let (_, fb_64, serial_64) =
+        run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
 
     assert!(
         lit_pixels(&fb_1) >= MIN_LIT,
@@ -367,10 +368,14 @@ fn oled_lab_framebuffer_is_byte_identical_across_tick_intervals() {
 fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
     for interval in [1u32, 64] {
         // reference: SYSTIMER on the legacy walk; test: SYSTIMER scheduler.
-        let (walk_cycles, walk_fb, walk_serial) =
-            run_lab(build_oled_lab(interval, false, true, false, false), PAINT_BUDGET);
-        let (sched_cycles, sched_fb, sched_serial) =
-            run_lab(build_oled_lab(interval, false, false, false, false), PAINT_BUDGET);
+        let (walk_cycles, walk_fb, walk_serial) = run_lab(
+            build_oled_lab(interval, false, true, false, false),
+            PAINT_BUDGET,
+        );
+        let (sched_cycles, sched_fb, sched_serial) = run_lab(
+            build_oled_lab(interval, false, false, false, false),
+            PAINT_BUDGET,
+        );
 
         assert!(
             lit_pixels(&walk_fb) >= MIN_LIT,

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -30,9 +30,10 @@
 //!    (`uses_scheduler() == true`), and after the C3/ESP32 Class-A inert
 //!    sweep (`needs_legacy_walk() == false` on the verified-inert models) the
 //!    remaining pinners are EXACTLY the verified real workers
-//!    (ledc / spi2 / apb_saradc / wifi_mac), asserted as an
-//!    exact set so the campaign report stays honest. SYSTIMER and I²C0 are now
-//!    scheduler-driven (walk-free C3 SYSTIMER + I²C0 batches) and no longer pin.
+//!    (ledc / wifi_mac), asserted as an
+//!    exact set so the campaign report stays honest. SYSTIMER, I²C0 and the
+//!    level-only pair spi2 + apb_saradc are now scheduler-driven (walk-free C3
+//!    SYSTIMER + I²C0 + spi2/apb_saradc batches) and no longer pin.
 
 #![cfg(feature = "event-scheduler")]
 
@@ -45,8 +46,10 @@ use labwired_core::bus::SystemBus;
 use labwired_core::cpu::RiscV;
 use labwired_core::memory::ProgramImage;
 use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc;
 use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
 use labwired_core::peripherals::esp32c3::rtc_timer::Esp32c3RtcTimer;
+use labwired_core::peripherals::esp32c3::spi::Esp32c3Spi;
 use labwired_core::{Arch, Bus, Cpu, DebugControl, Machine};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -90,14 +93,16 @@ struct OledLab {
 /// Build the OLED lab exactly as the browser fast-start does. `rtc_legacy`
 /// selects the reference config (RTC main timer pinned back onto the
 /// per-cycle walk via `force_legacy_walk`); `systimer_legacy` does the same for
-/// the SYSTIMER (the FreeRTOS-tick source) and `i2c0_legacy` for the I²C0
-/// bit-engine (the OLED bus master), so a walk-on-vs-scheduler differential can
-/// isolate each migration in turn.
+/// the SYSTIMER (the FreeRTOS-tick source), `i2c0_legacy` for the I²C0
+/// bit-engine (the OLED bus master), and `spi_adc_legacy` for the level-only
+/// pair (`spi2` + `apb_saradc`, migrated together), so a walk-on-vs-scheduler
+/// differential can isolate each migration in turn.
 fn build_oled_lab(
     tick_interval: u32,
     rtc_legacy: bool,
     systimer_legacy: bool,
     i2c0_legacy: bool,
+    spi_adc_legacy: bool,
 ) -> OledLab {
     let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
         .expect("load esp32c3 chip yaml");
@@ -212,6 +217,34 @@ fn build_oled_lab(
             .force_legacy_walk();
     }
 
+    if spi_adc_legacy {
+        // Level-only pair: pin both back onto the per-cycle walk so the
+        // reference config re-emits their matrix source via `tick()` instead of
+        // the scheduler export (`matrix_irq_sources`).
+        let spi_idx = machine
+            .bus
+            .find_peripheral_index_by_name("spi2")
+            .expect("oled bus registers spi2");
+        machine.bus.peripherals[spi_idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Esp32c3Spi>()
+            .expect("spi2 is the C3 GP-SPI2 controller")
+            .force_legacy_walk();
+        let adc_idx = machine
+            .bus
+            .find_peripheral_index_by_name("apb_saradc")
+            .expect("oled bus registers apb_saradc");
+        machine.bus.peripherals[adc_idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Esp32c3ApbSarAdc>()
+            .expect("apb_saradc is the C3 SAR ADC controller")
+            .force_legacy_walk();
+    }
+
     machine.config.peripheral_tick_interval = tick_interval;
     machine.bus.config.peripheral_tick_interval = tick_interval;
 
@@ -268,9 +301,9 @@ const MIN_LIT: usize = 400;
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
     let (walk_cycles, walk_fb, walk_serial) =
-        run_lab(build_oled_lab(1, true, false, false), PAINT_BUDGET);
+        run_lab(build_oled_lab(1, true, false, false, false), PAINT_BUDGET);
     let (sched_cycles, sched_fb, sched_serial) =
-        run_lab(build_oled_lab(1, false, false, false), PAINT_BUDGET);
+        run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
 
     assert!(
         lit_pixels(&walk_fb) >= MIN_LIT,
@@ -301,8 +334,8 @@ fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
 #[test]
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_framebuffer_is_byte_identical_across_tick_intervals() {
-    let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false, false), PAINT_BUDGET);
-    let (_, fb_64, serial_64) = run_lab(build_oled_lab(64, false, false, false), PAINT_BUDGET);
+    let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
+    let (_, fb_64, serial_64) = run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
 
     assert!(
         lit_pixels(&fb_1) >= MIN_LIT,
@@ -335,9 +368,9 @@ fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
     for interval in [1u32, 64] {
         // reference: SYSTIMER on the legacy walk; test: SYSTIMER scheduler.
         let (walk_cycles, walk_fb, walk_serial) =
-            run_lab(build_oled_lab(interval, false, true, false), PAINT_BUDGET);
+            run_lab(build_oled_lab(interval, false, true, false, false), PAINT_BUDGET);
         let (sched_cycles, sched_fb, sched_serial) =
-            run_lab(build_oled_lab(interval, false, false, false), PAINT_BUDGET);
+            run_lab(build_oled_lab(interval, false, false, false, false), PAINT_BUDGET);
 
         assert!(
             lit_pixels(&walk_fb) >= MIN_LIT,
@@ -386,9 +419,9 @@ fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
 fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
     // interval 1: full byte-identity (serial + total_cycles + framebuffer).
     let (walk_cycles, walk_fb, walk_serial) =
-        run_lab(build_oled_lab(1, false, false, true), PAINT_BUDGET);
+        run_lab(build_oled_lab(1, false, false, true, false), PAINT_BUDGET);
     let (sched_cycles, sched_fb, sched_serial) =
-        run_lab(build_oled_lab(1, false, false, false), PAINT_BUDGET);
+        run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
 
     assert!(
         lit_pixels(&walk_fb) >= MIN_LIT,
@@ -413,8 +446,8 @@ fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
     );
 
     // interval 64: bounded-stale reads must leave the painted OLED unchanged.
-    let (_, walk_fb_64, _) = run_lab(build_oled_lab(64, false, false, true), PAINT_BUDGET);
-    let (_, sched_fb_64, _) = run_lab(build_oled_lab(64, false, false, false), PAINT_BUDGET);
+    let (_, walk_fb_64, _) = run_lab(build_oled_lab(64, false, false, true, false), PAINT_BUDGET);
+    let (_, sched_fb_64, _) = run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
     assert!(
         walk_fb_64 == sched_fb_64,
         "SSD1306 framebuffer must be byte-identical (I²C0 walk vs scheduler) at interval 64 \
@@ -423,6 +456,56 @@ fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
     assert!(
         sched_fb_64 == sched_fb,
         "I²C0 scheduler framebuffer must be interval-independent (interval 64 == interval 1)"
+    );
+}
+
+/// spi2 + apb_saradc walk-free gate: the level-only pair migrates together. In
+/// THIS lab neither peripheral fires (the OLED demo drives the display over
+/// I²C0, never GP-SPI2 or the SAR ADC), so pinning them to the legacy walk
+/// (reference) vs scheduler-driven (test) must leave EVERY observable
+/// byte-identical — this proves the migration does not perturb the demo. The
+/// direct IRQ-delivery identity (where they actually fire) is proven at the bus
+/// level by `c3_level_peripheral_matrix_routing` in `bus::tick`; this end-to-end
+/// gate proves the quiescent case. RTC + SYSTIMER + I²C0 are scheduler-driven in
+/// both configs so the pair is the only variable.
+#[test]
+#[ignore = "runs the real C3 bootloader + app (~4x30M steps); run with --release --ignored"]
+fn oled_lab_spi2_apb_saradc_walk_on_vs_scheduler_is_byte_identical() {
+    // interval 1: full byte-identity (serial + total_cycles + framebuffer).
+    let (walk_cycles, walk_fb, walk_serial) =
+        run_lab(build_oled_lab(1, false, false, false, true), PAINT_BUDGET);
+    let (sched_cycles, sched_fb, sched_serial) =
+        run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
+
+    assert!(
+        lit_pixels(&walk_fb) >= MIN_LIT,
+        "reference (spi2/apb_saradc walk) must paint the OLED at interval 1 (lit={}); serial:\n{}",
+        lit_pixels(&walk_fb),
+        String::from_utf8_lossy(&walk_serial)
+    );
+    assert_eq!(
+        walk_cycles, sched_cycles,
+        "total_cycles must be byte-identical (spi2/apb_saradc walk vs scheduler) at interval 1"
+    );
+    assert!(
+        walk_serial == sched_serial,
+        "serial stream must be byte-identical (spi2/apb_saradc walk vs scheduler) at interval 1"
+    );
+    assert!(
+        walk_fb == sched_fb,
+        "SSD1306 framebuffer must be byte-identical (spi2/apb_saradc walk vs scheduler) at interval 1"
+    );
+
+    // interval 64: the quiescent pair must still not perturb the painted OLED.
+    let (_, walk_fb_64, _) = run_lab(build_oled_lab(64, false, false, false, true), PAINT_BUDGET);
+    let (_, sched_fb_64, _) = run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
+    assert!(
+        walk_fb_64 == sched_fb_64,
+        "SSD1306 framebuffer must be byte-identical (spi2/apb_saradc walk vs scheduler) at interval 64"
+    );
+    assert!(
+        sched_fb_64 == sched_fb,
+        "spi2/apb_saradc scheduler framebuffer must be interval-independent (interval 64 == interval 1)"
     );
 }
 
@@ -502,7 +585,7 @@ fn oled_lab_native_mips_probe() {
         .unwrap_or(1);
     let systimer_legacy = std::env::var("LABWIRED_MIPS_SYSTIMER_LEGACY").as_deref() == Ok("1");
     const STEPS: u64 = 50_000_000;
-    let mut lab = build_oled_lab(interval, false, systimer_legacy, false);
+    let mut lab = build_oled_lab(interval, false, systimer_legacy, false, false);
     let start = std::time::Instant::now();
     let mut steps = 0u64;
     while steps < STEPS {
@@ -526,17 +609,14 @@ fn oled_lab_native_mips_probe() {
 /// the remaining pinners are EXACTLY the verified real workers — models whose
 /// tick genuinely mutates state or asserts a level IRQ from the walk:
 ///
-///   (`systimer` — the free-running counter + FreeRTOS tick alarm — and `i2c0`
-///   — the OLED bit-level wire engine — are now scheduler-driven and no longer
-///   here.)
+///   (`systimer` — the free-running counter + FreeRTOS tick alarm —, `i2c0`
+///   — the OLED bit-level wire engine —, and the level-only pair `spi2` +
+///   `apb_saradc` are now scheduler-driven and no longer here. The pair export
+///   their level via `matrix_irq_sources` instead of re-emitting it from the
+///   walk's `tick()`; no scheduled events, since their `int_raw` is write-armed
+///   by a transaction / conversion rather than a free-running counter.)
 ///   - `ledc` — the four low-speed timers run as live up-counters clocked by
 ///     elapsed cycles (OVF latch) + level IRQ;
-///   - `spi2` — `tick()` re-asserts the level interrupt source while
-///     `int_raw & int_ena != 0` (reachable whenever firmware enables a
-///     TRANS_DONE/DMA int), so deleting the walk would starve the IRQ;
-///   - `apb_saradc` — same level-IRQ re-assert pattern from `tick()`
-///     (this is the chip-yaml `esp32c3_apb_saradc` controller; the rom-boot
-///     `apb_saradc` cal window at the same name is inert and no longer pins);
 ///   - `wifi_mac` — `tick_with_bus` pumps TX/RX descriptor rings + `tick()`
 ///     re-asserts the MAC level interrupt while events are pending.
 ///
@@ -552,9 +632,9 @@ fn oled_lab_walk_pinners_after_rtc_migration() {
     /// newly marked `needs_legacy_walk() == false` or migrated to the
     /// scheduler must shrink this set; a model that starts pinning again is a
     /// regression.
-    const EXPECTED_PINNERS: &[&str] = &["apb_saradc", "ledc", "spi2", "wifi_mac"];
+    const EXPECTED_PINNERS: &[&str] = &["ledc", "wifi_mac"];
 
-    let lab = build_oled_lab(1, false, false, false);
+    let lab = build_oled_lab(1, false, false, false, false);
     let bus = &lab.machine.bus;
 
     let mut pinners: Vec<&str> = Vec::new();

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -276,6 +276,19 @@ boards:
     # serial + total_cycles + SSD1306 framebuffer at interval 1, framebuffer at
     # interval 64). Register map, reset values, FIFO semantics unchanged; reset oracle
     # unaffected. No live re-capture this session.
+    # 2026-07-12: spi2 (esp32c3/spi.rs) + apb_saradc (esp32c3/apb_saradc.rs) walk-free
+    # migration — the level-only pair. Both are one-shot LEVEL re-emitters whose int_raw
+    # is write-armed by a transaction / conversion (no free-running counter), so they
+    # migrate off the per-cycle walk with uses_scheduler + a matrix_irq_sources level
+    # export and NO scheduled events (unlike i2c0). The walk-skipped level is re-derived
+    # by the bus each aggregation (refresh_esp32c3_sched_sources), delivering the routed
+    # RISC-V line identically to the legacy walk. Proven byte-identical: the direct
+    # IRQ-delivery gate c3_level_peripheral_matrix_routing (walk vs scheduler produce the
+    # same riscv_irq_lines for spi2 source 19 / apb_saradc source 43, and both de-assert
+    # after INT_CLR) + the quiescent-lab differential
+    # oled_lab_spi2_apb_saradc_walk_on_vs_scheduler_is_byte_identical (serial +
+    # total_cycles + SSD1306 framebuffer at interval 1/64). Register map, reset values,
+    # INT/one-shot semantics unchanged; reset oracle unaffected. No live re-capture.
     drift_ack: 2026-07-12
 
   - id: nucleo-l476rg


### PR DESCRIPTION
Continues the ESP32-C3 walk-free campaign after i2c0 #525. Migrates the **level-only pair** `spi2` + `apb_saradc` off the per-cycle walk onto the event scheduler. **Pinners 4 → 2**: remaining `{ledc, wifi_mac}`.

## Mechanism (simpler than i2c0 — no scheduled events)
Both are one-shot **level re-emitters**: `int_raw` is write-armed by a transaction (`spi2` launch) / conversion (`apb_saradc` ONETIME_START), with no free-running counter. So each gets:
- `uses_scheduler()` = feature-on AND a bus-attached `CycleClock`;
- `attach_cycle_clock()` stores the clock (bus attaches it at `push_peripheral`/`add_peripheral`);
- `matrix_irq_sources()` exports the interrupt-matrix source (spi2 = 19, apb_saradc = 43) while `int_st() != 0`;
- `force_legacy_walk()` test/differential knob;
- the walk skips them via `uses_scheduler()`.

**No scheduled events** — no counter to advance. **No bus glue changes**: `refresh_esp32c3_sched_sources` / `poll_scheduler_matrix_sources` already union any `uses_scheduler` peripheral, and the walk still runs (ledc + wifi_mac pin) so it re-derives the write-armed level each aggregation → routed to the RISC-V line identically to the walk.

## Gates (all green, `--features jit,event-scheduler`)
- **Direct IRQ-delivery identity** `c3_level_peripheral_matrix_routing` (bus::tick): walk (`force_legacy_walk`, `tick` `explicit_irqs`) vs scheduler (`matrix_irq_sources`) produce the same `riscv_irq_lines` for spi2 src 19 / apb_saradc src 43; both de-assert after INT_CLR. This is the gate that actually *fires* the peripherals.
- **Byte-identity differential** `oled_lab_spi2_apb_saradc_walk_on_vs_scheduler_is_byte_identical`: the pair is quiescent in the OLED demo, so serial + total_cycles + SSD1306 framebuffer are byte-identical at interval 1 and 64 (migration doesn't perturb the lab).
- **Pinner ledger** `oled_lab_walk_pinners_after_rtc_migration`: `EXPECTED_PINNERS = {ledc, wifi_mac}`; `derive_walk_deletable()` stays false, `max_safe_tick_interval` stays 1.
- **Regression**: `--lib` 1898 passed / 0 failed; rtc/systimer/i2c0/framebuffer heavy differentials 4/4 pass; `esp32c3_irq_choke_reaggregates_on_write` passes.
- **Drift gate**: dated 2026-07-12 note in `validation/manifest.yaml` (ack date unchanged — byte-identical, no live re-capture); `generate_validation_status.py --check --drift` rc 0 + `generate_firmware_exercise_matrix.py --check` rc 0.

Files: `peripherals/esp32c3/{spi,apb_saradc}.rs`, `bus/tick.rs` (test only), `tests/esp32c3_walk_differential.rs`, `validation/manifest.yaml`.