### PR TITLE
feat(esp32s3): attach SSD1306 OLED @ 0x3C to I2C0 for the S3 OLED lab

### DIFF
--- a/configs/systems/esp32s3-oled-demo.yaml
+++ b/configs/systems/esp32s3-oled-demo.yaml
@@ -1,0 +1,33 @@
+# LabWired - ESP32-S3 + SSD1306 OLED lab.
+#
+# A Waveshare ESP32-S3-Zero drives a 128x64 SSD1306 OLED over the command-list
+# I2C0 controller (0x6001_3000). The panel sits at 0x3C on SDA=GPIO8 / SCL=GPIO9
+# (3V3 / GND power). The curated esp-hal firmware (demo-esp32s3-oled.elf) inits
+# I2C0, brings up the SSD1306, and paints an "S3 OK" / "LabWired" frame; the
+# browser twin boots that ELF FAITHFULLY on the genuine Espressif boot ROM
+# (zero thunks) and the register-level I2C driver drives the real panel model.
+name: "esp32s3-oled-demo"
+chip: "../chips/esp32s3.yaml"
+
+external_devices:
+  # SSD1306 OLED on I2C0 at 0x3C. The ESP32-S3 system builder attaches the
+  # panel to the command-list Esp32s3I2c at i2c0; the firmware's register-level
+  # driver drives it with genuine I2C transactions.
+  - id: "oled"
+    type: "oled-ssd1306"
+    connection: "i2c0"
+    config:
+      i2c_address: 0x3C
+
+board_io:
+  # Framebuffer readback binding (WasmSimulator::get_ssd1306_framebuffer). The
+  # S3 GPIO matrix routes I2C0 SDA/SCL to GPIO8/GPIO9; the behavioral controller
+  # responds at its register block regardless, so the pin is documentation here.
+  - id: "oled"
+    kind: "i2c_device"
+    peripheral: "i2c0"
+    pin: 8
+    signal: "input"
+    active_high: true
+    i2c_address: 0x3C
+    device_type: "oled-ssd1306"

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -626,8 +626,9 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
     }
 
     // I2C0 carries board-specific I2C slaves the factory does not model: TMP102
-    // always, plus an opt-in PCA9685 (LABWIRED_ESP32S3_PCA9685) for the
-    // SpiceDispenser servos. Built directly so the slaves are attached.
+    // always, an SSD1306 OLED @ 0x3C always, plus an opt-in PCA9685
+    // (LABWIRED_ESP32S3_PCA9685) for the SpiceDispenser servos. Built directly
+    // so the slaves are attached.
     let i2c0 = Esp32s3I2c::new();
     // Register first, then attach every slave through the single bus choke point
     // so each is wrapped into the shared bus trace (universal logic analyzer) —
@@ -635,6 +636,16 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
     bus.add_peripheral("i2c0", I2C0_BASE as u64, I2C0_SIZE, None, Box::new(i2c0));
     bus.attach_i2c_slave("i2c0", Box::new(Tmp102::new()))
         .expect("i2c0 just registered as Esp32s3I2c");
+    // SSD1306 128x64 OLED @ 0x3C. Mirrors the TMP102 "always attached" pattern:
+    // the panel sits inert at its distinct address until firmware initializes
+    // and draws to it (the S3 OLED lab does; hello-world never addresses 0x3C,
+    // so its framebuffer stays blank and no board_io binding reads it back).
+    // Distinct address from TMP102 (0x48)/PCA9685 (0x40), so no bus contention.
+    bus.attach_i2c_slave(
+        "i2c0",
+        Box::new(crate::peripherals::components::Ssd1306::new(0x3C)),
+    )
+    .expect("i2c0 just registered as Esp32s3I2c");
     if std::env::var("LABWIRED_ESP32S3_PCA9685").is_ok() {
         bus.attach_i2c_slave(
             "i2c0",


### PR DESCRIPTION
Attaches an SSD1306 128x64 OLED @ 0x3C to the ESP32-S3 command-list I2C0 controller in `configure_xtensa_esp32s3`, mirroring the existing always-attached TMP102 pattern. This lets an esp-hal S3 firmware that drives I2C0 paint a real panel the browser twin reads back via `get_ssd1306_framebuffer` (the S3 readback path landed in 3f8485d4; the panel was just never attached on the config/wasm path).

- Distinct address from TMP102 (0x48) / PCA9685 (0x40); inert until firmware addresses 0x3C, so hello-world and existing S3 tests are unaffected.
- Adds `configs/systems/esp32s3-oled-demo.yaml`: the S3-Zero + SSD1306 lab manifest (`oled` external_device on i2c0 + the `oled` board_io readback binding) consumed by the playground `esp32s3-oled-lab`.

Verified natively: the S3 OLED ELF boots faithfully (zero thunks) and paints 3441/8192 lit pixels; verified in-browser via the superproject lab (S3 OK / LabWired frame renders).

Full `cargo test -p labwired-core --lib --features event-scheduler,jit`: 1896 passed, 0 failed.