### PR TITLE
esp32c3: migrate wifi_mac off the per-cycle walk (last C3 pinner → OLED lab ~5.2→16.2 MIPS)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1068,6 +1068,10 @@ fn run_two_c3_wifi(
                 uart.set_stdout_prefix(label);
             }
         }
+        // `attach_to_medium` flips the MAC's `needs_bus_tick()` on (medium
+        // stations poll their inbox + beacon each tick) but is a non-MMIO
+        // toggle, so rebuild the bus tick-index once to make the MAC resident.
+        m.bus.refresh_peripheral_index();
     }
 
     let limit = args.max_steps.unwrap_or(u64::MAX);

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -276,6 +276,37 @@ impl SystemBus {
     }
 
     pub(crate) fn sync_esp32c3_irq_cache_write(&mut self, idx: usize, offset: u64) {
+        // Walk-free de-assert glue (the last-walker bus addition): once the C3
+        // bus is walk-DELETED (every peripheral migrated → `legacy_walk_disabled`)
+        // the per-cycle walk no longer re-derives scheduler-driven peripheral
+        // LEVELS each tick (`aggregate_esp32c3_irqs` stops running on the trivial
+        // tick path). A write-armed level — an INT_RAW set by a transaction, or
+        // the MAC event, and above all the acknowledge that CLEARS it
+        // (INT_CLR / EVENT_CLR) — must therefore re-derive the routed line mask
+        // AT THE WRITE, or a level would latch forever and re-enter its ISR. Do
+        // it here, at the shared MMIO write choke, but ONLY for a
+        // scheduler-driven peripheral (an ordinary register write pays nothing).
+        //
+        // Gated on `legacy_walk_disabled`: on a walk-ON bus the per-tick
+        // aggregation already owns level derivation and `esp32c3_asserted_sources`
+        // carries the walk-emitted sources — recomputing mid-instruction from
+        // that (stale until the next tick rebuilds it) would perturb routing, so
+        // the choke stays off there. On a walk-DELETED bus the walk never runs,
+        // so `esp32c3_asserted_sources` is inert and the recompute is the clean,
+        // authoritative level derivation. `recompute_esp32c3_irq_lines` also
+        // no-ops without the INTC cache, keeping this inert on hand-built buses.
+        #[cfg(feature = "event-scheduler")]
+        if self.legacy_walk_disabled
+            && self.esp32c3_irq_routing
+            && self
+                .peripherals
+                .get(idx)
+                .is_some_and(|p| p.dev.uses_scheduler())
+        {
+            self.refresh_esp32c3_sched_sources();
+            self.recompute_esp32c3_irq_lines();
+        }
+
         if self.esp32c3_irq_cache.is_none() {
             return;
         }

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -79,6 +79,19 @@ impl SystemBus {
             .all(|p| p.dev.uses_scheduler() || !p.dev.needs_legacy_walk())
     }
 
+    /// Re-run [`Self::derive_walk_deletable`] and latch it into
+    /// `legacy_walk_disabled`. Callers that flip a peripheral's drive mode AFTER
+    /// bus assembly — swapping a model in, or pinning one back onto the walk with
+    /// `force_legacy_walk` — must call this so the walk-deletion flag matches the
+    /// live peripheral set (the rom-boot path derives it once over the initial
+    /// set). Without it, a peripheral pinned back to the walk on an
+    /// already-walk-deleted bus is silently starved of ticks. Mirrors the inline
+    /// recompute the rom-boot path (`esp32c3_rom`) and the in-crate routing gates
+    /// already perform; exposed publicly for out-of-crate test harnesses.
+    pub fn recompute_walk_deletable(&mut self) {
+        self.legacy_walk_disabled = self.derive_walk_deletable();
+    }
+
     pub(crate) fn tick_profile_entry_counts(&self) -> (usize, usize) {
         let bus_tick_entries = self.bus_tick_indices.len();
         let legacy_tick_entries = if cfg!(feature = "event-scheduler") && self.legacy_walk_disabled
@@ -1598,6 +1611,439 @@ mod c3_ledc_matrix_routing {
         assert_eq!(
             bus.riscv_irq_lines, 0,
             "routed line must de-assert once the LEDC overflow level clears"
+        );
+    }
+}
+
+/// Walk-free C3 WiFi-MAC batch — the LAST walk pinner on the OLED rom-boot bus.
+///
+/// `wifi_mac` pinned the walk on TWO axes; both are migrated here with NO new
+/// event machinery:
+///
+///   * the interrupt LEVEL (matrix source 0, asserted while a MAC event is
+///     pending) — was re-emitted every walk tick by `tick()`; now exported
+///     through `matrix_irq_sources` and re-derived by the bus. On a walk-DELETED
+///     bus there is no walk tick to re-derive it, so a write-armed level change
+///     (the `EVENT_CLR` acknowledge) is re-routed at the MMIO WRITE CHOKE
+///     (`sync_esp32c3_irq_cache_write`). This module proves both: the scheduler
+///     and walk paths route the MAC level to the SAME CPU line, and the
+///     write-choke de-asserts it on a fully walk-deleted bus.
+///
+///   * the descriptor-ring PUMP (`tick_with_bus`) — was pinned by an
+///     unconditional `needs_bus_tick() == true`; now honestly gated so it only
+///     ticks while WiFi is up (`rx_ring != 0` / a pending TX / medium mode). The
+///     companion `c3_wifi_mac_walk_differential` module drives a real TX + RX
+///     session and proves the pump's ring writeback + IRQ delivery are
+///     byte-identical walk-vs-scheduler at interval 1 AND 64.
+#[cfg(all(test, feature = "event-scheduler"))]
+mod c3_wifi_mac_matrix_routing {
+    use crate::bus::SystemBus;
+    use crate::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac;
+    use crate::Peripheral;
+    use labwired_config::{ChipDescriptor, SystemManifest};
+    use std::path::PathBuf;
+
+    const MAC_BASE: u64 = 0x6003_3000;
+    const INTMATRIX: u64 = 0x600C_2000;
+    const LINE: u32 = 6;
+    /// WiFi MAC interrupt-matrix source (MAC_INTR_MAP @ offset 0).
+    const MAC_SOURCE: u32 = 0;
+
+    // wifi_mac register offsets (private in wifi_mac.rs; mirrored for the test).
+    const EVENT_GET: u64 = 0xC3C; // MAC event word (HW-set; read by the ISR)
+    const EVENT_CLR: u64 = 0xC40; // W1C acknowledge
+    const EVENT_RX_DONE: u32 = 0x0100_4000;
+
+    /// Build a devkit C3 bus (real `interrupt_core0` → INTC cache), enable C3
+    /// routing, swap the declarative `wifi_mac` stub for the real behavioral
+    /// model, and route the MAC source (0) → CPU line 6. `scheduler` selects the
+    /// drive mode: with the bus cycle clock attached the model is
+    /// scheduler-driven (walk-skipped, level exported via `matrix_irq_sources`);
+    /// without it the model stays on the legacy per-cycle walk.
+    fn setup(scheduler: bool) -> SystemBus {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("load esp32c3 chip yaml");
+        let manifest =
+            SystemManifest::from_file(root.join("../../configs/systems/esp32c3-devkit.yaml"))
+                .expect("load esp32c3-devkit system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("build c3 devkit bus");
+        bus.esp32c3_irq_routing = true;
+
+        // Swap the declarative wifi_mac for the real behavioral model at its base.
+        let idx = bus
+            .find_peripheral_index_by_name("wifi_mac")
+            .expect("devkit bus carries a wifi_mac");
+        let mut dev = Esp32c3WifiMac::new();
+        if scheduler {
+            dev.attach_cycle_clock(bus.cycle_clock.clone());
+        }
+        bus.peripherals[idx].dev = Box::new(dev);
+        bus.refresh_peripheral_index();
+
+        // Route source 0 → line 6, priority 1, threshold 1, line enabled.
+        bus.write_u32(INTMATRIX + MAC_SOURCE as u64 * 4, LINE)
+            .unwrap();
+        bus.write_u32(INTMATRIX + 0x114 + (LINE as u64) * 4, 1)
+            .unwrap();
+        bus.write_u32(INTMATRIX + 0x194, 1).unwrap();
+        bus.write_u32(INTMATRIX + 0x104, 1 << LINE).unwrap();
+        bus
+    }
+
+    fn mac_mut(bus: &mut SystemBus) -> &mut Esp32c3WifiMac {
+        let idx = bus.find_peripheral_index_by_name("wifi_mac").unwrap();
+        bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Esp32c3WifiMac>()
+            .unwrap()
+    }
+
+    /// The scheduler routing arm and the legacy walk aggregation produce the
+    /// SAME `riscv_irq_lines` for the SAME pending MAC event level.
+    #[test]
+    fn scheduler_routing_matches_walk_routing_for_mac_event() {
+        let mut bus = setup(true);
+
+        // Arm the MAC event (HW normally sets it; the ISR reads it). The level
+        // asserts source 0 while the event word is non-zero.
+        bus.write_u32(MAC_BASE + EVENT_GET, EVENT_RX_DONE).unwrap();
+        assert_eq!(
+            mac_mut(&mut bus).matrix_irq_sources(),
+            vec![MAC_SOURCE],
+            "a MAC with a pending event must assert matrix source 0"
+        );
+
+        // Scheduler routing arm (what `apply_event_result` runs on the C3 bus).
+        bus.refresh_esp32c3_sched_sources();
+        bus.recompute_esp32c3_irq_lines();
+        let scheduler_lines = bus.riscv_irq_lines;
+        assert_eq!(
+            scheduler_lines,
+            1 << LINE,
+            "scheduler routing must assert the routed CPU line for source 0"
+        );
+
+        // Legacy walk routing reference: source 0 re-emitted by the walk. Must
+        // land on the identical line mask.
+        bus.aggregate_esp32c3_irqs(&[MAC_SOURCE]);
+        assert_eq!(
+            bus.riscv_irq_lines, scheduler_lines,
+            "walk aggregation and scheduler routing must produce identical riscv_irq_lines"
+        );
+    }
+
+    /// A wifi_mac pinned back onto the per-cycle walk (`force_legacy_walk`)
+    /// re-emits the SAME matrix source from its `tick()` — the level the
+    /// scheduler path exports via `matrix_irq_sources` — so both drive modes
+    /// deliver the MAC IRQ identically.
+    #[test]
+    fn force_legacy_walk_reemits_same_source() {
+        let mut bus = setup(false);
+        bus.write_u32(MAC_BASE + EVENT_GET, EVENT_RX_DONE).unwrap();
+        let mac = mac_mut(&mut bus);
+        assert!(
+            !mac.uses_scheduler(),
+            "no clock attached → wifi_mac stays on the per-cycle walk"
+        );
+        assert_eq!(
+            mac.tick().explicit_irqs,
+            Some(vec![MAC_SOURCE]),
+            "a walk-driven wifi_mac must re-emit its MAC level source from the walk tick"
+        );
+    }
+
+    /// THE write-choke proof: on a fully walk-DELETED bus (no per-cycle walk to
+    /// re-derive the level), the `EVENT_CLR` acknowledge must de-assert the
+    /// routed line AT THE WRITE — otherwise the MAC level latches forever and
+    /// re-enters its ISR. This is the one legitimate bus addition the last
+    /// walker needs (`sync_esp32c3_irq_cache_write`).
+    #[test]
+    fn event_clr_deasserts_on_walk_deleted_bus_at_the_write() {
+        let mut bus = setup(true);
+        // Delete the walk: with wifi_mac scheduler-driven and every other model
+        // inert/scheduler, the devkit bus derives walk-deletion.
+        bus.legacy_walk_disabled = bus.derive_walk_deletable();
+        assert!(
+            bus.legacy_walk_disabled,
+            "scheduler-driven wifi_mac must let the devkit bus derive walk-deletion"
+        );
+
+        // Arm the MAC level and route it at the write choke (writing EVENT_GET is
+        // a MAC-window write → the choke re-derives the scheduler level).
+        bus.write_u32(MAC_BASE + EVENT_GET, EVENT_RX_DONE).unwrap();
+        assert_eq!(
+            bus.riscv_irq_lines,
+            1 << LINE,
+            "MAC event must route to the CPU line at the write, with NO walk tick"
+        );
+
+        // Acknowledge via EVENT_CLR (W1C). On a walk-deleted bus the ONLY thing
+        // that can de-assert the level is the write choke re-derivation.
+        bus.write_u32(MAC_BASE + EVENT_CLR, EVENT_RX_DONE).unwrap();
+        assert!(
+            mac_mut(&mut bus).matrix_irq_sources().is_empty(),
+            "after EVENT_CLR the MAC asserts no matrix source"
+        );
+        assert_eq!(
+            bus.riscv_irq_lines, 0,
+            "EVENT_CLR must de-assert the routed line at the write on a walk-deleted bus"
+        );
+    }
+}
+
+/// Walk-free C3 WiFi-MAC PUMP fidelity — the WiFi-EXERCISING byte-identity
+/// differential. Drives a real descriptor-ring session (RX ring delivery + a TX
+/// kick) on a scheduler-driven MAC and a walk-driven MAC, at tick interval 1 and
+/// 64, and asserts every observable (descriptor writeback, MAC event word,
+/// captured TX frame, routed CPU line) is BYTE-IDENTICAL. Non-vacuity: the pump
+/// must actually move frames (RX delivered + TX captured > 0). The periodic
+/// beacon rides the very same `tick_with_bus` code (medium mode keeps the MAC
+/// resident every tick in both drive modes), so it is byte-identical by
+/// construction; it is exercised by the two-C3 CLI runs, not here (the medium is
+/// a process-global static that must not be touched from parallel unit tests).
+#[cfg(all(test, feature = "event-scheduler"))]
+mod c3_wifi_mac_walk_differential {
+    use crate::bus::SystemBus;
+    use crate::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac;
+    use crate::{Bus, Peripheral};
+    use labwired_config::{ChipDescriptor, SystemManifest};
+    use std::path::PathBuf;
+
+    const MAC_BASE: u64 = 0x6003_3000;
+    const INTMATRIX: u64 = 0x600C_2000;
+    const LINE: u32 = 6;
+    const MAC_SOURCE: u32 = 0;
+
+    // wifi_mac register offsets / bits (private; mirrored for the test).
+    const RX_RING_BASE: u64 = 0x88;
+    const EVENT_CLR: u64 = 0xC40;
+    const PLCP0_AC0: u64 = 0xD08;
+    const TX_KICK_BITS: u32 = 0xC000_0000;
+    const EVENT_RX_DONE: u32 = 0x0100_4000;
+    const EVENT_TX_DONE: u32 = 0x80;
+    const DESC_OWNER: u32 = 1 << 31;
+    const DESC_EOF: u32 = 1 << 30;
+
+    // DRAM layout, inside the devkit 0x3FC8_0000 400KB SRAM AND the
+    // 0x3fc0_0000..0x3fd0_0000 window `deliver_one_rx` accepts.
+    const RX_DESC: u32 = 0x3FC8_1000;
+    const RX_BUF: u32 = 0x3FC8_1200;
+    const TX_DESC: u32 = 0x3FC8_2000;
+    const TX_BUF: u32 = 0x3FC8_2200;
+
+    /// A tiny "802.11" data frame (enough header for the medium/len parse).
+    fn tx_frame() -> Vec<u8> {
+        let mut f = vec![0u8; 40];
+        f[0] = 0x08; // data frame (type 2)
+                     // addr2 (SA) bytes 10..16 — a nonzero source so the model is happy.
+        f[10..16].copy_from_slice(&[0x02, 0, 0, 0, 0, 0x02]);
+        f
+    }
+
+    fn rx_frame() -> Vec<u8> {
+        vec![0xB0u8, 0x00, 0xAA, 0xBB, 0xCC, 0xDD]
+    }
+
+    fn build_bus(scheduler: bool) -> SystemBus {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("load esp32c3 chip yaml");
+        let manifest =
+            SystemManifest::from_file(root.join("../../configs/systems/esp32c3-devkit.yaml"))
+                .expect("load esp32c3-devkit system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("build c3 devkit bus");
+        bus.esp32c3_irq_routing = true;
+
+        let idx = bus
+            .find_peripheral_index_by_name("wifi_mac")
+            .expect("devkit bus carries a wifi_mac");
+        let mut dev = Esp32c3WifiMac::new();
+        if scheduler {
+            dev.attach_cycle_clock(bus.cycle_clock.clone());
+        }
+        bus.peripherals[idx].dev = Box::new(dev);
+        bus.refresh_peripheral_index();
+
+        // Route source 0 → line 6.
+        bus.write_u32(INTMATRIX + MAC_SOURCE as u64 * 4, LINE)
+            .unwrap();
+        bus.write_u32(INTMATRIX + 0x114 + (LINE as u64) * 4, 1)
+            .unwrap();
+        bus.write_u32(INTMATRIX + 0x194, 1).unwrap();
+        bus.write_u32(INTMATRIX + 0x104, 1 << LINE).unwrap();
+
+        // Recompute walk-deletion over the swapped-in MAC: scheduler-driven ⇒
+        // walk-deleted (the real deploy path); walk-driven ⇒ the walk stays live
+        // so `tick()` re-emits the MAC level. (Without this the walk bus would
+        // inherit `from_config`'s stale `true`, computed when the declarative
+        // wifi_mac stub was still inert, and wrongly skip the walk.)
+        bus.legacy_walk_disabled = bus.derive_walk_deletable();
+        bus
+    }
+
+    fn wifi_mut(bus: &mut SystemBus) -> &mut Esp32c3WifiMac {
+        let idx = bus.find_peripheral_index_by_name("wifi_mac").unwrap();
+        bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Esp32c3WifiMac>()
+            .unwrap()
+    }
+
+    #[derive(PartialEq, Debug)]
+    struct SessionResult {
+        rx_desc_w0: u32,
+        rx_buf_frame: Vec<u8>,
+        event_word: u32,
+        line_while_pending: u32,
+        line_after_clear: u32,
+        tx_frames: Vec<Vec<u8>>,
+    }
+
+    /// Drive one full WiFi session and capture every observable. Steps the bus
+    /// one cycle at a time exactly as `Machine::step` does: publish the cycle,
+    /// then run the peripheral tick only every `interval` cycles (the pump
+    /// processes one TX/RX per tick call). The pump runs inside
+    /// `tick_peripherals_with_costs` (the bus-tick pass), armed by the ring-enable
+    /// / TX-kick MMIO writes below.
+    fn run_session(scheduler: bool, interval: u32) -> SessionResult {
+        let mut bus = build_bus(scheduler);
+
+        // Lay out a 1-entry RX ring: an owner-held descriptor + its buffer.
+        bus.write_u32(RX_DESC as u64, DESC_OWNER | 1600).unwrap(); // owner, cap 1600
+        bus.write_u32(RX_DESC as u64 + 4, RX_BUF).unwrap();
+        bus.write_u32(RX_DESC as u64 + 8, 0).unwrap();
+        // Enable the RX ring (MMIO write → arms the pump via the write choke).
+        bus.write_u32(MAC_BASE + RX_RING_BASE, RX_DESC).unwrap();
+
+        // Lay out a TX lldesc (word1 = buffer ptr) + the frame in DRAM.
+        let frame = tx_frame();
+        bus.write_u32(TX_DESC as u64, 0).unwrap();
+        bus.write_u32(TX_DESC as u64 + 4, TX_BUF).unwrap();
+        for (i, b) in frame.iter().enumerate() {
+            bus.write_u8(TX_BUF as u64 + i as u64, *b).unwrap();
+        }
+
+        // Queue a received frame (non-MMIO injection; the live ring keeps the MAC
+        // resident so it is pumped without any extra re-arm).
+        wifi_mut(&mut bus).queue_rx_frame(rx_frame());
+
+        // Kick a TX: PLCP0 low-20 bits point at the TX lldesc, kick bits set.
+        let plcp0 = TX_KICK_BITS | (TX_DESC & 0x000F_FFFF);
+        bus.write_u32(MAC_BASE + PLCP0_AC0, plcp0).unwrap();
+
+        // Step long enough to drain both rings (one TX + one RX, one per tick).
+        for c in 1..=(interval as u64 * 8) {
+            bus.set_current_cycle(c);
+            if c % interval as u64 == 0 {
+                bus.tick_peripherals_with_costs();
+            }
+        }
+
+        let rx_desc_w0 = bus.read_u32(RX_DESC as u64).unwrap();
+        let mut rx_buf_frame = vec![0u8; rx_frame().len()];
+        for (i, b) in rx_buf_frame.iter_mut().enumerate() {
+            // The rx-control header is 48 bytes; the 802.11 frame follows.
+            *b = bus.read_u8(RX_BUF as u64 + 48 + i as u64).unwrap();
+        }
+        let event_word = bus.read_u32(MAC_BASE + 0xC3C).unwrap();
+        let line_while_pending = bus.riscv_irq_lines;
+        let tx_frames = wifi_mut(&mut bus).take_tx_frames();
+
+        // Acknowledge every event (W1C) and confirm the routed line drops.
+        bus.write_u32(MAC_BASE + EVENT_CLR, event_word).unwrap();
+        // On a walk bus (walk still live) one more tick re-derives the level;
+        // on a scheduler/walk-deleted bus the write choke already did.
+        bus.set_current_cycle(interval as u64 * 9);
+        bus.tick_peripherals_with_costs();
+        let line_after_clear = bus.riscv_irq_lines;
+
+        SessionResult {
+            rx_desc_w0,
+            rx_buf_frame,
+            event_word,
+            line_while_pending,
+            line_after_clear,
+            tx_frames,
+        }
+    }
+
+    /// Non-vacuity: a captured session must actually have moved frames and
+    /// asserted the routed MAC line.
+    fn assert_non_vacuous(r: &SessionResult, what: &str) {
+        assert_eq!(
+            r.rx_desc_w0 & DESC_OWNER,
+            0,
+            "{what}: RX descriptor owner cleared (frame delivered)"
+        );
+        assert_ne!(r.rx_desc_w0 & DESC_EOF, 0, "{what}: RX descriptor EOF set");
+        assert_eq!(
+            r.rx_buf_frame,
+            rx_frame(),
+            "{what}: RX frame DMAed into the buffer"
+        );
+        assert_ne!(
+            r.event_word & EVENT_RX_DONE,
+            0,
+            "{what}: RX-done event latched"
+        );
+        assert_ne!(
+            r.event_word & EVENT_TX_DONE,
+            0,
+            "{what}: TX-done event latched"
+        );
+        assert_eq!(
+            r.tx_frames.len(),
+            1,
+            "{what}: exactly one TX frame captured"
+        );
+        assert_eq!(
+            r.line_while_pending,
+            1 << LINE,
+            "{what}: MAC level routed to the CPU line"
+        );
+        assert_eq!(
+            r.line_after_clear, 0,
+            "{what}: routed line de-asserts after EVENT_CLR"
+        );
+    }
+
+    #[test]
+    fn wifi_session_walk_vs_scheduler_byte_identical_interval_1() {
+        let walk = run_session(false, 1);
+        let sched = run_session(true, 1);
+        assert_non_vacuous(&walk, "walk@1");
+        assert_eq!(
+            walk, sched,
+            "WiFi session must be byte-identical walk-vs-scheduler at interval 1"
+        );
+    }
+
+    #[test]
+    fn wifi_session_walk_vs_scheduler_byte_identical_interval_64() {
+        let walk = run_session(false, 64);
+        let sched = run_session(true, 64);
+        assert_non_vacuous(&sched, "sched@64");
+        assert_eq!(
+            walk, sched,
+            "WiFi session must be byte-identical walk-vs-scheduler at interval 64"
+        );
+    }
+
+    #[test]
+    fn wifi_session_scheduler_interval_independent() {
+        // The pump's drained ring state + captured TX + event must not depend on
+        // the tick interval (batching is fidelity-safe for the descriptor rings).
+        let s1 = run_session(true, 1);
+        let s64 = run_session(true, 64);
+        assert_non_vacuous(&s1, "sched@1");
+        assert_eq!(
+            s1, s64,
+            "scheduler WiFi session must be interval-independent (1 == 64)"
         );
     }
 }

--- a/crates/core/src/peripherals/esp32c3/wifi_mac.rs
+++ b/crates/core/src/peripherals/esp32c3/wifi_mac.rs
@@ -29,7 +29,7 @@
 //! This is the SimNet-facing endpoint of the bridge; the frame source/sink (a
 //! frame-level `VirtualAp`) pushes/pulls via `queue_rx_frame` / `take_tx_frames`.
 
-use crate::{Bus, Peripheral, PeripheralTickResult, SimResult};
+use crate::{Bus, CycleClock, Peripheral, PeripheralTickResult, SimResult};
 use std::collections::VecDeque;
 use std::sync::atomic::AtomicU32;
 
@@ -134,6 +134,22 @@ pub struct Esp32c3WifiMac {
     medium_mac: Option<[u8; 6]>,
     /// Tick counter for periodic beacon injection in medium mode.
     medium_beacon_ctr: u32,
+    /// Bus-published cycle clock (walk-free plan). `Some` once
+    /// [`SystemBus::add_peripheral`](crate::bus::SystemBus) attaches it (under
+    /// the `event-scheduler` feature); its presence flips the model onto the
+    /// event-scheduler drive mode. In that mode the per-cycle legacy walk skips
+    /// this peripheral: the MAC interrupt LEVEL (source 0, asserted while an
+    /// event is pending) is exported through [`Self::matrix_irq_sources`] and
+    /// re-derived by the bus (`refresh_esp32c3_sched_sources`, run on the event
+    /// path and — crucially, on a walk-DELETED bus — at the MMIO write choke so
+    /// the level de-asserts after `EVENT_CLR`), rather than re-emitted every
+    /// tick by [`Self::tick`]. The descriptor-ring PUMP is orthogonal: it rides
+    /// the write-armed, self-perpetuating bus-tick path
+    /// ([`Self::needs_bus_tick`]), so it costs nothing while WiFi is idle. `None`
+    /// (feature off, a hand-built bus, or the differential's
+    /// [`Self::force_legacy_walk`]) keeps the legacy per-cycle walk. Not
+    /// serialized — re-attached by the bus.
+    clock: Option<CycleClock>,
 }
 
 impl Default for Esp32c3WifiMac {
@@ -155,7 +171,25 @@ impl Esp32c3WifiMac {
             medium_mode: false,
             medium_mac: None,
             medium_beacon_ctr: 0,
+            clock: None,
         }
+    }
+
+    /// True when the event scheduler owns this block's interrupt-level drive
+    /// (feature on AND bus clock attached). One predicate so the walk and
+    /// scheduler drive modes can never mix, mirroring the C3 SARADC/I²C/LEDC
+    /// migrations.
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Test/differential knob: detach the cycle clock, pinning the model to the
+    /// legacy per-cycle walk (`uses_scheduler() == false`). Used by the
+    /// walk-on-vs-scheduler differential gates to build the reference config
+    /// from the same bus assembly (mirrors `Esp32c3ApbSarAdc::force_legacy_walk`).
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
     }
 
     /// Attach this MAC to the shared [`virtual_wifi`] medium. Enables medium
@@ -439,8 +473,35 @@ impl Peripheral for Esp32c3WifiMac {
         Ok(())
     }
 
+    /// Walk-free plan (the descriptor-ring PUMP axis): the bus runs
+    /// [`Self::tick_with_bus`] only while WiFi is actually up, so an idle MAC
+    /// (WiFi off / unconfigured — the OLED demo never enables WiFi) arms NOTHING
+    /// and drops out of the bus-tick set. This is what lets a walk-DELETED C3
+    /// bus take the trivial per-cycle path (`per_cycle_tick_is_trivial` requires
+    /// an empty `bus_tick_indices`).
+    ///
+    /// Each condition is a WRITE-ARMED / setup flag re-consulted by the bus's
+    /// existing `refresh_bus_tick_index` (called after every MMIO write and
+    /// after every `tick_with_bus`), so no new event machinery is needed:
+    ///
+    /// * `rx_ring != 0` — the driver enabled the RX ring by writing its head to
+    ///   `0x88` (an MMIO write, so it arms the pump through the write choke) and
+    ///   the ring stays live for the whole WiFi session. Keying RX on the ring
+    ///   (NOT `pending_rx`) is deliberate: `queue_rx_frame` is a non-MMIO
+    ///   bridge/medium injection that can't refresh the index — but a frame can
+    ///   only be delivered once the ring exists, and once it does the MAC is
+    ///   already resident, so externally-queued frames are pumped without any
+    ///   extra re-arm. RX-down (ring never enabled) ⇒ idle.
+    /// * `!pending_tx.is_empty()` — a driver PLCP0 kick write (`0xC000_0000`
+    ///   bits) queued a frame to transmit; the pump drains it and drops out.
+    /// * `medium_mode` — a two-C3 medium station polls its shared inbox and
+    ///   beacons each tick; the toggle is one-time setup (`attach_to_medium`),
+    ///   which rebuilds the tick index once.
+    ///
+    /// The set is self-perpetuating: after every `tick_with_bus` the bus calls
+    /// `refresh_bus_tick_index`, so the pump keeps ticking until it has drained.
     fn needs_bus_tick(&self) -> bool {
-        true
+        self.rx_ring != 0 || !self.pending_tx.is_empty() || self.medium_mode
     }
 
     fn tick_with_bus(&mut self, bus: &mut dyn Bus) {
@@ -463,10 +524,14 @@ impl Peripheral for Esp32c3WifiMac {
         self.deliver_one_rx(bus);
     }
 
+    /// LEGACY per-cycle walk path (the interrupt-LEVEL axis): re-assert the MAC
+    /// interrupt source while an event is pending so `wDev_ProcessFiq` runs and
+    /// clears it via `EVENT_CLR`. In scheduler mode ([`Self::uses_scheduler`]
+    /// true) the walk skips this peripheral and the bus re-derives the level
+    /// from [`Self::matrix_irq_sources`] instead; this reporter is a pure no-op
+    /// on state, so a stray call is harmless. Matches the SYSTIMER/SARADC level
+    /// delivery model.
     fn tick(&mut self) -> PeripheralTickResult {
-        // Level-sensitive: while an RX (or other) event is pending, keep
-        // asserting the MAC interrupt source so wDev_ProcessFiq runs and clears
-        // it via EVENT_CLR. Matches the SYSTIMER alarm delivery model.
         if self.event() != 0 {
             PeripheralTickResult {
                 explicit_irqs: Some(vec![MAC_INTR_SOURCE]),
@@ -483,6 +548,48 @@ impl Peripheral for Esp32c3WifiMac {
 
     fn legacy_tick_dynamic(&self) -> bool {
         true
+    }
+
+    /// Walk-free plan: driven by the event scheduler once the bus has attached
+    /// its cycle clock (production `add_peripheral` always does, under the
+    /// `event-scheduler` feature). The per-cycle walk then skips this
+    /// peripheral's interrupt-level reporter; the MAC level is exported through
+    /// [`Self::matrix_irq_sources`] and re-derived by the bus. Without a clock
+    /// (feature off, a hand-built bus, or `force_legacy_walk`) it stays on the
+    /// legacy walk so those callers keep the old exact semantics.
+    fn uses_scheduler(&self) -> bool {
+        self.scheduler_mode()
+    }
+
+    /// The MAC interrupt LEVEL — re-asserting source 0 every walk tick while an
+    /// event is pending — is fully reproduced in scheduler mode by the level
+    /// export ([`Self::matrix_irq_sources`]) + the write-choke re-derivation, so
+    /// the walk is unnecessary there. The descriptor-ring pump does NOT need the
+    /// legacy walk either: it rides the write-armed bus-tick path
+    /// ([`Self::needs_bus_tick`]), which is orthogonal to the walk. In legacy
+    /// mode (no clock / feature off) the walk does real level work and the
+    /// conservative `true` stands.
+    fn needs_legacy_walk(&self) -> bool {
+        !self.scheduler_mode()
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        self.clock = Some(clock);
+    }
+
+    /// C3 interrupt-matrix level: the MAC source (0) while an event is pending —
+    /// the exact condition [`Self::tick`] pushes on the legacy walk. In
+    /// scheduler mode the walk no longer re-emits it, so the bus re-derives the
+    /// level from here (`refresh_esp32c3_sched_sources`, polled on the event
+    /// path and at the MMIO write choke) so the level-sensitive IRQ stays routed
+    /// and de-asserts the tick/write after firmware clears the event via
+    /// `EVENT_CLR`.
+    fn matrix_irq_sources(&self) -> Vec<u32> {
+        if self.event() != 0 {
+            vec![MAC_INTR_SOURCE]
+        } else {
+            Vec::new()
+        }
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -28,12 +28,12 @@
 //! 4. `oled_lab_walk_pinners_after_rtc_migration` — the endgame ledger: on
 //!    the real OLED rom-boot bus, `rtc_cntl_timer` no longer pins the walk
 //!    (`uses_scheduler() == true`), and after the C3/ESP32 Class-A inert
-//!    sweep (`needs_legacy_walk() == false` on the verified-inert models) the
-//!    only remaining pinner is the verified real worker `wifi_mac`, asserted as
-//!    an exact set so the campaign report stays honest. SYSTIMER, I²C0, the
-//!    level-only pair spi2 + apb_saradc, and the LEDC timer port are now all
-//!    scheduler-driven (walk-free C3 SYSTIMER + I²C0 + spi2/apb_saradc + ledc
-//!    batches) and no longer pin.
+//!    sweep (`needs_legacy_walk() == false` on the verified-inert models) plus
+//!    the SYSTIMER, I²C0, spi2/apb_saradc, LEDC and — finally — `wifi_mac`
+//!    scheduler migrations, the pinner set is EMPTY. `derive_walk_deletable()`
+//!    returns true, so the bus flips walk-deleted and `max_safe_tick_interval`
+//!    rises above 1 (the campaign payoff), asserted as an exact set so the
+//!    report stays honest.
 
 #![cfg(feature = "event-scheduler")]
 
@@ -244,6 +244,14 @@ fn build_oled_lab(
             .expect("apb_saradc is the C3 SAR ADC controller")
             .force_legacy_walk();
     }
+
+    // Any `*_legacy` reference above pinned a peripheral back onto the walk with
+    // `force_legacy_walk` AFTER the rom-boot path derived walk-deletion over the
+    // (then all-scheduler) peripheral set. Now that `wifi_mac` is migrated the
+    // rom-boot derivation reads walk-DELETED, so a pinned-back peripheral would
+    // be starved of ticks unless we recompute the flag over the live set (the
+    // same recompute the in-crate routing gates do after `force_legacy_walk`).
+    machine.bus.recompute_walk_deletable();
 
     machine.config.peripheral_tick_interval = tick_interval;
     machine.bus.config.peripheral_tick_interval = tick_interval;
@@ -623,22 +631,27 @@ fn oled_lab_native_mips_probe() {
 ///   advance lazily off the bus-published `CycleClock` and each `LSTIMERx_OVF`
 ///   rides a scheduled event that materialises the latch at its exact cycle and
 ///   re-arms — the SYSTIMER/STM32 TIMx pattern.)
-///   - `wifi_mac` — `tick_with_bus` pumps TX/RX descriptor rings + `tick()`
-///     re-asserts the MAC level interrupt while events are pending.
+///   - (`wifi_mac` was the LAST pinner and is now migrated too: its MAC
+///     interrupt LEVEL is exported through `matrix_irq_sources` + the write-choke
+///     re-derivation, and its descriptor-ring PUMP rides the write-armed,
+///     self-perpetuating bus-tick path — so `needs_bus_tick()` is false while
+///     WiFi is idle and `uses_scheduler()` is true. The OLED demo never enables
+///     WiFi, so the pump arms nothing and the bus is fully walk-deletable.)
 ///
-/// Every other model on the bus now proves walk-independence itself
-/// (`uses_scheduler()` or a verified `needs_legacy_walk() == false`).
-/// `derive_walk_deletable()` stays false and `max_safe_tick_interval` stays 1
-/// until this set empties — asserted so the report stays honest (zero
-/// behavior change is the point of the Class-A sweep).
+/// Every model on the bus now proves walk-independence itself
+/// (`uses_scheduler()` or a verified `needs_legacy_walk() == false`), so
+/// `derive_walk_deletable()` returns TRUE, `EXPECTED_PINNERS` is empty, and
+/// `max_safe_tick_interval` rises above 1 — the payoff of the campaign. This is
+/// the UNLOCK gate: it must stay empty (any model that starts pinning again is a
+/// regression).
 #[test]
 #[ignore = "builds the full rom-boot bus (needs ROM blobs + flash fixture); run with --ignored"]
 fn oled_lab_walk_pinners_after_rtc_migration() {
-    /// The verified real workers still awaiting scheduler migration. A model
-    /// newly marked `needs_legacy_walk() == false` or migrated to the
-    /// scheduler must shrink this set; a model that starts pinning again is a
-    /// regression.
-    const EXPECTED_PINNERS: &[&str] = &["wifi_mac"];
+    /// The C3 walk-free campaign is COMPLETE: no verified real worker still
+    /// pins the per-cycle walk on the OLED rom-boot bus. A model newly marked
+    /// `needs_legacy_walk() == true` (un-migrated) would re-populate this set —
+    /// a regression.
+    const EXPECTED_PINNERS: &[&str] = &[];
 
     let lab = build_oled_lab(1, false, false, false, false);
     let bus = &lab.machine.bus;
@@ -679,19 +692,19 @@ fn oled_lab_walk_pinners_after_rtc_migration() {
         expected,
     );
 
-    // Zero behavior change: the real workers above still force the walk, so
-    // the OLED bus must NOT flip walk-deletable and must stay on interval 1.
-    // `derive_walk_deletable()` (crate-private) is true iff every peripheral
-    // satisfies `uses_scheduler() || !needs_legacy_walk()` — i.e. iff this
-    // pinner set is empty — so a non-empty set IS the derivation staying
-    // false, and `max_safe_tick_interval() == 1` is its runtime effect.
+    // THE UNLOCK: every worker is migrated, so the OLED bus flips
+    // walk-deletable and the tick interval is free to rise. `derive_walk_deletable()`
+    // is true iff every peripheral satisfies `uses_scheduler() || !needs_legacy_walk()`
+    // — i.e. iff this pinner set is empty — so the empty set IS the derivation
+    // going true, and `max_safe_tick_interval() > 1` is its runtime payoff.
     assert!(
-        !pinners.is_empty(),
-        "OLED rom-boot bus must not derive walk-deletion while real workers remain"
+        pinners.is_empty(),
+        "OLED rom-boot bus must now derive walk-deletion (no real workers remain), \
+         but these still pin: {pinners:?}"
     );
-    assert_eq!(
-        bus.max_safe_tick_interval(),
-        1,
-        "bus cannot recommend interval > 1 until every pinner is migrated"
+    assert!(
+        bus.max_safe_tick_interval() > 1,
+        "bus must recommend an interval > 1 now that every pinner is migrated (got {})",
+        bus.max_safe_tick_interval()
     );
 }

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -306,6 +306,29 @@ boards:
     # same riscv_irq_lines for LEDC source 23; force_legacy_walk re-emits the same source;
     # INT_CLR de-asserts). Register map, reset values and MMIO byte paths unchanged; reset
     # oracle unaffected. No live re-capture. Remaining C3 walk pinner: wifi_mac only.
+    # 2026-07-12: wifi_mac (esp32c3/wifi_mac.rs) walk-free migration — the LAST C3 walk
+    # pinner, on TWO axes. (1) The MAC interrupt LEVEL (matrix source 0, asserted while a
+    # MAC event is pending) migrates off the walk with uses_scheduler + a matrix_irq_sources
+    # export (the level-only pattern); on a walk-DELETED bus the write-armed EVENT_CLR
+    # acknowledge is re-derived at the MMIO write choke (sync_esp32c3_irq_cache_write, gated
+    # on legacy_walk_disabled) so the level de-asserts without a walk tick. (2) The
+    # descriptor-ring PUMP (tick_with_bus) is honestly gated: needs_bus_tick() is now true
+    # only while WiFi is up (rx_ring != 0 / a pending TX / medium mode) instead of
+    # unconditionally, so an idle MAC (WiFi off — the OLED demo never enables WiFi) arms
+    # nothing and the bus is walk-DELETABLE. No new event machinery: the pump rides the
+    # existing write-armed, self-perpetuating bus-tick path (refresh_bus_tick_index). The
+    # WiFi frame-moving model is byte-for-byte preserved (no thunk change). Proven
+    # byte-identical to the walk by committed differentials: the WiFi-exercising pump
+    # differential c3_wifi_mac_walk_differential (TX ring + RX ring delivery byte-identical
+    # walk-vs-scheduler at interval 1 AND 64, non-vacuity = frames moved) + the direct
+    # IRQ-delivery gate c3_wifi_mac_matrix_routing (walk aggregation vs scheduler routing
+    # produce the same riscv_irq_lines for MAC source 0; force_legacy_walk re-emits the same
+    # source; EVENT_CLR de-asserts at the write choke on a walk-deleted bus) + the OLED
+    # rom-boot lab (serial + total_cycles + SSD1306 framebuffer byte-identical at interval 1
+    # and the now-unlocked interval 64). THE UNLOCK: with wifi_mac migrated the C3 OLED
+    # rom-boot bus derives walk-DELETED, EXPECTED_PINNERS is empty, and max_safe_tick_interval
+    # rises to 64 (native OLED-lab throughput ~5.2 → ~16.2 MIPS). Register map, reset values
+    # and MMIO byte paths unchanged; reset oracle unaffected. No live re-capture.
     drift_ack: 2026-07-12
 
   - id: nucleo-l476rg


### PR DESCRIPTION
The **final** ESP32-C3 walk-free migration: `wifi_mac` was the last peripheral pinning the per-cycle legacy walk on the OLED rom-boot bus. With it migrated the bus derives **walk-DELETED**, `max_safe_tick_interval` rises **1 → 64**, and the C3 OLED lab jumps **~5.2 → ~16.2 MIPS** (measured, native, 50M instructions, median of 3).

## The migration (no new event machinery)
`wifi_mac` pinned on two axes; both move with the established patterns:

1. **Interrupt LEVEL** (matrix source 0, asserted while a MAC event is pending) — off the walk via `uses_scheduler` + a `matrix_irq_sources` export (the level-only pattern shared with `spi2`/`apb_saradc`). `tick()` stays as the legacy reporter for the feature-off / `force_legacy_walk` path.
2. **Descriptor-ring PUMP** (`tick_with_bus`) — `needs_bus_tick()` was unconditionally `true`; now honest: `rx_ring != 0 || !pending_tx.is_empty() || medium_mode`. WiFi off (the OLED demo) ⇒ arms nothing ⇒ walk-deletable. The pump rides the existing write-armed, self-perpetuating bus-tick path (`refresh_bus_tick_index`), so **zero new event scheduling** and the frame-moving model is byte-for-byte unchanged (no thunk touched).

## Bus glue (the one legitimate addition)
Once the bus is fully walk-DELETED there is no per-tick aggregation to re-derive scheduler-driven levels. `sync_esp32c3_irq_cache_write` now re-derives the scheduler source set + routed lines at the MMIO write choke **for `uses_scheduler()` peripherals, gated on `legacy_walk_disabled`** — so a write-armed level (above all the `EVENT_CLR`/`INT_CLR` acknowledge) de-asserts at the write instead of latching forever. Gating on `legacy_walk_disabled` keeps walk-ON buses byte-identical (their per-tick aggregation still owns level derivation).

Also adds `SystemBus::recompute_walk_deletable()` for out-of-crate harnesses that flip a drive mode after assembly (`build_oled_lab`'s `force_legacy_walk`) — without it a peripheral pinned back onto a now-deletable bus is silently starved.

## Gates (all green)
- **WiFi-exercising differential** `c3_wifi_mac_walk_differential`: real TX ring + RX ring session, descriptor writeback + MAC event + captured TX + routed line **byte-identical walk-vs-scheduler at interval 1 AND 64**, plus interval-independence; non-vacuity = frames actually moved.
- **Direct IRQ-delivery** `c3_wifi_mac_matrix_routing`: walk vs scheduler route MAC source 0 to the same CPU line; `force_legacy_walk` re-emits the same source; **`EVENT_CLR` de-asserts at the write choke on a walk-deleted bus**.
- **THE UNLOCK** `oled_lab_walk_pinners_after_rtc_migration`: `EXPECTED_PINNERS = {}`, `derive_walk_deletable() == true`, `max_safe_tick_interval == 64`.
- **OLED rom-boot lab**: serial + total_cycles + SSD1306 framebuffer byte-identical at interval 1 and the now-unlocked interval 64 (exercises the write-choke de-assert for systimer/i2c0 end-to-end on the walk-deleted bus). systimer / i2c0 / spi2+saradc walk-on-vs-scheduler gates all pass.
- **MIPS**: interval 1 = 5.17 MIPS; interval 64 = 16.21 MIPS (~3.1× on this host; hits the ~16 target).
- Validation `--check --drift` rc 0 + firmware-exercise-matrix `--check` rc 0; `cargo fmt` + `clippy` clean; full core regression `--features jit,event-scheduler` = **2053 passed, 0 failed** (zero new failures vs `76d890ab`).

Not auto-merged — left open for review (biggest/riskiest diff of the campaign).