### PR TITLE
jit(riscv): RV32IMC frontend foundation (all-bail walker + host adapter + differential gate)

### DIFF
--- a/crates/core/src/cpu/jit_framework/mod.rs
+++ b/crates/core/src/cpu/jit_framework/mod.rs
@@ -49,6 +49,7 @@ pub mod differential;
 pub mod dispatch;
 pub mod fallback;
 pub mod frontend;
+pub mod riscv;
 pub mod runtime;
 pub mod side_exit;
 

--- a/crates/core/src/cpu/jit_framework/riscv/host.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/host.rs
@@ -1,0 +1,151 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! [`JitHost`] adapter for a `Machine<RiscV>`.
+//!
+//! The universal dispatch loop drives the guest **entirely** through the
+//! [`JitHost`] trait, never touching a concrete `Cpu`/`Bus`. This module is
+//! the RISC-V binding: it wraps `&mut Machine<RiscV>` and implements every
+//! hook — interpret one instruction, read the current PC, resume at a PC,
+//! hand out a flash code view, report the safety gate, and flatten
+//! architectural state into a [`StateVec`] for the differential harness.
+//!
+//! ## Two places the framework API did not match the RISC-V machine
+//!
+//! * **`code_view` is NOT backed by `Bus::fetch_slice`.** `SystemBus`'s
+//!   `fetch_slice` only serves the Xtensa `RamPeripheral` (it downcasts to
+//!   it and returns `None` otherwise), so it yields nothing for a RISC-V
+//!   flash region. We read `bus.flash` (a `LinearMemory` whose `data`
+//!   `Vec<u8>` never reallocates after config) directly instead — which is
+//!   exactly the position-stable, flash-resident code the block cache
+//!   requires. Extending `SystemBus::fetch_slice` to also serve `flash`/the
+//!   C3 XIP peripheral is a later cleanup; it is not needed to prove the
+//!   plumbing.
+//! * **There is no flash-dirty flag on the bus.** Nothing tracks flash
+//!   writes today, so [`take_flash_dirty`](JitHost::take_flash_dirty) is
+//!   conservatively `false`. That is correct for any run that does not
+//!   self-modify flash (the overwhelming common case, and every current
+//!   test); when flash self-write support lands it wires in here.
+
+use crate::cpu::RiscV;
+use crate::Machine;
+
+use super::super::fallback::{HostStep, JitHost, SafetyGate};
+use super::super::{CodeView, Pc, StateVec};
+
+/// Number of `u32` words in a RISC-V [`StateVec`]: `x0..x31` (32) + `pc`
+/// (1) + the eight architectural M-mode CSRs (8).
+pub const STATE_VEC_LEN: usize = 32 + 1 + 8;
+
+/// Flatten a [`RiscV`] into the differential-harness [`StateVec`].
+///
+/// Layout (mirrors [`RiscV::snapshot`]'s field set, minus the volatile
+/// `mtime`/`mtimecmp` CLINT words which are not architectural GPR/CSR
+/// state):
+///
+/// | index | contents |
+/// | ----- | -------- |
+/// | `0..32` | `x0..x31` (x0 always reads 0) |
+/// | `32` | `pc` |
+/// | `33..41` | `mstatus, mie, mip, mtvec, mscratch, mepc, mcause, mtval` |
+///
+/// The cycle/`mtime`-derived CSRs (`0xC00`/`0x802`/`0x7E2`, …) are read
+/// on demand from `mtime` and are deliberately **excluded**: a batched JIT
+/// block advances `mtime` in one lump, so a mid-block sample of those would
+/// differ from a per-instruction interpreter run. Excluding them (rather
+/// than sampling and masking) keeps the vector to pure architectural state.
+/// See also [`super::differential_cycle_ignore_indices`].
+pub fn snapshot_state(cpu: &RiscV) -> StateVec {
+    let mut v = Vec::with_capacity(STATE_VEC_LEN);
+    v.extend_from_slice(&cpu.x); // x0..x31
+    v.push(cpu.pc); // pc
+    v.push(cpu.mstatus);
+    v.push(cpu.mie);
+    v.push(cpu.mip);
+    v.push(cpu.mtvec);
+    v.push(cpu.mscratch);
+    v.push(cpu.mepc);
+    v.push(cpu.mcause);
+    v.push(cpu.mtval);
+    debug_assert_eq!(v.len(), STATE_VEC_LEN);
+    v
+}
+
+/// A [`JitHost`] view over a RISC-V machine, borrowing it for the lifetime
+/// of one dispatch run.
+pub struct RiscVJitHost<'m> {
+    machine: &'m mut Machine<RiscV>,
+}
+
+impl<'m> RiscVJitHost<'m> {
+    /// Wrap a machine for JIT dispatch.
+    pub fn new(machine: &'m mut Machine<RiscV>) -> Self {
+        Self { machine }
+    }
+
+    /// Borrow the underlying machine (telemetry / tests).
+    pub fn machine(&self) -> &Machine<RiscV> {
+        self.machine
+    }
+}
+
+impl JitHost for RiscVJitHost<'_> {
+    fn pc(&self) -> Pc {
+        self.machine.cpu.pc as Pc
+    }
+
+    fn interpret_one(&mut self) -> HostStep {
+        match self.machine.step() {
+            Ok(()) => HostStep::Advanced,
+            // A stopping condition (trap the interpreter cannot service,
+            // decode error, halt): the dispatch loop returns. The
+            // interpreter remains the single source of truth for *why*.
+            Err(_) => HostStep::Halted,
+        }
+    }
+
+    fn resume_at(&mut self, pc: Pc) {
+        self.machine.cpu.pc = pc as u32;
+    }
+
+    fn code_view(&self, pc: Pc) -> Option<CodeView<'_>> {
+        let flash = &self.machine.bus.flash;
+        let base = flash.base_addr;
+        let len = flash.data.len() as u64;
+        if pc >= base && (pc - base) < len {
+            Some(CodeView::new(base, &flash.data))
+        } else {
+            // Not flash-resident (RAM / MMIO / an XIP window we do not map
+            // here) — not compilable; the PC stays on the interpreter.
+            None
+        }
+    }
+
+    fn safety(&self) -> SafetyGate {
+        SafetyGate {
+            // Any per-instruction observer forces interpretation.
+            observers_active: !self.machine.observers.is_empty(),
+            // A block could step over a breakpoint address without stopping.
+            breakpoints_active: !self.machine.breakpoints.is_empty(),
+            // Logic-analyzer / DAP-watch taps and cycle-accurate mode are
+            // not surfaced through a stable accessor on this machine yet;
+            // understating them is always safe (it only lets the JIT run
+            // where it is in fact equivalent — the interpreter is the
+            // reference), and the all-bail frontend is byte-identical
+            // regardless. These wire in when the accessors land.
+            probes_active: false,
+            cycle_accurate: false,
+        }
+    }
+
+    fn snapshot_state(&self) -> StateVec {
+        snapshot_state(&self.machine.cpu)
+    }
+
+    fn take_flash_dirty(&mut self) -> bool {
+        // No flash-write tracking on the bus (see module docs). Correct for
+        // any run that does not self-modify flash.
+        false
+    }
+}

--- a/crates/core/src/cpu/jit_framework/riscv/mod.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/mod.rs
@@ -1,0 +1,522 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! RV32IMC frontend for the universal dispatch JIT.
+//!
+//! This is the **first real** [`IsaFrontend`] (the scaffold shipped only the
+//! [`super::frontend::PassthroughFrontend`]). The *foundation* milestone
+//! implemented here is deliberately an **all-bail** frontend: it walks a
+//! basic block over the flash [`CodeView`] using the shared RISC-V decoder
+//! ([`crate::decoder::riscv`]), classifies every instruction, and produces a
+//! correct [`BlockPlan`] — `entry_pc`, `end_pc`, `instr_count`, and the
+//! side-exit `exits` map — but with an **empty `code`** body
+//! ([`BlockPlan::is_stub`] is `true`). Every block therefore side-exits to
+//! the interpreter, exactly like the passthrough stub.
+//!
+//! Why build a real walker that emits no code? Because the walk +
+//! classification is the ISA-aware skeleton that the later codegen chunks
+//! (integer arithmetic, branches/jumps, loads/stores, CSR/system) hang wasm
+//! emission onto. Landing it all-bail lets the differential harness
+//! ([`super::differential`]) prove the *entire* dispatch / host / snapshot
+//! plumbing is byte-identical to the interpreter before a single wasm byte
+//! is emitted — the framework's merge gate #1. Each subsequent chunk fills
+//! `code` for a class of instructions and re-runs that same gate.
+//!
+//! ## The decode reuse
+//!
+//! [`crate::decoder::riscv::decode_rv32`] already decodes both 32-bit and
+//! (via its `(inst & 0x3) != 0x3` prefix check) 16-bit compressed
+//! instructions into one flat, `Copy` [`Instruction`] enum with
+//! pre-decoded, sign-extended immediates. The frontend does **not**
+//! re-implement any of that: it reads the instruction-length halfword
+//! (`(halfword & 0x3) == 0x3 ? 4 : 2`), assembles the little-endian word,
+//! calls `decode_rv32`, and classifies the result.
+
+use crate::decoder::riscv::{decode_rv32, Instruction};
+
+use super::frontend::{BlockPlan, ExitEdge, FrontendRefusal, IsaFrontend};
+use super::side_exit::BailReason;
+use super::{CodeView, Pc};
+
+pub mod host;
+pub use host::{snapshot_state, RiscVJitHost};
+
+/// Indices into the RISC-V [`StateVec`](super::StateVec) that a batched JIT
+/// run may legitimately compute differently from a per-instruction
+/// interpreter run and which the differential harness should mask.
+///
+/// In this all-bail foundation milestone the JIT executes **zero**
+/// instructions itself — every block side-exits and the interpreter runs
+/// each instruction — so nothing is volatile and this is empty. It is the
+/// designated hook for the codegen chunks: once blocks retire instructions
+/// in a lump, any cycle/`mtime`-derived word a block samples mid-run is
+/// added here. The `StateVec` layout ([`host::snapshot_state`]) already
+/// excludes the free-running `mtime` CSRs, so with block-boundary comparison
+/// this is expected to stay empty even after codegen lands.
+pub fn differential_cycle_ignore_indices() -> Vec<usize> {
+    Vec::new()
+}
+
+/// Hard cap on how many instructions one basic block may span. A basic
+/// block is bounded by construction (it ends at the first control-flow or
+/// unmodeled instruction), but flash could in principle contain a very long
+/// straight-line run; this keeps the walk — and the eventual emitted body —
+/// bounded regardless.
+const MAX_BLOCK_INSTRS: u32 = 1024;
+
+/// How a single decoded instruction affects the block walk.
+///
+/// The three-way split is the whole classification policy: it decides where
+/// a basic block ends and which [`BailReason`] the terminating edge carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstrClass {
+    /// A straight-line instruction the block subsumes: arithmetic, logic,
+    /// loads, stores, `LUI`/`AUIPC`, and every compressed form that decodes
+    /// to one of those (`C.ADDI`, `C.LW`, `C.MV`, `C.ADD`, …). The walk
+    /// includes it and continues to the next instruction.
+    Sequential,
+    /// A control-flow instruction the block ends **at and includes** —
+    /// conditional branches, `JAL`/`JALR`, and their compressed forms
+    /// (`C.J`, `C.JR`, `C.JALR`, `C.BEQZ`, `C.BNEZ`). A future codegen chunk
+    /// emits these and side-exits with [`super::side_exit::SideExit::Chain`];
+    /// until then the block bails with [`BailReason::PartialBlock`].
+    ControlFlow,
+    /// An instruction whose side effects are owned by the interpreter and
+    /// which this frontend does not translate — CSR access, `ECALL`/`EBREAK`,
+    /// `MRET`/`WFI`/`FENCE`, the A-extension atomics, and any `Unknown`
+    /// encoding. The block is **cut before** it (the interpreter executes
+    /// it), and the edge carries [`BailReason::UnsupportedInstruction`].
+    Unmodeled,
+}
+
+/// Classify one decoded RISC-V instruction for the block walker.
+///
+/// This mirrors the control-flow / side-effect structure of
+/// [`crate::cpu::riscv::RiscV::step`] without duplicating its semantics: it
+/// only answers "does the block continue, end here, or cut before here?".
+pub fn classify(inst: &Instruction) -> InstrClass {
+    use Instruction::*;
+    match inst {
+        // ── Sequential: integer / logical / shifts (R- and I-type) ──────
+        Lui { .. } | Auipc { .. }
+        | Addi { .. } | Slti { .. } | Sltiu { .. } | Xori { .. } | Ori { .. } | Andi { .. }
+        | Slli { .. } | Srli { .. } | Srai { .. }
+        | Add { .. } | Sub { .. } | Sll { .. } | Slt { .. } | Sltu { .. }
+        | Xor { .. } | Srl { .. } | Sra { .. } | Or { .. } | And { .. }
+        // RV32M
+        | Mul { .. } | Mulh { .. } | Mulhsu { .. } | Mulhu { .. }
+        | Div { .. } | Divu { .. } | Rem { .. } | Remu { .. }
+        // Loads / stores
+        | Lb { .. } | Lh { .. } | Lw { .. } | Lbu { .. } | Lhu { .. }
+        | Sb { .. } | Sh { .. } | Sw { .. }
+        // Compressed-only forms that decode to non-control-flow ops.
+        // (Many C.* instructions decode straight to the base variants above —
+        // C.ADD→Add, C.LUI→Lui, C.SUB→Sub, C.SRLI→Srli, …; only the
+        // genuinely compressed-only variants remain to be listed here.)
+        | CAddi { .. } | CLi { .. } | CMv { .. }
+        | CAddi16sp { .. } | CAddi4spn { .. } | CSli { .. }
+        | CLw { .. } | CSw { .. } | CLwsp { .. } | CSwsp { .. } => InstrClass::Sequential,
+
+        // ── Control flow: conditional branches, jumps (and C.* forms) ───
+        Beq { .. } | Bne { .. } | Blt { .. } | Bge { .. } | Bltu { .. } | Bgeu { .. }
+        | Jal { .. } | Jalr { .. }
+        | CJ { .. } | CJr { .. } | CJalr { .. } | CBeqz { .. } | CBnez { .. } => {
+            InstrClass::ControlFlow
+        }
+
+        // ── Unmodeled: interpreter-owned side effects + unknowns ─────────
+        Fence | Ecall | Ebreak | Mret | Wfi
+        | Csrrw { .. } | Csrrs { .. } | Csrrc { .. }
+        | Csrrwi { .. } | Csrrsi { .. } | Csrrci { .. }
+        | LrW { .. } | ScW { .. }
+        | AmoSwapW { .. } | AmoAddW { .. } | AmoXorW { .. } | AmoOrW { .. } | AmoAndW { .. }
+        | AmoMinW { .. } | AmoMaxW { .. } | AmoMinuW { .. } | AmoMaxuW { .. }
+        | Unknown(_) => InstrClass::Unmodeled,
+    }
+}
+
+/// Instruction length in bytes from the low halfword, per the RISC-V
+/// encoding rule: a base 32-bit instruction has its two low bits set
+/// (`0b11`); anything else is a 16-bit compressed instruction.
+#[inline]
+pub fn inst_len(low_halfword: u16) -> u64 {
+    if (low_halfword & 0x3) == 0x3 {
+        4
+    } else {
+        2
+    }
+}
+
+/// Why the block walk stopped — drives the terminating [`ExitEdge`]'s
+/// [`BailReason`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Termination {
+    /// Ended at (and including) a branch/jump the frontend recognizes.
+    ControlFlow,
+    /// Cut before an instruction the frontend does not model.
+    Unmodeled,
+    /// Ran off the end of the flash [`CodeView`] with no terminator (or hit
+    /// the [`MAX_BLOCK_INSTRS`] cap): a partial block.
+    RanOffView,
+}
+
+/// Outcome of walking a basic block — the raw material for a [`BlockPlan`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockWalk {
+    /// Entry PC (the block-cache key).
+    pub entry_pc: Pc,
+    /// PC one past the last instruction the block subsumes (its natural
+    /// fall-through). For an [`Termination::Unmodeled`] cut this is the PC of
+    /// the unmodeled instruction itself (the interpreter resumes there).
+    pub end_pc: Pc,
+    /// Number of guest instructions the block subsumes.
+    pub instr_count: u32,
+    /// Why the walk stopped.
+    termination: Termination,
+}
+
+impl BlockWalk {
+    /// The [`BailReason`] the terminating edge reports. Purely diagnostic in
+    /// this all-bail milestone (the interpreter is always correct), but it
+    /// gives honest telemetry: `PartialBlock` for a recognized block whose
+    /// body is not yet emitted, `UnsupportedInstruction` for a cut at an
+    /// instruction this frontend does not model.
+    fn bail_reason(&self) -> BailReason {
+        match self.termination {
+            Termination::ControlFlow | Termination::RanOffView => BailReason::PartialBlock,
+            Termination::Unmodeled => BailReason::UnsupportedInstruction,
+        }
+    }
+}
+
+/// Walk a basic block starting at `pc` over the flash `code` view.
+///
+/// Decodes instruction-by-instruction (reusing [`decode_rv32`]), advancing
+/// by the encoded length, and stops at the first control-flow or unmodeled
+/// instruction, at the end of the view, or at the [`MAX_BLOCK_INSTRS`] cap.
+/// Returns `None` if `pc` is not covered by `code`.
+pub fn walk_block(pc: Pc, code: &CodeView<'_>) -> Option<BlockWalk> {
+    // pc itself must be inside the view.
+    code.from(pc)?;
+
+    let mut cur = pc;
+    let mut instr_count = 0u32;
+
+    loop {
+        // Out of translatable flash — a partial block ending here.
+        let Some(bytes) = code.from(cur) else {
+            return Some(BlockWalk {
+                entry_pc: pc,
+                end_pc: cur,
+                instr_count,
+                termination: Termination::RanOffView,
+            });
+        };
+
+        // Need at least the length-defining halfword.
+        if bytes.len() < 2 {
+            return Some(BlockWalk {
+                entry_pc: pc,
+                end_pc: cur,
+                instr_count,
+                termination: Termination::RanOffView,
+            });
+        }
+        let low = u16::from_le_bytes([bytes[0], bytes[1]]);
+        let len = inst_len(low);
+
+        // A 4-byte instruction that runs past the view is not decodable.
+        if len == 4 && bytes.len() < 4 {
+            return Some(BlockWalk {
+                entry_pc: pc,
+                end_pc: cur,
+                instr_count,
+                termination: Termination::RanOffView,
+            });
+        }
+
+        // Assemble the little-endian word. `decode_rv32` inspects the low 16
+        // bits for a compressed instruction, so the high halfword being zero
+        // for a 2-byte instruction is harmless.
+        let word = if len == 4 {
+            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+        } else {
+            low as u32
+        };
+        let inst = decode_rv32(word);
+
+        match classify(&inst) {
+            InstrClass::Unmodeled => {
+                // Cut BEFORE this instruction: the interpreter owns it.
+                return Some(BlockWalk {
+                    entry_pc: pc,
+                    end_pc: cur,
+                    instr_count,
+                    termination: Termination::Unmodeled,
+                });
+            }
+            InstrClass::ControlFlow => {
+                // Include the terminator; the block ends after it.
+                instr_count += 1;
+                return Some(BlockWalk {
+                    entry_pc: pc,
+                    end_pc: cur + len,
+                    instr_count,
+                    termination: Termination::ControlFlow,
+                });
+            }
+            InstrClass::Sequential => {
+                instr_count += 1;
+                cur += len;
+                if instr_count >= MAX_BLOCK_INSTRS {
+                    return Some(BlockWalk {
+                        entry_pc: pc,
+                        end_pc: cur,
+                        instr_count,
+                        termination: Termination::RanOffView,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// The RV32IMC frontend. **Foundation milestone: all-bail** — it produces a
+/// correct block plan (entry/end PC, instruction count, side-exit map) with
+/// an empty `code` body, so every block side-exits to the interpreter. The
+/// codegen chunks replace the empty body class-by-class.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RiscVFrontend;
+
+impl RiscVFrontend {
+    /// Construct the frontend.
+    pub const fn new() -> Self {
+        RiscVFrontend
+    }
+}
+
+impl IsaFrontend for RiscVFrontend {
+    fn isa_name(&self) -> &'static str {
+        "rv32imc"
+    }
+
+    fn translate_block(&self, pc: Pc, code: &CodeView<'_>) -> Result<BlockPlan, FrontendRefusal> {
+        if !code.covers(pc) {
+            return Err(FrontendRefusal::PcOutOfRange);
+        }
+        let walk = walk_block(pc, code).ok_or(FrontendRefusal::PcOutOfRange)?;
+
+        // A block that subsumes no instruction (its entry is itself an
+        // unmodeled instruction) is not worth installing — the interpreter
+        // handles that single instruction directly.
+        if walk.instr_count == 0 {
+            return Err(FrontendRefusal::BlockTooShort);
+        }
+
+        // All-bail: no wasm body yet. The single exit edge carries the
+        // classification's bail reason. `code` is empty, so `is_stub()` is
+        // true and the interpreter runtime side-exits at entry.
+        Ok(BlockPlan {
+            entry_pc: walk.entry_pc,
+            end_pc: walk.end_pc,
+            instr_count: walk.instr_count,
+            code: Vec::new(),
+            exits: vec![ExitEdge {
+                wire_code: 0,
+                reason: walk.bail_reason(),
+            }],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Little-endian encoders for hand-built test programs.
+    fn w(bytes: &mut Vec<u8>, word: u32) {
+        bytes.extend_from_slice(&word.to_le_bytes());
+    }
+    fn c(bytes: &mut Vec<u8>, half: u16) {
+        bytes.extend_from_slice(&half.to_le_bytes());
+    }
+
+    const BASE: Pc = 0x4200_0000;
+
+    #[test]
+    fn inst_len_rule() {
+        assert_eq!(inst_len(0x0013), 4); // low bits 0b11 => 32-bit
+        assert_eq!(inst_len(0x4501), 2); // c.li a0,0 => 16-bit
+        assert_eq!(inst_len(0b11), 4);
+        assert_eq!(inst_len(0b01), 2);
+        assert_eq!(inst_len(0b00), 2);
+        assert_eq!(inst_len(0b10), 2);
+    }
+
+    #[test]
+    fn classifies_representative_instructions() {
+        assert_eq!(
+            classify(&Instruction::Addi {
+                rd: 1,
+                rs1: 0,
+                imm: 5
+            }),
+            InstrClass::Sequential
+        );
+        assert_eq!(
+            classify(&Instruction::Mul {
+                rd: 1,
+                rs1: 2,
+                rs2: 3
+            }),
+            InstrClass::Sequential
+        );
+        assert_eq!(
+            classify(&Instruction::Lw {
+                rd: 1,
+                rs1: 2,
+                imm: 0
+            }),
+            InstrClass::Sequential
+        );
+        assert_eq!(
+            classify(&Instruction::Beq {
+                rs1: 1,
+                rs2: 2,
+                imm: 8
+            }),
+            InstrClass::ControlFlow
+        );
+        assert_eq!(
+            classify(&Instruction::Jal { rd: 1, imm: 16 }),
+            InstrClass::ControlFlow
+        );
+        assert_eq!(
+            classify(&Instruction::CJ { imm: -4 }),
+            InstrClass::ControlFlow
+        );
+        assert_eq!(
+            classify(&Instruction::CJr { rs1: 1 }),
+            InstrClass::ControlFlow
+        );
+        assert_eq!(classify(&Instruction::Ecall), InstrClass::Unmodeled);
+        assert_eq!(
+            classify(&Instruction::Csrrw {
+                rd: 0,
+                rs1: 1,
+                csr: 0x300
+            }),
+            InstrClass::Unmodeled
+        );
+        assert_eq!(classify(&Instruction::Wfi), InstrClass::Unmodeled);
+        assert_eq!(
+            classify(&Instruction::AmoAddW {
+                rd: 1,
+                rs1: 2,
+                rs2: 3
+            }),
+            InstrClass::Unmodeled
+        );
+        assert_eq!(classify(&Instruction::Unknown(0)), InstrClass::Unmodeled);
+    }
+
+    #[test]
+    fn walk_sequential_run_ends_at_branch() {
+        // addi x1,x0,1 ; addi x2,x0,2 ; beq x1,x2,+8
+        let mut prog = Vec::new();
+        w(&mut prog, 0x0010_0093); // addi x1,x0,1
+        w(&mut prog, 0x0020_0113); // addi x2,x0,2
+        w(&mut prog, 0x0020_8463); // beq x1,x2,8
+        let view = CodeView::new(BASE, &prog);
+        let walk = walk_block(BASE, &view).unwrap();
+        assert_eq!(walk.entry_pc, BASE);
+        assert_eq!(walk.instr_count, 3); // two addi + the branch (included)
+        assert_eq!(walk.end_pc, BASE + 12);
+        assert_eq!(walk.bail_reason(), BailReason::PartialBlock);
+    }
+
+    #[test]
+    fn walk_cuts_before_unmodeled_ecall() {
+        // addi x1,x0,1 ; ecall
+        let mut prog = Vec::new();
+        w(&mut prog, 0x0010_0093); // addi x1,x0,1
+        w(&mut prog, 0x0000_0073); // ecall
+        let view = CodeView::new(BASE, &prog);
+        let walk = walk_block(BASE, &view).unwrap();
+        assert_eq!(walk.instr_count, 1); // ecall is NOT included
+        assert_eq!(walk.end_pc, BASE + 4); // cut point = pc of ecall
+        assert_eq!(walk.bail_reason(), BailReason::UnsupportedInstruction);
+    }
+
+    #[test]
+    fn walk_handles_compressed_lengths() {
+        // c.li a0,1 (2 bytes) ; addi x0,x0,0 (4 bytes) ; c.j 0 (2 bytes, CF)
+        let mut prog = Vec::new();
+        c(&mut prog, 0x4505); // c.li a0,1
+        w(&mut prog, 0x0000_0013); // addi x0,x0,0 (nop, 4 bytes)
+        c(&mut prog, 0xa001); // c.j 0
+        let view = CodeView::new(BASE, &prog);
+        let walk = walk_block(BASE, &view).unwrap();
+        assert_eq!(walk.instr_count, 3);
+        // 2 + 4 + 2 = 8 bytes, block includes the c.j terminator.
+        assert_eq!(walk.end_pc, BASE + 8);
+        assert_eq!(walk.termination, Termination::ControlFlow);
+    }
+
+    #[test]
+    fn walk_runs_off_end_of_view() {
+        // Pure straight-line run with no terminator inside the view.
+        let mut prog = Vec::new();
+        w(&mut prog, 0x0010_0093); // addi x1,x0,1
+        w(&mut prog, 0x0020_0113); // addi x2,x0,2
+        let view = CodeView::new(BASE, &prog);
+        let walk = walk_block(BASE, &view).unwrap();
+        assert_eq!(walk.instr_count, 2);
+        assert_eq!(walk.end_pc, BASE + 8);
+        assert_eq!(walk.termination, Termination::RanOffView);
+        assert_eq!(walk.bail_reason(), BailReason::PartialBlock);
+    }
+
+    #[test]
+    fn translate_block_produces_stub_plan() {
+        let mut prog = Vec::new();
+        w(&mut prog, 0x0010_0093); // addi x1,x0,1
+        w(&mut prog, 0x0000_006f); // jal x0,0 (self-loop terminator)
+        let view = CodeView::new(BASE, &prog);
+        let plan = RiscVFrontend::new().translate_block(BASE, &view).unwrap();
+        assert!(plan.is_stub(), "all-bail frontend emits no code");
+        assert_eq!(plan.entry_pc, BASE);
+        assert_eq!(plan.instr_count, 2);
+        assert_eq!(plan.end_pc, BASE + 8);
+        assert_eq!(plan.exits.len(), 1);
+        assert_eq!(plan.exits[0].reason, BailReason::PartialBlock);
+    }
+
+    #[test]
+    fn translate_block_refuses_out_of_range_pc() {
+        let prog = vec![0u8; 8];
+        let view = CodeView::new(BASE, &prog);
+        assert!(matches!(
+            RiscVFrontend::new().translate_block(BASE + 0x1000, &view),
+            Err(FrontendRefusal::PcOutOfRange)
+        ));
+    }
+
+    #[test]
+    fn translate_block_refuses_zero_instruction_block() {
+        // Entry is itself an unmodeled instruction (ecall) → BlockTooShort.
+        let mut prog = Vec::new();
+        w(&mut prog, 0x0000_0073); // ecall
+        let view = CodeView::new(BASE, &prog);
+        assert!(matches!(
+            RiscVFrontend::new().translate_block(BASE, &view),
+            Err(FrontendRefusal::BlockTooShort)
+        ));
+    }
+
+    #[test]
+    fn isa_name_is_rv32imc() {
+        assert_eq!(RiscVFrontend::new().isa_name(), "rv32imc");
+    }
+}

--- a/crates/core/tests/riscv_jit_lockstep.rs
+++ b/crates/core/tests/riscv_jit_lockstep.rs
@@ -1,0 +1,187 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential (lockstep) equivalence gate for the RV32IMC JIT frontend.
+//!
+//! This is the universal-dispatch framework's **merge gate #1** applied to
+//! RISC-V: run the *same* hand-assembled RV32IMC hot loop twice from the
+//! same reset — once on the pure interpreter, once through the
+//! [`DispatchLoop`] driving the [`RiscVFrontend`] + `InterpreterRuntime`
+//! over a [`RiscVJitHost`] — and assert the architectural state is
+//! byte-identical at *every* retired instruction.
+//!
+//! In this foundation milestone the frontend is **all-bail**: every block
+//! walks and classifies but emits no wasm, so it side-exits to the
+//! interpreter. The test therefore proves the entire dispatch / host /
+//! snapshot / cache / side-exit / fallback plumbing is correct and
+//! equivalence-preserving *before* any codegen exists. Each later codegen
+//! chunk re-runs this exact gate.
+//!
+//! Gated behind `jit-framework` (the module it exercises is), so it compiles
+//! away under the default and `jit` builds.
+
+#![cfg(feature = "jit-framework")]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::jit_framework::differential::{DiffPolicy, DifferentialHarness};
+use labwired_core::cpu::jit_framework::dispatch::DispatchLoop;
+use labwired_core::cpu::jit_framework::riscv::{
+    differential_cycle_ignore_indices, snapshot_state, RiscVFrontend, RiscVJitHost,
+};
+use labwired_core::cpu::jit_framework::runtime::{InterpreterRuntime, MemoryBinding};
+use labwired_core::cpu::RiscV;
+use labwired_core::Machine;
+
+// ── RV32I instruction encoders (standard field layouts) ──────────────────
+
+fn enc_addi(rd: u32, rs1: u32, imm: i32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | (rs1 << 15) | (rd << 7) | 0x13
+}
+
+fn enc_xor(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0x33
+}
+
+fn enc_jal(rd: u32, imm: i32) -> u32 {
+    let u = imm as u32;
+    let imm20 = (u >> 20) & 1;
+    let imm10_1 = (u >> 1) & 0x3FF;
+    let imm11 = (u >> 11) & 1;
+    let imm19_12 = (u >> 12) & 0xFF;
+    (imm20 << 31) | (imm10_1 << 21) | (imm11 << 20) | (imm19_12 << 12) | (rd << 7) | 0x6F
+}
+
+/// A self-contained RV32IMC hot loop laid at flash PC 0:
+///
+/// ```text
+/// 0x00:  addi x1, x1, 1     ; counter++
+/// 0x04:  xor  x3, x1, x2    ; some real ALU work depending on the counter
+/// 0x08:  jal  x0, -8        ; branch back to 0x00 (infinite loop)
+/// ```
+///
+/// Pure register + control-flow work: no memory, no CSRs, no traps — so the
+/// interpreter never errors and both runs stay perfectly PC-aligned.
+fn loop_program() -> Vec<u8> {
+    let words = [
+        enc_addi(1, 1, 1), // addi x1,x1,1
+        enc_xor(3, 1, 2),  // xor  x3,x1,x2
+        enc_jal(0, -8),    // jal  x0,-8  (back to 0x00)
+    ];
+    let mut bytes = Vec::with_capacity(words.len() * 4);
+    for w in words {
+        bytes.extend_from_slice(&w.to_le_bytes());
+    }
+    bytes
+}
+
+/// Build a fresh `Machine<RiscV>` with the hot loop in flash at base 0 and
+/// the reset PC at the loop head. Two calls produce two independent,
+/// identically-initialised machines.
+fn build_loop_machine() -> Machine<RiscV> {
+    let mut bus = SystemBus::new();
+    bus.flash.data = loop_program();
+    bus.flash.base_addr = 0;
+
+    let mut cpu = RiscV::new();
+    cpu.pc = 0;
+    // Keep the CLINT timer out of the way: with mtimecmp maxed, the
+    // free-running mtime never raises MTIP, so `mip` stays 0 throughout and
+    // no timer interrupt is ever pending (mie/mstatus.MIE are 0 anyway).
+    cpu.mtimecmp = u64::MAX;
+
+    Machine::new(cpu, bus)
+}
+
+#[test]
+fn riscv_all_bail_frontend_is_byte_identical_to_interpreter() {
+    // Comparison budget — well above any no-op floor.
+    const MAX_COMPARES: u64 = 3_000;
+    const FLOOR: u64 = 2_000;
+
+    let mut interp_machine = build_loop_machine();
+    let mut jit_machine = build_loop_machine();
+
+    // JIT side: the all-bail RV32IMC frontend on the interpreter runtime,
+    // driven by the universal dispatch loop. A low hot threshold makes the
+    // recurring loop PCs promote + compile (to body-less stubs) quickly, so
+    // the compiled-block dispatch path is genuinely exercised.
+    let flash_len = jit_machine.bus.flash.data.len();
+    let mem = MemoryBinding::NativeLinear {
+        guest_base: 0,
+        len: flash_len,
+    };
+    let mut jit_loop =
+        DispatchLoop::new(RiscVFrontend::new(), InterpreterRuntime, mem).with_hot_threshold(4);
+
+    let policy = DiffPolicy {
+        ignore_indices: differential_cycle_ignore_indices(),
+        block_boundary_only: false, // compare after every retired instruction
+    };
+    let harness = DifferentialHarness::new(MAX_COMPARES).with_policy(policy);
+
+    // Each closure advances its machine by exactly one retired instruction
+    // and returns the flattened architectural state, or `None` if the
+    // machine failed to advance (halt / trap the interpreter cannot service).
+    let interp_step = || match interp_machine.step() {
+        Ok(()) => Some(snapshot_state(&interp_machine.cpu)),
+        Err(_) => None,
+    };
+
+    let jit_step = || {
+        let before = jit_machine.total_cycles;
+        {
+            let mut host = RiscVJitHost::new(&mut jit_machine);
+            // One dispatch iteration retires exactly one guest instruction:
+            // the all-bail stub side-exits to the interpreter, which steps
+            // once (or a cold PC is interpreted directly).
+            jit_loop.run(&mut host, 1);
+        }
+        if jit_machine.total_cycles == before {
+            None // machine did not advance — treat as halt
+        } else {
+            Some(snapshot_state(&jit_machine.cpu))
+        }
+    };
+
+    let report = harness.run(interp_step, jit_step);
+
+    // (1) Byte-for-byte equivalence at every comparison point.
+    assert!(
+        report.is_equivalent(),
+        "JIT diverged from interpreter: {:?}",
+        report.divergence
+    );
+
+    // (2) Non-vacuous: the firmware really executed a hot loop, not a no-op.
+    assert!(
+        report.compares >= FLOOR,
+        "only {} instructions compared (expected >= {}); the run halted early",
+        report.compares,
+        FLOOR
+    );
+    assert!(
+        interp_machine.cpu.x[1] as u64 >= FLOOR / 3,
+        "counter x1={} too low — the loop body did not run enough",
+        interp_machine.cpu.x[1]
+    );
+
+    // (3) The JIT plumbing was genuinely engaged (not pure refusal): hot PCs
+    // were compiled and their (body-less) blocks dispatched + side-exited.
+    let stats = jit_loop.stats();
+    assert!(
+        stats.compiled > 0,
+        "no block ever crossed the hot threshold"
+    );
+    assert!(
+        stats.block_runs > 0,
+        "no compiled block was ever dispatched (JIT path not exercised)"
+    );
+    assert!(
+        stats.interpreted >= FLOOR,
+        "interpreter fallback retired only {} instructions",
+        stats.interpreted
+    );
+    // All-bail frontend never chains (every block side-exits to interp).
+    assert_eq!(stats.chained, 0, "an all-bail block must not chain");
+}


### PR DESCRIPTION
## RISC-V (RV32IMC) JIT frontend — foundation milestone (all-bail, zero codegen)

First real `IsaFrontend` for the universal dispatch JIT (the scaffold shipped only `PassthroughFrontend`). This is the **foundation** milestone: a correct block-walker + classification + host adapter + differential gate, with **zero wasm emission**. Every block side-exits to the interpreter, so the differential harness proves the entire dispatch / host / snapshot / cache / side-exit / fallback plumbing is byte-identical to the interpreter *before* any codegen lands. Each later codegen chunk (C/D/E/F) fills the empty `code` body class-by-class and re-runs this same gate.

Base branch: `jit-framework-scaffold` (not `main`). All new code is behind the existing `jit-framework` cargo feature.

### What's here
- **Block-walker + classification** (`riscv/mod.rs`): walks a basic block from `pc` over the flash `CodeView`, reusing `decoder::riscv::decode_rv32` + the `(halfword & 0x3)==0x3 ? 4 : 2` length rule. Classifies every `Instruction` as sequential / control-flow-terminator / unmodeled. Produces a `BlockPlan` with correct `entry_pc`, `end_pc`, `instr_count`, and a single side-exit `ExitEdge` carrying the honest `BailReason` (`PartialBlock` for a recognized block whose body isn't emitted yet, `UnsupportedInstruction` for a cut at a system/atomic/unknown op) — with an **empty `code`** body (`is_stub()` true). `RiscVFrontend::isa_name()` = `"rv32imc"`.
- **JitHost adapter** (`riscv/host.rs`): `JitHost` for `Machine<RiscV>` — `pc` / `interpret_one` (one `Machine::step`) / `resume_at` / `code_view` / `safety` / `snapshot_state` / `take_flash_dirty`. `snapshot_state` returns a `StateVec` of `x0..x31`, `pc`, then `mstatus, mie, mip, mtvec, mscratch, mepc, mcause, mtval`.
- **Differential gate** (`tests/riscv_jit_lockstep.rs`): runs a hand-assembled RV32IMC hot loop twice (pure interpreter vs `DispatchLoop`+`RiscVFrontend`+`InterpreterRuntime` over the adapter) and asserts `DiffReport::is_equivalent()` at every retired instruction. Non-vacuous: asserts ≥2000 instructions compared and that compiled blocks were actually dispatched.

### Gates
- `cargo fmt --check`: clean. `cargo clippy --features jit-framework --tests`: clean.
- CI-gate `cargo test -p labwired-core --features jit,event-scheduler`: **2034 passed / 0 failed / 32 ignored** (unchanged vs baseline — this build doesn't compile the gated module).
- `--features jit,event-scheduler,jit-framework`: baseline scaffold **2409 passed / 0 failed** → this PR **2420 passed / 0 failed** (+10 unit tests +1 differential test). **Zero new failures.**

### Scaffold API mismatches vs the implementation brief (for the C/D/E agents)
1. **`code_view` is NOT backed by `Bus::fetch_slice`.** `SystemBus::fetch_slice` only serves the Xtensa `RamPeripheral` (downcasts to it, returns `None` otherwise), so it yields nothing for a RISC-V flash region. The adapter reads `bus.flash` (a position-stable `LinearMemory`) directly. Extending `fetch_slice` to serve flash / the C3 XIP window is a later cleanup.
2. **No flash-dirty flag on the bus.** Nothing tracks flash writes today, so `take_flash_dirty()` is conservatively `false` (correct for any run that doesn't self-modify flash). Wire in when flash self-write support lands.
3. **The specified `StateVec` has no volatile cycle/mtime word**, so `DiffPolicy.ignore_indices` has nothing to mask in this all-bail milestone (`differential_cycle_ignore_indices()` returns empty). The `StateVec` layout deliberately excludes the free-running `mtime` CSRs; the ignore-index hook is in place for when batched codegen samples a cycle-derived word mid-block.
4. `BlockPlan` does not derive `PartialEq`, so tests compare via `matches!`/field access rather than `assert_eq!` on a whole plan.

Do not merge — foundation for the parallel codegen chunks.
