### PR TITLE
jit(riscv): wasm emit skeleton + integer-ALU codegen (chunk C)

### DIFF
--- a/crates/core/src/cpu/jit_framework/riscv/emit.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/emit.rs
@@ -1,0 +1,540 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! RV32IMC integer-ALU wasm codegen (JIT framework chunk C).
+//!
+//! This is the **first block that executes instead of bailing**. It turns a
+//! straight-line run of integer arithmetic / logical / shift / mul-div
+//! instructions into a real wasm module (via [`super::wasm_encode`]) that a
+//! runtime ([`super::exec`]) runs against the guest register file.
+//!
+//! ## The register-file-in-locals model
+//!
+//! The compiled module imports one memory — the **guest register file**,
+//! word `i` = `xi` at byte offset `i*4` (see
+//! [`wasm_encode::REGS_IMPORT_MODULE`]). Each block:
+//!
+//!   1. **Prologue** — loads every register it *reads* from that memory into
+//!      a wasm local (`x0..x31` map to locals `0..31`).
+//!   2. **Body** — one emit per guest instruction, operating purely on
+//!      locals. `x0` reads as the constant `0` and writes to it are dropped
+//!      (mirrors [`crate::cpu::riscv::RiscV::read_reg`]/`write_reg`).
+//!   3. **Epilogue** — stores every register it *wrote* back to the memory.
+//!
+//! Keeping the whole block's arithmetic in locals means only the touched
+//! registers cross the memory boundary, and only twice (in at entry, out at
+//! exit) regardless of block length — the shape that lets a hot ALU run beat
+//! the interpreter.
+//!
+//! ## Where a block ends (chunk-C scope)
+//!
+//! The walk collects the maximal prefix of **ALU-emittable** instructions
+//! ([`is_alu_emittable`]) from the entry PC and stops *before* the first
+//! instruction it cannot emit — a branch/jump (chunk D), a load/store
+//! (chunk E), or an interpreter-owned op (CSR/system/atomics). The block
+//! runs the prefix and side-exits with the [fall-through wire](WIRE_FALL_THROUGH)
+//! → [`SideExit::Chain`](super::super::side_exit::SideExit::Chain) to
+//! `end_pc`, where the interpreter (or a future compiled block) resumes.
+//! There is no in-block control flow yet, so every chunk-C block has exactly
+//! this one exit.
+
+use crate::decoder::riscv::{decode_rv32, Instruction};
+
+use super::super::frontend::ExitEdge;
+use super::super::side_exit::BailReason;
+use super::super::{CodeView, Pc};
+use super::inst_len;
+use super::wasm_encode::{build_module, enc, op};
+
+/// Wire code the emitted body returns on a clean straight-line fall-through
+/// to `end_pc`. The runtime maps it to
+/// [`SideExit::Chain`](super::super::side_exit::SideExit::Chain). Chunks D/E
+/// add further wire codes (taken branch, memory fault) alongside this one.
+pub const WIRE_FALL_THROUGH: i32 = 0;
+
+/// Number of `i32` locals every compiled block declares: one per guest
+/// register `x0..x31`. Local index == register number.
+const REG_LOCALS: u32 = 32;
+
+/// Is `inst` an integer-ALU instruction chunk C emits wasm for?
+///
+/// This is the codegen allowlist. It is a strict subset of the walker's
+/// [`InstrClass::Sequential`](super::InstrClass): loads/stores are
+/// `Sequential` too but belong to chunk E, so they are **not** here — a
+/// block ends before them. Anything not listed keeps the interpreter.
+pub fn is_alu_emittable(inst: &Instruction) -> bool {
+    use Instruction::*;
+    matches!(
+        inst,
+        Lui { .. }
+            | Auipc { .. }
+            | Addi { .. }
+            | Slti { .. }
+            | Sltiu { .. }
+            | Xori { .. }
+            | Ori { .. }
+            | Andi { .. }
+            | Slli { .. }
+            | Srli { .. }
+            | Srai { .. }
+            | Add { .. }
+            | Sub { .. }
+            | Sll { .. }
+            | Slt { .. }
+            | Sltu { .. }
+            | Xor { .. }
+            | Srl { .. }
+            | Sra { .. }
+            | Or { .. }
+            | And { .. }
+            | Mul { .. }
+            | Mulh { .. }
+            | Mulhsu { .. }
+            | Mulhu { .. }
+            | Div { .. }
+            | Divu { .. }
+            | Rem { .. }
+            | Remu { .. }
+            | CAddi { .. }
+            | CLi { .. }
+            | CMv { .. }
+            | CAddi16sp { .. }
+            | CAddi4spn { .. }
+            | CSli { .. }
+    )
+}
+
+/// One decoded ALU instruction plus the guest PC it sits at (needed for
+/// `AUIPC`, which folds `pc` into a constant).
+struct AluOp {
+    pc: u32,
+    inst: Instruction,
+}
+
+/// The result of emitting a block: the wasm bytes plus the metadata the
+/// frontend stamps onto its [`BlockPlan`](super::super::frontend::BlockPlan).
+pub struct EmittedAluBlock {
+    /// Real wasm module bytes (magic-prefixed), consumed by the runtime.
+    pub code: Vec<u8>,
+    /// Guest PC one past the last emitted instruction — the fall-through
+    /// continuation the runtime chains to.
+    pub end_pc: Pc,
+    /// Number of guest instructions the block retires in one run.
+    pub instr_count: u32,
+    /// Side-exit edges, indexed by returned wire code. Chunk C has exactly
+    /// the fall-through edge.
+    pub exits: Vec<ExitEdge>,
+}
+
+/// Emit a wasm block for the maximal ALU prefix at `pc`.
+///
+/// Returns `None` when the instruction at `pc` is not ALU-emittable (the
+/// caller keeps that PC on the interpreter — never an error).
+pub fn emit_alu_block(pc: Pc, code: &CodeView<'_>) -> Option<EmittedAluBlock> {
+    let ops = walk_alu_ops(pc, code);
+    if ops.is_empty() {
+        return None;
+    }
+    let end_pc = pc + ops.iter().map(|o| inst_len_of(o.pc, code)).sum::<u64>();
+    let instr_count = ops.len() as u32;
+
+    // Emit the body into a scratch buffer while recording which registers
+    // are read (load set) and written (store set), then frame the function
+    // expression as prologue + body + epilogue + fall-through wire code.
+    let mut body = Body::default();
+    for aop in &ops {
+        body.emit_instruction(aop.pc, &aop.inst);
+    }
+
+    let mut expr = Vec::with_capacity(body.buf.len() + 16 * REG_LOCALS as usize);
+    body.emit_prologue(&mut expr); // loads touched regs into locals
+    expr.extend_from_slice(&body.buf); // body operating purely on locals
+    body.emit_epilogue(&mut expr); // stores written regs back to mem
+    expr.push(op::I32_CONST); // the block's return value
+    enc::sleb(&mut expr, WIRE_FALL_THROUGH as i64);
+
+    let code_bytes = build_module(REG_LOCALS, &expr);
+
+    Some(EmittedAluBlock {
+        code: code_bytes,
+        end_pc,
+        instr_count,
+        exits: vec![ExitEdge {
+            wire_code: WIRE_FALL_THROUGH,
+            // The block is "partial": it retired its ALU prefix and hands
+            // the following (non-ALU) instruction to the interpreter / the
+            // next compiled block. Telemetry only — correctness is the
+            // runtime's Chain{end_pc}.
+            reason: BailReason::PartialBlock,
+        }],
+    })
+}
+
+/// Walk the maximal run of ALU-emittable instructions from `pc`.
+fn walk_alu_ops(pc: Pc, code: &CodeView<'_>) -> Vec<AluOp> {
+    let mut ops = Vec::new();
+    let mut cur = pc;
+    while let Some(bytes) = code.from(cur) {
+        if bytes.len() < 2 {
+            break;
+        }
+        let low = u16::from_le_bytes([bytes[0], bytes[1]]);
+        let len = inst_len(low);
+        if len == 4 && bytes.len() < 4 {
+            break;
+        }
+        let word = if len == 4 {
+            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+        } else {
+            low as u32
+        };
+        let inst = decode_rv32(word);
+        if !is_alu_emittable(&inst) {
+            break;
+        }
+        ops.push(AluOp {
+            pc: cur as u32,
+            inst,
+        });
+        cur += len;
+        if ops.len() as u32 >= super::MAX_BLOCK_INSTRS {
+            break;
+        }
+    }
+    ops
+}
+
+/// Byte length of the instruction at `pc` in `code` (2 or 4).
+fn inst_len_of(pc: u32, code: &CodeView<'_>) -> u64 {
+    let bytes = code.from(pc as Pc).expect("op pc was in view during walk");
+    inst_len(u16::from_le_bytes([bytes[0], bytes[1]]))
+}
+
+/// Accumulates the body opcodes plus the read/write register sets.
+#[derive(Default)]
+struct Body {
+    buf: Vec<u8>,
+    /// Registers read anywhere in the block (loaded in the prologue).
+    reads: [bool; 32],
+    /// Registers written anywhere in the block (stored in the epilogue).
+    writes: [bool; 32],
+}
+
+impl Body {
+    /// Push `local.get`/`i32.const 0` for reading guest register `r`.
+    fn read(&mut self, r: u8) {
+        if r == 0 {
+            self.buf.push(op::I32_CONST);
+            enc::sleb(&mut self.buf, 0);
+        } else {
+            self.reads[r as usize] = true;
+            self.buf.push(op::LOCAL_GET);
+            enc::uleb(&mut self.buf, r as u64);
+        }
+    }
+
+    /// Consume the value currently on the stack as the new value of guest
+    /// register `r` (`local.set`, or `drop` for `x0`).
+    fn write(&mut self, r: u8) {
+        if r == 0 {
+            self.buf.push(op::DROP);
+        } else {
+            self.writes[r as usize] = true;
+            self.buf.push(op::LOCAL_SET);
+            enc::uleb(&mut self.buf, r as u64);
+        }
+    }
+
+    /// Push an `i32.const`.
+    fn i32_const(&mut self, v: i32) {
+        self.buf.push(op::I32_CONST);
+        enc::sleb(&mut self.buf, v as i64);
+    }
+
+    /// Emit `read(rs1) read(rs2) <opcode> write(rd)`.
+    fn binop(&mut self, rd: u8, rs1: u8, rs2: u8, opcode: u8) {
+        self.read(rs1);
+        self.read(rs2);
+        self.buf.push(opcode);
+        self.write(rd);
+    }
+
+    /// Emit `read(rs1) i32.const(imm) <opcode> write(rd)`.
+    fn binop_imm(&mut self, rd: u8, rs1: u8, imm: i32, opcode: u8) {
+        self.read(rs1);
+        self.i32_const(imm);
+        self.buf.push(opcode);
+        self.write(rd);
+    }
+
+    /// Emit the high-half multiply family: extend both operands to i64 with
+    /// `s1`/`s2`, `i64.mul`, `>> 32`, wrap to i32.
+    fn mulh(&mut self, rd: u8, rs1: u8, rs2: u8, ext1: u8, ext2: u8) {
+        self.read(rs1);
+        self.buf.push(ext1);
+        self.read(rs2);
+        self.buf.push(ext2);
+        self.buf.push(op::I64_MUL);
+        self.buf.push(op::I64_CONST);
+        enc::sleb(&mut self.buf, 32);
+        self.buf.push(op::I64_SHR_U);
+        self.buf.push(op::I32_WRAP_I64);
+        self.write(rd);
+    }
+
+    /// Push `read(r) i32.eqz` (is register `r` zero?).
+    fn is_zero(&mut self, r: u8) {
+        self.read(r);
+        self.buf.push(op::I32_EQZ);
+    }
+
+    /// Push `(read(rs1) == i32::MIN) && (read(rs2) == -1)` — the signed
+    /// division overflow predicate.
+    fn is_signed_overflow(&mut self, rs1: u8, rs2: u8) {
+        self.read(rs1);
+        self.i32_const(i32::MIN);
+        self.buf.push(op::I32_EQ);
+        self.read(rs2);
+        self.i32_const(-1);
+        self.buf.push(op::I32_EQ);
+        self.buf.push(op::I32_AND);
+    }
+
+    /// Open an `if (result i32)` on the condition already on the stack.
+    fn if_i32(&mut self) {
+        self.buf.push(op::IF);
+        self.buf.push(op::T_I32);
+    }
+
+    /// Emit one guest instruction. `pc` is the instruction's own PC (for
+    /// `AUIPC`).
+    fn emit_instruction(&mut self, pc: u32, inst: &Instruction) {
+        use Instruction::*;
+        match *inst {
+            // ── upper immediates ───────────────────────────────────────
+            Lui { rd, imm } => {
+                self.i32_const(imm as i32);
+                self.write(rd);
+            }
+            Auipc { rd, imm } => {
+                self.i32_const(pc.wrapping_add(imm) as i32);
+                self.write(rd);
+            }
+
+            // ── register-immediate arithmetic / logic ──────────────────
+            Addi { rd, rs1, imm } => self.binop_imm(rd, rs1, imm, op::I32_ADD),
+            Xori { rd, rs1, imm } => self.binop_imm(rd, rs1, imm, op::I32_XOR),
+            Ori { rd, rs1, imm } => self.binop_imm(rd, rs1, imm, op::I32_OR),
+            Andi { rd, rs1, imm } => self.binop_imm(rd, rs1, imm, op::I32_AND),
+            Slti { rd, rs1, imm } => self.binop_imm(rd, rs1, imm, op::I32_LT_S),
+            Sltiu { rd, rs1, imm } => self.binop_imm(rd, rs1, imm, op::I32_LT_U),
+
+            // ── immediate shifts (shamt is a decoded 5-bit constant) ────
+            Slli { rd, rs1, shamt } => self.binop_imm(rd, rs1, shamt as i32, op::I32_SHL),
+            Srli { rd, rs1, shamt } => self.binop_imm(rd, rs1, shamt as i32, op::I32_SHR_U),
+            Srai { rd, rs1, shamt } => self.binop_imm(rd, rs1, shamt as i32, op::I32_SHR_S),
+
+            // ── register-register arithmetic / logic ───────────────────
+            Add { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_ADD),
+            Sub { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_SUB),
+            Xor { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_XOR),
+            Or { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_OR),
+            And { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_AND),
+            Slt { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_LT_S),
+            Sltu { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_LT_U),
+            // wasm masks the shift count to 5 bits — identical to the
+            // interpreter's explicit `& 0x1F`.
+            Sll { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_SHL),
+            Srl { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_SHR_U),
+            Sra { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_SHR_S),
+
+            // ── RV32M multiply ─────────────────────────────────────────
+            Mul { rd, rs1, rs2 } => self.binop(rd, rs1, rs2, op::I32_MUL),
+            Mulh { rd, rs1, rs2 } => {
+                self.mulh(rd, rs1, rs2, op::I64_EXTEND_I32_S, op::I64_EXTEND_I32_S)
+            }
+            Mulhsu { rd, rs1, rs2 } => {
+                self.mulh(rd, rs1, rs2, op::I64_EXTEND_I32_S, op::I64_EXTEND_I32_U)
+            }
+            Mulhu { rd, rs1, rs2 } => {
+                self.mulh(rd, rs1, rs2, op::I64_EXTEND_I32_U, op::I64_EXTEND_I32_U)
+            }
+
+            // ── RV32M divide / remainder (trap-free, guarded) ──────────
+            Div { rd, rs1, rs2 } => {
+                // divisor == 0 -> -1
+                self.is_zero(rs2);
+                self.if_i32();
+                self.i32_const(-1);
+                self.buf.push(op::ELSE);
+                // INT_MIN / -1 -> INT_MIN (== dividend); else div_s.
+                self.is_signed_overflow(rs1, rs2);
+                self.if_i32();
+                self.read(rs1);
+                self.buf.push(op::ELSE);
+                self.read(rs1);
+                self.read(rs2);
+                self.buf.push(op::I32_DIV_S);
+                self.buf.push(op::END);
+                self.buf.push(op::END);
+                self.write(rd);
+            }
+            Divu { rd, rs1, rs2 } => {
+                // divisor == 0 -> u32::MAX (0xFFFF_FFFF == -1 bits); else div_u.
+                self.is_zero(rs2);
+                self.if_i32();
+                self.i32_const(-1);
+                self.buf.push(op::ELSE);
+                self.read(rs1);
+                self.read(rs2);
+                self.buf.push(op::I32_DIV_U);
+                self.buf.push(op::END);
+                self.write(rd);
+            }
+            Rem { rd, rs1, rs2 } => {
+                // divisor == 0 -> dividend; INT_MIN/-1 -> 0; else rem_s.
+                self.is_zero(rs2);
+                self.if_i32();
+                self.read(rs1);
+                self.buf.push(op::ELSE);
+                self.is_signed_overflow(rs1, rs2);
+                self.if_i32();
+                self.i32_const(0);
+                self.buf.push(op::ELSE);
+                self.read(rs1);
+                self.read(rs2);
+                self.buf.push(op::I32_REM_S);
+                self.buf.push(op::END);
+                self.buf.push(op::END);
+                self.write(rd);
+            }
+            Remu { rd, rs1, rs2 } => {
+                // divisor == 0 -> dividend; else rem_u.
+                self.is_zero(rs2);
+                self.if_i32();
+                self.read(rs1);
+                self.buf.push(op::ELSE);
+                self.read(rs1);
+                self.read(rs2);
+                self.buf.push(op::I32_REM_U);
+                self.buf.push(op::END);
+                self.write(rd);
+            }
+
+            // ── compressed forms ───────────────────────────────────────
+            // `C.ADDI rd, imm` (rd == 0 is a hint/nop — the x0-drop makes it
+            // a no-op automatically, matching the interpreter's guard).
+            CAddi { rd, imm } => self.binop_imm(rd, rd, imm, op::I32_ADD),
+            CLi { rd, imm } => {
+                self.i32_const(imm);
+                self.write(rd);
+            }
+            CMv { rd, rs2 } => {
+                self.read(rs2);
+                self.write(rd);
+            }
+            CAddi16sp { imm } => self.binop_imm(2, 2, imm, op::I32_ADD),
+            // `C.ADDI4SPN rd, uimm` — rd = x2 + uimm (uimm zero-extended).
+            CAddi4spn { rd, imm } => self.binop_imm(rd, 2, imm as i32, op::I32_ADD),
+            CSli { rd, shamt } => self.binop_imm(rd, rd, shamt as i32, op::I32_SHL),
+
+            // Anything else must not reach here — the walk stops before it.
+            other => unreachable!("non-ALU instruction reached emit: {other:?}"),
+        }
+    }
+
+    /// Emit the prologue: `local.set r (i32.load (r*4))` for each read reg.
+    fn emit_prologue(&self, out: &mut Vec<u8>) {
+        for r in 1..32u8 {
+            if self.reads[r as usize] {
+                out.push(op::I32_CONST);
+                enc::sleb(out, (r as i64) * 4);
+                out.push(op::I32_LOAD);
+                enc::uleb(out, 2); // align = 2 (2^2 = 4-byte)
+                enc::uleb(out, 0); // offset = 0
+                out.push(op::LOCAL_SET);
+                enc::uleb(out, r as u64);
+            }
+        }
+    }
+
+    /// Emit the epilogue: `i32.store (r*4) (local.get r)` for each write reg.
+    fn emit_epilogue(&self, out: &mut Vec<u8>) {
+        for r in 1..32u8 {
+            if self.writes[r as usize] {
+                out.push(op::I32_CONST);
+                enc::sleb(out, (r as i64) * 4);
+                out.push(op::LOCAL_GET);
+                enc::uleb(out, r as u64);
+                out.push(op::I32_STORE);
+                enc::uleb(out, 2);
+                enc::uleb(out, 0);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: Pc = 0x4200_0000;
+
+    fn enc_addi(rd: u32, rs1: u32, imm: i32) -> u32 {
+        ((imm as u32 & 0xFFF) << 20) | (rs1 << 15) | (rd << 7) | 0x13
+    }
+    fn enc_add(rd: u32, rs1: u32, rs2: u32) -> u32 {
+        (rs2 << 20) | (rs1 << 15) | (rd << 7) | 0x33
+    }
+    fn enc_ecall() -> u32 {
+        0x0000_0073
+    }
+
+    fn view(words: &[u32]) -> Vec<u8> {
+        let mut b = Vec::new();
+        for w in words {
+            b.extend_from_slice(&w.to_le_bytes());
+        }
+        b
+    }
+
+    #[test]
+    fn refuses_non_alu_entry() {
+        let prog = view(&[enc_ecall()]);
+        let cv = CodeView::new(BASE, &prog);
+        assert!(emit_alu_block(BASE, &cv).is_none());
+    }
+
+    #[test]
+    fn walks_alu_prefix_and_stops_before_non_alu() {
+        // addi x1,x0,1 ; add x2,x1,x1 ; ecall
+        let prog = view(&[enc_addi(1, 0, 1), enc_add(2, 1, 1), enc_ecall()]);
+        let cv = CodeView::new(BASE, &prog);
+        let blk = emit_alu_block(BASE, &cv).unwrap();
+        assert_eq!(blk.instr_count, 2, "ecall is not included");
+        assert_eq!(blk.end_pc, BASE + 8, "ends before the ecall");
+        assert_eq!(blk.exits.len(), 1);
+        assert_eq!(blk.exits[0].wire_code, WIRE_FALL_THROUGH);
+        // Real wasm bytes.
+        assert_eq!(&blk.code[0..4], &[0x00, 0x61, 0x73, 0x6d]);
+    }
+
+    #[cfg(feature = "jit")]
+    #[test]
+    fn emitted_module_validates_in_wasmtime() {
+        // Emit a block exercising several op classes and assert the bytes are
+        // a valid wasm module (the strongest cheap structural check).
+        let prog = view(&[
+            enc_addi(1, 0, 5), // addi x1,x0,5
+            enc_add(2, 1, 1),  // add  x2,x1,x1
+            enc_add(1, 1, 2),  // add  x1,x1,x2
+            enc_ecall(),       // terminator (not emitted)
+        ]);
+        let cv = CodeView::new(BASE, &prog);
+        let blk = emit_alu_block(BASE, &cv).unwrap();
+        let engine = wasmtime::Engine::default();
+        wasmtime::Module::new(&engine, &blk.code).expect("emitted module must validate");
+        assert_eq!(blk.instr_count, 3);
+    }
+}

--- a/crates/core/src/cpu/jit_framework/riscv/exec.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/exec.rs
@@ -1,0 +1,296 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Native (`wasmtime`) executor for RV32IMC compiled blocks (JIT chunk C).
+//!
+//! This is the runtime that fills the register-marshalling slot the
+//! framework scaffold deliberately elided
+//! ([`JitRuntime::run`](super::super::runtime::JitRuntime::run)'s doc: *"the
+//! real runtimes take a register-file handle here"*). Because that handle
+//! is not yet in the generic trait, chunk C keeps the executor **RISC-V-
+//! local** rather than perturbing the generic `JitRuntime` contract: it runs
+//! an emitted [`BlockPlan`] directly against a `Machine<RiscV>`'s register
+//! file.
+//!
+//! ## Register marshalling
+//!
+//! Each compiled module imports one `wasmtime::Memory` — the guest register
+//! file (word `i` = `xi` at byte `i*4`; see
+//! [`super::emit`]). Running one block is:
+//!
+//!   1. copy `cpu.x[0..32]` into the memory (`128` bytes),
+//!   2. call the exported `run` (which loads the touched regs into locals,
+//!      computes, stores them back — all inside wasm),
+//!   3. copy the memory back into `cpu.x`, forcing `x0 = 0`,
+//!   4. map the returned `i32` wire code to a [`SideExit`].
+//!
+//! Only the touched registers actually move through the memory (the
+//! prologue/epilogue in the emitted body load/store just those), so the
+//! host-side copy is a fixed `128`-byte sync regardless of block length.
+//!
+//! ## Wire-code → side-exit protocol
+//!
+//! Chunk C emits exactly one edge:
+//! [`WIRE_FALL_THROUGH`](super::emit::WIRE_FALL_THROUGH) → [`SideExit::Chain`]
+//! to `end_pc` (the block ran its ALU prefix straight through; control flows
+//! on to the next instruction, which the interpreter or a chained block
+//! handles). Chunks D/E add non-zero wire codes for taken branches and
+//! memory faults; the `match` in [`CompiledBlock::run`] is the single place
+//! they extend.
+
+use wasmtime::{Engine, Instance, Memory, MemoryType, Module, Store, TypedFunc};
+
+use crate::cpu::RiscV;
+use crate::Machine;
+
+use super::super::block_cache::{BlockCache, Lookup};
+use super::super::frontend::{BlockPlan, IsaFrontend};
+use super::super::side_exit::{BailReason, SideExit};
+use super::super::{CodeView, Pc};
+use super::emit::WIRE_FALL_THROUGH;
+use super::RiscVFrontend;
+
+/// One instantiated, runnable compiled block: its own `wasmtime` store, the
+/// imported register-file memory, and the exported `run` entry.
+pub struct CompiledBlock {
+    store: Store<()>,
+    run: TypedFunc<(), i32>,
+    regs: Memory,
+    end_pc: Pc,
+    instr_count: u32,
+}
+
+impl CompiledBlock {
+    /// Run the block against the guest register file `x`, mutating it in
+    /// place. Returns the resolved [`SideExit`] and the number of guest
+    /// instructions the block retired.
+    pub fn run(&mut self, x: &mut [u32; 32]) -> (SideExit, u32) {
+        let mut bytes = [0u8; 128];
+        for (i, w) in x.iter().enumerate() {
+            bytes[i * 4..i * 4 + 4].copy_from_slice(&w.to_le_bytes());
+        }
+        self.regs
+            .write(&mut self.store, 0, &bytes)
+            .expect("register-file memory write");
+
+        let wire = self
+            .run
+            .call(&mut self.store, ())
+            .expect("compiled ALU block never traps");
+
+        self.regs
+            .read(&self.store, 0, &mut bytes)
+            .expect("register-file memory read");
+        for (i, w) in x.iter_mut().enumerate() {
+            *w = u32::from_le_bytes([
+                bytes[i * 4],
+                bytes[i * 4 + 1],
+                bytes[i * 4 + 2],
+                bytes[i * 4 + 3],
+            ]);
+        }
+        x[0] = 0; // x0 is hardwired to zero
+
+        let exit = match wire {
+            WIRE_FALL_THROUGH => SideExit::Chain {
+                next_pc: self.end_pc,
+            },
+            // No other edge exists in chunk C; treat an unknown wire as a
+            // conservative bail so a future emit bug can never silently
+            // corrupt state.
+            _ => SideExit::EnterInterpreter {
+                resume_pc: self.end_pc,
+                reason: BailReason::PartialBlock,
+            },
+        };
+        (exit, self.instr_count)
+    }
+}
+
+/// Compiles [`BlockPlan`]s into runnable [`CompiledBlock`]s on a shared
+/// `wasmtime` engine.
+pub struct RiscvWasmJit {
+    engine: Engine,
+}
+
+impl Default for RiscvWasmJit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RiscvWasmJit {
+    /// New JIT over a fresh `wasmtime` engine (module compilation amortises
+    /// across every block).
+    pub fn new() -> Self {
+        Self {
+            engine: Engine::default(),
+        }
+    }
+
+    /// Instantiate `plan`'s wasm into a runnable block with its own register
+    /// memory. Returns `None` if the plan is a body-less stub (nothing to
+    /// run) or the bytes fail to validate / instantiate — the caller keeps
+    /// the PC on the interpreter.
+    pub fn compile(&self, plan: &BlockPlan) -> Option<CompiledBlock> {
+        if plan.is_stub() {
+            return None;
+        }
+        let module = Module::new(&self.engine, &plan.code).ok()?;
+        let mut store = Store::new(&self.engine, ());
+        let regs = Memory::new(&mut store, MemoryType::new(1, None)).ok()?;
+        let instance = Instance::new(&mut store, &module, &[regs.into()]).ok()?;
+        let run = instance.get_typed_func::<(), i32>(&mut store, "run").ok()?;
+        Some(CompiledBlock {
+            store,
+            run,
+            regs,
+            end_pc: plan.end_pc,
+            instr_count: plan.instr_count,
+        })
+    }
+}
+
+/// Run counters for a [`RiscvJitEngine`] session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EngineStats {
+    /// Blocks that crossed the hot threshold and were compiled + installed.
+    pub compiled: u64,
+    /// Compiled-block invocations.
+    pub block_runs: u64,
+    /// Guest instructions retired inside compiled blocks.
+    pub block_instrs: u64,
+    /// Guest instructions retired on the interpreter fallback path.
+    pub interpreted: u64,
+}
+
+/// A minimal RISC-V dispatch engine: block-cache promotion + the
+/// [`RiscVFrontend`] emitter + the `wasmtime` executor, driving a
+/// `Machine<RiscV>` one *unit* (a compiled-block run or a single interpreted
+/// instruction) at a time.
+///
+/// It intentionally does **not** go through the generic
+/// [`DispatchLoop`](super::super::dispatch::DispatchLoop): that loop's
+/// `JitRuntime::run` cannot reach the guest register file (the elided
+/// handle), and the differential harness needs the per-unit *retired
+/// instruction count* to keep the interpreter reference aligned across a
+/// batched block. Both concerns are served by [`step_unit`](Self::step_unit).
+pub struct RiscvJitEngine {
+    frontend: RiscVFrontend,
+    jit: RiscvWasmJit,
+    cache: BlockCache<CompiledBlock>,
+    stats: EngineStats,
+}
+
+impl RiscvJitEngine {
+    /// New engine with the given hot-promotion threshold.
+    pub fn new(hot_threshold: u32) -> Self {
+        Self {
+            frontend: RiscVFrontend::new(),
+            jit: RiscvWasmJit::new(),
+            cache: BlockCache::new(hot_threshold),
+            stats: EngineStats::default(),
+        }
+    }
+
+    /// Accumulated statistics.
+    pub fn stats(&self) -> EngineStats {
+        self.stats
+    }
+
+    /// Advance `machine` by exactly one dispatch unit. Returns the number of
+    /// guest instructions retired (`0` == the machine halted).
+    ///
+    /// A unit is either one compiled-block run (retiring `instr_count`
+    /// instructions atomically) or a single interpreted instruction.
+    pub fn step_unit(&mut self, machine: &mut Machine<RiscV>) -> u32 {
+        let pc = machine.cpu.pc as Pc;
+        match self.cache.observe(pc) {
+            Lookup::Ready => {
+                let Some(block) = self.cache.run_artifact(pc) else {
+                    return self.interpret_one(machine);
+                };
+                let (exit, n) = block.run(&mut machine.cpu.x);
+                self.stats.block_runs += 1;
+                self.stats.block_instrs += n as u64;
+                machine.cpu.pc = exit.continuation_pc() as u32;
+                n
+            }
+            Lookup::Interpret { promote } => {
+                if promote {
+                    self.try_compile(machine, pc);
+                }
+                self.interpret_one(machine)
+            }
+        }
+    }
+
+    /// Interpret one instruction, counting it. Returns `1`, or `0` on halt.
+    fn interpret_one(&mut self, machine: &mut Machine<RiscV>) -> u32 {
+        match machine.step() {
+            Ok(()) => {
+                self.stats.interpreted += 1;
+                1
+            }
+            Err(_) => 0,
+        }
+    }
+
+    /// Translate + instantiate the block at `pc`, installing it on success.
+    /// Any refusal (non-ALU entry → stub, out-of-flash PC, instantiate
+    /// failure) leaves the PC on the interpreter — never an error.
+    fn try_compile(&mut self, machine: &Machine<RiscV>, pc: Pc) {
+        let flash = &machine.bus.flash;
+        let base = flash.base_addr;
+        let len = flash.data.len() as u64;
+        if pc < base || (pc - base) >= len {
+            return;
+        }
+        let view = CodeView::new(base, &flash.data);
+        let Ok(plan) = self.frontend.translate_block(pc, &view) else {
+            return;
+        };
+        if let Some(block) = self.jit.compile(&plan) {
+            self.cache.install(pc, block);
+            self.stats.compiled += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn words(ws: &[u32]) -> Vec<u8> {
+        let mut b = Vec::new();
+        for w in ws {
+            b.extend_from_slice(&w.to_le_bytes());
+        }
+        b
+    }
+
+    fn enc_addi(rd: u32, rs1: u32, imm: i32) -> u32 {
+        ((imm as u32 & 0xFFF) << 20) | (rs1 << 15) | (rd << 7) | 0x13
+    }
+
+    #[test]
+    fn compiled_block_executes_and_mutates_registers() {
+        // addi x1,x0,7 ; addi x2,x1,3 ; ecall(terminator)
+        let prog = words(&[enc_addi(1, 0, 7), enc_addi(2, 1, 3), 0x0000_0073]);
+        let plan = {
+            let view = CodeView::new(0, &prog);
+            RiscVFrontend::new().translate_block(0, &view).unwrap()
+        };
+        assert!(!plan.is_stub());
+        let jit = RiscvWasmJit::new();
+        let mut block = jit.compile(&plan).expect("compile");
+        let mut x = [0u32; 32];
+        let (exit, n) = block.run(&mut x);
+        assert_eq!(n, 2, "two addi retired");
+        assert_eq!(x[1], 7);
+        assert_eq!(x[2], 10);
+        assert_eq!(x[0], 0, "x0 stays zero");
+        assert_eq!(exit, SideExit::Chain { next_pc: 8 });
+    }
+}

--- a/crates/core/src/cpu/jit_framework/riscv/mod.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/mod.rs
@@ -39,8 +39,19 @@ use super::frontend::{BlockPlan, ExitEdge, FrontendRefusal, IsaFrontend};
 use super::side_exit::BailReason;
 use super::{CodeView, Pc};
 
+pub mod emit;
 pub mod host;
+pub mod wasm_encode;
+
 pub use host::{snapshot_state, RiscVJitHost};
+
+// Native (`wasmtime`) execution of emitted blocks lives behind the `jit`
+// feature so the browser build (which cannot pull in wasmtime) still gets
+// the pure-Rust walker + emitter above.
+#[cfg(feature = "jit")]
+pub mod exec;
+#[cfg(feature = "jit")]
+pub use exec::{CompiledBlock, EngineStats, RiscvJitEngine, RiscvWasmJit};
 
 /// Indices into the RISC-V [`StateVec`](super::StateVec) that a batched JIT
 /// run may legitimately compute differently from a per-instruction
@@ -305,18 +316,30 @@ impl IsaFrontend for RiscVFrontend {
         if !code.covers(pc) {
             return Err(FrontendRefusal::PcOutOfRange);
         }
-        let walk = walk_block(pc, code).ok_or(FrontendRefusal::PcOutOfRange)?;
 
-        // A block that subsumes no instruction (its entry is itself an
-        // unmodeled instruction) is not worth installing — the interpreter
-        // handles that single instruction directly.
+        // Chunk C: if the entry instruction is integer-ALU, emit real wasm
+        // for the maximal ALU prefix. The block runs that prefix and
+        // side-exits (fall-through Chain) to `end_pc`, where the interpreter
+        // (or a future compiled block) picks up the first non-ALU
+        // instruction.
+        if let Some(blk) = emit::emit_alu_block(pc, code) {
+            return Ok(BlockPlan {
+                entry_pc: pc,
+                end_pc: blk.end_pc,
+                instr_count: blk.instr_count,
+                code: blk.code,
+                exits: blk.exits,
+            });
+        }
+
+        // Entry is not ALU-emittable (a branch/jump → chunk D, a load/store →
+        // chunk E, or an interpreter-owned op). Fall back to the foundation's
+        // all-bail walk: a correct metadata-only plan with an empty body, so
+        // `is_stub()` is true and the runtime side-exits to the interpreter.
+        let walk = walk_block(pc, code).ok_or(FrontendRefusal::PcOutOfRange)?;
         if walk.instr_count == 0 {
             return Err(FrontendRefusal::BlockTooShort);
         }
-
-        // All-bail: no wasm body yet. The single exit edge carries the
-        // classification's bail reason. `code` is empty, so `is_stub()` is
-        // true and the interpreter runtime side-exits at entry.
         Ok(BlockPlan {
             entry_pc: walk.entry_pc,
             end_pc: walk.end_pc,
@@ -479,17 +502,33 @@ mod tests {
     }
 
     #[test]
-    fn translate_block_produces_stub_plan() {
+    fn translate_block_emits_alu_prefix() {
+        // addi x1,x0,1 ; jal x0,0 (self-loop terminator). Chunk C emits the
+        // addi and stops before the jal (chunk D territory).
         let mut prog = Vec::new();
         w(&mut prog, 0x0010_0093); // addi x1,x0,1
-        w(&mut prog, 0x0000_006f); // jal x0,0 (self-loop terminator)
+        w(&mut prog, 0x0000_006f); // jal x0,0
         let view = CodeView::new(BASE, &prog);
         let plan = RiscVFrontend::new().translate_block(BASE, &view).unwrap();
-        assert!(plan.is_stub(), "all-bail frontend emits no code");
+        assert!(!plan.is_stub(), "ALU entry now emits real wasm");
         assert_eq!(plan.entry_pc, BASE);
-        assert_eq!(plan.instr_count, 2);
-        assert_eq!(plan.end_pc, BASE + 8);
+        assert_eq!(plan.instr_count, 1, "only the addi; jal excluded");
+        assert_eq!(plan.end_pc, BASE + 4, "ends before the jal");
         assert_eq!(plan.exits.len(), 1);
+        assert_eq!(plan.exits[0].wire_code, emit::WIRE_FALL_THROUGH);
+        assert_eq!(&plan.code[0..4], &[0x00, 0x61, 0x73, 0x6d], "wasm magic");
+    }
+
+    #[test]
+    fn translate_block_non_alu_entry_falls_back_to_stub() {
+        // Entry is a jump (chunk D) → no ALU prefix, so the foundation's
+        // all-bail metadata plan is produced.
+        let mut prog = Vec::new();
+        w(&mut prog, 0x0000_006f); // jal x0,0
+        let view = CodeView::new(BASE, &prog);
+        let plan = RiscVFrontend::new().translate_block(BASE, &view).unwrap();
+        assert!(plan.is_stub(), "non-ALU entry stays all-bail");
+        assert_eq!(plan.instr_count, 1);
         assert_eq!(plan.exits[0].reason, BailReason::PartialBlock);
     }
 

--- a/crates/core/src/cpu/jit_framework/riscv/wasm_encode.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/wasm_encode.rs
@@ -1,0 +1,271 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Minimal WebAssembly **binary** encoder for the RV32IMC JIT emit core.
+//!
+//! The JIT frontend must produce a [`BlockPlan.code`](super::super::frontend::BlockPlan)
+//! that is a *real* wasm module byte stream — the same bytes the native
+//! (`wasmtime`) and (future) browser (`js_sys::WebAssembly`) runtimes both
+//! consume. This module is the smallest self-contained encoder that emits
+//! exactly the module shape the emit core needs:
+//!
+//! ```text
+//! (module
+//!   (import "regs" "mem" (memory 1))          ;; the guest register file
+//!   (func (export "run") (result i32)
+//!     (local i32 ... 32×)                       ;; x0..x31 held in locals
+//!     <prologue: load touched regs from mem>
+//!     <body: one emit per guest ALU instruction>
+//!     <epilogue: store written regs back to mem>
+//!     (i32.const <wire-code>)))                 ;; side-exit wire code
+//! ```
+//!
+//! It is deliberately tiny — no data/global/table sections, one function,
+//! one imported memory — and always compiled (no `wasmtime` dependency), so
+//! the browser build can share it verbatim when that runtime lands. The
+//! wasm opcodes the emit core uses are exposed as [`op`] constants; the
+//! [`ModuleBuilder`] frames the fixed section skeleton around a caller-
+//! supplied code body.
+
+/// LEB128 / opcode primitives shared by the emit core.
+pub mod enc {
+    /// Append an unsigned LEB128 encoding of `value`.
+    pub fn uleb(buf: &mut Vec<u8>, mut value: u64) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            buf.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
+    }
+
+    /// Append a signed LEB128 encoding of `value` (covers both `i32.const`
+    /// and `i64.const` operands — the encoding is width-agnostic).
+    pub fn sleb(buf: &mut Vec<u8>, mut value: i64) {
+        loop {
+            let byte = (value & 0x7f) as u8;
+            value >>= 7; // arithmetic shift keeps the sign bit
+            let sign_bit_set = (byte & 0x40) != 0;
+            let more = !((value == 0 && !sign_bit_set) || (value == -1 && sign_bit_set));
+            buf.push(if more { byte | 0x80 } else { byte & 0x7f });
+            if !more {
+                break;
+            }
+        }
+    }
+}
+
+/// WebAssembly opcode / type-tag byte constants used by the emit core.
+///
+/// Only the subset the RV32IMC ALU codegen emits is listed. Grouped by role
+/// to keep the emit core readable.
+#[allow(dead_code)]
+pub mod op {
+    // ── value / type tags ──────────────────────────────────────────────
+    /// `i32` value type tag (also the `if`/`block` result type for i32).
+    pub const T_I32: u8 = 0x7f;
+
+    // ── locals / constants ─────────────────────────────────────────────
+    pub const LOCAL_GET: u8 = 0x20;
+    pub const LOCAL_SET: u8 = 0x21;
+    pub const I32_CONST: u8 = 0x41;
+    pub const I64_CONST: u8 = 0x42;
+    pub const DROP: u8 = 0x1a;
+
+    // ── structured control flow ────────────────────────────────────────
+    pub const IF: u8 = 0x04;
+    pub const ELSE: u8 = 0x05;
+    pub const END: u8 = 0x0b;
+
+    // ── memory ─────────────────────────────────────────────────────────
+    pub const I32_LOAD: u8 = 0x28;
+    pub const I32_STORE: u8 = 0x36;
+
+    // ── i32 arithmetic / logic ─────────────────────────────────────────
+    pub const I32_EQZ: u8 = 0x45;
+    pub const I32_EQ: u8 = 0x46;
+    pub const I32_LT_S: u8 = 0x48;
+    pub const I32_LT_U: u8 = 0x49;
+    pub const I32_ADD: u8 = 0x6a;
+    pub const I32_SUB: u8 = 0x6b;
+    pub const I32_MUL: u8 = 0x6c;
+    pub const I32_DIV_S: u8 = 0x6d;
+    pub const I32_DIV_U: u8 = 0x6e;
+    pub const I32_REM_S: u8 = 0x6f;
+    pub const I32_REM_U: u8 = 0x70;
+    pub const I32_AND: u8 = 0x71;
+    pub const I32_OR: u8 = 0x72;
+    pub const I32_XOR: u8 = 0x73;
+    pub const I32_SHL: u8 = 0x74;
+    pub const I32_SHR_S: u8 = 0x75;
+    pub const I32_SHR_U: u8 = 0x76;
+
+    // ── i64 (used only by the MULH family) ─────────────────────────────
+    pub const I64_MUL: u8 = 0x7e;
+    pub const I64_SHR_U: u8 = 0x88;
+    pub const I64_EXTEND_I32_S: u8 = 0xac;
+    pub const I64_EXTEND_I32_U: u8 = 0xad;
+    pub const I32_WRAP_I64: u8 = 0xa7;
+}
+
+/// The name of the imported memory that backs the guest register file:
+/// `(import "regs" "mem" (memory 1))`. Word `i` (register `xi`) lives at
+/// byte offset `i * 4`.
+pub const REGS_IMPORT_MODULE: &str = "regs";
+/// Field name of the imported register-file memory (see
+/// [`REGS_IMPORT_MODULE`]).
+pub const REGS_IMPORT_FIELD: &str = "mem";
+/// Name the compiled block's entry function is exported under.
+pub const RUN_EXPORT: &str = "run";
+
+/// Assemble the fixed module skeleton around a code body.
+///
+/// The skeleton is constant across every compiled block (one imported
+/// memory, one exported `run` function returning `i32`); only the code body
+/// and the local count vary. `local_i32_count` is the number of `i32`
+/// locals the body references (the emit core uses 32 — one per `x0..x31`).
+pub fn build_module(local_i32_count: u32, body: &[u8]) -> Vec<u8> {
+    let mut m = Vec::with_capacity(64 + body.len());
+    // Magic + version.
+    m.extend_from_slice(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+
+    // ── Type section (id 1): one type `() -> i32`. ─────────────────────
+    {
+        let mut c = Vec::new();
+        enc::uleb(&mut c, 1); // one type
+        c.push(0x60); // functype
+        enc::uleb(&mut c, 0); // 0 params
+        enc::uleb(&mut c, 1); // 1 result
+        c.push(op::T_I32);
+        section(&mut m, 1, &c);
+    }
+
+    // ── Import section (id 2): (import "regs" "mem" (memory 1)). ────────
+    {
+        let mut c = Vec::new();
+        enc::uleb(&mut c, 1); // one import
+        name(&mut c, REGS_IMPORT_MODULE);
+        name(&mut c, REGS_IMPORT_FIELD);
+        c.push(0x02); // import kind: memory
+        c.push(0x00); // limits: min only (no max)
+        enc::uleb(&mut c, 1); // min 1 page
+        section(&mut m, 2, &c);
+    }
+
+    // ── Function section (id 3): one function of type 0. ───────────────
+    {
+        let mut c = Vec::new();
+        enc::uleb(&mut c, 1);
+        enc::uleb(&mut c, 0); // type index 0
+        section(&mut m, 3, &c);
+    }
+
+    // ── Export section (id 7): (export "run" (func 0)). ────────────────
+    {
+        let mut c = Vec::new();
+        enc::uleb(&mut c, 1);
+        name(&mut c, RUN_EXPORT);
+        c.push(0x00); // export kind: func
+        enc::uleb(&mut c, 0); // func index 0
+        section(&mut m, 7, &c);
+    }
+
+    // ── Code section (id 10): one function body. ───────────────────────
+    {
+        // The body proper: local declarations then the caller expression,
+        // terminated by `end`.
+        let mut func = Vec::with_capacity(body.len() + 8);
+        if local_i32_count == 0 {
+            enc::uleb(&mut func, 0); // no local groups
+        } else {
+            enc::uleb(&mut func, 1); // one local group
+            enc::uleb(&mut func, local_i32_count as u64);
+            func.push(op::T_I32);
+        }
+        func.extend_from_slice(body);
+        func.push(op::END);
+
+        let mut c = Vec::new();
+        enc::uleb(&mut c, 1); // one code entry
+        enc::uleb(&mut c, func.len() as u64);
+        c.extend_from_slice(&func);
+        section(&mut m, 10, &c);
+    }
+
+    m
+}
+
+/// Frame `content` as a section with the given `id`.
+fn section(out: &mut Vec<u8>, id: u8, content: &[u8]) {
+    out.push(id);
+    enc::uleb(out, content.len() as u64);
+    out.extend_from_slice(content);
+}
+
+/// Append a wasm `name` (length-prefixed UTF-8).
+fn name(out: &mut Vec<u8>, s: &str) {
+    enc::uleb(out, s.len() as u64);
+    out.extend_from_slice(s.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uleb_roundtrip_small_and_multibyte() {
+        let mut b = Vec::new();
+        enc::uleb(&mut b, 0);
+        assert_eq!(b, vec![0x00]);
+        b.clear();
+        enc::uleb(&mut b, 127);
+        assert_eq!(b, vec![0x7f]);
+        b.clear();
+        enc::uleb(&mut b, 128);
+        assert_eq!(b, vec![0x80, 0x01]);
+        b.clear();
+        enc::uleb(&mut b, 624_485);
+        assert_eq!(b, vec![0xE5, 0x8E, 0x26]);
+    }
+
+    #[test]
+    fn sleb_roundtrip_signed() {
+        // Canonical examples from the LEB128 spec.
+        let mut b = Vec::new();
+        enc::sleb(&mut b, 0);
+        assert_eq!(b, vec![0x00]);
+        b.clear();
+        enc::sleb(&mut b, -1);
+        assert_eq!(b, vec![0x7f]);
+        b.clear();
+        enc::sleb(&mut b, 63);
+        assert_eq!(b, vec![0x3f]);
+        b.clear();
+        enc::sleb(&mut b, 64);
+        assert_eq!(b, vec![0xC0, 0x00]);
+        b.clear();
+        enc::sleb(&mut b, -64);
+        assert_eq!(b, vec![0x40]);
+        b.clear();
+        enc::sleb(&mut b, i32::MIN as i64);
+        assert_eq!(b, vec![0x80, 0x80, 0x80, 0x80, 0x78]);
+    }
+
+    #[test]
+    fn empty_body_module_has_wasm_magic() {
+        // `(i32.const 0)` body — the minimal valid `run`.
+        let body = vec![op::I32_CONST, 0x00];
+        let m = build_module(0, &body);
+        assert_eq!(&m[0..4], &[0x00, 0x61, 0x73, 0x6d], "wasm magic");
+        assert_eq!(&m[4..8], &[0x01, 0x00, 0x00, 0x00], "wasm version 1");
+        // Section ids appear in canonical ascending order.
+        // (type=1, import=2, func=3, export=7, code=10)
+        assert!(m.contains(&10u8), "code section present");
+    }
+}

--- a/crates/core/tests/riscv_jit_alu_lockstep.rs
+++ b/crates/core/tests/riscv_jit_alu_lockstep.rs
@@ -1,0 +1,377 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential equivalence + performance gate for the RV32IMC integer-ALU
+//! JIT codegen (framework chunk C).
+//!
+//! Where the foundation gate (`riscv_jit_lockstep.rs`) proves the *all-bail*
+//! frontend is byte-identical on the interpreter runtime, this gate proves
+//! the **compiled ALU path actually executes** and is byte-identical to the
+//! interpreter:
+//!
+//!   1. [`alu_hot_loop_is_byte_identical_and_compiles`] — an ALU-heavy hot
+//!      loop (arith / logic / shift / mul / div / rem incl. the RISC-V
+//!      div-by-zero and `INT_MIN/-1` edge cases) run twice in lockstep;
+//!      state is compared byte-for-byte at every block/instruction boundary,
+//!      and the run is asserted non-vacuous (real compiled-block executions,
+//!      a floor of retired instructions).
+//!   2. [`every_alu_op_matches_interpreter`] — a per-op differential fuzz:
+//!      each supported op (and the divide edge cases) as a one-instruction
+//!      compiled block vs. the interpreter, over random operands.
+//!   3. [`bench_alu_loop_beats_interpreter`] (ignored) — a micro-benchmark
+//!      showing the compiled ALU loop beats the interpreter, reporting the
+//!      measured ratio.
+//!
+//! Gated behind `jit-framework` (the module) and `jit` (the native wasmtime
+//! executor).
+
+#![cfg(all(feature = "jit-framework", feature = "jit"))]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::jit_framework::differential::{compare, DiffPolicy};
+use labwired_core::cpu::jit_framework::frontend::IsaFrontend;
+use labwired_core::cpu::jit_framework::riscv::{
+    differential_cycle_ignore_indices, snapshot_state, RiscVFrontend, RiscvJitEngine, RiscvWasmJit,
+};
+use labwired_core::cpu::jit_framework::CodeView;
+use labwired_core::cpu::RiscV;
+use labwired_core::Machine;
+
+// ── RV32I / RV32M encoders (standard field layouts) ───────────────────────
+
+fn enc_i(rd: u32, rs1: u32, funct3: u32, imm: i32, opcode: u32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7) | opcode
+}
+fn enc_r(rd: u32, rs1: u32, rs2: u32, funct3: u32, funct7: u32) -> u32 {
+    (funct7 << 25) | (rs2 << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7) | 0x33
+}
+fn addi(rd: u32, rs1: u32, imm: i32) -> u32 {
+    enc_i(rd, rs1, 0b000, imm, 0x13)
+}
+fn ori(rd: u32, rs1: u32, imm: i32) -> u32 {
+    enc_i(rd, rs1, 0b110, imm, 0x13)
+}
+fn andi(rd: u32, rs1: u32, imm: i32) -> u32 {
+    enc_i(rd, rs1, 0b111, imm, 0x13)
+}
+fn slli(rd: u32, rs1: u32, sh: u32) -> u32 {
+    enc_i(rd, rs1, 0b001, sh as i32, 0x13)
+}
+fn add(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b000, 0)
+}
+fn sub(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b000, 0x20)
+}
+fn xor(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b100, 0)
+}
+fn sltu(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b011, 0)
+}
+fn mul(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b000, 0x01)
+}
+fn div(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b100, 0x01)
+}
+fn rem(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    enc_r(rd, rs1, rs2, 0b110, 0x01)
+}
+fn jal(rd: u32, imm: i32) -> u32 {
+    let u = imm as u32;
+    let imm20 = (u >> 20) & 1;
+    let imm10_1 = (u >> 1) & 0x3FF;
+    let imm11 = (u >> 11) & 1;
+    let imm19_12 = (u >> 12) & 0xFF;
+    (imm20 << 31) | (imm10_1 << 21) | (imm11 << 20) | (imm19_12 << 12) | (rd << 7) | 0x6F
+}
+
+fn build_machine(prog: &[u32]) -> Machine<RiscV> {
+    let mut bus = SystemBus::new();
+    let mut bytes = Vec::with_capacity(prog.len() * 4);
+    for w in prog {
+        bytes.extend_from_slice(&w.to_le_bytes());
+    }
+    bus.flash.data = bytes;
+    bus.flash.base_addr = 0;
+    let mut cpu = RiscV::new();
+    cpu.pc = 0;
+    cpu.mtimecmp = u64::MAX; // keep the CLINT timer from ever firing
+    Machine::new(cpu, bus)
+}
+
+/// An ALU-heavy hot loop. The straight-line body mixes every op class,
+/// **including** the divide/remainder edge cases (`div`/`rem` by the value
+/// in `x5` which is driven to 0 and to -1 across iterations, and an
+/// `INT_MIN` dividend), then a `jal` closes the loop. The `jal` is chunk-D
+/// territory, so each iteration executes the compiled ALU prefix and then
+/// interprets the single branch.
+fn alu_loop_program() -> Vec<u32> {
+    vec![
+        // ── loop body (all ALU, one compiled block) ──
+        addi(1, 1, 1),    // x1++  (loop counter)
+        slli(6, 1, 3),    // x6 = x1 << 3
+        add(7, 6, 1),     // x7 = x6 + x1
+        sub(8, 7, 6),     // x8 = x7 - x6  (== x1)
+        xor(9, 8, 1),     // x9 = x8 ^ x1  (== 0)
+        ori(10, 9, 0x2A), // x10 = x9 | 0x2A
+        andi(11, 7, 0xF), // x11 = x7 & 0xF
+        mul(12, 1, 7),    // x12 = x1 * x7
+        // Drive x5 through {0,1,2,...} so div/rem hit divide-by-zero, then
+        // normal divisors — exercising the guarded paths every iteration.
+        andi(5, 1, 0x3),  // x5 = x1 & 3   (cycles 1,2,3,0,1,2,3,0,...)
+        div(13, 12, 5),   // x13 = x12 / x5   (x5==0 → -1)
+        rem(14, 12, 5),   // x14 = x12 % x5   (x5==0 → x12)
+        addi(15, 0, -1),  // x15 = -1
+        slli(16, 15, 31), // x16 = INT_MIN (0x8000_0000)
+        div(17, 16, 15),  // x17 = INT_MIN / -1 → INT_MIN (overflow)
+        rem(18, 16, 15),  // x18 = INT_MIN % -1 → 0 (overflow)
+        sltu(19, 8, 7),   // x19 = (x8 <u x7)
+        // ── loop back ──
+        jal(0, -(16 * 4)), // jump to the top (16 instrs back)
+    ]
+}
+
+/// (1) Differential byte-identity + non-vacuity for the ALU hot loop.
+#[test]
+fn alu_hot_loop_is_byte_identical_and_compiles() {
+    const MAX_UNITS: u64 = 4_000;
+    const INSTR_FLOOR: u64 = 3_000;
+
+    let prog = alu_loop_program();
+    let mut interp = build_machine(&prog);
+    let mut jit = build_machine(&prog);
+
+    // Low threshold so the loop head promotes + compiles quickly and the
+    // compiled block is genuinely exercised.
+    let mut engine = RiscvJitEngine::new(4);
+    let policy = DiffPolicy {
+        ignore_indices: differential_cycle_ignore_indices(),
+        block_boundary_only: false,
+    };
+
+    let mut retired: u64 = 0;
+    let mut units: u64 = 0;
+    while retired < INSTR_FLOOR * 2 && units < MAX_UNITS {
+        units += 1;
+        // Advance the JIT side by one dispatch unit; it retires `n` guest
+        // instructions (a whole compiled block, or one interpreted branch).
+        let n = engine.step_unit(&mut jit);
+        assert!(n > 0, "jit machine halted unexpectedly at unit {units}");
+        // Advance the interpreter reference by the SAME instruction count to
+        // stay PC-aligned across the batched block.
+        for _ in 0..n {
+            interp
+                .step()
+                .expect("interpreter must not fault on pure ALU");
+        }
+        retired += n as u64;
+
+        // Byte-for-byte architectural equality at this aligned boundary.
+        let si = snapshot_state(&interp.cpu);
+        let sj = snapshot_state(&jit.cpu);
+        if let Some(d) = compare(units, &si, &sj, &policy) {
+            panic!(
+                "JIT diverged from interpreter at unit {units} (retired {retired}): {d:?}\n\
+                 interp x={:?}\n jit    x={:?}",
+                &interp.cpu.x, &jit.cpu.x
+            );
+        }
+    }
+
+    // Non-vacuous: a real hot loop ran through compiled blocks, not refusal.
+    let stats = engine.stats();
+    assert!(
+        stats.compiled > 0,
+        "no ALU block ever crossed the hot threshold / compiled"
+    );
+    assert!(
+        stats.block_runs > 0,
+        "no compiled block was ever executed (JIT path not engaged)"
+    );
+    assert!(
+        stats.block_instrs >= INSTR_FLOOR,
+        "compiled blocks retired only {} instructions (floor {INSTR_FLOOR})",
+        stats.block_instrs
+    );
+    assert!(
+        interp.cpu.x[1] as u64 >= 100,
+        "loop counter x1={} too low — the loop body did not run enough",
+        interp.cpu.x[1]
+    );
+    println!(
+        "alu_hot_loop: retired={retired} compiled_blocks={} block_runs={} block_instrs={} interpreted={}",
+        stats.compiled, stats.block_runs, stats.block_instrs, stats.interpreted
+    );
+}
+
+/// (2) Per-op differential fuzz: every supported op (and the divide edge
+/// cases) as a one-instruction compiled block vs. the interpreter.
+#[test]
+fn every_alu_op_matches_interpreter() {
+    // Small deterministic PRNG (xorshift) so the test is hermetic.
+    let mut seed: u64 = 0x1234_5678_9abc_def0;
+    let mut rng = move || {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        seed as u32
+    };
+
+    // (encoder, name). rd=1, rs1=2, rs2=3 throughout.
+    type OpEnc = fn(u32, u32, u32) -> u32;
+    let ops: &[(OpEnc, &str)] = &[
+        (|d, a, b| enc_r(d, a, b, 0b000, 0), "add"),
+        (|d, a, b| enc_r(d, a, b, 0b000, 0x20), "sub"),
+        (|d, a, b| enc_r(d, a, b, 0b001, 0), "sll"),
+        (|d, a, b| enc_r(d, a, b, 0b010, 0), "slt"),
+        (|d, a, b| enc_r(d, a, b, 0b011, 0), "sltu"),
+        (|d, a, b| enc_r(d, a, b, 0b100, 0), "xor"),
+        (|d, a, b| enc_r(d, a, b, 0b101, 0), "srl"),
+        (|d, a, b| enc_r(d, a, b, 0b101, 0x20), "sra"),
+        (|d, a, b| enc_r(d, a, b, 0b110, 0), "or"),
+        (|d, a, b| enc_r(d, a, b, 0b111, 0), "and"),
+        (|d, a, b| enc_r(d, a, b, 0b000, 0x01), "mul"),
+        (|d, a, b| enc_r(d, a, b, 0b001, 0x01), "mulh"),
+        (|d, a, b| enc_r(d, a, b, 0b010, 0x01), "mulhsu"),
+        (|d, a, b| enc_r(d, a, b, 0b011, 0x01), "mulhu"),
+        (|d, a, b| enc_r(d, a, b, 0b100, 0x01), "div"),
+        (|d, a, b| enc_r(d, a, b, 0b101, 0x01), "divu"),
+        (|d, a, b| enc_r(d, a, b, 0b110, 0x01), "rem"),
+        (|d, a, b| enc_r(d, a, b, 0b111, 0x01), "remu"),
+    ];
+
+    // Operand pairs: random, plus the arithmetic corner cases.
+    let mut pairs: Vec<(u32, u32)> = vec![
+        (0, 0),
+        (1, 0),                     // divide by zero
+        (0x8000_0000, 0xFFFF_FFFF), // INT_MIN / -1 overflow
+        (0xFFFF_FFFF, 0xFFFF_FFFF),
+        (0x7FFF_FFFF, 2),
+        (100, 7),
+        (0x8000_0000, 2),
+    ];
+    for _ in 0..200 {
+        pairs.push((rng(), rng()));
+    }
+
+    let frontend = RiscVFrontend::new();
+    let jit = RiscvWasmJit::new();
+
+    for &(enc, name) in ops {
+        // rd=1, rs1=2, rs2=3 ; terminator so the walk ends after the op.
+        let prog_words = [enc(1, 2, 3), 0x0000_0073 /* ecall */];
+        let flash = {
+            let mut b = Vec::new();
+            for w in prog_words {
+                b.extend_from_slice(&w.to_le_bytes());
+            }
+            b
+        };
+        let plan = {
+            let view = CodeView::new(0, &flash);
+            frontend.translate_block(0, &view).expect("translate")
+        };
+        assert!(!plan.is_stub(), "{name}: expected a compiled ALU block");
+        assert_eq!(plan.instr_count, 1, "{name}: one-instruction block");
+        let mut block = jit.compile(&plan).expect("compile");
+
+        for &(a, b) in &pairs {
+            // Interpreter reference.
+            let mut im = build_machine(&prog_words);
+            im.cpu.x[2] = a;
+            im.cpu.x[3] = b;
+            im.step().expect("op step");
+            let want = im.cpu.x[1];
+
+            // Compiled block run directly against a register file.
+            let mut x = [0u32; 32];
+            x[2] = a;
+            x[3] = b;
+            let (_exit, n) = block.run(&mut x);
+            assert_eq!(n, 1, "{name}: retires one instruction");
+            assert_eq!(
+                x[1], want,
+                "{name}(a=0x{a:08x}, b=0x{b:08x}) mismatch: jit=0x{:08x} interp=0x{want:08x}",
+                x[1]
+            );
+        }
+    }
+}
+
+/// (3) Micro-benchmark: the compiled ALU loop vs. the interpreter on the
+/// same firmware. Ignored by default (timing-sensitive); run with
+/// `--ignored --nocapture` to see the ratio.
+#[test]
+#[ignore = "micro-benchmark; run with --ignored --nocapture"]
+fn bench_alu_loop_beats_interpreter() {
+    use std::time::Instant;
+
+    // A long straight-line ALU body so the compiled block amortises the
+    // wasm-call + register-marshalling overhead, then a jal loop-back.
+    let mut prog: Vec<u32> = Vec::new();
+    for _ in 0..8 {
+        prog.push(addi(1, 1, 1));
+        prog.push(slli(2, 1, 1));
+        prog.push(add(3, 2, 1));
+        prog.push(xor(4, 3, 2));
+        prog.push(mul(5, 4, 3));
+        prog.push(sub(6, 5, 4));
+        prog.push(ori(7, 6, 0x5));
+        prog.push(andi(8, 7, 0x7F));
+    }
+    let body = prog.len() as i32;
+    prog.push(jal(0, -(body * 4)));
+
+    const ITERS: u64 = 400_000;
+
+    // Interpreter-only timing.
+    let mut im = build_machine(&prog);
+    let t0 = Instant::now();
+    let mut ic = 0u64;
+    while ic < ITERS {
+        im.step().unwrap();
+        ic += 1;
+    }
+    let interp_dt = t0.elapsed();
+
+    // JIT timing (warm up so the loop block is compiled first).
+    let mut jm = build_machine(&prog);
+    let mut engine = RiscvJitEngine::new(4);
+    for _ in 0..2_000 {
+        engine.step_unit(&mut jm);
+    }
+    let warm = engine.stats();
+    let t1 = Instant::now();
+    let mut jc = 0u64;
+    while jc < ITERS {
+        jc += engine.step_unit(&mut jm) as u64;
+    }
+    let jit_dt = t1.elapsed();
+    let stats = engine.stats();
+
+    let interp_mips = ITERS as f64 / interp_dt.as_secs_f64() / 1e6;
+    let jit_mips = ITERS as f64 / jit_dt.as_secs_f64() / 1e6;
+    let ratio = interp_dt.as_secs_f64() / jit_dt.as_secs_f64();
+
+    println!("--- RV32IMC ALU micro-bench ({ITERS} guest instr) ---");
+    println!("interp: {interp_dt:?}  ({interp_mips:.1} MIPS)");
+    println!("jit   : {jit_dt:?}  ({jit_mips:.1} MIPS)");
+    println!("speedup: {ratio:.2}x");
+    println!(
+        "jit path: compiled_blocks={} block_runs={} block_instrs={} interpreted={} (warmup block_runs={})",
+        stats.compiled, stats.block_runs, stats.block_instrs, stats.interpreted, warm.block_runs
+    );
+
+    assert!(
+        stats.block_runs > warm.block_runs,
+        "compiled blocks must run during the timed phase"
+    );
+    assert!(
+        ratio > 1.0,
+        "compiled ALU loop ({jit_mips:.1} MIPS) did not beat the interpreter \
+         ({interp_mips:.1} MIPS): {ratio:.2}x"
+    );
+}


### PR DESCRIPTION
## RISC-V JIT chunk C — wasm emit skeleton + integer-ALU codegen

First frontend block that **executes instead of bailing**. Builds the shared emit infrastructure (wasm module builder, guest register-file marshalling, wire-code→SideExit return protocol) that chunks D (branches) and E (load/store) layer onto, and emits real wasm for the full RV32IMC integer-ALU surface.

### What's emitted
- **Reg-imm / reg-reg arith + logic**: `lui, auipc, addi, slti[u], xori, ori, andi, add, sub, sll, slt[u], xor, srl, sra, or, and` and the immediate shifts.
- **RV32M**: `mul, mulh[su|u]` (i64-extend → `i64.mul` → `shr_u 32` → wrap), and trap-free `div[u]/rem[u]` with explicit guards for div-by-zero and the `INT_MIN/-1` signed-overflow case (wasm `div_s`/`rem_s` trap where RISC-V defines a result — every case guarded to match the interpreter).
- **Compressed**: `c.addi, c.li, c.mv, c.addi16sp, c.addi4spn, c.slli`.

### Model
Register-file-in-locals: prologue loads only the registers the block *reads* from an imported wasm memory into locals, the body operates purely on locals (`x0` reads as const 0, writes drop), the epilogue stores only *written* registers back. Fixed 128-byte host sync per block regardless of length. The executor is RISC-V-local (the generic `JitRuntime::run` deliberately elides the register-file handle) and drives `Machine<RiscV>` one dispatch unit at a time via `step_unit`.

### Correctness gate
`riscv_jit_alu_lockstep.rs`:
- **byte-identity** — a hot ALU loop (incl. div/rem guarded paths driven to their edge cases every iteration) run through compiled blocks is StateVec-identical to the interpreter, non-vacuously (`compiled > 0`, `block_runs > 0`, instruction floor).
- **per-op differential** — each ALU op as a one-instruction compiled block vs. the interpreter over random operands.
- **micro-bench** — compiled ALU loop vs. interpreter, reports the measured ratio.

Not yet wired into production dispatch — test-only until chunk H's JitHost/SafetyGate adapter. Full regression green (`jit,event-scheduler` + `jit-framework`), fmt + clippy clean.

Base: `jit-framework-scaffold` (do not merge to main until D/E land and the ≥3× invaders MIPS bar is met).
