### PR TITLE
jit(riscv): branch/jump codegen (chunk D)

### DIFF
--- a/crates/core/src/cpu/jit_framework/riscv/emit.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/emit.rs
@@ -49,13 +49,29 @@ use super::wasm_encode::{build_module, enc, op};
 
 /// Wire code the emitted body returns on a clean straight-line fall-through
 /// to `end_pc`. The runtime maps it to
-/// [`SideExit::Chain`](super::super::side_exit::SideExit::Chain). Chunks D/E
-/// add further wire codes (taken branch, memory fault) alongside this one.
+/// [`SideExit::Chain`](super::super::side_exit::SideExit::Chain) to `end_pc`.
 pub const WIRE_FALL_THROUGH: i32 = 0;
+
+/// Wire code a control-flow-terminated block (chunk D) returns. The block has
+/// already resolved its taken/not-taken/jump-target address **in wasm** and
+/// written it to the [`NEXT_PC_SLOT`] word of the register memory; the runtime
+/// reads that slot and maps this code to
+/// [`SideExit::Chain`](super::super::side_exit::SideExit::Chain) to it. One
+/// code covers every branch/jump kind — conditional branches pick the address
+/// with an in-wasm `if`, and `JALR`/`C.JR` compute a data-dependent one — so
+/// the runtime never needs a per-terminator code. Chunk E adds `2`
+/// (`MEM_FAULT`); do not renumber the two codes above it.
+pub const WIRE_CHAIN_DYNAMIC: i32 = 1;
 
 /// Number of `i32` locals every compiled block declares: one per guest
 /// register `x0..x31`. Local index == register number.
 const REG_LOCALS: u32 = 32;
+
+/// Byte offset in the imported register memory of the **dynamic next-PC slot**
+/// a [`WIRE_CHAIN_DYNAMIC`] block writes its resolved continuation address to.
+/// It sits at word `32`, immediately past `x31` (bytes `0..128`), so it never
+/// aliases a guest register. The runtime syncs `132` bytes to carry it.
+pub const NEXT_PC_SLOT: i32 = 32 * 4;
 
 /// Is `inst` an integer-ALU instruction chunk C emits wasm for?
 ///
@@ -105,6 +121,33 @@ pub fn is_alu_emittable(inst: &Instruction) -> bool {
     )
 }
 
+/// Is `inst` a control-flow terminator chunk D emits wasm for?
+///
+/// These are the branch/jump instructions the block ends **at and includes**
+/// (see [`super::InstrClass::ControlFlow`]). A block is the maximal ALU prefix
+/// followed by at most one of these; the terminator resolves the block's next
+/// PC in wasm and returns [`WIRE_CHAIN_DYNAMIC`]. `C.JAL` is absent because the
+/// decoder maps it to `Jal { rd: 1, .. }`, already covered here.
+pub fn is_terminator_emittable(inst: &Instruction) -> bool {
+    use Instruction::*;
+    matches!(
+        inst,
+        Beq { .. }
+            | Bne { .. }
+            | Blt { .. }
+            | Bge { .. }
+            | Bltu { .. }
+            | Bgeu { .. }
+            | Jal { .. }
+            | Jalr { .. }
+            | CJ { .. }
+            | CJr { .. }
+            | CJalr { .. }
+            | CBeqz { .. }
+            | CBnez { .. }
+    )
+}
+
 /// One decoded ALU instruction plus the guest PC it sits at (needed for
 /// `AUIPC`, which folds `pc` into a constant).
 struct AluOp {
@@ -114,61 +157,101 @@ struct AluOp {
 
 /// The result of emitting a block: the wasm bytes plus the metadata the
 /// frontend stamps onto its [`BlockPlan`](super::super::frontend::BlockPlan).
-pub struct EmittedAluBlock {
+pub struct EmittedBlock {
     /// Real wasm module bytes (magic-prefixed), consumed by the runtime.
     pub code: Vec<u8>,
-    /// Guest PC one past the last emitted instruction — the fall-through
-    /// continuation the runtime chains to.
+    /// Guest PC one past the last instruction the block subsumes. For a
+    /// fall-through (chunk-C) block this is the continuation the runtime
+    /// chains to; for a terminator (chunk-D) block the continuation is
+    /// dynamic (written to [`NEXT_PC_SLOT`]) and this is metadata only.
     pub end_pc: Pc,
     /// Number of guest instructions the block retires in one run.
     pub instr_count: u32,
-    /// Side-exit edges, indexed by returned wire code. Chunk C has exactly
-    /// the fall-through edge.
+    /// Side-exit edges. A block has exactly one: the fall-through edge
+    /// ([`WIRE_FALL_THROUGH`]) for an ALU-prefix-only block, or the dynamic
+    /// chain edge ([`WIRE_CHAIN_DYNAMIC`]) when it ends at a branch/jump.
     pub exits: Vec<ExitEdge>,
 }
 
-/// Emit a wasm block for the maximal ALU prefix at `pc`.
+/// Emit a wasm block starting at `pc`: the maximal ALU prefix, optionally
+/// ended by one control-flow terminator (chunk D).
 ///
-/// Returns `None` when the instruction at `pc` is not ALU-emittable (the
-/// caller keeps that PC on the interpreter — never an error).
-pub fn emit_alu_block(pc: Pc, code: &CodeView<'_>) -> Option<EmittedAluBlock> {
+/// - If a branch/jump ([`is_terminator_emittable`]) follows the ALU prefix
+///   (or sits at `pc` with no prefix), the block **includes** it, resolves
+///   its next PC in wasm, and exits with [`WIRE_CHAIN_DYNAMIC`].
+/// - Otherwise the block is the ALU prefix alone and exits with
+///   [`WIRE_FALL_THROUGH`] to `end_pc` (chunk-C behaviour).
+///
+/// Returns `None` when there is nothing to emit at `pc` — neither an ALU
+/// instruction nor an emittable terminator (the caller keeps that PC on the
+/// interpreter — never an error).
+pub fn emit_block(pc: Pc, code: &CodeView<'_>) -> Option<EmittedBlock> {
     let ops = walk_alu_ops(pc, code);
-    if ops.is_empty() {
+    let prefix_end = pc + ops.iter().map(|o| inst_len_of(o.pc, code)).sum::<u64>();
+
+    // The instruction immediately after the ALU prefix; the block ends at it
+    // when it is an emittable control-flow terminator.
+    let terminator = decode_at(prefix_end, code).filter(|(inst, _)| is_terminator_emittable(inst));
+
+    if ops.is_empty() && terminator.is_none() {
         return None;
     }
-    let end_pc = pc + ops.iter().map(|o| inst_len_of(o.pc, code)).sum::<u64>();
-    let instr_count = ops.len() as u32;
 
-    // Emit the body into a scratch buffer while recording which registers
-    // are read (load set) and written (store set), then frame the function
-    // expression as prologue + body + epilogue + fall-through wire code.
+    // Emit the ALU body into a scratch buffer, recording read/write sets.
     let mut body = Body::default();
     for aop in &ops {
         body.emit_instruction(aop.pc, &aop.inst);
     }
 
+    // Choose the terminating shape: dynamic chain (branch/jump) or the plain
+    // fall-through wire. Both carry `PartialBlock` — telemetry only; the
+    // runtime's resolved `Chain` is the correctness contract.
+    let (end_pc, instr_count, wire) = if let Some((tinst, tlen)) = terminator {
+        body.emit_terminator(prefix_end as u32, tlen as u32, &tinst);
+        (prefix_end + tlen, ops.len() as u32 + 1, WIRE_CHAIN_DYNAMIC)
+    } else {
+        (prefix_end, ops.len() as u32, WIRE_FALL_THROUGH)
+    };
+
     let mut expr = Vec::with_capacity(body.buf.len() + 16 * REG_LOCALS as usize);
     body.emit_prologue(&mut expr); // loads touched regs into locals
-    expr.extend_from_slice(&body.buf); // body operating purely on locals
+    expr.extend_from_slice(&body.buf); // body + terminator, purely on locals + slot
     body.emit_epilogue(&mut expr); // stores written regs back to mem
     expr.push(op::I32_CONST); // the block's return value
-    enc::sleb(&mut expr, WIRE_FALL_THROUGH as i64);
+    enc::sleb(&mut expr, wire as i64);
 
     let code_bytes = build_module(REG_LOCALS, &expr);
 
-    Some(EmittedAluBlock {
+    Some(EmittedBlock {
         code: code_bytes,
         end_pc,
         instr_count,
         exits: vec![ExitEdge {
-            wire_code: WIRE_FALL_THROUGH,
-            // The block is "partial": it retired its ALU prefix and hands
-            // the following (non-ALU) instruction to the interpreter / the
-            // next compiled block. Telemetry only — correctness is the
-            // runtime's Chain{end_pc}.
+            wire_code: wire,
             reason: BailReason::PartialBlock,
         }],
     })
+}
+
+/// Decode the instruction at `pc` in `code`, returning it with its byte
+/// length. `None` if `pc` is outside the view or a 4-byte instruction runs
+/// past its end.
+fn decode_at(pc: Pc, code: &CodeView<'_>) -> Option<(Instruction, u64)> {
+    let bytes = code.from(pc)?;
+    if bytes.len() < 2 {
+        return None;
+    }
+    let low = u16::from_le_bytes([bytes[0], bytes[1]]);
+    let len = inst_len(low);
+    if len == 4 && bytes.len() < 4 {
+        return None;
+    }
+    let word = if len == 4 {
+        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+    } else {
+        low as u32
+    };
+    Some((decode_rv32(word), len))
 }
 
 /// Walk the maximal run of ALU-emittable instructions from `pc`.
@@ -444,6 +527,122 @@ impl Body {
         }
     }
 
+    /// Store the `i32` currently on the stack (below it: the [`NEXT_PC_SLOT`]
+    /// address) to the dynamic next-PC slot.
+    fn store_next_pc(&mut self) {
+        self.buf.push(op::I32_STORE);
+        enc::uleb(&mut self.buf, 2); // align = 2 (4-byte)
+        enc::uleb(&mut self.buf, 0); // offset = 0 (address already == slot)
+    }
+
+    /// Write a **constant** next PC to the slot (`Jal`, `C.J`, and the two
+    /// arms of a conditional branch all resolve to compile-time addresses).
+    fn next_pc_const(&mut self, v: i32) {
+        self.i32_const(NEXT_PC_SLOT);
+        self.i32_const(v);
+        self.store_next_pc();
+    }
+
+    /// Emit a two-register conditional branch: `next = cmp(rs1,rs2) ? pc+imm
+    /// : pc+ilen`, stored to the slot. `cmp` is the wasm predicate opcode
+    /// (`I32_EQ`, `I32_LT_S`, …) mirroring the interpreter's comparison.
+    fn cond_branch(&mut self, rs1: u8, rs2: u8, cmp: u8, pc: u32, ilen: u32, imm: i32) {
+        self.i32_const(NEXT_PC_SLOT); // store address (stays below the `if`)
+        self.read(rs1);
+        self.read(rs2);
+        self.buf.push(cmp);
+        self.if_i32();
+        self.i32_const(pc.wrapping_add(imm as u32) as i32); // taken
+        self.buf.push(op::ELSE);
+        self.i32_const(pc.wrapping_add(ilen) as i32); // not taken
+        self.buf.push(op::END);
+        self.store_next_pc();
+    }
+
+    /// Emit a compressed compare-with-zero branch (`C.BEQZ`/`C.BNEZ`):
+    /// `next = (rs1 == 0)==want_zero ? pc+imm : pc+ilen`.
+    fn cond_branch_zero(&mut self, rs1: u8, want_zero: bool, pc: u32, ilen: u32, imm: i32) {
+        self.i32_const(NEXT_PC_SLOT);
+        self.read(rs1);
+        // `C.BEQZ` takes when rs1 == 0 → test with `i32.eqz`; `C.BNEZ` takes
+        // when rs1 != 0 → the raw value is already truthy for `if`.
+        if want_zero {
+            self.buf.push(op::I32_EQZ);
+        }
+        self.if_i32();
+        self.i32_const(pc.wrapping_add(imm as u32) as i32); // taken
+        self.buf.push(op::ELSE);
+        self.i32_const(pc.wrapping_add(ilen) as i32); // not taken
+        self.buf.push(op::END);
+        self.store_next_pc();
+    }
+
+    /// Emit `rs1 & !1` (jump-target low-bit mask) onto the stack.
+    fn read_masked(&mut self, rs1: u8) {
+        self.read(rs1);
+        self.i32_const(!1); // 0xFFFF_FFFE
+        self.buf.push(op::I32_AND);
+    }
+
+    /// Emit the block's control-flow terminator. `pc` is its own guest PC,
+    /// `ilen` its byte length. Mirrors the branch/jump arms of
+    /// [`crate::cpu::riscv::RiscV::step`] exactly — including link-register
+    /// timing (the next PC is resolved *before* the link write, so `rd == rs1`
+    /// `JALR` reads the old `rs1`) and the `& !1` target mask.
+    fn emit_terminator(&mut self, pc: u32, ilen: u32, inst: &Instruction) {
+        use Instruction::*;
+        match *inst {
+            Beq { rs1, rs2, imm } => self.cond_branch(rs1, rs2, op::I32_EQ, pc, ilen, imm),
+            Bne { rs1, rs2, imm } => self.cond_branch(rs1, rs2, op::I32_NE, pc, ilen, imm),
+            Blt { rs1, rs2, imm } => self.cond_branch(rs1, rs2, op::I32_LT_S, pc, ilen, imm),
+            Bge { rs1, rs2, imm } => self.cond_branch(rs1, rs2, op::I32_GE_S, pc, ilen, imm),
+            Bltu { rs1, rs2, imm } => self.cond_branch(rs1, rs2, op::I32_LT_U, pc, ilen, imm),
+            Bgeu { rs1, rs2, imm } => self.cond_branch(rs1, rs2, op::I32_GE_U, pc, ilen, imm),
+            CBeqz { rs1, imm } => self.cond_branch_zero(rs1, true, pc, ilen, imm),
+            CBnez { rs1, imm } => self.cond_branch_zero(rs1, false, pc, ilen, imm),
+
+            // Unconditional jump: next = pc + imm; link rd = pc + ilen (the
+            // decoder maps 2-byte C.JAL to Jal { rd: 1 }, so ilen links it at
+            // pc+2 while a 4-byte JAL links at pc+4).
+            Jal { rd, imm } => {
+                self.next_pc_const(pc.wrapping_add(imm as u32) as i32);
+                self.i32_const(pc.wrapping_add(ilen) as i32);
+                self.write(rd);
+            }
+            // Indirect jump: next = (rs1 + imm) & !1, computed BEFORE the link
+            // write so `jalr rd, rd, imm` reads the pre-write rs1.
+            Jalr { rd, rs1, imm } => {
+                self.i32_const(NEXT_PC_SLOT);
+                self.read(rs1);
+                self.i32_const(imm);
+                self.buf.push(op::I32_ADD);
+                self.i32_const(!1);
+                self.buf.push(op::I32_AND);
+                self.store_next_pc();
+                self.i32_const(pc.wrapping_add(ilen) as i32);
+                self.write(rd);
+            }
+
+            CJ { imm } => self.next_pc_const(pc.wrapping_add(imm as u32) as i32),
+            // C.JR: next = rs1 & !1 (no link).
+            CJr { rs1 } => {
+                self.i32_const(NEXT_PC_SLOT);
+                self.read_masked(rs1);
+                self.store_next_pc();
+            }
+            // C.JALR: next = rs1 & !1; link x1 = pc + 2 (always 2-byte).
+            CJalr { rs1 } => {
+                self.i32_const(NEXT_PC_SLOT);
+                self.read_masked(rs1);
+                self.store_next_pc();
+                self.i32_const(pc.wrapping_add(2) as i32);
+                self.write(1);
+            }
+
+            other => unreachable!("non-terminator reached emit_terminator: {other:?}"),
+        }
+    }
+
     /// Emit the prologue: `local.set r (i32.load (r*4))` for each read reg.
     fn emit_prologue(&self, out: &mut Vec<u8>) {
         for r in 1..32u8 {
@@ -503,7 +702,7 @@ mod tests {
     fn refuses_non_alu_entry() {
         let prog = view(&[enc_ecall()]);
         let cv = CodeView::new(BASE, &prog);
-        assert!(emit_alu_block(BASE, &cv).is_none());
+        assert!(emit_block(BASE, &cv).is_none());
     }
 
     #[test]
@@ -511,7 +710,7 @@ mod tests {
         // addi x1,x0,1 ; add x2,x1,x1 ; ecall
         let prog = view(&[enc_addi(1, 0, 1), enc_add(2, 1, 1), enc_ecall()]);
         let cv = CodeView::new(BASE, &prog);
-        let blk = emit_alu_block(BASE, &cv).unwrap();
+        let blk = emit_block(BASE, &cv).unwrap();
         assert_eq!(blk.instr_count, 2, "ecall is not included");
         assert_eq!(blk.end_pc, BASE + 8, "ends before the ecall");
         assert_eq!(blk.exits.len(), 1);
@@ -532,7 +731,7 @@ mod tests {
             enc_ecall(),       // terminator (not emitted)
         ]);
         let cv = CodeView::new(BASE, &prog);
-        let blk = emit_alu_block(BASE, &cv).unwrap();
+        let blk = emit_block(BASE, &cv).unwrap();
         let engine = wasmtime::Engine::default();
         wasmtime::Module::new(&engine, &blk.code).expect("emitted module must validate");
         assert_eq!(blk.instr_count, 3);

--- a/crates/core/src/cpu/jit_framework/riscv/exec.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/exec.rs
@@ -48,8 +48,14 @@ use super::super::block_cache::{BlockCache, Lookup};
 use super::super::frontend::{BlockPlan, IsaFrontend};
 use super::super::side_exit::{BailReason, SideExit};
 use super::super::{CodeView, Pc};
-use super::emit::WIRE_FALL_THROUGH;
+use super::emit::{NEXT_PC_SLOT, WIRE_CHAIN_DYNAMIC, WIRE_FALL_THROUGH};
 use super::RiscVFrontend;
+
+/// Bytes synced between the guest register file and the imported memory each
+/// block run: `x0..x31` (`128`) plus the one-word dynamic next-PC slot
+/// ([`NEXT_PC_SLOT`]) a [`WIRE_CHAIN_DYNAMIC`] block writes its resolved
+/// continuation address to.
+const REG_SYNC_BYTES: usize = NEXT_PC_SLOT as usize + 4;
 
 /// One instantiated, runnable compiled block: its own `wasmtime` store, the
 /// imported register-file memory, and the exported `run` entry.
@@ -66,7 +72,7 @@ impl CompiledBlock {
     /// place. Returns the resolved [`SideExit`] and the number of guest
     /// instructions the block retired.
     pub fn run(&mut self, x: &mut [u32; 32]) -> (SideExit, u32) {
-        let mut bytes = [0u8; 128];
+        let mut bytes = [0u8; REG_SYNC_BYTES];
         for (i, w) in x.iter().enumerate() {
             bytes[i * 4..i * 4 + 4].copy_from_slice(&w.to_le_bytes());
         }
@@ -77,7 +83,7 @@ impl CompiledBlock {
         let wire = self
             .run
             .call(&mut self.store, ())
-            .expect("compiled ALU block never traps");
+            .expect("compiled block never traps");
 
         self.regs
             .read(&self.store, 0, &mut bytes)
@@ -93,12 +99,20 @@ impl CompiledBlock {
         x[0] = 0; // x0 is hardwired to zero
 
         let exit = match wire {
+            // Straight-line ALU prefix ran through: chain to the static end PC.
             WIRE_FALL_THROUGH => SideExit::Chain {
                 next_pc: self.end_pc,
             },
-            // No other edge exists in chunk C; treat an unknown wire as a
-            // conservative bail so a future emit bug can never silently
-            // corrupt state.
+            // A branch/jump resolved its continuation in wasm and wrote it to
+            // the next-PC slot; chain there.
+            WIRE_CHAIN_DYNAMIC => {
+                let s = NEXT_PC_SLOT as usize;
+                let next_pc =
+                    u32::from_le_bytes([bytes[s], bytes[s + 1], bytes[s + 2], bytes[s + 3]]) as Pc;
+                SideExit::Chain { next_pc }
+            }
+            // No other edge exists yet; treat an unknown wire as a conservative
+            // bail so a future emit bug can never silently corrupt state.
             _ => SideExit::EnterInterpreter {
                 resume_pc: self.end_pc,
                 reason: BailReason::PartialBlock,

--- a/crates/core/src/cpu/jit_framework/riscv/mod.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/mod.rs
@@ -317,12 +317,13 @@ impl IsaFrontend for RiscVFrontend {
             return Err(FrontendRefusal::PcOutOfRange);
         }
 
-        // Chunk C: if the entry instruction is integer-ALU, emit real wasm
-        // for the maximal ALU prefix. The block runs that prefix and
-        // side-exits (fall-through Chain) to `end_pc`, where the interpreter
-        // (or a future compiled block) picks up the first non-ALU
-        // instruction.
-        if let Some(blk) = emit::emit_alu_block(pc, code) {
+        // Chunks C+D: emit real wasm for the maximal ALU prefix at `pc`,
+        // ended by one control-flow terminator (branch/jump) when present.
+        // An ALU-only block side-exits with the fall-through Chain to
+        // `end_pc`; a terminator block resolves its next PC in wasm and
+        // side-exits with the dynamic Chain. Only an entry the emitter can
+        // model neither ALU nor terminator falls through to the all-bail walk.
+        if let Some(blk) = emit::emit_block(pc, code) {
             return Ok(BlockPlan {
                 entry_pc: pc,
                 end_pc: blk.end_pc,
@@ -502,33 +503,38 @@ mod tests {
     }
 
     #[test]
-    fn translate_block_emits_alu_prefix() {
-        // addi x1,x0,1 ; jal x0,0 (self-loop terminator). Chunk C emits the
-        // addi and stops before the jal (chunk D territory).
+    fn translate_block_emits_alu_prefix_and_terminator() {
+        // addi x1,x0,1 ; jal x0,0 (self-loop terminator). Chunks C+D emit the
+        // addi AND the jal terminator as one block.
         let mut prog = Vec::new();
         w(&mut prog, 0x0010_0093); // addi x1,x0,1
         w(&mut prog, 0x0000_006f); // jal x0,0
         let view = CodeView::new(BASE, &prog);
         let plan = RiscVFrontend::new().translate_block(BASE, &view).unwrap();
-        assert!(!plan.is_stub(), "ALU entry now emits real wasm");
+        assert!(!plan.is_stub(), "ALU + terminator emits real wasm");
         assert_eq!(plan.entry_pc, BASE);
-        assert_eq!(plan.instr_count, 1, "only the addi; jal excluded");
-        assert_eq!(plan.end_pc, BASE + 4, "ends before the jal");
+        assert_eq!(plan.instr_count, 2, "the addi and the jal terminator");
+        assert_eq!(plan.end_pc, BASE + 8, "spans through the jal");
         assert_eq!(plan.exits.len(), 1);
-        assert_eq!(plan.exits[0].wire_code, emit::WIRE_FALL_THROUGH);
+        assert_eq!(plan.exits[0].wire_code, emit::WIRE_CHAIN_DYNAMIC);
         assert_eq!(&plan.code[0..4], &[0x00, 0x61, 0x73, 0x6d], "wasm magic");
     }
 
     #[test]
-    fn translate_block_non_alu_entry_falls_back_to_stub() {
-        // Entry is a jump (chunk D) → no ALU prefix, so the foundation's
-        // all-bail metadata plan is produced.
+    fn translate_block_terminator_only_entry_emits_dynamic_chain() {
+        // Entry is a jump (chunk D) with no ALU prefix → a terminator-only
+        // compiled block that resolves its next PC in wasm.
         let mut prog = Vec::new();
         w(&mut prog, 0x0000_006f); // jal x0,0
         let view = CodeView::new(BASE, &prog);
         let plan = RiscVFrontend::new().translate_block(BASE, &view).unwrap();
-        assert!(plan.is_stub(), "non-ALU entry stays all-bail");
+        assert!(
+            !plan.is_stub(),
+            "a branch/jump entry now compiles (chunk D)"
+        );
         assert_eq!(plan.instr_count, 1);
+        assert_eq!(plan.end_pc, BASE + 4);
+        assert_eq!(plan.exits[0].wire_code, emit::WIRE_CHAIN_DYNAMIC);
         assert_eq!(plan.exits[0].reason, BailReason::PartialBlock);
     }
 

--- a/crates/core/src/cpu/jit_framework/riscv/wasm_encode.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/wasm_encode.rs
@@ -90,8 +90,11 @@ pub mod op {
     // ── i32 arithmetic / logic ─────────────────────────────────────────
     pub const I32_EQZ: u8 = 0x45;
     pub const I32_EQ: u8 = 0x46;
+    pub const I32_NE: u8 = 0x47;
     pub const I32_LT_S: u8 = 0x48;
     pub const I32_LT_U: u8 = 0x49;
+    pub const I32_GE_S: u8 = 0x4e;
+    pub const I32_GE_U: u8 = 0x4f;
     pub const I32_ADD: u8 = 0x6a;
     pub const I32_SUB: u8 = 0x6b;
     pub const I32_MUL: u8 = 0x6c;

--- a/crates/core/tests/riscv_jit_branch_lockstep.rs
+++ b/crates/core/tests/riscv_jit_branch_lockstep.rs
@@ -1,0 +1,460 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Differential equivalence gate for the RV32IMC branch/jump JIT codegen
+//! (framework chunk D).
+//!
+//! Chunk D turns the block terminator — conditional branches, `JAL`/`JALR`,
+//! and the compressed `C.J`/`C.JR`/`C.JALR`/`C.BEQZ`/`C.BNEZ` — into real
+//! wasm. Each terminator resolves the block's next PC *in wasm*, writes it to
+//! the register memory's dynamic next-PC slot, and returns the single
+//! [`WIRE_CHAIN_DYNAMIC`](../src/cpu/jit_framework/riscv/emit.rs) wire code;
+//! the runtime chains to it. This gate proves that path is byte-identical to
+//! [`RiscV::step`]:
+//!
+//!   1. [`branch_hot_loop_is_byte_identical_and_chains`] — a real backward
+//!      branch drives a hot loop whose body block chains back to itself,
+//!      re-executing the *same* compiled block; state is compared byte-for-
+//!      byte at every aligned boundary and the run is asserted non-vacuous
+//!      (compiled blocks, block runs, a retired-instruction floor).
+//!   2. [`every_terminator_matches_interpreter`] — a per-terminator
+//!      differential: every branch/jump kind, taken AND not-taken, over
+//!      varied operands, covering `JALR`/`C.JR` low-bit masking, `rd == x0`
+//!      (no link), `rd == rs1` `JALR`, backward vs forward targets, and
+//!      signed vs unsigned compares.
+//!
+//! Gated behind `jit-framework` (the module) and `jit` (the native wasmtime
+//! executor), mirroring the chunk-C ALU gate.
+
+#![cfg(all(feature = "jit-framework", feature = "jit"))]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::jit_framework::differential::{compare, DiffPolicy};
+use labwired_core::cpu::jit_framework::frontend::IsaFrontend;
+use labwired_core::cpu::jit_framework::riscv::{
+    differential_cycle_ignore_indices, snapshot_state, RiscVFrontend, RiscvJitEngine, RiscvWasmJit,
+};
+use labwired_core::cpu::jit_framework::side_exit::SideExit;
+use labwired_core::cpu::jit_framework::CodeView;
+use labwired_core::cpu::RiscV;
+use labwired_core::decoder::riscv::{decode_rv32, Instruction};
+use labwired_core::Machine;
+
+// ── Encoders (standard RISC-V field layouts) ──────────────────────────────
+
+fn enc_i(rd: u32, rs1: u32, funct3: u32, imm: i32, opcode: u32) -> u32 {
+    ((imm as u32 & 0xFFF) << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7) | opcode
+}
+fn addi(rd: u32, rs1: u32, imm: i32) -> u32 {
+    enc_i(rd, rs1, 0b000, imm, 0x13)
+}
+fn slli(rd: u32, rs1: u32, sh: u32) -> u32 {
+    enc_i(rd, rs1, 0b001, sh as i32, 0x13)
+}
+fn xor(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0x33
+}
+fn add(rd: u32, rs1: u32, rs2: u32) -> u32 {
+    // funct3 = 0b000 for ADD (omitted — it contributes no bits).
+    (rs2 << 20) | (rs1 << 15) | (rd << 7) | 0x33
+}
+/// B-type conditional branch.
+fn enc_b(rs1: u32, rs2: u32, funct3: u32, imm: i32) -> u32 {
+    let u = imm as u32;
+    ((u >> 12) & 1) << 31
+        | ((u >> 5) & 0x3F) << 25
+        | (rs2 << 20)
+        | (rs1 << 15)
+        | (funct3 << 12)
+        | ((u >> 1) & 0xF) << 8
+        | ((u >> 11) & 1) << 7
+        | 0x63
+}
+fn beq(rs1: u32, rs2: u32, imm: i32) -> u32 {
+    enc_b(rs1, rs2, 0b000, imm)
+}
+fn jal(rd: u32, imm: i32) -> u32 {
+    let u = imm as u32;
+    let imm20 = (u >> 20) & 1;
+    let imm10_1 = (u >> 1) & 0x3FF;
+    let imm11 = (u >> 11) & 1;
+    let imm19_12 = (u >> 12) & 0xFF;
+    (imm20 << 31) | (imm10_1 << 21) | (imm11 << 20) | (imm19_12 << 12) | (rd << 7) | 0x6F
+}
+fn jalr(rd: u32, rs1: u32, imm: i32) -> u32 {
+    enc_i(rd, rs1, 0b000, imm, 0x67)
+}
+
+// Compressed (16-bit) terminators. Verified against `decode_rv32` in the test.
+fn c_jr(rs1: u32) -> u16 {
+    0x8002 | ((rs1 as u16) << 7)
+}
+fn c_jalr(rs1: u32) -> u16 {
+    0x9002 | ((rs1 as u16) << 7)
+}
+/// C.J with a (small) CJ-format offset.
+fn c_j(off: i32) -> u16 {
+    let u = off as u32;
+    let bit = |o: u32| ((u >> o) & 1) as u16;
+    0xA001
+        | (bit(11) << 12)
+        | (bit(4) << 11)
+        | ((((u >> 8) & 0x3) as u16) << 9)
+        | (bit(10) << 8)
+        | (bit(6) << 7)
+        | (bit(7) << 6)
+        | ((((u >> 1) & 0x7) as u16) << 3)
+        | (bit(5) << 2)
+}
+/// CB-format compare-with-zero branch. `rs1p` is the actual register 8..=15.
+fn c_cb(funct3: u16, rs1p: u32, off: i32) -> u16 {
+    let u = off as u32;
+    let bit = |o: u32| ((u >> o) & 1) as u16;
+    let rp = ((rs1p - 8) & 0x7) as u16;
+    0x0001
+        | (funct3 << 13)
+        | (bit(8) << 12)
+        | ((((u >> 3) & 0x3) as u16) << 10)
+        | (rp << 7)
+        | ((((u >> 6) & 0x3) as u16) << 5)
+        | ((((u >> 1) & 0x3) as u16) << 3)
+        | (bit(5) << 2)
+}
+fn c_beqz(rs1p: u32, off: i32) -> u16 {
+    c_cb(0b110, rs1p, off)
+}
+fn c_bnez(rs1p: u32, off: i32) -> u16 {
+    c_cb(0b111, rs1p, off)
+}
+
+// ── Machine builders ──────────────────────────────────────────────────────
+
+fn machine_from_bytes(bytes: &[u8]) -> Machine<RiscV> {
+    let mut bus = SystemBus::new();
+    bus.flash.data = bytes.to_vec();
+    bus.flash.base_addr = 0;
+    let mut cpu = RiscV::new();
+    cpu.pc = 0;
+    cpu.mtimecmp = u64::MAX; // keep the CLINT timer from ever firing
+    Machine::new(cpu, bus)
+}
+
+fn words_to_bytes(words: &[u32]) -> Vec<u8> {
+    let mut b = Vec::with_capacity(words.len() * 4);
+    for w in words {
+        b.extend_from_slice(&w.to_le_bytes());
+    }
+    b
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// (1) Backward-branch hot loop: chains compiled blocks, byte-identical.
+// ══════════════════════════════════════════════════════════════════════════
+
+/// A hot loop whose body block ends in a backward conditional branch, laid at
+/// flash 0:
+///
+/// ```text
+/// 0x00:  addi x2, x0, 500    ; loop limit (runs once, in the entry block)
+/// 0x04:  addi x1, x1, 1      ; <- loop top: counter++
+/// 0x08:  slli x3, x1, 2
+/// 0x0c:  add  x4, x3, x1
+/// 0x10:  xor  x5, x4, x2
+/// 0x14:  blt  x1, x2, -16    ; if x1 < x2 goto 0x04 (backward, taken 500x)
+/// 0x18:  jal  x0, 0          ; self-loop once the branch falls through
+/// ```
+///
+/// After warmup, the block at `0x04` compiles and its taken branch chains
+/// straight back to `0x04` — re-executing the *same* compiled block every
+/// iteration — which is the property the dynamic-chain wire must get right.
+fn branch_loop_program() -> Vec<u32> {
+    vec![
+        addi(2, 0, 500), // x2 = limit
+        addi(1, 1, 1),   // 0x04 loop top: x1++
+        slli(3, 1, 2),   // x3 = x1 << 2
+        add(4, 3, 1),    // x4 = x3 + x1
+        xor(5, 4, 2),    // x5 = x4 ^ x2
+        beq(0, 0, 0),    // placeholder, replaced below with blt
+        jal(0, 0),       // 0x18 self-loop terminator
+    ]
+}
+
+#[test]
+fn branch_hot_loop_is_byte_identical_and_chains() {
+    const MAX_UNITS: u64 = 20_000;
+    const INSTR_FLOOR: u64 = 1_500;
+
+    let mut prog = branch_loop_program();
+    // blt x1, x2, -16  (backward to 0x04); funct3=4 (BLT).
+    prog[5] = enc_b(1, 2, 0b100, -16);
+
+    let bytes = words_to_bytes(&prog);
+    let mut interp = machine_from_bytes(&bytes);
+    let mut jit = machine_from_bytes(&bytes);
+
+    let mut engine = RiscvJitEngine::new(4);
+    let policy = DiffPolicy {
+        ignore_indices: differential_cycle_ignore_indices(),
+        block_boundary_only: false,
+    };
+
+    let mut retired: u64 = 0;
+    let mut units: u64 = 0;
+    while retired < INSTR_FLOOR * 2 && units < MAX_UNITS {
+        units += 1;
+        let n = engine.step_unit(&mut jit);
+        assert!(n > 0, "jit machine halted unexpectedly at unit {units}");
+        for _ in 0..n {
+            interp
+                .step()
+                .expect("interpreter must not fault on this loop");
+        }
+        retired += n as u64;
+
+        let si = snapshot_state(&interp.cpu);
+        let sj = snapshot_state(&jit.cpu);
+        if let Some(d) = compare(units, &si, &sj, &policy) {
+            panic!(
+                "JIT diverged from interpreter at unit {units} (retired {retired}): {d:?}\n\
+                 interp pc={:#x} x={:?}\n jit    pc={:#x} x={:?}",
+                interp.cpu.pc, &interp.cpu.x, jit.cpu.pc, &jit.cpu.x
+            );
+        }
+    }
+
+    let stats = engine.stats();
+    assert!(
+        stats.compiled > 0,
+        "no block ever crossed the hot threshold / compiled"
+    );
+    assert!(
+        stats.block_runs > 0,
+        "no compiled block was ever executed (JIT path not engaged)"
+    );
+    assert!(
+        stats.block_instrs >= INSTR_FLOOR,
+        "compiled blocks retired only {} instructions (floor {INSTR_FLOOR})",
+        stats.block_instrs
+    );
+    // The loop counter reached the limit — the backward branch really cycled.
+    assert_eq!(
+        interp.cpu.x[1], 500,
+        "loop counter x1={} did not reach the limit",
+        interp.cpu.x[1]
+    );
+    println!(
+        "branch_hot_loop: retired={retired} compiled_blocks={} block_runs={} block_instrs={} interpreted={}",
+        stats.compiled, stats.block_runs, stats.block_instrs, stats.interpreted
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// (2) Per-terminator differential (taken + not-taken, edge cases).
+// ══════════════════════════════════════════════════════════════════════════
+
+/// Run one terminator block (`flash`) against both engines with the given
+/// register preset and assert the resolved next PC and full register file
+/// match the interpreter byte-for-byte.
+fn assert_terminator_matches(
+    label: &str,
+    flash: &[u8],
+    expect_kind: impl Fn(&Instruction),
+    setup: &[(usize, u32)],
+) {
+    // The bytes must decode to the terminator kind we intend to exercise.
+    let inst = if (flash[0] & 0x3) == 0x3 {
+        decode_rv32(u32::from_le_bytes([flash[0], flash[1], flash[2], flash[3]]))
+    } else {
+        decode_rv32(u16::from_le_bytes([flash[0], flash[1]]) as u32)
+    };
+    expect_kind(&inst);
+
+    // Interpreter reference.
+    let mut im = machine_from_bytes(flash);
+    for &(r, v) in setup {
+        im.cpu.x[r] = v;
+    }
+    im.step().expect("interpreter terminator step");
+    let want_pc = im.cpu.pc;
+    let want_x = im.cpu.x;
+
+    // Compiled block.
+    let frontend = RiscVFrontend::new();
+    let jit = RiscvWasmJit::new();
+    let plan = {
+        let view = CodeView::new(0, flash);
+        frontend.translate_block(0, &view).expect("translate")
+    };
+    assert!(
+        !plan.is_stub(),
+        "{label}: expected a compiled terminator block"
+    );
+    assert_eq!(plan.instr_count, 1, "{label}: one-instruction block");
+    let mut block = jit.compile(&plan).expect("compile");
+
+    let mut x = [0u32; 32];
+    for &(r, v) in setup {
+        x[r] = v;
+    }
+    let (exit, n) = block.run(&mut x);
+    assert_eq!(n, 1, "{label}: retires one instruction");
+    let got_pc = match exit {
+        SideExit::Chain { next_pc } => next_pc as u32,
+        other => panic!("{label}: expected Chain, got {other:?}"),
+    };
+    assert_eq!(
+        got_pc, want_pc,
+        "{label}: next-PC mismatch jit={got_pc:#x} interp={want_pc:#x} (setup {setup:?})"
+    );
+    assert_eq!(
+        x, want_x,
+        "{label}: register mismatch (setup {setup:?})\n jit={x:?}\n int={want_x:?}"
+    );
+}
+
+/// 32-bit terminator block = the instruction word followed by a padding word
+/// (so the view always has room to decode, and the not-taken fall-through
+/// lands on a valid slot).
+fn flash32(word: u32) -> Vec<u8> {
+    words_to_bytes(&[word, 0x0000_0013 /* nop */])
+}
+/// Compressed terminator block = the 2-byte instruction plus padding.
+fn flash16(half: u16) -> Vec<u8> {
+    let mut b = half.to_le_bytes().to_vec();
+    b.extend_from_slice(&[0x01, 0x00, 0x01, 0x00]); // c.nop padding
+    b
+}
+
+#[test]
+fn every_terminator_matches_interpreter() {
+    // ── conditional branches (B-type): taken + not-taken, both target dirs,
+    //    signed vs unsigned operands ──────────────────────────────────────
+    // (funct3, name, matches).
+    let branches: &[(u32, &str)] = &[
+        (0b000, "beq"),
+        (0b001, "bne"),
+        (0b100, "blt"),
+        (0b101, "bge"),
+        (0b110, "bltu"),
+        (0b111, "bgeu"),
+    ];
+    // Operand pairs chosen so signed and unsigned orderings disagree, plus
+    // equal / ordered cases — every branch sees taken and not-taken.
+    let pairs: &[(u32, u32)] = &[
+        (5, 5),
+        (5, 7),
+        (7, 5),
+        (0xFFFF_FFFF, 1), // -1 vs 1: signed lt, unsigned gt
+        (1, 0xFFFF_FFFF),
+        (0x8000_0000, 0x7FFF_FFFF), // INT_MIN vs INT_MAX
+    ];
+    let offsets: &[i32] = &[16, -16, 0x40];
+    for &(f3, name) in branches {
+        for &off in offsets {
+            for &(a, b) in pairs {
+                let flash = flash32(enc_b(1, 2, f3, off));
+                assert_terminator_matches(
+                    name,
+                    &flash,
+                    |i| {
+                        assert!(
+                            matches!(
+                                i,
+                                Instruction::Beq { .. }
+                                    | Instruction::Bne { .. }
+                                    | Instruction::Blt { .. }
+                                    | Instruction::Bge { .. }
+                                    | Instruction::Bltu { .. }
+                                    | Instruction::Bgeu { .. }
+                            ),
+                            "expected a branch, got {i:?}"
+                        )
+                    },
+                    &[(1, a), (2, b)],
+                );
+            }
+        }
+    }
+
+    // ── JAL: link (rd=1) and no-link (rd=0), forward + backward ───────────
+    for &rd in &[0u32, 1, 5] {
+        for &off in &[8i32, -8, 0x400] {
+            let flash = flash32(jal(rd, off));
+            assert_terminator_matches(
+                "jal",
+                &flash,
+                |i| assert!(matches!(i, Instruction::Jal { .. }), "got {i:?}"),
+                &[],
+            );
+        }
+    }
+
+    // ── JALR: low-bit masking, rd=x0, and the rd==rs1 aliasing case ───────
+    // (rd, rs1, imm, base_value)
+    let jalr_cases: &[(u32, u32, i32, u32)] = &[
+        (1, 2, 0, 0x1000),
+        (1, 2, 0, 0x1001),  // base low bit set -> masked off
+        (1, 2, 3, 0x1000),  // imm low bit set -> masked off after add
+        (1, 2, -4, 0x2000), // negative offset
+        (0, 2, 0, 0x1000),  // rd = x0: no link
+        (2, 2, 8, 0x1000),  // rd == rs1: reads pre-write rs1
+        (2, 2, 8, 0x1001),  // rd == rs1 with masking
+    ];
+    for &(rd, rs1, imm, base) in jalr_cases {
+        let flash = flash32(jalr(rd, rs1, imm));
+        assert_terminator_matches(
+            "jalr",
+            &flash,
+            |i| assert!(matches!(i, Instruction::Jalr { .. }), "got {i:?}"),
+            &[(rs1 as usize, base)],
+        );
+    }
+
+    // ── C.J ───────────────────────────────────────────────────────────────
+    for &off in &[8i32, -8, 20] {
+        let flash = flash16(c_j(off));
+        assert_terminator_matches(
+            "c.j",
+            &flash,
+            |i| assert!(matches!(i, Instruction::CJ { .. }), "got {i:?}"),
+            &[],
+        );
+    }
+
+    // ── C.JR / C.JALR: low-bit masking; C.JALR links x1 = pc+2 ────────────
+    for &base in &[0x1000u32, 0x1001, 0x2003] {
+        let flash = flash16(c_jr(5));
+        assert_terminator_matches(
+            "c.jr",
+            &flash,
+            |i| assert!(matches!(i, Instruction::CJr { .. }), "got {i:?}"),
+            &[(5, base)],
+        );
+        let flash = flash16(c_jalr(6));
+        assert_terminator_matches(
+            "c.jalr",
+            &flash,
+            |i| assert!(matches!(i, Instruction::CJalr { .. }), "got {i:?}"),
+            &[(6, base)],
+        );
+    }
+
+    // ── C.BEQZ / C.BNEZ: taken (rs1'==0 / !=0) and not-taken ──────────────
+    for &val in &[0u32, 1, 0xFFFF_FFFF] {
+        let flash = flash16(c_beqz(8, 12));
+        assert_terminator_matches(
+            "c.beqz",
+            &flash,
+            |i| assert!(matches!(i, Instruction::CBeqz { .. }), "got {i:?}"),
+            &[(8, val)],
+        );
+        let flash = flash16(c_bnez(9, 12));
+        assert_terminator_matches(
+            "c.bnez",
+            &flash,
+            |i| assert!(matches!(i, Instruction::CBnez { .. }), "got {i:?}"),
+            &[(9, val)],
+        );
+    }
+}


### PR DESCRIPTION
Chunk D of the RV32IMC wasm-JIT frontend: emit real wasm for the block
control-flow **terminators**, building on chunk C's ALU emit skeleton
(#533 / `riscv-jit-alu`).

## Scope
`Beq Bne Blt Bge Bltu Bgeu · Jal Jalr · C.J C.JR C.JALR C.BEQZ C.BNEZ`
(the decoder maps `C.JAL` to `Jal{rd:1}`, covered by the `Jal` arm). A
compiled block is now the maximal ALU prefix followed by at most one
terminator; a branch/jump ends the block.

## Exit / wire-code protocol (for chunk E + review alignment)
Chunk C had one wire code, `WIRE_FALL_THROUGH = 0` → `Chain{end_pc}`. This
adds exactly one more, `WIRE_CHAIN_DYNAMIC = 1`. A terminated block resolves
its taken / not-taken / jump-target address **in wasm** and writes it to a
fixed **next-PC slot** — word 32 (byte offset 128), just past `x31` in the
imported register memory — then returns the dynamic wire; the runtime reads
that slot and `Chain{}`s to it. One code covers every terminator kind:
conditional branches select between two compile-time addresses with an
in-wasm `if`, while `Jalr`/`C.JR`/`C.JALR` compute a data-dependent one — so
the runtime never needs a per-branch code. `CompiledBlock::run`'s register
sync grows `128 → 132` bytes to carry the slot; `WIRE_FALL_THROUGH` is
unchanged and `2` is left free for chunk E's `MEM_FAULT`.

## Byte-identity with `RiscV::step`
- sign-extended `pc + imm` branch/jump targets;
- `(rs1 + imm) & !1` low-bit mask for `Jalr`/`C.JR`/`C.JALR`;
- `pc + inst_len` links (so 2-byte `C.JAL` links `pc+2`, 4-byte `Jal` links
  `pc+4`); `C.JALR` links `x1 = pc+2`; `rd == x0` drops the link;
- the next PC is resolved **before** the link write, so `jalr rd, rd, imm`
  reads the pre-write `rs1`;
- signed (`Blt`/`Bge`) vs unsigned (`Bltu`/`Bgeu`) compares map to the
  matching wasm predicate opcodes.

## Tests — `crates/core/tests/riscv_jit_branch_lockstep.rs`
1. **branch_hot_loop_is_byte_identical_and_chains** — a real backward
   conditional branch drives a hot loop whose body block chains back to
   itself, re-executing the same compiled block. State compared byte-for-byte
   at every aligned boundary; non-vacuous: `compiled=6, block_runs=991,
   block_instrs=2975, interpreted=25`.
2. **every_terminator_matches_interpreter** — per-terminator differential,
   taken AND not-taken, over varied operands: `Jalr`/`C.JR` low-bit masking,
   `rd=x0` (no link), `rd==rs1` `Jalr`, forward vs backward targets, signed
   vs unsigned compares.

The foundation lockstep gate (`riscv_jit_lockstep.rs`) is unaffected — it
drives the `InterpreterRuntime`, which ignores emitted wasm and always bails,
so `stats.chained` stays 0.

## Regression (full suite, feature-flagged per CI)
- `cargo test -p labwired-core --features jit,event-scheduler`: **all passed, 0 failed** (7 result groups; 1898 lib + integration/doc, 1 ignored bench).
- `cargo test -p labwired-core --features jit,event-scheduler,jit-framework`: **1931 passed, 0 failed, 1+3 ignored** (lib) plus all integration/doc groups 0 failed.
- `cargo fmt --check` clean; `cargo clippy` clean (only the benign "profiles for non-root package" notes).

Zero new failures introduced.