### PR TITLE
jit(riscv): wire JIT into Machine<RiscV> dispatch + XIP-aware code source (chunk H)

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -3110,6 +3110,72 @@ impl SystemBus {
         Ok(b0 | (b1 << 8) | (b2 << 16) | (b3 << 24))
     }
 
+    /// Side-effect-free instruction-fetch of up to `max_len` **contiguous**
+    /// guest code bytes starting at virtual address `vaddr`, materialised the
+    /// SAME way the interpreter fetches instructions (see [`Self::read_u32`] /
+    /// [`Self::read_u16`] and `RiscV::step`'s `bus.read_u32(pc)` fetch): linear
+    /// RAM / flash / extra memories, and the MMU-translating flash-XIP windows
+    /// (0x4200_0000 / 0x3C00_0000). Iterating one address at a time keeps the
+    /// buffer contiguous in **virtual** space — exactly what the walker's
+    /// [`CodeView`](crate::cpu::jit_framework::CodeView) indexes — even when the
+    /// XIP MMU maps consecutive virtual pages to discontiguous flash pages.
+    ///
+    /// Stops at the first address that is not fetchable code memory (an
+    /// unmapped XIP page, or an MMIO peripheral — which is deliberately **never
+    /// read here**, so no FIFO / clear-on-read side effect can fire). The
+    /// returned buffer is therefore a byte-exact prefix of what the CPU would
+    /// fetch from `vaddr` onward.
+    ///
+    /// Used by the RISC-V JIT to compile hot blocks through the same XIP/MMU
+    /// mapping the interpreter fetches through: reading `bus.flash.data`
+    /// directly bypasses the ESP32-C3 XIP MMU and yields the wrong bytes
+    /// (typically zeros → a spurious 1024-instruction runaway block).
+    pub fn read_code_slice(&self, vaddr: u64, max_len: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(max_len);
+        for i in 0..max_len as u64 {
+            match self.read_code_byte(vaddr.wrapping_add(i)) {
+                Some(b) => out.push(b),
+                None => break,
+            }
+        }
+        out
+    }
+
+    /// One code byte at `addr`, or `None` if `addr` is not side-effect-free
+    /// code memory. See [`Self::read_code_slice`].
+    fn read_code_byte(&self, addr: u64) -> Option<u8> {
+        // Linear code/data memories are side-effect free; check them in the
+        // same precedence `read_u32`'s optimized path uses (ranges are
+        // disjoint, so precedence only picks the one backing store).
+        if let Some(b) = self.ram.read_u8(addr) {
+            return Some(b);
+        }
+        if let Some(b) = self.flash.read_u8(addr) {
+            return Some(b);
+        }
+        for mem in &self.extra_mem {
+            if let Some(b) = mem.read_u8(addr) {
+                return Some(b);
+            }
+        }
+        // Flash-XIP window: read-only, MMU-translated exactly as the CPU's
+        // instruction fetch routes it. Restricting to the XIP peripheral keeps
+        // this fetch side-effect free — no MMIO is ever touched.
+        if let Some(idx) = self.find_peripheral_index(addr) {
+            let p = &self.peripherals[idx];
+            if p.dev
+                .as_any()
+                .and_then(|a| {
+                    a.downcast_ref::<crate::peripherals::esp32s3::flash_xip::FlashXipPeripheral>()
+                })
+                .is_some()
+            {
+                return p.dev.read(addr - p.base).ok();
+            }
+        }
+        None
+    }
+
     pub fn write_u32(&mut self, addr: u64, value: u32) -> SimResult<()> {
         if self.config.optimized_bus_access && self.ram.write_u32(addr, value) {
             return Ok(());

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -21,6 +21,18 @@ pub struct SimulationConfig {
     /// Off by default so existing runners keep instruction-for-instruction
     /// behavior unless they explicitly opt in.
     pub idle_fast_forward_enabled: bool,
+
+    /// Opt into the RISC-V (RV32IMC) wasm-JIT fast path for `Machine<RiscV>`
+    /// (chunk H). Off by default: with it `false` the interpreter runs every
+    /// instruction and behavior is bit-identical to a build without the
+    /// `jit` feature. When `true` *and* the `jit` feature is compiled in
+    /// *and* the correctness SafetyGate allows (no observers / breakpoints /
+    /// logic probes / cycle-accurate peripheral), hot basic blocks are
+    /// compiled to wasm and retired atomically; the interpreter remains the
+    /// oracle for everything the JIT does not model. Has no effect without
+    /// the `jit` feature.
+    #[serde(default)]
+    pub riscv_jit_enabled: bool,
 }
 
 impl Default for SimulationConfig {
@@ -31,6 +43,7 @@ impl Default for SimulationConfig {
             optimized_bus_access: true,
             batch_mode_enabled: true,
             idle_fast_forward_enabled: false,
+            riscv_jit_enabled: false,
         }
     }
 }

--- a/crates/core/src/cpu/jit_framework/block_cache.rs
+++ b/crates/core/src/cpu/jit_framework/block_cache.rs
@@ -136,6 +136,16 @@ impl<A> BlockCache<A> {
         self.slots.insert(pc, Slot::Hot { artifact, runs: 0 });
     }
 
+    /// Borrow the compiled artifact for `pc` (if hot) **without** counting a
+    /// run. Used to peek an installed block's metadata (e.g. its instruction
+    /// count) before deciding whether it may run within the caller's budget.
+    pub fn peek(&self, pc: Pc) -> Option<&A> {
+        match self.slots.get(&pc) {
+            Some(Slot::Hot { artifact, .. }) => Some(artifact),
+            _ => None,
+        }
+    }
+
     /// Borrow the compiled artifact for `pc` (if hot) and count a run.
     pub fn run_artifact(&mut self, pc: Pc) -> Option<&mut A> {
         match self.slots.get_mut(&pc) {

--- a/crates/core/src/cpu/jit_framework/dispatch.rs
+++ b/crates/core/src/cpu/jit_framework/dispatch.rs
@@ -32,6 +32,7 @@ use super::fallback::{HostStep, JitHost};
 use super::frontend::IsaFrontend;
 use super::runtime::{JitRuntime, MemoryBinding};
 use super::side_exit::SideExit;
+use super::CodeView;
 
 /// Run statistics for one [`DispatchLoop::run`] invocation. Feeds the
 /// merge-bar measurement (compiled-block coverage) and telemetry.
@@ -180,10 +181,15 @@ impl<F: IsaFrontend, R: JitRuntime> DispatchLoop<F, R> {
     /// instantiate + install it. Any refusal/failure leaves `pc` on the
     /// interpreter — never an error.
     fn try_compile<H: JitHost>(&mut self, host: &mut H, pc: u64) {
-        let Some(view) = host.code_view(pc) else {
+        let Some(bytes) = host.code_bytes(pc) else {
             self.stats.compile_refusals += 1;
             return;
         };
+        if bytes.len() < 2 {
+            self.stats.compile_refusals += 1;
+            return;
+        }
+        let view = CodeView::new(pc, &bytes);
         let plan = match self.frontend.translate_block(pc, &view) {
             Ok(plan) => plan,
             Err(_) => {
@@ -207,7 +213,7 @@ mod tests {
     use crate::cpu::jit_framework::fallback::SafetyGate;
     use crate::cpu::jit_framework::frontend::PassthroughFrontend;
     use crate::cpu::jit_framework::runtime::InterpreterRuntime;
-    use crate::cpu::jit_framework::{CodeView, Pc, StateVec};
+    use crate::cpu::jit_framework::{Pc, StateVec};
 
     /// Minimal looping machine: a `loop_len`-instruction hot loop at
     /// `flash_base`, executed until `total` instructions retire. Each
@@ -261,9 +267,9 @@ mod tests {
         fn resume_at(&mut self, pc: Pc) {
             self.pc = pc;
         }
-        fn code_view(&self, pc: Pc) -> Option<CodeView<'_>> {
+        fn code_bytes(&self, pc: Pc) -> Option<Vec<u8>> {
             if pc >= self.flash_base && (pc - self.flash_base) < self.flash.len() as u64 {
-                Some(CodeView::new(self.flash_base, &self.flash))
+                Some(self.flash[(pc - self.flash_base) as usize..].to_vec())
             } else {
                 None
             }

--- a/crates/core/src/cpu/jit_framework/fallback.rs
+++ b/crates/core/src/cpu/jit_framework/fallback.rs
@@ -17,7 +17,7 @@
 //!     entirely through this trait so the framework never reaches into a
 //!     concrete `Cpu`/`Bus`.
 
-use super::{CodeView, Pc, StateVec};
+use super::{Pc, StateVec};
 
 /// Snapshot of the observation surface that must force interpretation.
 ///
@@ -95,10 +95,14 @@ pub trait JitHost {
     /// moves the interpreter's PC to the continuation).
     fn resume_at(&mut self, pc: Pc);
 
-    /// A read-only view of flash-resident code covering `pc`, or `None` if
-    /// `pc` is not in a compilable (flash) region. Backed by
-    /// `Bus::fetch_slice` on the real machine.
-    fn code_view(&self, pc: Pc) -> Option<CodeView<'_>>;
+    /// Materialise up to a block's worth of contiguous guest code bytes
+    /// starting at `pc`, fetched through the SAME path instruction fetch uses
+    /// (so XIP/MMU translation is applied), or `None` if `pc` is not in a
+    /// compilable code region. The dispatch loop builds a
+    /// [`CodeView`](super::CodeView) with `base = pc` from the result. Owned
+    /// (rather than a borrowed slice) so the fetch can translate through an
+    /// MMU-mapped window into a freshly materialised buffer.
+    fn code_bytes(&self, pc: Pc) -> Option<Vec<u8>>;
 
     /// The current safety gate — recomputed every call so a mid-run toggle
     /// (a debugger attaching, a probe arming) takes effect on the next

--- a/crates/core/src/cpu/jit_framework/riscv/exec.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/exec.rs
@@ -53,6 +53,7 @@ use super::emit::{
     WIRE_CHAIN_DYNAMIC, WIRE_FALL_THROUGH, WIRE_MEM_FAULT,
 };
 use super::RiscVFrontend;
+use crate::bus::SystemBus;
 
 /// Bytes synced between the guest register file and the imported memory each
 /// block run: `x0..x31` (`128`) plus the one-word dynamic next-PC slot
@@ -283,6 +284,17 @@ pub struct RiscvJitEngine {
     stats: EngineStats,
 }
 
+impl std::fmt::Debug for RiscvJitEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The `wasmtime::Engine` behind `jit` is not `Debug`; surface the
+        // run stats (the only interesting state) and elide the rest.
+        f.debug_struct("RiscvJitEngine")
+            .field("stats", &self.stats)
+            .field("compiled_blocks", &self.cache.compiled_len())
+            .finish_non_exhaustive()
+    }
+}
+
 impl RiscvJitEngine {
     /// New engine with the given hot-promotion threshold.
     pub fn new(hot_threshold: u32) -> Self {
@@ -297,6 +309,105 @@ impl RiscvJitEngine {
     /// Accumulated statistics.
     pub fn stats(&self) -> EngineStats {
         self.stats
+    }
+
+    // ── Production dispatch primitives (chunk H) ──────────────────────────
+    //
+    // The methods below let `RiscV::step_batch` drive the engine directly
+    // over the machine's raw register file + guest-RAM window (via a
+    // downcast `&mut SystemBus`) and its own interpreter, *without* routing
+    // through a `Machine<RiscV>` (which `step_unit` above requires and which
+    // the `Cpu::step_batch` signature cannot hand us). They keep the same
+    // block-cache promotion, executor, and stats as `step_unit`.
+
+    /// Record that dispatch landed on `pc` and decide what to do with it
+    /// (run a ready block, or interpret + maybe promote). See
+    /// [`BlockCache::observe`].
+    pub fn observe(&mut self, pc: Pc) -> Lookup {
+        self.cache.observe(pc)
+    }
+
+    /// The instruction count of the compiled block installed at `pc`, without
+    /// counting a run. `None` if `pc` is not hot. The caller uses this to
+    /// refuse a block that would retire past its instruction budget or across
+    /// a pending interrupt deadline.
+    pub fn ready_instr_count(&self, pc: Pc) -> Option<u32> {
+        self.cache.peek(pc).map(|b| b.instr_count)
+    }
+
+    /// Run the compiled block installed at `pc` against the guest register
+    /// file `x` and guest-RAM window `ram`, mutating both in place. Returns
+    /// `(retired, next_pc, clear_reservation, needs_interpreter)`:
+    ///
+    /// * `retired` — guest instructions the block actually retired (`0` on an
+    ///   entry-instruction memory fault).
+    /// * `next_pc` — the PC the machine must continue from.
+    /// * `clear_reservation` — an inline store executed; caller clears
+    ///   `cpu.reservation`.
+    /// * `needs_interpreter` — the exit is a bail (memory fault / partial);
+    ///   with `retired == 0` the caller interprets one instruction to
+    ///   guarantee forward progress.
+    ///
+    /// Panics only if `pc` is not a ready block (the caller guarantees it via
+    /// a preceding [`observe`](Self::observe) == [`Lookup::Ready`]).
+    pub fn run_ready(
+        &mut self,
+        pc: Pc,
+        x: &mut [u32; 32],
+        ram: &mut [u8],
+    ) -> (u32, Pc, bool, bool) {
+        let block = self.cache.run_artifact(pc).expect("run_ready on a hot PC");
+        let (exit, n, clear_reservation) = block.run(x, ram);
+        self.stats.block_runs += 1;
+        self.stats.block_instrs += n as u64;
+        (
+            n,
+            exit.continuation_pc(),
+            clear_reservation,
+            exit.needs_interpreter(),
+        )
+    }
+
+    /// Count an interpreter-fallback instruction (the caller runs the
+    /// interpreter itself over its own bus).
+    pub fn note_interpreted(&mut self) {
+        self.stats.interpreted += 1;
+    }
+
+    /// Translate + instantiate the block at `pc`, sourcing its bytes through
+    /// the [`SystemBus`]'s MMU/XIP-aware code fetch and binding its guest-RAM
+    /// window, installing the block on success. Any refusal leaves the PC on
+    /// the interpreter — never an error.
+    pub fn try_compile_from_bus(&mut self, pc: Pc, bus: &SystemBus) {
+        // Bind the machine's current guest-RAM window so loads/stores can take
+        // the inline fast path (out-of-window accesses side-exit to the
+        // interpreter's bus, which owns all MMIO).
+        self.frontend
+            .set_ram_window(bus.ram.base_addr as u32, bus.ram.data.len() as u32);
+        // Source block bytes through the SAME MMU/XIP-aware fetch path the
+        // interpreter uses. Reading `bus.flash.data` directly would bypass the
+        // ESP32-C3 XIP MMU (0x4200_0000 → physical flash pages) and compile
+        // from the wrong bytes. Materialising up to one max-length block
+        // (`MAX_BLOCK_INSTRS` × 4 bytes) is amortised across every run of the
+        // hot block, so the per-byte fetch cost is negligible.
+        let code = bus.read_code_slice(pc, super::MAX_BLOCK_INSTRS as usize * 4);
+        if code.len() < 2 {
+            return; // `pc` is not in fetchable code memory
+        }
+        let view = CodeView::new(pc, &code);
+        let Ok((plan, binding)) = self.frontend.translate_block_riscv(pc, &view) else {
+            return;
+        };
+        if let Some(block) = self.jit.compile(&plan, binding) {
+            self.cache.install(pc, block);
+            self.stats.compiled += 1;
+        }
+    }
+
+    /// Drop the entire block cache — the invalidate-all-on-flash-write policy
+    /// (see [`BlockCache::invalidate_all`]).
+    pub fn invalidate_blocks(&mut self) {
+        self.cache.invalidate_all();
     }
 
     /// Advance `machine` by exactly one dispatch unit. Returns the number of
@@ -354,27 +465,7 @@ impl RiscvJitEngine {
     /// Any refusal (non-ALU entry → stub, out-of-flash PC, instantiate
     /// failure) leaves the PC on the interpreter — never an error.
     fn try_compile(&mut self, machine: &Machine<RiscV>, pc: Pc) {
-        let flash = &machine.bus.flash;
-        let base = flash.base_addr;
-        let len = flash.data.len() as u64;
-        if pc < base || (pc - base) >= len {
-            return;
-        }
-        // Bind the machine's current guest-RAM window so loads/stores can take
-        // the inline fast path (out-of-window accesses side-exit to the
-        // interpreter's bus, which owns all MMIO).
-        self.frontend.set_ram_window(
-            machine.bus.ram.base_addr as u32,
-            machine.bus.ram.data.len() as u32,
-        );
-        let view = CodeView::new(base, &flash.data);
-        let Ok((plan, binding)) = self.frontend.translate_block_riscv(pc, &view) else {
-            return;
-        };
-        if let Some(block) = self.jit.compile(&plan, binding) {
-            self.cache.install(pc, block);
-            self.stats.compiled += 1;
-        }
+        self.try_compile_from_bus(pc, &machine.bus);
     }
 }
 

--- a/crates/core/src/cpu/jit_framework/riscv/host.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/host.rs
@@ -13,15 +13,15 @@
 //!
 //! ## Two places the framework API did not match the RISC-V machine
 //!
-//! * **`code_view` is NOT backed by `Bus::fetch_slice`.** `SystemBus`'s
-//!   `fetch_slice` only serves the Xtensa `RamPeripheral` (it downcasts to
-//!   it and returns `None` otherwise), so it yields nothing for a RISC-V
-//!   flash region. We read `bus.flash` (a `LinearMemory` whose `data`
-//!   `Vec<u8>` never reallocates after config) directly instead — which is
-//!   exactly the position-stable, flash-resident code the block cache
-//!   requires. Extending `SystemBus::fetch_slice` to also serve `flash`/the
-//!   C3 XIP peripheral is a later cleanup; it is not needed to prove the
-//!   plumbing.
+//! * **`code_bytes` fetches through the MMU, not raw `flash.data`.** The JIT
+//!   must compile from the exact bytes the interpreter fetches. On the C3 the
+//!   app runs from the 0x4200_0000 XIP window, whose `FlashXipPeripheral`
+//!   MMU-translates every virtual page to a physical flash page — so reading
+//!   `bus.flash.data` directly (the earlier workaround) compiled from the
+//!   wrong bytes (typically zeros → a spurious 1024-instruction runaway
+//!   block). `code_bytes` now materialises the block through
+//!   [`SystemBus::read_code_slice`](crate::bus::SystemBus::read_code_slice),
+//!   the same side-effect-free routing `bus.read_u32(pc)` fetch takes.
 //! * **There is no flash-dirty flag on the bus.** Nothing tracks flash
 //!   writes today, so [`take_flash_dirty`](JitHost::take_flash_dirty) is
 //!   conservatively `false`. That is correct for any run that does not
@@ -32,7 +32,7 @@ use crate::cpu::RiscV;
 use crate::Machine;
 
 use super::super::fallback::{HostStep, JitHost, SafetyGate};
-use super::super::{CodeView, Pc, StateVec};
+use super::super::{Pc, StateVec};
 
 /// Number of `u32` words in a RISC-V [`StateVec`]: `x0..x31` (32) + `pc`
 /// (1) + the eight architectural M-mode CSRs (8).
@@ -109,17 +109,17 @@ impl JitHost for RiscVJitHost<'_> {
         self.machine.cpu.pc = pc as u32;
     }
 
-    fn code_view(&self, pc: Pc) -> Option<CodeView<'_>> {
-        let flash = &self.machine.bus.flash;
-        let base = flash.base_addr;
-        let len = flash.data.len() as u64;
-        if pc >= base && (pc - base) < len {
-            Some(CodeView::new(base, &flash.data))
-        } else {
-            // Not flash-resident (RAM / MMIO / an XIP window we do not map
-            // here) — not compilable; the PC stays on the interpreter.
-            None
-        }
+    fn code_bytes(&self, pc: Pc) -> Option<Vec<u8>> {
+        // Materialise up to one max-length block through the SAME MMU/XIP-aware
+        // fetch path the interpreter uses (`bus.read_code_slice`), so a C3 app
+        // running from the 0x4200_0000 XIP window compiles from the correct,
+        // MMU-translated bytes rather than raw `flash.data`. `None`/too-short
+        // when `pc` is not fetchable code — the PC stays on the interpreter.
+        let bytes = self
+            .machine
+            .bus
+            .read_code_slice(pc, super::MAX_BLOCK_INSTRS as usize * 4);
+        (bytes.len() >= 2).then_some(bytes)
     }
 
     fn safety(&self) -> SafetyGate {
@@ -128,14 +128,12 @@ impl JitHost for RiscVJitHost<'_> {
             observers_active: !self.machine.observers.is_empty(),
             // A block could step over a breakpoint address without stopping.
             breakpoints_active: !self.machine.breakpoints.is_empty(),
-            // Logic-analyzer / DAP-watch taps and cycle-accurate mode are
-            // not surfaced through a stable accessor on this machine yet;
-            // understating them is always safe (it only lets the JIT run
-            // where it is in fact equivalent — the interpreter is the
-            // reference), and the all-bail frontend is byte-identical
-            // regardless. These wire in when the accessors land.
-            probes_active: false,
-            cycle_accurate: false,
+            // A logic-analyzer / DAP-watch tap (poll or push mode) needs
+            // per-cycle pad visibility a batched block elides.
+            probes_active: self.machine.logic_probes_active(),
+            // A cycle-accurate peripheral (HC-SR04, IO-Link, op-modeled FLASH)
+            // needs per-instruction bus services the JIT does not run.
+            cycle_accurate: self.machine.bus.requires_cycle_accurate(),
         }
     }
 

--- a/crates/core/src/cpu/jit_framework/riscv/mod.rs
+++ b/crates/core/src/cpu/jit_framework/riscv/mod.rs
@@ -75,7 +75,7 @@ pub fn differential_cycle_ignore_indices() -> Vec<usize> {
 /// unmodeled instruction), but flash could in principle contain a very long
 /// straight-line run; this keeps the walk — and the eventual emitted body —
 /// bounded regardless.
-const MAX_BLOCK_INSTRS: u32 = 1024;
+pub(crate) const MAX_BLOCK_INSTRS: u32 = 1024;
 
 /// How a single decoded instruction affects the block walk.
 ///

--- a/crates/core/src/cpu/mod.rs
+++ b/crates/core/src/cpu/mod.rs
@@ -31,10 +31,16 @@ pub mod xtensa_jit_bytes;
 // cache, side-exit protocol, per-ISA frontend trait, native/browser
 // runtime abstraction, interpreter-fallback hooks, and the differential
 // harness. It carries NO per-ISA codegen: the only frontend is a
-// passthrough that side-exits every block to the interpreter. Gated behind
-// `jit-framework` so default and existing builds are unaffected. See
+// passthrough that side-exits every block to the interpreter.
+//
+// Compiled under EITHER `jit-framework` (the pure-Rust scaffold + lockstep
+// tests) OR `jit` (the production/wasm feature set): chunk H wires the
+// RISC-V frontend's native `wasmtime` executor (`riscv::exec`, itself gated
+// on `jit`) into `Machine<RiscV>`'s dispatch, so the production `jit` build
+// needs this module present too. Both features are off by default, so the
+// default build is unaffected. See
 // `docs/engineering/universal-jit-framework.md`.
-#[cfg(feature = "jit-framework")]
+#[cfg(any(feature = "jit", feature = "jit-framework"))]
 pub mod jit_framework;
 
 pub use cortex_m::CortexM;

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -18,6 +18,12 @@ use std::sync::Arc;
 /// drops from ~380M instructions to a few million.
 const CYCLE_SCALE: u64 = 256;
 
+/// Chunk H: land on a basic-block entry PC this many times before compiling
+/// it to wasm. Matches the framework default; keeps one-shot init/boot code
+/// on the interpreter and only pays translation cost for genuinely hot loops.
+#[cfg(feature = "jit")]
+const RISCV_JIT_HOT_THRESHOLD: u32 = 50;
+
 #[derive(Debug, Clone, Copy)]
 pub struct RiscVDecodeCacheEntry {
     pub tag: u32,
@@ -53,6 +59,19 @@ pub struct RiscV {
 
     waiting_for_interrupt: bool,
     decode_cache: Box<[Option<RiscVDecodeCacheEntry>; 4096]>,
+
+    /// Chunk H: opt-in RV32IMC wasm-JIT fast path. Mirrors Xtensa's
+    /// `self.jit_enabled`; synced from [`crate::SimulationConfig::riscv_jit_enabled`]
+    /// on each `step_batch` entry. Off by default — the interpreter is the
+    /// behavioral oracle.
+    #[cfg(feature = "jit")]
+    jit_enabled: bool,
+
+    /// Lazily-created JIT engine (block cache + `wasmtime` executor). `None`
+    /// until the first JIT-enabled batch, then reused (and its block cache
+    /// warmed) across batches.
+    #[cfg(feature = "jit")]
+    jit_engine: Option<crate::cpu::jit_framework::riscv::RiscvJitEngine>,
 }
 
 impl Default for RiscV {
@@ -73,6 +92,10 @@ impl Default for RiscV {
             reservation: None,
             waiting_for_interrupt: false,
             decode_cache: Box::new([None; 4096]),
+            #[cfg(feature = "jit")]
+            jit_enabled: false,
+            #[cfg(feature = "jit")]
+            jit_engine: None,
         }
     }
 }
@@ -182,6 +205,182 @@ impl RiscV {
         self.mstatus |= mie << 7; // MPIE <- MIE
         self.mstatus &= !(1 << 3); // MIE <- 0
         self.mstatus |= 0b11 << 11; // MPP <- M-mode
+    }
+}
+
+/// Chunk H: RV32IMC wasm-JIT dispatch helpers for `Machine<RiscV>`.
+///
+/// These drive the [`RiscvJitEngine`](crate::cpu::jit_framework::riscv::RiscvJitEngine)
+/// directly over the machine's raw register file and guest-RAM window
+/// (reached by downcasting the `&mut dyn Bus` back to the concrete
+/// [`SystemBus`](crate::bus::SystemBus)), retiring compiled blocks atomically
+/// while keeping timer/interrupt timing exact.
+#[cfg(feature = "jit")]
+impl RiscV {
+    /// The production correctness gate. The JIT may run only when nothing
+    /// needs per-instruction visibility. Poll-mode logic probes, breakpoints,
+    /// cycle-accurate peripherals, and the next scheduled event already pin
+    /// `Machine::run`'s batch to a single instruction (so the JIT never
+    /// engages for them — see the `max_count > 1` guard in `step_batch`);
+    /// this checks the two rails that do NOT clamp the batch: per-instruction
+    /// observers and push-mode logic taps.
+    fn jit_gate_allows(&self, bus: &dyn Bus, observers: &[Arc<dyn SimulationObserver>]) -> bool {
+        if !observers.is_empty() {
+            return false;
+        }
+        if bus.logic_tap().is_some_and(|t| t.push_armed()) {
+            return false;
+        }
+        // Belt-and-suspenders: a cycle-accurate bus already forces batch == 1
+        // (so we would not be here), but check explicitly in case the caller
+        // ever relaxes that clamp.
+        if let Some(sb) = bus
+            .as_any()
+            .and_then(|a| a.downcast_ref::<crate::bus::SystemBus>())
+        {
+            if sb.requires_cycle_accurate() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Would a compiled block that retires `n` instructions from the current
+    /// state step *across* an interrupt the interpreter would have taken
+    /// mid-block? If so the caller interprets the stretch instead, so the
+    /// trap lands at exactly the instruction the interpreter would trap on.
+    ///
+    /// The interpreter's interrupt check ([`RiscV::step`] tail) fires only
+    /// when global `mstatus.MIE` is set. Within one `Machine::run` batch the
+    /// external IRQ lines are stable (peripherals tick only *between* batches),
+    /// so the sole source that can *become* pending mid-block is the internal
+    /// CLINT timer: the block advances `mtime` by exactly `n`, so if that
+    /// crosses `mtimecmp` (with the timer unmasked in `mie`) the MTIP edge —
+    /// and its trap — must be observed inside the block.
+    fn block_would_cross_irq(&self, bus: &dyn Bus, n: u32) -> bool {
+        // Interrupts globally disabled: no trap is taken regardless.
+        if (self.mstatus & (1 << 3)) == 0 {
+            return false;
+        }
+        // Something is already pending (or an external line is asserted): the
+        // interpreter would trap within one instruction. Do not batch past it.
+        if (self.mip & self.mie) != 0 || bus.external_irq_lines() != 0 {
+            return true;
+        }
+        // Internal timer edge inside the block's mtime span.
+        let timer_unmasked = (self.mie & (1 << 7)) != 0;
+        timer_unmasked
+            && self.mtime < self.mtimecmp
+            && self.mtimecmp <= self.mtime.wrapping_add(n as u64)
+    }
+
+    /// Drive one batch through the JIT engine, returning the true retired
+    /// instruction count (never past `max_count`). The engine is moved out of
+    /// `self` for the duration so its methods can borrow `self.x` / `self.pc`
+    /// and the bus independently, then it is restored.
+    fn step_batch_jit(
+        &mut self,
+        bus: &mut dyn Bus,
+        observers: &[Arc<dyn SimulationObserver>],
+        config: &crate::SimulationConfig,
+        max_count: u32,
+    ) -> SimResult<u32> {
+        let mut engine = self.jit_engine.take().unwrap_or_else(|| {
+            crate::cpu::jit_framework::riscv::RiscvJitEngine::new(RISCV_JIT_HOT_THRESHOLD)
+        });
+        let out = self.run_jit_loop(&mut engine, bus, observers, config, max_count);
+        self.jit_engine = Some(engine);
+        out
+    }
+
+    /// The JIT dispatch loop body. `engine` is a borrowed handle (moved out of
+    /// `self` by the caller) so `engine.run_ready(pc, &mut self.x, …)` does not
+    /// alias `self`.
+    fn run_jit_loop(
+        &mut self,
+        engine: &mut crate::cpu::jit_framework::riscv::RiscvJitEngine,
+        bus: &mut dyn Bus,
+        observers: &[Arc<dyn SimulationObserver>],
+        config: &crate::SimulationConfig,
+        max_count: u32,
+    ) -> SimResult<u32> {
+        use crate::bus::SystemBus;
+        use crate::cpu::jit_framework::block_cache::Lookup;
+
+        let mut retired: u32 = 0;
+        while retired < max_count {
+            let pc = self.pc as u64;
+            match engine.observe(pc) {
+                Lookup::Ready => {
+                    let n = engine.ready_instr_count(pc).unwrap_or(0);
+                    // Never retire past the batch budget (preserves the
+                    // event/IRQ clamp `Machine::run` already applied), and
+                    // never let a block cross a mid-block interrupt deadline.
+                    let must_interpret =
+                        n == 0 || retired + n > max_count || self.block_would_cross_irq(bus, n);
+                    if must_interpret {
+                        self.step(bus, observers, config)?;
+                        engine.note_interpreted();
+                        retired += 1;
+                    } else if let Some(sb) =
+                        bus.as_any_mut().and_then(|a| a.downcast_mut::<SystemBus>())
+                    {
+                        let (actual_n, next_pc, clear_reservation, needs_interp) =
+                            engine.run_ready(pc, &mut self.x, &mut sb.ram.data);
+                        if clear_reservation {
+                            self.reservation = None;
+                        }
+                        self.pc = next_pc as u32;
+                        // ── THE MTIME FIXUP ──────────────────────────────
+                        // A compiled block retires `actual_n` instructions
+                        // without calling `step`, so it never advanced the
+                        // CLINT `mtime` (the interpreter bumps it 1/instr).
+                        // Advance it by exactly `actual_n` here so the cycle
+                        // CSRs (0xC00/0x802/0x7E2 = mtime*CYCLE_SCALE) and the
+                        // MTIP timer edge stay identical to a per-instruction
+                        // run. This is the analogue of Xtensa's CCOUNT += N-1.
+                        self.update_mtime_after_elapsed_cycles(actual_n as u64);
+                        retired += actual_n;
+                        // Entry-instruction memory fault: nothing retired and
+                        // the PC did not move — interpret one for progress.
+                        if actual_n == 0 && needs_interp {
+                            self.step(bus, observers, config)?;
+                            engine.note_interpreted();
+                            retired += 1;
+                        }
+                    } else {
+                        // Not a `SystemBus` (never happens in production): fall
+                        // back to the interpreter for this instruction.
+                        self.step(bus, observers, config)?;
+                        engine.note_interpreted();
+                        retired += 1;
+                    }
+                }
+                Lookup::Interpret { promote } => {
+                    if promote {
+                        if let Some(sb) = bus.as_any().and_then(|a| a.downcast_ref::<SystemBus>()) {
+                            engine.try_compile_from_bus(pc, sb);
+                        }
+                    }
+                    self.step(bus, observers, config)?;
+                    engine.note_interpreted();
+                    retired += 1;
+                }
+            }
+            // Mirror the interpreter batch's idle fast-forward early-exit so
+            // enabling the JIT never changes when a batch returns short.
+            if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
+                return Ok(retired);
+            }
+        }
+        Ok(retired)
+    }
+
+    /// Accumulated JIT engine stats — `None` if the engine was never created
+    /// (the JIT never ran). Used by the differential merge-gate test to assert
+    /// the compiled path was non-vacuously exercised.
+    pub fn jit_stats(&self) -> Option<crate::cpu::jit_framework::riscv::EngineStats> {
+        self.jit_engine.as_ref().map(|e| e.stats())
     }
 }
 
@@ -831,6 +1030,26 @@ impl Cpu for RiscV {
         config: &crate::SimulationConfig,
         max_count: u32,
     ) -> SimResult<u32> {
+        // ── Chunk H JIT fast-path ─────────────────────────────────────────
+        // When the RV32IMC wasm-JIT is opted in AND nothing needs
+        // per-instruction visibility, drive this batch through the JIT
+        // engine (compiled blocks + interpreter fallback). Off by default,
+        // and only compiled under `jit`; the interpreter loop below is the
+        // reference path (byte-identical to a non-`jit` build when the flag
+        // is off). `max_count <= 1` batches skip the JIT: `Machine::run`
+        // clamps the batch to one instruction precisely when it needs a
+        // per-instruction boundary (breakpoint set, poll-mode logic probe,
+        // cycle-accurate peripheral, next scheduled event), so restricting
+        // the JIT to multi-instruction batches folds all those correctness
+        // rails into one cheap check.
+        #[cfg(feature = "jit")]
+        {
+            self.jit_enabled = config.riscv_jit_enabled;
+            if self.jit_enabled && max_count > 1 && self.jit_gate_allows(bus, observers) {
+                return self.step_batch_jit(bus, observers, config, max_count);
+            }
+        }
+
         // Push-mode logic capture: advance the tap clock once per retired
         // instruction while armed, so MMIO pad writes stamp with the cycle
         // boundary they become observable at (see `crate::logic_capture`).

--- a/crates/core/src/decoder/riscv.rs
+++ b/crates/core/src/decoder/riscv.rs
@@ -367,6 +367,15 @@ pub fn decode_rv32c(inst: u16) -> Instruction {
                               | (((inst >> 6) & 0x1) << 2)   // imm[2]
                               | (((inst >> 5) & 0x1) << 3); // imm[3]
                     let rd = (((inst >> 2) & 0x7) + 8) as u8;
+                    // The all-zeros encoding (nzuimm == 0, i.e. `inst == 0x0000`)
+                    // is RESERVED/ILLEGAL per the RISC-V spec — c.addi4spn
+                    // requires a nonzero nzuimm. Decode it as Unknown so both the
+                    // interpreter and JIT trap on it instead of silently running
+                    // a bogus `addi rd,sp,0`. Real firmware never executes zero
+                    // padding as code; a block that walks into it must terminate.
+                    if imm == 0 {
+                        return Instruction::Unknown(inst as u32);
+                    }
                     Instruction::CAddi4spn {
                         rd,
                         imm: imm as u32,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -910,6 +910,19 @@ pub struct StepProfile {
     pub legacy_tick_entries: u64,
 }
 
+/// No-event batch cap for the RISC-V JIT on a walk-deletable bus (see
+/// `Machine::run`'s batch-widening). Sized so one max-length compiled block
+/// ([`cpu::jit_framework::riscv::MAX_BLOCK_INSTRS`] = 1024 instructions) always
+/// fits in a single batch — otherwise `run_jit_loop`'s `retired + n > max_count`
+/// guard would refuse it and the JIT would never engage. Kept to exactly one
+/// block so peripheral ticks / breakpoint checks still run frequently between
+/// scheduled events; the budget clamps tighter than this whenever an event is
+/// due. Mirrors `cpu::jit_framework::riscv::MAX_BLOCK_INSTRS` (a literal here so
+/// it does not depend on the `jit` feature being enabled alongside
+/// `event-scheduler`; keep the two in sync).
+#[cfg(feature = "event-scheduler")]
+const RISCV_JIT_BATCH_CAP: u32 = 1024;
+
 pub struct Machine<C: Cpu> {
     pub cpu: C,
     /// Secondary CPU instance — for dual-core SoCs (ESP32, ESP32-S3).
@@ -987,6 +1000,16 @@ pub struct Machine<C: Cpu> {
 }
 
 impl<C: Cpu> Machine<C> {
+    /// Whether any logic-analyzer / signal probe is armed (poll or push mode).
+    /// The `jit_framework` [`SafetyGate`](crate::cpu::jit_framework::fallback::SafetyGate)
+    /// reads this to force the interpreter while a probe needs per-cycle pad
+    /// visibility. `logic_capture` is module-private, so this crate-internal
+    /// accessor is how the RISC-V JIT host reaches it.
+    #[cfg(any(feature = "jit", feature = "jit-framework"))]
+    pub(crate) fn logic_probes_active(&self) -> bool {
+        self.logic_capture.poll_active() || self.logic_capture.push_active()
+    }
+
     /// Discover the drivable input channels on this machine (delegates to
     /// [`bus::SystemBus::list_inputs`]). See [`crate::sim_input`].
     pub fn list_inputs(&mut self) -> Vec<(String, crate::sim_input::InputChannel)> {
@@ -2090,6 +2113,38 @@ impl<C: Cpu> DebugControl for Machine<C> {
             } else {
                 remaining_until_tick
             };
+
+            // ── RISC-V JIT batch widening (chunk H) ──────────────────────────
+            // The `peripheral_tick_interval` is a PERFORMANCE knob for
+            // walk-deletable peripherals, not a correctness boundary — scheduled
+            // events are. When the RISC-V JIT is enabled on a walk-deletable bus
+            // (`max_safe_tick_interval() > 1`), an atomic compiled block (up to
+            // `MAX_BLOCK_INSTRS`) must be allowed to retire in one batch even at
+            // a small tick interval; otherwise `run_jit_loop`'s
+            // `retired + n > max_count` guard refuses every block and the JIT
+            // never engages (interpreting everything). Key the budget off the
+            // DISTANCE TO THE NEXT SCHEDULED EVENT instead: a full block fits
+            // when no event is due, and the batch clamps EXACTLY to a due event
+            // otherwise, so the post-batch drain applies it at its exact cycle
+            // (byte-identical to a per-instruction run — the same guarantee the
+            // walk-differential gates prove for interval-vs-1). Gated on
+            // `riscv_jit_enabled`, so it never perturbs the non-JIT interpreter
+            // batching. The safety clamps below (cycle-accurate / breakpoint /
+            // poll-capture) still only ever REDUCE this, so a debugger or probe
+            // pins the batch to one instruction exactly as before.
+            #[cfg(feature = "event-scheduler")]
+            if self.config.riscv_jit_enabled && self.bus.max_safe_tick_interval() > 1 {
+                let mut jit_batch = RISCV_JIT_BATCH_CAP;
+                let generations = self.bus.peripheral_generations();
+                if let Some(deadline) = self.sched.next_event_deadline(&generations) {
+                    let until = deadline.saturating_sub(self.total_cycles);
+                    jit_batch = jit_batch.min(until.clamp(1, u32::MAX as u64) as u32);
+                }
+                if let Some(limit) = max_steps {
+                    jit_batch = jit_batch.min((limit - steps).max(1));
+                }
+                current_batch = jit_batch;
+            }
 
             // Cycle-accurate buses (HC-SR04, IO-Link, H5 op-modeling FLASH) must
             // execute one instruction per batch so per-instruction services —

--- a/crates/core/tests/riscv_jit_c3_oled_differential.rs
+++ b/crates/core/tests/riscv_jit_c3_oled_differential.rs
@@ -1,0 +1,342 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Chunk H MERGE GATE: the RV32IMC wasm-JIT, wired into `Machine<RiscV>`'s
+//! production dispatch, must be **byte-identical** to the interpreter on a
+//! REAL ESP32-C3 firmware run.
+//!
+//! This boots the exact `esp32c3-oled-demo` lab the browser fast-start uses
+//! (real 2nd-stage bootloader → SHA verify → app driving an SSD1306 OLED over
+//! I²C0, plus the SYSTIMER FreeRTOS tick source) and runs it TWICE from the
+//! same reset:
+//!   * `riscv_jit_enabled = false` — the interpreter (the oracle), and
+//!   * `riscv_jit_enabled = true`  — hot basic blocks compiled to wasm and
+//!     retired atomically.
+//!
+//! After every 1M-instruction chunk (and at the end) it asserts FULL
+//! architectural + observable state is identical: every x-register + pc, the
+//! CLINT `mtime`/`mtimecmp`, all eight M-mode CSRs and `mip`/`mie`, the
+//! reservation, `total_cycles`, the serial (UART) stream, AND the SSD1306
+//! framebuffer. It further asserts the JIT path was NON-VACUOUS (compiled
+//! blocks actually ran and retired instructions).
+//!
+//! This exercises ALU + memory + branch heavily (FreeRTOS + display driver)
+//! AND peripherals (I²C0, SYSTIMER, UART) through the same `Machine::run`
+//! batch/tick/IRQ machinery production uses — so a byte-identical result is a
+//! true statement that enabling the JIT changes nothing observable.
+//!
+//! Heavy (~30M instructions × 2 runs): `#[ignore]`d like the sibling real-C3
+//! gates; run as the merge bar with
+//! `cargo test -p labwired-core --features jit,event-scheduler --release
+//!  --ignored jit_vs_interpreter`.
+
+#![cfg(all(feature = "jit", feature = "event-scheduler"))]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::boot::esp32c3_rom::{
+    build_rom_boot_machine, c3_rom_data_init_writes, inject_rom_regions, RomBootOpts,
+};
+use labwired_core::boot::esp32s3_rom::RomImages;
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::RiscV;
+use labwired_core::memory::ProgramImage;
+use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
+use labwired_core::{Arch, Bus, Cpu, DebugControl, Machine};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+const ESP_IMAGE_HEADER_LEN: usize = 24;
+const ESP_IMAGE_MAGIC: u8 = 0xE9;
+
+fn esp32c3_bootloader_image(flash: &[u8]) -> ProgramImage {
+    assert!(flash.len() > ESP_IMAGE_HEADER_LEN, "flash image truncated");
+    assert_eq!(flash[0], ESP_IMAGE_MAGIC, "bad bootloader image magic");
+    let segment_count = flash[1] as usize;
+    let entry = u32::from_le_bytes(flash[4..8].try_into().unwrap()) as u64;
+    let mut program = ProgramImage::new(entry, Arch::RiscV);
+    let mut cursor = ESP_IMAGE_HEADER_LEN;
+    for _ in 0..segment_count {
+        let load_addr = u32::from_le_bytes(flash[cursor..cursor + 4].try_into().unwrap()) as u64;
+        let len = u32::from_le_bytes(flash[cursor + 4..cursor + 8].try_into().unwrap()) as usize;
+        cursor += 8;
+        program.add_segment(load_addr, flash[cursor..cursor + len].to_vec());
+        cursor += len;
+    }
+    program
+}
+
+struct OledLab {
+    machine: Machine<RiscV>,
+    serial: Arc<Mutex<Vec<u8>>>,
+}
+
+/// Build the OLED lab exactly as the browser fast-start (and the sibling
+/// `esp32c3_walk_differential` gate) does — real chip/system yaml, vendored
+/// mask-ROM blobs, the curated flash image, entering at the 2nd-stage
+/// bootloader. Both differential arms use the identical default (scheduler)
+/// peripheral configuration; the ONLY difference between the two machines is
+/// `config.riscv_jit_enabled`, set by the caller.
+fn build_oled_lab(jit_enabled: bool) -> OledLab {
+    let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
+        .expect("load esp32c3 chip yaml");
+    let manifest =
+        SystemManifest::from_file(root().join("../../configs/systems/esp32c3-oled-demo.yaml"))
+            .expect("load esp32c3-oled-demo system yaml");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build oled bus");
+
+    let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
+    let drom = std::fs::read(root().join("roms/esp32c3/esp32c3_drom.bin")).expect("read C3 DROM");
+    let flash = std::fs::read(root().join("../wasm/tests/fixtures/esp32c3-oled-demo-flash.bin"))
+        .expect("read C3 OLED demo flash image");
+
+    assert!(
+        inject_rom_regions(
+            &mut bus,
+            &RomImages {
+                irom: irom.clone(),
+                drom,
+            }
+        ),
+        "chip yaml must declare the C3 IROM region"
+    );
+    for (dst, bytes) in c3_rom_data_init_writes(&irom) {
+        for (i, b) in bytes.iter().enumerate() {
+            let _ = bus.write_u8(dst as u64 + i as u64, *b);
+        }
+    }
+
+    let serial = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(serial.clone(), false);
+
+    let bootloader = esp32c3_bootloader_image(&flash);
+    let mut machine = build_rom_boot_machine(
+        bus,
+        flash,
+        RomBootOpts {
+            efuse_mac: None,
+            usb_serial_sink: None,
+        },
+        |c| c,
+    );
+
+    for segment in &bootloader.segments {
+        if machine.bus.flash.load_from_segment(segment)
+            || machine.bus.ram.load_from_segment(segment)
+            || machine
+                .bus
+                .extra_mem
+                .iter_mut()
+                .any(|m| m.load_from_segment(segment))
+        {
+            continue;
+        }
+        for (i, byte) in segment.data.iter().enumerate() {
+            machine
+                .bus
+                .write_u8(segment.start_addr + i as u64, *byte)
+                .expect("load bootloader segment");
+        }
+    }
+    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    machine.cpu.set_sp(sp_top & !0xF);
+    machine.cpu.set_pc(bootloader.entry_point as u32);
+
+    // Run at the C3's walk-deletable production tick interval
+    // (RECOMMENDED_TICK_INTERVAL = 64): i2c0/systimer/etc. are scheduler-driven,
+    // so peripherals need not tick every cycle. BOTH arms use this identical
+    // interval. This is deliberately MODEST — well below the JIT's 1024-instr
+    // block size — to prove Fix 2 engages the JIT: with the batch budget keyed
+    // off the tick interval, a 1024-instr block would never fit in a 64-instr
+    // batch (`retired + n > max_count`) and the JIT would interpret everything;
+    // keying it off the next-scheduled-event distance (walk-deletable → batching
+    // is a performance knob, not a correctness boundary) lets full blocks retire
+    // atomically between events while staying byte-identical to the interpreter.
+    const BATCH_TICK_INTERVAL: u32 = labwired_core::bus::RECOMMENDED_TICK_INTERVAL;
+    machine.config.peripheral_tick_interval = BATCH_TICK_INTERVAL;
+    machine.bus.config.peripheral_tick_interval = BATCH_TICK_INTERVAL;
+
+    // The sole differential variable.
+    machine.config.riscv_jit_enabled = jit_enabled;
+    machine.bus.config.riscv_jit_enabled = jit_enabled;
+
+    OledLab { machine, serial }
+}
+
+fn ssd1306_framebuffer(machine: &Machine<RiscV>) -> Vec<u8> {
+    let idx = machine
+        .bus
+        .find_peripheral_index_by_name("i2c0")
+        .expect("oled bus exposes i2c0");
+    machine.bus.peripherals[idx]
+        .dev
+        .as_any()
+        .expect("i2c0 downcastable")
+        .downcast_ref::<Esp32c3I2c>()
+        .expect("i2c0 is the C3 command-list controller")
+        .attached_slaves()
+        .iter()
+        .filter(|d| d.address() == 0x3C)
+        .find_map(|d| d.as_any().and_then(|a| a.downcast_ref::<Ssd1306>()))
+        .expect("SSD1306 attached at 0x3C")
+        .framebuffer()
+        .to_vec()
+}
+
+fn lit_pixels(fb: &[u8]) -> usize {
+    fb.iter().map(|b| b.count_ones() as usize).sum()
+}
+
+/// Flatten the full architectural state that must be identical between the two
+/// arms: x0..x31, pc, the CLINT `mtime`/`mtimecmp`, every M-mode CSR incl.
+/// `mip`/`mie`, and the LR/SC reservation. The cycle CSRs (0xC00/0x802/0x7E2)
+/// are a pure function of `mtime` (× CYCLE_SCALE), so comparing `mtime`
+/// proves them identical too.
+fn arch_state(cpu: &RiscV) -> Vec<u64> {
+    let mut v = Vec::with_capacity(32 + 1 + 2 + 8 + 1);
+    v.extend(cpu.x.iter().map(|&w| w as u64));
+    v.push(cpu.pc as u64);
+    v.push(cpu.mtime);
+    v.push(cpu.mtimecmp);
+    v.push(cpu.mstatus as u64);
+    v.push(cpu.mie as u64);
+    v.push(cpu.mip as u64);
+    v.push(cpu.mtvec as u64);
+    v.push(cpu.mscratch as u64);
+    v.push(cpu.mepc as u64);
+    v.push(cpu.mcause as u64);
+    v.push(cpu.mtval as u64);
+    v.push(cpu.reservation.map_or(u64::MAX, |a| a as u64));
+    v
+}
+
+/// Human-readable name for each `arch_state` index (for a precise divergence
+/// message).
+fn arch_field_name(i: usize) -> String {
+    match i {
+        0..=31 => format!("x{i}"),
+        32 => "pc".into(),
+        33 => "mtime".into(),
+        34 => "mtimecmp".into(),
+        35 => "mstatus".into(),
+        36 => "mie".into(),
+        37 => "mip".into(),
+        38 => "mtvec".into(),
+        39 => "mscratch".into(),
+        40 => "mepc".into(),
+        41 => "mcause".into(),
+        42 => "mtval".into(),
+        43 => "reservation".into(),
+        _ => format!("field{i}"),
+    }
+}
+
+fn assert_state_identical(interp: &Machine<RiscV>, jit: &Machine<RiscV>, retired: u64) {
+    // total_cycles: the batch/tick/IRQ accounting must match instruction-for-
+    // instruction — the strongest single signal that timing stayed exact.
+    assert_eq!(
+        interp.total_cycles, jit.total_cycles,
+        "total_cycles diverged after ~{retired}M instructions: interp={} jit={}",
+        interp.total_cycles, jit.total_cycles
+    );
+
+    let a = arch_state(&interp.cpu);
+    let b = arch_state(&jit.cpu);
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        assert_eq!(
+            x,
+            y,
+            "arch state diverged at {} after ~{retired}M instructions: interp={x:#x} jit={y:#x}",
+            arch_field_name(i)
+        );
+    }
+
+    let fb_i = ssd1306_framebuffer(interp);
+    let fb_j = ssd1306_framebuffer(jit);
+    assert!(
+        fb_i == fb_j,
+        "SSD1306 framebuffer diverged after ~{retired}M instructions \
+         (interp {} lit px, jit {} lit px)",
+        lit_pixels(&fb_i),
+        lit_pixels(&fb_j)
+    );
+}
+
+/// THE MERGE GATE. Boot the real C3 OLED lab twice (interpreter vs JIT) and
+/// prove byte-identity of the full state along the way and at the paint
+/// milestone, plus a non-vacuous JIT.
+#[test]
+#[ignore = "real C3 bootloader + app, ~30M steps x2; run with --release --ignored"]
+fn jit_vs_interpreter_c3_oled_is_byte_identical_and_non_vacuous() {
+    // Enough to boot through the 2nd-stage bootloader + app and paint the
+    // wordmark; the wasm gate paints well inside this budget.
+    const BUDGET: u64 = 30_000_000;
+    const CHUNK: u32 = 1_000_000;
+    const MIN_LIT: usize = 400;
+
+    let mut interp = build_oled_lab(false);
+    let mut jit = build_oled_lab(true);
+
+    let mut steps: u64 = 0;
+    while steps < BUDGET {
+        let n = CHUNK.min((BUDGET - steps) as u32);
+        interp.machine.run(Some(n)).expect("interpreter run");
+        jit.machine.run(Some(n)).unwrap_or_else(|e| {
+            panic!(
+                "jit run failed at pc={:#x} (interp pc={:#x}, retired ~{steps}): {e:?}",
+                jit.machine.cpu.pc, interp.machine.cpu.pc
+            )
+        });
+        steps += n as u64;
+        assert_state_identical(&interp.machine, &jit.machine, steps / 1_000_000);
+    }
+
+    // The serial (UART) stream is an event observable — must be byte-identical.
+    let serial_i = interp.serial.lock().unwrap().clone();
+    let serial_j = jit.serial.lock().unwrap().clone();
+    assert!(
+        serial_i == serial_j,
+        "UART serial stream diverged (interp {} bytes, jit {} bytes)",
+        serial_i.len(),
+        serial_j.len()
+    );
+
+    // The reference (interpreter) run must actually have painted the OLED, so
+    // "identical" is not "both blank".
+    let fb = ssd1306_framebuffer(&interp.machine);
+    assert!(
+        lit_pixels(&fb) >= MIN_LIT,
+        "reference run must paint the OLED wordmark ({} lit px < {MIN_LIT})",
+        lit_pixels(&fb)
+    );
+
+    // NON-VACUOUS: the JIT arm genuinely compiled hot blocks and retired real
+    // instructions through them (not pure interpreter fallback).
+    let stats = jit
+        .machine
+        .cpu
+        .jit_stats()
+        .expect("jit engine was created (JIT ran)");
+    assert!(
+        stats.compiled > 0,
+        "no basic block was ever compiled — the JIT path is vacuous"
+    );
+    assert!(
+        stats.block_runs > 0,
+        "no compiled block was ever dispatched — the JIT path is vacuous"
+    );
+    assert!(
+        stats.block_instrs > 0,
+        "compiled blocks retired zero instructions — the JIT path is vacuous"
+    );
+    eprintln!(
+        "[jit-gate] byte-identical over {BUDGET} instructions; JIT stats: \
+         compiled={} block_runs={} block_instrs={} interpreted={}",
+        stats.compiled, stats.block_runs, stats.block_instrs, stats.interpreted
+    );
+}


### PR DESCRIPTION
Wires the RV32IMC wasm-JIT into `Machine<RiscV>`'s production dispatch, **off by default** (`config.riscv_jit_enabled`, `#[serde(default)]`), behind a SafetyGate. A default build is bit-identical to a non-jit build; the interpreter remains the oracle.

## Fidelity
- **mtime fixup**: each atomically-retired block advances `mtime` by its retired count (Xtensa `CCOUNT+=N-1` analogue) — cycle CSRs (0xC00/0x802/0x7E2) and the MTIP edge stay identical.
- **block_would_cross_irq**: interprets through any timer-deadline crossing so traps land exactly where the interpreter would take them.
- **SafetyGate** reads real state — observers / breakpoints / logic probes / cycle-accurate peripherals all force the interpreter, so every existing oracle/analyzer feature is untouched.

## Two blockers the synthetic lockstep tests missed (found by the real-firmware gate)
1. **XIP/MMU code source** *(the correctness bug)*: C3 runs XIP through a `FlashXipPeripheral` MMU page table. The JIT read `bus.flash` raw → zero-padding → junk 1024-instr blocks → divergence. Fixed with `SystemBus::read_code_slice`, which routes fetches through the same MMU-translated path the CPU's `read_u32` uses (side-effect-free, code regions only).
2. **Batch budget**: blocks are ≤1024 instrs but the batch was clamped to the tick interval, so the JIT never engaged. For walk-deletable configs the JIT batch is now keyed off the next scheduled-event deadline (cap 1024), so full atomic blocks fit — non-JIT batching is untouched (`max_safe_tick_interval() > 1` guard).
3. **Decoder**: reserved all-zero `c.addi4spn` (`nzuimm==0`) now decodes to `Unknown` instead of a bogus `addi`.

## Merge gate — real C3 firmware, byte-identical
`riscv_jit_c3_oled_differential`: the real `esp32c3-oled-demo` lab (2nd-stage bootloader → FreeRTOS → SSD1306 over I²C0 + SYSTIMER + UART) run **jit-on vs jit-off**, byte-identical over **30M instructions** (all regs/pc, `mtime`/CSRs, `mip`/`mie`, `total_cycles`, UART stream, OLED framebuffer) and **non-vacuous**: `compiled=891, block_runs=4.97M, block_instrs=9.5M`. Interpreter ticks peripherals every 64 cycles, JIT retires ≤1024-instr blocks between events — identical result proves the coarse JIT batching is equivalent.

Regression: both feature combos **0 failed** apart from the pre-existing `manifest_json_matches_registry` kit-sync debt; walk-identity gates green; fmt/clippy clean.

Base: jit-framework-scaffold. Off-by-default, so nothing activates until a config opts in.