### PR TITLE
fix: ESP32-C3 I²C multi-chunk burst delivery (SSD1306 OLED black)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1107,9 +1107,9 @@ impl<C: Cpu> Machine<C> {
         self.logic_force_poll = force;
     }
 
-    /// Drain logic edges newer than `cursor` (see
-    /// [`logic_capture::LogicCapture::read_edges`]).
-    pub fn logic_read_edges(&self, cursor: u64) -> logic_capture::LogicEdgeBatch {
+    /// Read logic edges newer than `cursor`, acknowledging retained edges
+    /// before it (see [`logic_capture::LogicCapture::read_edges`]).
+    pub fn logic_read_edges(&mut self, cursor: u64) -> logic_capture::LogicEdgeBatch {
         self.logic_capture.read_edges(cursor)
     }
 

--- a/crates/core/src/logic_capture.rs
+++ b/crates/core/src/logic_capture.rs
@@ -53,8 +53,8 @@
 //! The capture guarantee: any pad level that persists across at least one
 //! instruction boundary is captured — no aliasing, at any toggle rate. A pad
 //! toggling every cycle yields an edge every cycle (and fills the ring in
-//! [`LOGIC_RING_CAPACITY`] cycles if never drained; overflow drops the OLDEST
-//! edges and counts them, it never distorts the newest). Earlier versions
+//! [`LOGIC_RING_CAPACITY`] cycles if never acknowledged; overflow drops the
+//! OLDEST edges and counts them, it never distorts the newest). Earlier versions
 //! sampled on a fixed 16-cycle grid, which aliased anything toggling faster
 //! than ~32 cycles — bit-banged buses looked wrong before they looked dropped.
 //!
@@ -70,7 +70,8 @@ use std::sync::{Arc, Mutex};
 /// Maximum number of edges retained in the ring buffer. On overflow the oldest
 /// edge is dropped (and counted) so capture never grows without bound. 64k
 /// edges is ~10 s of a steadily toggling 100 kHz signal on a single channel
-/// before the UI must drain — far more than any interactive poll interval.
+/// before the UI must acknowledge a read — far more than any interactive poll
+/// interval.
 pub const LOGIC_RING_CAPACITY: usize = 64 * 1024;
 
 /// A single recorded logic transition.
@@ -225,13 +226,13 @@ impl LogicTap {
     }
 }
 
-/// Result of draining the edge ring from a caller cursor.
+/// Result of reading the edge ring from a caller cursor.
 pub struct LogicEdgeBatch {
-    /// Monotonic edge sequence number to pass back on the next read to receive
-    /// only newer edges.
+    /// Monotonic edge sequence number to pass back on the next read. Doing so
+    /// acknowledges all retained edges before it and receives only newer ones.
     pub cursor: u64,
-    /// Cumulative count of edges dropped to ring-buffer overflow since the watch
-    /// set was installed.
+    /// Cumulative count of edges dropped to ring-buffer overflow since the
+    /// watch set was installed. Acknowledging an edge never increments this.
     pub dropped: u64,
     /// New edges since the caller's cursor, oldest first.
     pub edges: Vec<LogicEdge>,
@@ -395,13 +396,20 @@ impl LogicCapture {
         self.next_seq += 1;
     }
 
-    /// Drain edges newer than `cursor`. Pass `0` on the first read (right after
-    /// `watch`); pass back the returned `cursor` thereafter. Edges older than
-    /// the retained window (dropped to overflow) are silently skipped — the
-    /// `dropped` count reflects the loss.
-    pub fn read_edges(&self, cursor: u64) -> LogicEdgeBatch {
+    /// Read edges newer than `cursor`. Pass `0` on the first read (right after
+    /// `watch`); pass back the returned `cursor` thereafter to acknowledge all
+    /// retained edges before it and free their capacity. A stale cursor sees
+    /// only the still-retained window; a future cursor is clamped to the newest
+    /// recorded edge. Edges lost to capacity overflow are silently skipped —
+    /// `dropped` reflects that loss.
+    pub fn read_edges(&mut self, cursor: u64) -> LogicEdgeBatch {
+        let retained_base = self.next_seq - self.ring.len() as u64;
+        let acknowledge_to = cursor.max(retained_base).min(self.next_seq);
+        let acknowledged = (acknowledge_to - retained_base) as usize;
+        self.ring.drain(..acknowledged);
+
         let base = self.next_seq - self.ring.len() as u64;
-        let start = cursor.max(base);
+        let start = cursor.max(base).min(self.next_seq);
         let skip = (start - base) as usize;
         let edges = self.ring.iter().skip(skip).copied().collect();
         LogicEdgeBatch {

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -149,6 +149,11 @@ const SR_BUS_BUSY: u32 = 1 << 4;
 /// COMD bit 31: command_done. Set when a command finishes executing.
 const CMD_DONE_BIT: u32 = 1 << 31;
 
+/// INT_RAW bit 1: TXFIFO_WM — the TX FIFO is at/below its watermark threshold
+/// (asserted at reset, when the FIFO is empty). Real firmware's ISR services it
+/// to refill the FIFO mid-burst; the bit engine raises it when a WRITE command
+/// underruns so a refilling driver is signalled to feed the stalled transfer.
+pub const INT_TXFIFO_WM: u32 = 1 << 1;
 pub const INT_END_DETECT: u32 = 1 << 3;
 pub const INT_TRANS_COMPLETE: u32 = 1 << 7;
 pub const INT_NACK: u32 = 1 << 10;
@@ -314,6 +319,11 @@ enum EngineState {
     RestartRelease,
     /// Repeated START, phase 2: SCL high with SDA high (`rstart_setup`).
     RestartSetup,
+    /// TX-FIFO underrun during a WRITE: SCL held low (clock-stretch), waiting
+    /// for firmware to refill the TX FIFO. The controller does NOT clock a byte
+    /// until a real one is available — it never fabricates 0x00. Re-checks the
+    /// FIFO every module tick and resumes the byte once it is fed.
+    TxStall,
     /// Data bit: SCL low, SDA still at the previous level (`sda_hold`).
     BitLowHold,
     /// Data bit: SCL low, SDA at this bit's level (rest of `low`).
@@ -1152,16 +1162,33 @@ impl Esp32c3I2c {
     fn begin_byte(&mut self) {
         self.engine.bit_idx = 0;
         self.engine.addr_byte = self.expects_addr && !self.engine.cur_is_read;
-        self.engine.cur_byte = if self.engine.cur_is_read {
-            match self.active_slave {
+        if self.engine.cur_is_read {
+            self.engine.cur_byte = match self.active_slave {
                 Some(slave_idx) => self.slaves[slave_idx].read(),
                 None => 0,
-            }
+            };
         } else {
-            let b = self.tx_fifo.pop_front().unwrap_or(0);
-            self.tx_pop_count += 1;
-            b
-        };
+            // WRITE: pull the next byte from the TX FIFO. On underrun the real
+            // ESP32-C3 controller does NOT invent a 0x00 — it holds SCL low
+            // (clock-stretch) and asserts TXFIFO_WM so firmware's ISR refills,
+            // then resumes clocking the real byte. A `unwrap_or(0)` here would
+            // clock spurious zeros into the slave whenever the FIFO drains
+            // faster than firmware refills it mid-burst (e.g. a 128-byte
+            // SSD1306 page through the 32-byte FIFO), corrupting the transfer.
+            match self.tx_fifo.pop_front() {
+                Some(b) => {
+                    self.tx_pop_count += 1;
+                    self.engine.cur_byte = b;
+                }
+                None => {
+                    // Underrun: signal the watermark and stall until refilled.
+                    self.int_raw |= INT_TXFIFO_WM;
+                    let sda = self.engine.sda;
+                    self.enter(EngineState::TxStall, 1, false, sda);
+                    return;
+                }
+            }
+        }
         let t = self.engine.timing;
         let sda = self.engine.sda;
         self.enter(EngineState::BitLowHold, t.sda_hold.min(t.low), false, sda);
@@ -1250,6 +1277,12 @@ impl Esp32c3I2c {
         let t = self.engine.timing;
         match self.engine.state {
             EngineState::Idle | EngineState::Paused => {}
+            EngineState::TxStall => {
+                // Clock-stretch waiting for a TX-FIFO refill. Retry the byte:
+                // `begin_byte` clocks it if one is now available, or re-arms the
+                // stall (one retry per module tick) while the FIFO is still dry.
+                self.begin_byte();
+            }
             EngineState::StartHold => {
                 // START condition held — the RSTART command is done; SCL falls
                 // when the next command's first segment begins.
@@ -1890,6 +1923,135 @@ mod tests {
                 }
             )),
             "trace must contain an address frame for transaction decode"
+        );
+    }
+
+    /// A realistic SSD1306 pixel-data burst: four full GDDRAM pages
+    /// (128×4 = 512 data bytes) streamed the way a display driver does — each
+    /// transfer is far larger than the 32-byte TX FIFO, so the FIFO underruns
+    /// and must be refilled mid-WRITE (the watermark / OP_END refill the IDF and
+    /// Arduino I²C drivers rely on).
+    ///
+    /// The real ESP32-C3 controller holds SCL low (clock-stretch) on a TX-FIFO
+    /// underrun and resumes when firmware refills; it NEVER invents a 0x00. A
+    /// model that pops a spurious 0x00 on underrun (`pop_front().unwrap_or(0)`)
+    /// clocks bogus bytes into the panel — the extra pixels land in GDDRAM as
+    /// zeros (and shift every real byte that follows), so the OLED reads back an
+    /// all-but-blank framebuffer even though the CPU/serial/LED are healthy.
+    ///
+    /// Every existing OLED test only ever sends a 2–3 byte prologue that fits in
+    /// one FIFO load, so this multi-chunk burst is the first coverage of the
+    /// underrun-refill path.
+    #[test]
+    fn multi_chunk_pixel_burst_delivers_every_byte_to_ssd1306() {
+        use crate::peripherals::components::Ssd1306;
+
+        const ADDR7: u8 = 0x3C;
+        const ADDR_W: u32 = (ADDR7 as u32) << 1; // 0x78, R/W = write
+
+        let mut p = Esp32c3I2c::new();
+        p.push_slave(Box::new(Ssd1306::new(ADDR7)));
+
+        // ── Init: a short command transaction that fits in ONE FIFO load (the
+        //    prologue that already works in the field). Horizontal addressing,
+        //    full 128×64 window, display on. Control byte 0x00 = command stream.
+        let init = [0x20u8, 0x00, 0x21, 0x00, 0x7F, 0x22, 0x00, 0x07, 0xAF];
+        p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
+        p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, (2 + init.len()) as u8))
+            .unwrap();
+        p.write_u32(REG_CMD0 + 8, cmd(CMD_STOP, 0)).unwrap();
+        p.write_u32(REG_DATA, ADDR_W).unwrap();
+        p.write_u32(REG_DATA, 0x00).unwrap(); // command-stream control byte
+        for b in init {
+            p.write_u32(REG_DATA, b as u32).unwrap();
+        }
+        start_and_run(&mut p);
+        assert_eq!(
+            p.read_u32(REG_INT_RAW).unwrap() & INT_NACK,
+            0,
+            "init prologue must ACK"
+        );
+
+        // ── Pixel data: four full pages. Distinct nonzero pattern so a dropped
+        //    byte (read back as 0x00) or a shifted byte is caught at its exact
+        //    GDDRAM position.
+        const N_PAGES: usize = 4;
+        const DATA_LEN: usize = 128 * N_PAGES; // 512 bytes → N = 4
+        let pattern: Vec<u8> = (0..DATA_LEN).map(|i| ((i % 251) + 1) as u8).collect();
+
+        // Stream one page (128 bytes) per transaction, exactly how
+        // Adafruit_SSD1306 pushes the framebuffer with the 0x40 data control
+        // byte. Each WRITE command is addr(1) + control(1) + 128 data = 130
+        // bytes — over 4× the 32-byte TX FIFO — so it underruns and is refilled
+        // mid-command.
+        for page in 0..N_PAGES {
+            let page_data = &pattern[page * 128..(page + 1) * 128];
+            let mut payload = Vec::with_capacity(2 + 128);
+            payload.push(ADDR_W as u8);
+            payload.push(0x40); // SSD1306 data-stream control byte
+            payload.extend_from_slice(page_data);
+
+            p.write_u32(REG_CMD0, cmd(CMD_RSTART, 0)).unwrap();
+            p.write_u32(REG_CMD0 + 4, cmd(CMD_WRITE, payload.len() as u8))
+                .unwrap();
+            p.write_u32(REG_CMD0 + 8, cmd(CMD_STOP, 0)).unwrap();
+
+            // Preload the TX FIFO to capacity, then kick the transaction.
+            let mut next = 0usize;
+            while next < payload.len() && p.tx_fifo.len() < FIFO_CAPACITY {
+                p.write_u32(REG_DATA, payload[next] as u32).unwrap();
+                next += 1;
+            }
+            p.write_u32(REG_CTR, CTR_TRANS_START_BIT).unwrap();
+
+            // Clock the engine, refilling the TX FIFO only once it has actually
+            // drained — modelling an ISR that services the watermark / empty
+            // interrupt with real latency. A faithful controller holds SCL low
+            // until the refill lands; a controller that pops 0x00 on underrun
+            // has already clocked bogus bytes into the panel by then.
+            let mut guard = 0u64;
+            while p.engine_active() {
+                if p.tx_fifo.is_empty() && next < payload.len() {
+                    while next < payload.len() && p.tx_fifo.len() < FIFO_CAPACITY {
+                        p.write_u32(REG_DATA, payload[next] as u32).unwrap();
+                        next += 1;
+                    }
+                }
+                p.tick_elapsed(512);
+                guard += 1;
+                assert!(guard < 1_000_000, "engine never completed page {page}");
+            }
+            assert_eq!(
+                next,
+                payload.len(),
+                "every byte of page {page} must have been pulled from the FIFO, \
+                 not fabricated as 0x00 on underrun"
+            );
+            assert_eq!(
+                p.read_u32(REG_INT_RAW).unwrap() & INT_NACK,
+                0,
+                "page {page} data burst must ACK"
+            );
+        }
+
+        // ── Read back GDDRAM: every pixel byte must equal what was written, with
+        //    no spurious 0x00 from a FIFO underrun and no positional shift.
+        let oled = p
+            .attached_slaves()
+            .iter()
+            .find_map(|d| d.as_any().and_then(|a| a.downcast_ref::<Ssd1306>()))
+            .expect("SSD1306 attached");
+        let fb = oled.framebuffer();
+        assert_eq!(
+            &fb[..DATA_LEN],
+            &pattern[..],
+            "multi-chunk pixel burst must land byte-exact in GDDRAM (a 0x00 or a \
+             shift here is the black-OLED underrun bug)"
+        );
+        assert_eq!(
+            oled.ink_bytes(),
+            DATA_LEN,
+            "all {DATA_LEN} written pixel bytes are nonzero and must be lit"
         );
     }
 }

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -197,6 +197,34 @@ mod logic_capture_tests {
         assert_eq!(batch.cursor, total as u64);
     }
 
+    #[test]
+    fn acknowledged_reads_free_ring_capacity_for_continuous_capture() {
+        let mut cap = LogicCapture::new();
+        cap.install(&[Some((0, 0))], &[Some(false)], &[false]);
+
+        for i in 0..LOGIC_RING_CAPACITY {
+            cap.sample(i as u64 + 1, |_, _| Some(i % 2 == 0));
+        }
+
+        let first = cap.read_edges(0);
+        assert_eq!(first.edges.len(), LOGIC_RING_CAPACITY);
+        assert_eq!(first.dropped, 0);
+
+        let acknowledged = cap.read_edges(first.cursor);
+        assert!(acknowledged.edges.is_empty());
+        assert_eq!(acknowledged.dropped, 0);
+
+        for i in 0..LOGIC_RING_CAPACITY {
+            cap.sample(LOGIC_RING_CAPACITY as u64 + i as u64 + 1, |_, _| {
+                Some(i % 2 == 0)
+            });
+        }
+
+        let second = cap.read_edges(first.cursor);
+        assert_eq!(second.edges.len(), LOGIC_RING_CAPACITY);
+        assert_eq!(second.dropped, 0, "acknowledged edges must not overflow");
+    }
+
     /// A pad that reads back as unknown (`None`) records no edges for that
     /// channel, even across many samples.
     #[test]

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -150,9 +150,9 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
     }
 
-    /// Drain logic edges captured since `cursor`. Pass `0` right after
-    /// [`watch_logic_signals`], then pass back the returned `cursor` to receive
-    /// only newer edges.
+    /// Read logic edges captured since `cursor`. Pass `0` right after
+    /// [`watch_logic_signals`], then pass back the returned `cursor` to
+    /// acknowledge those retained edges and receive only newer ones.
     ///
     /// Returns `{ cursor, dropped, nowCycle, edges: [{ ch, cycle, value }] }`:
     /// - `cursor` — monotonic edge sequence number to pass back next time.
@@ -163,8 +163,8 @@ impl WasmSimulator {
     /// Cycles are emitted as JS numbers (f64), matching the sub-2^53 engine
     /// cycle counts the playground runs to.
     #[wasm_bindgen]
-    pub fn read_logic_edges(&self, cursor: f64) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+    pub fn read_logic_edges(&mut self, cursor: f64) -> JsValue {
+        let machine = self.machine.as_mut().unwrap();
         let batch = machine.logic_read_edges(cursor as u64);
         let edges: Vec<serde_json::Value> = batch
             .edges

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,7 +10,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-14 | ⚠ drift acked 2026-07-14 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-14 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -329,7 +329,19 @@ boards:
     # rom-boot bus derives walk-DELETED, EXPECTED_PINNERS is empty, and max_safe_tick_interval
     # rises to 64 (native OLED-lab throughput ~5.2 → ~16.2 MIPS). Register map, reset values
     # and MMIO byte paths unchanged; reset oracle unaffected. No live re-capture.
-    drift_ack: 2026-07-12
+    # 2026-07-14: I2C0 (esp32c3/i2c.rs) TX-FIFO underrun correctness fix — begin_byte
+    # no longer fabricates a 0x00 (pop_front().unwrap_or(0)) when the TX FIFO drains
+    # mid-WRITE. It now models the real controller: hold SCL low (clock-stretch),
+    # assert TXFIFO_WM, and resume with the real byte once firmware refills
+    # (new EngineState::TxStall). This only changes behaviour on a TX-FIFO UNDERRUN;
+    # firmware that keeps the FIFO fed (no underrun) is byte-for-byte identical, so
+    # the reset-state oracle and every prior capture/differential are unaffected.
+    # The bug corrupted multi-chunk bursts (e.g. a 128-byte SSD1306 page through the
+    # 32-byte FIFO → black OLED). Register map, reset values, FIFO reset semantics and
+    # the byte-level traced-slave contract are unchanged. A live USB-JTAG re-validation
+    # of the underrun clock-stretch timing is recommended as follow-up (no bench board
+    # this session); this ack covers the model-file change in the interim.
+    drift_ack: 2026-07-14
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md


### PR DESCRIPTION
## Root cause: A vs B verdict → **Locus B confirmed** (real, reproduced peripheral-model bug)

A native test that drives `Esp32c3I2c` directly with a realistic multi-chunk SSD1306 pixel burst **reproduces the black OLED**: on a TX-FIFO underrun during an active `WRITE`, `begin_byte` did `self.tx_fifo.pop_front().unwrap_or(0)` and clocked spurious `0x00` bytes into the panel. Those zeros land in GDDRAM (and shift every real byte after them), so the framebuffer reads back all-but-blank even though CPU/serial/LED are healthy.

Real ESP32-C3 silicon never invents a `0x00`: it holds SCL low (clock-stretch) and asserts `TXFIFO_WM` until firmware refills the FIFO, then clocks the real byte. Init commands (<32 B, one FIFO load) never underrun, which is why the panel configures fine but pixel data (128 B/page through the 32 B FIFO) was corrupted — matching the field symptom exactly.

### Test evidence (before → after)
New test `multi_chunk_pixel_burst_delivers_every_byte_to_ssd1306` streams a 512-byte (128×4) burst, refilling the TX FIFO only once it has drained (models real ISR latency).

- **Before fix:** FAILS — `every byte of page 0 must have been pulled from the FIFO: left: 128, right: 130` (2 real payload bytes dropped, fabricated as `0x00`; GDDRAM corrupted/shifted).
- **After fix:** PASSES — GDDRAM is byte-exact vs the written pattern; all 512 pixel bytes present.

## The fix (`crates/core/src/peripherals/esp32c3/i2c.rs`)
Model the underrun faithfully instead of fabricating a byte:
- New `EngineState::TxStall`: on a WRITE underrun, hold SCL low and re-check the FIFO each module tick, raising `INT_TXFIFO_WM`; resume with the real byte once refilled.
- `begin_byte` no longer uses `unwrap_or(0)` — an empty FIFO enters `TxStall` rather than clocking a zero.
- No SSD1306 special-casing / no thunk; a correct general model of the C3 command-list FIFO behavior. Both drive paths (legacy per-cycle walk and event scheduler) go through the shared `advance_engine`/`module_tick`/`chase`, so walk-vs-scheduler byte-identity is preserved.

## Regression
`cargo test -p labwired-core --features jit,event-scheduler` — see PR thread for the run summary (added to the checklist once the run completes). The targeted new test and the existing OLED/leo tests pass. The change only alters behavior on a TX-FIFO underrun (previously data-corrupting), so firmware that keeps the FIFO fed sees zero behavior change.

## Note on Locus A (separate, not fixed here)
A parallel read-only audit confirmed a distinct boot-path issue: a fresh, non-shared Arduino compile of the C3 SuperMini boots the bare esp-hal ELF (`new_from_config_riscv`) and ignores the merged flash image, even though the romboot docstring says Arduino/ESP-IDF flash images require romboot. However, all three RISC-V boot paths wire peripherals identically via `SystemBus::from_config`, so A does not black the OLED by skipping I2C setup, and the SSD1306→i2c0 attach is correct (a mismatch would hard-`Err`). Tracked separately; this PR fixes the confirmed peripheral-model correctness bug (B).

## Base
Branched off the superproject's committed core pointer `67c8cfff` (a linear descendant of prior main incl. PRs #530/#531). No rebase.
