### PR TITLE
feat(cli): serialize deterministic logic-analyzer edges into result.json

### DIFF
--- a/crates/cli/src/artifacts.rs
+++ b/crates/cli/src/artifacts.rs
@@ -46,6 +46,15 @@ pub(crate) struct TestResult {
     /// clean. The builder maps this into `/run`'s `unmodeled_access[]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) fidelity: Vec<labwired_core::fidelity::FidelityGap>,
+    /// Deterministic logic-analyzer edge capture for the pads named by
+    /// `--watch-gpio`, drained from the SAME in-engine `LogicTap` the wasm
+    /// `read_logic_edges` accessor uses (byte-for-byte parity). Per-channel
+    /// transitions on the engine-cycle axis + a run-level `dropped` overflow
+    /// count. Absent (and omitted) unless at least one pad was watched — the
+    /// builder maps this into the oracle's `gpio` edge evidence for the
+    /// prove-blink `gpio_edges`/`gpio_period`/`gpio_duty` clauses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) logic_edges: Option<labwired_core::logic_capture::LogicEdgesResult>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -51,6 +51,21 @@ fn parse_u32_addr(s: &str) -> Result<u32, String> {
     }
 }
 
+/// Parse a `--watch-gpio` ref `peripheral:pin` into `(peripheral, pin)`. The pin
+/// is a decimal `u8`; the peripheral is any non-empty name resolved against the
+/// bus at run time (`gpio8`, `gpioa`, …). Returns `None` for a malformed ref
+/// (missing colon, empty peripheral, or an out-of-range/non-numeric pin) — the
+/// caller logs and skips it rather than aborting the whole run.
+fn parse_watch_gpio_ref(spec: &str) -> Option<(String, u8)> {
+    let (name, pin) = spec.trim().rsplit_once(':')?;
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let pin: u8 = pin.trim().parse().ok()?;
+    Some((name.to_string(), pin))
+}
+
 #[derive(Parser, Debug)]
 #[command(
     author,
@@ -640,6 +655,16 @@ struct TestArgs {
     /// Useful for local development and testing.
     #[arg(long)]
     no_key: bool,
+
+    /// Watch a GPIO pad's output for the deterministic logic-analyzer edge
+    /// capture, as `peripheral:pin` (e.g. `gpio8:8`, `gpioa:5`). Repeatable —
+    /// each ref is a channel (CH0, CH1, … in argument order). The captured
+    /// per-channel edge series lands in `result.json`'s `logic_edges` block, so
+    /// the oracle can prove a pad actually toggled / at a given period (the
+    /// prove-blink evidence). Edges are drained from the same in-engine tap the
+    /// browser logic analyzer uses. No watch → zero overhead, no block emitted.
+    #[arg(long = "watch-gpio", value_name = "PERIPHERAL:PIN")]
+    watch_gpio: Vec<String>,
 }
 
 /// Unified error response for agent consumption
@@ -1165,6 +1190,7 @@ fn handle_load_error<C: labwired_core::Cpu>(
         &None,
         &[],
         None,
+        None,
     );
     ExitCode::from(EXIT_RUNTIME_ERROR)
 }
@@ -1256,6 +1282,59 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     let mut prev_pc = machine.cpu.get_pc();
     let mut stuck_counter: u64 = 0;
 
+    // ── --watch-gpio: arm the deterministic logic-analyzer edge capture ──────
+    // Resolve each `peripheral:pin` ref ONCE (to a peripheral index + pin),
+    // exactly as the wasm `watch_logic_signals` accessor does, arm the in-engine
+    // tap, and keep the per-channel identity so the drained edges can be shaped
+    // into `result.json`'s `logic_edges` block after the run. An empty watch set
+    // is a no-op (no channels installed → zero-overhead capture path).
+    let logic_watch_meta: Vec<labwired_core::logic_capture::LogicChannelMeta> = {
+        let refs: Vec<(String, u8)> = args
+            .watch_gpio
+            .iter()
+            .filter_map(|spec| parse_watch_gpio_ref(spec))
+            .collect();
+        if refs.len() != args.watch_gpio.len() {
+            for spec in &args.watch_gpio {
+                if parse_watch_gpio_ref(spec).is_none() {
+                    error!("--watch-gpio: ignoring malformed ref {spec:?} (want `peripheral:pin`)");
+                }
+            }
+        }
+        if refs.is_empty() {
+            Vec::new()
+        } else {
+            let resolved: Vec<Option<(usize, u8)>> = refs
+                .iter()
+                .map(|(name, pin)| {
+                    machine
+                        .bus
+                        .find_peripheral_index_by_name(name)
+                        .map(|idx| (idx, *pin))
+                })
+                .collect();
+            for ((name, _), r) in refs.iter().zip(resolved.iter()) {
+                if r.is_none() {
+                    error!("--watch-gpio: peripheral {name:?} not found on the bus; channel will stay flat");
+                }
+            }
+            let initial = machine.logic_watch(&resolved);
+            refs.iter()
+                .zip(initial)
+                .enumerate()
+                .map(|(ch, ((name, pin), value))| {
+                    labwired_core::logic_capture::LogicChannelMeta {
+                        ch: ch as u32,
+                        peripheral: name.clone(),
+                        pin: *pin,
+                        initial: value,
+                    }
+                })
+                .collect()
+        }
+    };
+    let logic_capture_armed = !logic_watch_meta.is_empty();
+
     let batch_size = if machine.config.batch_mode_enabled
         && args.breakpoint.is_empty()
         && detect_stuck.is_none()
@@ -1264,6 +1343,11 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         // correctly when peripherals tick between every instruction; instruction
         // batching freezes them across the batch and the firmware measures 0.
         && !machine.bus.requires_cycle_accurate()
+        // A logic-analyzer POLL-mode channel must be sampled at EVERY cycle
+        // boundary, so clamp the batch to one instruction while one is armed
+        // (mirrors `Machine::run`). Push-mode channels report their own edges
+        // from the write sites and keep the full batch width.
+        && !machine.logic_poll_active()
     {
         10000.min(max_steps)
     } else {
@@ -1427,6 +1511,11 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         let to_execute = current_batch.min(remaining);
 
         if to_execute > 1 {
+            // Push-mode logic capture: seed the tap clock at the batch start;
+            // the CPU advances it once per retired instruction so pad writes
+            // stamp with the boundary they become observable at (mirrors
+            // `Machine::run`). No-op unless a push-mode watch set is armed.
+            machine.logic_seed_batch_clock(machine.total_cycles);
             match machine.cpu.step_batch(
                 &mut machine.bus,
                 &machine.observers,
@@ -1438,6 +1527,10 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                     step += executed as u64;
                     steps_executed = step;
                     machine.total_cycles += executed as u64;
+                    // Cycle boundary the batch ended at, BEFORE peripheral tick
+                    // costs — pushes stamped here are finalised to the post-cost
+                    // "now" by the observe below (see `Machine::logic_observe`).
+                    let logic_boundary = machine.total_cycles;
 
                     // Cycle-accurate tick propagation for batch runs
                     let tick_interval = machine.config.peripheral_tick_interval as u64;
@@ -1457,6 +1550,15 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         for irq in interrupts {
                             machine.cpu.set_exception_pending(irq);
                         }
+                    }
+
+                    // Logic-analyzer edge capture at this batch boundary: drain
+                    // the push tap (poll-mode channels force batch=1 → the
+                    // single-step branch's `machine.step()` observes them). Runs
+                    // before the early `continue` below so a partial batch's
+                    // edges are never lost. No-op when nothing is watched.
+                    if logic_capture_armed {
+                        machine.logic_observe_boundary(logic_boundary);
                     }
 
                     // Honor a firmware-requested system reset (AIRCR
@@ -1747,6 +1849,24 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         },
     );
 
+    // Drain the deterministic logic-analyzer edge capture for THIS run and shape
+    // it into the shared per-channel series form. Reading from cursor 0 returns
+    // every retained edge; `dropped` (surfaced in the block) is non-zero only if
+    // the 64k ring overflowed, which the oracle treats as fail-loud. This is the
+    // SAME `logic_read_edges` drain the wasm `read_logic_edges` accessor uses, so
+    // the CLI `result.json` edges and the browser edges are edge-for-edge equal.
+    let logic_edges = if logic_capture_armed {
+        let now_cycle = machine.logic_now_cycle();
+        let batch = machine.logic_read_edges(0);
+        Some(labwired_core::logic_capture::build_logic_edges_result(
+            &logic_watch_meta,
+            &batch,
+            now_cycle,
+        ))
+    } else {
+        None
+    };
+
     write_outputs(
         args,
         status,
@@ -1766,6 +1886,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         &coverage_observer,
         &fault_evidence,
         Some(inspect_block),
+        logic_edges,
     );
 
     if !all_passed
@@ -1800,6 +1921,7 @@ fn write_outputs<C: labwired_core::Cpu>(
     coverage_observer: &Option<Arc<labwired_core::pc_coverage::PcCoverageObserver>>,
     fault_evidence: &[labwired_cli::faults::FaultEvidence],
     inspect: Option<labwired_core::inspect::MachineInspect>,
+    logic_edges: Option<labwired_core::logic_capture::LogicEdgesResult>,
 ) {
     let mut hasher = Sha256::new();
     hasher.update(firmware_bytes);
@@ -1833,6 +1955,7 @@ fn write_outputs<C: labwired_core::Cpu>(
         },
         inspect,
         fidelity,
+        logic_edges,
     };
 
     if let Some(output_dir) = &args.output_dir {
@@ -2155,6 +2278,8 @@ pub(crate) fn write_config_error_outputs(
         inspect: None,
         // Config error: the sim never ran, so there are no coverage gaps to report.
         fidelity: Vec::new(),
+        // Nor any logic-analyzer edges — capture never armed.
+        logic_edges: None,
     };
 
     if let Some(output_dir) = &args.output_dir {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1322,14 +1322,14 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             refs.iter()
                 .zip(initial)
                 .enumerate()
-                .map(|(ch, ((name, pin), value))| {
-                    labwired_core::logic_capture::LogicChannelMeta {
+                .map(
+                    |(ch, ((name, pin), value))| labwired_core::logic_capture::LogicChannelMeta {
                         ch: ch as u32,
                         peripheral: name.clone(),
                         pin: *pin,
                         initial: value,
-                    }
-                })
+                    },
+                )
                 .collect()
         }
     };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1129,6 +1129,39 @@ impl<C: Cpu> Machine<C> {
         self.total_cycles
     }
 
+    /// `true` while at least one watched channel is on the per-cycle poll
+    /// fallback — the bespoke CLI test loop uses this to clamp its instruction
+    /// batch to one, exactly as [`Machine::run`] does, so polled pads are
+    /// sampled at every cycle boundary. Push-only watch sets keep the full
+    /// batch width (their peripherals report edges from the write sites).
+    #[inline]
+    pub fn logic_poll_active(&self) -> bool {
+        self.logic_capture.poll_active()
+    }
+
+    /// Seed the push-capture tap clock at a batch start, so pad writes during
+    /// the batch stamp with the boundary they become observable at (the CPU
+    /// bumps the clock once per retired instruction while armed). No-op unless
+    /// a push-mode watch set is armed. The bespoke CLI test loop calls this
+    /// before each `cpu.step_batch`, mirroring [`Machine::run`].
+    #[inline]
+    pub fn logic_seed_batch_clock(&self, batch_start_cycle: u64) {
+        if self.logic_capture.push_active() {
+            self.bus.logic_tap.set_clock(batch_start_cycle);
+        }
+    }
+
+    /// Public boundary-observe for run loops that step the CPU directly
+    /// (`cpu.step_batch` / `cpu.step`) instead of via [`Machine::step`] /
+    /// [`Machine::run`], which observe internally. Drains the push tap and
+    /// samples polled channels at `boundary` — the engine cycle at the end of
+    /// the just-executed batch, BEFORE peripheral tick costs. No-op when no
+    /// watch set is armed. See [`Machine::logic_observe`] for the semantics.
+    #[inline]
+    pub fn logic_observe_boundary(&mut self, boundary: u64) {
+        self.logic_observe(boundary);
+    }
+
     /// Observe the watched channels at the current cycle boundary: drain the
     /// push tap (event-driven channels) and sample the polled channels.
     /// Hooked into the step loop; the leading `is_active` guard is the entire

--- a/crates/core/src/logic_capture.rs
+++ b/crates/core/src/logic_capture.rs
@@ -238,6 +238,112 @@ pub struct LogicEdgeBatch {
     pub edges: Vec<LogicEdge>,
 }
 
+// ---------------------------------------------------------------------------
+// Serialized edge shape (shared with the TS `ChannelEdgeSeries`)
+// ---------------------------------------------------------------------------
+//
+// The hosted/CLI run path serializes captured edges into `result.json` as a
+// per-channel step series on the ENGINE-CYCLE axis — byte-shape-identical to
+// `packages/board-config`'s `ChannelEdgeSeries` (the ONE definition the browser
+// logic-analyzer export and the oracle also consume). `value` and `initial` are
+// emitted as 0/1 (never `true`/`false`) to match `EdgeLevel = 0 | 1`. The edges
+// themselves are drained from the SAME `LogicCapture::read_edges` the wasm
+// `read_logic_edges` accessor uses, so the two surfaces are edge-for-edge
+// identical (asserted by the native/wasm parity differential test).
+
+/// One recorded transition on the engine-cycle axis. `value` is 0/1 to match the
+/// TS `EdgeLevel`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct EdgeTransition {
+    pub cycle: u64,
+    pub value: u8,
+}
+
+/// One watched channel's captured transitions — the Rust mirror of the TS
+/// `ChannelEdgeSeries` (`packages/board-config`). `initial` is `Some(0|1)` or
+/// `null`; `gaps` lists engine cycles at which the capture ring overflowed
+/// (honest "edges lost here" markers — never interpolated over).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ChannelEdgeSeries {
+    /// Edge-record channel index (the pad's position in the armed watch set).
+    pub ch: u32,
+    /// Logic-analyzer channel id ("CH0"…).
+    pub channel: String,
+    pub peripheral: String,
+    pub pin: u8,
+    /// Pad level at arm time (0/1), or `null` when the engine can't resolve it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial: Option<u8>,
+    /// Transitions, oldest-first, each stamped with the engine cycle it occurred at.
+    pub transitions: Vec<EdgeTransition>,
+    /// Engine cycles at which the ring overflowed before this lane's next edge.
+    #[serde(default)]
+    pub gaps: Vec<u64>,
+}
+
+/// The whole logic-edge evidence block embedded in `result.json`. `dropped` is
+/// the cumulative ring-overflow count for the run — the oracle FAILS LOUD when
+/// it is non-zero (edges were lost, so any period/duty/edge assertion would be
+/// evaluated on an incomplete stream).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LogicEdgesResult {
+    /// Cumulative edges lost to ring-buffer overflow across the whole run.
+    pub dropped: u64,
+    /// Engine cycle at the end of the run (extends flat traces to "now").
+    pub now_cycle: u64,
+    pub channels: Vec<ChannelEdgeSeries>,
+}
+
+/// Per-channel identity resolved at watch time, paired with the drained edge
+/// batch to build a [`LogicEdgesResult`]. `initial[i]`/`peripheral[i]`/`pin[i]`
+/// describe channel `i` (the watch-set position, i.e. the edge `ch`).
+#[derive(Debug, Clone)]
+pub struct LogicChannelMeta {
+    pub ch: u32,
+    pub peripheral: String,
+    pub pin: u8,
+    pub initial: Option<bool>,
+}
+
+/// Shape a drained [`LogicEdgeBatch`] into the shared per-channel series form.
+/// PURE: the edges are grouped by their `ch` onto the pre-resolved channel
+/// metadata. Every edge in `batch` lands on exactly one channel (edges whose
+/// `ch` has no metadata are impossible — `ch` is a watch-set index — but are
+/// dropped defensively rather than panicking). Preserves edge order and value,
+/// so flattening the result back to `(ch, cycle, value)` reproduces `batch.edges`
+/// exactly (the native/wasm parity property).
+pub fn build_logic_edges_result(
+    meta: &[LogicChannelMeta],
+    batch: &LogicEdgeBatch,
+    now_cycle: u64,
+) -> LogicEdgesResult {
+    let mut channels: Vec<ChannelEdgeSeries> = meta
+        .iter()
+        .map(|m| ChannelEdgeSeries {
+            ch: m.ch,
+            channel: format!("CH{}", m.ch),
+            peripheral: m.peripheral.clone(),
+            pin: m.pin,
+            initial: m.initial.map(u8::from),
+            transitions: Vec::new(),
+            gaps: Vec::new(),
+        })
+        .collect();
+    for edge in &batch.edges {
+        if let Some(lane) = channels.iter_mut().find(|c| c.ch == edge.ch) {
+            lane.transitions.push(EdgeTransition {
+                cycle: edge.cycle,
+                value: u8::from(edge.value),
+            });
+        }
+    }
+    LogicEdgesResult {
+        dropped: batch.dropped,
+        now_cycle,
+        channels,
+    }
+}
+
 /// In-engine logic-analyzer capture buffer. Owned by [`Machine`](crate::Machine).
 #[derive(Default)]
 pub struct LogicCapture {

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -247,14 +247,36 @@ mod logic_capture_tests {
             cursor: 5,
             dropped: 2,
             edges: vec![
-                LogicEdge { ch: 0, cycle: 10, value: true },
-                LogicEdge { ch: 1, cycle: 12, value: true },
-                LogicEdge { ch: 0, cycle: 15, value: false },
+                LogicEdge {
+                    ch: 0,
+                    cycle: 10,
+                    value: true,
+                },
+                LogicEdge {
+                    ch: 1,
+                    cycle: 12,
+                    value: true,
+                },
+                LogicEdge {
+                    ch: 0,
+                    cycle: 15,
+                    value: false,
+                },
             ],
         };
         let meta = vec![
-            LogicChannelMeta { ch: 0, peripheral: "gpio8".into(), pin: 8, initial: Some(false) },
-            LogicChannelMeta { ch: 1, peripheral: "gpio9".into(), pin: 9, initial: None },
+            LogicChannelMeta {
+                ch: 0,
+                peripheral: "gpio8".into(),
+                pin: 8,
+                initial: Some(false),
+            },
+            LogicChannelMeta {
+                ch: 1,
+                peripheral: "gpio9".into(),
+                pin: 9,
+                initial: None,
+            },
         ];
         let r = build_logic_edges_result(&meta, &batch, 20);
 
@@ -265,13 +287,22 @@ mod logic_capture_tests {
         assert_eq!(
             r.channels[0].transitions,
             vec![
-                EdgeTransition { cycle: 10, value: 1 },
-                EdgeTransition { cycle: 15, value: 0 },
+                EdgeTransition {
+                    cycle: 10,
+                    value: 1
+                },
+                EdgeTransition {
+                    cycle: 15,
+                    value: 0
+                },
             ]
         );
         assert_eq!(
             r.channels[1].transitions,
-            vec![EdgeTransition { cycle: 12, value: 1 }]
+            vec![EdgeTransition {
+                cycle: 12,
+                value: 1
+            }]
         );
         assert!(r.channels.iter().all(|c| c.gaps.is_empty()));
     }

--- a/crates/core/src/tests/logic_capture.rs
+++ b/crates/core/src/tests/logic_capture.rs
@@ -168,6 +168,114 @@ mod logic_capture_tests {
         assert!(again.edges.is_empty());
     }
 
+    /// Native/wasm parity: the per-channel series the CLI serializes into
+    /// `result.json` (via `build_logic_edges_result`) reproduces, channel by
+    /// channel, the exact `{ch, cycle, value}` edge stream the wasm
+    /// `read_logic_edges` accessor surfaces for the SAME run — both drain the
+    /// identical `logic_read_edges`. The only encoding difference is 0/1 vs bool.
+    #[test]
+    fn cli_edge_series_matches_wasm_edge_stream() {
+        use crate::logic_capture::{build_logic_edges_result, LogicChannelMeta};
+
+        let mut machine = machine_with_gpio();
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("gpio_test")
+            .unwrap();
+        let initial = machine.logic_watch(&[Some((idx, 0))]);
+
+        let gap = 48;
+        step_n(&mut machine, gap);
+        set_pin0(&mut machine, true);
+        step_n(&mut machine, gap);
+        set_pin0(&mut machine, false);
+        step_n(&mut machine, gap);
+        set_pin0(&mut machine, true);
+        step_n(&mut machine, gap);
+
+        let now = machine.logic_now_cycle();
+        let batch = machine.logic_read_edges(0);
+        // The exact stream wasm's `read_logic_edges` would emit for this run.
+        let wasm_stream: Vec<(u32, u64, u8)> = batch
+            .edges
+            .iter()
+            .map(|e| (e.ch, e.cycle, u8::from(e.value)))
+            .collect();
+
+        let meta = vec![LogicChannelMeta {
+            ch: 0,
+            peripheral: "gpio_test".to_string(),
+            pin: 0,
+            initial: initial[0],
+        }];
+        let result = build_logic_edges_result(&meta, &batch, now);
+
+        assert_eq!(result.dropped, 0);
+        assert_eq!(result.now_cycle, now);
+        assert_eq!(result.channels.len(), 1);
+        let ch0 = &result.channels[0];
+        assert_eq!(ch0.channel, "CH0");
+        assert_eq!(ch0.peripheral, "gpio_test");
+        assert_eq!(ch0.pin, 0);
+        assert_eq!(ch0.initial, Some(0), "pad starts low");
+
+        // Reconstruct the CLI series back into a flat (ch, cycle, value) stream
+        // and assert it equals the wasm stream edge-for-edge (parity).
+        let cli_stream: Vec<(u32, u64, u8)> = result
+            .channels
+            .iter()
+            .flat_map(|c| c.transitions.iter().map(move |t| (c.ch, t.cycle, t.value)))
+            .collect();
+        assert_eq!(cli_stream, wasm_stream, "CLI series == wasm edge stream");
+        // Sanity: the toggle sequence was high, low, high.
+        assert_eq!(
+            ch0.transitions.iter().map(|t| t.value).collect::<Vec<_>>(),
+            vec![1, 0, 1]
+        );
+    }
+
+    /// `build_logic_edges_result` routes each edge to its channel by `ch`,
+    /// preserves order, encodes value/initial as 0/1, and surfaces the run-level
+    /// `dropped` overflow count (the oracle's fail-loud signal).
+    #[test]
+    fn build_logic_edges_result_routes_and_encodes() {
+        use crate::logic_capture::{
+            build_logic_edges_result, EdgeTransition, LogicChannelMeta, LogicEdge, LogicEdgeBatch,
+        };
+
+        let batch = LogicEdgeBatch {
+            cursor: 5,
+            dropped: 2,
+            edges: vec![
+                LogicEdge { ch: 0, cycle: 10, value: true },
+                LogicEdge { ch: 1, cycle: 12, value: true },
+                LogicEdge { ch: 0, cycle: 15, value: false },
+            ],
+        };
+        let meta = vec![
+            LogicChannelMeta { ch: 0, peripheral: "gpio8".into(), pin: 8, initial: Some(false) },
+            LogicChannelMeta { ch: 1, peripheral: "gpio9".into(), pin: 9, initial: None },
+        ];
+        let r = build_logic_edges_result(&meta, &batch, 20);
+
+        assert_eq!(r.dropped, 2, "overflow count surfaced for fail-loud");
+        assert_eq!(r.now_cycle, 20);
+        assert_eq!(r.channels[0].initial, Some(0));
+        assert_eq!(r.channels[1].initial, None);
+        assert_eq!(
+            r.channels[0].transitions,
+            vec![
+                EdgeTransition { cycle: 10, value: 1 },
+                EdgeTransition { cycle: 15, value: 0 },
+            ]
+        );
+        assert_eq!(
+            r.channels[1].transitions,
+            vec![EdgeTransition { cycle: 12, value: 1 }]
+        );
+        assert!(r.channels.iter().all(|c| c.gaps.is_empty()));
+    }
+
     /// Ring-buffer overflow at the capture layer: push more edges than capacity,
     /// assert some were dropped and the newest are retained.
     #[test]


### PR DESCRIPTION
Serialize the deterministic logic-analyzer edge stream into `result.json` so the **hosted** verify path can prove time-varying GPIO behavior (blink/toggle), not just static end-state.

## What
- New CLI flag `--watch-gpio <peripheral:pin>` arms the **same** `LogicTap` the wasm engine already uses (`logic_capture.rs`), so hosted and browser evidence are byte-identical.
- The bespoke CLI batch loop seeds the push clock per batch, clamps to 1 instruction in poll-mode, observes at each boundary, and drains via `machine.logic_read_edges` into a new optional `logic_edges` block in `TestResult` (`cli/src/artifacts.rs`).
- Shared serde shape `ChannelEdgeSeries`/`LogicEdgesResult` + pure `build_logic_edges_result`. New public `Machine` helpers: `logic_poll_active`/`logic_seed_batch_clock`/`logic_observe_boundary`.

## Why this design
No new capture algorithm — this is pure **exposure plumbing** on the existing tap. (Note: PR-604's logic-analyzer export is browser-only and can't reach the hosted path; this closes that gap deliberately without forking the shape.)

## Tests
- `cli_edge_series_matches_wasm_edge_stream` — native/wasm **parity**: the CLI series reproduces the `logic_read_edges` stream edge-for-edge.
- `build_logic_edges_result_routes_and_encodes` — routing/encoding/`dropped`.
- Full lib suite `--features jit,event-scheduler`: **1960 passed, 0 failed**.

Consumed downstream by labwired PR (prove-blink oracle): builder `parseLogicEdges` → `RunResult.gpio` → `gpio_edges`/`gpio_period`/`gpio_duty` oracle clauses (cycles-only, fail-loud on dropped edges / missing channel).
