### PR TITLE
Remove avoidable thunks/cheats so fake state can't reach a run path

### DIFF
--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -17,11 +17,12 @@ pub(crate) fn run_snapshot(args: SnapshotArgs) -> ExitCode {
 /// Drive a firmware mid-flight in a headless sim and write a runtime
 /// snapshot blob. The playground reads the same blob to skip cold boot.
 ///
-/// The `agentdeck` profile mirrors what
-/// `WasmSimulator::install_esp32_arduino_quirks` plus `step_with_esp32_aids`
+/// The `arduino-esp32` profile mirrors what
+/// `WasmSimulator::install_arduino_esp32_quirks` plus `step_with_esp32_aids`
 /// do on the web side — same configure_xtensa_esp32 bus, same handshake,
 /// same thunk setup, same IPI bridge cadence — so the captured state will
-/// resume bit-identically inside the browser.
+/// resume bit-identically inside the browser. Thunk PCs are resolved from the
+/// ELF symbol table (no hand-curated per-firmware address list).
 pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     use labwired_core::bus::SystemBus;
     use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor290};
@@ -31,9 +32,9 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     use labwired_core::{Machine, SimulationError};
     use labwired_loader::{extract_arduino_esp32_thunks, load_elf_bytes};
 
-    if args.profile != "agentdeck" && args.profile != "arduino-esp32" {
+    if args.profile != "arduino-esp32" {
         eprintln!(
-            "error: unknown profile '{p}' — supported: 'agentdeck' (preset-PC profile — hardcoded thunk addresses for a specific firmware build), 'arduino-esp32' (any Arduino-ESP32 ELF with symbols intact, auto-discovers thunk PCs)",
+            "error: unknown profile '{p}' — supported: 'arduino-esp32' (any Arduino-ESP32 ELF with symbols intact, auto-discovers thunk PCs)",
             p = args.profile
         );
         return ExitCode::from(EXIT_CONFIG_ERROR);
@@ -95,10 +96,8 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // FreeRTOS spins in `vListInsert` forever. Attach a secondary CPU
     // (PRID=0xABAB, halted at construction, released by
     // `ets_set_appcpu_boot_addr` during PRO_CPU boot).
-    if args.profile == "arduino-esp32" {
-        let cpu1 = labwired_core::cpu::xtensa_lx7::XtensaLx7::new_app_cpu();
-        machine.cpu_secondary = Some(Box::new(cpu1));
-    }
+    let cpu1 = labwired_core::cpu::xtensa_lx7::XtensaLx7::new_app_cpu();
+    machine.cpu_secondary = Some(Box::new(cpu1));
 
     // Load firmware FIRST — load_firmware writes ELF segments into bus
     // memory, so any bytes we write before this risk being clobbered.
@@ -148,15 +147,11 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     }
 
     // Arduino-ESP32 bootstrap — keep in sync with
-    // `wasm/src/lib.rs::install_esp32_arduino_quirks` and the e2e test.
+    // `wasm/src/lib.rs::install_arduino_esp32_quirks` and the e2e test.
     machine.cpu.set_sp(0x3FFE_0000);
-    // Handshake-byte pre-paint. Two paths:
-    //   * `agentdeck` profile — use the exact byte addresses the original
-    //     install_esp32_arduino_quirks wrote, byte-for-byte. the reference firmware's
-    //     ELF is stripped, so symbol auto-discovery returns nothing.
-    //   * `arduino-esp32` profile — resolve s_resume_cores / s_cpu_up /
-    //     s_cpu_inited / s_system_inited / s_other_cpu_startup_done from
-    //     the ELF symbol table and write 0x01 to both bytes of each.
+    // Handshake-byte pre-paint: resolve s_resume_cores / s_cpu_up /
+    // s_cpu_inited / s_system_inited / s_other_cpu_startup_done from the ELF
+    // symbol table and write 0x01 to both bytes of each.
     // Dual-core handshake pre-seed + 10k-cycle keep-alive — now only a FALLBACK
     // for when APP_CPU is halted (`LABWIRED_NO_DUALCORE=1`). By default we run
     // the real second core, which executes the firmware's own `call_start_cpu1`
@@ -168,79 +163,51 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // `LABWIRED_PRESEED_HANDSHAKE=1`.
     let preseed_handshake = std::env::var("LABWIRED_NO_DUALCORE").is_ok()
         || std::env::var("LABWIRED_PRESEED_HANDSHAKE").is_ok();
-    let (s_resume_cores, s_cpu_up, s_cpu_inited, s_system_inited, s_other_cpu_startup_done);
-    if args.profile == "agentdeck" {
-        s_resume_cores = 0;
-        s_cpu_up = 0;
-        s_cpu_inited = 0;
-        s_system_inited = 0;
-        s_other_cpu_startup_done = 0;
-        if preseed_handshake {
-            let _ = machine.bus.write_u8(0x3FFC_6F04, 0x01); // s_cpu_up[1]
-            let _ = machine.bus.write_u8(0x3FFC_6F01, 0x01); // s_cpu_inited[0]
-            let _ = machine.bus.write_u8(0x3FFC_6F02, 0x01); // s_cpu_inited[1]
-            let _ = machine.bus.write_u8(0x3FFC_6FFD, 0x01); // s_system_inited[0]
-            let _ = machine.bus.write_u8(0x3FFC_6FFE, 0x01); // s_system_inited[1]
-            let _ = machine.bus.write_u8(0x3FFC_7190, 0x01); // s_other_cpu_startup_done
-            let _ = machine.bus.write_u8(0x400E_90DE, 0x08); // loopTask -> PRO_CPU
-                                                             // Re-assert the same flags the instant PRO_CPU releases APP_CPU
-                                                             // (models APP_CPU bring-up; see rom_thunks::ets_set_appcpu_boot_addr).
-            rom_thunks::set_appcpu_up_flags(vec![
-                0x3FFC_6F04,
-                0x3FFC_6F01,
-                0x3FFC_6F02,
-                0x3FFC_6FFD,
-                0x3FFC_6FFE,
-                0x3FFC_7190,
-            ]);
+    let s_resume_cores = resolve_data("s_resume_cores", 0);
+    let s_cpu_up = resolve_data("s_cpu_up", 0);
+    let s_cpu_inited = resolve_data("s_cpu_inited", 0);
+    let s_system_inited = resolve_data("s_system_inited", 0);
+    let s_other_cpu_startup_done = resolve_data("s_other_cpu_startup_done", 0);
+    if preseed_handshake {
+        if s_resume_cores != 0 {
+            let _ = machine.bus.write_u8(s_resume_cores as u64, 0x01);
         }
-    } else {
-        s_resume_cores = resolve_data("s_resume_cores", 0);
-        s_cpu_up = resolve_data("s_cpu_up", 0);
-        s_cpu_inited = resolve_data("s_cpu_inited", 0);
-        s_system_inited = resolve_data("s_system_inited", 0);
-        s_other_cpu_startup_done = resolve_data("s_other_cpu_startup_done", 0);
-        if preseed_handshake {
-            if s_resume_cores != 0 {
-                let _ = machine.bus.write_u8(s_resume_cores as u64, 0x01);
-            }
-            if s_cpu_up != 0 {
-                let _ = machine.bus.write_u8(s_cpu_up as u64, 0x01);
-                let _ = machine.bus.write_u8(s_cpu_up as u64 + 1, 0x01);
-            }
-            if s_cpu_inited != 0 {
-                let _ = machine.bus.write_u8(s_cpu_inited as u64, 0x01);
-                let _ = machine.bus.write_u8(s_cpu_inited as u64 + 1, 0x01);
-            }
-            if s_system_inited != 0 {
-                let _ = machine.bus.write_u8(s_system_inited as u64, 0x01);
-                let _ = machine.bus.write_u8(s_system_inited as u64 + 1, 0x01);
-            }
-            if s_other_cpu_startup_done != 0 {
-                let _ = machine.bus.write_u8(s_other_cpu_startup_done as u64, 0x01);
-            }
-            // Re-assert these flags the instant PRO_CPU releases APP_CPU, so
-            // newer arduino-esp32 cores (whose `start_other_core` spin-waits
-            // with a tight timeout) see APP_CPU "up" without depending on the
-            // coarse 10k-cycle keep-alive below. Models APP_CPU bring-up; see
-            // rom_thunks::ets_set_appcpu_boot_addr.
-            let mut appcpu_up_flags: Vec<u32> = Vec::new();
-            for (base, two_byte) in [
-                (s_cpu_up, true),
-                (s_cpu_inited, true),
-                (s_system_inited, true),
-                (s_resume_cores, false),
-                (s_other_cpu_startup_done, false),
-            ] {
-                if base != 0 {
-                    appcpu_up_flags.push(base);
-                    if two_byte {
-                        appcpu_up_flags.push(base + 1);
-                    }
+        if s_cpu_up != 0 {
+            let _ = machine.bus.write_u8(s_cpu_up as u64, 0x01);
+            let _ = machine.bus.write_u8(s_cpu_up as u64 + 1, 0x01);
+        }
+        if s_cpu_inited != 0 {
+            let _ = machine.bus.write_u8(s_cpu_inited as u64, 0x01);
+            let _ = machine.bus.write_u8(s_cpu_inited as u64 + 1, 0x01);
+        }
+        if s_system_inited != 0 {
+            let _ = machine.bus.write_u8(s_system_inited as u64, 0x01);
+            let _ = machine.bus.write_u8(s_system_inited as u64 + 1, 0x01);
+        }
+        if s_other_cpu_startup_done != 0 {
+            let _ = machine.bus.write_u8(s_other_cpu_startup_done as u64, 0x01);
+        }
+        // Re-assert these flags the instant PRO_CPU releases APP_CPU, so
+        // newer arduino-esp32 cores (whose `start_other_core` spin-waits
+        // with a tight timeout) see APP_CPU "up" without depending on the
+        // coarse 10k-cycle keep-alive below. Models APP_CPU bring-up; see
+        // rom_thunks::ets_set_appcpu_boot_addr.
+        let mut appcpu_up_flags: Vec<u32> = Vec::new();
+        for (base, two_byte) in [
+            (s_cpu_up, true),
+            (s_cpu_inited, true),
+            (s_system_inited, true),
+            (s_resume_cores, false),
+            (s_other_cpu_startup_done, false),
+        ] {
+            if base != 0 {
+                appcpu_up_flags.push(base);
+                if two_byte {
+                    appcpu_up_flags.push(base + 1);
                 }
             }
-            rom_thunks::set_appcpu_up_flags(appcpu_up_flags);
         }
+        rom_thunks::set_appcpu_up_flags(appcpu_up_flags);
     }
     // RTC XTAL-freq probe = 40 MHz.
     let _ = machine.bus.write_u32(0x3FF4_80B0, 0x0050_0050);
@@ -323,8 +290,6 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // HardwareSerial::begin only exists when the sketch called Serial.begin().
     if let Some(&pc) = symbol_addrs.get("HardwareSerial::begin(unsigned long, unsigned int, signed char, signed char, bool, unsigned long, unsigned char)") {
         thunks.push((pc, rom_thunks::nop_return_zero));
-    } else if args.profile == "agentdeck" {
-        thunks.push((0x400e_2280, rom_thunks::nop_return_zero));
     }
     // Real-silicon noreturn functions — abort_halt prints diagnostics and
     // halts the CPU instead of returning. Without this, stubbing them as
@@ -519,20 +484,15 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // displaced slots while the AR file has the callee's data, so the
     // HAL walk reads garbage (callee's a1 is often 0 → store to
     // 0xfffffff0 traps). The custom thunk emulates the spill using
-    // shadow-stack snapshots when available. Only wired for
-    // arduino-esp32 profile — agentdeck's call path doesn't hit the
-    // crash, and replacing the real function with the thunk regresses
-    // a working flow (spill writes valid save-area data the callee
-    // later reads).
-    if args.profile == "arduino-esp32" {
-        // Only the `_nw` leaf (the spill loop that would trap) is thunked;
-        // the `xthal_window_spill` wrapper is a thin CALL{n}-entered
-        // PS-save shell that must run natively (its real ENTRY/RETW manage
-        // the window). Thunking the wrapper returns via a0 = the caller's
-        // return address, corrupting the first-task dispatch.
-        if let Some(&pc) = symbol_addrs.get("xthal_window_spill_nw") {
-            thunks.push((pc, rom_thunks::xthal_window_spill_thunk));
-        }
+    // shadow-stack snapshots when available.
+    //
+    // Only the `_nw` leaf (the spill loop that would trap) is thunked;
+    // the `xthal_window_spill` wrapper is a thin CALL{n}-entered
+    // PS-save shell that must run natively (its real ENTRY/RETW manage
+    // the window). Thunking the wrapper returns via a0 = the caller's
+    // return address, corrupting the first-task dispatch.
+    if let Some(&pc) = symbol_addrs.get("xthal_window_spill_nw") {
+        thunks.push((pc, rom_thunks::xthal_window_spill_thunk));
     }
     // xQueueCreateMutexStatic returns the caller's static buffer as the
     // handle. Callers (esp_newlib_locks_init in particular) assert that the
@@ -560,15 +520,10 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(&pc) = symbol_addrs.get("xQueueGenericSend") {
         thunks.push((pc, rom_thunks::return_pd_true));
     }
-    // ulTaskGenericNotifyTake — gated to arduino-esp32 only.
-    // the reference firmware has its own well-modeled lock-acquire path that
-    // expects a proper "block-then-wake" semantic; stubbing it to
-    // return pdTRUE causes the lock-acquire to skip its setup and
-    // later trip __assert_func inside lock_acquire_generic.
-    if args.profile == "arduino-esp32" {
-        if let Some(&pc) = symbol_addrs.get("ulTaskGenericNotifyTake") {
-            thunks.push((pc, rom_thunks::return_pd_true));
-        }
+    // ulTaskGenericNotifyTake — force pdTRUE so the lock-acquire's
+    // "block-then-wake" wait returns immediately in the single-render-path sim.
+    if let Some(&pc) = symbol_addrs.get("ulTaskGenericNotifyTake") {
+        thunks.push((pc, rom_thunks::return_pd_true));
     }
     if let Some(&pc) = symbol_addrs.get("spiStartBus") {
         thunks.push((pc, rom_thunks::spi_start_bus_fake));
@@ -600,15 +555,6 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         if let Some(&pc) = symbol_addrs.get("vListInsert") {
             thunks.push((pc, rom_thunks::vlist_insert_debug));
         }
-    }
-    // the reference firmware-only WiFi + sendHello thunks. Only install for that profile
-    // — sketches without those symbols wouldn't trip them anyway.
-    if args.profile == "agentdeck" {
-        thunks.extend_from_slice(&[
-            (0x400d_de98, rom_thunks::nop_return_zero), // WifiWsLink::begin
-            (0x400d_dccc, rom_thunks::nop_return_zero), // WifiWsLink::loop
-            (0x400e_0034, rom_thunks::nop_return_zero), // anon-ns sendHello
-        ]);
     }
     eprintln!(
         "labwired-cli snapshot: installing {} thunks ({} resolved from ELF symbols)",
@@ -702,36 +648,25 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         }
         // Re-stamp the dual-core handshake bytes every 10k cycles so
         // start_other_core / do_other_cpu_settings keep seeing them as
-        // "up." preset-PC path: byte-for-byte mirror of the original
-        // install_esp32_arduino_quirks. Auto-discovery path: write to
-        // each resolved symbol's [0]+[1] slots.
+        // "up." Write to each resolved symbol's [0]+[1] slots.
         if preseed_handshake && i.is_multiple_of(10_000) {
-            if args.profile == "agentdeck" {
-                let _ = machine.bus.write_u8(0x3FFC_6F04, 0x01);
-                let _ = machine.bus.write_u8(0x3FFC_6F01, 0x01);
-                let _ = machine.bus.write_u8(0x3FFC_6F02, 0x01);
-                let _ = machine.bus.write_u8(0x3FFC_6FFD, 0x01);
-                let _ = machine.bus.write_u8(0x3FFC_6FFE, 0x01);
-                let _ = machine.bus.write_u8(0x3FFC_7190, 0x01);
-            } else {
-                if s_resume_cores != 0 {
-                    let _ = machine.bus.write_u8(s_resume_cores as u64, 0x01);
-                }
-                if s_cpu_up != 0 {
-                    let _ = machine.bus.write_u8(s_cpu_up as u64, 0x01);
-                    let _ = machine.bus.write_u8(s_cpu_up as u64 + 1, 0x01);
-                }
-                if s_cpu_inited != 0 {
-                    let _ = machine.bus.write_u8(s_cpu_inited as u64, 0x01);
-                    let _ = machine.bus.write_u8(s_cpu_inited as u64 + 1, 0x01);
-                }
-                if s_system_inited != 0 {
-                    let _ = machine.bus.write_u8(s_system_inited as u64, 0x01);
-                    let _ = machine.bus.write_u8(s_system_inited as u64 + 1, 0x01);
-                }
-                if s_other_cpu_startup_done != 0 {
-                    let _ = machine.bus.write_u8(s_other_cpu_startup_done as u64, 0x01);
-                }
+            if s_resume_cores != 0 {
+                let _ = machine.bus.write_u8(s_resume_cores as u64, 0x01);
+            }
+            if s_cpu_up != 0 {
+                let _ = machine.bus.write_u8(s_cpu_up as u64, 0x01);
+                let _ = machine.bus.write_u8(s_cpu_up as u64 + 1, 0x01);
+            }
+            if s_cpu_inited != 0 {
+                let _ = machine.bus.write_u8(s_cpu_inited as u64, 0x01);
+                let _ = machine.bus.write_u8(s_cpu_inited as u64 + 1, 0x01);
+            }
+            if s_system_inited != 0 {
+                let _ = machine.bus.write_u8(s_system_inited as u64, 0x01);
+                let _ = machine.bus.write_u8(s_system_inited as u64 + 1, 0x01);
+            }
+            if s_other_cpu_startup_done != 0 {
+                let _ = machine.bus.write_u8(s_other_cpu_startup_done as u64, 0x01);
             }
         }
         match machine.cpu.step(&mut machine.bus, &observers, &config) {
@@ -863,11 +798,10 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         }
     }
 
-    // Sanity-check the captured state — for an `agentdeck` profile we
-    // expect the SSD1680 panel to have been driven through at least one
-    // refresh cycle by the time the snapshot lands. Print this so the
-    // operator can tell "yes, this snapshot is post-paint" without
-    // re-running the playground.
+    // Sanity-check the captured state — we expect the panel to have been
+    // driven through at least one refresh cycle by the time the snapshot
+    // lands. Print this so the operator can tell "yes, this snapshot is
+    // post-paint" without re-running the playground.
     if let Some(idx) = machine.bus.find_peripheral_index_by_name("spi3") {
         if let Some(any) = machine.bus.peripherals[idx].dev.as_any() {
             if let Some(spi3) = any.downcast_ref::<Esp32Spi>() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -281,13 +281,12 @@ pub struct SnapshotCaptureArgs {
     #[arg(long)]
     pub system: Option<PathBuf>,
 
-    /// Firmware profile to use. Currently only `agentdeck` is supported —
-    /// installs the Arduino-ESP32 / ESP32-classic bootstrap (heap-caps
-    /// thunks, dual-core handshake fakery, IPI bridge, image header,
-    /// SSD1680 tri-color panel attached to spi3 / GPIO5). Each Arduino-ESP32
-    /// firmware has a different set of thunk PCs, so the profile name maps
-    /// to a hand-curated address list inside the binary.
-    #[arg(long, default_value = "agentdeck")]
+    /// Firmware profile to use. Only `arduino-esp32` is supported — installs
+    /// the Arduino-ESP32 / ESP32-classic bootstrap (heap-caps thunks, dual-core
+    /// handshake, IPI bridge, image header) with thunk PCs resolved from the
+    /// ELF symbol table (no hand-curated per-firmware address list). External
+    /// peripherals come from the `--system` board manifest.
+    #[arg(long, default_value = "arduino-esp32")]
     pub profile: String,
 
     /// Print a progress line every N steps. 0 = silent.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -53,6 +53,12 @@ wasmtime = { version = "45", optional = true, default-features = false, features
 
 [features]
 default = []
+# ESP32 WiFi/lwIP functional-outcome thunks (`peripherals::esp32s3::wifi_thunks`
+# — canned WL_CONNECTED + simulated sockets). Off by default and NOT in the CI
+# feature set (`jit,event-scheduler`), so this fake WiFi state can never compile
+# into a production/run build; only the `e2e_labwired_wifi` bring-up harness
+# opts in. Run its tests with `--features wifi-thunks`.
+wifi-thunks = []
 # Egress-bridge transport tests that open real localhost sockets (TCP/MQTT/HTTP).
 # Off by default so the standard gate stays hermetic; run with
 # `cargo test -p labwired-core --features net-tests`.

--- a/crates/core/src/peripherals/esp32s3/mod.rs
+++ b/crates/core/src/peripherals/esp32s3/mod.rs
@@ -39,4 +39,8 @@ pub mod twai;
 pub mod uart;
 pub mod usb_otg;
 pub mod usb_serial_jtag;
+// Fake WiFi/lwIP functional-outcome thunks — behind an off-by-default feature
+// so this canned state can never compile into a production/run build. Only the
+// `e2e_labwired_wifi` bring-up harness enables it.
+#[cfg(feature = "wifi-thunks")]
 pub mod wifi_thunks;

--- a/crates/core/tests/e2e_labwired_wifi.rs
+++ b/crates/core/tests/e2e_labwired_wifi.rs
@@ -20,7 +20,12 @@
 // platformio/esp32-wifi-fixture, or set `LABWIRED_WIFI_ELF`) and runs
 // up to a 200M-cycle budget. Run with:
 //
-//     cargo test -p labwired-core --test e2e_labwired_wifi -- --ignored --nocapture
+//     cargo test -p labwired-core --features wifi-thunks --test e2e_labwired_wifi -- --ignored --nocapture
+//
+// Gated on the off-by-default `wifi-thunks` feature (the module it exercises is
+// too): without it the whole file compiles to nothing, so the CI feature set
+// (`jit,event-scheduler`) never pulls the fake WiFi state into the build.
+#![cfg(feature = "wifi-thunks")]
 
 use labwired_core::bus::SystemBus;
 use labwired_core::cpu::xtensa_lx7::XtensaLx7;

--- a/crates/wasm/src/inputs.rs
+++ b/crates/wasm/src/inputs.rs
@@ -125,8 +125,12 @@ impl WasmSimulator {
     }
 
     /// Read back the current sensor data from each I2C sensor declared in `board_io`.
-    /// Returns `[{ id, kind: "adxl345", x, y, z }, ...]` or `[{ id, kind: "mpu6050", ax, ay, az, gx, gy, gz }, ...]`
-    /// or `[{ id, kind: "bme280", temperature_c, humidity_pct, pressure_hpa }, ...]`.
+    /// Returns `[{ id, kind: "adxl345", x, y, z }, ...]` or `[{ id, kind: "mpu6050", ax, ay, az, gx, gy, gz }, ...]`.
+    ///
+    /// BME280 is intentionally OMITTED: its component model exposes no
+    /// register-backed temperature/humidity/pressure value to read (static
+    /// factory registers only, not SimInput-drivable). Rather than fabricate a
+    /// number, we emit no entry so the panel shows a tracked gap.
     #[wasm_bindgen]
     pub fn get_i2c_sensor_states(&self) -> JsValue {
         let machine = self.machine.as_ref().unwrap();
@@ -134,7 +138,7 @@ impl WasmSimulator {
 
         for binding in &self.board_io {
             let device_type = match binding.device_type.as_deref() {
-                Some(t) if t == "adxl345" || t == "mpu6050" || t == "bme280" => t,
+                Some(t) if t == "adxl345" || t == "mpu6050" => t,
                 _ => continue,
             };
             let Some(idx) = machine
@@ -191,31 +195,6 @@ impl WasmSimulator {
                             "gx": gx,
                             "gy": gy,
                             "gz": gz,
-                        }));
-                        break;
-                    }
-                }
-            } else if device_type == "bme280" {
-                // Static values: hard-coded factory calibration produces ~25°C / 50%RH / 1013hPa
-                let address = binding.i2c_address.unwrap_or(0x76);
-                for device in i2c.attached_devices() {
-                    let device = device.borrow();
-                    if device.address() != address {
-                        continue;
-                    }
-                    if device
-                        .as_any()
-                        .and_then(|any| {
-                            any.downcast_ref::<labwired_core::peripherals::components::Bme280>()
-                        })
-                        .is_some()
-                    {
-                        states.push(serde_json::json!({
-                            "id": binding.id,
-                            "kind": "bme280",
-                            "temperature_c": 25.0_f64,
-                            "humidity_pct": 50.0_f64,
-                            "pressure_hpa": 1013.0_f64,
                         }));
                         break;
                     }

--- a/crates/wasm/src/install.rs
+++ b/crates/wasm/src/install.rs
@@ -10,116 +10,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 impl WasmSimulator {
-    // ──────────────────────────────────────────────────────────────────────
-    //  Arduino-ESP32 bootstrap glue. Call after constructing the WasmSimulator
-    //  with an ESP32-classic manifest + an Arduino-ESP32 firmware ELF (e.g.
-    //  the reference firmware). Bakes in:
-    //    * Memory pre-fakes (partition header, RTC freq probe, dual-core
-    //      handshake bytes, ROM data region).
-    //    * Flash thunks for the ESP-IDF + Arduino-ESP32 functions whose real
-    //      behavior our sim can't model (heap_caps_*, esp_timer_init, locks,
-    //      setCpuFrequencyMhz, esp_ota_get_running_partition, HardwareSerial,
-    //      delay, WifiWsLink::begin, gpio_matrix_in/out, etc).
-    //    * One-byte runtime patch at 0x400E_90DE so loopTask gets pinned
-    //      to PRO_CPU instead of the APP_CPU we don't emulate.
-    //    * Enables the IPI bridge state so `step_with_esp32_aids` raises
-    //      INTERRUPT bits when firmware writes DPORT_CPU_INTR_FROM_CPU.
-    // ──────────────────────────────────────────────────────────────────────
-    #[wasm_bindgen]
-    pub fn install_esp32_arduino_quirks(&mut self) -> Result<(), JsValue> {
-        use labwired_core::peripherals::esp_xtensa_common::rom_thunks;
-        let machine = self
-            .machine
-            .as_mut()
-            .ok_or_else(|| JsValue::from_str("no machine"))?;
-
-        // Seed SP — call_start_cpu0 expects BROM to have placed SP near top
-        // of DRAM (0x3FFE_0000). We skip BROM, so do it ourselves.
-        machine.cpu.set_sp(0x3FFE_0000);
-        // Force loopTask onto PRO_CPU.
-        let _ = machine.bus.write_u8(0x400E_90DE, 0x08);
-
-        // Dual-core handshake fakes (single-CPU sim).
-        let _ = machine.bus.write_u8(0x3FFC_6F04, 0x01); // s_cpu_up[1]
-        let _ = machine.bus.write_u8(0x3FFC_6F01, 0x01); // s_cpu_inited[0]
-        let _ = machine.bus.write_u8(0x3FFC_6F02, 0x01); // s_cpu_inited[1]
-        let _ = machine.bus.write_u8(0x3FFC_6FFD, 0x01); // s_system_inited[0]
-        let _ = machine.bus.write_u8(0x3FFC_6FFE, 0x01); // s_system_inited[1]
-        let _ = machine.bus.write_u8(0x3FFC_7190, 0x01); // s_other_cpu_startup_done
-
-        // RTC_APB_FREQ_REG (0x3FF4_80B0) is now pre-seeded with the 40 MHz
-        // encoding (0x0050_0050) by the RtcCntl peripheral at construction —
-        // no quirk write needed here.
-
-        // Fake esp_image_header_t at 0x3F40_0000 (24 bytes), entry = the reference firmware.
-        let entry = 0x40081bf0_u32;
-        let header: [u8; 24] = [
-            0xE9,
-            0x01,
-            0x00,
-            0x00,
-            (entry & 0xFF) as u8,
-            ((entry >> 8) & 0xFF) as u8,
-            ((entry >> 16) & 0xFF) as u8,
-            ((entry >> 24) & 0xFF) as u8,
-            0xEE,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        ];
-        for (i, &b) in header.iter().enumerate() {
-            let _ = machine.bus.write_u8(0x3F40_0000 + i as u64, b);
-        }
-
-        // Flash thunks. Addresses are the reference firmware-firmware-specific (PC of the
-        // function in the ELF) — see crates/core/tests/e2e_external_arduino_esp32_in_sim.rs
-        // for the same list with detailed per-thunk rationale.
-        let thunks: &[(u32, rom_thunks::RomThunkFn)] = &[
-            (0x400e_e3b0, rom_thunks::esp_idf_heap_caps_init),
-            (0x4008_2904, rom_thunks::esp_idf_heap_caps_malloc),
-            (0x4008_2a70, rom_thunks::esp_idf_heap_caps_calloc),
-            (0x4008_25dc, rom_thunks::esp_idf_heap_caps_free),
-            (0x4008_29f0, rom_thunks::esp_idf_heap_caps_realloc),
-            (0x4012_9034, rom_thunks::nop_return_zero), // esp_timer_init
-            (0x4008_17dc, rom_thunks::nop_return_zero), // spi_flash_disable_...
-            (0x4008_188c, rom_thunks::nop_return_zero), // spi_flash_enable_...
-            (0x4008_3384, rom_thunks::nop_return_zero), // __retarget_lock_init_recursive
-            (0x4008_339c, rom_thunks::nop_return_zero), // __retarget_lock_close_recursive
-            (0x4008_33b0, rom_thunks::nop_return_zero), // __retarget_lock_acquire_recursive
-            (0x4008_33cc, rom_thunks::nop_return_zero), // __retarget_lock_release_recursive
-            (0x4008_bbd0, rom_thunks::nop_return_zero), // _esp_error_check_failed
-            (0x400e_99dc, rom_thunks::nop_return_zero), // setCpuFrequencyMhz
-            (0x400e_ae18, rom_thunks::nop_return_fake_ptr), // esp_ota_get_running_partition
-            (0x400e_2280, rom_thunks::nop_return_zero), // HardwareSerial::begin
-            (0x400e_5c28, rom_thunks::nop_return_zero), // Arduino delay()
-            (0x400d_de98, rom_thunks::nop_return_zero), // WifiWsLink::begin
-            (0x400d_dccc, rom_thunks::nop_return_zero), // WifiWsLink::loop
-            (0x400e_0034, rom_thunks::nop_return_zero), // anon-ns sendHello
-        ];
-        for &(pc, f) in thunks {
-            machine
-                .bus
-                .install_flash_thunk(pc, f)
-                .map_err(|e| JsValue::from_str(&format!("install thunk @{pc:#x}: {e}")))?;
-        }
-
-        self.esp32_ipi = Some(Esp32IpiBridge::default());
-        Ok(())
-    }
-
-    /// Auto-discovery counterpart to [`Self::install_esp32_arduino_quirks`].
+    /// Arduino-ESP32 boot bootstrap (symbol-table autodiscovery).
     ///
     /// Mirrors the CLI's `arduino-esp32` snapshot-capture profile —
     /// resolves Arduino-ESP32 thunk PCs from the ELF symbol table instead
@@ -468,11 +359,6 @@ impl WasmSimulator {
             });
         }
         Ok(())
-    }
-
-    pub fn apply_agentdeck_quirks(&mut self) -> Result<(), JsValue> {
-        #[allow(deprecated)]
-        self.install_esp32_arduino_quirks()
     }
 
     /// Apply a binary `MachineRuntimeSnapshot` (LWRS-framed bincode blob,

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-14 | ⚠ drift acked 2026-07-14 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-12 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-14 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -610,7 +610,18 @@ boards:
     # equivalence are preserved (elapsed-vs-repeated + walk-vs-scheduler
     # differential gates). S3 default construction is unchanged. No live
     # re-capture warranted.
-    drift_ack: 2026-07-12
+    # 2026-07-14: wifi_thunks (esp32s3/wifi_thunks.rs — test-only fake
+    # WL_CONNECTED WiFi outcome + simulated sockets) is now feature-gated behind
+    # an off-by-default `wifi-thunks` Cargo feature and excluded from the default
+    # build and the CI feature set (jit,event-scheduler). This only changes the
+    # esp32s3 module source surface (a `#[cfg(feature = "wifi-thunks")]` gate on
+    # the module declaration); no real silicon behaviour changes — wifi_thunks
+    # was never a live-verified peripheral (it is a functional thunk, not a
+    # register model, and the WiFi MAC/PHY is a closed RF-coprocessor blob with
+    # no executable image). Register map, reset values, MMIO byte paths and the
+    # 9-reg reset-state silicon anchor are byte-for-byte unaffected. No live
+    # re-capture warranted.
+    drift_ack: 2026-07-14
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Removes avoidable functional thunks/cheats from LabWired core so fabricated state can never reach a run path. Product principle: real register-level models, never functional thunks; an honest tracked gap (omit a value) beats a fabricated one. Each removal was verified dead / test-only against the whole core + `packages/` before deleting.

## Changes

- **`crates/wasm/src/install.rs`** — delete the hardcoded ESP32-Arduino preset-PC thunk table `install_esp32_arduino_quirks` (`install_flash_thunk(0x400e_e3b0, …)` etc.) and the deprecated `apply_agentdeck_quirks` alias. Production uses `quirks:'arduino-esp32-autodiscover'` → `install_arduino_esp32_quirks` (symbol-table PC resolution), which is kept intact. Verified no bundled config or bridge path sets `quirks:'esp32-arduino'` (only `arduino-esp32-autodiscover` is used).
- **`crates/cli/src/commands/snapshot.rs` + `crates/cli/src/main.rs`** — remove the `agentdeck` snapshot-capture profile (hardcoded thunk/boot PCs for one firmware build) and all its preset-PC branches; the sole supported profile is now `arduino-esp32` (symbol autodiscovery), and it is the new `--profile` default. Verified no bundled lab's `bootSnapshotUrl` depends on an agentdeck-produced snapshot (snapshot *load* via `apply_runtime_snapshot` is profile-agnostic; no config even assigns `bootSnapshotUrl`).
- **`crates/core/src/peripherals/esp32s3/wifi_thunks.rs`** — the canned `WL_CONNECTED` / fake-socket module is now gated behind a new off-by-default `wifi-thunks` Cargo feature (added to `crates/core/Cargo.toml`), together with its only consumer `tests/e2e_labwired_wifi.rs`. This fake WiFi state can no longer compile into the default build or the CI feature set (`jit,event-scheduler`). The e2e harness opts in with `--features wifi-thunks`.
- **`crates/wasm/src/inputs.rs`** — stop fabricating `temperature_c:25 / humidity_pct:50 / pressure_hpa:1013` in the BME280 panel readout. The `Bme280` component model exposes no register-backed engineering value to read (static factory registers only, `inputs: &[]`, not SimInput-drivable), so per the honest-gap rule the reading is **OMITTED** — the panel shows a tracked gap instead of a fake number. (The playground BME280 inspector already degrades gracefully to no readout when the entry is absent.)

## Not touched (load-bearing / oracle-preserving)
`esp_xtensa_common::rom_thunks` (`spi_t` / `esp_ota_get_running_partition` ptr / `nop_return_zero`), `loader` symbol autodiscovery, and the surviving `arduino-esp32` autodiscovery path — all left intact.

## Verification
Full core regression: `cargo test -p labwired-core --features jit,event-scheduler` — passes clean, 0 failures, exit 0. WiFi module + e2e test verified to compile and pass under `--features wifi-thunks` (unit test `install_sim_net_resets_fd_state` passes; the ELF-gated e2e test compiles and is `#[ignore]`d). `labwired-wasm`, `labwired-cli`, `labwired-core` all `cargo check` clean.