### PR TITLE
Ship a prebuilt CI runner and OCI release image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Local and VCS state is never needed to compile the release CLI.
+.git
+target
+out
+dist
+coverage
+
+# Locally produced archives, logs, and OS metadata only enlarge the build context.
+*.tar.gz
+*.zip
+*.log
+.DS_Store

--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -1,25 +1,24 @@
 # Core labwired-test action
 
-This composite action downloads a LabWired Core release archive for the GitHub
-Actions runner, then runs labwired test. It is useful when a workflow needs the
-archive-backed runner rather than the container image.
+This directory contains the Core action used by release smoke tests. For a
+public workflow, use the root LabWired action below: it downloads the pinned
+Core release archive rather than compiling Rust on the consumer's runner.
 
 ~~~yaml
 - name: Run LabWired tests
-  uses: w1ne/labwired-core/.github/actions/labwired-test@v0.18.0
+  uses: w1ne/labwired/.github/actions/labwired-test@main
   with:
     version: v0.18.0
     script: tests/firmware-test.yaml
-    output-dir: out/labwired
-    args: --no-uart-stdout
-    upload-artifacts: 'false'
+    output_dir: out/labwired
+    # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
 ~~~
 
-The action installs the matching archive asset named
-labwired-v0.18.0-<platform>.tar.gz from w1ne/labwired-core, writes a JUnit
-report plus result.json and uart.log, and fails when an assertion fails.
+The action source is referenced at `main` because the root repository does not
+publish a matching action tag. The `version` input independently selects the
+immutable Core CLI release archive named
+`labwired-v0.18.0-<platform>.tar.gz`.
 
-Inputs use this action's hyphenated names: script (required), version
-(default v0.18.0), args, junit, output-dir, upload-artifacts, repo, and
-github-token. The github-token input defaults to the workflow job token and
-can be overridden when a workflow needs different release-download access.
+The local Core action still uses its hyphenated names for its internal release
+smoke workflow. Its inputs are `script` (required), `version`, `args`, `junit`,
+`output-dir`, `upload-artifacts`, `repo`, and `github-token`.

--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -1,16 +1,25 @@
-# `labwired-test` action
+# Core labwired-test action
 
-Boot firmware on LabWired and assert against it, in one workflow step.
+This composite action downloads a LabWired Core release archive for the GitHub
+Actions runner, then runs labwired test. It is useful when a workflow needs the
+archive-backed runner rather than the container image.
 
-```yaml
-- uses: w1ne/labwired/.github/actions/labwired-test@main
+~~~yaml
+- name: Run LabWired tests
+  uses: w1ne/labwired-core/.github/actions/labwired-test@v0.18.0
   with:
-    script: examples/f103-fidelity-bench/clockbug-smoke.yaml
-```
+    version: v0.18.0
+    script: tests/firmware-test.yaml
+    output-dir: out/labwired
+    args: --no-uart-stdout
+    upload-artifacts: 'false'
+~~~
 
-Installs the matching `labwired` release for the runner, runs `labwired test`,
-writes a JUnit report, and uploads `result.json` + `uart.log` as an artifact.
-The step fails when an assertion fails.
+The action installs the matching archive asset named
+labwired-v0.18.0-<platform>.tar.gz from w1ne/labwired-core, writes a JUnit
+report plus result.json and uart.log, and fails when an assertion fails.
 
-Inputs: `script` (required); `version` (default `latest`), `args`, `junit`,
-`output-dir`, `upload-artifacts`, `repo`, `github-token`.
+Inputs use this action's hyphenated names: script (required), version
+(default v0.18.0), args, junit, output-dir, upload-artifacts, repo, and
+github-token. The github-token input defaults to the workflow job token and
+can be overridden when a workflow needs different release-download access.

--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -6,17 +6,17 @@ Core release archive rather than compiling Rust on the consumer's runner.
 
 ~~~yaml
 - name: Run LabWired tests
-  uses: w1ne/labwired/.github/actions/labwired-test@main
+  uses: w1ne/labwired-core/.github/actions/labwired-test@main
   with:
     version: v0.18.0
     script: tests/firmware-test.yaml
-    output_dir: out/labwired
-    # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
+    output-dir: out/labwired
+    args: --no-uart-stdout
 ~~~
 
-The action source is referenced at `main` because the root repository does not
-publish a matching action tag. The `version` input independently selects the
-immutable Core CLI release archive named
+The action source is referenced at `main` because no post-hardening Core action
+tag exists yet. The `version` input independently selects the immutable Core CLI
+release archive named
 `labwired-v0.18.0-<platform>.tar.gz`.
 
 The local Core action still uses its hyphenated names for its internal release

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: "w1ne/labwired-core"
   args:
-    description: "Extra flags appended to `labwired test`."
+    description: "Whitespace-separated extra flags appended to `labwired test` (shell quoting is not interpreted)."
     required: false
     default: ""
   junit:
@@ -44,12 +44,22 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        LABWIRED_VERSION: ${{ inputs.version }}
+        LABWIRED_REPO: ${{ inputs.repo }}
       run: |
         set -euo pipefail
-        ver='${{ inputs.version }}'
-        repo='${{ inputs.repo }}'
+        ver="$LABWIRED_VERSION"
+        repo="$LABWIRED_REPO"
+        if ! [[ "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+          echo "::error::repo must use the owner/name form."
+          exit 1
+        fi
         if [ "$ver" = "latest" ]; then
           ver="$(gh release view --repo "$repo" --json tagName -q .tagName)"
+        fi
+        if ! [[ "$ver" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::version must be a vMAJOR.MINOR.PATCH release tag or latest."
+          exit 1
         fi
         case "$(uname -s)-$(uname -m)" in
           Linux-x86_64)            plat=linux-x86_64 ;;
@@ -69,13 +79,22 @@ runs:
 
     - name: Run LabWired test
       shell: bash
+      env:
+        LABWIRED_SCRIPT: ${{ inputs.script }}
+        LABWIRED_JUNIT: ${{ inputs.junit }}
+        LABWIRED_OUTPUT_DIR: ${{ inputs.output-dir }}
+        LABWIRED_ARGS: ${{ inputs.args }}
       run: |
         set -euo pipefail
-        labwired test \
-          --script '${{ inputs.script }}' \
-          --junit '${{ inputs.junit }}' \
-          --output-dir '${{ inputs.output-dir }}' \
-          ${{ inputs.args }}
+        command=(labwired test
+          --script "$LABWIRED_SCRIPT"
+          --junit "$LABWIRED_JUNIT"
+          --output-dir "$LABWIRED_OUTPUT_DIR")
+        if [ -n "$LABWIRED_ARGS" ]; then
+          read -r -a extra_args <<< "$LABWIRED_ARGS"
+          command+=("${extra_args[@]}")
+        fi
+        "${command[@]}"
 
     - name: Upload artifacts
       if: ${{ always() && inputs.upload-artifacts == 'true' }}

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -11,11 +11,11 @@ inputs:
   version:
     description: "LabWired release tag to use, or 'latest'."
     required: false
-    default: "latest"
+    default: "v0.18.0"
   repo:
     description: "Repository that publishes the LabWired releases."
     required: false
-    default: "w1ne/labwired"
+    default: "w1ne/labwired-core"
   args:
     description: "Extra flags appended to `labwired test`."
     required: false

--- a/.github/workflows/core-backfill-runner-image.yml
+++ b/.github/workflows/core-backfill-runner-image.yml
@@ -1,0 +1,92 @@
+name: Backfill CI runner image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing LabWired Core release tag to package (for example v0.18.0).
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish an existing release runner image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release tag
+        shell: bash
+        env:
+          LABWIRED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$LABWIRED_VERSION"
+          if ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be an existing vMAJOR.MINOR.PATCH release tag."
+            exit 1
+          fi
+
+      - name: Check out the exact released source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+          path: source
+
+      - name: Check out the current packaging workflow
+        uses: actions/checkout@v4
+        with:
+          path: release-tools
+
+      - name: Resolve released source revision
+        id: source
+        shell: bash
+        run: echo "revision=$(git -C source rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish the immutable release runner image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./source
+          file: ./release-tools/Dockerfile.ci
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/w1ne/labwired:${{ inputs.version }}
+          build-args: |
+            VERSION=${{ inputs.version }}
+            REVISION=${{ steps.source.outputs.revision }}
+
+      - name: Pull the runner image anonymously
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io || true
+          if ! docker pull "ghcr.io/w1ne/labwired:${{ inputs.version }}"; then
+            echo "::error::Unable to anonymously pull the released runner image. Make the GHCR package public in GitHub Packages, then re-run this workflow."
+            exit 1
+          fi
+
+      - name: Run the backfilled runner image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE/source:/workspace" \
+            --workdir /workspace \
+            "ghcr.io/w1ne/labwired:${{ inputs.version }}" \
+            test \
+            --script examples/ci/dummy-max-steps.yaml \
+            --output-dir out/backfill-runner-smoke \
+            --no-uart-stdout
+          test -s source/out/backfill-runner-smoke/result.json

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -14,6 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This static verifier reads workflow/Dockerfile/action/docs text only; it
+  # intentionally needs neither Docker nor a Rust build.
+  release-runner-contract:
+    name: release-runner-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify release runner contract
+        run: bash scripts/ci/verify-release-runner-contract.sh
+
   # ── Fast PR gate (REQUIRED) ────────────────────────────────────────────────
   # Formatting, lints, and unit tests only — no firmware cross-builds, no
   # fixture-dependent integration tests, no Tier-1 sims. Target a few minutes so

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -109,3 +110,79 @@ jobs:
             See the [full changelog](CHANGELOG.md) for what's new.
           files: dist/*.tar.gz
           fail_on_unmatched_files: true
+
+  publish:
+    name: Publish CI runner image
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish CI runner image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.ci
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/w1ne/labwired:${{ github.ref_name }}
+            ghcr.io/w1ne/labwired:latest
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            REVISION=${{ github.sha }}
+
+  release-smoke:
+    name: Smoke released archives and runner image
+    needs: [release, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull the release runner image anonymously
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io || true
+          if ! docker pull "ghcr.io/w1ne/labwired:${{ github.ref_name }}"; then
+            echo "::error::Unable to anonymously pull the released runner image. Make the GHCR package public in GitHub Packages, then re-run this release workflow."
+            exit 1
+          fi
+
+      - name: Run the release runner image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /workspace \
+            "ghcr.io/w1ne/labwired:${{ github.ref_name }}" \
+            test \
+            --script examples/ci/dummy-max-steps.yaml \
+            --output-dir out/release-runner-smoke \
+            --no-uart-stdout
+          test -s out/release-runner-smoke/result.json
+
+      - name: Run the release archive through the core action
+        uses: ./.github/actions/labwired-test
+        with:
+          version: ${{ github.ref_name }}
+          github-token: ${{ github.token }}
+          script: examples/ci/dummy-max-steps.yaml
+          output-dir: out/release-action-smoke
+          args: --no-uart-stdout
+          upload-artifacts: 'false'
+
+      - name: Verify core action artifacts
+        shell: bash
+        run: test -s out/release-action-smoke/result.json

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,51 +4,41 @@
 # This software is released under the MIT License.
 # See the LICENSE file in the project root for full license information.
 
-# Multi-stage Dockerfile optimized for CI/CD usage
-# Produces a minimal image containing only the labwired CLI binary
+# Multi-stage Dockerfile for the versioned CI runner image. The image contains
+# only the labwired CLI, so `docker run ... image test --script ...` uses the
+# same command line as a native release archive.
 
 # Stage 1: Builder
-FROM rust:1.93-slim AS builder
+FROM rust:1.95-slim AS builder
 
-# Install build dependencies
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-
-# Copy all source code
 COPY . .
 
-# Build runtime binaries used in CI and Docker debugging flows
-RUN cargo build --release -p labwired-cli -p labwired-dap --locked
+RUN cargo build --release -p labwired-cli --locked
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim
 
-# Install minimal runtime dependencies
+ARG VERSION
+ARG REVISION
+
+LABEL org.opencontainers.image.source="https://github.com/w1ne/labwired-core" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security
-RUN useradd -m -u 1000 -s /bin/bash labwired
-
-# Copy binaries from builder
 COPY --from=builder /build/target/release/labwired /usr/local/bin/labwired
-COPY --from=builder /build/target/release/labwired-dap /usr/local/bin/labwired-dap
 
-# Set ownership
-RUN chown labwired:labwired /usr/local/bin/labwired /usr/local/bin/labwired-dap
-
-# Switch to non-root user
-USER labwired
 WORKDIR /workspace
-
-# Verify the binary works
 RUN labwired --version
 
-# Default command shows help
 ENTRYPOINT ["labwired"]
 CMD ["--help"]

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -68,13 +68,23 @@ This document outlines the standardized process for releasing new versions of La
 ### Artifacts
 - [ ] **Release Workflow**: Pushing `vX.Y.Z` triggers
   [`.github/workflows/core-release.yml`](.github/workflows/core-release.yml),
-  which builds CLI archives for Linux and macOS targets and uploads them to the
-  GitHub Release.
+  which builds CLI archives for Linux and macOS targets, uploads them to the
+  GitHub Release, and publishes the deployable CI runner image.
 - [ ] **Workflow Verification**: Confirm the release workflow completed and the
-  expected `labwired-vX.Y.Z-<platform>.tar.gz` assets are attached.
+  expected `labwired-vX.Y.Z-<platform>.tar.gz` assets are attached. Confirm
+  GHCR also contains the versioned `ghcr.io/w1ne/labwired:vX.Y.Z` runner
+  image. Use that versioned image in CI; the workflow also updates its moving
+  convenience tag.
+- [ ] **First GHCR publication**: After the first successful image push, open
+  the package settings in GitHub Packages and set the GHCR package visibility
+  to public. The release smoke job deliberately performs an anonymous pull; if
+  the package is still private, it fails with this instruction. Change the
+  visibility and re-run the release workflow.
 - [ ] **Manual Fallback**: If the release workflow fails, build the CLI locally
   with `cargo build -p labwired-cli --release`, package the `labwired` binary,
-  and attach the archive manually with a note in the release description.
+  and attach the archive manually with a note in the release description. For
+  the runner image, diagnose the failed publish job rather than retagging an
+  unverified local image.
 
 ## 4. Post-Release
 - [ ] **Announce**: Share the release notes on relevant channels (Discord, Twitter, Internal).

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -80,6 +80,15 @@ This document outlines the standardized process for releasing new versions of La
   to public. The release smoke job deliberately performs an anonymous pull; if
   the package is still private, it fails with this instruction. Change the
   visibility and re-run the release workflow.
+- [ ] **Initial v0.18.0 runner backfill (one time)**: The `v0.18.0` Git tag
+  predates the runner-image release workflow. After this workflow reaches
+  `main`, run
+  [`.github/workflows/core-backfill-runner-image.yml`](.github/workflows/core-backfill-runner-image.yml)
+  from Actions with `version` set to `v0.18.0`. It checks out that exact tag,
+  publishes only `ghcr.io/w1ne/labwired:v0.18.0` (never `latest`), and runs an
+  anonymous pull-and-run smoke test. If the smoke reports a private package,
+  make the package public and re-run the backfill workflow. Future release tags
+  publish their runner image automatically through `core-release.yml`.
 - [ ] **Manual Fallback**: If the release workflow fails, build the CLI locally
   with `cargo build -p labwired-cli --release`, package the `labwired` binary,
   and attach the archive manually with a note in the release description. For

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -1,14 +1,17 @@
 # CI Integration
 
-This guide details the integration of LabWired firmware simulations into continuous integration (CI) pipelines. By replacing physical hardware with deterministic simulation, teams can achieve scalable, parallelized regression testing.
+LabWired CI runs the same labwired test command locally, in GitHub Actions, and
+in GitLab. Pin the runner release to v0.18.0 so a firmware change is tested
+against a reproducible simulator version.
 
-## 1. Quick Start
+## GitHub Actions
 
-### GitHub Actions
-To enable automated testing on every push, create a workflow file at `.github/workflows/firmware-test.yml`:
+Use the public LabWired action at its published root location and select the
+Core CLI release with the version input:
 
-```yaml
-name: Firmware Simulation
+~~~yaml
+name: Firmware simulation
+
 on: [push, pull_request]
 
 jobs:
@@ -16,105 +19,84 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build Firmware
-        run: cargo build --release --target thumbv7m-none-eabi
-      
-      - name: Run Simulation
+
+      - name: Build firmware
+        run: cargo build --release --target thumbv7m-none-eabi -p firmware
+
+      - name: Run LabWired
         uses: w1ne/labwired/.github/actions/labwired-test@main
         with:
-          script: tests/basic_boot.yaml
-          output_dir: test-results
+          version: v0.18.0
+          script: tests/firmware-test.yaml
+          output_dir: out/labwired
+          # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
 
       - name: Upload LabWired artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: labwired-results
-          path: test-results/
-```
+          path: out/labwired
+          if-no-files-found: warn
+~~~
 
-### GitLab CI
-For GitLab, add the following to `.gitlab-ci.yml`:
+The public action reference remains at main because its repository has no
+v0.18.0 tag. The version input is the immutable Core CLI release pin.
 
-```yaml
-test_simulation:
-  image: rust:latest
+## Container runner
+
+The release image has labwired as its entrypoint. Pass test directly after the
+image name; do not repeat labwired in the container command:
+
+~~~bash
+docker run --rm \
+  --volume "$PWD:/workspace" \
+  --workdir /workspace \
+  ghcr.io/w1ne/labwired:v0.18.0 \
+  test --script tests/firmware-test.yaml \
+       --output-dir out/labwired \
+       --no-uart-stdout
+~~~
+
+The image runs as the runtime default user so it can write artifacts into the
+mounted workspace.
+
+## GitLab CI
+
+GitLab must clear the image entrypoint so it can start its normal job shell.
+The active template in [integration-templates/gitlab-ci.yml](integration-templates/gitlab-ci.yml)
+uses the pinned image and then invokes labwired test.
+
+~~~yaml
+test:firmware:
+  image:
+    name: ghcr.io/w1ne/labwired:v0.18.0
+    entrypoint: [""]
   script:
-    - cargo build --release --target thumbv7m-none-eabi
-    - curl -L https://github.com/w1ne/labwired/releases/latest/download/labwired-cli -o labwired
-    - chmod +x labwired
-    - ./labwired test --script tests/basic_boot.yaml
-```
+    - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
+~~~
 
-## 2. Test Script Schema
+## Artifacts and reporting
 
-LabWired uses a YAML-based test definition format to specify inputs, constraints, and assertions.
+Use --output-dir in every environment. A run writes result.json, snapshot.json,
+uart.log, and junit.xml under that directory. Upload the directory with an
+always/failure-safe artifact step so failed assertions retain their diagnostics.
 
-```yaml
-schema_version: "1.0"
+## Advanced: build from source
 
-inputs:
-  firmware: "target/thumbv7m-none-eabi/release/firmware.elf"
-  system: "configs/system.yaml"
+Building labwired-cli from this repository is useful for testing an unreleased
+commit or a local code change. It is intentionally an advanced alternative to
+the pinned release archive or runner image:
 
-limits:
-  max_steps: 100000        # Instruction limit
-  wall_time_ms: 5000       # Real-time timeout
-  max_cycles: 50000000     # Simulation cycle limit
+~~~bash
+cargo build --release -p labwired-cli
+./target/release/labwired test --script tests/firmware-test.yaml --output-dir out/labwired
+~~~
 
-assertions:
-  - uart_contains: "Boot Successful"
-  - expected_stop_reason: "halt"
-```
+## Onboarding KPI tracking
 
-## 3. Integration Patterns
-
-### Matrix Testing
-Validate firmware across multiple compile targets or configurations in parallel.
-
-**GitHub Actions Example:**
-```yaml
-strategy:
-  matrix:
-    target: [thumbv6m-none-eabi, thumbv7m-none-eabi]
-steps:
-  - run: cargo build --target ${{ matrix.target }}
-  - uses: w1ne/labwired/.github/actions/labwired-test@main
-    with:
-      script: tests/${{ matrix.target }}.yaml
-```
-
-### Fault Injection
-Simulate hardware failures (e.g., sensor disconnects) in CI to verify error handling paths that are difficult to trigger on physical devices.
-
-```yaml
-# tests/sensor_fail.yaml
-steps:
-  - run: 100ms
-  - write_peripheral:
-      id: "i2c1"
-      reg: "CR1"
-      value: 0x0000 # Disable I2C controller mid-operation
-  - assert_log: "I2C Error Detected"
-```
-
-## 4. Artifacts and Reporting
-
-The test runner produces machine-readable outputs for integration with CI reporting tools. The
-`labwired-test` GitHub Action fails when assertions fail, after writing these artifacts.
-
-- **`result.json`**: Detailed execution statistics (cycles, instructions, assertion results).
-- **`junit.xml`**: Standard JUnit format for test result visualization in GitHub/GitLab UI.
-- **`uart.log`**: Captured serial output for debugging failures.
-
-Ensure your CI pipeline is configured to archive these artifacts upon failure.
-
-## 5. Onboarding KPI Tracking
-
-For board onboarding competitiveness, `core-onboarding-smoke.yml` runs a deterministic smoke path and emits:
-
-- `onboarding-metrics.json`: elapsed time, failure stage, and first error signature.
-- `onboarding-summary.md`: per-target summary for step output.
-- `onboarding-scoreboard.json` / `onboarding-scoreboard.md`: aggregated run-level view.
-
-This workflow uses a soft threshold (`3600s`) to track time-to-first-smoke without blocking merges.
+For board onboarding competitiveness, core-onboarding-smoke.yml runs a
+deterministic smoke path and emits onboarding-metrics.json,
+onboarding-summary.md, onboarding-scoreboard.json, and
+onboarding-scoreboard.md. Its soft 3600-second threshold tracks
+time-to-first-smoke without blocking merges.

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -6,8 +6,8 @@ against a reproducible simulator version.
 
 ## GitHub Actions
 
-Use the public LabWired action at its published root location and select the
-Core CLI release with the version input:
+Use the public LabWired Core action and select the Core CLI release with its
+version input:
 
 ~~~yaml
 name: Firmware simulation
@@ -24,12 +24,12 @@ jobs:
         run: cargo build --release --target thumbv7m-none-eabi -p firmware
 
       - name: Run LabWired
-        uses: w1ne/labwired/.github/actions/labwired-test@main
+        uses: w1ne/labwired-core/.github/actions/labwired-test@main
         with:
           version: v0.18.0
           script: tests/firmware-test.yaml
-          output_dir: out/labwired
-          # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
+          output-dir: out/labwired
+          args: --no-uart-stdout
 
       - name: Upload LabWired artifacts
         if: always()
@@ -40,8 +40,8 @@ jobs:
           if-no-files-found: warn
 ~~~
 
-The public action reference remains at main because its repository has no
-v0.18.0 tag. The version input is the immutable Core CLI release pin.
+The public action reference remains at main until a post-hardening Core action
+tag is published. The version input is the immutable Core CLI release pin.
 
 ## Container runner
 

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -309,16 +309,24 @@ The runner writes `result.json` only when `--output-dir` is provided (including 
 }
 ```
 
-## GitHub Actions Example
+## CI release runners
 
-```yaml
+Use the pinned v0.18.0 release runner in CI. It runs the same labwired test
+command described above and writes the same artifact contract.
+
+### GitHub Actions
+
+Use the public root action and pin the Core CLI with its version input:
+
+~~~yaml
 - name: Run LabWired tests
-  run: |
-    cargo build --release -p labwired-cli
-    ./target/release/labwired test \
-      --script examples/ci/dummy-max-steps.yaml \
-      --output-dir out/artifacts \
-      --no-uart-stdout
+  uses: w1ne/labwired/.github/actions/labwired-test@main
+  with:
+    version: v0.18.0
+    script: examples/ci/dummy-max-steps.yaml
+    output_dir: out/artifacts
+    # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
+
 - name: Upload artifacts (pass/fail)
   if: always()
   uses: actions/upload-artifact@v4
@@ -326,66 +334,41 @@ The runner writes `result.json` only when `--output-dir` is provided (including 
     name: labwired-artifacts
     path: out/artifacts
     if-no-files-found: warn
-```
+~~~
 
-## Copy-Paste Workflow (Composite Action)
+The root action is intentionally referenced at main because that repository
+does not publish a v0.18.0 tag. The version input still selects the immutable
+Core CLI release.
 
-This repo includes a minimal composite action wrapper at `.github/actions/labwired-test` that:
-- builds `labwired` (`crates/cli`)
-- runs `labwired test`
-- emits artifact paths as outputs
-- writes a small summary into the GitHub Actions step summary
-- fails the action when `labwired test` exits nonzero, after writing artifacts and the summary
+### Docker and GitLab runners
 
-Copy-paste this workflow into `.github/workflows/labwired-test.yml`:
+The GHCR image has labwired as its entrypoint. For Docker, pass test directly
+after the pinned image name:
 
-```yaml
-name: LabWired CI Test
+~~~bash
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  ghcr.io/w1ne/labwired:v0.18.0 \
+  test --script examples/ci/dummy-max-steps.yaml \
+       --output-dir out/artifacts \
+       --no-uart-stdout
+~~~
 
-on:
-  pull_request:
-  push:
-    branches: [ "main" ]
+GitLab should clear that entrypoint and invoke labwired from its job shell:
 
-jobs:
-  labwired-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+~~~yaml
+image:
+  name: ghcr.io/w1ne/labwired:v0.18.0
+  entrypoint: [""]
+script:
+  - labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout
+~~~
 
-      - name: Run labwired test
-        id: labwired
-        uses: ./.github/actions/labwired-test
-        with:
-          script: examples/ci/dummy-max-steps.yaml
-          output_dir: out/artifacts
-          no_uart_stdout: true
-          profile: release
+### Advanced source build
 
-      - name: Upload artifacts (pass/fail)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: labwired-artifacts
-          path: ${{ steps.labwired.outputs.artifacts_dir }}
-          if-no-files-found: warn
-```
+Build from source only when validating an unreleased LabWired commit. It is not
+the normal CI path:
 
-## Local vs CI Parity
-
-CI runs the same `labwired test` command you can run locally; the only CI-specific behavior is how artifacts are uploaded and how the summary is displayed.
-
-Local (native):
-
-```bash
+~~~bash
 cargo build --release -p labwired-cli
 ./target/release/labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout
-```
-
-Local (Docker, closest to “clean CI machine”):
-
-```bash
-docker build -t labwired-ci .
-docker run --rm -v "$PWD:/work" -w /work labwired-ci \
-  labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout
-```
+~~~

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -316,16 +316,16 @@ command described above and writes the same artifact contract.
 
 ### GitHub Actions
 
-Use the public root action and pin the Core CLI with its version input:
+Use the public Core action and pin the Core CLI with its version input:
 
 ~~~yaml
 - name: Run LabWired tests
-  uses: w1ne/labwired/.github/actions/labwired-test@main
+  uses: w1ne/labwired-core/.github/actions/labwired-test@main
   with:
     version: v0.18.0
     script: examples/ci/dummy-max-steps.yaml
-    output_dir: out/artifacts
-    # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
+    output-dir: out/artifacts
+    args: --no-uart-stdout
 
 - name: Upload artifacts (pass/fail)
   if: always()
@@ -336,9 +336,9 @@ Use the public root action and pin the Core CLI with its version input:
     if-no-files-found: warn
 ~~~
 
-The root action is intentionally referenced at main because that repository
-does not publish a v0.18.0 tag. The version input still selects the immutable
-Core CLI release.
+The Core action is intentionally referenced at main until a post-hardening
+action tag is published. The version input still selects the immutable Core
+CLI release.
 
 ### Docker and GitLab runners
 

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -1,224 +1,55 @@
-# CI Workflow Templates
+# CI workflow templates
 
-This directory contains reference CI/CD workflow templates for integrating LabWired firmware testing into your continuous integration pipelines.
+These templates run a pinned LabWired Core v0.18.0 release and preserve the
+result.json, uart.log, snapshot.json, and junit.xml artifacts.
 
-## Available Templates
+## GitHub Actions
 
-### GitHub Actions ([github-actions.yml](./github-actions.yml))
+[github-actions.yml](github-actions.yml) is the primary GitHub template. It
+uses the public root action at
+w1ne/labwired/.github/actions/labwired-test@main and pins the Core CLI with
+version: v0.18.0. Set api-key from LABWIRED_API_KEY only when your project uses
+a Pro or Enterprise workspace; it is optional.
 
-Complete GitHub Actions workflow showing three integration approaches:
+Copy it into a firmware repository, then replace your-firmware and the test
+script path:
 
-1. **Composite Action** (Recommended) - Use the pre-built LabWired action
-2. **Docker Image** - Use the published Docker image directly
-3. **Build from Source** - Clone and build LabWired in your workflow
-
-Also includes a matrix testing example for testing across multiple ARM targets.
-
-**Quick Start:**
-```bash
-# Copy to your repository
+~~~bash
 cp docs/integration-templates/github-actions.yml .github/workflows/firmware-test.yml
+~~~
 
-# Customize the firmware build commands and test scripts
-# Then commit and push
-```
+## GitLab CI
 
-### GitLab CI ([gitlab-ci.yml](./gitlab-ci.yml))
+[gitlab-ci.yml](gitlab-ci.yml) is active as written. Its test job uses:
 
-GitLab CI pipeline template with:
+~~~yaml
+image:
+  name: ghcr.io/w1ne/labwired:v0.18.0
+  entrypoint: [""]
+~~~
 
-- Firmware build stage with caching
-- Test execution with artifact collection
-- JUnit XML test reporting integration
-- Matrix testing across Cortex-M variants
-- Test summary generation
+The empty entrypoint lets GitLab run its job shell, where the template calls
+labwired test. Copy it to the repository root and replace your-firmware plus
+the test script path.
 
-**Quick Start:**
-```bash
-# Copy to your repository root
-cp docs/integration-templates/gitlab-ci.yml .gitlab-ci.yml
+## Direct Docker use
 
-# Customize the firmware package name and test scripts
-# Then commit and push
-```
+For local or non-GitHub CI runs, the release image keeps labwired as its
+entrypoint:
 
-## Customization Guide
+~~~bash
+docker run --rm -v "$PWD:/workspace" -w /workspace \
+  ghcr.io/w1ne/labwired:v0.18.0 \
+  test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
+~~~
 
-### 1. Update Firmware Build Commands
+## Advanced source builds
 
-Replace `your-firmware` with your actual firmware package name:
+Use a source build only to validate an unreleased LabWired revision. Normal CI
+should use the pinned action or runner image so release behavior is
+reproducible.
 
-```yaml
-# Before
-cargo build --release --target thumbv7m-none-eabi -p your-firmware
-
-# After
-cargo build --release --target thumbv7m-none-eabi -p my-device-firmware
-```
-
-### 2. Configure Test Scripts
-
-Update the test script paths to match your project structure:
-
-```yaml
-# Point to your actual test scripts
-script: tests/my-firmware-test.yaml
-```
-
-### 3. Adjust Targets
-
-Modify the ARM targets based on your hardware:
-
-```yaml
-# For Cortex-M0/M0+
-targets: thumbv6m-none-eabi
-
-# For Cortex-M3
-targets: thumbv7m-none-eabi
-
-# For Cortex-M4/M4F
-targets: thumbv7em-none-eabi
-```
-
-## Integration Methods Comparison
-
-| Method | Speed | Setup Complexity | Use Case |
-|--------|-------|------------------|----------|
-| **Composite Action** | Fast (cached) | Low | Most projects, recommended |
-| **Docker Image** | Fast | Low | When you need consistent environment |
-| **Build from Source** | Slow | Medium | When you need latest features or custom builds |
-
-## Test Script Examples
-
-See [examples/ci/](../../examples/ci/) for working test script examples:
-
-- `uart-ok.yaml` - Basic UART output validation
-- `dummy-max-steps.yaml` - Step limit testing
-- `dummy-max-cycles.yaml` - Cycle limit testing
-- `dummy-fail-uart.yaml` - Assertion failure example
-
-## Artifact Collection
-
-All templates collect test artifacts including:
-
-- `result.json` - Machine-readable test results
-- `uart.log` - Complete UART output
-- `junit.xml` - JUnit format for CI integration
-
-These artifacts are automatically uploaded and available in your CI dashboard.
-
-## Unsupported-Instruction Audit Job
-
-For decoder/executor coverage, add a code-driven audit step:
-
-```bash
-./scripts/unsupported_instruction_audit.sh \
-  --firmware target/thumbv7m-none-eabi/release/<firmware-crate> \
-  --system configs/systems/<board>.yaml \
-  --max-steps 200000 \
-  --out-dir out/unsupported-audit/<board> \
-  --fail-on-unsupported
-```
-
-Recommended artifacts:
-
-- `out/unsupported-audit/<board>/report.md`
-- `out/unsupported-audit/<board>/*_summary.tsv`
-
-## Hardware-in-the-Loop Replacement
-
-### Before (Physical Hardware)
-```yaml
-- name: Flash and test
-  run: |
-    openocd -f interface/stlink.cfg -f target/stm32f1x.cfg -c "program firmware.elf verify reset exit"
-    # Wait for serial output...
-```
-
-### After (LabWired Simulation)
-```yaml
-- name: Test firmware
-  uses: w1ne/labwired/.github/actions/labwired-test@main
-  with:
-    script: tests/firmware-test.yaml
-```
-
-**Benefits:**
-- No physical hardware required
-- Deterministic, reproducible results
-- Parallel testing across multiple targets
-- Faster feedback (no flashing delays)
-- Test fault injection scenarios
-
-## Troubleshooting
-
-### Build Failures
-
-**Problem:** `cargo build` fails with linking errors
-
-**Solution:** Ensure you have the correct target installed:
-```bash
-rustup target add thumbv7m-none-eabi
-```
-
-### Test Timeouts
-
-**Problem:** Tests timeout with `wall_time` exceeded
-
-**Solution:** Increase timeout in your test script:
-```yaml
-limits:
-  wall_time_ms: 10000  # Increase from default 5000
-```
-
-### Assertion Failures
-
-**Problem:** UART assertions fail unexpectedly
-
-**Solution:** Check the actual UART output in `uart.log` artifact and adjust your assertions.
-
-## Advanced Usage
-
-### Caching
-
-Both templates include caching strategies to speed up builds:
-
-**GitHub Actions:**
-```yaml
-- uses: Swatinem/rust-cache@v2
-```
-
-**GitLab CI:**
-```yaml
-cache:
-  key: ${CI_COMMIT_REF_SLUG}
-  paths:
-    - .cargo/
-    - target/
-```
-
-### Matrix Testing
-
-Test multiple configurations in parallel:
-
-```yaml
-strategy:
-  matrix:
-    target: [thumbv6m-none-eabi, thumbv7m-none-eabi]
-    config: [debug, release]
-```
-
-## Next Steps
-
-1. Copy the appropriate template to your repository
-2. Customize firmware build commands and test scripts
-3. Create test YAML files (see [examples/ci/README.md](../../examples/ci/README.md))
-4. Commit and push to trigger your first CI run
-5. Review artifacts and adjust assertions as needed
-
-## Support
-
-For more information:
-- [LabWired Documentation](../../docs/)
-- [Test Script Schema](../../docs/test_script_schema.md)
-- [GitHub Issues](https://github.com/w1ne/labwired/issues)
+~~~bash
+cargo build --release -p labwired-cli
+./target/release/labwired test --script tests/firmware-test.yaml --output-dir out/labwired
+~~~

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -6,10 +6,10 @@ result.json, uart.log, snapshot.json, and junit.xml artifacts.
 ## GitHub Actions
 
 [github-actions.yml](github-actions.yml) is the primary GitHub template. It
-uses the public root action at
-w1ne/labwired/.github/actions/labwired-test@main and pins the Core CLI with
-version: v0.18.0. Set api-key from LABWIRED_API_KEY only when your project uses
-a Pro or Enterprise workspace; it is optional.
+uses the public Core action at
+w1ne/labwired-core/.github/actions/labwired-test@main and pins the Core CLI
+with version: v0.18.0. It passes --no-uart-stdout through the action's safe
+whitespace-separated args input.
 
 Copy it into a firmware repository, then replace your-firmware and the test
 script path:

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -1,32 +1,17 @@
-# LabWired - Firmware Simulation Platform
-# Copyright (C) 2026 Andrii Shylenko
-#
-# This software is released under the MIT License.
-# See the LICENSE file in the project root for full license information.
-
-# Reference CI Workflow Templates for GitHub Actions
-#
-# This template shows how to integrate LabWired firmware testing into your CI pipeline.
-# Copy this file to .github/workflows/firmware-test.yml in your repository and customize.
-
 name: Firmware CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
 
 jobs:
-  # Option 1: Use the composite action (recommended - easiest)
-  test-with-action:
-    name: Test with LabWired Action
+  firmware-test:
+    name: Test firmware with LabWired
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
-      # Build your firmware first
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -35,142 +20,22 @@ jobs:
       - name: Build firmware
         run: cargo build --release --target thumbv7m-none-eabi -p your-firmware
 
-      # Run LabWired tests using the composite action
-      - name: Run firmware tests
-        id: labwired
+      - name: Run LabWired test
         uses: w1ne/labwired/.github/actions/labwired-test@main
         with:
+          version: v0.18.0
           script: tests/firmware-test.yaml
-          output_dir: test-results
-          profile: release
-          no_uart_stdout: true
+          output_dir: out/labwired
+          # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
 
-      # Upload test artifacts. The LabWired action fails on failed assertions
-      # after writing result.json, uart.log, junit.xml, and summary.md.
-      - name: Upload test results
+      - name: Upload LabWired artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-test-results
-          path: test-results/
-          retention-days: 30
+          name: labwired-artifacts
+          path: out/labwired
+          if-no-files-found: warn
 
-  # Option 2: Use the Docker image directly (when published)
-  test-with-docker:
-    name: Test with Docker Image
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # Build your firmware
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: thumbv7m-none-eabi
-
-      - name: Build firmware
-        run: cargo build --release --target thumbv7m-none-eabi -p your-firmware
-
-      # Run tests using Docker image (uncomment when image is published)
-      # - name: Run firmware tests
-      #   run: |
-      #     docker run --rm \
-      #       -v ${{ github.workspace }}:/workspace \
-      #       -w /workspace \
-      #       ghcr.io/w1ne/labwired:latest \
-      #       test --script tests/firmware-test.yaml \
-      #            --output-dir test-results \
-      #            --no-uart-stdout
-
-      # - name: Upload test results
-      #   if: always()
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: firmware-test-results-docker
-      #     path: test-results/
-
-  # Option 3: Build from source (full control, slower)
-  test-from-source:
-    name: Test from Source
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # Clone LabWired
-      - name: Clone LabWired
-        run: git clone https://github.com/w1ne/labwired.git labwired-repo
-
-      # Build LabWired CLI
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: thumbv7m-none-eabi
-
-      - name: Build LabWired
-        run: |
-          cd labwired-repo
-          cargo build --release -p labwired-cli
-          echo "$PWD/target/release" >> $GITHUB_PATH
-
-      # Build your firmware
-      - name: Build firmware
-        run: cargo build --release --target thumbv7m-none-eabi -p your-firmware
-
-      # Run tests
-      - name: Run firmware tests
-        run: |
-          labwired test --script tests/firmware-test.yaml \
-                        --output-dir test-results \
-                        --no-uart-stdout
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: firmware-test-results-source
-          path: test-results/
-
-  # Advanced: Matrix testing across multiple targets
-  matrix-test:
-    name: Test ${{ matrix.target }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - thumbv6m-none-eabi
-          - thumbv7m-none-eabi
-          - thumbv7em-none-eabi
-        include:
-          - target: thumbv6m-none-eabi
-            test_script: tests/cortex-m0-test.yaml
-          - target: thumbv7m-none-eabi
-            test_script: tests/cortex-m3-test.yaml
-          - target: thumbv7em-none-eabi
-            test_script: tests/cortex-m4-test.yaml
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Build firmware
-        run: cargo build --release --target ${{ matrix.target }} -p your-firmware
-
-      - name: Run tests
-        uses: w1ne/labwired/.github/actions/labwired-test@main
-        with:
-          script: ${{ matrix.test_script }}
-          output_dir: test-results-${{ matrix.target }}
-          profile: release
-
-      - name: Upload results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results-${{ matrix.target }}
-          path: test-results-${{ matrix.target }}/
+# Advanced alternative: build LabWired from a source checkout only when testing
+# an unreleased LabWired change. For normal firmware CI, keep the pinned release
+# selected by version: v0.18.0 above.

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -21,12 +21,12 @@ jobs:
         run: cargo build --release --target thumbv7m-none-eabi -p your-firmware
 
       - name: Run LabWired test
-        uses: w1ne/labwired/.github/actions/labwired-test@main
+        uses: w1ne/labwired-core/.github/actions/labwired-test@main
         with:
           version: v0.18.0
           script: tests/firmware-test.yaml
-          output_dir: out/labwired
-          # Optional: api-key: ${{ secrets.LABWIRED_API_KEY }}
+          output-dir: out/labwired
+          args: --no-uart-stdout
 
       - name: Upload LabWired artifacts
         if: always()

--- a/docs/integration-templates/gitlab-ci.yml
+++ b/docs/integration-templates/gitlab-ci.yml
@@ -1,170 +1,36 @@
-# LabWired - Firmware Simulation Platform
-# Copyright (C) 2026 Andrii Shylenko
-#
-# This software is released under the MIT License.
-# See the LICENSE file in the project root for full license information.
-
-# Reference CI Workflow Template for GitLab CI
-#
-# This template shows how to integrate LabWired firmware testing into GitLab CI.
-# Copy this file to .gitlab-ci.yml in your repository and customize.
-
 stages:
   - build
   - test
-  - report
 
-variables:
-  # Uncomment when Docker image is published
-  # LABWIRED_IMAGE: ghcr.io/w1ne/labwired:latest
-  CARGO_HOME: ${CI_PROJECT_DIR}/.cargo
-
-# Cache Rust dependencies
-.rust_cache:
-  cache:
-    key: ${CI_COMMIT_REF_SLUG}
-    paths:
-      - .cargo/
-      - target/
-
-# Build firmware
 build:firmware:
   stage: build
-  image: rust:latest
-  extends: .rust_cache
-
+  image: rust:1.95
   before_script:
     - rustup target add thumbv7m-none-eabi
-
   script:
     - cargo build --release --target thumbv7m-none-eabi -p your-firmware
-
   artifacts:
     paths:
       - target/thumbv7m-none-eabi/release/your-firmware
     expire_in: 1 hour
 
-# Option 1: Test using Docker image (when published)
-# test:docker:
-#   stage: test
-#   image: ${LABWIRED_IMAGE}
-#   dependencies:
-#     - build:firmware
-#
-#   script:
-#     - labwired test --script tests/firmware-test.yaml
-#                     --output-dir test-results
-#                     --no-uart-stdout
-#
-#   artifacts:
-#     when: always
-#     paths:
-#       - test-results/
-#     reports:
-#       junit: test-results/junit.xml
-#     expire_in: 30 days
-
-# Option 2: Test by building LabWired from source
-test:source:
+test:labwired:
   stage: test
-  image: rust:latest
-  extends: .rust_cache
+  image:
+    name: ghcr.io/w1ne/labwired:v0.18.0
+    entrypoint: [""]
   dependencies:
     - build:firmware
-
-  before_script:
-    - apt-get update && apt-get install -y git
-    - git clone https://github.com/w1ne/labwired.git /tmp/labwired
-    - cd /tmp/labwired
-    - cargo build --release -p labwired-cli
-    - export PATH="/tmp/labwired/target/release:$PATH"
-    - cd ${CI_PROJECT_DIR}
-
   script:
-    - labwired test --script tests/firmware-test.yaml
-                    --output-dir test-results
-                    --no-uart-stdout
-
+    - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
   artifacts:
     when: always
     paths:
-      - test-results/
+      - out/labwired/
     reports:
-      junit: test-results/junit.xml
+      junit: out/labwired/junit.xml
     expire_in: 30 days
 
-# Generate test report summary
-report:summary:
-  stage: report
-  image: python:3.11-slim
-  dependencies:
-    - test:source
-
-  script:
-    - |
-      python3 << 'EOF'
-      import json
-      import sys
-
-      try:
-          with open('test-results/result.json', 'r') as f:
-              result = json.load(f)
-
-          status = result.get('status', 'unknown')
-          print(f"Test Status: {status}")
-          print(f"Instructions: {result.get('instructions_executed', 0)}")
-          print(f"Cycles: {result.get('cycles_executed', 0)}")
-
-          if status != 'pass':
-              print(f"Stop Reason: {result.get('stop_reason', 'unknown')}")
-              sys.exit(1)
-      except Exception as e:
-          print(f"Error reading results: {e}")
-          sys.exit(1)
-      EOF
-
-  when: always
-
-# Matrix testing example
-.test_template:
-  stage: test
-  image: rust:latest
-  extends: .rust_cache
-
-  before_script:
-    - rustup target add ${RUST_TARGET}
-    - git clone https://github.com/w1ne/labwired.git /tmp/labwired
-    - cd /tmp/labwired && cargo build --release -p labwired-cli
-    - export PATH="/tmp/labwired/target/release:$PATH"
-    - cd ${CI_PROJECT_DIR}
-
-  script:
-    - cargo build --release --target ${RUST_TARGET} -p your-firmware
-    - labwired test --script ${TEST_SCRIPT}
-                    --output-dir test-results-${RUST_TARGET}
-                    --no-uart-stdout
-
-  artifacts:
-    when: always
-    paths:
-      - test-results-${RUST_TARGET}/
-    reports:
-      junit: test-results-${RUST_TARGET}/junit.xml
-
-test:cortex-m0:
-  extends: .test_template
-  variables:
-    RUST_TARGET: thumbv6m-none-eabi
-    TEST_SCRIPT: tests/cortex-m0-test.yaml
-
-test:cortex-m3:
-  extends: .test_template
-  variables:
-    RUST_TARGET: thumbv7m-none-eabi
-    TEST_SCRIPT: tests/cortex-m3-test.yaml
-
-test:cortex-m4:
-  extends: .test_template
-  variables:
-    RUST_TARGET: thumbv7em-none-eabi
-    TEST_SCRIPT: tests/cortex-m4-test.yaml
+# Advanced alternative: build labwired-cli from a source checkout only when
+# validating an unreleased LabWired change. Normal GitLab CI should use the
+# pinned release image above.

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -8,6 +8,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
 workflow=.github/workflows/core-release.yml
+backfill_workflow=.github/workflows/core-backfill-runner-image.yml
 dockerfile=Dockerfile.ci
 action=.github/actions/labwired-test/action.yml
 dockerignore=.dockerignore
@@ -75,6 +76,7 @@ job_line() {
 }
 
 require_file "$workflow"
+require_file "$backfill_workflow"
 require_file "$dockerfile"
 require_file "$action"
 require_file "$dockerignore"
@@ -179,6 +181,38 @@ require_literal "$action" 'default: "v0.18.0"' 'core action defaults to the pinn
 require_literal "$action" 'default: "w1ne/labwired-core"' 'core action downloads release archives from the core repository'
 require_literal "$action" 'default: ${{ github.token }}' 'core action defaults its archive download token to the workflow token'
 require_literal "$action" 'GH_TOKEN: ${{ inputs.github-token }}' 'core action passes an explicit or default token to gh release download'
+require_literal "$action" 'LABWIRED_VERSION: ${{ inputs.version }}' 'core action passes the version through an environment binding'
+require_literal "$action" 'LABWIRED_REPO: ${{ inputs.repo }}' 'core action passes the repository through an environment binding'
+require_literal "$action" 'LABWIRED_SCRIPT: ${{ inputs.script }}' 'core action passes the script through an environment binding'
+require_literal "$action" 'LABWIRED_ARGS: ${{ inputs.args }}' 'core action passes extra args through an environment binding'
+require_literal "$action" 'command=(labwired test' 'core action constructs the test command as a Bash array'
+require_literal "$action" 'read -r -a extra_args <<< "$LABWIRED_ARGS"' 'core action splits extra args without shell evaluation'
+require_absent_literal "$action" "ver='\${{ inputs.version }}'" 'core action does not splice the version input into Bash source'
+require_absent_literal "$action" "repo='\${{ inputs.repo }}'" 'core action does not splice the repository input into Bash source'
+require_absent_literal "$action" "--script '\${{ inputs.script }}'" 'core action does not splice the script input into Bash source'
+require_absent_literal "$action" '          ${{ inputs.args }}' 'core action does not splice extra args into Bash source'
+repo_validation_line=$(grep -n -m 1 'repo must use the owner/name form' "$action" | cut -d: -f1 || true)
+latest_lookup_line=$(grep -n -m 1 'gh release view --repo' "$action" | cut -d: -f1 || true)
+if [[ -z "$repo_validation_line" || -z "$latest_lookup_line" || "$repo_validation_line" -ge "$latest_lookup_line" ]]; then
+  fail 'core action validates the release repository before using GH_TOKEN with gh release view'
+fi
+
+require_literal "$backfill_workflow" 'workflow_dispatch:' 'runner backfill workflow requires explicit manual dispatch'
+require_literal "$backfill_workflow" 'required: true' 'runner backfill requires an explicit release version'
+require_literal "$backfill_workflow" 'type: string' 'runner backfill version is a string input'
+require_literal "$backfill_workflow" '[[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]' 'runner backfill validates a semver release tag'
+require_literal "$backfill_workflow" 'ref: ${{ inputs.version }}' 'runner backfill checks out the exact released source tag'
+require_literal "$backfill_workflow" 'path: source' 'runner backfill keeps released source in a dedicated directory'
+require_literal "$backfill_workflow" 'path: release-tools' 'runner backfill keeps current release tooling in a dedicated directory'
+require_literal "$backfill_workflow" 'context: ./source' 'runner backfill builds the exact released source context'
+require_literal "$backfill_workflow" 'file: ./release-tools/Dockerfile.ci' 'runner backfill uses current CI runner packaging instructions'
+require_literal "$backfill_workflow" 'ghcr.io/w1ne/labwired:${{ inputs.version }}' 'runner backfill publishes the requested immutable image tag'
+require_absent_literal "$backfill_workflow" 'ghcr.io/w1ne/labwired:latest' 'runner backfill never overwrites the moving latest tag'
+require_literal "$backfill_workflow" 'docker logout ghcr.io || true' 'runner backfill verifies a public anonymous pull'
+require_literal "$backfill_workflow" 'docker pull "ghcr.io/w1ne/labwired:${{ inputs.version }}"' 'runner backfill pulls the immutable tag after publication'
+require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner backfill uses the deterministic CI smoke script'
+require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
+require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
 
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
@@ -189,7 +223,8 @@ require_literal docs/integration-templates/github-actions.yml 'w1ne/labwired/.gi
 require_literal docs/integration-templates/github-actions.yml 'version: v0.18.0' 'GitHub template pins the CLI release independently of the root action ref'
 require_literal docs/integration-templates/gitlab-ci.yml 'name: ghcr.io/w1ne/labwired:v0.18.0' 'GitLab template uses the pinned runner image'
 require_literal docs/integration-templates/gitlab-ci.yml 'entrypoint: [""]' 'GitLab template clears the image entrypoint before invoking labwired'
-require_literal .github/actions/labwired-test/README.md 'w1ne/labwired-core/.github/actions/labwired-test@v0.18.0' 'core action README names the core action and its pinned release'
+require_literal .github/actions/labwired-test/README.md 'w1ne/labwired/.github/actions/labwired-test@main' 'core action README directs users to the published root action'
+require_literal .github/actions/labwired-test/README.md 'version: v0.18.0' 'core action README pins the immutable CLI release separately from action source'
 
 if (( failures > 0 )); then
   printf 'Release runner contract failed with %d issue(s).\n' "$failures" >&2

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Verify the static contract for the versioned LabWired CI runner release.
+# This intentionally performs no network access and does not require Docker.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+workflow=.github/workflows/core-release.yml
+dockerfile=Dockerfile.ci
+action=.github/actions/labwired-test/action.yml
+dockerignore=.dockerignore
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+require_file() {
+  local file=$1
+  if [[ ! -f "$file" ]]; then
+    fail "missing required file: $file"
+  fi
+}
+
+require_literal() {
+  local file=$1
+  local literal=$2
+  local description=$3
+  if ! grep -Fq -- "$literal" "$file"; then
+    fail "$description (expected: $literal)"
+  fi
+}
+
+require_absent_literal() {
+  local file=$1
+  local literal=$2
+  local description=$3
+  if grep -Fq -- "$literal" "$file"; then
+    fail "$description (unexpected: $literal)"
+  fi
+}
+
+require_block_literal() {
+  local block=$1
+  local literal=$2
+  local description=$3
+  if ! grep -Fq -- "$literal" <<<"$block"; then
+    fail "$description (expected: $literal)"
+  fi
+}
+
+require_block_absent_literal() {
+  local block=$1
+  local literal=$2
+  local description=$3
+  if grep -Fq -- "$literal" <<<"$block"; then
+    fail "$description (unexpected: $literal)"
+  fi
+}
+
+job_block() {
+  local job=$1
+  awk -v job="$job" '
+    $0 == "  " job ":" { inside = 1; next }
+    inside && $0 ~ /^  [[:alnum:]_-]+:$/ { exit }
+    inside { print }
+  ' "$workflow"
+}
+
+job_line() {
+  grep -n -m 1 "^  $1:$" "$workflow" | cut -d: -f1
+}
+
+require_file "$workflow"
+require_file "$dockerfile"
+require_file "$action"
+require_file "$dockerignore"
+
+require_literal "$workflow" 'packages: write' 'release workflow grants GHCR package publishing permission'
+require_literal "$workflow" 'docker/setup-buildx-action@v3' 'publish job configures Docker Buildx'
+require_literal "$workflow" 'docker/login-action@v3' 'publish job logs into GHCR'
+require_literal "$workflow" 'docker/build-push-action@v6' 'publish job pushes the runner image'
+
+release_line=$(job_line release || true)
+publish_line=$(job_line publish || true)
+if [[ -z "$release_line" || -z "$publish_line" || "$publish_line" -le "$release_line" ]]; then
+  fail 'publish job appears after the archive release job'
+fi
+
+publish_block=$(job_block publish)
+require_block_literal "$publish_block" 'needs: release' 'publish waits for archive release completion'
+require_block_literal "$publish_block" 'registry: ghcr.io' 'publish logs into ghcr.io'
+require_block_literal "$publish_block" 'ghcr.io/w1ne/labwired:${{ github.ref_name }}' 'publish includes the immutable release tag'
+require_block_literal "$publish_block" 'ghcr.io/w1ne/labwired:latest' 'publish updates the latest tag'
+require_block_literal "$publish_block" 'platforms: linux/amd64' 'publish initially targets linux/amd64'
+require_block_literal "$publish_block" 'file: ./Dockerfile.ci' 'publish uses the CI runner Dockerfile'
+require_block_literal "$publish_block" 'VERSION=${{ github.ref_name }}' 'publish passes the OCI version build argument'
+require_block_literal "$publish_block" 'REVISION=${{ github.sha }}' 'publish passes the OCI revision build argument'
+
+smoke_block=$(job_block release-smoke)
+if [[ -z "$smoke_block" ]]; then
+  fail 'release-smoke job is present'
+fi
+require_block_literal "$smoke_block" 'needs: [release, publish]' 'release smoke waits for both archive release and image publish'
+require_block_literal "$smoke_block" 'actions/checkout@v4' 'release smoke checks out the test script before mounting it'
+require_block_literal "$smoke_block" 'docker logout ghcr.io || true' 'release smoke intentionally clears GHCR credentials before the pull'
+require_block_absent_literal "$smoke_block" 'docker/login-action@v3' 'release smoke remains anonymous for the GHCR pull'
+require_block_literal "$smoke_block" 'docker pull "ghcr.io/w1ne/labwired:${{ github.ref_name }}"' 'release smoke anonymously pulls the immutable image'
+require_block_literal "$smoke_block" 'Make the GHCR package public' 'release smoke explains how to fix a private first GHCR package'
+require_block_literal "$smoke_block" 'docker run --rm' 'release smoke runs the image directly'
+require_block_literal "$smoke_block" 'examples/ci/dummy-max-steps.yaml' 'release smoke uses the deterministic CI script'
+require_block_literal "$smoke_block" 'out/release-runner-smoke' 'release smoke writes runner artifacts to a dedicated directory'
+require_block_literal "$smoke_block" '--no-uart-stdout' 'release smoke suppresses UART output'
+require_block_literal "$smoke_block" 'test -s out/release-runner-smoke/result.json' 'release smoke asserts the runner result JSON exists and is nonempty'
+require_block_literal "$smoke_block" 'uses: ./.github/actions/labwired-test' 'release smoke exercises the checked-out core action'
+require_block_literal "$smoke_block" 'version: ${{ github.ref_name }}' 'release smoke pins the core action to the release tag'
+require_block_literal "$smoke_block" 'github-token: ${{ github.token }}' 'release smoke explicitly passes its workflow token to the core action'
+require_block_literal "$smoke_block" 'output-dir: out/release-action-smoke' 'release action smoke writes a dedicated output directory'
+require_block_literal "$smoke_block" "upload-artifacts: 'false'" 'release action smoke avoids duplicate workflow artifacts'
+require_block_literal "$smoke_block" 'test -s out/release-action-smoke/result.json' 'release smoke asserts the action result JSON exists and is nonempty'
+
+require_literal "$dockerfile" 'FROM rust:1.95-slim AS builder' 'runner image builds with Rust 1.95'
+require_literal "$dockerfile" 'RUN cargo build --release -p labwired-cli --locked' 'runner image builds only the CLI'
+require_literal "$dockerfile" 'ARG VERSION' 'runner image accepts a release version build argument'
+require_literal "$dockerfile" 'ARG REVISION' 'runner image accepts a source revision build argument'
+require_literal "$dockerfile" 'org.opencontainers.image.source="https://github.com/w1ne/labwired-core"' 'runner image declares its OCI source label'
+require_literal "$dockerfile" 'org.opencontainers.image.version="${VERSION}"' 'runner image declares its OCI version label'
+require_literal "$dockerfile" 'org.opencontainers.image.revision="${REVISION}"' 'runner image declares its OCI revision label'
+require_literal "$dockerfile" 'ENTRYPOINT ["labwired"]' 'runner image preserves the labwired CLI entrypoint'
+require_absent_literal "$dockerfile" 'USER ' 'runner image leaves the default user unchanged for bind-mounted output directories'
+require_absent_literal "$dockerfile" 'labwired-dap' 'runner image does not ship the DAP binary'
+
+if [[ -f "$dockerignore" ]]; then
+  for ignored_path in .git target out; do
+    if ! grep -Eq "^[[:space:]]*${ignored_path//./\\.}[[:space:]]*$" "$dockerignore"; then
+      fail "Docker build context excludes $ignored_path"
+    fi
+  done
+fi
+
+require_literal "$action" 'default: "v0.18.0"' 'core action defaults to the pinned supported release'
+require_literal "$action" 'default: "w1ne/labwired-core"' 'core action downloads release archives from the core repository'
+require_literal "$action" 'default: ${{ github.token }}' 'core action defaults its archive download token to the workflow token'
+require_literal "$action" 'GH_TOKEN: ${{ inputs.github-token }}' 'core action passes an explicit or default token to gh release download'
+
+for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md; do
+  require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
+done
+require_literal docs/ci_integration.md 'w1ne/labwired/.github/actions/labwired-test@main' 'CI guide uses the published root GitHub action'
+require_literal docs/ci_integration.md 'version: v0.18.0' 'CI guide pins the CLI release independently of the root action ref'
+require_literal docs/integration-templates/github-actions.yml 'w1ne/labwired/.github/actions/labwired-test@main' 'GitHub template uses the published root action'
+require_literal docs/integration-templates/github-actions.yml 'version: v0.18.0' 'GitHub template pins the CLI release independently of the root action ref'
+require_literal docs/integration-templates/gitlab-ci.yml 'name: ghcr.io/w1ne/labwired:v0.18.0' 'GitLab template uses the pinned runner image'
+require_literal docs/integration-templates/gitlab-ci.yml 'entrypoint: [""]' 'GitLab template clears the image entrypoint before invoking labwired'
+require_literal .github/actions/labwired-test/README.md 'w1ne/labwired-core/.github/actions/labwired-test@v0.18.0' 'core action README names the core action and its pinned release'
+
+if (( failures > 0 )); then
+  printf 'Release runner contract failed with %d issue(s).\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'Release runner contract passed.\n'

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -79,6 +79,28 @@ require_file "$dockerfile"
 require_file "$action"
 require_file "$dockerignore"
 
+require_literal "$workflow" 'tags:' 'release workflow declares a tag trigger'
+require_literal "$workflow" "'v[0-9]+.[0-9]+.[0-9]+'" 'release workflow triggers vMAJOR.MINOR.PATCH tags'
+for target in \
+  x86_64-unknown-linux-gnu \
+  aarch64-unknown-linux-gnu \
+  x86_64-apple-darwin \
+  aarch64-apple-darwin; do
+  require_literal "$workflow" "target: $target" "archive matrix includes $target"
+done
+for platform in linux-x86_64 linux-aarch64 darwin-x86_64 darwin-aarch64; do
+  require_literal "$workflow" "platform: $platform" "archive matrix includes $platform"
+done
+require_literal "$workflow" 'ARCHIVE="labwired-${VERSION}-${PLATFORM}.tar.gz"' 'archive names include the release version and platform'
+require_literal "$workflow" 'cp "target/${{ matrix.target }}/release/labwired" dist/labwired' 'archive package copies the labwired binary'
+require_literal "$workflow" 'tar -czf "${ARCHIVE}" -C dist labwired' 'archive package contains the labwired binary'
+require_literal "$workflow" 'name: labwired-${{ matrix.platform }}' 'archive artifact names follow the platform matrix'
+
+release_block=$(job_block release)
+require_block_literal "$release_block" 'needs: build' 'release waits for all archive builds'
+require_block_literal "$release_block" 'softprops/action-gh-release@v2' 'release creates the GitHub release with action-gh-release'
+require_block_literal "$release_block" 'files: dist/*.tar.gz' 'release uploads every generated archive asset'
+
 require_literal "$workflow" 'packages: write' 'release workflow grants GHCR package publishing permission'
 require_literal "$workflow" 'docker/setup-buildx-action@v3' 'publish job configures Docker Buildx'
 require_literal "$workflow" 'docker/login-action@v3' 'publish job logs into GHCR'
@@ -92,11 +114,16 @@ fi
 
 publish_block=$(job_block publish)
 require_block_literal "$publish_block" 'needs: release' 'publish waits for archive release completion'
+require_block_literal "$publish_block" 'docker/setup-buildx-action@v3' 'publish configures Buildx in the publish job'
+require_block_literal "$publish_block" 'docker/login-action@v3' 'publish logs into GHCR in the publish job'
+require_block_literal "$publish_block" 'docker/build-push-action@v6' 'publish uses build-push-action in the publish job'
 require_block_literal "$publish_block" 'registry: ghcr.io' 'publish logs into ghcr.io'
+require_block_literal "$publish_block" 'context: .' 'publish builds from the repository context'
 require_block_literal "$publish_block" 'ghcr.io/w1ne/labwired:${{ github.ref_name }}' 'publish includes the immutable release tag'
 require_block_literal "$publish_block" 'ghcr.io/w1ne/labwired:latest' 'publish updates the latest tag'
 require_block_literal "$publish_block" 'platforms: linux/amd64' 'publish initially targets linux/amd64'
 require_block_literal "$publish_block" 'file: ./Dockerfile.ci' 'publish uses the CI runner Dockerfile'
+require_block_literal "$publish_block" 'push: true' 'publish pushes the runner image to GHCR'
 require_block_literal "$publish_block" 'VERSION=${{ github.ref_name }}' 'publish passes the OCI version build argument'
 require_block_literal "$publish_block" 'REVISION=${{ github.sha }}' 'publish passes the OCI revision build argument'
 
@@ -111,6 +138,13 @@ require_block_absent_literal "$smoke_block" 'docker/login-action@v3' 'release sm
 require_block_literal "$smoke_block" 'docker pull "ghcr.io/w1ne/labwired:${{ github.ref_name }}"' 'release smoke anonymously pulls the immutable image'
 require_block_literal "$smoke_block" 'Make the GHCR package public' 'release smoke explains how to fix a private first GHCR package'
 require_block_literal "$smoke_block" 'docker run --rm' 'release smoke runs the image directly'
+runner_command_block=$(awk '
+  /docker run --rm/ { inside = 1 }
+  inside { print }
+  inside && /test -s out\/release-runner-smoke\/result\.json/ { exit }
+' <<<"$smoke_block")
+require_block_literal "$runner_command_block" '"ghcr.io/w1ne/labwired:${{ github.ref_name }}"' 'release smoke runs the immutable image that it pulled'
+require_block_absent_literal "$runner_command_block" 'ghcr.io/w1ne/labwired:latest' 'release smoke does not run the mutable latest tag'
 require_block_literal "$smoke_block" 'examples/ci/dummy-max-steps.yaml' 'release smoke uses the deterministic CI script'
 require_block_literal "$smoke_block" 'out/release-runner-smoke' 'release smoke writes runner artifacts to a dedicated directory'
 require_block_literal "$smoke_block" '--no-uart-stdout' 'release smoke suppresses UART output'

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -216,15 +216,19 @@ require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the init
 
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
+  require_absent_literal "$doc" 'w1ne/labwired/.github/actions/labwired-test@main' "$doc does not point public users at the private root action"
 done
-require_literal docs/ci_integration.md 'w1ne/labwired/.github/actions/labwired-test@main' 'CI guide uses the published root GitHub action'
-require_literal docs/ci_integration.md 'version: v0.18.0' 'CI guide pins the CLI release independently of the root action ref'
-require_literal docs/integration-templates/github-actions.yml 'w1ne/labwired/.github/actions/labwired-test@main' 'GitHub template uses the published root action'
-require_literal docs/integration-templates/github-actions.yml 'version: v0.18.0' 'GitHub template pins the CLI release independently of the root action ref'
+require_literal docs/ci_integration.md 'w1ne/labwired-core/.github/actions/labwired-test@main' 'CI guide uses the public Core GitHub action'
+require_literal docs/ci_integration.md 'version: v0.18.0' 'CI guide pins the CLI release independently of the public action ref'
+require_literal docs/ci_integration.md 'output-dir: out/labwired' 'CI guide uses the Core action artifact input spelling'
+require_literal docs/integration-templates/github-actions.yml 'w1ne/labwired-core/.github/actions/labwired-test@main' 'GitHub template uses the public Core action'
+require_literal docs/integration-templates/github-actions.yml 'version: v0.18.0' 'GitHub template pins the CLI release independently of the public action ref'
+require_literal docs/integration-templates/github-actions.yml 'output-dir: out/labwired' 'GitHub template uses the Core action artifact input spelling'
 require_literal docs/integration-templates/gitlab-ci.yml 'name: ghcr.io/w1ne/labwired:v0.18.0' 'GitLab template uses the pinned runner image'
 require_literal docs/integration-templates/gitlab-ci.yml 'entrypoint: [""]' 'GitLab template clears the image entrypoint before invoking labwired'
-require_literal .github/actions/labwired-test/README.md 'w1ne/labwired/.github/actions/labwired-test@main' 'core action README directs users to the published root action'
+require_literal .github/actions/labwired-test/README.md 'w1ne/labwired-core/.github/actions/labwired-test@main' 'core action README directs users to the public Core action'
 require_literal .github/actions/labwired-test/README.md 'version: v0.18.0' 'core action README pins the immutable CLI release separately from action source'
+require_literal .github/actions/labwired-test/README.md 'output-dir: out/labwired' 'core action README uses the Core action artifact input spelling'
 
 if (( failures > 0 )); then
   printf 'Release runner contract failed with %d issue(s).\n' "$failures" >&2


### PR DESCRIPTION
## Summary
- publish versioned GHCR runner images alongside release archives
- add a safe one-time backfill path for the existing `v0.18.0` image
- harden the public Core action and document its no-build integration path

## Why
Consumer CI was rebuilding LabWired from source instead of downloading or pulling a released runner.

## Validation
- `scripts/ci/verify-release-runner-contract.sh`
- YAML parsing for release/backfill workflows and action metadata
- anonymous-pull/run release-smoke contract coverage

## Deployment note
After merging, dispatch the documented `v0.18.0` backfill workflow, mark the first GHCR package public, and rerun it if the anonymous-pull smoke reports private visibility.