### PR TITLE
esp32c3: exact-cycle event delivery + HW-measured RTC slow-clock

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,7 +46,16 @@ ureq = { workspace = true }
 default = []
 # Phase 3.2 JIT pilot (issue #124) — pass-through to labwired-core's `jit`
 # feature. Build with `cargo build --release -p labwired-cli --features
-# jit-core` to enable wasmtime-backed JIT for the fillScreen body block.
+# jit-core` to enable the wasmtime-backed RV32IMC JIT.
+#
+# NOTE: this deliberately does NOT pull in `event-scheduler`. Enabling that
+# feature CLI-wide makes scheduler-driven peripherals defer work to events that
+# only `Machine::run` drains — the CLI's non-eligible manual step_batch path
+# does not, so coupling it here regressed unrelated chips (KW41Z stimulus,
+# ESP32/ESP32-S3 tier1 labs). The JIT-eligible C3 path drives `Machine::run` and
+# engages the JIT at its fixed tick window regardless of the scheduler, and the
+# JIT-on vs JIT-off differential is byte-identical either way (both arms tick
+# peripherals identically), so the scheduler is not required for this path.
 jit-core = ["labwired-core/jit"]
 # Swap the built-in fuzzing loop for the LibAFL engine (havoc/splice mutators,
 # map-feedback scheduler, crash objectives). Heavy dependency tree, so opt-in:

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -149,6 +149,21 @@ pub(crate) fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode 
     let bridge = std::env::var("LABWIRED_WIFI_BRIDGE").is_ok()
         || std::env::var("LABWIRED_WIFI_BRIDGE_RE").is_ok();
     let dhcp_trace = std::env::var("LABWIRED_DHCP_TRACE").is_ok();
+
+    // ── Non-instrumented hot path: batch through Machine::run ────────────────
+    // When nothing needs per-instruction visibility (no --break-at, no WiFi
+    // bridge, no DHCP trace), run in batches through `Machine::run` so the
+    // RV32IMC wasm-JIT can engage (it only compiles multi-instruction batches,
+    // and its correctness gate refuses to run when observers/breakpoints/etc.
+    // are present). The debug / bridge / dhcp paths below keep single-stepping
+    // via `machine.step()`, which pins the batch to one instruction and so keeps
+    // the JIT correctly OFF — preserving every existing break/halt-trail/inject
+    // behavior. Byte-identity of the batched (JIT-on) path to the single-step
+    // interpreter is proven by tests/riscv_jit_c3_oled_differential.rs.
+    if !debug && !bridge && !dhcp_trace {
+        return run_firmware_riscv_batched(machine, &args, limit);
+    }
+
     // Find the behavioral wifi_mac model by type (the declarative chip-yaml
     // "wifi_mac" shares the name; routing uses ours via greatest-start-wins, but
     // name lookup would return the declarative one).
@@ -304,6 +319,87 @@ pub(crate) fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode 
                 eprintln!("[trail] {}", trail.join(" -> "));
             }
             break;
+        }
+    }
+
+    export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
+    ExitCode::from(EXIT_PASS)
+}
+
+/// The RISC-V (ESP32-C3) non-instrumented hot path: run in batches through
+/// `Machine::run` so the RV32IMC wasm-JIT (core feature `jit`, CLI feature
+/// `jit-core`) can engage on multi-instruction batches. Only reached when no
+/// per-instruction instrumentation (--break-at / WiFi bridge / DHCP trace) is
+/// active, so the JIT's correctness gate (no observers, no push tap, not
+/// cycle-accurate) is satisfied and compiled blocks retire atomically.
+///
+/// The JIT is byte-identical to the single-step interpreter — proven on the
+/// real C3 OLED lab by tests/riscv_jit_c3_oled_differential.rs. It is default-ON
+/// here; set `LABWIRED_RISCV_JIT=0` to force the interpreter (the escape hatch).
+/// Preserves the single-step path's semantics: EXIT_PASS on completion, a halt
+/// ends the run, and the bus trace is exported if requested.
+fn run_firmware_riscv_batched(
+    mut machine: labwired_core::Machine<labwired_core::cpu::RiscV>,
+    args: &RunArgs,
+    limit: u64,
+) -> ExitCode {
+    use labwired_core::bus::RECOMMENDED_TICK_INTERVAL;
+    use labwired_core::DebugControl;
+
+    // Escape hatch: LABWIRED_RISCV_JIT=0 forces the interpreter (default on).
+    let jit_on = std::env::var("LABWIRED_RISCV_JIT").as_deref() != Ok("0");
+
+    // The C3 is walk-deletable at rom-boot: its peripherals are scheduler-driven,
+    // so batching at RECOMMENDED_TICK_INTERVAL (64) is byte-identical to
+    // interval-1 while giving the JIT a batch window wide enough to retire whole
+    // basic blocks between peripheral ticks (see the differential gate). Set on
+    // BOTH machine.config and machine.bus.config, exactly as the gate does.
+    machine.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+    machine.bus.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+    machine.config.riscv_jit_enabled = jit_on;
+    machine.bus.config.riscv_jit_enabled = jit_on;
+
+    // Chunk the run so a u64::MAX `limit` (no --max-steps) stays bounded per
+    // `Machine::run` call. `Machine::run` batches internally at the tick
+    // interval; we only cap the total instruction budget here.
+    const CHUNK: u32 = 4_000_000;
+    let mut ran: u64 = 0;
+    while ran < limit {
+        let n = if limit == u64::MAX {
+            CHUNK
+        } else {
+            CHUNK.min((limit - ran) as u32)
+        };
+        let before = machine.step_profile().cpu_instructions;
+        match machine.run(Some(n)) {
+            Ok(_) => {}
+            Err(e) => {
+                // A halt is the normal end of a fixture run; the fault PC/reason
+                // is only surfaced on the debug (--break-at) path.
+                tracing::debug!("labwired-riscv (batched): halt: {e}");
+                break;
+            }
+        }
+        let delta = machine.step_profile().cpu_instructions - before;
+        ran += delta;
+        // No forward progress (idle with no fast-forward budget): stop rather
+        // than spin re-issuing empty batches up to `limit`.
+        if delta == 0 {
+            break;
+        }
+    }
+
+    // Opt-in non-vacuity / diagnostic: prove the JIT actually compiled and ran
+    // hot blocks on this run (LABWIRED_JIT_STATS=1). Only meaningful in a
+    // `jit-core` build; the accessor does not exist otherwise.
+    #[cfg(feature = "jit-core")]
+    if std::env::var("LABWIRED_JIT_STATS").is_ok() {
+        match machine.cpu.jit_stats() {
+            Some(s) => eprintln!(
+                "[jit-stats] compiled={} block_runs={} block_instrs={} interpreted={}",
+                s.compiled, s.block_runs, s.block_instrs, s.interpreted
+            ),
+            None => eprintln!("[jit-stats] JIT engine never created (interpreter-only run)"),
         }
     }
 

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -476,6 +476,9 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 require_fault_fired,
                 fault_evidence,
                 &stimuli,
+                // Xtensa (ESP32) path: never JIT-eligible (the RV32IMC JIT is
+                // RISC-V only), so keep the exact current observer-based metrics.
+                false,
             );
             // Device-block render readout. Surfaces the attached panel block's
             // REAL render state — refresh_gen AND black-plane ink — so a generic
@@ -598,7 +601,25 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     macro_rules! run_machine {
         ($machine:expr) => {{
             let mut machine = $machine;
-            machine.observers.push(metrics.clone());
+            // JIT-eligible RISC-V runs source cycles/instructions from the
+            // machine's own counters (see `execute_test_loop`), so the metrics
+            // step observer must NOT be installed — its presence would gate the
+            // RV32IMC JIT's correctness check shut. Every other run keeps the
+            // exact current behavior: metrics is the live per-step observer.
+            // Gate on the `jit-core` build feature, which enables ONLY the core
+            // `jit` feature (NOT `event-scheduler` — see crates/cli/Cargo.toml
+            // for why the scheduler is deliberately left out). The C3
+            // tick-widening path is byte-identical without the scheduler; that
+            // is proven empirically by the differential tests
+            // (riscv_jit_c3_oled_test_differential: JIT on vs off, and
+            // riscv_tick_interval_fidelity_differential: tick interval 1 vs 64),
+            // not by the scheduler. In a plain build `cfg!` is false, so every
+            // run keeps the exact current observer-based, single-step behavior.
+            let jit_eligible = cfg!(feature = "jit-core")
+                && riscv_jit_test_eligible(&args, &resolved_limits, &machine, program.arch);
+            if !jit_eligible {
+                machine.observers.push(metrics.clone());
+            }
             let fault_evidence = handle_faults(&mut machine.bus, &faults);
             execute_test_loop(
                 &args,
@@ -614,6 +635,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 require_fault_fired,
                 fault_evidence,
                 &stimuli,
+                jit_eligible,
             )
         }};
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1230,6 +1230,70 @@ fn assertion_currently_passes(
     }
 }
 
+/// Does this `labwired test` run qualify for the RV32IMC wasm-JIT fast path?
+///
+/// True ⇔ the target is RISC-V (ESP32-C3), batch mode is on, and NONE of the
+/// per-instruction-visibility features that force the JIT's correctness gate
+/// shut is active. This is the SAME set of conditions that would otherwise pin
+/// the CLI batch to one instruction (`batch_size` in `execute_test_loop`) or
+/// make `RiscV::jit_gate_allows` refuse to run — folded into one predicate the
+/// caller evaluates BEFORE installing observers, so the eligible path can skip
+/// the metrics step observer entirely (its presence gates the JIT off) and
+/// source cycles/instructions from the machine's own counters instead.
+///
+/// Deliberately conservative: any `--trace`/`--coverage`/`--vcd`/`--breakpoint`/
+/// `--detect-stuck`/`--watch-gpio`, a `stop_when_assertions_pass` early-stop, or
+/// a cycle-accurate/poll-mode peripheral drops the run onto the exact current
+/// observer-based path (`jit_eligible == false`).
+fn riscv_jit_test_eligible<C: labwired_core::Cpu>(
+    args: &TestArgs,
+    limits: &TestLimits,
+    machine: &labwired_core::Machine<C>,
+    arch: labwired_core::Arch,
+) -> bool {
+    // NOTE: `batch_mode_enabled` is deliberately NOT required. The eligible path
+    // drives `Machine::run`, which batches to the peripheral-tick cadence
+    // regardless of that flag — indeed the C3 rom-boot machine turns it OFF (its
+    // fixed-width step_batch loop freezes FreeRTOS), which is exactly the case we
+    // want to accelerate.
+    matches!(arch, labwired_core::Arch::RiscV)
+        && !args.trace
+        && !args.coverage
+        && args.vcd.is_none()
+        && args.breakpoint.is_empty()
+        && args.watch_gpio.is_empty()
+        && args.capture_app_entry.is_none()
+        && limits.no_progress_steps.is_none()
+        && !limits.stop_when_assertions_pass
+        && !machine.bus.requires_cycle_accurate()
+        && !machine.logic_poll_active()
+}
+
+/// Map a core `SimulationError` to the CLI `StopReason`, identically to the
+/// step_batch / step arms of `execute_test_loop`. Shared by the JIT-eligible
+/// `Machine::run` arm so a halt/fault ends the run with the same reason.
+fn map_sim_error_to_stop_reason(e: &labwired_core::SimulationError) -> StopReason {
+    use labwired_core::SimulationError as E;
+    match e {
+        E::MemoryViolation(_) => StopReason::MemoryViolation,
+        E::DecodeError(_) => StopReason::DecodeError,
+        E::Halt => StopReason::Halt,
+        E::SnapshotSchemaMismatch { .. } => StopReason::Exception,
+        E::Other(_) => StopReason::Exception,
+        E::NotImplemented(_) => StopReason::Exception,
+        E::BreakpointHit(_) => StopReason::Halt,
+        E::ExceptionRaised { .. } => StopReason::Exception,
+    }
+}
+
+/// Instruction budget per `Machine::run` call on the JIT-eligible C3 path. The
+/// stimulus/limit checks at the top of `execute_test_loop`'s run loop run once
+/// per chunk, so this bounds their granularity; the chunk is further clamped so
+/// a run never steps PAST the nearest pending cycle threshold (time-triggered
+/// stimulus or `max_cycles`), keeping those firing points cycle-tight and
+/// identical between the JIT-on and JIT-off arms.
+const JIT_RUN_CHUNK: u32 = 1_000_000;
+
 #[allow(clippy::too_many_arguments)]
 fn execute_test_loop<C: labwired_core::Cpu>(
     args: &TestArgs,
@@ -1245,7 +1309,16 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     require_fault_fired: bool,
     mut fault_evidence: Vec<labwired_cli::faults::FaultEvidence>,
     stimuli: &[labwired_config::StimulusSpec],
+    // True when this run qualifies for the RV32IMC wasm-JIT fast path (decided
+    // by `riscv_jit_test_eligible` in the caller): RiscV arch, batch mode, and
+    // NONE of the per-instruction-visibility features that gate the JIT off.
+    // In this mode `metrics` was NOT installed as a step observer (its presence
+    // forces the JIT's correctness gate shut), so the loop mirrors the machine's
+    // own counters into `metrics` before each cycle-sensitive check.
+    jit_eligible: bool,
 ) -> ExitCode {
+    // `Machine::run` (the JIT-eligible arm) is a `DebugControl` trait method.
+    use labwired_core::DebugControl;
     let max_steps = resolved_limits.max_steps;
     let max_cycles = resolved_limits.max_cycles;
     let max_uart_bytes = resolved_limits.max_uart_bytes;
@@ -1334,6 +1407,55 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         }
     };
     let logic_capture_armed = !logic_watch_meta.is_empty();
+
+    // ── JIT-eligible cycle/instruction sourcing (RISC-V / ESP32-C3) ──────────
+    // When eligible, engage the RV32IMC wasm-JIT for this run and source the
+    // metrics counters from the machine's own state (no step observer). Sourcing
+    // cycles from `machine.total_cycles` (not the observer's per-step
+    // `on_step_end` tap) is what makes JIT-on and JIT-off byte-identical:
+    // compiled blocks retire WITHOUT firing `on_step_end`, so an observer would
+    // undercount them. Both JIT arms (`LABWIRED_RISCV_JIT=1` on, default off)
+    // STAY in this same machine-sourced regime, so they are byte-identical
+    // (proven by tests/riscv_jit_c3_oled_test_differential); the metrics numbers
+    // never depend on whether a batch was interpreted or compiled.
+    if jit_eligible {
+        // JIT is OPT-IN (LABWIRED_RISCV_JIT=1), NOT default-on. Measured on the
+        // esp32c3-oled-demo oracle lab, the wasmtime RV32IMC JIT is ~18× SLOWER
+        // than the interpreter here: the hot path is tight FreeRTOS/idle loops
+        // (~1.9 guest instr per compiled-block run), so the per-block-dispatch
+        // FFI overhead dwarfs the interpreted cost and ~⅔ of instructions still
+        // fall back to the interpreter. The genuine speedup on this path is the
+        // tick-interval widening below (Machine::run at the bus max-safe
+        // interval: ~2.6× faster than the pre-change single-step tick-1 oracle),
+        // which is applied UNCONDITIONALLY when eligible. The JIT stays wired,
+        // proven byte-identical, and one env var away for compute-heavy firmware
+        // where straight-line blocks amortize the dispatch cost. See the report.
+        let jit_on = std::env::var("LABWIRED_RISCV_JIT").as_deref() == Ok("1");
+        machine.config.riscv_jit_enabled = jit_on;
+        machine.bus.config.riscv_jit_enabled = jit_on;
+        // Widen the peripheral-tick interval to RECOMMENDED_TICK_INTERVAL so
+        // `Machine::run`'s per-tick batch (`remaining_until_tick`) is wide enough
+        // for compiled blocks to retire, and the peripheral tick count drops
+        // ~64×. The C3 rom-boot peripherals are walk-deletable, so this is
+        // observably identical to interval-1 (esp32c3_walk_differential); the
+        // eligibility gate already excludes any `requires_cycle_accurate` bus.
+        // `max_safe_tick_interval` is NOT used here because it only returns the
+        // wide interval under the `event-scheduler` feature, which the CLI does
+        // not enable (see crates/cli/Cargo.toml). Crucially this is applied to
+        // BOTH JIT arms, so it never perturbs the JIT-on vs JIT-off differential.
+        // TEST-ONLY escape hatch (regression gate riscv_jit_c3_oled_test_differential):
+        // override the widened interval with LABWIRED_TICK_INTERVAL so the
+        // interval-64 (widened) vs interval-1 (baseline) fidelity gate can be
+        // proven empirically with EVERYTHING else identical (same machine-sourced
+        // cycle counting, same eligible code path) — the tick interval is the ONLY
+        // variable. Unset = default (RECOMMENDED_TICK_INTERVAL).
+        let interval = std::env::var("LABWIRED_TICK_INTERVAL")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(labwired_core::bus::RECOMMENDED_TICK_INTERVAL);
+        machine.config.peripheral_tick_interval = interval;
+        machine.bus.config.peripheral_tick_interval = interval;
+    }
 
     let batch_size = if machine.config.batch_mode_enabled
         && args.breakpoint.is_empty()
@@ -1437,6 +1559,17 @@ fn execute_test_loop<C: labwired_core::Cpu>(
 
     let mut step = 0;
     while step < max_steps {
+        // JIT-eligible path: mirror the machine's authoritative counters into
+        // `metrics` BEFORE the cycle-sensitive checks below (stimulus
+        // `after_cycles`, `max_cycles`), so they fire at exactly the same batch
+        // boundary the observer path would. `step` is the retired-instruction
+        // count (accumulated from `step_batch` return values); `total_cycles`
+        // is the machine's canonical cycle counter. No-op for the non-eligible
+        // path, where `metrics` IS the live step observer.
+        if jit_eligible {
+            metrics.set_cycles(machine.total_cycles);
+            metrics.set_instructions(step);
+        }
         // --capture-app-entry: detect the first instant execution reaches the
         // application, snapshot the live machine, and write the resume blob.
         if let Some(cap) = &app_entry_capture {
@@ -1510,7 +1643,64 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         let current_batch = batch_size as u32;
         let to_execute = current_batch.min(remaining);
 
-        if to_execute > 1 {
+        if jit_eligible {
+            // ── JIT-eligible C3 rom-boot: drive the proven Machine::run engine ──
+            // `build_rom_boot_machine` disables `batch_mode` because the manual
+            // step_batch arm below runs a FIXED-width batch and only ticks
+            // peripherals AFTER it — which freezes interrupt delivery (hence
+            // FreeRTOS) across the batch. `Machine::run` instead batches to the
+            // peripheral-tick cadence (`peripheral_tick_interval`, raised to the
+            // bus's max-safe interval when eligible), delivering interrupts every
+            // tick while dispatching the RV32IMC JIT. This is the EXACT engine
+            // `riscv_jit_c3_oled_test_differential` proves byte-identical JIT-on
+            // vs JIT-off. Run in `JIT_RUN_CHUNK` chunks, clamped so we never step
+            // past the nearest pending cycle threshold, so the stimulus/limit
+            // checks at the loop top fire cycle-tight and identically per arm.
+            let cur = machine.total_cycles;
+            let mut n = remaining.min(JIT_RUN_CHUNK);
+            // Clamp the chunk so a run never steps past the nearest pending cycle
+            // threshold: cycles advance ≥ 1 per instruction, so capping the
+            // instruction budget at `threshold - cur` guarantees the NEXT loop-top
+            // check sees `metrics.get_cycles() >= threshold` and fires it — never
+            // a chunk late. `.max(1)` keeps forward progress at an already-reached
+            // threshold (the check then fires immediately next iteration).
+            for (s, fired) in &pending_stimuli {
+                if !*fired {
+                    if let labwired_config::FaultTrigger::AfterCycles { cycles: t } = s.trigger {
+                        if t > cur {
+                            n = n.min(((t - cur).min(u32::MAX as u64) as u32).max(1));
+                        }
+                    }
+                }
+            }
+            if let Some(limit) = max_cycles {
+                if limit > cur {
+                    n = n.min(((limit - cur).min(u32::MAX as u64) as u32).max(1));
+                }
+            }
+            let before = machine.step_profile().cpu_instructions;
+            match machine.run(Some(n)) {
+                Ok(_) => {
+                    let executed = machine.step_profile().cpu_instructions - before;
+                    step += executed;
+                    steps_executed = step;
+                    // No forward progress (idle spin, no fast-forward budget):
+                    // stop rather than re-issue empty runs up to `max_steps`.
+                    if executed == 0 {
+                        stop_reason = StopReason::Halt;
+                        break;
+                    }
+                }
+                Err(e) => {
+                    sim_error_happened = true;
+                    stop_reason = map_sim_error_to_stop_reason(&e);
+                    if stop_reason != StopReason::Halt {
+                        error!("Simulation error at step {}: {}", step, e);
+                    }
+                    break;
+                }
+            }
+        } else if to_execute > 1 {
             // Push-mode logic capture: seed the tap clock at the batch start;
             // the CPU advances it once per retired instruction so pad writes
             // stamp with the boundary they become observable at (mirrors
@@ -1707,6 +1897,29 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                     }
                 }
             }
+        }
+    }
+
+    // Final counter mirror for the JIT-eligible path: the loop-top sync runs
+    // before the LAST batch, so capture that batch's retired cycles/instructions
+    // here — `result.json` (`cycles`/`instructions`) and `stop_reason_details`
+    // read `metrics` below and must report the true totals.
+    if jit_eligible {
+        metrics.set_cycles(machine.total_cycles);
+        metrics.set_instructions(steps_executed);
+    }
+
+    // Opt-in JIT non-vacuity / diagnostic: prove hot blocks actually compiled
+    // and ran on this oracle run (LABWIRED_JIT_STATS=1). `jit_engine_stats` is a
+    // feature-agnostic Cpu-trait accessor: `Some(..)` only in a `jit-core` build
+    // whose JIT engine was created, `None` otherwise (interpreter-only).
+    if jit_eligible && std::env::var("LABWIRED_JIT_STATS").is_ok() {
+        match machine.cpu.jit_engine_stats() {
+            Some(s) => eprintln!(
+                "[jit-stats] compiled={} block_runs={} block_instrs={} interpreted={}",
+                s.compiled, s.block_runs, s.block_instrs, s.interpreted
+            ),
+            None => eprintln!("[jit-stats] JIT engine never created (interpreter-only run)"),
         }
     }
 

--- a/crates/cli/tests/riscv_jit_c3_oled_test_differential.rs
+++ b/crates/cli/tests/riscv_jit_c3_oled_test_differential.rs
@@ -1,0 +1,216 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! HARD GATE for engaging the RV32IMC wasm-JIT on the DEPLOYED `labwired test`
+//! ESP32-C3 firmware-verify oracle.
+//!
+//! Drives the REAL `labwired` binary (the same one the builder service runs) on
+//! the `esp32c3-oled-demo` rom-boot lab TWICE — JIT-on (`LABWIRED_RISCV_JIT=1`)
+//! vs JIT-off (`LABWIRED_RISCV_JIT=0`) — and asserts the emitted `result.json`
+//! is byte-identical. `result.json` carries no wall-time / IPS / timestamp field
+//! (only deterministic `cycles`/`instructions` counters, the decoded register
+//! and framebuffer inspect block, and serial-derived assertions), so no
+//! host-variant normalization is needed — the comparison is a literal byte diff.
+//!
+//! Both arms take the JIT-eligible path (`riscv_jit_test_eligible` →
+//! `Machine::run` at the bus max-safe tick interval, sourcing cycles from
+//! `machine.total_cycles` instead of the metrics step observer). The ONLY thing
+//! `LABWIRED_RISCV_JIT` changes is whether hot basic blocks are dispatched
+//! through the compiled engine; because cycles are machine-sourced (compiled
+//! blocks retire without firing `on_step_end`), the two arms match to the byte.
+//!
+//! Two scenarios, per the gate. The `max_steps` scenario runs to a step budget:
+//! the OLED paints ("OLED painted: LabWired" on serial, framebuffer in the
+//! inspect block), proving the verdict and telemetry match. The `max_cycles`
+//! scenario stops the run mid-flight on a cycle LIMIT, proving the cycle-sourcing
+//! swap fires `max_cycles` at the exact same point on both arms (the crux).
+//!
+//! Under a `jit-core` build the JIT-on arm is additionally asserted NON-VACUOUS
+//! (compiled blocks actually ran) by parsing the `LABWIRED_JIT_STATS=1` stderr.
+//! Without `jit-core` the eligible path is compiled out (`cfg!` false) so both
+//! arms run the identical interpreter and byte-identity holds trivially.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Repo root = crates/cli/../.. (matches the other CLI integration tests).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+fn require(path: PathBuf) -> PathBuf {
+    assert!(path.exists(), "missing fixture: {}", path.display());
+    path
+}
+
+struct Fixtures {
+    flash: PathBuf,
+    elf: PathBuf,
+    system: PathBuf,
+}
+
+fn fixtures() -> Fixtures {
+    let root = repo_root();
+    Fixtures {
+        // The curated OLED-demo flash image (bootloader + partition table + app)
+        // the browser fast-start and the core differential gate both boot.
+        flash: require(root.join("crates/wasm/tests/fixtures/esp32c3-oled-demo-flash.bin")),
+        // rom-boot executes the FLASH; the ELF only feeds symbols/diagnostics, so
+        // any RISC-V C3 ELF drives the same run (both arms use the identical one).
+        elf: require(root.join("tests/fixtures/esp32c3-demo.elf")),
+        system: require(root.join("configs/systems/esp32c3-oled-demo.yaml")),
+    }
+}
+
+/// Write a `labwired test` YAML script to `dir/name` and return its path.
+fn write_script(dir: &Path, name: &str, fx: &Fixtures, limits: &str, assertion: &str) -> PathBuf {
+    let script = format!(
+        "schema_version: \"1.0\"\n\
+         inputs:\n  \
+           firmware: \"{}\"\n  \
+           system: \"{}\"\n\
+         limits:\n{}\
+         assertions:\n{}\n",
+        fx.elf.display(),
+        fx.system.display(),
+        limits,
+        assertion,
+    );
+    let path = dir.join(name);
+    std::fs::write(&path, script).expect("write test script");
+    path
+}
+
+struct RunOutput {
+    result_json: Vec<u8>,
+    stderr: String,
+    exit_ok: bool,
+}
+
+/// Invoke the built `labwired test` binary once with the given JIT toggle.
+fn run_oracle(fx: &Fixtures, script: &Path, out_dir: &Path, jit_env: &str) -> RunOutput {
+    std::fs::create_dir_all(out_dir).expect("create out dir");
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(repo_root())
+        .env("LABWIRED_ESP32C3_FLASH", &fx.flash)
+        .env("LABWIRED_RISCV_JIT", jit_env)
+        .env("LABWIRED_JIT_STATS", "1")
+        .args([
+            "test",
+            "--script",
+            script.to_str().unwrap(),
+            "--rom-boot",
+            "--no-uart-stdout",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn labwired");
+    let result_path = out_dir.join("result.json");
+    let result_json = std::fs::read(&result_path).unwrap_or_else(|e| {
+        panic!(
+            "no result.json at {} (exit {:?}): {e}\nstderr:\n{}",
+            result_path.display(),
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    RunOutput {
+        result_json,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_ok: output.status.success(),
+    }
+}
+
+/// Parse the `[jit-stats] compiled=N block_runs=M ...` diagnostic line, if any.
+fn jit_compiled_blocks(stderr: &str) -> Option<u64> {
+    let line = stderr
+        .lines()
+        .find(|l| l.contains("[jit-stats] compiled="))?;
+    let tok = line
+        .split_whitespace()
+        .find(|t| t.starts_with("compiled="))?;
+    tok.trim_start_matches("compiled=").parse().ok()
+}
+
+/// Core assertion: run both arms, diff `result.json`, and (under `jit-core`)
+/// require the JIT-on arm to be non-vacuous.
+fn assert_arms_byte_identical(scenario: &str, fx: &Fixtures, script: &Path, tmp: &Path) {
+    let on = run_oracle(fx, script, &tmp.join(format!("{scenario}_on")), "1");
+    let off = run_oracle(fx, script, &tmp.join(format!("{scenario}_off")), "0");
+
+    assert!(on.exit_ok, "[{scenario}] JIT-on run failed:\n{}", on.stderr);
+    assert!(
+        off.exit_ok,
+        "[{scenario}] JIT-off run failed:\n{}",
+        off.stderr
+    );
+
+    assert!(
+        on.result_json == off.result_json,
+        "[{scenario}] result.json DIVERGED between JIT-on and JIT-off ({} vs {} bytes)\n\
+         JIT-on:\n{}\nJIT-off:\n{}",
+        on.result_json.len(),
+        off.result_json.len(),
+        String::from_utf8_lossy(&on.result_json),
+        String::from_utf8_lossy(&off.result_json),
+    );
+
+    // Non-vacuity: only meaningful when the binary was built WITH the JIT
+    // (`jit-core`). The test crate and the binary share the cargo feature set,
+    // so `cfg!(feature = "jit-core")` reflects the binary's capability.
+    if cfg!(feature = "jit-core") {
+        let compiled = jit_compiled_blocks(&on.stderr).unwrap_or(0);
+        assert!(
+            compiled > 0,
+            "[{scenario}] JIT-on arm was VACUOUS (compiled={compiled}); \
+             the eligible batch never ran through the compiled engine.\nstderr:\n{}",
+            on.stderr
+        );
+        // The JIT-off arm must NOT have created a JIT engine.
+        assert!(
+            jit_compiled_blocks(&off.stderr).is_none(),
+            "[{scenario}] JIT-off arm unexpectedly compiled blocks:\n{}",
+            off.stderr
+        );
+        eprintln!("[{scenario}] byte-identical; JIT-on compiled {compiled} blocks (non-vacuous)");
+    } else {
+        eprintln!("[{scenario}] byte-identical (no jit-core: eligible path compiled out)");
+    }
+}
+
+#[test]
+fn jit_on_vs_off_result_json_byte_identical_c3_oled() {
+    let fx = fixtures();
+    let tmp = std::env::temp_dir().join(format!("lw-jit-oled-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("create tmp dir");
+
+    // Scenario 1: run to a step budget — the OLED paints and serial reports it.
+    // 8M steps is comfortably past the "OLED painted: LabWired" milestone.
+    let s_steps = write_script(
+        &tmp,
+        "oled_max_steps.yaml",
+        &fx,
+        "  max_steps: 8000000\n",
+        "  - expected_stop_reason: max_steps\n  - uart_contains: \"OLED painted: LabWired\"",
+    );
+    assert_arms_byte_identical("max_steps", &fx, &s_steps, &tmp);
+
+    // Scenario 2: a CYCLE limit that stops the run mid-flight. This is what
+    // proves the cycle-sourcing swap (metrics.cycles ← machine.total_cycles)
+    // fires `max_cycles` at the identical point on both arms.
+    let s_cycles = write_script(
+        &tmp,
+        "oled_max_cycles.yaml",
+        &fx,
+        "  max_steps: 20000000\n  max_cycles: 5000000\n",
+        "  - expected_stop_reason: max_cycles",
+    );
+    assert_arms_byte_identical("max_cycles", &fx, &s_cycles, &tmp);
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/crates/cli/tests/riscv_tick_interval_fidelity_differential.rs
+++ b/crates/cli/tests/riscv_tick_interval_fidelity_differential.rs
@@ -1,0 +1,305 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! FIDELITY GUARD for the peripheral tick-WIDENING applied on the JIT-eligible
+//! ESP32-C3 `labwired test` rom-boot path.
+//!
+//! When a run is JIT-eligible (built with `jit-core`, C3 rom-boot, no
+//! cycle-accurate bus), the CLI widens the peripheral-tick interval from 1 to
+//! `RECOMMENDED_TICK_INTERVAL` (64) so `Machine::run`'s per-tick batch is wide
+//! enough for compiled blocks to retire and the peripheral tick count drops
+//! ~64x. That widening is the SHIPPED DEFAULT for every JIT-eligible C3 run,
+//! whether or not the JIT itself is engaged (`LABWIRED_RISCV_JIT`). This test
+//! is the empirical proof that the widening changes NO observable output.
+//!
+//! It drives the REAL `labwired test` binary (the same one the builder service
+//! runs) on the `esp32c3-oled-demo` oracle TWICE, with the JIT OFF on BOTH arms
+//! (`LABWIRED_RISCV_JIT=0`) so the tick interval is the ONLY variable:
+//!   * Arm A — `LABWIRED_TICK_INTERVAL=1`  (baseline, cycle-by-cycle ticking)
+//!   * Arm B — `LABWIRED_TICK_INTERVAL=64` (the widened shipped default)
+//!
+//! Both take the identical JIT-eligible code path (same machine-sourced cycle
+//! counting); the only difference is how often peripherals are ticked. The
+//! `LABWIRED_TICK_INTERVAL` env hook exists solely for this gate (see the
+//! comment in `crates/cli/src/main.rs`); unset it defaults to the widened 64.
+//!
+//! The test asserts every OBSERVABLE channel is byte-identical between the two
+//! arms: the serial/UART transcript (`uart.log`), the assertion verdicts
+//! (status == pass, `expected_stop_reason`, `uart_contains`), `stop_reason`,
+//! `steps_executed`, and the whole `inspect` block (the decoded SSD1306
+//! framebuffer / generation / lit pixels every peripheral exposes). It then
+//! strips the deliberately-excluded internal fields and asserts the ENTIRE
+//! remainder of `result.json` matches too, so any new observable field is
+//! caught automatically.
+//!
+//! DELIBERATELY EXCLUDED from the comparison (NOT observable output):
+//!   * `cpu_state` — the halt-instant register snapshot differs BY DESIGN:
+//!     interval-64 services peripheral interrupts on 64-cycle boundaries, so the
+//!     firmware is stopped at a different micro-instant and its live registers
+//!     (`pc`, `mepc`, a handful of GPRs) differ. This is internal CPU micro-state
+//!     at the arbitrary halt point, not a channel the firmware's behavior is
+//!     observed through.
+//!   * `cycles` / `instructions` — internal retirement counters. (They in fact
+//!     match today, but they are excluded on principle: they are engine
+//!     telemetry, not firmware-observable output.)
+//!   * any wall-clock / IPS / timestamp field — `result.json` carries none, so
+//!     nothing to strip, but excluded by policy for completeness.
+//!
+//! If this test EVER fails, the tick-widening has started perturbing observable
+//! behavior and MUST NOT ship as the default — the assertions must not be
+//! weakened to make it pass.
+//!
+//! This is a SEPARATE guard from the JIT-on vs JIT-off differential
+//! (`riscv_jit_c3_oled_test_differential`): that one fixes the tick interval and
+//! varies the JIT; this one fixes the JIT (off) and varies the tick interval.
+//! Together they prove both knobs of the eligible path are observably inert.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Repo root = crates/cli/../.. (matches the other CLI integration tests).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+fn require(path: PathBuf) -> PathBuf {
+    assert!(path.exists(), "missing fixture: {}", path.display());
+    path
+}
+
+struct Fixtures {
+    flash: PathBuf,
+    elf: PathBuf,
+    system: PathBuf,
+}
+
+fn fixtures() -> Fixtures {
+    let root = repo_root();
+    Fixtures {
+        // The curated OLED-demo flash image (bootloader + partition table + app)
+        // the browser fast-start and the core differential gate both boot.
+        flash: require(root.join("crates/wasm/tests/fixtures/esp32c3-oled-demo-flash.bin")),
+        // rom-boot executes the FLASH; the ELF only feeds symbols/diagnostics, so
+        // any RISC-V C3 ELF drives the same run (both arms use the identical one).
+        elf: require(root.join("tests/fixtures/esp32c3-demo.elf")),
+        system: require(root.join("configs/systems/esp32c3-oled-demo.yaml")),
+    }
+}
+
+/// Write a `labwired test` YAML script to `dir/name` and return its path.
+fn write_script(dir: &Path, name: &str, fx: &Fixtures, limits: &str, assertion: &str) -> PathBuf {
+    let script = format!(
+        "schema_version: \"1.0\"\n\
+         inputs:\n  \
+           firmware: \"{}\"\n  \
+           system: \"{}\"\n\
+         limits:\n{}\
+         assertions:\n{}\n",
+        fx.elf.display(),
+        fx.system.display(),
+        limits,
+        assertion,
+    );
+    let path = dir.join(name);
+    std::fs::write(&path, script).expect("write test script");
+    path
+}
+
+struct RunOutput {
+    /// Parsed `result.json`.
+    result: serde_json::Value,
+    /// The serial transcript artifact (`uart.log`) — the firmware's observable
+    /// serial output, the exact bytes the `uart_contains` assertion reads.
+    uart_log: Vec<u8>,
+    stderr: String,
+    exit_ok: bool,
+}
+
+/// Invoke the built `labwired test` binary once at the given peripheral-tick
+/// interval, JIT OFF. Requires the `jit-core` build so the eligible path (and
+/// thus the `LABWIRED_TICK_INTERVAL` override) is compiled in.
+fn run_oracle(fx: &Fixtures, script: &Path, out_dir: &Path, tick_interval: u32) -> RunOutput {
+    std::fs::create_dir_all(out_dir).expect("create out dir");
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(repo_root())
+        .env("LABWIRED_ESP32C3_FLASH", &fx.flash)
+        // JIT OFF on BOTH arms: the tick interval is the ONLY variable.
+        .env("LABWIRED_RISCV_JIT", "0")
+        // The test-only escape hatch that overrides the widened interval.
+        .env("LABWIRED_TICK_INTERVAL", tick_interval.to_string())
+        .args([
+            "test",
+            "--script",
+            script.to_str().unwrap(),
+            "--rom-boot",
+            "--no-uart-stdout",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn labwired");
+    let result_path = out_dir.join("result.json");
+    let result_bytes = std::fs::read(&result_path).unwrap_or_else(|e| {
+        panic!(
+            "no result.json at {} (exit {:?}): {e}\nstderr:\n{}",
+            result_path.display(),
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let result: serde_json::Value =
+        serde_json::from_slice(&result_bytes).expect("parse result.json");
+    // The serial transcript is written alongside result.json. It must exist —
+    // the whole point is to diff the firmware's serial output between arms.
+    let uart_log = std::fs::read(out_dir.join("uart.log")).unwrap_or_else(|e| {
+        panic!(
+            "no uart.log in {} (exit {:?}): {e}",
+            out_dir.display(),
+            output.status.code()
+        )
+    });
+    RunOutput {
+        result,
+        uart_log,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_ok: output.status.success(),
+    }
+}
+
+/// Return a clone of `result.json` with the deliberately-excluded, non-observable
+/// internal fields removed, so the remainder can be compared byte-for-byte.
+fn strip_non_observable(mut v: serde_json::Value) -> serde_json::Value {
+    if let Some(obj) = v.as_object_mut() {
+        // Halt-instant CPU register snapshot: differs by design (see module doc).
+        obj.remove("cpu_state");
+        // Internal engine retirement counters, not firmware-observable output.
+        obj.remove("cycles");
+        obj.remove("instructions");
+    }
+    v
+}
+
+fn pretty(v: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(v).unwrap_or_default()
+}
+
+#[test]
+fn tick_interval_1_vs_64_observable_output_identical_c3_oled() {
+    let fx = fixtures();
+    let tmp = std::env::temp_dir().join(format!("lw-tick-fidelity-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("create tmp dir");
+
+    // The `LABWIRED_TICK_INTERVAL` override only takes effect on the JIT-eligible
+    // path, which is compiled in only under `jit-core`. Without it both arms run
+    // the identical interpreter at interval-1 and the test is vacuous, so skip.
+    if !cfg!(feature = "jit-core") {
+        eprintln!(
+            "SKIP: built without `jit-core`; the tick-widening eligible path is \
+             compiled out, so interval-1 vs interval-64 is not exercised."
+        );
+        return;
+    }
+
+    // Run to a step budget large enough to paint the OLED and report it on serial
+    // (matches riscv_jit_c3_oled_test_differential's max_steps scenario).
+    let script = write_script(
+        &tmp,
+        "oled_max_steps.yaml",
+        &fx,
+        "  max_steps: 8000000\n",
+        "  - expected_stop_reason: max_steps\n  - uart_contains: \"OLED painted: LabWired\"",
+    );
+
+    let a = run_oracle(&fx, &script, &tmp.join("interval_1"), 1); // baseline
+    let b = run_oracle(&fx, &script, &tmp.join("interval_64"), 64); // widened default
+
+    assert!(a.exit_ok, "interval-1 run failed:\n{}", a.stderr);
+    assert!(b.exit_ok, "interval-64 run failed:\n{}", b.stderr);
+
+    // Both arms must actually pass (guards against a vacuous "both errored" match).
+    assert_eq!(
+        a.result["status"],
+        "pass",
+        "interval-1 did not pass:\n{}",
+        pretty(&a.result)
+    );
+    assert_eq!(
+        b.result["status"],
+        "pass",
+        "interval-64 did not pass:\n{}",
+        pretty(&b.result)
+    );
+
+    // --- OBSERVABLE CHANNEL 1: the serial/UART transcript, byte-for-byte. ---
+    assert!(
+        a.uart_log == b.uart_log,
+        "uart.log DIVERGED between interval-1 and interval-64 ({} vs {} bytes)\n\
+         interval-1:\n{}\ninterval-64:\n{}",
+        a.uart_log.len(),
+        b.uart_log.len(),
+        String::from_utf8_lossy(&a.uart_log),
+        String::from_utf8_lossy(&b.uart_log),
+    );
+
+    // --- OBSERVABLE CHANNEL 2: the assertion verdicts (status + each clause). ---
+    assert_eq!(
+        a.result["assertions"],
+        b.result["assertions"],
+        "assertion verdicts diverged\ninterval-1:\n{}\ninterval-64:\n{}",
+        pretty(&a.result["assertions"]),
+        pretty(&b.result["assertions"]),
+    );
+
+    // --- OBSERVABLE CHANNEL 3: the stop reason and steps executed. ---
+    assert_eq!(
+        a.result["stop_reason"], b.result["stop_reason"],
+        "stop_reason diverged"
+    );
+    assert_eq!(
+        a.result["steps_executed"], b.result["steps_executed"],
+        "steps_executed diverged"
+    );
+
+    // --- OBSERVABLE CHANNEL 4: the whole inspect block (decoded SSD1306 pixels /
+    //     generation / lit pixels / ink bytes every peripheral exposes). ---
+    assert_eq!(
+        a.result["inspect"],
+        b.result["inspect"],
+        "inspect block (framebuffer/peripheral decode) diverged\n\
+         interval-1:\n{}\ninterval-64:\n{}",
+        pretty(&a.result["inspect"]),
+        pretty(&b.result["inspect"]),
+    );
+
+    // --- CATCH-ALL: the ENTIRE result.json minus the excluded internal fields
+    //     (cpu_state / cycles / instructions) must be byte-identical, so any new
+    //     observable field is compared automatically without editing this test. ---
+    let stripped_a = strip_non_observable(a.result.clone());
+    let stripped_b = strip_non_observable(b.result.clone());
+    assert_eq!(
+        stripped_a,
+        stripped_b,
+        "result.json (excluding cpu_state/cycles/instructions) DIVERGED between \
+         interval-1 and interval-64 — the tick-widening perturbed observable output.\n\
+         interval-1:\n{}\ninterval-64:\n{}",
+        pretty(&stripped_a),
+        pretty(&stripped_b),
+    );
+
+    // Sanity: cpu_state IS present and IS expected to differ (proving the arms
+    // really did halt at different micro-instants — i.e. the widening was live,
+    // not a no-op that would make byte-identity trivial).
+    if a.result.get("cpu_state").is_some() && b.result.get("cpu_state").is_some() {
+        eprintln!(
+            "[tick-fidelity] observable output byte-identical at interval-1 vs -64; \
+             cpu_state differs as expected (differ={})",
+            a.result["cpu_state"] != b.result["cpu_state"]
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/crates/core/src/bus/accessors.rs
+++ b/crates/core/src/bus/accessors.rs
@@ -553,6 +553,21 @@ impl crate::Bus for SystemBus {
         self.riscv_irq_lines
     }
 
+    #[cfg(feature = "event-scheduler")]
+    fn has_pending_schedule(&self) -> bool {
+        !self.pending_schedule.is_empty()
+    }
+
+    #[cfg(feature = "event-scheduler")]
+    fn current_cycle(&self) -> u64 {
+        self.current_cycle
+    }
+
+    #[cfg(feature = "event-scheduler")]
+    fn publish_cycle(&mut self, cycle: u64) {
+        self.set_current_cycle(cycle);
+    }
+
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -307,8 +307,24 @@ impl RiscV {
         use crate::bus::SystemBus;
         use crate::cpu::jit_framework::block_cache::Lookup;
 
+        // Exact-cycle clock (see the interpreter `step_batch`): republish
+        // `batch_start + retired` before each dispatch so an interpreted MMIO
+        // read sees the cycle-exact clock. A compiled block never reads the bus
+        // clock (it touches only registers + RAM), so republishing before it is
+        // harmless, and the arming/reading store is ALWAYS interpreted — hence
+        // JIT-on observes the identical clock at every bus access as JIT-off,
+        // preserving byte-identity while making counter reads exact.
+        #[cfg(feature = "event-scheduler")]
+        let exact_clock = config.peripheral_tick_interval > 1;
+        #[cfg(feature = "event-scheduler")]
+        let batch_start = if exact_clock { bus.current_cycle() } else { 0 };
+
         let mut retired: u32 = 0;
         while retired < max_count {
+            #[cfg(feature = "event-scheduler")]
+            if exact_clock {
+                bus.publish_cycle(batch_start + retired as u64);
+            }
             let pc = self.pc as u64;
             match engine.observe(pc) {
                 Lookup::Ready => {
@@ -372,6 +388,17 @@ impl RiscV {
             if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
                 return Ok(retired);
             }
+            // Mirror the interpreter's Gap #1 mid-batch-arming early-exit (see
+            // `step_batch`). A compiled block never executes an MMIO store, so
+            // `pending_schedule` can only have been populated by an interpreted
+            // instruction (`self.step` above) — the SAME instruction the JIT-off
+            // interpreter would break on. Ending the batch at that identical
+            // point keeps JIT-on byte-identical to JIT-off while making the
+            // just-armed event deliverable at its exact cycle by the next batch.
+            #[cfg(feature = "event-scheduler")]
+            if config.peripheral_tick_interval > 1 && bus.has_pending_schedule() {
+                return Ok(retired);
+            }
         }
         Ok(retired)
     }
@@ -388,6 +415,19 @@ impl Cpu for RiscV {
     fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
         self.pc = 0;
         Ok(())
+    }
+
+    /// Mirror the RV32IMC JIT engine's counters into the feature-agnostic
+    /// [`crate::CpuJitStats`] so generic callers can prove non-vacuity. Only
+    /// present under `jit`; without it the trait default (`None`) applies.
+    #[cfg(feature = "jit")]
+    fn jit_engine_stats(&self) -> Option<crate::CpuJitStats> {
+        self.jit_stats().map(|s| crate::CpuJitStats {
+            compiled: s.compiled,
+            block_runs: s.block_runs,
+            block_instrs: s.block_instrs,
+            interpreted: s.interpreted,
+        })
     }
 
     fn step(
@@ -1054,12 +1094,48 @@ impl Cpu for RiscV {
         // instruction while armed, so MMIO pad writes stamp with the cycle
         // boundary they become observable at (see `crate::logic_capture`).
         let tap = bus.logic_tap().filter(|t| t.push_armed());
+        // Exact-cycle clock (event-scheduler, widened interval): the bus mirror
+        // is seeded once per batch by `Machine::run`, so a mid-batch MMIO read of
+        // a lazily-derived counter would see the STALE batch-start cycle. Capture
+        // the batch-start cycle here and republish `batch_start + i` before each
+        // instruction so those reads are cycle-EXACT — identical to interval-1
+        // (where the batch is one instruction). This is what removes the last
+        // cpu_state divergence: a firmware busy-waiting on a lazy counter now
+        // exits its poll on the same instruction at any tick interval. Skipped at
+        // interval 1 (already exact) so that hot path is byte-unchanged.
+        #[cfg(feature = "event-scheduler")]
+        let exact_clock = config.peripheral_tick_interval > 1;
+        #[cfg(feature = "event-scheduler")]
+        let batch_start = if exact_clock { bus.current_cycle() } else { 0 };
         for i in 0..max_count {
             if let Some(tap) = &tap {
                 tap.bump_clock();
             }
+            #[cfg(feature = "event-scheduler")]
+            if exact_clock {
+                bus.publish_cycle(batch_start + i as u64);
+            }
             self.step(bus, observers, config)?;
             if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
+                return Ok(i + 1);
+            }
+            // Event-scheduler Gap #1 (mid-batch arming): if this instruction was
+            // an MMIO write that armed a peripheral event (now sitting in the
+            // bus `pending_schedule`, not yet in the scheduler heap), END the
+            // batch here so `Machine::run`'s post-batch drain enqueues it and the
+            // NEXT batch's `next_event_deadline` clamp delivers it at its exact
+            // absolute cycle — instead of this widened batch overrunning the
+            // deadline and the event firing a batch late (which shifts the ISR
+            // entry instruction and diverges `cpu_state`). Gated on interval > 1:
+            // at interval 1 the batch is already one instruction so this never
+            // fires, keeping the interval-1 hot path (and every walk-identity
+            // gate) byte-unchanged and cost-free. Because compiled JIT blocks
+            // never execute MMIO stores (they touch only registers + RAM), the
+            // arming store is ALWAYS interpreted in both JIT-on and JIT-off, so
+            // mirroring this check in `run_jit_loop` breaks both arms at the same
+            // instruction — the JIT-on/off byte-identity gate is preserved.
+            #[cfg(feature = "event-scheduler")]
+            if config.peripheral_tick_interval > 1 && bus.has_pending_schedule() {
                 return Ok(i + 1);
             }
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -172,8 +172,31 @@ pub fn emit_trace_event(
 }
 
 /// Trait representing a CPU architecture
+/// Feature-agnostic JIT engine run counters, mirrored from a concrete CPU's
+/// engine so generic (`C: Cpu`) callers can observe non-vacuity without pulling
+/// in the JIT-only `EngineStats` type. All-zero / absent for interpreter-only
+/// CPUs and for runs where the JIT engine was never created.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CpuJitStats {
+    /// Blocks that crossed the hot threshold and were compiled + installed.
+    pub compiled: u64,
+    /// Compiled-block invocations.
+    pub block_runs: u64,
+    /// Guest instructions retired inside compiled blocks.
+    pub block_instrs: u64,
+    /// Guest instructions retired on the interpreter fallback path.
+    pub interpreted: u64,
+}
+
 pub trait Cpu: Send {
     fn reset(&mut self, bus: &mut dyn Bus) -> SimResult<()>;
+    /// JIT engine counters for this CPU, if it ran a JIT that was created.
+    /// Default `None` (interpreter-only CPUs / non-JIT builds). Lets generic
+    /// `C: Cpu` callers — e.g. the CLI oracle loop — assert the compiled path
+    /// was non-vacuously exercised without downcasting to the concrete CPU.
+    fn jit_engine_stats(&self) -> Option<CpuJitStats> {
+        None
+    }
     /// Downcast escape hatch for runtime fast-paths that need the
     /// concrete CPU type (e.g. the browser-side JIT prototype in
     /// `labwired-wasm` reaches into `XtensaLx7` for direct register
@@ -783,6 +806,38 @@ pub trait Bus {
     fn external_irq_lines(&self) -> u32 {
         0
     }
+
+    /// Event-scheduler Gap-#1 hook: `true` iff an MMIO write executed since the
+    /// last `drain_scheduler_events` armed a peripheral event that has not yet
+    /// been moved into the scheduler heap (it is sitting in `pending_schedule`).
+    /// A CPU batch loop polls this after each interpreted instruction while the
+    /// tick interval is widened (> 1) so it can END the batch on the arming
+    /// write — the just-armed event is then enqueued by the post-batch drain and
+    /// the NEXT batch's `next_event_deadline` clamp delivers it at its exact
+    /// cycle, instead of the batch overrunning the deadline. O(1); default false
+    /// for buses that don't model the scheduler.
+    #[cfg(feature = "event-scheduler")]
+    fn has_pending_schedule(&self) -> bool {
+        false
+    }
+
+    /// The bus's mirrored "current cycle" (what lazy peripherals read through the
+    /// shared `CycleClock`). A CPU batch loop reads this once at batch entry to
+    /// learn the batch-start cycle, then republishes the EXACT cycle before each
+    /// interpreted instruction via [`Self::publish_cycle`] so a mid-batch MMIO
+    /// read of a lazily-derived counter sees `batch_start + retired` — the same
+    /// value interval-1 would show — instead of the stale batch-start value.
+    /// Default 0 for buses that don't model a cycle clock.
+    #[cfg(feature = "event-scheduler")]
+    fn current_cycle(&self) -> u64 {
+        0
+    }
+
+    /// Republish the shared `CycleClock` to `cycle` (see [`Self::current_cycle`]).
+    /// Called per interpreted instruction while the tick interval is widened, so
+    /// the cost is a single relaxed atomic store on the hot path. Default no-op.
+    #[cfg(feature = "event-scheduler")]
+    fn publish_cycle(&mut self, _cycle: u64) {}
 
     /// Plan 2: deliver a coherent 32-bit value to peripherals after the
     /// four byte writes that compose a write_u32 have been dispatched.
@@ -2203,6 +2258,62 @@ impl<C: Cpu> DebugControl for Machine<C> {
                 }
             }
 
+            // Event-scheduler GENERAL clamp (Phase 0): end the batch exactly at
+            // the next scheduled peripheral event of ANY kind — SYSTIMER/TIMx
+            // alarms, SPI/UART frame edges, DMA elements, the LEDC overflow
+            // latch, and the HC-SR04 ECHO edges above — so the post-batch
+            // `drain_scheduler_events` applies it at its EXACT absolute cycle
+            // instead of at whatever coarse tick boundary the widened batch
+            // happened to land on. This generalises the single-peripheral
+            // HC-SR04 clamp directly above to the whole scheduler heap.
+            //
+            // With it, a wide `peripheral_tick_interval` delivers every event
+            // (and thus pends every IRQ, and thus enters every ISR) at the
+            // IDENTICAL cycle it would at interval 1: the CPU is never allowed
+            // to retire an instruction at a cycle past a pending event's
+            // deadline before that event fires. That makes ALL OBSERVABLE state
+            // — every peripheral snapshot (framebuffer, counters, GPIO…),
+            // memory, and `total_cycles` — byte-identical to interval-1 BY
+            // CONSTRUCTION (proven by esp32c3_clamped_full_state_differential).
+            //
+            // The `cpu_state` register snapshot (pc/mepc/GPRs) is NOT covered
+            // and provably cannot be: firmware that busy-waits on a lazy,
+            // tick-refreshed free-running counter (RTC/SYSTIMER) reads a value
+            // up to (interval-1) cycles stale, so a data-dependent branch can
+            // retire at a different pc at the same `total_cycles` — a property
+            // of the counter READ path, not event delivery, unclosable by any
+            // clamp short of ticking every cycle. That residual is exactly why
+            // the CLI fidelity gate excludes `cpu_state`: its exclusion is
+            // principled, not a workaround for an incomplete clamp.
+            //
+            // The `next_event_deadline` heap scan is O(heap) per batch, so we
+            // GATE the whole clamp on `peripheral_tick_interval > 1`: at
+            // interval 1 the batch is already one instruction (the drain runs
+            // every cycle and delivers events exactly), so the scan would be
+            // pure wasted cost on the hot interval-1 path the deploy pins.
+            // `current_batch > 1` further skips the scan whenever an earlier
+            // clamp (cycle-accurate bus, breakpoint, poll capture, HC-SR04)
+            // already pinned the batch to one instruction.
+            //
+            // NOTE: this does NOT cover an event a firmware ARMS via an MMIO
+            // write partway through THIS batch — that event is only enqueued at
+            // the post-batch drain, so it is not in the heap when this scan
+            // runs. That mid-batch-scheduling case is handled separately after
+            // `step_batch` returns (see the `pending_schedule` re-clamp below).
+            #[cfg(feature = "event-scheduler")]
+            if self.config.peripheral_tick_interval > 1 && current_batch > 1 {
+                let generations = self.bus.peripheral_generations();
+                if let Some(dl) = self.sched.next_event_deadline(&generations) {
+                    if dl > self.total_cycles {
+                        current_batch = current_batch.min((dl - self.total_cycles) as u32);
+                    } else {
+                        // Already due at/behind `now`: take one instruction so
+                        // the post-batch drain fires it before advancing further.
+                        current_batch = current_batch.min(1);
+                    }
+                }
+            }
+
             // Push-mode capture: seed the tap clock at the batch start; the
             // CPU advances it once per retired instruction so pad writes stamp
             // with the boundary they become observable at.
@@ -2218,6 +2329,21 @@ impl<C: Cpu> DebugControl for Machine<C> {
             self.total_cycles += executed as u64;
             self.step_profile.cpu_instructions += executed as u64;
             self.step_profile.cpu_batches += 1;
+
+            // Exact-cycle clock cleanup: `step_batch` republished the bus clock
+            // per interpreted instruction for cycle-exact mid-batch reads, so on
+            // return it sits at an implementation-dependent value (the last
+            // interpreted instruction's cycle under the interpreter, the last
+            // block's START cycle under the JIT — they differ). Everything below
+            // (the peripheral-tick block, which can read `current_cycle`) must
+            // see one arm-INDEPENDENT value, and it must be the SAME value main
+            // showed there before this optimisation: the batch-START cycle
+            // (`current_cycles`, seeded at the top of the loop). Restore it here
+            // so the tick path is byte-identical to main and to itself across
+            // the JIT-on/off arms; the drain below re-advances the clock to the
+            // batch-end cycle exactly as before.
+            #[cfg(feature = "event-scheduler")]
+            self.bus.set_current_cycle(current_cycles);
             // The cycle boundary the batch ended at, BEFORE peripheral tick
             // costs — logic pushes stamped at it are finalised to the
             // post-cost "now" (see `logic_observe`).

--- a/crates/core/src/metrics.rs
+++ b/crates/core/src/metrics.rs
@@ -49,6 +49,26 @@ impl PerformanceMetrics {
         self.instruction_count.load(Ordering::SeqCst)
     }
 
+    /// Overwrite the instruction counter from an authoritative external source.
+    ///
+    /// Used by the JIT-eligible CLI test path, which does NOT install this
+    /// object as a per-step observer (the observer presence gates the RV32IMC
+    /// JIT off). Instead it sources the retired-instruction count directly from
+    /// the machine's own batch return values, so the count stays exact whether
+    /// a batch was interpreted or compiled. See `execute_test_loop`.
+    pub fn set_instructions(&self, instructions: u64) {
+        self.instruction_count.store(instructions, Ordering::SeqCst);
+    }
+
+    /// Overwrite the cycle counter from an authoritative external source
+    /// (`Machine::total_cycles`). Peer to [`Self::set_instructions`]: the
+    /// JIT-eligible test path can't rely on the per-step `on_step_end` tap
+    /// (compiled blocks retire without firing it), so it mirrors the machine's
+    /// canonical cycle counter here before each stimulus/limit check.
+    pub fn set_cycles(&self, cycles: u64) {
+        self.cycle_count.store(cycles, Ordering::SeqCst);
+    }
+
     pub fn get_cycles(&self) -> u64 {
         self.cycle_count.load(Ordering::SeqCst)
     }

--- a/crates/core/src/peripherals/esp32c3/rtc_timer.rs
+++ b/crates/core/src/peripherals/esp32c3/rtc_timer.rs
@@ -22,9 +22,17 @@
 //!
 //! ## Time source (walk-free plan Part 1 — first production user)
 //!
-//! The counter advances one tick per simulated CPU cycle; the absolute
-//! slow-clock rate is not modelled — only that time *advances* monotonically,
-//! which is all the deadline comparisons observe. Two coexisting drive modes:
+//! The counter advances one tick per simulated CPU cycle; by default the
+//! absolute slow-clock rate is not modelled — only that time *advances*
+//! monotonically, which is all the deadline comparisons observe (and what the
+//! C3 boot budget + every existing test rely on). The real silicon rate — the
+//! internal RC_SLOW oscillator, measured on this board at ~136.7 kHz over the
+//! built-in USB-JTAG (see [`RTC_SLOW_HZ_MEASURED`]) — can be opted into via
+//! [`Esp32c3RtcTimer::set_slow_clock_hz`], which scales the firmware-visible
+//! time down to that rate at readout for firmware that needs absolute RTC
+//! wall-time. (Trade-off: RTC busy-wait delays then span ~1170x more simulated
+//! cycles, since one RTC tick becomes ~1170 CPU cycles.) Two coexisting drive
+//! modes:
 //!
 //! * **Scheduler mode** (`event-scheduler` feature + a [`crate::CycleClock`]
 //!   attached by `SystemBus::add_peripheral`): `uses_scheduler()` is true, the
@@ -65,11 +73,25 @@ const TIME_LOW: u64 = 0x10;
 const TIME_HIGH: u64 = 0x14;
 const TIME_UPDATE_BIT: u32 = 1 << 31;
 
+/// ESP32-C3 CPU clock the internal counter is anchored to (the cycle base the
+/// bus `CycleClock` publishes). Used as the denominator when scaling the
+/// free-running cycle count down to the RTC slow-clock rate.
+pub const CPU_HZ: u64 = 160_000_000;
+
+/// RTC slow-clock rate MEASURED on real silicon (this board, over the built-in
+/// USB-JTAG: SYSTIMER-referenced 16.0 MHz time base gave 136.7 kHz for the
+/// `RTC_CNTL` TIME counter — the internal RC_SLOW oscillator, nominal 150 kHz,
+/// calibrated ~136–137 kHz). At 160 MHz CPU this is ~1170 CPU cycles per RTC
+/// tick. See `Esp32c3RtcTimer::set_slow_clock_hz`.
+pub const RTC_SLOW_HZ_MEASURED: u64 = 136_700;
+
 #[derive(Debug)]
 pub struct Esp32c3RtcTimer {
     /// Register-backed storage for the whole window (non-timer registers).
     regs: Vec<u32>,
-    /// Free-running 48-bit slow-clock counter (one tick per CPU cycle).
+    /// Free-running 48-bit counter tracking RAW elapsed CPU cycles (one step
+    /// per cycle). The firmware-visible slow-clock time is this value scaled by
+    /// `slow_num/slow_den` at readout (default 1:1).
     counter: Cell<u64>,
     /// Counter value latched by the most recent TIME_UPDATE write; what the
     /// TIME0/TIME1 readout registers return.
@@ -82,6 +104,19 @@ pub struct Esp32c3RtcTimer {
     /// `SystemBus::add_peripheral` attaches it; `None` keeps the model on
     /// the legacy walk path.
     clock: Option<CycleClock>,
+    /// Slow-clock scale applied AT READOUT: the latched (firmware-visible) time
+    /// is `counter * slow_num / slow_den`. `counter` itself keeps tracking raw
+    /// elapsed CPU cycles (so all the monotonic/anchor logic is unchanged); only
+    /// the observable value is divided down to the RTC slow-clock rate.
+    ///
+    /// Default `(1, 1)` = one RTC tick per CPU cycle — the historical model
+    /// contract ("slow-clock rate is not modelled; time advances monotonically")
+    /// that every existing test and the C3 boot budget rely on. Call
+    /// [`Self::set_slow_clock_hz`] with [`RTC_SLOW_HZ_MEASURED`] to opt into the
+    /// silicon-faithful rate for firmware that needs absolute RTC wall-time
+    /// (note: RTC busy-wait delays then take ~1170x more simulated cycles).
+    slow_num: u64,
+    slow_den: u64,
 }
 
 impl Default for Esp32c3RtcTimer {
@@ -99,7 +134,30 @@ impl Esp32c3RtcTimer {
             latched: Cell::new(0),
             anchor_tick: Cell::new(0),
             clock: None,
+            slow_num: 1,
+            slow_den: 1,
         }
+    }
+
+    /// Opt into a modelled RTC slow-clock rate of `hz` (relative to the
+    /// [`CPU_HZ`] cycle base). Pass [`RTC_SLOW_HZ_MEASURED`] for the
+    /// silicon-measured ~136.7 kHz. `hz == CPU_HZ` (or leaving the default)
+    /// keeps the 1:1 "monotonic-only" contract. `hz == 0` is ignored.
+    pub fn set_slow_clock_hz(&mut self, hz: u64) {
+        if hz == 0 {
+            return;
+        }
+        self.slow_num = hz;
+        self.slow_den = CPU_HZ;
+    }
+
+    /// Scale a raw elapsed-cycle count down to the modelled RTC slow-clock rate.
+    #[inline]
+    fn to_slow_ticks(&self, cycles: u64) -> u64 {
+        if self.slow_num == self.slow_den {
+            return cycles; // 1:1 fast path — byte-identical to the old model.
+        }
+        (cycles as u128 * self.slow_num as u128 / self.slow_den as u128) as u64
     }
 
     pub fn new() -> Self {
@@ -177,7 +235,9 @@ impl Peripheral for Esp32c3RtcTimer {
             // before this write; the explicit sync keeps direct/unit-test
             // writes correct too, and is idempotent.)
             self.sync_from_clock();
-            self.latched.set(self.counter.get());
+            // Scale the raw elapsed-cycle counter down to the modelled RTC
+            // slow-clock rate at readout (default 1:1 → byte-identical).
+            self.latched.set(self.to_slow_ticks(self.counter.get()));
         }
         if let Some(slot) = self.regs.get_mut((offset / 4) as usize) {
             *slot = value;
@@ -358,6 +418,48 @@ mod tests {
 
         // Idempotent: re-latching at the same published cycle adds nothing.
         assert_eq!(rtc_time_get(&mut t), 1234 + 4096);
+    }
+
+    /// The opt-in silicon-faithful slow-clock rate: after
+    /// `set_slow_clock_hz(RTC_SLOW_HZ_MEASURED)`, the firmware-visible RTC time
+    /// advances at the HW-measured ~136.7 kHz relative to the CPU cycle base —
+    /// NOT 1:1. Locks in the rate captured on real hardware (this board, over
+    /// the built-in USB-JTAG). The default path stays 1:1 (asserted above), so
+    /// this is purely additive and breaks no existing timing.
+    #[cfg(feature = "event-scheduler")]
+    #[test]
+    fn faithful_slow_clock_rate_matches_measured_silicon() {
+        let clock = CycleClock::default();
+        let mut t = Esp32c3RtcTimer::new();
+        t.attach_cycle_clock(clock.clone());
+        t.set_slow_clock_hz(RTC_SLOW_HZ_MEASURED);
+
+        // Advance the CPU cycle base by exactly one second's worth of cycles.
+        clock.publish(CPU_HZ);
+        let ticks = rtc_time_get(&mut t);
+
+        // One CPU-second must read as ~RTC_SLOW_HZ_MEASURED RTC ticks (exact
+        // integer division of CPU_HZ * hz / CPU_HZ == hz here).
+        assert_eq!(
+            ticks, RTC_SLOW_HZ_MEASURED,
+            "faithful RTC rate: 1 CPU-second must read {RTC_SLOW_HZ_MEASURED} ticks, got {ticks}"
+        );
+
+        // Half a second → half the ticks (the scale is linear in elapsed cycles).
+        clock.publish(CPU_HZ + CPU_HZ / 2);
+        let ticks2 = rtc_time_get(&mut t);
+        assert_eq!(
+            ticks2,
+            RTC_SLOW_HZ_MEASURED + RTC_SLOW_HZ_MEASURED / 2,
+            "1.5 CPU-seconds must read 1.5x the RTC ticks"
+        );
+
+        // Sanity: the raw ~1170 CPU-cycles-per-RTC-tick ratio the capture found.
+        let cycles_per_tick = CPU_HZ / RTC_SLOW_HZ_MEASURED;
+        assert!(
+            (1160..=1180).contains(&cycles_per_tick),
+            "measured ratio ~1170 CPU cycles per RTC tick, got {cycles_per_tick}"
+        );
     }
 
     #[cfg(feature = "event-scheduler")]

--- a/crates/core/src/tests/esp32c3_rtc_delay_loop.rs
+++ b/crates/core/src/tests/esp32c3_rtc_delay_loop.rs
@@ -15,10 +15,25 @@
 //! bus-published `CycleClock`), at tick interval 1 and 64:
 //!
 //! * both paths TERMINATE (no stale-spin), and
-//! * they terminate at the SAME cycle with the SAME final counter value —
-//!   the walk itself quantises the counter to the tick grid at interval > 1,
-//!   and the lazy read-sync reproduces exactly that grid (batch-start
-//!   freshness == walk-tick freshness), so this holds at interval 64 too.
+//! * they terminate at the SAME cycle at interval 1 AND 64, and
+//! * the scheduler's counter READ is now cycle-EXACT and thus tick-interval
+//!   INDEPENDENT: `sched(1) == sched(64)` for both the termination cycle and
+//!   the final counter value.
+//!
+//! Fidelity note (event-scheduler exact-cycle clock): a lazily-derived counter
+//! read is anchored to `batch_start + retired` (the CPU republishes the exact
+//! cycle before each interpreted instruction — see `Cpu::step_batch`), so a
+//! mid-batch read returns the SAME value at any tick interval. On real silicon
+//! the RTC counter advances every cycle and a read returns the live value, so
+//! this exact read is the faithful behaviour. The LEGACY WALK, by contrast,
+//! only refreshes the counter at tick boundaries, so at interval > 1 its read
+//! is QUANTISED to the tick grid (it reports the last grid value, up to one
+//! interval stale). The two therefore agree at interval 1 (grid == every
+//! cycle) but the walk's final read lags the scheduler's exact read by up to
+//! one interval at interval 64 — the scheduler is the more faithful path, so
+//! this test pins scheduler interval-independence rather than equality to the
+//! coarser walk read at interval > 1. The termination CYCLE still matches the
+//! walk at both intervals (the deadline is crossed at the same cycle).
 
 #![cfg(all(test, feature = "event-scheduler"))]
 
@@ -101,10 +116,14 @@ fn run_delay_loop(mut machine: Machine<RiscV>) -> (bool, u64, u32) {
 }
 
 /// THE gate: the busy-poll delay loop terminates on both drive modes at
-/// interval 1 AND 64 (no stale-spin), and the scheduler path is byte-identical
-/// to the legacy walk — same termination cycle, same final counter read.
+/// interval 1 AND 64 (no stale-spin); the scheduler crosses the deadline at the
+/// SAME cycle as the legacy walk; the scheduler is byte-identical to the walk at
+/// interval 1; and — the property the exact-cycle clock buys — the scheduler is
+/// tick-interval INDEPENDENT (its exact counter read at interval 64 equals its
+/// read at interval 1), whereas the walk's read quantises to the tick grid.
 #[test]
 fn rtc_delay_loop_terminates_and_matches_walk() {
+    let mut sched_by_interval: Vec<(u64, u32)> = Vec::new();
     for tick_interval in [1u32, 64] {
         let (walk_done, walk_cycles, walk_cnt) = run_delay_loop(build_machine(tick_interval, true));
         let (sched_done, sched_cycles, sched_cnt) =
@@ -124,13 +143,33 @@ fn rtc_delay_loop_terminates_and_matches_walk() {
             "interval {tick_interval}: loop exited before the RTC deadline \
              (read {sched_cnt:#x} < {DEADLINE:#x})"
         );
+        // Termination CYCLE is byte-identical to the walk at every interval (the
+        // deadline is crossed at the same cycle; only the reported read value
+        // quantises under the walk at interval > 1).
         assert_eq!(
-            (walk_cycles, walk_cnt),
-            (sched_cycles, sched_cnt),
-            "interval {tick_interval}: scheduler-driven RTC must be byte-identical \
-             to the legacy walk (termination cycle + final counter read)"
+            walk_cycles, sched_cycles,
+            "interval {tick_interval}: scheduler must cross the RTC deadline at \
+             the same cycle as the legacy walk"
         );
+        if tick_interval == 1 {
+            // At interval 1 the walk grid IS every cycle, so the reads match too.
+            assert_eq!(
+                walk_cnt, sched_cnt,
+                "interval 1: scheduler counter read must equal the walk (grid == \
+                 every cycle)"
+            );
+        }
+        sched_by_interval.push((sched_cycles, sched_cnt));
     }
+
+    // The payoff: the scheduler's exact-cycle read makes the WHOLE observation
+    // (termination cycle + final counter value) tick-interval INDEPENDENT.
+    assert_eq!(
+        sched_by_interval[0], sched_by_interval[1],
+        "scheduler-driven RTC must be tick-interval independent \
+         (interval-1 {:?} != interval-64 {:?})",
+        sched_by_interval[0], sched_by_interval[1]
+    );
 }
 
 /// The scheduler path must actually be scheduler-driven (walk-independent) and

--- a/crates/core/tests/esp32c3_clamped_full_state_differential.rs
+++ b/crates/core/tests/esp32c3_clamped_full_state_differential.rs
@@ -1,0 +1,289 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Phase-0 event-scheduler CLAMP proof (the "by construction" gate).
+//!
+//! `Machine::run`'s batch loop now clamps every batch to the next scheduled
+//! peripheral event (`sched.next_event_deadline`) whenever
+//! `peripheral_tick_interval > 1` — the GENERAL clamp that generalises the
+//! HC-SR04 single-peripheral clamp to the whole scheduler heap. The claim it
+//! backs is strong: with it, a WIDE tick interval delivers every scheduled
+//! event (and thus pends every IRQ and enters every ISR) at the IDENTICAL
+//! absolute cycle it would at interval 1, so the two runs are byte-identical
+//! INCLUDING the `cpu_state` register snapshot (pc / mepc / GPRs / CSRs) — the
+//! one field the CLI interim fidelity gate
+//! (`riscv_tick_interval_fidelity_differential`) had to EXCLUDE because,
+//! without the clamp, interval-64 serviced interrupts on coarse 64-cycle
+//! boundaries and halted the firmware at a different micro-instant.
+//!
+//! This runs the REAL `esp32c3-oled-demo` lab (the exact browser fast-start
+//! assembly) for a fixed instruction budget at interval 1 and interval 64
+//! (scheduler-driven RTC/SYSTIMER/I²C0 in BOTH, the shipped config) and
+//! asserts the FULL machine snapshot — cpu_state AND every peripheral's state
+//! — is byte-identical. This is a STRICTLY stronger assertion than the walk
+//! differential's framebuffer-only identity: it also covers the CPU's live
+//! registers, which is exactly what the clamp is supposed to restore.
+//!
+//! It doubles as the Gap-#1 end-to-end probe: the OLED firmware arms SYSTIMER
+//! alarms and I²C0 module ticks via ordinary MMIO stores MID-batch, so if a
+//! mid-batch-scheduled event were delivered late at interval 64 the firmware
+//! would be interrupted at a different instruction and cpu_state would drift.
+//! A green run is evidence that the real mid-batch-arming workload stays
+//! cycle-exact under the clamp.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::boot::esp32c3_rom::{
+    build_rom_boot_machine, c3_rom_data_init_writes, inject_rom_regions, RomBootOpts,
+};
+use labwired_core::boot::esp32s3_rom::RomImages;
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::RiscV;
+use labwired_core::memory::ProgramImage;
+use labwired_core::{Arch, Bus, Cpu, DebugControl, Machine};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+const ESP_IMAGE_HEADER_LEN: usize = 24;
+const ESP_IMAGE_MAGIC: u8 = 0xE9;
+
+fn esp32c3_bootloader_image(flash: &[u8]) -> ProgramImage {
+    assert!(flash.len() > ESP_IMAGE_HEADER_LEN, "flash image truncated");
+    assert_eq!(flash[0], ESP_IMAGE_MAGIC, "bad bootloader image magic");
+    let segment_count = flash[1] as usize;
+    let entry = u32::from_le_bytes(flash[4..8].try_into().unwrap()) as u64;
+    let mut program = ProgramImage::new(entry, Arch::RiscV);
+    let mut cursor = ESP_IMAGE_HEADER_LEN;
+    for _ in 0..segment_count {
+        let load_addr = u32::from_le_bytes(flash[cursor..cursor + 4].try_into().unwrap()) as u64;
+        let len = u32::from_le_bytes(flash[cursor + 4..cursor + 8].try_into().unwrap()) as usize;
+        cursor += 8;
+        program.add_segment(load_addr, flash[cursor..cursor + len].to_vec());
+        cursor += len;
+    }
+    program
+}
+
+struct OledLab {
+    machine: Machine<RiscV>,
+    #[allow(dead_code)]
+    serial: Arc<Mutex<Vec<u8>>>,
+}
+
+/// Build the OLED lab exactly as the browser fast-start does, at the given
+/// tick interval, fully scheduler-driven (the shipped config). Mirrors
+/// `build_oled_lab(interval, false, false, false, false)` in
+/// `esp32c3_walk_differential.rs`.
+fn build_oled_lab(tick_interval: u32) -> OledLab {
+    let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
+        .expect("load esp32c3 chip yaml");
+    let manifest =
+        SystemManifest::from_file(root().join("../../configs/systems/esp32c3-oled-demo.yaml"))
+            .expect("load esp32c3-oled-demo system yaml");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build oled bus");
+
+    let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
+    let drom = std::fs::read(root().join("roms/esp32c3/esp32c3_drom.bin")).expect("read C3 DROM");
+    let flash = std::fs::read(root().join("../wasm/tests/fixtures/esp32c3-oled-demo-flash.bin"))
+        .expect("read C3 OLED demo flash image");
+
+    assert!(
+        inject_rom_regions(
+            &mut bus,
+            &RomImages {
+                irom: irom.clone(),
+                drom
+            }
+        ),
+        "chip yaml must declare the C3 IROM region"
+    );
+    for (dst, bytes) in c3_rom_data_init_writes(&irom) {
+        for (i, b) in bytes.iter().enumerate() {
+            let _ = bus.write_u8(dst as u64 + i as u64, *b);
+        }
+    }
+
+    let serial = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(serial.clone(), false);
+
+    let bootloader = esp32c3_bootloader_image(&flash);
+    let mut machine = build_rom_boot_machine(
+        bus,
+        flash,
+        RomBootOpts {
+            efuse_mac: None,
+            usb_serial_sink: None,
+        },
+        |c| c,
+    );
+
+    for segment in &bootloader.segments {
+        if machine.bus.flash.load_from_segment(segment)
+            || machine.bus.ram.load_from_segment(segment)
+            || machine
+                .bus
+                .extra_mem
+                .iter_mut()
+                .any(|m| m.load_from_segment(segment))
+        {
+            continue;
+        }
+        for (i, byte) in segment.data.iter().enumerate() {
+            machine
+                .bus
+                .write_u8(segment.start_addr + i as u64, *byte)
+                .expect("load bootloader segment");
+        }
+    }
+    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    machine.cpu.set_sp(sp_top & !0xF);
+    machine.cpu.set_pc(bootloader.entry_point as u32);
+
+    machine.bus.recompute_walk_deletable();
+    machine.config.peripheral_tick_interval = tick_interval;
+    machine.bus.config.peripheral_tick_interval = tick_interval;
+
+    OledLab { machine, serial }
+}
+
+/// Run exactly `budget` instructions in chunks and return the full snapshot.
+fn run_to_snapshot(mut lab: OledLab, budget: u64) -> (u64, labwired_core::snapshot::MachineSnapshot) {
+    const CHUNK: u32 = 1_000_000;
+    let mut steps = 0u64;
+    while steps < budget {
+        let n = CHUNK.min((budget - steps) as u32);
+        lab.machine.run(Some(n)).expect("run oled lab");
+        steps += n as u64;
+    }
+    (lab.machine.total_cycles, lab.machine.snapshot())
+}
+
+/// Instruction budget that covers bootloader + app + first OLED paint (the
+/// window where SYSTIMER alarms + I²C0 ticks are actively arming, i.e. Gap #1
+/// is live).
+const PAINT_BUDGET: u64 = 30_000_000;
+
+/// DIAGNOSTIC: run both arms in lockstep 100k-step chunks and report the FIRST
+/// checkpoint at which `pc` diverges — distinguishes a fixable late-event bug
+/// (sharp early divergence) from fundamental bounded-stale lazy-counter reads
+/// (gradual, small, late divergence).
+#[test]
+#[ignore = "diagnostic; run with --release --ignored --nocapture"]
+fn diag_first_divergence_point_interval_1_vs_64() {
+    const CHUNK: u32 = 100_000;
+    const MAX: u64 = 30_000_000;
+    let mut a = build_oled_lab(1).machine;
+    let mut b = build_oled_lab(64).machine;
+    let mut steps = 0u64;
+    while steps < MAX {
+        a.run(Some(CHUNK)).unwrap();
+        b.run(Some(CHUNK)).unwrap();
+        steps += CHUNK as u64;
+        let pa = a.cpu.get_pc();
+        let pb = b.cpu.get_pc();
+        if pa != pb || a.total_cycles != b.total_cycles {
+            eprintln!(
+                "FIRST DIVERGENCE at steps={steps}: pc 0x{pa:08x} vs 0x{pb:08x} (Δ={}), \
+                 total_cycles {} vs {} (Δ={})",
+                pa as i64 - pb as i64,
+                a.total_cycles,
+                b.total_cycles,
+                a.total_cycles as i64 - b.total_cycles as i64,
+            );
+            return;
+        }
+    }
+    eprintln!("NO pc/total_cycles divergence through {MAX} steps");
+}
+
+/// STEP-1 GO/NO-GO measurement: are ALL peripheral tick `costs` ZERO across the
+/// full OLED run at BOTH intervals? If yes, intra-batch instruction `i` retires
+/// at absolute cycle `batch_start + i` at every interval → exact cpu_state
+/// convergence is achievable by anchoring `bus.current_cycle` per instruction.
+/// If nonzero costs interleave mid-run, `batch_start + i` cannot equal the
+/// interval-1 cycle and full convergence is impossible via that mechanism.
+#[test]
+#[ignore = "diagnostic; run with --release --ignored --nocapture"]
+fn diag_measure_tick_costs_interval_1_and_64() {
+    use labwired_core::metrics::PerformanceMetrics;
+    for interval in [1u32, 64] {
+        let mut lab = build_oled_lab(interval);
+        let metrics = Arc::new(PerformanceMetrics::new());
+        lab.machine.observers.push(metrics.clone());
+        const CHUNK: u32 = 1_000_000;
+        let mut steps = 0u64;
+        while steps < PAINT_BUDGET {
+            let n = CHUNK.min((PAINT_BUDGET - steps) as u32);
+            lab.machine.run(Some(n)).expect("run oled lab");
+            steps += n as u64;
+        }
+        let instrs = metrics.get_instructions();
+        let cycles = lab.machine.total_cycles;
+        let periph_cost = metrics.get_peripheral_cycles_total();
+        eprintln!(
+            "[step1] interval={interval}: instructions={instrs} total_cycles={cycles} \
+             peripheral_cost_cycles={periph_cost} (GO iff peripheral_cost_cycles==0)"
+        );
+    }
+}
+
+/// THE clamp proof: interval-64 (general clamp + Gap-#1 break + exact-cycle
+/// clock active) produces a machine snapshot BYTE-IDENTICAL to interval-1 —
+/// INCLUDING `cpu_state` (pc / mepc / GPRs / CSRs), the field the CLI interim
+/// gate had to exclude. Three mechanisms combine to make this hold by
+/// construction:
+///   1. the general clamp ends every batch on the next scheduled event, so
+///      each IRQ/event is DELIVERED at its exact absolute cycle;
+///   2. the Gap-#1 break ends the batch on any mid-batch MMIO write that armed
+///      an event, so a just-armed event is enqueued before the batch overruns
+///      its deadline;
+///   3. the exact-cycle clock republishes `batch_start + retired` before each
+///      interpreted instruction, so a mid-batch READ of a lazily-derived
+///      RTC/SYSTIMER counter sees the SAME value interval-1 would — a firmware
+///      busy-waiting on that counter now exits its poll on the identical
+///      instruction at any tick interval.
+///
+/// With all three, nothing the firmware can observe (event, IRQ, or counter
+/// read) differs between intervals, so the CPU executes the identical
+/// instruction stream and halts in the identical register state. If this ever
+/// fails, one of the three regressed — the diagnostic
+/// `diag_first_divergence_point_interval_1_vs_64` bisects to the first
+/// diverging instruction.
+#[test]
+#[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
+fn oled_lab_full_state_byte_identical_interval_1_vs_64() {
+    let (cycles_1, snap_1) = run_to_snapshot(build_oled_lab(1), PAINT_BUDGET);
+    let (cycles_64, snap_64) = run_to_snapshot(build_oled_lab(64), PAINT_BUDGET);
+
+    let json_1 = serde_json::to_value(&snap_1).expect("serialize interval-1 snapshot");
+    let json_64 = serde_json::to_value(&snap_64).expect("serialize interval-64 snapshot");
+
+    assert_eq!(
+        cycles_1, cycles_64,
+        "total_cycles diverged (interval-1={cycles_1}, interval-64={cycles_64})"
+    );
+
+    // cpu_state first (the headline: this is what the CLI gate had to exclude).
+    assert_eq!(
+        json_1["cpu"], json_64["cpu"],
+        "cpu_state DIVERGED between interval-1 and interval-64.\n--- interval-1 ---\n{}\n\
+         --- interval-64 ---\n{}",
+        serde_json::to_string_pretty(&json_1["cpu"]).unwrap_or_default(),
+        serde_json::to_string_pretty(&json_64["cpu"]).unwrap_or_default(),
+    );
+
+    // Then the whole machine snapshot (cpu + every peripheral) byte-for-byte.
+    assert_eq!(
+        json_1, json_64,
+        "FULL machine snapshot diverged between interval-1 and interval-64 (a \
+         peripheral's state differs even though cpu_state matched)."
+    );
+
+    eprintln!("[clamp-proof] FULL machine snapshot (cpu_state + all peripherals) byte-identical at interval-1 vs -64");
+}

--- a/crates/core/tests/esp32c3_clamped_full_state_differential.rs
+++ b/crates/core/tests/esp32c3_clamped_full_state_differential.rs
@@ -153,7 +153,10 @@ fn build_oled_lab(tick_interval: u32) -> OledLab {
 }
 
 /// Run exactly `budget` instructions in chunks and return the full snapshot.
-fn run_to_snapshot(mut lab: OledLab, budget: u64) -> (u64, labwired_core::snapshot::MachineSnapshot) {
+fn run_to_snapshot(
+    mut lab: OledLab,
+    budget: u64,
+) -> (u64, labwired_core::snapshot::MachineSnapshot) {
     const CHUNK: u32 = 1_000_000;
     let mut steps = 0u64;
     while steps < budget {
@@ -271,7 +274,8 @@ fn oled_lab_full_state_byte_identical_interval_1_vs_64() {
 
     // cpu_state first (the headline: this is what the CLI gate had to exclude).
     assert_eq!(
-        json_1["cpu"], json_64["cpu"],
+        json_1["cpu"],
+        json_64["cpu"],
         "cpu_state DIVERGED between interval-1 and interval-64.\n--- interval-1 ---\n{}\n\
          --- interval-64 ---\n{}",
         serde_json::to_string_pretty(&json_1["cpu"]).unwrap_or_default(),


### PR DESCRIPTION
Makes wide peripheral-tick batching byte-identical to interval-1 by construction, and records the real-silicon RTC rate.

## Core (event-scheduler; gated `interval>1`, zero cost at interval-1)
- **General clamp** to `sched.next_event_deadline` — every scheduled event/IRQ delivered at its exact absolute cycle.
- **Gap #1 mid-batch-arming break** (`Bus::has_pending_schedule`) in both interpreter + JIT loops. Compiled blocks never touch the bus, so the arming store is always interpreted in both arms → JIT-on/off stay byte-identical.
- **Exact-cycle clock** (`Bus::current_cycle`/`publish_cycle`): republish `batch_start+retired` before each interpreted instruction so mid-batch lazy-counter reads are cycle-exact; restore batch-start after the batch so the tick path is arm-independent.

**Result:** interval-64 == interval-1 for the full machine snapshot **including `cpu_state`** (new `esp32c3_clamped_full_state_differential` gate).

## RTC HW fidelity (captured on real ESP32-C3 over built-in USB-JTAG)
- SYSTIMER measured **16.0 MHz** — matches the model.
- RTC_CNTL slow clock measured **136.7 kHz** (RC_SLOW, ~1170 CPU cycles/tick) vs the model's documented 1:1 simplification.
- Added `RTC_SLOW_HZ_MEASURED` + `Esp32c3RtcTimer::set_slow_clock_hz` (readout scaling). **Default stays 1:1** to preserve the boot budget and all existing timing; faithful path is opt-in, proven by a unit test.

## Validation
- CI-exact core suite: **2457 passed / 0 failed**.
- CLI JIT-on/off + tick-interval differentials: green.
- `rtc_delay_loop` updated to assert scheduler interval-independence + termination-cycle identity to the walk (the scheduler read is now more silicon-faithful than the coarse legacy walk at interval>1).

Note: carries the pre-existing parked CLI logic-edges / tick-widening plumbing this work builds on.