### PR TITLE
feat(esp32c3): add JTAG watch fidelity fixture

### DIFF
--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -95,7 +95,7 @@ peripherals:
     config:
       path: "../peripherals/esp32c3/systimer.yaml"
   - id: "io_mux"
-    type: "declarative"
+    type: "esp32c3_io_mux"
     base_address: 0x60009000
     config:
       path: "../peripherals/esp32c3/io_mux.yaml"

--- a/configs/systems/esp32c3-devkit.yaml
+++ b/configs/systems/esp32c3-devkit.yaml
@@ -1,6 +1,7 @@
 # LabWired - ESP32-C3 DevKit System Configuration
 name: "esp32c3-devkit"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 external_devices: []
 board_io:
   - id: "status_led"

--- a/configs/systems/esp32c3-epaper-workshop.yaml
+++ b/configs/systems/esp32c3-epaper-workshop.yaml
@@ -1,5 +1,6 @@
 name: "esp32c3-epaper-workshop"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "epaper"

--- a/configs/systems/esp32c3-jtag-watch.yaml
+++ b/configs/systems/esp32c3-jtag-watch.yaml
@@ -1,0 +1,20 @@
+# Headless Arduino watch fixture: input-only, no display or external devices.
+name: "esp32c3-jtag-watch"
+chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
+
+external_devices: []
+
+board_io:
+  - id: "mode"
+    kind: "button"
+    peripheral: "gpio"
+    pin: 4
+    signal: "input"
+    active_high: false
+  - id: "set"
+    kind: "button"
+    peripheral: "gpio"
+    pin: 5
+    signal: "input"
+    active_high: false

--- a/configs/systems/esp32c3-mlx90640-thermal.yaml
+++ b/configs/systems/esp32c3-mlx90640-thermal.yaml
@@ -10,6 +10,7 @@
 # `build_i2c_device` factory ("mlx90640" arm).
 name: "esp32c3-mlx90640-thermal"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "thermal_cam"

--- a/configs/systems/esp32c3-nokia5110-workshop.yaml
+++ b/configs/systems/esp32c3-nokia5110-workshop.yaml
@@ -1,5 +1,6 @@
 name: "esp32c3-nokia5110-workshop"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "lcd"

--- a/configs/systems/esp32c3-oled-128x32-workshop.yaml
+++ b/configs/systems/esp32c3-oled-128x32-workshop.yaml
@@ -1,5 +1,6 @@
 name: "esp32c3-oled-128x32-workshop"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "oled"

--- a/configs/systems/esp32c3-oled-demo.yaml
+++ b/configs/systems/esp32c3-oled-demo.yaml
@@ -7,6 +7,7 @@
 # twin boots that flash image faithfully through the real mask ROM (rom-boot).
 name: "esp32c3-oled-demo"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   # SSD1306 OLED on I2C0 at 0x3C. Attached to the C3 command-list controller by

--- a/configs/systems/esp32c3-tm1637-clock-workshop.yaml
+++ b/configs/systems/esp32c3-tm1637-clock-workshop.yaml
@@ -1,5 +1,6 @@
 name: "esp32c3-tm1637-clock-workshop"
 chip: "../chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "seg"

--- a/crates/core/src/bus/accessors.rs
+++ b/crates/core/src/bus/accessors.rs
@@ -216,8 +216,14 @@ impl crate::Bus for SystemBus {
                 #[cfg(feature = "event-scheduler")]
                 self.sync_scheduler_peripheral(idx);
                 self.maybe_latch_dc(idx);
-                let p = &mut self.peripherals[idx];
-                let r = p.dev.write(addr - p.base, value);
+                let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
+                let r = {
+                    let p = &mut self.peripherals[idx];
+                    p.dev.write(addr - p.base, value)
+                };
+                if r.is_ok() {
+                    self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
+                }
                 self.maybe_arm_hcsr04(idx);
                 self.maybe_clock_tm1637(idx);
                 #[cfg(feature = "event-scheduler")]
@@ -396,9 +402,15 @@ impl crate::Bus for SystemBus {
             #[cfg(feature = "event-scheduler")]
             self.sync_scheduler_peripheral(idx);
             self.maybe_latch_dc(idx);
-            let p = &mut self.peripherals[idx];
-            p.ticks_remaining = 0;
-            let r = p.dev.write_u16(addr - p.base, value);
+            let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
+            let r = {
+                let p = &mut self.peripherals[idx];
+                p.ticks_remaining = 0;
+                p.dev.write_u16(addr - p.base, value)
+            };
+            if r.is_ok() {
+                self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
+            }
             self.maybe_arm_hcsr04(idx);
             self.maybe_clock_tm1637(idx);
             #[cfg(feature = "event-scheduler")]
@@ -470,9 +482,15 @@ impl crate::Bus for SystemBus {
             #[cfg(feature = "event-scheduler")]
             self.sync_scheduler_peripheral(idx);
             self.maybe_latch_dc(idx);
-            let p = &mut self.peripherals[idx];
-            p.ticks_remaining = 0;
-            let r = p.dev.write_u32(addr - p.base, value);
+            let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
+            let r = {
+                let p = &mut self.peripherals[idx];
+                p.ticks_remaining = 0;
+                p.dev.write_u32(addr - p.base, value)
+            };
+            if r.is_ok() {
+                self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
+            }
             self.maybe_arm_hcsr04(idx);
             self.maybe_clock_tm1637(idx);
             #[cfg(feature = "event-scheduler")]

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -705,6 +705,10 @@ impl SystemBus {
         }
 
         bus.rebuild_peripheral_ranges();
+        // ESP32-C3: share IO_MUX pad controls with GPIO so an Arduino
+        // `INPUT_PULLUP` changes the floating input level. No-op for every
+        // other chip.
+        bus.wire_esp32c3_pad_controls();
         // ESP32-C3: share the I²C0 bit engine's live SDA/SCL line levels with
         // the C3 GPIO model so matrix-routed pads carry the real waveform.
         // No-op for every other chip.

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -1048,6 +1048,93 @@ impl SystemBus {
         }
     }
 
+    /// Wire C3 IO_MUX per-pad controls into C3 GPIO after both models have
+    /// been constructed. The IO_MUX owns the shared register bank; GPIO reads
+    /// `FUN_WPU` from it to model Arduino `INPUT_PULLUP`. No-op on any bus
+    /// without both C3 peripherals.
+    pub(crate) fn wire_esp32c3_pad_controls(&mut self) {
+        use crate::peripherals::esp32c3::gpio::Esp32c3Gpio;
+        use crate::peripherals::esp32c3::io_mux::Esp32c3IoMux;
+
+        let io_mux_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|any| any.is::<Esp32c3IoMux>())
+                .unwrap_or(false)
+        });
+        let gpio_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|any| any.is::<Esp32c3Gpio>())
+                .unwrap_or(false)
+        });
+        let (Some(io_mux_idx), Some(gpio_idx)) = (io_mux_idx, gpio_idx) else {
+            return;
+        };
+
+        let controls = self.peripherals[io_mux_idx]
+            .dev
+            .as_any()
+            .and_then(|any| any.downcast_ref::<Esp32c3IoMux>())
+            .map(Esp32c3IoMux::pad_controls);
+        if let (Some(controls), Some(gpio)) = (
+            controls,
+            self.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<Esp32c3Gpio>()),
+        ) {
+            gpio.set_pad_controls(controls);
+        }
+    }
+
+    /// Bracket a C3 IO_MUX write with GPIO push-capture sampling. A `FUN_WPU`
+    /// write changes an input pad electrically even though the GPIO register
+    /// block itself is not written, so the usual GPIO-local write hooks would
+    /// otherwise miss the edge. The returned GPIO index is passed to
+    /// [`Self::finish_esp32c3_io_mux_write`] after the MMIO write succeeds.
+    pub(crate) fn begin_esp32c3_io_mux_write(&mut self, io_mux_idx: usize) -> Option<usize> {
+        use crate::peripherals::esp32c3::gpio::Esp32c3Gpio;
+        use crate::peripherals::esp32c3::io_mux::Esp32c3IoMux;
+
+        if !self.peripherals.get(io_mux_idx).is_some_and(|p| {
+            p.dev
+                .as_any()
+                .map(|any| any.is::<Esp32c3IoMux>())
+                .unwrap_or(false)
+        }) {
+            return None;
+        }
+        let gpio_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|any| any.is::<Esp32c3Gpio>())
+                .unwrap_or(false)
+        })?;
+        self.peripherals[gpio_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())?
+            .tap_snapshot();
+        Some(gpio_idx)
+    }
+
+    /// Complete a successful C3 IO_MUX write started by
+    /// [`Self::begin_esp32c3_io_mux_write`], pushing any changed pad level to
+    /// the in-engine logic tap.
+    pub(crate) fn finish_esp32c3_io_mux_write(&mut self, gpio_idx: Option<usize>) {
+        let Some(gpio_idx) = gpio_idx else {
+            return;
+        };
+        if let Some(gpio) = self.peripherals[gpio_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|any| any.downcast_mut::<crate::peripherals::esp32c3::gpio::Esp32c3Gpio>())
+        {
+            gpio.tap_report();
+        }
+    }
+
     /// Wire the STM32 SPI bit engines' live SCK/MOSI/MISO levels into the
     /// STM32 GPIO ports, so pads whose MODER/AFR (V2) or CRL/CRH CNF (F1)
     /// route an SPI alternate function read the real waveform through
@@ -3198,10 +3285,17 @@ impl SystemBus {
             #[cfg(feature = "event-scheduler")]
             self.sync_scheduler_peripheral(idx);
             self.maybe_latch_dc(idx);
-            let p = &mut self.peripherals[idx];
-            p.ticks_remaining = 0;
-            let base = p.base;
-            let r = p.dev.write_u32(addr - base, value);
+            let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
+            let (base, r) = {
+                let p = &mut self.peripherals[idx];
+                p.ticks_remaining = 0;
+                let base = p.base;
+                let r = p.dev.write_u32(addr - base, value);
+                (base, r)
+            };
+            if r.is_ok() {
+                self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
+            }
             self.maybe_arm_hcsr04(idx);
             #[cfg(feature = "event-scheduler")]
             self.collect_scheduled_events(idx);
@@ -3272,10 +3366,17 @@ impl SystemBus {
             #[cfg(feature = "event-scheduler")]
             self.sync_scheduler_peripheral(idx);
             self.maybe_latch_dc(idx);
-            let p = &mut self.peripherals[idx];
-            p.ticks_remaining = 0;
-            let base = p.base;
-            let r = p.dev.write_u16(addr - base, value);
+            let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
+            let (base, r) = {
+                let p = &mut self.peripherals[idx];
+                p.ticks_remaining = 0;
+                let base = p.base;
+                let r = p.dev.write_u16(addr - base, value);
+                (base, r)
+            };
+            if r.is_ok() {
+                self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
+            }
             self.maybe_arm_hcsr04(idx);
             #[cfg(feature = "event-scheduler")]
             self.collect_scheduled_events(idx);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -613,6 +613,17 @@ pub trait Peripheral: std::fmt::Debug + Send {
         Ok(())
     }
 
+    /// Optional source register descriptor for debugger clients that need the
+    /// config-level layout (including reset values and descriptions), rather
+    /// than the display-oriented [`Self::describe_registers`] schema.
+    ///
+    /// Declarative peripherals return their original descriptor. Behavioral
+    /// peripherals that replace a declarative register surface may do the same
+    /// to keep debugger integrations faithful to the configured chip.
+    fn peripheral_descriptor(&self) -> Option<labwired_config::PeripheralDescriptor> {
+        None
+    }
+
     /// Optional register-layout schema for the universal inspect interface.
     /// Declarative peripherals ([`crate::peripherals::declarative::GenericPeripheral`])
     /// return their descriptor's registers, so every declarative peripheral
@@ -2470,12 +2481,8 @@ impl<C: Cpu> DebugControl for Machine<C> {
         &self,
         name: &str,
     ) -> Option<labwired_config::PeripheralDescriptor> {
-        use crate::peripherals::declarative::GenericPeripheral;
         let entry = self.bus.peripherals.iter().find(|p| p.name == name)?;
-        let gen_p = entry.dev.as_any()?.downcast_ref::<GenericPeripheral>()?;
-        // We need a way to get the descriptor from GenericPeripheral.
-        // It's private currently. Let's make it public or add a getter.
-        Some(gen_p.get_descriptor().clone())
+        entry.dev.peripheral_descriptor()
     }
 
     fn reset(&mut self) -> SimResult<()> {

--- a/crates/core/src/peripherals/declarative.rs
+++ b/crates/core/src/peripherals/declarative.rs
@@ -633,6 +633,10 @@ impl Peripheral for GenericPeripheral {
         self.write_register_storage_u32(offset, value)
     }
 
+    fn peripheral_descriptor(&self) -> Option<PeripheralDescriptor> {
+        Some(self.descriptor.clone())
+    }
+
     /// Expose the descriptor's register layout to the universal inspect
     /// interface. This one method makes every declarative peripheral — the
     /// whole ESP32-C3/S3 register wall — decode named registers + bitfields for

--- a/crates/core/src/peripherals/esp32c3/factory.rs
+++ b/crates/core/src/peripherals/esp32c3/factory.rs
@@ -10,9 +10,10 @@ use labwired_config::PeripheralConfig;
 pub fn try_build(canonical_type: &str, _p_cfg: &PeripheralConfig) -> Option<Box<dyn Peripheral>> {
     let dev: Box<dyn Peripheral> = match canonical_type {
         "esp32c3_gpio" => Box::new(super::gpio::Esp32c3Gpio::new()),
+        "esp32c3_io_mux" => Box::new(super::io_mux::Esp32c3IoMux::new()),
         _ => return None,
     };
     Some(dev)
 }
 
-pub const SUPPORTED_TYPES: &[&str] = &["esp32c3_gpio"];
+pub const SUPPORTED_TYPES: &[&str] = &["esp32c3_gpio", "esp32c3_io_mux"];

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -788,7 +788,7 @@ chip: "../chips/esp32c3.yaml"
         crate::Bus::write_u32(&mut bus, IO_MUX_GPIO5, 0x0000_1a02)
             .expect("firmware configures GPIO5 as INPUT");
         assert_eq!(
-            crate::Bus::read_u32(&mut bus, IO_MUX_GPIO5).unwrap(),
+            crate::Bus::read_u32(&bus, IO_MUX_GPIO5).unwrap(),
             0x0000_1a02
         );
 
@@ -806,7 +806,7 @@ chip: "../chips/esp32c3.yaml"
         crate::Bus::write_u8(&mut bus, IO_MUX_GPIO5 + 1, 0x1b)
             .expect("byte write enables GPIO5 FUN_WPU");
         assert_eq!(
-            crate::Bus::read_u32(&mut bus, IO_MUX_GPIO5).unwrap(),
+            crate::Bus::read_u32(&bus, IO_MUX_GPIO5).unwrap(),
             0x0000_1b02
         );
         assert_eq!(
@@ -821,7 +821,7 @@ chip: "../chips/esp32c3.yaml"
         crate::Bus::write_u16(&mut bus, IO_MUX_GPIO5, 0x1a02)
             .expect("halfword write clears GPIO5 FUN_WPU");
         assert_eq!(
-            crate::Bus::read_u32(&mut bus, IO_MUX_GPIO5).unwrap(),
+            crate::Bus::read_u32(&bus, IO_MUX_GPIO5).unwrap(),
             0x0000_1a02
         );
         assert_eq!(

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -86,12 +86,20 @@ pub struct Esp32c3Gpio {
     sdio_select: u32,
     enable: u32,
     strap: u32,
-    in_data: u32,
+    /// Host/browser-driven input levels. A bit only has electrical authority
+    /// when the matching `external_drive_mask` bit is set; otherwise the
+    /// IO_MUX pull-up (if any) supplies the released level.
+    external_levels: u32,
+    external_drive_mask: u32,
     status: u32,
     pin_cfg: [u32; PIN_COUNT as usize],
     /// `GPIO_FUNCn_OUT_SEL_CFG` per pad — the output-matrix selector read by
     /// `gpio_routing` to name the signal a pad is wired to.
     out_sel: [u32; PIN_COUNT as usize],
+    /// Shared IO_MUX per-pad register words. This is intentionally separate
+    /// from the output matrix: the pad's weak pull-up is an electrical input
+    /// condition, not a routed peripheral signal.
+    pad_controls: Option<super::io_mux::PadControls>,
     /// Live I²C0 SDA/SCL line levels, shared with the C3 I²C bit engine (see
     /// `crate::bus::SystemBus::wire_esp32c3_i2c_pads`). Pads whose output
     /// matrix routes I2CEXT0_SCL/SDA read the wire here instead of the
@@ -113,10 +121,12 @@ impl Esp32c3Gpio {
             sdio_select: 0,
             enable: 0,
             strap: STRAP_SPI_FAST_FLASH_BOOT,
-            in_data: 0,
+            external_levels: 0,
+            external_drive_mask: 0,
             status: 0,
             pin_cfg: [0; PIN_COUNT as usize],
             out_sel: [0; PIN_COUNT as usize],
+            pad_controls: None,
             i2c_lines: None,
             tap: None,
             cycle: 0,
@@ -128,6 +138,39 @@ impl Esp32c3Gpio {
     /// engine drives) so matrix-routed pads carry the real waveform.
     pub(crate) fn set_i2c_lines(&mut self, lines: std::sync::Arc<super::i2c::I2cLineLevels>) {
         self.i2c_lines = Some(lines);
+    }
+
+    /// Wire the C3 IO_MUX's shared per-pad controls after both peripherals
+    /// exist on the system bus.
+    pub(crate) fn set_pad_controls(&mut self, controls: super::io_mux::PadControls) {
+        self.pad_controls = Some(controls);
+    }
+
+    fn io_mux_pullup_mask(&self) -> u32 {
+        let Some(controls) = &self.pad_controls else {
+            return 0;
+        };
+        controls
+            .read()
+            .expect("ESP32-C3 IO_MUX pad controls poisoned")
+            .iter()
+            .enumerate()
+            .fold(0, |mask, (pin, word)| {
+                if word & (1 << 8) != 0 {
+                    mask | (1 << pin)
+                } else {
+                    mask
+                }
+            })
+    }
+
+    /// Firmware-visible input word. An explicit external drive always beats a
+    /// weak internal pull-up; otherwise the raw IO_MUX `FUN_WPU` bit supplies
+    /// the released level, including its descriptor-defined cold reset.
+    fn effective_input(&self) -> u32 {
+        ((self.external_levels & self.external_drive_mask)
+            | (self.io_mux_pullup_mask() & !self.external_drive_mask))
+            & PIN_MASK
     }
 
     /// Direction-aware pad level — the single truth `read_gpio_pad` and the
@@ -151,14 +194,14 @@ impl Esp32c3Gpio {
             }
             return Some((self.out & mask) != 0);
         }
-        Some((self.in_data & mask) != 0)
+        Some((self.effective_input() & mask) != 0)
     }
 
     /// Record every watched pad's current level before a mutation. No-op (one
     /// branch) while no tap is installed. The tap is briefly taken out of
     /// `self` so `pad_level(&self)` can run while the scratchpad is written.
     #[inline]
-    fn tap_snapshot(&mut self) {
+    pub(crate) fn tap_snapshot(&mut self) {
         let Some(mut t) = self.tap.take() else {
             return;
         };
@@ -174,7 +217,7 @@ impl Esp32c3Gpio {
     /// so a pad handed to (or taken from) the I²C matrix keeps pushing edges
     /// from the correct source afterwards.
     #[inline]
-    fn tap_report(&mut self) {
+    pub(crate) fn tap_report(&mut self) {
         let Some(t) = self.tap.take() else {
             return;
         };
@@ -246,10 +289,11 @@ impl Esp32c3Gpio {
     pub fn set_pin_input(&mut self, pin: u8, level: bool) {
         assert!(pin < PIN_COUNT, "set_pin_input: pin {pin} >= {PIN_COUNT}");
         if level {
-            self.in_data |= 1u32 << pin;
+            self.external_levels |= 1u32 << pin;
         } else {
-            self.in_data &= !(1u32 << pin);
+            self.external_levels &= !(1u32 << pin);
         }
+        self.external_drive_mask |= 1u32 << pin;
     }
 
     fn pin_cfg_index(off: u64) -> Option<usize> {
@@ -267,7 +311,7 @@ impl Esp32c3Gpio {
             SDIO_SELECT => self.sdio_select,
             ENABLE | ENABLE_W1TS | ENABLE_W1TC => self.enable,
             STRAP => self.strap,
-            IN => self.in_data,
+            IN => self.effective_input(),
             STATUS | STATUS_W1TS | STATUS_W1TC => self.status,
             PCPU_INT | PCPU_NMI_INT | CPUSDIO_INT => self.status,
             off => {
@@ -390,7 +434,7 @@ impl Peripheral for Esp32c3Gpio {
         serde_json::json!({
             "layout": "esp32c3",
             "odr": self.out,
-            "idr": self.in_data,
+            "idr": self.effective_input(),
             "enable": self.enable,
             "strap": self.strap,
             "status": self.status,
@@ -401,7 +445,7 @@ impl Peripheral for Esp32c3Gpio {
         if pin >= PIN_COUNT {
             return None;
         }
-        Some((self.in_data & (1u32 << pin)) != 0)
+        Some((self.effective_input() & (1u32 << pin)) != 0)
     }
 
     fn read_gpio_output(&self, pin: u8) -> Option<bool> {
@@ -510,6 +554,8 @@ impl Peripheral for Esp32c3Gpio {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bus::SystemBus;
+    use labwired_config::{ChipDescriptor, SystemManifest};
 
     #[test]
     fn w1ts_and_w1tc_update_output_register() {
@@ -575,5 +621,355 @@ mod tests {
         assert!(r9.func.is_none());
 
         assert!(g.gpio_routing(PIN_COUNT).is_none(), "out-of-range pin");
+    }
+
+    #[test]
+    fn esp32c3_input_pullup_releases_a_floating_pin_but_external_drive_wins() {
+        const IO_MUX_GPIO4: u64 = 0x6000_9000 + 0x04 + 4 * 4;
+        const GPIO_IN: u64 = 0x6000_4000 + IN;
+
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-input-pullup-test"
+chip: "../chips/esp32c3.yaml"
+"#,
+        )
+        .expect("parse system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("construct C3 bus");
+        let gpio_idx = bus
+            .find_peripheral_index_by_name("gpio")
+            .expect("C3 GPIO is present");
+
+        {
+            let gpio = bus.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())
+                .expect("C3 GPIO model");
+            assert_eq!(
+                gpio.read_gpio_input(4),
+                Some(true),
+                "the cold IO_MUX FUN_WPU bit releases a floating GPIO4"
+            );
+            assert_eq!(gpio.read_gpio_pad(4), Some(true));
+        }
+
+        assert_eq!(bus.read_u32(IO_MUX_GPIO4).unwrap(), 0x0000_0b00);
+        bus.write_u32(IO_MUX_GPIO4, 0x0000_1a02)
+            .expect("emulate Arduino pinMode(GPIO4, INPUT)");
+
+        {
+            let gpio = bus.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())
+                .expect("C3 GPIO model");
+            assert_eq!(gpio.read_gpio_input(4), Some(false), "INPUT clears FUN_WPU");
+            assert_eq!(gpio.read_gpio_pad(4), Some(false));
+        }
+
+        bus.write_u32(IO_MUX_GPIO4, 0x0000_1b02)
+            .expect("emulate Arduino pinMode(GPIO4, INPUT_PULLUP)");
+
+        {
+            let gpio = bus.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())
+                .expect("C3 GPIO model");
+            assert_eq!(gpio.read_gpio_input(4), Some(true), "pull-up releases high");
+            assert_eq!(gpio.read_gpio_pad(4), Some(true));
+            assert_ne!(gpio.snapshot()["idr"].as_u64().unwrap() & (1 << 4), 0);
+        }
+        assert_ne!(bus.read_u32(GPIO_IN).unwrap() & (1 << 4), 0);
+
+        let gpio = bus.peripherals[gpio_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())
+            .expect("C3 GPIO model");
+        assert!(gpio.set_gpio_input(4, false));
+        assert_eq!(gpio.read_gpio_input(4), Some(false), "injected low wins");
+        assert!(gpio.set_gpio_input(4, true));
+        assert_eq!(gpio.read_gpio_input(4), Some(true), "injected high wins");
+    }
+
+    #[test]
+    fn input_pullup_uses_the_same_effective_level_for_logic_capture() {
+        use crate::logic_capture::{LogicTap, PadEvent};
+        use crate::peripherals::esp32c3::io_mux::Esp32c3IoMux;
+
+        let mut io_mux = Esp32c3IoMux::new();
+        io_mux.write_u32(0x04 + 4 * 4, 1 << 8).unwrap();
+        let mut gpio = Esp32c3Gpio::new();
+        gpio.set_pad_controls(io_mux.pad_controls());
+        let tap = LogicTap::new();
+        assert!(gpio.install_logic_tap(&tap, &[(4, 0)]));
+
+        assert!(gpio.set_gpio_input(4, false));
+        assert_eq!(
+            tap.take_events(),
+            vec![PadEvent {
+                ch: 0,
+                cycle: 0,
+                value: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn io_mux_pullup_write_pushes_logic_capture_edge() {
+        use crate::logic_capture::{LogicTap, PadEvent};
+
+        const IO_MUX_GPIO4: u64 = 0x6000_9000 + 0x04 + 4 * 4;
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-input-pullup-capture-test"
+chip: "../chips/esp32c3.yaml"
+"#,
+        )
+        .expect("parse system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("construct C3 bus");
+        let gpio_idx = bus
+            .find_peripheral_index_by_name("gpio")
+            .expect("C3 GPIO is present");
+        crate::Bus::write_u32(&mut bus, IO_MUX_GPIO4, 0x0000_1a02)
+            .expect("firmware configures GPIO4 as INPUT before arming capture");
+        let tap = LogicTap::new();
+        {
+            let gpio = bus.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())
+                .expect("C3 GPIO model");
+            assert!(gpio.install_logic_tap(&tap, &[(4, 0)]));
+            assert_eq!(gpio.read_gpio_pad(4), Some(false));
+        }
+
+        crate::Bus::write_u32(&mut bus, IO_MUX_GPIO4, 0x0000_1b02)
+            .expect("firmware enables GPIO4 FUN_WPU");
+
+        assert_eq!(
+            tap.take_events(),
+            vec![PadEvent {
+                ch: 0,
+                cycle: 0,
+                value: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn io_mux_byte_and_halfword_writes_drive_pullups_and_emit_capture_edges() {
+        use crate::logic_capture::{LogicTap, PadEvent};
+
+        const IO_MUX_GPIO5: u64 = 0x6000_9000 + 0x04 + 5 * 4;
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-input-pullup-width-test"
+chip: "../chips/esp32c3.yaml"
+"#,
+        )
+        .expect("parse system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("construct C3 bus");
+        let gpio_idx = bus
+            .find_peripheral_index_by_name("gpio")
+            .expect("C3 GPIO is present");
+
+        crate::Bus::write_u32(&mut bus, IO_MUX_GPIO5, 0x0000_1a02)
+            .expect("firmware configures GPIO5 as INPUT");
+        assert_eq!(
+            crate::Bus::read_u32(&mut bus, IO_MUX_GPIO5).unwrap(),
+            0x0000_1a02
+        );
+
+        let tap = LogicTap::new();
+        {
+            let gpio = bus.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|any| any.downcast_mut::<Esp32c3Gpio>())
+                .expect("C3 GPIO model");
+            assert!(gpio.install_logic_tap(&tap, &[(5, 0)]));
+            assert_eq!(gpio.read_gpio_pad(5), Some(false));
+        }
+
+        crate::Bus::write_u8(&mut bus, IO_MUX_GPIO5 + 1, 0x1b)
+            .expect("byte write enables GPIO5 FUN_WPU");
+        assert_eq!(
+            crate::Bus::read_u32(&mut bus, IO_MUX_GPIO5).unwrap(),
+            0x0000_1b02
+        );
+        assert_eq!(
+            tap.take_events(),
+            vec![PadEvent {
+                ch: 0,
+                cycle: 0,
+                value: true,
+            }]
+        );
+
+        crate::Bus::write_u16(&mut bus, IO_MUX_GPIO5, 0x1a02)
+            .expect("halfword write clears GPIO5 FUN_WPU");
+        assert_eq!(
+            crate::Bus::read_u32(&mut bus, IO_MUX_GPIO5).unwrap(),
+            0x0000_1a02
+        );
+        assert_eq!(
+            tap.take_events(),
+            vec![PadEvent {
+                ch: 0,
+                cycle: 0,
+                value: false,
+            }]
+        );
+
+        crate::Bus::write_u16(&mut bus, IO_MUX_GPIO5, 0x1b02)
+            .expect("halfword write enables GPIO5 FUN_WPU");
+        assert_eq!(
+            tap.take_events(),
+            vec![PadEvent {
+                ch: 0,
+                cycle: 0,
+                value: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn machine_snapshot_restores_io_mux_pads_date_and_gpio_wiring() {
+        const IO_MUX_PIN_CTRL: u64 = 0x6000_9000;
+        const IO_MUX_GPIO4: u64 = 0x6000_9000 + 0x04 + 4 * 4;
+        const IO_MUX_DATE: u64 = 0x6000_90fc;
+        const GPIO_IN: u64 = 0x6000_4000 + IN;
+
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-input-pullup-machine-snapshot-test"
+chip: "../chips/esp32c3.yaml"
+"#,
+        )
+        .expect("parse system yaml");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("construct C3 bus");
+        let cpu = crate::system::riscv::configure_riscv(&mut bus);
+        let mut machine = crate::Machine::new(cpu, bus);
+
+        machine
+            .bus
+            .write_u32(IO_MUX_GPIO4, 0x0000_1a02)
+            .expect("set GPIO4 INPUT");
+        assert_eq!(machine.bus.read_u32(GPIO_IN).unwrap() & (1 << 4), 0);
+
+        machine
+            .bus
+            .write_u32(IO_MUX_GPIO4, 0x0000_1b02)
+            .expect("set GPIO4 INPUT_PULLUP");
+        machine
+            .bus
+            .write_u32(IO_MUX_PIN_CTRL, 0x321)
+            .expect("write IO_MUX PIN_CTRL");
+        machine
+            .bus
+            .write_u32(IO_MUX_DATE, 0x0bad_c0de)
+            .expect("write IO_MUX DATE");
+        let snapshot = machine.snapshot();
+
+        machine
+            .bus
+            .write_u32(IO_MUX_GPIO4, 0x0000_1a02)
+            .expect("mutate GPIO4 back to INPUT");
+        machine
+            .bus
+            .write_u32(IO_MUX_PIN_CTRL, 0x654)
+            .expect("mutate IO_MUX PIN_CTRL");
+        machine
+            .bus
+            .write_u32(IO_MUX_DATE, 0xfeed_face)
+            .expect("mutate IO_MUX DATE");
+        assert_eq!(machine.bus.read_u32(GPIO_IN).unwrap() & (1 << 4), 0);
+
+        machine
+            .apply_snapshot(snapshot)
+            .expect("restore full machine snapshot");
+        assert_ne!(
+            machine.bus.read_u32(GPIO_IN).unwrap() & (1 << 4),
+            0,
+            "GPIO retains the shared IO_MUX pad-control connection after restore"
+        );
+        assert_eq!(machine.bus.read_u32(IO_MUX_GPIO4).unwrap(), 0x0000_1b02);
+        assert_eq!(machine.bus.read_u32(IO_MUX_PIN_CTRL).unwrap(), 0x321);
+        assert_eq!(machine.bus.read_u32(IO_MUX_DATE).unwrap(), 0x0bad_c0de);
+    }
+
+    #[test]
+    fn fresh_machine_runtime_snapshot_restores_io_mux_state_and_gpio_wiring() {
+        const IO_MUX_PIN_CTRL: u64 = 0x6000_9000;
+        const IO_MUX_GPIO4: u64 = 0x6000_9000 + 0x04 + 4 * 4;
+        const IO_MUX_DATE: u64 = 0x6000_90fc;
+        const GPIO_IN: u64 = 0x6000_4000 + IN;
+
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-input-pullup-runtime-snapshot-test"
+chip: "../chips/esp32c3.yaml"
+"#,
+        )
+        .expect("parse system yaml");
+
+        let mut source_bus =
+            SystemBus::from_config(&chip, &manifest).expect("construct source C3 bus");
+        let source_cpu = crate::system::riscv::configure_riscv(&mut source_bus);
+        let mut source = crate::Machine::new(source_cpu, source_bus);
+        source
+            .bus
+            .write_u32(IO_MUX_GPIO4, 0xfeed_1a02)
+            .expect("set source GPIO4 INPUT without FUN_WPU");
+        source
+            .bus
+            .write_u32(IO_MUX_PIN_CTRL, 0xa5a5_f123)
+            .expect("write source IO_MUX PIN_CTRL");
+        source
+            .bus
+            .write_u32(IO_MUX_DATE, 0x0bad_c0de)
+            .expect("write source IO_MUX DATE");
+        assert_eq!(source.bus.read_u32(GPIO_IN).unwrap() & (1 << 4), 0);
+        let snapshot = source.take_runtime_snapshot();
+
+        let mut resumed_bus =
+            SystemBus::from_config(&chip, &manifest).expect("construct fresh C3 bus");
+        let resumed_cpu = crate::system::riscv::configure_riscv(&mut resumed_bus);
+        let mut resumed = crate::Machine::new(resumed_cpu, resumed_bus);
+        assert_ne!(
+            resumed.bus.read_u32(GPIO_IN).unwrap() & (1 << 4),
+            0,
+            "fresh C3 IO_MUX starts with its descriptor FUN_WPU reset"
+        );
+
+        resumed
+            .apply_runtime_snapshot(&snapshot)
+            .expect("restore runtime snapshot into fresh machine");
+        assert_eq!(resumed.bus.read_u32(GPIO_IN).unwrap() & (1 << 4), 0);
+        assert_eq!(
+            resumed.bus.read_u32(IO_MUX_GPIO4).unwrap(),
+            0xfeed_1a02,
+            "the restored IO_MUX state remains shared with GPIO"
+        );
+        assert_eq!(resumed.bus.read_u32(IO_MUX_PIN_CTRL).unwrap(), 0xa5a5_f123);
+        assert_eq!(resumed.bus.read_u32(IO_MUX_DATE).unwrap(), 0x0bad_c0de);
     }
 }

--- a/crates/core/src/peripherals/esp32c3/io_mux.rs
+++ b/crates/core/src/peripherals/esp32c3/io_mux.rs
@@ -1,0 +1,410 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 IO_MUX pad-control peripheral.
+//!
+//! The C3 keeps `PIN_CTRL` at offset `0x00`; its per-pad registers begin at
+//! `0x04` (`GPIO0`) rather than at the base address. GPIO shares this register
+//! bank so the pad-level `FUN_WPU` control used by Arduino `INPUT_PULLUP` is
+//! visible outside this MMIO model.
+
+use crate::{Peripheral, SimResult};
+use labwired_config::PeripheralDescriptor;
+use std::sync::{Arc, OnceLock, RwLock};
+
+const PIN_CTRL: u64 = 0x00;
+const GPIO0: u64 = 0x04;
+const DATE: u64 = 0xfc;
+/// ESP32-C3 IO_MUX has registers for GPIO0 through GPIO21. GPIO22 through
+/// GPIO25 exist in the separate 26-bit GPIO block but have no IO_MUX pad word.
+const PAD_COUNT: usize = 22;
+const PIN_CTRL_RESET: u32 = 0x07ff;
+const PAD_RESET: u32 = 0x0000_0b00;
+const DATE_RESET: u32 = 0x0200_6050;
+const FUN_WPU: u32 = 1 << 8;
+
+/// The behavioral model replaces the declarative peripheral, but debugger and
+/// inspect clients still need its original register contract. Keep the schema
+/// sourced from the same checked-in descriptor rather than duplicating it by
+/// hand in Rust.
+const IO_MUX_DESCRIPTOR_YAML: &str =
+    include_str!("../../../../../configs/peripherals/esp32c3/io_mux.yaml");
+
+fn io_mux_descriptor() -> &'static PeripheralDescriptor {
+    static DESCRIPTOR: OnceLock<PeripheralDescriptor> = OnceLock::new();
+    DESCRIPTOR.get_or_init(|| {
+        PeripheralDescriptor::from_yaml(IO_MUX_DESCRIPTOR_YAML)
+            .expect("embedded ESP32-C3 IO_MUX descriptor is valid")
+    })
+}
+
+pub(crate) type PadControls = Arc<RwLock<[u32; PAD_COUNT]>>;
+
+#[derive(Debug)]
+pub struct Esp32c3IoMux {
+    pin_ctrl: u32,
+    pads: PadControls,
+    date: u32,
+}
+
+impl Esp32c3IoMux {
+    pub fn new() -> Self {
+        Self {
+            pin_ctrl: PIN_CTRL_RESET,
+            // Keep the descriptor's raw cold-reset state observable. In
+            // particular, FUN_WPU is already set at reset, so GPIO's electrical
+            // input view must see the raw pull-up directly rather than a
+            // simulator-only "written" activation convention.
+            pads: Arc::new(RwLock::new([PAD_RESET; PAD_COUNT])),
+            date: DATE_RESET,
+        }
+    }
+
+    pub(crate) fn pad_controls(&self) -> PadControls {
+        Arc::clone(&self.pads)
+    }
+
+    pub fn fun_pull_up(&self, pin: u8) -> bool {
+        self.pads
+            .read()
+            .expect("ESP32-C3 IO_MUX pad controls poisoned")
+            .get(pin as usize)
+            .map(|word| word & FUN_WPU != 0)
+            .unwrap_or(false)
+    }
+
+    fn pad_index(word_off: u64) -> Option<usize> {
+        if (GPIO0..GPIO0 + (PAD_COUNT as u64) * 4).contains(&word_off) {
+            Some(((word_off - GPIO0) / 4) as usize)
+        } else {
+            None
+        }
+    }
+
+    fn read_word(&self, word_off: u64) -> u32 {
+        if word_off == PIN_CTRL {
+            self.pin_ctrl
+        } else if word_off == DATE {
+            self.date
+        } else if let Some(pin) = Self::pad_index(word_off) {
+            self.pads
+                .read()
+                .expect("ESP32-C3 IO_MUX pad controls poisoned")[pin]
+        } else {
+            0
+        }
+    }
+
+    fn write_word(&mut self, word_off: u64, value: u32) {
+        if word_off == PIN_CTRL {
+            self.pin_ctrl = value;
+        } else if word_off == DATE {
+            self.date = value;
+        } else if let Some(pin) = Self::pad_index(word_off) {
+            self.pads
+                .write()
+                .expect("ESP32-C3 IO_MUX pad controls poisoned")[pin] = value;
+        }
+    }
+
+    fn runtime_state(&self) -> IoMuxSnapshot {
+        IoMuxSnapshot {
+            pin_ctrl: self.pin_ctrl,
+            pads: *self
+                .pads
+                .read()
+                .expect("ESP32-C3 IO_MUX pad controls poisoned"),
+            date: self.date,
+        }
+    }
+
+    fn apply_runtime_state(&mut self, state: IoMuxSnapshot) {
+        self.pin_ctrl = state.pin_ctrl;
+        *self
+            .pads
+            .write()
+            .expect("ESP32-C3 IO_MUX pad controls poisoned") = state.pads;
+        self.date = state.date;
+    }
+}
+
+impl Default for Esp32c3IoMux {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct IoMuxSnapshot {
+    pin_ctrl: u32,
+    pads: [u32; PAD_COUNT],
+    date: u32,
+}
+
+impl Peripheral for Esp32c3IoMux {
+    // Inert walk: IO_MUX is a register bank whose pad controls take effect at
+    // the MMIO write. It has no time-based state, IRQ, DMA, or event output.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word = self.read_word(offset & !3);
+        Ok(((word >> ((offset & 3) * 8)) & 0xff) as u8)
+    }
+
+    fn peek(&self, offset: u64) -> Option<u8> {
+        let word = self.read_word(offset & !3);
+        Some(((word >> ((offset & 3) * 8)) & 0xff) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let word_off = offset & !3;
+        let shift = (offset & 3) * 8;
+        let mut word = self.read_word(word_off);
+        word &= !(0xff << shift);
+        word |= (value as u32) << shift;
+        self.write_word(word_off, word);
+        Ok(())
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if offset & 3 == 0 {
+            self.write_word(offset, value);
+            Ok(())
+        } else {
+            for byte in 0..4 {
+                self.write(offset + byte, ((value >> (byte * 8)) & 0xff) as u8)?;
+            }
+            Ok(())
+        }
+    }
+
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::to_value(self.runtime_state()).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn restore(&mut self, state: serde_json::Value) -> SimResult<()> {
+        if let Ok(state) = serde_json::from_value::<IoMuxSnapshot>(state) {
+            self.apply_runtime_state(state);
+        }
+        Ok(())
+    }
+
+    fn peripheral_descriptor(&self) -> Option<PeripheralDescriptor> {
+        Some(io_mux_descriptor().clone())
+    }
+
+    fn describe_registers(&self) -> Option<Vec<crate::inspect::RegisterSchema>> {
+        Some(
+            io_mux_descriptor()
+                .registers
+                .iter()
+                .map(|reg| crate::inspect::RegisterSchema {
+                    name: reg.id.clone(),
+                    offset: reg.address_offset,
+                    size: reg.size,
+                    access: match reg.access {
+                        labwired_config::Access::ReadWrite => "rw",
+                        labwired_config::Access::ReadOnly => "ro",
+                        labwired_config::Access::WriteOnly => "wo",
+                    },
+                    fields: reg
+                        .fields
+                        .iter()
+                        .map(|field| crate::inspect::FieldSchema {
+                            name: field.name.clone(),
+                            bits: field.bit_range,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        )
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        bincode::serialize(&self.runtime_state()).expect("bincode serialize Esp32c3IoMux")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let state: IoMuxSnapshot = bincode::deserialize(bytes).map_err(|error| {
+            crate::SimulationError::NotImplemented(format!("Esp32c3IoMux snapshot decode: {error}"))
+        })?;
+        self.apply_runtime_state(state);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::SystemBus;
+    use crate::{Bus, DebugControl, SimulationObserver};
+    use labwired_config::{ChipDescriptor, SystemManifest};
+    use std::sync::{Arc, Mutex};
+
+    fn c3_bus() -> SystemBus {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32c3.yaml"))
+            .expect("read esp32c3 chip yaml");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "esp32c3-io-mux-debug-surface-test"
+chip: "../chips/esp32c3.yaml"
+"#,
+        )
+        .expect("parse system yaml");
+        SystemBus::from_config(&chip, &manifest).expect("construct C3 bus")
+    }
+
+    #[test]
+    fn cold_descriptor_surface_has_twenty_two_pads_date_and_no_synthetic_registers() {
+        let mut io_mux = Esp32c3IoMux::new();
+
+        assert_eq!(io_mux.read_u32(PIN_CTRL).unwrap(), PIN_CTRL_RESET);
+        for pin in 0..22u64 {
+            assert_eq!(
+                io_mux.read_u32(GPIO0 + pin * 4).unwrap(),
+                0x0000_0b00,
+                "GPIO{pin} must retain the descriptor cold reset"
+            );
+        }
+        for pin in 22..26u64 {
+            assert_eq!(
+                io_mux.read_u32(GPIO0 + pin * 4).unwrap(),
+                0,
+                "GPIO{pin} is outside the ESP32-C3 IO_MUX pad bank"
+            );
+        }
+        assert_eq!(io_mux.read_u32(0xfc).unwrap(), 0x0200_6050);
+
+        // The declarative descriptor exposes these RW words raw: keep high
+        // reserved bits too, rather than introducing a simulator write mask.
+        io_mux.write_u32(PIN_CTRL, 0xa5a5_f123).unwrap();
+        io_mux.write_u32(GPIO0 + 4 * 4, 0xfeed_1b02).unwrap();
+        io_mux.write_u32(0xfc, 0xdead_beef).unwrap();
+        for pin in 22..26u64 {
+            io_mux.write_u32(GPIO0 + pin * 4, 0xfeed_face).unwrap();
+        }
+
+        assert_eq!(io_mux.read_u32(PIN_CTRL).unwrap(), 0xa5a5_f123);
+        assert_eq!(io_mux.read_u32(GPIO0 + 4 * 4).unwrap(), 0xfeed_1b02);
+        assert_eq!(io_mux.read_u32(0xfc).unwrap(), 0xdead_beef);
+        for pin in 22..26u64 {
+            assert_eq!(io_mux.read_u32(GPIO0 + pin * 4).unwrap(), 0);
+        }
+        assert!(io_mux.fun_pull_up(4));
+        assert!(!io_mux.fun_pull_up(22));
+    }
+
+    #[test]
+    fn c3_io_mux_is_registered_as_a_canonical_behavioral_model() {
+        assert!(crate::peripherals::generic_factory::is_canonical_model_type("esp32c3_io_mux"));
+    }
+
+    #[test]
+    fn c3_io_mux_keeps_its_descriptor_for_machine_debuggers() {
+        let mut bus = c3_bus();
+        let cpu = crate::system::riscv::configure_riscv(&mut bus);
+        let machine = crate::Machine::new(cpu, bus);
+
+        let descriptor = machine
+            .get_peripheral_descriptor("io_mux")
+            .expect("C3 IO_MUX retains its register descriptor");
+        assert!(
+            descriptor.registers.iter().any(|reg| reg.id == "PIN_CTRL"),
+            "debugger descriptor includes PIN_CTRL"
+        );
+        assert!(
+            descriptor.registers.iter().any(|reg| reg.id == "GPIO0"),
+            "debugger descriptor includes GPIO0"
+        );
+
+        let inspected = machine.inspect(Some("io_mux"), &crate::inspect::InspectOpts::default());
+        let registers = &inspected.peripherals[0].registers;
+        assert!(
+            registers.iter().any(|reg| reg.name == "PIN_CTRL"),
+            "inspect schema includes PIN_CTRL"
+        );
+        assert!(
+            registers.iter().any(|reg| reg.name == "GPIO0"),
+            "inspect schema includes GPIO0"
+        );
+    }
+
+    #[derive(Debug)]
+    struct MemoryWriteObserver {
+        writes: Arc<Mutex<Vec<(u64, u8, u8)>>>,
+    }
+
+    impl SimulationObserver for MemoryWriteObserver {
+        fn on_step_end(&self, _cycles: u32, _registers: &[u32]) {}
+
+        fn on_memory_write(&self, addr: u64, old: u8, new: u8) {
+            self.writes.lock().unwrap().push((addr, old, new));
+        }
+    }
+
+    #[test]
+    fn io_mux_byte_write_observer_sees_the_programmed_prior_byte() {
+        const IO_MUX_BASE: u64 = 0x6000_9000;
+        const GPIO4: u64 = IO_MUX_BASE + GPIO0 + 4 * 4;
+
+        let mut bus = c3_bus();
+        bus.write_u32(GPIO4, 0xfeed_1b02)
+            .expect("program GPIO4 IO_MUX word");
+
+        let writes = Arc::new(Mutex::new(Vec::new()));
+        bus.observers.push(Arc::new(MemoryWriteObserver {
+            writes: Arc::clone(&writes),
+        }));
+
+        bus.write_u8(GPIO4 + 2, 0xa5)
+            .expect("write GPIO4's third byte");
+
+        assert_eq!(
+            *writes.lock().unwrap(),
+            vec![(GPIO4 + 2, 0xed, 0xa5)],
+            "observer gets the raw prior byte, not a synthetic zero"
+        );
+    }
+
+    #[test]
+    fn io_mux_is_inert_for_the_legacy_tick_walk() {
+        assert!(
+            !Esp32c3IoMux::new().needs_legacy_walk(),
+            "IO_MUX only changes at MMIO write time and must not block C3 walk deletion"
+        );
+    }
+
+    #[test]
+    fn runtime_snapshot_keeps_pin_ctrl_date_and_pullup_released_for_gpio() {
+        let mut original = Esp32c3IoMux::new();
+        original.write_u32(PIN_CTRL, 0x321).unwrap();
+        original.write_u32(GPIO0 + 4 * 4, 0x0000_1b02).unwrap();
+        original.write_u32(0xfc, 0x0bad_c0de).unwrap();
+        let snapshot = original.runtime_snapshot();
+
+        let mut resumed = Esp32c3IoMux::new();
+        resumed.restore_runtime_snapshot(&snapshot).unwrap();
+        let mut gpio = crate::peripherals::esp32c3::gpio::Esp32c3Gpio::new();
+        gpio.set_pad_controls(resumed.pad_controls());
+
+        assert!(resumed.fun_pull_up(4));
+        assert_eq!(resumed.read_u32(PIN_CTRL).unwrap(), 0x321);
+        assert_eq!(resumed.read_u32(0xfc).unwrap(), 0x0bad_c0de);
+        assert_eq!(gpio.read_gpio_input(4), Some(true));
+    }
+}

--- a/crates/core/src/peripherals/esp32c3/mod.rs
+++ b/crates/core/src/peripherals/esp32c3/mod.rs
@@ -11,6 +11,7 @@ pub mod factory;
 pub mod forced_status;
 pub mod gpio;
 pub mod i2c;
+pub mod io_mux;
 pub mod ledc;
 pub mod reg_block;
 pub mod rng;

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -84,6 +84,7 @@ pub const MODEL_TYPES: &[&str] = &[
     "esp32c3_i2c",
     "esp32c3_spi",
     "esp32c3_gpio",
+    "esp32c3_io_mux",
     "esp32c3_apb_saradc",
     "esp32c3_ledc",
     // nRF52 behavioral models (nrf52 factory).

--- a/crates/wasm/src/inputs.rs
+++ b/crates/wasm/src/inputs.rs
@@ -341,7 +341,7 @@ board_io:
     peripheral: "gpio"
     pin: 2
     signal: "input"
-    active_high: true
+    active_high: false
 "#,
         )
         .expect("parse system yaml");
@@ -374,7 +374,14 @@ board_io:
     #[test]
     fn esp32c3_board_io_button_press_updates_gpio_input_state() {
         let mut sim = c3_button_sim();
+        let machine = sim.machine.as_mut().expect("machine");
+        machine
+            .bus
+            .write_u32(0x6000_9000 + 0x04 + 2 * 4, 1 << 8)
+            .expect("enable GPIO2 FUN_WPU");
 
+        // An active-low button with INPUT_PULLUP is released high, so it must
+        // start inactive before the browser injects its first press.
         assert!(!button_active(&sim));
 
         sim.set_board_io_input("left", true).expect("press left");

--- a/examples/esp32c3-jtag-watch-arduino/README.md
+++ b/examples/esp32c3-jtag-watch-arduino/README.md
@@ -1,0 +1,35 @@
+# ESP32-C3 headless JTAG watch
+
+This is a minimal Arduino ESP32-C3 watch fixture for compile and ROM-boot
+validation. It has no display or I2C dependency.
+
+The firmware starts at `12:34:00`, emits UART0 lines such as
+`WATCH 12:34:00 RUN`, and advances with a wrap-safe `millis()` elapsed-time
+gate. GPIO4 (`MODE_PIN`) toggles run/setting mode; GPIO5 (`SET_PIN`) advances
+the minute and resets seconds while setting. Both inputs use `INPUT_PULLUP` and
+active-low falling-edge debounce.
+
+UART0 is the fixture's only simulator display.
+
+The bundled system manifest provides the two active-low simulation inputs; it
+does not assert any physical button wiring.
+
+Open it in Studio at
+[`https://app.labwired.com/?board=esp32c3-jtag-watch`](https://app.labwired.com/?board=esp32c3-jtag-watch).
+
+`labwired_watch_state` is retained for debugger/JTAG inspection. Its packed
+layout is:
+
+- bits 0..5: seconds
+- bits 6..11: minutes
+- bits 12..16: hours
+- bit 17: setting mode
+- bits 18..31: monotonically increasing 14-bit state sequence
+
+`labwired_watch_state_schema` contains `0x57415431` (`WAT1`).
+
+Build locally with:
+
+```sh
+pio run
+```

--- a/examples/esp32c3-jtag-watch-arduino/platformio.ini
+++ b/examples/esp32c3-jtag-watch-arduino/platformio.ini
@@ -1,0 +1,5 @@
+[env:esp32c3-jtag-watch]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+monitor_speed = 115200

--- a/examples/esp32c3-jtag-watch-arduino/src/main.cpp
+++ b/examples/esp32c3-jtag-watch-arduino/src/main.cpp
@@ -1,0 +1,145 @@
+#include <Arduino.h>
+
+static constexpr uint8_t MODE_PIN = 4;
+static constexpr uint8_t SET_PIN = 5;
+static constexpr uint32_t BUTTON_DEBOUNCE_MS = 30;
+static constexpr uint32_t SECOND_MS = 1000;
+static constexpr char WATCH_BOOT_LINE[] = "WATCH 12:34:00 RUN";
+
+// Retained for debugger/JTAG inspection. The companion schema marker is
+// `WAT1` in ASCII, identifying this packing without relying on source text.
+extern "C" volatile uint32_t labwired_watch_state __attribute__((used)) = 0;
+extern "C" const uint32_t labwired_watch_state_schema __attribute__((used)) = 0x57415431UL;
+
+// Force a real volatile read so link-time garbage collection retains the schema
+// symbol for a debugger as well as the mutable watch-state word.
+static void retainWatchStateSchema() {
+  const volatile uint32_t *schema = &labwired_watch_state_schema;
+  (void)*schema;
+}
+
+static uint8_t hours = 12;
+static uint8_t minutes = 34;
+static uint8_t seconds = 0;
+static bool setting = false;
+static uint16_t state_sequence = 0;
+static uint32_t last_tick_ms = 0;
+
+struct DebouncedButton {
+  uint8_t pin;
+  int raw_level;
+  int stable_level;
+  uint32_t changed_at_ms;
+};
+
+static DebouncedButton mode_button{MODE_PIN, HIGH, HIGH, 0};
+static DebouncedButton set_button{SET_PIN, HIGH, HIGH, 0};
+
+static void initializeButton(DebouncedButton &button, uint32_t now) {
+  const int level = digitalRead(button.pin);
+  button.raw_level = level;
+  button.stable_level = level;
+  button.changed_at_ms = now;
+}
+
+// The falling edge is active-low because both watch controls use INPUT_PULLUP.
+static bool fellAfterDebounce(DebouncedButton &button, uint32_t now) {
+  const int sampled = digitalRead(button.pin);
+  if (sampled != button.raw_level) {
+    button.raw_level = sampled;
+    button.changed_at_ms = now;
+  }
+
+  if (button.stable_level == button.raw_level ||
+      static_cast<uint32_t>(now - button.changed_at_ms) < BUTTON_DEBOUNCE_MS) {
+    return false;
+  }
+
+  const int previous = button.stable_level;
+  button.stable_level = button.raw_level;
+  return previous == HIGH && button.stable_level == LOW;
+}
+
+static void advanceMinute() {
+  seconds = 0;
+  if (++minutes == 60) {
+    minutes = 0;
+    hours = static_cast<uint8_t>((hours + 1) % 24);
+  }
+}
+
+static void advanceSecond() {
+  if (++seconds == 60) {
+    seconds = 0;
+    if (++minutes == 60) {
+      minutes = 0;
+      hours = static_cast<uint8_t>((hours + 1) % 24);
+    }
+  }
+}
+
+static void publishWatchState() {
+  const uint32_t sequence = static_cast<uint32_t>(state_sequence++ & 0x3fffU);
+  labwired_watch_state =
+      (static_cast<uint32_t>(seconds) & 0x3fU) |
+      ((static_cast<uint32_t>(minutes) & 0x3fU) << 6) |
+      ((static_cast<uint32_t>(hours) & 0x1fU) << 12) |
+      (setting ? (1UL << 17) : 0UL) |
+      (sequence << 18);
+
+  if (sequence == 0 && hours == 12 && minutes == 34 && seconds == 0 && !setting) {
+    Serial.println(WATCH_BOOT_LINE);
+    return;
+  }
+
+  char line[32];
+  snprintf(
+      line,
+      sizeof(line),
+      "WATCH %02u:%02u:%02u %s",
+      static_cast<unsigned>(hours),
+      static_cast<unsigned>(minutes),
+      static_cast<unsigned>(seconds),
+      setting ? "SET" : "RUN");
+  Serial.println(line);
+}
+
+void setup() {
+  pinMode(MODE_PIN, INPUT_PULLUP);
+  pinMode(SET_PIN, INPUT_PULLUP);
+  Serial.begin(115200);
+  retainWatchStateSchema();
+
+  const uint32_t now = millis();
+  initializeButton(mode_button, now);
+  initializeButton(set_button, now);
+  last_tick_ms = now;
+  publishWatchState();
+}
+
+void loop() {
+  const uint32_t now = millis();
+  bool changed = false;
+
+  if (fellAfterDebounce(mode_button, now)) {
+    setting = !setting;
+    // Entering or leaving setup mode never charges the paused elapsed time.
+    last_tick_ms = now;
+    changed = true;
+  } else if (fellAfterDebounce(set_button, now) && setting) {
+    advanceMinute();
+    last_tick_ms = now;
+    changed = true;
+  }
+
+  // Unsigned subtraction is wrap-safe across the 32-bit millis() rollover.
+  if (!setting && static_cast<uint32_t>(now - last_tick_ms) >= SECOND_MS) {
+    last_tick_ms += SECOND_MS;
+    advanceSecond();
+    changed = true;
+  }
+
+  if (changed) {
+    publishWatchState();
+  }
+}

--- a/examples/esp32c3-leo-airquality/system-fresh.yaml
+++ b/examples/esp32c3-leo-airquality/system-fresh.yaml
@@ -14,6 +14,7 @@
 # blind to this scene config.
 name: "esp32c3-leo-airquality-fresh"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   # ── Sensirion SCD41: CO₂ + temperature + humidity ─────────────────────────

--- a/examples/esp32c3-leo-airquality/system-stuffy.yaml
+++ b/examples/esp32c3-leo-airquality/system-stuffy.yaml
@@ -14,6 +14,7 @@
 # blind to this scene config.
 name: "esp32c3-leo-airquality-stuffy"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   # ── Sensirion SCD41: CO₂ + temperature + humidity ─────────────────────────

--- a/examples/esp32c3-leo-airquality/system.yaml
+++ b/examples/esp32c3-leo-airquality/system.yaml
@@ -14,6 +14,7 @@
 # blind to this scene config.
 name: "esp32c3-leo-airquality-normal"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   # ── Sensirion SCD41: CO₂ + temperature + humidity ─────────────────────────

--- a/examples/esp32c3-mlx90640-thermal/system-fault.yaml
+++ b/examples/esp32c3-mlx90640-thermal/system-fault.yaml
@@ -11,6 +11,7 @@
 # hotspot crossing critical_c (OVERTEMP). Thresholds are firmware-side #defines.
 name: "esp32c3-mlx90640-thermal-fault"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "thermal_cam"

--- a/examples/esp32c3-mlx90640-thermal/system-iolink-fault.yaml
+++ b/examples/esp32c3-mlx90640-thermal/system-iolink-fault.yaml
@@ -13,6 +13,7 @@
 #   - UART1 (0x60010000): the IO-Link C/Q wire — device DLL <-> IO-Link master.
 name: "esp32c3-mlx90640-thermal-iolink-fault"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "thermal_cam"

--- a/examples/esp32c3-mlx90640-thermal/system-iolink.yaml
+++ b/examples/esp32c3-mlx90640-thermal/system-iolink.yaml
@@ -17,6 +17,7 @@
 # fault=NONE, and must NOT raise a temperature event.
 name: "esp32c3-mlx90640-thermal-iolink-normal"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "thermal_cam"

--- a/examples/esp32c3-mlx90640-thermal/system.yaml
+++ b/examples/esp32c3-mlx90640-thermal/system.yaml
@@ -15,6 +15,7 @@
 # blind to this — it classifies purely from the decoded thermal frames.
 name: "esp32c3-mlx90640-thermal-normal"
 chip: "../../configs/chips/esp32c3.yaml"
+cpu_hz: 160_000_000
 
 external_devices:
   - id: "thermal_cam"


### PR DESCRIPTION
## Summary

- add an ESP32-C3 JTAG digital-watch fidelity fixture and runnable Arduino example
- model the C3 GPIO/IO-MUX behavior required by the watch and related C3 systems
- validate the C3 system configurations and external-device paths

## Verification

- `cargo fmt --check --all`
- `cargo test -p labwired-core --lib --features event-scheduler` (1,925 passed)
- `cargo test -p labwired-wasm -q` (5 passed, 2 ignored)
