### PR TITLE
fix: complete environment CI worlds and runner release

### DIFF
--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -10,13 +10,13 @@ intentionally documents the action beside its implementation rather than
 choosing its own source SHA: every immutable revision therefore carries its own
 matching input and report contract.
 
-The `version` input defaults to `v0.19.0` and independently selects the
+The `version` input defaults to `v0.19.1` and independently selects the
 immutable Core CLI release archive named
-`labwired-v0.19.0-<platform>.tar.gz`. The action downloads that public archive
+`labwired-v0.19.1-<platform>.tar.gz`. The action downloads that public archive
 from the `w1ne/labwired-core` GitHub release with `curl`; it does not build Core
 on the consumer runner.
 
-Its inputs are exactly `script` (required), `version` (default `v0.19.0`),
+Its inputs are exactly `script` (required), `version` (default `v0.19.1`),
 `output-dir`, and `args`. `args` is whitespace-separated extra CLI flags; shell
 quoting inside this input is not interpreted.
 

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: "Immutable LabWired Core release tag to install."
     required: false
-    default: "v0.19.0"
+    default: "v0.19.1"
   output-dir:
     description: "Directory for run artifacts (result.json, uart.log, junit.xml, and reports)."
     required: false

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -106,6 +106,22 @@ jobs:
           --test kw41z_walk_free_differential
           --lib
 
+      # This is deliberately inside the required core-integrity check: every
+      # merge must prove the final OCI runtime can execute the CLI before a
+      # main commit can be tagged for release. Building from fresh base layers
+      # catches builder/runtime ABI drift such as a newer glibc in Rust's slim
+      # image than the release runtime provides.
+      - name: Smoke CI runner image
+        run: |
+          set -euo pipefail
+          docker build --pull \
+            --file Dockerfile.ci \
+            --tag labwired-ci-smoke:local \
+            --build-arg VERSION=ci-smoke \
+            --build-arg REVISION="$GITHUB_SHA" \
+            .
+          docker run --rm labwired-ci-smoke:local --version
+
   # ── Full suite (NOT a PR gate) ─────────────────────────────────────────────
   # Builds firmware fixtures, runs the complete workspace tests, the host-only
   # feature lanes, and the Tier-1 matrix + ratchet. This is expensive, so keep it

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -174,15 +174,14 @@ jobs:
           test -s out/release-runner-smoke/result.json
           test -s out/release-runner-smoke/junit.xml
 
-      - name: Run the release archive through the core action
+      - name: Run the default release archive through the core action
         uses: ./.github/actions/labwired-test
         with:
-          version: ${{ github.ref_name }}
           script: examples/ci/two-node-inputs-env.yaml
           output-dir: out/release-action-smoke
           args: --no-uart-stdout
 
-      - name: Run a second release archive through the core action
+      - name: Run an explicit release archive through the core action
         uses: ./.github/actions/labwired-test
         with:
           version: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.1] - 2026-07-14
+## [0.19.1] - 2026-07-15
 
 ### Fixed
 - **Environment completion**: `inputs.env` scripts can opt into the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-07-14
+
+### Fixed
+- **Environment completion**: `inputs.env` scripts can opt into the same
+  durable assertion-pass stop contract as single-machine runs, including the
+  settling window and minimum-step floor. Node runtime failures and configured
+  limits retain precedence over completion.
+- **CI runner image**: The image now builds against the same Debian/glibc
+  baseline it runs on. The required Core CI check builds and executes the final
+  image before a release tag can be created.
+
+### Changed
+- **Public runner default**: The one-step GitHub Action now defaults to the
+  v0.19.1 immutable CLI release; release smoke exercises both that default and
+  an explicit release pin.
+
 ## [0.19.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Environment completion**: `inputs.env` scripts can opt into the same
   durable assertion-pass stop contract as single-machine runs, including the
   settling window and minimum-step floor. Node runtime failures and configured
-  limits retain precedence over completion.
+  wall-time/cycle/UART limits retain precedence over completion.
 - **CI runner image**: The image now builds against the same Debian/glibc
   baseline it runs on. The required Core CI check builds and executes the final
   image before a release tag can be created.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1021,56 +1021,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
 ]
@@ -1717,7 +1717,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-egress-relay"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "labwired-core",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1884,11 +1884,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.19.0"
+version = "0.19.1"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3385,7 +3385,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,7 +9,7 @@
 # same command line as a native release archive.
 
 # Stage 1: Builder
-FROM rust:1.95-slim AS builder
+FROM rust:1.95-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
     pkg-config \

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ examples. Check the per-board docs before assuming a peripheral is modeled:
 Pinned release:
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.19.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.19.1 sh
 labwired --version
 ```
 
@@ -41,7 +41,7 @@ Prefer to inspect the installer first:
 ```sh
 curl -fsSL https://labwired.com/install.sh -o install.sh
 # review install.sh, then:
-LABWIRED_VERSION=v0.19.0 sh install.sh
+LABWIRED_VERSION=v0.19.1 sh install.sh
 ```
 
 Supported host environments:
@@ -52,7 +52,7 @@ Supported host environments:
 
 Install options:
 
-- `LABWIRED_VERSION=v0.19.0` pins the current documented release for a
+- `LABWIRED_VERSION=v0.19.1` pins the current documented release for a
   reproducible install.
 - `LABWIRED_FROM_SOURCE=1` forces a source build.
 - `LABWIRED_INSTALL_DIR=~/.local/bin` changes the install directory.

--- a/crates/cli/src/commands/environment_test.rs
+++ b/crates/cli/src/commands/environment_test.rs
@@ -405,6 +405,10 @@ fn run_world(
     let mut runtime_error = false;
     let mut rounds = 0_u64;
     let mut instructions = 0_u64;
+    // Environment worlds use the same durable assertion-completion contract
+    // as the single-machine runner. A passing snapshot begins a settling
+    // window; a regression restarts it, and a runtime/safety stop always wins.
+    let mut assertions_first_passed_at = None;
 
     while rounds < limits.max_steps {
         let cycles = max_cycles(world);
@@ -444,6 +448,26 @@ fn run_world(
         if let Some(reason) = reached_world_limit_stop(&limits, cycles, uart_bytes, &start) {
             stop_reason = reason;
             break;
+        }
+        if limits.stop_when_assertions_pass {
+            let all_assertions_passed = evaluate_assertions(&script.assertions, world)
+                .iter()
+                .all(|assertion| assertion.passed);
+            if all_assertions_passed {
+                if assertions_first_passed_at.is_none()
+                    && rounds >= limits.stop_when_assertions_pass_min_steps
+                {
+                    assertions_first_passed_at = Some(rounds);
+                }
+            } else {
+                assertions_first_passed_at = None;
+            }
+            if let Some(first) = assertions_first_passed_at {
+                if rounds.saturating_sub(first) >= limits.stop_when_assertions_pass_settle_steps {
+                    stop_reason = StopReason::AssertionsPassed;
+                    break;
+                }
+            }
         }
     }
 

--- a/crates/cli/tests/environment_runner.rs
+++ b/crates/cli/tests/environment_runner.rs
@@ -543,6 +543,54 @@ assertions:
 }
 
 #[test]
+fn environment_runner_stops_when_world_assertions_pass_durably() {
+    let dir = unique_dir("assertions-passed");
+    write_two_node_environment(&dir);
+    let output = run_environment_script(
+        &dir,
+        r#"schema_version: "1.0"
+inputs:
+  env: "two-node.yaml"
+limits:
+  max_steps: 100
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 2
+  stop_when_assertions_pass_min_steps: 4
+assertions:
+  - memory_value:
+      node: alpha
+      address: 0x20000000
+      expected_value: 0
+"#,
+        &[],
+    );
+
+    assert!(
+        output.status.success(),
+        "early-completion world failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join("artifacts/result.json")).expect("read result.json"),
+    )
+    .expect("parse result.json");
+    assert_eq!(result["status"], "pass");
+    assert_eq!(result["stop_reason"], "assertions_passed");
+    assert_eq!(result["steps_executed"], 6);
+    assert!(result["steps_executed"].as_u64().unwrap() < 100);
+    assert_eq!(result["assertions"][0]["passed"], true);
+    assert_eq!(result["limits"]["stop_when_assertions_pass"], true);
+    assert_eq!(
+        result["limits"]["stop_when_assertions_pass_settle_steps"],
+        2
+    );
+    assert_eq!(result["limits"]["stop_when_assertions_pass_min_steps"], 4);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn environment_runner_records_aggregate_world_metering_after_key_validation() {
     const TEST_KEY: &str = "environment-metering-test-key";
 
@@ -1250,6 +1298,8 @@ inputs:
 limits:
   max_steps: 100
   wall_time_ms: 0
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 0
 assertions:
   - memory_value:
       node: alpha
@@ -1320,6 +1370,8 @@ inputs:
   env: "tiny-two-node.yaml"
 limits:
   max_steps: 100
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 50
 assertions:
   - memory_value:
       node: alpha

--- a/crates/cli/tests/environment_runner.rs
+++ b/crates/cli/tests/environment_runner.rs
@@ -591,6 +591,45 @@ assertions:
 }
 
 #[test]
+fn environment_runner_can_complete_on_the_final_allowed_world_round() {
+    let dir = unique_dir("assertions-passed-final-round");
+    write_two_node_environment(&dir);
+    let output = run_environment_script(
+        &dir,
+        r#"schema_version: "1.0"
+inputs:
+  env: "two-node.yaml"
+limits:
+  max_steps: 1
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 0
+assertions:
+  - memory_value:
+      node: alpha
+      address: 0x20000000
+      expected_value: 0
+"#,
+        &[],
+    );
+
+    assert!(
+        output.status.success(),
+        "final-round completion failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.join("artifacts/result.json")).expect("read result.json"),
+    )
+    .expect("parse result.json");
+    assert_eq!(result["status"], "pass");
+    assert_eq!(result["stop_reason"], "assertions_passed");
+    assert_eq!(result["steps_executed"], 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn environment_runner_records_aggregate_world_metering_after_key_validation() {
     const TEST_KEY: &str = "environment-metering-test-key";
 
@@ -1260,6 +1299,8 @@ inputs:
 limits:
   max_steps: 1
   max_cycles: 1
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 0
 assertions:
   - memory_value:
       node: alpha

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2520,6 +2520,43 @@ assertions:
     }
 
     #[test]
+    fn env_script_preserves_explicit_assertion_completion_defaults() {
+        let script: EnvTestScript = serde_yaml::from_str(
+            r#"
+schema_version: "1.0"
+inputs: { env: "twonode-env.yaml" }
+limits:
+  max_steps: 10
+  stop_when_assertions_pass: false
+  stop_when_assertions_pass_settle_steps: 100000
+  stop_when_assertions_pass_min_steps: 0
+assertions:
+  - memory_value: { node: tester, address: 0x20010000, expected_value: 1 }
+"#,
+        )
+        .unwrap();
+
+        script.validate().unwrap();
+        let serialized = serde_yaml::to_string(&script).unwrap();
+        for field in [
+            "stop_when_assertions_pass: false",
+            "stop_when_assertions_pass_settle_steps: 100000",
+            "stop_when_assertions_pass_min_steps: 0",
+        ] {
+            assert!(serialized.contains(field), "missing {field}: {serialized}");
+        }
+
+        let round_tripped: EnvTestScript = serde_yaml::from_str(&serialized).unwrap();
+        round_tripped.validate().unwrap();
+        assert!(!round_tripped.limits.stop_when_assertions_pass);
+        assert_eq!(
+            round_tripped.limits.stop_when_assertions_pass_settle_steps,
+            100_000
+        );
+        assert_eq!(round_tripped.limits.stop_when_assertions_pass_min_steps, 0);
+    }
+
+    #[test]
     fn env_script_rejects_null_assertion_completion_limits() {
         for (name, extra, field) in [
             (
@@ -2553,6 +2590,38 @@ assertions:
                 ),
             );
             let err = load_test_script(&script_path).unwrap_err().to_string();
+            assert!(err.contains(field), "unexpected error: {err}");
+            assert!(err.contains("must not be null"), "unexpected error: {err}");
+        }
+    }
+
+    #[test]
+    fn env_script_preserves_invalid_null_assertion_completion_limits() {
+        for (field, value) in [
+            ("stop_when_assertions_pass", "null"),
+            ("stop_when_assertions_pass_settle_steps", "null"),
+            ("stop_when_assertions_pass_min_steps", "null"),
+        ] {
+            let script: EnvTestScript = serde_yaml::from_str(&format!(
+                r#"
+schema_version: "1.0"
+inputs: {{ env: "twonode-env.yaml" }}
+limits:
+  max_steps: 10
+  {field}: {value}
+assertions:
+  - memory_value: {{ node: tester, address: 0x20010000, expected_value: 1 }}
+"#
+            ))
+            .unwrap();
+
+            let serialized = serde_yaml::to_string(&script).unwrap();
+            assert!(
+                serialized.contains(&format!("{field}: {value}")),
+                "explicit null {field} was lost during serialization: {serialized}"
+            );
+            let round_tripped: EnvTestScript = serde_yaml::from_str(&serialized).unwrap();
+            let err = round_tripped.validate().unwrap_err().to_string();
             assert!(err.contains(field), "unexpected error: {err}");
             assert!(err.contains("must not be null"), "unexpected error: {err}");
         }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1386,8 +1386,8 @@ pub struct EnvTestScript {
 
 /// A field whose parser records the difference between being absent and being
 /// explicitly configured to a default value (or `null`). Environment scripts
-/// use this for single-node-only early-stop tuning: every explicit occurrence
-/// is rejected instead of being normalized away during deserialization.
+/// use it to preserve their strict serialization contract and to distinguish
+/// an absent setting from an invalid explicit `null`.
 #[derive(Debug, Clone, Copy, Default)]
 enum FieldPresence<T> {
     #[default]
@@ -1437,9 +1437,9 @@ struct EnvExplicitUnsupportedFields {
 }
 
 /// Serialization keeps the user-visible environment contract strict in both
-/// directions. Valid scripts omit runner options that environment execution
-/// cannot honor; invalid parsed or programmatically-mutated scripts retain the
-/// unsupported field so a serialize/parse cycle cannot make them look valid.
+/// directions. Valid scripts omit defaulted limits; invalid parsed or
+/// programmatically-mutated unsupported fields remain visible so a
+/// serialize/parse cycle cannot make them look valid.
 #[derive(Serialize)]
 struct SerializableEnvTestScript<'a> {
     schema_version: &'a str,
@@ -1486,7 +1486,7 @@ fn serialize_unsupported_option_limit(
     }
 }
 
-fn serialize_unsupported_bool_limit(
+fn serialize_explicit_bool_limit(
     explicit: FieldPresence<bool>,
     value: bool,
 ) -> Option<Option<bool>> {
@@ -1501,7 +1501,7 @@ fn serialize_unsupported_bool_limit(
     }
 }
 
-fn serialize_unsupported_defaulted_limit(
+fn serialize_explicit_defaulted_limit(
     explicit: FieldPresence<u64>,
     value: u64,
     default: u64,
@@ -1564,16 +1564,16 @@ impl Serialize for EnvTestScript {
                     self.explicit_limits.max_vcd_bytes,
                     self.limits.max_vcd_bytes,
                 ),
-                stop_when_assertions_pass: serialize_unsupported_bool_limit(
+                stop_when_assertions_pass: serialize_explicit_bool_limit(
                     self.explicit_limits.stop_when_assertions_pass,
                     self.limits.stop_when_assertions_pass,
                 ),
-                stop_when_assertions_pass_settle_steps: serialize_unsupported_defaulted_limit(
+                stop_when_assertions_pass_settle_steps: serialize_explicit_defaulted_limit(
                     self.explicit_limits.stop_when_assertions_pass_settle_steps,
                     self.limits.stop_when_assertions_pass_settle_steps,
                     default_stop_settle_steps(),
                 ),
-                stop_when_assertions_pass_min_steps: serialize_unsupported_defaulted_limit(
+                stop_when_assertions_pass_min_steps: serialize_explicit_defaulted_limit(
                     self.explicit_limits.stop_when_assertions_pass_min_steps,
                     self.limits.stop_when_assertions_pass_min_steps,
                     0,
@@ -1598,8 +1598,8 @@ impl Serialize for EnvTestScript {
 }
 
 /// Wire shape for an environment limits block. It resolves to `TestLimits`
-/// after retaining presence information for settings the environment runner
-/// intentionally does not implement.
+/// after retaining presence information for settings whose explicit defaults
+/// and nullability need a stable public contract.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct EnvTestLimits {
@@ -1653,8 +1653,8 @@ impl EnvTestLimits {
 }
 
 /// Strict deserialization wire form for `EnvTestScript`. The public type keeps
-/// `TestLimits` for runners, while this shape preserves which unsupported
-/// early-stop fields were explicitly supplied in YAML.
+/// `TestLimits` for runners, while this shape preserves explicit values needed
+/// for strict serialization and validation.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct EnvTestScriptWire {
@@ -1731,31 +1731,28 @@ impl EnvTestScript {
         if self.explicit_limits.max_vcd_bytes.is_present() || self.limits.max_vcd_bytes.is_some() {
             anyhow::bail!("Environment test scripts do not support 'limits.max_vcd_bytes'");
         }
-        if self.explicit_limits.stop_when_assertions_pass.is_present()
-            || self.limits.stop_when_assertions_pass
-        {
+        if matches!(
+            self.explicit_limits.stop_when_assertions_pass,
+            FieldPresence::Present(None)
+        ) {
             anyhow::bail!(
-                "Environment test scripts do not support 'limits.stop_when_assertions_pass'"
+                "Environment test script limit 'stop_when_assertions_pass' must not be null"
             );
         }
-        if self
-            .explicit_limits
-            .stop_when_assertions_pass_settle_steps
-            .is_present()
-            || self.limits.stop_when_assertions_pass_settle_steps != default_stop_settle_steps()
-        {
+        if matches!(
+            self.explicit_limits.stop_when_assertions_pass_settle_steps,
+            FieldPresence::Present(None)
+        ) {
             anyhow::bail!(
-                "Environment test scripts do not support 'limits.stop_when_assertions_pass_settle_steps'"
+                "Environment test script limit 'stop_when_assertions_pass_settle_steps' must not be null"
             );
         }
-        if self
-            .explicit_limits
-            .stop_when_assertions_pass_min_steps
-            .is_present()
-            || self.limits.stop_when_assertions_pass_min_steps != 0
-        {
+        if matches!(
+            self.explicit_limits.stop_when_assertions_pass_min_steps,
+            FieldPresence::Present(None)
+        ) {
             anyhow::bail!(
-                "Environment test scripts do not support 'limits.stop_when_assertions_pass_min_steps'"
+                "Environment test script limit 'stop_when_assertions_pass_min_steps' must not be null"
             );
         }
         if self.explicit_unsupported_fields.faults.is_present() || !self.faults.is_empty() {
@@ -2476,6 +2473,91 @@ assertions:
         round_tripped.validate().unwrap();
     }
 
+    #[test]
+    fn env_script_accepts_and_round_trips_assertion_completion_limits() {
+        let script: EnvTestScript = serde_yaml::from_str(
+            r#"
+schema_version: "1.0"
+inputs: { env: "twonode-env.yaml" }
+limits:
+  max_steps: 10
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 7
+  stop_when_assertions_pass_min_steps: 3
+assertions:
+  - memory_value: { node: tester, address: 0x20010000, expected_value: 1 }
+"#,
+        )
+        .unwrap();
+
+        script.validate().unwrap();
+        assert!(script.limits.stop_when_assertions_pass);
+        assert_eq!(script.limits.stop_when_assertions_pass_settle_steps, 7);
+        assert_eq!(script.limits.stop_when_assertions_pass_min_steps, 3);
+
+        let serialized = serde_yaml::to_string(&script).unwrap();
+        for field in [
+            "stop_when_assertions_pass: true",
+            "stop_when_assertions_pass_settle_steps: 7",
+            "stop_when_assertions_pass_min_steps: 3",
+        ] {
+            assert!(serialized.contains(field), "missing {field}: {serialized}");
+        }
+        let round_tripped: EnvTestScript = serde_yaml::from_str(&serialized).unwrap();
+        round_tripped.validate().unwrap();
+        assert_eq!(
+            round_tripped.limits.stop_when_assertions_pass,
+            script.limits.stop_when_assertions_pass
+        );
+        assert_eq!(
+            round_tripped.limits.stop_when_assertions_pass_settle_steps,
+            script.limits.stop_when_assertions_pass_settle_steps
+        );
+        assert_eq!(
+            round_tripped.limits.stop_when_assertions_pass_min_steps,
+            script.limits.stop_when_assertions_pass_min_steps
+        );
+    }
+
+    #[test]
+    fn env_script_rejects_null_assertion_completion_limits() {
+        for (name, extra, field) in [
+            (
+                "early-pass-null",
+                "  stop_when_assertions_pass: null",
+                "stop_when_assertions_pass",
+            ),
+            (
+                "early-pass-settle-null",
+                "  stop_when_assertions_pass_settle_steps: null",
+                "stop_when_assertions_pass_settle_steps",
+            ),
+            (
+                "early-pass-minimum-null",
+                "  stop_when_assertions_pass_min_steps: null",
+                "stop_when_assertions_pass_min_steps",
+            ),
+        ] {
+            let script_path = write_temp_file(
+                name,
+                &format!(
+                    r#"
+schema_version: "1.0"
+inputs: {{ env: "twonode-env.yaml" }}
+limits:
+  max_steps: 10
+{extra}
+assertions:
+  - memory_value: {{ node: tester, address: 0x20010000, expected_value: 1 }}
+"#
+                ),
+            );
+            let err = load_test_script(&script_path).unwrap_err().to_string();
+            assert!(err.contains(field), "unexpected error: {err}");
+            assert!(err.contains("must not be null"), "unexpected error: {err}");
+        }
+    }
+
     fn valid_env_script_for_mutation() -> EnvTestScript {
         serde_yaml::from_str(
             r#"
@@ -2518,21 +2600,6 @@ assertions:
         assert_rejected_and_round_trips_invalid!("max_vcd_bytes", |script: &mut EnvTestScript| {
             script.limits.max_vcd_bytes = Some(1)
         });
-        assert_rejected_and_round_trips_invalid!(
-            "stop_when_assertions_pass",
-            |script: &mut EnvTestScript| script.limits.stop_when_assertions_pass = true
-        );
-        assert_rejected_and_round_trips_invalid!(
-            "stop_when_assertions_pass_settle_steps",
-            |script: &mut EnvTestScript| {
-                script.limits.stop_when_assertions_pass_settle_steps =
-                    default_stop_settle_steps() + 1
-            }
-        );
-        assert_rejected_and_round_trips_invalid!(
-            "stop_when_assertions_pass_min_steps",
-            |script: &mut EnvTestScript| script.limits.stop_when_assertions_pass_min_steps = 1
-        );
         assert_rejected_and_round_trips_invalid!("faults", |script: &mut EnvTestScript| {
             script.faults.push(
                 serde_yaml::from_str(
@@ -2574,24 +2641,6 @@ value: 1.0
                 "",
                 "max_vcd_bytes: null",
                 "max_vcd_bytes",
-            ),
-            (
-                "  stop_when_assertions_pass: false",
-                "",
-                "stop_when_assertions_pass: false",
-                "stop_when_assertions_pass",
-            ),
-            (
-                "  stop_when_assertions_pass_settle_steps: 100000",
-                "",
-                "stop_when_assertions_pass_settle_steps: 100000",
-                "stop_when_assertions_pass_settle_steps",
-            ),
-            (
-                "  stop_when_assertions_pass_min_steps: 0",
-                "",
-                "stop_when_assertions_pass_min_steps: 0",
-                "stop_when_assertions_pass_min_steps",
             ),
             ("", "faults: null", "faults: null", "faults"),
             ("", "faults: []", "faults: []", "faults"),
@@ -2927,41 +2976,6 @@ assertions:
             ),
             ("vcd", "  max_vcd_bytes: 1024", "max_vcd_bytes"),
             ("vcd-null", "  max_vcd_bytes: null", "max_vcd_bytes"),
-            (
-                "early-pass",
-                "  stop_when_assertions_pass: true",
-                "stop_when_assertions_pass",
-            ),
-            (
-                "early-pass-false",
-                "  stop_when_assertions_pass: false",
-                "stop_when_assertions_pass",
-            ),
-            (
-                "early-pass-null",
-                "  stop_when_assertions_pass: null",
-                "stop_when_assertions_pass",
-            ),
-            (
-                "early-pass-settle",
-                "  stop_when_assertions_pass_settle_steps: 100000",
-                "stop_when_assertions_pass_settle_steps",
-            ),
-            (
-                "early-pass-settle-null",
-                "  stop_when_assertions_pass_settle_steps: null",
-                "stop_when_assertions_pass_settle_steps",
-            ),
-            (
-                "early-pass-minimum",
-                "  stop_when_assertions_pass_min_steps: 0",
-                "stop_when_assertions_pass_min_steps",
-            ),
-            (
-                "early-pass-minimum-null",
-                "  stop_when_assertions_pass_min_steps: null",
-                "stop_when_assertions_pass_min_steps",
-            ),
             (
                 "faults",
                 "faults:\n  - id: x\n    kind: missing_clock",

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -1,7 +1,7 @@
 # CI Integration
 
 LabWired CI runs the same labwired test command locally, in GitHub Actions, and
-in GitLab. Pin the runner release to v0.19.0 so a firmware change is tested
+in GitLab. Pin the runner release to v0.19.1 so a firmware change is tested
 against a reproducible simulator version.
 
 ## GitHub Actions
@@ -25,10 +25,10 @@ jobs:
 
       - id: labwired
         name: Run LabWired
-        uses: w1ne/labwired-core/.github/actions/labwired-test@82c6c78983669f8688f3823db9a81d1c2bdef202
+        uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
         with:
           script: tests/firmware-test.yaml
-          version: v0.19.0
+          version: v0.19.1
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -38,8 +38,8 @@ jobs:
 ~~~
 
 The public action reference is an immutable action-source pin to
-`82c6c78983669f8688f3823db9a81d1c2bdef202`. Its only inputs are `script`
-(required), `version` (default `v0.19.0`), `output-dir`, and `args`; it downloads
+`fda6a7bfb0328d9909ee07ba53ed05c84901f627`. Its only inputs are `script`
+(required), `version` (default `v0.19.1`), `output-dir`, and `args`; it downloads
 the selected public CLI release archive with `curl`. The action writes JUnit to
 `output-dir/junit.xml`, appends `summary.md` to the job summary, and always
 uploads the entire output directory, even when the test fails. Its `status`,
@@ -55,7 +55,7 @@ image name; do not repeat labwired in the container command:
 docker run --rm \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
-  ghcr.io/w1ne/labwired:v0.19.0 \
+  ghcr.io/w1ne/labwired:v0.19.1 \
   test --script tests/firmware-test.yaml \
        --output-dir out/labwired \
        --no-uart-stdout
@@ -75,7 +75,7 @@ uses the pinned image and then invokes labwired test.
 ~~~yaml
 test:firmware:
   image:
-    name: ghcr.io/w1ne/labwired:v0.19.0
+    name: ghcr.io/w1ne/labwired:v0.19.1
     entrypoint: [""]
   script:
     - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -113,8 +113,10 @@ same durable completion contract as a single-machine run. Once every
 node-qualified `memory_value` assertion passes at or after
 `stop_when_assertions_pass_min_steps`, it must remain true for
 `stop_when_assertions_pass_settle_steps` world rounds (default `100000`). A
-regression restarts that window. A runtime failure or a configured limit reached
-on the same round wins over completion; otherwise the result has
+regression restarts that window. A runtime failure or a same-round
+`wall_time_ms`, `max_cycles`, or `max_uart_bytes` limit wins over completion.
+`max_steps` remains the outer execution bound, so completion on its final
+allowed world round reports `assertions_passed`; otherwise the result has
 `stop_reason: assertions_passed`. The three fields are respectively a boolean
 and non-negative integers; explicit YAML `null` is rejected.
 

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -50,6 +50,9 @@ limits:
   max_cycles: 123456     # optional
   max_uart_bytes: 4096   # optional
   wall_time_ms: 5000     # optional
+  stop_when_assertions_pass: true          # optional; default false
+  stop_when_assertions_pass_settle_steps: 1000  # optional; default 100000
+  stop_when_assertions_pass_min_steps: 1000     # optional; default 0
 assertions:
   - memory_value:
       node: alpha
@@ -105,6 +108,16 @@ Each `config` mapping is closed and type-checked:
 Environment scripts do not accept single-machine firmware/system overrides or
 topology-affecting CLI options.
 
+`stop_when_assertions_pass` is opt-in for an environment world and has the
+same durable completion contract as a single-machine run. Once every
+node-qualified `memory_value` assertion passes at or after
+`stop_when_assertions_pass_min_steps`, it must remain true for
+`stop_when_assertions_pass_settle_steps` world rounds (default `100000`). A
+regression restarts that window. A runtime failure or a configured limit reached
+on the same round wins over completion; otherwise the result has
+`stop_reason: assertions_passed`. The three fields are respectively a boolean
+and non-negative integers; explicit YAML `null` is rejected.
+
 ## Exit Codes
 
 | Code | Meaning | Notes |
@@ -157,7 +170,9 @@ Notes:
 The single-machine example above permits the documented single-machine
 assertions. Environment scripts are stricter: they require at least one
 node-qualified `memory_value` assertion and support `max_steps`, `max_cycles`,
-`max_uart_bytes`, and `wall_time_ms` limits. They reject
+`max_uart_bytes`, `wall_time_ms`, `stop_when_assertions_pass`,
+`stop_when_assertions_pass_settle_steps`, and
+`stop_when_assertions_pass_min_steps` limits. They reject
 `limits.no_progress_steps` and single-machine-only controls such as
 `--breakpoint`.
 
@@ -184,6 +199,7 @@ assertions: []
 - `max_uart_bytes`
 - `no_progress`
 - `wall_time`
+- `assertions_passed`
 - `memory_violation`
 - `decode_error`
 - `halt`
@@ -194,6 +210,8 @@ Semantics:
 - If the simulator hits `wall_time_ms`, the run is treated as an assertion failure (exit code `1`) unless an `expected_stop_reason` assertion matches `wall_time`.
 - If the simulator hits `max_uart_bytes` or `no_progress_steps`, the run is treated as an assertion failure (exit code `1`) unless an `expected_stop_reason` assertion matches (`max_uart_bytes` / `no_progress`).
 - If the simulator hits `max_steps` or `max_cycles`, the run is considered a normal stop (exit code `0`) as long as assertions pass.
+- If opt-in assertion completion reaches its durable settling window, the run
+  stops with `assertions_passed` and passes.
 - If the simulator hits a runtime error stop reason (e.g. `memory_violation`), the run is treated as a runtime error (exit code `3`) unless an `expected_stop_reason` assertion matches the stop reason.
 
 `result.json` uses:
@@ -277,6 +295,7 @@ firmware identity.
             "max_uart_bytes",
             "no_progress",
             "wall_time",
+            "assertions_passed",
             "memory_violation",
             "decode_error",
             "halt",
@@ -375,21 +394,21 @@ configuration; these produce `status: "error"` with `stop_reason:
 
 ## CI release runners
 
-Use the pinned v0.19.0 release runner in CI. It runs the same `labwired test`
+Use the pinned v0.19.1 release runner in CI. It runs the same `labwired test`
 command described above and writes the same artifact contract.
 
 ### GitHub Actions
 
 Use the public Core action and pin the Core CLI with its version input. Its
 only inputs are required `script`, optional `version` (default
-`v0.19.0`), `output-dir`, and `args`:
+`v0.19.1`), `output-dir`, and `args`:
 
 ~~~yaml
 - id: labwired
   name: Run LabWired tests
-  uses: w1ne/labwired-core/.github/actions/labwired-test@82c6c78983669f8688f3823db9a81d1c2bdef202
+  uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
   with:
-    version: v0.19.0
+    version: v0.19.1
     script: examples/ci/dummy-max-steps.yaml
     output-dir: out/artifacts
     args: --no-uart-stdout
@@ -400,7 +419,7 @@ only inputs are required `script`, optional `version` (default
 ~~~
 
 The Core action is an immutable action-source pin to
-`82c6c78983669f8688f3823db9a81d1c2bdef202`; `version: v0.19.0` independently
+`fda6a7bfb0328d9909ee07ba53ed05c84901f627`; `version: v0.19.1` independently
 pins the immutable Core CLI release. It downloads that public release archive
 with `curl`, creates `output-dir/junit.xml` plus Markdown and HTML reports,
 appends the Markdown report to the job summary, and always uploads the entire
@@ -416,7 +435,7 @@ use either a single-machine script or an `inputs.env` world script.
 
 ~~~bash
 docker run --rm -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.19.0 \
+  ghcr.io/w1ne/labwired:v0.19.1 \
   test --script examples/ci/dummy-max-steps.yaml \
        --output-dir out/artifacts \
        --no-uart-stdout
@@ -426,7 +445,7 @@ GitLab should clear that entrypoint and invoke labwired from its job shell:
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.19.0
+  name: ghcr.io/w1ne/labwired:v0.19.1
   entrypoint: [""]
 script:
   - labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -92,8 +92,10 @@ World completion stays in the `inputs.env` test script, not the manifest. Set
 all node-qualified assertions must pass at or after the optional
 `stop_when_assertions_pass_min_steps` floor and remain true for the optional
 `stop_when_assertions_pass_settle_steps` window (default `100000`). The default
-is `false`, and a same-round runtime failure or configured limit takes
-precedence over `assertions_passed`.
+is `false`; a same-round runtime failure or `wall_time_ms`, `max_cycles`, or
+`max_uart_bytes` limit takes precedence over `assertions_passed`. `max_steps`
+remains the outer execution bound, so an all-pass final world round reports
+`assertions_passed`.
 
 ## 4. CLI Usage
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -87,6 +87,14 @@ Thumb reset vector at `flash.base + reset_vector_offset` (SP in RAM and
 Thumb-bit reset handler in flash). See the [CI Test Runner](ci_test_runner.md)
 for the closed world-interconnect schema.
 
+World completion stays in the `inputs.env` test script, not the manifest. Set
+`limits.stop_when_assertions_pass: true` to opt into a durable early completion:
+all node-qualified assertions must pass at or after the optional
+`stop_when_assertions_pass_min_steps` floor and remain true for the optional
+`stop_when_assertions_pass_settle_steps` window (default `100000`). The default
+is `false`, and a same-round runtime failure or configured limit takes
+precedence over `assertions_passed`.
+
 ## 4. CLI Usage
 
 To run a simulation, provide both the firmware and the system manifest:

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -1,14 +1,14 @@
 # CI workflow templates
 
-These templates run a pinned LabWired Core v0.19.0 release and preserve the
+These templates run a pinned LabWired Core v0.19.1 release and preserve the
 result.json, uart.log, snapshot.json, and junit.xml artifacts.
 
 ## GitHub Actions
 
 [github-actions.yml](github-actions.yml) is the primary GitHub template. It
 uses the public Core action at
-w1ne/labwired-core/.github/actions/labwired-test@82c6c78983669f8688f3823db9a81d1c2bdef202
-as an immutable action-source pin, while `version: v0.19.0` independently pins
+w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
+as an immutable action-source pin, while `version: v0.19.1` independently pins
 the Core CLI. Its only inputs are `script` (required), `version`, `output-dir`,
 and whitespace-separated `args`. The action downloads the public release archive
 with `curl`, writes JUnit at `output-dir/junit.xml`, renders the GitHub report,
@@ -27,7 +27,7 @@ cp docs/integration-templates/github-actions.yml .github/workflows/firmware-test
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.19.0
+  name: ghcr.io/w1ne/labwired:v0.19.1
   entrypoint: [""]
 ~~~
 
@@ -42,7 +42,7 @@ entrypoint:
 
 ~~~bash
 docker run --rm -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.19.0 \
+  ghcr.io/w1ne/labwired:v0.19.1 \
   test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
 ~~~
 

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -23,10 +23,10 @@ jobs:
       - id: labwired
         name: Run LabWired test
         # This immutable action-source pin is separate from the CLI version below.
-        uses: w1ne/labwired-core/.github/actions/labwired-test@82c6c78983669f8688f3823db9a81d1c2bdef202
+        uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
         with:
           script: tests/firmware-test.yaml
-          version: v0.19.0
+          version: v0.19.1
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -36,4 +36,4 @@ jobs:
 
 # Advanced alternative: build LabWired from a source checkout only when testing
 # an unreleased LabWired change. For normal firmware CI, keep the pinned release
-# selected by version: v0.19.0 above.
+# selected by version: v0.19.1 above.

--- a/docs/integration-templates/gitlab-ci.yml
+++ b/docs/integration-templates/gitlab-ci.yml
@@ -17,7 +17,7 @@ build:firmware:
 test:labwired:
   stage: test
   image:
-    name: ghcr.io/w1ne/labwired:v0.19.0
+    name: ghcr.io/w1ne/labwired:v0.19.1
     entrypoint: [""]
   dependencies:
     - build:firmware

--- a/docs/reference_client_flows.md
+++ b/docs/reference_client_flows.md
@@ -37,16 +37,16 @@ jobs:
       # Step 2: Run the public immutable Core action
       - id: labwired
         name: Run LabWired CLI
-        uses: w1ne/labwired-core/.github/actions/labwired-test@82c6c78983669f8688f3823db9a81d1c2bdef202
+        uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
         with:
           script: tests/hardware_validation.yaml
-          version: v0.19.0
+          version: v0.19.1
           output-dir: out/labwired
           args: --no-uart-stdout
 ```
 
 The action source is an immutable action-source pin. It has exactly four inputs:
-`script` (required), `version` (default `v0.19.0`), `output-dir`, and
+`script` (required), `version` (default `v0.19.1`), `output-dir`, and
 `args`. It downloads the selected public release
 with `curl`; callers do not need to add a token, repository, JUnit, or artifact
 upload setting. It automatically uploads `out/labwired/`, including

--- a/docs/simulation_protocol.md
+++ b/docs/simulation_protocol.md
@@ -66,6 +66,9 @@ inputs:
   env: "two-node-env.yaml"
 limits:
   max_steps: 100000
+  stop_when_assertions_pass: true
+  stop_when_assertions_pass_settle_steps: 1000  # optional; default 100000
+  stop_when_assertions_pass_min_steps: 1000     # optional; default 0
 assertions:
   - memory_value:
       node: gateway
@@ -82,6 +85,14 @@ Its firmware must be an `EM_ARM` ELF with a valid Cortex-M Thumb reset vector
 at `flash.base + reset_vector_offset`: the initial stack pointer is in RAM and
 the Thumb-bit reset handler is in flash. Anything outside that contract is a
 configuration error before a Cortex-M machine is constructed.
+
+Environment worlds may opt into `stop_when_assertions_pass`. The runner latches
+the first world round at or after `stop_when_assertions_pass_min_steps` where
+all node-qualified assertions pass, and accepts it only after they remain true
+for `stop_when_assertions_pass_settle_steps` rounds (default `100000`). The
+default is `false`; a regression resets the window, and a runtime error or
+configured limit on the same round takes precedence. A durable completion is
+reported as `stop_reason: assertions_passed`.
 
 ### 2.2 System Manifest (`system.yaml`)
 
@@ -275,6 +286,7 @@ out of the Execution Loop. Result JSON uses snake-case values:
 - `max_uart_bytes`: Exceeded `max_uart_bytes`.
 - `no_progress`: The single-machine CPU made no progress for its configured limit.
 - `wall_time`: Exceeded `wall_time_ms`.
+- `assertions_passed`: Opt-in assertions remained true through their settling window.
 - `memory_violation`: Accessed unmapped memory or violated access permissions.
 - `decode_error`: Encountered an invalid opcode.
 - `halt`: Reached a software breakpoint or halted intentionally.

--- a/docs/simulation_protocol.md
+++ b/docs/simulation_protocol.md
@@ -91,8 +91,9 @@ the first world round at or after `stop_when_assertions_pass_min_steps` where
 all node-qualified assertions pass, and accepts it only after they remain true
 for `stop_when_assertions_pass_settle_steps` rounds (default `100000`). The
 default is `false`; a regression resets the window, and a runtime error or
-configured limit on the same round takes precedence. A durable completion is
-reported as `stop_reason: assertions_passed`.
+same-round `wall_time_ms`, `max_cycles`, or `max_uart_bytes` limit takes
+precedence. `max_steps` remains the outer execution bound, so completion on its
+final allowed world round is reported as `stop_reason: assertions_passed`.
 
 ### 2.2 System Manifest (`system.yaml`)
 

--- a/docs/superpowers/plans/2026-07-14-environment-world-early-stop.md
+++ b/docs/superpowers/plans/2026-07-14-environment-world-early-stop.md
@@ -4,7 +4,7 @@
 
 **Goal:** Let an environment YAML opt into the same durable, assertion-based completion contract as the single-machine runner, so a successful multi-node CI run stops after its assertions have remained true for a settling window instead of always consuming `max_steps`.
 
-**Architecture:** Keep the behavior opt-in and retain the existing default (`false`). Accept the three existing `TestLimits` fields for `inputs.env`, evaluate the already-supported node-qualified memory assertions after each successful world round, and emit `AssertionsPassed` only after the configured minimum and settling window. Runtime failures and safety limits remain higher-precedence stops. Release the behavior as v0.19.1 and point the public action/default/docs at that release.
+**Architecture:** Keep the behavior opt-in and retain the existing default (`false`). Accept the three existing `TestLimits` fields for `inputs.env`, evaluate the already-supported node-qualified memory assertions after each successful world round, and emit `AssertionsPassed` only after the configured minimum and settling window. Runtime failures and safety limits remain higher-precedence stops. Release the behavior as v0.19.1, point the public action/default/docs at that release, and repair the OCI image's builder/runtime glibc compatibility before it can be published.
 
 **Tech Stack:** Rust, `labwired-config`, `labwired-cli` environment runner, GitHub Actions release archives, YAML contract tests.
 
@@ -29,6 +29,7 @@
 - [ ] Document environment assertion completion alongside the existing YAML limits reference.
 - [ ] Change the public action default to `v0.19.1`.
 - [ ] Pin Core consumer examples and the static release-runner verifier to the immutable action commit that carries that default.
+- [ ] Use a bookworm Rust builder with the bookworm runtime and add a PR image build/run smoke so an ABI mismatch fails before a public release is made.
 - [ ] Run focused config/CLI tests, formatting/lints, contract verification, and a real two-node smoke before merge.
 
 ### 4. Consume and prove it downstream

--- a/docs/superpowers/plans/2026-07-14-environment-world-early-stop.md
+++ b/docs/superpowers/plans/2026-07-14-environment-world-early-stop.md
@@ -1,0 +1,38 @@
+# Environment-world assertion early-stop implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Let an environment YAML opt into the same durable, assertion-based completion contract as the single-machine runner, so a successful multi-node CI run stops after its assertions have remained true for a settling window instead of always consuming `max_steps`.
+
+**Architecture:** Keep the behavior opt-in and retain the existing default (`false`). Accept the three existing `TestLimits` fields for `inputs.env`, evaluate the already-supported node-qualified memory assertions after each successful world round, and emit `AssertionsPassed` only after the configured minimum and settling window. Runtime failures and safety limits remain higher-precedence stops. Release the behavior as v0.19.1 and point the public action/default/docs at that release.
+
+**Tech Stack:** Rust, `labwired-config`, `labwired-cli` environment runner, GitHub Actions release archives, YAML contract tests.
+
+## Tasks
+
+### 1. Specify acceptance in tests
+
+- [ ] Add a configuration test proving environment YAML accepts and round-trips all three assertion-completion limit fields.
+- [ ] Remove only those fields from the existing unsupported-environment limit matrix; retain all genuinely unsupported controls.
+- [ ] Add a CLI black-box world test with a small `min_steps` and `settle_steps`, asserting `status=pass`, `stop_reason=assertions_passed`, and a step count below `max_steps`.
+- [ ] Add/retain a runtime-stop regression that proves a node fault wins over early completion.
+
+### 2. Implement the world completion contract
+
+- [ ] Stop rejecting `stop_when_assertions_pass`, `stop_when_assertions_pass_settle_steps`, and `stop_when_assertions_pass_min_steps` in `EnvTestScript::validate`.
+- [ ] In `run_world`, evaluate assertions after a completed round and after runtime/safety checks.
+- [ ] Latch the first all-pass round only once `min_steps` has been reached; reset the latch if an assertion regresses.
+- [ ] Stop with `StopReason::AssertionsPassed` after the all-pass duration reaches `settle_steps`.
+
+### 3. Publish a coherent v0.19.1 runner contract
+
+- [ ] Document environment assertion completion alongside the existing YAML limits reference.
+- [ ] Change the public action default to `v0.19.1`.
+- [ ] Pin Core consumer examples and the static release-runner verifier to the immutable action commit that carries that default.
+- [ ] Run focused config/CLI tests, formatting/lints, contract verification, and a real two-node smoke before merge.
+
+### 4. Consume and prove it downstream
+
+- [ ] Tag/release v0.19.1 only after Core checks are green.
+- [ ] Update UDSLib’s YAML to opt in, repin the public action/version, and extend its static contract to protect environment wiring and the no-secret guarantee.
+- [ ] Run the real H5 UDS workflow; preserve its generated report artifact as the landing-page proof and update only the article links.

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -194,7 +194,14 @@ require_block_literal "$smoke_block" '--no-uart-stdout' 'release smoke suppresse
 require_block_literal "$smoke_block" 'test -s out/release-runner-smoke/result.json' 'release smoke asserts the runner result JSON exists and is nonempty'
 require_block_literal "$smoke_block" 'test -s out/release-runner-smoke/junit.xml' 'release smoke asserts the OCI runner writes JUnit in its output directory'
 require_block_literal "$smoke_block" 'uses: ./.github/actions/labwired-test' 'release smoke exercises the checked-out core action'
-require_block_literal "$smoke_block" 'version: ${{ github.ref_name }}' 'release smoke pins the core action to the release tag'
+default_action_smoke_block=$(awk '
+  /- name: Run the default release archive through the core action/ { inside = 1 }
+  inside && /^      - name:/ && $0 !~ /Run the default release archive through the core action/ { exit }
+  inside { print }
+' <<<"$smoke_block")
+require_block_literal "$default_action_smoke_block" 'uses: ./.github/actions/labwired-test' 'release smoke exercises the action default'
+require_block_absent_literal "$default_action_smoke_block" 'version:' 'release smoke verifies the action default without an override'
+require_block_literal "$smoke_block" 'version: ${{ github.ref_name }}' 'release smoke separately exercises an explicit release pin'
 require_block_absent_literal "$smoke_block" 'github-token:' 'release smoke does not need an archive-download token'
 require_block_literal "$smoke_block" 'output-dir: out/release-action-smoke' 'release action smoke writes a dedicated output directory'
 require_block_absent_literal "$smoke_block" 'upload-artifacts:' 'release action smoke cannot disable artifact uploads'
@@ -357,14 +364,16 @@ require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner 
 require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
 require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
 
-safe_action_sha=82c6c78983669f8688f3823db9a81d1c2bdef202
-safe_action_version=v0.19.0
+safe_action_sha=fda6a7bfb0328d9909ee07ba53ed05c84901f627
+safe_action_version=v0.19.1
 safe_action_ref="w1ne/labwired-core/.github/actions/labwired-test@${safe_action_sha}"
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md docs/reference_client_flows.md .github/actions/labwired-test/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
   require_absent_literal "$doc" 'w1ne/labwired/.github/actions/labwired-test@main' "$doc does not point public users at the private root action"
   require_absent_literal "$doc" '3a13349ad6c4f65b4fa19276f576bc3086b219e6' "$doc does not retain the superseded public action pin"
+  require_absent_literal "$doc" '82c6c78983669f8688f3823db9a81d1c2bdef202' "$doc does not retain the superseded action pin"
   require_absent_literal "$doc" 'version: v0.18.0' "$doc does not retain the superseded Core release version"
+  require_absent_literal "$doc" 'version: v0.19.0' "$doc does not retain the superseded Core release version"
 done
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/README.md docs/reference_client_flows.md; do
   require_absent_literal "$doc" 'w1ne/labwired-core/.github/actions/labwired-test@main' "$doc does not use a mutable public Core action ref"
@@ -403,7 +412,7 @@ else
     fail "immutable action-source commit $safe_action_sha contains its action README"
   fi
   if [[ -n "$pinned_action" ]]; then
-    require_block_literal "$pinned_action" 'default: "v0.19.0"' 'pinned action defaults to the supported public release'
+    require_block_literal "$pinned_action" 'default: "v0.19.1"' 'pinned action defaults to the supported public release'
     require_block_literal "$pinned_action" 'https://github.com/w1ne/labwired-core/releases/download/${version}/${asset}' 'pinned action downloads the public release archive'
     pinned_action_inputs=$(awk '
       /^inputs:$/ { inside = 1; next }
@@ -438,6 +447,9 @@ require_literal docs/ci_test_runner.md '"1.0-environment"' 'runner guide documen
 require_literal docs/ci_test_runner.md '"run_type"' 'runner guide documents the environment run discriminator'
 require_literal docs/ci_test_runner.md 'world_firmware_hash' 'runner guide documents world provenance'
 require_literal docs/ci_test_runner.md 'inputs.env' 'runner guide documents environment test inputs'
+require_literal docs/ci_test_runner.md 'stop_when_assertions_pass' 'runner guide documents opt-in environment assertion completion'
+require_literal docs/ci_test_runner.md 'stop_when_assertions_pass_settle_steps' 'runner guide documents the environment assertion settling window'
+require_literal docs/ci_test_runner.md 'assertions_passed' 'runner guide documents the assertion-completion stop reason'
 require_literal docs/ci_test_runner.md 'config.peripheral' 'runner guide documents the CAN-bus peripheral requirement'
 require_literal docs/ci_test_runner.md 'Cortex-M-only' 'runner guide documents the current world architecture boundary'
 require_literal docs/ci_test_runner.md 'core: cortex-m*' 'runner guide documents the explicit Cortex-M core requirement'
@@ -448,6 +460,8 @@ require_literal docs/ci_test_runner.md 'uart_cross_link' 'runner guide documents
 require_literal docs/ci_test_runner.md 'egress' 'runner guide documents egress membership validation'
 require_literal docs/ci_test_runner.md 'Each `config` mapping is closed and type-checked' 'runner guide documents strict interconnect config mappings'
 require_literal docs/simulation_protocol.md 'schema_version: "1.0"' 'simulation protocol documents the released environment schema'
+require_literal docs/simulation_protocol.md 'stop_when_assertions_pass' 'simulation protocol documents opt-in environment assertion completion'
+require_literal docs/simulation_protocol.md 'assertions_passed' 'simulation protocol documents the assertion-completion stop reason'
 require_literal docs/simulation_protocol.md 'world_firmware_hash' 'simulation protocol documents environment provenance'
 require_literal docs/simulation_protocol.md 'config.peripheral' 'simulation protocol documents the CAN-bus peripheral requirement'
 require_literal docs/simulation_protocol.md 'Cortex-M-only' 'simulation protocol documents the current world architecture boundary'
@@ -461,10 +475,11 @@ require_literal docs/simulation_protocol.md 'strict and closed' 'simulation prot
 require_absent_literal docs/simulation_protocol.md 'Future v1.1' 'simulation protocol does not label released environments as future work'
 require_literal docs/configuration_reference.md 'core: cortex-m*' 'configuration reference documents the explicit Cortex-M core requirement'
 require_literal docs/configuration_reference.md 'including `{}` and `null`' 'configuration reference documents explicit empty and null override rejection'
+require_literal docs/configuration_reference.md 'stop_when_assertions_pass' 'configuration reference documents world assertion completion'
 require_literal examples/egress-demo/README.md 'config` is a closed mapping' 'egress example documents its closed config mapping'
 require_literal examples/egress-demo/README.md 'positive integer' 'egress example documents buffer_max type validation'
-require_literal README.md 'LABWIRED_VERSION=v0.19.0' 'public README pins the current release version'
-require_absent_literal README.md 'LABWIRED_VERSION=v0.18.0' 'public README does not retain the superseded release version'
+require_literal README.md 'LABWIRED_VERSION=v0.19.1' 'public README pins the current release version'
+require_absent_literal README.md 'LABWIRED_VERSION=v0.19.0' 'public README does not retain the superseded release version'
 
 if (( failures > 0 )); then
   printf 'Release runner contract failed with %d issue(s).\n' "$failures" >&2

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -103,6 +103,23 @@ release_runner_contract_block=$(awk '
 require_block_literal "$release_runner_contract_block" 'actions/checkout@v4' 'release runner contract job checks out the source'
 require_block_literal "$release_runner_contract_block" 'fetch-depth: 0' 'release runner contract job fetches immutable action-source pins'
 
+core_integrity_block=$(awk '
+  $0 == "  integrity:" { inside = 1; next }
+  inside && $0 ~ /^  [[:alnum:]_-]+:$/ { exit }
+  inside { print }
+' "$core_ci_workflow")
+if [[ -z "$core_integrity_block" ]]; then
+  fail 'core-integrity job is present in Core CI'
+fi
+require_block_literal "$core_integrity_block" 'docker build --pull' 'required Core integrity builds the runner image from fresh base layers'
+require_block_literal "$core_integrity_block" '--file Dockerfile.ci' 'required Core integrity uses the CI runner Dockerfile'
+require_block_literal "$core_integrity_block" 'labwired-ci-smoke:local' 'required Core integrity gives the local image a stable tag'
+require_block_literal "$core_integrity_block" 'VERSION=ci-smoke' 'required Core integrity provides OCI version metadata'
+require_block_literal "$core_integrity_block" 'REVISION="$GITHUB_SHA"' 'required Core integrity provides OCI revision metadata'
+require_block_literal "$core_integrity_block" 'docker run --rm labwired-ci-smoke:local --version' 'required Core integrity executes the final image entrypoint'
+require_block_absent_literal "$core_integrity_block" 'docker/login-action@v3' 'required Core integrity does not need registry credentials'
+require_block_absent_literal "$core_integrity_block" 'docker/build-push-action@v6' 'required Core integrity does not publish an untagged PR image'
+
 require_literal "$workflow" 'tags:' 'release workflow declares a tag trigger'
 require_literal "$workflow" "'v[0-9]+.[0-9]+.[0-9]+'" 'release workflow triggers vMAJOR.MINOR.PATCH tags'
 for target in \
@@ -191,13 +208,15 @@ require_block_literal "$smoke_block" 'output-dir: out/release-action-smoke-secon
 require_block_literal "$smoke_block" 'test -s out/release-action-smoke-second/result.json' 'release smoke asserts the second action result JSON exists and is nonempty'
 require_block_literal "$smoke_block" 'test -s out/release-action-smoke-second/junit.xml' 'release smoke asserts the second action writes JUnit in its output directory'
 
-require_literal "$dockerfile" 'FROM rust:1.95-slim AS builder' 'runner image builds with Rust 1.95'
+require_literal "$dockerfile" 'FROM rust:1.95-slim-bookworm AS builder' 'runner image builds with Rust 1.95 on bookworm'
+require_literal "$dockerfile" 'FROM debian:bookworm-slim' 'runner image runtime matches the builder libc baseline'
 require_literal "$dockerfile" 'RUN cargo build --release -p labwired-cli --locked' 'runner image builds only the CLI'
 require_literal "$dockerfile" 'ARG VERSION' 'runner image accepts a release version build argument'
 require_literal "$dockerfile" 'ARG REVISION' 'runner image accepts a source revision build argument'
 require_literal "$dockerfile" 'org.opencontainers.image.source="https://github.com/w1ne/labwired-core"' 'runner image declares its OCI source label'
 require_literal "$dockerfile" 'org.opencontainers.image.version="${VERSION}"' 'runner image declares its OCI version label'
 require_literal "$dockerfile" 'org.opencontainers.image.revision="${REVISION}"' 'runner image declares its OCI revision label'
+require_literal "$dockerfile" 'RUN labwired --version' 'runner image verifies the final runtime can execute the CLI'
 require_literal "$dockerfile" 'ENTRYPOINT ["labwired"]' 'runner image preserves the labwired CLI entrypoint'
 require_absent_literal "$dockerfile" 'USER ' 'runner image leaves the default user unchanged for bind-mounted output directories'
 require_absent_literal "$dockerfile" 'labwired-dap' 'runner image does not ship the DAP binary'

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -229,7 +229,7 @@ if [[ -f "$dockerignore" ]]; then
   done
 fi
 
-require_literal "$action" 'default: "v0.19.0"' 'core action defaults to the supported public release'
+require_literal "$action" 'default: "v0.19.1"' 'core action defaults to the supported public release'
 action_inputs=$(awk '
   /^inputs:$/ { inside = 1; next }
   inside && /^[^[:space:]]/ { exit }


### PR DESCRIPTION
Fixes the environment-world spin after assertions pass and prepares a complete v0.19.1 runner release.

- adds opt-in durable assertion completion for inputs.env YAML, with matching null semantics and precedence tests
- makes the OCI image builder/runtime glibc-compatible and smoke-tests it inside required core-integrity
- defaults the public Action to v0.19.1, pins consumers immutably, and smoke-tests the default plus an explicit pin

Verified locally: config suite, environment runner suite, targeted clippy, release-runner contract.