### PR TITLE
fix(release): publish verified v0.19.2 runner

### DIFF
--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -10,13 +10,13 @@ intentionally documents the action beside its implementation rather than
 choosing its own source SHA: every immutable revision therefore carries its own
 matching input and report contract.
 
-The `version` input defaults to `v0.19.1` and independently selects the
+The `version` input defaults to `v0.19.2` and independently selects the
 immutable Core CLI release archive named
-`labwired-v0.19.1-<platform>.tar.gz`. The action downloads that public archive
+`labwired-v0.19.2-<platform>.tar.gz`. The action downloads that public archive
 from the `w1ne/labwired-core` GitHub release with `curl`; it does not build Core
 on the consumer runner.
 
-Its inputs are exactly `script` (required), `version` (default `v0.19.1`),
+Its inputs are exactly `script` (required), `version` (default `v0.19.2`),
 `output-dir`, and `args`. `args` is whitespace-separated extra CLI flags; shell
 quoting inside this input is not interpreted.
 

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: "Immutable LabWired Core release tag to install."
     required: false
-    default: "v0.19.1"
+    default: "v0.19.2"
   output-dir:
     description: "Directory for run artifacts (result.json, uart.log, junit.xml, and reports)."
     required: false

--- a/.github/workflows/core-backfill-runner-image.yml
+++ b/.github/workflows/core-backfill-runner-image.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE/source:/workspace" \
             --workdir /workspace \
             "ghcr.io/w1ne/labwired:${{ inputs.version }}" \

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -164,6 +164,7 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             --volume "$GITHUB_WORKSPACE:/workspace" \
             --workdir /workspace \
             "ghcr.io/w1ne/labwired:${{ github.ref_name }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-07-15
+
+### Fixed
+- **Release runner smoke**: Bind-mounted container runs now preserve the
+  caller's artifact ownership, so the published image and archive-backed
+  GitHub Action can write report bundles in the same workspace.
+
+### Changed
+- **Public runner default**: The GitHub Action, integration templates, and
+  documented release pins now use the verified v0.19.2 runner contract.
+
 ## [0.19.1] - 2026-07-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1021,56 +1021,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
 ]
@@ -1717,7 +1717,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-egress-relay"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "labwired-core",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1884,11 +1884,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.19.1"
+version = "0.19.2"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3385,7 +3385,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ examples. Check the per-board docs before assuming a peripheral is modeled:
 Pinned release:
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.19.1 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.19.2 sh
 labwired --version
 ```
 
@@ -41,7 +41,7 @@ Prefer to inspect the installer first:
 ```sh
 curl -fsSL https://labwired.com/install.sh -o install.sh
 # review install.sh, then:
-LABWIRED_VERSION=v0.19.1 sh install.sh
+LABWIRED_VERSION=v0.19.2 sh install.sh
 ```
 
 Supported host environments:
@@ -52,7 +52,7 @@ Supported host environments:
 
 Install options:
 
-- `LABWIRED_VERSION=v0.19.1` pins the current documented release for a
+- `LABWIRED_VERSION=v0.19.2` pins the current documented release for a
   reproducible install.
 - `LABWIRED_FROM_SOURCE=1` forces a source build.
 - `LABWIRED_INSTALL_DIR=~/.local/bin` changes the install directory.

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -1,7 +1,7 @@
 # CI Integration
 
 LabWired CI runs the same labwired test command locally, in GitHub Actions, and
-in GitLab. Pin the runner release to v0.19.1 so a firmware change is tested
+in GitLab. Pin the runner release to v0.19.2 so a firmware change is tested
 against a reproducible simulator version.
 
 ## GitHub Actions
@@ -25,10 +25,10 @@ jobs:
 
       - id: labwired
         name: Run LabWired
-        uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
+        uses: w1ne/labwired-core/.github/actions/labwired-test@0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d
         with:
           script: tests/firmware-test.yaml
-          version: v0.19.1
+          version: v0.19.2
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -38,8 +38,8 @@ jobs:
 ~~~
 
 The public action reference is an immutable action-source pin to
-`fda6a7bfb0328d9909ee07ba53ed05c84901f627`. Its only inputs are `script`
-(required), `version` (default `v0.19.1`), `output-dir`, and `args`; it downloads
+`0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d`. Its only inputs are `script`
+(required), `version` (default `v0.19.2`), `output-dir`, and `args`; it downloads
 the selected public CLI release archive with `curl`. The action writes JUnit to
 `output-dir/junit.xml`, appends `summary.md` to the job summary, and always
 uploads the entire output directory, even when the test fails. Its `status`,
@@ -56,7 +56,7 @@ docker run --rm \
   --user "$(id -u):$(id -g)" \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
-  ghcr.io/w1ne/labwired:v0.19.1 \
+  ghcr.io/w1ne/labwired:v0.19.2 \
   test --script tests/firmware-test.yaml \
        --output-dir out/labwired \
        --no-uart-stdout
@@ -76,7 +76,7 @@ uses the pinned image and then invokes labwired test.
 ~~~yaml
 test:firmware:
   image:
-    name: ghcr.io/w1ne/labwired:v0.19.1
+    name: ghcr.io/w1ne/labwired:v0.19.2
     entrypoint: [""]
   script:
     - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -53,6 +53,7 @@ image name; do not repeat labwired in the container command:
 
 ~~~bash
 docker run --rm \
+  --user "$(id -u):$(id -g)" \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
   ghcr.io/w1ne/labwired:v0.19.1 \
@@ -61,10 +62,10 @@ docker run --rm \
        --no-uart-stdout
 ~~~
 
-The image runs as the runtime default user so it can write artifacts into the
-mounted workspace. The Docker command and GitHub action accept the same test
-YAML: it can be a single-machine script or a world script that selects its
-environment through `inputs.env`.
+When bind-mounting a workspace, pass the caller UID/GID so generated artifacts
+remain writable on the host. The Docker command and GitHub action accept the
+same test YAML: it can be a single-machine script or a world script that
+selects its environment through `inputs.env`.
 
 ## GitLab CI
 

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -396,21 +396,21 @@ configuration; these produce `status: "error"` with `stop_reason:
 
 ## CI release runners
 
-Use the pinned v0.19.1 release runner in CI. It runs the same `labwired test`
+Use the pinned v0.19.2 release runner in CI. It runs the same `labwired test`
 command described above and writes the same artifact contract.
 
 ### GitHub Actions
 
 Use the public Core action and pin the Core CLI with its version input. Its
 only inputs are required `script`, optional `version` (default
-`v0.19.1`), `output-dir`, and `args`:
+`v0.19.2`), `output-dir`, and `args`:
 
 ~~~yaml
 - id: labwired
   name: Run LabWired tests
-  uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
+  uses: w1ne/labwired-core/.github/actions/labwired-test@0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d
   with:
-    version: v0.19.1
+    version: v0.19.2
     script: examples/ci/dummy-max-steps.yaml
     output-dir: out/artifacts
     args: --no-uart-stdout
@@ -421,7 +421,7 @@ only inputs are required `script`, optional `version` (default
 ~~~
 
 The Core action is an immutable action-source pin to
-`fda6a7bfb0328d9909ee07ba53ed05c84901f627`; `version: v0.19.1` independently
+`0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d`; `version: v0.19.2` independently
 pins the immutable Core CLI release. It downloads that public release archive
 with `curl`, creates `output-dir/junit.xml` plus Markdown and HTML reports,
 appends the Markdown report to the job summary, and always uploads the entire
@@ -437,7 +437,7 @@ use either a single-machine script or an `inputs.env` world script.
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.19.1 \
+  ghcr.io/w1ne/labwired:v0.19.2 \
   test --script examples/ci/dummy-max-steps.yaml \
        --output-dir out/artifacts \
        --no-uart-stdout
@@ -447,7 +447,7 @@ GitLab should clear that entrypoint and invoke labwired from its job shell:
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.19.1
+  name: ghcr.io/w1ne/labwired:v0.19.2
   entrypoint: [""]
 script:
   - labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -436,7 +436,7 @@ after the pinned image name. Docker and the Action accept the same test YAML:
 use either a single-machine script or an `inputs.env` world script.
 
 ~~~bash
-docker run --rm -v "$PWD:/workspace" -w /workspace \
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
   ghcr.io/w1ne/labwired:v0.19.1 \
   test --script examples/ci/dummy-max-steps.yaml \
        --output-dir out/artifacts \

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -1,14 +1,14 @@
 # CI workflow templates
 
-These templates run a pinned LabWired Core v0.19.1 release and preserve the
+These templates run a pinned LabWired Core v0.19.2 release and preserve the
 result.json, uart.log, snapshot.json, and junit.xml artifacts.
 
 ## GitHub Actions
 
 [github-actions.yml](github-actions.yml) is the primary GitHub template. It
 uses the public Core action at
-w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
-as an immutable action-source pin, while `version: v0.19.1` independently pins
+w1ne/labwired-core/.github/actions/labwired-test@0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d
+as an immutable action-source pin, while `version: v0.19.2` independently pins
 the Core CLI. Its only inputs are `script` (required), `version`, `output-dir`,
 and whitespace-separated `args`. The action downloads the public release archive
 with `curl`, writes JUnit at `output-dir/junit.xml`, renders the GitHub report,
@@ -27,7 +27,7 @@ cp docs/integration-templates/github-actions.yml .github/workflows/firmware-test
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.19.1
+  name: ghcr.io/w1ne/labwired:v0.19.2
   entrypoint: [""]
 ~~~
 
@@ -42,7 +42,7 @@ entrypoint:
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.19.1 \
+  ghcr.io/w1ne/labwired:v0.19.2 \
   test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
 ~~~
 

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -41,7 +41,7 @@ For local or non-GitHub CI runs, the release image keeps labwired as its
 entrypoint:
 
 ~~~bash
-docker run --rm -v "$PWD:/workspace" -w /workspace \
+docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
   ghcr.io/w1ne/labwired:v0.19.1 \
   test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
 ~~~

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -23,10 +23,10 @@ jobs:
       - id: labwired
         name: Run LabWired test
         # This immutable action-source pin is separate from the CLI version below.
-        uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
+        uses: w1ne/labwired-core/.github/actions/labwired-test@0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d
         with:
           script: tests/firmware-test.yaml
-          version: v0.19.1
+          version: v0.19.2
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -36,4 +36,4 @@ jobs:
 
 # Advanced alternative: build LabWired from a source checkout only when testing
 # an unreleased LabWired change. For normal firmware CI, keep the pinned release
-# selected by version: v0.19.1 above.
+# selected by version: v0.19.2 above.

--- a/docs/integration-templates/gitlab-ci.yml
+++ b/docs/integration-templates/gitlab-ci.yml
@@ -17,7 +17,7 @@ build:firmware:
 test:labwired:
   stage: test
   image:
-    name: ghcr.io/w1ne/labwired:v0.19.1
+    name: ghcr.io/w1ne/labwired:v0.19.2
     entrypoint: [""]
   dependencies:
     - build:firmware

--- a/docs/reference_client_flows.md
+++ b/docs/reference_client_flows.md
@@ -37,16 +37,16 @@ jobs:
       # Step 2: Run the public immutable Core action
       - id: labwired
         name: Run LabWired CLI
-        uses: w1ne/labwired-core/.github/actions/labwired-test@fda6a7bfb0328d9909ee07ba53ed05c84901f627
+        uses: w1ne/labwired-core/.github/actions/labwired-test@0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d
         with:
           script: tests/hardware_validation.yaml
-          version: v0.19.1
+          version: v0.19.2
           output-dir: out/labwired
           args: --no-uart-stdout
 ```
 
 The action source is an immutable action-source pin. It has exactly four inputs:
-`script` (required), `version` (default `v0.19.1`), `output-dir`, and
+`script` (required), `version` (default `v0.19.2`), `output-dir`, and
 `args`. It downloads the selected public release
 with `curl`; callers do not need to add a token, repository, JUnit, or artifact
 upload setting. It automatically uploads `out/labwired/`, including

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -366,16 +366,18 @@ require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner 
 require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
 require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
 
-safe_action_sha=fda6a7bfb0328d9909ee07ba53ed05c84901f627
-safe_action_version=v0.19.1
+safe_action_sha=0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d
+safe_action_version=v0.19.2
 safe_action_ref="w1ne/labwired-core/.github/actions/labwired-test@${safe_action_sha}"
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md docs/reference_client_flows.md .github/actions/labwired-test/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
   require_absent_literal "$doc" 'w1ne/labwired/.github/actions/labwired-test@main' "$doc does not point public users at the private root action"
   require_absent_literal "$doc" '3a13349ad6c4f65b4fa19276f576bc3086b219e6' "$doc does not retain the superseded public action pin"
   require_absent_literal "$doc" '82c6c78983669f8688f3823db9a81d1c2bdef202' "$doc does not retain the superseded action pin"
+  require_absent_literal "$doc" 'fda6a7bfb0328d9909ee07ba53ed05c84901f627' "$doc does not retain the superseded action pin"
   require_absent_literal "$doc" 'version: v0.18.0' "$doc does not retain the superseded Core release version"
   require_absent_literal "$doc" 'version: v0.19.0' "$doc does not retain the superseded Core release version"
+  require_absent_literal "$doc" 'v0.19.1' "$doc does not retain the superseded Core release version"
 done
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/README.md; do
   require_literal "$doc" '--user "$(id -u):$(id -g)"' "$doc keeps bind-mounted container artifacts writable by the caller"
@@ -417,7 +419,7 @@ else
     fail "immutable action-source commit $safe_action_sha contains its action README"
   fi
   if [[ -n "$pinned_action" ]]; then
-    require_block_literal "$pinned_action" 'default: "v0.19.1"' 'pinned action defaults to the supported public release'
+    require_block_literal "$pinned_action" 'default: "v0.19.2"' 'pinned action defaults to the supported public release'
     require_block_literal "$pinned_action" 'https://github.com/w1ne/labwired-core/releases/download/${version}/${asset}' 'pinned action downloads the public release archive'
     pinned_action_inputs=$(awk '
       /^inputs:$/ { inside = 1; next }
@@ -438,6 +440,7 @@ else
     require_block_literal "$pinned_action" 'name: labwired-${{ github.job }}-${{ github.run_id }}-${{ github.action }}' 'pinned action gives each invocation a unique artifact name'
   fi
   if [[ -n "$pinned_action_readme" ]]; then
+    require_block_literal "$pinned_action_readme" 'defaults to `v0.19.2`' 'pinned action README states the supported public release'
     require_block_literal "$pinned_action_readme" '[CI integration guide](../../../docs/ci_integration.md)' 'pinned action README links the canonical consumer guide'
     require_block_literal "$pinned_action_readme" 'intentionally documents the action beside its implementation' 'pinned action README explains its source-local contract'
     require_block_absent_literal "$pinned_action_readme" 'uses: w1ne/labwired-core/.github/actions/labwired-test@' 'pinned action README does not recursively choose its own SHA'
@@ -483,8 +486,10 @@ require_literal docs/configuration_reference.md 'including `{}` and `null`' 'con
 require_literal docs/configuration_reference.md 'stop_when_assertions_pass' 'configuration reference documents world assertion completion'
 require_literal examples/egress-demo/README.md 'config` is a closed mapping' 'egress example documents its closed config mapping'
 require_literal examples/egress-demo/README.md 'positive integer' 'egress example documents buffer_max type validation'
-require_literal README.md 'LABWIRED_VERSION=v0.19.1' 'public README pins the current release version'
-require_absent_literal README.md 'LABWIRED_VERSION=v0.19.0' 'public README does not retain the superseded release version'
+require_literal Cargo.toml 'version = "0.19.2"' 'workspace metadata uses the current release version'
+require_literal CHANGELOG.md '## [0.19.2] - 2026-07-15' 'changelog records the current release version'
+require_literal README.md 'LABWIRED_VERSION=v0.19.2' 'public README pins the current release version'
+require_absent_literal README.md 'LABWIRED_VERSION=v0.19.1' 'public README does not retain the superseded release version'
 
 if (( failures > 0 )); then
   printf 'Release runner contract failed with %d issue(s).\n' "$failures" >&2

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -188,6 +188,7 @@ runner_command_block=$(awk '
 ' <<<"$smoke_block")
 require_block_literal "$runner_command_block" '"ghcr.io/w1ne/labwired:${{ github.ref_name }}"' 'release smoke runs the immutable image that it pulled'
 require_block_absent_literal "$runner_command_block" 'ghcr.io/w1ne/labwired:latest' 'release smoke does not run the mutable latest tag'
+require_block_literal "$runner_command_block" '--user "$(id -u):$(id -g)"' 'release smoke preserves host ownership for bind-mounted runner artifacts'
 require_block_literal "$smoke_block" 'examples/ci/two-node-inputs-env.yaml' 'release smoke uses the explicit two-node inputs.env script'
 require_block_literal "$smoke_block" 'out/release-runner-smoke' 'release smoke writes runner artifacts to a dedicated directory'
 require_block_literal "$smoke_block" '--no-uart-stdout' 'release smoke suppresses UART output'

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -361,6 +361,7 @@ require_literal "$backfill_workflow" 'ghcr.io/w1ne/labwired:${{ inputs.version }
 require_absent_literal "$backfill_workflow" 'ghcr.io/w1ne/labwired:latest' 'runner backfill never overwrites the moving latest tag'
 require_literal "$backfill_workflow" 'docker logout ghcr.io || true' 'runner backfill verifies a public anonymous pull'
 require_literal "$backfill_workflow" 'docker pull "ghcr.io/w1ne/labwired:${{ inputs.version }}"' 'runner backfill pulls the immutable tag after publication'
+require_literal "$backfill_workflow" '--user "$(id -u):$(id -g)"' 'runner backfill preserves host ownership for bind-mounted artifacts'
 require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner backfill uses the deterministic CI smoke script'
 require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
 require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
@@ -375,6 +376,9 @@ for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templa
   require_absent_literal "$doc" '82c6c78983669f8688f3823db9a81d1c2bdef202' "$doc does not retain the superseded action pin"
   require_absent_literal "$doc" 'version: v0.18.0' "$doc does not retain the superseded Core release version"
   require_absent_literal "$doc" 'version: v0.19.0' "$doc does not retain the superseded Core release version"
+done
+for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/README.md; do
+  require_literal "$doc" '--user "$(id -u):$(id -g)"' "$doc keeps bind-mounted container artifacts writable by the caller"
 done
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/README.md docs/reference_client_flows.md; do
   require_absent_literal "$doc" 'w1ne/labwired-core/.github/actions/labwired-test@main' "$doc does not use a mutable public Core action ref"

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -237,7 +237,7 @@ if [[ -f "$dockerignore" ]]; then
   done
 fi
 
-require_literal "$action" 'default: "v0.19.1"' 'core action defaults to the supported public release'
+require_literal "$action" 'default: "v0.19.2"' 'core action defaults to the supported public release'
 action_inputs=$(awk '
   /^inputs:$/ { inside = 1; next }
   inside && /^[^[:space:]]/ { exit }


### PR DESCRIPTION
## Why

v0.19.1 published its archives and runner image, but the final release smoke failed after the container created a root-owned `out/` directory in the bind-mounted workspace. The following archive-backed action could not write its report bundle.

## What changed

- run bind-mounted runner smoke containers as the host UID/GID, including the backfill path
- protect the ownership contract in the release verifier and document the safe raw-Docker invocation
- prepare v0.19.2 as the coherent public default: workspace metadata/lock, action source, immutable source pin, templates, docs, and changelog

## Verification

- static release-runner contract + 13 renderer tests
- `cargo test -p labwired-config` (71 tests)
- `cargo test -p labwired-cli --test environment_runner` (22 tests)
- `cargo clippy -p labwired-config -p labwired-cli --all-targets -- -D warnings`
- `cargo fmt --check`, locked metadata, YAML parsing, and diff check

Merge normally (not squash/rebase) so immutable action source `0cadd18fc9a3c0cbd1ecb0a6ddcd8ce66d56283d` remains reachable before tagging `v0.19.2`.