### PR TITLE
perf: optimize ESP32-S3 OLED profile path

### DIFF
--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -27,6 +27,22 @@ mod tick;
 pub use bus_trace::{new_log, BusPayload, BusTraceEvent, BusTraceLog, I2cSym};
 
 impl SystemBus {
+    /// Describe the currently active legacy per-step entries.
+    ///
+    /// This is intentionally a diagnostic view of the assembled bus, not a
+    /// second execution path.  Consumers use it to tie profile entries back
+    /// to the concrete device window before attempting a scheduler migration.
+    pub fn legacy_tick_entry_descriptors(&self) -> Vec<(String, u64, u64)> {
+        self.legacy_tick_indices
+            .iter()
+            .filter_map(|&idx| {
+                self.peripherals
+                    .get(idx)
+                    .map(|p| (p.name.clone(), p.base, p.size))
+            })
+            .collect()
+    }
+
     #[inline]
     fn legacy_tick_index_active(p: &PeripheralEntry) -> bool {
         if cfg!(feature = "event-scheduler") && p.dev.uses_scheduler() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -967,6 +967,14 @@ pub enum StopReason {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// Counters collected during one measured machine run.
+///
+/// These are execution-path counters, not wall-clock or workload markers:
+/// `cpu_instructions` counts retired instructions, `cpu_batches` counts CPU
+/// dispatch batches, and the remaining fields describe peripheral/bus work
+/// driven by that same pass. Workload-specific observables (for example an
+/// OLED first-paint cycle or a serial completion marker) belong to the
+/// workload harness and must not be added here.
 pub struct StepProfile {
     pub cpu_instructions: u64,
     pub cpu_batches: u64,

--- a/crates/core/src/peripherals/esp32s3/io_mux.rs
+++ b/crates/core/src/peripherals/esp32s3/io_mux.rs
@@ -52,6 +52,16 @@ impl Default for Esp32s3IoMux {
 }
 
 impl Peripheral for Esp32s3IoMux {
+    // Pin-function selection is a synchronous register file. It has no
+    // elapsed-time state, IRQs, DMA, or scheduled events.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = offset & !3;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
+++ b/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
@@ -62,6 +62,16 @@ impl Default for SystemStub {
 }
 
 impl Peripheral for SystemStub {
+    // This is a register file only: all state changes happen synchronously on
+    // MMIO writes, with no elapsed-time state, IRQs, DMA, or events.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = offset & !3;
         let byte_off = (offset & 3) * 8;
@@ -410,6 +420,16 @@ impl EfuseStub {
 }
 
 impl Peripheral for EfuseStub {
+    // eFuse reads are immutable canned values; the stub has no time-driven
+    // behavior to service from the legacy walk.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word_off = offset & !3;
         let byte_off = (offset & 3) * 8;

--- a/crates/core/src/system/xtensa/mod.rs
+++ b/crates/core/src/system/xtensa/mod.rs
@@ -84,6 +84,17 @@ impl std::fmt::Debug for RamPeripheral {
 }
 
 impl crate::Peripheral for RamPeripheral {
+    // RAM/ROM windows only store and serve bytes. They have no elapsed-time
+    // state, IRQs, DMA, or scheduled events, so the legacy per-step walk is
+    // provably unnecessary for every firmware state.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
     fn read(&self, offset: u64) -> crate::SimResult<u8> {
         Ok(*self.data.borrow().get(offset as usize).unwrap_or(&0))
     }

--- a/crates/core/src/tests/test_cycles.rs
+++ b/crates/core/src/tests/test_cycles.rs
@@ -97,6 +97,30 @@ fn machine_run_records_step_profile_counters() {
     assert_eq!(profile.legacy_tick_entries, expected_legacy_tick_entries);
 }
 
+#[test]
+fn step_profile_serializes_the_standardized_counter_contract() {
+    let profile = crate::StepProfile {
+        cpu_instructions: 1,
+        cpu_batches: 2,
+        peripheral_ticks: 3,
+        peripheral_ticked_entries: 4,
+        bus_tick_entries: 5,
+        legacy_tick_entries: 6,
+    };
+    let value = serde_json::to_value(profile).unwrap();
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "cpu_instructions": 1,
+            "cpu_batches": 2,
+            "peripheral_ticks": 3,
+            "peripheral_ticked_entries": 4,
+            "bus_tick_entries": 5,
+            "legacy_tick_entries": 6,
+        })
+    );
+}
+
 /// A peripheral that reports a fixed byte from the side-effect-free `peek`.
 #[derive(Debug)]
 struct PeekTag(u8);

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -26,8 +26,11 @@ const GOLDEN_FIRST_PAINT_FNV1A: u64 = 0x41ac26506ebe964b;
 const GOLDEN_SERIAL_FNV1A: u64 = 0xaf2df535cf6fd7e4;
 const GOLDEN_FRAMEBUFFER_FNV1A: u64 = 0xc4eb9ef771b3ded8;
 const GOLDEN_COMPLETION_CYCLES: u64 = 2_139_600;
-const GOLDEN_LEGACY_TICK_MULTIPLIER: u64 = 49;
-const GOLDEN_LEGACY_TICK_ENTRIES: u64 = 104_840_400;
+// `tick_profile_entry_counts()` counts the active legacy index vector.  The
+// faithful-fast-boot S3 wiring registers 48 such entries; this is a golden
+// source-level invariant, not a performance range.
+const GOLDEN_LEGACY_TICK_MULTIPLIER: u64 = 48;
+const GOLDEN_LEGACY_TICK_ENTRIES: u64 = 102_700_800;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -205,9 +205,10 @@ fn esp32s3_oled_native_baseline() {
             retired < max_cycles,
             "S3 OLED serial marker was not emitted"
         );
-        let remaining = u32::try_from(max_cycles - retired)
-            .expect("LABWIRED_ESP32S3_OLED_MAX_CYCLES remaining budget must fit in u32");
-        let count = CHUNK.min(remaining);
+        let remaining = max_cycles - retired;
+        // Machine::run accepts a u32 chunk. Clamp the u64 budget first so a
+        // valid max_cycles above u32::MAX cannot panic or wrap during narrowing.
+        let count = CHUNK.min(remaining.min(u64::from(u32::MAX)) as u32);
         machine.run(Some(count)).expect("run S3 OLED completion");
         retired += u64::from(count);
     }

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -5,6 +5,7 @@
 //! interpreter; it does not add timing, clock, or simulator-only execution
 //! behaviour.
 
+use labwired_config::{Arch, ChipDescriptor, SystemManifest};
 use labwired_core::boot::esp32s3::{fast_boot, BootOpts};
 use labwired_core::bus::SystemBus;
 use labwired_core::cpu::XtensaLx7;
@@ -20,6 +21,10 @@ use std::time::Instant;
 const CHUNK: u32 = 1_000_000;
 const DEFAULT_MAX_CYCLES: u64 = 200_000_000;
 const DEFAULT_SERIAL_MARKER: &str = "S3 OLED painted";
+const GOLDEN_FIRST_PAINT_CYCLES: u64 = 2_000_000;
+const GOLDEN_FIRST_PAINT_FNV1A: u64 = 0xc4eb9ef771b3ded8;
+const GOLDEN_SERIAL_FNV1A: u64 = 0xaf2df535cf6fd7e4;
+const GOLDEN_FRAMEBUFFER_FNV1A: u64 = 0xc4eb9ef771b3ded8;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -66,7 +71,50 @@ fn oled_framebuffer(machine: &Machine<XtensaLx7>) -> Vec<u8> {
         .to_vec()
 }
 
-fn build_machine(elf: &[u8]) -> (Machine<XtensaLx7>, Arc<Mutex<Vec<u8>>>) {
+/// This is the faithful-fast-boot baseline used by the WASM constructor.  It
+/// loads the real S3 ROM images through `Esp32s3Opts` and then uses the
+/// existing `fast_boot` seam, which skips replaying the ROM reset/bootloader.
+/// It must not be described as a full hardware-boot benchmark.
+///
+/// Full ROM boot is a separate benchmark boundary: it must use the
+/// `boot::esp32s3_rom` path and its own fixture/trace golden values.  Keeping
+/// that boundary separate prevents a fast-boot result from being silently
+/// presented as ROM-boot fidelity.
+fn build_machine(
+    chip: &ChipDescriptor,
+    manifest: &SystemManifest,
+    elf: &[u8],
+) -> (Machine<XtensaLx7>, Arc<Mutex<Vec<u8>>>) {
+    assert_eq!(chip.name, "esp32s3");
+    assert_eq!(chip.arch, Arch::Xtensa);
+    assert!(
+        chip.peripherals
+            .iter()
+            .any(|peripheral| peripheral.id == "i2c0"),
+        "S3 chip descriptor must declare i2c0"
+    );
+    let oled = manifest
+        .external_devices
+        .iter()
+        .find(|device| device.id == "oled")
+        .expect("S3 OLED manifest must declare external device 'oled'");
+    assert_eq!(oled.r#type, "oled-ssd1306");
+    assert_eq!(oled.connection, "i2c0");
+    assert_eq!(
+        oled.config
+            .get("i2c_address")
+            .and_then(|value| value.as_u64()),
+        Some(0x3c)
+    );
+    let oled_io = manifest
+        .board_io
+        .iter()
+        .find(|binding| binding.id == "oled")
+        .expect("S3 OLED manifest must declare board_io binding 'oled'");
+    assert_eq!(oled_io.peripheral, "i2c0");
+    assert_eq!(oled_io.i2c_address, Some(0x3c));
+    assert_eq!(oled_io.device_type.as_deref(), Some("oled-ssd1306"));
+
     let mut bus = SystemBus::new();
     let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
     let serial = Arc::new(Mutex::new(Vec::new()));
@@ -105,21 +153,8 @@ fn esp32s3_oled_native_baseline() {
     let root = repo_root();
     let chip_yaml = root.join("core/configs/chips/esp32s3.yaml");
     let system_yaml = root.join("core/configs/systems/esp32s3-oled-demo.yaml");
-    assert!(
-        chip_yaml.is_file(),
-        "missing S3 chip config: {}",
-        chip_yaml.display()
-    );
-    assert!(
-        system_yaml.is_file(),
-        "missing S3 OLED system config: {}",
-        system_yaml.display()
-    );
-    let system = std::fs::read_to_string(&system_yaml).expect("read S3 OLED system config");
-    assert!(
-        system.contains("i2c_address: 0x3C"),
-        "S3 OLED config must bind 0x3C"
-    );
+    let chip = ChipDescriptor::from_file(&chip_yaml).expect("parse S3 chip descriptor");
+    let manifest = SystemManifest::from_file(&system_yaml).expect("parse S3 OLED manifest");
 
     let elf_path = required_asset(
         "curated OLED ELF",
@@ -127,7 +162,7 @@ fn esp32s3_oled_native_baseline() {
         "packages/playground/public/wasm/demo-esp32s3-oled.elf",
     );
     let elf = std::fs::read(&elf_path).expect("read curated S3 OLED ELF");
-    let (mut machine, serial) = build_machine(&elf);
+    let (mut machine, serial) = build_machine(&chip, &manifest, &elf);
     let max_cycles = std::env::var("LABWIRED_ESP32S3_OLED_MAX_CYCLES")
         .ok()
         .and_then(|value| value.parse().ok())
@@ -164,6 +199,33 @@ fn esp32s3_oled_native_baseline() {
         output_text.contains(&marker),
         "S3 OLED serial marker {marker:?} was not emitted; serial:\n{output_text}"
     );
+
+    let (first_paint_cycles, first_paint_digest) = first_paint.expect("first paint asserted above");
+    assert_eq!(
+        first_paint_cycles, GOLDEN_FIRST_PAINT_CYCLES,
+        "first-paint cycle drifted from the faithful-fast-boot baseline"
+    );
+    assert_eq!(
+        first_paint_digest, GOLDEN_FIRST_PAINT_FNV1A,
+        "first-paint framebuffer digest drifted"
+    );
+    assert_eq!(fnv1a(&output), GOLDEN_SERIAL_FNV1A, "serial digest drifted");
+    assert_eq!(
+        fnv1a(&framebuffer),
+        GOLDEN_FRAMEBUFFER_FNV1A,
+        "final framebuffer digest drifted"
+    );
+
+    // These counters are deterministic for this fixed 1M-chunk, interval-1
+    // baseline.  They are intentionally golden: a scheduler or interpreter
+    // change must update this benchmark and its observable-output review
+    // together, rather than silently changing the measured workload.
+    assert_eq!(profile.cpu_instructions, machine.total_cycles);
+    assert_eq!(profile.cpu_batches, profile.cpu_instructions);
+    assert_eq!(profile.peripheral_ticks, machine.total_cycles);
+    assert_eq!(profile.peripheral_ticked_entries, 0);
+    assert_eq!(profile.bus_tick_entries, 0);
+    assert_eq!(profile.legacy_tick_entries, machine.total_cycles * 48);
 
     let mips = machine.total_cycles as f64 / elapsed.as_secs_f64() / 1_000_000.0;
     eprintln!(

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -27,10 +27,53 @@ const GOLDEN_SERIAL_FNV1A: u64 = 0xaf2df535cf6fd7e4;
 const GOLDEN_FRAMEBUFFER_FNV1A: u64 = 0xc4eb9ef771b3ded8;
 const GOLDEN_COMPLETION_CYCLES: u64 = 2_139_600;
 // `tick_profile_entry_counts()` counts the active legacy index vector.  The
-// faithful-fast-boot S3 wiring registers 48 such entries; this is a golden
+// faithful-fast-boot S3 wiring registers 37 such entries; this is a golden
 // source-level invariant, not a performance range.
 const GOLDEN_LEGACY_TICK_MULTIPLIER: u64 = 37;
 const GOLDEN_LEGACY_TICK_ENTRIES: u64 = 79_165_200;
+
+// Complete assembled-bus mapping for the OLED workload. The role labels make
+// review failures actionable: entries marked "retained" have observable
+// per-step behavior, while the removed inert classes must never reappear.
+const EXPECTED_LEGACY_S3_OLED_ROLES: &[(&str, &str)] = &[
+    ("intmatrix", "retained: interrupt routing"),
+    ("crosscore_ipi", "retained: SMP doorbell"),
+    ("core1_control", "retained: secondary-core release"),
+    ("extmem", "retained: external-memory timing"),
+    ("system_regs", "retained: S3 system register behavior"),
+    ("system_regs_hi", "retained: S3 system register behavior"),
+    ("rtc_cntl", "retained: RTC calibration/timing"),
+    ("gpio", "retained: GPIO observer cycle timestamps"),
+    ("sens_s3", "retained: S3 sensor model"),
+    ("rng", "retained: RNG model"),
+    ("sha", "retained: SHA accelerator model"),
+    ("pcnt", "retained: pulse-counter timing"),
+    ("ledc", "retained: PWM timing"),
+    ("timg0_s3", "retained: timer-group timing"),
+    ("timg1_s3", "retained: timer-group timing"),
+    ("rmt_s3", "retained: waveform timing"),
+    ("spi2_s3", "retained: SPI timing"),
+    ("spi3_s3", "retained: SPI timing"),
+    ("sar_adc_s3", "retained: ADC behavior"),
+    ("gdma", "retained: DMA behavior"),
+    ("i2s0_s3", "retained: I2S timing"),
+    ("i2s1_s3", "retained: I2S timing"),
+    ("twai", "retained: TWAI timing"),
+    ("aes", "retained: AES accelerator model"),
+    ("rsa", "retained: RSA accelerator model"),
+    ("hmac", "retained: HMAC accelerator model"),
+    ("ds", "retained: DS accelerator model"),
+    ("mcpwm0", "retained: motor-PWM timing"),
+    ("mcpwm1", "retained: motor-PWM timing"),
+    ("sdmmc", "retained: SDMMC timing"),
+    ("lcd_cam", "retained: LCD/CAM timing"),
+    ("usb_otg", "retained: USB OTG behavior"),
+    ("i2c1", "retained: I2C timing"),
+    ("uart0_s3", "retained: UART timing"),
+    ("uart1_s3", "retained: UART timing"),
+    ("uart2_s3", "retained: UART timing"),
+    ("i2c0", "retained: OLED I2C level IRQ timing"),
+];
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -170,6 +213,20 @@ fn esp32s3_oled_native_baseline() {
     let elf = std::fs::read(&elf_path).expect("read curated S3 OLED ELF");
     let (mut machine, serial) = build_machine(&chip, &manifest, &elf);
     let legacy_entries = machine.bus.legacy_tick_entry_descriptors();
+    let mut actual_names: Vec<&str> = legacy_entries
+        .iter()
+        .map(|(name, _, _)| name.as_str())
+        .collect();
+    let mut expected_names: Vec<&str> = EXPECTED_LEGACY_S3_OLED_ROLES
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    actual_names.sort_unstable();
+    expected_names.sort_unstable();
+    assert_eq!(
+        actual_names, expected_names,
+        "complete S3 OLED legacy mapping changed; review each named role"
+    );
     assert!(
         legacy_entries.iter().any(|(name, _, _)| name == "gpio"),
         "GPIO remains on the legacy path because observer timestamps are tick-driven"
@@ -188,6 +245,24 @@ fn esp32s3_oled_native_baseline() {
             .all(|(name, _, _)| name != "usb_serial_jtag"),
         "polling USB serial sink must remain inert for the legacy walk"
     );
+    for removed in [
+        "iram",
+        "dram",
+        "rtc_slow",
+        "rtc_fast",
+        "rom",
+        "drom",
+        "system",
+        "efuse",
+        "low_mmio",
+        "mmio_rest",
+        "io_mux",
+    ] {
+        assert!(
+            legacy_entries.iter().all(|(name, _, _)| name != removed),
+            "inert {removed} must remain removed from the legacy walk"
+        );
+    }
     eprintln!("S3_OLED_LEGACY_ENTRIES {:?}", legacy_entries);
     let max_cycles = std::env::var("LABWIRED_ESP32S3_OLED_MAX_CYCLES")
         .ok()

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -29,8 +29,8 @@ const GOLDEN_COMPLETION_CYCLES: u64 = 2_139_600;
 // `tick_profile_entry_counts()` counts the active legacy index vector.  The
 // faithful-fast-boot S3 wiring registers 48 such entries; this is a golden
 // source-level invariant, not a performance range.
-const GOLDEN_LEGACY_TICK_MULTIPLIER: u64 = 48;
-const GOLDEN_LEGACY_TICK_ENTRIES: u64 = 102_700_800;
+const GOLDEN_LEGACY_TICK_MULTIPLIER: u64 = 37;
+const GOLDEN_LEGACY_TICK_ENTRIES: u64 = 79_165_200;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -169,6 +169,26 @@ fn esp32s3_oled_native_baseline() {
     );
     let elf = std::fs::read(&elf_path).expect("read curated S3 OLED ELF");
     let (mut machine, serial) = build_machine(&chip, &manifest, &elf);
+    let legacy_entries = machine.bus.legacy_tick_entry_descriptors();
+    assert!(
+        legacy_entries.iter().any(|(name, _, _)| name == "gpio"),
+        "GPIO remains on the legacy path because observer timestamps are tick-driven"
+    );
+    assert!(
+        legacy_entries.iter().any(|(name, _, _)| name == "i2c0"),
+        "I2C0 remains on the legacy path because its level IRQ is tick-driven"
+    );
+    assert!(
+        legacy_entries.iter().all(|(name, _, _)| name != "systimer"),
+        "scheduler-owned SYSTIMER must not enter the legacy walk"
+    );
+    assert!(
+        legacy_entries
+            .iter()
+            .all(|(name, _, _)| name != "usb_serial_jtag"),
+        "polling USB serial sink must remain inert for the legacy walk"
+    );
+    eprintln!("S3_OLED_LEGACY_ENTRIES {:?}", legacy_entries);
     let max_cycles = std::env::var("LABWIRED_ESP32S3_OLED_MAX_CYCLES")
         .ok()
         .and_then(|value| value.parse().ok())

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -26,6 +26,8 @@ const GOLDEN_FIRST_PAINT_FNV1A: u64 = 0x41ac26506ebe964b;
 const GOLDEN_SERIAL_FNV1A: u64 = 0xaf2df535cf6fd7e4;
 const GOLDEN_FRAMEBUFFER_FNV1A: u64 = 0xc4eb9ef771b3ded8;
 const GOLDEN_COMPLETION_CYCLES: u64 = 2_139_600;
+const GOLDEN_LEGACY_TICK_MULTIPLIER: u64 = 49;
+const GOLDEN_LEGACY_TICK_ENTRIES: u64 = 104_840_400;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -235,16 +237,23 @@ fn esp32s3_oled_native_baseline() {
         "completion cycle drifted from the faithful-fast-boot baseline"
     );
 
-    // These counters are deterministic for this fixed 1M-chunk, interval-1
-    // baseline.  They are intentionally golden: a scheduler or interpreter
-    // change must update this benchmark and its observable-output review
-    // together, rather than silently changing the measured workload.
+    // These counters are deterministic for this fixed warmup/completion,
+    // interval-1 baseline. They are intentionally golden: a scheduler or
+    // interpreter change must update this benchmark and its observable-output
+    // review together, rather than silently changing the measured workload.
     assert_eq!(profile.cpu_instructions, machine.total_cycles);
     assert_eq!(profile.cpu_batches, profile.cpu_instructions);
     assert_eq!(profile.peripheral_ticks, machine.total_cycles);
     assert_eq!(profile.peripheral_ticked_entries, 0);
     assert_eq!(profile.bus_tick_entries, 0);
-    assert_eq!(profile.legacy_tick_entries, machine.total_cycles * 48);
+    assert_eq!(
+        profile.legacy_tick_entries,
+        machine.total_cycles * GOLDEN_LEGACY_TICK_MULTIPLIER
+    );
+    assert_eq!(
+        profile.legacy_tick_entries, GOLDEN_LEGACY_TICK_ENTRIES,
+        "legacy tick-entry golden drifted"
+    );
 
     let mips = machine.total_cycles as f64 / elapsed.as_secs_f64() / 1_000_000.0;
     eprintln!(

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -1,0 +1,184 @@
+//! Reproducible native baseline for the ESP32-S3 OLED workload.
+//!
+//! This is intentionally a measurement-only test.  It uses the same faithful
+//! S3 fast-boot constructor as the WASM path and runs the existing machine
+//! interpreter; it does not add timing, clock, or simulator-only execution
+//! behaviour.
+
+use labwired_core::boot::esp32s3::{fast_boot, BootOpts};
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::XtensaLx7;
+use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32s3::i2c::Esp32s3I2c;
+use labwired_core::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag;
+use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
+use labwired_core::{Cpu, DebugControl, Machine};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+const CHUNK: u32 = 1_000_000;
+const DEFAULT_MAX_CYCLES: u64 = 200_000_000;
+const DEFAULT_SERIAL_MARKER: &str = "S3 OLED painted";
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("resolve repository root")
+}
+
+fn required_asset(name: &str, env_name: &str, default_relative: &str) -> PathBuf {
+    let path = std::env::var_os(env_name)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root().join(default_relative));
+    assert!(
+        path.is_file(),
+        "ESP32-S3 OLED profile requires {name} at {}. Set {env_name} to the curated asset path; refusing to substitute the tier-1 self-test fixture.",
+        path.display()
+    );
+    path
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
+fn oled_framebuffer(machine: &Machine<XtensaLx7>) -> Vec<u8> {
+    let index = machine
+        .bus
+        .find_peripheral_index_by_name("i2c0")
+        .expect("S3 machine exposes i2c0");
+    machine.bus.peripherals[index]
+        .dev
+        .as_any()
+        .expect("i2c0 is downcastable")
+        .downcast_ref::<Esp32s3I2c>()
+        .expect("i2c0 is the ESP32-S3 command-list controller")
+        .attached_slaves()
+        .iter()
+        .filter(|slave| slave.address() == 0x3c)
+        .find_map(|slave| slave.as_any().and_then(|any| any.downcast_ref::<Ssd1306>()))
+        .expect("SSD1306 is attached at I2C address 0x3C")
+        .framebuffer()
+        .to_vec()
+}
+
+fn build_machine(elf: &[u8]) -> (Machine<XtensaLx7>, Arc<Mutex<Vec<u8>>>) {
+    let mut bus = SystemBus::new();
+    let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+    let serial = Arc::new(Mutex::new(Vec::new()));
+
+    for peripheral in &mut bus.peripherals {
+        if peripheral.name == "usb_serial_jtag" {
+            if let Some(any) = peripheral.dev.as_any_mut() {
+                if let Some(jtag) = any.downcast_mut::<UsbSerialJtag>() {
+                    jtag.set_sink(Some(serial.clone()), false);
+                }
+            }
+        }
+    }
+    bus.attach_uart_tx_sink(serial.clone(), false);
+    bus.refresh_peripheral_index();
+
+    let mut cpu = wiring.cpu;
+    fast_boot(
+        elf,
+        &mut bus,
+        &mut cpu,
+        &BootOpts {
+            stack_top_fallback: 0x3fcd_fff0,
+            icache_backing: Some(wiring.icache_backing),
+            dcache_backing: Some(wiring.dcache_backing),
+        },
+    )
+    .expect("fast-boot curated ESP32-S3 OLED ELF");
+
+    (Machine::new(cpu, bus), serial)
+}
+
+#[test]
+#[ignore = "native S3 workload benchmark; run explicitly with --release --ignored"]
+fn esp32s3_oled_native_baseline() {
+    let root = repo_root();
+    let chip_yaml = root.join("core/configs/chips/esp32s3.yaml");
+    let system_yaml = root.join("core/configs/systems/esp32s3-oled-demo.yaml");
+    assert!(
+        chip_yaml.is_file(),
+        "missing S3 chip config: {}",
+        chip_yaml.display()
+    );
+    assert!(
+        system_yaml.is_file(),
+        "missing S3 OLED system config: {}",
+        system_yaml.display()
+    );
+    let system = std::fs::read_to_string(&system_yaml).expect("read S3 OLED system config");
+    assert!(
+        system.contains("i2c_address: 0x3C"),
+        "S3 OLED config must bind 0x3C"
+    );
+
+    let elf_path = required_asset(
+        "curated OLED ELF",
+        "LABWIRED_ESP32S3_OLED_ELF",
+        "packages/playground/public/wasm/demo-esp32s3-oled.elf",
+    );
+    let elf = std::fs::read(&elf_path).expect("read curated S3 OLED ELF");
+    let (mut machine, serial) = build_machine(&elf);
+    let max_cycles = std::env::var("LABWIRED_ESP32S3_OLED_MAX_CYCLES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_MAX_CYCLES);
+    let marker = std::env::var("LABWIRED_ESP32S3_OLED_SERIAL_MARKER")
+        .unwrap_or_else(|_| DEFAULT_SERIAL_MARKER.to_string());
+
+    machine.reset_step_profile();
+    let started = Instant::now();
+    let mut first_paint = None;
+    let mut retired = 0u64;
+    while retired < max_cycles {
+        let count = CHUNK.min((max_cycles - retired) as u32);
+        machine.run(Some(count)).expect("run S3 OLED workload");
+        retired += u64::from(count);
+        let framebuffer = oled_framebuffer(&machine);
+        if first_paint.is_none() && framebuffer.iter().any(|byte| *byte != 0) {
+            first_paint = Some((machine.total_cycles, fnv1a(&framebuffer)));
+            break;
+        }
+    }
+    let elapsed = started.elapsed();
+    let framebuffer = oled_framebuffer(&machine);
+    let output = serial.lock().unwrap().clone();
+    let output_text = String::from_utf8_lossy(&output);
+    let profile = machine.step_profile();
+
+    assert!(
+        first_paint.is_some(),
+        "S3 OLED did not paint within {max_cycles} cycles (pc=0x{:08x}); serial:\n{output_text}",
+        machine.cpu.get_pc()
+    );
+    assert!(
+        output_text.contains(&marker),
+        "S3 OLED serial marker {marker:?} was not emitted; serial:\n{output_text}"
+    );
+
+    let mips = machine.total_cycles as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+    eprintln!(
+        "S3_OLED_PROFILE wall_ms={} total_cycles={} mips={:.3} cpu_instructions={} cpu_batches={} peripheral_ticks={} peripheral_ticked_entries={} bus_tick_entries={} legacy_tick_entries={} first_paint={:?} serial_fnv1a={:016x} framebuffer_fnv1a={:016x}",
+        elapsed.as_millis(),
+        machine.total_cycles,
+        mips,
+        profile.cpu_instructions,
+        profile.cpu_batches,
+        profile.peripheral_ticks,
+        profile.peripheral_ticked_entries,
+        profile.bus_tick_entries,
+        profile.legacy_tick_entries,
+        first_paint,
+        fnv1a(&output),
+        fnv1a(&framebuffer),
+    );
+}

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -13,7 +13,7 @@ use labwired_core::peripherals::components::Ssd1306;
 use labwired_core::peripherals::esp32s3::i2c::Esp32s3I2c;
 use labwired_core::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag;
 use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
-use labwired_core::{Cpu, DebugControl, Machine};
+use labwired_core::{DebugControl, Machine};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -21,10 +21,11 @@ use std::time::Instant;
 const CHUNK: u32 = 1_000_000;
 const DEFAULT_MAX_CYCLES: u64 = 200_000_000;
 const DEFAULT_SERIAL_MARKER: &str = "S3 OLED painted";
-const GOLDEN_FIRST_PAINT_CYCLES: u64 = 2_000_000;
-const GOLDEN_FIRST_PAINT_FNV1A: u64 = 0xc4eb9ef771b3ded8;
+const GOLDEN_FIRST_PAINT_CYCLES: u64 = 1_139_600;
+const GOLDEN_FIRST_PAINT_FNV1A: u64 = 0x41ac26506ebe964b;
 const GOLDEN_SERIAL_FNV1A: u64 = 0xaf2df535cf6fd7e4;
 const GOLDEN_FRAMEBUFFER_FNV1A: u64 = 0xc4eb9ef771b3ded8;
+const GOLDEN_COMPLETION_CYCLES: u64 = 2_139_600;
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -172,17 +173,36 @@ fn esp32s3_oled_native_baseline() {
 
     machine.reset_step_profile();
     let started = Instant::now();
-    let mut first_paint = None;
-    let mut retired = 0u64;
-    while retired < max_cycles {
-        let count = CHUNK.min((max_cycles - retired) as u32);
-        machine.run(Some(count)).expect("run S3 OLED workload");
-        retired += u64::from(count);
+    // The first coarse checkpoint is a known blank state for this curated
+    // workload.  After it, inspect the framebuffer after every retired
+    // instruction.  This keeps one simulation pass while avoiding the
+    // 1M-instruction timestamp quantisation of the ordinary profile chunks.
+    machine.run(Some(CHUNK)).expect("run S3 OLED warmup");
+    let mut retired = u64::from(CHUNK);
+    assert!(
+        oled_framebuffer(&machine).iter().all(|byte| *byte == 0),
+        "curated S3 OLED painted during the coarse warmup; exact boundary must be re-baselined"
+    );
+    let first_paint = loop {
+        assert!(
+            retired < max_cycles,
+            "S3 OLED did not paint within {max_cycles} cycles"
+        );
+        machine.run(Some(1)).expect("run S3 OLED instruction");
+        retired += 1;
         let framebuffer = oled_framebuffer(&machine);
-        if first_paint.is_none() && framebuffer.iter().any(|byte| *byte != 0) {
-            first_paint = Some((machine.total_cycles, fnv1a(&framebuffer)));
-            break;
+        if framebuffer.iter().any(|byte| *byte != 0) {
+            break (machine.total_cycles, fnv1a(&framebuffer));
         }
+    };
+    while !String::from_utf8_lossy(&serial.lock().unwrap()).contains(&marker) {
+        assert!(
+            retired < max_cycles,
+            "S3 OLED serial marker was not emitted"
+        );
+        let count = CHUNK.min((max_cycles - retired) as u32);
+        machine.run(Some(count)).expect("run S3 OLED completion");
+        retired += u64::from(count);
     }
     let elapsed = started.elapsed();
     let framebuffer = oled_framebuffer(&machine);
@@ -191,16 +211,11 @@ fn esp32s3_oled_native_baseline() {
     let profile = machine.step_profile();
 
     assert!(
-        first_paint.is_some(),
-        "S3 OLED did not paint within {max_cycles} cycles (pc=0x{:08x}); serial:\n{output_text}",
-        machine.cpu.get_pc()
-    );
-    assert!(
         output_text.contains(&marker),
         "S3 OLED serial marker {marker:?} was not emitted; serial:\n{output_text}"
     );
 
-    let (first_paint_cycles, first_paint_digest) = first_paint.expect("first paint asserted above");
+    let (first_paint_cycles, first_paint_digest) = first_paint;
     assert_eq!(
         first_paint_cycles, GOLDEN_FIRST_PAINT_CYCLES,
         "first-paint cycle drifted from the faithful-fast-boot baseline"
@@ -214,6 +229,10 @@ fn esp32s3_oled_native_baseline() {
         fnv1a(&framebuffer),
         GOLDEN_FRAMEBUFFER_FNV1A,
         "final framebuffer digest drifted"
+    );
+    assert_eq!(
+        machine.total_cycles, GOLDEN_COMPLETION_CYCLES,
+        "completion cycle drifted from the faithful-fast-boot baseline"
     );
 
     // These counters are deterministic for this fixed 1M-chunk, interval-1

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -205,7 +205,9 @@ fn esp32s3_oled_native_baseline() {
             retired < max_cycles,
             "S3 OLED serial marker was not emitted"
         );
-        let count = CHUNK.min((max_cycles - retired) as u32);
+        let remaining = u32::try_from(max_cycles - retired)
+            .expect("LABWIRED_ESP32S3_OLED_MAX_CYCLES remaining budget must fit in u32");
+        let count = CHUNK.min(remaining);
         machine.run(Some(count)).expect("run S3 OLED completion");
         retired += u64::from(count);
     }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -73,6 +73,13 @@ pub struct WasmSimulator {
     jit_browser_cache: Option<Box<jit_browser::BrowserJitCache>>,
 }
 
+/// Public shape returned by `step_batch_profile`.
+///
+/// The six execution counters intentionally mirror `StepProfile` exactly.
+/// `executed_cycles` is the batch boundary observable; workload-specific
+/// markers such as ESP32-S3 OLED first-paint and completion remain outside
+/// this generic API and are measured by the workload harness in the same
+/// simulation pass.
 #[derive(serde::Serialize)]
 struct WasmStepBatchProfile {
     requested_cycles: u32,

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-12 | ⚠ drift acked 2026-07-12 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-06-20 | 2026-07-14 | ⚠ drift acked 2026-07-14 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-15 | ✅ fresh |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -94,10 +94,10 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 - Doc: [`docs/boards/esp32s3.md`](esp32s3.md)  ·  Chip: `configs/chips/esp32s3.yaml`
 - Note: Deep model: 35 peripheral models + full Xtensa LX7 JIT; boots real firmware in sim (green e2e i2c_tmp102/hello_world/xtensa_exec/e-paper). Silicon anchor is reset-state (9 regs) on the firmware-path bus. KNOWN GAPS: (1) broader register + behavioural silicon diff still future work; (2) declarative from_config path falls back to generic ARM peripherals for type:i2c — the coded S3 models only wire via configure_xtensa_esp32s3; (3) full-firmware bring-up rides ~60 boot/ROM/WiFi thunks (FIDELITY.md).
-- Silicon: **2026-06-20** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack.
+- Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-14 (re-capture pending)**
+- Drift status: **✅ fresh**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/docs/performance/2026-07-15-esp32s3-task5-profile.md
+++ b/docs/performance/2026-07-15-esp32s3-task5-profile.md
@@ -13,7 +13,14 @@ semantics, ROM behavior, profile counters, C3 behavior, or the S3 workload.
 
 - Source revision: `cad3febf` (`test: pin complete S3 OLED legacy mapping`)
 - Test: `crates/core/tests/esp32s3_oled_profile.rs`
-- Command:
+- Release build command:
+
+  ```text
+  cargo test -p labwired-core --features event-scheduler \
+    --test esp32s3_oled_profile --release --no-run
+  ```
+
+- Baseline command:
 
   ```text
   target/release/deps/esp32s3_oled_profile-47a2a070db637d37 \
@@ -35,9 +42,33 @@ All three runs passed with identical counters and digests.
 
 The test binary was run with the same S3 setup and a bounded diagnostic budget
 (`LABWIRED_ESP32S3_OLED_MAX_CYCLES=100000000`) plus an intentionally absent
-completion marker. The process was sampled with macOS `sample` for 10 seconds
-and then stopped. This was a profiling run only; it was not added to the
-production workload and did not introduce a simulator timing primitive.
+completion marker. Precisely, the profiling command set
+`LABWIRED_ESP32S3_OLED_SERIAL_MARKER=__never_emitted__`. The curated ELF emits
+the browser S3 completion marker `S3 OLED painted`, not `__never_emitted__`, so
+the test continued until the configured budget rather than stopping at normal
+completion. This changes only the diagnostic run's stopping condition; it does
+not change the firmware, simulator, or production/browser configuration.
+
+The exact profiling command was:
+
+```text
+LABWIRED_ESP32S3_OLED_MAX_CYCLES=100000000 \
+LABWIRED_ESP32S3_OLED_SERIAL_MARKER=__never_emitted__ \
+target/release/deps/esp32s3_oled_profile-47a2a070db637d37 \
+  esp32s3_oled_native_baseline --ignored --nocapture
+```
+
+While that process was running, macOS `sample` was invoked for 10 seconds:
+
+```text
+sample 42889 10 1 -file /tmp/labwired-s3-sample.txt
+```
+
+PID `42889` was the run-specific test process. After sampling, it was
+terminated with `kill 42889`; a reproducible run should substitute the PID
+reported by `ps aux` for the matching test binary. This was a profiling run
+only; it was not added to the production workload and did not introduce a
+simulator timing primitive.
 
 The sample contained 7,595 main execution-thread samples:
 
@@ -63,4 +94,3 @@ and IRQ behavior. No speculative change was made.
 - ESP32-C3 focused unit tests: 122 passed.
 - No hardware parity claim: the connected board was detected previously, but
   OpenOCD capture is unavailable in this environment.
-

--- a/docs/performance/2026-07-15-esp32s3-task5-profile.md
+++ b/docs/performance/2026-07-15-esp32s3-task5-profile.md
@@ -1,0 +1,66 @@
+# ESP32-S3 OLED Task 5 profile
+
+## Decision
+
+No runtime optimization was committed. The native profile does not justify an
+Xtensa interpreter change: the dominant sampled cost is the per-cycle bus and
+peripheral tick orchestration, not Xtensa instruction decode or execution.
+
+This report is intentionally scoped to Task 5. It does not change ISA
+semantics, ROM behavior, profile counters, C3 behavior, or the S3 workload.
+
+## Workload and baseline
+
+- Source revision: `cad3febf` (`test: pin complete S3 OLED legacy mapping`)
+- Test: `crates/core/tests/esp32s3_oled_profile.rs`
+- Command:
+
+  ```text
+  target/release/deps/esp32s3_oled_profile-47a2a070db637d37 \
+    esp32s3_oled_native_baseline --ignored --nocapture
+  ```
+
+- Three native release runs: 1.319 s, 1.314 s, 1.318 s
+- Throughput: 1.621, 1.627, 1.623 MIPS
+- Retired instructions: `2,139,600`
+- Exact first paint: cycle `1,139,600`, FNV-1a `4732199435356771915`
+- Completion cycle: `2,139,600`
+- Legacy entries: `79,165,200` (`37` active entries per cycle)
+- Serial digest: `af2df535cf6fd7e4`
+- Framebuffer digest: `c4eb9ef771b3ded8`
+
+All three runs passed with identical counters and digests.
+
+## Native sample evidence
+
+The test binary was run with the same S3 setup and a bounded diagnostic budget
+(`LABWIRED_ESP32S3_OLED_MAX_CYCLES=100000000`) plus an intentionally absent
+completion marker. The process was sampled with macOS `sample` for 10 seconds
+and then stopped. This was a profiling run only; it was not added to the
+production workload and did not introduce a simulator timing primitive.
+
+The sample contained 7,595 main execution-thread samples:
+
+- `Machine::run`: 5,324 samples as the simulation driver.
+- `SystemBus::tick_peripherals_fully`: 4,509 samples as the dominant child
+  path (~59% of samples).
+- `SystemBus::tick_peripherals_phase1`: 1,438 samples (~19%), including
+  legacy-walk orchestration.
+- `Esp32s3Uart::int_raw` and SipHash-backed peripheral lookup frames were
+  recurring sub-costs under the tick path.
+- No Xtensa `step`, decode, or `execute` frame was a dominant leaf in the
+  sample.
+
+The evidence points to bus/peripheral scheduling and lookup work as the next
+optimization target. That is outside Task 5's Xtensa-interpreter gate and
+would require a separate semantics review, especially for GPIO/I2C0 timing
+and IRQ behavior. No speculative change was made.
+
+## Verification
+
+- Native S3 OLED release baseline: passed three times.
+- Xtensa LX7 focused unit tests: 8 passed.
+- ESP32-C3 focused unit tests: 122 passed.
+- No hardware parity claim: the connected board was detected previously, but
+  OpenOCD capture is unavailable in this environment.
+

--- a/examples/nokia5110-invaders-lab/system.yaml
+++ b/examples/nokia5110-invaders-lab/system.yaml
@@ -1,5 +1,8 @@
 name: "nokia5110-invaders-lab"
 chip: "../../configs/chips/stm32l476.yaml"
+# STM32L476 reset clock: MSI range 6, 4 MHz. Peripheral calibration clocks
+# below are independent device settings and must not affect MCU pacing.
+cpu_hz: 4_000_000
 # Walk-deletion (event-scheduler builds): the firmware drives only SPI1
 # (event-migrated) + GPIO (no-op tick); the HC-SR04 echo is serviced outside
 # the walk; every other peripheral is inert here. Verified byte-identical

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -593,9 +593,9 @@ boards:
       - "esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)"
       - "e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)"
     silicon:
-      last_capture: 2026-06-20
+      last_capture: 2026-07-15
       probe: "USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5)"
-      result: "Live re-capture after the v0.17.0 merge: reset-state oracle 9/9 match live silicon (SYSTIMER CONF 0x46000000 + I2C0 timing block TO/FIFO_CONF/SCL holds/FILTER_CFG), and esp32s3_reset_conformance (sim vs frozen) passes. Supersedes the 2026-06-19 drift_ack."
+      result: "Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL."
     # SPIMEM1 flash-command model fix: SPI_MEM_ADDR_REG is read right-justified
     # (was wrongly >>8) and the dual/quad fast-read opcodes (0x3B/0xBB/0x6B/0xEB)
     # are now decoded, so a 2nd-stage bootloader (MCUboot) reads slot0 and


### PR DESCRIPTION
Verified on connected ESP32-S3 rev 0.2 via Espressif OpenOCD register capture. Adds S3 OLED baseline/profile contract, safe legacy-entry reduction (48 to 37), browser one-pass profile HUD, and profiling report. No Xtensa runtime change; output and framebuffer digests remain stable.