### PR TITLE
perf(esp32c3): stop uart0 waking the scheduler every cycle (12.2x on the shipped lab) + unified machine advance

### DIFF
--- a/crates/core/src/bus/construct.rs
+++ b/crates/core/src/bus/construct.rs
@@ -97,6 +97,7 @@ impl SystemBus {
             esp32s3_asserted_sources: [0; 2],
             esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
+            iolink_master_attached: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
@@ -161,6 +162,7 @@ impl SystemBus {
             esp32s3_asserted_sources: [0; 2],
             esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
+            iolink_master_attached: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,
@@ -202,6 +204,8 @@ impl SystemBus {
         // bus's shared cycle clock before it is registered, so read-side lazy
         // sync is available from the first instruction.
         dev.attach_cycle_clock(self.cycle_clock.clone());
+        // Twin of the `push_peripheral` attach — see there.
+        dev.attach_irq_line(irq);
         self.peripherals.push(PeripheralEntry {
             name: name.to_string(),
             base,
@@ -534,6 +538,10 @@ impl SystemBus {
         // models (SysTick et al.) get read-side lazy sync too. No-op for the
         // vast majority of models (the default `attach_cycle_clock` discards).
         dev.attach_cycle_clock(self.cycle_clock.clone());
+        // Same choke point, same contract: tell the model whether its own-IRQ is
+        // wired, so one whose only per-cycle wakeup holds a level-triggered IRQ
+        // can stop scheduling itself on a bus where that pend is dropped.
+        dev.attach_irq_line(p_cfg.irq);
         self.peripherals.push(PeripheralEntry {
             name: p_cfg.id.clone(),
             base: p_cfg.base_address,

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -94,6 +94,7 @@ impl SystemBus {
             esp32s3_asserted_sources: [0; 2],
             esp32s3_sched_asserted_sources: [0; 2],
             flash_models_ops: false,
+            iolink_master_attached: false,
             nordic_gpio_service: false,
             hcsr04_scheduling_disabled: false,
             flash_error_flags_idx: None,

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -374,6 +374,23 @@ pub struct SystemBus {
     /// `requires_cycle_accurate` — called per run-loop iteration — never scans
     /// peripherals. `false` on every bus without an H5 op-modeling FLASH.
     flash_models_ops: bool,
+    /// True when an IO-Link master peer is attached to any UART on this bus
+    /// (see [`SystemBus::has_iolink_master`]). Cached because the underlying
+    /// probe is a NESTED scan — every peripheral, `as_any` + downcast to
+    /// `Uart`, then every UART's `attached_streams` downcast to `IolinkMaster`
+    /// — while `requires_cycle_accurate` consults it per batch plan
+    /// (`machine/plan.rs`), per step (`cpu/riscv.rs`) and in the idle
+    /// fast-forward check (`lib.rs`). Uncached it cost ~55% of wall on the
+    /// shipped ESP32-C3 lab purely to answer "no".
+    ///
+    /// Staleness contract: recomputed by `rebuild_peripheral_ranges` (which
+    /// every peripheral-set mutation funnels through, incl. `add_peripheral`)
+    /// AND by `attach_uart_stream_by_id`, the only post-build seam that appends
+    /// to a UART's `attached_streams`. Code that mutates the `pub peripherals`
+    /// vector or a UART's streams by hand must call `refresh_peripheral_index`
+    /// to re-derive it — the same contract already carried by `flash_models_ops`
+    /// and `dport_idx`/`rcc_idx`. `bus/tests_main.rs` pins every path.
+    iolink_master_attached: bool,
     /// Cached in `rebuild_peripheral_ranges`: true when a Nordic `gpio0`/`gpio1`
     /// port is present, so the per-cycle tick runs the GPIO-edge/GPIOTE service
     /// pass. Lets `tick_peripherals_fully` decide in O(1) whether the walk-free

--- a/crates/core/src/bus/policy.rs
+++ b/crates/core/src/bus/policy.rs
@@ -41,6 +41,17 @@ impl SystemBus {
     /// layer, an invariant that only holds at batch size 1. Without this the
     /// CLI/batch run path would record the op in the FLASH cell but never apply
     /// it (no 0xFF fill, no bank swap, no reset).
+    ///
+    /// HOT: called per batch plan (`machine/plan.rs`), per interpreted step
+    /// (`cpu/riscv.rs`) and in the idle fast-forward check (`lib.rs`), so every
+    /// clause must be O(1). Two of the three read bools cached at bus
+    /// build/mutation (`iolink_master_attached`, `flash_models_ops`); the
+    /// HC-SR04 clause is deliberately NOT cached because it is run-dynamic —
+    /// `hcsr04_event_scheduled` gates on `config.peripheral_tick_interval`,
+    /// which the wasm engine (`set_peripheral_tick_interval`) and the
+    /// differential tests change after build. It stays cheap on its own terms:
+    /// a `Vec::is_empty` plus a few bool/int reads, no scan and no downcast.
+    #[inline]
     pub fn requires_cycle_accurate(&self) -> bool {
         let hcsr04_needs_cycle_accurate = !self.hcsr04.is_empty() && !self.hcsr04_event_scheduled();
         hcsr04_needs_cycle_accurate || self.has_iolink_master() || self.flash_models_ops
@@ -140,8 +151,26 @@ impl SystemBus {
     /// inter-frame gap. Under instruction batching the UART would tick only once
     /// per ~10k-instruction batch, stretching the handshake to hundreds of
     /// millions of steps; ticking per instruction keeps it well within the
-    /// runner's step budget. Cheap: called once at loop setup.
+    /// runner's step budget.
+    ///
+    /// O(1): reads the `iolink_master_attached` bool cached at every
+    /// peripheral-set mutation (`rebuild_peripheral_ranges`) and at the
+    /// post-build stream seam (`attach_uart_stream_by_id`); the nested scan
+    /// itself lives in [`Self::scan_iolink_master`]. This is NOT a
+    /// once-at-setup predicate — an earlier doc comment claimed so and was
+    /// wrong: `requires_cycle_accurate` calls it per batch plan
+    /// (`machine/plan.rs`), per step (`cpu/riscv.rs`) and in the idle
+    /// fast-forward check (`lib.rs`), so the scan ran millions of times per
+    /// run and dominated the profile of buses with no IO-Link at all.
+    #[inline]
     pub(crate) fn has_iolink_master(&self) -> bool {
+        self.iolink_master_attached
+    }
+
+    /// The authoritative nested scan behind `iolink_master_attached`. Only the
+    /// cache-refresh points call this; every hot-path reader goes through
+    /// [`Self::has_iolink_master`].
+    pub(crate) fn scan_iolink_master(&self) -> bool {
         use crate::peripherals::components::IolinkMaster;
         for p in &self.peripherals {
             let Some(any) = p.dev.as_any() else { continue };

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -196,6 +196,13 @@ impl SystemBus {
                 .and_then(|a| a.downcast_ref::<crate::peripherals::flash::Flash>())
                 .is_some_and(|f| f.models_ops())
         });
+        // Cache whether an IO-Link master is attached to any UART. The probe is
+        // a nested scan (peripherals → downcast Uart → streams → downcast
+        // IolinkMaster), and `requires_cycle_accurate` asks per batch plan, per
+        // step and per idle-FF check — so it is answered from this bool instead
+        // of walking the bus every time. `attach_uart_stream_by_id` refreshes it
+        // too: it is the only post-build path that appends a UART stream.
+        self.iolink_master_attached = self.scan_iolink_master();
         // Cache the index of a FLASH peripheral whose opt-in H5 program-error
         // gate is on, so the flash-region write path can validate programs
         // without scanning. `None` (gate off) ⇒ that path is unchanged.
@@ -542,6 +549,13 @@ impl SystemBus {
             .ok_or_else(|| anyhow::anyhow!("peripheral '{uart_id}' is not a UART"))?;
         uart.set_sink(None, false);
         uart.attach_stream(dev);
+        // This is the one post-build path that appends to a UART's
+        // `attached_streams`, so the `iolink_master_attached` cache that
+        // `requires_cycle_accurate` reads would otherwise go stale here — a
+        // stale `false` would batch a bus that must run cycle-accurate and
+        // silently change IO-Link timing. Re-derive it from the streams we just
+        // mutated. Cheap: attaching is a wiring-time operation, not a hot path.
+        self.iolink_master_attached = self.scan_iolink_master();
         Ok(())
     }
 

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -2185,6 +2185,7 @@ fn test_flash_boot_alias_read_and_write() {
         esp32s3_asserted_sources: [0; 2],
         esp32s3_sched_asserted_sources: [0; 2],
         flash_models_ops: false,
+        iolink_master_attached: false,
         nordic_gpio_service: false,
         hcsr04_scheduling_disabled: false,
         flash_error_flags_idx: None,
@@ -2273,6 +2274,7 @@ fn h5_flash_bus(gate: bool) -> SystemBus {
         esp32s3_asserted_sources: [0; 2],
         esp32s3_sched_asserted_sources: [0; 2],
         flash_models_ops: false,
+        iolink_master_attached: false,
         nordic_gpio_service: false,
         hcsr04_scheduling_disabled: false,
         flash_error_flags_idx: None,
@@ -2512,6 +2514,7 @@ fn h5_rww_bus(gate: bool) -> SystemBus {
         esp32s3_asserted_sources: [0; 2],
         esp32s3_sched_asserted_sources: [0; 2],
         flash_models_ops: false,
+        iolink_master_attached: false,
         nordic_gpio_service: false,
         hcsr04_scheduling_disabled: false,
         flash_error_flags_idx: None,
@@ -2750,6 +2753,7 @@ fn test_peripheral_range_index_lookup() {
         esp32s3_asserted_sources: [0; 2],
         esp32s3_sched_asserted_sources: [0; 2],
         flash_models_ops: false,
+        iolink_master_attached: false,
         nordic_gpio_service: false,
         hcsr04_scheduling_disabled: false,
         flash_error_flags_idx: None,
@@ -2842,6 +2846,7 @@ fn test_dma_tick_executes_copy_and_raises_irq() {
         esp32s3_asserted_sources: [0; 2],
         esp32s3_sched_asserted_sources: [0; 2],
         flash_models_ops: false,
+        iolink_master_attached: false,
         nordic_gpio_service: false,
         hcsr04_scheduling_disabled: false,
         flash_error_flags_idx: None,
@@ -3594,4 +3599,73 @@ fn uds_tester_expect_nrc_negative_response_completes() {
     inject_ecu_reply(&mut bus, 0x222, &[0x03, 0x7F, 0x2E, 0x31]);
     bus.service_can_uds_testers();
     assert_eq!(bus.can_uds_testers[0].state, CanUdsTesterState::Done);
+}
+
+/// The `iolink_master_attached` cache backing `has_iolink_master` (and thus
+/// `requires_cycle_accurate`, which the run loop consults per batch plan / per
+/// step / per idle-FF check) must never disagree with the authoritative
+/// `scan_iolink_master` nested scan. A stale `false` would let a bus that must
+/// run cycle-accurate be batched, silently changing IO-Link timing — a fidelity
+/// break, not a perf regression. Pin every mutation path that can flip it.
+#[test]
+fn iolink_master_cache_tracks_every_mutation_path() {
+    use crate::peripherals::components::{IolinkComSpeed, IolinkMaster};
+
+    // Empty bus: nothing attached, nothing to find.
+    let mut bus = SystemBus::empty();
+    assert_eq!(bus.has_iolink_master(), bus.scan_iolink_master());
+    assert!(!bus.has_iolink_master());
+
+    // `add_peripheral` funnels through `rebuild_peripheral_ranges`. A plain
+    // UART carries no master, so the answer stays false.
+    bus.add_peripheral(
+        "uart0",
+        0x4000_0000,
+        0x1000,
+        None,
+        Box::new(crate::peripherals::uart::Uart::new()),
+    );
+    assert_eq!(bus.has_iolink_master(), bus.scan_iolink_master());
+    assert!(!bus.has_iolink_master());
+    assert!(!bus.requires_cycle_accurate());
+
+    // THE STALENESS SEAM: the post-build stream attach. This mutates a UART's
+    // `attached_streams` without touching the peripheral SET, so nothing else
+    // would rebuild the cache.
+    bus.attach_uart_stream_by_id(
+        "uart0",
+        Box::new(IolinkMaster::new(1, 1, IolinkComSpeed::Com2)),
+    )
+    .expect("attach IO-Link master to uart0");
+    assert_eq!(
+        bus.has_iolink_master(),
+        bus.scan_iolink_master(),
+        "attach_uart_stream_by_id must refresh the iolink cache"
+    );
+    assert!(bus.has_iolink_master());
+    assert!(
+        bus.requires_cycle_accurate(),
+        "an attached IO-Link master must force cycle-accurate execution"
+    );
+
+    // A later peripheral-set mutation re-derives the cache; it must not clobber
+    // the master discovered through the stream seam back to false.
+    bus.add_peripheral(
+        "uart1",
+        0x4000_1000,
+        0x1000,
+        None,
+        Box::new(crate::peripherals::uart::Uart::new()),
+    );
+    assert_eq!(bus.has_iolink_master(), bus.scan_iolink_master());
+    assert!(
+        bus.has_iolink_master(),
+        "rebuild_peripheral_ranges must not lose the attached master"
+    );
+
+    // `refresh_peripheral_index` is the documented escape hatch for code that
+    // mutates the `pub peripherals` vector by hand.
+    bus.refresh_peripheral_index();
+    assert_eq!(bus.has_iolink_master(), bus.scan_iolink_master());
+    assert!(bus.has_iolink_master());
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -776,6 +776,23 @@ pub trait Peripheral: std::fmt::Debug + Send {
     /// buses that bypass `add_peripheral` keep the old exact semantics.
     fn attach_cycle_clock(&mut self, _clock: CycleClock) {}
 
+    /// Tell the peripheral which NVIC/matrix line it was registered with (the
+    /// `irq` of its `PeripheralEntry`), or `None` when the descriptor wired
+    /// none. Called once at the same attach choke points as
+    /// [`Peripheral::attach_cycle_clock`] (`add_peripheral` / `push_peripheral`).
+    ///
+    /// Exists because [`crate::sched::EventResult::raise_own_irq`] is DROPPED by
+    /// the machine when the entry has no `irq` (`lib.rs`, `apply_event_result`):
+    /// a model whose only reason to wake per cycle is holding a level-triggered
+    /// own-IRQ is doing provably unobservable work on such a bus, and can stop
+    /// scheduling itself. Only the shared `Uart` opts in today.
+    ///
+    /// Default no-op, and the conservative contract matches
+    /// `attach_cycle_clock`: a model that never receives this must assume its
+    /// IRQ *is* wired and keep its legacy wakeup cadence, so hand-built buses
+    /// that bypass the choke points keep the old exact semantics.
+    fn attach_irq_line(&mut self, _irq: Option<u32>) {}
+
     /// Classify an MMIO access at `offset` for host idle/coalesce policy.
     /// Default [`MmioAccessClass::SideEffecting`] — only models that are
     /// proven poll-safe (or proven side-effect-free) override this.

--- a/crates/core/src/peripherals/uart.rs
+++ b/crates/core/src/peripherals/uart.rs
@@ -678,6 +678,33 @@ pub struct Uart {
     /// under the `event-scheduler` feature (flag-off drives via `tick()`).
     #[serde(skip)]
     scheduled: bool,
+    /// Whether this UART was registered with an IRQ line (`PeripheralEntry::irq`).
+    /// Set at the bus attach choke points via `attach_irq_line`.
+    ///
+    /// `true` by DEFAULT — the conservative value. `has_active_work` uses it to
+    /// decide whether holding a level-triggered TXEIE/TCIE is worth a per-cycle
+    /// wakeup: the machine drops `raise_own_irq` when the entry has no `irq`, so
+    /// on such a bus (e.g. the ESP32-C3, whose chip yaml declares `uart0` with no
+    /// `irq:` and whose intmatrix never reads this model — it implements no
+    /// `matrix_irq_sources`) those wakeups are provably unobservable. Defaulting
+    /// to `true` means any bus that bypasses the choke points keeps the exact
+    /// legacy cadence.
+    ///
+    /// ⚠️ `true`-by-default holds only because the CONSTRUCTOR sets it. `Uart`
+    /// derives `Serialize` ALONE — there is no `Deserialize`. If you ever add
+    /// one, `#[serde(skip)]` will populate this from `bool::default()` == FALSE,
+    /// which is the UNSAFE direction: a restored UART would silently stop
+    /// scheduling real IRQ wakeups on buses that DO wire an IRQ (STM32 et al),
+    /// dropping interrupts with no error. Adding `Deserialize` REQUIRES
+    /// `#[serde(skip, default = "…")]` returning `true`. Stale `true` is merely
+    /// slow; stale `false` breaks fidelity.
+    #[serde(skip)]
+    irq_wired: bool,
+    /// Test/differential knob: pin this model to the legacy per-cycle walk
+    /// (`uses_scheduler() == false`). `false` in every real config. See
+    /// [`Uart::force_legacy_walk`].
+    #[serde(skip)]
+    legacy_walk_forced: bool,
 }
 
 impl core::fmt::Debug for Uart {
@@ -727,7 +754,24 @@ impl Uart {
             trace_seq: 0,
             elapsed_us: 0,
             scheduled: false,
+            // Conservative until the bus says otherwise (see `attach_irq_line`).
+            irq_wired: true,
+            legacy_walk_forced: false,
         }
+    }
+
+    /// Test/differential knob: pin the UART to the legacy per-cycle walk
+    /// (`uses_scheduler() == false`), so the bus drives it through `tick()`
+    /// every cycle — the exact pre-scheduler semantics. Used by
+    /// `esp32c3_walk_differential` to build the ground-truth reference config
+    /// from the same bus assembly (mirrors `Esp32c3I2c::force_legacy_walk`).
+    ///
+    /// This is the reference the `has_active_work` IRQ gate is proven against:
+    /// the walk ticks this model every cycle unconditionally, so if skipping
+    /// unobservable scheduler wakeups changed ANY guest-visible byte, the
+    /// walk-on-vs-scheduler differential would diverge.
+    pub fn force_legacy_walk(&mut self) {
+        self.legacy_walk_forced = true;
     }
 
     /// Attach a stream device to the UART RX path.
@@ -747,7 +791,21 @@ impl Uart {
     fn has_active_work(&self) -> bool {
         let txeie_set = (self.cr1 & self.txeie_mask()) != 0 && self.txeie_mask() != 0;
         let tcie_set = (self.cr1 & self.tcie_mask()) != 0 && self.tcie_mask() != 0;
-        txeie_set || tcie_set || !self.attached_streams.is_empty() || self.dma_tx_pending
+        // The TXEIE/TCIE arm's ONLY product is `raise_own_irq` — `advance_one_tick`
+        // feeds it nowhere else, and it mutates no state on this path (the
+        // `elapsed_us`/stream bookkeeping lives behind the `attached_streams`
+        // arm, the DMA signal behind `dma_tx_pending`). The machine DROPS
+        // `raise_own_irq` when the entry carries no `irq` (`apply_event_result`),
+        // so on an IRQ-less bus a wakeup held open by TXEIE/TCIE alone can
+        // neither pend a line nor change a byte: it is unobservable work. Skip
+        // scheduling it there, and keep the exact legacy cadence everywhere the
+        // line is actually wired (`irq_wired` defaults to `true`).
+        //
+        // This narrows WAKEUPS only. Event DELIVERY is untouched: the moment an
+        // MMIO write gives the UART real work (a stream byte to pace, a DMA TX),
+        // `take_scheduled_events` re-arms at the same cycle it always did.
+        let level_irq_observable = self.irq_wired && (txeie_set || tcie_set);
+        level_irq_observable || !self.attached_streams.is_empty() || self.dma_tx_pending
     }
 
     /// Phase 2B.3b: one tick-equivalent of work, shared verbatim by the legacy
@@ -1075,7 +1133,14 @@ impl crate::Peripheral for Uart {
     /// cycle; `take_scheduled_events` / `on_event` drive it instead. With the
     /// feature off this is ignored and `tick()` still runs.
     fn uses_scheduler(&self) -> bool {
-        true
+        !self.legacy_walk_forced
+    }
+
+    /// Record whether a line was wired, so `has_active_work` can tell a
+    /// level-triggered own-IRQ that someone observes from one that the machine
+    /// will drop on the floor. See the field docs on `irq_wired`.
+    fn attach_irq_line(&mut self, irq: Option<u32>) {
+        self.irq_wired = irq.is_some();
     }
 
     /// Hand the bus a single self-perpetuating WAKE event when the UART has
@@ -1531,5 +1596,95 @@ mod v2_irq_gating_tests {
         assert!(uart.tick().irq, "TXEIE must pend");
         uart.write_u32(0x00, 0x2000_004D).unwrap(); // TCIE instead
         assert!(uart.tick().irq, "TCIE must pend");
+    }
+}
+
+/// Wakeup-observability gates: when may a `Uart` hold a per-cycle scheduler
+/// wakeup open just to re-assert a level-triggered own-IRQ?
+#[cfg(test)]
+mod wakeup_observability_tests {
+    use super::*;
+    use crate::Peripheral;
+
+    // ── IRQ-observability gate for the per-cycle wakeup ──────────────────
+    // A `Uart` holding TXEIE/TCIE re-arms a scheduler event EVERY guest cycle
+    // (`reschedule_delay: Some(1)`), which pins the whole machine's batch width
+    // to 1. That is the right thing to do when someone can observe the level:
+    // the machine pends the entry's `irq`. It is pure waste when the entry has
+    // NO irq, because `apply_event_result` drops `raise_own_irq` on the floor —
+    // and on that path `advance_one_tick` mutates nothing either. The ESP32-C3
+    // is exactly that bus (chip yaml declares `uart0` with no `irq:`), where
+    // this cost ~97% of all batch clamps and held the shipped display-workshop
+    // lab at RTF 0.003.
+    //
+    // These pin the decision table so the collapse cannot come back.
+
+    #[test]
+    fn irqless_uart_holding_txeie_schedules_no_wakeups() {
+        let mut uart = Uart::new_with_layout(UartRegisterLayout::Stm32F1);
+        uart.attach_irq_line(None); // the C3 `uart0` case
+        uart.write(0x0C, 1 << 7).unwrap(); // TXEIE
+
+        assert!(
+            uart.take_scheduled_events().is_empty(),
+            "an IRQ-less UART must not arm a per-cycle wakeup for a level nobody \
+             can observe (the machine drops `raise_own_irq` with no entry irq)"
+        );
+        assert!(
+            !uart.has_active_work(),
+            "TXEIE alone is not 'active work' when the own-IRQ is unobservable"
+        );
+    }
+
+    #[test]
+    fn irq_wired_uart_holding_txeie_still_wakes_every_cycle() {
+        let mut uart = Uart::new_with_layout(UartRegisterLayout::Stm32F1);
+        uart.attach_irq_line(Some(37)); // a real NVIC line (e.g. an STM32 lab)
+        uart.write(0x0C, 1 << 7).unwrap(); // TXEIE
+
+        assert_eq!(
+            uart.take_scheduled_events(),
+            vec![(0, UART_WAKE_TOKEN)],
+            "a wired level-triggered IRQ must keep its exact legacy cadence"
+        );
+    }
+
+    #[test]
+    fn uart_defaults_to_wiring_its_irq_when_never_told() {
+        // Buses that bypass the attach choke points (hand-built `PeripheralEntry`
+        // literals) never call `attach_irq_line`. The conservative default must
+        // preserve the legacy cadence — same contract as `attach_cycle_clock`.
+        let mut uart = Uart::new_with_layout(UartRegisterLayout::Stm32F1);
+        uart.write(0x0C, 1 << 7).unwrap(); // TXEIE, no attach_irq_line call
+        assert!(
+            uart.has_active_work(),
+            "without an explicit attach, a UART must assume its IRQ is wired"
+        );
+    }
+
+    #[test]
+    fn irqless_uart_still_wakes_for_real_work() {
+        // The gate narrows ONLY the unobservable-level arm. Anything that
+        // actually mutates state or emits bytes must still be scheduled.
+        struct Silent;
+        impl UartStreamDevice for Silent {
+            fn poll(&mut self, _elapsed_us: u32) -> Option<u8> {
+                None
+            }
+            fn on_tx_byte(&mut self, _byte: u8) {}
+        }
+
+        let mut uart = Uart::new_with_layout(UartRegisterLayout::Stm32F1);
+        uart.attach_irq_line(None);
+        uart.attach_stream(Box::new(Silent));
+        assert!(
+            uart.has_active_work(),
+            "an attached RX stream is real work (byte pacing) regardless of IRQ wiring"
+        );
+        assert_eq!(
+            uart.take_scheduled_events(),
+            vec![(0, UART_WAKE_TOKEN)],
+            "stream pacing must still arm on an IRQ-less bus"
+        );
     }
 }

--- a/crates/core/tests/esp32c3_oled_profile.rs
+++ b/crates/core/tests/esp32c3_oled_profile.rs
@@ -1,0 +1,491 @@
+// THROWAWAY measurement harness — DO NOT COMMIT.
+//! Native profile baseline for the ESP32-C3 OLED lab (the browser fast-start
+//! assembly, verbatim from `esp32c3_walk_differential`'s `build_oled_lab`).
+//!
+//! Measurement only: no semantics change, no timing primitive.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::boot::esp32c3_rom::{
+    build_rom_boot_machine, c3_rom_data_init_writes, inject_rom_regions, RomBootOpts,
+};
+use labwired_core::boot::esp32s3_rom::RomImages;
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::RiscV;
+use labwired_core::memory::ProgramImage;
+use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
+use labwired_core::{Arch, Bus, Cpu, DebugControl, Machine, SimulationObserver};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+const ESP_IMAGE_HEADER_LEN: usize = 24;
+const ESP_IMAGE_MAGIC: u8 = 0xE9;
+
+fn esp32c3_bootloader_image(flash: &[u8]) -> ProgramImage {
+    assert!(flash.len() > ESP_IMAGE_HEADER_LEN, "flash image truncated");
+    assert_eq!(flash[0], ESP_IMAGE_MAGIC, "bad bootloader image magic");
+    let segment_count = flash[1] as usize;
+    let entry = u32::from_le_bytes(flash[4..8].try_into().unwrap()) as u64;
+    let mut program = ProgramImage::new(entry, Arch::RiscV);
+    let mut cursor = ESP_IMAGE_HEADER_LEN;
+    for _ in 0..segment_count {
+        let load_addr = u32::from_le_bytes(flash[cursor..cursor + 4].try_into().unwrap()) as u64;
+        let len = u32::from_le_bytes(flash[cursor + 4..cursor + 8].try_into().unwrap()) as usize;
+        cursor += 8;
+        program.add_segment(load_addr, flash[cursor..cursor + len].to_vec());
+        cursor += len;
+    }
+    program
+}
+
+struct OledLab {
+    machine: Machine<RiscV>,
+    serial: Arc<Mutex<Vec<u8>>>,
+}
+
+/// Verbatim browser fast-start assembly (chip yaml + system yaml + vendored
+/// mask ROM + curated flash, entering at the 2nd-stage bootloader).
+fn build_oled_lab() -> OledLab {
+    let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
+        .expect("load esp32c3 chip yaml");
+    let manifest =
+        SystemManifest::from_file(root().join("../../configs/systems/esp32c3-oled-demo.yaml"))
+            .expect("load esp32c3-oled-demo system yaml");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build oled bus");
+
+    let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
+    let drom = std::fs::read(root().join("roms/esp32c3/esp32c3_drom.bin")).expect("read C3 DROM");
+    // LABWIRED_C3_FLASH lets us point the SAME lab at the flash image the
+    // DEPLOYED playground lab actually ships (demo-esp32c3-display-workshop-flash.bin,
+    // bundled-configs.ts:894) instead of the test fixture — measurement only.
+    let flash_path = std::env::var("LABWIRED_C3_FLASH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| root().join("../wasm/tests/fixtures/esp32c3-oled-demo-flash.bin"));
+    let flash = std::fs::read(&flash_path)
+        .unwrap_or_else(|e| panic!("read C3 flash image {}: {e}", flash_path.display()));
+
+    assert!(
+        inject_rom_regions(
+            &mut bus,
+            &RomImages {
+                irom: irom.clone(),
+                drom
+            }
+        ),
+        "chip yaml must declare the C3 IROM region"
+    );
+    for (dst, bytes) in c3_rom_data_init_writes(&irom) {
+        for (i, b) in bytes.iter().enumerate() {
+            let _ = bus.write_u8(dst as u64 + i as u64, *b);
+        }
+    }
+
+    let serial = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(serial.clone(), false);
+
+    let bootloader = esp32c3_bootloader_image(&flash);
+    let mut machine = build_rom_boot_machine(
+        bus,
+        flash,
+        RomBootOpts {
+            efuse_mac: None,
+            usb_serial_sink: None,
+        },
+        |c| c,
+    );
+
+    for segment in &bootloader.segments {
+        if machine.bus.flash.load_from_segment(segment)
+            || machine.bus.ram.load_from_segment(segment)
+            || machine
+                .bus
+                .extra_mem
+                .iter_mut()
+                .any(|m| m.load_from_segment(segment))
+        {
+            continue;
+        }
+        for (i, byte) in segment.data.iter().enumerate() {
+            machine
+                .bus
+                .write_u8(segment.start_addr + i as u64, *byte)
+                .expect("load bootloader segment");
+        }
+    }
+    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    machine.cpu.set_sp(sp_top & !0xF);
+    machine.cpu.set_pc(bootloader.entry_point as u32);
+
+    // EXACT browser policy: `apply_browser_c3_policy` (crates/wasm/src/lib.rs:1948)
+    // = recommended tick interval + idle fast-forward on.
+    let rec = std::env::var("LABWIRED_C3_TICK")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| machine.bus.max_safe_tick_interval());
+    machine.config.peripheral_tick_interval = rec;
+    machine.bus.config.peripheral_tick_interval = rec;
+    machine.config.idle_fast_forward_enabled =
+        std::env::var("LABWIRED_C3_IDLE_FF").as_deref() != Ok("0");
+
+    OledLab { machine, serial }
+}
+
+fn ssd1306_framebuffer(machine: &Machine<RiscV>) -> Vec<u8> {
+    let idx = machine
+        .bus
+        .find_peripheral_index_by_name("i2c0")
+        .expect("oled bus exposes i2c0");
+    machine.bus.peripherals[idx]
+        .dev
+        .as_any()
+        .expect("i2c0 downcastable")
+        .downcast_ref::<Esp32c3I2c>()
+        .expect("i2c0 is the C3 command-list controller")
+        .attached_slaves()
+        .iter()
+        .filter(|d| d.address() == 0x3C)
+        .find_map(|d| d.as_any().and_then(|a| a.downcast_ref::<Ssd1306>()))
+        .expect("SSD1306 attached at 0x3C")
+        .framebuffer()
+        .to_vec()
+}
+
+fn lit_pixels(fb: &[u8]) -> usize {
+    fb.iter().map(|b| b.count_ones() as usize).sum()
+}
+
+fn budget() -> u64 {
+    std::env::var("LABWIRED_C3_OLED_BUDGET")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30_000_000)
+}
+
+/// D1/D2/D8/D10: baseline throughput, RTF, idle-vs-interpreted split.
+#[test]
+#[ignore = "native C3 workload benchmark; run with --release --ignored"]
+fn esp32c3_oled_native_baseline() {
+    const CHUNK: u32 = 1_000_000;
+    let budget = budget();
+
+    let mut lab = build_oled_lab();
+    eprintln!(
+        "C3_OLED_SETUP tick_interval={} idle_ff={} walk_deleted={} legacy_entries={}",
+        lab.machine.config.peripheral_tick_interval,
+        lab.machine.config.idle_fast_forward_enabled,
+        lab.machine.bus.max_safe_tick_interval() > 1,
+        lab.machine.bus.legacy_tick_entry_descriptors().len(),
+    );
+
+    lab.machine.reset_step_profile();
+    let started = Instant::now();
+    let mut fuel: u64 = 0;
+    while fuel < budget {
+        let n = CHUNK.min((budget - fuel) as u32);
+        lab.machine.run(Some(n)).expect("run C3 OLED");
+        fuel += u64::from(n);
+    }
+    let elapsed = started.elapsed();
+
+    let profile = lab.machine.step_profile();
+    let total = lab.machine.total_cycles;
+    let idle = lab.machine.idle_fast_forward_cycles_skipped;
+    let interpreted = profile.cpu_instructions;
+    let fb = ssd1306_framebuffer(&lab.machine);
+    let serial_len = lab.serial.lock().unwrap().len();
+
+    let secs = elapsed.as_secs_f64();
+    let interp_mips = interpreted as f64 / secs / 1e6;
+    let guest_cycles_per_sec = total as f64 / secs;
+    let rtf = guest_cycles_per_sec / 160e6;
+
+    eprintln!(
+        "C3_OLED_PROFILE wall_s={:.4} total_cycles={} idle_ff_cycles={} interpreted={} \
+         idle_pct={:.3} interp_mips={:.3} guest_cycles_per_sec={:.0} rtf={:.4} \
+         cpu_batches={} mean_batch={:.3} peripheral_ticks={} peripheral_ticked_entries={} \
+         bus_tick_entries={} legacy_tick_entries={} lit_px={} serial_bytes={} pc={:#x}",
+        secs,
+        total,
+        idle,
+        interpreted,
+        idle as f64 / total as f64 * 100.0,
+        interp_mips,
+        guest_cycles_per_sec,
+        rtf,
+        profile.cpu_batches,
+        interpreted as f64 / profile.cpu_batches.max(1) as f64,
+        profile.peripheral_ticks,
+        profile.peripheral_ticked_entries,
+        profile.bus_tick_entries,
+        profile.legacy_tick_entries,
+        lit_pixels(&fb),
+        serial_len,
+        lab.machine.cpu.pc,
+    );
+}
+
+// NOTE (D4): the batch-width distribution + clamp attribution reported in the
+// write-up required TEMPORARY instrumentation of `crates/core/src/machine/plan.rs`
+// (a `batch_probe` module recording width/clamp-reason) and a
+// `EventScheduler::next_event_deadline_owner` probe in
+// `crates/core/src/sched/event_scheduler.rs`. Those src edits were REVERTED after
+// measurement; the patch is preserved outside the repo at
+// scratchpad/batch-probe-instrumentation.patch. Re-apply it to reproduce.
+
+/// D8/D5: phase decomposition — RTF and idle share per 1M-fuel chunk, so boot
+/// (interpretation-heavy) is separated from steady state (idle-dominated).
+#[test]
+#[ignore = "phase decomposition; run with --release --ignored"]
+fn esp32c3_oled_phase_decomposition() {
+    const CHUNK: u32 = 1_000_000;
+    let budget = budget();
+    let mut lab = build_oled_lab();
+    lab.machine.reset_step_profile();
+
+    let mut fuel: u64 = 0;
+    let mut prev_total = 0u64;
+    let mut prev_idle = 0u64;
+    let mut prev_interp = 0u64;
+    let mut prev_batches = 0u64;
+    let mut first_paint: Option<(u64, u64, f64)> = None;
+    let started = Instant::now();
+    let mut prev_wall = 0.0f64;
+
+    eprintln!("C3_PHASE chunk fuel wall_ms d_total d_idle d_interp idle_pct chunk_mips chunk_rtf mean_batch lit_px");
+    while fuel < budget {
+        let n = CHUNK.min((budget - fuel) as u32);
+        lab.machine.run(Some(n)).expect("run C3 OLED");
+        fuel += u64::from(n);
+        let wall = started.elapsed().as_secs_f64();
+        let d_wall = wall - prev_wall;
+        let p = lab.machine.step_profile();
+        let d_total = lab.machine.total_cycles - prev_total;
+        let d_idle = lab.machine.idle_fast_forward_cycles_skipped - prev_idle;
+        let d_interp = p.cpu_instructions - prev_interp;
+        let d_batches = p.cpu_batches - prev_batches;
+        let lit = lit_pixels(&ssd1306_framebuffer(&lab.machine));
+        if first_paint.is_none() && lit > 0 {
+            first_paint = Some((fuel, lab.machine.total_cycles, wall));
+        }
+        eprintln!(
+            "C3_PHASE {:>4} {:>10} {:>8.2} {:>9} {:>9} {:>9} {:>7.2} {:>8.3} {:>7.3} {:>8.2} {:>6}",
+            fuel / u64::from(CHUNK),
+            fuel,
+            d_wall * 1000.0,
+            d_total,
+            d_idle,
+            d_interp,
+            d_idle as f64 / d_total.max(1) as f64 * 100.0,
+            d_interp as f64 / d_wall / 1e6,
+            d_total as f64 / d_wall / 160e6,
+            d_interp as f64 / d_batches.max(1) as f64,
+            lit,
+        );
+        prev_total = lab.machine.total_cycles;
+        prev_idle = lab.machine.idle_fast_forward_cycles_skipped;
+        prev_interp = p.cpu_instructions;
+        prev_batches = p.cpu_batches;
+        prev_wall = wall;
+    }
+    if let Some((fuel, cyc, wall)) = first_paint {
+        eprintln!(
+            "C3_FIRST_PAINT fuel={} total_cycles={} wall_s={:.4} guest_ms={:.3} rtf_to_paint={:.3}",
+            fuel,
+            cyc,
+            wall,
+            cyc as f64 / 160e6 * 1000.0,
+            (cyc as f64 / 160e6) / wall
+        );
+    }
+}
+
+/// Long-running variant for `sample`: no budget, runs until killed.
+/// This is STEADY STATE (post-paint, idle-FF dominated).
+#[test]
+#[ignore = "sampling target; run with --release --ignored and kill after sampling"]
+fn esp32c3_oled_sample_target() {
+    let mut lab = build_oled_lab();
+    let started = Instant::now();
+    let mut fuel: u64 = 0;
+    loop {
+        lab.machine.run(Some(1_000_000)).expect("run C3 OLED");
+        fuel += 1_000_000;
+        if fuel.is_multiple_of(500_000_000) {
+            eprintln!(
+                "C3_OLED_SAMPLE_PROGRESS fuel={} total_cycles={} idle_ff={} wall_s={:.2}",
+                fuel,
+                lab.machine.total_cycles,
+                lab.machine.idle_fast_forward_cycles_skipped,
+                started.elapsed().as_secs_f64()
+            );
+        }
+    }
+}
+
+/// D3 PRIMARY sampling target: loop the BOOT phase (fuel 0..2M), the only
+/// interpretation-bound phase of this workload. Rebuild cost shows as
+/// `build_oled_lab` frames in the sample and is excluded when reading it.
+#[test]
+#[ignore = "boot-loop sampling target; run with --release --ignored and kill after sampling"]
+fn esp32c3_oled_boot_loop_sample_target() {
+    let boot_fuel: u64 = std::env::var("LABWIRED_C3_BOOT_FUEL")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_000_000);
+    let started = Instant::now();
+    let mut iters = 0u64;
+    loop {
+        let mut lab = build_oled_lab();
+        let mut fuel = 0u64;
+        while fuel < boot_fuel {
+            let n = 1_000_000u32.min((boot_fuel - fuel) as u32);
+            lab.machine.run(Some(n)).expect("run C3 OLED boot");
+            fuel += u64::from(n);
+        }
+        iters += 1;
+        if iters.is_multiple_of(50) {
+            eprintln!(
+                "C3_BOOT_LOOP iters={} wall_s={:.2} lit_px={}",
+                iters,
+                started.elapsed().as_secs_f64(),
+                lit_pixels(&ssd1306_framebuffer(&lab.machine))
+            );
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct PcHistogram {
+    counts: Mutex<HashMap<u32, u64>>,
+    total: AtomicU64,
+}
+
+impl SimulationObserver for PcHistogram {
+    fn on_step_start(&self, pc: u32, _opcode: u32) {
+        self.total.fetch_add(1, Ordering::Relaxed);
+        *self.counts.lock().unwrap().entry(pc).or_insert(0) += 1;
+    }
+}
+
+/// D9: attribute interpreted guest instructions by PC.
+#[test]
+#[ignore = "guest PC attribution; run with --release --ignored"]
+fn esp32c3_oled_guest_pc_attribution() {
+    const CHUNK: u32 = 1_000_000;
+    let budget = budget();
+    let mut lab = build_oled_lab();
+    let hist = Arc::new(PcHistogram::default());
+    lab.machine.observers.push(hist.clone());
+
+    lab.machine.reset_step_profile();
+    let mut fuel: u64 = 0;
+    while fuel < budget {
+        let n = CHUNK.min((budget - fuel) as u32);
+        lab.machine.run(Some(n)).expect("run C3 OLED");
+        fuel += u64::from(n);
+    }
+
+    let counts = hist.counts.lock().unwrap();
+    let total = hist.total.load(Ordering::Relaxed);
+    let mut by_pc: Vec<(u32, u64)> = counts.iter().map(|(k, v)| (*k, *v)).collect();
+    by_pc.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+
+    // Coarse region buckets for the C3 memory map.
+    let mut regions: HashMap<&str, u64> = HashMap::new();
+    for (pc, c) in by_pc.iter() {
+        let region = match *pc {
+            0x4000_0000..=0x4005_FFFF => "mask ROM (irom)",
+            0x3FF0_0000..=0x3FFF_FFFF => "drom/data",
+            0x4037_0000..=0x403F_FFFF => "IRAM (sram, .text/ISR)",
+            0x4200_0000..=0x42FF_FFFF => "flash XIP (app .text)",
+            0x3C00_0000..=0x3CFF_FFFF => "flash XIP (rodata)",
+            _ => "other",
+        };
+        *regions.entry(region).or_insert(0) += c;
+    }
+    let mut regions: Vec<(&str, u64)> = regions.into_iter().collect();
+    regions.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+
+    eprintln!(
+        "C3_PC_ATTRIBUTION total_interpreted={} distinct_pcs={} idle_ff_cycles={} total_cycles={}",
+        total,
+        by_pc.len(),
+        lab.machine.idle_fast_forward_cycles_skipped,
+        lab.machine.total_cycles
+    );
+    for (region, c) in &regions {
+        eprintln!(
+            "C3_PC_REGION {:<24} {:>12}  {:>6.2}%",
+            region,
+            c,
+            *c as f64 / total as f64 * 100.0
+        );
+    }
+    eprintln!("C3_PC_TOP40:");
+    let mut cum = 0u64;
+    for (pc, c) in by_pc.iter().take(40) {
+        cum += c;
+        eprintln!(
+            "C3_PC_HOT pc={:#010x} count={:>10} pct={:>6.3}% cum={:>6.2}%",
+            pc,
+            c,
+            *c as f64 / total as f64 * 100.0,
+            cum as f64 / total as f64 * 100.0
+        );
+    }
+    // How concentrated is the workload?
+    for topn in [1usize, 10, 50, 100, 500, 1000] {
+        let s: u64 = by_pc.iter().take(topn).map(|(_, c)| *c).sum();
+        eprintln!(
+            "C3_PC_CONCENTRATION top{:<5} = {:>6.2}%",
+            topn,
+            s as f64 / total as f64 * 100.0
+        );
+    }
+}
+
+/// TEMP DIAGNOSTIC: which `has_active_work()` arm keeps uart0 re-arming?
+#[test]
+#[ignore = "diagnostic; run with --release --ignored"]
+fn esp32c3_uart0_active_work_arms() {
+    use labwired_core::peripherals::uart::Uart;
+    let budget = budget();
+    let mut lab = build_oled_lab();
+    let mut fuel: u64 = 0;
+    while fuel < budget {
+        let n = 1_000_000u32.min((budget - fuel) as u32);
+        lab.machine.run(Some(n)).expect("run C3 OLED");
+        fuel += u64::from(n);
+    }
+    let idx = lab
+        .machine
+        .bus
+        .find_peripheral_index_by_name("uart0")
+        .expect("uart0 present");
+    let base = lab.machine.bus.peripherals[idx].base;
+    let streams = lab.machine.bus.peripherals[idx]
+        .dev
+        .as_any()
+        .and_then(|a| a.downcast_ref::<Uart>())
+        .map(|u| u.attached_streams.len())
+        .expect("uart0 is a generic Uart");
+    // Stm32F1 layout: CR1 @ 0x0C, TXEIE = 1<<7, TCIE = 1<<6.
+    let cr1 = lab.machine.bus.read_u32(base + 0x0C).unwrap_or(0);
+    eprintln!(
+        "C3_UART0_ARMS base={:#x} attached_streams={} cr1={:#010x} txeie_set={} tcie_set={}",
+        base,
+        streams,
+        cr1,
+        (cr1 & (1 << 7)) != 0,
+        (cr1 & (1 << 6)) != 0,
+    );
+}

--- a/crates/core/tests/esp32c3_shipped_lab_batch_gate.rs
+++ b/crates/core/tests/esp32c3_shipped_lab_batch_gate.rs
@@ -1,0 +1,282 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! THROUGHPUT GATE FOR THE FIRMWARE USERS ACTUALLY BOOT.
+//!
+//! Why this file exists
+//! ===================
+//! Every existing C3 benchmark and differential drives
+//! `crates/wasm/tests/fixtures/esp32c3-oled-demo-flash.bin`. The deployed
+//! playground boots a DIFFERENT image — `demo-esp32c3-display-workshop-flash.bin`
+//! (named in the superproject at
+//! `packages/playground/src/.../bundled-configs.ts:894`). Those two firmwares
+//! stress the engine completely differently:
+//!
+//! | image                        | mean batch | RTF (native) |
+//! |------------------------------|-----------:|-------------:|
+//! | fixture (what the gates ran) |      42.29 |         1.27 |
+//! | shipped (what users run)     |       1.38 |        0.010 |
+//!
+//! So a ~330x-below-real-time collapse shipped while every gate stayed green:
+//! the shipped app leaves the UART's TXFIFO-empty interrupt enabled, which held
+//! a per-cycle scheduler wakeup open and pinned every batch to width 1. The
+//! fixture never sets that bit, so the fixture could not see it.
+//!
+//! What this gate asserts
+//! ======================
+//! MEAN BATCH WIDTH, not wall-clock time. Batch width is a pure function of the
+//! model (`cpu_instructions / cpu_batches`), so it is bit-deterministic and
+//! machine-independent — a wall-clock RTF assert would flake on a loaded CI box.
+//! It is also the *direct* proxy for this failure class: the pathology IS the
+//! batch collapsing toward 1.
+//!
+//! Cross-repo note
+//! ===============
+//! The flash image lives in the SUPERPROJECT, not here, and is deliberately not
+//! vendored into core (one artifact, one home — a copy would drift silently and
+//! reintroduce exactly the skew this file exists to catch). The gate resolves
+//! the image in this order:
+//! 1. `$LABWIRED_C3_SHIPPED_FLASH` — explicit override (what CI should set);
+//! 2. the sibling superproject checkout, when core is a submodule inside it.
+//!
+//! If neither resolves the test SKIPS loudly rather than failing, so a
+//! standalone core checkout stays green. The superproject CI must set the env
+//! var (or run with the playground present) for this gate to bite.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::boot::esp32c3_rom::{
+    build_rom_boot_machine, c3_rom_data_init_writes, inject_rom_regions, RomBootOpts,
+};
+use labwired_core::boot::esp32s3_rom::RomImages;
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::RiscV;
+use labwired_core::memory::ProgramImage;
+use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
+use labwired_core::{Arch, Bus, Cpu, DebugControl, Machine};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The image the deployed playground boots. See the module docs for why this is
+/// resolved rather than vendored.
+fn shipped_flash_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("LABWIRED_C3_SHIPPED_FLASH") {
+        let p = PathBuf::from(p);
+        assert!(
+            p.exists(),
+            "LABWIRED_C3_SHIPPED_FLASH points at a missing file: {}",
+            p.display()
+        );
+        return Some(p);
+    }
+    // core/crates/core → core → <superproject>
+    let sibling = root()
+        .join("../../../packages/playground/public/wasm/demo-esp32c3-display-workshop-flash.bin");
+    sibling.exists().then_some(sibling)
+}
+
+const ESP_IMAGE_HEADER_LEN: usize = 24;
+const ESP_IMAGE_MAGIC: u8 = 0xE9;
+
+fn esp32c3_bootloader_image(flash: &[u8]) -> ProgramImage {
+    assert!(flash.len() > ESP_IMAGE_HEADER_LEN, "flash image truncated");
+    assert_eq!(flash[0], ESP_IMAGE_MAGIC, "bad bootloader image magic");
+    let segment_count = flash[1] as usize;
+    let entry = u32::from_le_bytes(flash[4..8].try_into().unwrap()) as u64;
+    let mut program = ProgramImage::new(entry, Arch::RiscV);
+    let mut cursor = ESP_IMAGE_HEADER_LEN;
+    for _ in 0..segment_count {
+        let load_addr = u32::from_le_bytes(flash[cursor..cursor + 4].try_into().unwrap()) as u64;
+        let len = u32::from_le_bytes(flash[cursor + 4..cursor + 8].try_into().unwrap()) as usize;
+        cursor += 8;
+        program.add_segment(load_addr, flash[cursor..cursor + len].to_vec());
+        cursor += len;
+    }
+    program
+}
+
+struct Lab {
+    machine: Machine<RiscV>,
+}
+
+/// The browser fast-start assembly, verbatim (`esp32c3_walk_differential`'s
+/// `build_oled_lab`), but pointed at `flash_path` and running the EXACT browser
+/// policy (`apply_browser_c3_policy`: recommended tick interval + idle FF).
+fn build_lab(flash_path: &PathBuf) -> Lab {
+    let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
+        .expect("load esp32c3 chip yaml");
+    let manifest =
+        SystemManifest::from_file(root().join("../../configs/systems/esp32c3-oled-demo.yaml"))
+            .expect("load esp32c3-oled-demo system yaml");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build oled bus");
+
+    let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
+    let drom = std::fs::read(root().join("roms/esp32c3/esp32c3_drom.bin")).expect("read C3 DROM");
+    let flash = std::fs::read(flash_path)
+        .unwrap_or_else(|e| panic!("read shipped flash {}: {e}", flash_path.display()));
+
+    assert!(
+        inject_rom_regions(
+            &mut bus,
+            &RomImages {
+                irom: irom.clone(),
+                drom
+            }
+        ),
+        "chip yaml must declare the C3 IROM region"
+    );
+    for (dst, bytes) in c3_rom_data_init_writes(&irom) {
+        for (i, b) in bytes.iter().enumerate() {
+            let _ = bus.write_u8(dst as u64 + i as u64, *b);
+        }
+    }
+
+    let serial = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(serial, false);
+
+    let bootloader = esp32c3_bootloader_image(&flash);
+    let mut machine = build_rom_boot_machine(
+        bus,
+        flash,
+        RomBootOpts {
+            efuse_mac: None,
+            usb_serial_sink: None,
+        },
+        |c| c,
+    );
+
+    for segment in &bootloader.segments {
+        if machine.bus.flash.load_from_segment(segment)
+            || machine.bus.ram.load_from_segment(segment)
+            || machine
+                .bus
+                .extra_mem
+                .iter_mut()
+                .any(|m| m.load_from_segment(segment))
+        {
+            continue;
+        }
+        for (i, byte) in segment.data.iter().enumerate() {
+            machine
+                .bus
+                .write_u8(segment.start_addr + i as u64, *byte)
+                .expect("load bootloader segment");
+        }
+    }
+    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    machine.cpu.set_sp(sp_top & !0xF);
+    machine.cpu.set_pc(bootloader.entry_point as u32);
+
+    // EXACT browser policy (`apply_browser_c3_policy`, crates/wasm/src/lib.rs).
+    let rec = machine.bus.max_safe_tick_interval();
+    machine.config.peripheral_tick_interval = rec;
+    machine.bus.config.peripheral_tick_interval = rec;
+    machine.config.idle_fast_forward_enabled = true;
+    Lab { machine }
+}
+
+fn ssd1306_lit_pixels(machine: &Machine<RiscV>) -> usize {
+    let idx = machine
+        .bus
+        .find_peripheral_index_by_name("i2c0")
+        .expect("oled bus exposes i2c0");
+    machine.bus.peripherals[idx]
+        .dev
+        .as_any()
+        .expect("i2c0 downcastable")
+        .downcast_ref::<Esp32c3I2c>()
+        .expect("i2c0 is the C3 command-list controller")
+        .attached_slaves()
+        .iter()
+        .filter(|d| d.address() == 0x3C)
+        .find_map(|d| d.as_any().and_then(|a| a.downcast_ref::<Ssd1306>()))
+        .expect("SSD1306 attached at 0x3C")
+        .framebuffer()
+        .iter()
+        .map(|b| b.count_ones() as usize)
+        .sum()
+}
+
+const BUDGET: u64 = 30_000_000;
+
+/// Floor for the shipped lab's mean batch width.
+///
+/// Measured on this branch: **19.42**. Before the UART wakeup fix: **1.376**
+/// (the shipped regression), and the theoretical floor of the collapse is 1.0.
+/// 8.0 sits 5.8x above the broken value and 2.4x below the healthy one, so it
+/// cannot flake (the metric is deterministic — this margin absorbs legitimate
+/// firmware/model churn, not host noise) yet still trips long before a collapse
+/// toward 1 could reach users. The remaining clamp owner is `i2c0` at its
+/// module clock (CPU/4), which bounds any honest future value near ~4 during
+/// active I²C traffic; 8.0 stays above that only because traffic is bursty.
+/// If a legitimate change drives this below 8, re-measure and move it
+/// deliberately — do not delete the gate.
+const MIN_MEAN_BATCH: f64 = 8.0;
+
+/// The OLED must still paint: a fast engine that renders nothing is not a pass.
+const MIN_LIT: usize = 400;
+
+#[test]
+#[ignore = "runs the real C3 bootloader + shipped app (~30M steps); run with --release --ignored"]
+fn shipped_c3_display_workshop_lab_keeps_batching() {
+    let Some(flash) = shipped_flash_path() else {
+        eprintln!(
+            "SKIP: shipped C3 flash image not found. Set LABWIRED_C3_SHIPPED_FLASH \
+             to <superproject>/packages/playground/public/wasm/\
+             demo-esp32c3-display-workshop-flash.bin, or run with the superproject \
+             checked out around this submodule. This gate is the ONLY one that \
+             exercises the firmware users actually boot."
+        );
+        return;
+    };
+    eprintln!("shipped flash: {}", flash.display());
+
+    let mut lab = build_lab(&flash);
+    lab.machine.reset_step_profile();
+    let mut fuel: u64 = 0;
+    while fuel < BUDGET {
+        let n = 1_000_000u32.min((BUDGET - fuel) as u32);
+        lab.machine.run(Some(n)).expect("run shipped C3 lab");
+        fuel += u64::from(n);
+    }
+
+    let profile = lab.machine.step_profile();
+    let mean_batch = profile.cpu_instructions as f64 / profile.cpu_batches.max(1) as f64;
+    let lit = ssd1306_lit_pixels(&lab.machine);
+    let rtf_hint = lab.machine.total_cycles as f64 / 160e6;
+
+    eprintln!(
+        "SHIPPED_C3_GATE mean_batch={mean_batch:.3} (min {MIN_MEAN_BATCH}) batches={} \
+         interpreted={} idle_ff={} total_cycles={} guest_ms={:.1} lit_px={lit}",
+        profile.cpu_batches,
+        profile.cpu_instructions,
+        lab.machine.idle_fast_forward_cycles_skipped,
+        lab.machine.total_cycles,
+        rtf_hint * 1000.0,
+    );
+
+    assert!(
+        lit >= MIN_LIT,
+        "shipped lab must still paint the OLED (lit={lit}, min {MIN_LIT}) — a fast \
+         engine that renders nothing is not a pass"
+    );
+    assert!(
+        mean_batch >= MIN_MEAN_BATCH,
+        "SHIPPED C3 lab batch width collapsed to {mean_batch:.3} (min {MIN_MEAN_BATCH}).\n\
+         This is the regression that shipped once already: some peripheral is \
+         scheduling an event every ~{mean_batch:.1} guest instructions, which pinned \
+         the browser to ~RTF 0.003 (a guest second costing ~5.5 wall minutes).\n\
+         MEASURE the owner before assuming it is the UART again — attribute batch \
+         clamps by peripheral (`EventScheduler::next_event_deadline`) rather than \
+         guessing. Last time the owner was `uart0`, holding a per-cycle wakeup to \
+         re-assert a level-triggered IRQ that the C3 bus does not even wire \
+         (see `Uart::has_active_work`)."
+    );
+}

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -96,13 +96,17 @@ struct OledLab {
 /// the SYSTIMER (the FreeRTOS-tick source), `i2c0_legacy` for the I²C0
 /// bit-engine (the OLED bus master), and `spi_adc_legacy` for the level-only
 /// pair (`spi2` + `apb_saradc`, migrated together), so a walk-on-vs-scheduler
-/// differential can isolate each migration in turn.
+/// differential can isolate each migration in turn. `uart0_legacy` does the same
+/// for the shared `Uart`, whose scheduler path skips wakeups that only hold an
+/// unobservable level-triggered own-IRQ (`has_active_work`); the walk reference
+/// ticks it every cycle unconditionally.
 fn build_oled_lab(
     tick_interval: u32,
     rtc_legacy: bool,
     systimer_legacy: bool,
     i2c0_legacy: bool,
     spi_adc_legacy: bool,
+    uart0_legacy: bool,
 ) -> OledLab {
     let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
         .expect("load esp32c3 chip yaml");
@@ -245,6 +249,20 @@ fn build_oled_lab(
             .force_legacy_walk();
     }
 
+    if uart0_legacy {
+        let idx = machine
+            .bus
+            .find_peripheral_index_by_name("uart0")
+            .expect("oled bus registers uart0");
+        machine.bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<labwired_core::peripherals::uart::Uart>()
+            .expect("uart0 is the shared Uart model")
+            .force_legacy_walk();
+    }
+
     // Any `*_legacy` reference above pinned a peripheral back onto the walk with
     // `force_legacy_walk` AFTER the rom-boot path derived walk-deletion over the
     // (then all-scheduler) peripheral set. Now that `wifi_mac` is migrated the
@@ -308,10 +326,14 @@ const MIN_LIT: usize = 400;
 #[test]
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
-    let (walk_cycles, walk_fb, walk_serial) =
-        run_lab(build_oled_lab(1, true, false, false, false), PAINT_BUDGET);
-    let (sched_cycles, sched_fb, sched_serial) =
-        run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
+    let (walk_cycles, walk_fb, walk_serial) = run_lab(
+        build_oled_lab(1, true, false, false, false, false),
+        PAINT_BUDGET,
+    );
+    let (sched_cycles, sched_fb, sched_serial) = run_lab(
+        build_oled_lab(1, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
 
     assert!(
         lit_pixels(&walk_fb) >= MIN_LIT,
@@ -342,9 +364,14 @@ fn oled_lab_walk_on_vs_scheduler_rtc_is_byte_identical_at_interval_1() {
 #[test]
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_framebuffer_is_byte_identical_across_tick_intervals() {
-    let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
-    let (_, fb_64, serial_64) =
-        run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
+    let (_, fb_1, _) = run_lab(
+        build_oled_lab(1, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
+    let (_, fb_64, serial_64) = run_lab(
+        build_oled_lab(64, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
 
     assert!(
         lit_pixels(&fb_1) >= MIN_LIT,
@@ -367,9 +394,12 @@ fn oled_lab_framebuffer_is_byte_identical_across_tick_intervals() {
 #[test]
 #[ignore = "runs the real C3 bootloader + app (~2x30M steps); run with --release --ignored"]
 fn oled_lab_framebuffer_is_byte_identical_at_tick_512() {
-    let (_, fb_1, _) = run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
+    let (_, fb_1, _) = run_lab(
+        build_oled_lab(1, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
     let (_, fb_512, serial_512) = run_lab(
-        build_oled_lab(512, false, false, false, false),
+        build_oled_lab(512, false, false, false, false, false),
         PAINT_BUDGET,
     );
 
@@ -403,11 +433,11 @@ fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
     for interval in [1u32, 64] {
         // reference: SYSTIMER on the legacy walk; test: SYSTIMER scheduler.
         let (walk_cycles, walk_fb, walk_serial) = run_lab(
-            build_oled_lab(interval, false, true, false, false),
+            build_oled_lab(interval, false, true, false, false, false),
             PAINT_BUDGET,
         );
         let (sched_cycles, sched_fb, sched_serial) = run_lab(
-            build_oled_lab(interval, false, false, false, false),
+            build_oled_lab(interval, false, false, false, false, false),
             PAINT_BUDGET,
         );
 
@@ -457,10 +487,14 @@ fn oled_lab_systimer_walk_on_vs_scheduler_is_byte_identical() {
 #[ignore = "runs the real C3 bootloader + app (~4x30M steps); run with --release --ignored"]
 fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
     // interval 1: full byte-identity (serial + total_cycles + framebuffer).
-    let (walk_cycles, walk_fb, walk_serial) =
-        run_lab(build_oled_lab(1, false, false, true, false), PAINT_BUDGET);
-    let (sched_cycles, sched_fb, sched_serial) =
-        run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
+    let (walk_cycles, walk_fb, walk_serial) = run_lab(
+        build_oled_lab(1, false, false, true, false, false),
+        PAINT_BUDGET,
+    );
+    let (sched_cycles, sched_fb, sched_serial) = run_lab(
+        build_oled_lab(1, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
 
     assert!(
         lit_pixels(&walk_fb) >= MIN_LIT,
@@ -485,8 +519,14 @@ fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
     );
 
     // interval 64: bounded-stale reads must leave the painted OLED unchanged.
-    let (_, walk_fb_64, _) = run_lab(build_oled_lab(64, false, false, true, false), PAINT_BUDGET);
-    let (_, sched_fb_64, _) = run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
+    let (_, walk_fb_64, _) = run_lab(
+        build_oled_lab(64, false, false, true, false, false),
+        PAINT_BUDGET,
+    );
+    let (_, sched_fb_64, _) = run_lab(
+        build_oled_lab(64, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
     assert!(
         walk_fb_64 == sched_fb_64,
         "SSD1306 framebuffer must be byte-identical (I²C0 walk vs scheduler) at interval 64 \
@@ -511,10 +551,14 @@ fn oled_lab_i2c0_walk_on_vs_scheduler_is_byte_identical() {
 #[ignore = "runs the real C3 bootloader + app (~4x30M steps); run with --release --ignored"]
 fn oled_lab_spi2_apb_saradc_walk_on_vs_scheduler_is_byte_identical() {
     // interval 1: full byte-identity (serial + total_cycles + framebuffer).
-    let (walk_cycles, walk_fb, walk_serial) =
-        run_lab(build_oled_lab(1, false, false, false, true), PAINT_BUDGET);
-    let (sched_cycles, sched_fb, sched_serial) =
-        run_lab(build_oled_lab(1, false, false, false, false), PAINT_BUDGET);
+    let (walk_cycles, walk_fb, walk_serial) = run_lab(
+        build_oled_lab(1, false, false, false, true, false),
+        PAINT_BUDGET,
+    );
+    let (sched_cycles, sched_fb, sched_serial) = run_lab(
+        build_oled_lab(1, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
 
     assert!(
         lit_pixels(&walk_fb) >= MIN_LIT,
@@ -536,8 +580,14 @@ fn oled_lab_spi2_apb_saradc_walk_on_vs_scheduler_is_byte_identical() {
     );
 
     // interval 64: the quiescent pair must still not perturb the painted OLED.
-    let (_, walk_fb_64, _) = run_lab(build_oled_lab(64, false, false, false, true), PAINT_BUDGET);
-    let (_, sched_fb_64, _) = run_lab(build_oled_lab(64, false, false, false, false), PAINT_BUDGET);
+    let (_, walk_fb_64, _) = run_lab(
+        build_oled_lab(64, false, false, false, true, false),
+        PAINT_BUDGET,
+    );
+    let (_, sched_fb_64, _) = run_lab(
+        build_oled_lab(64, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
     assert!(
         walk_fb_64 == sched_fb_64,
         "SSD1306 framebuffer must be byte-identical (spi2/apb_saradc walk vs scheduler) at interval 64"
@@ -632,7 +682,7 @@ fn oled_lab_native_mips_probe() {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(50_000_000);
-    let mut lab = build_oled_lab(interval, false, systimer_legacy, false, false);
+    let mut lab = build_oled_lab(interval, false, systimer_legacy, false, false, false);
     lab.machine.config.idle_fast_forward_enabled = idle_ff;
     lab.machine.config.riscv_jit_enabled = jit;
     lab.machine.bus.config.riscv_jit_enabled = jit;
@@ -712,7 +762,7 @@ fn oled_lab_walk_pinners_after_rtc_migration() {
     /// a regression.
     const EXPECTED_PINNERS: &[&str] = &[];
 
-    let lab = build_oled_lab(1, false, false, false, false);
+    let lab = build_oled_lab(1, false, false, false, false, false);
     let bus = &lab.machine.bus;
 
     let mut pinners: Vec<&str> = Vec::new();
@@ -776,7 +826,7 @@ fn oled_lab_walk_pinners_after_rtc_migration() {
 fn oled_lab_sim_serial_vs_silicon_report() {
     use std::time::Instant;
     let t0 = Instant::now();
-    let mut lab = build_oled_lab(512, false, false, false, false);
+    let mut lab = build_oled_lab(512, false, false, false, false, false);
     lab.machine.config.idle_fast_forward_enabled = true;
     lab.machine.bus.config.idle_fast_forward_enabled = true;
     // Match browser recommended interval after #557.
@@ -839,5 +889,72 @@ fn oled_lab_sim_serial_vs_silicon_report() {
     assert!(
         lit_pixels(&fb) >= MIN_LIT,
         "sim framebuffer must light pixels"
+    );
+}
+
+/// GROUND-TRUTH GATE for the `Uart::has_active_work` IRQ-observability gate.
+///
+/// The shared `Uart` re-armed a scheduler event EVERY guest cycle for as long as
+/// TXEIE/TCIE was set (`reschedule_delay: Some(1)`), faithfully reproducing the
+/// legacy per-cycle `tick()`. On the C3 that wakeup is provably inert: the chip
+/// yaml declares `uart0` with no `irq:`, the machine DROPS `EventResult::
+/// raise_own_irq` when the entry has no IRQ, and the generic `Uart` exports no
+/// `matrix_irq_sources`, so nothing downstream can observe it. With no RX stream
+/// and no pending DMA, `advance_one_tick` mutates nothing either — it is a pure
+/// function of `cr1`. So the model now skips those wakeups, which restored batch
+/// widths (mean 1.38 → 19.4 on the shipped display-workshop lab).
+///
+/// "Provably inert" has to be proven, not asserted. The legacy walk is the
+/// pre-scheduler ground truth: it ticks `uart0` every single cycle,
+/// unconditionally, exactly as the old scheduler path did. If skipping those
+/// wakeups changed ANY guest-visible byte, this differential diverges.
+#[test]
+#[ignore = "runs the real C3 bootloader + app (~4x30M steps); run with --release --ignored"]
+fn oled_lab_uart0_walk_on_vs_scheduler_is_byte_identical() {
+    // interval 1: full byte-identity (serial + total_cycles + framebuffer).
+    let (walk_cycles, walk_fb, walk_serial) = run_lab(
+        build_oled_lab(1, false, false, false, false, true),
+        PAINT_BUDGET,
+    );
+    let (sched_cycles, sched_fb, sched_serial) = run_lab(
+        build_oled_lab(1, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
+
+    assert!(
+        lit_pixels(&walk_fb) >= MIN_LIT,
+        "reference (uart0 walk) must paint the OLED at interval 1 (lit={}); serial:\n{}",
+        lit_pixels(&walk_fb),
+        String::from_utf8_lossy(&walk_serial)
+    );
+    assert_eq!(
+        walk_cycles, sched_cycles,
+        "total_cycles must be byte-identical (uart0 walk vs scheduler) at interval 1"
+    );
+    assert!(
+        walk_serial == sched_serial,
+        "serial stream must be byte-identical (uart0 walk vs scheduler) at interval 1\n\
+         --- walk ---\n{}\n--- sched ---\n{}",
+        String::from_utf8_lossy(&walk_serial),
+        String::from_utf8_lossy(&sched_serial)
+    );
+    assert!(
+        walk_fb == sched_fb,
+        "SSD1306 framebuffer must be byte-identical (uart0 walk vs scheduler) at interval 1"
+    );
+
+    // interval 64: the batched path the browser actually runs must paint the
+    // same pixels as the per-cycle walk reference.
+    let (_, walk_fb_64, _) = run_lab(
+        build_oled_lab(64, false, false, false, false, true),
+        PAINT_BUDGET,
+    );
+    let (_, sched_fb_64, _) = run_lab(
+        build_oled_lab(64, false, false, false, false, false),
+        PAINT_BUDGET,
+    );
+    assert!(
+        walk_fb_64 == sched_fb_64,
+        "SSD1306 framebuffer must be byte-identical (uart0 walk vs scheduler) at interval 64"
     );
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,7 +9,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-14 | ⚠ drift acked 2026-07-14 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-15 | ⚠ drift acked 2026-07-15 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-14 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-17 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -173,7 +173,19 @@ boards:
     # inter-node wire instead of an inert topology. This changes dynamic CAN
     # frame delivery, which the reset/MMIO/flash capture does not cover. A live
     # H563 FDCAN data-path re-diff remains tracked; no probe was attached here.
-    drift_ack: 2026-07-14
+    # 2026-07-17: shared uart.rs gained `irq_wired` (set at the bus attach choke
+    # points), gating the per-cycle scheduler wakeup a held level-triggered
+    # TXEIE/TCIE requests. THIS BOARD IS UNTOUCHED: its USARTs declare real IRQ
+    # lines (uart1 irq:58, uart2 irq:59, uart3 irq:60 in configs/chips/stm32h563.yaml),
+    # so attach_irq_line sets irq_wired=true and has_active_work returns exactly what
+    # it did before — identical cadence. The flag also DEFAULTS to true, so any bus
+    # bypassing the choke points keeps the legacy behaviour; only stale `false` could
+    # matter and no path produces it. Only the ESP32-C3 changes, whose yaml declares
+    # uart0 with NO irq: (making those wakeups provably unobservable). Register
+    # layout, reset values and byte paths unchanged; stm32_timer (5/5) + stm32_dma
+    # (2/2) differentials and h563_mmio_diff/conformance pass unchanged. Drift is the
+    # shared-file hash only. No live re-capture (no H563 probe attached this session).
+    drift_ack: 2026-07-17
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
## The bug

The C3 lab the playground **actually ships** ran at **RTF 0.0103 native / 0.0030 in wasm** — ~330× below real-time, a guest second per 5.5 wall minutes.

Every gate stayed green because they all benchmark `esp32c3-oled-demo-flash.bin`, while the playground boots `demo-esp32c3-display-workshop-flash.bin`. **Same class as the drift guard that watched an emitter nobody ran: a gate measuring something other than what ships.**

## Measured by owner — it was not i2c0, and not the RTC

```
before: uart0 5,685,871 (97.13%, width 1.00) | i2c0 2.55% | systimer 0.32%
after:  i2c0    149,194 (88.78%, width 3.99) | systimer 11.22%
```

`uart0` held a level-triggered TXEIE/TCIE and requested a scheduler wakeup **every cycle**. On the C3 those wakeups are *provably unobservable*:

- `esp32c3.yaml:51-54` declares `uart0` with no `irq:` — the chip yaml has **zero** `irq:` keys
- the machine drops `raise_own_irq` when the entry has no `irq` (`lib.rs:1933-1937`)
- `Uart` implements no `matrix_irq_sources` (default returns empty)
- the TXEIE/TCIE-only `advance_one_tick` path **mutates nothing**

So the wakeup is gated on `irq_wired`, set at the bus attach choke points. It **defaults to `true`** — conservative, so any bus bypassing the choke points keeps the exact legacy cadence.

| | before | after |
|---|---|---|
| mean batch | 1.376 | **19.424** |
| RTF (shipped lab) | 0.0121 | **0.1474** |
| wall, 30M cycles | 15.48 s | **1.27 s** |
| `lit_px` | 782 | 782 |

## Why `interpreted` drops 8.08M → 3.40M (not divergence)

The per-cycle event capped every idle-fast-forward skip at 1 cycle, so the CPU re-executed WFI ~4.6M times — architecturally a no-op.

**Proven, not argued:** new `oled_lab_uart0_walk_on_vs_scheduler_is_byte_identical` asserts serial, `total_cycles` and framebuffer **byte-identical at intervals 1 and 64** against a walk reference that ticks `uart0` every cycle unconditionally.

The old fixture is unchanged (`mean_batch` 42.285 / idle 93.154%) — it never sets TXEIE, which is exactly why it could never have caught this.

## Also: cache `has_iolink_master()` — 54.59% of wall

An O(~45 peripherals) nested scan with dynamic downcasts, called **per batch plan**, **per step**, and in the **idle-FF check** — returning `false` on every C3 run. Its doc comment claimed "Cheap: called once at loop setup"; it was not.

Cached at every peripheral-set mutation + the post-build stream seam. Staleness audited exhaustively: **stale `true` is safe** (conservative, merely slow); only **stale `false`** could break fidelity, and no path attaches an `IolinkMaster` without a subsequent rebuild. The HC-SR04 clause is deliberately **not** cached — it is run-dynamic via `peripheral_tick_interval`.

`irq_wired` carries an explicit warning: `Uart` derives `Serialize` alone, and adding `Deserialize` would populate it from `bool::default()` == `false` — the unsafe direction.

## Gates

lib **1993/0** (`event-scheduler`), **2040/0** (`jit,event-scheduler`); differentials: esp32c3 incl. new uart0, clamped_full_state 3/3, esp32s3 2/2, kw41z 6/6, stm32 timer 5/5 + dma 2/2, systick 4/4; `fmt` + `clippy` clean.

## Known weakness — please read

`esp32c3_shipped_lab_batch_gate` is `#[ignore]`d **and** skips unless `LABWIRED_C3_SHIPPED_FLASH` (or a sibling superproject) resolves the flash. **Superproject CI must set that env var or the gate is vacuous** — which would reproduce the exact hole this PR exists to close.

## Follow-ups (not here)

- `i2c0` is now the top clamp owner (88.78%, width 3.99 = the CPU/4 module clock). `advance_engine` already does lazy catch-up, so scheduling to the next *observable* boundary should apply — byte-identity preserving.
- Superproject pins core `ab7e555f`, which predates the ROM-init CSR arms `9561f5a2` (`0x000`/ustatus) and `e11a9122` (`0x800`/`0x801`). That is why `builder-ci` has been red on main since #647 — a **core pointer bump** fixes it, not a code change.