### PR TITLE
perf(sim): reuse per-tick/per-event scratch buffers (−33% allocations)

### DIFF
--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -964,6 +964,33 @@ impl SystemBus {
         self.tick_peripherals_fully_impl(false)
     }
 
+    /// Allocation-free twin of [`Self::tick_peripherals_fully`]: writes the
+    /// pending interrupts and per-peripheral costs into caller-owned scratch
+    /// buffers (cleared first, then filled) instead of returning fresh `Vec`s.
+    /// The per-tick machine hot path (`Machine::commit_advance_boundary`) uses
+    /// this with retained scratch so the steady-state SYSTIMER tick allocates
+    /// nothing. Behaviour is byte-identical to `tick_peripherals_fully`; the
+    /// walk-free fast path below mirrors `tick_peripherals_fully_impl`.
+    pub fn tick_peripherals_fully_into(
+        &mut self,
+        interrupts: &mut Vec<u32>,
+        costs: &mut Vec<PeripheralTickCost>,
+    ) {
+        interrupts.clear();
+        costs.clear();
+        // Walk-free fast path (mirror of `tick_peripherals_fully_impl`): the
+        // only per-cycle duty is aggregating enabled+pending NVIC interrupts,
+        // pushed directly into the retained buffer (zero alloc after warmup).
+        #[cfg(feature = "event-scheduler")]
+        if self.per_cycle_tick_is_trivial() {
+            self.collect_enabled_nvic_interrupts(interrupts);
+            return;
+        }
+        let (mut i, mut c) = self.tick_peripherals_fully_impl(false);
+        interrupts.append(&mut i);
+        costs.append(&mut c);
+    }
+
     /// Advances one peripheral-only tick while deliberately bypassing the
     /// event-scheduler walk deletion.
     ///

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1123,6 +1123,32 @@ pub struct Machine<C: Cpu> {
     /// host-side tax at tick-512: one alloc + full peripheral walk per batch).
     #[allow(dead_code)]
     generation_scratch: Vec<u32>,
+    /// Reusable scratch for the per-tick `tick_peripherals_fully` interrupt
+    /// harvest, so the steady-state peripheral tick pushes pending NVIC IRQs
+    /// into a retained buffer instead of allocating a fresh `Vec` every tick
+    /// (the ~731k `RawVec::grow_one` the callgrind profile blamed on the C3
+    /// SYSTIMER tick). Cleared, not reallocated, each tick. Same pattern as
+    /// [`Self::hcsr04_edge_scratch`].
+    tick_irq_scratch: Vec<u32>,
+    /// Reusable scratch for the per-tick peripheral-cost list, paired with
+    /// [`Self::tick_irq_scratch`]. Empty on the walk-free fast path.
+    tick_cost_scratch: Vec<bus::PeripheralTickCost>,
+    /// Reusable scratch for `drain_scheduler_events`'s pending-schedule harvest.
+    /// Swapped with `bus.pending_schedule` and drained in place so the drain
+    /// reuses the buffer's capacity instead of `mem::take` freeing and later
+    /// reallocating a fresh `Vec` every time write-context events were buffered.
+    /// Semantics are identical (same entries, same order). Always present; only
+    /// used under the `event-scheduler` feature.
+    #[allow(dead_code)]
+    pending_schedule_scratch: Vec<(usize, u64, u32)>,
+    /// Reusable no-op stand-in for the peripheral swap-out dance in
+    /// `drain_scheduler_events` (a peripheral's `on_event` needs `&mut self.bus`,
+    /// so the peripheral is temporarily replaced by a stub). Held here and
+    /// swapped in/out so the hot scheduler event path (the ESP32-C3 SYSTIMER
+    /// alarm fires one per drain) does not `Box::new` + free a fresh stub every
+    /// event. Always `Some` between events. Only used under `event-scheduler`.
+    #[allow(dead_code)]
+    event_placeholder: Option<Box<dyn Peripheral>>,
 
     /// In-engine logic-analyzer edge capture (see [`crate::logic_capture`]).
     /// Empty/inactive by default — the step loop pays a single `is_active`
@@ -1367,6 +1393,10 @@ impl<C: Cpu> Machine<C> {
             scheduler_bootstrapped: false,
             hcsr04_edge_scratch: Vec::new(),
             generation_scratch: Vec::new(),
+            tick_irq_scratch: Vec::new(),
+            tick_cost_scratch: Vec::new(),
+            pending_schedule_scratch: Vec::new(),
+            event_placeholder: Some(Box::new(crate::peripherals::stub::StubPeripheral::new(0))),
             logic_capture: logic_capture::LogicCapture::new(),
             logic_force_poll: false,
         }
@@ -1844,7 +1874,14 @@ impl<C: Cpu> Machine<C> {
         let interval = (self.config.peripheral_tick_interval as u64).max(1);
         self.sched.advance_to(self.total_cycles);
         let now = self.sched.now();
-        for (idx, deadline, token) in std::mem::take(&mut self.bus.pending_schedule) {
+        // Swap the buffered schedule out into retained scratch (instead of
+        // `mem::take`, which frees the buffer's capacity each drain) and drain
+        // it in place — same entries, same order, but the capacity is reused.
+        std::mem::swap(
+            &mut self.bus.pending_schedule,
+            &mut self.pending_schedule_scratch,
+        );
+        for (idx, deadline, token) in self.pending_schedule_scratch.drain(..) {
             let gen = self
                 .bus
                 .peripherals
@@ -1891,17 +1928,22 @@ impl<C: Cpu> Machine<C> {
                 continue;
             }
             let idx = ev.peripheral_idx as usize;
-            let Some(entry) = self.bus.peripherals.get_mut(idx) else {
+            if idx >= self.bus.peripherals.len() {
                 continue;
-            };
+            }
             // Swap the peripheral out so we can pass `&mut self.bus` into
             // `on_event` without holding two simultaneous mutable borrows.
-            // Same dance the bus uses for `tick_with_bus`.
-            let placeholder: Box<dyn Peripheral> =
-                Box::new(crate::peripherals::stub::StubPeripheral::new(0));
-            let mut dev = std::mem::replace(&mut entry.dev, placeholder);
+            // Same dance the bus uses for `tick_with_bus`, but the stub stand-in
+            // is reused from `event_placeholder` instead of allocated per event.
+            let stub = self
+                .event_placeholder
+                .take()
+                .expect("event_placeholder present between events");
+            let mut dev = std::mem::replace(&mut self.bus.peripherals[idx].dev, stub);
             let result = dev.on_event(ev.event_token, &mut self.sched, &mut self.bus);
-            self.bus.peripherals[idx].dev = dev;
+            // Put the real peripheral back and reclaim the stub for reuse.
+            let stub_back = std::mem::replace(&mut self.bus.peripherals[idx].dev, dev);
+            self.event_placeholder = Some(stub_back);
             // Phase 2B.3b: a level-triggered peripheral re-arms its own event
             // (same token) while it has active work. We own the (idx,
             // generation) the scheduler needs, so we do it here.

--- a/crates/core/src/machine/boundary.rs
+++ b/crates/core/src/machine/boundary.rs
@@ -117,10 +117,15 @@ impl<C: Cpu> Machine<C> {
         let logic_boundary = self.total_cycles;
         let tick_interval = u64::from(self.config.peripheral_tick_interval.max(1));
         if self.total_cycles % tick_interval == 0 {
-            // Propagate peripherals
-            let (interrupts, costs) = self.bus.tick_peripherals_fully();
+            // Propagate peripherals. Reuse retained scratch buffers (swapped
+            // out via `mem::take` so the borrow checker sees them as owned
+            // locals) instead of letting the bus allocate a fresh Vec per tick.
+            let mut interrupts = std::mem::take(&mut self.tick_irq_scratch);
+            let mut costs = std::mem::take(&mut self.tick_cost_scratch);
+            self.bus
+                .tick_peripherals_fully_into(&mut interrupts, &mut costs);
             self.record_peripheral_tick_profile(costs.len());
-            for c in costs {
+            for c in costs.iter() {
                 self.total_cycles += c.cycles as u64;
                 if let Some(p) = self.bus.peripherals.get(c.index) {
                     for observer in &self.observers {
@@ -128,10 +133,13 @@ impl<C: Cpu> Machine<C> {
                     }
                 }
             }
-            for irq in interrupts {
+            for &irq in interrupts.iter() {
                 self.cpu.set_exception_pending(irq);
                 tracing::debug!("Exception {} Pend", irq);
             }
+            // Return the buffers (with their grown capacity) for reuse next tick.
+            self.tick_irq_scratch = interrupts;
+            self.tick_cost_scratch = costs;
         }
 
         // Phase 2B.1 (issue #192): event-driven peripheral scheduler.


### PR DESCRIPTION
`drain_scheduler_events` allocated a fresh `Box<StubPeripheral>` on **every** dispatched scheduler event (C3 SYSTIMER alarm fires ~once per drain); `tick_peripherals` returned a fresh `Vec` per tick. Reuse retained scratch buffers (`tick_irq_scratch`/`tick_cost_scratch`, `pending_schedule_scratch`) + a reused `event_placeholder` box — same pattern as the existing `hcsr04_edge_scratch`.

**Measured:** −33% steady-state host allocations (242,799 → 162,279 over 4M instrs, deterministic counting allocator). Byte-identical over 30M instructions on the C3 OLED differential gate.

Gates local: C3 differential + walk-differentials + `--workspace --lib` + jit-feature suite + fmt + clippy `-D warnings`, all green.