### PR TITLE
refactor(bus): consolidate duplicate SystemBus access methods to one trait impl

### DIFF
--- a/crates/cli/src/coverage.rs
+++ b/crates/cli/src/coverage.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use labwired_core::coverage::{probe_peripheral, Access, ProbeReg, ProbeTarget, RegStatus};
+use labwired_core::Bus; // BusTarget probes via the single Bus-trait accessor
 use serde::{Deserialize, Serialize};
 use svd_parser::svd::{Peripheral, Register, RegisterCluster};
 

--- a/crates/cli/src/faults.rs
+++ b/crates/cli/src/faults.rs
@@ -117,6 +117,7 @@ pub fn finalize_fault_evidence(
 mod tests {
     use super::*;
     use labwired_config::{FaultKind, FaultSpec, FaultTarget, FaultTrigger};
+    use labwired_core::Bus;
 
     fn spec(id: &str, kind: FaultKind, target: FaultTarget, value: Option<u64>) -> FaultSpec {
         FaultSpec {

--- a/crates/cli/tests/config_validation.rs
+++ b/crates/cli/tests/config_validation.rs
@@ -1,5 +1,6 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::peripherals::i2c::I2c;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 #[test]

--- a/crates/core/src/boot/esp32c3_rom.rs
+++ b/crates/core/src/boot/esp32c3_rom.rs
@@ -23,6 +23,7 @@
 //! overlay for sections in no PT_LOAD segment.
 
 use super::esp32s3_rom::{build_window, DramWindow, RomImages};
+use crate::Bus; // seed writes below route through the single Bus-trait accessor
 use goblin::elf::Elf;
 use std::path::PathBuf;
 

--- a/crates/core/src/bus/mmio_words.rs
+++ b/crates/core/src/bus/mmio_words.rs
@@ -2,57 +2,25 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! Word/halfword MMIO helpers (byte-path composition + clock-gate checks).
+//! Side-effect-free instruction-fetch helpers for the RISC-V JIT.
+//!
+//! The word/halfword MMIO accessors (`read_u32`/`read_u16`/`write_u32`/
+//! `write_u16`) live solely in the [`crate::Bus`] trait impl in
+//! `bus/accessors.rs` — that is the single source of truth the CPU runs and the
+//! fidelity gates cover. Direct `SystemBus` callers reach them through the
+//! trait (`use crate::Bus`), so there is no second, drift-prone inherent copy.
 
 use super::*;
 
 impl SystemBus {
-    pub fn read_u32(&self, addr: u64) -> SimResult<u32> {
-        if self.config.optimized_bus_access {
-            if let Some(val) = self.ram.read_u32(addr) {
-                return Ok(val);
-            }
-            if let Some(val) = self.flash.read_u32(addr) {
-                return Ok(val);
-            }
-            for mem in &self.extra_mem {
-                if let Some(val) = mem.read_u32(addr) {
-                    return Ok(val);
-                }
-            }
-            // Boot alias handle
-            if self.flash.base_addr != 0 {
-                let alias_end = self.flash.data.len() as u64;
-                if addr + 3 < alias_end {
-                    if let Some(val) = self.flash.read_u32(self.flash.base_addr + addr) {
-                        return Ok(val);
-                    }
-                }
-            }
-        }
-
-        if let Some(idx) = self.find_peripheral_index(addr) {
-            if !self.is_peripheral_clocked(idx) {
-                return Ok(0); // unclocked peripheral reads 0 (silicon gating)
-            }
-            let p = &self.peripherals[idx];
-            return p.dev.read_u32(addr - p.base);
-        }
-
-        let b0 = self.read_u8(addr)? as u32;
-        let b1 = self.read_u8(addr + 1)? as u32;
-        let b2 = self.read_u8(addr + 2)? as u32;
-        let b3 = self.read_u8(addr + 3)? as u32;
-        Ok(b0 | (b1 << 8) | (b2 << 16) | (b3 << 24))
-    }
-
     /// Side-effect-free instruction-fetch of up to `max_len` **contiguous**
     /// guest code bytes starting at virtual address `vaddr`, materialised the
-    /// SAME way the interpreter fetches instructions (see [`Self::read_u32`] /
-    /// [`Self::read_u16`] and `RiscV::step`'s `bus.read_u32(pc)` fetch): linear
-    /// RAM / flash / extra memories, and the MMU-translating flash-XIP windows
-    /// (0x4200_0000 / 0x3C00_0000). Iterating one address at a time keeps the
-    /// buffer contiguous in **virtual** space — exactly what the walker's
+    /// SAME way the interpreter fetches instructions (see
+    /// [`<Self as crate::Bus>::read_u32`] / [`<Self as crate::Bus>::read_u16`]
+    /// and `RiscV::step`'s `bus.read_u32(pc)` fetch): linear RAM / flash / extra
+    /// memories, and the MMU-translating flash-XIP windows (0x4200_0000 /
+    /// 0x3C00_0000). Iterating one address at a time keeps the buffer contiguous
+    /// in **virtual** space — exactly what the walker's
     /// [`CodeView`](crate::cpu::jit_framework::CodeView) indexes — even when the
     /// XIP MMU maps consecutive virtual pages to discontiguous flash pages.
     ///
@@ -110,136 +78,5 @@ impl SystemBus {
             }
         }
         None
-    }
-
-    pub fn write_u32(&mut self, addr: u64, value: u32) -> SimResult<()> {
-        if self.config.optimized_bus_access && self.ram.write_u32(addr, value) {
-            return Ok(());
-        }
-        if self.config.optimized_bus_access {
-            for mem in &mut self.extra_mem {
-                if mem.write_u32(addr, value) {
-                    return Ok(());
-                }
-            }
-        }
-        // Flash is read-only via bus writes usually, but let's stick to the behavior of write_u8
-        // which would likely fail or do nothing if it's flash.
-        // Actually write_u8 checks flash_alias_old etc.
-
-        if let Some(idx) = self.find_peripheral_index(addr) {
-            if !self.is_peripheral_clocked(idx) {
-                return Ok(()); // unclocked peripheral: write dropped (gating)
-            }
-            #[cfg(feature = "event-scheduler")]
-            self.sync_scheduler_peripheral(idx);
-            self.maybe_latch_dc(idx);
-            let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
-            let (base, r) = {
-                let p = &mut self.peripherals[idx];
-                p.ticks_remaining = 0;
-                let base = p.base;
-                let r = p.dev.write_u32(addr - base, value);
-                (base, r)
-            };
-            if r.is_ok() {
-                self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
-            }
-            self.maybe_arm_hcsr04(idx);
-            #[cfg(feature = "event-scheduler")]
-            self.collect_scheduled_events(idx);
-            if r.is_ok() {
-                // Keep the C3 IRQ routing cache coherent on this inherent
-                // write path too (the Bus-trait accessors already do this) —
-                // host/tooling writes to INTC or FROM_CPU must re-aggregate
-                // exactly like CPU stores.
-                self.sync_esp32c3_irq_cache_write(idx, addr - base);
-                self.refresh_legacy_tick_index(idx);
-                self.refresh_bus_tick_index(idx);
-            }
-            return r;
-        }
-
-        self.write_u8(addr, (value & 0xFF) as u8)?;
-        self.write_u8(addr + 1, ((value >> 8) & 0xFF) as u8)?;
-        self.write_u8(addr + 2, ((value >> 16) & 0xFF) as u8)?;
-        self.write_u8(addr + 3, ((value >> 24) & 0xFF) as u8)?;
-        Ok(())
-    }
-
-    pub fn read_u16(&self, addr: u64) -> SimResult<u16> {
-        if self.config.optimized_bus_access {
-            if let Some(val) = self.ram.read_u16(addr) {
-                return Ok(val);
-            }
-            if let Some(val) = self.flash.read_u16(addr) {
-                return Ok(val);
-            }
-            for mem in &self.extra_mem {
-                if let Some(val) = mem.read_u16(addr) {
-                    return Ok(val);
-                }
-            }
-            // Boot alias handle
-            if self.flash.base_addr != 0 {
-                let alias_end = self.flash.data.len() as u64;
-                if addr + 1 < alias_end {
-                    if let Some(val) = self.flash.read_u16(self.flash.base_addr + addr) {
-                        return Ok(val);
-                    }
-                }
-            }
-        }
-
-        if let Some(idx) = self.find_peripheral_index(addr) {
-            if !self.is_peripheral_clocked(idx) {
-                return Ok(0); // unclocked peripheral reads 0 (silicon gating)
-            }
-            let p = &self.peripherals[idx];
-            return p.dev.read_u16(addr - p.base);
-        }
-
-        let b0 = self.read_u8(addr)? as u16;
-        let b1 = self.read_u8(addr + 1)? as u16;
-        Ok(b0 | (b1 << 8))
-    }
-
-    pub fn write_u16(&mut self, addr: u64, value: u16) -> SimResult<()> {
-        if self.config.optimized_bus_access && self.ram.write_u16(addr, value) {
-            return Ok(());
-        }
-        if let Some(idx) = self.find_peripheral_index(addr) {
-            if !self.is_peripheral_clocked(idx) {
-                return Ok(()); // unclocked peripheral: write dropped (gating)
-            }
-            #[cfg(feature = "event-scheduler")]
-            self.sync_scheduler_peripheral(idx);
-            self.maybe_latch_dc(idx);
-            let c3_io_mux_capture = self.begin_esp32c3_io_mux_write(idx);
-            let (base, r) = {
-                let p = &mut self.peripherals[idx];
-                p.ticks_remaining = 0;
-                let base = p.base;
-                let r = p.dev.write_u16(addr - base, value);
-                (base, r)
-            };
-            if r.is_ok() {
-                self.finish_esp32c3_io_mux_write(c3_io_mux_capture);
-            }
-            self.maybe_arm_hcsr04(idx);
-            #[cfg(feature = "event-scheduler")]
-            self.collect_scheduled_events(idx);
-            if r.is_ok() {
-                // Cache coherence — see the write_u32 note above.
-                self.sync_esp32c3_irq_cache_write(idx, addr - base);
-                self.refresh_legacy_tick_index(idx);
-                self.refresh_bus_tick_index(idx);
-            }
-            return r;
-        }
-
-        self.write_u8(addr, (value & 0xFF) as u8)?;
-        self.write_u8(addr + 1, ((value >> 8) & 0xFF) as u8)?;
-        Ok(())
     }
 }

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1304,6 +1304,7 @@ mod walk_free_campaign {
 mod c3_systimer_matrix_routing {
     use crate::bus::SystemBus;
     use crate::peripherals::esp32s3::systimer::Systimer;
+    use crate::Bus;
     use crate::Peripheral;
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;
@@ -1446,6 +1447,7 @@ mod c3_level_peripheral_matrix_routing {
     use crate::bus::SystemBus;
     use crate::peripherals::esp32c3::apb_saradc::{Esp32c3ApbSarAdc, APB_SARADC_INTR_SOURCE_ID};
     use crate::peripherals::esp32c3::spi::{Esp32c3Spi, SPI2_INTR_SOURCE_ID, TRANS_DONE};
+    use crate::Bus;
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;
 
@@ -1659,6 +1661,7 @@ mod c3_level_peripheral_matrix_routing {
 mod c3_ledc_matrix_routing {
     use crate::bus::SystemBus;
     use crate::peripherals::esp32c3::ledc::{Esp32c3Ledc, LEDC_BASE, LEDC_INTR_SOURCE_ID};
+    use crate::Bus;
     use crate::Peripheral;
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;
@@ -1822,6 +1825,7 @@ mod c3_ledc_matrix_routing {
 mod c3_wifi_mac_matrix_routing {
     use crate::bus::SystemBus;
     use crate::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac;
+    use crate::Bus;
     use crate::Peripheral;
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -296,6 +296,7 @@ impl PeripheralKit for Pcd8544Kit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Bus;
 
     /// Drive a realistic init + pixel-write sequence and assert the D/C line
     /// correctly steers command vs data, the addressing advances, and the

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -631,6 +631,7 @@ impl Peripheral for Esp32c3Gpio {
 mod tests {
     use super::*;
     use crate::bus::SystemBus;
+    use crate::Bus;
     use labwired_config::{ChipDescriptor, SystemManifest};
 
     #[test]

--- a/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
+++ b/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
@@ -115,6 +115,7 @@ impl Peripheral for UsbSerialJtag {
 mod tests {
     use super::*;
     use crate::bus::SystemBus;
+    use crate::Bus;
 
     #[test]
     fn ep1_conf_reads_constant() {

--- a/crates/core/src/peripherals/hc_sr04.rs
+++ b/crates/core/src/peripherals/hc_sr04.rs
@@ -320,6 +320,7 @@ mod tests {
     fn echo_driven_through_bus() {
         use crate::bus::SystemBus;
         use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+        use crate::Bus;
 
         const GPIOA: u64 = 0x4800_0000; // stm32v2: ODR @ 0x14, IDR @ 0x10, BSRR @ 0x18
         let echo_bit = 9u8; // PA9 (ECHO input)

--- a/crates/core/src/tests/esp32c3_rtc_delay_loop.rs
+++ b/crates/core/src/tests/esp32c3_rtc_delay_loop.rs
@@ -39,7 +39,7 @@
 
 use crate::cpu::RiscV;
 use crate::peripherals::esp32c3::rtc_timer::Esp32c3RtcTimer;
-use crate::{Cpu, DebugControl, Machine};
+use crate::{Bus, Cpu, DebugControl, Machine};
 
 const RTC_BASE: u64 = 0x6000_8000;
 /// The delay-loop deadline in RTC counter ticks (== CPU cycles in this model).

--- a/crates/core/src/tests/hcsr04_event_tick_differential.rs
+++ b/crates/core/src/tests/hcsr04_event_tick_differential.rs
@@ -28,7 +28,7 @@ mod hcsr04_event_tick_differential_tests {
     use crate::cpu::CortexM;
     use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
     use crate::peripherals::hc_sr04::HcSr04;
-    use crate::{DebugControl, Machine};
+    use crate::{Bus, DebugControl, Machine};
 
     const GPIO_BASE: u64 = 0x4800_0000; // stm32v2: IDR @0x10, ODR @0x14
     const IDR: u64 = 0x10;

--- a/crates/core/src/tests/scb_reset.rs
+++ b/crates/core/src/tests/scb_reset.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod scb_reset_tests {
-    use crate::{Cpu, DebugControl, Machine};
+    use crate::{Bus, Cpu, DebugControl, Machine};
 
     /// AIRCR address: SCB base (0xE000_ED00) + 0x0C.
     const SCB_AIRCR: u64 = 0xE000_ED0C;

--- a/crates/core/tests/bench_walk_free_kw41z.rs
+++ b/crates/core/tests/bench_walk_free_kw41z.rs
@@ -15,6 +15,7 @@ use labwired_core::bus::SystemBus;
 use labwired_core::cpu::CortexM;
 use labwired_core::peripherals::i2c::I2c;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::{DebugControl, Machine};
 use std::time::Instant;
 

--- a/crates/core/tests/chip_conformance.rs
+++ b/crates/core/tests/chip_conformance.rs
@@ -28,6 +28,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 /// One chip's conformance inputs. `reset_oracle` and `behavior_gate` are `None`

--- a/crates/core/tests/e2e_nrf52840_proximity.rs
+++ b/crates/core/tests/e2e_nrf52840_proximity.rs
@@ -10,6 +10,7 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::cpu::cortex_m::CortexM;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::Machine;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/crates/core/tests/e2e_spi3_dc_epaper.rs
+++ b/crates/core/tests/e2e_spi3_dc_epaper.rs
@@ -15,6 +15,7 @@ use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor
 use labwired_core::peripherals::esp32::spi::Esp32Spi;
 use labwired_core::peripherals::spi::SpiDevice;
 use labwired_core::system::xtensa::configure_xtensa_esp32;
+use labwired_core::Bus;
 
 const SPI3_BASE: u64 = 0x3FF6_5000;
 const GPIO_BASE: u64 = 0x3FF4_4000;

--- a/crates/core/tests/event_scheduler.rs
+++ b/crates/core/tests/event_scheduler.rs
@@ -256,6 +256,7 @@ fn machine_step_parity_with_no_scheduler_users() {
 #[cfg(feature = "event-scheduler")]
 mod write_context_scheduling {
     use labwired_core::bus::SystemBus;
+    use labwired_core::Bus;
     use labwired_core::{Peripheral, SimResult};
 
     const ARM_TOKEN: u32 = 0xE5;

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -14,7 +14,7 @@
 use labwired_config::ChipDescriptor;
 use labwired_core::peripherals::flash::h5;
 use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::{Cpu, DebugControl, Machine};
+use labwired_core::{Bus, Cpu, DebugControl, Machine};
 
 /// FLASH interface peripheral base address (RM0481, stm32h563.yaml).
 const FLASH_BASE: u64 = 0x4002_2000;

--- a/crates/core/tests/h563_conformance.rs
+++ b/crates/core/tests/h563_conformance.rs
@@ -16,6 +16,7 @@
 //! produce identical lines on the board (VCP) and in the simulator.
 
 use labwired_config::ChipDescriptor;
+use labwired_core::Bus;
 
 fn h563_bus() -> labwired_core::bus::SystemBus {
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/core/tests/kw41z_clock_boot.rs
+++ b/crates/core/tests/kw41z_clock_boot.rs
@@ -16,6 +16,7 @@
 
 use labwired_config::ChipDescriptor;
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 
 // Absolute MMIO addresses on the boot path.
 const RSIM_CONTROL: u64 = 0x4005_9000;

--- a/crates/core/tests/kw41z_walk_free_differential.rs
+++ b/crates/core/tests/kw41z_walk_free_differential.rs
@@ -49,6 +49,7 @@ use labwired_core::bus::SystemBus;
 use labwired_core::cpu::CortexM;
 use labwired_core::peripherals::dwt::Dwt;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::{DebugControl, Machine, Peripheral};
 
 // ── DWT differential (hand-built Cortex-M) ──────────────────────────────────

--- a/crates/core/tests/logic_capture_bench.rs
+++ b/crates/core/tests/logic_capture_bench.rs
@@ -29,6 +29,7 @@ use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::peripherals::gpio::{GpioPort, GpioRegisterLayout};
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::{cpu::CortexM, DebugControl, Machine};
 use std::path::PathBuf;
 use std::time::Instant;

--- a/crates/core/tests/nrf5340_clock_boot.rs
+++ b/crates/core/tests/nrf5340_clock_boot.rs
@@ -22,6 +22,7 @@
 
 use labwired_config::ChipDescriptor;
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 
 // Peripherals at the non-secure alias the cpuapp DT uses (peripheral@50000000).
 const CLOCK: u64 = 0x5000_5000;

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -3,6 +3,7 @@
 
 use labwired_config::{Arch, ChipDescriptor};
 use labwired_core::system;
+use labwired_core::Bus;
 use labwired_core::Cpu;
 use labwired_core::Machine;
 use std::fs;

--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -29,7 +29,7 @@
 
 use labwired_config::{Arch, ChipDescriptor};
 use labwired_core::bus::SystemBus;
-use labwired_core::{system, Machine};
+use labwired_core::{system, Bus, Machine};
 use std::path::PathBuf;
 
 /// All supported chips: (name, chip yaml, optional in-tree SVD).

--- a/crates/core/tests/stm32_timer_walk_differential.rs
+++ b/crates/core/tests/stm32_timer_walk_differential.rs
@@ -55,6 +55,7 @@ use labwired_core::bus::SystemBus;
 use labwired_core::cpu::CortexM;
 use labwired_core::peripherals::timer::Timer;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::{DebugControl, Machine};
 
 /// ISR increment target.

--- a/crates/core/tests/systick_walk_differential.rs
+++ b/crates/core/tests/systick_walk_differential.rs
@@ -41,6 +41,7 @@ use labwired_core::cpu::CortexM;
 use labwired_core::peripherals::scb::Scb;
 use labwired_core::peripherals::systick::Systick;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::{DebugControl, Machine, Peripheral};
 
 /// ISR increment target.

--- a/crates/core/tests/uart_attach_seam.rs
+++ b/crates/core/tests/uart_attach_seam.rs
@@ -3,6 +3,7 @@
 
 use labwired_core::bus::SystemBus;
 use labwired_core::peripherals::uart::UartStreamDevice;
+use labwired_core::Bus;
 use std::sync::{Arc, Mutex};
 
 struct Recorder(Arc<Mutex<Vec<u8>>>);

--- a/crates/hw-oracle/src/bin/esp32_replay_in_sim.rs
+++ b/crates/hw-oracle/src/bin/esp32_replay_in_sim.rs
@@ -38,7 +38,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use labwired_core::bus::SystemBus;
 use labwired_core::system::xtensa::configure_xtensa_esp32;
-use labwired_core::{Cpu, Machine};
+use labwired_core::{Bus, Cpu, Machine};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;

--- a/crates/hw-oracle/src/lib.rs
+++ b/crates/hw-oracle/src/lib.rs
@@ -632,6 +632,7 @@ fn capture_sim_state(case: &OracleCase) -> OracleState {
     use labwired_core::bus::SystemBus;
     use labwired_core::cpu::xtensa_lx7::XtensaLx7;
     use labwired_core::cpu::xtensa_sr::{EPC1 as EPC1_SR, EXCCAUSE as EXCCAUSE_SR};
+    use labwired_core::Bus;
     use labwired_core::{Cpu, SimulationError};
     use ram_peripheral::RamPeripheral;
 

--- a/crates/hw-oracle/src/riscv.rs
+++ b/crates/hw-oracle/src/riscv.rs
@@ -452,6 +452,7 @@ mod ram_peripheral {
 fn capture_sim_state(case: &RiscVOracleCase) -> RiscVOracleState {
     use labwired_core::bus::SystemBus;
     use labwired_core::cpu::riscv::RiscV;
+    use labwired_core::Bus;
     use labwired_core::Cpu;
     use ram_peripheral::RamPeripheral;
 

--- a/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
@@ -51,6 +51,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 /// Curated silicon-corroborated reset values (descriptor == live C3), drawn

--- a/crates/hw-oracle/tests/esp32s3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32s3_reset_conformance.rs
@@ -22,6 +22,7 @@
 
 use labwired_core::bus::SystemBus;
 use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
+use labwired_core::Bus;
 
 /// Silicon-read reset values (live S3, reset halt). Each must equal the sim's
 /// modeled reset value. Curated to static config registers the coded S3 model

--- a/crates/hw-oracle/tests/f103_conformance.rs
+++ b/crates/hw-oracle/tests/f103_conformance.rs
@@ -19,6 +19,7 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::Machine;
 use labwired_loader::load_elf;
 use std::path::{Path, PathBuf};

--- a/crates/hw-oracle/tests/f103_fuzz_phase0.rs
+++ b/crates/hw-oracle/tests/f103_fuzz_phase0.rs
@@ -19,6 +19,7 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::Machine;
 use labwired_loader::load_elf;
 use std::path::{Path, PathBuf};

--- a/crates/hw-oracle/tests/foreign_firmware_probe.rs
+++ b/crates/hw-oracle/tests/foreign_firmware_probe.rs
@@ -9,6 +9,7 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::{Cpu, Machine};
 use labwired_loader::load_elf;
 use std::collections::HashMap;

--- a/crates/hw-oracle/tests/h563_mmio_diff.rs
+++ b/crates/hw-oracle/tests/h563_mmio_diff.rs
@@ -41,6 +41,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 // ── RCC (0x4402_0C00, h5 profile) ───────────────────────────────────────────

--- a/crates/hw-oracle/tests/l476_mmio_diff.rs
+++ b/crates/hw-oracle/tests/l476_mmio_diff.rs
@@ -34,6 +34,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 // ── RCC (0x4002_1000) ────────────────────────────────────────────────────────

--- a/crates/hw-oracle/tests/nrf52_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_conformance.rs
@@ -19,6 +19,7 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::Machine;
 use labwired_loader::load_elf;
 use std::path::{Path, PathBuf};

--- a/crates/hw-oracle/tests/nrf52_cpu_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_cpu_conformance.rs
@@ -20,6 +20,7 @@
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Bus;
 use labwired_core::Machine;
 use labwired_loader::load_elf;
 use std::path::{Path, PathBuf};

--- a/crates/hw-oracle/tests/stm32f1_mmio_diff.rs
+++ b/crates/hw-oracle/tests/stm32f1_mmio_diff.rs
@@ -49,6 +49,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 // ── RCC (0x4002_1000, RM0008 §7 — F1 layout) ─────────────────────────────────

--- a/crates/hw-oracle/tests/stm32f4_mmio_diff.rs
+++ b/crates/hw-oracle/tests/stm32f4_mmio_diff.rs
@@ -35,6 +35,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 // ── RCC (0x4002_3800, F4 layout) ─────────────────────────────────────────────

--- a/crates/hw-oracle/tests/stm32l0_mmio_diff.rs
+++ b/crates/hw-oracle/tests/stm32l0_mmio_diff.rs
@@ -39,6 +39,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use std::path::PathBuf;
 
 // ── RCC (0x4002_1000, RM0367 §7 — L0 layout) ─────────────────────────────────

--- a/crates/labwired-fuzz/src/lib.rs
+++ b/crates/labwired-fuzz/src/lib.rs
@@ -14,7 +14,7 @@ use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::memory::ProgramImage;
 use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::{Cpu, Machine};
+use labwired_core::{Bus, Cpu, Machine};
 use labwired_loader::load_elf;
 use std::path::Path;
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,12 +10,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-15 | ⚠ drift acked 2026-07-15 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-16 | ⚠ drift acked 2026-07-16 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
@@ -52,7 +52,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-15 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-18 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-16 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-18 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -379,7 +379,15 @@ boards:
     # the physical GPIO4/GPIO5 contract. This does not replace the reset-state
     # oracle or claim visible OLED photons/I2C ACK; visual or wire-level capture
     # remains pending.
-    drift_ack: 2026-07-15
+    # 2026-07-18: bus access-method consolidation — deleted the stale duplicate
+    # inherent SystemBus::{read,write}_u{16,32} shadow in bus/mmio_words.rs; all
+    # direct-SystemBus callers now route through the single Bus-trait impl. Pure
+    # refactor: byte-identical over 30M instructions on the C3 OLED differential
+    # gate, register/IRQ/elapsed semantics unchanged. Additionally re-validated
+    # LIVE on real C3 silicon this date (USB-JTAG/openocd + esptool): boot->paint
+    # UART parity vs sim ("OLED painted: LabWired"), SYSTIMER 16.34 MHz and the
+    # known RC_SLOW ~148 kHz board deviation captured — consistent with prior.
+    drift_ack: 2026-07-18
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -680,7 +688,13 @@ boards:
     # mirror). Same MMU entry semantics and same flash bytes as before — pure
     # host-side speed; the 9-reg reset-state silicon anchor is unaffected.
     # No live re-capture warranted.
-    drift_ack: 2026-07-16
+    # 2026-07-18: bus access-method consolidation — deleted the stale duplicate
+    # inherent SystemBus::{read,write}_u{16,32} shadow in bus/mmio_words.rs; all
+    # direct-SystemBus callers route through the single Bus-trait impl. Pure
+    # refactor, additive/behaviour-neutral; the 9-reg reset-state anchor is
+    # unaffected. No S3 board attached this session (no live re-capture); C3
+    # sibling silicon re-validated live this date. See esp32c3 drift_ack.
+    drift_ack: 2026-07-18
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
`bus/mmio_words.rs` held a second, **stale, divergent** inherent impl of `read_u32`/`read_u16`/`write_u32`/`write_u16` shadowing the authoritative `impl Bus for SystemBus` in `bus/accessors.rs`. Because Rust resolves inherent methods before trait methods for a concrete receiver, every direct-`SystemBus` caller (tests, tooling, and the esp32c3 rom-boot seed writes) silently hit the shadow — which **lacked** bit-band aliasing, RP2040 atomic-register aliases, MMIO-activity accounting, TM1637 clocking, and the correct `optimized_bus_access==false` XIP/peripheral ordering.

This deletes the 4 duplicate inherent methods (keeping the genuinely-unique JIT helpers `read_code_slice`/`read_code_byte`) and routes all direct callers through the single `Bus`-trait impl via imports. **One definition per bus-access method** — no more parallel sources of truth for the memory-access contract.

Diff is +60/−183 across 45 files (mostly one-line `use` additions; the −183 is the removed shadow). No test was pinning divergent behavior — the whole suite passed with import-only edits.

Gates: C3 OLED differential **byte-identical over 30M instructions**; `cargo test --workspace` **2971 passed / 0 failed**; `--workspace --lib` green; fmt + clippy `-D warnings` clean. Re-verified byte-identical after merging current main (P1 + allocation).