### PR TITLE
perf(sched): drain due events into retained scratch instead of a fresh Vec

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1141,6 +1141,14 @@ pub struct Machine<C: Cpu> {
     /// used under the `event-scheduler` feature.
     #[allow(dead_code)]
     pending_schedule_scratch: Vec<(usize, u64, u32)>,
+    /// Reusable scratch for the due-events batch drained out of the scheduler
+    /// each `drain_scheduler_events`. Taken out, filled by
+    /// `EventScheduler::drain_due_into`, iterated, then restored — so the
+    /// steady-state SYSTIMER tick (which drains an event nearly every batch)
+    /// reuses the buffer's capacity instead of allocating a fresh `Vec` per
+    /// drain. Always present; only used under the `event-scheduler` feature.
+    #[allow(dead_code)]
+    due_events_scratch: Vec<sched::ScheduledEvent>,
     /// Reusable no-op stand-in for the peripheral swap-out dance in
     /// `drain_scheduler_events` (a peripheral's `on_event` needs `&mut self.bus`,
     /// so the peripheral is temporarily replaced by a stub). Held here and
@@ -1396,6 +1404,7 @@ impl<C: Cpu> Machine<C> {
             tick_irq_scratch: Vec::new(),
             tick_cost_scratch: Vec::new(),
             pending_schedule_scratch: Vec::new(),
+            due_events_scratch: Vec::new(),
             event_placeholder: Some(Box::new(crate::peripherals::stub::StubPeripheral::new(0))),
             logic_capture: logic_capture::LogicCapture::new(),
             logic_force_poll: false,
@@ -1919,8 +1928,13 @@ impl<C: Cpu> Machine<C> {
             return;
         }
         self.refresh_generation_scratch();
-        let due = self.sched.drain_due(&self.generation_scratch);
-        for ev in due {
+        // Fill the retained scratch (taken out so `on_event` below can borrow
+        // `&mut self.sched` / `&mut self.bus`) instead of allocating a fresh
+        // `Vec` per drain; restored at the end with its capacity intact.
+        let mut due = std::mem::take(&mut self.due_events_scratch);
+        self.sched
+            .drain_due_into(&self.generation_scratch, &mut due);
+        for ev in due.drain(..) {
             // Bus-subsystem pseudo-peripheral (HC-SR04): no `peripherals[]`
             // entry — dispatch straight to the shared ECHO choke point.
             if ev.peripheral_idx == sched::SUBSYSTEM_PERIPHERAL_IDX {
@@ -1955,6 +1969,8 @@ impl<C: Cpu> Machine<C> {
             }
             self.apply_event_result(idx, result);
         }
+        // `drain(..)` above emptied it but kept its capacity; restore for reuse.
+        self.due_events_scratch = due;
     }
 
     /// Phase 2B.1 (issue #192): fan out the side-effects produced by a

--- a/crates/core/src/sched/event_scheduler.rs
+++ b/crates/core/src/sched/event_scheduler.rs
@@ -163,14 +163,28 @@ impl EventScheduler {
     /// generation) are popped and silently discarded. Returned in
     /// `(deadline asc, event_id asc)` order.
     pub fn drain_due(&mut self, peripheral_generations: &[u32]) -> Vec<ScheduledEvent> {
-        // Nothing due: return without allocating. `Vec::new()` is non-allocating
-        // but this also skips the peek loop setup when the heap is empty.
+        let mut out = Vec::new();
+        self.drain_due_into(peripheral_generations, &mut out);
+        out
+    }
+
+    /// Push-based twin of [`Self::drain_due`]: append the due events into a
+    /// CALLER-OWNED buffer instead of returning a freshly-allocated `Vec`. The
+    /// per-batch drain (`Machine::drain_scheduler_events`) passes retained
+    /// scratch so the steady-state SYSTIMER tick — which drains at least one
+    /// event nearly every batch — no longer allocates. `out` is cleared first.
+    pub fn drain_due_into(
+        &mut self,
+        peripheral_generations: &[u32],
+        out: &mut Vec<ScheduledEvent>,
+    ) {
+        out.clear();
+        // Nothing due: return without touching the heap loop.
         match self.heap.peek() {
-            None => return Vec::new(),
-            Some(Reverse(top)) if top.deadline > self.now => return Vec::new(),
+            None => return,
+            Some(Reverse(top)) if top.deadline > self.now => return,
             _ => {}
         }
-        let mut out = Vec::new();
         while let Some(Reverse(top)) = self.heap.peek() {
             if top.deadline > self.now {
                 break;
@@ -181,7 +195,6 @@ impl EventScheduler {
             }
             out.push(ev);
         }
-        out
     }
 
     /// True once no events remain queued. Lets the per-step drain skip its


### PR DESCRIPTION
## What

Milestone-3 interpreter hot-path pass (companion to #568, independent + additive). Same interpreter-only C3 OLED profile: after the matrix-source allocation, the next movable alloc on the warm path is the scheduler's due-event batch.

`EventScheduler::drain_due` allocated a fresh `Vec<ScheduledEvent>` per call, and `Machine::drain_scheduler_events` calls it once per batch. On the C3 OLED lab the SYSTIMER alarm makes ≥1 event due nearly every batch, so this was an alloc/free of the due-batch buffer per warm batch.

## Change

- Add `drain_due_into(&mut self, gens, &mut Vec<_>)`; the returning `drain_due` becomes a thin wrapper (tests / one-shot callers).
- The per-batch drain fills a retained `due_events_scratch`, taken out so `on_event` can still borrow `&mut self.sched`/`&mut self.bus`, and restored with its capacity intact — mirroring the existing `pending_schedule_scratch` reuse.

## Numbers

- Warm-window callgrind (C3 OLED, 30M instr, JIT off): **-1.2% Ir** on its own; combined with #568: **2,316M → 1,992M Ir (-14.0%)**, warm throughput ~164M → ~215M guest-cycles/s.
- Browser-transferable (pure interpreter, no wasmtime).

## Verification (byte-identical oracle)

- `riscv_jit_c3_oled_differential` byte-identical over 30M instructions ✅
- C3 + S3 walk differentials, clamped full-state differential, shipped-lab batch gate, 14 scheduler unit tests ✅
- `cargo fmt` + `clippy` clean.