### PR TITLE
perf(bus): walk-free campaign — full STM32F1 board flip (I2C/EXTI/ADC/RTC)

### DIFF
--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1257,17 +1257,23 @@ mod walk_free_campaign {
     /// re-assertion with all byte/device work synchronous in read/write — IS
     /// migrated in this batch, unblocking the FRDM-KW41Z board flip; the STM32
     /// countdown engine is the part that cannot.) Remaining plan Class-B on this
-    /// bus: 3 i2c + adc + exti + bxcan.
+    /// bus: 3 i2c + adc + exti.
+    ///
+    /// bxCAN (`can1`) NO LONGER forces the walk: its `tick()` only drains a
+    /// `CanBus` mpsc interconnect, so `needs_legacy_walk()` now reports
+    /// `bus_rx.is_some()` — false on this bus (no multi-node CanBus is wired;
+    /// can-player replay is pushed by `service_can_log_players`, not the tick).
     #[cfg(feature = "event-scheduler")]
-    const EXPECTED_WALK_FORCING: &[&str] = &["i2c1", "i2c2", "i2c3", "adc1", "exti", "can1"];
+    const EXPECTED_WALK_FORCING: &[&str] = &["i2c1", "i2c2", "i2c3", "adc1", "exti"];
 
     /// Featureless builds: the scheduler does not exist, so SysTick and SCB
-    /// stay on the legacy walk — the full post-B0 set of 22.
+    /// stay on the legacy walk. bxCAN (`can1`) is excluded regardless of the
+    /// feature — its walk-forcing is gated on an attached interconnect, not the
+    /// scheduler.
     #[cfg(not(feature = "event-scheduler"))]
     const EXPECTED_WALK_FORCING: &[&str] = &[
         "systick", "tim1", "tim2", "tim3", "tim4", "tim5", "tim6", "tim7", "tim8", "tim15",
-        "tim16", "tim17", "dma1", "dma2", "i2c1", "i2c2", "i2c3", "adc1", "exti", "scb", "can1",
-        "dwt",
+        "tim16", "tim17", "dma1", "dma2", "i2c1", "i2c2", "i2c3", "adc1", "exti", "scb", "dwt",
     ];
 
     fn invaders_bus_walk_stripped() -> SystemBus {
@@ -1316,9 +1322,10 @@ mod walk_free_campaign {
 
     #[test]
     fn remaining_class_b_walkers_still_pin_walk_deletion() {
-        // I2C/ADC/EXTI/bxCAN (+DWT) still force the walk, so B4
-        // cannot flip the invaders bus yet: the derivation must stay
-        // conservative until every Class-B walker is migrated.
+        // I2C/ADC/EXTI still force the walk, so the invaders bus cannot
+        // flip yet: the derivation must stay conservative until every
+        // Class-B walker is migrated. (bxCAN no longer forces it — its
+        // walk work is gated on an attached CanBus interconnect.)
         let bus = invaders_bus_walk_stripped();
         assert!(
             !bus.derive_walk_deletable(),

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1263,10 +1263,19 @@ mod walk_free_campaign {
     /// EXTI (`exti`) NO LONGER forces the walk: its held-level `explicit_irqs`
     /// re-emission is driven by a delay-1 self-perpetuating event chain (armed on
     /// the MMIO write that raises a masked pending line, stopping when firmware
-    /// clears PR). Byte-identical proof: `exti::scheduler_diff`. Remaining plan
-    /// Class-B on this bus: adc.
+    /// clears PR). Byte-identical proof: `exti::scheduler_diff`.
+    ///
+    /// ADC (`adc1`) NO LONGER forces the walk: its F1 conversion countdown is
+    /// event-scheduled (delay-1 chain armed on SWSTART, perpetuating through
+    /// continuous mode), and the legacy `cycles: 1` per-converting-tick cost is
+    /// normalized to zero in BOTH modes (SysTick B1 pattern) so `total_cycles`
+    /// agrees. Byte-identical proof: `adc::scheduler_diff`.
+    ///
+    /// The forcing set is now EMPTY — with every Class-B walker migrated the
+    /// runtime invaders (L476) bus derives walk-deletion with no hand flag: the
+    /// campaign's full STM32 board flip.
     #[cfg(feature = "event-scheduler")]
-    const EXPECTED_WALK_FORCING: &[&str] = &["adc1"];
+    const EXPECTED_WALK_FORCING: &[&str] = &[];
 
     /// Featureless builds: the scheduler does not exist, so SysTick and SCB
     /// stay on the legacy walk. bxCAN (`can1`) is excluded regardless of the
@@ -1323,16 +1332,17 @@ mod walk_free_campaign {
     }
 
     #[test]
-    fn remaining_class_b_walkers_still_pin_walk_deletion() {
-        // I2C/ADC/EXTI still force the walk, so the invaders bus cannot
-        // flip yet: the derivation must stay conservative until every
-        // Class-B walker is migrated. (bxCAN no longer forces it — its
-        // walk work is gated on an attached CanBus interconnect.)
+    fn invaders_bus_now_flips_with_every_class_b_migrated() {
+        // With I2C, EXTI and ADC all event-scheduled, the runtime invaders
+        // (L476) bus has an EMPTY walk-forcing set and derives walk-deletion
+        // with no hand `walk_deleted` flag — the campaign's full STM32 board
+        // flip. (bxCAN never forced it here — its walk work is gated on an
+        // attached CanBus interconnect, absent on this bus.)
         let bus = invaders_bus_walk_stripped();
         assert!(
-            !bus.derive_walk_deletable(),
-            "invaders bus became walk-deletable after B4, but Class-B walkers remain — \
-             each batch must be honest bookkeeping with no premature walk deletion"
+            bus.derive_walk_deletable(),
+            "invaders bus should be walk-deletable once every Class-B walker \
+             (i2c/exti/adc) is migrated and the forcing set is empty"
         );
     }
 }

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1259,8 +1259,14 @@ mod walk_free_campaign {
     /// `CanBus` mpsc interconnect, so `needs_legacy_walk()` now reports
     /// `bus_rx.is_some()` — false on this bus (no multi-node CanBus is wired;
     /// can-player replay is pushed by `service_can_log_players`, not the tick).
+    ///
+    /// EXTI (`exti`) NO LONGER forces the walk: its held-level `explicit_irqs`
+    /// re-emission is driven by a delay-1 self-perpetuating event chain (armed on
+    /// the MMIO write that raises a masked pending line, stopping when firmware
+    /// clears PR). Byte-identical proof: `exti::scheduler_diff`. Remaining plan
+    /// Class-B on this bus: adc.
     #[cfg(feature = "event-scheduler")]
-    const EXPECTED_WALK_FORCING: &[&str] = &["adc1", "exti"];
+    const EXPECTED_WALK_FORCING: &[&str] = &["adc1"];
 
     /// Featureless builds: the scheduler does not exist, so SysTick and SCB
     /// stay on the legacy walk. bxCAN (`can1`) is excluded regardless of the

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1241,30 +1241,26 @@ mod walk_free_campaign {
     use labwired_config::{ChipDescriptor, SystemManifest};
     use std::path::PathBuf;
 
-    /// Walk-forcing ids on the runtime invaders bus after B4 (event-scheduler
-    /// builds): the prior 8 (B2/B3 timers + the DWT lazy-CYCCNT migration from
-    /// #522) minus the 2 `dma*` (B4 — per-channel element event chains, delay-1
-    /// mem2mem self-pacing, request-armed via the `route_dma_signal` hook) = 6.
-    /// The 3 `i2c*` STAY on the walk: THIS bus instantiates the STM32 **F1** I2C
-    /// variant, whose transaction engine is a `cycles_remaining` countdown
-    /// driven by `&self`-read side effects (`rxne_consumed` / `read_dr_consumed`)
-    /// that arm subsequent IRQ-raising state transitions. The bus read path is
-    /// `&self` (cannot schedule events) with event arming only on writes, so a
-    /// per-byte receive IRQ cannot be delivered through the event path without
-    /// dropping it or overrunning the read-gated byte stream (a fidelity loss).
-    /// Per the non-negotiable fidelity rule F1/L4 I2C stays on the legacy walk.
-    /// (The NXP **Kinetis** I2C variant — whose `tick()` is a pure level-IRQ
-    /// re-assertion with all byte/device work synchronous in read/write — IS
-    /// migrated in this batch, unblocking the FRDM-KW41Z board flip; the STM32
-    /// countdown engine is the part that cannot.) Remaining plan Class-B on this
-    /// bus: 3 i2c + adc + exti.
+    /// Walk-forcing ids on the runtime invaders bus after the I2C migration
+    /// (event-scheduler builds): the prior 6 (B2/B3 timers minus the 2 `dma*`,
+    /// with the DWT lazy-CYCCNT migration from #522) minus the 3 `i2c*` = 2.
+    /// The 3 `i2c*` NOW migrate: the STM32 F1/L4 transaction engine is self-paced
+    /// by the SAME held-level, delay-1 self-perpetuating event chain the Kinetis
+    /// variant uses. The chain runs `F1I2c::tick()`/`L4I2c::tick()` every cycle
+    /// while a transfer is *active* (countdown in flight OR SR2.BUSY set), so the
+    /// `&self`-read side effects (`rxne_consumed` / device byte pulls) are
+    /// observed by the already-live chain's next `on_event` exactly as the walk's
+    /// next `tick()` would — no event needs arming from the read path. Proven
+    /// byte-identical (registers + read bytes + NVIC-pend cycles) by the
+    /// `kinetis_scheduler` differential module (`f1_*`/`l4_*` cases). Remaining
+    /// plan Class-B on this bus: adc + exti.
     ///
     /// bxCAN (`can1`) NO LONGER forces the walk: its `tick()` only drains a
     /// `CanBus` mpsc interconnect, so `needs_legacy_walk()` now reports
     /// `bus_rx.is_some()` — false on this bus (no multi-node CanBus is wired;
     /// can-player replay is pushed by `service_can_log_players`, not the tick).
     #[cfg(feature = "event-scheduler")]
-    const EXPECTED_WALK_FORCING: &[&str] = &["i2c1", "i2c2", "i2c3", "adc1", "exti"];
+    const EXPECTED_WALK_FORCING: &[&str] = &["adc1", "exti"];
 
     /// Featureless builds: the scheduler does not exist, so SysTick and SCB
     /// stay on the legacy walk. bxCAN (`can1`) is excluded regardless of the

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -1339,10 +1339,18 @@ mod walk_free_campaign {
         // flip. (bxCAN never forced it here — its walk work is gated on an
         // attached CanBus interconnect, absent on this bus.)
         let bus = invaders_bus_walk_stripped();
+        #[cfg(feature = "event-scheduler")]
         assert!(
             bus.derive_walk_deletable(),
             "invaders bus should be walk-deletable once every Class-B walker \
              (i2c/exti/adc) is migrated and the forcing set is empty"
+        );
+        // Featureless builds have no scheduler, so the migrated models honestly
+        // stay on the walk and the bus does NOT flip.
+        #[cfg(not(feature = "event-scheduler"))]
+        assert!(
+            !bus.derive_walk_deletable(),
+            "featureless build keeps the walk (no scheduler to migrate onto)"
         );
     }
 }

--- a/crates/core/src/peripherals/adc.rs
+++ b/crates/core/src/peripherals/adc.rs
@@ -11,7 +11,7 @@
 // directly by the WASM value-injection bridge), the conversion engine and the
 // per-channel injected inputs are architecture-independent and stay shared.
 
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
 use std::any::Any;
 use std::str::FromStr;
 
@@ -111,6 +111,14 @@ pub struct Adc {
     conversion_time: u32,
     /// Per-channel injected values (12-bit counts). 0xFFFF = "no injection".
     channel_inputs: [u16; 18],
+
+    /// Bus-published cycle clock (walk-free campaign). `Some` once attached →
+    /// event-schedulable; `None` keeps the legacy walk.
+    #[serde(skip)]
+    clock: Option<CycleClock>,
+    /// Scheduler mode: `true` while the conversion-countdown event is live.
+    #[serde(skip)]
+    chain_live: bool,
 }
 
 impl Adc {
@@ -138,7 +146,56 @@ impl Adc {
             cycles_remaining: 0,
             conversion_time: 14,
             channel_inputs: [0xFFFF; 18],
+            clock: None,
+            chain_live: false,
         }
+    }
+
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Test/differential knob: detach the clock, pinning the model to the legacy
+    /// walk (the walk-on reference for the differential gate).
+    pub fn force_legacy_walk(&mut self) {
+        self.clock = None;
+    }
+
+    /// One cycle of the F1 conversion countdown. Returns whether an EOC IRQ
+    /// should be raised this cycle. Shared verbatim by the legacy walk `tick()`
+    /// and the scheduler `on_event`, so the two routes are identical by
+    /// construction.
+    fn advance_conversion(&mut self) -> bool {
+        let mut irq = false;
+        if self.converting {
+            if self.cycles_remaining > 0 {
+                self.cycles_remaining -= 1;
+            } else {
+                self.converting = false;
+                let (cr1, cr2) = self.f1_ctrl();
+
+                // Injected channel value if available; else increment DR for
+                // visual feedback. SQR3 ch fallback uses CR2 low bits (legacy).
+                let ch = (cr2 & 0x1F) as usize;
+                if ch < self.channel_inputs.len() && self.channel_inputs[ch] != 0xFFFF {
+                    self.dr = self.channel_inputs[ch] as u32;
+                } else {
+                    self.dr = (self.dr + 1) & 0xFFF;
+                }
+
+                self.sr |= 1 << 1; // EOC
+
+                if (cr1 & (1 << 5)) != 0 {
+                    irq = true; // EOCIE
+                }
+                // Continuous mode (CONT bit1 + ADON bit0).
+                if (cr2 & (1 << 1)) != 0 && (cr2 & 1) != 0 {
+                    self.start_conversion();
+                }
+            }
+        }
+        irq
     }
 
     /// Inject a millivolt reading for a specific ADC channel. The next
@@ -313,41 +370,76 @@ impl Peripheral for Adc {
     }
 
     fn tick(&mut self) -> PeripheralTickResult {
-        let mut irq = false;
-        let mut cycles = 0;
-
-        if self.converting {
-            cycles = 1;
-            if self.cycles_remaining > 0 {
-                self.cycles_remaining -= 1;
-            } else {
-                self.converting = false;
-                let (cr1, cr2) = self.f1_ctrl();
-
-                // Injected channel value if available; else increment DR for
-                // visual feedback. SQR3 ch fallback uses CR2 low bits (legacy).
-                let ch = (cr2 & 0x1F) as usize;
-                if ch < self.channel_inputs.len() && self.channel_inputs[ch] != 0xFFFF {
-                    self.dr = self.channel_inputs[ch] as u32;
-                } else {
-                    self.dr = (self.dr + 1) & 0xFFF;
-                }
-
-                self.sr |= 1 << 1; // EOC
-
-                if (cr1 & (1 << 5)) != 0 {
-                    irq = true; // EOCIE
-                }
-                // Continuous mode (CONT bit1 + ADON bit0).
-                if (cr2 & (1 << 1)) != 0 && (cr2 & 1) != 0 {
-                    self.start_conversion();
-                }
-            }
+        // Scheduler-mode instances are walk-skipped; the event chain owns the
+        // conversion countdown. Guard against a stray direct call.
+        if self.scheduler_mode() {
+            return PeripheralTickResult::default();
         }
-
+        let irq = self.advance_conversion();
+        // Tick-cost normalization (mirrors SysTick B1): the legacy model charged
+        // `cycles: 1` per converting tick into `total_cycles` — a sim artifact (a
+        // real ADC conversion runs on the ADC clock and consumes zero *core*
+        // cycles) that is structurally incompatible with deleting the walk (the
+        // scheduler never runs a per-cycle tick to charge it). Both modes now
+        // charge zero, so the walk-on reference and the scheduler path agree
+        // cycle-for-cycle.
         PeripheralTickResult {
             irq,
-            cycles,
+            cycles: 0,
+            ..Default::default()
+        }
+    }
+
+    fn uses_scheduler(&self) -> bool {
+        self.scheduler_mode()
+    }
+
+    fn needs_legacy_walk(&self) -> bool {
+        !self.scheduler_mode()
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        self.clock = Some(clock);
+    }
+
+    fn sync_to(&mut self, _now_cycle: u64) {
+        // No lazily-accumulated state: the conversion countdown is advanced
+        // cycle-by-cycle by the event chain (drained up to the current cycle by
+        // `Machine::step` before any MMIO access observes DR/SR).
+    }
+
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        // Arm the conversion-countdown chain the moment a write starts a
+        // conversion (`converting` set by SWSTART on F1). L4 converts
+        // synchronously in `write` and never sets `converting`, so it arms
+        // nothing. delay-0 → deadline `current_cycle + 1` = the walk's next tick.
+        if self.scheduler_mode() && self.converting && !self.chain_live {
+            self.chain_live = true;
+            vec![(0u64, 0u32)]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn on_event(
+        &mut self,
+        _event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if !self.scheduler_mode() {
+            return crate::sched::EventResult::default();
+        }
+        // Run one cycle of the SAME conversion countdown the walk runs and pend
+        // the EOC line on its verdict. Continuous mode re-arms `converting` in
+        // `advance_conversion`, so re-check it AFTER and perpetuate at delay 1
+        // while still converting; stop when the conversion completes (single
+        // shot) so idle fast-forward engages.
+        let irq = self.advance_conversion();
+        self.chain_live = self.converting;
+        crate::sched::EventResult {
+            raise_own_irq: irq,
+            reschedule_delay: self.converting.then_some(1),
             ..Default::default()
         }
     }
@@ -476,6 +568,22 @@ mod tests {
     }
 
     #[test]
+    fn tick_cost_is_normalized_to_zero_while_converting() {
+        // The legacy `cycles: 1` per converting tick is gone in BOTH modes.
+        let mut adc = Adc::new();
+        adc.write(0x08, 1).unwrap(); // ADON
+        adc.write(0x0B, 1 << 6).unwrap(); // SWSTART
+        assert!(adc.converting);
+        for _ in 0..14 {
+            assert_eq!(
+                adc.tick().cycles,
+                0,
+                "converting tick must charge zero cost"
+            );
+        }
+    }
+
+    #[test]
     fn test_l4_adc_code_helpers() {
         assert_eq!(l4_resolution_bits(0), 12);
         assert_eq!(l4_resolution_bits(1 << 3), 10);
@@ -484,5 +592,103 @@ mod tests {
         assert_eq!(l4_adc_code(12), 3723);
         assert_eq!(l4_adc_code(10), 930);
         assert_ne!(l4_adc_code(12), l4_adc_code(10));
+    }
+}
+
+// ── Walk-free differential: F1 ADC conversion engine walk vs scheduler ────────
+#[cfg(all(test, feature = "event-scheduler"))]
+mod scheduler_diff {
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum Op {
+        Write(u64, u8),
+    }
+
+    fn build(scheduler: bool) -> Adc {
+        let mut adc = Adc::new(); // F1
+        adc.set_channel_input(3, 1650); // deterministic conversion result on ch3
+        if scheduler {
+            adc.attach_cycle_clock(CycleClock::default());
+        }
+        adc
+    }
+
+    /// Drive the SAME op script against (a) the per-cycle walk and (b) the event
+    /// path; assert the register snapshot AND the EOC-IRQ pend cycles are
+    /// identical every cycle. The conversion countdown, DR latch, EOC flag and
+    /// continuous-mode restart must all line up cycle-for-cycle.
+    fn assert_walk_identical(script: &[(u64, Op)], cycles: u64) {
+        let mut walk = build(false);
+        let mut sched = build(true);
+        let clock = sched.clock.clone().unwrap();
+
+        let mut events: Vec<(u64, u32)> = Vec::new();
+        let bus = &mut crate::bus::SystemBus::new();
+        let mut walk_pends = Vec::new();
+        let mut sched_pends = Vec::new();
+
+        for c in 1..=cycles {
+            for (sc, Op::Write(off, val)) in script.iter().copied() {
+                if sc == c {
+                    walk.write(off, val).unwrap();
+                    sched.write(off, val).unwrap();
+                    for (delay, token) in sched.take_scheduled_events() {
+                        events.push((c - 1 + 1 + delay, token));
+                    }
+                }
+            }
+
+            if walk.tick().irq {
+                walk_pends.push(c);
+            }
+
+            clock.publish(c);
+            let due: Vec<(u64, u32)> = events.iter().copied().filter(|(d, _)| *d <= c).collect();
+            events.retain(|(d, _)| *d > c);
+            let mut esched = crate::sched::EventScheduler::new();
+            esched.advance_to(c);
+            for (_, token) in due {
+                let res = sched.on_event(token, &mut esched, bus);
+                if res.raise_own_irq {
+                    sched_pends.push(c);
+                }
+                if let Some(delay) = res.reschedule_delay {
+                    events.push((c + delay, token));
+                }
+            }
+
+            assert_eq!(
+                walk.snapshot(),
+                sched.snapshot(),
+                "register snapshot diverged at cycle {c}"
+            );
+        }
+        assert_eq!(walk_pends, sched_pends, "EOC-IRQ pend cycles diverged");
+    }
+
+    #[test]
+    fn f1_single_conversion_walk_identity() {
+        // EOCIE + ADON + SWSTART on channel 3 → 14-cycle countdown → EOC + DR.
+        let script = [
+            (1u64, Op::Write(0x04, 1 << 5)), // CR1.EOCIE
+            (1, Op::Write(0x08, 1 | 3)),     // CR2.ADON, SQR-fallback channel 3
+            (2, Op::Write(0x0B, 1 << 6)),    // CR2.SWSTART (bit 30) → convert
+            (20, Op::Write(0x00, 0)),        // read-back settle (no-op SR write)
+        ];
+        assert_walk_identical(&script, 26);
+    }
+
+    #[test]
+    fn f1_continuous_conversion_walk_identity() {
+        // CONT + ADON: after the first EOC the engine re-arms and converts again,
+        // so the chain must perpetuate across multiple completions.
+        let script = [
+            (1u64, Op::Write(0x04, 1 << 5)),        // CR1.EOCIE
+            (1, Op::Write(0x08, 1 | (1 << 1) | 3)), // CR2.ADON | CONT | channel 3
+            (2, Op::Write(0x0B, 1 << 6)),           // SWSTART → first conversion
+        ];
+        // 2 + 15 + 15 + 15 ≈ 47 cycles covers three back-to-back conversions.
+        assert_walk_identical(&script, 50);
     }
 }

--- a/crates/core/src/peripherals/afio.rs
+++ b/crates/core/src/peripherals/afio.rs
@@ -89,6 +89,16 @@ impl Peripheral for Afio {
         Ok(())
     }
 
+    fn needs_legacy_walk(&self) -> bool {
+        // AFIO is a pure configuration register bank (MAPR/EXTICR remap bits).
+        // It has no `tick()` override, so its per-cycle walk callback is the
+        // default no-op: it never mutates observable state, emits an IRQ/DMA
+        // request, or fires an event from the walk. Deleting the walk is
+        // therefore byte-identical for every reachable firmware state, so it
+        // must not pin the walk on for the rest of the bus.
+        false
+    }
+
     fn as_any(&self) -> Option<&dyn Any> {
         Some(self)
     }

--- a/crates/core/src/peripherals/bxcan.rs
+++ b/crates/core/src/peripherals/bxcan.rs
@@ -564,6 +564,25 @@ impl Peripheral for BxCan {
         PeripheralTickResult::with_irq(false)
     }
 
+    fn needs_legacy_walk(&self) -> bool {
+        // The ONLY thing bxCAN's `tick()` does is drain the `CanBus` mpsc
+        // interconnect (`bus_rx`) into the receiver. With no interconnect
+        // attached (`bus_rx == None`) the tick is a proven no-op for every
+        // reachable firmware state, so the walk can be deleted byte-identically.
+        //
+        // Frame injection from a `can-player` external device does NOT flow
+        // through this tick: it is pushed by `SystemBus::service_can_log_players`
+        // (a per-cycle CAN orchestration service that runs whenever any player
+        // is present — `per_cycle_tick_is_trivial` keeps the tick alive for it —
+        // independent of walk deletion), so replay labs stay correct with the
+        // walk deleted. The mpsc `bus_rx` path is used only by a multi-node
+        // `CanBus` interconnect; when one is wired (`bus_rx == Some`) the walk
+        // must stay on to poll it, and this reports `true` at that instant. The
+        // interconnect is attached at construction (`new_with_bus`), before the
+        // bus derives walk-deletion, so the derivation always sees the truth.
+        self.bus_rx.is_some()
+    }
+
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }

--- a/crates/core/src/peripherals/exti.rs
+++ b/crates/core/src/peripherals/exti.rs
@@ -11,7 +11,7 @@
 // (or be tricked into addressing) bank-2 state. Bank-1 IRQ routing, shared by
 // both families, lives in one stateless helper.
 
-use crate::{Peripheral, PeripheralTickResult, SimResult};
+use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
 use std::any::Any;
 use std::str::FromStr;
 
@@ -117,6 +117,14 @@ fn route_bank1_irqs(active1: u32, irqs: &mut Vec<u32>) {
 pub struct F1Exti {
     bank1: ExtiBank,
     line_mask: u32,
+
+    /// Bus-published cycle clock (walk-free campaign). `Some` once attached →
+    /// event-schedulable; `None` keeps the legacy walk.
+    #[serde(skip)]
+    clock: Option<CycleClock>,
+    /// Scheduler mode: `true` while the held-level re-emit event is live.
+    #[serde(skip)]
+    chain_live: bool,
 }
 
 impl Default for F1Exti {
@@ -124,6 +132,8 @@ impl Default for F1Exti {
         Self {
             bank1: ExtiBank::default(),
             line_mask: 0x000F_FFFF, // 20 lines
+            clock: None,
+            chain_live: false,
         }
     }
 }
@@ -133,6 +143,11 @@ impl Default for F1Exti {
 pub struct L4Exti {
     bank1: ExtiBank,
     bank2: ExtiBank,
+
+    #[serde(skip)]
+    clock: Option<CycleClock>,
+    #[serde(skip)]
+    chain_live: bool,
 }
 
 impl L4Exti {
@@ -220,6 +235,87 @@ impl Exti {
             },
         }
     }
+
+    /// The set of NVIC IRQ lines the held level asserts this cycle — exactly the
+    /// list `tick()` re-emits. Shared by the legacy walk and the event chain so
+    /// both routes are byte-identical by construction.
+    fn pending_irqs(&self) -> Vec<u32> {
+        let mut irqs = Vec::new();
+        match self {
+            Self::Stm32F1(e) => {
+                let active1 = e.bank1.pr & e.bank1.imr;
+                if active1 != 0 {
+                    route_bank1_irqs(active1, &mut irqs);
+                }
+            }
+            Self::Stm32L4(e) => {
+                let active1 = e.bank1.pr & e.bank1.imr;
+                let active2 = e.bank2.pr & e.bank2.imr;
+                if active1 != 0 {
+                    route_bank1_irqs(active1, &mut irqs);
+                }
+                if active2 != 0 {
+                    // Bank-2 wakeup lines → their peripheral's NVIC IRQ
+                    // (RM0351 §13.3). Lines without an entry are tracked at the
+                    // register level but don't synthesize an IRQ yet.
+                    for &(line, irq) in &[
+                        (35u32, 70u32), // LPUART1 wakeup
+                        (36, 31),       // I2C1 wakeup
+                        (37, 33),       // I2C2 wakeup
+                        (38, 72),       // I2C3 wakeup
+                        (39, 37),       // USART1 wakeup
+                    ] {
+                        if (active2 >> (line - 32)) & 1 != 0 {
+                            irqs.push(irq);
+                        }
+                    }
+                }
+            }
+        }
+        irqs
+    }
+
+    /// True while the held level is asserted (any masked pending line). Outside
+    /// this window `tick()` emits nothing, so the event chain may stop and let
+    /// idle fast-forward engage; firmware clearing PR (rc_w1) drops it.
+    fn active(&self) -> bool {
+        match self {
+            Self::Stm32F1(e) => (e.bank1.pr & e.bank1.imr) != 0,
+            Self::Stm32L4(e) => (e.bank1.pr & e.bank1.imr) != 0 || (e.bank2.pr & e.bank2.imr) != 0,
+        }
+    }
+
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        let clock = match self {
+            Self::Stm32F1(e) => &e.clock,
+            Self::Stm32L4(e) => &e.clock,
+        };
+        cfg!(feature = "event-scheduler") && clock.is_some()
+    }
+
+    fn set_chain_live(&mut self, live: bool) {
+        match self {
+            Self::Stm32F1(e) => e.chain_live = live,
+            Self::Stm32L4(e) => e.chain_live = live,
+        }
+    }
+
+    fn chain_live(&self) -> bool {
+        match self {
+            Self::Stm32F1(e) => e.chain_live,
+            Self::Stm32L4(e) => e.chain_live,
+        }
+    }
+
+    /// Test/differential knob: detach the clock, pinning the model to the legacy
+    /// walk (the walk-on reference for the differential gate).
+    pub fn force_legacy_walk(&mut self) {
+        match self {
+            Self::Stm32F1(e) => e.clock = None,
+            Self::Stm32L4(e) => e.clock = None,
+        }
+    }
 }
 
 impl Peripheral for Exti {
@@ -260,41 +356,74 @@ impl Peripheral for Exti {
     }
 
     fn tick(&mut self) -> PeripheralTickResult {
-        let mut irqs = Vec::new();
-        match self {
-            Self::Stm32F1(e) => {
-                let active1 = e.bank1.pr & e.bank1.imr;
-                if active1 != 0 {
-                    route_bank1_irqs(active1, &mut irqs);
-                }
-            }
-            Self::Stm32L4(e) => {
-                let active1 = e.bank1.pr & e.bank1.imr;
-                let active2 = e.bank2.pr & e.bank2.imr;
-                if active1 != 0 {
-                    route_bank1_irqs(active1, &mut irqs);
-                }
-                if active2 != 0 {
-                    // Bank-2 wakeup lines → their peripheral's NVIC IRQ
-                    // (RM0351 §13.3). Lines without an entry are tracked at
-                    // the register level but don't synthesize an IRQ yet.
-                    for &(line, irq) in &[
-                        (35u32, 70u32), // LPUART1 wakeup
-                        (36, 31),       // I2C1 wakeup
-                        (37, 33),       // I2C2 wakeup
-                        (38, 72),       // I2C3 wakeup
-                        (39, 37),       // USART1 wakeup
-                    ] {
-                        if (active2 >> (line - 32)) & 1 != 0 {
-                            irqs.push(irq);
-                        }
-                    }
-                }
-            }
+        // Scheduler-mode instances are walk-skipped; the event chain owns the
+        // held-level re-emission. Guard against a stray direct call.
+        if self.scheduler_mode() {
+            return PeripheralTickResult::default();
         }
-
+        let irqs = self.pending_irqs();
         PeripheralTickResult {
             explicit_irqs: (!irqs.is_empty()).then_some(irqs),
+            ..Default::default()
+        }
+    }
+
+    fn uses_scheduler(&self) -> bool {
+        self.scheduler_mode()
+    }
+
+    fn needs_legacy_walk(&self) -> bool {
+        !self.scheduler_mode()
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        match self {
+            Self::Stm32F1(e) => e.clock = Some(clock),
+            Self::Stm32L4(e) => e.clock = Some(clock),
+        }
+    }
+
+    fn sync_to(&mut self, _now_cycle: u64) {
+        // No lazily-accumulated state: PR/IMR mutate synchronously in write, and
+        // the held level is re-derived from them every cycle by the event chain.
+    }
+
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        // Arm the held-level re-emit chain the moment a write raises a masked
+        // pending line (SWIER→PR, or IMR unmasking a pending PR). Every EXTI
+        // PR-setting path today is an MMIO write (SWIER edge-detect or a direct
+        // PR/IMR write), so `take_scheduled_events` — drained after every MMIO
+        // write — always catches the activation. (`trigger_line`, the external
+        // GPIO-edge injector, has no runtime caller; were it ever wired to a bus
+        // path, that path must re-arm the chain the same way, since a `&mut`
+        // injector cannot itself return events.) delay-0 → deadline
+        // `current_cycle + 1` = the walk's next tick.
+        if self.scheduler_mode() && self.active() && !self.chain_live() {
+            self.set_chain_live(true);
+            vec![(0u64, 0u32)]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn on_event(
+        &mut self,
+        _event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if !self.scheduler_mode() {
+            return crate::sched::EventResult::default();
+        }
+        // Re-emit the held level every cycle while any masked line stays pending
+        // — the event-path equivalent of the legacy `tick()` returning its
+        // `explicit_irqs` each cycle. Perpetuate at delay 1 while active; stop
+        // when firmware clears PR (rc_w1), letting fast-forward engage.
+        let active = self.active();
+        self.set_chain_live(active);
+        crate::sched::EventResult {
+            explicit_irqs: self.pending_irqs(),
+            reschedule_delay: active.then_some(1),
             ..Default::default()
         }
     }
@@ -367,6 +496,25 @@ mod tests {
     }
 
     #[test]
+    fn all_variants_flip_to_scheduler_when_clock_attached() {
+        for layout in [ExtiRegisterLayout::Stm32F1, ExtiRegisterLayout::Stm32L4] {
+            let mut e = Exti::new_with_layout(layout);
+            assert!(e.needs_legacy_walk() && !e.uses_scheduler());
+            e.attach_cycle_clock(crate::CycleClock::default());
+            #[cfg(feature = "event-scheduler")]
+            {
+                assert!(e.uses_scheduler() && !e.needs_legacy_walk());
+                // Held level latched, but the walk tick is inert in scheduler mode.
+                e.write_u32(0x00, 1).unwrap();
+                e.write_u32(0x10, 1).unwrap();
+                assert!(e.tick().explicit_irqs.is_none());
+                e.force_legacy_walk();
+                assert!(e.needs_legacy_walk() && !e.uses_scheduler());
+            }
+        }
+    }
+
+    #[test]
     fn f1_word_write_pr_clear_is_atomic_and_clears_swier() {
         // Whole-word access (as a 32-bit STR performs). SWIER=0x5 software-
         // triggers lines 0 and 2 -> PR=0x5; an rc_w1 word-write of 0x1 clears
@@ -384,5 +532,139 @@ mod tests {
             0x4,
             "SWIER line 0 cleared with PR"
         );
+    }
+}
+
+// ── Walk-free differential: held-level EXTI walk vs scheduler ────────────────
+#[cfg(all(test, feature = "event-scheduler"))]
+mod scheduler_diff {
+    use super::*;
+    use crate::Peripheral;
+
+    #[derive(Clone, Copy)]
+    enum Op {
+        /// 32-bit register write at cycle (as firmware STRs it).
+        Write(u64, u32),
+    }
+
+    fn build(layout: ExtiRegisterLayout, scheduler: bool) -> Exti {
+        let mut e = Exti::new_with_layout(layout);
+        if scheduler {
+            e.attach_cycle_clock(CycleClock::default());
+        }
+        e
+    }
+
+    /// Drive the SAME op script against (a) the per-cycle walk and (b) the event
+    /// path; assert the emitted IRQ set AND the register snapshot are identical
+    /// every cycle. An `Op` scheduled at cycle `c` is applied before that cycle's
+    /// tick. This is the held-level analogue of the I2C `kinetis_scheduler` gate.
+    fn assert_walk_identical(layout: ExtiRegisterLayout, script: &[(u64, Op)], cycles: u64) {
+        let mut walk = build(layout, false);
+        let mut sched = build(layout, true);
+        let clock = match &sched {
+            Exti::Stm32F1(e) => e.clock.clone(),
+            Exti::Stm32L4(e) => e.clock.clone(),
+        }
+        .unwrap();
+
+        // (deadline_cycle, token) event queue, driven exactly like Machine +
+        // SystemBus at tick interval 1.
+        let mut events: Vec<(u64, u32)> = Vec::new();
+        let bus = &mut crate::bus::SystemBus::new();
+
+        for c in 1..=cycles {
+            for (sc, Op::Write(off, val)) in script.iter().copied() {
+                if sc == c {
+                    walk.write_u32(off, val).unwrap();
+                    // Scheduler: write, then harvest events at cycle+1+delay
+                    // (`now == c - 1` at the point of the write).
+                    sched.write_u32(off, val).unwrap();
+                    for (delay, token) in sched.take_scheduled_events() {
+                        events.push((c - 1 + 1 + delay, token));
+                    }
+                }
+            }
+
+            // Walk: tick emits the held level this cycle.
+            let walk_irqs = walk.tick().explicit_irqs.unwrap_or_default();
+
+            // Scheduler: publish the clock, drain due events through on_event.
+            clock.publish(c);
+            let due: Vec<(u64, u32)> = events.iter().copied().filter(|(d, _)| *d <= c).collect();
+            events.retain(|(d, _)| *d > c);
+            let mut esched = crate::sched::EventScheduler::new();
+            esched.advance_to(c);
+            let mut sched_irqs = Vec::new();
+            for (_, token) in due {
+                let res = sched.on_event(token, &mut esched, bus);
+                sched_irqs.extend(res.explicit_irqs);
+                if let Some(delay) = res.reschedule_delay {
+                    events.push((c + delay, token));
+                }
+            }
+
+            assert_eq!(
+                walk_irqs, sched_irqs,
+                "emitted IRQ set diverged at cycle {c}"
+            );
+            assert_eq!(
+                walk.snapshot(),
+                sched.snapshot(),
+                "register snapshot diverged at cycle {c}"
+            );
+        }
+    }
+
+    #[test]
+    fn f1_swier_hold_and_clear_walk_identity() {
+        // IMR lines 0,2; SWIER trigger → PR held (IRQs re-emit every cycle);
+        // firmware clears PR line 0 (rc_w1) mid-hold; then clears line 2.
+        let script = [
+            (1u64, Op::Write(0x00, 0x5)), // IMR lines 0,2
+            (1, Op::Write(0x10, 0x5)),    // SWIER lines 0,2 → PR (held level)
+            (5, Op::Write(0x14, 0x1)),    // clear PR line 0 → EXTI0 stops
+            (9, Op::Write(0x14, 0x4)),    // clear PR line 2 → level drops
+        ];
+        assert_walk_identical(ExtiRegisterLayout::Stm32F1, &script, 14);
+    }
+
+    #[test]
+    fn f1_grouped_irq_line_walk_identity() {
+        // Lines in the EXTI9_5 group (shared IRQ 23) plus EXTI15_10 (IRQ 40).
+        let script = [
+            (1u64, Op::Write(0x00, (1 << 7) | (1 << 12))), // IMR lines 7,12
+            (1, Op::Write(0x10, (1 << 7) | (1 << 12))),    // SWIER → PR
+            (6, Op::Write(0x14, 1 << 7)),                  // clear line 7 (IRQ23 drops)
+            (9, Op::Write(0x14, 1 << 12)),                 // clear line 12 (IRQ40 drops)
+        ];
+        assert_walk_identical(ExtiRegisterLayout::Stm32F1, &script, 14);
+    }
+
+    #[test]
+    fn l4_bank2_wakeup_hold_walk_identity() {
+        // Bank-2 line 36 (I2C1 wakeup → IRQ 31) plus a bank-1 line, held and
+        // cleared independently across banks.
+        let script = [
+            (1u64, Op::Write(0x00, 1 << 1)), // IMR1 line 1
+            (1, Op::Write(0x10, 1 << 1)),    // SWIER1 → PR1
+            (1, Op::Write(0x20, 1 << 4)),    // IMR2 line 36
+            (1, Op::Write(0x30, 1 << 4)),    // SWIER2 → PR2 (I2C1 wakeup)
+            (6, Op::Write(0x14, 1 << 1)),    // clear bank-1
+            (10, Op::Write(0x34, 1 << 4)),   // clear bank-2
+        ];
+        assert_walk_identical(ExtiRegisterLayout::Stm32L4, &script, 15);
+    }
+
+    #[test]
+    fn imr_unmask_after_pending_arms_walk_identity() {
+        // PR set while masked (no IRQ), THEN IMR unmasks it — the write that
+        // raises the level must arm the chain. Validates the arming predicate.
+        let script = [
+            (1u64, Op::Write(0x10, 0x2)), // SWIER line 1 → PR (but IMR=0 → masked)
+            (5, Op::Write(0x00, 0x2)),    // IMR line 1 → level rises here
+            (9, Op::Write(0x14, 0x2)),    // clear
+        ];
+        assert_walk_identical(ExtiRegisterLayout::Stm32F1, &script, 13);
     }
 }

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -111,6 +111,19 @@ pub struct F1I2c {
     rxne_consumed: Cell<bool>,
     #[serde(skip)]
     read_dr_consumed: Cell<bool>,
+
+    /// Bus-published cycle clock (walk-free campaign). `Some` once the bus
+    /// registration choke attaches it; `None` keeps the model on the legacy
+    /// walk. Mirrors the Kinetis variant — see `F1I2c::scheduler_mode`.
+    #[serde(skip)]
+    clock: Option<CycleClock>,
+    /// Scheduler mode only: `true` while the per-cycle transaction-engine event
+    /// is live in the scheduler heap. Armed when the transaction becomes active
+    /// (a write starts a countdown, or a `&self` receive read latches a re-arm);
+    /// self-perpetuates at delay 1 while the transfer stays active, stops when it
+    /// returns fully idle. Same held-level self-pacing the Kinetis variant uses.
+    #[serde(skip)]
+    chain_live: bool,
 }
 
 impl Default for F1I2c {
@@ -136,11 +149,37 @@ impl Default for F1I2c {
             stop_requested: false,
             rxne_consumed: Cell::new(false),
             read_dr_consumed: Cell::new(true),
+            clock: None,
+            chain_live: false,
         }
     }
 }
 
 impl F1I2c {
+    /// True when the event scheduler owns this controller's transaction engine
+    /// (feature on AND bus clock attached).
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Cycles on which the legacy `tick()` does observable work: any in-flight
+    /// countdown (`state != Idle`), the master transfer window (SR2.BUSY), a
+    /// pending `&self`-read RXNE re-arm, or a deferred STOP. Outside this window
+    /// `tick()` is a proven no-op (the `rxne_consumed` drain and the countdown
+    /// are the only side effects, and both are gated by exactly these flags), so
+    /// the event chain may stop and let idle fast-forward engage — while any
+    /// extra idle cycle it does run is observationally inert. Over-covering is
+    /// therefore always safe; this predicate is deliberately generous so a
+    /// receive re-arm latched by a `&self` DR read is never missed.
+    #[inline]
+    fn active(&self) -> bool {
+        self.state != I2cState::Idle
+            || (self.sr2 & 0x0002) != 0 // BUSY: master transfer in flight
+            || self.rxne_consumed.get()
+            || self.stop_requested
+    }
+
     fn read_reg(&self, offset: u64) -> u32 {
         match offset {
             0x00 => self.cr1,
@@ -389,6 +428,13 @@ pub struct L4I2c {
     /// data byte is loaded into TXDR (write) — mirrors F1's START→DR ordering.
     #[serde(skip)]
     start_armed: bool,
+
+    /// Bus-published cycle clock (walk-free campaign) — see `L4I2c::scheduler_mode`.
+    #[serde(skip)]
+    clock: Option<CycleClock>,
+    /// Scheduler mode: `true` while the per-cycle engine event is live.
+    #[serde(skip)]
+    chain_live: bool,
 }
 
 impl Default for L4I2c {
@@ -412,11 +458,28 @@ impl Default for L4I2c {
             is_reading: false,
             autoend: false,
             start_armed: false,
+            clock: None,
+            chain_live: false,
         }
     }
 }
 
 impl L4I2c {
+    /// True when the event scheduler owns this controller's engine.
+    #[inline]
+    fn scheduler_mode(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Cycles on which the legacy `tick()` does observable work: an in-flight
+    /// countdown or the BUSY master-transfer window. The L4 read path is pure
+    /// (no `&self` side effects), so the write-armed countdown plus BUSY fully
+    /// bound the engine. Outside this window `tick()` returns immediately.
+    #[inline]
+    fn active(&self) -> bool {
+        self.state != I2cState::Idle || (self.isr & (1 << 15)) != 0
+    }
+
     fn read_reg(&self, offset: u64) -> u32 {
         match offset {
             0x00 => self.cr1,
@@ -923,29 +986,35 @@ impl I2c {
         }
     }
 
-    /// True when the event scheduler owns this instance's IRQ delivery. ONLY
-    /// the Kinetis variant migrates: its `tick()` is a pure level-IRQ
-    /// re-assertion (all byte/device work is synchronous in read/write), which
-    /// the held-level re-pend event pattern reproduces cycle-exactly. The STM32
-    /// F1/L4 variants run a `cycles_remaining` transaction countdown driven by
-    /// `&self`-read side effects (`rxne_consumed` / `read_dr_consumed`) that arm
-    /// subsequent IRQ-raising transitions — un-expressible through the write-
-    /// armed event path under the `&self` read constraint — so they STAY on the
-    /// legacy walk (`false` here), per the non-negotiable fidelity rule.
+    /// True when the event scheduler owns this instance's IRQ delivery. All
+    /// three variants migrate. Kinetis: its `tick()` is a pure level-IRQ
+    /// re-assertion. STM32 F1/L4: their `cycles_remaining` transaction engine is
+    /// self-paced by a delay-1 event chain that runs `tick()` every cycle while
+    /// the transfer is *active* (see `F1I2c::active`) — the SAME held-level
+    /// self-perpetuating pattern Kinetis uses. The `&self`-read side effects
+    /// (`rxne_consumed` / device byte pulls) mutate `Cell`/`RefCell` state that
+    /// the already-live chain's next `on_event` observes exactly as the walk's
+    /// next `tick()` would, so no event needs arming from the read path. Idle
+    /// fast-forward still engages: the chain stops the moment the transfer goes
+    /// fully idle (BUSY clear, no countdown), which on a real lab is between
+    /// transactions when the firmware is not busy-polling anyway.
     #[inline]
     fn scheduler_mode(&self) -> bool {
         match self {
+            Self::Stm32F1(i) => i.scheduler_mode(),
+            Self::Stm32L4(i) => i.scheduler_mode(),
             Self::Kinetis(i) => i.scheduler_mode(),
-            _ => false,
         }
     }
 
-    /// Test/differential knob: detach the cycle clock, pinning the (Kinetis)
-    /// model to the legacy walk path. Used by the walk-on-vs-scheduler
-    /// differential gates to build the reference config from the same assembly.
+    /// Test/differential knob: detach the cycle clock, pinning the model to the
+    /// legacy walk path. Used by the walk-on-vs-scheduler differential gates to
+    /// build the reference config from the same assembly.
     pub fn force_legacy_walk(&mut self) {
-        if let Self::Kinetis(i) = self {
-            i.clock = None;
+        match self {
+            Self::Stm32F1(i) => i.clock = None,
+            Self::Stm32L4(i) => i.clock = None,
+            Self::Kinetis(i) => i.clock = None,
         }
     }
 }
@@ -969,8 +1038,8 @@ impl crate::Peripheral for I2c {
     }
 
     fn tick(&mut self) -> crate::PeripheralTickResult {
-        // Kinetis in scheduler mode is walk-skipped (the guard keeps a stray
-        // direct call from double-pending the level IRQ the event chain owns).
+        // Scheduler-mode instances are walk-skipped (the guard keeps a stray
+        // direct call from double-advancing the engine the event chain owns).
         if self.scheduler_mode() {
             return crate::PeripheralTickResult::default();
         }
@@ -987,45 +1056,71 @@ impl crate::Peripheral for I2c {
     }
 
     fn uses_scheduler(&self) -> bool {
-        // Only the Kinetis variant with a bus clock attached (event-scheduler
-        // builds). F1/L4 stay on the legacy walk — see `I2c::scheduler_mode`.
+        // Any variant with a bus clock attached (event-scheduler builds). See
+        // `I2c::scheduler_mode`.
         self.scheduler_mode()
     }
 
     fn needs_legacy_walk(&self) -> bool {
-        // Kinetis-scheduler: the pure level-IRQ re-assertion is fully event-
-        // expressible, so the walk is unnecessary. F1/L4 (and Kinetis without a
-        // clock / feature off): the transaction countdown / level re-assertion
-        // is real walk work → conservative `true`.
+        // Scheduler-mode: the transaction engine (F1/L4) or level re-assertion
+        // (Kinetis) is fully driven by the event chain, so the walk is
+        // unnecessary. Feature off / no clock: real per-cycle walk work → `true`.
         !self.scheduler_mode()
     }
 
     fn sync_to(&mut self, _now_cycle: u64) {
-        // No free-running state to advance: the Kinetis registers, the device
-        // byte stream and IICIF all mutate synchronously in read/write, never
-        // between accesses. Explicit no-op for symmetry with the other
-        // scheduler-migrated models.
+        // No lazily-accumulated state to reconcile: the F1/L4 transaction
+        // countdown is advanced cycle-by-cycle by the self-perpetuating event
+        // chain (drained up to the current cycle by `Machine::step` before any
+        // MMIO access observes it), and the Kinetis registers / device byte
+        // stream / IICIF all mutate synchronously in read/write. Explicit no-op
+        // for symmetry with the other scheduler-migrated models.
     }
 
     fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
-        let Self::Kinetis(i) = self else {
-            return Vec::new();
-        };
-        if !i.scheduler_mode() {
-            return Vec::new();
-        }
-        // Arm the self-perpetuating level-check the moment interrupts are armed
-        // (IICIE set) and no chain is live. The chain then re-polls every cycle
-        // while IICIE stays set (delay-0 → deadline `current_cycle + 1`, the
-        // cycle the legacy walk's next tick would first check the level), so a
-        // `&self` `D`-read that latches IICIF is picked up the next cycle,
-        // exactly as the walk would. The `chain_live` guard prevents duplicate
-        // chains across the multiple C1/D/S writes of a transfer.
-        if (i.c1 & KI_C1_IICIE) != 0 && !i.chain_live {
-            i.chain_live = true;
-            vec![(0u64, 0u32)]
-        } else {
-            Vec::new()
+        match self {
+            Self::Kinetis(i) => {
+                if !i.scheduler_mode() {
+                    return Vec::new();
+                }
+                // Arm the self-perpetuating level-check the moment interrupts are
+                // armed (IICIE set) and no chain is live. The chain then re-polls
+                // every cycle while IICIE stays set (delay-0 → deadline
+                // `current_cycle + 1`, the cycle the legacy walk's next tick would
+                // first check the level), so a `&self` `D`-read that latches IICIF
+                // is picked up the next cycle, exactly as the walk would. The
+                // `chain_live` guard prevents duplicate chains across the multiple
+                // C1/D/S writes of a transfer.
+                if (i.c1 & KI_C1_IICIE) != 0 && !i.chain_live {
+                    i.chain_live = true;
+                    vec![(0u64, 0u32)]
+                } else {
+                    Vec::new()
+                }
+            }
+            // STM32 F1/L4: arm the per-cycle transaction-engine chain the moment
+            // a write makes the transfer active (START/DR countdown, BUSY). The
+            // chain then self-perpetuates every cycle while the transfer stays
+            // active — including across the `&self` receive reads that cannot arm
+            // an event themselves (their re-arm is caught by the already-live
+            // chain's next `on_event`, exactly as the walk's next tick would).
+            // delay-0 → deadline `current_cycle + 1` = the walk's next tick.
+            Self::Stm32F1(i) => {
+                if i.scheduler_mode() && i.active() && !i.chain_live {
+                    i.chain_live = true;
+                    vec![(0u64, 0u32)]
+                } else {
+                    Vec::new()
+                }
+            }
+            Self::Stm32L4(i) => {
+                if i.scheduler_mode() && i.active() && !i.chain_live {
+                    i.chain_live = true;
+                    vec![(0u64, 0u32)]
+                } else {
+                    Vec::new()
+                }
+            }
         }
     }
 
@@ -1036,31 +1131,70 @@ impl crate::Peripheral for I2c {
         _bus: &mut dyn crate::Bus,
     ) -> crate::sched::EventResult {
         let _ = sched;
-        let Self::Kinetis(i) = self else {
-            return crate::sched::EventResult::default();
-        };
-        if !i.scheduler_mode() {
-            return crate::sched::EventResult::default();
-        }
-        // Pend the peripheral's own NVIC line while the level (IICIF & IICIE) is
-        // asserted — the event-path equivalent of the legacy `tick()` returning
-        // its level bool every cycle. Perpetuate at delay 1 while IICIE stays
-        // set so a byte completion latched by a `&self` read (which cannot arm
-        // an event) is caught the next cycle; stop when firmware disables IICIE.
-        let iicie = (i.c1 & KI_C1_IICIE) != 0;
-        i.chain_live = iicie;
-        crate::sched::EventResult {
-            raise_own_irq: i.irq_level(),
-            reschedule_delay: iicie.then_some(1),
-            ..Default::default()
+        match self {
+            Self::Kinetis(i) => {
+                if !i.scheduler_mode() {
+                    return crate::sched::EventResult::default();
+                }
+                // Pend the peripheral's own NVIC line while the level
+                // (IICIF & IICIE) is asserted — the event-path equivalent of the
+                // legacy `tick()` returning its level bool every cycle. Perpetuate
+                // at delay 1 while IICIE stays set so a byte completion latched by
+                // a `&self` read is caught the next cycle; stop when firmware
+                // disables IICIE.
+                let iicie = (i.c1 & KI_C1_IICIE) != 0;
+                i.chain_live = iicie;
+                crate::sched::EventResult {
+                    raise_own_irq: i.irq_level(),
+                    reschedule_delay: iicie.then_some(1),
+                    ..Default::default()
+                }
+            }
+            // STM32 F1: run one cycle of the transaction engine — byte-for-byte
+            // the same `F1I2c::tick()` the walk runs — and pend the NVIC line on
+            // its IRQ verdict. Re-check `active()` AFTER the tick (it may have
+            // just delivered the last byte and cleared BUSY) and perpetuate at
+            // delay 1 while still active; stop when fully idle so fast-forward can
+            // engage. An extra idle cycle would be inert, so the tight stop is
+            // safe. The `on_event` runs at the same per-cycle cadence as the walk,
+            // so the countdown timing and IRQ edges are identical.
+            Self::Stm32F1(i) => {
+                if !i.scheduler_mode() {
+                    return crate::sched::EventResult::default();
+                }
+                let irq = i.tick();
+                let active = i.active();
+                i.chain_live = active;
+                crate::sched::EventResult {
+                    raise_own_irq: irq,
+                    reschedule_delay: active.then_some(1),
+                    ..Default::default()
+                }
+            }
+            Self::Stm32L4(i) => {
+                if !i.scheduler_mode() {
+                    return crate::sched::EventResult::default();
+                }
+                let irq = i.tick();
+                let active = i.active();
+                i.chain_live = active;
+                crate::sched::EventResult {
+                    raise_own_irq: irq,
+                    reschedule_delay: active.then_some(1),
+                    ..Default::default()
+                }
+            }
         }
     }
 
     fn attach_cycle_clock(&mut self, clock: CycleClock) {
-        // Only the Kinetis variant opts into the scheduler; F1/L4 ignore the
-        // clock and stay on the walk (their `scheduler_mode` is always false).
-        if let Self::Kinetis(i) = self {
-            i.clock = Some(clock);
+        // All three variants opt into the scheduler once the bus attaches its
+        // clock (event-scheduler builds); featureless builds ignore it via
+        // `scheduler_mode`.
+        match self {
+            Self::Stm32F1(i) => i.clock = Some(clock),
+            Self::Stm32L4(i) => i.clock = Some(clock),
+            Self::Kinetis(i) => i.clock = Some(clock),
         }
     }
 
@@ -1528,16 +1662,48 @@ mod kinetis_scheduler {
         fn write(&mut self, _data: u8) {}
     }
 
-    fn kinetis(scheduler: bool) -> I2c {
-        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Kinetis);
-        i2c.push_slave(Box::new(RampDevice {
+    fn ramp_slave() -> Box<dyn I2cDevice> {
+        Box::new(RampDevice {
             address: 0x1E,
             next: std::cell::Cell::new(0x40),
-        }));
+        })
+    }
+
+    fn kinetis(scheduler: bool) -> I2c {
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Kinetis);
+        i2c.push_slave(ramp_slave());
         if scheduler {
             i2c.attach_cycle_clock(CycleClock::default());
         }
         i2c
+    }
+
+    fn f1(scheduler: bool) -> I2c {
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32F1);
+        i2c.push_slave(ramp_slave());
+        if scheduler {
+            i2c.attach_cycle_clock(CycleClock::default());
+        }
+        i2c
+    }
+
+    fn l4(scheduler: bool) -> I2c {
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
+        i2c.push_slave(ramp_slave());
+        if scheduler {
+            i2c.attach_cycle_clock(CycleClock::default());
+        }
+        i2c
+    }
+
+    /// Clone the bus clock a scheduler-mode instance latched (any variant).
+    fn clock_of(i2c: &I2c) -> CycleClock {
+        match i2c {
+            I2c::Stm32F1(i) => i.clock.clone(),
+            I2c::Stm32L4(i) => i.clock.clone(),
+            I2c::Kinetis(i) => i.clock.clone(),
+        }
+        .expect("scheduler-mode instance has a clock")
     }
 
     #[derive(Clone, Copy, Debug)]
@@ -1561,12 +1727,9 @@ mod kinetis_scheduler {
     }
 
     impl SchedHarness {
-        fn new() -> Self {
-            let i2c = kinetis(true);
-            let clock = match &i2c {
-                I2c::Kinetis(k) => k.clock.clone().unwrap(),
-                _ => unreachable!(),
-            };
+        fn new(build: &dyn Fn(bool) -> I2c) -> Self {
+            let i2c = build(true);
+            let clock = clock_of(&i2c);
             Self {
                 i2c,
                 clock,
@@ -1626,9 +1789,14 @@ mod kinetis_scheduler {
     /// snapshot AND every returned read byte at every cycle, plus the exact set
     /// of NVIC-pend cycles. An `Op` scheduled at cycle `c` is applied before
     /// that cycle's tick.
-    fn assert_walk_identical(script: &[(u64, Op)], cycles: u64, what: &str) {
-        let mut walk = kinetis(false);
-        let mut sched = SchedHarness::new();
+    fn assert_walk_identical_with(
+        build: &dyn Fn(bool) -> I2c,
+        script: &[(u64, Op)],
+        cycles: u64,
+        what: &str,
+    ) {
+        let mut walk = build(false);
+        let mut sched = SchedHarness::new(build);
         let mut walk_pends: Vec<u64> = Vec::new();
 
         for c in 1..=cycles {
@@ -1663,6 +1831,11 @@ mod kinetis_scheduler {
         assert_eq!(walk_pends, sched.pends, "{what}: NVIC pend cycles diverged");
     }
 
+    /// Kinetis-variant convenience wrapper.
+    fn assert_walk_identical(script: &[(u64, Op)], cycles: u64, what: &str) {
+        assert_walk_identical_with(&kinetis, script, cycles, what);
+    }
+
     #[test]
     fn clock_attach_flips_to_scheduler_and_walk_tick_is_inert() {
         let mut i2c = kinetis(true);
@@ -1675,16 +1848,125 @@ mod kinetis_scheduler {
     }
 
     #[test]
-    fn f1_and_l4_variants_stay_on_the_walk() {
-        // Even with a clock attached, the STM32 variants must NOT migrate.
-        let mut f1 = I2c::new_with_layout(I2cRegisterLayout::Stm32F1);
-        f1.attach_cycle_clock(CycleClock::default());
-        assert!(!f1.uses_scheduler());
-        assert!(f1.needs_legacy_walk());
-        let mut l4 = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
-        l4.attach_cycle_clock(CycleClock::default());
-        assert!(!l4.uses_scheduler());
-        assert!(l4.needs_legacy_walk());
+    fn all_three_variants_flip_to_scheduler_and_walk_tick_is_inert() {
+        // With a clock attached (event-scheduler builds) every I2C variant now
+        // migrates: the F1/L4 transaction engine is self-paced by the same
+        // held-level event chain the Kinetis variant uses, so the per-cycle walk
+        // is no longer needed. The walk-guarded `tick()` is inert in that mode.
+        for build in [&f1 as &dyn Fn(bool) -> I2c, &l4, &kinetis] {
+            let mut i2c = build(true);
+            assert!(i2c.uses_scheduler());
+            assert!(!i2c.needs_legacy_walk());
+            assert!(
+                !i2c.tick().irq && i2c.tick().cycles == 0,
+                "walk tick must be inert in scheduler mode"
+            );
+            // Clock detached (differential reference / featureless): back to walk.
+            i2c.force_legacy_walk();
+            assert!(!i2c.uses_scheduler());
+            assert!(i2c.needs_legacy_walk());
+        }
+    }
+
+    // ── STM32 F1 transaction-engine walk-vs-scheduler byte identity ───────────
+
+    /// Master WRITE: START → address(W) → data byte → STOP, with ITEVTEN|ITBUFEN
+    /// enabled so the completion IRQs are pend-compared. Every register snapshot,
+    /// read byte and NVIC-pend cycle must be byte-identical between the per-cycle
+    /// walk and the event-scheduled engine.
+    #[test]
+    fn f1_master_write_walk_identity() {
+        let addr_w = 0x1E << 1; // 0x3C
+        let script = [
+            (1u64, Op::Write(0x05, 0x06)), // CR2 = ITEVTEN|ITBUFEN (bits 9,10)
+            (1, Op::Write(0x01, 0x01)),    // CR1.START (bit 8)
+            (4, Op::Read(0x14)),           // poll SR1 (SB)
+            (5, Op::Write(0x10, addr_w)),  // DR = address(W) → AddressPending
+            (28, Op::Read(0x14)),          // poll SR1 (ADDR/TXE)
+            (28, Op::Read(0x18)),          // poll SR2 (MSL/BUSY)
+            (30, Op::Write(0x10, 0xAF)),   // DR = data byte → DataPending
+            (54, Op::Read(0x14)),          // poll SR1 (TXE/BTF)
+            (56, Op::Write(0x01, 0x02)),   // CR1.STOP (bit 9)
+        ];
+        assert_walk_identical_with(&f1, &script, 64, "f1 master write");
+    }
+
+    /// Master READ: START → address(R) → multi-byte receive (the `&self` DR-read
+    /// path that the prior model claimed could not be event-scheduled) → STOP.
+    /// The receive bytes come straight from the device in `read()`; the engine
+    /// only paces the START/ADDR/first-byte countdowns. The already-live chain
+    /// keeps the register state identical across the read-gated stream.
+    #[test]
+    fn f1_master_read_multibyte_walk_identity() {
+        let addr_r = (0x1E << 1) | 1; // 0x3D
+        let script = [
+            (1u64, Op::Write(0x05, 0x06)), // CR2 = ITEVTEN|ITBUFEN
+            (1, Op::Write(0x01, 0x01)),    // START
+            (5, Op::Write(0x10, addr_r)),  // DR = address(R) → AddressPending(read)
+            (30, Op::Read(0x14)),          // poll SR1 (ADDR)
+            (54, Op::Read(0x14)),          // poll SR1 (RXNE after first byte)
+            (54, Op::Read(0x10)),          // read byte 0 (buffered dr)
+            (55, Op::Read(0x10)),          // read byte 1 (device pull)
+            (56, Op::Read(0x10)),          // read byte 2 (device pull)
+            (57, Op::Read(0x18)),          // SR2 still BUSY
+            (58, Op::Write(0x01, 0x02)),   // STOP
+        ];
+        assert_walk_identical_with(&f1, &script, 66, "f1 master read multibyte");
+    }
+
+    /// Address NACK (no slave at the addressed target) — the AF/MSL/BUSY latch
+    /// and the ITERREN-gated error IRQ must match. Uses a mismatched address so
+    /// `current_target` is `None`.
+    #[test]
+    fn f1_address_nack_walk_identity() {
+        let script = [
+            (1u64, Op::Write(0x05, 0x01)), // CR2 ITERREN (bit 8) → byte at offset 0x05
+            (1, Op::Write(0x01, 0x01)),    // START
+            (5, Op::Write(0x10, 0x40)),    // DR = address 0x20<<1 (no device) → NACK
+            (30, Op::Read(0x14)),          // poll SR1 (AF)
+            (30, Op::Read(0x18)),          // poll SR2 (MSL/BUSY held)
+            (32, Op::Write(0x01, 0x02)),   // STOP releases the bus
+        ];
+        assert_walk_identical_with(&f1, &script, 40, "f1 address NACK");
+    }
+
+    // ── STM32 L4 transaction-engine walk-vs-scheduler byte identity ───────────
+
+    /// L4 master WRITE via CR2 START/AUTOEND + TXDR, with TCIE|NACKIE enabled.
+    #[test]
+    fn l4_master_write_walk_identity() {
+        // CR1.PE (bit0) | TCIE (bit6) | NACKIE (bit4) = 0x51.
+        // CR2 = SADD(0x1E<<1) | NBYTES=1<<16 | AUTOEND<<25 | START<<13.
+        let cr2: u32 = ((0x1E << 1) as u32) | (1 << 16) | (1 << 25) | (1 << 13);
+        let script = [
+            (1u64, Op::Write(0x00, 0x51)), // CR1 = PE|TCIE|NACKIE
+            (2, Op::Write(0x04, (cr2 & 0xFF) as u8)),
+            (2, Op::Write(0x05, ((cr2 >> 8) & 0xFF) as u8)),
+            (2, Op::Write(0x06, ((cr2 >> 16) & 0xFF) as u8)),
+            (2, Op::Write(0x07, ((cr2 >> 24) & 0xFF) as u8)), // START latches BUSY
+            (3, Op::Read(0x19)),                              // ISR byte3 (BUSY bit15)
+            (4, Op::Write(0x28, 0xAF)),                       // TXDR → AddressPending
+            (28, Op::Read(0x18)),                             // ISR byte0 (TXE/TC)
+            (28, Op::Read(0x19)),                             // ISR byte3 (BUSY cleared by AUTOEND)
+        ];
+        assert_walk_identical_with(&l4, &script, 36, "l4 master write");
+    }
+
+    /// L4 address NACK (no device) — NACKF + AUTOEND STOPF, NACKIE IRQ.
+    #[test]
+    fn l4_address_nack_walk_identity() {
+        let cr2: u32 = ((0x20 << 1) as u32) | (1 << 16) | (1 << 25) | (1 << 13);
+        let script = [
+            (1u64, Op::Write(0x00, 0x51)), // CR1 = PE|TCIE|NACKIE
+            (2, Op::Write(0x04, (cr2 & 0xFF) as u8)),
+            (2, Op::Write(0x05, ((cr2 >> 8) & 0xFF) as u8)),
+            (2, Op::Write(0x06, ((cr2 >> 16) & 0xFF) as u8)),
+            (2, Op::Write(0x07, ((cr2 >> 24) & 0xFF) as u8)),
+            (4, Op::Write(0x28, 0xAF)), // TXDR → AddressPending → NACK
+            (28, Op::Read(0x18)),       // ISR (NACKF/STOPF)
+            (28, Op::Read(0x19)),       // ISR byte3 (BUSY)
+        ];
+        assert_walk_identical_with(&l4, &script, 36, "l4 address NACK");
     }
 
     #[test]

--- a/crates/core/src/peripherals/rtc_f1.rs
+++ b/crates/core/src/peripherals/rtc_f1.rs
@@ -106,6 +106,19 @@ impl crate::Peripheral for RtcF1 {
         self.write_reg(reg, v);
         Ok(())
     }
+    fn needs_legacy_walk(&self) -> bool {
+        // The STM32F1 RTC is modelled as a plain register bank: CNT/DIV/CRL only
+        // change on MMIO access (there is NO `tick()` override, so the per-cycle
+        // walk callback is the default no-op — the counter does not free-run in
+        // this model). Deleting the walk is therefore byte-identical for every
+        // reachable firmware state (the walk did nothing for it), so the RTC must
+        // not pin the whole STM32F1 bus onto the per-cycle walk. This was the last
+        // walker on every f103 lab bus — with it gone the full f103 board flips
+        // walk-deletable (see the walk_free_campaign / perf acceptance). Mirrors
+        // the AFIO no-op-bank fix.
+        false
+    }
+
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }
@@ -133,6 +146,26 @@ mod tests {
         assert_eq!(read32(&r, 0x1C), 0, "CNTL");
         // CRL is NOT the L4 DR (0x2101) — that was the bug this model fixes.
         assert_ne!(read32(&r, 0x04), 0x2101);
+    }
+
+    #[test]
+    fn tick_is_a_genuine_no_op_so_walk_is_deletable() {
+        // The RTC is a pure register bank: drive it through a boot-like write
+        // sequence, then tick it many times — the snapshot must be byte-identical
+        // before and after, and the tick result must be default(). This is the
+        // inertness proof behind `needs_legacy_walk() == false`.
+        let mut r = RtcF1::new();
+        r.write(0x00, 0x7).unwrap(); // CRH: all IE bits
+        r.write(0x0C, 0xFF).unwrap(); // PRLL
+        r.write(0x18, 0x12).unwrap(); // CNTH
+        r.write(0x1C, 0x34).unwrap(); // CNTL
+        assert!(!r.needs_legacy_walk());
+        let before = r.snapshot();
+        for _ in 0..1000 {
+            let res = r.tick();
+            assert!(!res.irq && res.cycles == 0, "tick must be inert");
+        }
+        assert_eq!(before, r.snapshot(), "no tick may mutate RTC state");
     }
 
     #[test]

--- a/crates/core/tests/walk_deletion.rs
+++ b/crates/core/tests/walk_deletion.rs
@@ -45,21 +45,34 @@ fn nokia_explicit_flag_reaches_bus() {
     );
 }
 
-/// Auto-derivation is CONSERVATIVE at the real-config level: with the Nokia lab's
-/// explicit flag REMOVED (`None`), the bus does NOT derive walk-deletion, because
-/// the stm32l476 descriptor instantiates native timers / SysTick / ADC / DMA /
-/// EXTI / CAN whose `tick()` does real work once firmware arms them. Their
-/// byte-identity walk-free is a *firmware-specific* fact (this firmware never arms
-/// them) that no config-time predicate can prove — so the walk stays on and the
-/// explicit flag remains load-bearing.
+/// Auto-derivation with the Nokia lab's explicit flag REMOVED (`None`).
+///
+/// The stm32l476 descriptor instantiates native timers / SysTick / ADC / DMA /
+/// EXTI / I2C / CAN. The walk-free campaign migrated every one of them to the
+/// event scheduler (each proven byte-identical walk-free for ALL firmware states
+/// by its own walk-vs-scheduler differential), so the model-level predicate
+/// `derive_walk_deletable` now legitimately flips:
+///
+///   * `event-scheduler` builds: every peripheral reports `uses_scheduler()`
+///     (or `!needs_legacy_walk()`), the forcing set is empty, and the bus
+///     auto-derives walk-deletion with no hand flag — the explicit
+///     `walk_deleted: true` is now redundant, not load-bearing.
+///   * featureless builds: the scheduler does not exist, so the migrated models
+///     honestly stay on the walk and derivation keeps it on.
 #[test]
-fn nokia_without_flag_does_not_auto_derive_deletion() {
+fn nokia_without_flag_auto_derivation_tracks_scheduler_feature() {
     let (chip, mut manifest) = nokia();
     manifest.walk_deleted = None; // simulate removing the yaml line
     let bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+    #[cfg(feature = "event-scheduler")]
+    assert!(
+        bus.legacy_walk_disabled,
+        "every L476 peripheral is now event-scheduled → derivation deletes the walk"
+    );
+    #[cfg(not(feature = "event-scheduler"))]
     assert!(
         !bus.legacy_walk_disabled,
-        "conservative derivation must keep the walk (native timers are armable)"
+        "featureless build has no scheduler → migrated models stay on the walk"
     );
 }
 

--- a/crates/core/tests/walk_deletion.rs
+++ b/crates/core/tests/walk_deletion.rs
@@ -11,6 +11,10 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
+#[allow(unused_imports)]
+use labwired_core::bus::RECOMMENDED_TICK_INTERVAL;
+#[allow(unused_imports)]
+use labwired_core::Peripheral;
 use std::path::PathBuf;
 
 fn root(rel: &str) -> PathBuf {
@@ -86,6 +90,46 @@ fn explicit_false_pins_walk_on() {
         !bus.legacy_walk_disabled,
         "walk_deleted: false must pin the walk on"
     );
+}
+
+/// The headline campaign result: a real **stm32f103** lab bus, built exactly the
+/// way the run path does (`from_config` + `configure_cortex_m`) with any hand
+/// `walk_deleted` flag stripped, auto-derives walk-deletion under
+/// `event-scheduler` — the whole f103 peripheral set (i2c/exti/adc migrated,
+/// rtc/afio/bxcan no-op-gated, timers/dma/systick from earlier batches) is now
+/// walk-free, so the browser fast path lifts recommended_tick_interval 1→512 and
+/// engages idle fast-forward. Featureless builds honestly keep the walk.
+#[test]
+fn f103_lab_bus_flips_walk_deletable_under_scheduler() {
+    let chip = ChipDescriptor::from_file(root("configs/chips/stm32f103.yaml"))
+        .expect("load stm32f103 chip");
+    let mut manifest = SystemManifest::from_file(root("examples/ssd1306-hello-lab/system.yaml"))
+        .expect("load f103 i2c lab manifest");
+    manifest.walk_deleted = None; // derive from the models, not the manifest hatch
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build f103 bus");
+    let _ = labwired_core::system::cortex_m::configure_cortex_m(&mut bus);
+
+    let forcing: Vec<&str> = bus
+        .peripherals
+        .iter()
+        .filter(|p| p.dev.needs_legacy_walk() && !p.dev.uses_scheduler())
+        .map(|p| p.name.as_str())
+        .collect();
+
+    #[cfg(feature = "event-scheduler")]
+    {
+        assert!(
+            forcing.is_empty(),
+            "f103 lab bus still has walk-forcing peripherals: {forcing:?}"
+        );
+        assert_eq!(bus.max_safe_tick_interval(), RECOMMENDED_TICK_INTERVAL);
+    }
+    #[cfg(not(feature = "event-scheduler"))]
+    {
+        // Featureless: the migrated models stay on the walk (no scheduler).
+        assert!(!forcing.is_empty());
+        assert_eq!(bus.max_safe_tick_interval(), 1);
+    }
 }
 
 /// A manifest without the field parses to `None` (auto-derive), not a hard-coded

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,12 +9,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-10 | ⚠ drift acked 2026-07-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-17 | ⚠ drift acked 2026-07-17 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-18 | ⚠ drift acked 2026-07-18 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
@@ -44,7 +44,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-17 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-18 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-17 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-18 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-17 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-18 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-17 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-18 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -185,7 +185,16 @@ boards:
     # layout, reset values and byte paths unchanged; stm32_timer (5/5) + stm32_dma
     # (2/2) differentials and h563_mmio_diff/conformance pass unchanged. Drift is the
     # shared-file hash only. No live re-capture (no H563 probe attached this session).
-    drift_ack: 2026-07-17
+    # 2026-07-18: STM32 I2C + EXTI + ADC walk-free migration (walk-free campaign).
+    # H563 maps I2C to the L4/modern engine (now event-scheduled via a delay-1
+    # BUSY-gated chain) and shares the ADC file (F1 conversion-cost artifact
+    # normalized to zero in both modes; the L4/modern ADC path this board uses
+    # converts synchronously in write and is untouched). Both are byte-identical to
+    # the walk, pinned by i2c::kinetis_scheduler l4_* + adc::scheduler_diff.
+    # Featureless builds keep the walk. Register layout, reset values and byte
+    # paths unchanged; h563_mmio_diff/conformance pass unchanged. Drift is the
+    # shared-file hash only. No live re-capture.
+    drift_ack: 2026-07-18
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -436,13 +445,26 @@ boards:
     # bare-CPU hardware-oracle settle loop; the Machine lifecycle and normal DMA
     # execution are unchanged. The frozen-settle and scheduler regressions pass.
     # No live re-capture was run this session.
-    drift_ack: 2026-07-17
+    # 2026-07-18: STM32 L4 I2C + EXTI + ADC walk-free migration (walk-free
+    # campaign). event-scheduler builds now event-schedule the L4 I2C transaction
+    # engine (delay-1 self-perpetuating chain, BUSY-gated), the EXTI held-level
+    # explicit_irqs re-emission (incl. bank-2 wakeup lines), and the F1-shared ADC
+    # conversion countdown, so the L476's whole peripheral set is walk-free — the
+    # runtime invaders bus now auto-derives walk-deletion with no hand flag. The
+    # legacy walk path is byte-identical, pinned by committed differentials
+    # (i2c::kinetis_scheduler l4_* cases, exti::scheduler_diff l4 case,
+    # adc::scheduler_diff). The ADC tick-cost sim artifact is removed in BOTH modes
+    # (SysTick B1 pattern). Featureless builds keep the walk. Register layout,
+    # reset values and MMIO byte paths unchanged; l476_mmio_diff + l476_parity_diff
+    # pass unchanged. No live re-capture.
+    drift_ack: 2026-07-18
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
       - crates/core/src/peripherals/uart.rs
       - crates/core/src/peripherals/spi.rs
       - crates/core/src/peripherals/i2c.rs
+      - crates/core/src/peripherals/exti.rs
       - crates/core/src/peripherals/timer.rs
       - crates/core/src/peripherals/dma.rs
       - crates/core/src/peripherals/adc.rs
@@ -547,7 +569,20 @@ boards:
     # bare-CPU hardware-oracle settle loop; the Machine lifecycle and normal DMA
     # execution are unchanged. The frozen-settle and scheduler regressions pass.
     # No live re-capture was run this session.
-    drift_ack: 2026-07-17
+    # 2026-07-18: STM32 F1 I2C + EXTI + ADC walk-free migration (walk-free
+    # campaign). event-scheduler builds now event-schedule the F1 I2C transaction
+    # engine (delay-1 self-perpetuating chain; the read-gated receive is caught by
+    # the already-live chain — no byte dropped), the EXTI held-level explicit_irqs
+    # re-emission, and the F1 ADC conversion countdown, so the F103's whole
+    # peripheral set is walk-free. The legacy walk path is byte-identical, pinned
+    # by committed walk-vs-scheduler differentials (i2c::kinetis_scheduler f1_*
+    # cases, exti::scheduler_diff, adc::scheduler_diff — registers + read bytes +
+    # NVIC-pend cycles). The ADC tick-cost sim artifact (cycles:1 per converting
+    # tick) is removed in BOTH modes (SysTick B1 pattern; a real conversion runs
+    # on the ADC clock, zero core cycles). Featureless builds keep the walk.
+    # Register layout, reset values and MMIO byte paths unchanged; stm32f1_mmio_diff
+    # (102/102) + f103_conformance pass unchanged. No live re-capture.
+    drift_ack: 2026-07-18
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -555,6 +590,7 @@ boards:
       - crates/core/src/peripherals/uart.rs
       - crates/core/src/peripherals/spi.rs
       - crates/core/src/peripherals/i2c.rs
+      - crates/core/src/peripherals/exti.rs
       - crates/core/src/peripherals/timer.rs
       - crates/core/src/peripherals/dma.rs
       - crates/core/src/peripherals/adc.rs
@@ -608,7 +644,15 @@ boards:
     # bare-CPU hardware-oracle settle loop; the Machine lifecycle and normal DMA
     # execution are unchanged. The frozen-settle and scheduler regressions pass.
     # No live re-capture was run this session.
-    drift_ack: 2026-07-17
+    # 2026-07-18: STM32 F1 I2C walk-free migration (walk-free campaign) — the F1
+    # I2C transaction engine (this board's I2C variant) is now event-scheduled via
+    # a delay-1 self-perpetuating chain; the read-gated receive is caught by the
+    # already-live chain with no byte dropped. The legacy walk path is
+    # byte-identical, pinned by the i2c::kinetis_scheduler f1_* differentials.
+    # Featureless builds keep the walk. Register layout, reset values and MMIO byte
+    # paths unchanged; stm32f4_mmio_diff (RCC/GPIO/SPI/TIM, not I2C — I2C stays
+    # smoke-tier) passes unchanged. No live re-capture.
+    drift_ack: 2026-07-18
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -579,7 +579,12 @@ boards:
     # cases, exti::scheduler_diff, adc::scheduler_diff — registers + read bytes +
     # NVIC-pend cycles). The ADC tick-cost sim artifact (cycles:1 per converting
     # tick) is removed in BOTH modes (SysTick B1 pattern; a real conversion runs
-    # on the ADC clock, zero core cycles). Featureless builds keep the walk.
+    # on the ADC clock, zero core cycles). Additionally the F1 RTC (rtc_f1.rs) —
+    # a pure register bank with NO tick() override (its default per-cycle callback
+    # is a proven no-op) — gets needs_legacy_walk()=false (the AFIO no-op-bank
+    # pattern), which was the LAST walker on every f103 lab bus: the full f103
+    # board now flips walk-deletable (recommended_tick_interval 1→512, idle
+    # fast-forward). All byte-identical; featureless builds keep the walk.
     # Register layout, reset values and MMIO byte paths unchanged; stm32f1_mmio_diff
     # (102/102) + f103_conformance pass unchanged. No live re-capture.
     drift_ack: 2026-07-18


### PR DESCRIPTION
## Walk-free campaign — full STM32F1 board flip

Completes the STM32F103 walk-delete campaign: the whole f103 peripheral set is now
event-schedulable, so every f103 browser lab flips walk-deletable and the browser
fast path lifts `recommended_tick_interval` 1→512 with idle fast-forward.

### The decisive blocker — F1/L4 I2C (solved, not a wall)
The prior note claimed the read-gated F1/L4 I2C transaction engine could **not** be
event-scheduled without dropping bytes ("event arming only on writes"). That was a
false wall: it missed the Kinetis-style **liveness-gated self-perpetuating chain**.
The engine is now driven by a delay-1 event that runs the *same* `tick()` every
cycle while a transfer is active (a countdown in flight **or** `SR2.BUSY`), and
stops when fully idle. The `&self`-read side effects (`rxne_consumed`, device byte
pulls) are observed by the already-live chain's next `on_event` exactly as the
walk's next `tick()` would — **no byte dropped**, no event armed from the read path.
Reuses the existing scheduler seam (`uses_scheduler`/`take_scheduled_events`/
`on_event`), single source of truth.

### Also migrated
- **EXTI** — held-level `explicit_irqs` re-emission via a delay-1 chain armed on the
  MMIO write that raises a masked pending line (SWIER / IMR unmask), stopping when
  firmware clears PR. `tick()` and `on_event` share one `pending_irqs()` helper.
- **ADC** — F1 conversion countdown event-scheduled; the legacy `cycles:1`
  per-converting-tick cost (a sim artifact — a real conversion runs on the ADC
  clock, zero core cycles) normalized to **0 in both modes** (SysTick B1 pattern).
- **RTC (F1)** — a pure register bank with no `tick()` override (proven no-op);
  `needs_legacy_walk()=false` (AFIO pattern). This was the **last** walker on every
  f103 lab bus.

### Byte-identical proof (the oracle — every step, BOTH feature sets)
New walk-vs-scheduler differentials (registers + read bytes + NVIC-pend cycles,
every cycle): `i2c::kinetis_scheduler` (`f1_*`/`l4_*`), `exti::scheduler_diff`,
`adc::scheduler_diff`, plus inertness/flip gates. Green under **`event-scheduler`**
AND **`jit event-scheduler`** (the lane that broke a sibling PR), and default:
- Full `labwired-core` suite: green on all 3 lanes
- `stm32f1_mmio_diff` (4/4), `stm32f1_exec_oracle` (14/14), `l476_mmio_diff`,
  `stm32f4_mmio_diff` unchanged
- All walk differentials: `walk_deletion`, `stm32_dma`/`timer`/`systick`,
  `esp32s3`/`esp32c3`, `kw41z` — green
- `cargo fmt --check` clean, clippy clean (default + both feature lanes)

### Labs flipped — before→after host-MIPS (real f103 ELFs, browser fast path)
`recommended_tick_interval` + `set_idle_fast_forward_enabled(true)` + step loop,
40M device cycles each, walk-pinned reference vs walk-deleted:

| lab (f103) | rec_tick | host-MIPS | idle-FF skipped |
|---|---|---|---|
| demo-blinky (GPIO) | 1 → **512** | 2.14 → **8.82** | 0% (busy-loop) |
| ssd1306-hello (I2C) | 1 → **512** | 2.19 → **8.51** | 0% (busy-loop) |
| epaper-tricolor (SPI) | 1 → **512** | 2.15 → **98.5** | 0% → **91.5%** (WFI) |

WFI labs gain the full idle fast-forward (46× on epaper); busy-polling labs still
gain ~4× from walk deletion + tick batching.

### Silicon-drift ledger
The shared `i2c.rs`/`exti.rs`/`adc.rs`/`rtc_f1.rs` changes tripped the drift gate for
`stm32f103`, `nucleo-l476rg`, `stm32f407`, `stm32h563`. Each got a dated **2026-07-18**
`drift_ack` justified by the byte-identical walk-migration (models byte-identical on
the walk path; the ADC cost-artifact removal mirrors the already-acked SysTick/timer/
DMA normalizations) — the sanctioned honesty ledger, not gate-tampering.
`VALIDATION_STATUS.md` regenerated; `--drift` + `--check` pass.
