### PR TITLE
test(rp2040): close the RP2040 fidelity-coverage gap

### DIFF
--- a/crates/core/tests/board_coverage_ratchet.rs
+++ b/crates/core/tests/board_coverage_ratchet.rs
@@ -199,19 +199,12 @@ const SHIPPED: &[Board] = &[
 /// convention test), then DELETE the row — the gate fails if a listed gap is
 /// found already covered, so stale rows cannot accumulate.
 const KNOWN_GAPS: &[(&str, Class)] = &[
-    // RP2040 ships (firmware-rp2040-demo, rp2040-pio-onboarding) but has only a
-    // `firmware_survival` boot test — no walk differential or silicon oracle for
-    // its core SysTick/PIO/IRQ path. Fill with
-    // `crates/core/tests/rp2040_walk_differential.rs`.
+    // RP2040 executing-fidelity is now covered by rp2040_timer_exec_oracle +
+    // rp2040_reset_conformance + rp2040_pio_onboarding (PR that added this row's
+    // deletion). NOTE: RP2040 DMA remains a MODELING gap (no `dma` block in
+    // `configs/chips/rp2040.yaml`) tracked in issue #577 — the ratchet deliberately
+    // does not demand a DMA test for a peripheral the chip does not model.
     //
-    // NOTE — this is a TEST gap on the timer/IRQ path, NOT a DMA gap. RP2040 DMA
-    // is not modelled at all (there is no `dma` block in `configs/chips/rp2040.yaml`),
-    // so it is a MODELING gap, tracked separately. This ratchet deliberately does
-    // not demand a DMA differential for RP2040: gating a test for a peripheral the
-    // chip does not model would be a false blocker. The executing-fidelity class
-    // here is satisfied by ANY timer/IRQ walk-diff or oracle; add DMA coverage
-    // only if/when the DMA block is modelled.
-    ("rp2040", Class::Exec),
     // STM32F401 (BlackPill / demo) ships but its executing coverage is only
     // `firmware_survival::test_stm32f401_blinky_survival`. The F4 exec-oracle /
     // mmio-diff target real F407 silicon, not F401. Fill with an F401 walk

--- a/crates/core/tests/rp2040_pio_onboarding.rs
+++ b/crates/core/tests/rp2040_pio_onboarding.rs
@@ -1,0 +1,123 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! RP2040 PIO executing-fidelity golden test.
+//!
+//! The PIO block is the RP2040's signature peripheral, and the shipped
+//! `rp2040-pio` onboarding lab (`examples/rp2040-pio/io-smoke.yaml`) drives it.
+//! This test loads that lab's real compiled firmware
+//! (`firmware-rp2040-pio-onboarding`) onto the full RP2040 chip bus and runs it,
+//! asserting the firmware's own PIO self-check reaches its success verdict over
+//! the UART console.
+//!
+//! What the firmware exercises, end to end, through the modelled PIO
+//! (`peripherals/pio.rs`) — none of it reachable by a register poke:
+//!   1. writes a 2-instruction PIO program (`SET X,10`; `PULL block`) into
+//!      INSTR_MEM,
+//!   2. configures SM0 wrap and enables the state machine (CTRL.SM0),
+//!   3. the state machine executes `SET`, advances PC, and **stalls on `PULL`**
+//!      with an empty TX FIFO,
+//!   4. the CPU pushes a word into TXF0, unblocking the stalled `PULL`,
+//!   5. the state machine consumes the FIFO word, which the firmware confirms by
+//!      reading FSTAT.TXEMPTY(SM0) and printing `PIO_OK`.
+//!
+//! `PIO_FAIL` (the FIFO never drained → the state machine never ran the program)
+//! is asserted-against explicitly, so a broken PIO cannot pass by emitting the
+//! failure banner.
+//!
+//! The fixture is built by the core-ci "Build test firmware fixture" step:
+//! ```text
+//! RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2040-pio-onboarding \
+//!     --release --target thumbv6m-none-eabi
+//! ```
+//! When it is absent (a plain `cargo test` without that pre-build) the test
+//! skips with a notice rather than failing spuriously.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Machine;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn rp2040_chip() -> (ChipDescriptor, SystemManifest) {
+    let chip_path = workspace_root().join("configs/chips/rp2040.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|e| panic!("load rp2040 chip {chip_path:?}: {e}"));
+    let manifest = SystemManifest {
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "rp2040-pio-onboarding".to_string(),
+        chip: chip_path.to_string_lossy().to_string(),
+        external_devices: vec![],
+        board_io: vec![],
+        debug_uart: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    (chip, manifest)
+}
+
+#[test]
+fn rp2040_pio_onboarding_reaches_pio_ok() {
+    let firmware =
+        workspace_root().join("target/thumbv6m-none-eabi/release/firmware-rp2040-pio-onboarding");
+    if !firmware.exists() {
+        eprintln!(
+            "SKIP rp2040_pio_onboarding_reaches_pio_ok: fixture not built at {firmware:?}. \
+             Build it with: RUSTFLAGS=\"-C link-arg=-Tlink.x\" cargo build \
+             -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi"
+        );
+        return;
+    }
+
+    let (chip, manifest) = rp2040_chip();
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build RP2040 bus");
+    let uart_sink = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(uart_sink.clone(), false);
+
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+
+    let image = labwired_loader::load_elf(&firmware)
+        .unwrap_or_else(|e| panic!("load ELF {firmware:?}: {e}"));
+    machine.load_firmware(&image).expect("load firmware");
+
+    // The onboarding lab caps at 10k steps; give a generous budget and stop as
+    // soon as the firmware has printed its verdict.
+    const MAX_STEPS: u32 = 200_000;
+    for step in 0..MAX_STEPS {
+        machine
+            .step()
+            .unwrap_or_else(|e| panic!("sim crashed at step {step}: {e}"));
+        if step % 512 == 0 {
+            let out = uart_sink.lock().unwrap();
+            if out.windows(6).any(|w| w == b"PIO_OK") || out.windows(8).any(|w| w == b"PIO_FAIL") {
+                break;
+            }
+        }
+    }
+
+    let out = uart_sink.lock().unwrap().clone();
+    let text = String::from_utf8_lossy(&out);
+    assert!(
+        !text.contains("PIO_FAIL"),
+        "PIO state machine failed its self-check (FIFO never drained). UART: {text:?}"
+    );
+    assert!(
+        text.contains("PIO_OK"),
+        "RP2040 PIO onboarding firmware did not reach PIO_OK. UART: {text:?}"
+    );
+}

--- a/crates/hw-oracle/tests/rp2040_reset_conformance.rs
+++ b/crates/hw-oracle/tests/rp2040_reset_conformance.rs
@@ -1,0 +1,178 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! RP2040 reset-state MMIO conformance oracle.
+//!
+//! The RP2040 ships in the browser catalog (`configs/chips/rp2040.yaml`) but,
+//! unlike the STM32/ESP32/nRF families, carried no register-level fidelity
+//! coverage — only in-tree unit tests on the individual peripheral models. This
+//! oracle closes the reset/boot half of that gap: it builds the full RP2040 sim
+//! bus exactly as the runtime does (`SystemBus::from_config`) and pins the
+//! **cold-reset** value of every wired block against the RP2040 datasheet
+//! (RP2040 Datasheet, release 2.1). Every RP2040 peripheral is walk-only /
+//! free-running (`uses_scheduler()` is false for all of them), so the correct
+//! fidelity instrument is a deterministic reset/exec oracle, not a
+//! walk-vs-scheduler differential (there is no scheduler path to diff against).
+//!
+//! Two classes of assertion:
+//!   1. **Silicon reset values** — registers whose datasheet reset value is
+//!      load-bearing (SYSINFO identity that the pico-sdk USB errata workaround
+//!      reads, the free-running timer at rest, the PL011/PL022 status flags,
+//!      SIO core id). A wrong value here is a real fidelity bug.
+//!   2. **Mapping conformance** — every wired window must answer a read without
+//!      a bus fault. A fault means the block is mis-mapped in the chip yaml and
+//!      firmware would hard-fault the moment it touched it.
+//!
+//! Sim-only (normal CI); there is no `_hw` variant because the project has no
+//! attached RP2040 bench target:
+//! ```text
+//! cargo test -p labwired-hw-oracle --test rp2040_reset_conformance
+//! ```
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
+use std::path::PathBuf;
+
+// ── RP2040 register map (RP2040 Datasheet §2.21, §4.6, §4.4, §4.3, §2.3.1) ──────
+
+// SYSINFO (§2.21) — read-only identity block at 0x40000000.
+const SYSINFO_CHIP_ID: u32 = 0x4000_0000;
+const SYSINFO_PLATFORM: u32 = 0x4000_0004;
+/// CHIP_ID for an RP2040 B2 stepping: REVISION=0x2, PART=0x0002,
+/// MANUFACTURER=0x927 (Raspberry Pi). The pico-sdk USB errata-E5 fix, run from
+/// the USB ISR on bus reset, asserts MANUFACTURER==0x927 — a zero here aborts
+/// enumeration inside the ISR.
+const SYSINFO_CHIP_ID_RESET: u32 = 0x2000_2927;
+/// PLATFORM with the ASIC bit (bit 1) set and FPGA (bit 0) clear: the sim is a
+/// real part, so `running_on_fpga()` must read false.
+const SYSINFO_PLATFORM_RESET: u32 = 0x0000_0002;
+
+// TIMER (§4.6) — 64-bit free-running microsecond counter at 0x40054000.
+const TIMER_BASE: u32 = 0x4005_4000;
+const TIMER_ARMED: u32 = TIMER_BASE + 0x20; // alarm armed bits
+const TIMER_TIMERAWH: u32 = TIMER_BASE + 0x24; // live high word
+const TIMER_TIMERAWL: u32 = TIMER_BASE + 0x28; // live low word
+const TIMER_PAUSE: u32 = TIMER_BASE + 0x30; // freeze control
+const TIMER_INTR: u32 = TIMER_BASE + 0x34; // raw interrupt
+const TIMER_INTE: u32 = TIMER_BASE + 0x38; // interrupt enable
+const TIMER_INTS: u32 = TIMER_BASE + 0x40; // masked status
+
+// UART0 PL011 (§4.2) — the console at 0x40034000. UARTFR flag register at +0x18.
+const UART0_UARTFR: u32 = 0x4003_4018;
+/// PL011 UARTFR at reset: TXFE (bit 7) | RXFE (bit 4) — both FIFOs empty. This
+/// is the PrimeCell PL011 (DDI 0183G) documented reset flag state.
+const UART0_UARTFR_RESET: u32 = 0x0000_0090;
+
+// SPI0 PL022 SSP (§4.4) — at 0x4003c000. Status register SSPSR at +0x0c.
+const SPI0_SSPSR: u32 = 0x4003_c00c;
+/// PL022 SSPSR at reset: TFE (bit 0, TX FIFO empty) | TNF (bit 1, TX FIFO not
+/// full). No RX data, not busy.
+const SPI0_SSPSR_RESET: u32 = 0x0000_0003;
+
+// SIO (§2.3.1) — single-cycle IO at 0xD0000000 (outside the APB/AHB window).
+const SIO_CPUID: u32 = 0xD000_0000;
+const SIO_GPIO_IN: u32 = 0xD000_0004;
+const SIO_GPIO_OUT: u32 = 0xD000_0010;
+const SIO_GPIO_OE: u32 = 0xD000_0020;
+
+/// (label, address, expected cold-reset value). Datasheet-anchored; a mismatch
+/// is a real model-vs-silicon fidelity bug.
+const RESET_VALUES: &[(&str, u32, u32)] = &[
+    ("SYSINFO CHIP_ID", SYSINFO_CHIP_ID, SYSINFO_CHIP_ID_RESET),
+    ("SYSINFO PLATFORM", SYSINFO_PLATFORM, SYSINFO_PLATFORM_RESET),
+    // Free-running timer at rest: the counter and all alarm state read zero
+    // before any tick advances it.
+    ("TIMER TIMERAWL", TIMER_TIMERAWL, 0x0000_0000),
+    ("TIMER TIMERAWH", TIMER_TIMERAWH, 0x0000_0000),
+    ("TIMER ARMED", TIMER_ARMED, 0x0000_0000),
+    ("TIMER PAUSE", TIMER_PAUSE, 0x0000_0000),
+    ("TIMER INTR", TIMER_INTR, 0x0000_0000),
+    ("TIMER INTE", TIMER_INTE, 0x0000_0000),
+    ("TIMER INTS", TIMER_INTS, 0x0000_0000),
+    ("UART0 UARTFR", UART0_UARTFR, UART0_UARTFR_RESET),
+    ("SPI0 SSPSR", SPI0_SSPSR, SPI0_SSPSR_RESET),
+    // SIO: single core context → CPUID reads core 0; no pin driven at reset.
+    ("SIO CPUID", SIO_CPUID, 0x0000_0000),
+    ("SIO GPIO_IN", SIO_GPIO_IN, 0x0000_0000),
+    ("SIO GPIO_OUT", SIO_GPIO_OUT, 0x0000_0000),
+    ("SIO GPIO_OE", SIO_GPIO_OE, 0x0000_0000),
+];
+
+/// Every wired window must answer a read without a bus fault (proves the chip
+/// yaml maps the block). Value is not asserted here — only that the access is
+/// serviced rather than faulting the CPU.
+const MAPPED_WINDOWS: &[(&str, u32)] = &[
+    ("PIO0", 0x5020_0000),
+    ("CLK_RST", 0x4000_8000),
+    ("ROSC", 0x4006_0000),
+    ("WATCHDOG", 0x4005_8000),
+    ("I2C0", 0x4004_4000),
+    ("XIP_SSI", 0x1800_0000),
+    ("USBCTRL regs", 0x5011_0000),
+    ("TBMAN", 0x4006_c000),
+];
+
+fn build_sim_bus() -> SystemBus {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip_path = manifest_dir.join("../../configs/chips/rp2040.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
+    let manifest = SystemManifest {
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "rp2040-reset-conformance".to_string(),
+        chip: chip_path.to_string_lossy().to_string(),
+        external_devices: vec![],
+        board_io: vec![],
+        debug_uart: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    SystemBus::from_config(&chip, &manifest).unwrap_or_else(|e| panic!("build RP2040 sim bus: {e}"))
+}
+
+/// Every wired RP2040 block must return its datasheet cold-reset value.
+#[test]
+fn rp2040_reset_values_match_datasheet() {
+    let sim = build_sim_bus();
+    let mut failures = Vec::new();
+
+    for &(label, addr, expect) in RESET_VALUES {
+        match sim.read_u32(addr as u64) {
+            Ok(got) if got == expect => {}
+            Ok(got) => failures.push(format!(
+                "  [DIFF] {label} 0x{addr:08X}: sim=0x{got:08X} datasheet=0x{expect:08X}"
+            )),
+            Err(e) => failures.push(format!("  [FAULT] {label} 0x{addr:08X}: {e:?}")),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "RP2040 reset-state model diverged from datasheet in {} of {} register(s):\n{}",
+        failures.len(),
+        RESET_VALUES.len(),
+        failures.join("\n")
+    );
+}
+
+/// Every wired RP2040 window must be mapped (a read is serviced, not faulted).
+#[test]
+fn rp2040_wired_windows_are_mapped() {
+    let sim = build_sim_bus();
+    let mut failures = Vec::new();
+
+    for &(label, addr) in MAPPED_WINDOWS {
+        if let Err(e) = sim.read_u32(addr as u64) {
+            failures.push(format!("  [FAULT] {label} 0x{addr:08X}: {e:?}"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "RP2040 has {} unmapped wired window(s) — firmware would hard-fault on first access:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs
+++ b/crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs
@@ -1,0 +1,260 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! RP2040 timer **peripheral-execution** oracle bank.
+//!
+//! Where `rp2040_reset_conformance` pins the static reset estate, this bank
+//! closes the executing-fidelity loop for the free-running microsecond timer
+//! (RP2040 Datasheet §4.6): it executes real Thumb machine code on the **full
+//! RP2040 chip bus**, driving the timer through its MMIO interface with the
+//! peripheral walk live, and asserts the dynamics a register poke can't reach —
+//! the counter's monotonic advance, `PAUSE` freeze/resume, and the alarm →
+//! NVIC → ISR interrupt-delivery path end to end.
+//!
+//! The RP2040 has no attached bench target, so only the always-compiled `_sim`
+//! variant runs (the macro's `_hw` / `_diff` variants are feature-gated and
+//! `#[ignore]`). Sim advances the counter one tick per executed instruction —
+//! the absolute rate is arbitrary (the sim has no wall clock) but strictly
+//! deterministic, so the pinned deltas below are exact regression locks, not
+//! timing-fidelity claims.
+//!
+//! ```text
+//! cargo test -p labwired-hw-oracle --test rp2040_timer_exec_oracle
+//! ```
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_hw_oracle::arm_thumb::{
+    adds_imm8, assemble, bx, ldr_imm5, movs_imm8, movt_imm16, movw_imm16, str_imm5, Thumb,
+    ThumbOracleCase, INIT_SP, PROG_BASE_HW,
+};
+use labwired_hw_oracle::thumb_oracle_test;
+use std::path::PathBuf;
+
+// ── RP2040 TIMER register map (§4.6, base 0x40054000) ───────────────────────────
+const TIMER_BASE: u32 = 0x4005_4000;
+const TIMER_ALARM0: u32 = TIMER_BASE + 0x10;
+const TIMER_ARMED: u32 = TIMER_BASE + 0x20;
+const TIMER_TIMERAWL: u32 = TIMER_BASE + 0x28; // live low word
+const TIMER_PAUSE: u32 = TIMER_BASE + 0x30; // bit0 freezes the counter
+const TIMER_INTR: u32 = TIMER_BASE + 0x34; // raw interrupt, write-1-clear
+const TIMER_INTE: u32 = TIMER_BASE + 0x38; // interrupt enable
+
+// Cortex-M0+ system registers (SCS).
+const VTOR_REG: u32 = 0xE000_ED08; // SCB->VTOR
+const NVIC_ISER0: u32 = 0xE000_E100;
+
+// RAM scratch, clear of the program (table @ PROG_BASE_HW=0x2000_2000, growing
+// up) and the stack (down from INIT_SP=0x2000_4FF8).
+const SAMPLE_A: u32 = 0x2000_0300;
+const SAMPLE_B: u32 = 0x2000_0304;
+const SAMPLE_C: u32 = 0x2000_0308;
+const MARKER: u32 = 0x2000_0310;
+const MARKER_VALUE: u32 = 0x600D_A1A1;
+
+/// `MOV.W rd,#lo ; MOVT rd,#hi` — materialise a 32-bit address in `rd`.
+fn load_addr(rd: u8, addr: u32) -> [Thumb; 2] {
+    [
+        Thumb::W(movw_imm16(rd, (addr & 0xFFFF) as u16)),
+        Thumb::W(movt_imm16(rd, (addr >> 16) as u16)),
+    ]
+}
+
+/// `MOV.W r1,#lo ; MOVT r1,#hi ; STR r1,[r0]` — store a 32-bit immediate to the
+/// MMIO/RAM address already in r0.
+fn store_imm32(value: u32) -> [Thumb; 3] {
+    [
+        Thumb::W(movw_imm16(1, (value & 0xFFFF) as u16)),
+        Thumb::W(movt_imm16(1, (value >> 16) as u16)),
+        Thumb::H(str_imm5(1, 0, 0)),
+    ]
+}
+
+/// `LDR r3,[addr] ; STR r3,[sample]` — sample a 32-bit MMIO register into a RAM
+/// slot. Uses r0/r2 as scratch address registers.
+fn sample_reg_to(src: u32, dst: u32) -> Vec<Thumb> {
+    let mut s = Vec::new();
+    s.extend(load_addr(0, src));
+    s.push(Thumb::H(ldr_imm5(3, 0, 0))); // r3 = *src
+    s.extend(load_addr(2, dst));
+    s.push(Thumb::H(str_imm5(3, 2, 0))); // *dst = r3
+    s
+}
+
+/// A run of distinct-PC filler instructions so the peripheral walk advances the
+/// timer this many ticks while the CPU is still executing (the harness breaks
+/// two steps after the PC settles on the `B .` terminator, so ticks must elapse
+/// *before* then). Each `MOVS` is one instruction → one tick.
+fn filler(n: usize) -> Vec<Thumb> {
+    (0..n)
+        .map(|i| Thumb::H(movs_imm8(4, (i & 0xFF) as u8)))
+        .collect()
+}
+
+/// Build the full RP2040 simulator bus (peripherals mapped), matching the
+/// runtime's `SystemBus::from_config` path.
+fn rp2040_bus() -> SystemBus {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip_path = manifest_dir.join("../../configs/chips/rp2040.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
+    let manifest = SystemManifest {
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "rp2040-timer-exec-oracle".to_string(),
+        chip: chip_path.to_string_lossy().to_string(),
+        external_devices: vec![],
+        board_io: vec![],
+        debug_uart: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    SystemBus::from_config(&chip, &manifest).unwrap_or_else(|e| panic!("build RP2040 sim bus: {e}"))
+}
+
+// ── 1. Free-running counter monotonic advance ───────────────────────────────────
+//
+// Sample TIMERAWL, run a fixed filler window, sample again. With the peripheral
+// walk live (one tick per executed instruction) the second sample must be
+// strictly greater — the counter genuinely advanced through CPU→bus→timer, not
+// via a poke. The exact delta is the deterministic instruction count between the
+// two reads and is pinned as a regression lock.
+#[thumb_oracle_test]
+fn rp2040_timer_free_running() -> ThumbOracleCase {
+    let mut prog: Vec<Thumb> = Vec::new();
+    prog.extend(sample_reg_to(TIMER_TIMERAWL, SAMPLE_A));
+    prog.extend(filler(16));
+    prog.extend(sample_reg_to(TIMER_TIMERAWL, SAMPLE_B));
+
+    ThumbOracleCase::mixed(&prog)
+        .sim_bus(rp2040_bus)
+        .live_peripherals(true)
+        .capture_mem(&[SAMPLE_A, SAMPLE_B])
+        .expect(|st| {
+            let a = st.read_mem(SAMPLE_A);
+            let b = st.read_mem(SAMPLE_B);
+            assert!(
+                b > a,
+                "TIMERAWL must advance monotonically: A=0x{a:08X} B=0x{b:08X}"
+            );
+            // Deterministic tick count between the two samples (filler + the
+            // second sample's address-materialise/load run). Pinned from the
+            // model; a change here means the timer's advance cadence or the
+            // executor's per-instruction tick moved.
+            assert_eq!(b - a, 22, "pinned free-running delta");
+        })
+}
+
+// ── 2. PAUSE freezes the counter, clearing it resumes ───────────────────────────
+//
+// Set PAUSE.bit0, sample TIMERAWL twice across a filler window: frozen, so the
+// two samples are equal. Then clear PAUSE and sample once more: it advances
+// again. PAUSE=1 holding the counter across live ticks is the load-bearing
+// assertion — a poke could never show the freeze.
+#[thumb_oracle_test]
+fn rp2040_timer_pause_freezes() -> ThumbOracleCase {
+    let mut prog: Vec<Thumb> = Vec::new();
+    // PAUSE = 1
+    prog.extend(load_addr(0, TIMER_PAUSE));
+    prog.extend(store_imm32(0x1));
+    prog.extend(sample_reg_to(TIMER_TIMERAWL, SAMPLE_A));
+    prog.extend(filler(16));
+    prog.extend(sample_reg_to(TIMER_TIMERAWL, SAMPLE_B));
+    // PAUSE = 0 (resume), then let it advance and sample again.
+    prog.extend(load_addr(0, TIMER_PAUSE));
+    prog.extend(store_imm32(0x0));
+    prog.extend(filler(16));
+    prog.extend(sample_reg_to(TIMER_TIMERAWL, SAMPLE_C));
+
+    ThumbOracleCase::mixed(&prog)
+        .sim_bus(rp2040_bus)
+        .live_peripherals(true)
+        .capture_mem(&[SAMPLE_A, SAMPLE_B, SAMPLE_C])
+        .expect(|st| {
+            let a = st.read_mem(SAMPLE_A);
+            let b = st.read_mem(SAMPLE_B);
+            let c = st.read_mem(SAMPLE_C);
+            assert_eq!(a, b, "paused counter must hold: A=0x{a:08X} B=0x{b:08X}");
+            assert!(
+                c > b,
+                "counter must resume after PAUSE clear: B=0x{b:08X} C=0x{c:08X}"
+            );
+        })
+}
+
+// ── 3. Alarm → NVIC → ISR interrupt delivery ────────────────────────────────────
+//
+// The end-to-end tick-source path: arm ALARM0 a fixed margin ahead of the live
+// counter, enable INTE + the NVIC line, and let the free-running counter reach
+// the target. On match the timer latches INTR, disarms, and asserts TIMER_IRQ_0
+// (NVIC IRQ 0 → exception 16) level-sensitively; the CPU vectors to the ISR,
+// which writes a RAM marker and acknowledges INTR (write-1-clear). Final state:
+// marker set (the exception was delivered), INTR clear (ISR acked), ARMED clear
+// (alarm auto-disarmed on fire). None of this is reachable by a register poke.
+#[thumb_oracle_test]
+fn rp2040_timer_alarm_delivers_irq() -> ThumbOracleCase {
+    const TIMER_IRQ0_EXC: usize = 16; // IRQ 0 → exception number 16
+    const ALARM_MARGIN: u8 = 0x40; // ticks ahead of "now" to arm the alarm
+
+    // ISR: write the marker, acknowledge INTR (write-1-clear bit0), return.
+    let mut isr: Vec<Thumb> = Vec::new();
+    isr.extend(load_addr(0, MARKER));
+    isr.extend(store_imm32(MARKER_VALUE));
+    isr.extend(load_addr(0, TIMER_INTR));
+    isr.extend(store_imm32(0x1)); // ack alarm-0 raw interrupt
+    isr.push(Thumb::H(bx(14))); // BX LR — exception return
+
+    // main: relocate VTOR, zero the marker, enable INTE + NVIC IRQ0, arm ALARM0
+    // a margin ahead of the live counter, then spin through filler so the
+    // counter reaches the target while the CPU is still stepping.
+    let mut main: Vec<Thumb> = Vec::new();
+    main.extend(load_addr(0, VTOR_REG));
+    main.extend(store_imm32(PROG_BASE_HW)); // VTOR = table base
+    main.extend(load_addr(0, MARKER));
+    main.extend(store_imm32(0x0)); // clear marker → proves the ISR set it
+    main.extend(load_addr(0, TIMER_INTE));
+    main.extend(store_imm32(0x1)); // enable alarm-0 interrupt
+    main.extend(load_addr(0, NVIC_ISER0));
+    main.extend(store_imm32(1 << 0)); // enable NVIC IRQ0 (TIMER_IRQ_0)
+                                      // ALARM0 = TIMERAWL + margin (guaranteed in the future: only a handful of
+                                      // ticks elapse before the arming store, margin is comfortably larger).
+    main.extend(load_addr(0, TIMER_TIMERAWL));
+    main.push(Thumb::H(ldr_imm5(3, 0, 0))); // r3 = live low word
+    main.push(Thumb::H(adds_imm8(3, ALARM_MARGIN))); // r3 += margin
+    main.extend(load_addr(0, TIMER_ALARM0));
+    main.push(Thumb::H(str_imm5(3, 0, 0))); // arm alarm 0
+    main.extend(filler(128)); // > margin ticks so the match lands mid-execution
+
+    let (prog, entry) = interrupt_program(&isr, &main, TIMER_IRQ0_EXC);
+
+    ThumbOracleCase::mixed(&prog)
+        .sim_bus(rp2040_bus)
+        .entry_offset(entry)
+        .live_peripherals(true)
+        .capture_mem(&[MARKER, TIMER_INTR, TIMER_ARMED])
+        .expect(|st| {
+            st.assert_mem(MARKER, MARKER_VALUE); // ISR ran → exception delivered
+            st.assert_mem(TIMER_INTR, 0); // ISR acknowledged the raw interrupt
+            st.assert_mem(TIMER_ARMED, 0); // alarm auto-disarmed on fire
+        })
+}
+
+/// Build `[32-entry vector table][isr][main]` and return the program plus the
+/// byte offset of `main` (the entry point). `exc_num` is the exception number
+/// (IRQ + 16) whose vector points at the ISR. VTOR is 128-byte aligned, so the
+/// 32-entry (128-byte) table sits at the load base.
+fn interrupt_program(isr: &[Thumb], main: &[Thumb], exc_num: usize) -> (Vec<Thumb>, u32) {
+    const TABLE_ENTRIES: usize = 32;
+    let table_bytes = (TABLE_ENTRIES * 4) as u32;
+    let isr_bytes = assemble(isr).len() as u32;
+    let isr_addr = PROG_BASE_HW + table_bytes;
+    let main_offset = table_bytes + isr_bytes;
+
+    let mut prog: Vec<Thumb> = vec![Thumb::Data(0); TABLE_ENTRIES];
+    prog[0] = Thumb::Data(INIT_SP); // initial SP (vector 0)
+    prog[1] = Thumb::Data((PROG_BASE_HW + main_offset) | 1); // reset vector (unused; PC set directly)
+    prog[exc_num] = Thumb::Data(isr_addr | 1); // the handler under test
+    prog.extend_from_slice(isr);
+    prog.extend_from_slice(main);
+    (prog, main_offset)
+}


### PR DESCRIPTION
## Why

The RP2040 ships in the browser catalog (`configs/chips/rp2040.yaml`) but, unlike the STM32/ESP32/nRF families, carried **no register-level fidelity coverage** — only in-tree unit tests on the individual peripheral models. This adds meaningful, deterministic conformance + executing-fidelity tests, named `rp2040_*` so the coverage ratchet discovers them.

## Test-type choice

Every RP2040 peripheral is **walk-only / free-running** (`uses_scheduler()` is false for all of them). A walk-vs-scheduler byte-identical differential is therefore not applicable (there is no scheduler path to diff against). The right instruments are reset conformance + silicon-style execution oracles, mirroring `esp32c3_reset_conformance` and `stm32f1_exec_oracle`.

## What's covered

- **Reset/boot conformance** — `crates/hw-oracle/tests/rp2040_reset_conformance.rs`
  Builds the full RP2040 sim bus via `SystemBus::from_config` and pins datasheet cold-reset values (SYSINFO CHIP_ID `0x20002927` + PLATFORM, free-running timer at rest, PL011 UARTFR `0x90`, PL022 SSPSR `0x03`, SIO CPUID/GPIO) plus a mapping-conformance sweep that every wired window answers without a bus fault.

- **Timer executing-fidelity** — `crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs`
  Real Thumb code on the full chip bus with the peripheral walk live:
  - `rp2040_timer_free_running` — TIMERAWL monotonic advance (pinned deterministic delta),
  - `rp2040_timer_pause_freezes` — PAUSE freezes then resumes the counter,
  - `rp2040_timer_alarm_delivers_irq` — full ALARM0 → INTR → NVIC IRQ0 → ISR delivery path (VTOR relocation, vectoring, ack, auto-disarm).

- **PIO executing-fidelity** — `crates/core/tests/rp2040_pio_onboarding.rs`
  Loads the shipped `rp2040-pio` onboarding lab's real firmware and asserts its PIO self-check reaches `PIO_OK` (SET/PULL execution, TX-FIFO stall/unblock, FSTAT.TXEMPTY), with `PIO_FAIL` asserted-against. Requires the core-ci "Build test firmware fixture" step; skips with a notice when the fixture is absent.

## Notes

- No RP2040 bench target exists, so only the always-compiled `_sim` oracle variants run (`_hw`/`_diff` stay feature-gated + `#[ignore]`).
- Test + fixture-wiring only; no RP2040 model behavior changed. No fidelity bug uncovered — the models matched every datasheet/oracle assertion.
- **Coverage gap left open (out of scope):** the RP2040 DMA controller is not wired in `rp2040.yaml`, so there is nothing to test there yet.

`cargo fmt` + `clippy` clean; all new tests deterministic and passing.