### PR TITLE
test(coverage): board-coverage ratchet + generalized shipped-lab perf gate

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -85,6 +85,15 @@ jobs:
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
 
+      # Board-coverage ratchet: a cheap static/naming scan (no fixtures, no
+      # firmware build) that fails if a SHIPPED chip lacks its required coverage
+      # classes — reset conformance, an executing-fidelity test, and a display
+      # assertion where it drives a shipped display lab. Missing coverage is only
+      # allowed via the shrink-only KNOWN_GAPS allowlist inside the test; a new
+      # uncovered board, or a filled gap left stale in the allowlist, fails here.
+      - name: Board-coverage ratchet (static naming scan)
+        run: cargo test -p labwired-core --test board_coverage_ratchet -- --nocapture
+
       # Scheduler-driven interrupt delivery, all three MCU fabrics. This lane
       # (event-scheduler + jit) previously ran ONLY in core-full, which is how an
       # ESP32-S3 intmatrix scheduler-delivery hole stayed hidden. These targeted

--- a/crates/core/tests/board_coverage_ratchet.rs
+++ b/crates/core/tests/board_coverage_ratchet.rs
@@ -201,7 +201,16 @@ const SHIPPED: &[Board] = &[
 const KNOWN_GAPS: &[(&str, Class)] = &[
     // RP2040 ships (firmware-rp2040-demo, rp2040-pio-onboarding) but has only a
     // `firmware_survival` boot test — no walk differential or silicon oracle for
-    // its SysTick/PIO/IRQ path. Fill with `crates/core/tests/rp2040_walk_differential.rs`.
+    // its core SysTick/PIO/IRQ path. Fill with
+    // `crates/core/tests/rp2040_walk_differential.rs`.
+    //
+    // NOTE — this is a TEST gap on the timer/IRQ path, NOT a DMA gap. RP2040 DMA
+    // is not modelled at all (there is no `dma` block in `configs/chips/rp2040.yaml`),
+    // so it is a MODELING gap, tracked separately. This ratchet deliberately does
+    // not demand a DMA differential for RP2040: gating a test for a peripheral the
+    // chip does not model would be a false blocker. The executing-fidelity class
+    // here is satisfied by ANY timer/IRQ walk-diff or oracle; add DMA coverage
+    // only if/when the DMA block is modelled.
     ("rp2040", Class::Exec),
     // STM32F401 (BlackPill / demo) ships but its executing coverage is only
     // `firmware_survival::test_stm32f401_blinky_survival`. The F4 exec-oracle /

--- a/crates/core/tests/board_coverage_ratchet.rs
+++ b/crates/core/tests/board_coverage_ratchet.rs
@@ -1,0 +1,450 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! BOARD-COVERAGE RATCHET — "rock solid per board", enforced.
+//!
+//! Why this file exists
+//! ====================
+//! A chip can appear in the shipped catalog (`bundled-configs.ts` +
+//! `configs/chips/`) with a green CI and still have NO test that actually runs
+//! its firmware against a reference. That is exactly how RP2040 and STM32F401
+//! shipped: they boot in the playground but nothing pins their core timer/IRQ
+//! path to a differential or a silicon oracle. This gate makes that state
+//! *visible and un-expandable*: every shipped chip must carry a minimum set of
+//! coverage classes, discovered BY CONVENTION (we grep the test corpus for
+//! naming patterns), never a hand-maintained manifest that drifts.
+//!
+//! The required coverage classes (policy)
+//! ======================================
+//! For every SHIPPED chip:
+//!
+//! (a) RESET / BOOT CONFORMANCE — a `*conformance*` / `*clock_boot*` / `*reset*`
+//! test that references the chip (the fleet-wide `chip_conformance.rs`
+//! scoreboard satisfies this for every chip).
+//!
+//! (b) EXECUTING FIDELITY — at least one test that *runs code* and compares it to
+//! a reference on the chip's core timer/IRQ path: a walk-vs-scheduler
+//! differential, a silicon exec-oracle / MMIO-diff, a golden trace, or a JIT
+//! lockstep. A "firmware survival" boot-and-don't-crash test does NOT count —
+//! surviving is not the same as being *right*. A chip that ships with no
+//! executing-fidelity test is the RP2040/F401 exposure.
+//!
+//! (c) DISPLAY ASSERTION — for chips that drive a shipped display lab, a
+//! display-level test (`*oled*` / `*nokia*` / `*epaper*` / `*ssd1306*` /
+//! framebuffer assert) that references the chip.
+//!
+//! Naming CONVENTIONS the gap-filler PRs follow (this IS the contract)
+//! ==================================================================
+//! - walk differentials: `crates/core/tests/<chip>_walk_differential.rs`
+//! - silicon oracle/mmio: `crates/hw-oracle/tests/<chip>_exec_oracle.rs`,
+//!   `crates/hw-oracle/tests/<chip>_mmio_diff.rs`
+//! - reset conformance: the `chip_conformance` scoreboard, or
+//!   `crates/hw-oracle/tests/<chip>_reset_conformance.rs`
+//! - display differentials: `*_<display>_differential` / framebuffer asserts
+//!
+//! The KNOWN-GAP allowlist
+//! =======================
+//! `KNOWN_GAPS` is a *shrink-only* ratchet allowlist, exactly like
+//! `strict_onboarding.rs`'s `SMOKE_LESS_ALLOWLIST`. A chip/class listed there is
+//! allowed to be missing TODAY — but a NEW uncovered chip/class that is NOT on
+//! the list fails the gate, and a listed gap that has since been FILLED also
+//! fails the gate (stale entry), so the allowlist can only get shorter. Gap-filler PRs land the missing test,
+//! then delete the matching `KNOWN_GAPS` row. Do NOT add rows to make a red gate
+//! green — that re-opens the exact hole this file exists to close.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A required coverage class.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Class {
+    Reset,
+    Exec,
+    Display,
+}
+
+impl Class {
+    fn label(self) -> &'static str {
+        match self {
+            Class::Reset => "reset/boot conformance",
+            Class::Exec => {
+                "executing fidelity (walk-diff / exec-oracle / mmio-diff / golden / lockstep)"
+            }
+            Class::Display => "display-level assertion",
+        }
+    }
+    /// Filename substrings that mark a test file as belonging to this class.
+    fn filename_markers(self) -> &'static [&'static str] {
+        match self {
+            Class::Reset => &["conformance", "clock_boot", "reset"],
+            Class::Exec => &[
+                "walk_differential",
+                "walk_free_differential",
+                "exec_oracle",
+                "mmio_diff",
+                "lockstep",
+                "golden",
+                "full_state_differential",
+            ],
+            Class::Display => &[
+                "oled",
+                "nokia",
+                "epaper",
+                "ssd1306",
+                "framebuffer",
+                "_lcd",
+                "display",
+            ],
+        }
+    }
+}
+
+/// One shipped chip and the coverage it must carry.
+struct Board {
+    /// Canonical catalog id.
+    chip: &'static str,
+    /// Case-insensitive substrings that identify this chip inside a test file
+    /// (filename or body). Aliases exist because hw-oracle files are named by
+    /// family (`stm32f1_*`, `stm32f4_*`, `stm32l0_*`) rather than by part.
+    aliases: &'static [&'static str],
+    /// `configs/chips/<stem>.yaml` file stem. A test that LOADS this config is
+    /// unambiguously targeting this chip — the strong signal used for the
+    /// reset/exec classes, where family-shared files (`stm32f4_*` naming both
+    /// F407 and F401 in prose) make a loose prose match unsafe.
+    yaml_stem: &'static str,
+    /// Does this chip drive a SHIPPED display lab (per `bundled-configs.ts`)?
+    /// Only then is the display-assertion class required.
+    display_lab: bool,
+}
+
+/// The canonical SHIPPED board/chip list (verified against
+/// `packages/playground/src/bundled-configs.ts` + `configs/chips/`).
+///
+/// A chip added to the shipped catalog MUST be added here, or the cross-check at
+/// the bottom of this file fails — a shipped board can never bypass the ratchet.
+const SHIPPED: &[Board] = &[
+    Board {
+        chip: "stm32f103",
+        aliases: &["stm32f103", "f103", "stm32f1"],
+        yaml_stem: "stm32f103",
+        display_lab: true,
+    },
+    Board {
+        chip: "stm32f401",
+        aliases: &["stm32f401", "f401"],
+        yaml_stem: "stm32f401",
+        display_lab: false,
+    },
+    Board {
+        chip: "stm32f407",
+        aliases: &["stm32f407", "f407", "stm32f4", "nucleo-f407"],
+        yaml_stem: "stm32f407",
+        display_lab: false,
+    },
+    Board {
+        chip: "stm32l073",
+        aliases: &["stm32l073", "l073", "stm32l0"],
+        yaml_stem: "stm32l073",
+        display_lab: false,
+    },
+    Board {
+        chip: "stm32l476",
+        aliases: &["stm32l476", "l476", "stm32l4"],
+        yaml_stem: "stm32l476",
+        display_lab: true,
+    },
+    Board {
+        chip: "stm32h563",
+        aliases: &["stm32h563", "h563"],
+        yaml_stem: "stm32h563",
+        display_lab: false,
+    },
+    Board {
+        chip: "nrf52840",
+        aliases: &["nrf52840", "nrf52_", "nrf52 "],
+        yaml_stem: "nrf52840",
+        display_lab: false,
+    },
+    Board {
+        chip: "esp32c3",
+        aliases: &["esp32c3"],
+        yaml_stem: "esp32c3",
+        display_lab: true,
+    },
+    Board {
+        chip: "esp32s3",
+        aliases: &["esp32s3"],
+        yaml_stem: "esp32s3",
+        display_lab: true,
+    },
+    Board {
+        chip: "kw41z",
+        aliases: &["kw41z", "mkw41z"],
+        yaml_stem: "mkw41z4",
+        display_lab: false,
+    },
+    Board {
+        chip: "rp2040",
+        aliases: &["rp2040"],
+        yaml_stem: "rp2040",
+        display_lab: false,
+    },
+];
+
+/// SHRINK-ONLY allowlist of (chip, class) pairs known to lack coverage today.
+///
+/// Every entry is a debt with a tracking note. Fill the gap (land the named
+/// convention test), then DELETE the row — the gate fails if a listed gap is
+/// found already covered, so stale rows cannot accumulate.
+const KNOWN_GAPS: &[(&str, Class)] = &[
+    // RP2040 ships (firmware-rp2040-demo, rp2040-pio-onboarding) but has only a
+    // `firmware_survival` boot test — no walk differential or silicon oracle for
+    // its SysTick/PIO/IRQ path. Fill with `crates/core/tests/rp2040_walk_differential.rs`.
+    ("rp2040", Class::Exec),
+    // STM32F401 (BlackPill / demo) ships but its executing coverage is only
+    // `firmware_survival::test_stm32f401_blinky_survival`. The F4 exec-oracle /
+    // mmio-diff target real F407 silicon, not F401. Fill with an F401 walk
+    // differential or an F401 mmio-diff/exec-oracle.
+    ("stm32f401", Class::Exec),
+];
+
+fn core_crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every `.rs` file under `crates/core/tests` and `crates/hw-oracle/tests`,
+/// with its filename (lowercased) and full body (lowercased) for scanning.
+struct Corpus {
+    files: Vec<(String, String)>, // (lowercased filename, lowercased contents)
+}
+
+impl Corpus {
+    fn load() -> Self {
+        let core_tests = core_crate_root().join("tests");
+        let oracle_tests = core_crate_root().join("../hw-oracle/tests");
+        let mut files = Vec::new();
+        for dir in [core_tests, oracle_tests] {
+            collect_rs(&dir, &mut files);
+        }
+        assert!(
+            !files.is_empty(),
+            "board_coverage_ratchet found no test files — check the corpus paths"
+        );
+        Corpus { files }
+    }
+
+    /// Does a file whose NAME marks it as `class` actually TARGET this chip?
+    ///
+    /// Matching strength depends on the class:
+    ///   * `Reset`/`Exec` — the STRONG signal: the chip appears in the FILENAME
+    ///     (a family alias like `stm32f4_*`) OR the file explicitly LOADS this
+    ///     chip's config (`chips/<stem>.yaml`). Prose alone does not count,
+    ///     because family-shared files name sibling parts (e.g. the F407
+    ///     mmio-diff mentions F401 in a comment) — a prose match there would
+    ///     falsely credit F401 with an executing-fidelity test it does not have.
+    ///   * `Display` — filename alias OR any body reference (prose included):
+    ///     display labs name their target board in a header comment
+    ///     (`NUCLEO-F103RB`, `NUCLEO-L476RG`) and the display-required set is a
+    ///     small explicit list, so a loose match is safe and necessary here.
+    fn covers(&self, board: &Board, class: Class) -> bool {
+        let markers = class.filename_markers();
+        let config_needle = format!("chips/{}.yaml", board.yaml_stem);
+        for (name, body) in &self.files {
+            let is_class_file = markers.iter().any(|m| name.contains(m));
+            if !is_class_file {
+                continue;
+            }
+            let filename_alias = board
+                .aliases
+                .iter()
+                .any(|a| name.contains(&a.to_lowercase()));
+            let targets = match class {
+                Class::Reset | Class::Exec => filename_alias || body.contains(&config_needle),
+                Class::Display => {
+                    filename_alias
+                        || body.contains(&config_needle)
+                        || board
+                            .aliases
+                            .iter()
+                            .any(|a| body.contains(&a.to_lowercase()))
+                }
+            };
+            if targets {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+fn collect_rs(dir: &Path, out: &mut Vec<(String, String)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs(&path, out);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_lowercase();
+        let body = fs::read_to_string(&path).unwrap_or_default().to_lowercase();
+        out.push((name, body));
+    }
+}
+
+fn required_classes(board: &Board) -> Vec<Class> {
+    let mut v = vec![Class::Reset, Class::Exec];
+    if board.display_lab {
+        v.push(Class::Display);
+    }
+    v
+}
+
+fn is_allowlisted(chip: &str, class: Class) -> bool {
+    KNOWN_GAPS.iter().any(|(c, k)| *c == chip && *k == class)
+}
+
+#[test]
+fn board_coverage_ratchet() {
+    let corpus = Corpus::load();
+
+    let mut hard_failures: Vec<String> = Vec::new(); // uncovered AND not allowlisted
+    let mut stale_allowlist: Vec<String> = Vec::new(); // allowlisted BUT now covered
+    let mut honored_gaps: Vec<String> = Vec::new(); // allowlisted AND still missing
+
+    for board in SHIPPED {
+        for class in required_classes(board) {
+            let covered = corpus.covers(board, class);
+            let allowlisted = is_allowlisted(board.chip, class);
+            match (covered, allowlisted) {
+                (false, false) => hard_failures.push(format!(
+                    "  MISSING  {:<10} needs {}",
+                    board.chip,
+                    class.label()
+                )),
+                (false, true) => {
+                    honored_gaps.push(format!("  KNOWN-GAP {:<10} {}", board.chip, class.label()))
+                }
+                (true, true) => stale_allowlist.push(format!(
+                    "  STALE     {:<10} {} — now COVERED; delete its KNOWN_GAPS row",
+                    board.chip,
+                    class.label()
+                )),
+                (true, false) => {}
+            }
+        }
+    }
+
+    // Any (chip, class) in the allowlist that is not even a shipped requirement
+    // is dead weight — catch typos / removed chips.
+    let shipped_ids: BTreeSet<&str> = SHIPPED.iter().map(|b| b.chip).collect();
+    for (chip, class) in KNOWN_GAPS {
+        let required = SHIPPED
+            .iter()
+            .find(|b| b.chip == *chip)
+            .map(|b| required_classes(b).contains(class))
+            .unwrap_or(false);
+        if !shipped_ids.contains(chip) {
+            stale_allowlist.push(format!("  STALE     {chip} — not a shipped board"));
+        } else if !required {
+            stale_allowlist.push(format!(
+                "  STALE     {chip} {} — not a required class for this board",
+                class.label()
+            ));
+        }
+    }
+
+    if !honored_gaps.is_empty() {
+        eprintln!(
+            "board-coverage ratchet: {} known gap(s) tracked (shrink-only):\n{}",
+            honored_gaps.len(),
+            honored_gaps.join("\n")
+        );
+    }
+
+    let mut msg = String::new();
+    if !hard_failures.is_empty() {
+        msg.push_str(&format!(
+            "\nSHIPPED BOARD(S) LACK REQUIRED COVERAGE (add the convention test, do NOT \
+             weaken the gate):\n{}\n",
+            hard_failures.join("\n")
+        ));
+    }
+    if !stale_allowlist.is_empty() {
+        msg.push_str(&format!(
+            "\nSTALE KNOWN_GAPS entries (coverage exists — delete the row so the ratchet \
+             tightens):\n{}\n",
+            stale_allowlist.join("\n")
+        ));
+    }
+    assert!(msg.is_empty(), "{msg}");
+}
+
+/// A shipped chip descriptor must be represented in `SHIPPED`, so no board can
+/// bypass the ratchet by simply not being listed. (Non-shipped / template /
+/// in-progress descriptors are excluded explicitly.)
+#[test]
+fn every_shipped_descriptor_is_ratcheted() {
+    // Chip descriptors that exist in configs/chips but are NOT in the canonical
+    // shipped catalog (bundled-configs.ts). They are intentionally not ratcheted.
+    const NOT_SHIPPED: &[&str] = &[
+        "esp32",         // classic Xtensa, separate e2e lane, not a catalog board
+        "esp32s3-zero",  // board variant of esp32s3 (covered by esp32s3)
+        "stm32f401cdu6", // BlackPill variant of stm32f401 (covered by stm32f401)
+        "stm32g474re",   // G4 peripheral models in progress, not shipped
+        "stm32wb55",     // BLE not modelled, not shipped
+        "stm32wba52",    // WBA early onboarding, not shipped
+        "nrf52832",      // covered by nrf52840 family; not a catalog board
+        "nrf5340",       // dual-core, not a shipped catalog board
+    ];
+    // configs/chips id -> ratchet chip id (kw41z ships as mkw41z4.yaml).
+    fn to_ratchet_id(stem: &str) -> &str {
+        match stem {
+            "mkw41z4" => "kw41z",
+            other => other,
+        }
+    }
+
+    let chips_dir = core_crate_root().join("../../configs/chips");
+    let shipped_ids: BTreeSet<&str> = SHIPPED.iter().map(|b| b.chip).collect();
+    let not_shipped: BTreeSet<&str> = NOT_SHIPPED.iter().copied().collect();
+
+    let mut unaccounted = Vec::new();
+    for entry in fs::read_dir(&chips_dir)
+        .expect("read configs/chips")
+        .flatten()
+    {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("yaml") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default();
+        if stem.starts_with('_') || stem.starts_with("ci-fixture") {
+            continue;
+        }
+        let id = to_ratchet_id(stem);
+        if !shipped_ids.contains(id) && !not_shipped.contains(stem) {
+            unaccounted.push(format!(
+                "  {stem}: neither in SHIPPED nor in NOT_SHIPPED — decide and list it"
+            ));
+        }
+    }
+    assert!(
+        unaccounted.is_empty(),
+        "chip descriptor(s) escape the coverage ratchet:\n{}",
+        unaccounted.join("\n")
+    );
+}

--- a/crates/core/tests/esp32c3_shipped_lab_batch_gate.rs
+++ b/crates/core/tests/esp32c3_shipped_lab_batch_gate.rs
@@ -31,18 +31,33 @@
 //! It is also the *direct* proxy for this failure class: the pathology IS the
 //! batch collapsing toward 1.
 //!
+//! Generalized over the shipped labs
+//! =================================
+//! The per-lab table + budget lives in `docs/coverage/lab-perf-budget.json`
+//! (one row per shipped lab: chip/system yaml, flash basename, and the
+//! `min_mean_batch` / `min_lit_px` / `min_idle_ff_ratio` floors). This test
+//! runs every `boot: "esp32c3-rom"` row through the exact browser fast-start
+//! policy and asserts each floor. Adding a shipped lab is a JSON row, not a code
+//! change. Other boot kinds SKIP until their boot path is wired here.
+//!
 //! Cross-repo note
 //! ===============
-//! The flash image lives in the SUPERPROJECT, not here, and is deliberately not
-//! vendored into core (one artifact, one home — a copy would drift silently and
-//! reintroduce exactly the skew this file exists to catch). The gate resolves
-//! the image in this order:
-//! 1. `$LABWIRED_C3_SHIPPED_FLASH` — explicit override (what CI should set);
-//! 2. the sibling superproject checkout, when core is a submodule inside it.
+//! The flash images live in the SUPERPROJECT (`packages/playground/public/wasm/`),
+//! not here, and are deliberately not vendored into core (one artifact, one home
+//! — a copy would drift silently and reintroduce exactly the skew this file
+//! exists to catch). Each row resolves its image in this order:
+//! 1. `$LABWIRED_WASM_DIR/<basename>` — the superproject CI sets this once so
+//!    every lab resolves (what the SUPERPROJECT PR CI should export);
+//! 2. `$LABWIRED_C3_SHIPPED_FLASH` — legacy single-image override (128x64 only);
+//! 3. the sibling superproject checkout, when core is a submodule inside it.
 //!
-//! If neither resolves the test SKIPS loudly rather than failing, so a
-//! standalone core checkout stays green. The superproject CI must set the env
-//! var (or run with the playground present) for this gate to bite.
+//! If none resolves, the row SKIPS loudly rather than failing, so a standalone
+//! core checkout stays green. This is `#[ignore]`d + `event-scheduler`-gated, so
+//! it does NOT run in core-ci's default lanes; the SUPERPROJECT PR CI runs it:
+//!   cargo test -p labwired-core --release --features event-scheduler \
+//!     --test esp32c3_shipped_lab_batch_gate -- --ignored --nocapture
+//! with `LABWIRED_WASM_DIR=packages/playground/public/wasm` exported. That is the
+//! only environment where the shipped binaries are present for the gate to bite.
 
 #![cfg(feature = "event-scheduler")]
 
@@ -64,21 +79,40 @@ fn root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-/// The image the deployed playground boots. See the module docs for why this is
-/// resolved rather than vendored.
-fn shipped_flash_path() -> Option<PathBuf> {
-    if let Ok(p) = std::env::var("LABWIRED_C3_SHIPPED_FLASH") {
-        let p = PathBuf::from(p);
-        assert!(
-            p.exists(),
-            "LABWIRED_C3_SHIPPED_FLASH points at a missing file: {}",
-            p.display()
-        );
-        return Some(p);
+/// Resolve a SHIPPED flash image by basename. See the module docs for why these
+/// live in the superproject and are resolved rather than vendored into core.
+///
+/// Resolution order:
+///   1. `$LABWIRED_WASM_DIR/<basename>` — the superproject CI points this at
+///      `packages/playground/public/wasm/` so every lab resolves at once.
+///   2. `$LABWIRED_C3_SHIPPED_FLASH` — legacy single-image override; only honored
+///      for the 128x64 primary lab it was introduced for.
+///   3. the sibling superproject checkout, when core is a submodule inside it.
+///
+/// Returns `None` (test SKIPS) when the image is absent, so a standalone core
+/// checkout stays green.
+fn shipped_flash_path(basename: &str) -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("LABWIRED_WASM_DIR") {
+        let p = PathBuf::from(dir).join(basename);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    if basename == "demo-esp32c3-display-workshop-flash.bin" {
+        if let Ok(p) = std::env::var("LABWIRED_C3_SHIPPED_FLASH") {
+            let p = PathBuf::from(p);
+            assert!(
+                p.exists(),
+                "LABWIRED_C3_SHIPPED_FLASH points at a missing file: {}",
+                p.display()
+            );
+            return Some(p);
+        }
     }
     // core/crates/core → core → <superproject>
     let sibling = root()
-        .join("../../../packages/playground/public/wasm/demo-esp32c3-display-workshop-flash.bin");
+        .join("../../../packages/playground/public/wasm")
+        .join(basename);
     sibling.exists().then_some(sibling)
 }
 
@@ -109,12 +143,11 @@ struct Lab {
 /// The browser fast-start assembly, verbatim (`esp32c3_walk_differential`'s
 /// `build_oled_lab`), but pointed at `flash_path` and running the EXACT browser
 /// policy (`apply_browser_c3_policy`: recommended tick interval + idle FF).
-fn build_lab(flash_path: &PathBuf) -> Lab {
-    let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
-        .expect("load esp32c3 chip yaml");
-    let manifest =
-        SystemManifest::from_file(root().join("../../configs/systems/esp32c3-oled-demo.yaml"))
-            .expect("load esp32c3-oled-demo system yaml");
+fn build_lab(chip_yaml: &str, system_yaml: &str, flash_path: &PathBuf) -> Lab {
+    let chip = ChipDescriptor::from_file(root().join("../..").join(chip_yaml))
+        .unwrap_or_else(|e| panic!("load chip yaml {chip_yaml}: {e}"));
+    let manifest = SystemManifest::from_file(root().join("../..").join(system_yaml))
+        .unwrap_or_else(|e| panic!("load system yaml {system_yaml}: {e}"));
     let mut bus = SystemBus::from_config(&chip, &manifest).expect("build oled bus");
 
     let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
@@ -206,77 +239,148 @@ fn ssd1306_lit_pixels(machine: &Machine<RiscV>) -> usize {
 
 const BUDGET: u64 = 30_000_000;
 
-/// Floor for the shipped lab's mean batch width.
+/// One row of the committed per-lab budget (`docs/coverage/lab-perf-budget.json`).
+struct LabBudget {
+    lab: String,
+    boot: String,
+    chip_yaml: String,
+    system_yaml: String,
+    flash_basename: String,
+    min_mean_batch: f64,
+    min_lit_px: usize,
+    min_idle_ff_ratio: f64,
+}
+
+fn budget_path() -> PathBuf {
+    root().join("../../docs/coverage/lab-perf-budget.json")
+}
+
+/// Parse the committed budget. The budget file is authoritative — a lab with no
+/// row here is not gated, and a row is a *contract* the shipped binary must meet.
+fn load_budget() -> Vec<LabBudget> {
+    let raw = std::fs::read_to_string(budget_path())
+        .unwrap_or_else(|e| panic!("read {}: {e}", budget_path().display()));
+    let json: serde_json::Value = serde_json::from_str(&raw).expect("budget json parses");
+    json["labs"]
+        .as_array()
+        .expect("budget.labs is an array")
+        .iter()
+        .map(|row| LabBudget {
+            lab: row["lab"].as_str().expect("lab").to_string(),
+            boot: row["boot"].as_str().expect("boot").to_string(),
+            chip_yaml: row["chip_yaml"].as_str().expect("chip_yaml").to_string(),
+            system_yaml: row["system_yaml"]
+                .as_str()
+                .expect("system_yaml")
+                .to_string(),
+            flash_basename: row["flash_basename"]
+                .as_str()
+                .expect("flash_basename")
+                .to_string(),
+            min_mean_batch: row["min_mean_batch"].as_f64().expect("min_mean_batch"),
+            min_lit_px: row["min_lit_px"].as_u64().expect("min_lit_px") as usize,
+            min_idle_ff_ratio: row["min_idle_ff_ratio"]
+                .as_f64()
+                .expect("min_idle_ff_ratio"),
+        })
+        .collect()
+}
+
+/// The batch-collapse throughput gate for the firmware users actually boot,
+/// generalized over every shipped lab in the committed budget.
 ///
-/// Measured on this branch: **19.42**. Before the UART wakeup fix: **1.376**
-/// (the shipped regression), and the theoretical floor of the collapse is 1.0.
-/// 8.0 sits 5.8x above the broken value and 2.4x below the healthy one, so it
-/// cannot flake (the metric is deterministic — this margin absorbs legitimate
-/// firmware/model churn, not host noise) yet still trips long before a collapse
-/// toward 1 could reach users. The remaining clamp owner is `i2c0` at its
-/// module clock (CPU/4), which bounds any honest future value near ~4 during
-/// active I²C traffic; 8.0 stays above that only because traffic is bursty.
-/// If a legitimate change drives this below 8, re-measure and move it
-/// deliberately — do not delete the gate.
-const MIN_MEAN_BATCH: f64 = 8.0;
-
-/// The OLED must still paint: a fast engine that renders nothing is not a pass.
-const MIN_LIT: usize = 400;
-
+/// Only `boot: "esp32c3-rom"` rows run today — that ROM-boot path is the only
+/// one wired here. Other boot kinds (ELF-loaded ARM labs, esp32s3 Xtensa) SKIP
+/// with a note until their boot machinery is added; their binaries also live in
+/// the superproject, not core. Rows whose flash image is not resolvable SKIP
+/// cleanly so a standalone core checkout stays green — the SUPERPROJECT CI sets
+/// `LABWIRED_WASM_DIR=packages/playground/public/wasm` for the gate to bite.
 #[test]
-#[ignore = "runs the real C3 bootloader + shipped app (~30M steps); run with --release --ignored"]
-fn shipped_c3_display_workshop_lab_keeps_batching() {
-    let Some(flash) = shipped_flash_path() else {
-        eprintln!(
-            "SKIP: shipped C3 flash image not found. Set LABWIRED_C3_SHIPPED_FLASH \
-             to <superproject>/packages/playground/public/wasm/\
-             demo-esp32c3-display-workshop-flash.bin, or run with the superproject \
-             checked out around this submodule. This gate is the ONLY one that \
-             exercises the firmware users actually boot."
-        );
-        return;
-    };
-    eprintln!("shipped flash: {}", flash.display());
+#[ignore = "runs real shipped bootloaders (~30M steps/lab); run with --release --ignored"]
+fn shipped_labs_keep_batching() {
+    let budget = load_budget();
+    let mut ran = 0usize;
+    let mut failures: Vec<String> = Vec::new();
 
-    let mut lab = build_lab(&flash);
-    lab.machine.reset_step_profile();
-    let mut fuel: u64 = 0;
-    while fuel < BUDGET {
-        let n = 1_000_000u32.min((BUDGET - fuel) as u32);
-        lab.machine.run(Some(n)).expect("run shipped C3 lab");
-        fuel += u64::from(n);
+    for b in &budget {
+        if b.boot != "esp32c3-rom" {
+            eprintln!(
+                "SKIP {}: boot kind '{}' not wired in this gate yet (superproject binary + \
+                 boot path pending).",
+                b.lab, b.boot
+            );
+            continue;
+        }
+        let Some(flash) = shipped_flash_path(&b.flash_basename) else {
+            eprintln!(
+                "SKIP {}: shipped flash '{}' not found. Set LABWIRED_WASM_DIR to \
+                 <superproject>/packages/playground/public/wasm/, or run with the \
+                 superproject checked out around this submodule.",
+                b.lab, b.flash_basename
+            );
+            continue;
+        };
+        eprintln!("{}: shipped flash {}", b.lab, flash.display());
+
+        let mut lab = build_lab(&b.chip_yaml, &b.system_yaml, &flash);
+        lab.machine.reset_step_profile();
+        let mut fuel: u64 = 0;
+        while fuel < BUDGET {
+            let n = 1_000_000u32.min((BUDGET - fuel) as u32);
+            lab.machine.run(Some(n)).expect("run shipped lab");
+            fuel += u64::from(n);
+        }
+
+        let profile = lab.machine.step_profile();
+        let mean_batch = profile.cpu_instructions as f64 / profile.cpu_batches.max(1) as f64;
+        let lit = ssd1306_lit_pixels(&lab.machine);
+        let idle_ff_ratio = lab.machine.idle_fast_forward_cycles_skipped as f64
+            / lab.machine.total_cycles.max(1) as f64;
+
+        eprintln!(
+            "SHIPPED_LAB_GATE {} mean_batch={mean_batch:.3} (min {}) lit_px={lit} (min {}) \
+             idle_ff_ratio={idle_ff_ratio:.3} (min {}) batches={} interpreted={} total_cycles={}",
+            b.lab,
+            b.min_mean_batch,
+            b.min_lit_px,
+            b.min_idle_ff_ratio,
+            profile.cpu_batches,
+            profile.cpu_instructions,
+            lab.machine.total_cycles,
+        );
+
+        if lit < b.min_lit_px {
+            failures.push(format!(
+                "{}: OLED painted only {lit} px (min {}) — a fast engine that renders \
+                 nothing is not a pass",
+                b.lab, b.min_lit_px
+            ));
+        }
+        if mean_batch < b.min_mean_batch {
+            failures.push(format!(
+                "{}: batch width collapsed to {mean_batch:.3} (min {}). Some peripheral is \
+                 scheduling an event every ~{mean_batch:.1} guest instructions — the shipped \
+                 regression class. MEASURE the owner (`EventScheduler::next_event_deadline`) \
+                 before assuming it is the UART.",
+                b.lab, b.min_mean_batch
+            ));
+        }
+        if idle_ff_ratio < b.min_idle_ff_ratio {
+            failures.push(format!(
+                "{}: idle fast-forward ratio {idle_ff_ratio:.3} below floor {} — the browser \
+                 fast-start policy stopped skipping idle time.",
+                b.lab, b.min_idle_ff_ratio
+            ));
+        }
+        ran += 1;
     }
 
-    let profile = lab.machine.step_profile();
-    let mean_batch = profile.cpu_instructions as f64 / profile.cpu_batches.max(1) as f64;
-    let lit = ssd1306_lit_pixels(&lab.machine);
-    let rtf_hint = lab.machine.total_cycles as f64 / 160e6;
-
-    eprintln!(
-        "SHIPPED_C3_GATE mean_batch={mean_batch:.3} (min {MIN_MEAN_BATCH}) batches={} \
-         interpreted={} idle_ff={} total_cycles={} guest_ms={:.1} lit_px={lit}",
-        profile.cpu_batches,
-        profile.cpu_instructions,
-        lab.machine.idle_fast_forward_cycles_skipped,
-        lab.machine.total_cycles,
-        rtf_hint * 1000.0,
-    );
-
-    assert!(
-        lit >= MIN_LIT,
-        "shipped lab must still paint the OLED (lit={lit}, min {MIN_LIT}) — a fast \
-         engine that renders nothing is not a pass"
-    );
-    assert!(
-        mean_batch >= MIN_MEAN_BATCH,
-        "SHIPPED C3 lab batch width collapsed to {mean_batch:.3} (min {MIN_MEAN_BATCH}).\n\
-         This is the regression that shipped once already: some peripheral is \
-         scheduling an event every ~{mean_batch:.1} guest instructions, which pinned \
-         the browser to ~RTF 0.003 (a guest second costing ~5.5 wall minutes).\n\
-         MEASURE the owner before assuming it is the UART again — attribute batch \
-         clamps by peripheral (`EventScheduler::next_event_deadline`) rather than \
-         guessing. Last time the owner was `uart0`, holding a per-cycle wakeup to \
-         re-assert a level-triggered IRQ that the C3 bus does not even wire \
-         (see `Uart::has_active_work`)."
-    );
+    if ran == 0 {
+        eprintln!(
+            "SKIP: no shipped flash image resolved — this gate exercises the firmware \
+             users actually boot and needs the superproject binaries present."
+        );
+        return;
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
 }

--- a/docs/coverage/lab-perf-budget.json
+++ b/docs/coverage/lab-perf-budget.json
@@ -1,0 +1,55 @@
+{
+  "_README": [
+    "Committed per-lab PERFORMANCE budget for the SHIPPED firmware users actually",
+    "boot. Enforced by crates/core/tests/esp32c3_shipped_lab_batch_gate.rs.",
+    "",
+    "Each row is one shipped lab (see packages/playground/src/bundled-configs.ts).",
+    "The metric is MEAN BATCH WIDTH = cpu_instructions / cpu_batches, a pure",
+    "function of the model — bit-deterministic and machine-independent, NOT",
+    "wall-clock MIPS (which would flake on a loaded CI box). A collapsing batch",
+    "width IS the shipped-regression class this gate exists to catch (a per-cycle",
+    "scheduler wakeup pinning every batch to width ~1, dragging the browser far",
+    "below real time).",
+    "",
+    "Fields per lab:",
+    "  boot            - boot machinery required to run the binary. Only",
+    "                    'esp32c3-rom' rows are executed by the current gate; other",
+    "                    kinds SKIP cleanly with a note until their boot path is",
+    "                    wired (see the test module docs).",
+    "  chip_yaml       - configs/chips/<chip>.yaml",
+    "  system_yaml     - configs/systems/<system>.yaml",
+    "  flash_basename  - shipped flash image under",
+    "                    packages/playground/public/wasm/ (NOT vendored into core).",
+    "  min_mean_batch  - floor for mean batch width. Set well below the healthy",
+    "                    measured value and well above the collapse floor (1.0).",
+    "  min_lit_px      - floor for lit OLED pixels: a fast engine that renders",
+    "                    nothing is not a pass.",
+    "  min_idle_ff_ratio - floor for idle_fast_forward_cycles_skipped / total_cycles;",
+    "                    the browser fast-start policy must keep skipping idle time.",
+    "",
+    "Raising a floor tightens the gate (good). Lowering one is a deliberate act:",
+    "re-measure, explain, and move it in the same PR that changes the firmware."
+  ],
+  "labs": [
+    {
+      "lab": "esp32c3-oled-lab",
+      "boot": "esp32c3-rom",
+      "chip_yaml": "configs/chips/esp32c3.yaml",
+      "system_yaml": "configs/systems/esp32c3-oled-demo.yaml",
+      "flash_basename": "demo-esp32c3-display-workshop-flash.bin",
+      "min_mean_batch": 8.0,
+      "min_lit_px": 400,
+      "min_idle_ff_ratio": 0.5
+    },
+    {
+      "lab": "esp32c3-oled-128x32-lab",
+      "boot": "esp32c3-rom",
+      "chip_yaml": "configs/chips/esp32c3.yaml",
+      "system_yaml": "configs/systems/esp32c3-oled-128x32-workshop.yaml",
+      "flash_basename": "demo-esp32c3-display-workshop-128x32-flash.bin",
+      "min_mean_batch": 8.0,
+      "min_lit_px": 150,
+      "min_idle_ff_ratio": 0.5
+    }
+  ]
+}


### PR DESCRIPTION
## Board-coverage ratchet — "rock solid per board", enforced

Defines and enforces a minimum coverage floor for every SHIPPED board, discovered **by convention** (grep the test corpus for naming patterns), not a hand-maintained manifest that drifts.

### What lands
- **`crates/core/tests/board_coverage_ratchet.rs`** — for each shipped chip, asserts the presence of its required coverage classes by scanning `crates/core/tests` + `crates/hw-oracle/tests`:
  - **(a) reset/boot conformance** — satisfied fleet-wide by `chip_conformance.rs`.
  - **(b) executing fidelity** — a walk-vs-scheduler differential, silicon exec-oracle / MMIO-diff, golden trace, or JIT lockstep on the core timer/IRQ path. A `firmware_survival` boot-and-don't-crash test does **not** count.
  - **(c) display assertion** — required only for chips that drive a shipped display lab.
  - Reset/Exec match on the strong signal (filename family-alias or an explicit `chips/<stem>.yaml` load) so a family-shared file (e.g. the F407 mmio-diff naming F401 in a comment) can't falsely credit a sibling part.
- **Shrink-only `KNOWN_GAPS` allowlist** (same pattern as `strict_onboarding.rs`'s `SMOKE_LESS_ALLOWLIST`): a new uncovered board fails; a filled gap left stale in the list also fails — so the list can only get shorter.
- **Generalized perf gate** — `esp32c3_shipped_lab_batch_gate.rs` is parameterized over a lab→binary table from **`docs/coverage/lab-perf-budget.json`** (one row per shipped lab: `min_mean_batch`, `min_lit_px`, `min_idle_ff_ratio`). Metric is the deterministic mean batch width, not wall-clock MIPS. Seeded for the two esp32c3 OLED labs whose shipped binaries exist; resolves images from `LABWIRED_WASM_DIR` and skips cleanly where the superproject binary is absent.
- **CI wiring** — the ratchet runs in `core-ci.yml` core-integrity as a cheap fixture-free static scan.

### The worklist (current executing-fidelity gaps = the allowlist)
| chip | class | note |
|------|-------|------|
| `rp2040` | executing fidelity | only a `firmware_survival` boot test; needs a timer/IRQ walk-diff or oracle. (RP2040 DMA is a separate **modeling** gap — no `dma` block in `rp2040.yaml` — deliberately not gated as a test.) |
| `stm32f401` | executing fidelity | executing coverage is only `firmware_survival::test_stm32f401_blinky_survival`; the F4 exec-oracle/mmio-diff target real F407 silicon. |

Every other shipped chip (`stm32f103/f407/l073/l476/h563`, `nrf52840`, `esp32c3/s3`, `kw41z`) already has an executing-fidelity test. Gap-filler PRs land the named convention test, then delete the matching `KNOWN_GAPS` row.

### Verification
- Ratchet passes with the honest allowlist; removing an entry makes it fail (`MISSING rp2040 …`), and covering an allowlisted chip makes it fail (`STALE …`) — the gate bites both directions.
- Perf gate run against the real shipped binaries: 128×64 batch **19.4** / idle-ff **0.89**, 128×32 batch **26.3** / idle-ff **0.90** — floors set conservatively below these.
- `cargo fmt --check` + `cargo clippy` clean; firmware fixtures built first.

Does **not** modify any peripheral/bus source — gate + budget + workflow only.
