### PR TITLE
test: ESP32-S3 I2C/GDMA/SPI, nRF52 EasyDMA, and multi-board display fidelity oracles

### DIFF
--- a/crates/core/tests/epaper_ssd1680_differential.rs
+++ b/crates/core/tests/epaper_ssd1680_differential.rs
@@ -1,0 +1,113 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Display fidelity for the SSD1680 tri-color 2.9" e-paper panel shipped by the
+//! `esp32-epaper-lab` / `epaper-tricolor-lab` — a display beyond the C3
+//! SSD1306, with independent black and red planes.
+//!
+//! GxEPD2 always configures the RAM window (0x44/0x45) and address counters
+//! (0x4E/0x4F) before opening a 0x24 (black) or 0x26 (red) pixel stream. This
+//! drives that exact datasheet sequence through the component's command/data
+//! path and asserts each plane renders EXACTLY the streamed bytes at the
+//! windowed cells, that the X-major auto-advance walks rows correctly, and that
+//! the power/refresh sequence (0x22 selector + 0x20 master activation) toggles
+//! `power_on()` and bumps `refresh_generation()`. A window/counter, plane-
+//! routing, or refresh-sequence regression fails here.
+//!
+//! Named `*_ssd1680_differential` so the board-coverage ratchet discovers it.
+
+use labwired_core::peripherals::components::Ssd1680Tricolor290;
+
+const WIDTH_BYTES: usize = 16; // 128 native px / 8
+
+/// A windowed black+red stream lands the exact bytes in each plane at the
+/// windowed row cells (X-major auto-advance), leaving all other cells at the
+/// erased default.
+#[test]
+fn ssd1680_windowed_stream_renders_both_planes() {
+    let mut panel = Ssd1680Tricolor290::new("GPIO5").with_dc_pin("GPIO17");
+
+    // Fresh panel: both planes erased (0xFF = white / no-red).
+    assert!(panel.black_plane().iter().all(|&b| b == 0xFF));
+    assert!(panel.red_plane().iter().all(|&b| b == 0xFF));
+
+    // Reset + data-entry mode 0x03 (X+/Y+), then a 1-byte-wide, 4-row window.
+    panel.command_byte(0x12); // SWRESET
+    panel.command_byte(0x11); // data entry mode
+    panel.data_byte(0x03);
+    panel.command_byte(0x44); // RAM-X window: start/8, end/8
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+    panel.command_byte(0x45); // RAM-Y window: start_lo/hi, end_lo/hi
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+    panel.data_byte(0x03);
+    panel.data_byte(0x00);
+    panel.command_byte(0x4E); // RAM-X counter
+    panel.data_byte(0x00);
+    panel.command_byte(0x4F); // RAM-Y counter
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+
+    // Black plane: 4 bytes (window is 1 byte wide x 4 rows).
+    let black: [u8; 4] = [0x00, 0xF0, 0x0F, 0xAA];
+    panel.command_byte(0x24);
+    for &b in &black {
+        panel.data_byte(b);
+    }
+    // Red plane: same window.
+    let red: [u8; 4] = [0xFF, 0x81, 0x18, 0x55];
+    panel.command_byte(0x26);
+    for &b in &red {
+        panel.data_byte(b);
+    }
+
+    // Cells land at row-major idx = row * WIDTH_BYTES + col_byte (col 0).
+    for (row, (&b, &r)) in black.iter().zip(red.iter()).enumerate() {
+        let idx = row * WIDTH_BYTES;
+        assert_eq!(panel.black_plane()[idx], b, "black plane row {row}");
+        assert_eq!(panel.red_plane()[idx], r, "red plane row {row}");
+    }
+
+    // Everything outside the 4 windowed cells stays at the erased default.
+    let touched_black = black.iter().filter(|&&b| b != 0xFF).count();
+    assert_eq!(
+        panel.black_plane().iter().filter(|&&b| b != 0xFF).count(),
+        touched_black,
+        "only windowed black cells differ from the erased default"
+    );
+}
+
+/// The GxEPD2 power/refresh handshake: 0x22 selector 0xF8 powers the panel on,
+/// and each 0x20 master activation advances the refresh generation.
+#[test]
+fn ssd1680_power_and_refresh_sequence() {
+    let mut panel = Ssd1680Tricolor290::new("GPIO5").with_dc_pin("GPIO17");
+    assert!(!panel.power_on(), "panel starts powered off");
+    assert_eq!(panel.refresh_generation(), 0);
+
+    // 0x22 = 0xF8 (power-on-only), then 0x20 activates it.
+    panel.command_byte(0x22);
+    panel.data_byte(0xF8);
+    panel.command_byte(0x20);
+    assert!(panel.power_on(), "0x22=0xF8 + 0x20 powers the panel on");
+    assert_eq!(panel.refresh_generation(), 1);
+
+    // A full-update refresh (0x22 = 0xF7) advances the generation again.
+    panel.command_byte(0x22);
+    panel.data_byte(0xF7);
+    panel.command_byte(0x20);
+    assert_eq!(
+        panel.refresh_generation(),
+        2,
+        "each master activation bumps the refresh generation"
+    );
+
+    // 0x22 = 0x83 powers the panel back off.
+    panel.command_byte(0x22);
+    panel.data_byte(0x83);
+    panel.command_byte(0x20);
+    assert!(!panel.power_on(), "0x22=0x83 powers the panel off");
+    assert_eq!(panel.refresh_generation(), 3);
+}

--- a/crates/core/tests/esp32s3_gdma_oracle.rs
+++ b/crates/core/tests/esp32s3_gdma_oracle.rs
@@ -1,0 +1,225 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Executing oracle for the ESP32-S3 GDMA (general DMA) mem-to-mem engine.
+//!
+//! `esp32s3/gdma.rs` is a ~4000-line behavioural model that had rich in-module
+//! unit tests but no ratchet-discoverable integration coverage. This file
+//! drives the controller the same way firmware does — build linked-list DMA
+//! descriptors in real DRAM, arm `MEM_TRANS_EN`, kick `OUTLINK_START` /
+//! `INLINK_START`, then `tick_with_bus` — and asserts that bytes were ACTUALLY
+//! moved through the bus router (not merely that registers latched). Everything
+//! goes through the public `Peripheral` MMIO API (`read_u32`/`write_u32`) and a
+//! real `SystemBus`, so a register or descriptor-decode regression fails here.
+//!
+//! Named `esp32s3_*` so the board-coverage ratchet discovers it.
+
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::esp32s3::gdma::Esp32s3Gdma;
+use labwired_core::system::xtensa::RamPeripheral;
+use labwired_core::{Bus, Peripheral};
+
+// Per-channel register block stride and offsets (base-relative, what the
+// `Peripheral` MMIO API expects). Mirrors the S3 GDMA register map.
+const CHANNEL_STRIDE: u64 = 0xC0;
+const IN_CONF0: u64 = 0x00;
+const IN_INT_RAW: u64 = 0x08;
+const IN_INT_CLR: u64 = 0x14;
+const IN_LINK: u64 = 0x20;
+const OUT_INT_RAW: u64 = 0x68;
+const OUT_INT_CLR: u64 = 0x74;
+const OUT_LINK: u64 = 0x80;
+
+const MEM_TRANS_EN: u32 = 1 << 4; // IN_CONF0.mem_trans_en
+const IN_LINK_START: u32 = 1 << 22;
+const OUT_LINK_START: u32 = 1 << 21;
+const LINK_ADDR_MASK: u32 = 0x000F_FFFF;
+const IN_SUC_EOF: u32 = 1 << 1; // IN_INT_RAW.in_suc_eof
+const OUT_TOTAL_EOF: u32 = 1 << 3; // OUT_INT_RAW.out_total_eof
+
+// Real ESP32-S3 RX-channel-0 interrupt source id.
+const IN_CH0_SRC: u32 = 66;
+
+// The S3 DRAM window the model reconstructs descriptor addresses into
+// (`DRAM_ADDR_PREFIX | link_addr[19:0]`). Descriptors and buffers must live
+// here so the descriptor walk resolves through the bus router.
+const DRAM_BASE: u64 = 0x3FC8_8000;
+const DRAM_SIZE: usize = 256 * 1024;
+
+fn ch_base(n: u64) -> u64 {
+    n * CHANNEL_STRIDE
+}
+
+fn bus_with_dram() -> SystemBus {
+    let mut bus = SystemBus::new();
+    bus.add_peripheral(
+        "dram_test",
+        DRAM_BASE,
+        DRAM_SIZE as u64,
+        None,
+        Box::new(RamPeripheral::new(DRAM_SIZE)),
+    );
+    bus
+}
+
+fn write_desc(bus: &mut SystemBus, addr: u64, dw0: u32, buffer: u64, next: u64) {
+    bus.write_u32(addr, dw0).unwrap();
+    bus.write_u32(addr + 4, buffer as u32).unwrap();
+    bus.write_u32(addr + 8, next as u32).unwrap();
+}
+
+// TX descriptor dw0: owner=DMA, suc_eof, length=size=len.
+fn tx_dw0(len: u32) -> u32 {
+    (1 << 31) | (1 << 30) | (len << 12) | len
+}
+
+// RX descriptor dw0: owner=DMA, size (length filled by the engine).
+fn rx_dw0(size: u32) -> u32 {
+    (1 << 31) | size
+}
+
+/// A single-descriptor mem-to-mem transfer moves the exact source bytes to the
+/// destination and latches IN_SUC_EOF / OUT_TOTAL_EOF.
+#[test]
+fn gdma_mem2mem_single_descriptor_moves_bytes() {
+    let mut bus = bus_with_dram();
+
+    let src: u64 = DRAM_BASE;
+    let dst: u64 = DRAM_BASE + 0x1000;
+    let payload: &[u8] = b"LABWIRED-S3-GDMA-ORACLE!\x00";
+    let len = payload.len() as u32;
+
+    for (i, &b) in payload.iter().enumerate() {
+        bus.write_u8(src + i as u64, b).unwrap();
+        // Poison the destination so a no-op "transfer" cannot pass.
+        bus.write_u8(dst + i as u64, 0x5A).unwrap();
+    }
+
+    let tx_desc: u64 = DRAM_BASE + 0x2000;
+    let rx_desc: u64 = DRAM_BASE + 0x3000;
+    write_desc(&mut bus, tx_desc, tx_dw0(len), src, 0);
+    write_desc(&mut bus, rx_desc, rx_dw0(len), dst, 0);
+
+    let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
+    let b = ch_base(0);
+
+    g.write_u32(b + IN_CONF0, MEM_TRANS_EN).unwrap();
+    g.write_u32(b + IN_INT_CLR, 0xFFFF_FFFF).unwrap();
+    g.write_u32(b + OUT_INT_CLR, 0xFFFF_FFFF).unwrap();
+    g.write_u32(
+        b + IN_LINK,
+        ((rx_desc as u32) & LINK_ADDR_MASK) | IN_LINK_START,
+    )
+    .unwrap();
+    g.write_u32(
+        b + OUT_LINK,
+        ((tx_desc as u32) & LINK_ADDR_MASK) | OUT_LINK_START,
+    )
+    .unwrap();
+
+    // The copy is deferred to the bus-tick, not done inside the register write.
+    assert!(
+        g.needs_bus_tick(),
+        "mem2mem must be pending before bus tick"
+    );
+    assert_eq!(
+        g.read_u32(b + IN_INT_RAW).unwrap() & IN_SUC_EOF,
+        0,
+        "IN_SUC_EOF must not latch before the descriptor walk"
+    );
+
+    g.tick_with_bus(&mut bus);
+
+    assert_ne!(
+        g.read_u32(b + IN_INT_RAW).unwrap() & IN_SUC_EOF,
+        0,
+        "IN_SUC_EOF must latch after the walk"
+    );
+    assert_ne!(
+        g.read_u32(b + OUT_INT_RAW).unwrap() & OUT_TOTAL_EOF,
+        0,
+        "OUT_TOTAL_EOF must latch after the walk"
+    );
+
+    let moved: Vec<u8> = (0..payload.len())
+        .map(|i| bus.read_u8(dst + i as u64).unwrap())
+        .collect();
+    assert_eq!(moved, payload, "GDMA must copy the exact source bytes");
+    assert!(!g.needs_bus_tick(), "pending_m2m must clear after the walk");
+}
+
+/// A two-link scatter/gather chain concatenates both source fragments into a
+/// single contiguous destination — exercising the descriptor `next` walk.
+#[test]
+fn gdma_mem2mem_two_link_chain_concatenates() {
+    let mut bus = bus_with_dram();
+
+    let src_a: u64 = DRAM_BASE;
+    let src_b: u64 = DRAM_BASE + 0x400;
+    let dst: u64 = DRAM_BASE + 0x1000;
+    let frag_a: &[u8] = b"HELLO-";
+    let frag_b: &[u8] = b"WORLD!";
+    let expected: Vec<u8> = frag_a.iter().chain(frag_b.iter()).copied().collect();
+
+    for (i, &b) in frag_a.iter().enumerate() {
+        bus.write_u8(src_a + i as u64, b).unwrap();
+    }
+    for (i, &b) in frag_b.iter().enumerate() {
+        bus.write_u8(src_b + i as u64, b).unwrap();
+    }
+    for i in 0..expected.len() {
+        bus.write_u8(dst + i as u64, 0x00).unwrap();
+    }
+
+    // Two TX descriptors chained via `next`; single RX sink big enough for both.
+    let tx0: u64 = DRAM_BASE + 0x2000;
+    let tx1: u64 = DRAM_BASE + 0x2010;
+    let rx: u64 = DRAM_BASE + 0x3000;
+    // First TX fragment: owner, length, NOT suc_eof (more to come), next=tx1.
+    write_desc(
+        &mut bus,
+        tx0,
+        (1 << 31) | ((frag_a.len() as u32) << 12) | frag_a.len() as u32,
+        src_a,
+        tx1,
+    );
+    write_desc(&mut bus, tx1, tx_dw0(frag_b.len() as u32), src_b, 0);
+    write_desc(&mut bus, rx, rx_dw0(expected.len() as u32), dst, 0);
+
+    let mut g = Esp32s3Gdma::new(IN_CH0_SRC);
+    let b = ch_base(0);
+    g.write_u32(b + IN_CONF0, MEM_TRANS_EN).unwrap();
+    g.write_u32(b + IN_INT_CLR, 0xFFFF_FFFF).unwrap();
+    g.write_u32(b + OUT_INT_CLR, 0xFFFF_FFFF).unwrap();
+    g.write_u32(b + IN_LINK, ((rx as u32) & LINK_ADDR_MASK) | IN_LINK_START)
+        .unwrap();
+    g.write_u32(
+        b + OUT_LINK,
+        ((tx0 as u32) & LINK_ADDR_MASK) | OUT_LINK_START,
+    )
+    .unwrap();
+
+    // Drain the transfer (walk may span more than one bus tick for a chain).
+    for _ in 0..8 {
+        if !g.needs_bus_tick() {
+            break;
+        }
+        g.tick_with_bus(&mut bus);
+    }
+
+    assert!(!g.needs_bus_tick(), "chained walk must complete");
+    assert_ne!(
+        g.read_u32(b + IN_INT_RAW).unwrap() & IN_SUC_EOF,
+        0,
+        "IN_SUC_EOF must latch once the RX sink sees suc_eof"
+    );
+
+    let moved: Vec<u8> = (0..expected.len())
+        .map(|i| bus.read_u8(dst + i as u64).unwrap())
+        .collect();
+    assert_eq!(
+        moved, expected,
+        "chained TX fragments must land contiguously in the RX buffer"
+    );
+}

--- a/crates/core/tests/esp32s3_gpspi_oracle.rs
+++ b/crates/core/tests/esp32s3_gpspi_oracle.rs
@@ -1,0 +1,107 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Executing oracle for the ESP32-S3 GP-SPI2/3 controller (`esp32s3/gpspi.rs`,
+//! `Esp32s3Spi`) CPU / data-buffer transfer path.
+//!
+//! The S3 had no SPI executing coverage in the ratchet-discoverable `tests/`
+//! tree. This drives the controller the way an esp-hal CPU-mode `SpiBus`
+//! transfer does — stage the MOSI payload into the W0.. data buffer, program
+//! the transfer length in `MS_DLEN` (bits − 1), then set `CMD.usr` — and
+//! asserts the transfer engine actually EXECUTES: `usr` auto-clears, the
+//! `TRANS_DONE` interrupt latches, and the MISO half of the data buffer is
+//! filled for exactly the programmed byte count (0xFF with no device on the
+//! bus, matching real fast-read-with-no-slave behaviour). A length-decode or
+//! completion-latch regression fails here.
+//!
+//! The full-duplex MOSI-capture / MISO-injection path (attached `SpiDevice` +
+//! DMA pump) is exercised by the in-module `gpspi.rs` tests; the device-attach
+//! entry point is crate-private, so this integration oracle drives the
+//! externally reachable CPU path.
+//!
+//! Named `esp32s3_*` so the board-coverage ratchet discovers it.
+
+use labwired_core::peripherals::esp32s3::gpspi::Esp32s3Spi;
+use labwired_core::Peripheral;
+
+const CMD: u64 = 0x00;
+const MS_DLEN: u64 = 0x1C;
+const DMA_INT_RAW: u64 = 0x3C;
+const W0: u64 = 0x98;
+
+const USR: u32 = 1 << 24;
+const TRANS_DONE: u32 = 1 << 12;
+
+const SPI2_SOURCE: u32 = 21;
+
+/// An 8-byte CPU-mode transfer executes to completion: USR self-clears,
+/// TRANS_DONE latches, and the MISO region is filled for all 8 bytes.
+#[test]
+fn gpspi_cpu_transfer_executes_and_latches_done() {
+    let mut s = Esp32s3Spi::new(SPI2_SOURCE);
+
+    // Stage MOSI bytes DE AD BE EF | 11 22 33 44 into W0/W1.
+    s.write_u32(W0, 0xEFBE_ADDE).unwrap();
+    s.write_u32(W0 + 4, 0x4433_2211).unwrap();
+
+    // 8-byte (64-bit) transfer: MS_DLEN holds bits − 1.
+    s.write_u32(MS_DLEN, 64 - 1).unwrap();
+
+    // No completion latched before the transfer is kicked.
+    assert_eq!(s.read_u32(DMA_INT_RAW).unwrap() & TRANS_DONE, 0);
+
+    // Kick.
+    s.write_u32(CMD, USR).unwrap();
+
+    // CPU-path completion is synchronous.
+    assert_eq!(
+        s.read_u32(CMD).unwrap() & USR,
+        0,
+        "USR must auto-clear once the transfer completes"
+    );
+    assert_ne!(
+        s.read_u32(DMA_INT_RAW).unwrap() & TRANS_DONE,
+        0,
+        "TRANS_DONE must latch after the transfer"
+    );
+
+    // With no device on the bus the MISO half of the buffer reads back 0xFF for
+    // exactly the two words (8 bytes) that were clocked.
+    assert_eq!(
+        s.read_u32(W0).unwrap(),
+        0xFFFF_FFFF,
+        "clocked bytes read back as 0xFF MISO"
+    );
+    assert_eq!(s.read_u32(W0 + 4).unwrap(), 0xFFFF_FFFF);
+}
+
+/// The programmed transfer length bounds how many bytes the engine clocks: a
+/// 3-byte transfer fills only the first three MISO bytes, leaving the 4th
+/// buffer byte untouched.
+#[test]
+fn gpspi_transfer_length_bounds_clocked_bytes() {
+    let mut s = Esp32s3Spi::new(SPI2_SOURCE);
+
+    // Fill the word so an over-run into the 4th byte is visible.
+    s.write_u32(W0, 0xFFFF_FFFF).unwrap();
+    s.write_u32(MS_DLEN, 24 - 1).unwrap(); // 3 bytes
+    s.write_u32(CMD, USR).unwrap();
+
+    assert_ne!(s.read_u32(DMA_INT_RAW).unwrap() & TRANS_DONE, 0);
+
+    // Only the 3 clocked bytes read back as 0xFF MISO; the 4th byte is NOT
+    // clocked (the engine does not touch it as a MISO byte), so the low 3 bytes
+    // are 0xFF and the top byte is not.
+    let w0 = s.read_u32(W0).unwrap();
+    assert_eq!(
+        w0 & 0x00FF_FFFF,
+        0x00FF_FFFF,
+        "the 3 clocked bytes read back as 0xFF MISO"
+    );
+    assert_ne!(
+        (w0 >> 24) & 0xFF,
+        0xFF,
+        "the 4th byte must not be clocked by a 3-byte transfer"
+    );
+}

--- a/crates/core/tests/esp32s3_ssd1306_differential.rs
+++ b/crates/core/tests/esp32s3_ssd1306_differential.rs
@@ -1,0 +1,195 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Executing oracle for the ESP32-S3 command-list I2C controller
+//! (`esp32s3/i2c.rs`, `Esp32s3I2c`) AND display fidelity for the shipped
+//! esp32s3-oled lab's SSD1306 panel.
+//!
+//! The S3 had GPIO/timer/IRQ-matrix walk differentials but no I2C executing
+//! coverage, even though the S3 I2C command engine is ~byte-identical to the
+//! C3's (which does have one). Here the FULL bus is assembled with
+//! `configure_xtensa_esp32s3` — the same wiring the browser twin boots — which
+//! attaches an SSD1306 @ 0x3C to `i2c0`. We then drive the command-list engine
+//! exactly as firmware does, over real bus MMIO at `I2C0_BASE`: load a command
+//! list (RSTART / WRITE / STOP) into CMD0.., stage the I2C bytes in the TX
+//! FIFO, and kick `CTR.trans_start`. The controller executes the transaction
+//! synchronously, ACKs the 0x3C address, and streams the payload into the
+//! panel — after which we read the SSD1306 GDDRAM back and assert the panel
+//! renders EXACTLY the expected content. A register-map, command-decode,
+//! address-match, or GDDRAM-addressing regression fails here.
+//!
+//! Named `esp32s3_*` / `*_ssd1306_*` so the board-coverage ratchet discovers it
+//! as both the S3 I2C oracle and the S3 display differential.
+
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::components::Ssd1306;
+use labwired_core::peripherals::esp32s3::i2c::Esp32s3I2c;
+use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3Opts};
+use labwired_core::Bus;
+
+// ESP32-S3 I2C0 register block base and command-list register map (offsets are
+// base-relative; the bus router subtracts the base for us).
+const I2C0_BASE: u64 = 0x6001_3000;
+const CTR: u64 = 0x04;
+const DATA: u64 = 0x1C; // TX/RX FIFO data register
+const INT_RAW: u64 = 0x20;
+const INT_CLR: u64 = 0x24;
+const CMD0: u64 = 0x58; // CMD0..CMD7, stride 4
+
+const CTR_TRANS_START: u32 = 1 << 5;
+const TRANS_COMPLETE: u32 = 1 << 7;
+const NACK: u32 = 1 << 10;
+
+// Command-list opcodes (bits [13:11]); byte_num in bits [7:0].
+const OP_WRITE: u32 = 1;
+const OP_STOP: u32 = 2;
+const OP_RSTART: u32 = 6;
+
+const SSD1306_ADDR: u8 = 0x3C;
+const CTRL_CMD_STREAM: u8 = 0x00; // Co=0, D/C#=0 -> command stream
+const CTRL_DATA_STREAM: u8 = 0x40; // Co=0, D/C#=1 -> data stream
+
+fn cmd(opcode: u32, byte_num: u8) -> u32 {
+    ((opcode & 0x7) << 11) | u32::from(byte_num)
+}
+
+/// Assemble the same bus the browser twin boots (SSD1306 attached @ 0x3C).
+fn build_bus() -> SystemBus {
+    let mut bus = SystemBus::new();
+    let _wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+    bus.refresh_peripheral_index();
+    bus
+}
+
+fn read_ssd1306(bus: &SystemBus) -> &Ssd1306 {
+    let idx = bus
+        .find_peripheral_index_by_name("i2c0")
+        .expect("S3 bus exposes i2c0");
+    bus.peripherals[idx]
+        .dev
+        .as_any()
+        .expect("i2c0 is downcastable")
+        .downcast_ref::<Esp32s3I2c>()
+        .expect("i2c0 is the S3 command-list controller")
+        .attached_slaves()
+        .iter()
+        .filter(|s| s.address() == SSD1306_ADDR)
+        .find_map(|s| s.as_any().and_then(|a| a.downcast_ref::<Ssd1306>()))
+        .expect("SSD1306 attached @ 0x3C")
+}
+
+/// Drive one I2C write transaction (address + payload) through the command-list
+/// engine at `I2C0_BASE` and return the completion INT_RAW word.
+fn i2c_write_transaction(bus: &mut SystemBus, payload: &[u8]) -> u32 {
+    // Command list: RSTART, WRITE (addr + payload bytes), STOP.
+    let byte_num = (payload.len() + 1) as u8; // +1 for the address byte
+    bus.write_u32(I2C0_BASE + CMD0, cmd(OP_RSTART, 0)).unwrap();
+    bus.write_u32(I2C0_BASE + CMD0 + 4, cmd(OP_WRITE, byte_num))
+        .unwrap();
+    bus.write_u32(I2C0_BASE + CMD0 + 8, cmd(OP_STOP, 0))
+        .unwrap();
+
+    // TX FIFO: 7-bit address + write bit, then the payload.
+    bus.write_u32(I2C0_BASE + DATA, u32::from(SSD1306_ADDR) << 1)
+        .unwrap();
+    for &b in payload {
+        bus.write_u32(I2C0_BASE + DATA, u32::from(b)).unwrap();
+    }
+
+    // Clear stale status, then kick the transaction (runs synchronously).
+    bus.write_u32(I2C0_BASE + INT_CLR, 0xFFFF_FFFF).unwrap();
+    bus.write_u32(I2C0_BASE + CTR, CTR_TRANS_START).unwrap();
+    bus.read_u32(I2C0_BASE + INT_RAW).unwrap()
+}
+
+/// A data-stream write lands the exact payload in SSD1306 GDDRAM at page 0 /
+/// column 0 (the panel's power-on horizontal-addressing origin), and the
+/// address phase is ACKed (no NACK).
+#[test]
+fn s3_i2c_data_stream_renders_expected_framebuffer() {
+    let mut bus = build_bus();
+
+    // Blank at boot: firmware has not drawn anything.
+    assert!(
+        read_ssd1306(&bus).framebuffer().iter().all(|&b| b == 0),
+        "SSD1306 GDDRAM must be blank before any transaction"
+    );
+
+    // Control byte 0x40 (data stream) + a deterministic pixel pattern.
+    let pattern: [u8; 8] = [0xFF, 0x81, 0x42, 0x24, 0x18, 0xAA, 0x55, 0x3C];
+    let mut payload = vec![CTRL_DATA_STREAM];
+    payload.extend_from_slice(&pattern);
+
+    let status = i2c_write_transaction(&mut bus, &payload);
+    assert_ne!(
+        status & TRANS_COMPLETE,
+        0,
+        "transaction must complete (TRANS_COMPLETE)"
+    );
+    assert_eq!(status & NACK, 0, "SSD1306 @ 0x3C must ACK its address");
+
+    let oled = read_ssd1306(&bus);
+    let fb = oled.framebuffer();
+    assert_eq!(fb.len(), 1024, "128x64 GDDRAM is 1024 bytes");
+    assert_eq!(
+        &fb[0..8],
+        &pattern,
+        "data-stream bytes must land verbatim at page 0 / column 0"
+    );
+    assert!(
+        fb[8..].iter().all(|&b| b == 0),
+        "only the written columns may be non-zero"
+    );
+    assert_eq!(
+        oled.ink_bytes(),
+        pattern.iter().filter(|&&b| b != 0).count(),
+        "ink accounting must match the non-zero payload bytes"
+    );
+}
+
+/// A command-stream write reaches the panel's command path: 0xAF (display on)
+/// flips `display_on()`, and a set-page / set-column pair retargets where a
+/// following data write lands.
+#[test]
+fn s3_i2c_command_stream_controls_panel_state() {
+    let mut bus = build_bus();
+    assert!(
+        !read_ssd1306(&bus).display_on(),
+        "panel starts with the display off"
+    );
+
+    // Command stream: 0xAF = display ON.
+    assert_ne!(
+        i2c_write_transaction(&mut bus, &[CTRL_CMD_STREAM, 0xAF]) & TRANS_COMPLETE,
+        0
+    );
+    assert!(
+        read_ssd1306(&bus).display_on(),
+        "0xAF command must turn the display on"
+    );
+
+    // Command stream: set page 2 (0xB2) and column 5 (lower 0x05, upper 0x10),
+    // then a data write must land at page-2/column-5, not the origin.
+    assert_ne!(
+        i2c_write_transaction(&mut bus, &[CTRL_CMD_STREAM, 0xB2, 0x05, 0x10]) & TRANS_COMPLETE,
+        0
+    );
+    assert_ne!(
+        i2c_write_transaction(&mut bus, &[CTRL_DATA_STREAM, 0x7E]) & TRANS_COMPLETE,
+        0
+    );
+
+    let oled = read_ssd1306(&bus);
+    let fb = oled.framebuffer();
+    let idx = 2 * 128 + 5; // page 2, column 5, page-major layout
+    assert_eq!(
+        fb[idx], 0x7E,
+        "addressed data byte must land at page 2 / column 5"
+    );
+    assert_eq!(
+        oled.ink_bytes(),
+        1,
+        "exactly one GDDRAM byte was written after re-addressing"
+    );
+}

--- a/crates/core/tests/nokia5110_pcd8544_differential.rs
+++ b/crates/core/tests/nokia5110_pcd8544_differential.rs
@@ -1,0 +1,92 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Display fidelity for the Nokia 5110 (PCD8544) panel shipped by the
+//! `nokia5110-invaders-lab` — the panel used beyond the C3 SSD1306.
+//!
+//! The PCD8544 frames command vs pixel bytes by a dedicated D/C GPIO line, not
+//! by byte semantics. This drives the component exactly as the bus does — latch
+//! D/C low for commands, high for pixel data — programming the X/Y address
+//! pointer and streaming pixel bytes, then asserts the panel's DDRAM renders
+//! EXACTLY the expected content at the addressed cells (and that the
+//! column-first auto-advance walks to the next cell). An addressing or
+//! data-routing regression fails here.
+//!
+//! Named `*_pcd8544_differential` so the board-coverage ratchet discovers it.
+
+use labwired_core::peripherals::components::Pcd8544;
+use labwired_core::peripherals::spi::SpiDevice;
+
+const WIDTH: usize = 84;
+
+fn cmd(p: &mut Pcd8544, byte: u8) {
+    p.set_dc_level(false);
+    p.transfer(byte);
+}
+
+fn data(p: &mut Pcd8544, byte: u8) {
+    p.set_dc_level(true);
+    p.transfer(byte);
+}
+
+/// A pixel byte written at an addressed (bank, column) lands at exactly that
+/// DDRAM cell, and the column-first pointer auto-advances to the next column.
+#[test]
+fn pcd8544_addressed_pixel_write_renders_expected_cells() {
+    let mut p = Pcd8544::new("PB6".into(), "PC7".into());
+
+    assert!(
+        p.framebuffer().iter().all(|&b| b == 0),
+        "DDRAM must be blank before any write"
+    );
+
+    // Set X = column 5, Y = bank 2 (basic instruction set, H = 0).
+    cmd(&mut p, 0x80 | 5); // set X address
+    cmd(&mut p, 0x40 | 2); // set Y address (bank)
+
+    // Stream three deterministic pixel columns.
+    data(&mut p, 0xAA);
+    data(&mut p, 0x3C);
+    data(&mut p, 0xFF);
+
+    let fb = p.framebuffer();
+    assert_eq!(fb.len(), WIDTH * 6, "PCD8544 DDRAM is 84x6 = 504 bytes");
+    assert_eq!(fb[2 * WIDTH + 5], 0xAA, "column 5 of bank 2");
+    assert_eq!(fb[2 * WIDTH + 6], 0x3C, "auto-advanced to column 6");
+    assert_eq!(fb[2 * WIDTH + 7], 0xFF, "auto-advanced to column 7");
+    assert!(
+        fb.iter().filter(|&&b| b != 0).count() == 3,
+        "exactly the three written columns are non-blank"
+    );
+}
+
+/// The function-set command routes the extended instruction set (contrast /
+/// bias) away from DDRAM, and a following command re-selects the basic set so
+/// pixel writes resume — i.e. command framing is honoured, not written as data.
+#[test]
+fn pcd8544_command_bytes_do_not_leak_into_framebuffer() {
+    let mut p = Pcd8544::new("PB6".into(), "PC7".into());
+
+    // Enter extended set (H = 1) and program Vop/bias — none of this is pixels.
+    cmd(&mut p, 0x21); // function set: H = 1
+    cmd(&mut p, 0x80 | 0x3F); // set Vop (contrast)
+    cmd(&mut p, 0x14); // bias system
+    cmd(&mut p, 0x20); // function set: back to basic (H = 0)
+    cmd(&mut p, 0x0C); // display control: normal mode
+
+    assert!(
+        p.framebuffer().iter().all(|&b| b == 0),
+        "command bytes must not appear in DDRAM"
+    );
+
+    // Now a real pixel write at the origin lands.
+    cmd(&mut p, 0x80); // X = 0
+    cmd(&mut p, 0x40); // Y = 0
+    data(&mut p, 0x5A);
+    assert_eq!(
+        p.framebuffer()[0],
+        0x5A,
+        "pixel write resumes after commands"
+    );
+}

--- a/crates/core/tests/nrf52_spim_easydma_executing.rs
+++ b/crates/core/tests/nrf52_spim_easydma_executing.rs
@@ -1,0 +1,152 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Executing EasyDMA oracle for the nRF52840 SPIM (`peripherals/spi.rs`,
+//! `SpiRegisterLayout::Nrf52Spim`).
+//!
+//! The shipped nRF52 SPIM/TWIM EasyDMA conformance suites are hardware-oracle
+//! (SWD) and register-surface diffs — they do not observe DMA byte movement in
+//! the sim. The model IS fully executing (it reads the TX buffer from RAM and
+//! writes the RX buffer back to RAM inside `tick_with_bus`), so this adds a
+//! ratchet-discoverable integration test that proves REAL data movement:
+//! program `TXD.PTR/MAXCNT` + `RXD.PTR/MAXCNT`, trigger `TASKS_START`, run the
+//! DMA on a real `SystemBus`-backed RAM region, and assert the destination RAM
+//! bytes — plus the `AMOUNT` counters and `EVENTS_END*` — reflect the transfer.
+//!
+//! Named `nrf52_*` so the board-coverage ratchet discovers it.
+
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::spi::{Spi, SpiRegisterLayout};
+use labwired_core::system::xtensa::RamPeripheral;
+use labwired_core::{Bus, Peripheral};
+
+// nRF52 SPIM register offsets (base-relative).
+const TASKS_START: u64 = 0x010;
+const EVENTS_ENDRX: u64 = 0x110;
+const EVENTS_END: u64 = 0x118;
+const EVENTS_ENDTX: u64 = 0x120;
+const ENABLE: u64 = 0x500;
+const RXD_PTR: u64 = 0x534;
+const RXD_MAXCNT: u64 = 0x538;
+const RXD_AMOUNT: u64 = 0x53C;
+const TXD_PTR: u64 = 0x544;
+const TXD_MAXCNT: u64 = 0x548;
+const TXD_AMOUNT: u64 = 0x54C;
+
+const ENABLE_SPIM: u32 = 7;
+
+// nRF52 RAM window.
+const RAM_BASE: u64 = 0x2000_0000;
+const RAM_SIZE: usize = 64 * 1024;
+
+fn bus_with_ram() -> SystemBus {
+    let mut bus = SystemBus::new();
+    bus.add_peripheral(
+        "ram",
+        RAM_BASE,
+        RAM_SIZE as u64,
+        None,
+        Box::new(RamPeripheral::new(RAM_SIZE)),
+    );
+    bus
+}
+
+/// EasyDMA with loopback: the RX buffer in RAM must end up holding exactly the
+/// bytes that were fetched from the TX buffer, and the completion events /
+/// AMOUNT counters must reflect the full-length transfer.
+#[test]
+fn nrf52_spim_easydma_loopback_moves_bytes_through_ram() {
+    let mut bus = bus_with_ram();
+    let mut spim = Spi::new_with_layout(SpiRegisterLayout::Nrf52Spim);
+    spim.set_loopback(true); // MISO mirrors MOSI, so RX == TX deterministically.
+
+    let tx_ptr = RAM_BASE;
+    let rx_ptr = RAM_BASE + 0x100;
+    let tx_data: [u8; 6] = [0xDE, 0xAD, 0xBE, 0xEF, 0xA5, 0x5A];
+    for (i, &b) in tx_data.iter().enumerate() {
+        bus.write_u8(tx_ptr + i as u64, b).unwrap();
+        // Poison the RX region so a no-op cannot pass.
+        bus.write_u8(rx_ptr + i as u64, 0x00).unwrap();
+    }
+
+    spim.write_u32(ENABLE, ENABLE_SPIM).unwrap();
+    spim.write_u32(TXD_PTR, tx_ptr as u32).unwrap();
+    spim.write_u32(TXD_MAXCNT, tx_data.len() as u32).unwrap();
+    spim.write_u32(RXD_PTR, rx_ptr as u32).unwrap();
+    spim.write_u32(RXD_MAXCNT, tx_data.len() as u32).unwrap();
+
+    spim.write_u32(TASKS_START, 1).unwrap();
+    assert_eq!(
+        spim.read_u32(EVENTS_END).unwrap(),
+        0,
+        "EVENTS_END must not fire before the DMA runs"
+    );
+    assert!(spim.needs_bus_tick(), "START must arm a pending bus tick");
+
+    // Run the EasyDMA engine (SPIM completes in a single bus tick).
+    spim.tick_with_bus(&mut bus);
+
+    assert_eq!(spim.read_u32(EVENTS_END).unwrap(), 1, "EVENTS_END");
+    assert_eq!(spim.read_u32(EVENTS_ENDTX).unwrap(), 1, "EVENTS_ENDTX");
+    assert_eq!(spim.read_u32(EVENTS_ENDRX).unwrap(), 1, "EVENTS_ENDRX");
+    assert_eq!(spim.read_u32(TXD_AMOUNT).unwrap(), tx_data.len() as u32);
+    assert_eq!(spim.read_u32(RXD_AMOUNT).unwrap(), tx_data.len() as u32);
+    assert!(
+        !spim.needs_bus_tick(),
+        "pending START must clear after the DMA"
+    );
+
+    let rx: Vec<u8> = (0..tx_data.len())
+        .map(|i| bus.read_u8(rx_ptr + i as u64).unwrap())
+        .collect();
+    assert_eq!(
+        rx, tx_data,
+        "loopback EasyDMA must land the TX bytes verbatim in the RX buffer"
+    );
+}
+
+/// RXD.MAXCNT shorter than TXD.MAXCNT bounds how many bytes are written back to
+/// RAM: the RX buffer past MAXCNT stays untouched and RXD.AMOUNT reflects the
+/// clamp, while TXD.AMOUNT still reports the full clocked length.
+#[test]
+fn nrf52_spim_easydma_rxd_maxcnt_clamps_written_bytes() {
+    let mut bus = bus_with_ram();
+    let mut spim = Spi::new_with_layout(SpiRegisterLayout::Nrf52Spim);
+    spim.set_loopback(true);
+
+    let tx_ptr = RAM_BASE;
+    let rx_ptr = RAM_BASE + 0x100;
+    let tx_data: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
+    for (i, &b) in tx_data.iter().enumerate() {
+        bus.write_u8(tx_ptr + i as u64, b).unwrap();
+    }
+    // Sentinel across the whole RX region.
+    for i in 0..tx_data.len() {
+        bus.write_u8(rx_ptr + i as u64, 0x99).unwrap();
+    }
+
+    spim.write_u32(ENABLE, ENABLE_SPIM).unwrap();
+    spim.write_u32(TXD_PTR, tx_ptr as u32).unwrap();
+    spim.write_u32(TXD_MAXCNT, 4).unwrap();
+    spim.write_u32(RXD_PTR, rx_ptr as u32).unwrap();
+    spim.write_u32(RXD_MAXCNT, 2).unwrap(); // only 2 bytes captured
+
+    spim.write_u32(TASKS_START, 1).unwrap();
+    spim.tick_with_bus(&mut bus);
+
+    assert_eq!(spim.read_u32(TXD_AMOUNT).unwrap(), 4, "all 4 bytes clocked");
+    assert_eq!(
+        spim.read_u32(RXD_AMOUNT).unwrap(),
+        2,
+        "only 2 bytes captured"
+    );
+    assert_eq!(bus.read_u8(rx_ptr).unwrap(), 0x11);
+    assert_eq!(bus.read_u8(rx_ptr + 1).unwrap(), 0x22);
+    assert_eq!(
+        bus.read_u8(rx_ptr + 2).unwrap(),
+        0x99,
+        "RX bytes past RXD.MAXCNT must remain untouched"
+    );
+    assert_eq!(bus.read_u8(rx_ptr + 3).unwrap(), 0x99);
+}


### PR DESCRIPTION
Closes fidelity-coverage gaps on the ESP32-S3, nRF52840, and non-C3 display panels. Test + no model-behavior changes; all executing/oracle-valid, deterministic, and named by chip/display so the board-coverage ratchet discovers them.

## What was added

### ESP32-S3 (was: GPIO/timer/IRQ-matrix walk diffs only)
- **`esp32s3_ssd1306_differential`** — executing I2C oracle + display fidelity. Assembles the full S3 bus (`configure_xtensa_esp32s3`, which attaches an SSD1306 @ 0x3C to the command-list `Esp32s3I2c`), then drives the command engine over real bus MMIO (RSTART/WRITE/STOP command list + TX FIFO + `CTR.trans_start`) exactly as firmware does, and asserts the panel framebuffer renders EXACT content — data stream at the origin, `0xAF` display-on via command stream, and page/column re-addressing. The S3 I2C command engine is ~byte-identical to the C3's (which already had a differential); this closes the S3 side.
- **`esp32s3_gdma_oracle`** — mem-to-mem GDMA on a `SystemBus`-backed DRAM region (`gdma.rs`, ~4000 lines, previously no ratchet-discoverable coverage). Single-descriptor and two-link scatter/gather, asserting real byte movement through the bus router plus `IN_SUC_EOF` / `OUT_TOTAL_EOF`.
- **`esp32s3_gpspi_oracle`** — GP-SPI2 CPU data-buffer transfer path executes to completion: `USR` auto-clear, `TRANS_DONE` latch, length-bounded MISO fill. (The full-duplex DMA MOSI-capture path is already covered by in-module `gpspi.rs` tests; that device-attach entry point is crate-private.)

### nRF52840
- **`nrf52_spim_easydma_executing`** — the shipped SPIM/TWIM EasyDMA suites are hardware-oracle (SWD) / register-surface diffs and don't observe DMA byte movement in the sim. The model IS executing, so this adds an integration test proving real data movement: loopback RX mirrors TX verbatim, and `RXD.MAXCNT` clamps written bytes while `TXD.AMOUNT` reports the full clocked length.

### Displays beyond the C3 SSD1306
- **`nokia5110_pcd8544_differential`** — drives the PCD8544 via its D/C-framed command/data path; asserts pixel bytes render at addressed cells with correct column-first auto-advance, and that command bytes never leak into DDRAM.
- **`epaper_ssd1680_differential`** — drives the SSD1680 tri-color window/counter/stream datasheet sequence; asserts each of the black and red planes renders the exact streamed bytes at windowed cells, plus the power/refresh handshake.

## Verification
- All 12 tests pass under **default**, **`event-scheduler`**, and **`jit,event-scheduler`** feature lanes.
- `cargo fmt --check` and `cargo clippy --tests` clean.
- No model behavior changed; no real bug surfaced (all peripherals executed byte/oracle-correctly).

## Notes / findings
- **nRF52 EasyDMA and non-C3 displays already had strong in-crate coverage.** The SPIM/TWIM `#[cfg(test)]` modules assert real RAM byte movement, and PCD8544/SSD1680 have in-module byte-exact tests; the genuine gap was that none were discoverable by the name-based ratchet. These new files close that at the integration level.
- **GDMA mem-to-mem** was already tested in-module (`m2m_single_descriptor_bytes_move`); the two-link chain here is new.