### PR TITLE
test: executing walk-vs-scheduler fidelity gates for STM32 f401/l073/l476/h563 + F103 DMA

### DIFF
--- a/crates/core/tests/board_coverage_ratchet.rs
+++ b/crates/core/tests/board_coverage_ratchet.rs
@@ -212,11 +212,8 @@ const KNOWN_GAPS: &[(&str, Class)] = &[
     // here is satisfied by ANY timer/IRQ walk-diff or oracle; add DMA coverage
     // only if/when the DMA block is modelled.
     ("rp2040", Class::Exec),
-    // STM32F401 (BlackPill / demo) ships but its executing coverage is only
-    // `firmware_survival::test_stm32f401_blinky_survival`. The F4 exec-oracle /
-    // mmio-diff target real F407 silicon, not F401. Fill with an F401 walk
-    // differential or an F401 mmio-diff/exec-oracle.
-    ("stm32f401", Class::Exec),
+    // STM32F401 executing-fidelity is now covered by stm32f401_walk_differential.
+    // (F401 cold-reset value divergences vs RM0368 tracked separately in issue #576.)
 ];
 
 fn core_crate_root() -> PathBuf {

--- a/crates/core/tests/stm32_walk_free/mod.rs
+++ b/crates/core/tests/stm32_walk_free/mod.rs
@@ -196,10 +196,22 @@ pub fn assert_walk_free_boot_identical(
     cycles: u64,
     snapshot_every: u64,
 ) {
-    let (walk_snaps, walk_uart) =
-        run_lane(chip_name, system_name, fixture, true, cycles, snapshot_every);
-    let (sched_snaps, sched_uart) =
-        run_lane(chip_name, system_name, fixture, false, cycles, snapshot_every);
+    let (walk_snaps, walk_uart) = run_lane(
+        chip_name,
+        system_name,
+        fixture,
+        true,
+        cycles,
+        snapshot_every,
+    );
+    let (sched_snaps, sched_uart) = run_lane(
+        chip_name,
+        system_name,
+        fixture,
+        false,
+        cycles,
+        snapshot_every,
+    );
 
     assert_eq!(
         walk_snaps.len(),
@@ -208,7 +220,8 @@ pub fn assert_walk_free_boot_identical(
     );
     for (i, (w, s)) in walk_snaps.iter().zip(sched_snaps.iter()).enumerate() {
         assert_eq!(
-            w, s,
+            w,
+            s,
             "{chip_name}: walk-vs-scheduler diverged at snapshot {i} \
              (window ~{} instructions)\n  walk={w:?}\n  sched={s:?}",
             (i as u64 + 1) * snapshot_every

--- a/crates/core/tests/stm32_walk_free/mod.rs
+++ b/crates/core/tests/stm32_walk_free/mod.rs
@@ -1,0 +1,240 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Shared harness for the per-chip STM32 **walk-vs-scheduler** executing
+//! differentials (`stm32f401_walk_differential`, `stm32l073_walk_differential`,
+//! `stm32l476_walk_differential`, `stm32h563_walk_differential`).
+//!
+//! Each chip test loads a REAL committed firmware fixture (the stock Zephyr
+//! `hello_world`, whose kernel tick is driven from the Cortex **SysTick** and
+//! whose console output is deterministic) onto that chip's `from_config` bus and
+//! runs it twice:
+//!
+//!   * the **reference** lane pins the scheduler-migrated core timing blocks
+//!     (SysTick + SCB + DWT) and the SoC `Timer`/`Uart`/`Adc`/`Dma1` models back
+//!     onto the legacy per-cycle walk (`force_legacy_walk`), and
+//!   * the **candidate** lane leaves them scheduler-driven (the production path
+//!     under the `event-scheduler` feature).
+//!
+//! A snapshot vector — `(total_cycles, pc, uart-stream length, SRAM hash)` taken
+//! every `snapshot_every` instructions plus the final UART byte stream — must be
+//! **byte-identical** between the two lanes. Because the Zephyr kernel schedules
+//! off the SysTick IRQ cadence, any drift in the scheduler's tick/IRQ delivery
+//! timing (relative to the walk reference) perturbs the kernel's uptime, the
+//! console banner timing and the resulting SRAM, so equality is a genuine
+//! IRQ-cadence + timing gate on that chip's real boot, not a static register
+//! check.
+//!
+//! Divergence here is a real fidelity bug in the scheduler migration for that
+//! chip — it must be reported, never masked.
+
+#![allow(dead_code)]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::adc::Adc;
+use labwired_core::peripherals::dma::Dma1;
+use labwired_core::peripherals::dwt::Dwt;
+use labwired_core::peripherals::scb::Scb;
+use labwired_core::peripherals::systick::Systick;
+use labwired_core::peripherals::timer::Timer;
+use labwired_core::peripherals::uart::Uart;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{Bus, Cpu, DebugControl, Machine};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+/// SRAM window hashed into each snapshot (16 KiB at the common 0x2000_0000
+/// base — mapped on every STM32 family covered here).
+const SRAM_BASE: u64 = 0x2000_0000;
+const SRAM_HASH_LEN: u64 = 0x4000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    pub cycles: u64,
+    pub pc: u32,
+    pub uart_len: usize,
+    pub sram_hash: u64,
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn load_system(chip_name: &str, system_name: &str) -> (ChipDescriptor, SystemManifest) {
+    let chip_path = workspace_root()
+        .join("configs/chips")
+        .join(format!("{chip_name}.yaml"));
+    let sys_path = workspace_root()
+        .join("configs/systems")
+        .join(format!("{system_name}.yaml"));
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|e| panic!("load chip {chip_name}: {e}"));
+    let mut manifest = SystemManifest::from_file(&sys_path)
+        .unwrap_or_else(|e| panic!("load system {system_name}: {e}"));
+    manifest.chip = sys_path
+        .parent()
+        .unwrap()
+        .join(&manifest.chip)
+        .to_str()
+        .unwrap()
+        .to_string();
+    (chip, manifest)
+}
+
+/// Pin every scheduler-migrated model on the bus back onto the legacy per-cycle
+/// walk, forming the reference lane. Peripheral types not present on a given
+/// chip are simply skipped; any model left scheduler-driven here is
+/// scheduler-driven in BOTH lanes, so it contributes identically.
+fn force_all_legacy_walk(bus: &mut SystemBus) {
+    for entry in bus.peripherals.iter_mut() {
+        let Some(any) = entry.dev.as_any_mut() else {
+            continue;
+        };
+        if let Some(p) = any.downcast_mut::<Systick>() {
+            p.force_legacy_walk();
+        } else if let Some(p) = any.downcast_mut::<Scb>() {
+            p.force_legacy_walk();
+        } else if let Some(p) = any.downcast_mut::<Dwt>() {
+            p.force_legacy_walk();
+        } else if let Some(p) = any.downcast_mut::<Timer>() {
+            p.force_legacy_walk();
+        } else if let Some(p) = any.downcast_mut::<Uart>() {
+            p.force_legacy_walk();
+        } else if let Some(p) = any.downcast_mut::<Adc>() {
+            p.force_legacy_walk();
+        } else if let Some(p) = any.downcast_mut::<Dma1>() {
+            p.force_legacy_walk();
+        }
+    }
+}
+
+fn sram_hash(bus: &SystemBus) -> u64 {
+    // FNV-1a over the SRAM window (word reads; unmapped words fault → treated as
+    // a stable sentinel so both lanes agree on any hole).
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut addr = SRAM_BASE;
+    while addr < SRAM_BASE + SRAM_HASH_LEN {
+        let word = bus.read_u32(addr).unwrap_or(0xDEAD_BEEF);
+        hash ^= word as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01B3);
+        addr += 4;
+    }
+    hash
+}
+
+/// Run one lane to completion, snapshotting every `snapshot_every` instructions.
+fn run_lane(
+    chip_name: &str,
+    system_name: &str,
+    fixture: &str,
+    reference: bool,
+    cycles: u64,
+    snapshot_every: u64,
+) -> (Vec<Snapshot>, Vec<u8>) {
+    let (chip, manifest) = load_system(chip_name, system_name);
+    let mut bus = SystemBus::from_config(&chip, &manifest)
+        .unwrap_or_else(|e| panic!("build {chip_name} bus: {e}"));
+
+    let uart_sink = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(uart_sink.clone(), false);
+
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    if reference {
+        force_all_legacy_walk(&mut bus);
+        // Pinning a peripheral back onto the walk after `from_config` derived a
+        // walk-DELETED bus would starve it of per-cycle ticks; recompute the
+        // flag over the live set so the walk reference actually runs.
+        bus.recompute_walk_deletable();
+    }
+    let mut machine = Machine::new(cpu, bus);
+    // Pin the scheduler drain to one instruction per tick (the walk reference
+    // ticks every cycle unconditionally), so lazy free-running-counter reads are
+    // NOT quantised to a coarse batch grid — the exact-match regime the
+    // per-model walk differentials are calibrated to.
+    machine.config.peripheral_tick_interval = 1;
+    machine.bus.config.peripheral_tick_interval = 1;
+
+    let fixture_path = workspace_root().join("tests/fixtures").join(fixture);
+    let image = labwired_loader::load_elf(&fixture_path)
+        .unwrap_or_else(|e| panic!("load ELF {fixture_path:?}: {e}"));
+    machine
+        .load_firmware(&image)
+        .expect("load firmware into machine");
+
+    let mut snaps = Vec::new();
+    let mut done = 0u64;
+    while done < cycles {
+        let chunk = snapshot_every.min(cycles - done);
+        machine.run(Some(chunk as u32)).expect("run chunk");
+        done += chunk;
+        snaps.push(Snapshot {
+            cycles: machine.total_cycles,
+            pc: machine.cpu.get_pc(),
+            uart_len: uart_sink.lock().unwrap().len(),
+            sram_hash: sram_hash(&machine.bus),
+        });
+    }
+    let uart = uart_sink.lock().unwrap().clone();
+    (snaps, uart)
+}
+
+/// The shared gate body: build the walk reference and the scheduler candidate,
+/// assert the snapshot trace and UART stream are byte-identical, and assert the
+/// firmware genuinely executed (the deterministic banner appeared).
+pub fn assert_walk_free_boot_identical(
+    chip_name: &str,
+    system_name: &str,
+    fixture: &str,
+    expected_uart: &[u8],
+    cycles: u64,
+    snapshot_every: u64,
+) {
+    let (walk_snaps, walk_uart) =
+        run_lane(chip_name, system_name, fixture, true, cycles, snapshot_every);
+    let (sched_snaps, sched_uart) =
+        run_lane(chip_name, system_name, fixture, false, cycles, snapshot_every);
+
+    assert_eq!(
+        walk_snaps.len(),
+        sched_snaps.len(),
+        "{chip_name}: snapshot count mismatch"
+    );
+    for (i, (w, s)) in walk_snaps.iter().zip(sched_snaps.iter()).enumerate() {
+        assert_eq!(
+            w, s,
+            "{chip_name}: walk-vs-scheduler diverged at snapshot {i} \
+             (window ~{} instructions)\n  walk={w:?}\n  sched={s:?}",
+            (i as u64 + 1) * snapshot_every
+        );
+    }
+
+    assert_eq!(
+        walk_uart, sched_uart,
+        "{chip_name}: UART stream diverged between walk and scheduler lanes"
+    );
+
+    // The firmware must have actually run its application logic (not spun in a
+    // reset loop) — otherwise the byte-identity above would be vacuous.
+    assert!(
+        walk_uart
+            .windows(expected_uart.len())
+            .any(|w| w == expected_uart),
+        "{chip_name}: firmware did not emit the expected banner {:?}; got {:?}",
+        String::from_utf8_lossy(expected_uart),
+        String::from_utf8_lossy(&walk_uart),
+    );
+
+    // And total_cycles must have advanced identically to the full budget.
+    let last = walk_snaps.last().expect("at least one snapshot");
+    assert_eq!(
+        last.cycles, cycles,
+        "{chip_name}: total_cycles did not reach the instruction budget"
+    );
+}

--- a/crates/core/tests/stm32f103_dma_walk_differential.rs
+++ b/crates/core/tests/stm32f103_dma_walk_differential.rs
@@ -1,0 +1,200 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! STM32F103 DMA1 executing walk-vs-scheduler fidelity differential (on the
+//! REAL `stm32f103` `from_config` bus).
+//!
+//! Closes the DMA gap: the only prior DMA differential
+//! (`stm32_dma_walk_differential`) drives the `Dma1` model on a hand-built,
+//! chip-agnostic bus. This one builds the actual F103 chip bus — DMA1 mapped at
+//! its silicon base `0x4002_0000`, clock-gated behind `RCC_AHBENR.DMA1EN`
+//! (RM0008 §7) exactly as the shipped F1 DMA labs see it — and runs a
+//! CPU-executed memory-to-memory transfer twice: once with the `Dma1` model
+//! pinned onto the legacy per-cycle walk (reference) and once scheduler-driven.
+//!
+//! After EVERY instruction, the full architectural state (total_cycles, PC, all
+//! 16 core registers), the DMA destination buffer, and the polled DMA ISR word
+//! must be byte-identical — pinning the per-element transfer cadence, the
+//! TCIF/GIF latch cycle, and the copied bytes on the real chip's DMA wiring.
+//!
+//! Divergence is a real fidelity bug in the F103 DMA scheduler migration and
+//! must be reported, never masked.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::dma::Dma1;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{Bus, Cpu, DebugControl, Machine};
+use std::path::PathBuf;
+
+const DMA_BASE: u32 = 0x4002_0000;
+// RCC_AHBENR (RM0008 §7.3.6); DMA1EN is bit 0. Writes to DMA1 are dropped until
+// the clock is enabled, so the harness enables it before the run (identically in
+// both lanes).
+const RCC_AHBENR: u64 = 0x4002_1014;
+
+// SRAM layout (20 KiB at 0x2000_0000 on the F103C8).
+const MAIN_COUNT_ADDR: u64 = 0x2000_0000;
+const SRC_ADDR: u32 = 0x2000_0100;
+const DST_ADDR: u32 = 0x2000_0200;
+const FW_BASE: u64 = 0x2000_1000;
+const INITIAL_SP: u32 = 0x2000_5000;
+const N: u32 = 16;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn build_machine(reference: bool) -> Machine<labwired_core::cpu::CortexM> {
+    let chip_path = workspace_root().join("configs/chips/stm32f103.yaml");
+    let sys_path = workspace_root().join("configs/systems/stm32f103-bare.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load stm32f103 chip");
+    let mut manifest = SystemManifest::from_file(&sys_path).expect("load stm32f103-bare system");
+    manifest.chip = sys_path
+        .parent()
+        .unwrap()
+        .join(&manifest.chip)
+        .to_str()
+        .unwrap()
+        .to_string();
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build F103 bus");
+
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    if reference {
+        let idx = bus
+            .find_peripheral_index_by_name("dma1")
+            .expect("F103 bus registers dma1");
+        bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .unwrap()
+            .downcast_mut::<Dma1>()
+            .expect("dma1 is the Dma1 model")
+            .force_legacy_walk();
+        bus.recompute_walk_deletable();
+    }
+
+    // Enable the DMA1 clock (RCC_AHBENR.DMA1EN) and fill the source buffer — both
+    // are identical setup in the two lanes.
+    bus.write_u32(RCC_AHBENR, 0x1).expect("enable DMA1 clock");
+    for i in 0..N {
+        bus.write_u8(SRC_ADDR as u64 + i as u64, 0xA0 ^ (i as u8).wrapping_mul(7))
+            .unwrap();
+    }
+
+    // mem2mem poll firmware in SRAM (see module docs). CCR =
+    // EN|DIR|PINC|MINC|MEM2MEM (bits 0,4,6,7,14 = 0x40D1); no TCIE (polled).
+    let fw: [u16; 16] = [
+        0x4807,
+        0x4908,
+        0x6101,
+        0x4908,
+        0x6141,
+        0x2100 | (N as u16),
+        0x60C1,
+        0x4907,
+        0x6081,
+        0x4A07,
+        0x2300,
+        0x3301,
+        0x6013,
+        0x6804,
+        0xE7FB,
+        0xBF00,
+    ];
+    for (i, hw) in fw.iter().enumerate() {
+        bus.write_u16(FW_BASE + (i as u64) * 2, *hw).unwrap();
+    }
+    // Literal pool at FW_BASE + 0x20.
+    bus.write_u32(FW_BASE + 0x20, DMA_BASE).unwrap();
+    bus.write_u32(FW_BASE + 0x24, DST_ADDR).unwrap();
+    bus.write_u32(FW_BASE + 0x28, SRC_ADDR).unwrap();
+    bus.write_u32(FW_BASE + 0x2C, 0x40D1).unwrap();
+    bus.write_u32(FW_BASE + 0x30, MAIN_COUNT_ADDR as u32)
+        .unwrap();
+
+    let mut machine = Machine::new(cpu, bus);
+    machine.config.peripheral_tick_interval = 1;
+    machine.bus.config.peripheral_tick_interval = 1;
+    machine.cpu.sp = INITIAL_SP;
+    machine
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Probe {
+    step: u64,
+    total_cycles: u64,
+    pc: u32,
+    regs: [u32; 16],
+    isr: u32,
+    dst: Vec<u8>,
+}
+
+fn probe(m: &Machine<labwired_core::cpu::CortexM>, step: u64) -> Probe {
+    let mut regs = [0u32; 16];
+    for (i, r) in regs.iter_mut().enumerate() {
+        *r = m.read_core_reg(i as u8);
+    }
+    let dst = (0..N)
+        .map(|i| m.bus.read_u8(DST_ADDR as u64 + i as u64).unwrap())
+        .collect();
+    Probe {
+        step,
+        total_cycles: m.total_cycles,
+        pc: m.cpu.get_pc(),
+        regs,
+        isr: m.bus.read_u32(DMA_BASE as u64).unwrap(),
+        dst,
+    }
+}
+
+fn run_probed(reference: bool, steps: u64) -> Vec<Probe> {
+    let mut m = build_machine(reference);
+    m.cpu.pc = FW_BASE as u32;
+    let mut probes = Vec::with_capacity(steps as usize);
+    for s in 0..steps {
+        m.run(Some(1)).unwrap();
+        probes.push(probe(&m, s + 1));
+    }
+    probes
+}
+
+/// mem2mem transfer on the real F103 DMA1: walk reference vs scheduler,
+/// byte-identical after every instruction, and the destination holds the copied
+/// source pattern with TCIF latched.
+#[test]
+fn stm32f103_dma_mem2mem_walk_vs_scheduler_is_byte_identical() {
+    const STEPS: u64 = 800;
+    let walk = run_probed(true, STEPS);
+    let sched = run_probed(false, STEPS);
+
+    assert_eq!(walk.len(), sched.len());
+    for (w, s) in walk.iter().zip(sched.iter()) {
+        assert_eq!(
+            w, s,
+            "F103 DMA mem2mem: first divergence at step {} (walk vs scheduler)",
+            w.step
+        );
+    }
+
+    // The transfer must have actually completed on the real chip bus.
+    let last = walk.last().unwrap();
+    let expected: Vec<u8> = (0..N).map(|i| 0xA0u8 ^ (i as u8).wrapping_mul(7)).collect();
+    assert_eq!(
+        last.dst, expected,
+        "F103 DMA1 mem2mem must copy the source bytes to the destination"
+    );
+    // TCIF1 (bit 1) latched in the DMA ISR register at completion.
+    assert!(
+        walk.iter().any(|p| p.isr & (1 << 1) != 0),
+        "F103 DMA1 must latch TCIF1 on transfer completion"
+    );
+}

--- a/crates/core/tests/stm32f401_walk_differential.rs
+++ b/crates/core/tests/stm32f401_walk_differential.rs
@@ -1,0 +1,32 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! STM32F401 (Cortex-M4) executing walk-vs-scheduler fidelity differential.
+//!
+//! Closes the F401 gap: the family previously had only a survival smoke test and
+//! the fleet scoreboard, with no dedicated executing-fidelity gate. This runs the
+//! stock Zephyr `hello_world` for `nucleo_f401re` — whose kernel tick is driven
+//! from the Cortex SysTick and whose USART2 console output is deterministic — on
+//! the real `stm32f401` `from_config` bus, once with the SysTick/SCB/DWT + SoC
+//! timing models pinned to the legacy walk and once scheduler-driven, and asserts
+//! the boot trace + console stream are byte-identical. See `stm32_walk_free`.
+
+#![cfg(feature = "event-scheduler")]
+
+#[path = "stm32_walk_free/mod.rs"]
+mod harness;
+
+/// F401 kernel-tick (SysTick) IRQ-cadence + console differential over the real
+/// Zephyr boot.
+#[test]
+fn stm32f401_zephyr_boot_walk_vs_scheduler_is_byte_identical() {
+    harness::assert_walk_free_boot_identical(
+        "stm32f401",
+        "nucleo-f401re",
+        "stm32f401-zephyr-hello.elf",
+        b"Hello World! nucleo_f401re",
+        800_000,
+        50_000,
+    );
+}

--- a/crates/core/tests/stm32h563_walk_differential.rs
+++ b/crates/core/tests/stm32h563_walk_differential.rs
@@ -1,0 +1,33 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! STM32H563 (Cortex-M33) executing walk-vs-scheduler fidelity differential.
+//!
+//! Closes the H563 gap: the family previously had static register MMIO diffs
+//! (`h563_mmio_diff`) and the FDCAN/flash suites but no executing/timing gate on
+//! the core-timer path. This runs the stock Zephyr `hello_world` for
+//! `nucleo_h563zi` — whose kernel tick is driven from the Cortex SysTick and
+//! whose console output is deterministic — on the real `stm32h563`
+//! `from_config` bus, once with the SysTick/SCB/DWT + SoC timing models pinned to
+//! the legacy walk and once scheduler-driven, and asserts the boot trace +
+//! console stream are byte-identical. See `stm32_walk_free`.
+
+#![cfg(feature = "event-scheduler")]
+
+#[path = "stm32_walk_free/mod.rs"]
+mod harness;
+
+/// H563 kernel-tick (SysTick) IRQ-cadence + console differential over the real
+/// Zephyr boot.
+#[test]
+fn stm32h563_zephyr_boot_walk_vs_scheduler_is_byte_identical() {
+    harness::assert_walk_free_boot_identical(
+        "stm32h563",
+        "nucleo-h563zi-demo",
+        "stm32h563-zephyr-hello.elf",
+        b"Hello World! nucleo_h563zi",
+        800_000,
+        50_000,
+    );
+}

--- a/crates/core/tests/stm32l073_walk_differential.rs
+++ b/crates/core/tests/stm32l073_walk_differential.rs
@@ -1,0 +1,33 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! STM32L073 (Cortex-M0+) executing walk-vs-scheduler fidelity differential.
+//!
+//! Closes the L073 gap: the family previously had only static register MMIO
+//! diffs (`stm32l0_mmio_diff`) with no executing/timing gate. This runs the
+//! stock Zephyr `hello_world` for `nucleo_l073rz` — whose kernel tick is driven
+//! from the Cortex SysTick and whose console output is deterministic — on the
+//! real `stm32l073` `from_config` bus, once with the SysTick/SCB/DWT + SoC
+//! timing models pinned to the legacy walk and once scheduler-driven, and
+//! asserts the boot trace + console stream are byte-identical. See
+//! `stm32_walk_free`.
+
+#![cfg(feature = "event-scheduler")]
+
+#[path = "stm32_walk_free/mod.rs"]
+mod harness;
+
+/// L073 kernel-tick (SysTick) IRQ-cadence + console differential over the real
+/// Zephyr boot.
+#[test]
+fn stm32l073_zephyr_boot_walk_vs_scheduler_is_byte_identical() {
+    harness::assert_walk_free_boot_identical(
+        "stm32l073",
+        "nucleo-l073rz",
+        "stm32l073-zephyr-hello.elf",
+        b"Hello World! nucleo_l073rz",
+        800_000,
+        50_000,
+    );
+}

--- a/crates/core/tests/stm32l476_walk_differential.rs
+++ b/crates/core/tests/stm32l476_walk_differential.rs
@@ -1,0 +1,32 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! STM32L476 (Cortex-M4) executing walk-vs-scheduler fidelity differential.
+//!
+//! Closes the L476 gap: the family previously had static register MMIO diffs
+//! (`l476_mmio_diff`) but no executing/timing gate. This runs the stock Zephyr
+//! `hello_world` for `nucleo_l476rg` — whose kernel tick is driven from the
+//! Cortex SysTick and whose console output is deterministic — on the real
+//! `stm32l476` `from_config` bus, once with the SysTick/SCB/DWT + SoC timing
+//! models pinned to the legacy walk and once scheduler-driven, and asserts the
+//! boot trace + console stream are byte-identical. See `stm32_walk_free`.
+
+#![cfg(feature = "event-scheduler")]
+
+#[path = "stm32_walk_free/mod.rs"]
+mod harness;
+
+/// L476 kernel-tick (SysTick) IRQ-cadence + console differential over the real
+/// Zephyr boot.
+#[test]
+fn stm32l476_zephyr_boot_walk_vs_scheduler_is_byte_identical() {
+    harness::assert_walk_free_boot_identical(
+        "stm32l476",
+        "nucleo-l476rg",
+        "stm32l476-zephyr-hello.elf",
+        b"Hello World! nucleo_l476rg",
+        800_000,
+        50_000,
+    );
+}


### PR DESCRIPTION
## What

Closes the STM32-family executing-fidelity coverage gaps. Adds meaningful,
byte-identical **walk-vs-scheduler** differentials — never a fake green cell —
named for the coverage ratchet (`<chip>_walk_differential.rs`).

### Executing boot differentials (new)
`stm32f401`, `stm32l073`, `stm32l476`, `stm32h563` each previously had only
static register MMIO diffs or a survival smoke test — no executing/timing gate.
Each new test runs the stock Zephyr `hello_world` for that chip on its real
`from_config` bus **twice**: SysTick/SCB/DWT + the SoC `Timer`/`Uart`/`Adc`
models pinned to the legacy per-cycle walk (reference) vs scheduler-driven, and
asserts the boot trace (`total_cycles`, PC, SRAM hash every 50k instructions)
**plus the console byte stream** are byte-identical. Because the Zephyr kernel
schedules off the SysTick IRQ cadence, equality is a genuine IRQ-cadence +
timing gate on the real boot. Shared harness in `tests/stm32_walk_free/`.

### F103 DMA executing differential (new)
`stm32f103_dma_walk_differential.rs` runs a CPU-executed memory-to-memory
transfer on the **real F103 bus** (DMA1 at silicon base `0x40020000`, clock-gated
behind `RCC_AHBENR.DMA1EN`), comparing the `Dma1` model on the legacy walk vs
scheduler-driven — full architectural state, the copied destination buffer and
the polled DMA ISR word byte-identical after every instruction, transfer
confirmed complete (TCIF1 latched). Complements the chip-agnostic mem2mem
differential by exercising the real chip DMA wiring.

## Verification
`cargo fmt` + `clippy` clean. All new + existing differential/oracle suites pass
under the `event-scheduler` feature; default-feature build compiles (tests are
`#![cfg(feature = "event-scheduler")]`).

## Notes / findings (reported, not fixed here — test-only PR)
- **F407 DMA not wired**: `configs/chips/stm32f407.yaml` declares no DMA block,
  so no config-bus DMA lab can run on F407 today. DMA executing coverage is
  therefore on F103 (which does wire DMA1).
- **Display gap N/A for STM32**: no shipped STM32 lab drives SSD1306/ILI9341
  (those systems are ESP32-only); the STM32 displays that do ship (F103 e-paper,
  L476 Nokia-5110) already have framebuffer-level tests.
- **F401 reset-value discrepancies vs RM0368** (surfaced while scoping a reset
  conformance): the model's cold-reset reads diverge from ST-documented silicon
  for several registers — `RCC_CR=0x03` (missing HSITRIM default `0x10` → ST
  `0x83`), `FLASH_ACR=0x30` (ST `0x00`), `PWR_CR=0x200` (ST `0x00`),
  `GPIOA/B_MODER=0x00` (ST SWD/JTAG defaults `0x0C000000`/`0x00000280`).
  `RCC_PLLCFGR=0x24003010` matches. Left for a separate model fix; a
  cherry-picked green subset was deliberately not shipped. Reset values are
  already ratcheted generically by `register_coverage`.
