### PR TITLE
Wire manifest external_devices on ESP32-S3 (render the SH1107 deck OLED)

### DIFF
--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -11,6 +11,27 @@ use crate::cpu::xtensa_lx7::XtensaLx7;
 use crate::peripherals::esp_xtensa_common::rom_thunks;
 use crate::Bus;
 
+/// Build an I2C-attached external device from its manifest declaration, or
+/// `None` if `ext.type` is not a known I2C device (so the caller falls through
+/// to the SPI path). The panel is addressed by `config.i2c_address` — a real
+/// board-level fact, not a builder default — so a manifest declaring an SH1107
+/// on `i2c0` at 0x3D gets exactly that, on every path that wires the manifest.
+fn build_i2c_external_device(
+    ext: &labwired_config::ExternalDevice,
+) -> Option<Box<dyn crate::peripherals::i2c::I2cDevice>> {
+    match ext.r#type.as_str() {
+        "oled-sh1107" => {
+            let addr = ext
+                .config
+                .get("i2c_address")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0x3D) as u8;
+            Some(Box::new(crate::peripherals::components::Sh1107::new(addr)))
+        }
+        _ => None,
+    }
+}
+
 /// Attach external devices declared in `manifest.external_devices` to an
 /// ESP32-classic bus that was already set up by `configure_xtensa_esp32`.
 ///
@@ -28,6 +49,22 @@ pub fn attach_esp32_external_devices(
     use crate::peripherals::spi::SpiDevice;
 
     for ext in &manifest.external_devices {
+        // I2C-attached devices are wired to an I2C controller by `connection`
+        // and addressed by `config.i2c_address` — the SPI cs_pin/dc_pin framing
+        // below is meaningless for them, so handle and `continue` first. This is
+        // how a manifest that declares an SH1107 on i2c0 gets the panel wired,
+        // instead of the builder hardcoding "every board always has one".
+        if let Some(dev) = build_i2c_external_device(ext) {
+            bus.attach_i2c_slave(&ext.connection, dev).map_err(|_| {
+                anyhow::anyhow!(
+                    "External I2C device '{}' connection '{}' is not an ESP32 I2C peripheral",
+                    ext.id,
+                    ext.connection
+                )
+            })?;
+            continue;
+        }
+
         let cs_pin = ext
             .config
             .get("cs_pin")

--- a/crates/core/tests/openai_deck_s3_boot.rs
+++ b/crates/core/tests/openai_deck_s3_boot.rs
@@ -94,11 +94,25 @@ fn openai_deck_s3_renders_and_reports_key_press() {
     let mut bus = SystemBus::new();
     let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
 
-    // Attach the SH1107 at 0x3D. The default S3 wiring already put an SSD1306 at
-    // 0x3C; adding the SH1107 at its SA0=high address keeps them collision-free
-    // (Esp32s3I2c dispatches a transaction to the first slave matching the addr).
-    bus.attach_i2c_slave("i2c0", Box::new(Sh1107::new(OLED_ADDR)))
-        .expect("attach SH1107 to i2c0");
+    // Wire the SH1107 the SAME way the app does: from the manifest's declared
+    // `external_devices`, through the generic `attach_esp32_external_devices`
+    // factory — NOT an out-of-band `attach_i2c_slave`. A pass therefore proves the
+    // real product path (app/CLI) renders the deck, not a test-only bypass.
+    let manifest: labwired_config::SystemManifest = serde_yaml::from_str(
+        r#"
+name: openai-deck-s3
+chip: esp32s3
+external_devices:
+  - id: oled
+    type: oled-sh1107
+    connection: i2c0
+    config:
+      i2c_address: 0x3D
+"#,
+    )
+    .expect("parse inline deck manifest");
+    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+        .expect("attach SH1107 from manifest");
     bus.refresh_peripheral_index();
 
     // Sink USB-Serial-JTAG for the host-protocol assertions.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -779,6 +779,13 @@ impl WasmSimulator {
         // Also capture UART0 in case a sketch uses the classic UART path.
         bus.attach_uart_tx_sink(uart_sink.clone(), false);
         let uart_rx_bufs = bus.attach_uart_rx_source();
+
+        // Wire any devices the manifest declares (e.g. an SH1107 OLED on i2c0) —
+        // the same factory the classic-ESP32 and native builder paths use. Without
+        // this, an S3 board's `external_devices` were silently dropped and the
+        // panel never rendered. Connect the blocks the manifest says are wired.
+        labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, manifest)
+            .map_err(|e| JsValue::from_str(&format!("ESP32-S3 external_devices: {:#}", e)))?;
         bus.refresh_peripheral_index();
 
         fast_boot(


### PR DESCRIPTION
## The bug (found by dogfooding via the CLI)
The ESP32-S3 fast-boot constructor (`new_from_config_xtensa_esp32s3`, the app's path) **never called `attach_esp32_external_devices`**. The classic-ESP32 path wired declared `external_devices`; S3 silently dropped them. So the OpenAI-deck SH1107 — declared on `i2c0 @ 0x3D` in its `system.yaml` — never attached, and the OLED was blank in the real app. The deck's native boot test masked this by attaching the panel out-of-band.

## The fix (connect the blocks the manifest declares — no hardcoding)
- `attach_esp32_external_devices`: new `build_i2c_external_device` wires I2C OLED type `oled-sh1107` to its declared `connection` at `config.i2c_address`. SPI e-paper path unchanged (returns `None` → falls through).
- **S3 constructor** now calls the factory after `configure_xtensa_esp32s3`, exactly like the classic-ESP32 path.
- **Deck boot test de-cheated**: attaches the SH1107 through the factory from a declared manifest, not an out-of-band `attach_i2c_slave`. A pass now proves the real app/CLI path renders.

## Safety (never break existing chips)
- `system::xtensa` unit tests: 13/13 (SPI e-paper attach unaffected).
- Existing S3 configs: `esp32s3-zero` / `spice-dispenser` declare no devices (no-op); `esp32s3-oled-demo`'s SSD1306 still renders via the pre-existing `0x3C` hardcode (untested standalone config, not app-loaded).
- Deck boot test green; `cargo check -p labwired-wasm` green.

Follow-up debt (not in scope): the unconditional `SSD1306@0x3C` hardcode in `configure_xtensa_esp32s3` is the older smell; migrating it to the manifest factory is a separate change.