### PR TITLE
fix(stm32f401cdu6): reset-value parity with stm32f401 (SVD-correct GPIO/FLASH/PWR)

### DIFF
--- a/configs/chips/stm32f401cdu6.yaml
+++ b/configs/chips/stm32f401cdu6.yaml
@@ -92,9 +92,13 @@ peripherals:
     size: "1KB"
     irq: 72
   - id: "pwr"
-    type: "stub"
+    type: "pwr"
     base_address: 0x40007000
     size: "1KB"
+    config:
+      # F4 PWR (RM0368 §5.4): only PWR_CR/PWR_CSR exist, both reset 0. The
+      # default L4 model surfaced CR1=0x200 / CR3=0x8000 and phantom PUCRx regs.
+      profile: "stm32f4"
   - id: "tim1"
     type: "timer"
     base_address: 0x40010000
@@ -160,9 +164,14 @@ peripherals:
     base_address: 0x40023000
     size: "1KB"
   - id: "flash_ctrl"
-    type: "stub"
+    type: "flash"
     base_address: 0x40023C00
     size: "1KB"
+    config:
+      # F4 embedded-flash interface (RM0368 §3.8): ACR reset 0 (no F1-style
+      # prefetch default), CR LOCK at bit 31, OPTCR present. The F1 profile's
+      # 0x30 ACR default and bit-7 LOCK are silicon-wrong for F401.
+      profile: "stm32f4"
   - id: "dma1"
     type: "stub"
     base_address: 0x40026000
@@ -177,12 +186,19 @@ peripherals:
     size: "1KB"
     config:
       profile: "stm32v2"
+      # SWD/JTAG defaults (RM0368 §8.4 / STM32F401 SVD): PA13/14/15 in AF mode.
+      reset_moder: 0xA8000000
+      reset_pupdr: 0x64000000
   - id: "gpiob"
     type: "gpio"
     base_address: 0x40020400
     size: "1KB"
     config:
       profile: "stm32v2"
+      # JTAG defaults (RM0368 §8.4 / STM32F401 SVD): PB3 (JTDO/SWO), PB4 (NJTRST).
+      reset_moder: 0x00000280
+      reset_ospeedr: 0x000000C0
+      reset_pupdr: 0x00000100
   - id: "gpioc"
     type: "gpio"
     base_address: 0x40020800


### PR DESCRIPTION
Follow-up flagged by #581: the BlackPill variant descriptor `configs/chips/stm32f401cdu6.yaml` was left behind when `stm32f401.yaml` had its cold-reset values corrected to the ST CMSIS SVD. Both describe the same F401 silicon, so they should model it identically.

## Changes (one file)
- `flash_ctrl`: `type: stub` → real `flash` model with the `stm32f4` profile. The F1 profile's ACR=0x30 default and bit-7 LOCK are silicon-wrong for F401 (RM0368 §3.8: ACR reset 0, CR LOCK at bit 31, OPTCR present).
- `pwr`: `type: stub` → real `pwr` model with the `stm32f4` profile. The default L4 model surfaced CR1=0x200 / CR3=0x8000 and phantom PUCRx registers; F4 has only PWR_CR/PWR_CSR, both reset 0 (RM0368 §5.4).
- `gpioa`: SWD/JTAG reset defaults `reset_moder: 0xA8000000`, `reset_pupdr: 0x64000000` (PA13/14/15 in AF mode).
- `gpiob`: JTAG defaults `reset_moder: 0x00000280`, `reset_ospeedr: 0x000000C0`, `reset_pupdr: 0x00000100` (PB3 JTDO/SWO, PB4 NJTRST).

Note the stub→real promotion is a fidelity gain beyond reset values: writes to FLASH/PWR now hit modelled registers instead of being silently swallowed. `stm32f401cdu6` backs a shipped lab (`stm32f401cdu6-blackpill`), so that path was exercised specifically.

## Verification
- `cargo test -p labwired-core --lib` — 1947 passed
- `cargo test -p labwired-core stm32f401` — passed
- `strict_onboarding` (boots every onboarded board incl. the BlackPill) — passed
- `board_coverage_ratchet` — passed
- `generate_validation_status.py --check --drift` — clean, no drift_ack needed
- `cargo fmt --check` — clean

Refs #576.