### PR TITLE
No hardcoded I2C slaves on ESP32-S3 — wire off-chip devices from the manifest

### DIFF
--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -19,15 +19,24 @@ use crate::Bus;
 fn build_i2c_external_device(
     ext: &labwired_config::ExternalDevice,
 ) -> Option<Box<dyn crate::peripherals::i2c::I2cDevice>> {
+    let addr = |default: u8| {
+        ext.config
+            .get("i2c_address")
+            .and_then(|v| v.as_u64())
+            .map(|a| a as u8)
+            .unwrap_or(default)
+    };
     match ext.r#type.as_str() {
-        "oled-sh1107" => {
-            let addr = ext
-                .config
-                .get("i2c_address")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0x3D) as u8;
-            Some(Box::new(crate::peripherals::components::Sh1107::new(addr)))
-        }
+        "oled-sh1107" => Some(Box::new(crate::peripherals::components::Sh1107::new(addr(
+            0x3D,
+        )))),
+        "oled-ssd1306" => Some(Box::new(crate::peripherals::components::Ssd1306::new(
+            addr(0x3C),
+        ))),
+        "tmp102" => Some(Box::new(crate::peripherals::esp32s3::tmp102::Tmp102::new())),
+        "pca9685" => Some(Box::new(
+            crate::peripherals::components::pca9685::Pca9685::new(),
+        )),
         _ => None,
     }
 }

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -11,7 +11,6 @@ use crate::peripherals::esp32s3::flash_xip::{new_mmu_table, Esp32s3MmuTable, Fla
 use crate::peripherals::esp32s3::gpio::{Esp32s3Gpio, GpioObserver};
 use crate::peripherals::esp32s3::i2c::{Esp32s3I2c, I2C0_BASE, I2C0_SIZE};
 use crate::peripherals::esp32s3::intmatrix::Esp32s3IntMatrix;
-use crate::peripherals::esp32s3::tmp102::Tmp102;
 use crate::peripherals::esp_xtensa_common::rom_thunks::{self, RomThunkBank};
 use crate::peripherals::esp_xtensa_common::system_stub::{EfuseStub, RtcCntlStub, SystemStub};
 use crate::{Bus, Cpu};
@@ -625,35 +624,12 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
         bus.add_peripheral(id, base, size, None, dev);
     }
 
-    // I2C0 carries board-specific I2C slaves the factory does not model: TMP102
-    // always, an SSD1306 OLED @ 0x3C always, plus an opt-in PCA9685
-    // (LABWIRED_ESP32S3_PCA9685) for the SpiceDispenser servos. Built directly
-    // so the slaves are attached.
+    // Register the on-chip I2C0 controller. Off-chip I2C slaves (TMP102, SSD1306,
+    // SH1107, PCA9685, …) are NOT attached here — they are wired from the board
+    // manifest's `external_devices` by `attach_esp32_external_devices`, the same
+    // way real hardware is: the board says what's on the bus, not the SoC config.
     let i2c0 = Esp32s3I2c::new();
-    // Register first, then attach every slave through the single bus choke point
-    // so each is wrapped into the shared bus trace (universal logic analyzer) —
-    // no per-callsite set_bus_trace ordering to get wrong.
     bus.add_peripheral("i2c0", I2C0_BASE as u64, I2C0_SIZE, None, Box::new(i2c0));
-    bus.attach_i2c_slave("i2c0", Box::new(Tmp102::new()))
-        .expect("i2c0 just registered as Esp32s3I2c");
-    // SSD1306 128x64 OLED @ 0x3C. Mirrors the TMP102 "always attached" pattern:
-    // the panel sits inert at its distinct address until firmware initializes
-    // and draws to it (the S3 OLED lab does; hello-world never addresses 0x3C,
-    // so its framebuffer stays blank and no board_io binding reads it back).
-    // Distinct address from TMP102 (0x48)/PCA9685 (0x40), so no bus contention.
-    bus.attach_i2c_slave(
-        "i2c0",
-        Box::new(crate::peripherals::components::Ssd1306::new(0x3C)),
-    )
-    .expect("i2c0 just registered as Esp32s3I2c");
-    if std::env::var("LABWIRED_ESP32S3_PCA9685").is_ok() {
-        bus.attach_i2c_slave(
-            "i2c0",
-            Box::new(crate::peripherals::components::pca9685::Pca9685::new()),
-        )
-        .expect("i2c0 just registered as Esp32s3I2c");
-        eprintln!("configure_xtensa_esp32s3: attached PCA9685 @ 0x40 on I2C0");
-    }
 }
 
 /// Register the default thunk set for esp-hal hello-world boot.

--- a/crates/core/src/system/xtensa/mod.rs
+++ b/crates/core/src/system/xtensa/mod.rs
@@ -454,13 +454,36 @@ mod tests {
     }
 
     #[test]
-    fn configure_registers_i2c0_with_tmp102_attached() {
+    fn configure_registers_i2c0_and_factory_attaches_manifest_tmp102() {
         let mut bus = SystemBus::new();
         let _wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
 
         // I2C0 should be present at 0x6001_3000.
         let names: Vec<_> = bus.peripherals.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"i2c0"), "i2c0 missing; have: {names:?}");
+
+        // The TMP102 is NOT hardcoded by the builder — it is wired from the board
+        // manifest's external_devices through the generic factory, exactly as the
+        // app/CLI do. Declare it, attach it, then probe below.
+        let manifest = labwired_config::SystemManifest {
+            walk_deleted: Some(false),
+            schema_version: "1.0".to_string(),
+            name: "test-s3-tmp102".to_string(),
+            chip: "esp32s3.yaml".to_string(),
+            memory_overrides: std::collections::HashMap::new(),
+            peripherals: vec![],
+            external_devices: vec![labwired_config::ExternalDevice {
+                id: "tmp102".to_string(),
+                r#type: "tmp102".to_string(),
+                connection: "i2c0".to_string(),
+                route: Default::default(),
+                config: std::collections::HashMap::new(),
+            }],
+            board_io: vec![],
+            debug_uart: None,
+        };
+        attach_esp32_external_devices(&mut bus, &manifest)
+            .expect("attach TMP102 from manifest must succeed");
 
         // The attached TMP102 should respond at address 0x48 by setting
         // INT_NACK to 0 after a one-byte write probe.

--- a/crates/core/tests/e2e_i2c_tmp102.rs
+++ b/crates/core/tests/e2e_i2c_tmp102.rs
@@ -62,6 +62,23 @@ fn i2c_tmp102_firmware_runs_and_prints_temperature() {
     let mut bus = SystemBus::new();
     let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
 
+    // Wire the TMP102 from a board manifest through the generic factory — the
+    // same path app/CLI use — instead of relying on a hardcoded builder attach.
+    let manifest: labwired_config::SystemManifest = serde_yaml::from_str(
+        r#"
+name: esp32s3-tmp102
+chip: esp32s3
+external_devices:
+  - id: tmp102
+    type: tmp102
+    connection: i2c0
+"#,
+    )
+    .expect("parse tmp102 manifest");
+    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+        .expect("attach TMP102 from manifest");
+    bus.refresh_peripheral_index();
+
     let obs = Arc::new(RecordingObserver::default());
     wiring.add_gpio_observer(&mut bus, obs.clone());
 

--- a/crates/core/tests/esp32s3_oled_profile.rs
+++ b/crates/core/tests/esp32s3_oled_profile.rs
@@ -166,6 +166,10 @@ fn build_machine(
 
     let mut bus = SystemBus::new();
     let wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+    // Wire the manifest's declared SSD1306 through the generic factory (no
+    // hardcoded builder attach) — the manifest is esp32s3-oled-demo.yaml.
+    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, manifest)
+        .expect("attach S3 OLED from manifest");
     let serial = Arc::new(Mutex::new(Vec::new()));
 
     for peripheral in &mut bus.peripherals {

--- a/crates/core/tests/esp32s3_ssd1306_differential.rs
+++ b/crates/core/tests/esp32s3_ssd1306_differential.rs
@@ -54,10 +54,27 @@ fn cmd(opcode: u32, byte_num: u8) -> u32 {
     ((opcode & 0x7) << 11) | u32::from(byte_num)
 }
 
-/// Assemble the same bus the browser twin boots (SSD1306 attached @ 0x3C).
+/// Assemble the same bus the browser twin boots. The SSD1306 @ 0x3C is wired
+/// from the board manifest through `attach_esp32_external_devices` — the SAME
+/// path the app/CLI use — not a hardcoded builder attach.
 fn build_bus() -> SystemBus {
     let mut bus = SystemBus::new();
     let _wiring = configure_xtensa_esp32s3(&mut bus, &Esp32s3Opts::default());
+    let manifest: labwired_config::SystemManifest = serde_yaml::from_str(
+        r#"
+name: esp32s3-ssd1306
+chip: esp32s3
+external_devices:
+  - id: oled
+    type: oled-ssd1306
+    connection: i2c0
+    config:
+      i2c_address: 0x3C
+"#,
+    )
+    .expect("parse ssd1306 manifest");
+    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+        .expect("attach SSD1306 from manifest");
     bus.refresh_peripheral_index();
     bus
 }

--- a/examples/spice-dispenser/VALIDATION.md
+++ b/examples/spice-dispenser/VALIDATION.md
@@ -26,7 +26,8 @@ bootloader, and the app entry jump.
 
 After `entry 0x403c88b8`, the model boots the full ESP-IDF/Arduino app: ROM
 `memory_layout` bring-up, the SMP scheduler, `Wire`/`i2c_master` init, and the
-dispense loop. Attaching the PCA9685 twin (`LABWIRED_ESP32S3_PCA9685=1`):
+dispense loop. Attaching the PCA9685 twin (run with `--system system-pca9685.yaml`,
+which declares the expander so the factory wires it):
 
 - **Real hardware (bare board, no PCA9685):** the dispense loop logs
   `i2c_master_transmit failed: ESP_ERR_INVALID_STATE` — the real driver runs but

--- a/examples/spice-dispenser/system-pca9685.yaml
+++ b/examples/spice-dispenser/system-pca9685.yaml
@@ -1,0 +1,21 @@
+# LabWired — SpiceDispenser board WITH the PCA9685 twin attached.
+#
+# Same board as system.yaml, but the PCA9685 I2C PWM expander is declared as an
+# external device so the factory wires it (replaces the old
+# LABWIRED_ESP32S3_PCA9685=1 env hack — no builder-baked attach).
+#
+# Two validation states, both manifest-driven:
+#   system.yaml           — bare board, no expander: the driver logs
+#                           i2c_master_transmit ESP_ERR_INVALID_STATE (matches
+#                           real hardware with no PCA9685 populated).
+#   system-pca9685.yaml    — expander present: the dispense loop's I2C writes ACK.
+name: "spice-dispenser-pca9685"
+chip: "../../configs/chips/esp32s3-zero.yaml"
+
+# ESP32-S3 GPIO5 (SDA) / GPIO6 (SCL) --> PCA9685 @ I2C 0x40, 400 kHz, 50 Hz PWM.
+external_devices:
+  - id: "pca9685"
+    type: "pca9685"
+    connection: "i2c0"
+    config:
+      i2c_address: 0x40


### PR DESCRIPTION
`configure_xtensa_esp32s3` unconditionally attached a TMP102, an SSD1306 @ 0x3C, and an env-gated PCA9685 — off-chip devices baked into the SoC config. This removes all three: the builder now registers only the on-chip I2C0 controller, and every off-chip I2C slave is wired from the board manifest's `external_devices` through `attach_esp32_external_devices` — like real hardware, the board declares what's on the bus, not the chip config.

## Changes
- `build_i2c_external_device` maps `oled-sh1107`, `oled-ssd1306`, `tmp102`, `pca9685` → I2C slave at the declared address.
- Every dependent migrated to declare its device via the factory: `esp32s3_ssd1306_differential`, `e2e_i2c_tmp102`, `esp32s3_oled_profile`, and the `configure_registers_*` unit test.
- spice-dispenser: new `system-pca9685.yaml` variant declares the expander (replaces the `LABWIRED_ESP32S3_PCA9685` env hack).

## Verified (never break existing chips)
- `system::xtensa` lib tests 13/13 (SPI e-paper attach path unchanged).
- `esp32s3_ssd1306_differential` 2/2; `configure_registers_…_tmp102` factory probe ACKs; deck boot test renders the SH1107.
- No app-loaded S3 lab relied on the hardcodes (only the deck uses an S3 OLED and it declares SH1107).
- `e2e_i2c_tmp102` was **already red on pristine main** (empty JTAG; esp-hal I2C driver hangs in the manual-step harness, 640s) — confirmed by a stash-and-baseline run; this refactor doesn't change that.

Builds on #583 (which taught the S3 fast-boot path to wire external_devices at all).