### PR TITLE
OpenAI Deck pots: knob → temperature, fader → max-tokens (SENS ADC injection)

### DIFF
--- a/crates/core/src/peripherals/esp32s3/sens.rs
+++ b/crates/core/src/peripherals/esp32s3/sens.rs
@@ -113,9 +113,14 @@ const MEAS_START_SAR: u32 = 1 << 17;
 const MEAS_DONE_SAR: u32 = 1 << 16;
 /// `SENS_MEAS*_DATA_SAR` (bits [15:0], RO) — conversion result.
 const MEAS_DATA_MASK: u32 = 0x0000_FFFF;
-/// Fixed plausible reading latched on every oneshot: mid-scale of the 12-bit
-/// SAR range. Deterministic — LabWired runs must be reproducible.
+/// Fixed plausible reading latched on an oneshot when no analog source is
+/// injected on the selected channel: mid-scale of the 12-bit SAR range.
+/// Deterministic — LabWired runs must be reproducible.
 const MEAS_DATA_FIXED: u32 = 0x800;
+/// `SENS_SAR1_EN_PAD` (bits [30:19] of `SAR_MEAS1_CTRL2`) — the 12-bit channel
+/// enable mask esp-hal sets to `1 << channel` before launching a oneshot.
+const SAR1_EN_PAD_S: u32 = 19;
+const SAR1_EN_PAD_M: u32 = 0x0FFF;
 
 /// One word past the last architected register (`SAR_SARDATE` @ 0x1FC).
 const NWORDS: usize = 0x200 / 4;
@@ -173,6 +178,12 @@ pub struct Esp32s3Sens {
     /// Register file for the architected map (word-indexed; holes stay 0 and
     /// are never read back — `spec()` gates both directions).
     regs: [u32; NWORDS],
+    /// Per-ADC1-channel injected 12-bit counts (CH0..9 = GPIO1..10). `0xFFFF` =
+    /// "no injection" → fall back to `MEAS_DATA_FIXED`. A potentiometer/analog
+    /// source writes its wiper here so `analogRead()` returns a controllable,
+    /// position-driven value instead of the fixed mid-scale placeholder. This is
+    /// the SENS path esp-hal's ESP32-S3 ADC oneshot actually reads.
+    channel_inputs: [u16; 10],
 }
 
 impl std::fmt::Debug for Esp32s3Sens {
@@ -202,7 +213,20 @@ impl Esp32s3Sens {
             }
             w += 1;
         }
-        Self { regs }
+        Self {
+            regs,
+            channel_inputs: [0xFFFF; 10],
+        }
+    }
+
+    /// Inject a millivolt reading for an ADC1 channel (CH0..9 = GPIO1..10). The
+    /// next SENS oneshot that selects this channel returns the equivalent 12-bit
+    /// count (3.3 V Vref) instead of the fixed mid-scale placeholder.
+    pub fn set_channel_input(&mut self, channel: u8, millivolts: u16) {
+        if (channel as usize) < self.channel_inputs.len() {
+            let count = ((millivolts as u32 * 4095) / 3300).min(4095) as u16;
+            self.channel_inputs[channel as usize] = count;
+        }
     }
 
     fn reg(&self, off: u64) -> u32 {
@@ -242,11 +266,30 @@ impl Esp32s3Sens {
         self.set_reg_masked(off, value);
         let stored = self.reg(off);
         let updated = if value & MEAS_START_SAR != 0 {
-            (stored & !MEAS_DATA_MASK) | MEAS_DONE_SAR | MEAS_DATA_FIXED
+            (stored & !MEAS_DATA_MASK) | MEAS_DONE_SAR | self.meas_data(off, stored)
         } else {
             stored & !MEAS_DONE_SAR
         };
         self.set_reg_raw(off, updated);
+    }
+
+    /// The 12-bit result to latch for a oneshot on `off`: the injected value for
+    /// the selected ADC1 channel if one is set, else the fixed mid-scale sample.
+    /// Only ADC1 (`SAR_MEAS1_CTRL2`) carries per-channel injection today; ADC2
+    /// keeps the fixed placeholder.
+    fn meas_data(&self, off: u64, stored: u32) -> u32 {
+        if off != SAR_MEAS1_CTRL2 {
+            return MEAS_DATA_FIXED;
+        }
+        let en_pad = (stored >> SAR1_EN_PAD_S) & SAR1_EN_PAD_M;
+        if en_pad == 0 {
+            return MEAS_DATA_FIXED;
+        }
+        let channel = en_pad.trailing_zeros() as usize;
+        match self.channel_inputs.get(channel) {
+            Some(&c) if c != 0xFFFF => (c as u32) & MEAS_DATA_MASK,
+            _ => MEAS_DATA_FIXED,
+        }
     }
 }
 

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -41,6 +41,24 @@ fn build_i2c_external_device(
     }
 }
 
+/// Seed an ESP32-S3 ADC1 channel's injected input (12-bit-count-from-mV) on the
+/// SENS controller — the register path esp-hal's S3 ADC oneshot reads. Returns
+/// false if the bus has no S3 SENS block (e.g. a classic-ESP32 bus), so the
+/// caller can warn rather than silently drop the declaration.
+fn seed_sar_adc_channel(bus: &mut SystemBus, channel: u8, millivolts: u16) -> bool {
+    let Some(idx) = bus.find_peripheral_index_by_name("sens_s3") else {
+        return false;
+    };
+    let Some(any) = bus.peripherals[idx].dev.as_any_mut() else {
+        return false;
+    };
+    let Some(sens) = any.downcast_mut::<crate::peripherals::esp32s3::sens::Esp32s3Sens>() else {
+        return false;
+    };
+    sens.set_channel_input(channel, millivolts);
+    true
+}
+
 /// Attach external devices declared in `manifest.external_devices` to an
 /// ESP32-classic bus that was already set up by `configure_xtensa_esp32`.
 ///
@@ -71,6 +89,32 @@ pub fn attach_esp32_external_devices(
                     ext.connection
                 )
             })?;
+            continue;
+        }
+
+        // Potentiometer: an analog wiper on a SAR-ADC channel. It is not a bus
+        // slave — it seeds the ADC channel's injected value from its declared
+        // position, so `analogRead()` on that channel returns the wiper voltage.
+        if ext.r#type == "potentiometer" {
+            let channel = ext
+                .config
+                .get("channel")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u8;
+            let position_pct = ext
+                .config
+                .get("initial_position_pct")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(50.0) as f32;
+            let mv = crate::peripherals::components::Potentiometer::new(channel, position_pct)
+                .wiper_output_mv();
+            if !seed_sar_adc_channel(bus, channel, mv) {
+                tracing::warn!(
+                    "potentiometer '{}': no ESP32-S3 SAR ADC on the bus to seed channel {}; skipping",
+                    ext.id,
+                    channel
+                );
+            }
             continue;
         }
 

--- a/crates/core/tests/openai_deck_s3_boot.rs
+++ b/crates/core/tests/openai_deck_s3_boot.rs
@@ -108,6 +108,18 @@ external_devices:
     connection: i2c0
     config:
       i2c_address: 0x3D
+  - id: knob
+    type: potentiometer
+    connection: sar_adc_s3
+    config:
+      channel: 0
+      initial_position_pct: 60.0
+  - id: fader
+    type: potentiometer
+    connection: sar_adc_s3
+    config:
+      channel: 1
+      initial_position_pct: 40.0
 "#,
     )
     .expect("parse inline deck manifest");
@@ -197,6 +209,15 @@ external_devices:
     assert!(
         saw_key && text.contains("KEY1 PRESS action=SLOT1"),
         "expected a 'KEY1 PRESS action=SLOT1' line after pressing GPIO{KEY1_GPIO}; serial:\n{text}"
+    );
+
+    // The two pots are seeded from the manifest (knob 60 %, fader 40 %) through
+    // the SENS ADC, and the firmware's analogRead maps them: knob → temperature,
+    // fader → max-tokens. Exact values prove the manifest→factory→SENS→firmware
+    // path, not a mid-scale placeholder (0x800 → temp=1.00 max_tokens=2048).
+    assert!(
+        text.contains("PARAMS knob_raw=2457 fader_raw=1638 temp=1.20 max_tokens=1638"),
+        "expected the pot-driven PARAMS line (knob 60 %, fader 40 %); serial:\n{text}"
     );
 
     let lit_after_press = oled_lit_pixels(&bus);

--- a/examples/openai-deck-s3/Cargo.lock
+++ b/examples/openai-deck-s3/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "esp-backtrace",
  "esp-hal",
  "esp-println",
+ "nb 1.1.0",
 ]
 
 [[package]]

--- a/examples/openai-deck-s3/Cargo.toml
+++ b/examples/openai-deck-s3/Cargo.toml
@@ -15,6 +15,7 @@ esp-hal       = { version = "1.1", features = ["esp32s3", "unstable"] }
 esp-println   = { version = "0.17", default-features = false, features = ["esp32s3", "jtag-serial", "colors", "critical-section"] }
 esp-backtrace = { version = "0.19", features = ["esp32s3", "panic-handler", "println"] }
 critical-section = "1.2"
+nb            = "1.1"
 
 [profile.release]
 opt-level     = "s"

--- a/examples/openai-deck-s3/src/main.rs
+++ b/examples/openai-deck-s3/src/main.rs
@@ -32,6 +32,7 @@
 
 use esp_backtrace as _;
 use esp_hal::{
+    analog::adc::{Adc, AdcConfig, Attenuation},
     gpio::{Input, InputConfig},
     i2c::master::{Config as I2cConfig, I2c},
     main,
@@ -252,6 +253,27 @@ fn main() -> ! {
     oled_init(&mut i2c);
     render_deck(&mut i2c);
     println!("openai-deck-s3: OLED ready");
+
+    // Two analog controls: a rotary knob (temperature) and a slide fader
+    // (max-tokens), read once at startup off ADC1. Knob = GPIO1 (ADC1_CH0),
+    // fader = GPIO2 (ADC1_CH1) — free pins (keys use 4-7/10-15, I²C uses 8/9).
+    let mut adc_cfg = AdcConfig::new();
+    let mut knob = adc_cfg.enable_pin(p.GPIO1, Attenuation::_11dB);
+    let mut fader = adc_cfg.enable_pin(p.GPIO2, Attenuation::_11dB);
+    let mut adc1 = Adc::new(p.ADC1, adc_cfg);
+    let knob_raw: u16 = nb::block!(adc1.read_oneshot(&mut knob)).unwrap();
+    let fader_raw: u16 = nb::block!(adc1.read_oneshot(&mut fader)).unwrap();
+    // Map: knob → temperature 0.00..2.00; fader → max_tokens 0..4096.
+    let temp_centi = (knob_raw as u32 * 200) / 4095;
+    let max_tokens = (fader_raw as u32 * 4096) / 4095;
+    println!(
+        "PARAMS knob_raw={} fader_raw={} temp={}.{:02} max_tokens={}",
+        knob_raw,
+        fader_raw,
+        temp_centi / 100,
+        temp_centi % 100,
+        max_tokens,
+    );
 
     // Edge-detected polling loop. On a rising edge emit the host-protocol line
     // and highlight the cell; on a falling edge redraw the cell normally.

--- a/examples/openai-deck-s3/system.yaml
+++ b/examples/openai-deck-s3/system.yaml
@@ -14,14 +14,32 @@ name: "openai-deck-s3"
 chip: "../../configs/chips/esp32s3.yaml"
 
 external_devices:
-  # SH1107 128x128 OLED on I2C0 at 0x3D (SA0=high). Attached by the native test
-  # harness to the command-list Esp32s3I2c at i2c0; the firmware's register-level
-  # driver drives it with genuine I2C transactions.
+  # SH1107 128x128 OLED on I2C0 at 0x3D (SA0=high). Wired from this manifest by
+  # attach_esp32_external_devices; the firmware's register-level driver drives it
+  # with genuine I2C transactions.
   - id: "oled"
     type: "oled-sh1107"
     connection: "i2c0"
     config:
       i2c_address: 0x3D
+
+  # Rotary knob → temperature. A potentiometer wiper on ADC1 channel 0 (GPIO1).
+  # attach_esp32_external_devices seeds the SAR-ADC channel from the position, so
+  # the firmware's analogRead() returns the wiper voltage.
+  - id: "knob"
+    type: "potentiometer"
+    connection: "sar_adc_s3"
+    config:
+      channel: 0
+      initial_position_pct: 60.0
+
+  # Slide fader → max-tokens. A potentiometer wiper on ADC1 channel 1 (GPIO2).
+  - id: "fader"
+    type: "potentiometer"
+    connection: "sar_adc_s3"
+    config:
+      channel: 1
+      initial_position_pct: 40.0
 
 board_io:
   # Framebuffer readback binding. The S3 GPIO matrix routes I2C0 SDA/SCL to


### PR DESCRIPTION
Milestone 2 — the deck reads two analog controls off ADC1 and maps them to OpenAI params.

## The interesting bit
esp-hal's ESP32-S3 ADC oneshot reads its result from **`SENS.SAR_MEAS1_CTRL2`** (the RTC/SENS path), **not** the DIG `APB_SARADC` controller. So the SENS model was returning a fixed mid-scale `0x800` placeholder for every read. Per-channel injection therefore lives in the SENS model: a started oneshot latches the injected count for the channel selected in `SAR1_EN_PAD`, else the placeholder (so runs with no analog source are unchanged — existing SENS tests still see `0x800`).

## Changes
- `sens.rs`: `set_channel_input` + per-channel injected value in `write_meas_ctrl2`.
- `attach_esp32_external_devices`: a `potentiometer` external_device seeds its SENS channel from `initial_position_pct`.
- Firmware: read GPIO1 (knob) + GPIO2 (fader) via esp-hal ADC, map knob→temperature 0.00..2.00, fader→max_tokens 0..4096, print `PARAMS …`.
- `system.yaml`: knob (ch0, 60 %) + fader (ch1, 40 %).
- Boot test: seed both pots from the manifest, assert the exact mapped line.

## Verified
Native boot test + `labwired test` + `labwired_run` through the MCP all show `PARAMS knob_raw=2457 fader_raw=1638 temp=1.20 max_tokens=1638`. Regression: xtensa 13, sens 8, potentiometer 4, sar_adc 20 green.