### PR TITLE
fix(nrf54l15): GRTC compare-match IRQ — unmodified Zephyr's tickless kernel runs in the sim

### DIFF
--- a/configs/chips/nrf54l15.yaml
+++ b/configs/chips/nrf54l15.yaml
@@ -255,10 +255,15 @@ peripherals:
   # cc-num = 12 comes from the Zephyr DT node `grtc@e2000` and matches the MDK
   # `GRTC_CC_MaxCount`.
   #
-  # IRQ: the MDK IRQn table gives GRTC_0..GRTC_3 = 226..229. The Zephyr DT node
-  # carries no `interrupts` property (the per-CPU group is picked by
-  # GRTC_IRQ_GROUP in the nrfx config), so GRTC_0 is mapped here and the model
-  # collapses all four interrupt groups onto it. Needs bench confirmation.
+  # IRQ: the MDK IRQn table gives GRTC_0..GRTC_3 = 226..229 — FOUR independent
+  # interrupt lines, one per INTEN group. `irq` below is GRTC_0 (the base); the
+  # model routes a compare enabled in INTEN group `g` to GRTC_g = irq + g. This
+  # is load-bearing: nrfx on the secure app core sets `GRTC_IRQ_GROUP = 2`
+  # (nrf54l15 MDK interim header), enables the kernel-tick compare via INTENSET2,
+  # and connects `DT_IRQN(GRTC_NODE)` = GRTC_2 = 228 (the first entry of the
+  # resolved cpuapp devicetree `interrupts`). Collapsing all groups onto GRTC_0
+  # (226) — which Zephyr never enables in the NVIC — left the tickless kernel
+  # tick permanently undelivered, so the model must pend the group's own line.
   - id: "grtc"
     type: "nrf54l_grtc"
     base_address: 0x500E2000

--- a/crates/core/src/peripherals/nrf54l/factory.rs
+++ b/crates/core/src/peripherals/nrf54l/factory.rs
@@ -37,9 +37,16 @@ pub fn try_build(
                 .and_then(|v| v.as_u64())
                 .map(|n| n as usize)
                 .unwrap_or(12);
-            Box::new(crate::peripherals::nrf54l::grtc::Nrf54lGrtc::new_with_cc(
-                num_cc,
-            ))
+            // The chip profile's `irq` is GRTC_0's NVIC position; the model
+            // routes INTEN group `g` to `irq + g` (GRTC_0..3). nrfx on the
+            // secure app core enables the kernel tick in group 2 and expects it
+            // on GRTC_2 = irq + 2, so this base MUST reach the model.
+            let irq_base = p_cfg
+                .irq
+                .unwrap_or(crate::peripherals::nrf54l::grtc::GRTC_IRQ_BASE_DEFAULT);
+            Box::new(
+                crate::peripherals::nrf54l::grtc::Nrf54lGrtc::new_with_cc_and_irq(num_cc, irq_base),
+            )
         }
         "nrf54l_uarte" => Box::new(crate::peripherals::nrf54l::uarte::Nrf54lUarte::new()),
         "nrf54l_twim" => {

--- a/crates/core/src/peripherals/nrf54l/grtc.rs
+++ b/crates/core/src/peripherals/nrf54l/grtc.rs
@@ -159,6 +159,17 @@ pub const CPU_HZ_DEFAULT: u32 = 128_000_000;
 /// sets this to 1 so small tick counts advance the counter.
 pub const CYCLES_PER_SYSCOUNTER_TICK: u32 = CPU_HZ_DEFAULT / SYSCOUNTER_HZ;
 
+/// NVIC position of GRTC_0 on the nRF54L15 application core (MDK IRQn table:
+/// GRTC_0..GRTC_3 = 226..229). The four INTEN groups drive four *independent*
+/// interrupt lines: a compare enabled in INTEN group `g` asserts GRTC_`g` =
+/// `GRTC_IRQ_BASE + g`. Zephyr/nrfx on the secure app core uses
+/// `GRTC_IRQ_GROUP = 2` (nrf54l15 MDK interim header), so the kernel tick
+/// compare is enabled via INTENSET2 and delivered on GRTC_2 = 228 — which is
+/// exactly the first entry of the resolved devicetree `interrupts` property
+/// and the line `DT_IRQN(GRTC_NODE)` connects. Routing the generic peripheral
+/// IRQ (GRTC_0 = 226) instead left the tick permanently undelivered.
+pub const GRTC_IRQ_BASE_DEFAULT: u32 = 226;
+
 /// Nordic nRF54L GRTC — behavioural SYSCOUNTER + compare-channel model.
 #[derive(Debug)]
 pub struct Nrf54lGrtc {
@@ -195,6 +206,12 @@ pub struct Nrf54lGrtc {
     /// INTEN[0..3] — one enable word per interrupt group.
     inten: [u32; NUM_INT_GROUPS],
 
+    /// NVIC position of GRTC_0. Interrupt group `g` pends `irq_base + g` (the
+    /// four GRTC lines are independent). Taken from the chip profile's `irq`
+    /// field so the model never hard-codes a family constant; defaults to
+    /// [`GRTC_IRQ_BASE_DEFAULT`] (226) for the nRF54L15 app core.
+    irq_base: u32,
+
     // Config/state registers with no modelled behaviour: written by drivers,
     // read back verbatim.
     shorts: u32,
@@ -229,6 +246,7 @@ impl Default for Nrf54lGrtc {
             cc_en: [0u32; MAX_CC],
             events_compare: [0u32; MAX_CC],
             inten: [0u32; NUM_INT_GROUPS],
+            irq_base: GRTC_IRQ_BASE_DEFAULT,
             shorts: 0,
             evten: 0,
             mode: 0,
@@ -254,6 +272,18 @@ impl Nrf54lGrtc {
     pub fn new_with_cc(num_cc: usize) -> Self {
         Self {
             num_cc: num_cc.clamp(1, MAX_CC),
+            ..Self::default()
+        }
+    }
+
+    /// Construct with an explicit CC count and the NVIC position of GRTC_0
+    /// (interrupt group `g` pends `irq_base + g`). The chip profile's `irq`
+    /// field feeds `irq_base`; falls back to [`GRTC_IRQ_BASE_DEFAULT`] when the
+    /// profile omits it.
+    pub fn new_with_cc_and_irq(num_cc: usize, irq_base: u32) -> Self {
+        Self {
+            num_cc: num_cc.clamp(1, MAX_CC),
+            irq_base,
             ..Self::default()
         }
     }
@@ -367,7 +397,13 @@ impl Nrf54lGrtc {
         self.cycle_accum %= self.cycles_per_tick;
         self.counter = self.counter.wrapping_add(increments) & COUNTER_MASK;
 
-        let mut irq = false;
+        // Each INTEN group drives an independent GRTC line (GRTC_g =
+        // irq_base + g), so a fired compare pends the line of *every* group
+        // whose enable bit is set — not one collapsed generic IRQ. nrfx on the
+        // secure app core enables the kernel-tick compare in group 2, so the
+        // tick is delivered on GRTC_2; collapsing all groups onto GRTC_0 left
+        // it undelivered. Accumulate per group and de-dup into explicit_irqs.
+        let mut pended_groups = 0u32;
         let mut fired_events = Vec::new();
         for i in 0..self.num_cc {
             if self.cc_en[i] & CCEN_ACTIVE == 0 {
@@ -379,14 +415,39 @@ impl Nrf54lGrtc {
                 self.events_compare[i] = 1;
                 fired_events.push(OFF_EVENTS_COMPARE0 as u32 + 4 * i as u32);
                 let bit = 1u32 << (INTEN_COMPARE_SHIFT + i as u32);
-                if self.inten.iter().any(|g| g & bit != 0) {
-                    irq = true;
+                for (g, group) in self.inten.iter().enumerate() {
+                    if group & bit != 0 {
+                        pended_groups |= 1 << g;
+                    }
+                }
+                // A fired compare is one-shot: the hardware clears CCEN.ACTIVE
+                // so the channel does not re-fire the instant firmware clears
+                // EVENTS_COMPARE (which would double-tick the kernel). The sole
+                // exception is CC0 running as an auto-reload interval timer,
+                // where the deadline advances by INTERVAL and the channel stays
+                // armed. Both match Nordic's `nhw_GRTC_compare_reached`.
+                if i == 0 && self.interval != 0 {
+                    let next = self.cc_value(0).wrapping_add(self.interval as u64);
+                    self.set_cc_value(0, next);
+                } else {
+                    self.cc_en[i] &= !CCEN_ACTIVE;
                 }
             }
         }
 
+        let explicit_irqs = if pended_groups != 0 {
+            Some(
+                (0..NUM_INT_GROUPS as u32)
+                    .filter(|g| pended_groups & (1 << g) != 0)
+                    .map(|g| self.irq_base + g)
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
         PeripheralTickResult {
-            irq,
+            explicit_irqs,
             cycles: cycles as u32,
             fired_events,
             ..Default::default()
@@ -511,6 +572,9 @@ impl Peripheral for Nrf54lGrtc {
                 if i < self.num_cc {
                     let now = self.counter;
                     self.set_cc_value(i, now);
+                    // Triggering the capture task disables the compare feature
+                    // on that channel (Nordic `NHW_GRTC` CAPTURE side effect).
+                    self.cc_en[i] &= !CCEN_ACTIVE;
                 }
             }
             OFF_TASKS_START if value & 1 != 0 => self.task_started = true,
@@ -571,11 +635,29 @@ impl Peripheral for Nrf54lGrtc {
                 let reg = (offset - OFF_CC0) % CC_STRIDE;
                 if i < self.num_cc {
                     match reg {
-                        0x0 => self.cc_l[i] = value,
-                        0x4 => self.cc_h[i] = value & CCH_VALUE_MASK,
+                        // Arming is a WRITE SIDE EFFECT of CCL/CCH/CCADD, not a
+                        // separate CCEN write — this is how the GRTC actually
+                        // arms, and the reason nrfx/Zephyr's `nrf_grtc_sys_-
+                        // counter_cc_set` (CCL then CCH, never CCEN) works.
+                        // Verified against Nordic's own HW model
+                        // (`bsim_hw_models/.../NHW_GRTC.c`
+                        // `nhw_GRTC_regw_sideeffects_CC_{CCL,CCH,CCADD}`):
+                        //   * writing CCL DISABLES the channel (CCEN.ACTIVE←0),
+                        //   * writing CCH ENABLES it (CCEN.ACTIVE←1),
+                        //   * writing CCADD ENABLES it.
+                        // The CCL-then-CCH order leaves the channel armed with
+                        // the freshly written 52-bit value.
+                        0x0 => {
+                            self.cc_l[i] = value;
+                            self.cc_en[i] &= !CCEN_ACTIVE;
+                        }
+                        0x4 => {
+                            self.cc_h[i] = value & CCH_VALUE_MASK;
+                            self.cc_en[i] |= CCEN_ACTIVE;
+                        }
                         // CCADD: add VALUE to either the live SYSCOUNTER
                         // (REFERENCE=SYSCOUNTER) or the current CC
-                        // (REFERENCE=CC), and store the result in CC[i].
+                        // (REFERENCE=CC), store the result in CC[i], and arm.
                         0x8 => {
                             let base = if value & CCADD_REFERENCE_CC != 0 {
                                 self.cc_value(i)
@@ -584,7 +666,10 @@ impl Peripheral for Nrf54lGrtc {
                             };
                             let sum = base.wrapping_add((value & CCADD_VALUE_MASK) as u64);
                             self.set_cc_value(i, sum);
+                            self.cc_en[i] |= CCEN_ACTIVE;
                         }
+                        // Direct CCEN write still honoured (the disable in
+                        // nrfx's cc_channel_prepare and any bare-metal arm).
                         _ => self.cc_en[i] = value & CCEN_ACTIVE,
                     }
                 }
@@ -773,7 +858,9 @@ mod tests {
 
         let mut irqs = 0;
         for _ in 0..12 {
-            if g.tick().irq {
+            if let Some(lines) = g.tick().explicit_irqs {
+                // Group 0's compare pends GRTC_0 = irq_base (226 by default).
+                assert_eq!(lines, vec![GRTC_IRQ_BASE_DEFAULT]);
                 irqs += 1;
             }
         }
@@ -787,6 +874,92 @@ mod tests {
     }
 
     #[test]
+    fn compare_pends_the_group_that_enabled_it() {
+        // nrfx on the secure app core enables the kernel-tick compare in INTEN
+        // group 2 and expects it on GRTC_2 = irq_base + 2. A compare enabled in
+        // group g must pend exactly line irq_base + g — not a collapsed GRTC_0.
+        let mut g = Nrf54lGrtc::new_with_cc_and_irq(12, GRTC_IRQ_BASE_DEFAULT);
+        // Arm CC[6] the way nrfx does: CCL then CCH (the CCH write arms it).
+        g.write_u32(cc_reg(6, 0x0), 5).unwrap();
+        g.write_u32(cc_reg(6, 0x4), 0).unwrap();
+        // INTENSET2.COMPARE6.
+        g.write_u32(OFF_INTEN0 + 2 * INT_GROUP_STRIDE + 0x4, 1 << 6)
+            .unwrap();
+        g.write_u32(OFF_MODE, MODE_SYSCOUNTEREN).unwrap();
+
+        let mut pended = None;
+        for _ in 0..(6 * CYCLES_PER_SYSCOUNTER_TICK) {
+            if let Some(lines) = g.tick().explicit_irqs {
+                pended = Some(lines);
+                break;
+            }
+        }
+        assert_eq!(
+            pended,
+            Some(vec![GRTC_IRQ_BASE_DEFAULT + 2]),
+            "a group-2 compare must pend GRTC_2 = irq_base + 2"
+        );
+    }
+
+    #[test]
+    fn writing_cch_arms_and_writing_ccl_disarms() {
+        // The arm bit is a write side effect of CCL/CCH, exactly how nrfx's
+        // `nrf_grtc_sys_counter_cc_set` (CCL then CCH, never CCEN) arms the
+        // system-timer compare.
+        let mut g = Nrf54lGrtc::new_fast();
+        g.write_u32(cc_reg(3, 0x0), 4).unwrap(); // CCL → disarmed
+        assert_eq!(g.read_u32(cc_reg(3, 0xC)).unwrap(), 0, "CCL write disarms");
+        g.write_u32(cc_reg(3, 0x4), 0).unwrap(); // CCH → armed
+        assert_eq!(
+            g.read_u32(cc_reg(3, 0xC)).unwrap(),
+            CCEN_ACTIVE,
+            "CCH write arms the channel"
+        );
+        g.write_u32(OFF_INTEN0 + 0x4, 1 << 3).unwrap();
+        g.write_u32(OFF_TASKS_START, 1).unwrap();
+        let mut fired = false;
+        for _ in 0..8 {
+            if g.tick().explicit_irqs.is_some() {
+                fired = true;
+            }
+        }
+        assert!(fired, "a CCH-armed compare must fire");
+    }
+
+    #[test]
+    fn fired_compare_is_one_shot_and_does_not_refire_after_event_clear() {
+        // After a compare fires the hardware clears CCEN.ACTIVE, so clearing
+        // EVENTS_COMPARE (as the ISR does) must NOT immediately re-fire — that
+        // would double-tick the kernel.
+        let mut g = Nrf54lGrtc::new_fast();
+        g.write_u32(cc_reg(0, 0x0), 3).unwrap();
+        g.write_u32(cc_reg(0, 0x4), 0).unwrap(); // arm CC[0] at 3
+        g.write_u32(OFF_INTEN0 + 0x4, 1 << 0).unwrap();
+        g.write_u32(OFF_TASKS_START, 1).unwrap();
+
+        let mut irqs = 0;
+        for _ in 0..5 {
+            if g.tick().explicit_irqs.is_some() {
+                irqs += 1;
+            }
+        }
+        assert_eq!(irqs, 1);
+        assert_eq!(
+            g.read_u32(cc_reg(0, 0xC)).unwrap(),
+            0,
+            "CCEN.ACTIVE must self-clear on fire (one-shot)"
+        );
+        // ISR clears the event; the counter is still past the stale CC.
+        g.write_u32(OFF_EVENTS_COMPARE0, 0).unwrap();
+        for _ in 0..5 {
+            assert!(
+                g.tick().explicit_irqs.is_none(),
+                "a one-shot compare must not re-fire after event clear"
+            );
+        }
+    }
+
+    #[test]
     fn compare_does_not_interrupt_when_disabled() {
         let mut g = Nrf54lGrtc::new_fast();
         g.write_u32(cc_reg(0, 0x0), 5).unwrap();
@@ -796,7 +969,7 @@ mod tests {
 
         let mut irqs = 0;
         for _ in 0..12 {
-            if g.tick().irq {
+            if g.tick().explicit_irqs.is_some() {
                 irqs += 1;
             }
         }
@@ -817,7 +990,7 @@ mod tests {
         g.write_u32(OFF_INTEN0 + 0x4, 1 << 0).unwrap();
         g.write_u32(OFF_TASKS_START, 1).unwrap();
         for _ in 0..10 {
-            assert!(!g.tick().irq);
+            assert!(g.tick().explicit_irqs.is_none());
         }
         assert_eq!(g.read_u32(OFF_EVENTS_COMPARE0).unwrap(), 0);
     }

--- a/docs/specs/nrf54l15-radio-model-spec.md
+++ b/docs/specs/nrf54l15-radio-model-spec.md
@@ -1,0 +1,76 @@
+# nRF54L15 RADIO behavioural model — implementation spec
+
+Scope: enough of the RADIO peripheral to make Zephyr's software Link-Layer RUN on
+the advertising + single-connection path, at real timing, observable on the logic
+analyzer. NOT RF physics / whitening / CRC math / encryption / coded PHY.
+
+## Fixed facts
+- RADIO base 0x5008_A000, size 0x1000. RADIO IRQ = 138 (RADIO_0_IRQn). NOT nRF52 layout.
+- Anchor timer = TIMER10 @ 1 MHz (1 us/tick). Coarse anchor = GRTC CC[11]
+  (HAL_CNTR_GRTC_CC_IDX_RADIO 11; ticker uses CC 10). Interconnect = DPPI + PPIB
+  (LabWired has neither today — behavioural shortcut recommended).
+
+## Critical SHORTS (54L bit map)
+READY_START=0, DISABLED_TXEN=2, DISABLED_RXEN=3, PHYEND_DISABLE=19 (54L auto-disables
+on PHYEND, NOT END — NRF_RADIO_SHORTS_TRX_END_DISABLE == PHYEND_DISABLE). These four
+cover the whole advertise + connection path.
+
+## Key registers (RADIO-relative)
+Tasks: TXEN 0x000, RXEN 0x004, START 0x008, DISABLE 0x010. SUBSCRIBE_* 0x100+.
+Events: READY 0x200, TXREADY 0x204, RXREADY 0x208, ADDRESS 0x20C, END 0x218,
+PHYEND 0x21C (turnaround/disable trigger), DISABLED 0x220 (primary IRQ the LLL waits on),
+CRCOK 0x22C. PUBLISH_* 0x300+.
+Config: SHORTS 0x400, INTENSET00 0x488 / INTENCLR00 0x490, MODE 0x500, STATE(RO) 0x520,
+FREQUENCY 0x708, TIFS 0x714, PCNF0 0xE20, PCNF1 0xE28 (MAXLEN read back), CRCSTATUS(RO)
+0xE0C (=1 when scripted RX delivered), PACKETPTR 0xED0 (EasyDMA PDU ptr — load-bearing;
+TX airtime from *(PACKETPTR+1) len). Everything else: benign store/readback stub.
+
+## FSM
+STATE: Disabled=0,RxRu=1,RxIdle=2,Rx=3,RxDisable=4,TxRu=9,TxIdle=0xA,Tx=0xB,TxDisable=0xC.
+DISABLED --TXEN--> TxRu --(tx_ru)--> READY/TXREADY; if READY_START auto START.
+TxIdle --START--> Tx --(AA airtime)--> ADDRESS --(payload+crc)--> END,PHYEND.
+  on PHYEND: if PHYEND_DISABLE -> TxDisable --(ramp-down)--> DISABLED -> EVENTS_DISABLED,
+  IRQ 138 if INTENSET00.DISABLED. on DISABLED: if DISABLED_RXEN auto RXEN (turnaround).
+Symmetric for RX. Every 0->1 EVENTS_* -> PeripheralTickResult.fired_events (for DPPI) +
+result.irq if enabled. radio_is_idle() reads STATE==0 so ramp-down MUST reach DISABLED.
+
+## Timing (us guest time; x128 -> cycles)
+Ramp-up 1M: fast TX ~41us / RX ~40us; default TX ~141 / RX ~140 (LLL selects via TIMING/
+MODECNF0). Airtime 1M: preamble 8 + AA 32 + header + len*8 + CRC 24 (1us/bit) — MUST be
+proportional to len (adv PDUs ~130-350us). tIFS ~150us turnaround (SW-switch on 54L: LLL
+arms TIMER10 compare; model the EFFECT off the SHORTS bits, not the plumbing — auto-issue
+opposite ramp-up ~T_IFS after PHYEND). Fake instant: whitening/CRC/RSSI/PLL/FREQUENCY.
+
+## Anchor (hard part)
+GRTC CC[11] compare -> (PPIB) -> TIMER10 START; TIMER10 CC[0]=remainder_us -> (DPPI ch9) ->
+RADIO TXEN/RXEN. Companion: ch13 END/PHYEND->TIMER10 CAPTURE; ch12 TIMER10 hcto -> RADIO
+DISABLE (this is what times out an RX window into the void). SHORTCUT for M1: minimal DPPI
+channel table (store CHIDX from SUBSCRIBE/PUBLISH, route published events to subscribed task
+addrs via the lib.rs route_ppi_events/mmio_writes seam) OR hardcode channels 8,9,12,13.
+DEPENDS ON the GRTC absolute-compare (>=) fix — a strict == would drop every anchor.
+
+## Medium
+Advertising needs NO peer: TX into void, RX window hits HCTO timeout -> DISABLE -> next
+channel/interval. Connection needs a scripted peer: CONNECT_IND into RX PACKETPTR during the
+post-adv RX window (latch ADDRESS/END/CRCOK), then once/interval an empty LL data PDU
+(LLID=1,len=0) ping-pong. Plug a `ScriptedBleMedium` in at the Rx-START boundary (BabbleSim-lite,
+no RF), matching the SimInput stimulus pattern.
+
+## Staged plan
+1. Advertise-only (no peer): FSM+SHORTS+events+IRQ + timing wheel + GRTC CC[11]->TXEN + HCTO->
+   DISABLE via minimal DPPI table. ~60% of the work.
+2. Scripted-peer connection: ScriptedBleMedium, CONNECT_IND + empty-PDU ping-pong, CRCOK,
+   RX->TX tIFS turnaround. Validates lll_conn/lll_peripheral.
+3. BabbleSim-style medium (later): two RADIO instances, real PDU exchange, filtering, enc.
+
+## Risks
+DPPI/PPIB cross-domain routing (use behavioural collapse); timing tolerances (ramp-up + airtime
++ tIFS must be real, sub-us can be constant; GRTC-anchor->TXEN latency is the delicate number);
+GRTC >= compare fix must be live; confirm TIMER10 actually ticks at 1 MHz on 54L (prescaler 5);
+TIFS_HW Kconfig unknown -> key off SHORTS bits actually written.
+
+## Logic-analyzer tagging (BLE connection-event timeline)
+Anchor = GRTC CC[11] fire. TX window = TXREADY..PHYEND (tag FREQUENCY channel + PDU len).
+RX window = RXREADY..END/HCTO (mark ADDRESS = peer detected vs HCTO timeout). ADDRESS marker =
+on-air SOP. PHYEND marker = EOP/turnaround pivot. tIFS gap = shaded PHYEND..next READY (~150us).
+DISABLED marker = event end / IRQ 138 (tag whether NVIC pended). STATE lane = enum step signal.


### PR DESCRIPTION
Makes the nRF54L15 GRTC deliver its compare-match interrupt so **unmodified tickless Zephyr runs in LabWired** (previously froze at the first `k_sleep`). Two register-level bugs, both traced to the register level and cross-checked against Nordic's `NHW_GRTC` / nrfx:

1. **Per-group IRQ routing.** GRTC has 4 lines (GRTC_g = 226+g); nrfx on secure cpuapp uses group 2 → INTENSET2 → NVIC line 228, but the model pended one collapsed IRQ on 226 (never enabled). Now routes each fired compare to its group's line via `explicit_irqs`.
2. **Arm bit.** nrfx never writes CCEN=Enable — arming is a CCH-write side-effect. Now CCH arms / CCL·CCADD·CAPTURE (dis)arm / fired-compare one-shot clears (CC0+INTERVAL auto-reloads).

**Result:** a scheduler-only Zephyr app ticks to completion in the sim. Also ships the RADIO behavioural-model spec (next step: run the real BLE stack for Issue-A).

**Regression (all green):** 2297 lib tests; `nrf54l15_boot`, `firmware_survival` (incl. `test_nrf54l15_zephyr_survival`), `chip_conformance`, `board_coverage_ratchet`, `walk_deletion`; clippy `-D warnings`; fmt; drift `--check` (exit 0). No silicon-verified capture altered. Idle fast-forward still off (GRTC on the per-cycle walk) — clean follow-up.