### PR TITLE
feat(core): declarative GPIO-device path — migrate rotary encoder to a descriptor

### DIFF
--- a/configs/devices/rotary_encoder.yaml
+++ b/configs/devices/rotary_encoder.yaml
@@ -1,0 +1,39 @@
+# Declarative descriptor — incremental (quadrature) rotary encoder, EC11-style.
+#
+# The encoder DRIVES two MCU input pins (CLK/DT) a quarter-cycle out of phase;
+# its irreducible algorithm is the Gray-code detent walk, provided by the
+# `quadrature` primitive (crate::peripherals::components::rotary_encoder). This
+# descriptor supplies everything around that primitive as data: the device type,
+# the pin bindings, and the canvas-compiler emit mapping. The push switch (SW)
+# is an ordinary momentary button and is emitted separately as plain board_io.
+type: rotary_encoder
+
+# --- Runtime behavior (consumed by bus/declarative_device.rs) --------------
+behavior:
+  primitive: quadrature
+  # Abstract quadrature channels A/B → the config keys carrying their pad label.
+  pins:
+    a: clk_pin
+    b: dt_pin
+  params:
+    # CPU clock used to convert the internal edge interval (µs) → cycles.
+    cpu_hz: { key: cpu_hz, default: 80000000 }
+
+# --- Display / manifest metadata (phase 2: derives KitMetadata) ------------
+metadata:
+  label: "Rotary encoder"
+  summary: "Incremental quadrature knob (EC11)"
+  category: gpio
+  # Drivable stimulus channels (must match the primitive's SimInput impl).
+  inputs:
+    - { key: position, label: "Position", unit: detents, min: -1000, max: 1000 }
+
+# --- Canvas-compiler emit mapping (phase 2: unifies the TS/Rust emitters) ---
+# Both engines derive the external_devices block from this, killing the
+# hand-mirrored emit_rotary_encoder / emitRotaryEncoder pair.
+emit:
+  connection: gpio
+  config:
+    - { key: clk_pin, from_part_pin: [CLK, A] }
+    - { key: dt_pin, from_part_pin: [DT, B] }
+    - { key: cpu_hz, from: sim_cpu_hz }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -706,6 +706,57 @@ pub struct PeripheralDescriptor {
     pub timing: Option<Vec<TimingDescriptor>>,
 }
 
+/// Declarative descriptor for a GPIO / pin-timing external device — the family
+/// that DRIVES pins the MCU samples as inputs (rotary encoder, matrix keypad,
+/// DHT22, HC-SR04, NeoPixel). Unlike register-mapped [`PeripheralDescriptor`]
+/// peripherals, these live directly on the [`SystemBus`] as bus-resident
+/// devices (or GPIO observers) and each carries a genuinely irreducible timing
+/// algorithm — the **primitive** (quadrature walk, matrix reflect, one-wire
+/// frame, …). This descriptor makes EVERYTHING AROUND the primitive data: the
+/// device `type`, its pin bindings, and (later) the canvas-compiler emit
+/// mapping. A device that reuses an existing primitive is then one YAML file
+/// with zero Rust in either engine.
+///
+/// The struct deserializes only the fields the current implementation wires.
+/// Serde ignores unknown keys, so a descriptor YAML may already carry
+/// `metadata:` / `emit:` sections (documenting the full intent) before the code
+/// that consumes them exists.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DeviceDescriptor {
+    /// `type:` string in a system.yaml `external_devices` entry. Unique across
+    /// all declarative device descriptors.
+    pub r#type: String,
+    /// Runtime behavior: which irreducible primitive backs this device and how
+    /// its abstract pin roles bind to `config:` keys.
+    pub behavior: DeviceBehavior,
+}
+
+/// The runtime half of a [`DeviceDescriptor`]: the primitive to instantiate and
+/// how to source its pins/params from the placed device's `config:` block.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DeviceBehavior {
+    /// Name of the irreducible Rust primitive to instantiate — e.g.
+    /// `"quadrature"` (rotary encoder). The `bus/declarative_device.rs`
+    /// attach dispatch matches on this.
+    pub primitive: String,
+    /// Abstract pin role → the `config:` key that carries its pad label. For
+    /// the quadrature primitive: `{ "a": "clk_pin", "b": "dt_pin" }`. Ordered
+    /// (BTreeMap) so attach is deterministic.
+    #[serde(default)]
+    pub pins: std::collections::BTreeMap<String, String>,
+    /// Optional scalar params (with their `config:` key and default) the
+    /// primitive needs beyond pins — e.g. `cpu_hz`. Kept as raw YAML values so
+    /// the primitive decides the concrete type.
+    #[serde(default)]
+    pub params: std::collections::BTreeMap<String, serde_yaml::Value>,
+}
+
+impl DeviceDescriptor {
+    pub fn from_yaml(yaml: &str) -> Result<Self> {
+        serde_yaml::from_str(yaml).context("Failed to parse Device Descriptor")
+    }
+}
+
 impl PeripheralDescriptor {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let content = std::fs::read_to_string(&path)?;

--- a/crates/core/src/bus/declarative_device.rs
+++ b/crates/core/src/bus/declarative_device.rs
@@ -1,0 +1,157 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Data-driven attach path for the GPIO / pin-timing external-device family.
+//!
+//! The register-mapped I²C/SPI devices already dispatch through the
+//! [`PeripheralKit`](crate::peripherals::kit) registry (no hand-written
+//! `from_config` arm each). The GPIO family — rotary encoder, matrix keypad,
+//! DHT22, HC-SR04, NeoPixel — historically kept a bespoke `match` arm in
+//! [`from_config`](super::from_config) PLUS a hand-mirrored emitter in both the
+//! Rust and the TypeScript compiler. That double surface is what this module
+//! begins to collapse.
+//!
+//! Each such device gets ONE [`labwired_config::DeviceDescriptor`] YAML under
+//! `configs/devices/`. The descriptor names an irreducible **primitive** (the
+//! genuinely un-data-fiable timing algorithm — the Gray-code walk, the matrix
+//! reflect, the one-wire frame) and binds its abstract pins to `config:` keys.
+//! [`attach`] resolves those bindings and instantiates the primitive; the
+//! primitive's Rust model is unchanged, so behavior is byte-identical to the old
+//! hand-written arm. Adding a device that reuses an existing primitive is then
+//! one YAML file — no new Rust in the attach path.
+//!
+//! Phase 1 migrates the rotary encoder (`quadrature`). Keypad / DHT22 / HC-SR04
+//! follow as their primitives are given descriptors; the emitter unification
+//! (both engines reading the descriptor's `emit:` block) is the next step.
+
+use super::SystemBus;
+use anyhow::{anyhow, Context, Result};
+use labwired_config::{DeviceDescriptor, ExternalDevice};
+
+/// The embedded device descriptors, keyed by their `type:` string. Embedded via
+/// `include_str!` so the wasm build (no `std::fs`) resolves them too — the same
+/// approach as [`embedded_descriptors`](super::embedded_descriptors) for
+/// register peripherals.
+fn embedded_yaml(device_type: &str) -> Option<&'static str> {
+    match device_type {
+        "rotary_encoder" | "rotary-encoder" => Some(include_str!(
+            "../../../../configs/devices/rotary_encoder.yaml"
+        )),
+        _ => None,
+    }
+}
+
+/// Parse the declarative descriptor for `device_type`, if one is embedded.
+/// Returns `Ok(None)` when the type is not declarative (the caller then falls
+/// through to the legacy hand-written arms).
+pub(crate) fn lookup(device_type: &str) -> Result<Option<DeviceDescriptor>> {
+    match embedded_yaml(device_type) {
+        Some(yaml) => Ok(Some(DeviceDescriptor::from_yaml(yaml).with_context(
+            || format!("Failed to parse declarative device descriptor for '{device_type}'"),
+        )?)),
+        None => Ok(None),
+    }
+}
+
+impl SystemBus {
+    /// Attach a declarative GPIO device described by `desc` for the placed
+    /// `ext`. Dispatches on the descriptor's primitive; each primitive arm
+    /// resolves the descriptor's pin bindings and constructs the (unchanged)
+    /// Rust model, so behavior matches the former hand-written arm exactly.
+    pub(crate) fn attach_declarative_device(
+        &mut self,
+        ext: &ExternalDevice,
+        desc: &DeviceDescriptor,
+    ) -> Result<()> {
+        match desc.behavior.primitive.as_str() {
+            "quadrature" => self.attach_quadrature(ext, desc),
+            other => Err(anyhow!(
+                "declarative device '{}' names unknown primitive '{}'",
+                ext.id,
+                other
+            )),
+        }
+    }
+
+    /// `quadrature` primitive → [`RotaryEncoder`]. Reproduces the former
+    /// `"rotary-encoder"` arm: both channels resolve to a GPIO **input** (IDR)
+    /// register, the model walks the Gray sequence onto them, and rotation is
+    /// host-controlled through the `position` stimulus channel.
+    fn attach_quadrature(&mut self, ext: &ExternalDevice, desc: &DeviceDescriptor) -> Result<()> {
+        let clk = self.pin_config(ext, desc, "a", "PA0")?;
+        let dt = self.pin_config(ext, desc, "b", "PA1")?;
+        let cpu_hz = param_u64(desc, ext, "cpu_hz", 80_000_000);
+
+        let (clk_idr_addr, clk_bit) = Self::resolve_pin_idr(self, &clk).ok_or_else(|| {
+            anyhow!(
+                "rotary-encoder '{}' clk_pin '{}' could not be resolved to a GPIO input",
+                ext.id,
+                clk
+            )
+        })?;
+        let (dt_idr_addr, dt_bit) = Self::resolve_pin_idr(self, &dt).ok_or_else(|| {
+            anyhow!(
+                "rotary-encoder '{}' dt_pin '{}' could not be resolved to a GPIO input",
+                ext.id,
+                dt
+            )
+        })?;
+
+        self.gpio_devices.push(Box::new(
+            crate::peripherals::components::rotary_encoder::RotaryEncoder::new(
+                ext.id.clone(),
+                clk_idr_addr,
+                clk_bit,
+                dt_idr_addr,
+                dt_bit,
+                cpu_hz,
+            ),
+        ));
+        Ok(())
+    }
+
+    /// Resolve the pad label for the abstract pin `role`: read the `config:` key
+    /// the descriptor binds that role to, falling back to `default` (preserving
+    /// the old arm's fallback for a config that omits the pin).
+    fn pin_config(
+        &self,
+        ext: &ExternalDevice,
+        desc: &DeviceDescriptor,
+        role: &str,
+        default: &str,
+    ) -> Result<String> {
+        let key = desc.behavior.pins.get(role).ok_or_else(|| {
+            anyhow!(
+                "declarative device '{}' descriptor is missing pin role '{}'",
+                ext.id,
+                role
+            )
+        })?;
+        Ok(ext
+            .config
+            .get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or(default)
+            .to_string())
+    }
+}
+
+/// Read a `u64` primitive param: the descriptor's `params.<name>` entry gives
+/// the `config:` key and default; `config[key]` overrides it when present.
+/// Falls back to `fallback` when the descriptor omits the param entirely.
+fn param_u64(desc: &DeviceDescriptor, ext: &ExternalDevice, name: &str, fallback: u64) -> u64 {
+    let (config_key, default) = match desc.behavior.params.get(name) {
+        Some(v) => (
+            v.get("key").and_then(|k| k.as_str()).unwrap_or(name),
+            v.get("default")
+                .and_then(|d| d.as_u64())
+                .unwrap_or(fallback),
+        ),
+        None => (name, fallback),
+    };
+    ext.config
+        .get(config_key)
+        .and_then(|v| v.as_u64())
+        .unwrap_or(default)
+}

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -545,6 +545,14 @@ impl SystemBus {
                 kit.attach(&mut ctx)?;
                 continue;
             }
+            // Second-pass: the GPIO / pin-timing family migrated to declarative
+            // `configs/devices/*.yaml` descriptors. `attach_declarative_device`
+            // resolves the descriptor's pin bindings and instantiates the named
+            // primitive — no hand-written arm here.
+            if let Some(desc) = super::declarative_device::lookup(&ext.r#type)? {
+                bus.attach_declarative_device(ext, &desc)?;
+                continue;
+            }
             match ext.r#type.as_str() {
                 // ili9341, adxl345/mpu6050/bme280/oled-ssd1306, neo6m-gps,
                 // and bg770a-cellular dispatch through the PeripheralKit
@@ -674,60 +682,9 @@ impl SystemBus {
                         ),
                     ));
                 }
-                "rotary-encoder" | "rotary_encoder" => {
-                    // Incremental quadrature knob. Like the HC-SR04/DHT22 it
-                    // DRIVES pins the MCU samples as inputs (CLK/DT), so it lives
-                    // directly on the bus and the per-tick pass
-                    // (`service_gpio_devices`) walks the Gray sequence onto the
-                    // two input registers. Rotation is host-controlled through the
-                    // standard `position` stimulus channel. The push switch (SW)
-                    // is a plain board_io button, emitted separately.
-                    let clk = ext
-                        .config
-                        .get("clk_pin")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("PA0")
-                        .to_string();
-                    let dt = ext
-                        .config
-                        .get("dt_pin")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("PA1")
-                        .to_string();
-                    let cpu_hz = ext
-                        .config
-                        .get("cpu_hz")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(80_000_000);
-
-                    let (clk_idr_addr, clk_bit) =
-                        Self::resolve_pin_idr(&bus, &clk).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "rotary-encoder '{}' clk_pin '{}' could not be resolved to a GPIO input",
-                                ext.id,
-                                clk
-                            )
-                        })?;
-                    let (dt_idr_addr, dt_bit) =
-                        Self::resolve_pin_idr(&bus, &dt).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "rotary-encoder '{}' dt_pin '{}' could not be resolved to a GPIO input",
-                                ext.id,
-                                dt
-                            )
-                        })?;
-
-                    bus.gpio_devices.push(Box::new(
-                        crate::peripherals::components::rotary_encoder::RotaryEncoder::new(
-                            ext.id.clone(),
-                            clk_idr_addr,
-                            clk_bit,
-                            dt_idr_addr,
-                            dt_bit,
-                            cpu_hz,
-                        ),
-                    ));
-                }
+                // rotary-encoder / rotary_encoder now dispatches through the
+                // declarative device path above (configs/devices/rotary_encoder.yaml,
+                // `quadrature` primitive) — see super::declarative_device.
                 "keypad" => {
                     // 4×4 matrix keypad. Like the rotary encoder / DHT22 it
                     // DRIVES pins the MCU samples as inputs (the columns) while

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -22,6 +22,7 @@ mod attach;
 pub mod bus_trace;
 mod can_devices;
 mod construct;
+mod declarative_device;
 mod device_hooks;
 mod embedded_descriptors;
 mod faults;

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -630,6 +630,60 @@ external_devices:
     );
 }
 
+/// The `rotary_encoder` external device dispatches through the DECLARATIVE
+/// device path (`configs/devices/rotary_encoder.yaml`, `quadrature` primitive)
+/// rather than a hand-written `from_config` arm. This locks that seam: a
+/// rotary device in a system.yaml must still land a `RotaryEncoder` on the bus
+/// with its CLK/DT pins resolved from the descriptor's pin bindings — byte for
+/// byte what the deleted arm produced.
+#[test]
+fn test_from_config_attaches_rotary_encoder_via_declarative_descriptor() {
+    use crate::peripherals::components::rotary_encoder::RotaryEncoder;
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip = ChipDescriptor::from_file(root.join("../../configs/chips/stm32f103.yaml"))
+        .expect("read STM32F103 chip descriptor");
+    // Both `type:` spellings must resolve to the same declarative descriptor.
+    for type_str in ["rotary_encoder", "rotary-encoder"] {
+        let manifest: SystemManifest = serde_yaml::from_str(&format!(
+            r#"
+name: "rotary-declarative"
+chip: "../chips/stm32f103.yaml"
+external_devices:
+  - id: "knob"
+    type: "{type_str}"
+    connection: "gpio"
+    config:
+      clk_pin: "PA0"
+      dt_pin: "PA1"
+      cpu_hz: 8000000
+board_io: []
+"#
+        ))
+        .expect("parse rotary manifest");
+
+        let bus = SystemBus::from_config(&chip, &manifest).expect("build bus with rotary");
+        let encoders: Vec<&RotaryEncoder> = bus.gpio_devices_of::<RotaryEncoder>().collect();
+        assert_eq!(
+            encoders.len(),
+            1,
+            "exactly one RotaryEncoder attached for type '{type_str}'"
+        );
+        let enc = encoders[0];
+        assert_eq!(enc.id, "knob");
+        // PA0 → gpioa IDR bit 0; PA1 → bit 1. The descriptor bound role `a`→
+        // clk_pin and `b`→dt_pin, so CLK follows PA0 and DT follows PA1.
+        assert_eq!(enc.clk_bit, 0, "clk_pin PA0 → bit 0");
+        assert_eq!(enc.dt_bit, 1, "dt_pin PA1 → bit 1");
+        assert_eq!(
+            enc.clk_idr_addr, enc.dt_idr_addr,
+            "both channels on the same GPIOA IDR"
+        );
+        // cpu_hz threaded from config through the descriptor's params mapping.
+        assert_eq!(enc.cpu_hz, 8_000_000, "cpu_hz sourced from config");
+    }
+}
+
 #[test]
 fn curated_esp32c3_i2c_manifests_declare_physical_routes() {
     #[derive(serde::Deserialize)]


### PR DESCRIPTION
North-star: define labwired devices in YAML, not bespoke Rust. This is **phase 1** of the declarative device DSL.

## Why
Register-mapped I²C/SPI devices already dispatch through the `PeripheralKit` registry — no hand-written `from_config` arm each. The **GPIO / pin-timing family** (rotary, keypad, dht22, hc-sr04, neopixel) still carried a bespoke `match` arm in `from_config` **plus** a hand-mirrored emitter in *both* Rust (`canonical.rs`) and TypeScript (`emitters.ts`), guarded by a byte-parity gate. Adding one device was surgery in ~15 sites across two languages.

## What
A data-driven attach path for that family. Each device gets **one** `configs/devices/*.yaml` `DeviceDescriptor` naming an irreducible **primitive** (the genuinely un-data-fiable timing algorithm — the Gray-code walk, the matrix reflect, the one-wire frame) and binding its abstract pins to `config:` keys. `bus/declarative_device.rs` resolves those bindings and instantiates the **unchanged** primitive model, so behavior is **byte-identical** to the deleted arm. A device that reuses an existing primitive is then one YAML file — zero Rust in the attach path.

Phase 1 migrates the **rotary encoder** (`quadrature` primitive) and deletes its `from_config` arm as proof.

- `labwired_config::DeviceDescriptor` / `DeviceBehavior` (`type` + `behavior{primitive,pins,params}`; `metadata`/`emit` carried in the YAML for phase 2, ignored by serde for now)
- `configs/devices/rotary_encoder.yaml`
- `bus/declarative_device.rs` — generic dispatch (`quadrature` → `RotaryEncoder`)
- `from_config` — declarative check right after the kit lookup; **54-line rotary arm removed**
- new `from_config` dispatch test (both `type:` spellings; CLK→PA0/bit0, DT→PA1/bit1, cpu_hz threaded)

## Verification
- 9 original rotary tests + new dispatch test green
- **full `labwired-core` suite green** (`--features jit,event-scheduler`)
- `clippy --all-targets -- -D warnings` clean; `fmt --check` clean
- No behavior change to any existing chip — only the rotary *attach path* moved from a hand arm to a descriptor; the `RotaryEncoder` model is untouched.

## Next (not in this PR)
- Emitter unification: both engines read the descriptor `emit:` block → collapses the TS↔Rust `emit_rotary_encoder` mirror, parity gate becomes trivial.
- Migrate keypad → dht22 → hc-sr04 as descriptors (framed-bit protocols grow DSL primitives rather than defaulting to a Rust core).