### PR TITLE
feat(core): migrate keypad to a declarative descriptor (matrix primitive)

### DIFF
--- a/configs/devices/keypad.yaml
+++ b/configs/devices/keypad.yaml
@@ -1,0 +1,33 @@
+# Declarative descriptor — 4×4 matrix keypad (sixteen passive switches).
+#
+# A membrane keypad has no chip: each key shorts a row to a column while
+# pressed. Firmware animates the matrix (drive rows LOW one at a time, read
+# columns) — so the device OBSERVES four MCU output pins (rows) and DRIVES four
+# MCU input pins (columns). That row-drive/column-read scan is the irreducible
+# `matrix` primitive (crate::peripherals::components::keypad). The keypad does
+# not self-time (it is combinational), so it carries no cpu_hz.
+type: keypad
+
+# --- Runtime behavior (consumed by bus/declarative_device.rs) --------------
+behavior:
+  primitive: matrix
+  # List-valued pin roles: each binds to a config key holding a 4-entry list.
+  # rows resolve to GPIO outputs (ODR, observed); cols to inputs (IDR, driven).
+  pins:
+    rows: row_pins
+    cols: col_pins
+
+# --- Display / manifest metadata (phase 2: derives KitMetadata) ------------
+metadata:
+  label: "Matrix keypad"
+  summary: "4×4 membrane keypad (row-drive / column-read)"
+  category: gpio
+  inputs:
+    - { key: key, label: "Key", unit: index, min: -1, max: 15 }
+
+# --- Canvas-compiler emit mapping (phase 2: unifies the TS/Rust emitters) ---
+emit:
+  connection: gpio
+  config:
+    - { key: row_pins, from_part_pins: [R1, R2, R3, R4] }
+    - { key: col_pins, from_part_pins: [C1, C2, C3, C4] }

--- a/crates/core/src/bus/declarative_device.rs
+++ b/crates/core/src/bus/declarative_device.rs
@@ -38,6 +38,7 @@ fn embedded_yaml(device_type: &str) -> Option<&'static str> {
         "rotary_encoder" | "rotary-encoder" => Some(include_str!(
             "../../../../configs/devices/rotary_encoder.yaml"
         )),
+        "keypad" => Some(include_str!("../../../../configs/devices/keypad.yaml")),
         _ => None,
     }
 }
@@ -66,12 +67,52 @@ impl SystemBus {
     ) -> Result<()> {
         match desc.behavior.primitive.as_str() {
             "quadrature" => self.attach_quadrature(ext, desc),
+            "matrix" => self.attach_matrix(ext, desc),
             other => Err(anyhow!(
                 "declarative device '{}' names unknown primitive '{}'",
                 ext.id,
                 other
             )),
         }
+    }
+
+    /// `matrix` primitive → [`Keypad`]. Reproduces the former `"keypad"` arm:
+    /// the `rows` role binds to a 4-entry list of GPIO **output** pads (ODR,
+    /// which the keypad observes) and `cols` to a 4-entry list of GPIO **input**
+    /// pads (IDR, which it drives); the pressed key is host-controlled through
+    /// the `key` stimulus channel.
+    fn attach_matrix(&mut self, ext: &ExternalDevice, desc: &DeviceDescriptor) -> Result<()> {
+        use crate::peripherals::components::keypad::{Keypad, COLS, ROWS};
+
+        let row_pins = self.pin_list_config(ext, desc, "rows")?;
+        let col_pins = self.pin_list_config(ext, desc, "cols")?;
+
+        // Rows are MCU outputs the keypad observes → resolve to ODR.
+        let mut row_odr = [(0u64, 0u8); ROWS];
+        for (i, pin) in row_pins.iter().enumerate() {
+            row_odr[i] = Self::resolve_pin_odr(self, pin).ok_or_else(|| {
+                anyhow!(
+                    "keypad '{}' row_pin '{}' could not be resolved to a GPIO output",
+                    ext.id,
+                    pin
+                )
+            })?;
+        }
+        // Columns are MCU inputs the keypad drives → resolve to IDR.
+        let mut col_idr = [(0u64, 0u8); COLS];
+        for (i, pin) in col_pins.iter().enumerate() {
+            col_idr[i] = Self::resolve_pin_idr(self, pin).ok_or_else(|| {
+                anyhow!(
+                    "keypad '{}' col_pin '{}' could not be resolved to a GPIO input",
+                    ext.id,
+                    pin
+                )
+            })?;
+        }
+
+        self.gpio_devices
+            .push(Box::new(Keypad::new(ext.id.clone(), row_odr, col_idr)));
+        Ok(())
     }
 
     /// `quadrature` primitive → [`RotaryEncoder`]. Reproduces the former
@@ -134,6 +175,45 @@ impl SystemBus {
             .and_then(|v| v.as_str())
             .unwrap_or(default)
             .to_string())
+    }
+
+    /// Resolve a list-valued pin role (e.g. the keypad's `rows`/`cols`): read
+    /// the `config:` key the descriptor binds it to as a 4-entry list of pad
+    /// labels. Errors — keyed on the config field name — mirror the former
+    /// hand-written `keypad` arm exactly.
+    fn pin_list_config(
+        &self,
+        ext: &ExternalDevice,
+        desc: &DeviceDescriptor,
+        role: &str,
+    ) -> Result<Vec<String>> {
+        const EXPECTED: usize = 4;
+        let key = desc.behavior.pins.get(role).ok_or_else(|| {
+            anyhow!(
+                "declarative device '{}' descriptor is missing pin role '{}'",
+                ext.id,
+                role
+            )
+        })?;
+        let arr = ext
+            .config
+            .get(key)
+            .and_then(|v| v.as_sequence())
+            .ok_or_else(|| anyhow!("keypad '{}' config is missing a '{}' list", ext.id, key))?;
+        let pins: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        if pins.len() != EXPECTED {
+            return Err(anyhow!(
+                "keypad '{}' expects exactly {} '{}' entries, got {}",
+                ext.id,
+                EXPECTED,
+                key,
+                pins.len()
+            ));
+        }
+        Ok(pins)
     }
 }
 

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -685,71 +685,9 @@ impl SystemBus {
                 // rotary-encoder / rotary_encoder now dispatches through the
                 // declarative device path above (configs/devices/rotary_encoder.yaml,
                 // `quadrature` primitive) — see super::declarative_device.
-                "keypad" => {
-                    // 4×4 matrix keypad. Like the rotary encoder / DHT22 it
-                    // DRIVES pins the MCU samples as inputs (the columns) while
-                    // OBSERVING pins the MCU drives as outputs (the rows), so it
-                    // lives directly on the bus and the per-tick pass
-                    // (`service_gpio_devices`) reads the row ODR bits and drives the
-                    // column IDR bits. The pressed key is host-controlled through
-                    // the standard `key` stimulus channel (index row*4+col).
-                    let read_pins = |field: &str| -> anyhow::Result<Vec<String>> {
-                        let arr = ext.config.get(field).and_then(|v| v.as_sequence());
-                        let Some(arr) = arr else {
-                            return Err(anyhow::anyhow!(
-                                "keypad '{}' config is missing a '{}' list",
-                                ext.id,
-                                field
-                            ));
-                        };
-                        let pins: Vec<String> = arr
-                            .iter()
-                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                            .collect();
-                        if pins.len() != 4 {
-                            return Err(anyhow::anyhow!(
-                                "keypad '{}' expects exactly 4 '{}' entries, got {}",
-                                ext.id,
-                                field,
-                                pins.len()
-                            ));
-                        }
-                        Ok(pins)
-                    };
-                    let row_pins = read_pins("row_pins")?;
-                    let col_pins = read_pins("col_pins")?;
-
-                    // Rows are MCU outputs the keypad observes → resolve to ODR.
-                    let mut row_odr = [(0u64, 0u8); 4];
-                    for (i, pin) in row_pins.iter().enumerate() {
-                        row_odr[i] = Self::resolve_pin_odr(&bus, pin).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "keypad '{}' row_pin '{}' could not be resolved to a GPIO output",
-                                ext.id,
-                                pin
-                            )
-                        })?;
-                    }
-                    // Columns are MCU inputs the keypad drives → resolve to IDR.
-                    let mut col_idr = [(0u64, 0u8); 4];
-                    for (i, pin) in col_pins.iter().enumerate() {
-                        col_idr[i] = Self::resolve_pin_idr(&bus, pin).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "keypad '{}' col_pin '{}' could not be resolved to a GPIO input",
-                                ext.id,
-                                pin
-                            )
-                        })?;
-                    }
-
-                    bus.gpio_devices.push(Box::new(
-                        crate::peripherals::components::keypad::Keypad::new(
-                            ext.id.clone(),
-                            row_odr,
-                            col_idr,
-                        ),
-                    ));
-                }
+                // keypad now dispatches through the declarative device path above
+                // (configs/devices/keypad.yaml, `matrix` primitive) — see
+                // super::declarative_device.
                 "neopixel" | "ws2812" => {
                     // Addressable LED strip driven by a single-wire, self-clocked
                     // bit-stream on ONE GPIO. On the ESP32-S3 the RMT peripheral

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -685,6 +685,90 @@ board_io: []
     }
 }
 
+/// The `keypad` external device dispatches through the DECLARATIVE device path
+/// (`configs/devices/keypad.yaml`, `matrix` primitive). This locks that seam: a
+/// keypad in a system.yaml must still land a `Keypad` on the bus with its four
+/// ROW pins resolved to GPIO outputs (ODR) and four COLUMN pins to inputs (IDR),
+/// exactly what the deleted hand-written arm produced.
+#[test]
+fn test_from_config_attaches_keypad_via_declarative_descriptor() {
+    use crate::peripherals::components::keypad::Keypad;
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip = ChipDescriptor::from_file(root.join("../../configs/chips/stm32f103.yaml"))
+        .expect("read STM32F103 chip descriptor");
+    let manifest: SystemManifest = serde_yaml::from_str(
+        r#"
+name: "keypad-declarative"
+chip: "../chips/stm32f103.yaml"
+external_devices:
+  - id: "pad"
+    type: "keypad"
+    connection: "gpio"
+    config:
+      row_pins: ["PA0", "PA1", "PA2", "PA3"]
+      col_pins: ["PA4", "PA5", "PA6", "PA7"]
+board_io: []
+"#,
+    )
+    .expect("parse keypad manifest");
+
+    let bus = SystemBus::from_config(&chip, &manifest).expect("build bus with keypad");
+    let pads: Vec<&Keypad> = bus.gpio_devices_of::<Keypad>().collect();
+    assert_eq!(pads.len(), 1, "exactly one Keypad attached");
+    let pad = pads[0];
+    assert_eq!(pad.id, "pad");
+    // Rows PA0..PA3 → GPIOA ODR bits 0..3; cols PA4..PA7 → GPIOA IDR bits 4..7.
+    for i in 0..4 {
+        assert_eq!(pad.row_odr[i].1, i as u8, "row {i} → ODR bit {i}");
+        assert_eq!(
+            pad.col_idr[i].1,
+            (i + 4) as u8,
+            "col {i} → IDR bit {}",
+            i + 4
+        );
+    }
+    // Rows on the ODR, cols on the IDR — distinct register offsets on the same port.
+    assert_ne!(
+        pad.row_odr[0].0, pad.col_idr[0].0,
+        "rows drive ODR, cols read IDR — different registers"
+    );
+}
+
+/// A keypad descriptor with the wrong number of pins is rejected with the same
+/// message the hand-written arm gave — the declarative path preserves the
+/// validation, keyed on the config field name.
+#[test]
+fn test_declarative_keypad_rejects_wrong_pin_count() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip = ChipDescriptor::from_file(root.join("../../configs/chips/stm32f103.yaml"))
+        .expect("read STM32F103 chip descriptor");
+    let manifest: SystemManifest = serde_yaml::from_str(
+        r#"
+name: "keypad-bad"
+chip: "../chips/stm32f103.yaml"
+external_devices:
+  - id: "pad"
+    type: "keypad"
+    connection: "gpio"
+    config:
+      row_pins: ["PA0", "PA1", "PA2"]
+      col_pins: ["PA4", "PA5", "PA6", "PA7"]
+board_io: []
+"#,
+    )
+    .expect("parse keypad manifest");
+
+    let err = match SystemBus::from_config(&chip, &manifest) {
+        Ok(_) => panic!("3-row keypad must be rejected"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.contains("expects exactly 4 'row_pins'") && err.contains("got 3"),
+        "error must name the field and count: {err}"
+    );
+}
+
 #[test]
 fn curated_esp32c3_i2c_manifests_declare_physical_routes() {
     #[derive(serde::Deserialize)]


### PR DESCRIPTION
Second device on the declarative GPIO-device path (after the rotary encoder in #605, now merged). Proves the pattern generalizes beyond single-pin devices.

## What
The 4×4 matrix keypad's row-drive/column-read scan is the irreducible `matrix` primitive; everything around it becomes data:
- **`configs/devices/keypad.yaml`** — `matrix` primitive with **list-valued** pin roles (`rows`→`row_pins`, `cols`→`col_pins`), plus `metadata`/`emit` carried for phase 2.
- **`bus/declarative_device.rs`** — `attach_matrix` + a `pin_list_config` helper that reads a 4-entry pin list and reproduces the old arm's validation errors (keyed on the config field name).
- **`from_config`** — the ~65-line hand-written keypad arm **deleted**.
- **tests** — `from_config` dispatch (rows→ODR outputs, cols→IDR inputs) + a wrong-pin-count rejection test.

## Verification
- Behavior **byte-identical** to the deleted arm: same `Keypad` model, same error messages.
- keypad + declarative + rotary tests green; **full `labwired-core` suite green**; `clippy --all-targets -- -D warnings` clean; `fmt` clean.

## Pattern note
This extends the descriptor schema to list-valued pin roles — the last shape needed before dht22/hc-sr04 (single-pin, self-timed) migrate trivially. The emitter unification (both engines reading the descriptor `emit:` block) remains the separate next step.