### PR TITLE
feat(core): migrate dht22/am2302 to a declarative descriptor (one_wire primitive)

### DIFF
--- a/configs/devices/dht22.yaml
+++ b/configs/devices/dht22.yaml
@@ -1,0 +1,37 @@
+# Declarative descriptor — DHT22 / AM2302 one-wire temperature+humidity sensor.
+#
+# A single bidirectional data line: the MCU pulls it low >=1 ms to request a
+# reading, then the sensor drives back a 40-bit frame with microsecond bit-cell
+# timing. That framed-bit protocol is the irreducible `one_wire` primitive
+# (crate::peripherals::components::dht22) — the sensor self-times off cpu_hz, so
+# cpu_hz must be the real firmware clock. Temperature and humidity are
+# host-controlled through the standard stimulus API.
+type: dht22
+
+# --- Runtime behavior (consumed by bus/declarative_device.rs) --------------
+behavior:
+  primitive: one_wire
+  # The one wire is bidirectional: `data` resolves to BOTH the pin's output
+  # (ODR, how the host drives it) and input (IDR, where the sensor replies).
+  pins:
+    data: data_pin
+  params:
+    cpu_hz: { key: cpu_hz, default: 80000000 }
+    temperature_c: { key: temperature_c, default: 22.0 }
+    humidity_pct: { key: humidity_pct, default: 50.0 }
+
+# --- Display / manifest metadata (phase 2: derives KitMetadata) ------------
+metadata:
+  label: "DHT22 / AM2302"
+  summary: "One-wire temperature + humidity sensor"
+  category: gpio
+  inputs:
+    - { key: temperature, label: "Temperature", unit: "°C", min: -40, max: 80 }
+    - { key: humidity, label: "Humidity", unit: "%", min: 0, max: 100 }
+
+# --- Canvas-compiler emit mapping (phase 2: unifies the TS/Rust emitters) ---
+emit:
+  connection: gpio
+  config:
+    - { key: data_pin, from_part_pin: [DATA, DAT, OUT] }
+    - { key: cpu_hz, from: sim_cpu_hz }

--- a/crates/core/src/bus/declarative_device.rs
+++ b/crates/core/src/bus/declarative_device.rs
@@ -21,9 +21,10 @@
 //! hand-written arm. Adding a device that reuses an existing primitive is then
 //! one YAML file — no new Rust in the attach path.
 //!
-//! Phase 1 migrates the rotary encoder (`quadrature`). Keypad / DHT22 / HC-SR04
-//! follow as their primitives are given descriptors; the emitter unification
-//! (both engines reading the descriptor's `emit:` block) is the next step.
+//! Migrated so far: rotary encoder (`quadrature`), 4×4 keypad (`matrix`), and
+//! DHT22/AM2302 (`one_wire`). HC-SR04 (`pulse_echo`) follows; the emitter
+//! unification (both engines reading the descriptor's `emit:` block) is the
+//! separate next step.
 
 use super::SystemBus;
 use anyhow::{anyhow, Context, Result};
@@ -39,6 +40,7 @@ fn embedded_yaml(device_type: &str) -> Option<&'static str> {
             "../../../../configs/devices/rotary_encoder.yaml"
         )),
         "keypad" => Some(include_str!("../../../../configs/devices/keypad.yaml")),
+        "dht22" | "am2302" => Some(include_str!("../../../../configs/devices/dht22.yaml")),
         _ => None,
     }
 }
@@ -68,12 +70,56 @@ impl SystemBus {
         match desc.behavior.primitive.as_str() {
             "quadrature" => self.attach_quadrature(ext, desc),
             "matrix" => self.attach_matrix(ext, desc),
+            "one_wire" => self.attach_one_wire(ext, desc),
             other => Err(anyhow!(
                 "declarative device '{}' names unknown primitive '{}'",
                 ext.id,
                 other
             )),
         }
+    }
+
+    /// `one_wire` primitive → [`Dht22`]. Reproduces the former `"dht22"`/
+    /// `"am2302"` arm: the single `data` role resolves to BOTH the pin's output
+    /// (ODR, host drive) and input (IDR, sensor reply) register — one
+    /// bidirectional wire — and temperature/humidity are host-controlled through
+    /// the standard stimulus API.
+    fn attach_one_wire(&mut self, ext: &ExternalDevice, desc: &DeviceDescriptor) -> Result<()> {
+        let data = self.pin_config(ext, desc, "data", "PA8")?;
+        let cpu_hz = param_u64(desc, ext, "cpu_hz", 80_000_000);
+        let temperature_c = param_f64(desc, ext, "temperature_c", 22.0) as f32;
+        let humidity_pct = param_f64(desc, ext, "humidity_pct", 50.0) as f32;
+
+        let (odr_addr, odr_bit) = Self::resolve_pin_odr(self, &data).ok_or_else(|| {
+            anyhow!(
+                "DHT22 '{}' data_pin '{}' could not be resolved to a GPIO output",
+                ext.id,
+                data
+            )
+        })?;
+        let (idr_addr, idr_bit) = Self::resolve_pin_idr(self, &data).ok_or_else(|| {
+            anyhow!(
+                "DHT22 '{}' data_pin '{}' could not be resolved to a GPIO input",
+                ext.id,
+                data
+            )
+        })?;
+        debug_assert_eq!(
+            odr_bit, idr_bit,
+            "ODR and IDR of one pin must share a bit index"
+        );
+
+        self.gpio_devices
+            .push(Box::new(crate::peripherals::components::dht22::Dht22::new(
+                ext.id.clone(),
+                odr_addr,
+                idr_addr,
+                odr_bit,
+                cpu_hz,
+                temperature_c,
+                humidity_pct,
+            )));
+        Ok(())
     }
 
     /// `matrix` primitive → [`Keypad`]. Reproduces the former `"keypad"` arm:
@@ -233,5 +279,23 @@ fn param_u64(desc: &DeviceDescriptor, ext: &ExternalDevice, name: &str, fallback
     ext.config
         .get(config_key)
         .and_then(|v| v.as_u64())
+        .unwrap_or(default)
+}
+
+/// Read an `f64` primitive param (temperature, humidity): same `{key, default}`
+/// descriptor shape as [`param_u64`], overridden by `config[key]` when present.
+fn param_f64(desc: &DeviceDescriptor, ext: &ExternalDevice, name: &str, fallback: f64) -> f64 {
+    let (config_key, default) = match desc.behavior.params.get(name) {
+        Some(v) => (
+            v.get("key").and_then(|k| k.as_str()).unwrap_or(name),
+            v.get("default")
+                .and_then(|d| d.as_f64())
+                .unwrap_or(fallback),
+        ),
+        None => (name, fallback),
+    };
+    ext.config
+        .get(config_key)
+        .and_then(|v| v.as_f64())
         .unwrap_or(default)
 }

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -615,73 +615,9 @@ impl SystemBus {
                         distance_cm,
                     ));
                 }
-                "dht22" | "am2302" => {
-                    // One-wire temperature/humidity sensor — no SPI/I2C
-                    // connection. Like the HC-SR04 it DRIVES a pin the MCU
-                    // samples as an input, so it lives directly on the bus:
-                    // the data pin's GPIO write-hook (`maybe_start_dht22`)
-                    // watches for the >=1 ms start pulse, and the per-tick pass
-                    // (`service_gpio_devices`) drives the reply frame onto the pin's
-                    // input register. Both `temperature` and `humidity` are
-                    // host-controlled through the standard stimulus API.
-                    let data = ext
-                        .config
-                        .get("data_pin")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("PA8")
-                        .to_string();
-                    let temperature_c = ext
-                        .config
-                        .get("temperature_c")
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(22.0) as f32;
-                    let humidity_pct = ext
-                        .config
-                        .get("humidity_pct")
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(50.0) as f32;
-                    let cpu_hz = ext
-                        .config
-                        .get("cpu_hz")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(80_000_000);
-
-                    // The one wire is bidirectional: the ODR bit is how the
-                    // host drives it, the IDR bit is where the sensor drives
-                    // back. Same pin, same bit, two registers.
-                    let (odr_addr, odr_bit) =
-                        Self::resolve_pin_odr(&bus, &data).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "DHT22 '{}' data_pin '{}' could not be resolved to a GPIO output",
-                                ext.id,
-                                data
-                            )
-                        })?;
-                    let (idr_addr, idr_bit) =
-                        Self::resolve_pin_idr(&bus, &data).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "DHT22 '{}' data_pin '{}' could not be resolved to a GPIO input",
-                                ext.id,
-                                data
-                            )
-                        })?;
-                    debug_assert_eq!(
-                        odr_bit, idr_bit,
-                        "ODR and IDR of one pin must share a bit index"
-                    );
-
-                    bus.gpio_devices.push(Box::new(
-                        crate::peripherals::components::dht22::Dht22::new(
-                            ext.id.clone(),
-                            odr_addr,
-                            idr_addr,
-                            odr_bit,
-                            cpu_hz,
-                            temperature_c,
-                            humidity_pct,
-                        ),
-                    ));
-                }
+                // dht22 / am2302 now dispatches through the declarative device
+                // path above (configs/devices/dht22.yaml, `one_wire` primitive) —
+                // see super::declarative_device.
                 // rotary-encoder / rotary_encoder now dispatches through the
                 // declarative device path above (configs/devices/rotary_encoder.yaml,
                 // `quadrature` primitive) — see super::declarative_device.

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -769,6 +769,56 @@ board_io: []
     );
 }
 
+/// The `dht22`/`am2302` external device dispatches through the DECLARATIVE
+/// device path (`configs/devices/dht22.yaml`, `one_wire` primitive). This locks
+/// that seam: the single bidirectional data pin must resolve to BOTH the GPIO
+/// output (ODR) and input (IDR) register, and cpu_hz must thread from config —
+/// exactly what the deleted hand-written arm produced.
+#[test]
+fn test_from_config_attaches_dht22_via_declarative_descriptor() {
+    use crate::peripherals::components::dht22::Dht22;
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip = ChipDescriptor::from_file(root.join("../../configs/chips/stm32f103.yaml"))
+        .expect("read STM32F103 chip descriptor");
+    // Both `type:` spellings must resolve to the same declarative descriptor.
+    for type_str in ["dht22", "am2302"] {
+        let manifest: SystemManifest = serde_yaml::from_str(&format!(
+            r#"
+name: "dht22-declarative"
+chip: "../chips/stm32f103.yaml"
+external_devices:
+  - id: "sensor"
+    type: "{type_str}"
+    connection: "gpio"
+    config:
+      data_pin: "PA8"
+      cpu_hz: 8000000
+      temperature_c: 25.0
+      humidity_pct: 60.0
+board_io: []
+"#
+        ))
+        .expect("parse dht22 manifest");
+
+        let bus = SystemBus::from_config(&chip, &manifest).expect("build bus with dht22");
+        let sensors: Vec<&Dht22> = bus.gpio_devices_of::<Dht22>().collect();
+        assert_eq!(
+            sensors.len(),
+            1,
+            "exactly one Dht22 attached for type '{type_str}'"
+        );
+        let s = sensors[0];
+        assert_eq!(s.id, "sensor");
+        assert_eq!(s.data_bit, 8, "data_pin PA8 → bit 8");
+        assert_ne!(
+            s.data_odr_addr, s.data_idr_addr,
+            "one bidirectional wire resolves to distinct ODR and IDR registers"
+        );
+        assert_eq!(s.cpu_hz, 8_000_000, "cpu_hz sourced from config");
+    }
+}
+
 #[test]
 fn curated_esp32c3_i2c_manifests_declare_physical_routes() {
     #[derive(serde::Deserialize)]


### PR DESCRIPTION
Third device on the declarative GPIO-device path (after rotary #605 + keypad #606, both merged). Proves the descriptor covers a **framed-bit self-timed** protocol.

## What
The DHT22's single bidirectional data line + 40-bit framed reply is the irreducible `one_wire` primitive; everything around it becomes data:
- **`configs/devices/dht22.yaml`** — `one_wire` primitive; the single `data` role resolves to **both** the pin's ODR (host drive) and IDR (sensor reply); `cpu_hz`/`temperature_c`/`humidity_pct` params; `metadata`/`emit` carried for phase 2.
- **`bus/declarative_device.rs`** — `attach_one_wire` + a `param_f64` helper (temperature/humidity).
- **`from_config`** — the hand-written `dht22`/`am2302` arm **deleted**.
- **tests** — `from_config` dispatch (both spellings; data pin → distinct ODR+IDR; cpu_hz threaded).

## Verification
- Behavior **byte-identical** to the deleted arm: same `Dht22` model, same errors, same defaults (PA8 / 22 °C / 50 % / 80 MHz).
- dht22 + declarative + rotary + keypad tests green; **full `labwired-core` suite green**; `clippy --all-targets -- -D warnings` clean; `fmt` clean.

Next and last device: HC-SR04 (`pulse_echo`). Then the emitter unification.