### PR TITLE
feat(core): migrate hc-sr04 to a declarative descriptor (pulse_echo primitive)

### DIFF
--- a/configs/devices/hc_sr04.yaml
+++ b/configs/devices/hc_sr04.yaml
@@ -1,0 +1,40 @@
+# Declarative descriptor — HC-SR04 ultrasonic distance sensor.
+#
+# Two GPIO wires: the MCU pulses TRIG (an output the sensor observes), and the
+# sensor replies on ECHO (an input it drives) with a pulse whose width is
+# proportional to distance. That trigger→timed-echo behavior is the irreducible
+# `pulse_echo` primitive (crate::peripherals::hc_sr04). Unlike the bus-resident
+# devices, HC-SR04 carries the event-scheduler edge-deadline path, so it lives
+# on its own bus list. `distance_cm` is the host-controlled "hand position".
+type: hc-sr04
+
+# --- Runtime behavior (consumed by bus/declarative_device.rs) --------------
+behavior:
+  primitive: pulse_echo
+  # trig resolves to a GPIO output (ODR, observed); echo to an input (IDR, driven).
+  pins:
+    trig: trig_pin
+    echo: echo_pin
+  params:
+    cpu_hz: { key: cpu_hz, default: 80000000 }
+    distance_cm: { key: distance_cm, default: 50.0 }
+
+# --- Display / manifest metadata (phase 2: derives KitMetadata) ------------
+metadata:
+  label: "HC-SR04"
+  summary: "Ultrasonic distance sensor (trigger / echo)"
+  category: gpio
+  inputs:
+    - { key: distance, label: "Distance", unit: cm, min: 2, max: 400 }
+
+# --- Canvas-compiler emit mapping (phase 2: unifies the TS/Rust emitters) ---
+# NOTE: unlike the self-timed one-wire/quadrature devices, HC-SR04's cpu_hz uses
+# the emitter's echo-pacing override (DEFAULT_CPU_HZ_BY_BOARD), not sim_cpu_hz —
+# firmware times the echo itself, so the stretched clock is tolerated. Phase 2
+# must preserve that when it derives the emit from this descriptor.
+emit:
+  connection: gpio
+  config:
+    - { key: trig_pin, from_part_pin: [TRIG, TRG] }
+    - { key: echo_pin, from_part_pin: [ECHO, ECH] }
+    - { key: cpu_hz, from: echo_pacing_cpu_hz }

--- a/crates/core/src/bus/declarative_device.rs
+++ b/crates/core/src/bus/declarative_device.rs
@@ -21,10 +21,11 @@
 //! hand-written arm. Adding a device that reuses an existing primitive is then
 //! one YAML file — no new Rust in the attach path.
 //!
-//! Migrated so far: rotary encoder (`quadrature`), 4×4 keypad (`matrix`), and
-//! DHT22/AM2302 (`one_wire`). HC-SR04 (`pulse_echo`) follows; the emitter
-//! unification (both engines reading the descriptor's `emit:` block) is the
-//! separate next step.
+//! Migrated: rotary encoder (`quadrature`), 4×4 keypad (`matrix`), DHT22/AM2302
+//! (`one_wire`), and HC-SR04 (`pulse_echo`). NeoPixel stays a GPIO observer for
+//! now (ESP32-S3-specific, not a `BusResidentDevice`). The emitter unification
+//! (both engines reading the descriptor's `emit:` block) is the separate next
+//! step.
 
 use super::SystemBus;
 use anyhow::{anyhow, Context, Result};
@@ -41,6 +42,7 @@ fn embedded_yaml(device_type: &str) -> Option<&'static str> {
         )),
         "keypad" => Some(include_str!("../../../../configs/devices/keypad.yaml")),
         "dht22" | "am2302" => Some(include_str!("../../../../configs/devices/dht22.yaml")),
+        "hc-sr04" | "hcsr04" => Some(include_str!("../../../../configs/devices/hc_sr04.yaml")),
         _ => None,
     }
 }
@@ -71,12 +73,53 @@ impl SystemBus {
             "quadrature" => self.attach_quadrature(ext, desc),
             "matrix" => self.attach_matrix(ext, desc),
             "one_wire" => self.attach_one_wire(ext, desc),
+            "pulse_echo" => self.attach_pulse_echo(ext, desc),
             other => Err(anyhow!(
                 "declarative device '{}' names unknown primitive '{}'",
                 ext.id,
                 other
             )),
         }
+    }
+
+    /// `pulse_echo` primitive → [`HcSr04`]. Reproduces the former `"hc-sr04"`/
+    /// `"hcsr04"` arm: `trig` resolves to a GPIO **output** (ODR, the sensor
+    /// observes the MCU's trigger pulse) and `echo` to a GPIO **input** (IDR,
+    /// the sensor drives a distance-proportional pulse back). Unlike the
+    /// bus-resident devices this pushes onto the dedicated `hcsr04` list (it
+    /// carries the event-scheduler edge path); `distance_cm` is the
+    /// host-controlled hand position.
+    fn attach_pulse_echo(&mut self, ext: &ExternalDevice, desc: &DeviceDescriptor) -> Result<()> {
+        let trig = self.pin_config(ext, desc, "trig", "PA8")?;
+        let echo = self.pin_config(ext, desc, "echo", "PA9")?;
+        let cpu_hz = param_u64(desc, ext, "cpu_hz", 80_000_000);
+        let distance_cm = param_f64(desc, ext, "distance_cm", 50.0) as f32;
+
+        let (trig_addr, trig_bit) = Self::resolve_pin_odr(self, &trig).ok_or_else(|| {
+            anyhow!(
+                "HC-SR04 '{}' trig_pin '{}' could not be resolved to a GPIO",
+                ext.id,
+                trig
+            )
+        })?;
+        let (echo_addr, echo_bit) = Self::resolve_pin_idr(self, &echo).ok_or_else(|| {
+            anyhow!(
+                "HC-SR04 '{}' echo_pin '{}' could not be resolved to a GPIO",
+                ext.id,
+                echo
+            )
+        })?;
+
+        self.hcsr04.push(crate::peripherals::hc_sr04::HcSr04::new(
+            ext.id.clone(),
+            trig_addr,
+            trig_bit,
+            echo_addr,
+            echo_bit,
+            cpu_hz,
+            distance_cm,
+        ));
+        Ok(())
     }
 
     /// `one_wire` primitive → [`Dht22`]. Reproduces the former `"dht22"`/

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -560,61 +560,9 @@ impl SystemBus {
                 // iolink-master dispatches through the PeripheralKit registry above.
                 // max31855, sn74hc165, ssd1680_tricolor_290, and pcd8544
                 // dispatch through the PeripheralKit registry above.
-                "hc-sr04" | "hcsr04" => {
-                    // GPIO-wired ultrasonic sensor — no SPI/I2C connection. The
-                    // bus services it each tick: reads TRIG (an MCU output) and
-                    // drives ECHO (an MCU input) with a distance-proportional
-                    // pulse. `distance_cm` is the host-controlled "hand position".
-                    let trig = ext
-                        .config
-                        .get("trig_pin")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("PA8")
-                        .to_string();
-                    let echo = ext
-                        .config
-                        .get("echo_pin")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("PA9")
-                        .to_string();
-                    let distance_cm = ext
-                        .config
-                        .get("distance_cm")
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(50.0) as f32;
-                    let cpu_hz = ext
-                        .config
-                        .get("cpu_hz")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(80_000_000);
-
-                    let (trig_addr, trig_bit) =
-                        Self::resolve_pin_odr(&bus, &trig).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "HC-SR04 '{}' trig_pin '{}' could not be resolved to a GPIO",
-                                ext.id,
-                                trig
-                            )
-                        })?;
-                    let (echo_addr, echo_bit) =
-                        Self::resolve_pin_idr(&bus, &echo).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "HC-SR04 '{}' echo_pin '{}' could not be resolved to a GPIO",
-                                ext.id,
-                                echo
-                            )
-                        })?;
-
-                    bus.hcsr04.push(crate::peripherals::hc_sr04::HcSr04::new(
-                        ext.id.clone(),
-                        trig_addr,
-                        trig_bit,
-                        echo_addr,
-                        echo_bit,
-                        cpu_hz,
-                        distance_cm,
-                    ));
-                }
+                // hc-sr04 / hcsr04 now dispatches through the declarative device
+                // path above (configs/devices/hc_sr04.yaml, `pulse_echo`
+                // primitive) — see super::declarative_device.
                 // dht22 / am2302 now dispatches through the declarative device
                 // path above (configs/devices/dht22.yaml, `one_wire` primitive) —
                 // see super::declarative_device.

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -819,6 +819,53 @@ board_io: []
     }
 }
 
+/// The `hc-sr04`/`hcsr04` external device dispatches through the DECLARATIVE
+/// device path (`configs/devices/hc_sr04.yaml`, `pulse_echo` primitive). Unlike
+/// the bus-resident devices it lands on the dedicated `bus.hcsr04` list, with
+/// TRIG resolved to a GPIO output (ODR) and ECHO to an input (IDR) — exactly
+/// what the deleted hand-written arm produced.
+#[test]
+fn test_from_config_attaches_hcsr04_via_declarative_descriptor() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip = ChipDescriptor::from_file(root.join("../../configs/chips/stm32f103.yaml"))
+        .expect("read STM32F103 chip descriptor");
+    for type_str in ["hc-sr04", "hcsr04"] {
+        let manifest: SystemManifest = serde_yaml::from_str(&format!(
+            r#"
+name: "hcsr04-declarative"
+chip: "../chips/stm32f103.yaml"
+external_devices:
+  - id: "dist"
+    type: "{type_str}"
+    connection: "gpio"
+    config:
+      trig_pin: "PA8"
+      echo_pin: "PA9"
+      cpu_hz: 8000000
+      distance_cm: 30.0
+board_io: []
+"#
+        ))
+        .expect("parse hc-sr04 manifest");
+
+        let bus = SystemBus::from_config(&chip, &manifest).expect("build bus with hc-sr04");
+        assert_eq!(
+            bus.hcsr04.len(),
+            1,
+            "exactly one HcSr04 attached for type '{type_str}'"
+        );
+        let s = &bus.hcsr04[0];
+        assert_eq!(s.id, "dist");
+        assert_eq!(s.trig_bit, 8, "trig_pin PA8 → bit 8");
+        assert_eq!(s.echo_bit, 9, "echo_pin PA9 → bit 9");
+        assert_ne!(
+            s.trig_odr_addr, s.echo_idr_addr,
+            "TRIG drives ODR, ECHO reads IDR — different registers"
+        );
+        assert_eq!(s.cpu_hz, 8_000_000, "cpu_hz sourced from config");
+    }
+}
+
 #[test]
 fn curated_esp32c3_i2c_manifests_declare_physical_routes() {
     #[derive(serde::Deserialize)]


### PR DESCRIPTION
Fourth and final GPIO/pin-timing device on the declarative path (after rotary #605, keypad #606, dht22 #607 — all merged). Completes migrating the family.

## What
The HC-SR04's trigger→timed-echo behavior is the irreducible `pulse_echo` primitive:
- **`configs/devices/hc_sr04.yaml`** — `pulse_echo`; `trig`→GPIO output (ODR), `echo`→input (IDR); `cpu_hz`/`distance_cm` params. The `emit` note records that HC-SR04 uses the echo-pacing cpu_hz override, **not** `sim_cpu_hz` (firmware times the echo itself) — phase 2 must preserve that.
- **`bus/declarative_device.rs`** — `attach_pulse_echo`, which pushes to the dedicated `bus.hcsr04` list (HC-SR04 carries the event-scheduler edge path, so it is not a `BusResidentDevice`).
- **`from_config`** — the hand-written `hc-sr04`/`hcsr04` arm **deleted**.
- **tests** — `from_config` dispatch (both spellings; trig→ODR, echo→IDR).

## Verification
- Behavior **byte-identical** to the deleted arm: same `HcSr04` model, same errors, same defaults (PA8/PA9 / 50 cm / 80 MHz).
- Full `labwired-core` suite green; `clippy --all-targets -- -D warnings` clean; `fmt` clean.

## State after this
The whole GPIO/pin-timing family — rotary, keypad, dht22, hc-sr04 — is now descriptor-driven. Adding one that reuses a primitive is a single YAML file, zero Rust in the attach path. Only NeoPixel remains hand-wired (an ESP32-S3 GPIO observer). The emitter unification (both engines reading the descriptor `emit:` block) is the separate next step.