### PR TITLE
examples: add canonical .labwired/lab.yaml to every example

### DIFF
--- a/examples/adxl345-sensor-lab/.labwired/lab.yaml
+++ b/examples/adxl345-sensor-lab/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - ADXL345 Sensor Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/adxl345-sensor-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "ADXL345 Sensor Lab"
+  - uart_contains: "DEVID=0xE5"
+  - expected_stop_reason: max_steps

--- a/examples/arm-c-hello/.labwired/lab.yaml
+++ b/examples/arm-c-hello/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/bme280-weather-lab/.labwired/lab.yaml
+++ b/examples/bme280-weather-lab/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - BME280 Weather Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/bme280-weather-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "BME280 Weather Lab"
+  - uart_contains: "ChipID=0x"
+  - expected_stop_reason: max_steps

--- a/examples/canmod-gps-sim/.labwired/lab.yaml
+++ b/examples/canmod-gps-sim/.labwired/lab.yaml
@@ -1,0 +1,20 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/build/canmod_gps_sim.elf"
+limits:
+  max_steps: 300000
+assertions:
+  # Simulated CANmod.gps on the emulated F103 bxCAN (classical CAN, loopback).
+  - uart_contains: "CANMOD-GPS-SIM"
+  # Decoded, human-readable beat (tick 0):
+  - uart_contains: "FIX type=3 sats=11"
+  - uart_contains: "POS lat=55.676100 lon=12.568300"
+  - uart_contains: "SPEED 10.000 m/s"
+  # Raw frames — all 9 DBC IDs appear on the bus:
+  - uart_contains: "CAN_TX 0001: 5B"
+  - uart_contains: "CAN_TX 0003:"
+  - uart_contains: "CAN_TX 0007:"
+  - uart_contains: "CAN_TX 0009:"
+  - uart_contains: "CANMOD_OK frames=45"
+  - expected_stop_reason: max_steps

--- a/examples/cosim-plant-demo/.labwired/lab.yaml
+++ b/examples/cosim-plant-demo/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/demo-blinky/.labwired/lab.yaml
+++ b/examples/demo-blinky/.labwired/lab.yaml
@@ -1,0 +1,18 @@
+# LabWired - Demo Blinky IO smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/demo-blinky"
+  system: "../system.yaml"
+limits:
+  max_steps: 10000
+assertions:
+  # Verify GPIOA_CRL (0x40010800) is configured.
+  # Main sets PA5 to output push-pull 50MHz (0x3).
+  # CRL bits 23:20 (for pin 5).
+  # We check if bits 21:20 are 11 (0x3). 
+  # Mask 0x00300000. Expected 0x00300000.
+  - memory_value:
+      address: 0x40010800
+      expected_value: 0x00300000
+      mask: 0x00300000
+  - expected_stop_reason: max_steps

--- a/examples/epaper-tricolor-lab/.labwired/lab.yaml
+++ b/examples/epaper-tricolor-lab/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/esp32-epaper-lab/.labwired/lab.yaml
+++ b/examples/esp32-epaper-lab/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/esp32c3-blinky/.labwired/lab.yaml
+++ b/examples/esp32c3-blinky/.labwired/lab.yaml
@@ -1,0 +1,21 @@
+# Headless run of the ESP32-C3 blinky firmware.
+#
+# Asserts the firmware actually drives the LED pin: GPIO8 is enabled as an
+# output (GPIO_ENABLE, 0x60004020, bit 8) and the blink loop runs long enough
+# to log several on/off transitions over UART0.
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/esp32c3_blinky.elf"
+limits:
+  max_steps: 400000
+assertions:
+  - uart_contains: "C3 BLINKY BOOT"
+  - uart_contains: "LED ON"
+  - uart_contains: "LED OFF"
+  # GPIO_ENABLE bit 8: the LED pin is configured as an output.
+  - memory_value:
+      address: 0x60004020
+      expected_value: 0x00000100
+      mask: 0x00000100
+  - expected_stop_reason: max_steps

--- a/examples/esp32c3-leo-airquality/.labwired/lab.yaml
+++ b/examples/esp32c3-leo-airquality/.labwired/lab.yaml
@@ -1,0 +1,383 @@
+# Headless run of the ESP32-C3 Leo air-quality firmware — NORMAL scenario.
+#
+# The firmware reads four sensors over the real C3 I²C0 controller using the
+# unmodified Sensirion vendor drivers ON-TARGET, and prints a plain-language air
+# verdict per cycle. NORMAL: a closed room fills up, CO₂ climbs from fresh
+# (~450 ppm) toward stuffy (~1400 ppm), and the verdict flips from "air quality
+# is good" to "crack a window" as CO₂ crosses 1000 ppm.
+#
+# NB: the simple_regex engine supports only `.`, `*`, `^`, `$` — no char classes
+# or alternation — so all assertions below are literal substrings.
+schema_version: "1.2"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/leo_airquality.elf"
+limits:
+  # The C3 I2C0 model clocks every transaction bit-by-bit at the wire rate the
+  # timing registers dictate, and the firmware busy-waits on TRANS_COMPLETE like
+  # real silicon. MEASURED: one measurement cycle costs ~343.8k core cycles, so
+  # the 64 samples + the OLED renders run to `LEO DONE` and the final frame dump
+  # at ~8.65M steps / ~22.6M cycles. 12M steps leaves ~38 % headroom; anything
+  # far above that just burns the post-DONE idle spin (2 cycles/instruction) and
+  # pushes the `cycles` counter far past the window the stimuli ladder lives in.
+  max_steps: 12000000
+assertions:
+  # Boot banner + all four sensors brought up over real I²C.
+  - uart_contains: "LEO BOOT"
+  - uart_contains: "SCD41 READY"
+  - uart_contains: "SGP41 READY"
+  - uart_contains: "SPS30 READY"
+  - uart_contains: "VEML7700 READY"
+  - uart_contains: "OLED READY"
+  - uart_contains: "OLED render done"
+  # Early cycles: fresh air. The decoded CO₂ starts low.
+  - uart_contains: "AIR: fresh - air quality is good"
+  # The headline transition once CO₂ climbs past 1000 ppm — the plain-language
+  # verdict Leo's product is built around.
+  - uart_contains: "crack a window"
+  # Surface-condensation channel (MLX90614 IR + SCD41 dew point): the cold wall
+  # crosses below the dew point and the surface RH hits condensation while the
+  # *air* RH is still benign — the moisture-first mold signal an air-only Mold
+  # Index cannot see. This is the differentiator, so it is gated here.
+  - uart_contains: "SURFACE:"
+  - uart_contains: "CONDENSING - wall is wet"
+  - uart_contains: "surface condensation"
+  # The run completes its measurement cycles.
+  - uart_contains: "LEO DONE"
+
+# ── Scene ─────────────────────────────────────────────────────────────────
+# The sensor models hold whatever value they were last given: there is exactly
+# ONE way to move a reading, `set_input` (see labwired_core::sim_input). The
+# room's story is therefore written here, as a ladder of driven values on the
+# devices' real engineering-unit channels.
+#
+# PACING (measured, not guessed). `after_cycles` is the only time trigger the
+# stimuli schema offers, so every rung is an absolute cycle count and it MUST
+# sit inside the window in which the firmware is still sampling. That window was
+# measured against this exact firmware ELF by probing it with a 250k-cycle
+# ladder of marker values and reading back which `t=` sample each one reached:
+#
+#   sample t=4 reads at 1.25M cycles ... sample t=60 reads at 20.5M cycles
+#   => ~343.8k cycles per measurement cycle; all 64 samples done by ~21M cycles.
+#
+# The 15 rungs below are the original first-order glide sampled every 4th
+# measurement cycle, each placed at the measured read cycle of samples
+# t = 4, 8, 12 ... 60. A rung placed past ~21M cycles fires after the firmware
+# has stopped measuring and is DEAD: it changes no reading, and a scenario built
+# from dead rungs passes (or fails) for reasons that have nothing to do with it.
+stimuli:
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 719
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 912
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 1051
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 1150
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 1221
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 1272
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 1308
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 1334
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 1353
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 1366
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 1376
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 1383
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 1388
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 1391
+  - target: { component: "scd41", channel: "co2" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 1394
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 53.3
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 56.1
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 58.5
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 60.6
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 62.3
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 63.7
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 65.0
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 66.0
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 66.9
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 67.7
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 68.3
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 68.9
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 69.4
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 69.8
+  - target: { component: "scd41", channel: "humidity" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 70.1
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 22.2
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 22.4
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 22.6
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 22.7
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 22.8
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 22.9
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 23.0
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 23.1
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 23.2
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 23.2
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 23.3
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 23.3
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 23.3
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 23.3
+  - target: { component: "scd41", channel: "temperature" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 23.4
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 15.73
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 14.11
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 12.94
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 12.11
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 11.51
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 11.08
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 10.77
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 10.56
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 10.40
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 10.28
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 10.20
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 10.15
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 10.10
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 10.08
+  - target: { component: "surface-ir", channel: "surface_temp" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 10.05
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 347.9
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 274.8
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 222.4
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 184.8
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 157.9
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 138.7
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 124.9
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 115.0
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 107.9
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 102.8
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 99.2
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 96.6
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 94.7
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 93.4
+  - target: { component: "veml7700", channel: "lux" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 92.4
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 10.54
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 13.79
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 16.12
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 17.79
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 18.98
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 19.84
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 20.45
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 20.89
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 21.20
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 21.43
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 21.59
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 21.71
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 21.79
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 21.85
+  - target: { component: "sps30", channel: "pm2_5" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 21.89
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 1250000 }
+    value: 29702
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 2500000 }
+    value: 30921
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 3750000 }
+    value: 31794
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 5250000 }
+    value: 32420
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 6500000 }
+    value: 32868
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 7750000 }
+    value: 33189
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 9000000 }
+    value: 33419
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 10250000 }
+    value: 33584
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 11750000 }
+    value: 33702
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 13000000 }
+    value: 33786
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 14250000 }
+    value: 33847
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 15750000 }
+    value: 33890
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 17250000 }
+    value: 33921
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 18750000 }
+    value: 33944
+  - target: { component: "sgp41", channel: "voc_sraw" }
+    trigger: !after_cycles { cycles: 20500000 }
+    value: 33960

--- a/examples/esp32c3-mlx90640-thermal/.labwired/lab.yaml
+++ b/examples/esp32c3-mlx90640-thermal/.labwired/lab.yaml
@@ -1,0 +1,30 @@
+# Headless run of the ESP32-C3 thermal-fingerprint firmware — NORMAL scenario.
+#
+# The firmware reads the MLX90640 over the real C3 I²C0 controller, decodes
+# per-pixel °C with the unmodified Melexis driver ON-TARGET, runs the spatial
+# thermal-fingerprint state machine, and prints a verdict per frame.
+#
+# NORMAL: the fan-cooled hotspot warms up to a bounded ~49 °C plateau and never
+# faults. Assert the firmware boots, reaches the STABLE state, and reports
+# fault=NONE with full health (100). The frame loop is driven by I²C
+# status-poll → frame-read → STATUS-clear, which advances the thermal scene.
+#
+# NB: the simple_regex engine supports only `.`, `*`, `^`, `$` — no char
+# classes or alternation — so all assertions below are literal substrings.
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/thermal_fingerprint.elf"
+limits:
+  max_steps: 50000000
+assertions:
+  # Boot banner + sensor brought up over real I²C.
+  - uart_contains: "TFS BOOT"
+  - uart_contains: "MLX90640 READY"
+  # The fingerprint state machine progresses through warm-up to STABLE.
+  - uart_contains: "state=WARMUP"
+  - uart_contains: "state=STABLE"
+  # NORMAL never faults; the per-frame verdict reports fault=NONE.
+  - uart_contains: "fault=NONE"
+  # Health stays at full margin in the bounded-plateau regime.
+  - uart_contains: "health=100"

--- a/examples/f103-fidelity-bench/.labwired/lab.yaml
+++ b/examples/f103-fidelity-bench/.labwired/lab.yaml
@@ -1,0 +1,13 @@
+schema_version: "1.0"
+# rambug: firmware stores 4 KB past the end of the 20 KB SRAM. Ground truth: that
+# address is unimplemented on an F103C8, the store faults (HardFault), and
+# BENCH_RAM_OK never prints. LabWired (real 20 KB RAM) reproduces this: a memory
+# violation, no marker — EXPECTED TO FAIL. A pass here means the emulator mapped
+# an oversized RAM (a false pass).
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/build/rambug.elf"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "BENCH_RAM_OK"

--- a/examples/f103-i2c-silicon/.labwired/lab.yaml
+++ b/examples/f103-i2c-silicon/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - STM32F103 I²C silicon-validation smoke
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/firmware-f103-i2c-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 50000000
+assertions:
+  - uart_contains: "F103 I2C"
+  - uart_contains: "DONE"
+  - expected_stop_reason: max_steps

--- a/examples/f103-j1939-monitor/.labwired/lab.yaml
+++ b/examples/f103-j1939-monitor/.labwired/lab.yaml
@@ -1,0 +1,21 @@
+schema_version: "1.0"
+inputs:
+  system: "../replay-system.yaml"
+  firmware: "../firmware/build/j1939_monitor.elf"
+limits:
+  max_steps: 9000000
+assertions:
+  - uart_contains: "J1939-MONITOR START"
+  # Per-SA BAM reassembly under interleaved traffic: the engine (SA 00) and
+  # retarder (SA 0F) BAM sessions open 10 ms apart in this synthetic capture
+  # and their TP.DT packets interleave before either session closes. A
+  # single-global-session reassembler would corrupt one payload with bytes
+  # from the other session; per-SA keying (sess_for) avoids that.
+  - uart_contains: "BAM sa=00 pgn=FEE3 len=39 data=C012A2A3A4A5A6A7"
+  - uart_contains: "ENGINE idle_rpm=600"
+  - uart_contains: "BAM sa=0F pgn=FEE1 len=19 data=5051525354555657"
+  # DM1 from all 9 distinct source addresses in the capture:
+  - uart_contains: "DM1 sa=00 lamps=03"
+  - uart_contains: "DM1 sources=9"
+  - uart_contains: "RX total=1000"
+  - expected_stop_reason: max_steps

--- a/examples/f103-uds-ecu/.labwired/lab.yaml
+++ b/examples/f103-uds-ecu/.labwired/lab.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/build/f103_uds_ecu.elf"
+limits:
+  max_steps: 600000
+assertions:
+  # Two real nodes on the bus: a virtual UDS tester drives the multi-frame
+  # SecurityAccess request, and real UDSLib on the emulated F103 bxCAN (normal
+  # mode, valid BTR, acceptance filter) reassembles it and answers. UDS_SEED_SERVED
+  # means the reassembled request actually dispatched to the ECU's seed handler.
+  - uart_contains: "F103-UDS-ECU"
+  - uart_contains: "ECU_READY"
+  - uart_contains: "UDS_SEED_SERVED"
+  - expected_stop_reason: max_steps

--- a/examples/h563-uds-bootloader/.labwired/lab.yaml
+++ b/examples/h563-uds-bootloader/.labwired/lab.yaml
@@ -1,0 +1,24 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../../../../udslib/examples/h563_uds_bootloader/bootloader/build/h563_uds_bootloader_sim.elf"
+limits:
+  # The full OTA flow (handshake → download → verify → activate → bank-swap →
+  # reset → boot APP-B) completes in ~440k steps; the new app then idles, so
+  # the run terminates on max_steps after every milestone has printed.
+  max_steps: 15000000
+assertions:
+  - uart_contains: "BL-START"
+  - uart_contains: "BL-RECOVERY"
+  - uart_contains: "BL: UDS server ready"
+  - uart_contains: "SIM: copy OK"
+  - uart_contains: "BL: routine erase"
+  - uart_contains: "BL: erasing inactive app"
+  - uart_contains: "BL: download armed"
+  - uart_contains: "OTA-WRITE-OK"
+  - uart_contains: "OTA-VERIFY-OK"
+  - uart_contains: "OTA-ACTIVATE"
+  - uart_contains: "BL: marking inactive bank pending"
+  - uart_contains: "BL: activate software"
+  - uart_contains: "BL-JUMP"
+  - uart_contains: "APP-B v2"

--- a/examples/h563-uds-ecu/.labwired/lab.yaml
+++ b/examples/h563-uds-ecu/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/h563_uds_ecu.elf"
+limits:
+  max_steps: 2000000
+assertions:
+  - uart_contains: "H563-UDS-ECU"
+  - uart_contains: "ECU_READY"
+  - uds_tester: { id: "uds-tester", result: done }

--- a/examples/hc595-7seg-lab/.labwired/lab.yaml
+++ b/examples/hc595-7seg-lab/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/hil-displacement-showcase/.labwired/lab.yaml
+++ b/examples/hil-displacement-showcase/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - HIL Displacement Showcase Test Manifest
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../../../target/thumbv7m-none-eabi/release/firmware-hil-showcase"
+limits:
+  max_steps: 1000000
+  max_cycles: 5000000
+assertions:
+  - uart_contains: "HIL Stress Test Passed"
+  - expected_stop_reason: halt

--- a/examples/ili9341-tft-lab/.labwired/lab.yaml
+++ b/examples/ili9341-tft-lab/.labwired/lab.yaml
@@ -1,0 +1,12 @@
+# LabWired - ILI9341 TFT Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/ili9341-tft-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 20000000
+assertions:
+  - uart_contains: "ILI9341 TFT Lab"
+  - uart_contains: "TFT init done"
+  - uart_contains: "frame done"
+  - expected_stop_reason: max_steps

--- a/examples/iolink-dido/.labwired/lab.yaml
+++ b/examples/iolink-dido/.labwired/lab.yaml
@@ -1,0 +1,12 @@
+# Headless run of the IO-Link DI device firmware in the simulator.
+# M1 gate: the firmware boots and prints its banner over the debug UART.
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+  firmware: "../firmware/iolink_dido.elf"
+limits:
+  max_steps: 20000000
+assertions:
+  - uart_contains: "IOLINK DIDO BOOT"
+  - uart_contains: "IOLINK INIT OK"
+  - uart_contains: "OPERATE PD="

--- a/examples/iolink-station/device-svc/.labwired/lab.yaml
+++ b/examples/iolink-station/device-svc/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/iolink-station/master/.labwired/lab.yaml
+++ b/examples/iolink-station/master/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/iolink-station/sensor/.labwired/lab.yaml
+++ b/examples/iolink-station/sensor/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/iolink-station/sensor2/.labwired/lab.yaml
+++ b/examples/iolink-station/sensor2/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/iolink-station/sensor3/.labwired/lab.yaml
+++ b/examples/iolink-station/sensor3/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/iolink-station/sensor4/.labwired/lab.yaml
+++ b/examples/iolink-station/sensor4/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/max31855-thermocouple-lab/.labwired/lab.yaml
+++ b/examples/max31855-thermocouple-lab/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - MAX31855 Thermocouple Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/max31855-thermocouple-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "MAX31855 Thermocouple Lab"
+  - uart_contains: "word=0x"
+  - expected_stop_reason: max_steps

--- a/examples/mb1355c/.labwired/lab.yaml
+++ b/examples/mb1355c/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - MB1355C UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../board_firmware/target/thumbv7em-none-eabi/release/firmware-mb1355c-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/mpu6050-sensor-lab/.labwired/lab.yaml
+++ b/examples/mpu6050-sensor-lab/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - MPU6050 IMU Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/mpu6050-sensor-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "MPU6050 IMU Lab"
+  - uart_contains: "WHO_AM_I=0x"
+  - expected_stop_reason: max_steps

--- a/examples/neo6m-gps-lab/.labwired/lab.yaml
+++ b/examples/neo6m-gps-lab/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - NEO-6M GPS Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/neo6m-gps-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "NEO-6M GPS Lab"
+  - uart_contains: "[GPS] "
+  - expected_stop_reason: max_steps

--- a/examples/nokia5110-invaders-lab/.labwired/lab.yaml
+++ b/examples/nokia5110-invaders-lab/.labwired/lab.yaml
@@ -1,0 +1,12 @@
+# LabWired - Nokia 5110 (PCD8544) + HC-SR04 "Invaders" smoke test.
+# Visual lab: the real output is the LCD framebuffer (see the web playground).
+# This CLI smoke is a clean-run check — boot, attach both devices, run the game
+# loop fault-free for 5M steps.
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7em-none-eabi/release/nokia5110-invaders-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 5000000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/nrf52840-proximity-lab/.labwired/lab.yaml
+++ b/examples/nrf52840-proximity-lab/.labwired/lab.yaml
@@ -1,0 +1,41 @@
+schema_version: "1.0"
+# CLI smoke test for the nRF52840 + HC-SR04 proximity lab.
+#
+# Mirrors the browser demo and the Rust e2e test (e2e_nrf52840_proximity.rs),
+# but exercises the SAME firmware through the `labwired-cli test` harness so the
+# lab has a reproducible command-line entry point.
+#
+# IMPORTANT: this drives the lab via `test --script` (which loads system.yaml and
+# therefore WIRES the HC-SR04). `run --chip ...` does NOT attach the sensor, so
+# the ECHO line never fires and the ranging statics stay 0.
+#
+# The firmware ranges the sensor and BLE-broadcasts every cycle; a full cycle
+# (TRIG -> ECHO timing -> RADIO TX with blocking event waits) costs millions of
+# CPU steps, so the assertions need a multi-million step budget — a small budget
+# reads the statics before the first cycle completes (they are still 0).
+#
+# Build the firmware first:
+#   cargo build -p firmware-nrf52840-proximity --target thumbv7em-none-eabi --release
+# Then run:
+#   cargo run -q -p labwired-cli -- test \
+#     --script examples/nrf52840-proximity-lab/proximity-smoke.yaml \
+#     --output-dir out/nrf52840-proximity
+inputs:
+  system: "../system.yaml"
+  firmware: "../../../target/thumbv7em-none-eabi/release/firmware-nrf52840-proximity"
+limits:
+  max_steps: 6000000
+assertions:
+  # DISTANCE_MM (0x20000000) ranges the 10 cm target to ~99 mm (0x63). Proves
+  # the ECHO pulse was actually timed (not left at the 0 reset value).
+  - memory_value:
+      address: 0x20000000
+      expected_value: 99
+      size: 4
+  # IN_RANGE (0x20000004) latches to 1: 99 mm is inside the firmware's 500 mm
+  # (50 cm) threshold.
+  - memory_value:
+      address: 0x20000004
+      expected_value: 1
+      size: 4
+  - expected_stop_reason: max_steps

--- a/examples/ntc-thermistor-lab/.labwired/lab.yaml
+++ b/examples/ntc-thermistor-lab/.labwired/lab.yaml
@@ -1,0 +1,11 @@
+# LabWired - NTC Thermistor Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/ntc-thermistor-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "NTC Thermistor Lab"
+  - uart_contains: "[NTC] iter="
+  - expected_stop_reason: max_steps

--- a/examples/nucleo-f401re/.labwired/lab.yaml
+++ b/examples/nucleo-f401re/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - NUCLEO-F401RE IO/UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7em-none-eabi/release/firmware-f401-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/nucleo-f407-i2c/.labwired/lab.yaml
+++ b/examples/nucleo-f407-i2c/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/nucleo-h563zi/.labwired/lab.yaml
+++ b/examples/nucleo-h563zi/.labwired/lab.yaml
@@ -1,0 +1,13 @@
+# LabWired - NUCLEO-H563ZI IO smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/firmware-h563-io-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 5000000
+assertions:
+  - uart_contains: "H563-IO"
+  - uart_contains: "PB0=1 PF4=1 PG4=1"
+  - uart_contains: "PB0=0 PF4=0 PG4=0"
+  - uart_contains: "BTN13=0"
+  - expected_stop_reason: max_steps

--- a/examples/nucleo-l073rz/.labwired/lab.yaml
+++ b/examples/nucleo-l073rz/.labwired/lab.yaml
@@ -1,0 +1,21 @@
+# LabWired - NUCLEO-L073RZ IO/UART smoke test
+#
+# Strict-onboarding gate. Flips stm32l073 from [SKIP] to [PASS] in
+# crates/core/tests/strict_onboarding.rs: builds the demo firmware (if absent),
+# runs it, and asserts the silicon-validated boot tokens appear on USART2.
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv6m-none-eabi/release/firmware-l073-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 500000
+assertions:
+  # Device identity read back from the real DBGMCU (silicon-matched).
+  - uart_contains: "DEV=20086447"
+  # CLK=00000004 proves the stm32l0 RCC SW->SWS clock-switch readback fix.
+  - uart_contains: "CLK=00000004"
+  # CRC peripheral output — matches real silicon byte-for-byte.
+  - uart_contains: "CRC=B874177A"
+  # DMA mem-to-mem copy verified.
+  - uart_contains: "DMA=OK"
+  - expected_stop_reason: max_steps

--- a/examples/nucleo-l476rg/.labwired/lab.yaml
+++ b/examples/nucleo-l476rg/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/nucleo_g474re/.labwired/lab.yaml
+++ b/examples/nucleo_g474re/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - NUCLEO_G474RE UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../board_firmware/target/thumbv7em-none-eabi/release/firmware-nucleo_g474re-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/nucleo_wba52cg/.labwired/lab.yaml
+++ b/examples/nucleo_wba52cg/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - NUCLEO_WBA52CG UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../board_firmware/target/thumbv8m.main-none-eabi/release/firmware-nucleo_wba52cg-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/openai-deck-s3/.labwired/lab.yaml
+++ b/examples/openai-deck-s3/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/quectel-bg770a-lab/.labwired/lab.yaml
+++ b/examples/quectel-bg770a-lab/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/riscv-virt/.labwired/lab.yaml
+++ b/examples/riscv-virt/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/rp2040-pio/.labwired/lab.yaml
+++ b/examples/rp2040-pio/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - RP2040 PIO smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv6m-none-eabi/release/firmware-rp2040-pio-onboarding"
+  system: "../system.yaml"
+limits:
+  max_steps: 10000
+assertions:
+  - uart_contains: "PIO_OK"
+  - expected_stop_reason: max_steps

--- a/examples/seeed-xiao-nrf52840-sense/.labwired/lab.yaml
+++ b/examples/seeed-xiao-nrf52840-sense/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - Seeed XIAO nRF52840 Sense UART/GPIO/SPI smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7em-none-eabi/release/firmware-nrf52840-demo"
+  system: "../../../configs/systems/seeed-xiao-nrf52840-sense.yaml"
+limits:
+  max_steps: 20000
+assertions:
+  - uart_contains: "NRF52840_SMOKE_OK"
+  - expected_stop_reason: max_steps

--- a/examples/spice-dispenser/.labwired/lab.yaml
+++ b/examples/spice-dispenser/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/ssd1306-128x32-lab/.labwired/lab.yaml
+++ b/examples/ssd1306-128x32-lab/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/ssd1306-hello-lab/.labwired/lab.yaml
+++ b/examples/ssd1306-hello-lab/.labwired/lab.yaml
@@ -1,0 +1,12 @@
+# LabWired - SSD1306 Hello Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/ssd1306-hello-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "SSD1306 Hello Lab"
+  - uart_contains: "OLED init done"
+  - uart_contains: "OLED render done"
+  - expected_stop_reason: max_steps

--- a/examples/stm32f401cdu6-blackpill/.labwired/lab.yaml
+++ b/examples/stm32f401cdu6-blackpill/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - STM32F401CDU6 Black Pill IO smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7em-none-eabi/release/firmware-f401cdu6-blackpill-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/stm32f401cdu6/.labwired/lab.yaml
+++ b/examples/stm32f401cdu6/.labwired/lab.yaml
@@ -1,0 +1,10 @@
+# LabWired - STM32F401CDU6 UART smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7em-none-eabi/release/firmware-f401-demo"
+  system: "../system.yaml"
+limits:
+  max_steps: 64
+assertions:
+  - uart_contains: "OK"
+  - expected_stop_reason: max_steps

--- a/examples/stm32h735-smoke/.labwired/lab.yaml
+++ b/examples/stm32h735-smoke/.labwired/lab.yaml
@@ -1,0 +1,20 @@
+# LabWired - STM32H735VG IO smoke test
+#
+# Runs the prebuilt tier-1 fixture ELF (raw-register peripheral self-tests) and
+# asserts the TIER1 transcript. The firmware path points at the committed
+# tier-1 fixture blob rather than a build output, so no cross-compile is needed
+# for the strict-onboarding gate.
+schema_version: "1.0"
+inputs:
+  firmware: "../../../tests/fixtures/tier1/stm32h735.elf"
+  system: "../system.yaml"
+limits:
+  max_steps: 5000000
+assertions:
+  - uart_contains: "TIER1 clock PASS"
+  - uart_contains: "TIER1 gpio PASS"
+  - uart_contains: "TIER1 spi PASS"
+  - uart_contains: "TIER1 i2c PASS"
+  - uart_contains: "TIER1 irq PASS"
+  - uart_contains: "TIER1 done"
+  - expected_stop_reason: max_steps

--- a/examples/tm1637-7seg-lab/.labwired/lab.yaml
+++ b/examples/tm1637-7seg-lab/.labwired/lab.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps

--- a/examples/vl53l1x-tof-lab/.labwired/lab.yaml
+++ b/examples/vl53l1x-tof-lab/.labwired/lab.yaml
@@ -1,0 +1,13 @@
+# LabWired - VL53L1X ToF Lab smoke test
+schema_version: "1.0"
+inputs:
+  firmware: "../../../target/thumbv7m-none-eabi/release/vl53l1x-tof-lab"
+  system: "../system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "VL53L1X ToF Lab"
+  - uart_contains: "MODEL_ID=0xEACC OK"
+  # Default host distance is 500 mm; with a 300 mm threshold that classifies as FAR.
+  - uart_contains: "RANGE=500 mm PROXIMITY=FAR"
+  - expected_stop_reason: max_steps

--- a/scripts/migrate-examples-to-lab.mjs
+++ b/scripts/migrate-examples-to-lab.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// Migrate LabWired example projects to the canonical run file:
+//   <project>/.labwired/lab.yaml
+//
+// For every example dir under core/examples/** that contains a system.yaml,
+// create <dir>/.labwired/lab.yaml using the EXISTING labwired test-script schema.
+// Paths in inputs.* are resolved relative to the lab.yaml's own directory
+// (i.e. relative to the .labwired/ subfolder), so any firmware/system path
+// copied from a script that lived in <dir> is rewritten accordingly.
+//
+// Deterministic + idempotent: re-running skips dirs that already have lab.yaml.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+// Works from the superproject root (core/examples) or a core checkout root (examples).
+// Override with LABWIRED_EXAMPLES_DIR when neither default applies.
+const EXAMPLES =
+  process.env.LABWIRED_EXAMPLES_DIR ||
+  (fs.existsSync(path.join(ROOT, "core", "examples"))
+    ? path.join(ROOT, "core", "examples")
+    : path.join(ROOT, "examples"));
+
+// --- enumerate example dirs (those directly containing a system.yaml) --------
+function findSystemDirs(base) {
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    // record this dir if it holds a system.yaml
+    if (entries.some((e) => e.isFile() && e.name === "system.yaml")) {
+      out.push(dir);
+    }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      const name = e.name;
+      // never descend into worktree / build / fixture noise
+      if (
+        name === "node_modules" ||
+        name === ".wt" ||
+        name === "wt-riscv-jit-enable" ||
+        name === ".worktrees" ||
+        name === "target" ||
+        name === "ci" // core/examples/ci dummies have no system.yaml anyway
+      ) {
+        continue;
+      }
+      walk(path.join(dir, name));
+    }
+  };
+  walk(base);
+  return out.sort();
+}
+
+// --- minimal detection: does a yaml file look like a test-script? ------------
+function looksLikeTestScript(text) {
+  return /(^|\n)\s*schema_version\s*:/.test(text) &&
+    /(^|\n)\s*assertions\s*:/.test(text);
+}
+
+// --- pick the best candidate script in a dir ---------------------------------
+function pickScript(dir) {
+  const files = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile())
+    .map((e) => e.name)
+    .filter((n) => /\.ya?ml$/i.test(n) && n !== "system.yaml");
+
+  const candidates = files
+    .filter((n) => {
+      try {
+        return looksLikeTestScript(fs.readFileSync(path.join(dir, n), "utf8"));
+      } catch {
+        return false;
+      }
+    })
+    .sort(canonicalFirst);
+
+  if (candidates.length === 0) return null;
+
+  const bySmoke = candidates.filter((n) => /smoke/i.test(n));
+  if (bySmoke.length) return bySmoke.sort(canonicalFirst)[0];
+  const byTest = candidates.filter((n) => /test/i.test(n));
+  if (byTest.length) return byTest.sort(canonicalFirst)[0];
+  return candidates[0];
+}
+
+// Prefer the bare/canonical script name over suffixed variants:
+// `test.yaml` beats `test-fresh.yaml`, `uds-smoke.yaml` beats `uds-reset-smoke.yaml`.
+// Shortest name wins (bare has no `-<variant>` suffix), then alphabetical.
+function canonicalFirst(a, b) {
+  return a.length - b.length || a.localeCompare(b);
+}
+
+// --- rewrite an inputs.* value for the new .labwired/ location ---------------
+// oldValue was relative to `dir` (the script lived there); the new file lives in
+// `dir/.labwired`, so recompute the relative path to the same resolved target.
+function rewriteValue(dir, oldValue) {
+  const resolved = path.resolve(dir, oldValue);
+  const newDir = path.join(dir, ".labwired");
+  let rel = path.relative(newDir, resolved);
+  if (!rel.startsWith(".") && !path.isAbsolute(rel)) rel = "./" + rel;
+  return rel;
+}
+
+// --- strip surrounding quotes from a scalar ----------------------------------
+function unquote(s) {
+  s = s.trim();
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// --- transform a whole script's text, rewriting only inputs.{firmware,system}-
+// Preserves comments, limits, assertions verbatim.
+function transformScript(dir, text) {
+  const lines = text.split("\n");
+  let inInputs = false;
+  let inputsIndent = 0;
+
+  const isKeyLine = (line) => /^(\s*)([A-Za-z0-9_.-]+)\s*:/.exec(line);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "" || /^\s*#/.test(line)) continue;
+
+    const m = isKeyLine(line);
+    if (!m) continue;
+    const indent = m[1].length;
+    const key = m[2];
+
+    if (!inInputs) {
+      if (indent === 0 && key === "inputs") {
+        inInputs = true;
+        inputsIndent = indent;
+      }
+      continue;
+    }
+
+    // inside inputs: a key at the same-or-lower indent than `inputs:` ends it
+    if (indent <= inputsIndent) {
+      inInputs = false;
+      // re-evaluate this line as a possible new top-level inputs (won't be)
+      if (indent === 0 && key === "inputs") {
+        inInputs = true;
+        inputsIndent = indent;
+      }
+      continue;
+    }
+
+    if (key === "firmware" || key === "system") {
+      const colon = line.indexOf(":");
+      const rawVal = line.slice(colon + 1);
+      const oldValue = unquote(rawVal);
+      if (oldValue === "") continue; // nested block, leave alone
+      const newValue = rewriteValue(dir, oldValue);
+      lines[i] = `${" ".repeat(indent)}${key}: "${newValue}"`;
+    }
+  }
+  return lines.join("\n");
+}
+
+const MINIMAL = `schema_version: "1.0"
+inputs:
+  system: "../system.yaml"
+limits:
+  max_steps: 100000
+assertions:
+  - expected_stop_reason: max_steps
+`;
+
+// --- main --------------------------------------------------------------------
+function main() {
+  const dirs = findSystemDirs(EXAMPLES);
+  let migrated = 0;
+  let created = 0;
+  let skipped = 0;
+
+  for (const dir of dirs) {
+    const labDir = path.join(dir, ".labwired");
+    const labFile = path.join(labDir, "lab.yaml");
+    const rel = path.relative(ROOT, dir);
+
+    if (fs.existsSync(labFile)) {
+      console.log(`SKIP ${rel} (exists)`);
+      skipped++;
+      continue;
+    }
+
+    const script = pickScript(dir);
+    fs.mkdirSync(labDir, { recursive: true });
+
+    if (script) {
+      const text = fs.readFileSync(path.join(dir, script), "utf8");
+      const out = transformScript(dir, text);
+      fs.writeFileSync(labFile, out);
+      console.log(`MIGRATED ${rel} from ${script}`);
+      migrated++;
+    } else {
+      fs.writeFileSync(labFile, MINIMAL);
+      console.log(`CREATED ${rel} (minimal)`);
+      created++;
+    }
+  }
+
+  console.log(
+    `\nDONE  migrated=${migrated} created=${created} skipped=${skipped} total=${dirs.length}`
+  );
+}
+
+main();


### PR DESCRIPTION
Upgrades all existing example projects to the one-file run contract used by the VS Code extension and CI (`labwired test --script .labwired/lab.yaml`).

- 54 examples: 35 migrated from an existing smoke/test script (with `inputs.*` paths re-relativized to the `.labwired/` subdir), 19 synthesized minimally (system-only) where no script existed.
- Generated by `scripts/migrate-examples-to-lab.mjs` — deterministic + idempotent (re-run = all SKIP).
- Pairs with the extension change (w1ne/labwired-vscode#7), which reads this same file.

Follow-up: examples that live only on other branches will pick up their `lab.yaml` by running the same script there.