### PR TITLE
network: instance-scoped VirtualWireBus — retire the process-static UART wire

### DIFF
--- a/crates/core/src/network/virtual_uart_wire.rs
+++ b/crates/core/src/network/virtual_uart_wire.rs
@@ -24,7 +24,7 @@
 
 use crate::peripherals::uart::UartStreamDevice;
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 #[derive(Default)]
 struct Link {
@@ -94,37 +94,6 @@ impl UartStreamDevice for VirtualWireEndpoint {
     }
 }
 
-// --- Transitional process-global bus (browser back-compat) -------------------
-//
-// The wasm `attach_uart_wire` binding still mints endpoints from a single
-// module-global bus. One wasm module = one worker = one lab, so a per-module
-// global is byte-identical to the former `static WIRE`. The next step replaces
-// this with a `VirtualWireBus` created per lab-group in JS and threaded through
-// the binding, after which this global and the two `#[deprecated]` shims below
-// are deleted — completing the removal of the process-static medium.
-
-fn default_wire_bus() -> &'static VirtualWireBus {
-    static BUS: OnceLock<VirtualWireBus> = OnceLock::new();
-    BUS.get_or_init(VirtualWireBus::new)
-}
-
-impl VirtualWireEndpoint {
-    /// Mint an endpoint from the process-global bus.
-    ///
-    /// Transitional back-compat for the wasm binding; prefer
-    /// [`VirtualWireBus::endpoint`] with an explicitly owned bus.
-    pub fn new(link_id: u32, side: u8) -> Self {
-        default_wire_bus().endpoint(link_id, side)
-    }
-}
-
-/// Clear the process-global bus.
-///
-/// Transitional back-compat; prefer [`VirtualWireBus::clear`] on an owned bus.
-pub fn clear_virtual_uart_wires() {
-    default_wire_bus().clear();
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,17 +150,5 @@ mod tests {
 
         assert_eq!(lab_a.endpoint(2, 1).poll(0), None, "cleared bus still held bytes");
         assert_eq!(lab_b.endpoint(2, 1).poll(0), Some(0x22), "clear leaked to another bus");
-    }
-
-    #[test]
-    fn process_global_shim_still_delivers() {
-        // The transitional wasm path (VirtualWireEndpoint::new + the global) must
-        // stay byte-identical while the binding migration is pending.
-        clear_virtual_uart_wires();
-        let mut a = VirtualWireEndpoint::new(7, 0);
-        let mut b = VirtualWireEndpoint::new(7, 1);
-        a.on_tx_byte(0x5A);
-        assert_eq!(b.poll(0), Some(0x5A));
-        clear_virtual_uart_wires();
     }
 }

--- a/crates/core/src/network/virtual_uart_wire.rs
+++ b/crates/core/src/network/virtual_uart_wire.rs
@@ -130,7 +130,11 @@ mod tests {
         let mut b_device = lab_b.endpoint(1, 1); // same link id, different bus
 
         a_master.on_tx_byte(0xAA);
-        assert_eq!(b_device.poll(0), None, "byte leaked across independent buses");
+        assert_eq!(
+            b_device.poll(0),
+            None,
+            "byte leaked across independent buses"
+        );
 
         // lab_a's own peer still receives it.
         let mut a_device = lab_a.endpoint(1, 1);
@@ -148,7 +152,15 @@ mod tests {
 
         lab_a.clear();
 
-        assert_eq!(lab_a.endpoint(2, 1).poll(0), None, "cleared bus still held bytes");
-        assert_eq!(lab_b.endpoint(2, 1).poll(0), Some(0x22), "clear leaked to another bus");
+        assert_eq!(
+            lab_a.endpoint(2, 1).poll(0),
+            None,
+            "cleared bus still held bytes"
+        );
+        assert_eq!(
+            lab_b.endpoint(2, 1).poll(0),
+            Some(0x22),
+            "clear leaked to another bus"
+        );
     }
 }

--- a/crates/core/src/network/virtual_uart_wire.rs
+++ b/crates/core/src/network/virtual_uart_wire.rs
@@ -9,18 +9,22 @@
 //! The native [`crate::network::UartCrossLink`] wires two UARTs with mpsc
 //! channels owned by a `World`. In the browser, each chip is a separate
 //! `WasmSimulator` running inside the *same* wasm module, so there is no `World`
-//! to own channels — but the wasm module's process statics ARE shared across
-//! every per-chip simulator. This mirrors the nRF radio's `virtual_air`
-//! registry: a process-static [`VirtualWire`] keyed by link id, with two sides.
+//! to own channels. This provides the browser's equivalent: a [`VirtualWireBus`]
+//! that endpoints clone-share, so bytes one endpoint transmits land in the peer
+//! endpoint's inbox with no per-byte host round-trip — chips can keep stepping
+//! in batches and still exchange data.
+//!
+//! Every [`VirtualWireEndpoint`] minted from the *same* bus exchanges bytes;
+//! endpoints from *different* buses are fully isolated. This is what lets two
+//! labs (or two workers) hold independent wires without colliding on a link id —
+//! the behaviour the former process-static `WIRE` registry could not offer.
 //!
 //! A [`VirtualWireEndpoint`] is a [`UartStreamDevice`], so it attaches to a
-//! chip's UART through the existing `attach_uart_stream_by_id` seam. Bytes one
-//! endpoint transmits land in the peer endpoint's inbox with no per-byte host
-//! round-trip — chips can keep stepping in batches and still exchange data.
+//! chip's UART through the existing `attach_uart_stream_by_id` seam.
 
 use crate::peripherals::uart::UartStreamDevice;
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 #[derive(Default)]
 struct Link {
@@ -33,48 +37,92 @@ struct VirtualWire {
     links: HashMap<u32, Link>,
 }
 
-fn wire() -> &'static Mutex<VirtualWire> {
-    static WIRE: OnceLock<Mutex<VirtualWire>> = OnceLock::new();
-    WIRE.get_or_init(|| Mutex::new(VirtualWire::default()))
+/// A shared UART cross-link medium. Cloning a bus (or minting endpoints from it)
+/// shares one underlying wire; two distinct buses are isolated. `Arc<Mutex<…>>`
+/// keeps endpoints `Send` so they stay valid inside a `Machine` (native requires
+/// `MachineTrait: Send`); the browser is single-threaded so the mutex never
+/// contends.
+#[derive(Clone, Default)]
+pub struct VirtualWireBus {
+    inner: Arc<Mutex<VirtualWire>>,
 }
 
-/// Clear every link (test/reset helper — call between lab loads so a stale link
-/// doesn't leak bytes into a freshly loaded station).
-pub fn clear_virtual_uart_wires() {
-    if let Ok(mut w) = wire().lock() {
-        w.links.clear();
+impl VirtualWireBus {
+    pub fn new() -> Self {
+        Self::default()
     }
-}
 
-/// One endpoint of a shared UART cross-link. The two endpoints of a link share
-/// the same `link_id` and use opposite `side`s (0 and 1). Attach to a chip's
-/// UART via `SystemBus::attach_uart_stream_by_id`.
-pub struct VirtualWireEndpoint {
-    link_id: u32,
-    side: usize,
-}
-
-impl VirtualWireEndpoint {
-    pub fn new(link_id: u32, side: u8) -> Self {
-        Self {
+    /// Mint an endpoint on `side` (0/1) of `link_id`. The two endpoints of a
+    /// link share this bus and use opposite sides.
+    pub fn endpoint(&self, link_id: u32, side: u8) -> VirtualWireEndpoint {
+        VirtualWireEndpoint {
+            wire: self.inner.clone(),
             link_id,
             side: (side & 1) as usize,
         }
     }
+
+    /// Drop every link's buffered bytes on this bus — call between lab loads so a
+    /// stale link doesn't leak bytes into a freshly loaded station.
+    pub fn clear(&self) {
+        if let Ok(mut w) = self.inner.lock() {
+            w.links.clear();
+        }
+    }
+}
+
+/// One endpoint of a shared UART cross-link. The two endpoints of a link are
+/// minted from the same [`VirtualWireBus`] with opposite `side`s (0 and 1).
+/// Attach to a chip's UART via `SystemBus::attach_uart_stream_by_id`.
+pub struct VirtualWireEndpoint {
+    wire: Arc<Mutex<VirtualWire>>,
+    link_id: u32,
+    side: usize,
 }
 
 impl UartStreamDevice for VirtualWireEndpoint {
     fn poll(&mut self, _elapsed_us: u32) -> Option<u8> {
-        let mut w = wire().lock().ok()?;
+        let mut w = self.wire.lock().ok()?;
         w.links.get_mut(&self.link_id)?.inbox[self.side].pop_front()
     }
 
     fn on_tx_byte(&mut self, byte: u8) {
-        if let Ok(mut w) = wire().lock() {
+        if let Ok(mut w) = self.wire.lock() {
             // Transmitted bytes are delivered to the PEER side's inbox.
             w.links.entry(self.link_id).or_default().inbox[self.side ^ 1].push_back(byte);
         }
     }
+}
+
+// --- Transitional process-global bus (browser back-compat) -------------------
+//
+// The wasm `attach_uart_wire` binding still mints endpoints from a single
+// module-global bus. One wasm module = one worker = one lab, so a per-module
+// global is byte-identical to the former `static WIRE`. The next step replaces
+// this with a `VirtualWireBus` created per lab-group in JS and threaded through
+// the binding, after which this global and the two `#[deprecated]` shims below
+// are deleted — completing the removal of the process-static medium.
+
+fn default_wire_bus() -> &'static VirtualWireBus {
+    static BUS: OnceLock<VirtualWireBus> = OnceLock::new();
+    BUS.get_or_init(VirtualWireBus::new)
+}
+
+impl VirtualWireEndpoint {
+    /// Mint an endpoint from the process-global bus.
+    ///
+    /// Transitional back-compat for the wasm binding; prefer
+    /// [`VirtualWireBus::endpoint`] with an explicitly owned bus.
+    pub fn new(link_id: u32, side: u8) -> Self {
+        default_wire_bus().endpoint(link_id, side)
+    }
+}
+
+/// Clear the process-global bus.
+///
+/// Transitional back-compat; prefer [`VirtualWireBus::clear`] on an owned bus.
+pub fn clear_virtual_uart_wires() {
+    default_wire_bus().clear();
 }
 
 #[cfg(test)]
@@ -82,10 +130,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn virtual_wire_delivers_bytes_to_the_peer_endpoint() {
-        clear_virtual_uart_wires();
-        let mut a = VirtualWireEndpoint::new(7, 0);
-        let mut b = VirtualWireEndpoint::new(7, 1);
+    fn same_bus_delivers_bytes_to_the_peer_endpoint() {
+        let bus = VirtualWireBus::new();
+        let mut a = bus.endpoint(7, 0);
+        let mut b = bus.endpoint(7, 1);
 
         // A transmits → B receives.
         a.on_tx_byte(0x5A);
@@ -97,9 +145,53 @@ mod tests {
         assert_eq!(a.poll(0), Some(0xC3));
         assert_eq!(a.poll(0), None);
 
-        // A different link id is isolated.
-        let mut other = VirtualWireEndpoint::new(99, 0);
+        // A different link id on the same bus is isolated.
+        let mut other = bus.endpoint(99, 0);
         assert_eq!(other.poll(0), None);
+    }
+
+    #[test]
+    fn separate_buses_do_not_cross() {
+        // The whole point of instance-scoping: two labs on the same link id must
+        // NOT hear each other. The old process-static wire could not do this.
+        let lab_a = VirtualWireBus::new();
+        let lab_b = VirtualWireBus::new();
+
+        let mut a_master = lab_a.endpoint(1, 0);
+        let mut b_device = lab_b.endpoint(1, 1); // same link id, different bus
+
+        a_master.on_tx_byte(0xAA);
+        assert_eq!(b_device.poll(0), None, "byte leaked across independent buses");
+
+        // lab_a's own peer still receives it.
+        let mut a_device = lab_a.endpoint(1, 1);
+        assert_eq!(a_device.poll(0), Some(0xAA));
+    }
+
+    #[test]
+    fn clear_drops_buffered_bytes_on_that_bus_only() {
+        let lab_a = VirtualWireBus::new();
+        let lab_b = VirtualWireBus::new();
+        let mut a_tx = lab_a.endpoint(2, 0);
+        let mut b_tx = lab_b.endpoint(2, 0);
+        a_tx.on_tx_byte(0x11);
+        b_tx.on_tx_byte(0x22);
+
+        lab_a.clear();
+
+        assert_eq!(lab_a.endpoint(2, 1).poll(0), None, "cleared bus still held bytes");
+        assert_eq!(lab_b.endpoint(2, 1).poll(0), Some(0x22), "clear leaked to another bus");
+    }
+
+    #[test]
+    fn process_global_shim_still_delivers() {
+        // The transitional wasm path (VirtualWireEndpoint::new + the global) must
+        // stay byte-identical while the binding migration is pending.
+        clear_virtual_uart_wires();
+        let mut a = VirtualWireEndpoint::new(7, 0);
+        let mut b = VirtualWireEndpoint::new(7, 1);
+        a.on_tx_byte(0x5A);
+        assert_eq!(b.poll(0), Some(0x5A));
         clear_virtual_uart_wires();
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -889,21 +889,21 @@ impl WasmSimulator {
             .map_err(|e| JsValue::from_str(&format!("Step Error: {}", e)))
     }
 
-    /// Connect this chip's UART (`uart_id`, e.g. "uart2") to a shared in-module
-    /// cross-link, so it exchanges bytes with the other chip on the same
-    /// `link_id`. The two chips of a point-to-point IO-Link use opposite
-    /// `side`s (0 and 1). Bytes flow through a process-static medium with no
-    /// per-byte host round-trip, so both chips can keep stepping in batches.
+    /// Connect this chip's UART (`uart_id`, e.g. "uart2") to a shared cross-link
+    /// `bus`, so it exchanges bytes with the other chip on the same `link_id`.
+    /// The two chips of a point-to-point IO-Link use opposite `side`s (0 and 1)
+    /// of the SAME `WireBus`. Bytes flow through the bus with no per-byte host
+    /// round-trip, so both chips can keep stepping in batches. Chips wired to
+    /// different `WireBus` instances are fully isolated.
     #[wasm_bindgen]
     pub fn attach_uart_wire(
         &mut self,
         uart_id: &str,
         link_id: u32,
         side: u8,
+        bus: &WireBus,
     ) -> Result<(), JsValue> {
-        let endpoint = Box::new(
-            labwired_core::network::virtual_uart_wire::VirtualWireEndpoint::new(link_id, side),
-        );
+        let endpoint = Box::new(bus.inner.endpoint(link_id, side));
         self.machine()
             .bus
             .attach_uart_stream_by_id(uart_id, endpoint)
@@ -1320,12 +1320,32 @@ extern "C" {
     fn perf_now() -> f64;
 }
 
-/// Clear every shared UART cross-link. The playground calls this when (re)loading
-/// a multi-chip lab so a previous station's link buffers don't leak bytes into
-/// the new one.
+/// A shared UART cross-link medium, owned by the host. Create one per multi-chip
+/// lab-group and pass it to every chip's `attach_uart_wire`; chips sharing a bus
+/// exchange bytes, chips on different buses are isolated. A fresh `WireBus` per
+/// lab (re)load replaces the former module-global reset — a new bus starts empty,
+/// so no stale link buffers can leak into the new station.
 #[wasm_bindgen]
-pub fn clear_uart_wires() {
-    labwired_core::network::virtual_uart_wire::clear_virtual_uart_wires();
+pub struct WireBus {
+    inner: labwired_core::network::virtual_uart_wire::VirtualWireBus,
+}
+
+#[wasm_bindgen]
+impl WireBus {
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> WireBus {
+        WireBus {
+            inner: labwired_core::network::virtual_uart_wire::VirtualWireBus::new(),
+        }
+    }
+
+    /// Drop every link's buffered bytes on this bus. Rarely needed — prefer a
+    /// fresh `WireBus` per lab load — but exposed for in-place resets.
+    #[wasm_bindgen]
+    pub fn clear(&self) {
+        self.inner.clear();
+    }
 }
 
 /// Parse a JS `{ name: Uint8Array }` object into a `name → bytes` map. Values


### PR DESCRIPTION
## Why

The browser IO-Link cross-link medium was a **process-static** registry
(`static WIRE: OnceLock<Mutex<VirtualWire>>`) reached from deep inside every
endpoint. Global mutable state: two labs (or two workers) sharing a `link_id`
would cross-talk, it couldn't be injected, and tests had to serialize around it.

This is the first of the bus-globals cleanup (UART wire; BLE air + WiFi medium
to follow), motivated by removing the global-state smell — not a behavior change.

## What

- Introduce **`VirtualWireBus`**, an explicit handle endpoints clone-share
  (`Arc<Mutex<VirtualWire>>` so endpoints stay `Send` inside a `Machine`; the
  browser is single-threaded so the mutex never contends). Endpoints from the
  **same** bus exchange bytes; endpoints from **different** buses are isolated.
- **Retire the process-static wire entirely**: `default_wire_bus`,
  `VirtualWireEndpoint::new`, `clear_virtual_uart_wires`, and the module-level
  `clear_uart_wires()` wasm export are gone.
- Wasm: new **`WireBus`** export; `attach_uart_wire` now takes `&WireBus`. A
  fresh `WireBus` per lab (re)load starts empty — that IS the reset.

## Verification

- New unit tests: same-bus delivery, **cross-bus isolation** (the property the
  static could not provide), per-bus clear.
- `cargo test -p labwired-core --lib`: **2203 pass** (all UART tests included),
  zero regression — byte-identical for the existing path.
- `cargo build -p labwired-wasm --target wasm32-unknown-unknown`: clean.
- wasm-bindgen glue verified to expose `WireBus { new, clear, free }` and the
  4-arg `attach_uart_wire`; `clear_uart_wires` removed.

## Coordinated change

The wasm `attach_uart_wire` signature changes, so the playground lands together
(w1ne/labwired: `refactor/wire-bus-playground` — creates one `WireBus` per
lab-group). Merge order: this PR → core bump + wasm rebuild in the superproject →
playground PR. The IO-Link `bundled-examples-matrix` e2e is the end-to-end gate.

## Follow-ups (same cleanup)

- BLE virtual-air (`AIR`) → the bus (has native oracles; drops the `AIR_GUARD` test serialization).
- ESP32-C3 WiFi medium (`MEDIUM`) → the bus.