### PR TITLE
nrf52: instance-scoped VirtualAirBus for the BLE virtual air

### DIFF
--- a/crates/core/src/peripherals/nrf52/radio.rs
+++ b/crates/core/src/peripherals/nrf52/radio.rs
@@ -50,7 +50,7 @@
 
 use crate::{Bus, Peripheral, PeripheralTickResult, SimResult};
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 // ── Global "virtual air" registry ────────────────────────────────────────────
 //
@@ -118,26 +118,68 @@ pub struct AirFrameTrace {
     pub whitening_iv: u8,
 }
 
-/// Public view of the current TX trace, intended for WASM consumption
-/// by the playground's BLE-air visualization. Most recent frames first.
-pub fn virtual_air_trace_snapshot() -> Vec<AirFrameTrace> {
-    let air = match virtual_air().lock() {
-        Ok(a) => a,
-        Err(_) => return Vec::new(),
-    };
-    air.tx_history.iter().rev().cloned().collect()
+/// A shared BLE "virtual air" medium. Radios minted with the same bus hear each
+/// other's frames (matched by frequency + mode + address); radios on different
+/// buses are fully isolated — the behaviour the former process-static `AIR`
+/// registry could not offer, so two BLE labs (or two workers) can coexist.
+/// `Arc<Mutex<…>>` keeps radios `Send` inside a `Machine` (native requires
+/// `MachineTrait: Send`); the browser is single-threaded so it never contends.
+#[derive(Debug, Clone, Default)]
+pub struct VirtualAirBus {
+    inner: Arc<Mutex<VirtualAir>>,
 }
 
-fn virtual_air() -> &'static Mutex<VirtualAir> {
-    static AIR: OnceLock<Mutex<VirtualAir>> = OnceLock::new();
-    AIR.get_or_init(|| Mutex::new(VirtualAir::default()))
-}
-
-/// Clear the global virtual air (test helper).
-pub fn clear_virtual_air() {
-    if let Ok(mut a) = virtual_air().lock() {
-        a.queues.clear();
+impl VirtualAirBus {
+    pub fn new() -> Self {
+        Self::default()
     }
+
+    /// Most-recent-first snapshot of the TX trace, for the playground's BLE-air
+    /// visualization.
+    pub fn trace_snapshot(&self) -> Vec<AirFrameTrace> {
+        match self.inner.lock() {
+            Ok(a) => a.tx_history.iter().rev().cloned().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// Drop every frequency queue on this bus. Keeps `tx_history` (the UI trace),
+    /// exactly as the former `clear_virtual_air` did.
+    pub fn clear(&self) {
+        if let Ok(mut a) = self.inner.lock() {
+            a.queues.clear();
+        }
+    }
+
+    /// Lock the underlying air for the radio's TX/RX paths (same module).
+    fn lock(&self) -> std::sync::LockResult<std::sync::MutexGuard<'_, VirtualAir>> {
+        self.inner.lock()
+    }
+}
+
+// --- Transitional process-global air (browser back-compat) -------------------
+//
+// Radios built via `Nrf52Radio::new()` share this one module-global bus, and the
+// wasm trace/clear exports below operate on it. One wasm module = one worker =
+// one lab, so this is byte-identical to the former `static AIR`. The follow-up
+// threads a per-lab-group `VirtualAirBus` through an attach seam, after which
+// this global and the two shims are deleted.
+fn default_air_bus() -> &'static VirtualAirBus {
+    static BUS: OnceLock<VirtualAirBus> = OnceLock::new();
+    BUS.get_or_init(VirtualAirBus::new)
+}
+
+/// Public view of the current TX trace on the process-global air, for WASM
+/// consumption by the playground's BLE-air visualization. Most recent first.
+/// Transitional; prefer [`VirtualAirBus::trace_snapshot`] on an owned bus.
+pub fn virtual_air_trace_snapshot() -> Vec<AirFrameTrace> {
+    default_air_bus().trace_snapshot()
+}
+
+/// Clear the process-global air (test/back-compat helper). Prefer
+/// [`VirtualAirBus::clear`] on an owned bus.
+pub fn clear_virtual_air() {
+    default_air_bus().clear();
 }
 
 // ── Tasks (PS §6.20.13, table 222) ───────────────────────────────────────────
@@ -359,6 +401,10 @@ pub struct Nrf52Radio {
     events_devmiss: u32,
     /// Deterministic PRNG state for RSSI sampling.
     rssi_prng: u32,
+    /// The shared air medium this radio transmits into and receives from.
+    /// Radios sharing a bus hear each other; `new()` uses the process-global
+    /// default, `with_air` binds an explicit per-group bus.
+    air: VirtualAirBus,
 }
 
 impl Nrf52Radio {
@@ -366,6 +412,7 @@ impl Nrf52Radio {
         Self {
             // Reset values per PS table 226.
             state: STATE_DISABLED,
+            air: default_air_bus().clone(),
             frequency: 0,
             mode: 0, // Nrf_1Mbit
             pcnf0: 0,
@@ -386,6 +433,13 @@ impl Nrf52Radio {
             modecnf0: 0,
             ..Self::default()
         }
+    }
+
+    /// Build a radio bound to an explicit air bus. Radios sharing a bus hear
+    /// each other; radios on different buses are isolated. Prefer this over
+    /// `new()`'s process-global default once the host owns per-lab-group buses.
+    pub fn with_air(air: VirtualAirBus) -> Self {
+        Self { air, ..Self::new() }
     }
 
     /// Apply SHORTS-style automatic task triggers when an event fires.
@@ -1016,7 +1070,7 @@ impl Peripheral for Nrf52Radio {
             // Push to the global virtual air keyed by FREQUENCY. Frames carry
             // their MODE so receivers tuned to a different mode on the same
             // band correctly fail to decode.
-            if let Ok(mut air) = virtual_air().lock() {
+            if let Ok(mut air) = self.air.lock() {
                 let key = self.frequency as u8;
                 let trace = AirFrameTrace {
                     channel: key,
@@ -1056,7 +1110,7 @@ impl Peripheral for Nrf52Radio {
             // are also computed here against the DAB/DAP whitelist.
             let mut popped = None;
             let mut popped_frame_addr: Option<(u32, u8)> = None;
-            if let Ok(mut air) = virtual_air().lock() {
+            if let Ok(mut air) = self.air.lock() {
                 let key = self.frequency as u8;
                 if let Some(queue) = air.queues.get_mut(&key) {
                     let pos = queue
@@ -1459,6 +1513,78 @@ mod tests {
         assert_eq!(bus_rx.read_u8(0x2000_3003).unwrap(), 0xAD);
         assert_eq!(bus_rx.read_u8(0x2000_3004).unwrap(), 0xBE);
         assert_eq!(bus_rx.read_u8(0x2000_3005).unwrap(), 0xEF);
+    }
+
+    #[test]
+    fn air_bus_scopes_delivery() {
+        use crate::bus::SystemBus;
+        use crate::Bus;
+
+        // Run a full BLE TX→RX exchange with the TX radio bound to `tx_air` and
+        // the RX radio bound to `rx_air`; return (crc_status, first payload byte
+        // landed in RX RAM). Explicit per-radio buses — no AIR_GUARD needed.
+        fn exchange(tx_air: VirtualAirBus, rx_air: VirtualAirBus) -> (u32, u8) {
+            let mut bus_tx = SystemBus::new();
+            for (off, v) in [
+                (0u64, 0xAAu8),
+                (1, 4),
+                (2, 0xDE),
+                (3, 0xAD),
+                (4, 0xBE),
+                (5, 0xEF),
+            ] {
+                bus_tx.write_u8(0x2000_0000 + off, v).unwrap();
+            }
+            let mut tx = Nrf52Radio::with_air(tx_air);
+            tx.write_u32(OFF_PCNF0, 8 | (1 << 8)).unwrap();
+            tx.write_u32(OFF_PCNF1, 0xFF | (1 << 25)).unwrap();
+            tx.write_u32(OFF_PACKETPTR, 0x2000_0000).unwrap();
+            tx.write_u32(OFF_FREQUENCY, 73).unwrap();
+            tx.write_u32(OFF_MODE, 3).unwrap();
+            tx.write_u32(OFF_DATAWHITEIV, 50).unwrap();
+            tx.write_u32(OFF_CRCINIT, 0x555555).unwrap();
+            tx.write_u32(OFF_BASE0, 0xCAFE_BA00).unwrap();
+            tx.write_u32(OFF_PREFIX0, 0xBE).unwrap();
+            tx.write_u32(OFF_TXADDRESS, 0).unwrap();
+            tx.write_u32(OFF_TASKS_TXEN, 1).unwrap();
+            tx.tick();
+            tx.write_u32(OFF_TASKS_START, 1).unwrap();
+            tx.tick();
+            tx.tick_with_bus(&mut bus_tx);
+
+            let mut bus_rx = SystemBus::new();
+            let mut rx = Nrf52Radio::with_air(rx_air);
+            rx.write_u32(OFF_PCNF0, 8 | (1 << 8)).unwrap();
+            rx.write_u32(OFF_PCNF1, 0xFF | (1 << 25)).unwrap();
+            rx.write_u32(OFF_PACKETPTR, 0x2000_3000).unwrap();
+            rx.write_u32(OFF_FREQUENCY, 73).unwrap();
+            rx.write_u32(OFF_MODE, 3).unwrap();
+            rx.write_u32(OFF_DATAWHITEIV, 50).unwrap();
+            rx.write_u32(OFF_CRCINIT, 0x555555).unwrap();
+            rx.write_u32(OFF_BASE0, 0xCAFE_BA00).unwrap();
+            rx.write_u32(OFF_PREFIX0, 0xBE).unwrap();
+            rx.write_u32(OFF_RXADDRESSES, 0x01).unwrap();
+            rx.write_u32(OFF_TASKS_RXEN, 1).unwrap();
+            rx.tick();
+            rx.write_u32(OFF_TASKS_START, 1).unwrap();
+            rx.tick();
+            rx.tick_with_bus(&mut bus_rx);
+            (rx.crc_status, bus_rx.read_u8(0x2000_3002).unwrap())
+        }
+
+        // Same bus → the frame crosses (positive control, mirrors the global path).
+        let shared = VirtualAirBus::new();
+        let (crc, payload) = exchange(shared.clone(), shared.clone());
+        assert_eq!(crc, 1, "same-bus radios must exchange the frame");
+        assert_eq!(payload, 0xDE);
+
+        // Different buses → silence. This is the isolation the process-static
+        // AIR could not provide.
+        let (crc_iso, _) = exchange(VirtualAirBus::new(), VirtualAirBus::new());
+        assert_eq!(
+            crc_iso, 0,
+            "radios on different air buses must not hear each other"
+        );
     }
 
     #[test]

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,8 +7,8 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-22 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-22 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-19 | ⚠ drift acked 2026-07-20 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
@@ -20,7 +20,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-06-27 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-07-18 | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-21 | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-22 | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-21 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
@@ -29,7 +29,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — conformance 16/16; mmio 16/16; GPIO P0 22/0, P1 23/0; onboarding 22/22; POWER 10/0, SPIS 19/0, TWIS 20/0, RTC0 12/0, TIMER0 16/0; SPIM0/CCM/full-register clean
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-07-21 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-22 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -37,7 +37,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — rides the nrf52840 full register sweep (16/16) re-confirmed 2026-06-17
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-07-21 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-22 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -115,7 +115,14 @@ boards:
     # on_edge (the exact test that caught the reverted attempt) passes, and all
     # cross-chip walk-vs-scheduler byte-identical differentials pass (82 walk
     # tests + f401/h563/l073/l476 Zephyr-boot). No live re-capture required.
-    drift_ack: 2026-07-21
+    # 2026-07-22: BLE virtual air moved from a process-static (static AIR) to an
+    # injected VirtualAirBus handle each Nrf52Radio holds. Nrf52Radio::new() (what
+    # the factory builds) binds a transitional process-global bus, so existing
+    # behaviour is byte-identical: cross_instance_via_virtual_air and
+    # nrf52840_ble_loopback_through_virtual_air pass UNCHANGED. No register
+    # read/write path, reset value or layout touched — drift is the shared nrf52
+    # file commit date only. No live re-capture.
+    drift_ack: 2026-07-22
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -166,7 +173,10 @@ boards:
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: rides the nrf52840 GPIOTE/NVIC walk opt-out (same silicon);
     # queue-state-gated, byte-identical. See the nrf52840 drift_ack note.
-    drift_ack: 2026-07-21
+    # 2026-07-22: rides the nrf52840 BLE virtual-air VirtualAirBus refactor (same
+    # silicon); byte-identical, transitional global default. See the nrf52840
+    # drift_ack note.
+    drift_ack: 2026-07-22
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml


### PR DESCRIPTION
## Why

Second of the bus-globals cleanup (after #614's UART wire). The BLE virtual air
was a process-static (`static AIR: OnceLock<Mutex<VirtualAir>>`) the RADIO model
reached into on every TX/RX — global mutable state, so two BLE labs (or two
workers) on the same frequency would cross-talk, and tests had to serialize
around it (`AIR_GUARD`).

## What

- Introduce **`VirtualAirBus`**, an explicit handle each `Nrf52Radio` holds
  (`Arc<Mutex<VirtualAir>>` so the radio stays `Send` inside a `Machine`;
  single-threaded browser never contends). Same bus → radios hear each other;
  different buses → isolated. TX/RX use `self.air`.
- `Nrf52Radio::with_air(bus)` binds an explicit per-group bus. `new()` (what the
  factory builds) binds a **transitional process-global** bus, and the wasm
  trace/clear exports operate on it — byte-identical to the former `static AIR`
  (one wasm module = one worker = one lab). The playground follow-up threads a
  per-lab-group bus, after which the global is removed.

## Verification (native oracles)

- New **`air_bus_scopes_delivery`**: a full BLE TX→RX exchange asserting same-bus
  radios exchange the frame and different-bus radios stay silent (the isolation
  the static could not provide).
- Existing **`cross_instance_via_virtual_air`** + **`nrf52840_ble_loopback_through_virtual_air`** oracles unchanged and green.
- `cargo test -p labwired-core --lib`: **2203 pass**; fmt + clippy clean; wasm builds.

## Follow-ups

- Playground: create one `VirtualAirBus` per BLE lab-group + attach seam, retire the transitional global.
- WiFi medium (`MEDIUM`) → the same treatment.