### PR TITLE
esp32c3: instance-scoped VirtualWifiBus for the WiFi medium

### DIFF
--- a/crates/core/src/peripherals/esp32c3/virtual_wifi.rs
+++ b/crates/core/src/peripherals/esp32c3/virtual_wifi.rs
@@ -124,6 +124,12 @@ pub fn default_medium() -> VirtualWifiBus {
     default_wifi_bus().clone()
 }
 
+/// Reset the process-global medium (the CLI bridge calls this for a fresh run).
+/// Transitional; prefer [`VirtualWifiBus::reset`] on an owned bus.
+pub fn reset() {
+    default_wifi_bus().reset();
+}
+
 impl VirtualWifi {
     fn sta(&mut self, mac: [u8; 6]) -> &mut StaState {
         self.stas.entry(mac).or_default()

--- a/crates/core/src/peripherals/esp32c3/virtual_wifi.rs
+++ b/crates/core/src/peripherals/esp32c3/virtual_wifi.rs
@@ -21,7 +21,7 @@
 //! bridge proved, lifted into core and made MAC-aware so it scales to N stations.
 
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// AP identity.
 const AP_BSSID: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
@@ -51,45 +51,77 @@ struct VirtualWifi {
     next_host: u8,
 }
 
-static MEDIUM: OnceLock<Mutex<VirtualWifi>> = OnceLock::new();
-
-fn with_medium<R>(f: impl FnOnce(&mut VirtualWifi) -> R) -> R {
-    let m = MEDIUM.get_or_init(|| Mutex::new(VirtualWifi::default()));
-    f(&mut m.lock().unwrap())
+/// A shared WiFi medium — the infrastructure AP plus every associated station.
+/// WiFi MACs minted from the same bus associate to the same virtual AP, get
+/// distinct DHCP leases, and route to each other; MACs on different buses are
+/// fully isolated — the behaviour the former process-static `MEDIUM` could not
+/// offer, so two WiFi labs (or two workers) can coexist. `Arc<Mutex<…>>` keeps
+/// the MAC `Send` inside a `Machine` (native requires `MachineTrait: Send`); the
+/// browser is single-threaded so it never contends.
+#[derive(Debug, Clone, Default)]
+pub struct VirtualWifiBus {
+    inner: Arc<Mutex<VirtualWifi>>,
 }
 
-/// Reset the medium (tests / fresh runs).
-pub fn reset() {
-    with_medium(|m| {
-        m.stas.clear();
-        m.next_host = 0;
-    });
+impl VirtualWifiBus {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn with<R>(&self, f: impl FnOnce(&mut VirtualWifi) -> R) -> R {
+        f(&mut self.inner.lock().unwrap())
+    }
+
+    /// Reset the medium (tests / fresh runs).
+    pub fn reset(&self) {
+        self.with(|m| {
+            m.stas.clear();
+            m.next_host = 0;
+        });
+    }
+
+    /// Submit a frame a station transmitted. The AP processes it: management →
+    /// response to the sender; DHCP → DORA; ARP → reply (gateway or another STA's
+    /// MAC); IP destined to another station → routed into that station's inbox.
+    pub fn submit(&self, src_mac: [u8; 6], frame: &[u8]) {
+        self.with(|m| m.handle_tx(src_mac, frame));
+    }
+
+    /// Drain frames the medium has queued for `mac` (delivered to its RX ring).
+    pub fn take_inbox(&self, mac: [u8; 6]) -> Vec<Vec<u8>> {
+        self.with(|m| {
+            m.stas
+                .get_mut(&mac)
+                .map(|s| s.inbox.drain(..).collect())
+                .unwrap_or_default()
+        })
+    }
+
+    /// Queue a beacon for `mac` (the AP beacons so a scanning STA finds it).
+    /// Called periodically by the MAC while not yet associated.
+    pub fn queue_beacon(&self, mac: [u8; 6], channel: u8) {
+        self.with(|m| {
+            let frame = build_beacon(channel);
+            m.enqueue(mac, frame);
+        });
+    }
 }
 
-/// Submit a frame a station transmitted. The AP processes it: management →
-/// response to the sender; DHCP → DORA; ARP → reply (gateway or another STA's
-/// MAC); IP destined to another station → routed into that station's inbox.
-pub fn submit(src_mac: [u8; 6], frame: &[u8]) {
-    with_medium(|m| m.handle_tx(src_mac, frame));
+// --- Transitional process-global medium (browser back-compat) ----------------
+//
+// WiFi MACs built via `Esp32c3WifiMac::new()` share this one module-global bus.
+// One wasm module = one worker = one lab, so this is byte-identical to the former
+// `static MEDIUM`. The follow-up threads a per-lab-group `VirtualWifiBus` through
+// the MAC's construction, after which this global is deleted.
+fn default_wifi_bus() -> &'static VirtualWifiBus {
+    static BUS: OnceLock<VirtualWifiBus> = OnceLock::new();
+    BUS.get_or_init(VirtualWifiBus::new)
 }
 
-/// Drain frames the medium has queued for `mac` (delivered to its RX ring).
-pub fn take_inbox(mac: [u8; 6]) -> Vec<Vec<u8>> {
-    with_medium(|m| {
-        m.stas
-            .get_mut(&mac)
-            .map(|s| s.inbox.drain(..).collect())
-            .unwrap_or_default()
-    })
-}
-
-/// Queue a beacon for `mac` (the AP beacons so a scanning STA finds it). Called
-/// periodically by the MAC while not yet associated.
-pub fn queue_beacon(mac: [u8; 6], channel: u8) {
-    with_medium(|m| {
-        let frame = build_beacon(channel);
-        m.enqueue(mac, frame);
-    });
+/// The process-global WiFi medium every `Esp32c3WifiMac::new()` binds to.
+/// Transitional; prefer an explicitly owned [`VirtualWifiBus`].
+pub fn default_medium() -> VirtualWifiBus {
+    default_wifi_bus().clone()
 }
 
 impl VirtualWifi {
@@ -493,26 +525,27 @@ mod tests {
         [0x02, 0, 0, 0, 0, n]
     }
 
-    // The medium is a process-global, so all assertions share one test to run
-    // sequentially (parallel #[test]s would race on reset()/assign_ip).
+    // Each test owns its VirtualWifiBus, so they no longer race on a shared
+    // process-global (the old `static MEDIUM` forced everything into one
+    // sequential test).
     #[test]
     fn medium_assoc_dhcp_and_routing() {
-        reset();
+        let bus = VirtualWifiBus::new();
         let (a, b) = (sta_mac(2), sta_mac(3));
 
         // ── Association handshake responds to the sender ──
-        submit(a, &[0x40, 0, 0, 0]); // probe-req (mgmt subtype 4)
-        let inbox = take_inbox(a);
+        bus.submit(a, &[0x40, 0, 0, 0]); // probe-req (mgmt subtype 4)
+        let inbox = bus.take_inbox(a);
         assert_eq!(inbox.len(), 1);
         assert_eq!(inbox[0][0], 0x50); // probe response
         assert_eq!(&inbox[0][4..10], &a); // addressed to the sender
 
         // ── Distinct, idempotent DHCP IPs per station ──
-        let ip_a = with_medium(|m| m.assign_ip(a));
-        let ip_b = with_medium(|m| m.assign_ip(b));
+        let ip_a = bus.with(|m| m.assign_ip(a));
+        let ip_b = bus.with(|m| m.assign_ip(b));
         assert_eq!(ip_a, [192, 168, 4, 2]);
         assert_eq!(ip_b, [192, 168, 4, 3]);
-        assert_eq!(with_medium(|m| m.assign_ip(a)), ip_a);
+        assert_eq!(bus.with(|m| m.assign_ip(a)), ip_a);
 
         // ── IPv4 routed station-to-station ──
         // Station A sends an IPv4/UDP datagram to B's IP (to-DS data frame).
@@ -549,9 +582,9 @@ mod tests {
         tx.extend_from_slice(&[0x00, 0x00]);
         tx.extend_from_slice(&[0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x08, 0x00]);
         tx.extend_from_slice(&ip);
-        submit(a, &tx);
+        bus.submit(a, &tx);
         // B should receive a from-DS frame carrying the same payload.
-        let inbox_b = take_inbox(b);
+        let inbox_b = bus.take_inbox(b);
         assert_eq!(inbox_b.len(), 1, "B should receive the routed frame");
         let f = &inbox_b[0];
         assert_eq!(f[1] & 0x02, 0x02, "from-DS");
@@ -560,6 +593,20 @@ mod tests {
             f.windows(payload.len()).any(|w| w == payload),
             "payload preserved"
         );
-        assert!(take_inbox(a).is_empty(), "A gets nothing back");
+        assert!(bus.take_inbox(a).is_empty(), "A gets nothing back");
+
+        // ── Isolation: a station on a DIFFERENT bus hears nothing ──
+        // Re-send A→B's routed datagram; a second, independent medium must not
+        // deliver it to B. This is what the process-static MEDIUM could not do.
+        let other = VirtualWifiBus::new();
+        other.with(|m| {
+            m.assign_ip(a);
+            m.assign_ip(b);
+        });
+        bus.submit(a, &tx);
+        assert!(
+            other.take_inbox(b).is_empty(),
+            "frame leaked across independent WiFi buses"
+        );
     }
 }

--- a/crates/core/src/peripherals/esp32c3/wifi_mac.rs
+++ b/crates/core/src/peripherals/esp32c3/wifi_mac.rs
@@ -150,6 +150,10 @@ pub struct Esp32c3WifiMac {
     /// [`Self::force_legacy_walk`]) keeps the legacy per-cycle walk. Not
     /// serialized — re-attached by the bus.
     clock: Option<CycleClock>,
+    /// The shared WiFi medium this MAC submits to / pulls its inbox from in
+    /// medium mode. `new()` binds the process-global default; `with_wifi` binds
+    /// an explicit per-group bus (MACs sharing a bus form one virtual network).
+    wifi: super::virtual_wifi::VirtualWifiBus,
 }
 
 impl Default for Esp32c3WifiMac {
@@ -172,6 +176,17 @@ impl Esp32c3WifiMac {
             medium_mac: None,
             medium_beacon_ctr: 0,
             clock: None,
+            wifi: super::virtual_wifi::default_medium(),
+        }
+    }
+
+    /// Build a MAC bound to an explicit WiFi bus. MACs sharing a bus form one
+    /// virtual network (same AP, DHCP, STA↔STA routing); MACs on different buses
+    /// are isolated. Prefer over `new()`'s process-global default.
+    pub fn with_wifi(wifi: super::virtual_wifi::VirtualWifiBus) -> Self {
+        Self {
+            wifi,
+            ..Self::new()
         }
     }
 
@@ -290,7 +305,7 @@ impl Esp32c3WifiMac {
                 if self.medium_mac.is_none() && sa != [0u8; 6] {
                     self.medium_mac = Some(sa);
                 }
-                super::virtual_wifi::submit(sa, &raw);
+                self.wifi.submit(sa, &raw);
             }
         } else {
             self.tx_out.push_back(raw);
@@ -514,9 +529,9 @@ impl Peripheral for Esp32c3WifiMac {
                 // Periodic beacon so the scanning station keeps seeing the AP.
                 self.medium_beacon_ctr = self.medium_beacon_ctr.wrapping_add(1);
                 if self.medium_beacon_ctr % 2_000_000 == 0 {
-                    super::virtual_wifi::queue_beacon(mac, 1);
+                    self.wifi.queue_beacon(mac, 1);
                 }
-                for frame in super::virtual_wifi::take_inbox(mac) {
+                for frame in self.wifi.take_inbox(mac) {
                     self.pending_rx.push_back(frame);
                 }
             }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,7 +10,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-19 | ⚠ drift acked 2026-07-20 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-22 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-21 | ⚠ drift acked 2026-07-21 (re-capture pending) |
@@ -53,7 +53,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-20 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-22 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -499,7 +499,15 @@ boards:
     # detects IN edges rather than draining a queue, and
     # nrf52840_onboarding_gpiote_event_in_fires_on_edge caught it. Offline
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
-    drift_ack: 2026-07-20
+    # 2026-07-22: WiFi virtual medium moved from a process-static (static MEDIUM)
+    # to an injected VirtualWifiBus each Esp32c3WifiMac holds. Esp32c3WifiMac::new()
+    # (the factory path) binds a transitional process-global bus, so existing
+    # behaviour is byte-identical: medium_assoc_dhcp_and_routing passes (now
+    # bus-owned) plus a new cross-bus isolation assertion. No register read/write
+    # path, reset value or layout touched — the esp32c3 reset oracle
+    # (esp32c3_reset_values_match_silicon) is unaffected. Drift is the shared
+    # esp32c3 file commit date only. No live re-capture.
+    drift_ack: 2026-07-22
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md


### PR DESCRIPTION
## Why

Third and last of the bus-globals cleanup (after #614 UART wire, #615 BLE air).
The virtual WiFi medium (AP + associated stations) was a process-static
(`static MEDIUM: OnceLock<Mutex<VirtualWifi>>`) that `Esp32c3WifiMac` reached via
free functions — global mutable state, so two WiFi labs (or two workers) shared
one AP and cross-talked, and the routing test had to be a single sequential test
to avoid racing on it.

## What

- Introduce **`VirtualWifiBus`**, an explicit handle each `Esp32c3WifiMac` holds
  (`Arc<Mutex<VirtualWifi>>`, `Send` for the native `Machine`; single-threaded
  browser never contends). `submit`/`take_inbox`/`queue_beacon`/`reset` become
  methods; MACs sharing a bus form one virtual network, different buses isolate.
- **The free functions are gone** — the MAC uses `self.wifi`.
- `with_wifi(bus)` binds an explicit per-group bus. `new()` (the factory path)
  binds a **transitional process-global** bus — byte-identical to the former
  `static MEDIUM` (one wasm module = one worker = one lab). The playground
  follow-up threads a per-group bus, then the global is removed.

## Verification

- **`medium_assoc_dhcp_and_routing`** now owns its bus (no more forced-sequential
  process-global) and additionally asserts a station on a **different** bus
  receives nothing — the isolation the static could not provide.
- `cargo test -p labwired-core --lib`: **2202 pass**; fmt + clippy clean; wasm
  builds; validation drift gate green (esp32c3 not silicon-tier gated).

## The set is complete (core side)

All three in-process media — UART wire (#614), BLE air (#615), WiFi medium (this)
— are now explicit, injectable, isolation-tested `*Bus` handles. The transitional
process-globals back only `new()`; the playground follow-ups thread per-lab-group
buses and delete them.