### PR TITLE
fix(esp32s3): RMT TX-done IRQ holdoff for Arduino L2 RGB

### DIFF
--- a/crates/core/src/peripherals/esp32s3/rmt.rs
+++ b/crates/core/src/peripherals/esp32s3/rmt.rs
@@ -264,14 +264,12 @@ pub struct Esp32s3Rmt {
     /// a limitation adequate for single-strip WS2812 (the Stage-3 target).
     playback: Option<TxPlayback>,
 
-    /// Channels with a deferred `CHn_TX_END` still to latch (bit `n` = TX ch n).
-    ///
-    /// Instantaneous TX_END on the same MMIO write as `TX_START` re-enters the
-    /// FreeRTOS/IDF TX-done ISR while `rmt_transmit` still holds driver locks
-    /// (Arduino-ESP32 `rmtWrite` / WS2812). Defer completion to the next
-    /// peripheral tick so the starting instruction finishes first — silicon
-    /// also cannot complete a multi-symbol frame in zero cycles.
-    pending_tx_end: u8,
+    /// Sim cycles remaining before level-IRQ emission is allowed after a
+    /// `TX_START`. INT_RAW latches immediately; `explicit_irqs` stay quiet
+    /// until this hits zero so the IDF `rmt_transmit` path can release its
+    /// locks / reach `WaitBits` before `rmt_tx_default_isr` runs (Arduino
+    /// WS2812 / `rgbLedWrite` FreeRTOS queue corruption).
+    irq_holdoff_cycles: u32,
 }
 
 impl Esp32s3Rmt {
@@ -315,9 +313,18 @@ impl Esp32s3Rmt {
             int_raw: 0,
             int_ena: 0,
             playback: None,
-            pending_tx_end: 0,
+            irq_holdoff_cycles: 0,
         }
     }
+
+    /// Hold off TX-done IRQ for this many sim cycles after TX_START.
+    /// Long enough for IDF `rmt_transmit` to return into the caller's
+    /// WaitBits while still short for WS2812 bit times at 10 MHz RMT clk.
+    /// Sim cycles between TX_START and first TX-done IRQ. Must cover
+    /// `rmt_transmit` return + `rmtWrite` blocking on the completion queue.
+    /// Too short → GiveFromISR with no waiter → permanent block or queue
+    /// corruption (Arduino S3 RGB L2 @ 0x20406a).
+    const TX_IRQ_HOLDOFF: u32 = 2000;
 
     /// Map an MMIO word offset to the TX channel index whose CONF0 it is, if
     /// any. TX CONF0 offsets are 0x20, 0x24, 0x28, 0x2C (channels 0..3).
@@ -610,10 +617,11 @@ impl Esp32s3Rmt {
         if let Some(i) = Self::tx_conf0_index(offset) {
             // Store everything except the self-clearing write-trigger bits.
             self.tx_conf0[i] = value & !TX_CONF0_WT_MASK;
-            // TX start: arm pad playback and schedule CHn_TX_END for the next
-            // tick (see `pending_tx_end`). Write-trigger bits already cleared.
+            // TX start: latch CHn_TX_END in INT_RAW immediately (status/poll),
+            // but hold off level-IRQ emission (see `irq_holdoff_cycles`).
             if value & TX_START_BIT != 0 {
-                self.pending_tx_end |= 1 << i;
+                self.int_raw |= tx_end_bit(i);
+                self.irq_holdoff_cycles = Self::TX_IRQ_HOLDOFF;
                 // RMT Stage 2: timed pad waveform for observers / logic capture.
                 self.arm_tx_playback(i);
             }
@@ -708,21 +716,14 @@ impl Peripheral for Esp32s3Rmt {
     }
 
     /// Level-sensitive IRQ delivery: while any enabled interrupt is pending
-    /// (INT_ST != 0), re-emit the RMT source on every tick so the bus
-    /// aggregator keeps the CPU's pending line asserted until firmware ACKs at
-    /// the source (INT_CLR). Mirrors the SYSTIMER model.
-    ///
-    /// Also retires deferred `CHn_TX_END` latches scheduled by `TX_START`.
+    /// (INT_ST != 0) **and** the post-TX_START holdoff has expired, re-emit
+    /// the RMT source on every tick so the bus aggregator keeps the CPU's
+    /// pending line asserted until firmware ACKs at the source (INT_CLR).
     fn tick(&mut self) -> PeripheralTickResult {
-        if self.pending_tx_end != 0 {
-            for ch in 0..TX_CHANNELS {
-                if self.pending_tx_end & (1 << ch) != 0 {
-                    self.int_raw |= tx_end_bit(ch);
-                }
-            }
-            self.pending_tx_end = 0;
+        if self.irq_holdoff_cycles > 0 {
+            self.irq_holdoff_cycles = self.irq_holdoff_cycles.saturating_sub(1);
         }
-        let explicit_irqs = if self.int_st() != 0 {
+        let explicit_irqs = if self.irq_holdoff_cycles == 0 && self.int_st() != 0 {
             Some(vec![self.source_id])
         } else {
             None
@@ -733,16 +734,13 @@ impl Peripheral for Esp32s3Rmt {
         }
     }
 
-    /// Bus-tick opt-in: active while a timed playback is in flight **or** a
-    /// deferred TX_END is pending (so the next walk retires completion).
+    /// Bus-tick opt-in: active while a timed playback is in flight.
     fn needs_bus_tick(&self) -> bool {
-        self.playback.is_some() || self.pending_tx_end != 0
+        self.playback.is_some()
     }
 
     fn needs_legacy_walk(&self) -> bool {
-        // Ensure `tick()` runs to retire deferred TX_END even when the
-        // bus-tick path is not engaged (no pad routing / no playback edges).
-        self.pending_tx_end != 0 || self.playback.is_some()
+        true
     }
 
     /// Play out the armed TX waveform onto the routed GPIO pad(s), one bus tick
@@ -817,8 +815,9 @@ mod tests {
         Esp32s3Rmt::new(RMT_SOURCE)
     }
 
-    /// Retire deferred `CHn_TX_END` latches (one peripheral tick).
+    /// Drain TX IRQ holdoff so subsequent ticks emit level IRQs.
     fn retire_tx_end(r: &mut Esp32s3Rmt) {
+        r.irq_holdoff_cycles = 0;
         let _ = r.tick();
     }
 
@@ -913,9 +912,7 @@ mod tests {
         let conf = TX_START_BIT | TX_CONF_UPDATE_BIT | (5 << 8);
         r.write_word(0x28, conf); // CH2CONF0
 
-        // TX_END is deferred one tick (avoids re-entrant TX-done ISR).
-        assert_eq!(r.read_word(0x70) & tx_end_bit(2), 0, "not yet");
-        retire_tx_end(&mut r);
+        // INT_RAW latches immediately; IRQ emission is deferred one tick.
         assert_eq!(r.read_word(0x70) & tx_end_bit(2), tx_end_bit(2));
 
         // tx_start (and conf_update) auto-cleared in stored CONF0; the config
@@ -931,7 +928,6 @@ mod tests {
         for (off, ch) in [(0x20u64, 0usize), (0x24, 1), (0x28, 2), (0x2C, 3)] {
             let mut r = rmt();
             r.write_word(off, TX_START_BIT);
-            retire_tx_end(&mut r);
             assert_eq!(
                 r.read_word(0x70),
                 tx_end_bit(ch),
@@ -955,7 +951,6 @@ mod tests {
         // Latch TX_END on channels 0 and 3.
         r.write_word(0x20, TX_START_BIT);
         r.write_word(0x2C, TX_START_BIT);
-        retire_tx_end(&mut r);
         assert_eq!(r.read_word(0x70), tx_end_bit(0) | tx_end_bit(3));
 
         // INT_CLR bit 0 only — clears channel 0, leaves channel 3.
@@ -972,8 +967,7 @@ mod tests {
     #[test]
     fn int_st_masks_raw_with_ena() {
         let mut r = rmt();
-        r.write_word(0x20, TX_START_BIT); // schedule TX_END ch0
-        retire_tx_end(&mut r);
+        r.write_word(0x20, TX_START_BIT); // TX_END ch0 raw
         assert_eq!(r.read_word(0x70), tx_end_bit(0));
         // INT_ENA = 0 → INT_ST masked to 0.
         assert_eq!(r.read_word(0x74), 0, "INT_ST masked when ENA=0");
@@ -988,9 +982,12 @@ mod tests {
         // No pending → no IRQ.
         assert!(r.tick().explicit_irqs.is_none());
 
-        // Schedule TX_END and enable it; first tick retires + emits.
+        // Latch TX_END and enable it; holdoff must expire before emit.
         r.write_word(0x20, TX_START_BIT);
         r.write_word(0x78, tx_end_bit(0));
+        // During holdoff, no IRQ even though INT_ST is live.
+        assert!(r.tick().explicit_irqs.is_none(), "holdoff suppresses IRQ");
+        retire_tx_end(&mut r);
 
         // Level-sensitive: emits the RMT source every tick while INT_ST != 0.
         assert_eq!(r.tick().explicit_irqs.as_deref(), Some(&[RMT_SOURCE][..]));
@@ -1004,9 +1001,9 @@ mod tests {
     #[test]
     fn int_raw_pending_but_disabled_emits_no_irq() {
         let mut r = rmt();
-        r.write_word(0x20, TX_START_BIT); // schedule raw, ENA=0
-        retire_tx_end(&mut r);
+        r.write_word(0x20, TX_START_BIT); // raw pending, ENA=0
         assert_eq!(r.read_word(0x70), tx_end_bit(0));
+        retire_tx_end(&mut r);
         assert!(
             r.tick().explicit_irqs.is_none(),
             "raw pending without ENA must not emit"
@@ -1023,7 +1020,6 @@ mod tests {
         assert_eq!(r.read_word(0x70), 0, "no completion before TX_START byte");
         // Now the low byte with TX_START.
         r.write(0x20, 0x01).unwrap();
-        retire_tx_end(&mut r);
         assert_eq!(r.read_word(0x70), tx_end_bit(0), "TX_END latched");
     }
 
@@ -1032,6 +1028,7 @@ mod tests {
         let mut r = Esp32s3Rmt::new(99);
         r.write_word(0x20, TX_START_BIT);
         r.write_word(0x78, tx_end_bit(0));
+        retire_tx_end(&mut r);
         assert_eq!(r.tick().explicit_irqs.as_deref(), Some(&[99][..]));
     }
 

--- a/crates/core/tests/diag_esp32s3_l2.rs
+++ b/crates/core/tests/diag_esp32s3_l2.rs
@@ -144,7 +144,7 @@ fn diag_s3_l2() {
 
     dump_maps(&machine.bus, "pre-step");
 
-    for step in 1..=2_000_000u64 {
+    for step in 1..=6_000_000u64 {
         match machine.step() {
             Ok(()) => {}
             Err(e) => {
@@ -202,7 +202,7 @@ fn diag_s3_l2() {
             .unwrap_or(0);
 
         // Trace who fills the intmatrix 1k..15k
-        if step > 1000 && step < 15000 {
+        if step > 1000 && step < 8000 {
             static mut LAST: String = String::new();
             let f = nearest(&syms, pc);
             let base = f.split('+').next().unwrap_or(&f);

--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,40 +1,17 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 02:54:36 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-23 03:21:05 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
 Legend: ✅ pass · 🔧 compile fail · 📦 toolchain/platform missing · 🔴 boot/sim fail · 🟠 UART ran but marker missing · 🟣 unmodeled/unsupported · ⏱️ timeout
 
-| chip | L2_blink_serial | notes |
-|------|------|-------|
-| `esp32s3` | 🟣 | L2_blink_serial:unmodeled |
+| chip | L0_serial_boot | L1_serial_loop | L2_blink_serial | notes |
+|------|------|------|------|-------|
+| `esp32s3` | ✅ | ✅ | ✅ |  |
 
 ## Summary
 
-- Cells: **1**
-- `unmodeled`: 1
+- Cells: **3**
+- `pass`: 3
 
 ## Failures (detail)
-
-### `esp32s3` × `L2_blink_serial` → **unmodeled**
-```
-seeded factory MMU (12 entries, app0 @ flash 0x10000) for cache2phys
-labwired-cli test: seeded S3 factory MMU for cache2phys (app0 @ 0x10000)
-labwired-cli test: S3 APP handshake flags @ [
-    0x3fc9c733,
-    0x3fc9c734,
-    0x3fc9c731,
-    0x3fc9c732,
-]
-labwired-cli test: pxCurrentTCBs @0x3fc9cc98 (hybrid preserve key)
-labwired-cli test: installed xthal_window_spill_nw CPU spill workaround @0x4038839c
-labwired-cli test: ESP32-S3 fast-boot entry=0x40379b90 (dual-core APP_CPU)
-2026-07-23T00:54:35.477146Z  INFO esp32s3::rom::ets_printf: 
-2026-07-23T00:54:36.387093Z ERROR labwired: Simulation error at step 1085861: Memory access violation at 0x20406a
-2026-07-23T00:54:36.387110Z ERROR labwired: Assertion failed: UartContains(UartContainsAssertion { uart_contains: "LW_L2_OK" }) (captured len=8)
-
-```
-UART tail:
-```
-LW_L2_BO
-```
 

--- a/validation/arduino-matrix/PROBLEMS.md
+++ b/validation/arduino-matrix/PROBLEMS.md
@@ -24,13 +24,12 @@ Full matrix: 15 chips × 3 sketches. Scoreboard:
 | **nRF52832** | **Fixed L0–L2** — RTC1 @ `0x40011000` (was mis-mapped RADIO); real UART model |
 | **RP2040** | **Fixed L0–L2** — bootrom `@0` must win over low-address flash alias; minimal B0-compatible `rom_func_lookup` |
 | **ESP32-C3** | **Fixed L0–L2** — FreeRTOS yield + factory MMU/`cache2phys` + C3 RMT for RGB `LED_BUILTIN` (pin 30 → `rgbLedWrite`) |
-| **ESP32-S3** | **Fixed L0–L1** on plain `labwired test` (`LW_L0_OK` / `LW_L1_OK`); L2 still open |
+| **ESP32-S3** | **Fixed L0–L2** on plain `labwired test` — dual-core + ROM strlen + RMT TX-done IRQ holdoff for RGB `LED_BUILTIN` |
 
 ## Open gaps (model work only)
 
 | Chip | Symptom | Honest next model work |
 |------|---------|-------------------------|
-| **ESP32-S3 L2** | After first `digitalWrite(RGB)` → `rgbLedWrite` → `rmtInit`/`rmtWrite`, `rmt_tx_default_isr` runs once then `xQueueReceive` on PRO with bad queue → `EnterCritical` read `@0x20406a` | RGB=`97`→pin48 RMT; map40=[6/6] both cores; ISR@APP raw/ena=1; then PRO `xQueueReceive(a2=1)` corruption. Next: dual-core RMT IRQ/queue integrity after `xQueueGiveFromISR`, or high-DRAM spill (range expanded to `0x3FC8_8000..0x3FD0_0000`) |
 | **STM32WBA52** | No PIO Arduino board | Toolchain gap |
 
 ## Fixes already landed (honest)
@@ -91,6 +90,5 @@ python3 validation/arduino-matrix/run_matrix.py --boards stm32f407,nrf52832
 36. **ESP32-S3 SYSTIMER legacy tick** — factory uses `new_with_source_legacy_tick` (scheduler-driven never advances without `event-scheduler` feature).
 37. **`px_current_tcb` multi-chip** — hybrid CALL preserve parks under FreeRTOS TCB via `pxCurrentTCBs[core]`. Classic-only `0x3FFC_27C8` left S3 at `0x3FC9_B2B4` unparked → APP `_WindowUnderflow8` loop after `vTaskDelay`. Now: ELF `PX_CURRENT_TCB_ADDR` + probe classic/S3 DRAM TCB pointers.
 38. **ESP32-S3 ROM `strlen` @ `0x40001248`** — harness prefill is `nop_return_zero`; `Print::write(const char*)` got length 0 so `Serial.println("LW_L0_OK")` wrote nothing. Real `rom_strlen` thunk; memcpy/memset already registered.
-39. **ESP32-S3 DRAM spill range** — hybrid/xthal spill only accepted S3 SP in `0x3FC8_0000..0x3FCF_0000`; top of 512 KiB SRAM / heap excluded. Now `0x3FC8_8000..0x3FD0_0000` (+ model DRAM 512 KiB).
-40. **ESP32-S3 L2 `LED_BUILTIN` (RGB/RMT)** — `pinMode`/`digitalWrite` on GPIO2/48 pass; `digitalWrite(LED_BUILTIN)` → `rgbLedWrite` → `rmtWrite` corrupts FreeRTOS `xTimerQueue` (handle becomes `0x204016`) → `xQueueReceive` / `xPortEnterCriticalTimeout` at `0x20406a`. `rmtInit` alone OK. Deferred RMT `TX_END` (1 tick) did not clear it — still open.
-39. **S3 DRAM spill/TCB range** — hybrid spill + `looks_like_tcb` now use `0x3FC8_8000..0x3FD0_0000` (was `..0x3FCF_0000`, dropped top ~64 KiB of the 480 KiB SRAM / heap).
+39. **ESP32-S3 DRAM spill/TCB range** — hybrid spill + `looks_like_tcb` use `0x3FC8_8000..0x3FD0_0000` (was capped at `0x3FCF_0000` / 480 KiB model).
+40. **ESP32-S3 RMT TX-done IRQ holdoff** — instantaneous TX_END+IRQ on `TX_START` re-entered `rmt_tx_default_isr` while IDF `rmt_transmit` still held locks → FreeRTOS `xTimerQueue` corruption (`EnterCritical` @ `0x20406a`). Latch INT_RAW immediately; suppress level IRQ for ~2000 sim ticks so WaitBits can arm. Arduino L2 `LED_BUILTIN`/`rgbLedWrite` green.


### PR DESCRIPTION
## Summary
- Hold off ESP32-S3 RMT level IRQ for ~2000 sim ticks after `TX_START` (INT_RAW still latches immediately).
- Fixes FreeRTOS queue corruption when Arduino `digitalWrite(LED_BUILTIN)` → `rgbLedWrite` → `rmtWrite` raced the TX-done ISR.
- Matrix: **esp32s3 L0/L1/L2 all pass** (`LW_L2_OK` @ ~4.4M steps).

## Test plan
- [x] `cargo test -p labwired-core --lib peripherals::esp32s3::rmt`
- [x] `python3 validation/arduino-matrix/run_matrix.py --boards esp32s3` → 3/3 pass
- [ ] CI core-integrity green