### PR TITLE
perf+chore: matrix speed opts + harness reorg (matrix_lib, sim-only, L2 GPIO)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -57,6 +57,11 @@ default = []
 # JIT-on vs JIT-off differential is byte-identical either way (both arms tick
 # peripherals identically), so the scheduler is not required for this path.
 jit-core = ["labwired-core/jit"]
+# Opt-in event scheduler + walk-delete / idle-FF infrastructure used by the
+# Arduino matrix speed path (`LABWIRED_MATRIX_SPEED=1`). Build:
+#   cargo build -p labwired-cli --release --features event-scheduler
+# Do NOT combine with `jit-core` for general CLI use (see note above).
+event-scheduler = ["labwired-core/event-scheduler"]
 # Swap the built-in fuzzing loop for the LibAFL engine (havoc/splice mutators,
 # map-feedback scheduler, crash objectives). Heavy dependency tree, so opt-in:
 # `cargo build --release -p labwired-cli --features fuzz-libafl`.

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -9,6 +9,25 @@
 use crate::*;
 use tracing::warn;
 
+/// Opt-in Arduino-matrix speed path (`LABWIRED_MATRIX_SPEED=1`).
+///
+/// Enables idle/delay fast-forward only (requires a CLI build with
+/// `--features event-scheduler`). Tick-interval widening is intentionally
+/// **not** applied here: under the event-scheduler feature, wide ticks have
+/// regressed ESP classic/S3/C3 FreeRTOS labs before, and the matrix already
+/// gets most of its wall-time win from shorter L2 delays + Waiti park.
+/// Default CLI / green labs are unchanged when the env var is unset.
+fn apply_matrix_speed_opts<C: labwired_core::Cpu>(machine: &mut labwired_core::Machine<C>) {
+    if std::env::var("LABWIRED_MATRIX_SPEED").as_deref() != Ok("1") {
+        return;
+    }
+    machine.config.idle_fast_forward_enabled = true;
+    eprintln!(
+        "labwired-cli test: LABWIRED_MATRIX_SPEED=1 (idle_ff=on, event_scheduler={})",
+        cfg!(feature = "event-scheduler")
+    );
+}
+
 /// Apply the script's faults to the built bus before the run, logging any that
 /// could not be applied. Returns the provisional evidence; runtime-observed
 /// outcomes (and the require_fault_fired gate) are finalised after the run in
@@ -1056,6 +1075,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     macro_rules! run_machine {
         ($machine:expr) => {{
             let mut machine = $machine;
+            apply_matrix_speed_opts(&mut machine);
             // JIT-eligible RISC-V runs source cycles/instructions from the
             // machine's own counters (see `execute_test_loop`), so the metrics
             // step observer must NOT be installed — its presence would gate the

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -143,6 +143,11 @@ pub struct XtensaLx7 {
     /// app-cpu boot address (mirrors real silicon's reset-hold). Default
     /// false; ESP32 dual-core setup sets it on cpu_secondary at boot.
     pub halted: bool,
+    /// Set when the last retired instruction was `WAITI` (PC does not
+    /// advance). Subsequent steps take a cheap CCOUNT/IRQ path until a
+    /// wake-capable interrupt arrives — important for dual-core APP_CPU
+    /// FreeRTOS idle (`vApplicationIdleHook` / idle task Waiti loop).
+    waiti_parked: bool,
     /// Faithful windowed-register mode. When true, the CPU uses the REAL
     /// Xtensa window machinery — per-access window-overflow checks that vector
     /// to the firmware's OF{4,8,12} handlers (which spill to the stack save
@@ -239,6 +244,7 @@ impl XtensaLx7 {
             pc: 0x4000_0400,
             branched: false,
             halted: false,
+            waiti_parked: false,
             faithful_windows: false,
             app_cpu: false,
             call_preserve_stack: Vec::new(),
@@ -1197,7 +1203,10 @@ impl XtensaLx7 {
                 // the CPU stays at this instruction (PC doesn't advance),
                 // so a caller poll-loop sees the same PC each step and
                 // can detect "halted" without us tracking extra state.
+                // `waiti_parked` lets later steps skip fetch/decode until a
+                // wake-capable IRQ arrives (dual-core APP idle win).
                 self.ps.set_intlevel(level);
+                self.waiti_parked = true;
             }
             // Xtensa Zero Overhead Loops (LOOP / LOOPNEZ / LOOPGTZ).
             // ISA RM §4.3.2: LCOUNT = as_ - 1, LBEG = PC + 3 (after LOOP),
@@ -2988,17 +2997,60 @@ impl Cpu for XtensaLx7 {
         // Machine::load_firmware reset, otherwise it'd race PRO_CPU
         // through the firmware entry point.
         self.halted = was_halted;
+        self.waiti_parked = false;
         Ok(())
     }
 
     fn halt(&mut self) {
         self.halted = true;
+        self.waiti_parked = false;
     }
     fn unhalt(&mut self) {
         self.halted = false;
     }
     fn intlevel(&self) -> u8 {
         self.ps.intlevel()
+    }
+
+    fn idle_fast_forward_budget(&self, bus: &dyn Bus) -> Option<u64> {
+        // Architectural WAITI park (FreeRTOS idle / vTaskDelay sleep). Only
+        // offer a budget while no wake-capable interrupt is already visible.
+        if !self.waiti_parked || self.halted {
+            return None;
+        }
+        if !self.ps.excm() {
+            if let Some(irq_level) = self.pending_irq_level(bus) {
+                if irq_level > self.ps.intlevel() {
+                    return None;
+                }
+            }
+        }
+        Some(u64::MAX)
+    }
+
+    fn fast_forward_idle_cycles(&mut self, cycles: u64) {
+        // Keep CCOUNT coherent with machine total_cycles so CCOMPARE0 edges
+        // still fire after an idle skip (FreeRTOS tick source on classic ESP).
+        if cycles == 0 {
+            return;
+        }
+        use crate::cpu::xtensa_sr::{CCOMPARE0, CCOUNT};
+        let before = self.sr.read(CCOUNT);
+        let after = before.wrapping_add(cycles as u32);
+        self.sr.write(CCOUNT, after);
+        let ccompare0 = self.sr.read(CCOMPARE0);
+        if ccompare0 != 0 {
+            // Raise timer-0 if the skipped window crossed CCOMPARE0.
+            let crossed = if after >= before {
+                ccompare0 > before && ccompare0 <= after
+            } else {
+                // wrap
+                ccompare0 > before || ccompare0 <= after
+            };
+            if crossed {
+                self.sr.raise_interrupt_bits(1 << 6);
+            }
+        }
     }
 
     fn step(
@@ -3017,7 +3069,10 @@ impl Cpu for XtensaLx7 {
         }
         // FreeRTOS may have switched tasks via stack context restore without
         // our RFE; re-bind CALL8 preserve for the current TCB if needed.
-        self.maybe_restore_task_preserve(bus);
+        // Skip when WAITI-parked: idle task is not mid-context-switch.
+        if !self.waiti_parked {
+            self.maybe_restore_task_preserve(bus);
+        }
         // ── Pre-fetch interrupt check ─────────────────────────────────────────
         // Per Xtensa ISA RM §4.4.1: check for pending interrupts before fetching
         // the next instruction.
@@ -3050,9 +3105,18 @@ impl Cpu for XtensaLx7 {
         if !self.ps.excm() {
             if let Some(irq_level) = self.pending_irq_level(bus) {
                 if irq_level > self.ps.intlevel() {
+                    self.waiti_parked = false;
                     return self.dispatch_irq(irq_level, bus);
                 }
             }
+        }
+
+        // WAITI park: stay at the same PC without re-fetching/decoding.
+        // Dual-core APP_CPU spends most cycles here after FreeRTOS idle starts;
+        // skipping fetch/decode is the highest-ROI dual-core idle win that
+        // still advances CCOUNT (and therefore CCOMPARE0 tick edges).
+        if self.waiti_parked {
+            return Ok(());
         }
 
         // ── Phase 3.2 JIT fast-path (issue #124) ──────────────────────────────

--- a/crates/core/src/peripherals/hsem.rs
+++ b/crates/core/src/peripherals/hsem.rs
@@ -82,6 +82,12 @@ impl crate::Peripheral for Hsem {
     fn snapshot(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }
+
+    /// Pure register bank / grant-on-read lock model — no time-driven state.
+    /// Class A walk-free: default no-op `tick()` is a genuine no-op.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -104,5 +110,16 @@ mod tests {
         let mut h = Hsem::new();
         h.write_u32(0x110, 0xDEAD_BEEF).unwrap(); // ICR/IER region
         assert_eq!(h.read_u32(0x110).unwrap(), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn class_a_walk_free() {
+        let mut h = Hsem::new();
+        assert!(!h.needs_legacy_walk());
+        // Default tick is a genuine no-op on an armed instance.
+        let r = h.tick();
+        assert!(!r.irq);
+        assert_eq!(r.cycles, 0);
+        assert!(r.explicit_irqs.is_none());
     }
 }

--- a/crates/core/src/peripherals/rp2040_clocks.rs
+++ b/crates/core/src/peripherals/rp2040_clocks.rs
@@ -60,6 +60,11 @@ impl Rp2040ClockReset {
 }
 
 impl Peripheral for Rp2040ClockReset {
+    /// Pure clock/reset register bank — no time-driven tick work.
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
     fn read_u32(&self, offset: u64) -> SimResult<u32> {
         let abs = self.base + offset;
         let val = match abs {

--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,8 +1,8 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 12:02:17 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-23 12:35:00 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
-Legend: ✅ pass · 🔧 compile fail · 📦 toolchain/platform missing · 🔴 boot/sim fail · 🟠 UART ran but marker missing · 🟣 unmodeled/unsupported · ⏱️ timeout
+Legend: ✅ pass · 🔧 compile/build fail · 📦 toolchain missing · 🔴 boot/sim fail · 🟠 oracle miss · 🟣 unmodeled · ⏱️ timeout
 
 | chip | L0_serial_boot | L1_serial_loop | L2_blink_serial | notes |
 |------|------|------|------|-------|

--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,6 +1,6 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 11:12:36 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-23 12:02:17 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
 Legend: ✅ pass · 🔧 compile fail · 📦 toolchain/platform missing · 🔴 boot/sim fail · 🟠 UART ran but marker missing · 🟣 unmodeled/unsupported · ⏱️ timeout
 

--- a/docs/engineering/test_harness.md
+++ b/docs/engineering/test_harness.md
@@ -1,0 +1,153 @@
+# LabWired test harness
+
+How tests are layered, what “green” means, and where new tests go.
+
+This is the contract for harness work started in `chore/test-harness-organize`
+(2026-07-23). Product matrices are **smoke**, not full silicon proof.
+
+---
+
+## Layers
+
+```text
+L3  Product matrices     validation/{arduino,zephyr}-matrix/
+    Real stock FW + labwired test. Stage-classified pass/fail.
+
+L2  labwired test        crates/cli (test subcommand)
+    Script → build machine → advance → assertions → result.json
+
+L1  Core tests           crates/core/{src,tests}
+    Units next to models; differentials; e2e; diag (never CI)
+```
+
+**Rule:** L3 must not special-case silicon. Chip bring-up belongs in
+`system` / `boot` / models — not in matrix Python or growing `if is_esp32s3`
+trees in the CLI (extraction is phased; see roadmap below).
+
+---
+
+## What “pass” means
+
+| Layer | Pass means | Not a pass if… |
+|-------|------------|----------------|
+| **Unit** (`--lib`) | Rust assertions hold | model math/API wrong |
+| **Differential** | Walk vs scheduler (or tick-1 vs N) traces match | time-base drift, IRQ mismatch |
+| **E2E** (`crates/core/tests/e2e_*`) | Specific lab/fixture contract | that demo broken |
+| **Matrix cell** | Staged: compile → boot → **oracle** | any stage fails |
+| **Diag** | N/A — manual only | never gate CI |
+
+### Matrix oracle (current + target)
+
+| Level | Current | Target |
+|-------|---------|--------|
+| L0 | UART contains marker | same (boot smoke) |
+| L1 | UART contains marker after loop/delay | same + marker from scheduling path |
+| L2 | UART contains marker | UART **and** (when configured) **LED GPIO edges** via `--watch-gpio` |
+
+Matrix is **not** a substitute for walk differentials or hw-oracle.
+
+### Failure buckets (matrix)
+
+| Status | Meaning |
+|--------|---------|
+| `pass` | Oracle satisfied |
+| `compile_fail` / `build_fail` | Toolchain rejected the sketch/sample |
+| `toolchain_missing` | Platform/board package or west missing |
+| `boot_fail` | Sim ran; empty UART / no progress toward marker |
+| `oracle_fail` | UART (or GPIO) ran but assertion missed |
+| `unmodeled` | Gap signal in result/stop_reason or known fault strings |
+| `timeout` | Wall clock budget |
+| `sim_error` | Hard sim failure |
+
+Classification prefers `result.json` `status` / `stop_reason` over grepping stderr.
+
+---
+
+## Env vars (matrix / test)
+
+| Var | Role |
+|-----|------|
+| `LABWIRED_MATRIX_SPEED=1` | Opt-in idle fast-forward in `labwired test` (**requires** CLI built with `--features event-scheduler`). Does **not** widen tick interval. Experimental; ESP FreeRTOS labs may fail under event-scheduler — default CLI is the fidelity path. |
+| `LABWIRED_RP2040_BOOTROM` | Path to RP2040 mask ROM; matrix sets default when in-tree image exists. Empty env can opt out for bare-metal tests. |
+| `LABWIRED_RISCV_JIT` / `LABWIRED_TICK_INTERVAL` | C3 JIT / tick experiments (not matrix default). |
+
+Default `cargo build -p labwired-cli --release` does **not** enable `event-scheduler`.
+
+---
+
+## Where to put a new test
+
+| You are proving… | Put it here |
+|------------------|-------------|
+| One peripheral / CPU helper | Unit next to the model in `crates/core/src/...` |
+| Walk-delete / idle-FF / tick identity | `crates/core/tests/*differential*` (prefer always-on or small fixture; full-boot diffs may `#[ignore]`) |
+| A shipped lab / multi-peripheral story | `crates/core/tests/e2e_*.rs` |
+| Temporary “what is PC doing” archaeology | `diag_*.rs` with **`#[ignore]`** — never CI |
+| Stock Arduino/Zephyr still boots on a chip | Matrix board row + sketch/sample |
+
+**Do not** add new hardcoded PlatformIO work paths to `crates/cli`.
+
+---
+
+## Integration test inventory (`crates/core/tests/`)
+
+Counts as of 2026-07-23 (~109 `*.rs` files). Buckets are **logical** (naming);
+physical rehome is a later PR.
+
+| Bucket | Count | Policy |
+|--------|------:|--------|
+| `diag_*` | 6 | Always `#[ignore]`; never CI |
+| `*differential*` / walk-free | 19 | Many need `event-scheduler`; some full-boot ignored |
+| `e2e_*` / survival / shipped-lab | 17 | Mix of always-on and fixture/feature gated |
+| `*_profile` / bench | 2 | `#[ignore]` + release |
+| other | 65 | Conformance, world, JIT lockstep, onboarding, … |
+
+### diag (manual only)
+
+| Test | ignored | features |
+|------|---------|----------|
+| `diag_c3_yield` | yes | — |
+| `diag_esp32_dual_core_boot` | yes | — |
+| `diag_esp32c3_boot` | yes | — |
+| `diag_esp32c3_panic` | yes | — |
+| `diag_esp32s3_boot` | yes | — |
+| `diag_esp32s3_l2` | yes | — |
+
+### differential (representative)
+
+Prefer small fixtures in PR CI. Full ROM+app walk diffs stay `--ignored` until cheaper.
+
+Many files use `#![cfg(feature = "event-scheduler")]`. Default CI does **not** prove
+scheduler identity unless a workflow enables the feature.
+
+### Product matrices
+
+| Matrix | Driver | Shared engine |
+|--------|--------|----------------|
+| Arduino L0–L2 | `validation/arduino-matrix/run_matrix.py` | `validation/matrix_lib/` |
+| Zephyr L0–L2 | `validation/zephyr-matrix/run_matrix.py` | `validation/matrix_lib/` |
+
+---
+
+## Roadmap (harness reorg)
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| **A** Doc + inventory | **done** (this file) | Contract freeze |
+| **B** `matrix_lib` + `--sim-only` + ELF hash cache | **done** | Local branch only |
+| **C** L2 GPIO oracle + budget reasons | **done** | `led_watch` + ratcheted `max_steps` |
+| **D** Structured fail classify | partial | `matrix_lib.classify_failure` prefers result.json |
+| **E** Extract ESP bring-up from CLI | later | Highest risk; re-run 45/45 |
+| **F** Physical test rehome | later | `tests/{diag,differential,e2e}/` |
+| **G** Dual-universe nightly (Cortex) | later | event-scheduler smoke |
+
+Work log: [`test_harness_reorg_log.md`](test_harness_reorg_log.md).
+
+---
+
+## Related docs
+
+- `validation/arduino-matrix/README.md` / `PROBLEMS.md`
+- `validation/zephyr-matrix/README.md`
+- `docs/walk_free_plan.md` — walk vs scheduler strategy
+- `docs/coverage_scoreboard.md` — coverage matrix (separate from Arduino matrix)

--- a/docs/engineering/test_harness_reorg_log.md
+++ b/docs/engineering/test_harness_reorg_log.md
@@ -1,0 +1,33 @@
+# Test harness reorg — work log
+
+Local branch: `chore/test-harness-organize` (do **not** push until asked).
+
+## 2026-07-23 — Phase A
+
+- Added `docs/engineering/test_harness.md` (layers, pass contracts, env vars,
+  inventory table, roadmap).
+- Inventory of `crates/core/tests`: ~6 diag / 19 differential / 17 e2e-ish /
+  2 bench / 65 other.
+
+## 2026-07-23 — Phase B
+
+- Introduced `validation/matrix_lib/` shared by Arduino + Zephyr runners:
+  - `find_labwired`, `write_test_script`, `run_labwired`, `classify_failure`
+  - `render_scoreboard`
+  - compile content-hash cache helpers
+- Arduino `run_matrix.py`: `--sim-only`, ELF hash skip-recompile, uses matrix_lib.
+- Zephyr `run_matrix.py`: uses matrix_lib for script + invoke + scoreboard.
+- Removed no-op `LABWIRED_MATRIX_SPEED` reassignment; env is passed through as-is.
+
+## 2026-07-23 — Phase C
+
+- `boards.yaml`: required-style `budget_reason` comments/fields; ratchet some
+  `max_steps` where L2 delays are short.
+- Optional `led_watch: "peripheral:pin"` + matrix `--watch-gpio` + post-check
+  min edge count on L2 (UART-only for RGB RMT boards without led_watch).
+
+## Verification
+
+- `python3 -c "import matrix_lib; ..."` import smoke
+- `run_matrix.py --sim-only` on subset (STM32 + ESP) after A–C
+- Full 45/45 when convenient; not pushed to remote

--- a/validation/arduino-matrix/README.md
+++ b/validation/arduino-matrix/README.md
@@ -27,24 +27,36 @@ cargo build -p labwired-cli --release   # once (fidelity-default CLI)
 python3 validation/arduino-matrix/run_matrix.py
 python3 validation/arduino-matrix/run_matrix.py --boards stm32f103,esp32
 python3 validation/arduino-matrix/run_matrix.py --sketches L0_serial_boot
+
+# Re-sim without PlatformIO (needs prior firmware.elf under out/)
+python3 validation/arduino-matrix/run_matrix.py --sim-only --boards esp32s3
+
+# Content-hash cache skips recompile when sketch+board inputs unchanged
+python3 validation/arduino-matrix/run_matrix.py   # second full run hits cache
+python3 validation/arduino-matrix/run_matrix.py --force-compile
 ```
 
-### Matrix speed path (optional)
+Shared helpers live in `validation/matrix_lib/` (also used by the Zephyr matrix).
+Harness contract: `docs/engineering/test_harness.md`.
 
-For wall-time measurement / faster re-checks, build with the event scheduler
-and enable idle/delay fast-forward:
+### Oracles
+
+| Level | UART | GPIO |
+|-------|------|------|
+| L0 / L1 | marker string | — |
+| L2 | `LW_L2_OK` | if `boards.yaml` has `led_watch: peripheral:pin`, require ≥`led_min_edges` logic edges |
+
+RGB `LED_BUILTIN` boards (C3/S3) stay UART-only until an RMT-side oracle exists.
+
+### Matrix speed path (optional)
 
 ```bash
 cargo build -p labwired-cli --release --features event-scheduler
 LABWIRED_MATRIX_SPEED=1 python3 validation/arduino-matrix/run_matrix.py
 ```
 
-`LABWIRED_MATRIX_SPEED=1` turns on `idle_fast_forward_enabled` (WFI / WAITI /
-timer-poll coalesce). It does **not** widen the peripheral tick interval —
-that path has regressed ESP FreeRTOS labs under the scheduler. Default labs
-and plain `labwired test` stay on the instruction-faithful path when the env
-is unset. Do not ship the default CLI with `event-scheduler` enabled globally
-(see `crates/cli/Cargo.toml`).
+Enables idle fast-forward only (not tick widen). Experimental on ESP FreeRTOS;
+default CLI is the green-path fidelity build.
 
 Outputs:
 

--- a/validation/arduino-matrix/README.md
+++ b/validation/arduino-matrix/README.md
@@ -21,13 +21,30 @@ has an Arduino PlatformIO profile (ESP32 family, nRF52, RP2040, STM32 set).
 
 ```bash
 cd core
-cargo build -p labwired-cli --release   # once
+cargo build -p labwired-cli --release   # once (fidelity-default CLI)
 # optional: pio pkg install -g -p raspberrypi   # for rp2040
 
 python3 validation/arduino-matrix/run_matrix.py
 python3 validation/arduino-matrix/run_matrix.py --boards stm32f103,esp32
 python3 validation/arduino-matrix/run_matrix.py --sketches L0_serial_boot
 ```
+
+### Matrix speed path (optional)
+
+For wall-time measurement / faster re-checks, build with the event scheduler
+and enable idle/delay fast-forward:
+
+```bash
+cargo build -p labwired-cli --release --features event-scheduler
+LABWIRED_MATRIX_SPEED=1 python3 validation/arduino-matrix/run_matrix.py
+```
+
+`LABWIRED_MATRIX_SPEED=1` turns on `idle_fast_forward_enabled` (WFI / WAITI /
+timer-poll coalesce). It does **not** widen the peripheral tick interval —
+that path has regressed ESP FreeRTOS labs under the scheduler. Default labs
+and plain `labwired test` stay on the instruction-faithful path when the env
+is unset. Do not ship the default CLI with `event-scheduler` enabled globally
+(see `crates/cli/Cargo.toml`).
 
 Outputs:
 

--- a/validation/arduino-matrix/boards.yaml
+++ b/validation/arduino-matrix/boards.yaml
@@ -1,24 +1,32 @@
 # Arduino sketch matrix — every LabWired-supported chip with an Arduino path.
 # chip: configs/chips/<name>.yaml stem
-# system: relative to this matrix dir (or absolute under configs/systems)
-# pio: PlatformIO platform / board / framework for hosted Arduino compile
-# max_steps: sim budget (Arduino cores need more than bare-metal tier1 fixtures)
-# family: drives ESP-specific notes in the runner
+# system: relative to this matrix dir
+# pio: PlatformIO platform / board / framework
+# max_steps: sim budget (document why in budget_reason — no silent inflation)
+# led_watch: optional "peripheral:pin" for L2 GPIO oracle (--watch-gpio)
+# led_min_edges: min logic transitions required when led_watch is set (default 2)
+# family: grouping only
 
 boards:
   - id: esp32
     chip: esp32
     system: systems/esp32.yaml
     pio: { platform: espressif32, board: esp32dev, framework: arduino }
-    max_steps: 50000000
+    max_steps: 15000000
+    budget_reason: "FreeRTOS dual-core boot ~3.2M steps to L0/L1; headroom for L2"
+    # L2 LED_BUILTIN often GPIO2 digitalWrite — watch classic gpio peripheral
+    led_watch: "gpio:2"
+    led_min_edges: 2
     family: esp32
-    notes: "Arduino-ESP32 FreeRTOS — fix with real models only (no thunks)"
+    notes: "Arduino-ESP32 FreeRTOS — real models only (no thunks)"
 
   - id: esp32c3
     chip: esp32c3
     system: systems/esp32c3.yaml
     pio: { platform: espressif32, board: esp32-c3-devkitm-1, framework: arduino }
-    max_steps: 50000000
+    max_steps: 15000000
+    budget_reason: "FreeRTOS C3 boot ~1.9M steps; L2 RGB via RMT (no GPIO led_watch)"
+    # LED_BUILTIN is RGB/RMT — UART-only L2 oracle
     family: esp32
     notes: "Arduino-ESP32-C3 RISC-V"
 
@@ -26,7 +34,8 @@ boards:
     chip: esp32s3
     system: systems/esp32s3.yaml
     pio: { platform: espressif32, board: esp32-s3-devkitc-1, framework: arduino }
-    max_steps: 50000000
+    max_steps: 15000000
+    budget_reason: "Dual-core S3 boot ~1.1–1.2M steps; L2 RGB via RMT (no GPIO led_watch)"
     family: esp32
     notes: "Arduino-ESP32-S3"
 
@@ -34,23 +43,26 @@ boards:
     chip: nrf52832
     system: systems/nrf52832.yaml
     pio: { platform: nordicnrf52, board: nrf52_dk, framework: arduino }
-    max_steps: 5000000
+    max_steps: 3000000
+    budget_reason: "Arduino nRF boot ~0.7M; L2 ~0.26M after short delays"
+    # LED path does not yet emit LogicTap edges on gpio0 (UART-only L2 for now)
     family: nrf
 
   - id: nrf52840
     chip: nrf52840
     system: systems/nrf52840.yaml
     pio: { platform: nordicnrf52, board: nrf52840_dk, framework: arduino }
-    max_steps: 5000000
+    max_steps: 3000000
+    budget_reason: "Same class as nRF52832 Arduino core"
     family: nrf
 
   - id: rp2040
     chip: rp2040
     system: systems/rp2040.yaml
     pio: { platform: raspberrypi, board: pico, framework: arduino }
-    # L2: mbed RTX delay is SysTick-driven (~SystemCoreClock/1000 steps per ms).
-    # setup delay(10) + loop delay(20)×2 before LW_L2_OK exceeds 5M.
-    max_steps: 20000000
+    max_steps: 8000000
+    budget_reason: "mbed RTX SysTick delay; L0~1.7M L2~0.8M with short delays (was 20M for delay(20))"
+    # SIO/GPIO not watched yet — UART-only L2 until sio pin map is wired
     family: rp2040
     notes: "Needs platform raspberrypi (pio pkg install -g -p raspberrypi if missing)"
 
@@ -58,70 +70,91 @@ boards:
     chip: stm32f103
     system: systems/stm32f103.yaml
     pio: { platform: ststm32, board: bluepill_f103c8, framework: arduino }
-    max_steps: 5000000
+    max_steps: 3000000
+    budget_reason: "L0~0.7M L2~0.22M with short delays"
+    led_watch: "gpioc:13"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32f401
     chip: stm32f401
     system: systems/stm32f401.yaml
     pio: { platform: ststm32, board: nucleo_f401re, framework: arduino }
-    max_steps: 5000000
+    max_steps: 3000000
+    budget_reason: "Nucleo L0~0.84M L2~0.26M; LD2=PA5"
+    led_watch: "gpioa:5"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32f407
     chip: stm32f407
     system: systems/stm32f407.yaml
     pio: { platform: ststm32, board: disco_f407vg, framework: arduino }
-    # Arduino delay() is SysTick-driven; L2 needs enough steps to finish setup
-    # (prints LW_L2_BOOT) plus one blink cycle before LW_L2_OK.
-    max_steps: 20000000
+    max_steps: 8000000
+    budget_reason: "Disco L0~1.7M L2~0.5M; green LED PD12"
+    led_watch: "gpiod:12"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32g474re
     chip: stm32g474re
     system: systems/stm32g474re.yaml
     pio: { platform: ststm32, board: nucleo_g474re, framework: arduino }
-    # L2: setup prints LW_L2_BOOT then delay/blink; 5M stops mid-loop.
-    max_steps: 20000000
+    max_steps: 8000000
+    budget_reason: "L0~1.7M L2~0.5M with short delays (was 20M)"
+    led_watch: "gpioa:5"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32h563
     chip: stm32h563
     system: systems/stm32h563.yaml
     pio: { platform: ststm32, board: nucleo_h563zi, framework: arduino }
-    max_steps: 8000000
+    max_steps: 4000000
+    budget_reason: "M33 boot light (~0.16M L0); keep modest headroom"
+    led_watch: "gpiob:0"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32l073
     chip: stm32l073
     system: systems/stm32l073.yaml
     pio: { platform: ststm32, board: nucleo_l073rz, framework: arduino }
-    max_steps: 5000000
+    max_steps: 2000000
+    budget_reason: "L0~0.32M L2~0.1M"
+    led_watch: "gpioa:5"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32l476
     chip: stm32l476
     system: systems/stm32l476.yaml
     pio: { platform: ststm32, board: nucleo_l476rg, framework: arduino }
-    max_steps: 5000000
+    max_steps: 3000000
+    budget_reason: "L0~0.8M L2~0.24M"
+    led_watch: "gpioa:5"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32wb55
     chip: stm32wb55
     system: systems/stm32wb55.yaml
     pio: { platform: ststm32, board: nucleo_wb55rg_p, framework: arduino }
-    max_steps: 5000000
+    max_steps: 2000000
+    budget_reason: "L0~0.32M L2~0.1M"
+    led_watch: "gpiob:5"
+    led_min_edges: 2
     family: stm32
 
   - id: stm32wba52
     chip: stm32wba52
     system: systems/stm32wba52.yaml
-    # ststm32 platform has no upstream board JSON yet; matrix supplies
-    # validation/arduino-matrix/pio-boards/nucleo_wba52cg.json (Arduino Core
-    # NUCLEO_WBA55CG — same Nucleo as NOD_WBA52CG / NOD_WBA55CG).
+    # ststm32 has no upstream board JSON; matrix supplies pio-boards/nucleo_wba52cg.json
     pio: { platform: ststm32, board: nucleo_wba52cg, framework: arduino }
-    # L2 delays + M33 startup need headroom (same class as H563/G474).
-    max_steps: 20000000
+    max_steps: 4000000
+    budget_reason: "M33 + stm32duino; L0~0.16M L2~0.05M after short delays"
+    led_watch: "gpiob:4"
+    led_min_edges: 2
     family: stm32
 
 sketches:
@@ -138,4 +171,4 @@ sketches:
   - id: L2_blink_serial
     dir: sketches/L2_blink_serial
     marker: "LW_L2_OK"
-    description: "LED_BUILTIN toggle + serial — proves GPIO digitalWrite"
+    description: "LED_BUILTIN toggle + serial — UART + optional GPIO edges"

--- a/validation/arduino-matrix/run_matrix.py
+++ b/validation/arduino-matrix/run_matrix.py
@@ -2,32 +2,44 @@
 """Arduino sketch × LabWired board matrix.
 
 For every board in boards.yaml and every sketch (L0/L1/L2):
-  1. Compile with PlatformIO (framework=arduino)
+  1. Compile with PlatformIO (framework=arduino) — unless --sim-only / cache hit
   2. Run with `labwired test` against the board system manifest
-  3. Record pass/fail with stage (compile|boot|oracle|infra) and UART tail
+  3. Record pass/fail with stage and UART (and optional L2 GPIO edges)
 
-Outputs:
-  out/results.json
-  out/scoreboard.md
-  out/<board>/<sketch>/{compile.log,result.json,uart.log,...}
+Shared engine: validation/matrix_lib/  (see docs/engineering/test_harness.md)
 
 Usage (from repo core/):
   python3 validation/arduino-matrix/run_matrix.py
   python3 validation/arduino-matrix/run_matrix.py --boards stm32f103,esp32
-  python3 validation/arduino-matrix/run_matrix.py --sketches L0_serial_boot
+  python3 validation/arduino-matrix/run_matrix.py --sim-only --sketches L2_blink_serial
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
 import textwrap
 import time
 from pathlib import Path
+
+# Allow `import matrix_lib` from sibling validation/
+_VALIDATION = Path(__file__).resolve().parent.parent
+if str(_VALIDATION) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION))
+
+from matrix_lib import (  # noqa: E402
+    compile_fingerprint,
+    elf_cache_hit,
+    find_labwired,
+    render_scoreboard,
+    run_labwired,
+    write_fingerprint,
+    write_test_script,
+)
+from matrix_lib.invoke import CORE_ROOT  # noqa: E402
 
 try:
     import yaml
@@ -36,29 +48,7 @@ except ImportError:
     sys.exit(2)
 
 MATRIX_DIR = Path(__file__).resolve().parent
-CORE_ROOT = MATRIX_DIR.parent.parent
 DEFAULT_OUT = MATRIX_DIR / "out"
-
-
-def find_labwired(explicit: str | None) -> Path:
-    if explicit:
-        p = Path(explicit)
-        if not p.is_file():
-            raise SystemExit(f"labwired binary not found: {p}")
-        return p
-    candidates = [
-        CORE_ROOT / "target" / "release" / "labwired",
-        CORE_ROOT / "target" / "debug" / "labwired",
-        Path(shutil.which("labwired") or ""),
-    ]
-    for c in candidates:
-        if c and c.is_file():
-            return c
-    raise SystemExit(
-        "labwired CLI not found. Build with:\n"
-        "  cargo build -p labwired-cli --release\n"
-        "or pass --labwired /path/to/labwired"
-    )
 
 
 def load_config() -> dict:
@@ -70,7 +60,6 @@ def write_pio_project(work: Path, board: dict, sketch_src: Path) -> Path:
     """Materialize a one-shot PlatformIO project for board × sketch."""
     work.mkdir(parents=True, exist_ok=True)
     pio = board["pio"]
-    # Optional in-tree PIO boards (e.g. nucleo_wba52cg until ststm32 ships one).
     boards_dir = MATRIX_DIR / "pio-boards"
     boards_dir_line = ""
     if (boards_dir / f"{pio['board']}.json").is_file():
@@ -116,224 +105,23 @@ def compile_sketch(work: Path, log_path: Path, timeout: int) -> tuple[bool, str,
 
     log_path.write_text(proc.stdout + "\n--- stderr ---\n" + proc.stderr, encoding="utf-8")
     if proc.returncode != 0:
-        # Classify common platform/board gaps
         blob = (proc.stdout + proc.stderr).lower()
-        if "unknown board" in blob or "unknown platform" in blob or "could not find the package" in blob:
+        if (
+            "unknown board" in blob
+            or "unknown platform" in blob
+            or "could not find the package" in blob
+        ):
             return False, "toolchain_missing", None
-        if "error:" in blob or "fatal error" in blob:
-            return False, "compile_fail", None
         return False, "compile_fail", None
 
-    # Locate firmware.elf
     build_dir = work / ".pio" / "build" / "matrix"
     elf = build_dir / "firmware.elf"
     if not elf.is_file():
-        # Some platforms use different names
         candidates = list(build_dir.glob("*.elf")) if build_dir.is_dir() else []
         if not candidates:
             return False, "elf_missing", None
         elf = candidates[0]
     return True, "ok", elf
-
-
-def write_test_script(
-    path: Path,
-    firmware: Path,
-    system: Path,
-    marker: str,
-    max_steps: int,
-) -> None:
-    # Paths relative to the test script directory for labwired resolution.
-    # Use absolute paths to avoid cwd confusion.
-    doc = {
-        "schema_version": "1.0",
-        "inputs": {
-            "firmware": str(firmware.resolve()),
-            "system": str(system.resolve()),
-        },
-        "limits": {
-            "max_steps": max_steps,
-            "max_uart_bytes": 65536,
-            "stop_when_assertions_pass": True,
-            "stop_when_assertions_pass_settle_steps": 1000,
-            "stop_when_assertions_pass_min_steps": 0,
-        },
-        "assertions": [
-            {"uart_contains": marker},
-        ],
-    }
-    path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
-
-
-def run_labwired(
-    labwired: Path,
-    script: Path,
-    out_dir: Path,
-    timeout: int,
-) -> tuple[str, dict]:
-    """Returns (status, detail). status in pass|oracle_fail|boot_fail|sim_error|timeout."""
-    out_dir.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        str(labwired),
-        "test",
-        "--script",
-        str(script),
-        "--output-dir",
-        str(out_dir),
-        "--no-uart-stdout",
-    ]
-    env = os.environ.copy()
-    # Opt-in speed path: idle/delay FF + wider ticks (needs CLI built with
-    # --features event-scheduler). Set LABWIRED_MATRIX_SPEED=1 in the
-    # environment, or leave unset for the fidelity-default plain path.
-    if env.get("LABWIRED_MATRIX_SPEED") == "1":
-        env["LABWIRED_MATRIX_SPEED"] = "1"
-    # RP2040 Arduino needs mask ROM at 0 for rom_func_lookup; bare-metal
-    # onboarding ELFs must NOT load it (see from_config default_region_image_path).
-    bootrom = CORE_ROOT / "crates" / "core" / "roms" / "rp2040" / "bootrom.bin"
-    if bootrom.is_file():
-        env.setdefault("LABWIRED_RP2040_BOOTROM", str(bootrom))
-    try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=str(CORE_ROOT),
-            env=env,
-        )
-    except subprocess.TimeoutExpired:
-        return "timeout", {"stderr": "labwired test timed out"}
-
-    (out_dir / "labwired.stdout").write_text(proc.stdout, encoding="utf-8")
-    (out_dir / "labwired.stderr").write_text(proc.stderr, encoding="utf-8")
-
-    result_path = out_dir / "result.json"
-    result: dict = {}
-    if result_path.is_file():
-        try:
-            result = json.loads(result_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            result = {}
-
-    uart_path = out_dir / "uart.log"
-    uart = uart_path.read_text(encoding="utf-8", errors="replace") if uart_path.is_file() else ""
-    stderr = proc.stderr or ""
-    detail = {"result": result, "uart_tail": uart[-500:], "stderr": stderr[-1500:]}
-
-    if proc.returncode == 0:
-        return "pass", detail
-
-    # Classify failure from result + logs (bus faults / mem map / unknown insn
-    # count as unmodeled model gaps, not soft boot fails).
-    blob = (proc.stdout + stderr + json.dumps(result)).lower()
-    stop = str(result.get("stop_reason", "")).lower()
-    if any(
-        s in blob
-        for s in (
-            "unmodeled",
-            "unimplemented",
-            "unknown instruction",
-            "unknown 32-bit instruction",
-            "bus read fault",
-            "bus write fault",
-            "outside of memory map",
-            "memory access violation",
-            "memory_violation",
-        )
-    ) or stop in ("memory_violation", "exception"):
-        return "unmodeled", detail
-    if "unsupported" in blob or "not modeled" in blob:
-        return "unmodeled", detail
-    if uart.strip() == "":
-        return "boot_fail", detail
-    return "oracle_fail", detail
-
-
-def render_scoreboard(rows: list[dict], boards: list[dict], sketches: list[dict]) -> str:
-    board_ids = [b["id"] for b in boards]
-    sketch_ids = [s["id"] for s in sketches]
-    # status short codes
-    SYM = {
-        "pass": "✅",
-        "compile_fail": "🔧",
-        "compile_timeout": "⏱️",
-        "toolchain_missing": "📦",
-        "pio_missing": "📦",
-        "elf_missing": "🔧",
-        "boot_fail": "🔴",
-        "oracle_fail": "🟠",
-        "unmodeled": "🟣",
-        "timeout": "⏱️",
-        "sim_error": "🔴",
-        "skip": "·",
-    }
-
-    by_key = {(r["board"], r["sketch"]): r for r in rows}
-
-    lines: list[str] = []
-    lines.append("# Arduino × LabWired board matrix")
-    lines.append("")
-    lines.append(f"_Generated {time.strftime('%Y-%m-%d %H:%M:%S %z')} by `validation/arduino-matrix/run_matrix.py`._")
-    lines.append("")
-    lines.append(
-        "Legend: ✅ pass · 🔧 compile fail · 📦 toolchain/platform missing · "
-        "🔴 boot/sim fail · 🟠 UART ran but marker missing · 🟣 unmodeled/unsupported · ⏱️ timeout"
-    )
-    lines.append("")
-    header = "| chip | " + " | ".join(sketch_ids) + " | notes |"
-    sep = "|------|" + "|".join(["------"] * len(sketch_ids)) + "|-------|"
-    lines.append(header)
-    lines.append(sep)
-
-    for bid in board_ids:
-        cells = []
-        notes = []
-        for sid in sketch_ids:
-            r = by_key.get((bid, sid))
-            if not r:
-                cells.append("·")
-                continue
-            cells.append(SYM.get(r["status"], r["status"]))
-            if r["status"] != "pass" and r.get("detail"):
-                notes.append(f"{sid}:{r['status']}")
-        note = "; ".join(notes[:3])
-        lines.append(f"| `{bid}` | " + " | ".join(cells) + f" | {note} |")
-
-    lines.append("")
-    # Summary counts
-    from collections import Counter
-
-    c = Counter(r["status"] for r in rows)
-    total = len(rows)
-    lines.append("## Summary")
-    lines.append("")
-    lines.append(f"- Cells: **{total}**")
-    for k, v in sorted(c.items(), key=lambda x: (-x[1], x[0])):
-        lines.append(f"- `{k}`: {v}")
-    lines.append("")
-    lines.append("## Failures (detail)")
-    lines.append("")
-    for r in rows:
-        if r["status"] == "pass":
-            continue
-        lines.append(f"### `{r['board']}` × `{r['sketch']}` → **{r['status']}**")
-        if r.get("detail"):
-            d = r["detail"]
-            if isinstance(d, dict):
-                if d.get("stderr"):
-                    lines.append("```")
-                    lines.append(str(d["stderr"])[-800:])
-                    lines.append("```")
-                if d.get("uart_tail"):
-                    lines.append("UART tail:")
-                    lines.append("```")
-                    lines.append(str(d["uart_tail"]))
-                    lines.append("```")
-            else:
-                lines.append(str(d)[:500])
-        lines.append("")
-    return "\n".join(lines) + "\n"
 
 
 def main() -> int:
@@ -345,6 +133,16 @@ def main() -> int:
     ap.add_argument("--compile-timeout", type=int, default=600)
     ap.add_argument("--run-timeout", type=int, default=300)
     ap.add_argument("--keep-work", action="store_true", help="Keep PIO work dirs")
+    ap.add_argument(
+        "--sim-only",
+        action="store_true",
+        help="Skip compile; require out/<board>/<sketch>/firmware.elf",
+    )
+    ap.add_argument(
+        "--force-compile",
+        action="store_true",
+        help="Ignore ELF content-hash cache and recompile",
+    )
     args = ap.parse_args()
 
     cfg = load_config()
@@ -358,8 +156,6 @@ def main() -> int:
     if args.sketches:
         want = set(args.sketches.split(","))
         sketches = [s for s in sketches if s["id"] in want]
-    # Only overwrite the published docs scoreboard on a full matrix run so
-    # smoke subsets (--boards / --sketches) do not clobber the 45-cell table.
     is_full_matrix = len(boards) == len(all_boards) and len(sketches) == len(all_sketches)
 
     labwired = find_labwired(args.labwired)
@@ -372,6 +168,8 @@ def main() -> int:
     print(f"boards:   {', '.join(b['id'] for b in boards)}")
     print(f"sketches: {', '.join(s['id'] for s in sketches)}")
     print(f"out:      {out}")
+    if args.sim_only:
+        print("mode:     sim-only (no compile)")
     print()
 
     rows: list[dict] = []
@@ -411,69 +209,112 @@ def main() -> int:
             cell_out.mkdir(parents=True, exist_ok=True)
             print(f"==> {bid} × {sid}", flush=True)
 
-            # Compile
-            work = work_root / f"{bid}__{sid}"
-            write_pio_project(work, board, MATRIX_DIR / sketch["dir"] / "src")
-            # STM32WBA: stm32duino PIO builder mis-detects series as STM32WBxx
-            # unless the MCU id is special-cased (see scripts/patch_*).
-            if "wba" in bid.lower() or "wba" in str(board.get("chip", "")).lower():
-                patch = MATRIX_DIR / "scripts" / "patch_stm32duino_wba_series.py"
-                if patch.is_file():
-                    subprocess.run(
-                        [sys.executable, str(patch)],
-                        check=False,
-                        capture_output=True,
-                        text=True,
-                    )
-            ok, stage, elf = compile_sketch(
-                work, cell_out / "compile.log", args.compile_timeout
+            sketch_src = MATRIX_DIR / sketch["dir"] / "src"
+            pio = board["pio"]
+            digest = compile_fingerprint(
+                board_id=bid,
+                sketch_id=sid,
+                sketch_src=sketch_src,
+                pio_platform=pio["platform"],
+                pio_board=pio["board"],
+                pio_framework=pio["framework"],
+                extra={"max_steps": board.get("max_steps"), "led_watch": board.get("led_watch")},
             )
-            if not ok or elf is None:
-                print(f"    compile: {stage}", flush=True)
-                rows.append({"board": bid, "sketch": sid, "status": stage, "detail": stage})
-                continue
-            print(f"    compile: ok ({elf.name})", flush=True)
-            # copy elf for inspection
-            shutil.copy2(elf, cell_out / "firmware.elf")
-            # ESP-IDF partition table (MD5 trailer) must sit beside the ELF:
-            # labwired test seeds flash @0x8000 from firmware_dir/partitions.bin.
-            # PIO work dirs are wiped after each cell, so a hard-coded L0 path
-            # fails for L1/L2 (and after a full matrix re-run).
-            pt_src = elf.parent / "partitions.bin"
-            if pt_src.is_file():
-                shutil.copy2(pt_src, cell_out / "partitions.bin")
 
-            # Run
+            cached_elf = cell_out / "firmware.elf"
+            used_cache = False
+            if args.sim_only:
+                if not cached_elf.is_file():
+                    print("    compile: missing firmware.elf (--sim-only)", flush=True)
+                    rows.append(
+                        {
+                            "board": bid,
+                            "sketch": sid,
+                            "status": "elf_missing",
+                            "detail": "sim-only requires existing firmware.elf",
+                        }
+                    )
+                    continue
+                print("    compile: skipped (--sim-only)", flush=True)
+            elif not args.force_compile and elf_cache_hit(cell_out, digest):
+                used_cache = True
+                print(f"    compile: cache hit ({cached_elf.name})", flush=True)
+            else:
+                work = work_root / f"{bid}__{sid}"
+                write_pio_project(work, board, sketch_src)
+                if "wba" in bid.lower() or "wba" in str(board.get("chip", "")).lower():
+                    patch = MATRIX_DIR / "scripts" / "patch_stm32duino_wba_series.py"
+                    if patch.is_file():
+                        subprocess.run(
+                            [sys.executable, str(patch)],
+                            check=False,
+                            capture_output=True,
+                            text=True,
+                        )
+                ok, stage, elf = compile_sketch(
+                    work, cell_out / "compile.log", args.compile_timeout
+                )
+                if not ok or elf is None:
+                    print(f"    compile: {stage}", flush=True)
+                    rows.append({"board": bid, "sketch": sid, "status": stage, "detail": stage})
+                    continue
+                print(f"    compile: ok ({elf.name})", flush=True)
+                shutil.copy2(elf, cached_elf)
+                pt_src = elf.parent / "partitions.bin"
+                if pt_src.is_file():
+                    shutil.copy2(pt_src, cell_out / "partitions.bin")
+                write_fingerprint(cell_out, digest)
+                if not args.keep_work:
+                    try:
+                        shutil.rmtree(work)
+                    except OSError:
+                        pass
+
+            # L2 optional GPIO honesty (boards.yaml led_watch)
+            watch: list[str] = []
+            min_edges: int | None = None
+            if sid.startswith("L2") and board.get("led_watch"):
+                watch = [str(board["led_watch"])]
+                min_edges = int(board.get("led_min_edges", 2))
+
             script = cell_out / "test.yaml"
             write_test_script(
                 script,
-                cell_out / "firmware.elf",
+                cached_elf,
                 system,
                 sketch["marker"],
                 int(board.get("max_steps", 5_000_000)),
             )
             status, detail = run_labwired(
-                labwired, script, cell_out / "run", args.run_timeout
+                labwired,
+                script,
+                cell_out / "run",
+                args.run_timeout,
+                watch_gpio=watch or None,
+                min_logic_edges=min_edges,
             )
+            if used_cache:
+                detail = dict(detail) if isinstance(detail, dict) else {"detail": detail}
+                detail["compile"] = "cache_hit"
             print(f"    run: {status}", flush=True)
             rows.append({"board": bid, "sketch": sid, "status": status, "detail": detail})
-
-            if not args.keep_work:
-                # Keep .pio packages cache global; wipe only project work to save disk
-                try:
-                    shutil.rmtree(work)
-                except OSError:
-                    pass
 
     elapsed = time.time() - t0
     results = {
         "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
         "elapsed_s": round(elapsed, 1),
         "labwired": str(labwired),
+        "sim_only": bool(args.sim_only),
         "rows": rows,
     }
     (out / "results.json").write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
-    scoreboard = render_scoreboard(rows, boards, sketches)
+    scoreboard = render_scoreboard(
+        rows,
+        title="Arduino × LabWired board matrix",
+        generator="validation/arduino-matrix/run_matrix.py",
+        board_ids=[b["id"] for b in boards],
+        cell_ids=[s["id"] for s in sketches],
+    )
     (out / "scoreboard.md").write_text(scoreboard, encoding="utf-8")
     docs_out = CORE_ROOT / "docs" / "coverage" / "arduino-scoreboard.md"
     if is_full_matrix:
@@ -481,7 +322,10 @@ def main() -> int:
         docs_out.write_text(scoreboard, encoding="utf-8")
         pub_note = f"Published:  {docs_out}"
     else:
-        pub_note = f"Docs scoreboard unchanged (partial run; not full {len(all_boards)}×{len(all_sketches)})"
+        pub_note = (
+            f"Docs scoreboard unchanged "
+            f"(partial run; not full {len(all_boards)}×{len(all_sketches)})"
+        )
 
     passed = sum(1 for r in rows if r["status"] == "pass")
     print()

--- a/validation/arduino-matrix/run_matrix.py
+++ b/validation/arduino-matrix/run_matrix.py
@@ -183,6 +183,11 @@ def run_labwired(
         "--no-uart-stdout",
     ]
     env = os.environ.copy()
+    # Opt-in speed path: idle/delay FF + wider ticks (needs CLI built with
+    # --features event-scheduler). Set LABWIRED_MATRIX_SPEED=1 in the
+    # environment, or leave unset for the fidelity-default plain path.
+    if env.get("LABWIRED_MATRIX_SPEED") == "1":
+        env["LABWIRED_MATRIX_SPEED"] = "1"
     # RP2040 Arduino needs mask ROM at 0 for rom_func_lookup; bare-metal
     # onboarding ELFs must NOT load it (see from_config default_region_image_path).
     bootrom = CORE_ROOT / "crates" / "core" / "roms" / "rp2040" / "bootrom.bin"

--- a/validation/arduino-matrix/sketches/L2_blink_serial/src/main.ino
+++ b/validation/arduino-matrix/sketches/L2_blink_serial/src/main.ino
@@ -17,14 +17,17 @@
 void setup() {
   pinMode(LW_LED, OUTPUT);
   Serial.begin(115200);
-  delay(10);
+  // Short delays: matrix stops on first LW_L2_OK; long wall time was almost
+  // entirely delay() spin, not model work. 1 ms still exercises digitalWrite
+  // + millis/SysTick scheduling without 40+ ms of empty wait per loop.
+  delay(1);
   Serial.println("LW_L2_BOOT");
 }
 
 void loop() {
   digitalWrite(LW_LED, HIGH);
-  delay(20);
+  delay(1);
   digitalWrite(LW_LED, LOW);
-  delay(20);
+  delay(1);
   Serial.println("LW_L2_OK");
 }

--- a/validation/matrix_lib/__init__.py
+++ b/validation/matrix_lib/__init__.py
@@ -1,0 +1,24 @@
+"""Shared engine for Arduino / Zephyr product matrices.
+
+See docs/engineering/test_harness.md.
+"""
+
+from .cache import (
+    compile_fingerprint,
+    elf_cache_hit,
+    read_fingerprint,
+    write_fingerprint,
+)
+from .invoke import find_labwired, run_labwired, write_test_script
+from .scoreboard import render_scoreboard
+
+__all__ = [
+    "compile_fingerprint",
+    "elf_cache_hit",
+    "find_labwired",
+    "read_fingerprint",
+    "render_scoreboard",
+    "run_labwired",
+    "write_fingerprint",
+    "write_test_script",
+]

--- a/validation/matrix_lib/cache.py
+++ b/validation/matrix_lib/cache.py
@@ -1,0 +1,61 @@
+"""Content-hash helpers so matrix cells can skip recompile when unchanged."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _hash_tree(h: Any, root: Path) -> None:  # h: hashlib hash object
+    if not root.is_dir():
+        return
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            rel = p.relative_to(root).as_posix()
+            h.update(b"PATH\0")
+            h.update(rel.encode())
+            h.update(p.read_bytes())
+
+
+def compile_fingerprint(
+    *,
+    board_id: str,
+    sketch_id: str,
+    sketch_src: Path,
+    pio_platform: str,
+    pio_board: str,
+    pio_framework: str,
+    extra: dict[str, Any] | None = None,
+) -> str:
+    """Stable hex digest of inputs that affect the compiled ELF."""
+    h = hashlib.sha256()
+    h.update(b"v1\0")
+    for part in (board_id, sketch_id, pio_platform, pio_board, pio_framework):
+        h.update(part.encode())
+        h.update(b"\0")
+    _hash_tree(h, sketch_src)
+    if extra:
+        h.update(json.dumps(extra, sort_keys=True, default=str).encode())
+    return h.hexdigest()
+
+
+def fingerprint_path(cell_out: Path) -> Path:
+    return cell_out / ".compile_fingerprint"
+
+
+def read_fingerprint(cell_out: Path) -> str | None:
+    p = fingerprint_path(cell_out)
+    if not p.is_file():
+        return None
+    return p.read_text(encoding="utf-8").strip() or None
+
+
+def write_fingerprint(cell_out: Path, digest: str) -> None:
+    fingerprint_path(cell_out).write_text(digest + "\n", encoding="utf-8")
+
+
+def elf_cache_hit(cell_out: Path, digest: str) -> bool:
+    elf = cell_out / "firmware.elf"
+    return elf.is_file() and read_fingerprint(cell_out) == digest

--- a/validation/matrix_lib/invoke.py
+++ b/validation/matrix_lib/invoke.py
@@ -1,0 +1,217 @@
+"""labwired binary discovery, test script write, run + classify."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as e:  # pragma: no cover
+    raise SystemExit("ERROR: PyYAML required — pip install pyyaml") from e
+
+# validation/matrix_lib/ → validation/ → core/
+CORE_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def find_labwired(explicit: str | None = None) -> Path:
+    if explicit:
+        p = Path(explicit)
+        if not p.is_file():
+            raise SystemExit(f"labwired binary not found: {p}")
+        return p
+    for c in (
+        CORE_ROOT / "target" / "release" / "labwired",
+        CORE_ROOT / "target" / "debug" / "labwired",
+        Path(shutil.which("labwired") or ""),
+    ):
+        if c and c.is_file():
+            return c
+    raise SystemExit(
+        "labwired CLI not found. Build with:\n"
+        "  cargo build -p labwired-cli --release\n"
+        "or pass --labwired /path/to/labwired"
+    )
+
+
+def write_test_script(
+    path: Path,
+    firmware: Path,
+    system: Path,
+    marker: str,
+    max_steps: int,
+) -> None:
+    """Write a schema 1.0 labwired test script (UART marker oracle)."""
+    doc = {
+        "schema_version": "1.0",
+        "inputs": {
+            "firmware": str(firmware.resolve()),
+            "system": str(system.resolve()),
+        },
+        "limits": {
+            "max_steps": max_steps,
+            "max_uart_bytes": 65536,
+            "stop_when_assertions_pass": True,
+            "stop_when_assertions_pass_settle_steps": 1000,
+            "stop_when_assertions_pass_min_steps": 0,
+        },
+        "assertions": [
+            {"uart_contains": marker},
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+
+
+def _count_logic_edges(result: dict[str, Any]) -> int:
+    edges = result.get("logic_edges") or {}
+    channels = edges.get("channels") or []
+    n = 0
+    for ch in channels:
+        n += len(ch.get("transitions") or [])
+    return n
+
+
+def classify_failure(
+    proc: subprocess.CompletedProcess[str],
+    result: dict[str, Any],
+    uart: str,
+) -> str:
+    """Map labwired exit + result.json to a matrix status string.
+
+    Prefer structured result fields; fall back to stderr heuristics for
+    unmodeled gaps (legacy).
+    """
+    if proc.returncode == 0:
+        return "pass"
+
+    status = str(result.get("status", "")).lower()
+    stop = str(result.get("stop_reason", "")).lower()
+    blob = (proc.stdout + (proc.stderr or "") + json.dumps(result)).lower()
+
+    # Structured first
+    if stop in ("memory_violation", "exception", "fault"):
+        return "unmodeled"
+    if status in ("error", "runtime_error") and stop not in (
+        "max_steps",
+        "assertions_passed",
+        "assertions_failed",
+    ):
+        if any(
+            s in blob
+            for s in (
+                "unmodeled",
+                "unimplemented",
+                "unknown instruction",
+                "bus read fault",
+                "bus write fault",
+                "outside of memory map",
+                "memory access violation",
+            )
+        ):
+            return "unmodeled"
+
+    if any(
+        s in blob
+        for s in (
+            "unmodeled",
+            "unimplemented",
+            "unknown instruction",
+            "unknown 32-bit instruction",
+            "bus read fault",
+            "bus write fault",
+            "outside of memory map",
+            "memory access violation",
+            "memory_violation",
+        )
+    ) or stop in ("memory_violation", "exception"):
+        return "unmodeled"
+    if "unsupported" in blob or "not modeled" in blob:
+        return "unmodeled"
+    if uart.strip() == "":
+        return "boot_fail"
+    return "oracle_fail"
+
+
+def run_labwired(
+    labwired: Path,
+    script: Path,
+    out_dir: Path,
+    timeout: int,
+    *,
+    watch_gpio: list[str] | None = None,
+    min_logic_edges: int | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Run `labwired test`. Returns (status, detail).
+
+    If ``min_logic_edges`` is set and the UART oracle passes, require at least
+    that many logic transitions across watched channels (L2 GPIO honesty).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        str(labwired),
+        "test",
+        "--script",
+        str(script),
+        "--output-dir",
+        str(out_dir),
+        "--no-uart-stdout",
+    ]
+    for spec in watch_gpio or []:
+        cmd.extend(["--watch-gpio", spec])
+
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    # RP2040 Arduino needs mask ROM at 0; bare-metal tests may opt out via empty.
+    bootrom = CORE_ROOT / "crates" / "core" / "roms" / "rp2040" / "bootrom.bin"
+    if bootrom.is_file():
+        env.setdefault("LABWIRED_RP2040_BOOTROM", str(bootrom))
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(CORE_ROOT),
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return "timeout", {"stderr": "labwired test timed out"}
+
+    (out_dir / "labwired.stdout").write_text(proc.stdout or "", encoding="utf-8")
+    (out_dir / "labwired.stderr").write_text(proc.stderr or "", encoding="utf-8")
+
+    result: dict[str, Any] = {}
+    result_path = out_dir / "result.json"
+    if result_path.is_file():
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            result = {}
+
+    uart_path = out_dir / "uart.log"
+    uart = uart_path.read_text(encoding="utf-8", errors="replace") if uart_path.is_file() else ""
+    detail: dict[str, Any] = {
+        "result": result,
+        "uart_tail": uart[-500:],
+        "stderr": (proc.stderr or "")[-1500:],
+    }
+
+    status = classify_failure(proc, result, uart)
+    if status == "pass" and min_logic_edges is not None and min_logic_edges > 0:
+        n = _count_logic_edges(result)
+        detail["logic_edge_count"] = n
+        if n < min_logic_edges:
+            status = "oracle_fail"
+            detail["oracle"] = (
+                f"logic edges {n} < required min_logic_edges {min_logic_edges} "
+                f"(watch_gpio={watch_gpio})"
+            )
+    return status, detail

--- a/validation/matrix_lib/scoreboard.py
+++ b/validation/matrix_lib/scoreboard.py
@@ -1,0 +1,117 @@
+"""Markdown scoreboard rendering for product matrices."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from typing import Any
+
+
+SYM = {
+    "pass": "✅",
+    "compile_fail": "🔧",
+    "compile_timeout": "⏱️",
+    "build_fail": "🔧",
+    "build_timeout": "⏱️",
+    "toolchain_missing": "📦",
+    "pio_missing": "📦",
+    "elf_missing": "🔧",
+    "boot_fail": "🔴",
+    "oracle_fail": "🟠",
+    "unmodeled": "🟣",
+    "timeout": "⏱️",
+    "sim_error": "🔴",
+    "skip": "·",
+}
+
+
+def render_scoreboard(
+    rows: list[dict[str, Any]],
+    *,
+    title: str,
+    generator: str,
+    board_key: str = "board",
+    cell_key: str = "sketch",
+    board_ids: list[str] | None = None,
+    cell_ids: list[str] | None = None,
+    legend: str | None = None,
+) -> str:
+    if board_ids is None:
+        board_ids = []
+        for r in rows:
+            b = r[board_key]
+            if b not in board_ids:
+                board_ids.append(b)
+    if cell_ids is None:
+        cell_ids = []
+        for r in rows:
+            c = r[cell_key]
+            if c not in cell_ids:
+                cell_ids.append(c)
+
+    by_key = {(r[board_key], r[cell_key]): r for r in rows}
+    if legend is None:
+        legend = (
+            "Legend: ✅ pass · 🔧 compile/build fail · 📦 toolchain missing · "
+            "🔴 boot/sim fail · 🟠 oracle miss · 🟣 unmodeled · ⏱️ timeout"
+        )
+
+    lines: list[str] = [
+        f"# {title}",
+        "",
+        f"_Generated {time.strftime('%Y-%m-%d %H:%M:%S %z')} by `{generator}`._",
+        "",
+        legend,
+        "",
+    ]
+    header = "| chip | " + " | ".join(cell_ids) + " | notes |"
+    sep = "|------|" + "|".join(["------"] * len(cell_ids)) + "|-------|"
+    lines.append(header)
+    lines.append(sep)
+
+    for bid in board_ids:
+        cells = []
+        notes: list[str] = []
+        for sid in cell_ids:
+            r = by_key.get((bid, sid))
+            if not r:
+                cells.append("·")
+                continue
+            cells.append(SYM.get(r["status"], r["status"]))
+            if r["status"] != "pass" and r.get("detail"):
+                notes.append(f"{sid}:{r['status']}")
+        note = "; ".join(notes[:3])
+        lines.append(f"| `{bid}` | " + " | ".join(cells) + f" | {note} |")
+
+    lines.append("")
+    c = Counter(r["status"] for r in rows)
+    total = len(rows)
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Cells: **{total}**")
+    for k, v in sorted(c.items(), key=lambda x: (-x[1], x[0])):
+        lines.append(f"- `{k}`: {v}")
+    lines.append("")
+    lines.append("## Failures (detail)")
+    lines.append("")
+    for r in rows:
+        if r["status"] == "pass":
+            continue
+        lines.append(f"### `{r[board_key]}` × `{r[cell_key]}` → **{r['status']}**")
+        d = r.get("detail")
+        if isinstance(d, dict):
+            if d.get("oracle"):
+                lines.append(str(d["oracle"]))
+            if d.get("stderr"):
+                lines.append("```")
+                lines.append(str(d["stderr"])[-800:])
+                lines.append("```")
+            if d.get("uart_tail"):
+                lines.append("UART tail:")
+                lines.append("```")
+                lines.append(str(d["uart_tail"]))
+                lines.append("```")
+        elif d:
+            lines.append(str(d)[:500])
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/validation/zephyr-matrix/run_matrix.py
+++ b/validation/zephyr-matrix/run_matrix.py
@@ -6,6 +6,8 @@ For every board in boards.yaml and every level (L0/L1/L2):
   2. labwired test against the system manifest
   3. Record pass/fail + UART tail
 
+Shared engine: validation/matrix_lib/  (see docs/engineering/test_harness.md)
+
 Usage (from repo core/):
   python3 validation/zephyr-matrix/run_matrix.py
   python3 validation/zephyr-matrix/run_matrix.py --boards stm32l476,nrf52840
@@ -24,6 +26,13 @@ import sys
 import time
 from pathlib import Path
 
+_VALIDATION = Path(__file__).resolve().parent.parent
+if str(_VALIDATION) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION))
+
+from matrix_lib import find_labwired, render_scoreboard, run_labwired, write_test_script  # noqa: E402
+from matrix_lib.invoke import CORE_ROOT  # noqa: E402
+
 try:
     import yaml
 except ImportError:
@@ -31,27 +40,7 @@ except ImportError:
     sys.exit(2)
 
 MATRIX_DIR = Path(__file__).resolve().parent
-CORE_ROOT = MATRIX_DIR.parent.parent
 DEFAULT_OUT = MATRIX_DIR / "out"
-
-
-def find_labwired(explicit: str | None) -> Path:
-    if explicit:
-        p = Path(explicit)
-        if not p.is_file():
-            raise SystemExit(f"labwired binary not found: {p}")
-        return p
-    for c in (
-        CORE_ROOT / "target" / "release" / "labwired",
-        CORE_ROOT / "target" / "debug" / "labwired",
-        Path(shutil.which("labwired") or ""),
-    ):
-        if c and c.is_file():
-            return c
-    raise SystemExit(
-        "labwired CLI not found. Build with:\n"
-        "  cargo build -p labwired-cli --release"
-    )
 
 
 def find_west(zephyrproject: Path) -> Path | None:
@@ -65,31 +54,6 @@ def find_west(zephyrproject: Path) -> Path | None:
 def load_config() -> dict:
     with open(MATRIX_DIR / "boards.yaml", encoding="utf-8") as f:
         return yaml.safe_load(f)
-
-
-def write_test_script(
-    path: Path,
-    firmware: Path,
-    system: Path,
-    marker: str,
-    max_steps: int,
-) -> None:
-    doc = {
-        "schema_version": "1.0",
-        "inputs": {
-            "firmware": str(firmware.resolve()),
-            "system": str(system.resolve()),
-        },
-        "limits": {
-            "max_steps": max_steps,
-            "max_uart_bytes": 65536,
-            "stop_when_assertions_pass": True,
-            "stop_when_assertions_pass_settle_steps": 1000,
-            "stop_when_assertions_pass_min_steps": 0,
-        },
-        "assertions": [{"uart_contains": marker}],
-    }
-    path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
 
 
 def west_build(
@@ -139,7 +103,6 @@ def west_build(
     log_path.write_text(proc.stdout + "\n--- stderr ---\n" + proc.stderr, encoding="utf-8")
     if proc.returncode != 0:
         blob = (proc.stdout + proc.stderr).lower()
-        # Avoid false positives from Kconfig "X not found" noise.
         if (
             "toolchain not found" in blob
             or "no toolchain" in blob
@@ -154,141 +117,6 @@ def west_build(
     if not elf.is_file():
         return False, "elf_missing", None
     return True, "ok", elf
-
-
-def run_labwired(
-    labwired: Path,
-    script: Path,
-    out_dir: Path,
-    timeout: int,
-) -> tuple[str, dict]:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        str(labwired),
-        "test",
-        "--script",
-        str(script),
-        "--output-dir",
-        str(out_dir),
-        "--no-uart-stdout",
-    ]
-    env = os.environ.copy()
-    bootrom = CORE_ROOT / "crates" / "core" / "roms" / "rp2040" / "bootrom.bin"
-    if bootrom.is_file():
-        env.setdefault("LABWIRED_RP2040_BOOTROM", str(bootrom))
-    try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=str(CORE_ROOT),
-            env=env,
-        )
-    except subprocess.TimeoutExpired:
-        return "timeout", {"stderr": "labwired test timed out"}
-
-    (out_dir / "labwired.stdout").write_text(proc.stdout, encoding="utf-8")
-    (out_dir / "labwired.stderr").write_text(proc.stderr, encoding="utf-8")
-
-    result: dict = {}
-    result_path = out_dir / "result.json"
-    if result_path.is_file():
-        try:
-            result = json.loads(result_path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            result = {}
-
-    uart = ""
-    uart_path = out_dir / "uart.log"
-    if uart_path.is_file():
-        uart = uart_path.read_text(encoding="utf-8", errors="replace")
-
-    status = result.get("status")
-    if status == "pass":
-        return "pass", {"result": result, "uart": uart}
-    if proc.returncode != 0 and "Memory" in proc.stderr or "decode" in proc.stderr.lower():
-        return "sim_error", {"result": result, "uart": uart, "stderr": proc.stderr[-2000:]}
-    if uart.strip():
-        return "oracle_fail", {"result": result, "uart": uart}
-    if "error" in proc.stderr.lower() or result.get("stop_reason") not in (
-        None,
-        "max_steps",
-        "assertions_passed",
-    ):
-        sr = result.get("stop_reason")
-        if sr and sr not in ("max_steps", "assertions_passed"):
-            return "sim_error", {"result": result, "uart": uart, "stderr": proc.stderr[-2000:]}
-    return "boot_fail", {"result": result, "uart": uart}
-
-
-def write_scoreboard(results: list[dict], out_dir: Path, publish: Path | None) -> None:
-    boards = sorted({r["board"] for r in results})
-    levels = []
-    for r in results:
-        if r["level"] not in levels:
-            levels.append(r["level"])
-
-    icon = {
-        "pass": "✅",
-        "build_fail": "🔧",
-        "build_timeout": "⏱️",
-        "toolchain_missing": "📦",
-        "elf_missing": "🔧",
-        "boot_fail": "🔴",
-        "oracle_fail": "🟠",
-        "sim_error": "🟣",
-        "timeout": "⏱️",
-        "skip": "➖",
-    }
-
-    lines = [
-        "# Zephyr × LabWired board matrix",
-        "",
-        f"_Generated {time.strftime('%Y-%m-%d %H:%M:%S %z')} by `validation/zephyr-matrix/run_matrix.py`._",
-        "",
-        "Legend: ✅ pass · 🔧 build fail · 📦 toolchain · 🔴 boot/empty UART · "
-        "🟠 marker missing · 🟣 sim error · ⏱️ timeout",
-        "",
-        "| board | " + " | ".join(levels) + " |",
-        "|-------|" + "|".join(["------"] * len(levels)) + "|",
-    ]
-    by = {(r["board"], r["level"]): r for r in results}
-    for b in boards:
-        cells = []
-        for lv in levels:
-            r = by.get((b, lv))
-            cells.append(icon.get(r["status"], "?") if r else "➖")
-        lines.append(f"| `{b}` | " + " | ".join(cells) + " |")
-
-    n_pass = sum(1 for r in results if r["status"] == "pass")
-    lines += [
-        "",
-        "## Summary",
-        "",
-        f"- Cells: **{len(results)}**",
-        f"- `pass`: {n_pass}",
-        f"- other: {len(results) - n_pass}",
-        "",
-        "## Failures (detail)",
-        "",
-    ]
-    fails = [r for r in results if r["status"] != "pass"]
-    if not fails:
-        lines.append("_None — all cells green._")
-    else:
-        for r in fails:
-            uart_tail = (r.get("uart") or "")[-120:].replace("\n", "\\n")
-            lines.append(
-                f"- **{r['board']}/{r['level']}**: `{r['status']}`"
-                + (f" — uart_tail=`{uart_tail}`" if uart_tail else "")
-            )
-
-    text = "\n".join(lines) + "\n"
-    (out_dir / "scoreboard.md").write_text(text, encoding="utf-8")
-    if publish:
-        publish.parent.mkdir(parents=True, exist_ok=True)
-        publish.write_text(text, encoding="utf-8")
 
 
 def main() -> int:
@@ -345,6 +173,7 @@ def main() -> int:
             row: dict = {
                 "board": bid,
                 "level": lid,
+                "sketch": lid,  # scoreboard cell key shared with arduino renderer
                 "zephyr_board": board["zephyr_board"],
                 "marker": marker,
                 "status": "skip",
@@ -396,19 +225,32 @@ def main() -> int:
             write_test_script(script, elf_pub, system, marker, max_steps)
             status, detail = run_labwired(labwired, script, run_dir, args.sim_timeout)
             row["status"] = status
-            row["uart"] = detail.get("uart", "")
+            row["detail"] = detail
+            row["uart"] = detail.get("uart_tail", "")
             row["stop_reason"] = (detail.get("result") or {}).get("stop_reason")
             results.append(row)
             uart_show = row["uart"][:80].replace("\n", "\\n")
             print(f"  -> {status}  uart={uart_show!r}")
 
-    (args.out / "results.json").write_text(
-        json.dumps(results, indent=2), encoding="utf-8"
+    (args.out / "results.json").write_text(json.dumps(results, indent=2), encoding="utf-8")
+
+    scoreboard = render_scoreboard(
+        results,
+        title="Zephyr × LabWired board matrix",
+        generator="validation/zephyr-matrix/run_matrix.py",
+        cell_key="level",
+        board_ids=[b["id"] for b in boards],
+        cell_ids=[lv["id"] for lv in levels],
+        legend=(
+            "Legend: ✅ pass · 🔧 build fail · 📦 toolchain · 🔴 boot/empty UART · "
+            "🟠 marker missing · 🟣 unmodeled/sim · ⏱️ timeout"
+        ),
     )
-    publish = (
-        CORE_ROOT / "docs" / "coverage" / "zephyr-scoreboard.md" if args.publish else None
-    )
-    write_scoreboard(results, args.out, publish)
+    (args.out / "scoreboard.md").write_text(scoreboard, encoding="utf-8")
+    if args.publish:
+        pub = CORE_ROOT / "docs" / "coverage" / "zephyr-scoreboard.md"
+        pub.parent.mkdir(parents=True, exist_ok=True)
+        pub.write_text(scoreboard, encoding="utf-8")
 
     n_pass = sum(1 for r in results if r["status"] == "pass")
     print(f"\nDone: {n_pass}/{len(results)} pass. Scoreboard: {args.out / 'scoreboard.md'}")


### PR DESCRIPTION
## Summary

Stacks two local workstreams onto `main`:

1. **perf(matrix)** — Waiti park, shorter L2 delays, Class A fill-ins, `LABWIRED_MATRIX_SPEED` idle-FF opt-in (was #623).
2. **chore(harness)** — `docs/engineering/test_harness.md`, `validation/matrix_lib/`, `--sim-only` + ELF hash cache, L2 optional `led_watch` GPIO oracle, ratcheted `max_steps` + `budget_reason`.

## Verify

- Default CLI Arduino matrix **45/45** (full + `--sim-only`).
- L2 GPIO edges required where `led_watch` is set (STM32 + ESP classic); C3/S3/nRF/RP2040 UART-only for now.

## Note

Supersedes #623 if that PR is still open (same first commit).