### PR TITLE
fix(harness): roast follow-ups — dual-core WAITI batch live, no PIO hardcodes

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -66,10 +66,12 @@ fn metering_exit_status(exit_code: &ExitCode) -> i32 {
 
 /// Resolve an ESP-IDF `partitions.bin` for flash seeding @ 0x8000.
 ///
-/// Prefer the table next to the firmware ELF (matrix runner copies it there),
-/// then the live PIO work dir for this cell, then a few L0 fallbacks used by
-/// older diag scripts. Hard-coded L0-only paths break L1/L2 after matrix
-/// cleanup deletes `_pio_work/<cell>`.
+/// Only firmware-adjacent paths — never hard-coded matrix L0 work dirs
+/// (those go stale when `_pio_work` is wiped or the sketch is L1/L2).
+///
+/// Search order:
+/// 1. `partitions.bin` next to the ELF (matrix runner copies it there)
+/// 2. Live PIO build dir for this matrix cell, if present
 fn resolve_esp_partitions_bin(firmware_path: &std::path::Path) -> Option<std::path::PathBuf> {
     let mut cands: Vec<std::path::PathBuf> = Vec::new();
     if let Some(parent) = firmware_path.parent() {
@@ -90,13 +92,6 @@ fn resolve_esp_partitions_bin(firmware_path: &std::path::Path) -> Option<std::pa
                 );
             }
         }
-    }
-    for rel in [
-        "validation/arduino-matrix/out/_pio_work/esp32__L0_serial_boot/.pio/build/matrix/partitions.bin",
-        "validation/arduino-matrix/out/_pio_work/esp32c3__L0_serial_boot/.pio/build/matrix/partitions.bin",
-        "validation/arduino-matrix/out/_pio_work/esp32s3__L0_serial_boot/.pio/build/matrix/partitions.bin",
-    ] {
-        cands.push(std::path::PathBuf::from(rel));
     }
     cands.into_iter().find(|p| p.is_file())
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2097,6 +2097,21 @@ impl<C: Cpu> Machine<C> {
             .unwrap_or(false)
     }
 
+    /// True while RTC_CNTL has a latched SW_SYS_RST (not yet drained).
+    fn rtc_cntl_reset_pending(&self) -> bool {
+        let Some(idx) = self.rtc_cntl_index else {
+            return false;
+        };
+        let Some(p) = self.bus.peripherals.get(idx) else {
+            return false;
+        };
+        p.dev
+            .as_any()
+            .and_then(|a| a.downcast_ref::<crate::peripherals::esp32::rtc_cntl::RtcCntl>())
+            .map(|rtc| rtc.reset_request_pending())
+            .unwrap_or(false)
+    }
+
     /// Returns true (and clears the latch) if the registered SCB peripheral
     /// has a pending SYSRESETREQ — an AIRCR write with the correct VECTKEY and
     /// the SYSRESETREQ bit set (`Scb::write_reg`, offset 0x0C). The

--- a/crates/core/src/machine/boundary.rs
+++ b/crates/core/src/machine/boundary.rs
@@ -134,7 +134,25 @@ impl<C: Cpu> Machine<C> {
 
         let logic_boundary = self.total_cycles;
         let tick_interval = u64::from(self.config.peripheral_tick_interval.max(1));
-        if self.total_cycles % tick_interval == 0 {
+        // Dual-core WAITI coalesced batch: primary advanced N cycles while APP
+        // was parked; peripherals must advance by N, not by tick_interval once.
+        // Detected via secondary_steps == primary_steps from the parked path.
+        let coalesced_dual_idle = mode == ExecutionMode::RunBatch
+            && progress.secondary_steps > 0
+            && progress.primary_steps > 1;
+        let should_tick = if coalesced_dual_idle {
+            true
+        } else {
+            self.total_cycles % tick_interval == 0
+        };
+        if should_tick {
+            let saved_m = self.config.peripheral_tick_interval;
+            let saved_b = self.bus.config.peripheral_tick_interval;
+            if coalesced_dual_idle {
+                let n = progress.primary_steps.max(1);
+                self.config.peripheral_tick_interval = n;
+                self.bus.config.peripheral_tick_interval = n;
+            }
             // Propagate peripherals. Reuse retained scratch buffers (swapped
             // out via `mem::take` so the borrow checker sees them as owned
             // locals) instead of letting the bus allocate a fresh Vec per tick.
@@ -158,6 +176,10 @@ impl<C: Cpu> Machine<C> {
             // Return the buffers (with their grown capacity) for reuse next tick.
             self.tick_irq_scratch = interrupts;
             self.tick_cost_scratch = costs;
+            if coalesced_dual_idle {
+                self.config.peripheral_tick_interval = saved_m;
+                self.bus.config.peripheral_tick_interval = saved_b;
+            }
         }
 
         // Phase 2B.1 (issue #192): event-driven peripheral scheduler.

--- a/crates/core/src/machine/plan.rs
+++ b/crates/core/src/machine/plan.rs
@@ -10,8 +10,7 @@ impl<C: Cpu> Machine<C> {
         elapsed_cycles: u64,
     ) -> u32 {
         let tick_interval = u64::from(self.config.peripheral_tick_interval.max(1));
-        let until_tick = tick_interval - (self.total_cycles % tick_interval);
-        let mut count = until_tick.min(u64::from(u32::MAX));
+        let mut count = u64::from(u32::MAX);
 
         if let Some(limit) = request.limits().fuel {
             count = count.min(limit.saturating_sub(fuel_consumed));
@@ -23,20 +22,20 @@ impl<C: Cpu> Machine<C> {
             count = count.min(u64::from(cap.get()));
         }
 
-        // Any instruction may request an RTC or SCB reset. Commit it before
-        // the next instruction, intentionally trading Cortex/RTC throughput
-        // for reset fidelity even while no request is currently latched.
-        // (SCB presence also keeps push-mode logic capture cycle-accurate.)
-        let reset_fidelity = self.rtc_cntl_index.is_some() || self.scb_index.is_some();
-        // Interleave both cores one quantum when the secondary is active or
-        // still in reset-hold. A secondary parked in WAITI (FreeRTOS idle)
-        // does not need lockstep — primary may batch; secondary CCOUNT is
-        // advanced via `fast_forward_idle_cycles` after the batch.
-        let secondary_lockstep = match self.cpu_secondary.as_ref() {
-            Some(sec) if sec.is_parked_idle() => false,
-            Some(_) => true,
-            None => false,
-        };
+        // Dual-core: only lockstep while APP is active or still in reset-hold.
+        // WAITI-parked APP (FreeRTOS idle) lets PRO batch.
+        let secondary_parked = self
+            .cpu_secondary
+            .as_ref()
+            .is_some_and(|sec| sec.is_parked_idle());
+        let secondary_lockstep = self.cpu_secondary.is_some() && !secondary_parked;
+
+        // SCB presence permanently forces quantum-1 (cycle-accurate push
+        // capture + SYSRESETREQ fidelity). RTC_CNTL only clamps while a
+        // SW_SYS_RST is actually latched — otherwise ESP dual-core would
+        // never leave quantum-1 and WAITI primary batch would be dead code.
+        let reset_fidelity = self.scb_index.is_some() || self.rtc_cntl_reset_pending();
+
         // Pending cycle-accurate bus cells and operations require a lifecycle
         // commit after every instruction.
         let cycle_accurate_bus = self.bus.requires_cycle_accurate();
@@ -53,10 +52,19 @@ impl<C: Cpu> Machine<C> {
             || honored_breakpoints
         {
             count = count.min(1);
+        } else if secondary_parked {
+            // Coalesced dual-core idle batch: allow multi-instruction PRO
+            // windows even when tick_interval is 1. Commit advances peripherals
+            // once with elapsed = primary_steps (see boundary.rs).
+            count = count.min(1024);
+        } else {
+            // Normal path: batch only up to the next peripheral tick boundary.
+            let until_tick = tick_interval - (self.total_cycles % tick_interval);
+            count = count.min(until_tick);
         }
 
         #[cfg(feature = "event-scheduler")]
-        if count > 1 {
+        if count > 1 && !secondary_parked {
             if let Some(deadline) = self.bus.next_hcsr04_deadline_cycle() {
                 let until = deadline.saturating_sub(self.total_cycles);
                 count = count.min(until.clamp(1, u64::from(u32::MAX)));
@@ -73,6 +81,6 @@ impl<C: Cpu> Machine<C> {
             }
         }
 
-        count as u32
+        count.max(1) as u32
     }
 }

--- a/crates/core/src/peripherals/esp32/rtc_cntl.rs
+++ b/crates/core/src/peripherals/esp32/rtc_cntl.rs
@@ -162,6 +162,13 @@ impl RtcCntl {
         self.reset_requested.replace(false)
     }
 
+    /// Peek without clearing. Batch planning only forces quantum-1 while a
+    /// SW_SYS_RST is latched — unlike SCB, RTC presence alone must not kill
+    /// dual-core WAITI primary batching for the whole run.
+    pub fn reset_request_pending(&self) -> bool {
+        self.reset_requested.get()
+    }
+
     /// Base MMIO address (informational).
     pub fn base(&self) -> u32 {
         self.base

--- a/crates/core/src/tests/machine_advance.rs
+++ b/crates/core/src/tests/machine_advance.rs
@@ -770,7 +770,9 @@ fn rtc_reset_is_drained_at_the_first_unified_boundary() {
     assert_eq!(report.secondary_steps, 0);
     assert_eq!(report.elapsed_cycles, 8);
     assert_eq!(report.idle_cycles, 0);
-    assert_eq!(report.cpu_batches, 8);
+    // Quantum-1 only while SW_SYS_RST is latched; remaining fuel batches under
+    // tick_interval 64 once the latch is drained.
+    assert_eq!(report.cpu_batches, 2);
     assert_eq!(machine.cpu.pc, 0x4000_0400 + 14);
     assert_eq!(machine.cpu.sp, 0x3FFE_0000);
 }

--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,6 +1,6 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 12:35:00 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-23 13:39:47 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
 Legend: ✅ pass · 🔧 compile/build fail · 📦 toolchain missing · 🔴 boot/sim fail · 🟠 oracle miss · 🟣 unmodeled · ⏱️ timeout
 

--- a/docs/engineering/test_harness.md
+++ b/docs/engineering/test_harness.md
@@ -141,6 +141,17 @@ scheduler identity unless a workflow enables the feature.
 | **F** Physical test rehome | later | `tests/{diag,differential,e2e}/` |
 | **G** Dual-universe nightly (Cortex) | later | event-scheduler smoke |
 
+### Honest perf notes (2026-07-23)
+
+- Dual-core `is_parked_idle` primary batch is **live** when APP is WAITI-parked:
+  plan allows multi-instruction PRO windows even at `tick_interval=1`, and
+  commit coalesces peripheral `tick_elapsed(N)`.
+- SCB presence still forces quantum-1 (cycle-accurate logic capture). RTC_CNTL
+  only forces quantum-1 while SW_SYS_RST is latched.
+- `LABWIRED_MATRIX_SPEED=1` + `event-scheduler` remains experimental on ESP
+  FreeRTOS; default CLI is the fidelity matrix path.
+- CLI must not hard-code matrix PIO work paths for partitions.
+
 Work log: [`test_harness_reorg_log.md`](test_harness_reorg_log.md).
 
 ---

--- a/docs/engineering/test_harness_reorg_log.md
+++ b/docs/engineering/test_harness_reorg_log.md
@@ -31,3 +31,12 @@ Local branch: `chore/test-harness-organize` (do **not** push until asked).
 - `python3 -c "import matrix_lib; ..."` import smoke
 - `run_matrix.py --sim-only` on subset (STM32 + ESP) after A–C
 - Full 45/45 when convenient; not pushed to remote
+
+## 2026-07-23 — Roast follow-ups
+
+- Removed hard-coded L0 `_pio_work/.../partitions.bin` candidates from CLI.
+- L0/L1 sketch delays shortened to 1 ms (L2 already 1 ms).
+- Dual-core WAITI primary batch: RTC pending-only clamp + coalesced
+  `tick_elapsed(N)` under interval-1 so the path is not dead code.
+- SCB permanent quantum-1 kept (logic-capture fidelity).
+- PROBLEMS.md budget claims updated to match `boards.yaml`.

--- a/validation/arduino-matrix/PROBLEMS.md
+++ b/validation/arduino-matrix/PROBLEMS.md
@@ -98,11 +98,11 @@ python3 validation/arduino-matrix/run_matrix.py --boards stm32f407,nrf52832
 
 41. **RP2040 bootrom auto-load** — `from_config` loads in-tree `roms/rp2040/bootrom.bin` when `LABWIRED_RP2040_BOOTROM` is unset (empty env opts out for bare-metal flash-alias PIO onboarding). Plain `labwired test` no longer needs the matrix to export the env.
 
-42. **RP2040 L2 step budget** — mbed RTX `delay()` is SysTick-driven (~`SystemCoreClock/1000` steps/ms). L2 setup `delay(10)` + loop `delay(20)×2` before `LW_L2_OK` exceeds 5M; board `max_steps: 20_000_000` (same class as F407/G474 L2).
+42. **RP2040 L2 step budget** — mbed RTX `delay()` is SysTick-driven. After matrix L2 delays shrank to 1 ms, measured L2 is ~0.8M steps; board `max_steps: 8_000_000` with `budget_reason` in `boards.yaml` (was 20M when delays were 20 ms).
 
-43. **ESP partition table beside firmware** — matrix wiped `_pio_work/<cell>` after each run while CLI only fell back to hard-coded L0 `partitions.bin`, so L1/L2 saw empty flash@0x8000 → `No MD5 found` / exception. Runner copies PIO `partitions.bin` next to `firmware.elf`; CLI `resolve_esp_partitions_bin` prefers that path (classic/C3/S3).
+43. **ESP partition table beside firmware** — matrix wiped `_pio_work/<cell>` after each run while CLI fell back to hard-coded L0 `partitions.bin`, so L1/L2 saw empty flash@0x8000. Runner copies PIO `partitions.bin` next to `firmware.elf`; CLI only resolves ELF-adjacent / live cell PIO paths (hard-coded L0 paths removed).
 
-44. **STM32G474 L2 step budget** — `max_steps: 20_000_000` so setup `LW_L2_BOOT` + blink delays reach `LW_L2_OK`.
+44. **STM32G474 L2 step budget** — after short L2 delays, measured ~0.5M steps; `max_steps: 8_000_000` + `budget_reason` in `boards.yaml` (was 20M).
 
 45. **STM32WBA52 Arduino path** — in-tree `pio-boards/nucleo_wba52cg.json` (Arduino Core `NUCLEO_WBA55CG` / NOD_WBA52CG); matrix `boards_dir` + runner auto-applies `scripts/patch_stm32duino_wba_series.py` so PIO does not mis-detect series as `STM32WBxx`.
 

--- a/validation/arduino-matrix/sketches/L0_serial_boot/src/main.ino
+++ b/validation/arduino-matrix/sketches/L0_serial_boot/src/main.ino
@@ -1,8 +1,8 @@
 // LabWired Arduino matrix L0 — prove setup() + Serial after core boot.
 void setup() {
   Serial.begin(115200);
-  // Some cores need a short wait for USB CDC; sim UART is ready immediately.
-  delay(10);
+  // Minimal settle; sim UART is ready immediately (was delay(10) spin tax).
+  delay(1);
   Serial.println("LW_L0_OK");
 }
 

--- a/validation/arduino-matrix/sketches/L1_serial_loop/src/main.ino
+++ b/validation/arduino-matrix/sketches/L1_serial_loop/src/main.ino
@@ -1,11 +1,13 @@
-// LabWired Arduino matrix L1 — prove loop() runs and millis advances.
+// LabWired Arduino matrix L1 — prove loop() + delay/millis scheduling.
 void setup() {
   Serial.begin(115200);
-  delay(10);
+  delay(1);
   Serial.println("LW_L1_BOOT");
 }
 
 void loop() {
+  // Short delay still exercises millis/SysTick/RTOS tick paths without
+  // dominating wall time (was delay(50)).
+  delay(1);
   Serial.println("LW_L1_OK");
-  delay(50);
 }


### PR DESCRIPTION
## Roast (again) → fixes

| Smell | Fix |
|-------|-----|
| Dual-core WAITI batch never fired (interval=1 + RTC always quantum-1) | RTC pending-only clamp; coalesced `tick_elapsed(N)` for parked APP |
| Hard-coded L0 `partitions.bin` paths in CLI | ELF-adjacent / live cell only |
| L0/L1 still delay-taxed | `delay(1)` |
| Stale PROBLEMS.md budgets | Updated to measured post-short-delay numbers |
| Docs claimed batch win that wasn't real | Honest notes in `test_harness.md` |

SCB permanent quantum-1 kept (cycle-accurate push capture).

## Verify

- `cargo test -p labwired-core --lib -- machine_advance scb_reset stm32_bitbang_push` → 45/45 filtered
- Full Arduino matrix **45/45 pass**
- esp32 L0 wall **~0.48s** (was ~2.0s)