### PR TITLE
fix(harness): round-3 — nRF LED, RMT L2 oracle, mid-batch reset

### DIFF
--- a/crates/cli/src/commands/esp32_boot_state.rs
+++ b/crates/cli/src/commands/esp32_boot_state.rs
@@ -2,14 +2,41 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! Post-BROM DRAM seeds for classic ESP32 when the boot ROM is skipped.
+//! ESP bring-up helpers used by `labwired test` (and only that path).
 //!
-//! This is **not** a firmware flash-thunk path: it writes the same DRAM
-//! globals a real `esp_rom_spiflash_attach` + clock init would leave so
-//! IDF `esp_flash_init_default_chip` / delay math observe valid state.
+//! Keep chip-specific flash/DRAM seeds out of the generic test driver so
+//! `test.rs` stays a script runner, not a second ESP-IDF stage.
 
 use labwired_core::bus::SystemBus;
 use labwired_core::Bus;
+use std::path::{Path, PathBuf};
+
+/// Resolve an ESP-IDF `partitions.bin` for flash seeding @ 0x8000.
+///
+/// Firmware-adjacent paths only (matrix copies next to the ELF). Never
+/// hard-code matrix PIO work-dir L0 fall-backs.
+pub fn resolve_esp_partitions_bin(firmware_path: &Path) -> Option<PathBuf> {
+    let mut cands: Vec<PathBuf> = Vec::new();
+    if let Some(parent) = firmware_path.parent() {
+        cands.push(parent.join("partitions.bin"));
+        // out/<board>/<sketch>/firmware.elf → out/_pio_work/<board>__<sketch>/...
+        if let (Some(sketch), Some(board_dir), Some(out)) = (
+            parent.file_name(),
+            parent.parent(),
+            parent.parent().and_then(|p| p.parent()),
+        ) {
+            if let Some(board) = board_dir.file_name() {
+                let cell = format!("{}__{}", board.to_string_lossy(), sketch.to_string_lossy());
+                cands.push(
+                    out.join("_pio_work")
+                        .join(cell)
+                        .join(".pio/build/matrix/partitions.bin"),
+                );
+            }
+        }
+    }
+    cands.into_iter().find(|p| p.is_file())
+}
 
 /// Seed `g_rom_flashchip` + `g_ticks_per_us_*` from ELF symbols.
 pub fn seed_esp32_post_brom_dram(bus: &mut SystemBus, elf_bytes: &[u8]) {

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -64,37 +64,7 @@ fn metering_exit_status(exit_code: &ExitCode) -> i32 {
     }
 }
 
-/// Resolve an ESP-IDF `partitions.bin` for flash seeding @ 0x8000.
-///
-/// Only firmware-adjacent paths — never hard-coded matrix L0 work dirs
-/// (those go stale when `_pio_work` is wiped or the sketch is L1/L2).
-///
-/// Search order:
-/// 1. `partitions.bin` next to the ELF (matrix runner copies it there)
-/// 2. Live PIO build dir for this matrix cell, if present
-fn resolve_esp_partitions_bin(firmware_path: &std::path::Path) -> Option<std::path::PathBuf> {
-    let mut cands: Vec<std::path::PathBuf> = Vec::new();
-    if let Some(parent) = firmware_path.parent() {
-        // Matrix copies partitions.bin next to firmware.elf (survives work wipe).
-        cands.push(parent.join("partitions.bin"));
-        // out/<board>/<sketch>/firmware.elf → out/_pio_work/<board>__<sketch>/...
-        if let (Some(sketch), Some(board_dir), Some(out)) = (
-            parent.file_name(),
-            parent.parent(),
-            parent.parent().and_then(|p| p.parent()),
-        ) {
-            if let Some(board) = board_dir.file_name() {
-                let cell = format!("{}__{}", board.to_string_lossy(), sketch.to_string_lossy());
-                cands.push(
-                    out.join("_pio_work")
-                        .join(cell)
-                        .join(".pio/build/matrix/partitions.bin"),
-                );
-            }
-        }
-    }
-    cands.into_iter().find(|p| p.is_file())
-}
+use super::esp32_boot_state::resolve_esp_partitions_bin;
 
 pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     // ── API key validation (Pro tier gate) ──────────────────────────────

--- a/crates/core/src/machine/boundary.rs
+++ b/crates/core/src/machine/boundary.rs
@@ -37,9 +37,29 @@ impl<C: Cpu> Machine<C> {
                 if self.logic_capture.push_active() {
                     self.bus.logic_tap.set_clock(self.total_cycles);
                 }
-                let executed =
+                // Dual-core WAITI path (or any batch): step one-by-one when RTC
+                // is present so a mid-batch SW_SYS_RST latches and stops the
+                // window before more PRO instructions retire past the reset.
+                // Otherwise use step_batch for throughput.
+                let parked_secondary = self
+                    .cpu_secondary
+                    .as_ref()
+                    .is_some_and(|s| s.is_parked_idle());
+                let executed = if parked_secondary && self.rtc_cntl_index.is_some() {
+                    let mut n = 0u32;
+                    for _ in 0..count {
+                        self.cpu
+                            .step(&mut self.bus, &self.observers, &self.config)?;
+                        n += 1;
+                        if self.rtc_cntl_reset_pending() {
+                            break;
+                        }
+                    }
+                    n
+                } else {
                     self.cpu
-                        .step_batch(&mut self.bus, &self.observers, &self.config, count)?;
+                        .step_batch(&mut self.bus, &self.observers, &self.config, count)?
+                };
                 if executed == 0 {
                     self.bus.set_current_cycle(self.total_cycles);
                     self.bus.bus_trace.set_cycle(self.total_cycles);

--- a/crates/core/src/peripherals/esp32c3/rmt.rs
+++ b/crates/core/src/peripherals/esp32c3/rmt.rs
@@ -34,6 +34,8 @@ pub struct Esp32c3Rmt {
     regs: [u32; 0x40],
     /// RMTMEM shadow (optional; firmware may write symbols here).
     mem: Vec<u32>,
+    /// Count of TX_START pulses (rgbLedWrite / RMT TX). Matrix L2 oracle.
+    tx_start_count: u32,
 }
 
 impl Esp32c3Rmt {
@@ -47,7 +49,13 @@ impl Esp32c3Rmt {
             int_ena: 0,
             regs: [0; 0x40],
             mem: vec![0; 256],
+            tx_start_count: 0,
         }
+    }
+
+    /// Number of TX_START pulses observed (matrix / inspect oracle).
+    pub fn tx_start_count(&self) -> u32 {
+        self.tx_start_count
     }
 
     pub fn new_default() -> Self {
@@ -69,6 +77,7 @@ impl Esp32c3Rmt {
         if value & TX_START_BIT != 0 {
             // Instant TX complete: CHn_TX_END = bit n.
             self.int_raw |= 1 << ch;
+            self.tx_start_count = self.tx_start_count.saturating_add(1);
         }
     }
 }
@@ -170,5 +179,22 @@ impl Peripheral for Esp32c3Rmt {
 
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
+    }
+
+    fn inspect(
+        &self,
+        base: u64,
+        name: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> crate::inspect::PeripheralInspect {
+        let mut view = crate::inspect::default_inspect(self, base, name, opts);
+        view.kind = "rmt".into();
+        view.artifacts.push(crate::inspect::Artifact {
+            kind: "rmt_tx".into(),
+            id: "tx_start".into(),
+            meta: serde_json::json!({ "count": self.tx_start_count }),
+            bytes: None,
+        });
+        view
     }
 }

--- a/crates/core/src/peripherals/esp32s3/rmt.rs
+++ b/crates/core/src/peripherals/esp32s3/rmt.rs
@@ -270,6 +270,8 @@ pub struct Esp32s3Rmt {
     /// locks / reach `WaitBits` before `rmt_tx_default_isr` runs (Arduino
     /// WS2812 / `rgbLedWrite` FreeRTOS queue corruption).
     irq_holdoff_cycles: u32,
+    /// Count of TX_START pulses (rgbLedWrite / RMT TX). Matrix L2 oracle.
+    tx_start_count: u32,
 }
 
 impl Esp32s3Rmt {
@@ -314,7 +316,13 @@ impl Esp32s3Rmt {
             int_ena: 0,
             playback: None,
             irq_holdoff_cycles: 0,
+            tx_start_count: 0,
         }
+    }
+
+    /// Number of TX_START pulses observed (matrix / inspect oracle).
+    pub fn tx_start_count(&self) -> u32 {
+        self.tx_start_count
     }
 
     /// Hold off TX-done IRQ for this many sim cycles after TX_START.
@@ -622,6 +630,7 @@ impl Esp32s3Rmt {
             if value & TX_START_BIT != 0 {
                 self.int_raw |= tx_end_bit(i);
                 self.irq_holdoff_cycles = Self::TX_IRQ_HOLDOFF;
+                self.tx_start_count = self.tx_start_count.saturating_add(1);
                 // RMT Stage 2: timed pad waveform for observers / logic capture.
                 self.arm_tx_playback(i);
             }
@@ -800,6 +809,23 @@ impl Peripheral for Esp32s3Rmt {
 
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
+    }
+
+    fn inspect(
+        &self,
+        base: u64,
+        name: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> crate::inspect::PeripheralInspect {
+        let mut view = crate::inspect::default_inspect(self, base, name, opts);
+        view.kind = "rmt".into();
+        view.artifacts.push(crate::inspect::Artifact {
+            kind: "rmt_tx".into(),
+            id: "tx_start".into(),
+            meta: serde_json::json!({ "count": self.tx_start_count }),
+            bytes: None,
+        });
+        view
     }
 }
 

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -254,6 +254,17 @@ impl Nrf52Gpio {
                 let k = ((offset - 0x700) / 4) as usize;
                 if k < self.num_pins as usize {
                     self.pin_cnf[k] = value;
+                    // PIN_CNF[n].DIR (bit 0) is the authoritative direction for
+                    // pin n; the bulk DIR register mirrors those bits. Arduino
+                    // / nrfx configure via PIN_CNF only — without this sync,
+                    // pad_level (OUT∩DIR) never sees digitalWrite and LogicTap
+                    // stays silent on nRF LEDs.
+                    let bit = 1u32 << k;
+                    if value & 1 != 0 {
+                        self.dir |= bit & mask;
+                    } else {
+                        self.dir &= !bit;
+                    }
                 }
             }
             _ => {}
@@ -952,6 +963,19 @@ mod routing_tests {
         assert_eq!(g.gpio_routing(5).unwrap().mode, GpioMode::Output);
         assert!(g.gpio_routing(5).unwrap().func.is_none());
         assert_eq!(g.gpio_routing(6).unwrap().mode, GpioMode::Input);
+    }
+
+    #[test]
+    fn nrf52_pin_cnf_dir_syncs_bulk_dir_and_pad() {
+        let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Nrf52);
+        // Arduino/nrfx: DIR via PIN_CNF only, then OUTSET/OUTCLR.
+        g.write_u32(0x700 + 13 * 4, 1).unwrap(); // PIN_CNF[13].DIR = Output
+        assert_eq!(g.gpio_routing(13).unwrap().mode, GpioMode::Output);
+        assert_eq!(g.read_gpio_pad(13), Some(false));
+        g.write_u32(0x508, 1 << 13).unwrap(); // OUTSET pin 13
+        assert_eq!(g.read_gpio_pad(13), Some(true));
+        g.write_u32(0x50C, 1 << 13).unwrap(); // OUTCLR
+        assert_eq!(g.read_gpio_pad(13), Some(false));
     }
 
     #[test]

--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,6 +1,6 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 13:39:47 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-23 14:10:51 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
 Legend: ✅ pass · 🔧 compile/build fail · 📦 toolchain missing · 🔴 boot/sim fail · 🟠 oracle miss · 🟣 unmodeled · ⏱️ timeout
 

--- a/docs/engineering/test_harness.md
+++ b/docs/engineering/test_harness.md
@@ -149,8 +149,12 @@ scheduler identity unless a workflow enables the feature.
 - SCB presence still forces quantum-1 (cycle-accurate logic capture). RTC_CNTL
   only forces quantum-1 while SW_SYS_RST is latched.
 - `LABWIRED_MATRIX_SPEED=1` + `event-scheduler` remains experimental on ESP
-  FreeRTOS; default CLI is the fidelity matrix path.
+  FreeRTOS; default CLI is the fidelity matrix path. Class-M dual-universe
+  smoke: `validation/arduino-matrix/scripts/matrix_speed_subset.sh`.
 - CLI must not hard-code matrix PIO work paths for partitions.
+- L2 oracles: GPIO edges via `led_watch` (STM32, ESP classic, nRF after
+  PIN_CNF.DIR sync); RMT TX_START count via inspect `rmt_tx` + `min_rmt_tx`
+  (C3/S3 RGB).
 
 Work log: [`test_harness_reorg_log.md`](test_harness_reorg_log.md).
 

--- a/docs/engineering/test_harness_reorg_log.md
+++ b/docs/engineering/test_harness_reorg_log.md
@@ -40,3 +40,12 @@ Local branch: `chore/test-harness-organize` (do **not** push until asked).
   `tick_elapsed(N)` under interval-1 so the path is not dead code.
 - SCB permanent quantum-1 kept (logic-capture fidelity).
 - PROBLEMS.md budget claims updated to match `boards.yaml`.
+
+## 2026-07-23 — Roast round 3
+
+- Mid-batch SW_SYS_RST: dual-core WAITI primary steps one-by-one when RTC
+  present so a latched reset ends the batch early.
+- nRF PIN_CNF.DIR syncs bulk DIR → LogicTap sees LED (P0.17) edges.
+- C3/S3 RMT `tx_start_count` + inspect `rmt_tx` artifact; `min_rmt_tx` L2 oracle.
+- Class-M dual-universe script: `scripts/matrix_speed_subset.sh`.
+- Partitions resolve moved to `commands/esp32_boot_state.rs` (Phase E start).

--- a/validation/arduino-matrix/README.md
+++ b/validation/arduino-matrix/README.md
@@ -55,8 +55,14 @@ cargo build -p labwired-cli --release --features event-scheduler
 LABWIRED_MATRIX_SPEED=1 python3 validation/arduino-matrix/run_matrix.py
 ```
 
-Enables idle fast-forward only (not tick widen). Experimental on ESP FreeRTOS;
-default CLI is the green-path fidelity build.
+Enables idle fast-forward only (not tick widen). **Do not** use on ESP
+FreeRTOS for the green path — default CLI is fidelity. For a dual-universe
+smoke on Class-M boards (STM32/nRF/RP2040) after a scheduler build:
+
+```bash
+cargo build -p labwired-cli --release --features event-scheduler
+bash validation/arduino-matrix/scripts/matrix_speed_subset.sh
+```
 
 Outputs:
 

--- a/validation/arduino-matrix/boards.yaml
+++ b/validation/arduino-matrix/boards.yaml
@@ -25,8 +25,9 @@ boards:
     system: systems/esp32c3.yaml
     pio: { platform: espressif32, board: esp32-c3-devkitm-1, framework: arduino }
     max_steps: 15000000
-    budget_reason: "FreeRTOS C3 boot ~1.9M steps; L2 RGB via RMT (no GPIO led_watch)"
-    # LED_BUILTIN is RGB/RMT — UART-only L2 oracle
+    budget_reason: "FreeRTOS C3 boot ~1.9M steps; L2 RGB via RMT"
+    # LED_BUILTIN → rgbLedWrite → RMT TX_START (inspect rmt_tx artifact)
+    min_rmt_tx: 1
     family: esp32
     notes: "Arduino-ESP32-C3 RISC-V"
 
@@ -35,7 +36,8 @@ boards:
     system: systems/esp32s3.yaml
     pio: { platform: espressif32, board: esp32-s3-devkitc-1, framework: arduino }
     max_steps: 15000000
-    budget_reason: "Dual-core S3 boot ~1.1–1.2M steps; L2 RGB via RMT (no GPIO led_watch)"
+    budget_reason: "Dual-core S3 boot ~1.1–1.2M steps; L2 RGB via RMT"
+    min_rmt_tx: 1
     family: esp32
     notes: "Arduino-ESP32-S3"
 
@@ -45,7 +47,9 @@ boards:
     pio: { platform: nordicnrf52, board: nrf52_dk, framework: arduino }
     max_steps: 3000000
     budget_reason: "Arduino nRF boot ~0.7M; L2 ~0.26M after short delays"
-    # LED path does not yet emit LogicTap edges on gpio0 (UART-only L2 for now)
+    # PIN_CNF.DIR sync + LED1 = P0.17 on nRF52 DK Arduino core
+    led_watch: "gpio0:17"
+    led_min_edges: 2
     family: nrf
 
   - id: nrf52840
@@ -54,6 +58,8 @@ boards:
     pio: { platform: nordicnrf52, board: nrf52840_dk, framework: arduino }
     max_steps: 3000000
     budget_reason: "Same class as nRF52832 Arduino core"
+    led_watch: "gpio0:17"
+    led_min_edges: 2
     family: nrf
 
   - id: rp2040

--- a/validation/arduino-matrix/run_matrix.py
+++ b/validation/arduino-matrix/run_matrix.py
@@ -270,12 +270,16 @@ def main() -> int:
                     except OSError:
                         pass
 
-            # L2 optional GPIO honesty (boards.yaml led_watch)
+            # L2 optional GPIO / RMT honesty (boards.yaml)
             watch: list[str] = []
             min_edges: int | None = None
-            if sid.startswith("L2") and board.get("led_watch"):
-                watch = [str(board["led_watch"])]
-                min_edges = int(board.get("led_min_edges", 2))
+            min_rmt: int | None = None
+            if sid.startswith("L2"):
+                if board.get("led_watch"):
+                    watch = [str(board["led_watch"])]
+                    min_edges = int(board.get("led_min_edges", 2))
+                if board.get("min_rmt_tx") is not None:
+                    min_rmt = int(board["min_rmt_tx"])
 
             script = cell_out / "test.yaml"
             write_test_script(
@@ -292,6 +296,7 @@ def main() -> int:
                 args.run_timeout,
                 watch_gpio=watch or None,
                 min_logic_edges=min_edges,
+                min_rmt_tx=min_rmt,
             )
             if used_cache:
                 detail = dict(detail) if isinstance(detail, dict) else {"detail": detail}

--- a/validation/arduino-matrix/scripts/matrix_speed_subset.sh
+++ b/validation/arduino-matrix/scripts/matrix_speed_subset.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Dual-universe smoke: MATRIX_SPEED + event-scheduler on Class-M boards only.
+# ESP FreeRTOS labs are intentionally excluded (known event-scheduler gaps).
+#
+# Build once:
+#   cargo build -p labwired-cli --release --features event-scheduler
+#
+# Run (from core/):
+#   LABWIRED_MATRIX_SPEED=1 bash validation/arduino-matrix/scripts/matrix_speed_subset.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$ROOT"
+export LABWIRED_MATRIX_SPEED="${LABWIRED_MATRIX_SPEED:-1}"
+BOARDS="${BOARDS:-stm32f401,stm32f103,stm32l073,stm32wb55,nrf52840,rp2040}"
+exec python3 validation/arduino-matrix/run_matrix.py \
+  --sim-only \
+  --boards "$BOARDS" \
+  --sketches L0_serial_boot,L2_blink_serial \
+  "$@"

--- a/validation/matrix_lib/invoke.py
+++ b/validation/matrix_lib/invoke.py
@@ -76,6 +76,21 @@ def _count_logic_edges(result: dict[str, Any]) -> int:
     return n
 
 
+def _count_rmt_tx(result: dict[str, Any]) -> int:
+    """Sum RMT TX_START counts from inspect artifacts (C3/S3 rgbLedWrite)."""
+    inspect = result.get("inspect") or {}
+    total = 0
+    for peri in inspect.get("peripherals") or []:
+        for art in peri.get("artifacts") or []:
+            if art.get("kind") == "rmt_tx":
+                meta = art.get("meta") or {}
+                try:
+                    total += int(meta.get("count") or 0)
+                except (TypeError, ValueError):
+                    pass
+    return total
+
+
 def classify_failure(
     proc: subprocess.CompletedProcess[str],
     result: dict[str, Any],
@@ -145,12 +160,15 @@ def run_labwired(
     *,
     watch_gpio: list[str] | None = None,
     min_logic_edges: int | None = None,
+    min_rmt_tx: int | None = None,
     extra_env: dict[str, str] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Run `labwired test`. Returns (status, detail).
 
     If ``min_logic_edges`` is set and the UART oracle passes, require at least
     that many logic transitions across watched channels (L2 GPIO honesty).
+    If ``min_rmt_tx`` is set, require at least that many RMT TX_START pulses
+    (inspect artifact ``rmt_tx``) — C3/S3 RGB ``rgbLedWrite`` path.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     cmd = [
@@ -214,4 +232,10 @@ def run_labwired(
                 f"logic edges {n} < required min_logic_edges {min_logic_edges} "
                 f"(watch_gpio={watch_gpio})"
             )
+    if status == "pass" and min_rmt_tx is not None and min_rmt_tx > 0:
+        n = _count_rmt_tx(result)
+        detail["rmt_tx_count"] = n
+        if n < min_rmt_tx:
+            status = "oracle_fail"
+            detail["oracle"] = f"rmt TX_START count {n} < required min_rmt_tx {min_rmt_tx}"
     return status, detail


### PR DESCRIPTION
## Third-roast remaining items

| Item | Status |
|------|--------|
| Mid-batch SW_SYS_RST in dual-core WAITI batch | **Fixed** — step one-by-one when RTC present; stop if latched |
| nRF L2 no LogicTap edges | **Fixed** — PIN_CNF.DIR → bulk DIR; `led_watch: gpio0:17` |
| C3/S3 RGB UART-only | **Fixed** — `min_rmt_tx` via inspect `rmt_tx` TX_START count |
| MATRIX_SPEED dual-universe | **Scripted** Class-M only (`matrix_speed_subset.sh`) |
| ESP bring-up out of test.rs | **Started** — partitions resolve → `esp32_boot_state` |

## Verify

- Full matrix `--sim-only` **45/45**
- nRF L2 edges ≥ 2; C3/S3 `rmt_tx` count ≥ 1