### PR TITLE
fix(harness): open-item oracles — RP2040 SIO, C3 RMT edges, ESP extract

### DIFF
--- a/configs/chips/esp32c3.yaml
+++ b/configs/chips/esp32c3.yaml
@@ -130,11 +130,14 @@ peripherals:
     type: "esp32c3_ledc"
     base_address: 0x60019000
     size: "1KB"
+  # Behavioral RMT (instant TX_END + TX_START count / LogicTap edges).
+  # Arduino LED_BUILTIN / pin 30 → rgbLedWrite → RMT TX. Declarative SVD
+  # stub never completed TX → digitalWrite hung; dual-stack add in test left
+  # led_watch on the stub while MMIO hit the twin (edges=0, rmt count green).
   - id: "rmt"
-    type: "declarative"
+    type: "esp32c3_rmt"
     base_address: 0x60016000
-    config:
-      path: "../peripherals/esp32c3/rmt.yaml"
+    size: "2KB"
   # --- Estate completion 2026-06-11: the remaining SVD-documented blocks the
   # --- ESP32-C3 silicon exposes. Bases are authoritative from the ESP32-C3 SVD
   # --- (tests/fixtures/real_world/esp32c3.svd). Reset values silicon-validated

--- a/crates/cli/src/commands/esp32_boot_state.rs
+++ b/crates/cli/src/commands/esp32_boot_state.rs
@@ -38,6 +38,142 @@ pub fn resolve_esp_partitions_bin(firmware_path: &Path) -> Option<PathBuf> {
     cands.into_iter().find(|p| p.is_file())
 }
 
+/// Install hybrid-preserve TCB base + xthal window spill CPU-model workaround
+/// (not a flash-init firmware thunk). Shared by classic and S3 test paths.
+pub fn install_xtensa_freertos_workarounds(bus: &mut SystemBus, elf_bytes: &[u8]) {
+    use labwired_core::peripherals::esp_xtensa_common::rom_thunks;
+    for sym in ["pxCurrentTCBs", "pxCurrentTCB"] {
+        if let Some(a) = labwired_loader::resolve_symbol_in_elf(elf_bytes, sym) {
+            rom_thunks::PX_CURRENT_TCB_ADDR.with(|s| s.set(Some(a)));
+            eprintln!("labwired-cli test: pxCurrentTCBs @0x{a:08x} (hybrid preserve key)");
+            break;
+        }
+    }
+    if let Some(pc) = labwired_loader::resolve_symbol_in_elf(elf_bytes, "xthal_window_spill_nw") {
+        if let Err(e) = bus.install_flash_thunk(pc, rom_thunks::xthal_window_spill_thunk) {
+            eprintln!("labwired-cli test: warn: xthal_window_spill_nw install failed: {e}");
+        } else {
+            eprintln!(
+                "labwired-cli test: installed xthal_window_spill_nw CPU spill workaround @0x{pc:08x}"
+            );
+        }
+    }
+}
+
+/// Install ESP32-C3 fast-boot behavioral twins used by `labwired test`.
+///
+/// Chip yaml alone is not enough for Arduino FreeRTOS app-entry: SPIMEM CMD
+/// clear, ANA I2C, cache, SYSTIMER VALUE_VALID, RMT TX_END, MMU/XIP, and
+/// matrix IRQ routing. Prefer [`SystemBus::replace_or_add_peripheral`] for
+/// named stubs so `--watch-gpio` / inspect match the MMIO owner.
+pub fn install_esp32c3_fast_boot(bus: &mut SystemBus, firmware_path: &Path) {
+    use labwired_core::peripherals::esp32s3::flash_xip::{
+        Esp32s3MmuTable, FlashXipPeripheral, SharedMmu, MMU_FMT_C3,
+    };
+    use std::sync::atomic::AtomicU64;
+    use std::sync::{Arc, Mutex};
+
+    let mut flash_img = vec![0xFFu8; 4 * 1024 * 1024];
+    if let Some(p) = resolve_esp_partitions_bin(firmware_path) {
+        if let Ok(pt) = std::fs::read(&p) {
+            let n = pt.len().min(0xC00);
+            flash_img[0x8000..0x8000 + n].copy_from_slice(&pt[..n]);
+            eprintln!(
+                "labwired-cli test: seeded C3 flash partitions ({} bytes) from {}",
+                n,
+                p.display()
+            );
+        }
+    }
+    let flash = Arc::new(Mutex::new(flash_img));
+    bus.add_peripheral(
+        "spimem1_flash",
+        0x6000_2000,
+        0x100,
+        None,
+        Box::new(
+            labwired_core::peripherals::esp32s3::spi_mem_flash::SpiMemFlash::new(flash.clone()),
+        ),
+    );
+    bus.add_peripheral(
+        "spimem0_flash",
+        0x6000_3000,
+        0x100,
+        None,
+        Box::new(
+            labwired_core::peripherals::esp32s3::spi_mem_flash::SpiMemFlash::new(flash.clone()),
+        ),
+    );
+    bus.add_peripheral(
+        "rtc_i2c_ana",
+        0x6000_E000,
+        0x400,
+        None,
+        Box::new(labwired_core::peripherals::esp32c3::ana_i2c::Esp32c3AnaI2c::new()),
+    );
+    bus.add_peripheral(
+        "extmem_cache",
+        0x600C_4000,
+        0x400,
+        None,
+        Box::new(labwired_core::peripherals::esp32c3::cache::Esp32c3Cache::new()),
+    );
+    bus.replace_or_add_peripheral(
+        "systimer",
+        0x6002_3000,
+        0x100,
+        None,
+        Box::new(
+            labwired_core::peripherals::esp32s3::systimer::Systimer::new_with_source(
+                160_000_000,
+                37,
+            ),
+        ),
+    );
+    bus.add_peripheral(
+        "apb_saradc",
+        0x6004_0000,
+        0x100,
+        None,
+        Box::new(labwired_core::peripherals::esp32c3::sar_adc::Esp32c3SarAdc::new()),
+    );
+    bus.replace_or_add_peripheral(
+        "rmt",
+        0x6001_6000,
+        0x800,
+        None,
+        Box::new(labwired_core::peripherals::esp32c3::rmt::Esp32c3Rmt::new_default()),
+    );
+    let entries = vec![MMU_FMT_C3.invalid_bit; 128];
+    let mmu_table = Arc::new(SharedMmu {
+        entries: Mutex::new(entries),
+        generation: AtomicU64::new(1),
+    });
+    bus.add_peripheral(
+        "mmu_table",
+        0x600C_5000,
+        0x800,
+        None,
+        Box::new(Esp32s3MmuTable::new(mmu_table.clone())),
+    );
+    bus.add_peripheral(
+        "flash_xip_drom",
+        0x3C00_0000,
+        0x80_0000,
+        None,
+        Box::new(FlashXipPeripheral::new_mmu_fmt(
+            flash,
+            0x3C00_0000,
+            mmu_table,
+            MMU_FMT_C3,
+        )),
+    );
+    bus.config.optimized_bus_access = false;
+    // FreeRTOS first yield needs FROM_CPU matrix → riscv_irq_lines.
+    bus.esp32c3_irq_routing = true;
+    bus.refresh_peripheral_index();
+}
+
 /// Seed `g_rom_flashchip` + `g_ticks_per_us_*` from ELF symbols.
 pub fn seed_esp32_post_brom_dram(bus: &mut SystemBus, elf_bytes: &[u8]) {
     // esp_rom_spiflash_chip_t — Winbond W25Q32-class (4 MiB).

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -582,23 +582,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                             break;
                         }
                     }
-                    // Same xthal spill CPU-model workaround as classic.
-                    if let Some(pc) = labwired_loader::resolve_symbol_in_elf(
+                    super::esp32_boot_state::install_xtensa_freertos_workarounds(
+                        &mut bus,
                         &firmware_bytes,
-                        "xthal_window_spill_nw",
-                    ) {
-                        if let Err(e) =
-                            bus.install_flash_thunk(pc, rom_thunks::xthal_window_spill_thunk)
-                        {
-                            eprintln!(
-                                "labwired-cli test: warn: xthal_window_spill_nw install failed: {e}"
-                            );
-                        } else {
-                            eprintln!(
-                                "labwired-cli test: installed xthal_window_spill_nw CPU spill workaround @0x{pc:08x}"
-                            );
-                        }
-                    }
+                    );
                     // Real APP_CPU: start_cpu0 waits on s_system_inited[0]&[1];
                     // APP sets [1] in do_system_init_fn after s_resume_cores.
                     // ets_set_appcpu_boot_addr still raises s_cpu_up/s_cpu_inited
@@ -710,36 +697,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     &mut machine.bus,
                     &firmware_bytes,
                 );
-                // CPU-model workaround for shadow-window vs firmware spill
-                // (FIDELITY Batch D). Not a flash-init firmware thunk.
-                {
-                    use labwired_core::peripherals::esp_xtensa_common::rom_thunks;
-                    for sym in ["pxCurrentTCBs", "pxCurrentTCB"] {
-                        if let Some(a) =
-                            labwired_loader::resolve_symbol_in_elf(&firmware_bytes, sym)
-                        {
-                            rom_thunks::PX_CURRENT_TCB_ADDR.with(|s| s.set(Some(a)));
-                            break;
-                        }
-                    }
-                    if let Some(pc) = labwired_loader::resolve_symbol_in_elf(
-                        &firmware_bytes,
-                        "xthal_window_spill_nw",
-                    ) {
-                        if let Err(e) = machine
-                            .bus
-                            .install_flash_thunk(pc, rom_thunks::xthal_window_spill_thunk)
-                        {
-                            eprintln!(
-                                "labwired-cli test: warn: xthal_window_spill_nw install failed: {e}"
-                            );
-                        } else {
-                            eprintln!(
-                                "labwired-cli test: installed xthal_window_spill_nw CPU spill workaround @0x{pc:08x}"
-                            );
-                        }
-                    }
-                }
+                super::esp32_boot_state::install_xtensa_freertos_workarounds(
+                    &mut machine.bus,
+                    &firmware_bytes,
+                );
                 machine
             };
             let fault_evidence = handle_faults(&mut machine.bus, &faults);
@@ -857,142 +818,12 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 })
         });
         if is_c3 == Some(true) {
-            use std::sync::{Arc, Mutex};
-            // SPIMEM0/1 flash-command controllers: Arduino `call_start_cpu0` →
-            // `bootloader_read_flash_id` busy-polls CMD until 0. Declarative
-            // stubs never clear. Same S3 SPIMEM model as rom-boot (layout match).
-            let mut flash_img = vec![0xFFu8; 4 * 1024 * 1024];
-            // Partition table @ flash 0x8000 — `esp_partition` requires MD5
-            // trailer (0xEBEB…). Prefer matrix/PIO build artifact beside the
-            // firmware ELF (same on-disk format for C3).
-            if let Some(p) = resolve_esp_partitions_bin(std::path::Path::new(&firmware_path)) {
-                if let Ok(pt) = std::fs::read(&p) {
-                    let n = pt.len().min(0xC00);
-                    flash_img[0x8000..0x8000 + n].copy_from_slice(&pt[..n]);
-                    eprintln!(
-                        "labwired-cli test: seeded C3 flash partitions ({} bytes) from {}",
-                        n,
-                        p.display()
-                    );
-                }
-            }
-            let flash = Arc::new(Mutex::new(flash_img));
-            bus.add_peripheral(
-                "spimem1_flash",
-                0x6000_2000,
-                0x100,
-                None,
-                Box::new(
-                    labwired_core::peripherals::esp32s3::spi_mem_flash::SpiMemFlash::new(
-                        flash.clone(),
-                    ),
-                ),
+            // SPIMEM / ANA I2C / cache / SYSTIMER / SAR / RMT / MMU+XIP /
+            // irq routing — see esp32_boot_state::install_esp32c3_fast_boot.
+            super::esp32_boot_state::install_esp32c3_fast_boot(
+                &mut bus,
+                std::path::Path::new(&firmware_path),
             );
-            bus.add_peripheral(
-                "spimem0_flash",
-                0x6000_3000,
-                0x100,
-                None,
-                Box::new(
-                    labwired_core::peripherals::esp32s3::spi_mem_flash::SpiMemFlash::new(
-                        flash.clone(),
-                    ),
-                ),
-            );
-            bus.add_peripheral(
-                "rtc_i2c_ana",
-                0x6000_E000,
-                0x400,
-                None,
-                Box::new(labwired_core::peripherals::esp32c3::ana_i2c::Esp32c3AnaI2c::new()),
-            );
-            bus.add_peripheral(
-                "extmem_cache",
-                0x600C_4000,
-                0x400,
-                None,
-                Box::new(labwired_core::peripherals::esp32c3::cache::Esp32c3Cache::new()),
-            );
-            // SYSTIMER: declarative stub never asserts VALUE_VALID → spin in
-            // systimer_hal_get_counter_value. S3 model (same IP) + C3 IRQ 37.
-            bus.add_peripheral(
-                "systimer",
-                0x6002_3000,
-                0x100,
-                None,
-                Box::new(
-                    labwired_core::peripherals::esp32s3::systimer::Systimer::new_with_source(
-                        160_000_000,
-                        37,
-                    ),
-                ),
-            );
-            // SAR ADC: calibrate loops need valid conversions.
-            bus.add_peripheral(
-                "apb_saradc",
-                0x6004_0000,
-                0x100,
-                None,
-                Box::new(labwired_core::peripherals::esp32c3::sar_adc::Esp32c3SarAdc::new()),
-            );
-            // RMT @ 0x6001_6000: Arduino `LED_BUILTIN`/pin 30 is RGB_BUILTIN →
-            // `rgbLedWrite` → RMT TX. Instant TX_END so digitalWrite completes.
-            bus.add_peripheral(
-                "rmt",
-                0x6001_6000,
-                0x800,
-                None,
-                Box::new(labwired_core::peripherals::esp32c3::rmt::Esp32c3Rmt::new_default()),
-            );
-            // Flash cache MMU @ 0x600C_5000 + DROM FlashXip.
-            //
-            // Start with *all* entries invalid (silicon reset). Full identity
-            // mapping of 128 pages left `spi_flash_mmap` with zero free entries
-            // → partition load never maps flash[0x8000] → silent hang / empty
-            // UART. Bootloader-equivalent maps for app DROM pages are applied
-            // after ELF load (see post-load C3 flash sync below) only for pages
-            // that actually hold rodata, leaving the rest free for mmap.
-            //
-            // `optimized_bus_access=false` so FlashXip wins over DROM extra_mem
-            // when an entry is valid. IROM (0x4200_0000) stays on chip `flash`
-            // / extra_mem (no XIP window installed there for CLI fast-boot).
-            use labwired_core::peripherals::esp32s3::flash_xip::{
-                Esp32s3MmuTable, FlashXipPeripheral, SharedMmu, MMU_FMT_C3,
-            };
-            use std::sync::atomic::AtomicU64;
-            let entries = vec![MMU_FMT_C3.invalid_bit; 128];
-            let mmu_table = Arc::new(SharedMmu {
-                entries: Mutex::new(entries),
-                generation: AtomicU64::new(1),
-            });
-            bus.add_peripheral(
-                "mmu_table",
-                0x600C_5000,
-                0x800,
-                None,
-                Box::new(Esp32s3MmuTable::new(mmu_table.clone())),
-            );
-            bus.add_peripheral(
-                "flash_xip_drom",
-                0x3C00_0000,
-                0x80_0000,
-                None,
-                Box::new(FlashXipPeripheral::new_mmu_fmt(
-                    flash.clone(),
-                    0x3C00_0000,
-                    mmu_table,
-                    MMU_FMT_C3,
-                )),
-            );
-            bus.config.optimized_bus_access = false;
-            // FreeRTOS first context switch: vPortYield → write SYSTEM
-            // CPU_INTR_FROM_CPU_0 (0x600C_0028) → FROM_CPU source 50 →
-            // esp_crosscore_isr → vPortYieldFromISR. Without this flag the
-            // bus never routes matrix sources into `riscv_irq_lines`, so
-            // yield is a no-op and `vTaskStartScheduler` returns into the
-            // intentional infinite loop at start_cpu0+0x56.
-            bus.esp32c3_irq_routing = true;
-            bus.refresh_peripheral_index();
         }
     }
 

--- a/crates/core/src/bus/construct.rs
+++ b/crates/core/src/bus/construct.rs
@@ -197,9 +197,10 @@ impl SystemBus {
     /// dynamic configuration that bypasses `from_config`.
     ///
     /// **No overlap check is performed.** If two peripherals claim overlapping
-    /// address ranges, reads and writes are routed to the **first** matching
-    /// peripheral in registration order (i.e. the earlier-registered peripheral
-    /// wins). Callers are responsible for ensuring non-overlapping ranges.
+    /// address ranges, routing is last-start-wins (equal bases → last-registered
+    /// entry). Callers are responsible for ensuring non-overlapping ranges, or
+    /// for using [`replace_or_add_peripheral`] when a behavioral model should
+    /// own a name already present as a declarative stub.
     pub fn add_peripheral(
         &mut self,
         name: &str,
@@ -224,6 +225,47 @@ impl SystemBus {
             clock_gate: None,
         });
         self.rebuild_peripheral_ranges();
+    }
+
+    /// Replace the first peripheral with `name`, or append if missing.
+    ///
+    /// Prefer this over [`add_peripheral`] when installing a behavioral twin
+    /// of a chip-yaml declarative stub: name lookup (`find_peripheral_index_by_name`,
+    /// `--watch-gpio`, inspect) and MMIO must agree on one entry. Stacking two
+    /// `"rmt"` devices left TX_START on the later MMIO winner while LogicTap
+    /// armed the earlier stub → `min_rmt_tx` green, `led_watch` edges zero.
+    pub fn replace_or_add_peripheral(
+        &mut self,
+        name: &str,
+        base: u64,
+        size: u64,
+        irq: Option<u32>,
+        mut dev: Box<dyn Peripheral>,
+    ) {
+        dev.attach_cycle_clock(self.cycle_clock.clone());
+        dev.attach_irq_line(irq);
+        if let Some(idx) = self.peripherals.iter().position(|p| p.name == name) {
+            let e = &mut self.peripherals[idx];
+            e.base = base;
+            e.size = size;
+            e.irq = irq;
+            e.dev = dev;
+            e.ticks_remaining = 0;
+            e.clock_gate = None;
+            self.rebuild_peripheral_ranges();
+        } else {
+            // attach already done; push without double-attach
+            self.peripherals.push(PeripheralEntry {
+                name: name.to_string(),
+                base,
+                size,
+                irq,
+                dev,
+                ticks_remaining: 0,
+                clock_gate: None,
+            });
+            self.rebuild_peripheral_ranges();
+        }
     }
 
     /// Look up a registered ROM thunk by absolute PC.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1732,25 +1732,36 @@ impl<C: Cpu> Machine<C> {
         }
         self.reset()?;
 
-        // Resolve the reset vector. Reset reads the initial (SP, PC) from the
-        // vector table at VTOR, which defaults to 0 and aliases to the flash
-        // base — correct for the common case (STM32/nRF/etc.). Some SoCs
-        // prepend a second-stage bootloader: the RP2040 bootrom runs a 256-byte
-        // stage-2 (boot2) blob from flash and only then enters the application
-        // vector table at `flash_base + reset_vector_offset`. We don't execute
-        // boot2 (flash is directly mapped), so when the flash-base vectors are
-        // not valid, relocate to the declared post-stage-2 table — emulating
-        // boot2's only observable effect.
+        // Resolve the reset vector.
+        //
+        // `cpu.reset` reads (SP, PC) from VTOR (default 0). On STM32/nRF that
+        // aliases the flash image, so reset is already correct. On RP2040 the
+        // in-tree mask ROM is mapped at 0 (`LABWIRED_RP2040_BOOTROM` default),
+        // so reset installs *bootrom* vectors and would park the core in the
+        // ROM WFI loop forever for bare-metal images that put a valid vector
+        // table at `flash_base` (no stage-2 boot2). Prefer flash-base vectors
+        // when they are valid; only then fall back to post-boot2 relocation.
         let flash_base = self.bus.flash.base_addr;
-        if !self.bus.vector_pair_valid(flash_base) {
+        if self.bus.vector_pair_valid(flash_base) {
+            let sp = self.bus.read_u32(flash_base)?;
+            let pc = self.bus.read_u32(flash_base + 4)? & !1;
+            // If address 0 does not already present the same SP (bootrom or
+            // empty), retarget VTOR so exceptions hit the app table too.
+            let sp0 = self.bus.read_u32(0).unwrap_or(0);
+            if flash_base != 0 && sp0 != sp {
+                let _ = self.bus.write_u32(0xE000_ED08, flash_base as u32);
+            }
+            self.cpu.set_sp(sp);
+            self.cpu.set_pc(pc);
+        } else {
+            // Stage-2 present (e.g. RP2040 boot2 at flash[0..0x100]): vectors
+            // at flash_base are garbage. Relocate to `reset_vector_offset`.
             let offset = self.bus.reset_vector_offset;
             let relocated = if offset != 0 {
                 let table = flash_base + offset;
                 if self.bus.vector_pair_valid(table) {
                     let sp = self.bus.read_u32(table)?;
                     let pc = self.bus.read_u32(table + 4)? & !1;
-                    // Point VTOR at the relocated table so early exceptions
-                    // (before firmware sets VTOR itself) vector correctly.
                     let _ = self.bus.write_u32(0xE000_ED08, table as u32);
                     self.cpu.set_sp(sp);
                     self.cpu.set_pc(pc);

--- a/crates/core/src/peripherals/esp32c3/factory.rs
+++ b/crates/core/src/peripherals/esp32c3/factory.rs
@@ -11,9 +11,12 @@ pub fn try_build(canonical_type: &str, _p_cfg: &PeripheralConfig) -> Option<Box<
     let dev: Box<dyn Peripheral> = match canonical_type {
         "esp32c3_gpio" => Box::new(super::gpio::Esp32c3Gpio::new()),
         "esp32c3_io_mux" => Box::new(super::io_mux::Esp32c3IoMux::new()),
+        // RMT TX model (Arduino RGB_BUILTIN / rgbLedWrite). Instant TX_END +
+        // LogicTap pulse on TX_START for matrix `led_watch: rmt:0`.
+        "esp32c3_rmt" => Box::new(super::rmt::Esp32c3Rmt::new_default()),
         _ => return None,
     };
     Some(dev)
 }
 
-pub const SUPPORTED_TYPES: &[&str] = &["esp32c3_gpio", "esp32c3_io_mux"];
+pub const SUPPORTED_TYPES: &[&str] = &["esp32c3_gpio", "esp32c3_io_mux", "esp32c3_rmt"];

--- a/crates/core/src/peripherals/esp32c3/rmt.rs
+++ b/crates/core/src/peripherals/esp32c3/rmt.rs
@@ -19,6 +19,20 @@ const TX_START_BIT: u32 = 1 << 0;
 /// Write-trigger bits in TX CONF0 that self-clear (start/rst/conf_update).
 const TX_CONF0_WT_MASK: u32 = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 23) | (1 << 24);
 
+/// Logic-tap state: pin N = TX channel N; each TX_START pulses high→low.
+struct RmtTap {
+    tap: crate::logic_capture::LogicTap,
+    watched: Vec<(u8, u32)>,
+}
+
+impl std::fmt::Debug for RmtTap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RmtTap")
+            .field("watched", &self.watched)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug)]
 pub struct Esp32c3Rmt {
     source_id: u32,
@@ -36,6 +50,8 @@ pub struct Esp32c3Rmt {
     mem: Vec<u32>,
     /// Count of TX_START pulses (rgbLedWrite / RMT TX). Matrix L2 oracle.
     tx_start_count: u32,
+    /// Optional push-mode edges for watched TX channels.
+    tap: Option<RmtTap>,
 }
 
 impl Esp32c3Rmt {
@@ -50,12 +66,31 @@ impl Esp32c3Rmt {
             regs: [0; 0x40],
             mem: vec![0; 256],
             tx_start_count: 0,
+            tap: None,
         }
     }
 
     /// Number of TX_START pulses observed (matrix / inspect oracle).
     pub fn tx_start_count(&self) -> u32 {
         self.tx_start_count
+    }
+
+    fn pulse_tx_edge(&self, ch: usize) {
+        let Some(t) = &self.tap else {
+            return;
+        };
+        let pin = ch as u8;
+        for &(p, channel) in &t.watched {
+            if p == pin {
+                // High then low must land on *distinct* provisional cycles:
+                // `LogicCapture::ingest_push` is same-cycle last-wins, so a
+                // high→low pair stamped at one cycle collapses to a single
+                // net level (and often only one matrix edge).
+                t.tap.push(channel, true);
+                t.tap.bump_clock();
+                t.tap.push(channel, false);
+            }
+        }
     }
 
     pub fn new_default() -> Self {
@@ -78,6 +113,7 @@ impl Esp32c3Rmt {
             // Instant TX complete: CHn_TX_END = bit n.
             self.int_raw |= 1 << ch;
             self.tx_start_count = self.tx_start_count.saturating_add(1);
+            self.pulse_tx_edge(ch);
         }
     }
 }
@@ -196,5 +232,48 @@ impl Peripheral for Esp32c3Rmt {
             bytes: None,
         });
         view
+    }
+
+    fn install_logic_tap(
+        &mut self,
+        tap: &crate::logic_capture::LogicTap,
+        watched: &[(u8, u32)],
+    ) -> bool {
+        // pin = TX channel index (0..1). Used by matrix `led_watch: rmt:0`.
+        if watched.is_empty() {
+            self.tap = None;
+        } else {
+            self.tap = Some(RmtTap {
+                tap: tap.clone(),
+                watched: watched.to_vec(),
+            });
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logic_capture::LogicTap;
+    use crate::Peripheral;
+
+    #[test]
+    fn logic_tap_sees_tx_start_pulse() {
+        let mut rmt = Esp32c3Rmt::new_default();
+        let tap = LogicTap::new();
+        assert!(rmt.install_logic_tap(&tap, &[(0, 0)]));
+        tap.set_armed(true);
+        // CH0 CONF0 TX_START
+        rmt.write_u32(0x10, TX_START_BIT).unwrap();
+        assert_eq!(rmt.tx_start_count(), 1);
+        let events = tap.take_events();
+        assert!(
+            events.len() >= 2,
+            "expected high→low TX pulse edges, got {:?}",
+            events
+        );
+        assert_eq!(events[0].value, true);
+        assert_eq!(events[1].value, false);
     }
 }

--- a/crates/core/src/peripherals/esp32c3/rmt.rs
+++ b/crates/core/src/peripherals/esp32c3/rmt.rs
@@ -120,7 +120,11 @@ impl Esp32c3Rmt {
 
 impl Peripheral for Esp32c3Rmt {
     fn needs_legacy_walk(&self) -> bool {
-        true
+        // Instant TX on CONF0 write + level IRQ via `matrix_irq_sources` —
+        // no per-cycle walk work. Must stay walk-independent so the C3 chip
+        // yaml (which now installs this model) can still derive walk-deletion
+        // for wifi_mac / rom-boot paths.
+        false
     }
 
     fn read_u32(&self, offset: u64) -> SimResult<u32> {

--- a/crates/core/src/peripherals/esp32c3/rmt.rs
+++ b/crates/core/src/peripherals/esp32c3/rmt.rs
@@ -273,7 +273,7 @@ mod tests {
             "expected high→low TX pulse edges, got {:?}",
             events
         );
-        assert_eq!(events[0].value, true);
-        assert_eq!(events[1].value, false);
+        assert!(events[0].value);
+        assert!(!events[1].value);
     }
 }

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -89,6 +89,7 @@ pub const MODEL_TYPES: &[&str] = &[
     "esp32c3_io_mux",
     "esp32c3_apb_saradc",
     "esp32c3_ledc",
+    "esp32c3_rmt",
     // nRF52 behavioral models (nrf52 factory).
     "nrf52840_twim",
     "nrf52_saadc",

--- a/crates/core/src/peripherals/rp2040/sio.rs
+++ b/crates/core/src/peripherals/rp2040/sio.rs
@@ -44,6 +44,22 @@ const SPINLOCK31: u64 = 0x17c;
 // The RP2040 exposes 30 GPIOs (0..29) on bank 0.
 const GPIO_MASK: u32 = 0x3fff_ffff;
 
+/// Push-mode logic capture for SIO bank-0 pads (Arduino `digitalWrite` / LED).
+struct SioTap {
+    tap: crate::logic_capture::LogicTap,
+    /// `(pin, channel)` watch set.
+    watched: Vec<(u8, u32)>,
+    scratch: Vec<Option<bool>>,
+}
+
+impl std::fmt::Debug for SioTap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SioTap")
+            .field("watched", &self.watched)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct Rp2040Sio {
     gpio_out: u32,
@@ -51,6 +67,8 @@ pub struct Rp2040Sio {
     /// Bit `n` set == spinlock `n` is currently claimed. `Cell` because a
     /// spinlock read is a claim (a write side-effect) on the `&self` read path.
     spinlocks_held: Cell<u32>,
+    /// Logic-analyzer push tap (not snapshot state).
+    tap: Option<SioTap>,
 }
 
 impl Rp2040Sio {
@@ -62,6 +80,42 @@ impl Rp2040Sio {
     /// own output when its output-enable is set, otherwise it floats to 0.
     fn gpio_in(&self) -> u32 {
         self.gpio_out & self.gpio_oe
+    }
+
+    fn pad_level(&self, pin: u8) -> Option<bool> {
+        if pin >= 30 {
+            return None;
+        }
+        let bit = 1u32 << pin;
+        // Match GPIO_IN: only OE-enabled pins drive a known level.
+        if self.gpio_oe & bit == 0 {
+            return Some(false);
+        }
+        Some(self.gpio_out & bit != 0)
+    }
+
+    fn tap_snapshot(&mut self) {
+        let Some(mut t) = self.tap.take() else {
+            return;
+        };
+        for (k, &(pin, _)) in t.watched.iter().enumerate() {
+            t.scratch[k] = self.pad_level(pin);
+        }
+        self.tap = Some(t);
+    }
+
+    fn tap_report(&mut self) {
+        let Some(t) = self.tap.take() else {
+            return;
+        };
+        for (k, &(pin, ch)) in t.watched.iter().enumerate() {
+            if let Some(level) = self.pad_level(pin) {
+                if t.scratch[k] != Some(level) {
+                    t.tap.push(ch, level);
+                }
+            }
+        }
+        self.tap = Some(t);
     }
 
     /// True if `offset` names a SPINLOCKn register.
@@ -119,6 +173,20 @@ impl Peripheral for Rp2040Sio {
             return Ok(());
         }
         let v = value & GPIO_MASK;
+        let mut_out = matches!(
+            offset,
+            GPIO_OUT
+                | GPIO_OUT_SET
+                | GPIO_OUT_CLR
+                | GPIO_OUT_XOR
+                | GPIO_OE
+                | GPIO_OE_SET
+                | GPIO_OE_CLR
+                | GPIO_OE_XOR
+        );
+        if mut_out {
+            self.tap_snapshot();
+        }
         match offset {
             GPIO_OUT => self.gpio_out = v,
             GPIO_OUT_SET => self.gpio_out |= v,
@@ -129,6 +197,9 @@ impl Peripheral for Rp2040Sio {
             GPIO_OE_CLR => self.gpio_oe &= !v,
             GPIO_OE_XOR => self.gpio_oe ^= v,
             _ => {}
+        }
+        if mut_out {
+            self.tap_report();
         }
         Ok(())
     }
@@ -145,9 +216,34 @@ impl Peripheral for Rp2040Sio {
             return self.write_u32(aligned, value as u32);
         }
         let shift = (offset & 0x3) * 8;
-        let cur = self.read_u32(aligned)?;
+        let cur = match aligned {
+            GPIO_OUT | GPIO_OUT_SET | GPIO_OUT_CLR | GPIO_OUT_XOR => self.gpio_out,
+            GPIO_OE | GPIO_OE_SET | GPIO_OE_CLR | GPIO_OE_XOR => self.gpio_oe,
+            _ => self.read_u32(aligned)?,
+        };
         let new = (cur & !(0xFF << shift)) | ((value as u32) << shift);
         self.write_u32(aligned, new)
+    }
+
+    fn read_gpio_pad(&self, pin: u8) -> Option<bool> {
+        self.pad_level(pin)
+    }
+
+    fn install_logic_tap(
+        &mut self,
+        tap: &crate::logic_capture::LogicTap,
+        watched: &[(u8, u32)],
+    ) -> bool {
+        if watched.is_empty() {
+            self.tap = None;
+        } else {
+            self.tap = Some(SioTap {
+                tap: tap.clone(),
+                watched: watched.to_vec(),
+                scratch: vec![None; watched.len()],
+            });
+        }
+        true
     }
 }
 
@@ -175,6 +271,26 @@ mod tests {
         // Clear the output → reads back low.
         sio.write_u32(GPIO_OUT_CLR, PIN25).unwrap();
         assert_eq!(sio.read_u32(GPIO_IN).unwrap() & PIN25, 0);
+    }
+
+    #[test]
+    fn logic_tap_sees_led_pin25_toggle() {
+        use crate::logic_capture::LogicTap;
+        use crate::Peripheral;
+        let mut sio = Rp2040Sio::new();
+        let tap = LogicTap::new();
+        assert!(sio.install_logic_tap(&tap, &[(25, 0)]));
+        // Arm push mode so ingest is live (machine does this on logic_watch).
+        tap.set_armed(true);
+        sio.write_u32(GPIO_OE_SET, PIN25).unwrap();
+        sio.write_u32(GPIO_OUT_SET, PIN25).unwrap();
+        sio.write_u32(GPIO_OUT_CLR, PIN25).unwrap();
+        let events = tap.take_events();
+        assert!(
+            events.len() >= 2,
+            "expected LED toggle edges, got {:?}",
+            events
+        );
     }
 
     #[test]

--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,6 +1,6 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 14:10:51 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-23 14:49:04 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
 Legend: ✅ pass · 🔧 compile/build fail · 📦 toolchain missing · 🔴 boot/sim fail · 🟠 oracle miss · 🟣 unmodeled · ⏱️ timeout
 

--- a/docs/engineering/test_harness.md
+++ b/docs/engineering/test_harness.md
@@ -148,13 +148,15 @@ scheduler identity unless a workflow enables the feature.
   commit coalesces peripheral `tick_elapsed(N)`.
 - SCB presence still forces quantum-1 (cycle-accurate logic capture). RTC_CNTL
   only forces quantum-1 while SW_SYS_RST is latched.
-- `LABWIRED_MATRIX_SPEED=1` + `event-scheduler` remains experimental on ESP
-  FreeRTOS; default CLI is the fidelity matrix path. Class-M dual-universe
-  smoke: `validation/arduino-matrix/scripts/matrix_speed_subset.sh`.
+- Dual-universe (`event-scheduler` + `MATRIX_SPEED=1`): green on Class-M and
+  **ESP32-S3**; classic ESP empty UART; C3 L2 may hang after `LW_L2_BOOT`.
+  Smoke script: `validation/arduino-matrix/scripts/matrix_speed_subset.sh`.
+  Default CLI remains the full-matrix fidelity path.
 - CLI must not hard-code matrix PIO work paths for partitions.
-- L2 oracles: GPIO edges via `led_watch` (STM32, ESP classic, nRF after
-  PIN_CNF.DIR sync); RMT TX_START count via inspect `rmt_tx` + `min_rmt_tx`
-  (C3/S3 RGB).
+- L2 oracles: GPIO/`sio` edges via `led_watch` (STM32, ESP classic, nRF P0.17,
+  RP2040 SIO:25); C3 `rmt:0` synthetic TX edges + `min_rmt_tx` (single
+  `esp32c3_rmt` entry — no declarative+behavioral dual stack); S3 `min_rmt_tx`
+  inspect count.
 
 Work log: [`test_harness_reorg_log.md`](test_harness_reorg_log.md).
 

--- a/validation/arduino-matrix/boards.yaml
+++ b/validation/arduino-matrix/boards.yaml
@@ -26,8 +26,10 @@ boards:
     pio: { platform: espressif32, board: esp32-c3-devkitm-1, framework: arduino }
     max_steps: 15000000
     budget_reason: "FreeRTOS C3 boot ~1.9M steps; L2 RGB via RMT"
-    # LED_BUILTIN → rgbLedWrite → RMT TX_START (inspect rmt_tx artifact)
+    # LED_BUILTIN → rgbLedWrite → RMT TX_START (inspect + synthetic ch0 edges)
     min_rmt_tx: 1
+    led_watch: "rmt:0"
+    led_min_edges: 2
     family: esp32
     notes: "Arduino-ESP32-C3 RISC-V"
 
@@ -68,7 +70,9 @@ boards:
     pio: { platform: raspberrypi, board: pico, framework: arduino }
     max_steps: 8000000
     budget_reason: "mbed RTX SysTick delay; L0~1.7M L2~0.8M with short delays (was 20M for delay(20))"
-    # SIO/GPIO not watched yet — UART-only L2 until sio pin map is wired
+    # Pico LED = GPIO25 via SIO (not APB GPIO)
+    led_watch: "sio:25"
+    led_min_edges: 2
     family: rp2040
     notes: "Needs platform raspberrypi (pio pkg install -g -p raspberrypi if missing)"
 

--- a/validation/arduino-matrix/scripts/matrix_speed_subset.sh
+++ b/validation/arduino-matrix/scripts/matrix_speed_subset.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Dual-universe smoke: MATRIX_SPEED + event-scheduler on Class-M boards only.
-# ESP FreeRTOS labs are intentionally excluded (known event-scheduler gaps).
+# Dual-universe smoke: MATRIX_SPEED + event-scheduler on boards that stay green.
+#
+# Green under event-scheduler + MATRIX_SPEED=1 (2026-07-23):
+#   STM32 / nRF / RP2040 Class-M, plus ESP32-S3 L0+L2.
+# Still broken / flaky (excluded by default):
+#   ESP32 classic (empty UART), ESP32-C3 L2 (hangs after LW_L2_BOOT).
 #
 # Build once:
 #   cargo build -p labwired-cli --release --features event-scheduler
@@ -11,7 +15,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 cd "$ROOT"
 export LABWIRED_MATRIX_SPEED="${LABWIRED_MATRIX_SPEED:-1}"
-BOARDS="${BOARDS:-stm32f401,stm32f103,stm32l073,stm32wb55,nrf52840,rp2040}"
+BOARDS="${BOARDS:-stm32f401,stm32f103,stm32l073,stm32wb55,nrf52840,rp2040,esp32s3}"
 exec python3 validation/arduino-matrix/run_matrix.py \
   --sim-only \
   --boards "$BOARDS" \


### PR DESCRIPTION
## Summary
Closes the post-roast open items on the Arduino matrix harness:

- **RP2040 L2 honesty**: SIO push-mode LogicTap + `led_watch: sio:25` (Pico LED)
- **ESP32-C3 L2 honesty**: `esp32c3_rmt` is the sole `rmt` entry (no declarative+behavioral dual stack that armed LogicTap on the stub while TX_START hit the twin). Synthetic TX edges span two provisional cycles so same-cycle last-wins does not collapse the high→low pulse
- **`replace_or_add_peripheral`**: for declarative → behavioral twins where name lookup must match MMIO
- **ESP extract**: C3 fast-boot install + Xtensa FreeRTOS workarounds moved into `esp32_boot_state`
- **Docs**: dual-universe script stays honest (Class-M + S3 green; classic empty UART; C3 L2 hang under event-scheduler)

## Test plan
- [x] `cargo test -p labwired-core --lib logic_tap_sees`
- [x] `cargo build -p labwired-cli --release`
- [x] `python3 validation/arduino-matrix/run_matrix.py --sim-only` → **45/45**
- [x] C3 L2: 4 logic edges + rmt_tx count 2; RP2040 L2: 2 edges on sio:25