### PR TITLE
feat(sim): servo actuator twins + get_actuator_states

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -700,48 +700,73 @@ impl SystemBus {
                     bus.ws2812.push(strip);
                 }
                 "servo" | "sg90" | "mg996r" => {
-                    // Hobby PWM servo on one control pin. Driven by GPIO edges
-                    // (and LEDC duty observers when LEDC is present).
+                    // Hobby PWM servo twin. Driven by GPIO edges and/or LEDC
+                    // duty observers (ledcWrite path). Part id is stored so
+                    // WASM `get_actuator_states` can key canvas animation.
                     let pin_label = ext
                         .config
-                        .get("control_pin")
+                        .get("signal_pin")
+                        .or_else(|| ext.config.get("control_pin"))
                         .or_else(|| ext.config.get("pwm_pin"))
+                        .or_else(|| ext.config.get("pin"))
                         .and_then(|v| v.as_str())
                         .unwrap_or("GPIO18");
                     let pin = Self::parse_esp32s3_gpio_pin(pin_label)
                         .or_else(|| Self::parse_esp32_gpio_pin(pin_label))
                         .ok_or_else(|| {
                             anyhow::anyhow!(
-                                "servo '{}' control_pin '{}' is not a parseable GPIO",
+                                "servo '{}' control/signal pin '{}' is not a parseable GPIO",
                                 ext.id,
                                 pin_label
                             )
                         })?;
-                    let cal = match ext.r#type.as_str() {
+                    // Prefer explicit config.model; fall back to the type alias
+                    // (sg90/mg996r as top-level type) then standard cal.
+                    let model = ext
+                        .config
+                        .get("model")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(ext.r#type.as_str());
+                    let cal = match model {
                         "sg90" => crate::peripherals::components::servo::ServoCal::sg90(),
                         "mg996r" => crate::peripherals::components::servo::ServoCal::mg996r(),
                         _ => crate::peripherals::components::servo::ServoCal::standard(),
                     };
-                    let servo = std::sync::Arc::new(
-                        crate::peripherals::components::servo::Servo::new(cal, pin),
-                    );
+                    let servo =
+                        std::sync::Arc::new(crate::peripherals::components::servo::Servo::with_id(
+                            ext.id.clone(),
+                            cal,
+                            pin,
+                        ));
                     Self::install_gpio_observer(&mut bus, servo.clone());
-                    // Also bind LEDC channels if present (ESP32 Arduino Servo path).
-                    if let Some(idx) = bus.find_peripheral_index_by_name("ledc") {
-                        if let Some(ledc) = bus.peripherals[idx]
-                            .dev
-                            .as_any_mut()
-                            .and_then(|a| a.downcast_mut::<crate::peripherals::esp32::ledc::Ledc>())
-                        {
-                            // Observe all channels; driver filters by channel id
-                            // when firmware assigns the servo's pin to a channel.
-                            for ch in 0..8u64 {
-                                ledc.add_duty_observer(std::sync::Arc::new(
-                                    crate::peripherals::components::servo::LedcServoDriver::new(
-                                        ch,
-                                        servo.clone(),
-                                    ),
-                                ));
+                    // LEDC duty path (classic ESP32). Optional `ledc_channel`
+                    // binds one channel; otherwise fan out to all channels
+                    // (fine for single-servo boards).
+                    let ledc_channel = ext.config.get("ledc_channel").and_then(|v| v.as_u64());
+                    for name in ["ledc", "LEDC"] {
+                        if let Some(idx) = bus.find_peripheral_index_by_name(name) {
+                            if let Some(ledc) =
+                                bus.peripherals[idx].dev.as_any_mut().and_then(|a| {
+                                    a.downcast_mut::<crate::peripherals::esp32::ledc::Ledc>()
+                                })
+                            {
+                                if let Some(ch) = ledc_channel {
+                                    ledc.add_duty_observer(std::sync::Arc::new(
+                                        crate::peripherals::components::servo::LedcServoDriver::new(
+                                            ch,
+                                            servo.clone(),
+                                        ),
+                                    ));
+                                } else {
+                                    for ch in 0..16u64 {
+                                        ledc.add_duty_observer(std::sync::Arc::new(
+                                            crate::peripherals::components::servo::LedcServoDriver::new(
+                                                ch,
+                                                servo.clone(),
+                                            ),
+                                        ));
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -318,7 +318,9 @@ pub struct SystemBus {
     /// edge-driven with no per-tick pass. Held here as `Arc` clones purely so the
     /// UI/oracle can read the decoded pixels back. Empty by default → zero cost.
     pub ws2812: Vec<std::sync::Arc<crate::peripherals::components::ws2812::Ws2812>>,
-    /// Hobby PWM servos (SG90/MG996R). GPIO-observer driven; held for angle readback.
+    /// Hobby PWM servos (SG90 / MG996R-class). Driven by GPIO edges and/or LEDC
+    /// duty observers; held as `Arc` clones so the UI can poll shaft angle via
+    /// `get_actuator_states`. Empty by default → zero cost.
     pub servos: Vec<std::sync::Arc<crate::peripherals::components::servo::Servo>>,
     /// STEP/DIR steppers (A4988/DRV8825/TMC2209). GPIO-observer driven.
     pub step_dir_motors:

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -631,6 +631,43 @@ external_devices:
     );
 }
 
+/// Hobby servo twins attach via a dedicated `from_config` arm so the UI can
+/// poll shaft angle through `get_actuator_states`.
+#[test]
+fn test_from_config_attaches_servo_with_part_id() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let chip = ChipDescriptor::from_file(root.join("../../configs/chips/esp32.yaml"))
+        .expect("read ESP32 chip descriptor");
+    let manifest: SystemManifest = serde_yaml::from_str(
+        r#"
+name: "servo-twin"
+chip: "../chips/esp32.yaml"
+external_devices:
+  - id: "srv1"
+    type: "servo"
+    connection: "gpio"
+    config:
+      signal_pin: "GPIO5"
+      model: "sg90"
+board_io: []
+"#,
+    )
+    .expect("parse servo manifest");
+
+    let bus = SystemBus::from_config(&chip, &manifest).expect("build bus with servo");
+    assert_eq!(bus.servos.len(), 1, "one servo twin attached");
+    assert_eq!(bus.servos[0].id(), "srv1");
+    assert_eq!(bus.servos[0].pin(), 5);
+    // Until commanded, parks at min_angle (0° for sg90).
+    assert_eq!(bus.servos[0].angle_degrees(), 0.0);
+    bus.servos[0].apply_duty_fraction(0.075);
+    assert!(
+        (bus.servos[0].angle_degrees() - 94.7).abs() < 1.0,
+        "sg90 mid duty → ~94.7°, got {}",
+        bus.servos[0].angle_degrees()
+    );
+}
+
 /// The `rotary_encoder` external device dispatches through the DECLARATIVE
 /// device path (`configs/devices/rotary_encoder.yaml`, `quadrature` primitive)
 /// rather than a hand-written `from_config` arm. This locks that seam: a

--- a/crates/core/src/peripherals/components/servo.rs
+++ b/crates/core/src/peripherals/components/servo.rs
@@ -129,6 +129,9 @@ struct ServoState {
 /// A hobby PWM servo digital twin. See module docs.
 #[derive(Debug)]
 pub struct Servo {
+    /// Canvas / board_io part id — used by `get_actuator_states` so the UI can
+    /// map shaft angle back onto the diagram part.
+    id: String,
     cal: ServoCal,
     /// GPIO pin this servo's control wire is connected to (for the
     /// observer path). Edges on other pins are ignored.
@@ -138,9 +141,16 @@ pub struct Servo {
 
 impl Servo {
     /// Create a servo with the given calibration, listening on `pin` for
-    /// the GPIO-edge drive path.
+    /// the GPIO-edge drive path. Prefer [`Self::with_id`] when the angle must
+    /// be exported to the UI under a known part id.
     pub fn new(cal: ServoCal, pin: u8) -> Self {
+        Self::with_id(String::new(), cal, pin)
+    }
+
+    /// Create a servo bound to a diagram part id for UI readback.
+    pub fn with_id(id: impl Into<String>, cal: ServoCal, pin: u8) -> Self {
         Self {
+            id: id.into(),
             cal,
             pin,
             state: Mutex::new(ServoState::default()),
@@ -155,6 +165,11 @@ impl Servo {
     /// Convenience: an SG90 micro servo on `pin`.
     pub fn sg90(pin: u8) -> Self {
         Self::new(ServoCal::sg90(), pin)
+    }
+
+    /// Diagram / board_io part id (empty when constructed without one).
+    pub fn id(&self) -> &str {
+        &self.id
     }
 
     /// The GPIO pin this servo is wired to.

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -367,6 +367,36 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&states).unwrap_or(JsValue::NULL)
     }
 
+    /// Live actuator state for canvas animation.
+    ///
+    /// Returns `[{ id, kind, angle?, active?, effort?, steps? }]`:
+    /// - hobby servos (`kind: "servo"`) export shaft `angle` in degrees
+    /// - future motor twins may add `effort` / `steps`
+    ///
+    /// Ids match the diagram part id / external_devices id so the UI maps
+    /// straight onto `boardIoStates[partId]`.
+    #[wasm_bindgen]
+    pub fn get_actuator_states(&self) -> JsValue {
+        let machine = self.machine.as_ref().unwrap();
+        let mut states: Vec<serde_json::Value> = Vec::new();
+
+        for servo in &machine.bus.servos {
+            let id = servo.id();
+            if id.is_empty() {
+                continue;
+            }
+            states.push(serde_json::json!({
+                "id": id,
+                "kind": "servo",
+                "angle": servo.angle_degrees() as f64,
+                "active": servo.is_commanded(),
+                "pulse_us": servo.pulse_us() as f64,
+            }));
+        }
+
+        serde_wasm_bindgen::to_value(&states).unwrap_or(JsValue::NULL)
+    }
+
     /// Return the SSD1306 GDDRAM framebuffer for the device identified by `device_id`.
     ///
     /// `device_id` must match a `board_io` binding with `device_type: "oled-ssd1306"`.


### PR DESCRIPTION
## Summary
- Attach hobby-servo digital twins from `external_devices` (`type: servo`) with part id, GPIO edges, and ESP32 LEDC duty observers
- Store twins on `SystemBus.servos` for UI/oracle readback
- Export live shaft state via `WasmSimulator::get_actuator_states` (`id`, `kind`, `angle`, `active`, `pulse_us`)
- Unit coverage for attach + angle transfer function

## Test plan
- [x] `cargo test -p labwired-core --lib test_from_config_attaches_servo`
- [x] `cargo test -p labwired-core --lib peripherals::components::servo`
- [ ] Pair with monorepo PR that rebuilds playground wasm and wires liveSim/Scene3D