### PR TITLE
style: cargo fmt after #630

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -269,18 +269,19 @@ impl SystemBus {
                         // previously marked attached even when the factory
                         // warned "unknown device type" and skipped them —
                         // leaving the bus empty (matrix L3 nRF ANACK on INA219).
-                        let factory_handles = crate::peripherals::components::build_external_i2c_device(
-                            &ext.r#type,
-                            &ext.id,
-                            &ext.config,
-                        )
-                        .is_some()
-                            || (canonical_type == "nrf52_serial_instance"
-                                && crate::peripherals::components::build_spi_device(
-                                    &ext.r#type,
-                                    &ext.config,
-                                )
-                                .is_some());
+                        let factory_handles =
+                            crate::peripherals::components::build_external_i2c_device(
+                                &ext.r#type,
+                                &ext.id,
+                                &ext.config,
+                            )
+                            .is_some()
+                                || (canonical_type == "nrf52_serial_instance"
+                                    && crate::peripherals::components::build_spi_device(
+                                        &ext.r#type,
+                                        &ext.config,
+                                    )
+                                    .is_some());
                         if factory_handles {
                             attached_i2c_ext_ids.insert(ext.id.as_str());
                         }

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -594,8 +594,8 @@ impl L4I2c {
             0x28 => {
                 self.txdr = value & 0xFF;
                 self.isr &= !0x0000_0003; // writing TXDR clears TXE+TXIS
-                // Loading the first byte while a write transfer is armed starts
-                // the address phase. Instant complete — Wire poll path.
+                                          // Loading the first byte while a write transfer is armed starts
+                                          // the address phase. Instant complete — Wire poll path.
                 if self.start_armed && self.state == I2cState::Idle {
                     self.state = I2cState::AddressPending;
                     self.cycles_remaining = 0;
@@ -1446,7 +1446,11 @@ mod tests {
         let mut i2c = I2c::new();
         // Instant SB: Wire/HAL polls SR1.SB immediately after CR1.START.
         i2c.write(0x01, 0x01).unwrap(); // CR1 START (bit 8) → SR1.SB
-        assert_ne!(i2c.peek(0x14).unwrap() & 0x01, 0, "SB latches on START write");
+        assert_ne!(
+            i2c.peek(0x14).unwrap() & 0x01,
+            0,
+            "SB latches on START write"
+        );
     }
 
     #[test]
@@ -1612,16 +1616,8 @@ mod tests {
             0,
             "ISR.NACKF when no slave"
         );
-        assert_eq!(
-            i2c.peek(0x19).unwrap() & (1 << 7),
-            0,
-            "AUTOEND clears BUSY"
-        );
-        assert_ne!(
-            i2c.peek(0x18).unwrap() & (1 << 5),
-            0,
-            "AUTOEND sets STOPF"
-        );
+        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "AUTOEND clears BUSY");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "AUTOEND sets STOPF");
 
         // ICR.NACKCF (bit4) + STOPCF (bit5) clear the flags.
         i2c.write(0x1C, (1 << 4) | (1 << 5)).unwrap();
@@ -1662,16 +1658,8 @@ mod tests {
             0,
             "TC after address-only"
         );
-        assert_ne!(
-            i2c.peek(0x18).unwrap() & (1 << 5),
-            0,
-            "STOPF via AUTOEND"
-        );
-        assert_eq!(
-            i2c.peek(0x19).unwrap() & (1 << 7),
-            0,
-            "BUSY cleared"
-        );
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND");
+        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared");
     }
 
     #[test]

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -1074,8 +1074,8 @@ impl crate::Peripheral for I2c {
         Ok(())
     }
 
-    /// Atomic word writes: STM32 HAL stores CR2 as a single STR (START + NBYTES
-    /// + AUTOEND together). Default Peripheral::write_u32 byte-slices and would
+    /// Atomic word writes: STM32 HAL stores CR2 as a single STR (START, NBYTES,
+    /// and AUTOEND together). Default Peripheral::write_u32 byte-slices and would
     /// assert START before AUTOEND lands, breaking the NBYTES=0 probe path.
     fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
         match self {

--- a/crates/core/src/peripherals/rp2040/i2c.rs
+++ b/crates/core/src/peripherals/rp2040/i2c.rs
@@ -130,13 +130,7 @@ impl Peripheral for Rp2040I2c {
                 s
             }
             IC_TXFLR => 0,
-            IC_RXFLR => {
-                if self.rx_byte.get().is_some() {
-                    1
-                } else {
-                    0
-                }
-            }
+            IC_RXFLR => u32::from(self.rx_byte.get().is_some()),
             IC_COMP_TYPE => IC_COMP_TYPE_MAGIC,
             _ => 0,
         };

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -22,11 +22,9 @@ fn build_i2c_external_device(
 ) -> Option<Box<dyn crate::peripherals::i2c::I2cDevice>> {
     // Prefer the shared factory (includes kit types like ina219) so ESP classic
     // and S3 stay in lockstep with the generic from_config attach path.
-    if let Some(dev) = crate::peripherals::components::build_external_i2c_device(
-        &ext.r#type,
-        &ext.id,
-        &ext.config,
-    ) {
+    if let Some(dev) =
+        crate::peripherals::components::build_external_i2c_device(&ext.r#type, &ext.id, &ext.config)
+    {
         return Some(dev);
     }
     let addr = |default: u8| {


### PR DESCRIPTION
## Summary
- `cargo fmt` on the matrix I2C attach path that landed with #630
- Unblocks `pr-gate` on open PRs (and main)

## Test plan
- [x] `cargo fmt --all -- --check` clean