### PR TITLE
fix(esp32c3): don't double-register mmu_table on rom-boot resume

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -803,7 +803,20 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     // stubs can't supply — same set `build_rom_boot_machine` / wasm C3 path
     // install. Without them, ROM clock bring-up faults on unmapped ANA_I2C
     // (0x6000_E000) and cache invalidate busy-polls forever.
-    {
+    //
+    // These stubs are the ELF-app-entry ALTERNATIVE to the faithful rom-boot
+    // machine: `build_c3_rom_boot_machine` (below) installs the same set,
+    // including the real 512-entry MMU table. On the rom-boot / capture /
+    // resume paths that machine is built on THIS bus, so installing the
+    // fast-boot stubs here would double-register `mmu_table` (a 128-entry
+    // ELF-app-entry stub + the 512-entry rom-boot table). A resume snapshot
+    // then carries two `mmu_table` blobs, and `apply_runtime_snapshot` — which
+    // resolves peripherals by name to the FIRST match — misroutes the 512-entry
+    // blob onto the 128-entry stub and fails ("snapshot has 512 entries, table
+    // has 128"). Only install the fast-boot stubs on the plain ELF path.
+    let rom_boot_path =
+        args.rom_boot || args.capture_app_entry.is_some() || args.resume_snapshot.is_some();
+    if !rom_boot_path {
         let is_c3 = system_path.as_ref().and_then(|sys_path| {
             labwired_config::SystemManifest::from_file(sys_path)
                 .ok()
@@ -1183,16 +1196,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 ) {
                     Ok(s) => s,
                     Err(e) => {
-                        let msg = format!("invalid resume snapshot {snap_path:?}: {e}");
-                        error!("{}", msg);
-                        write_config_error_outputs(
-                            &args,
-                            Some(&firmware_path),
-                            system_path.as_ref(),
-                            Some(&firmware_bytes),
-                            Some(&resolved_limits),
-                            msg,
-                        );
+                        // Corrupt or version-mismatched blob. Snapshot-invalid:
+                        // write NO result.json so the caller cold-boots and
+                        // refreshes the cache.
+                        error!("invalid resume snapshot {snap_path:?}: {e}; cold-boot required");
                         return ExitCode::from(EXIT_CONFIG_ERROR);
                     }
                 };
@@ -1215,17 +1222,12 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     }
                 };
                 if let Err(e) = snap.validate_self_key(chip, &fw_sha) {
-                    let msg =
-                        format!("resume snapshot self-key mismatch ({e}); cold-boot required");
-                    error!("{}", msg);
-                    write_config_error_outputs(
-                        &args,
-                        Some(&firmware_path),
-                        system_path.as_ref(),
-                        Some(&firmware_bytes),
-                        Some(&resolved_limits),
-                        msg,
-                    );
+                    // Stale/foreign snapshot (captured against a different chip or
+                    // firmware). Write NO result.json so a cache-backed caller
+                    // treats it as "resume did not run" and cold-boots to refresh
+                    // the cache — the snapshot-invalid contract the resume-error
+                    // fallback in the run service depends on.
+                    error!("resume snapshot self-key mismatch ({e}); cold-boot required");
                     return ExitCode::from(EXIT_CONFIG_ERROR);
                 }
                 let mut machine = match crate::build_c3_rom_boot_machine(bus, None) {
@@ -1233,17 +1235,20 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     Err(code) => return code,
                 };
                 if let Err(e) = machine.apply_runtime_snapshot(&snap) {
-                    let msg = format!("failed to apply resume snapshot: {e}");
-                    error!("{}", msg);
-                    write_config_error_outputs(
-                        &args,
-                        Some(&firmware_path),
-                        system_path.as_ref(),
-                        Some(&firmware_bytes),
-                        Some(&resolved_limits),
-                        msg,
+                    // The snapshot self-keyed clean (same chip + firmware) but is
+                    // structurally incompatible with the freshly-built machine —
+                    // e.g. a stale blob captured by an older, buggy core whose bus
+                    // topology differs (the C3 double-`mmu_table` window). This is
+                    // a snapshot-invalid signal, NOT a firmware fault: deliberately
+                    // write NO result.json so the caller (which resumes from a
+                    // cache) sees the resume did not run and falls back to a cold
+                    // `--rom-boot`, refreshing the cache with a compatible capture.
+                    // Same contract as a self-key mismatch above.
+                    error!(
+                        "resume snapshot incompatible with this machine ({e}); \
+                         cold-boot required (stale/foreign snapshot)"
                     );
-                    return ExitCode::from(EXIT_RUNTIME_ERROR);
+                    return ExitCode::from(EXIT_CONFIG_ERROR);
                 }
                 eprintln!(
                     "labwired-riscv: resumed from app-entry snapshot {snap_path:?} (chip {chip}); \

--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -687,6 +687,78 @@ mod tests {
         assert_eq!(mmu.entries.lock().unwrap()[128], 64);
     }
 
+    /// Build a C3-shaped (128-entry) flash MMU table peripheral. The C3 table is
+    /// half the S3's width, so its snapshot word count differs — the axis of the
+    /// rom-boot resume regression.
+    fn new_c3_mmu_table() -> SharedMmuTable {
+        Arc::new(SharedMmu {
+            entries: Mutex::new(vec![MMU_FMT_C3.invalid_bit; 128]),
+            generation: AtomicU64::new(1),
+        })
+    }
+
+    #[test]
+    fn c3_mmu_table_snapshot_round_trips_128_entries() {
+        // ESP32-C3's flash MMU has exactly 128 entries. A resume snapshot must
+        // carry — and restore onto — that many, preserving every programmed
+        // mapping. This guards the C3 rom-boot resume path, where a mismatched
+        // entry count fails apply ("snapshot has N entries, table has M").
+        let mmu = new_c3_mmu_table();
+        let mut p = Esp32s3MmuTable::new(mmu);
+        // Two live mappings the 2nd-stage bootloader would program.
+        p.write_u32(0, 0x0000_0000).unwrap(); // entry 0 → phys page 0, valid
+        p.write_u32(64 * 4, 0x0000_002A).unwrap(); // entry 64 → phys page 42
+
+        let blob = p.runtime_snapshot();
+        assert_eq!(blob.len(), 128 * 4, "C3 snapshot must be 128 u32 words");
+
+        // A freshly-built C3 table (as a resume constructs) restores cleanly and
+        // the entry count is preserved.
+        let mmu2 = new_c3_mmu_table();
+        let mut p2 = Esp32s3MmuTable::new(mmu2.clone());
+        p2.restore_runtime_snapshot(&blob)
+            .expect("C3 128-entry snapshot must round-trip");
+        assert_eq!(mmu2.entries.lock().unwrap().len(), 128);
+        assert_eq!(p2.read_u32(0).unwrap(), 0x0000_0000);
+        assert_eq!(p2.read_u32(64 * 4).unwrap(), 0x0000_002A);
+    }
+
+    #[test]
+    fn s3_mmu_table_snapshot_round_trips_512_entries() {
+        // The S3 direction: 512 entries, preserved across snapshot/restore. Guards
+        // against a fix that "corrects" C3 by breaking the S3 width.
+        let mmu = new_mmu_table(); // 512-entry S3 table
+        let mut p = Esp32s3MmuTable::new(mmu);
+        p.write_u32(500 * 4, 0x0000_0100).unwrap();
+
+        let blob = p.runtime_snapshot();
+        assert_eq!(blob.len(), 512 * 4, "S3 snapshot must be 512 u32 words");
+
+        let mmu2 = new_mmu_table();
+        let mut p2 = Esp32s3MmuTable::new(mmu2.clone());
+        p2.restore_runtime_snapshot(&blob)
+            .expect("S3 512-entry snapshot must round-trip");
+        assert_eq!(mmu2.entries.lock().unwrap().len(), 512);
+        assert_eq!(p2.read_u32(500 * 4).unwrap(), 0x0000_0100);
+    }
+
+    #[test]
+    fn mmu_table_snapshot_size_mismatch_is_rejected_clearly() {
+        // A 512-entry (S3) snapshot must NOT silently apply onto a 128-entry (C3)
+        // table: the size guard rejects it with a clear message so a caller can
+        // treat it as snapshot-invalid and cold-boot. This is exactly the failure
+        // the C3 rom-boot double-`mmu_table` regression surfaced.
+        let s3_blob = Esp32s3MmuTable::new(new_mmu_table()).runtime_snapshot();
+        let mut c3_table = Esp32s3MmuTable::new(new_c3_mmu_table());
+        match c3_table.restore_runtime_snapshot(&s3_blob).unwrap_err() {
+            SimulationError::NotImplemented(msg) => {
+                assert!(msg.contains("512 entries"), "clear size-mismatch error: {msg}");
+                assert!(msg.contains("table has 128"), "clear size-mismatch error: {msg}");
+            }
+            other => panic!("expected NotImplemented size-mismatch, got {other:?}"),
+        }
+    }
+
     #[test]
     fn shared_backing_visible_to_both_aliases() {
         let mut buf = vec![0u8; PAGE_SIZE as usize];


### PR DESCRIPTION
## Root cause

The C3 rom-boot / capture / resume paths build the faithful rom-boot machine (`build_c3_rom_boot_machine`), which installs the real **512-entry** flash MMU table. The CLI (`crates/cli/src/commands/test.rs`) was **also** layering `install_esp32c3_fast_boot` on the same bus first — but that path is the ELF-app-entry *alternative* and registers its own **128-entry** `mmu_table` stub.

The bus then carried two peripherals named `mmu_table` (128 + 512). A resume snapshot serialized both; `apply_runtime_snapshot` resolves peripherals by name to the **first** match, so it misrouted the 512-entry blob onto the 128-entry stub and failed with `snapshot has 512 entries, table has 128`. Fresh capture worked; **resume** broke.

## Fix

Gate the fast-boot stubs off the rom-boot / capture / resume paths, so only the faithful machine's single `mmu_table` exists there. The plain ELF-app-entry path — including the C3 `min_rmt_tx`/`led_watch` matrix test, which is the *only* consumer of the behavioral RMT that fast-boot uniquely adds — is unchanged.

## Snapshot-compatibility policy

On the resume path, snapshot-invalid conditions (corrupt/version-mismatched blob, self-key mismatch, structurally incompatible apply — e.g. a stale blob written by the buggy window) now write **no `result.json`** and exit non-zero. A cache-backed caller (the run service) already treats a missing `result.json` as "resume did not run" and falls back to a cold `--rom-boot`, refreshing the cache. No silent fallback in core — the error is logged loudly.

## Tests

- `c3_mmu_table_snapshot_round_trips_128_entries` — C3 128-entry snapshot/restore preserves entry count + mappings.
- `s3_mmu_table_snapshot_round_trips_512_entries` — guards the S3 width isn't broken by the C3 fix.
- `mmu_table_snapshot_size_mismatch_is_rejected_clearly` — 512-onto-128 apply rejected with a clear size-mismatch error.

Library unit suite: **2294 passed, 0 failed**. (Pre-existing, unrelated `strict_onboarding` integration failure re: nrf54l15 example matching, refs #309/#310 — untouched by this diff.)