### PR TITLE
style: rustfmt the c3 mmu size-mismatch test (fixes main fmt gate)

### DIFF
--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -752,8 +752,14 @@ mod tests {
         let mut c3_table = Esp32s3MmuTable::new(new_c3_mmu_table());
         match c3_table.restore_runtime_snapshot(&s3_blob).unwrap_err() {
             SimulationError::NotImplemented(msg) => {
-                assert!(msg.contains("512 entries"), "clear size-mismatch error: {msg}");
-                assert!(msg.contains("table has 128"), "clear size-mismatch error: {msg}");
+                assert!(
+                    msg.contains("512 entries"),
+                    "clear size-mismatch error: {msg}"
+                );
+                assert!(
+                    msg.contains("table has 128"),
+                    "clear size-mismatch error: {msg}"
+                );
             }
             other => panic!("expected NotImplemented size-mismatch, got {other:?}"),
         }


### PR DESCRIPTION
Follow-up to #633. That PR auto-merged at its first commit before the rustfmt fix landed, so main's `cargo fmt --all --check` (pr-gate) is red on the multi-line `assert!` in `c3_mmu_table` size-mismatch test. This applies exactly what rustfmt wants. No logic change.