### PR TITLE
feat(sensors): migrate VEML7700 to a declarative I²C descriptor

### DIFF
--- a/configs/devices/veml7700.yaml
+++ b/configs/devices/veml7700.yaml
@@ -1,0 +1,137 @@
+# Vishay VEML7700 ambient-light sensor — declarative I²C register-pointer device.
+#
+# The master writes a 1-byte register pointer, then reads/writes a 16-bit
+# LITTLE-ENDIAN word (low byte first). Datasheet (VEML7700, Vishay, rev 1.6)
+# register map:
+#   0x00 ALS_CONF  config: gain [12:11], integration time [9:6], power  (rw)
+#   0x01 ALS_WH    high threshold window                                (rw)
+#   0x02 ALS_WL    low threshold window                                 (rw)
+#   0x03 PSM       power-saving mode                                    (rw)
+#   0x04 ALS       ambient-light output count                           (r)
+#   0x05 WHITE     white-channel output count                           (r)
+#   0x06 ALS_INT   interrupt status                                     (r, reads 0)
+#
+# Illuminance → counts. The datasheet gives lux = count × resolution, and the
+# resolution (lux/count) scales with the programmed gain and integration time,
+# anchored at 0.0576 lux/count for the power-on default (gain ×1, IT 100 ms):
+#
+#     resolution = 0.0576 × (100 ms / IT) ÷ gain
+#     count      = illuminance / resolution
+#
+# Because BOTH the gain and the integration-time fields (two bit-fields of the
+# same ALS_CONF register) move the resolution, a single scale mapping cannot
+# express it — the ALS/WHITE registers use `resolution` mode with a LIST of
+# `scale_from` factors that multiply into the resolution divisor:
+#   * the IT field maps to the ratio (100 ms / IT) — 1.0, 0.5, 0.25, 0.125,
+#     2.0, 4.0 — each an exact power of two, so it reproduces `100.0 / IT`
+#     bit-for-bit;
+#   * the gain field maps to 1/gain — 1.0, 0.5, 8.0, 4.0 — again exact, so
+#     multiplying the resolution by it is byte-identical to dividing by gain.
+# Reserved IT encodings fall through to 1.0 (the datasheet 100 ms default).
+#
+# WHITE reads a slightly brighter value than the visible ALS channel; the model
+# uses the white-photodiode responsivity ratio 1.15 as a `source_scale` (a
+# distinct multiply on the illuminance, matching the reference model's
+# intermediate exactly).
+#
+# The illuminance is an externally driven input (channel `lux`); config only
+# seeds its initial value. Default address 0x10 (fixed on the VEML7700).
+type: veml7700
+
+behavior:
+  primitive: i2c_device
+  i2c:
+    default_address: 0x10
+    registers:
+      # Config: firmware writes it; its gain [12:11] and IT [9:6] fields drive
+      # the ALS/WHITE resolution via their scale_from references below.
+      - name: ALS_CONF
+        addr: 0x00
+        width: 2
+        endian: le
+        access: rw
+        reset: 0x0000
+      # Interrupt threshold windows — plain rw storage, echoed back on read.
+      - name: ALS_WH
+        addr: 0x01
+        width: 2
+        endian: le
+        access: rw
+        reset: 0x0000
+      - name: ALS_WL
+        addr: 0x02
+        width: 2
+        endian: le
+        access: rw
+        reset: 0x0000
+      # Power-saving mode — plain rw storage.
+      - name: PSM
+        addr: 0x03
+        width: 2
+        endian: le
+        access: rw
+        reset: 0x0000
+      # Ambient-light count = round(lux / resolution), little-endian.
+      - name: ALS
+        addr: 0x04
+        width: 2
+        endian: le
+        access: r
+        source: lux
+        resolution: 0.0576
+        scale_from:
+          # Integration-time field → (100 ms / IT) resolution ratio.
+          - register: ALS_CONF
+            mask: 0xF
+            shift: 6
+            map: { 0x0: 1.0, 0x1: 0.5, 0x2: 0.25, 0x3: 0.125, 0x8: 2.0, 0xC: 4.0 }
+          # Gain field → 1/gain resolution factor.
+          - register: ALS_CONF
+            mask: 0x3
+            shift: 11
+            map: { 0x0: 1.0, 0x1: 0.5, 0x2: 8.0, 0x3: 4.0 }
+      # White-channel count = round((lux × 1.15) / resolution), little-endian.
+      - name: WHITE
+        addr: 0x05
+        width: 2
+        endian: le
+        access: r
+        source: lux
+        source_scale: 1.15
+        resolution: 0.0576
+        scale_from:
+          - register: ALS_CONF
+            mask: 0xF
+            shift: 6
+            map: { 0x0: 1.0, 0x1: 0.5, 0x2: 0.25, 0x3: 0.125, 0x8: 2.0, 0xC: 4.0 }
+          - register: ALS_CONF
+            mask: 0x3
+            shift: 11
+            map: { 0x0: 1.0, 0x1: 0.5, 0x2: 8.0, 0x3: 4.0 }
+      # Interrupt status — reads 0 (the reference model never latches a flag).
+      - name: ALS_INT
+        addr: 0x06
+        width: 2
+        endian: le
+        access: r
+        reset: 0x0000
+
+metadata:
+  label: "Vishay VEML7700 Light"
+  summary: "Ambient-light sensor (lux) over I2C."
+  detail: "Vishay VEML7700 at fixed address 0x10, a register-pointer device with 16-bit little-endian words. Reports a raw ALS count the firmware scales to lux at the default gain ×1 / 100 ms resolution (0.0576 lux/count). The illuminance is an externally driven input (channel lux); config only seeds its initial value."
+  category: i2c
+  config_keys:
+    - name: i2c_address
+      ty: int
+      doc: "7-bit slave address. Defaults to the VEML7700 fixed address 0x10."
+    - name: lux
+      ty: float
+      doc: "Initial illuminance, lux. Default 450 (daylit room). Drive it at runtime with the `lux` input channel."
+  labs:
+    - board_id: esp32c3-leo-airquality
+      chip: esp32c3
+      example_dir: esp32c3-leo-airquality
+      demo_elf: demo-esp32c3-leo-airquality.elf
+  inputs:
+    - { key: lux, label: "Illuminance", unit: lx, min: 0, max: 120000, default: 450 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -812,14 +812,50 @@ pub struct DeviceMetadata {
     pub label: Option<String>,
     #[serde(default)]
     pub summary: Option<String>,
+    /// Long-form description shown in the library detail view. Absent ⇒ the kit
+    /// falls back to `summary` (the pre-existing declarative-kit behaviour).
+    #[serde(default)]
+    pub detail: Option<String>,
     #[serde(default)]
     pub category: Option<String>,
+    /// Extra `config:` keys this device accepts beyond `i2c_address`, mirrored
+    /// verbatim into the peripheral manifest. When present this list is taken as
+    /// the COMPLETE set of config keys (list `i2c_address` explicitly if the
+    /// device accepts it); when absent the kit synthesises the lone
+    /// `i2c_address` key. Carrying these lets a declarative descriptor reproduce
+    /// a hand-written kit's manifest entry byte-for-byte.
+    #[serde(default)]
+    pub config_keys: Vec<ConfigKeySpec>,
+    /// Starter labs that ship a one-click demo using this device, mirrored into
+    /// the manifest exactly like a hand-written kit's `labs`.
+    #[serde(default)]
+    pub labs: Vec<LabSpec>,
     /// The named stimulus channels this device accepts. For an `i2c_device`
     /// primitive these are the measurement slots that register/response
     /// `source:` keys read; each `default` seeds the value the part reports
     /// until something drives it, and `min`/`max` bound accepted stimuli.
     #[serde(default)]
     pub inputs: Vec<InputSpec>,
+}
+
+/// A `config:` key advertised in the peripheral manifest. Mirrors the engine's
+/// `KitMetadata::config_keys` entries so a declarative descriptor can reproduce
+/// a hand-written kit's manifest documentation.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConfigKeySpec {
+    pub name: String,
+    /// One of `str` | `int` | `bool` | `float`.
+    pub ty: String,
+    pub doc: String,
+}
+
+/// A starter-lab reference, mirroring the engine's `KitMetadata::labs` entries.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LabSpec {
+    pub board_id: String,
+    pub chip: String,
+    pub example_dir: String,
+    pub demo_elf: String,
 }
 
 /// One drivable stimulus channel (a measurement slot). Datasheet-facing
@@ -917,10 +953,52 @@ pub struct I2cRegister {
     /// in the register word.
     #[serde(default)]
     pub encode: Option<Encode>,
-    /// A bit-field of another register selects an extra scale factor (e.g. a
-    /// gain / integration-time field that changes the counts-per-unit).
+    /// A constant the sourced value is multiplied by *before* encoding, applied
+    /// as its own floating-point step (not folded into `encode.scale`). This is
+    /// a datasheet responsivity ratio — e.g. the VEML7700 white channel reads
+    /// `1.15 ×` the visible ALS illuminance. Absent ⇒ 1.0 (no pre-scale). It is
+    /// a distinct multiply so the intermediate rounds byte-identically to a
+    /// reference model that scales the measurement before converting it.
     #[serde(default)]
-    pub scale_from: Option<ScaleFrom>,
+    pub source_scale: Option<f64>,
+    /// Zero or more bit-field-selected scale factors, each read from another
+    /// register's field and **multiplied together** (a single mapping or a YAML
+    /// list are both accepted). In the default (multiply) mode these compound
+    /// the counts-per-unit — e.g. a gain field ×1/×2/×4. In `resolution` mode
+    /// they compound the resolution divisor instead (gain **and**
+    /// integration-time fields together, which one field alone cannot express).
+    #[serde(default, deserialize_with = "de_scale_from_list")]
+    pub scale_from: Vec<ScaleFrom>,
+    /// Resolution-divide mode. When present, the register reports
+    /// `round((value × source_scale) ÷ resolution)`, where
+    /// `resolution = <this base> × Π(scale_from factors)` folded left-to-right.
+    /// This is the datasheet form for parts whose count = illuminance ÷
+    /// resolution and whose resolution scales with programmed gain and
+    /// integration time (VEML7700). Absent ⇒ the register uses the multiply
+    /// encoding (`value × encode.scale × Π factors`). Mutually exclusive with a
+    /// `source`-less register.
+    #[serde(default)]
+    pub resolution: Option<f64>,
+}
+
+/// Accept either a single `scale_from` mapping or a YAML list of them, yielding
+/// a `Vec`. A bare mapping is the common single-field case (backward-compatible
+/// with descriptors written before compounding fields existed); a list is used
+/// when several bit-fields multiply together (e.g. gain × integration time).
+fn de_scale_from_list<'de, D>(deserializer: D) -> Result<Vec<ScaleFrom>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(ScaleFrom),
+        Many(Vec<ScaleFrom>),
+    }
+    Ok(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(s) => vec![s],
+        OneOrMany::Many(v) => v,
+    })
 }
 
 /// Linear measurement encoding: `raw = value * scale + offset`, clamped to the
@@ -1126,6 +1204,7 @@ pub fn embedded_device_yaml(device_type: &str) -> Option<&'static str> {
         "hc-sr04" | "hcsr04" => Some(include_str!("../../../configs/devices/hc_sr04.yaml")),
         "sht31" => Some(include_str!("../../../configs/devices/sht31.yaml")),
         "bh1750" => Some(include_str!("../../../configs/devices/bh1750.yaml")),
+        "veml7700" => Some(include_str!("../../../configs/devices/veml7700.yaml")),
         _ => None,
     }
 }

--- a/crates/core/src/peripherals/components/declarative_i2c.rs
+++ b/crates/core/src/peripherals/components/declarative_i2c.rs
@@ -85,6 +85,18 @@ fn encode_raw(value: f64, enc: Option<&Encode>, extra_scale: f64, width: u8) -> 
     raw.round().clamp(0.0, width_max(width)) as u32
 }
 
+/// Convert a measurement to a raw count by DIVIDING it by a resolution
+/// (`count = round(value / resolution)`), clamped into a `width`-byte word.
+/// This is the divide dual of [`encode_raw`], for parts the datasheet describes
+/// as `count = quantity / resolution` (VEML7700). A zero/negative resolution
+/// clamps to the max (defensive; descriptors never declare one).
+fn divide_raw(value: f64, resolution: f64, width: u8) -> u32 {
+    if resolution <= 0.0 {
+        return width_max(width) as u32;
+    }
+    (value / resolution).round().clamp(0.0, width_max(width)) as u32
+}
+
 /// Pack `raw` into `width` bytes in the given order.
 fn pack(raw: u32, width: u8, endian: Endian) -> Vec<u8> {
     let mut le: Vec<u8> = (0..width).map(|i| (raw >> (8 * i as u32)) as u8).collect();
@@ -221,6 +233,16 @@ impl GenericI2cDevice {
         Self::from_descriptor(&descriptor, address, channels)
     }
 
+    /// Seed a measurement slot's initial value from a `config:` override. Only
+    /// keys that name a declared input channel take effect (others are ignored),
+    /// so a descriptor's `config_keys` like `lux` seed the part's starting
+    /// reading exactly as a hand-written kit's `config_f64("lux")` did.
+    pub fn seed_input(&mut self, key: &str, value: f64) {
+        if self.channels.iter().any(|c| c.key == key) {
+            self.slots.insert(key.to_string(), value);
+        }
+    }
+
     fn find_register(&self, addr: u8) -> Option<&I2cRegister> {
         self.registers.iter().find(|r| r.addr == addr)
     }
@@ -229,23 +251,50 @@ impl GenericI2cDevice {
         self.commands.iter().find(|c| c.code == code)
     }
 
-    /// The extra scale factor a register's `scale_from` selects from the current
-    /// value of another register's bit-field (1.0 when absent / unmapped).
-    fn scale_from_factor(&self, reg: &I2cRegister) -> f64 {
-        let Some(sf) = &reg.scale_from else {
-            return 1.0;
-        };
+    /// The scale factor one `scale_from` entry selects from the current value of
+    /// another register's bit-field (1.0 when the field value is unmapped).
+    fn scale_from_one(&self, sf: &labwired_config::ScaleFrom) -> f64 {
         let regval = self.reg_values.get(&sf.register).copied().unwrap_or(0);
         let field = (regval >> sf.shift as u32) & sf.mask;
         sf.map.get(&field).copied().unwrap_or(1.0)
     }
 
+    /// Product of a register's `scale_from` factors, folded left-to-right from
+    /// 1.0 (the empty list ⇒ 1.0). Used in the multiply encoding to compound the
+    /// counts-per-unit.
+    fn scale_from_product(&self, reg: &I2cRegister) -> f64 {
+        reg.scale_from
+            .iter()
+            .fold(1.0, |acc, sf| acc * self.scale_from_one(sf))
+    }
+
     /// The bytes a read of the currently pointed register returns.
     fn register_read_bytes(&self, reg: &I2cRegister) -> Vec<u8> {
         let raw = if let Some(src) = &reg.source {
-            let value = self.slots.get(src).copied().unwrap_or(0.0);
-            let extra = self.scale_from_factor(reg);
-            encode_raw(value, reg.encode.as_ref(), extra, reg.width)
+            // A distinct pre-multiply on the measurement (datasheet responsivity
+            // ratio), applied as its own float step so the intermediate matches
+            // a reference model that scales the value before converting it.
+            let value =
+                self.slots.get(src).copied().unwrap_or(0.0) * reg.source_scale.unwrap_or(1.0);
+            match reg.resolution {
+                Some(base) => {
+                    // Resolution-divide mode: resolution = base × Π(factors),
+                    // folded left-to-right from `base` (so the op tree matches a
+                    // reference `base * (100/it) / gain`); count = value ÷ res.
+                    let resolution = reg
+                        .scale_from
+                        .iter()
+                        .fold(base, |acc, sf| acc * self.scale_from_one(sf));
+                    divide_raw(value, resolution, reg.width)
+                }
+                // Multiply mode: value × encode.scale × Π(factors).
+                None => encode_raw(
+                    value,
+                    reg.encode.as_ref(),
+                    self.scale_from_product(reg),
+                    reg.width,
+                ),
+            }
         } else {
             // Plain storage register: echo the written value (seeded to reset).
             self.reg_values.get(&reg.name).copied().unwrap_or(reg.reset)
@@ -476,7 +525,7 @@ fn leak_channels(descriptor: &DeviceDescriptor) -> &'static [InputChannel] {
 // ─── PeripheralKit registration ────────────────────────────────────────────
 
 use crate::peripherals::kit::{
-    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
 };
 
 /// A [`PeripheralKit`] backed by a declarative `i2c_device` descriptor — one
@@ -520,6 +569,17 @@ impl DeclarativeI2cKit {
     }
 }
 
+/// Map a descriptor's `config_keys[].ty` string onto a [`ConfigType`].
+/// Unknown spellings fall back to `Str` (the most permissive display type).
+fn config_type_from_str(ty: &str) -> ConfigType {
+    match ty {
+        "int" => ConfigType::Int,
+        "float" => ConfigType::Float,
+        "bool" => ConfigType::Bool,
+        _ => ConfigType::Str,
+    }
+}
+
 /// Derive a `&'static KitMetadata` from the descriptor's display metadata.
 fn leak_metadata(
     descriptor: &DeviceDescriptor,
@@ -534,27 +594,65 @@ fn leak_metadata(
     let summary = meta
         .and_then(|m| m.summary.clone())
         .unwrap_or_else(|| "Declarative I²C device.".to_string());
+    // Long-form detail: explicit `metadata.detail` if given, else the summary
+    // (the pre-existing declarative-kit fallback).
+    let detail = meta
+        .and_then(|m| m.detail.clone())
+        .unwrap_or_else(|| summary.clone());
 
-    let config_keys: &'static [ConfigKey] = Box::leak(
-        vec![ConfigKey {
-            name: "i2c_address",
-            ty: ConfigType::Int,
-            doc: leak(format!(
-                "7-bit slave address. Defaults to 0x{default_address:02x}."
-            )),
-        }]
-        .into_boxed_slice(),
+    // Config keys: an explicit `metadata.config_keys` is taken as the COMPLETE
+    // set (it may list `i2c_address` itself); otherwise synthesise the lone
+    // `i2c_address` key from the default address.
+    let declared_keys = meta.map(|m| m.config_keys.as_slice()).unwrap_or(&[]);
+    let config_keys: &'static [ConfigKey] = if declared_keys.is_empty() {
+        Box::leak(
+            vec![ConfigKey {
+                name: "i2c_address",
+                ty: ConfigType::Int,
+                doc: leak(format!(
+                    "7-bit slave address. Defaults to 0x{default_address:02x}."
+                )),
+            }]
+            .into_boxed_slice(),
+        )
+    } else {
+        Box::leak(
+            declared_keys
+                .iter()
+                .map(|k| ConfigKey {
+                    name: leak(k.name.clone()),
+                    ty: config_type_from_str(&k.ty),
+                    doc: leak(k.doc.clone()),
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        )
+    };
+
+    // Labs: mirror any declared starter labs verbatim.
+    let declared_labs = meta.map(|m| m.labs.as_slice()).unwrap_or(&[]);
+    let labs: &'static [LabRef] = Box::leak(
+        declared_labs
+            .iter()
+            .map(|l| LabRef {
+                board_id: leak(l.board_id.clone()),
+                chip: leak(l.chip.clone()),
+                example_dir: leak(l.example_dir.clone()),
+                demo_elf: leak(l.demo_elf.clone()),
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
     );
 
     Box::leak(Box::new(KitMetadata {
         device_type: leak(descriptor.r#type.clone()),
         label: leak(label),
-        summary: leak(summary.clone()),
-        detail: leak(summary),
+        summary: leak(summary),
+        detail: leak(detail),
         transport: Transport::I2c,
         category: Category::I2c,
         config_keys,
-        labs: &[],
+        labs,
         inputs: channels,
     }))
 }
@@ -572,7 +670,15 @@ impl PeripheralKit for DeclarativeI2cKit {
             .as_ref()
             .context("declarative i2c kit is missing behavior.i2c")?;
         let address = ctx.i2c_address_or(spec.default_address)?;
-        let device = GenericI2cDevice::from_descriptor(&self.descriptor, address, self.channels)?;
+        let mut device =
+            GenericI2cDevice::from_descriptor(&self.descriptor, address, self.channels)?;
+        // Honour `config:` overrides that name an input channel (e.g. a `lux`
+        // seed), matching how a hand-written kit seeded its initial reading.
+        for input in self.channels {
+            if let Some(v) = ctx.config_f64(input.key) {
+                device.seed_input(input.key, v);
+            }
+        }
         ctx.attach_i2c_device(Box::new(device))
     }
 }
@@ -612,6 +718,18 @@ pub static BH1750_KIT: LazyLock<DeclarativeI2cKit> = LazyLock::new(|| {
         labwired_config::embedded_device_yaml("bh1750").expect("bh1750 descriptor is embedded"),
     )
     .expect("bh1750.yaml is a valid declarative i2c descriptor")
+});
+
+/// Vishay VEML7700 ambient-light sensor (declarative `veml7700.yaml`). Migrated
+/// from the hand-written [`super::veml7700::Veml7700`] model, which now survives
+/// only as the byte-parity oracle (see `veml7700_parity.rs`). The register-pointer
+/// wire protocol, the gain × integration-time resolution table, and the manifest
+/// metadata all live in the descriptor.
+pub static VEML7700_KIT: LazyLock<DeclarativeI2cKit> = LazyLock::new(|| {
+    DeclarativeI2cKit::from_yaml(
+        labwired_config::embedded_device_yaml("veml7700").expect("veml7700 descriptor is embedded"),
+    )
+    .expect("veml7700.yaml is a valid declarative i2c descriptor")
 });
 
 #[cfg(test)]

--- a/crates/core/src/peripherals/components/mod.rs
+++ b/crates/core/src/peripherals/components/mod.rs
@@ -79,7 +79,15 @@ pub mod tm1637_7seg;
 pub mod tmp117;
 pub mod uc8151d_tricolor_290;
 pub mod unipolar_stepper;
+/// Hand-written VEML7700 model, retained only as the byte-parity oracle the
+/// declarative descriptor is proven identical against (see `veml7700_parity`).
+/// The shipping device is `declarative_i2c::VEML7700_KIT`, so this module is
+/// test-only.
+#[cfg(test)]
 pub mod veml7700;
+/// Byte-parity harness: the declarative VEML7700 vs the hand-written oracle.
+#[cfg(test)]
+mod veml7700_parity;
 pub mod vl53l0x;
 pub mod vl53l1x;
 pub mod ws2812;
@@ -128,5 +136,6 @@ pub use ssd1680_tricolor_290::Ssd1680Tricolor290;
 pub use tm1637_7seg::Tm1637;
 pub use tmp117::Tmp117;
 pub use uc8151d_tricolor_290::Uc8151dTricolor290;
+#[cfg(test)]
 pub use veml7700::{Veml7700, VEML7700_ADDR};
 pub use vl53l1x::Vl53l1x;

--- a/crates/core/src/peripherals/components/veml7700.rs
+++ b/crates/core/src/peripherals/components/veml7700.rs
@@ -4,6 +4,14 @@
 
 //! Vishay **VEML7700** ambient-light sensor as an [`I2cDevice`].
 //!
+//! **Status: byte-parity oracle only.** The shipping VEML7700 is now the
+//! declarative descriptor `configs/devices/veml7700.yaml`, driven by
+//! [`super::declarative_i2c::GenericI2cDevice`] and registered as
+//! [`super::declarative_i2c::VEML7700_KIT`]. This hand-written model is retained
+//! solely as the reference the parity test (`super::veml7700_parity`) proves the
+//! declarative device byte-identical against — hence the whole module is
+//! `#[cfg(test)]`. It is no longer a registry kit.
+//!
 //! Unlike the Sensirion parts on this board, the VEML7700 is a classic
 //! command-register device: the master writes a 1-byte register pointer, then
 //! reads/writes a **16-bit little-endian** word (low byte first).
@@ -215,58 +223,11 @@ impl crate::sim_input::SimInput for Veml7700 {
     }
 }
 
-// ─── PeripheralKit registration ────────────────────────────────────────────
-
-use crate::peripherals::kit::{
-    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
-};
-
-pub struct Veml7700Kit;
-pub static VEML7700_KIT: Veml7700Kit = Veml7700Kit;
-
-static VEML7700_METADATA: KitMetadata = KitMetadata {
-    inputs: INPUT_CHANNELS,
-    device_type: "veml7700",
-    label: "Vishay VEML7700 Light",
-    summary: "Ambient-light sensor (lux) over I2C.",
-    detail: "Vishay VEML7700 at fixed address 0x10, a register-pointer device with \
-             16-bit little-endian words. Reports a raw ALS count the firmware scales \
-             to lux at the default gain ×1 / 100 ms resolution (0.0576 lux/count). \
-             The illuminance is an externally driven input (channel lux); config only \
-             seeds its initial value.",
-    transport: Transport::I2c,
-    category: Category::I2c,
-    config_keys: &[
-        ConfigKey {
-            name: "i2c_address",
-            ty: ConfigType::Int,
-            doc: "7-bit slave address. Defaults to the VEML7700 fixed address 0x10.",
-        },
-        ConfigKey {
-            name: "lux",
-            ty: ConfigType::Float,
-            doc: "Initial illuminance, lux. Default 450 (daylit room). Drive it at \
-                  runtime with the `lux` input channel.",
-        },
-    ],
-    labs: &[LabRef {
-        board_id: "esp32c3-leo-airquality",
-        chip: "esp32c3",
-        example_dir: "esp32c3-leo-airquality",
-        demo_elf: "demo-esp32c3-leo-airquality.elf",
-    }],
-};
-
-impl PeripheralKit for Veml7700Kit {
-    fn metadata(&self) -> &'static KitMetadata {
-        &VEML7700_METADATA
-    }
-    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
-        let address = ctx.i2c_address_or(VEML7700_ADDR)?;
-        let lux = ctx.config_f64("lux").unwrap_or(450.0);
-        ctx.attach_i2c_device(Box::new(Veml7700::new(address, lux)))
-    }
-}
+// The `PeripheralKit` registration that once lived here now lives in the
+// declarative descriptor `configs/devices/veml7700.yaml` +
+// `super::declarative_i2c::VEML7700_KIT`. All of that metadata (label, summary,
+// detail, config_keys, the Leo lab, and the lux input) moved verbatim into the
+// YAML `metadata:` block, so the offline peripherals manifest is unchanged.
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/peripherals/components/veml7700_parity.rs
+++ b/crates/core/src/peripherals/components/veml7700_parity.rs
@@ -1,0 +1,335 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! **Byte-parity harness: declarative VEML7700 vs the hand-written oracle.**
+//!
+//! The shipping VEML7700 is now the declarative descriptor
+//! `configs/devices/veml7700.yaml`, interpreted by
+//! [`super::declarative_i2c::GenericI2cDevice`]. The hand-written
+//! [`super::veml7700::Veml7700`] model is retained *only* as the reference this
+//! module proves the declarative device byte-identical against: every test here
+//! drives the OLD and NEW devices through the exact same I²C script and asserts
+//! the two produce byte-equal reads.
+//!
+//! ## Why divide, not multiply-by-reciprocal
+//!
+//! The oracle converts illuminance to a raw count by **dividing**:
+//! `count = round(lux / resolution)`, where
+//! `resolution = 0.0576 × (100 / IT) / gain`. The tempting way to express this
+//! declaratively is a list of `scale_from` factors multiplied straight onto the
+//! value (a counts-per-lux of `1 / resolution`). That is **not** byte-faithful:
+//! on the "nice" firmware values (13.5, 27, 40.5 … lux) the WHITE channel's
+//! ×1.15 pushes the true quotient onto an exact x.5 rounding tie, where
+//! `round(lux / resolution)` and `round(lux × (1/resolution))` disagree by one
+//! LSB (the reciprocal lands a hair below x.5 and rounds down). A dense uniform
+//! random sweep never surfaces it — the ties are measure-zero — but real
+//! firmware hits them constantly.
+//!
+//! So the declarative descriptor uses `resolution` mode (`divide_raw`) and
+//! rebuilds the oracle's exact float op-tree: because the IT ratio (100/IT ∈
+//! {1, 0.5, 0.25, 0.125, 2, 4}) and inverse-gain (1/gain ∈ {1, 0.5, 8, 4}) are
+//! all exact powers of two in f64, folding `0.0576 × IT_factor × gain_factor`
+//! left-to-right reproduces `0.0576 × (100/IT) / gain` bit-for-bit. The
+//! [`nice_value_tie_sweep`] test below is the load-bearing case: it walks the
+//! very lux values where a reciprocal-multiply regression would diverge, across
+//! every gain × integration-time combination, on **both** ALS and WHITE.
+
+use super::declarative_i2c::GenericI2cDevice;
+use super::veml7700::{Veml7700, VEML7700_ADDR};
+use crate::peripherals::i2c::I2cDevice;
+use crate::sim_input::SimInputError;
+
+// VEML7700 register pointers (datasheet).
+const REG_ALS_CONF: u8 = 0x00;
+const REG_ALS_WH: u8 = 0x01;
+const REG_ALS_WL: u8 = 0x02;
+const REG_PSM: u8 = 0x03;
+const REG_ALS: u8 = 0x04;
+const REG_WHITE: u8 = 0x05;
+const REG_ALS_INT: u8 = 0x06;
+
+// ─── device construction ───────────────────────────────────────────────────
+
+/// The hand-written oracle at its default 450 lux / power-on config.
+fn oracle() -> Veml7700 {
+    Veml7700::new_default(VEML7700_ADDR)
+}
+
+/// The declarative device from the embedded descriptor (default address).
+fn declarative() -> GenericI2cDevice {
+    let yaml =
+        labwired_config::embedded_device_yaml("veml7700").expect("veml7700 descriptor is embedded");
+    GenericI2cDevice::from_yaml(yaml, 0).expect("veml7700.yaml is a valid descriptor")
+}
+
+// ─── I²C script helpers (generic over &mut dyn I2cDevice) ───────────────────
+
+/// Write a 16-bit little-endian word to `reg` (pointer, low byte, high byte),
+/// framed by START … STOP exactly as a controller would.
+fn write_reg(d: &mut dyn I2cDevice, reg: u8, word: u16) {
+    d.start();
+    d.write(reg);
+    d.write((word & 0xFF) as u8);
+    d.write((word >> 8) as u8);
+    d.stop();
+}
+
+/// Point at `reg`, repeated-START into the read phase, and read `n` bytes.
+fn read_reg_n(d: &mut dyn I2cDevice, reg: u8, n: usize) -> Vec<u8> {
+    d.start();
+    d.write(reg);
+    d.start(); // repeated START into the read phase
+    (0..n).map(|_| d.read()).collect()
+}
+
+/// Read a register's 2-byte word (the common case).
+fn read_reg(d: &mut dyn I2cDevice, reg: u8) -> Vec<u8> {
+    read_reg_n(d, reg, 2)
+}
+
+/// Drive the `lux` input channel; returns the same Result both devices give.
+fn set_lux(d: &mut dyn I2cDevice, lux: f64) -> Result<(), SimInputError> {
+    d.as_sim_input_mut()
+        .expect("veml7700 exposes a SimInput")
+        .set_input("lux", lux)
+}
+
+/// Assert the oracle and the declarative device return byte-identical reads of
+/// `reg` for the current state. Returns the (shared) bytes for further checks.
+#[track_caller]
+fn assert_reg_equal(o: &mut Veml7700, g: &mut GenericI2cDevice, reg: u8, ctx: &str) -> Vec<u8> {
+    let ob = read_reg(o, reg);
+    let gb = read_reg(g, reg);
+    assert_eq!(
+        ob, gb,
+        "reg 0x{reg:02x} diverged ({ctx}): oracle={ob:02x?} declarative={gb:02x?}"
+    );
+    ob
+}
+
+// The ALS_CONF bit layout: gain in [12:11], integration time in [6:9] (4 bits).
+fn als_conf(gain_field: u16, it_field: u16) -> u16 {
+    ((gain_field & 0x3) << 11) | ((it_field & 0xF) << 6)
+}
+
+/// Every integration-time field the oracle distinguishes, plus a spread of the
+/// reserved encodings (which must both fall through to the 100 ms / ×1 default).
+const IT_FIELDS: &[u16] = &[
+    0x0, 0x1, 0x2, 0x3, 0x8, 0xC, // distinguished: 100/200/400/800/50/25 ms
+    0x4, 0x5, 0x6, 0x7, 0x9, 0xA, 0xB, 0xD, 0xE, 0xF, // reserved → default
+];
+/// All four gain fields (the field is 2 bits, so every value is defined).
+const GAIN_FIELDS: &[u16] = &[0x0, 0x1, 0x2, 0x3];
+
+// ─── power-on defaults ──────────────────────────────────────────────────────
+
+#[test]
+fn power_on_defaults_match_across_every_register() {
+    let mut o = oracle();
+    let mut g = declarative();
+    assert_eq!(o.address(), g.address(), "default address");
+    for reg in [
+        REG_ALS_CONF,
+        REG_ALS_WH,
+        REG_ALS_WL,
+        REG_PSM,
+        REG_ALS,
+        REG_WHITE,
+        REG_ALS_INT,
+    ] {
+        assert_reg_equal(&mut o, &mut g, reg, "power-on");
+    }
+}
+
+#[test]
+fn als_int_reads_zero_and_unknown_register_reads_zero() {
+    let mut o = oracle();
+    let mut g = declarative();
+    assert_eq!(read_reg(&mut o, REG_ALS_INT), vec![0, 0]);
+    assert_eq!(read_reg(&mut g, REG_ALS_INT), vec![0, 0]);
+    // An unmapped pointer reads a zero word on both.
+    assert_reg_equal(&mut o, &mut g, 0x7E, "unknown register");
+}
+
+// ─── rw storage registers round-trip identically ───────────────────────────
+
+#[test]
+fn threshold_and_psm_registers_round_trip_identically() {
+    let mut o = oracle();
+    let mut g = declarative();
+    for (reg, word) in [
+        (REG_ALS_WH, 0xBEEFu16),
+        (REG_ALS_WL, 0x1234),
+        (REG_PSM, 0x0007),
+        (REG_ALS_CONF, 0x1846),
+    ] {
+        write_reg(&mut o, reg, word);
+        write_reg(&mut g, reg, word);
+        let bytes = assert_reg_equal(&mut o, &mut g, reg, "rw round-trip");
+        let read_back = (bytes[0] as u16) | ((bytes[1] as u16) << 8);
+        assert_eq!(read_back, word, "reg 0x{reg:02x} stored its written word");
+    }
+}
+
+// ─── the full gain × IT resolution matrix ───────────────────────────────────
+
+/// For every gain × integration-time combination, drive a spread of lux values
+/// and assert ALS + WHITE read byte-identically. This walks the whole
+/// resolution table, including the reserved IT encodings.
+#[test]
+fn full_gain_it_matrix_matches_on_als_and_white() {
+    // A spread that spans the count range without being a random sweep: small
+    // values, the default, and values large enough to clamp at high gain / long
+    // integration time.
+    let lux_points: &[f64] = &[
+        0.0, 0.01, 0.0288, 0.0576, 1.0, 13.5, 27.0, 40.5, 100.0, 450.0, 1000.0, 12000.0, 60000.0,
+        120000.0,
+    ];
+    for &gain in GAIN_FIELDS {
+        for &it in IT_FIELDS {
+            let conf = als_conf(gain, it);
+            let mut o = oracle();
+            let mut g = declarative();
+            write_reg(&mut o, REG_ALS_CONF, conf);
+            write_reg(&mut g, REG_ALS_CONF, conf);
+            for &lux in lux_points {
+                set_lux(&mut o, lux).unwrap();
+                set_lux(&mut g, lux).unwrap();
+                let ctx = format!("gain={gain:#x} it={it:#x} lux={lux}");
+                assert_reg_equal(&mut o, &mut g, REG_ALS, &ctx);
+                assert_reg_equal(&mut o, &mut g, REG_WHITE, &ctx);
+            }
+        }
+    }
+}
+
+// ─── the load-bearing nice-value tie sweep ──────────────────────────────────
+
+/// The case that exposes a reciprocal-multiply regression. Sweeps a dense grid
+/// of "nice" firmware lux values — the exact family (13.5, 27, 40.5, …) where
+/// the WHITE channel's ×1.15 lands the quotient on an x.5 rounding tie — across
+/// every gain × IT combination, on both ALS and WHITE, and asserts the
+/// declarative device is byte-identical to the divide-based oracle. If the
+/// descriptor ever regresses to multiplying by a `1/resolution` counts-per-lux,
+/// these ties diverge by one LSB and this test fails.
+#[test]
+fn nice_value_tie_sweep() {
+    // 0.0 … 5000.0 in steps of 0.5 — the "nice" decimals firmware actually
+    // reports, dense enough that the ×1.15 WHITE path repeatedly hits x.5 ties.
+    let nice_luxes: Vec<f64> = (0..=10_000).map(|k| k as f64 * 0.5).collect();
+    let mut mismatches = 0usize;
+    for &gain in GAIN_FIELDS {
+        for &it in &[0x0u16, 0x1, 0x2, 0x3, 0x8, 0xC] {
+            let conf = als_conf(gain, it);
+            let mut o = oracle();
+            let mut g = declarative();
+            write_reg(&mut o, REG_ALS_CONF, conf);
+            write_reg(&mut g, REG_ALS_CONF, conf);
+            for &lux in &nice_luxes {
+                set_lux(&mut o, lux).unwrap();
+                set_lux(&mut g, lux).unwrap();
+                for reg in [REG_ALS, REG_WHITE] {
+                    if read_reg(&mut o, reg) != read_reg(&mut g, reg) {
+                        mismatches += 1;
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(
+        mismatches, 0,
+        "declarative VEML7700 diverged from the divide-based oracle on {mismatches} nice-value ties"
+    );
+}
+
+// ─── set_input validation parity ────────────────────────────────────────────
+
+#[test]
+fn set_input_range_rejection_matches() {
+    let mut o = oracle();
+    let mut g = declarative();
+    // Below range and above the 120 000 lx maximum are rejected on both.
+    assert!(set_lux(&mut o, -1.0).is_err());
+    assert!(set_lux(&mut g, -1.0).is_err());
+    assert!(set_lux(&mut o, 120_000.1).is_err());
+    assert!(set_lux(&mut g, 120_000.1).is_err());
+    // The exact bounds are accepted on both.
+    assert!(set_lux(&mut o, 0.0).is_ok());
+    assert!(set_lux(&mut g, 0.0).is_ok());
+    assert!(set_lux(&mut o, 120_000.0).is_ok());
+    assert!(set_lux(&mut g, 120_000.0).is_ok());
+}
+
+#[test]
+fn unknown_input_channel_is_rejected_on_both() {
+    let mut o = oracle();
+    let mut g = declarative();
+    assert!(o
+        .as_sim_input_mut()
+        .unwrap()
+        .set_input("brightness", 10.0)
+        .is_err());
+    assert!(g
+        .as_sim_input_mut()
+        .unwrap()
+        .set_input("brightness", 10.0)
+        .is_err());
+}
+
+// ─── transaction-framing edge cases ─────────────────────────────────────────
+
+#[test]
+fn over_read_past_the_word_yields_ff_on_both() {
+    let mut o = oracle();
+    let mut g = declarative();
+    // A third byte past the 16-bit word reads 0xFF on both.
+    let ob = read_reg_n(&mut o, REG_ALS, 3);
+    let gb = read_reg_n(&mut g, REG_ALS, 3);
+    assert_eq!(ob, gb, "over-read: oracle={ob:02x?} declarative={gb:02x?}");
+    assert_eq!(ob[2], 0xFF, "3rd byte is a not-present marker");
+}
+
+#[test]
+fn incomplete_config_write_does_not_store_on_either() {
+    let mut o = oracle();
+    let mut g = declarative();
+    // First a real config write so a stored value exists to (not) overwrite.
+    write_reg(&mut o, REG_ALS_CONF, 0x0846);
+    write_reg(&mut g, REG_ALS_CONF, 0x0846);
+    // Now a partial write: pointer + a single data byte, no high byte.
+    o.start();
+    o.write(REG_ALS_CONF);
+    o.write(0xFF);
+    o.stop();
+    g.start();
+    g.write(REG_ALS_CONF);
+    g.write(0xFF);
+    g.stop();
+    // Neither device commits the incomplete word.
+    let bytes = assert_reg_equal(&mut o, &mut g, REG_ALS_CONF, "after partial write");
+    assert_eq!(
+        (bytes[0] as u16) | ((bytes[1] as u16) << 8),
+        0x0846,
+        "partial write left the prior value intact"
+    );
+}
+
+#[test]
+fn repeated_reads_are_stable_and_identical() {
+    // Reading the same register many times without re-driving lux returns the
+    // same bytes on both devices (no self-running scene).
+    let mut o = oracle();
+    let mut g = declarative();
+    set_lux(&mut o, 333.0).unwrap();
+    set_lux(&mut g, 333.0).unwrap();
+    let first = read_reg(&mut o, REG_ALS);
+    for _ in 0..16 {
+        assert_eq!(read_reg(&mut o, REG_ALS), first, "oracle stable");
+        assert_eq!(
+            read_reg(&mut g, REG_ALS),
+            first,
+            "declarative matches + stable"
+        );
+    }
+}

--- a/crates/core/src/peripherals/kit/registry.rs
+++ b/crates/core/src/peripherals/kit/registry.rs
@@ -68,14 +68,16 @@ pub static KITS: &[&'static dyn PeripheralKit] = &[
     &components::scd41::SCD41_KIT,
     &components::sgp41::SGP41_KIT,
     &components::sps30::SPS30_KIT,
-    &components::veml7700::VEML7700_KIT,
     &components::mlx90614::MLX90614_KIT,
     &components::max7219::MAX7219_KIT,
     &components::lcd1602::LCD1602_KIT,
     // Declarative I²C devices — model lives entirely in configs/devices/*.yaml,
-    // interpreted by the generic GenericI2cDevice (zero per-part Rust).
+    // interpreted by the generic GenericI2cDevice (zero per-part Rust). VEML7700
+    // was migrated here from a hand-written model; the model survives only as the
+    // byte-parity oracle (components::veml7700, #[cfg(test)]).
     &components::declarative_i2c::SHT31_KIT,
     &components::declarative_i2c::BH1750_KIT,
+    &components::declarative_i2c::VEML7700_KIT,
 ];
 
 /// Borrow the registry slice.

--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -1481,43 +1481,6 @@
       ]
     },
     {
-      "device_type": "veml7700",
-      "label": "Vishay VEML7700 Light",
-      "summary": "Ambient-light sensor (lux) over I2C.",
-      "detail": "Vishay VEML7700 at fixed address 0x10, a register-pointer device with 16-bit little-endian words. Reports a raw ALS count the firmware scales to lux at the default gain ×1 / 100 ms resolution (0.0576 lux/count). The illuminance is an externally driven input (channel lux); config only seeds its initial value.",
-      "transport": "i2c",
-      "category": "i2c",
-      "config_keys": [
-        {
-          "name": "i2c_address",
-          "ty": "int",
-          "doc": "7-bit slave address. Defaults to the VEML7700 fixed address 0x10."
-        },
-        {
-          "name": "lux",
-          "ty": "float",
-          "doc": "Initial illuminance, lux. Default 450 (daylit room). Drive it at runtime with the `lux` input channel."
-        }
-      ],
-      "labs": [
-        {
-          "board_id": "esp32c3-leo-airquality",
-          "chip": "esp32c3",
-          "example_dir": "esp32c3-leo-airquality",
-          "demo_elf": "demo-esp32c3-leo-airquality.elf"
-        }
-      ],
-      "inputs": [
-        {
-          "key": "lux",
-          "label": "Illuminance",
-          "unit": "lx",
-          "min": 0.0,
-          "max": 120000.0
-        }
-      ]
-    },
-    {
       "device_type": "mlx90614",
       "label": "Melexis MLX90614 IR Temp",
       "summary": "Single-point IR (non-contact) thermometer over SMBus/I2C.",
@@ -1654,6 +1617,43 @@
           "unit": "lx",
           "min": 0.0,
           "max": 65535.0
+        }
+      ]
+    },
+    {
+      "device_type": "veml7700",
+      "label": "Vishay VEML7700 Light",
+      "summary": "Ambient-light sensor (lux) over I2C.",
+      "detail": "Vishay VEML7700 at fixed address 0x10, a register-pointer device with 16-bit little-endian words. Reports a raw ALS count the firmware scales to lux at the default gain ×1 / 100 ms resolution (0.0576 lux/count). The illuminance is an externally driven input (channel lux); config only seeds its initial value.",
+      "transport": "i2c",
+      "category": "i2c",
+      "config_keys": [
+        {
+          "name": "i2c_address",
+          "ty": "int",
+          "doc": "7-bit slave address. Defaults to the VEML7700 fixed address 0x10."
+        },
+        {
+          "name": "lux",
+          "ty": "float",
+          "doc": "Initial illuminance, lux. Default 450 (daylit room). Drive it at runtime with the `lux` input channel."
+        }
+      ],
+      "labs": [
+        {
+          "board_id": "esp32c3-leo-airquality",
+          "chip": "esp32c3",
+          "example_dir": "esp32c3-leo-airquality",
+          "demo_elf": "demo-esp32c3-leo-airquality.elf"
+        }
+      ],
+      "inputs": [
+        {
+          "key": "lux",
+          "label": "Illuminance",
+          "unit": "lx",
+          "min": 0.0,
+          "max": 120000.0
         }
       ]
     }


### PR DESCRIPTION
## What

Migrates the Vishay **VEML7700** ambient-light sensor from a hand-written Rust model to a **declarative descriptor** (`configs/devices/veml7700.yaml`) driven by `GenericI2cDevice`. The register-pointer wire protocol, the gain × integration-time resolution table, and the manifest metadata now live entirely in YAML — zero per-part Rust. The registry points at `declarative_i2c::VEML7700_KIT`.

## Why divide, not multiply-by-reciprocal (the load-bearing detail)

The oracle converts illuminance by **dividing**: `count = round(lux / resolution)`, `resolution = 0.0576 × (100/IT) / gain`. Expressing that declaratively as a multiply by a `1/resolution` counts-per-lux is **not** byte-faithful: on the "nice" firmware values (13.5, 27, 40.5 … lux) the white channel's ×1.15 lands the quotient on an exact x.5 rounding tie where `round(x/r)` and `round(x·(1/r))` disagree by one LSB. A random-float sweep never surfaces it; real firmware hits it constantly.

So the config schema gains a `resolution` divide mode, a `source_scale` pre-multiply (the 1.15 white responsivity ratio), and a one-or-many `scale_from` list. Because the IT ratio (100/IT ∈ {1, .5, .25, .125, 2, 4}) and inverse-gain (1/gain ∈ {1, .5, 8, 4}) are all exact powers of two in f64, folding `0.0576 × IT_factor × gain_factor` reproduces the oracle's float op-tree **bit-for-bit**.

## Parity oracle

The hand-written model is retained `#[cfg(test)]` solely as the byte-parity oracle. `veml7700_parity.rs` drives the old and new devices through identical I²C scripts and asserts byte-equal reads:

- power-on defaults across every register
- rw threshold / PSM / ALS_CONF round-trips
- the **full gain × IT matrix**, including reserved IT encodings
- a **dense nice-value tie sweep** on both ALS and WHITE (the case that catches a reciprocal-multiply regression)
- `set_input` range rejection + unknown-channel rejection
- transaction-framing edges (over-read → 0xFF, incomplete write → no store, repeated-read stability)

All 0 mismatches.

## Manifest

`DeviceMetadata` gains `detail` / `config_keys` / `labs` so the descriptor reproduces the kit's manifest entry verbatim. The vendored `crates/core/tests/fixtures/peripherals/manifest.json` `veml7700` object is **byte-identical** — the only diff is its array position moving into the declarative group with the registry reorder (`manifest_json_matches_registry` gate passes).

## Testing

- `cargo test -p labwired-config` — green
- `cargo test -p labwired-core` — all VEML7700 + manifest-gate + 2301 lib unit + 70 integration binaries green. Two failures (`strict_onboarding` nrf54l15 gap, `xtensa_exec` MOVSP tests) are **pre-existing on the base branch** — verified identical with my changes stashed; both are in subsystems this PR does not touch (board onboarding, Xtensa CPU).
- `cargo fmt` + `cargo clippy` clean.