### PR TITLE
fix(i2c): fleet L3 digital twin — AHB/S3 attach, L4 TXIS, F1 TRA, RP IRQ

### DIFF
--- a/configs/chips/rp2040.yaml
+++ b/configs/chips/rp2040.yaml
@@ -96,6 +96,10 @@ peripherals:
     type: "rp2040_i2c"
     base_address: 0x40044000
     size: "4KB"
+    # RP2040 datasheet §2.3.2 — I2C0_IRQ = 23 (NVIC). Zephyr i2c_dw is
+    # interrupt-driven (TX_EMPTY / STOP_DET → device_sync_sem); without this
+    # the transfer times out with -EAGAIN.
+    irq: 23
   # Cortex-M0+ SysTick (SCS). Behavioural model: the ARMv7-M SysTick timer
   # (edge-triggered — raises system exception 15 only on the count-down to
   # zero, and only while ENABLE+TICKINT are set). The Arduino Mbed-OS core

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -427,6 +427,23 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                         ..Esp32s3Opts::default()
                     };
                     let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
+                    // Wire matrix kits (INA219, OLED, …) the same way classic ESP32 does.
+                    if let Err(e) = labwired_core::system::xtensa::attach_esp32_external_devices(
+                        &mut bus, manifest,
+                    ) {
+                        let msg = format!("ESP32-S3 external_devices attach: {e:#}");
+                        error!("{}", msg);
+                        write_config_error_outputs(
+                            &args,
+                            Some(&firmware_path),
+                            system_path.as_ref(),
+                            Some(&firmware_bytes),
+                            Some(&resolved_limits),
+                            msg,
+                        );
+                        return ExitCode::from(EXIT_CONFIG_ERROR);
+                    }
+                    bus.refresh_peripheral_index();
                     if wiring.boot_mode != Esp32s3BootMode::Faithful {
                         let msg =
                             "--rom-boot needs the real ESP32-S3 boot ROM, but none was found. \
@@ -467,6 +484,25 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     if _fast.is_none() {
                         std::env::remove_var("LABWIRED_ESP32S3_FASTBOOT");
                     }
+                    // Matrix L3 kits live in system.yaml external_devices — attach
+                    // after the SoC bank is registered (classic path does this in
+                    // build_esp32_system_from_manifest; S3 must do it here too).
+                    if let Err(e) = labwired_core::system::xtensa::attach_esp32_external_devices(
+                        &mut bus, manifest,
+                    ) {
+                        let msg = format!("ESP32-S3 external_devices attach: {e:#}");
+                        error!("{}", msg);
+                        write_config_error_outputs(
+                            &args,
+                            Some(&firmware_path),
+                            system_path.as_ref(),
+                            Some(&firmware_bytes),
+                            Some(&resolved_limits),
+                            msg,
+                        );
+                        return ExitCode::from(EXIT_CONFIG_ERROR);
+                    }
+                    bus.refresh_peripheral_index();
                     // Seed partition table + app image magic into D-cache
                     // identity window (VA 0x3C00_0000 → dcache[off]).
                     {

--- a/crates/core/src/peripherals/esp32/i2c.rs
+++ b/crates/core/src/peripherals/esp32/i2c.rs
@@ -110,7 +110,8 @@ pub struct Esp32I2c {
     int_ena: u32,
     fifo_conf: u32,
     cmds: [u32; NUM_CMDS],
-    tx_fifo: std::collections::VecDeque<u8>,
+    /// Shared with the AHB FIFO alias at `0x6001_301c` (esp-idf writes TX here).
+    tx_fifo: std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<u8>>>,
     /// TX-FIFO read pointer (bytes consumed by the current command-list run).
     /// Surfaced as FIFO_ST.TXFIFO_START_ADDR; 0 at cold reset.
     tx_pop_count: usize,
@@ -120,6 +121,18 @@ pub struct Esp32I2c {
     intr_source_id: u32,
     /// Round-trip backing for timing / config registers the engine ignores.
     other: BTreeMap<u64, u32>,
+}
+
+/// AHB-bus TX FIFO alias (`I2C0` at `0x6001_301c`). esp-idf `i2c_ll_write_txfifo`
+/// writes here instead of the APB DATA register at `0x3FF5_301c`.
+pub struct Esp32I2cAhbFifo {
+    tx_fifo: std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<u8>>>,
+}
+
+impl std::fmt::Debug for Esp32I2cAhbFifo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Esp32I2cAhbFifo")
+    }
 }
 
 impl Esp32I2c {
@@ -132,7 +145,9 @@ impl Esp32I2c {
             int_ena: 0,
             fifo_conf: 0,
             cmds: [0; NUM_CMDS],
-            tx_fifo: std::collections::VecDeque::with_capacity(FIFO_CAPACITY),
+            tx_fifo: std::sync::Arc::new(std::sync::Mutex::new(
+                std::collections::VecDeque::with_capacity(FIFO_CAPACITY),
+            )),
             tx_pop_count: 0,
             rx_fifo: RefCell::new(std::collections::VecDeque::with_capacity(FIFO_CAPACITY)),
             slaves: Vec::new(),
@@ -147,6 +162,13 @@ impl Esp32I2c {
         Self {
             intr_source_id,
             ..Self::new()
+        }
+    }
+
+    /// AHB FIFO window paired with this APB I2C (same TX FIFO).
+    pub fn ahb_tx_fifo_alias(&self) -> Esp32I2cAhbFifo {
+        Esp32I2cAhbFifo {
+            tx_fifo: std::sync::Arc::clone(&self.tx_fifo),
         }
     }
 
@@ -168,7 +190,7 @@ impl Esp32I2c {
     fn status_register(&self) -> u32 {
         // SR: bit 0 ACK_REC, RXFIFO_CNT at bits 13..8, TXFIFO_CNT at bits 23..18.
         let rx = (self.rx_fifo.borrow().len() as u32) & 0x3F;
-        let tx = (self.tx_fifo.len() as u32) & 0x3F;
+        let tx = (self.tx_fifo.lock().unwrap().len() as u32) & 0x3F;
         (self.sr & SR_ACK_REC) | (rx << 8) | (tx << 18)
     }
 
@@ -202,6 +224,25 @@ impl std::fmt::Debug for Esp32I2c {
             .field("int_ena", &self.int_ena)
             .field("slaves_count", &self.slaves.len())
             .finish()
+    }
+}
+
+impl Peripheral for Esp32I2cAhbFifo {
+    fn read(&self, _offset: u64) -> SimResult<u8> {
+        Ok(0)
+    }
+    fn write(&mut self, _offset: u64, value: u8) -> SimResult<()> {
+        let mut tx = self.tx_fifo.lock().unwrap();
+        if tx.len() < FIFO_CAPACITY {
+            tx.push_back(value);
+        }
+        Ok(())
+    }
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        self.write(offset, (value & 0xFF) as u8)
+    }
+    fn read_u32(&self, _offset: u64) -> SimResult<u32> {
+        Ok(0)
     }
 }
 
@@ -255,10 +296,12 @@ impl Peripheral for Esp32I2c {
                 }
             }
             REG_SLAVE_ADDR => self.slave_addr = value,
-            REG_DATA if self.tx_fifo.len() < FIFO_CAPACITY => {
-                self.tx_fifo.push_back((value & 0xFF) as u8);
+            REG_DATA => {
+                let mut tx = self.tx_fifo.lock().unwrap();
+                if tx.len() < FIFO_CAPACITY {
+                    tx.push_back((value & 0xFF) as u8);
+                }
             }
-            REG_DATA => {}
             REG_FIFO_CONF => {
                 self.fifo_conf = value;
                 // Bit 12 = RX_FIFO_RST; bit 13 = TX_FIFO_RST. Self-clearing.
@@ -266,7 +309,7 @@ impl Peripheral for Esp32I2c {
                     self.rx_fifo.borrow_mut().clear();
                 }
                 if value & (1 << 13) != 0 {
-                    self.tx_fifo.clear();
+                    self.tx_fifo.lock().unwrap().clear();
                     self.tx_pop_count = 0;
                 }
                 self.fifo_conf &= !((1 << 12) | (1 << 13));
@@ -376,7 +419,7 @@ impl Esp32I2c {
                         expects_addr = false;
                     }
                     for i in 0..byte_num {
-                        let b = self.tx_fifo.pop_front().unwrap_or(0);
+                        let b = self.tx_fifo.lock().unwrap().pop_front().unwrap_or(0);
                         self.tx_pop_count += 1;
                         if expects_addr && i == 0 {
                             // First byte of a WRITE following RSTART is addr+R/W.

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -204,6 +204,8 @@ impl F1I2c {
             || (self.sr2 & 0x0002) != 0 // BUSY: master transfer in flight
             || self.rxne_consumed.get()
             || self.stop_requested
+            // Level EV must keep walking while ITEVTEN/ITBUFEN flags are live.
+            || self.irq_level()
     }
 
     /// SR1 with ADDR masked once the SR1→SR2 clear sequence has completed.
@@ -214,6 +216,28 @@ impl F1I2c {
             s &= !0x0002;
         }
         s
+    }
+
+    /// Level-sensitive I2C event IRQ (RM0008 §26.5 / NVIC): the EV line stays
+    /// asserted while any enabled status flag is set. One-shot pulse-on-transition
+    /// is not silicon — HAL_I2C_EV_IRQHandler chains SB → ADDR → TXE → BTF across
+    /// re-entries, and each entry requires the line still high after the previous
+    /// flag is cleared.
+    ///
+    /// ITEVTEN (CR2.9): SB, ADDR, ADD10, STOPF, BTF.
+    /// ITBUFEN (CR2.10): TXE, RXNE (used with ITEVTEN by HAL Master_Transmit_IT).
+    #[inline]
+    fn irq_level(&self) -> bool {
+        let itevt = (self.cr2 & (1 << 9)) != 0;
+        let itbuf = (self.cr2 & (1 << 10)) != 0;
+        if !itevt && !itbuf {
+            return false;
+        }
+        let sr1 = self.effective_sr1();
+        // SB=0, ADDR=1, BTF=2, STOPF=4 (ADD10=3 rare — leave in 0x1F with EVT).
+        let evt_flags = sr1 & 0x001F;
+        let buf_flags = sr1 & 0x00C0; // TXE=7, RXNE=6
+        (itevt && evt_flags != 0) || (itbuf && buf_flags != 0)
     }
 
     fn read_reg(&self, offset: u64) -> u32 {
@@ -268,7 +292,12 @@ impl F1I2c {
                         self.stop_requested = true;
                     } else {
                         self.cr1 &= !0x0200;
-                        self.sr2 &= !0x0003;
+                        // STOP clears master/busy/TRA (RM0008 SR2).
+                        self.sr2 &= !0x0007;
+                        // Drop bus-event flags so the level EV line deasserts.
+                        self.sr1 &= !0x00C7; // TXE|RXNE|BTF|ADDR|SB
+                        self.addr_cleared.set(false);
+                        self.addr_sr1_seen.set(false);
                         if let Some(idx) = self.current_target {
                             self.attached_devices[idx].borrow_mut().stop();
                         }
@@ -285,9 +314,10 @@ impl F1I2c {
             0x10 => {
                 self.dr = (value & 0xFF) as u32;
                 if self.state == I2cState::Idle {
-                    if (self.sr1 & 0x01) != 0 {
+                    // SB uses effective SR1 (ADDR-clear overlay does not mask SB).
+                    if (self.effective_sr1() & 0x01) != 0 {
                         self.state = I2cState::AddressPending;
-                        // Instant ADDR/TXE (same rationale as START/SB).
+                        // Instant ADDR/TXE: one I2C bit-time ≪ ISR/poll interval.
                         self.cycles_remaining = 0;
                         let addr = (self.dr >> 1) as u8;
                         self.is_reading = (self.dr & 1) != 0;
@@ -299,7 +329,8 @@ impl F1I2c {
                             self.attached_devices[idx].borrow_mut().start();
                         }
                         let _ = self.tick();
-                    } else {
+                    } else if (self.effective_sr1() & 0x80) != 0 || (self.sr2 & 0x0001) != 0 {
+                        // Data byte while master (TXE or MSL): shift out, clear TXE/BTF.
                         self.state = I2cState::DataPending;
                         self.cycles_remaining = 0;
                         self.sr1 &= !0x80;
@@ -397,23 +428,37 @@ impl F1I2c {
                             self.sr1 |= 0x0400; // AF
                             self.sr2 |= 0x0001; // MSL
                             self.sr2 |= 0x0002; // BUSY
+                            // TRA follows R/W of the address byte (write → TRA=1).
+                            if !self.is_reading {
+                                self.sr2 |= 0x0004; // TRA
+                            } else {
+                                self.sr2 &= !0x0004;
+                            }
                             self.state = I2cState::Idle;
                             if (self.cr2 & (1 << 8)) != 0 {
                                 irq = true; // ITERR
                             }
-                            return irq;
+                            return irq || self.irq_level();
                         }
 
                         self.sr1 |= 0x0002; // ADDR
                         self.sr2 |= 0x0001; // MSL
                         self.sr2 |= 0x0002; // BUSY
+                        // SR2.TRA (bit2): set in master transmitter after address
+                        // ACK with R/W=0. HAL_I2C_EV_IRQHandler gates the TXE/BTF
+                        // path on TRA — without it the ISR never writes data.
+                        if self.is_reading {
+                            self.sr2 &= !0x0004;
+                        } else {
+                            self.sr2 |= 0x0004;
+                        }
                         // Fresh ADDR — cancel any prior software clear.
                         self.addr_cleared.set(false);
                         self.addr_sr1_seen.set(false);
 
                         if self.is_reading {
                             self.state = I2cState::DataPending;
-                            self.cycles_remaining = 20;
+                            self.cycles_remaining = 0;
                         } else {
                             self.sr1 |= 0x0080; // TXE
                             self.state = I2cState::Idle;
@@ -435,7 +480,10 @@ impl F1I2c {
                         if self.stop_requested {
                             self.stop_requested = false;
                             self.cr1 &= !0x0200;
-                            self.sr2 &= !0x0003;
+                            self.sr2 &= !0x0007; // MSL|BUSY|TRA
+                            self.sr1 &= !0x00C7;
+                            self.addr_cleared.set(false);
+                            self.addr_sr1_seen.set(false);
                             if let Some(idx) = self.current_target {
                                 self.attached_devices[idx].borrow_mut().stop();
                             }
@@ -445,13 +493,14 @@ impl F1I2c {
                     I2cState::Idle => {}
                 }
 
-                if (self.cr2 & (1 << 9)) != 0 || (self.cr2 & (1 << 10)) != 0 {
-                    irq = true; // ITEVTEN or ITBUFEN
+                if self.irq_level() {
+                    irq = true;
                 }
             }
         }
 
-        irq
+        // Level re-assert every tick while enabled flags remain (see irq_level).
+        irq || self.irq_level()
     }
 }
 
@@ -1605,6 +1654,13 @@ mod tests {
         assert_eq!(i2c.peek(0x14).unwrap() & 0x01, 0); // SB cleared
         assert_ne!(i2c.peek(0x14).unwrap() & 0x02, 0); // ADDR
         assert_ne!(i2c.peek(0x18).unwrap() & 0x01, 0); // MSL
+        // TRA (SR2 bit2) must rise on write-address ACK — HAL EV IRQ gates
+        // the TXE/BTF path on TRA (RM0008 §26.6.7).
+        assert_ne!(
+            i2c.peek(0x18).unwrap() & 0x04,
+            0,
+            "TRA set after write-address ACK"
+        );
 
         i2c.write(0x10, 0x42).unwrap();
         for _ in 0..20 {
@@ -1618,10 +1674,49 @@ mod tests {
             i2c.tick();
         }
         assert_eq!(
-            i2c.peek(0x18).unwrap() & 0x03,
+            i2c.peek(0x18).unwrap() & 0x07,
             0,
-            "STOP must clear MSL+BUSY"
+            "STOP must clear MSL+BUSY+TRA"
         );
+    }
+
+    #[test]
+    fn f1_write_address_sets_tra_and_level_ev_stays_asserted() {
+        use crate::Peripheral;
+        struct Ack {
+            address: u8,
+        }
+        impl I2cDevice for Ack {
+            fn address(&self) -> u8 {
+                self.address
+            }
+            fn read(&mut self) -> u8 {
+                0
+            }
+            fn write(&mut self, _: u8) {}
+        }
+        let mut i2c = I2c::new_with_layout(super::I2cRegisterLayout::Stm32F1);
+        i2c.push_slave(Box::new(Ack { address: 0x40 }));
+        // Enable ITEVTEN|ITBUFEN like HAL_I2C_Master_Transmit_IT.
+        i2c.write_u32(0x04, (1 << 9) | (1 << 10)).unwrap();
+        i2c.write(0x01, 0x01).unwrap(); // START → SB
+        assert!(i2c.tick().irq, "SB with ITEVTEN asserts EV");
+        i2c.write(0x10, 0x80).unwrap(); // 0x40 write
+        // After address ACK: ADDR+TXE+TRA; level EV stays high across ticks.
+        assert_ne!(i2c.peek(0x18).unwrap() & 0x04, 0, "TRA");
+        assert_ne!(i2c.peek(0x14).unwrap() & 0x80, 0, "TXE");
+        assert!(i2c.tick().irq, "level EV while TXE+ITBUFEN");
+        assert!(i2c.tick().irq, "level EV re-assert next tick");
+        // Clear ADDR via SR1 then SR2 (silicon sequence).
+        let _ = i2c.read_u32(0x14).unwrap();
+        let _ = i2c.read_u32(0x18).unwrap();
+        assert_eq!(
+            i2c.peek(0x14).unwrap() & 0x02,
+            0,
+            "ADDR cleared by SR1→SR2"
+        );
+        // TXE still live → EV still asserted for MasterTransmit_TXE.
+        assert!(i2c.tick().irq, "TXE keeps EV high after ADDR clear");
     }
 
     #[test]

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -127,6 +127,14 @@ pub struct F1I2c {
     rxne_consumed: Cell<bool>,
     #[serde(skip)]
     read_dr_consumed: Cell<bool>,
+    /// ADDR (SR1 bit1) software-clear sequence: set after SR1 is read while
+    /// ADDR is set; consumed on the following SR2 read (RM0008 §26.6.6 —
+    /// "ADDR is cleared by reading SR1 then SR2"). Held in a Cell so the
+    /// clear can happen on a pure `&self` read path.
+    #[serde(skip)]
+    addr_sr1_seen: Cell<bool>,
+    #[serde(skip)]
+    addr_cleared: Cell<bool>,
 
     /// Bus-published cycle clock (walk-free campaign). `Some` once the bus
     /// registration choke attaches it; `None` keeps the model on the legacy
@@ -165,6 +173,8 @@ impl Default for F1I2c {
             stop_requested: false,
             rxne_consumed: Cell::new(false),
             read_dr_consumed: Cell::new(true),
+            addr_sr1_seen: Cell::new(false),
+            addr_cleared: Cell::new(false),
             clock: None,
             chain_live: false,
         }
@@ -196,6 +206,16 @@ impl F1I2c {
             || self.stop_requested
     }
 
+    /// SR1 with ADDR masked once the SR1→SR2 clear sequence has completed.
+    #[inline]
+    fn effective_sr1(&self) -> u32 {
+        let mut s = self.sr1;
+        if self.addr_cleared.get() {
+            s &= !0x0002;
+        }
+        s
+    }
+
     fn read_reg(&self, offset: u64) -> u32 {
         match offset {
             0x00 => self.cr1,
@@ -203,8 +223,21 @@ impl F1I2c {
             0x08 => self.oar1,
             0x0C => self.oar2,
             0x10 => self.dr,
-            0x14 => self.sr1,
-            0x18 => self.sr2,
+            0x14 => {
+                let s = self.effective_sr1();
+                // Start of ADDR-clear sequence (RM0008 §26.6.6).
+                if (s & 0x0002) != 0 {
+                    self.addr_sr1_seen.set(true);
+                }
+                s
+            }
+            0x18 => {
+                // Completing ADDR clear: SR1 was read with ADDR set, now SR2.
+                if self.addr_sr1_seen.replace(false) {
+                    self.addr_cleared.set(true);
+                }
+                self.sr2
+            }
             0x1C => self.ccr,
             0x20 => self.trise,
             _ => 0,
@@ -374,6 +407,9 @@ impl F1I2c {
                         self.sr1 |= 0x0002; // ADDR
                         self.sr2 |= 0x0001; // MSL
                         self.sr2 |= 0x0002; // BUSY
+                        // Fresh ADDR — cancel any prior software clear.
+                        self.addr_cleared.set(false);
+                        self.addr_sr1_seen.set(false);
 
                         if self.is_reading {
                             self.state = I2cState::DataPending;
@@ -503,12 +539,33 @@ impl L4I2c {
     }
 
     /// Cycles on which the legacy `tick()` does observable work: an in-flight
-    /// countdown or the BUSY master-transfer window. The L4 read path is pure
-    /// (no `&self` side effects), so the write-armed countdown plus BUSY fully
-    /// bound the engine. Outside this window `tick()` returns immediately.
+    /// countdown, the BUSY master-transfer window, or a live enabled IRQ flag
+    /// (TXIS/TC/STOPF/NACKF) that Master_Transmit_IT still needs delivered.
     #[inline]
     fn active(&self) -> bool {
-        self.state != I2cState::Idle || (self.isr & (1 << 15)) != 0
+        if self.state != I2cState::Idle || (self.isr & (1 << 15)) != 0 {
+            return true;
+        }
+        // Level IRQ bits that can still need a walk tick after the engine idles.
+        let pending = self.isr
+            & (((self.cr1 & (1 << 1)) != 0) as u32 * (1 << 1) // TXIE→TXIS
+                | ((self.cr1 & (1 << 2)) != 0) as u32 * (1 << 2) // RXIE→RXNE
+                | ((self.cr1 & (1 << 4)) != 0) as u32 * (1 << 4) // NACKIE
+                | ((self.cr1 & (1 << 5)) != 0) as u32 * (1 << 5) // STOPIE
+                | ((self.cr1 & (1 << 6)) != 0) as u32 * (1 << 6)); // TCIE
+        pending != 0
+    }
+
+    /// Level-triggered EV IRQ: any enabled status flag still latched.
+    #[inline]
+    fn irq_level(&self) -> bool {
+        let cr1 = self.cr1;
+        let isr = self.isr;
+        ((cr1 & (1 << 1)) != 0 && (isr & (1 << 1)) != 0) // TXIE & TXIS
+            || ((cr1 & (1 << 2)) != 0 && (isr & (1 << 2)) != 0) // RXIE & RXNE
+            || ((cr1 & (1 << 4)) != 0 && (isr & (1 << 4)) != 0) // NACKIE & NACKF
+            || ((cr1 & (1 << 5)) != 0 && (isr & (1 << 5)) != 0) // STOPIE & STOPF
+            || ((cr1 & (1 << 6)) != 0 && (isr & (1 << 6)) != 0) // TCIE & TC
     }
 
     fn read_reg(&self, offset: u64) -> u32 {
@@ -532,7 +589,11 @@ impl L4I2c {
         match offset {
             0x00 => self.cr1 = value & 0x00FF_E1FF,
             0x04 => {
-                self.cr2 = value;
+                // START (bit13) and STOP (bit14) are write-triggers that
+                // self-clear in silicon. Storing them latched makes every
+                // subsequent RMW (Zephyr LL_I2C_SetTransferSize etc.) re-fire
+                // START and abort the transfer with a spurious NACK/EIO.
+                self.cr2 = value & !((1 << 13) | (1 << 14));
                 if (value & (1 << 13)) != 0 {
                     // START: latch BUSY and arm a master transfer. Capture the
                     // addressed slave (SADD[7:1] in 7-bit mode), direction
@@ -552,19 +613,20 @@ impl L4I2c {
                         if let Some(idx) = self.current_target {
                             self.attached_devices[idx].borrow_mut().start();
                         }
-                        self.start_armed = true;
-                        // Read / NBYTES=0+AUTOEND (IsDeviceReady): start now.
-                        if self.is_reading || (self.nbytes == 0 && self.autoend) {
-                            self.state = I2cState::AddressPending;
-                            self.cycles_remaining = 0;
-                            self.start_armed = false;
-                            let _ = self.tick();
-                        }
+                        // Always run the address phase immediately. On a write
+                        // with NBYTES>0 the engine then asserts TXIS and waits
+                        // in DataPending for TXDR (matches L4 silicon + HAL
+                        // Master_Transmit_IT). Read / NBYTES=0 complete in tick.
+                        self.start_armed = false;
+                        self.state = I2cState::AddressPending;
+                        self.cycles_remaining = 0;
+                        let _ = self.tick();
                     }
                 }
                 if (value & (1 << 14)) != 0 {
-                    // STOP: release the bus and tear down any armed/in-flight
-                    // transfer.
+                    // STOP (software, AUTOEND=0 path — Zephyr stm32 v2 poll):
+                    // silicon sets STOPF and clears BUSY when the stop is done.
+                    self.isr |= 1 << 5; // STOPF
                     self.isr &= !(1 << 15); // clear BUSY
                     if let Some(idx) = self.current_target {
                         self.attached_devices[idx].borrow_mut().stop();
@@ -594,9 +656,35 @@ impl L4I2c {
             0x28 => {
                 self.txdr = value & 0xFF;
                 self.isr &= !0x0000_0003; // writing TXDR clears TXE+TXIS
-                                          // Loading the first byte while a write transfer is armed starts
-                                          // the address phase. Instant complete — Wire poll path.
-                if self.start_armed && self.state == I2cState::Idle {
+                // After address ACK the engine waits in DataPending with TXIS
+                // set; firmware (HAL IT / poll) writes TXDR here.
+                if self.state == I2cState::DataPending {
+                    self.first_tx_loaded = true;
+                    if let Some(idx) = self.current_target {
+                        self.attached_devices[idx]
+                            .borrow_mut()
+                            .write(self.txdr as u8);
+                    }
+                    self.isr |= 1 << 0; // TXE
+                    self.isr |= 1 << 6; // TC
+                    if self.autoend {
+                        self.isr |= 1 << 5; // STOPF
+                        self.isr &= !(1 << 15); // BUSY
+                        if let Some(i) = self.current_target {
+                            self.attached_devices[i].borrow_mut().stop();
+                        }
+                        self.current_target = None;
+                    }
+                    self.state = I2cState::Idle;
+                    self.nbytes = 0;
+                    self.first_tx_loaded = false;
+                    self.start_armed = false;
+                    // Completion IRQ for Master_Transmit_IT (TCIE/STOPIE).
+                    // Note: write_reg cannot return irq; the next tick()
+                    // re-checks level flags below. Also pulse via active BUSY
+                    // window so the walk doesn't skip us before ISR runs.
+                } else if self.start_armed && self.state == I2cState::Idle {
+                    // Legacy test path: TXDR before address phase completes.
                     self.state = I2cState::AddressPending;
                     self.cycles_remaining = 0;
                     self.start_armed = false;
@@ -642,11 +730,12 @@ impl L4I2c {
     fn tick(&mut self) -> bool {
         let mut irq = false;
         if self.state == I2cState::Idle {
-            return irq;
+            // Still re-assert level IRQs while flags are latched (IT completion).
+            return self.irq_level();
         }
         self.cycles_remaining = self.cycles_remaining.saturating_sub(1);
         if self.cycles_remaining != 0 {
-            return irq;
+            return self.irq_level();
         }
         if self.state == I2cState::AddressPending {
             match self.current_target {
@@ -663,41 +752,85 @@ impl L4I2c {
                     if (self.cr1 & (1 << 4)) != 0 {
                         irq = true; // NACKIE
                     }
+                    if (self.cr1 & (1 << 5)) != 0 && (self.isr & (1 << 5)) != 0 {
+                        irq = true; // STOPIE
+                    }
+                    self.state = I2cState::Idle;
+                    self.nbytes = 0;
+                    self.first_tx_loaded = false;
                 }
                 Some(idx) => {
-                    // Slave ACKed. Deliver data only when NBYTES>0 and a TXDR
-                    // byte was loaded (write) or fetch one (read). Address-only
-                    // probes (NBYTES=0) complete with TC without data path.
+                    // Slave ACKed.
                     if self.is_reading && self.nbytes > 0 {
                         self.rxdr = self.attached_devices[idx].borrow_mut().read() as u32;
                         self.isr |= 1 << 2; // RXNE
+                        self.isr |= 1 << 6; // TC
+                        if self.autoend {
+                            self.isr |= 1 << 5; // STOPF
+                            self.isr &= !(1 << 15);
+                            self.attached_devices[idx].borrow_mut().stop();
+                            self.current_target = None;
+                        }
+                        if (self.cr1 & (1 << 6)) != 0 {
+                            irq = true; // TCIE
+                        }
+                        if (self.cr1 & (1 << 2)) != 0 {
+                            irq = true; // RXIE
+                        }
+                        self.state = I2cState::Idle;
+                        self.nbytes = 0;
+                        self.first_tx_loaded = false;
                     } else if !self.is_reading && self.nbytes > 0 && self.first_tx_loaded {
+                        // TXDR already loaded (legacy unit-test ordering).
                         self.attached_devices[idx]
                             .borrow_mut()
                             .write(self.txdr as u8);
                         self.isr |= 1 << 0; // TXE
-                    } else {
-                        self.isr |= 1 << 0; // TXE free after address-only
-                    }
-                    self.isr |= 1 << 6; // TC (NBYTES transferred)
-                    if self.autoend {
-                        self.isr |= 1 << 5; // STOPF
-                        self.isr &= !(1 << 15); // BUSY released
-                        if let Some(i) = self.current_target {
-                            self.attached_devices[i].borrow_mut().stop();
+                        self.isr |= 1 << 6; // TC
+                        if self.autoend {
+                            self.isr |= 1 << 5; // STOPF
+                            self.isr &= !(1 << 15);
+                            self.attached_devices[idx].borrow_mut().stop();
+                            self.current_target = None;
                         }
-                        self.current_target = None;
-                    }
-                    if (self.cr1 & (1 << 6)) != 0 {
-                        irq = true; // TCIE
+                        if (self.cr1 & (1 << 6)) != 0 {
+                            irq = true; // TCIE
+                        }
+                        self.state = I2cState::Idle;
+                        self.nbytes = 0;
+                        self.first_tx_loaded = false;
+                    } else if !self.is_reading && self.nbytes > 0 {
+                        // Silicon order: address ACKed → TXIS requests first
+                        // data byte. Stay in DataPending until TXDR is written
+                        // (Arduino/Zephyr Master_Transmit_IT path).
+                        self.isr |= 1 << 1; // TXIS
+                        self.isr |= 1 << 0; // TXE
+                        self.state = I2cState::DataPending;
+                        if (self.cr1 & (1 << 1)) != 0 {
+                            irq = true; // TXIE
+                        }
+                        // Keep nbytes / current_target / BUSY for the data phase.
+                    } else {
+                        // Address-only (NBYTES=0): TC without data path.
+                        self.isr |= 1 << 0; // TXE
+                        self.isr |= 1 << 6; // TC
+                        if self.autoend {
+                            self.isr |= 1 << 5; // STOPF
+                            self.isr &= !(1 << 15);
+                            self.attached_devices[idx].borrow_mut().stop();
+                            self.current_target = None;
+                        }
+                        if (self.cr1 & (1 << 6)) != 0 {
+                            irq = true; // TCIE
+                        }
+                        self.state = I2cState::Idle;
+                        self.nbytes = 0;
+                        self.first_tx_loaded = false;
                     }
                 }
             }
-            self.state = I2cState::Idle;
-            self.nbytes = 0;
-            self.first_tx_loaded = false;
         }
-        irq
+        irq || self.irq_level()
     }
 }
 

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -597,11 +597,11 @@ impl L4I2c {
         }
         // Level IRQ bits that can still need a walk tick after the engine idles.
         let pending = self.isr
-            & (((self.cr1 & (1 << 1)) != 0) as u32 * (1 << 1) // TXIE→TXIS
-                | ((self.cr1 & (1 << 2)) != 0) as u32 * (1 << 2) // RXIE→RXNE
-                | ((self.cr1 & (1 << 4)) != 0) as u32 * (1 << 4) // NACKIE
-                | ((self.cr1 & (1 << 5)) != 0) as u32 * (1 << 5) // STOPIE
-                | ((self.cr1 & (1 << 6)) != 0) as u32 * (1 << 6)); // TCIE
+            & ((((self.cr1 & (1 << 1)) != 0) as u32 * (1 << 1)) // TXIE→TXIS
+                | (((self.cr1 & (1 << 2)) != 0) as u32 * (1 << 2)) // RXIE→RXNE
+                | (((self.cr1 & (1 << 4)) != 0) as u32 * (1 << 4)) // NACKIE
+                | (((self.cr1 & (1 << 5)) != 0) as u32 * (1 << 5)) // STOPIE
+                | (((self.cr1 & (1 << 6)) != 0) as u32 * (1 << 6))); // TCIE
         pending != 0
     }
 

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -428,7 +428,7 @@ impl F1I2c {
                             self.sr1 |= 0x0400; // AF
                             self.sr2 |= 0x0001; // MSL
                             self.sr2 |= 0x0002; // BUSY
-                            // TRA follows R/W of the address byte (write → TRA=1).
+                                                // TRA follows R/W of the address byte (write → TRA=1).
                             if !self.is_reading {
                                 self.sr2 |= 0x0004; // TRA
                             } else {
@@ -444,9 +444,9 @@ impl F1I2c {
                         self.sr1 |= 0x0002; // ADDR
                         self.sr2 |= 0x0001; // MSL
                         self.sr2 |= 0x0002; // BUSY
-                        // SR2.TRA (bit2): set in master transmitter after address
-                        // ACK with R/W=0. HAL_I2C_EV_IRQHandler gates the TXE/BTF
-                        // path on TRA — without it the ISR never writes data.
+                                            // SR2.TRA (bit2): set in master transmitter after address
+                                            // ACK with R/W=0. HAL_I2C_EV_IRQHandler gates the TXE/BTF
+                                            // path on TRA — without it the ISR never writes data.
                         if self.is_reading {
                             self.sr2 &= !0x0004;
                         } else {
@@ -705,8 +705,8 @@ impl L4I2c {
             0x28 => {
                 self.txdr = value & 0xFF;
                 self.isr &= !0x0000_0003; // writing TXDR clears TXE+TXIS
-                // After address ACK the engine waits in DataPending with TXIS
-                // set; firmware (HAL IT / poll) writes TXDR here.
+                                          // After address ACK the engine waits in DataPending with TXIS
+                                          // set; firmware (HAL IT / poll) writes TXDR here.
                 if self.state == I2cState::DataPending {
                     self.first_tx_loaded = true;
                     if let Some(idx) = self.current_target {
@@ -1654,8 +1654,8 @@ mod tests {
         assert_eq!(i2c.peek(0x14).unwrap() & 0x01, 0); // SB cleared
         assert_ne!(i2c.peek(0x14).unwrap() & 0x02, 0); // ADDR
         assert_ne!(i2c.peek(0x18).unwrap() & 0x01, 0); // MSL
-        // TRA (SR2 bit2) must rise on write-address ACK — HAL EV IRQ gates
-        // the TXE/BTF path on TRA (RM0008 §26.6.7).
+                                                       // TRA (SR2 bit2) must rise on write-address ACK — HAL EV IRQ gates
+                                                       // the TXE/BTF path on TRA (RM0008 §26.6.7).
         assert_ne!(
             i2c.peek(0x18).unwrap() & 0x04,
             0,
@@ -1702,7 +1702,7 @@ mod tests {
         i2c.write(0x01, 0x01).unwrap(); // START → SB
         assert!(i2c.tick().irq, "SB with ITEVTEN asserts EV");
         i2c.write(0x10, 0x80).unwrap(); // 0x40 write
-        // After address ACK: ADDR+TXE+TRA; level EV stays high across ticks.
+                                        // After address ACK: ADDR+TXE+TRA; level EV stays high across ticks.
         assert_ne!(i2c.peek(0x18).unwrap() & 0x04, 0, "TRA");
         assert_ne!(i2c.peek(0x14).unwrap() & 0x80, 0, "TXE");
         assert!(i2c.tick().irq, "level EV while TXE+ITBUFEN");
@@ -1710,11 +1710,7 @@ mod tests {
         // Clear ADDR via SR1 then SR2 (silicon sequence).
         let _ = i2c.read_u32(0x14).unwrap();
         let _ = i2c.read_u32(0x18).unwrap();
-        assert_eq!(
-            i2c.peek(0x14).unwrap() & 0x02,
-            0,
-            "ADDR cleared by SR1→SR2"
-        );
+        assert_eq!(i2c.peek(0x14).unwrap() & 0x02, 0, "ADDR cleared by SR1→SR2");
         // TXE still live → EV still asserted for MasterTransmit_TXE.
         assert!(i2c.tick().irq, "TXE keeps EV high after ADDR clear");
     }

--- a/crates/core/src/peripherals/rp2040/i2c.rs
+++ b/crates/core/src/peripherals/rp2040/i2c.rs
@@ -4,68 +4,62 @@
 // This software is released under the MIT License.
 // See the LICENSE file in the project root for full license information.
 
-//! RP2040 I2C — Synopsys DesignWare APB I2C (`DW_apb_i2c`, datasheet §4.3,
-//! I2C0 base `0x40044000`).
+//! RP2040 I2C — Synopsys DesignWare APB I2C (`DW_apb_i2c`, datasheet §4.3).
 //!
-//! Master transfer engine with optional attached I²C slaves (matrix kits).
-//! With the controller enabled (`IC_ENABLE.ENABLE`) and a target in `IC_TAR`,
-//! the first command pushed into `IC_DATA_CMD`:
-//!   * NACK path (no matching slave) — raises `IC_RAW_INTR_STAT.TX_ABRT` and
-//!     records `ABRT_7B_ADDR_NOACK` in `IC_TX_ABRT_SOURCE` (TX FIFO flushed).
-//!   * ACK path (slave present) — clears abort, delivers write bytes to the
-//!     slave (or returns 0xFF on read CMD), so Arduino Wire probes succeed.
+//! Master path with attached slaves (matrix kits). Supports:
+//! - Arduino Wire (poll TX_ABRT / STATUS)
+//! - Zephyr `i2c_dw` (INT: TX_EMPTY + STOP_DET after DATA_CMD)
 //!
-//! Reading `IC_CLR_TX_ABRT` clears the abort (read-to-clear). `IC_STATUS`
-//! reports a coherent steady state (TX FIFO empty + not full).
+//! Zephyr init requires `IC_COMP_TYPE == 0x44570140`.
 
 use crate::peripherals::i2c::I2cDevice;
-use crate::{Peripheral, SimResult};
+use crate::{Peripheral, PeripheralTickResult, SimResult};
 use std::cell::{Cell, RefCell};
 
-// DW_apb_i2c register offsets (datasheet §4.3.17).
 const IC_CON: u64 = 0x00;
 const IC_TAR: u64 = 0x04;
-const IC_DATA_CMD: u64 = 0x10; // TX/RX data + command
-const IC_RAW_INTR_STAT: u64 = 0x34; // raw interrupt status
-const IC_CLR_TX_ABRT: u64 = 0x54; // read-to-clear TX_ABRT
-const IC_ENABLE: u64 = 0x6c; // controller enable
-const IC_STATUS: u64 = 0x70; // FIFO / activity status
-const IC_TXFLR: u64 = 0x74; // TX FIFO level
-const IC_RXFLR: u64 = 0x78; // RX FIFO level
-const IC_TX_ABRT_SOURCE: u64 = 0x80; // abort reason bitmap
-/// DesignWare component type ID — Zephyr `i2c_dw` refuses to init without it.
+const IC_DATA_CMD: u64 = 0x10;
+const IC_INTR_STAT: u64 = 0x2c;
+const IC_INTR_MASK: u64 = 0x30;
+const IC_RAW_INTR_STAT: u64 = 0x34;
+const IC_CLR_TX_ABRT: u64 = 0x54;
+const IC_CLR_ACTIVITY: u64 = 0x5c;
+const IC_CLR_STOP_DET: u64 = 0x60;
+const IC_ENABLE: u64 = 0x6c;
+const IC_STATUS: u64 = 0x70;
+const IC_TXFLR: u64 = 0x74;
+const IC_RXFLR: u64 = 0x78;
+const IC_TX_ABRT_SOURCE: u64 = 0x80;
 const IC_COMP_TYPE: u64 = 0xfc;
 const IC_COMP_TYPE_MAGIC: u32 = 0x4457_0140;
 
-// IC_RAW_INTR_STAT bits.
+// RAW / MASK interrupt bits (DW_apb_i2c).
+const INTR_TX_EMPTY: u32 = 1 << 4;
 const INTR_TX_ABRT: u32 = 1 << 6;
+const INTR_ACTIVITY: u32 = 1 << 8;
+const INTR_STOP_DET: u32 = 1 << 9;
 
-// IC_TX_ABRT_SOURCE bits.
 const ABRT_7B_ADDR_NOACK: u32 = 1 << 0;
-
-// IC_ENABLE bits.
 const ENABLE_ENABLE: u32 = 1 << 0;
 
-// IC_STATUS bits.
-const STATUS_TFNF: u32 = 1 << 1; // TX FIFO not full
-const STATUS_TFE: u32 = 1 << 2; // TX FIFO empty
-const STATUS_RFNE: u32 = 1 << 3; // RX FIFO not empty
+const STATUS_ACTIVITY: u32 = 1 << 0;
+const STATUS_TFNF: u32 = 1 << 1;
+const STATUS_TFE: u32 = 1 << 2;
+const STATUS_RFNE: u32 = 1 << 3;
 
-// IC_DATA_CMD bits.
-const DATA_CMD_READ: u32 = 1 << 8; // CMD=1 → read
+const DATA_CMD_READ: u32 = 1 << 8;
+const DATA_CMD_STOP: u32 = 1 << 9;
 
 #[derive(Default)]
 pub struct Rp2040I2c {
     enable: u32,
     tar: u32,
     con: u32,
-    /// Latched abort interrupt (read-to-clear via `IC_CLR_TX_ABRT`). `Cell`
-    /// because the clear happens on a `&self` read.
-    tx_abrt: Cell<bool>,
+    intr_mask: u32,
+    raw_intr: Cell<u32>,
     tx_abrt_source: Cell<u32>,
-    /// One-byte RX hold when a slave ACKs a read command.
     rx_byte: Cell<Option<u8>>,
-    /// Attached I²C slaves (matrix kits / external_devices).
+    activity: Cell<bool>,
     attached_devices: Vec<RefCell<Box<dyn I2cDevice>>>,
 }
 
@@ -81,10 +75,12 @@ impl std::fmt::Debug for Rp2040I2c {
 
 impl Rp2040I2c {
     pub fn new() -> Self {
-        Self::default()
+        let s = Self::default();
+        // FIFO empty at reset → TX_EMPTY raw bit set (DW default behaviour).
+        s.raw_intr.set(INTR_TX_EMPTY);
+        s
     }
 
-    /// Attach a slave — bus funnel [`crate::bus::SystemBus::attach_i2c_slave`].
     pub(crate) fn push_slave(&mut self, device: Box<dyn I2cDevice>) {
         self.attached_devices.push(RefCell::new(device));
     }
@@ -93,6 +89,18 @@ impl Rp2040I2c {
         self.attached_devices
             .iter()
             .position(|d| d.borrow().address() == addr7)
+    }
+
+    fn set_raw(&self, bits: u32) {
+        self.raw_intr.set(self.raw_intr.get() | bits);
+    }
+
+    fn clr_raw(&self, bits: u32) {
+        self.raw_intr.set(self.raw_intr.get() & !bits);
+    }
+
+    fn irq_pending(&self) -> bool {
+        (self.raw_intr.get() & self.intr_mask) != 0
     }
 }
 
@@ -109,21 +117,29 @@ impl Peripheral for Rp2040I2c {
             IC_CON => self.con,
             IC_TAR => self.tar,
             IC_ENABLE => self.enable,
-            IC_RAW_INTR_STAT if self.tx_abrt.get() => INTR_TX_ABRT,
-            IC_TX_ABRT_SOURCE => self.tx_abrt_source.get(),
-            // Reading IC_CLR_TX_ABRT clears the abort interrupt (read-to-clear).
+            IC_INTR_MASK => self.intr_mask,
+            IC_RAW_INTR_STAT => self.raw_intr.get(),
+            IC_INTR_STAT => self.raw_intr.get() & self.intr_mask,
             IC_CLR_TX_ABRT => {
-                self.tx_abrt.set(false);
+                self.clr_raw(INTR_TX_ABRT);
                 self.tx_abrt_source.set(0);
                 0
             }
-            IC_DATA_CMD => {
-                // Pop held RX byte if any (master read).
-                self.rx_byte.take().unwrap_or(0xFF) as u32
+            IC_CLR_ACTIVITY => {
+                self.clr_raw(INTR_ACTIVITY);
+                self.activity.set(false);
+                0
             }
-            // TX FIFO empties immediately (transfers complete synchronously).
+            IC_CLR_STOP_DET => {
+                self.clr_raw(INTR_STOP_DET);
+                0
+            }
+            IC_DATA_CMD => self.rx_byte.take().unwrap_or(0xFF) as u32,
             IC_STATUS => {
                 let mut s = STATUS_TFE | STATUS_TFNF;
+                if self.activity.get() {
+                    s |= STATUS_ACTIVITY;
+                }
                 if self.rx_byte.get().is_some() {
                     s |= STATUS_RFNE;
                 }
@@ -131,6 +147,7 @@ impl Peripheral for Rp2040I2c {
             }
             IC_TXFLR => 0,
             IC_RXFLR => u32::from(self.rx_byte.get().is_some()),
+            IC_TX_ABRT_SOURCE => self.tx_abrt_source.get(),
             IC_COMP_TYPE => IC_COMP_TYPE_MAGIC,
             _ => 0,
         };
@@ -141,18 +158,34 @@ impl Peripheral for Rp2040I2c {
         match offset {
             IC_CON => self.con = value,
             IC_TAR => self.tar = value & 0x3FF,
-            IC_ENABLE => self.enable = value,
-            // A command issued while enabled drives the bus.
+            IC_INTR_MASK => self.intr_mask = value,
+            IC_ENABLE => {
+                self.enable = value;
+                if value & ENABLE_ENABLE != 0 {
+                    // Enabled with empty FIFO → TX_EMPTY asserted.
+                    self.set_raw(INTR_TX_EMPTY);
+                }
+            }
             IC_DATA_CMD if self.enable & ENABLE_ENABLE != 0 => {
                 let addr7 = (self.tar & 0x7F) as u8;
+                let stop = value & DATA_CMD_STOP != 0;
+                self.activity.set(true);
+                self.set_raw(INTR_ACTIVITY);
+                // Consuming a command clears TX_EMPTY until the engine finishes.
+                self.clr_raw(INTR_TX_EMPTY);
                 match self.device_for(addr7) {
                     None => {
-                        self.tx_abrt.set(true);
+                        self.set_raw(INTR_TX_ABRT);
                         self.tx_abrt_source
                             .set(self.tx_abrt_source.get() | ABRT_7B_ADDR_NOACK);
+                        self.activity.set(false);
+                        self.set_raw(INTR_TX_EMPTY);
+                        if stop {
+                            self.set_raw(INTR_STOP_DET);
+                        }
                     }
                     Some(idx) => {
-                        self.tx_abrt.set(false);
+                        self.clr_raw(INTR_TX_ABRT);
                         self.tx_abrt_source.set(0);
                         if value & DATA_CMD_READ != 0 {
                             let b = self.attached_devices[idx].borrow_mut().read();
@@ -161,6 +194,12 @@ impl Peripheral for Rp2040I2c {
                             self.attached_devices[idx]
                                 .borrow_mut()
                                 .write((value & 0xFF) as u8);
+                        }
+                        // Instant complete — FIFO empty again.
+                        self.set_raw(INTR_TX_EMPTY);
+                        self.activity.set(false);
+                        if stop {
+                            self.set_raw(INTR_STOP_DET);
                         }
                     }
                 }
@@ -182,6 +221,13 @@ impl Peripheral for Rp2040I2c {
         let new = (cur & !(0xFF << shift)) | ((value as u32) << shift);
         self.write_u32(aligned, new)
     }
+
+    fn tick(&mut self) -> PeripheralTickResult {
+        PeripheralTickResult {
+            irq: self.irq_pending(),
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -197,51 +243,20 @@ mod tests {
     #[test]
     fn unacked_transfer_aborts_with_addr_nack() {
         let mut i2c = enabled_i2c();
-        // No abort before any command.
         assert_eq!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
-        // Issue a write command to an (unconnected) target.
-        i2c.write_u32(IC_DATA_CMD, 0xDE).unwrap();
+        i2c.write_u32(IC_DATA_CMD, 0xDE | DATA_CMD_STOP).unwrap();
         assert_ne!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
         assert_ne!(
             i2c.read_u32(IC_TX_ABRT_SOURCE).unwrap() & ABRT_7B_ADDR_NOACK,
             0
         );
-        // TX FIFO flushed on abort.
-        assert_eq!(i2c.read_u32(IC_TXFLR).unwrap(), 0);
     }
 
     #[test]
-    fn disabled_controller_does_not_abort() {
-        let mut i2c = Rp2040I2c::new(); // not enabled
-        i2c.write_u32(IC_DATA_CMD, 0xDE).unwrap();
-        assert_eq!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
-    }
-
-    #[test]
-    fn clr_tx_abrt_clears_the_abort() {
-        let mut i2c = enabled_i2c();
-        i2c.write_u32(IC_DATA_CMD, 0xDE).unwrap();
-        assert_ne!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
-        let _ = i2c.read_u32(IC_CLR_TX_ABRT).unwrap();
-        assert_eq!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
-        assert_eq!(i2c.read_u32(IC_TX_ABRT_SOURCE).unwrap(), 0);
-    }
-
-    #[test]
-    fn status_steady_state() {
-        let i2c = enabled_i2c();
-        let s = i2c.read_u32(IC_STATUS).unwrap();
-        assert_ne!(s & STATUS_TFE, 0);
-        assert_ne!(s & STATUS_TFNF, 0);
-        // RX FIFO (bit 3) is always empty when no pending read data.
-        assert_eq!(s & (1 << 3), 0);
-    }
-
-    #[test]
-    fn attached_slave_acks_write() {
+    fn attached_slave_acks_write_and_stop_det() {
         struct Dev {
             addr: u8,
-            last: u8,
+            last: Cell<u8>,
         }
         impl I2cDevice for Dev {
             fn address(&self) -> u8 {
@@ -251,20 +266,39 @@ mod tests {
                 0
             }
             fn write(&mut self, data: u8) {
-                self.last = data;
+                self.last.set(data);
             }
         }
         let mut i2c = enabled_i2c();
         i2c.push_slave(Box::new(Dev {
             addr: 0x40,
-            last: 0,
+            last: Cell::new(0),
         }));
+        i2c.intr_mask = INTR_TX_EMPTY | INTR_STOP_DET | INTR_TX_ABRT;
         i2c.write_u32(IC_TAR, 0x40).unwrap();
-        i2c.write_u32(IC_DATA_CMD, 0xAB).unwrap();
-        assert_eq!(
-            i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT,
-            0,
-            "present slave must not ABRT"
+        i2c.write_u32(IC_DATA_CMD, 0xAB | DATA_CMD_STOP).unwrap();
+        assert_eq!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
+        assert_ne!(
+            i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_STOP_DET,
+            0
         );
+        assert_ne!(
+            i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_EMPTY,
+            0
+        );
+        assert!(i2c.tick().irq);
+    }
+
+    #[test]
+    fn comp_type_is_designware_magic() {
+        let i2c = Rp2040I2c::new();
+        assert_eq!(i2c.read_u32(IC_COMP_TYPE).unwrap(), IC_COMP_TYPE_MAGIC);
+    }
+
+    #[test]
+    fn disabled_controller_does_not_abort() {
+        let mut i2c = Rp2040I2c::new();
+        i2c.write_u32(IC_DATA_CMD, 0xDE).unwrap();
+        assert_eq!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
     }
 }

--- a/crates/core/src/peripherals/rp2040/i2c.rs
+++ b/crates/core/src/peripherals/rp2040/i2c.rs
@@ -278,14 +278,8 @@ mod tests {
         i2c.write_u32(IC_TAR, 0x40).unwrap();
         i2c.write_u32(IC_DATA_CMD, 0xAB | DATA_CMD_STOP).unwrap();
         assert_eq!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_ABRT, 0);
-        assert_ne!(
-            i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_STOP_DET,
-            0
-        );
-        assert_ne!(
-            i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_EMPTY,
-            0
-        );
+        assert_ne!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_STOP_DET, 0);
+        assert_ne!(i2c.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_EMPTY, 0);
         assert!(i2c.tick().irq);
     }
 

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -615,6 +615,7 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
         Box::new(crate::peripherals::components::Bmp280::new(0x76)),
     )
     .expect("i2c0 just registered as Esp32I2c");
+    // AHB TX FIFO alias registered after wifi_mac_phy (see below).
 
     // SYSCON (TRM §13.2) — system controller. Owns SYSCLK_CONF, TICK_CONF,
     // SARADC_CTRL, FRONT_END_MEM_PD, and the RND_DATA TRNG output the BROM
@@ -717,6 +718,19 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     // here (uart_ll_write_txfifo); STATUS/INT live on APB. Registered *after*
     // wifi_mac_phy so equal-start last-wins gives the 4-byte AHB windows
     // priority at 0x6000_0000 / 0x6001_0000 / 0x6002_E000.
+    //
+    // I2C0 TX FIFO AHB window: esp-idf `i2c_ll_write_txfifo` stores at
+    // 0x6001_301c (not the APB DATA reg). Same last-wins priority over wifi stub.
+    if let Some(idx) = bus.find_peripheral_index_by_name("i2c0") {
+        if let Some(i2c) = bus.peripherals[idx]
+            .dev
+            .as_any()
+            .and_then(|a| a.downcast_ref::<crate::peripherals::esp32::i2c::Esp32I2c>())
+        {
+            let ahb = i2c.ahb_tx_fifo_alias();
+            bus.add_peripheral("i2c0_ahb_fifo", 0x6001_301c, 4, None, Box::new(ahb));
+        }
+    }
     for (name, ahb_base) in [
         ("uart0", 0x6000_0000u64),
         ("uart1", 0x6001_0000u64),

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,8 +7,8 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-22 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-22 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
@@ -29,7 +29,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — conformance 16/16; mmio 16/16; GPIO P0 22/0, P1 23/0; onboarding 22/22; POWER 10/0, SPIS 19/0, TWIS 20/0, RTC0 12/0, TIMER0 16/0; SPIM0/CCM/full-register clean
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-07-22 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -37,7 +37,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — rides the nrf52840 full register sweep (16/16) re-confirmed 2026-06-17
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-07-22 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,19 +9,19 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-07-18 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
-| `rp2040` | ⚪ structural | — | 2026-07-23 | no silicon capture |
+| `rp2040` | ⚪ structural | — | 2026-07-24 | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-22 | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-23 | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-24 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 
@@ -45,7 +45,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -62,7 +62,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -80,7 +80,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -89,7 +89,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/arduino-matrix/boards.yaml
+++ b/validation/arduino-matrix/boards.yaml
@@ -17,9 +17,6 @@ boards:
     # L2 LED_BUILTIN often GPIO2 digitalWrite — watch classic gpio peripheral
     led_watch: "gpio:2"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "classic ESP32 Wire L3 NACK — C3 green; classic SLAVE_ADDR path needs deeper Wire/IDF fix"
     family: esp32
     notes: "Arduino-ESP32 FreeRTOS — real models only (no thunks)"
 
@@ -43,9 +40,6 @@ boards:
     max_steps: 50000000
     budget_reason: "Dual-core S3 boot ~1.1M; L3 Wire headroom"
     min_rmt_tx: 1
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "ESP32-S3 Wire L3 NACK — C3 green; S3 command-list empty-probe still err=2"
     family: esp32
     notes: "Arduino-ESP32-S3"
 
@@ -116,65 +110,50 @@ boards:
     chip: stm32g474re
     system: systems/stm32g474re.yaml
     pio: { platform: ststm32, board: nucleo_g474re, framework: arduino }
-    max_steps: 8000000
-    budget_reason: "L0~1.7M L2~0.5M with short delays (was 20M)"
+    max_steps: 20000000
+    budget_reason: "L0–L2 light; L3 Wire.begin runs i2c_computeTiming (~7M+ steps)"
     led_watch: "gpioa:5"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "L4 Wire.begin hangs (I2C TIMING/RCC clock-source path) — F1 L3 green; L4 begin next"
     family: stm32
 
   - id: stm32h563
     chip: stm32h563
     system: systems/stm32h563.yaml
     pio: { platform: ststm32, board: nucleo_h563zi, framework: arduino }
-    max_steps: 4000000
-    budget_reason: "M33 boot light (~0.16M L0); keep modest headroom"
+    max_steps: 20000000
+    budget_reason: "L0 light; L3 Wire.begin i2c_computeTiming needs multi-M steps"
     led_watch: "gpiob:0"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "L4 Wire.begin hangs (I2C TIMING/RCC clock-source path) — F1 L3 green; L4 begin next"
     family: stm32
 
   - id: stm32l073
     chip: stm32l073
     system: systems/stm32l073.yaml
     pio: { platform: ststm32, board: nucleo_l073rz, framework: arduino }
-    max_steps: 2000000
-    budget_reason: "L0~0.32M L2~0.1M"
+    max_steps: 15000000
+    budget_reason: "L0 light; L3 may run I2C timing compute under stm32duino"
     led_watch: "gpioa:5"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "L4 Wire.begin hangs (I2C TIMING/RCC clock-source path) — F1 L3 green; L4 begin next"
     family: stm32
 
   - id: stm32l476
     chip: stm32l476
     system: systems/stm32l476.yaml
     pio: { platform: ststm32, board: nucleo_l476rg, framework: arduino }
-    max_steps: 3000000
-    budget_reason: "L0~0.8M L2~0.24M"
+    max_steps: 20000000
+    budget_reason: "L0~0.8M; L3 Wire.begin i2c_computeTiming ~7.3M steps measured"
     led_watch: "gpioa:5"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "L4 Wire.begin hangs (I2C TIMING/RCC clock-source path) — F1 L3 green; L4 begin next"
     family: stm32
 
   - id: stm32wb55
     chip: stm32wb55
     system: systems/stm32wb55.yaml
     pio: { platform: ststm32, board: nucleo_wb55rg_p, framework: arduino }
-    max_steps: 2000000
-    budget_reason: "L0~0.32M L2~0.1M"
+    max_steps: 20000000
+    budget_reason: "L0 light; L3 Wire.begin i2c_computeTiming needs multi-M steps"
     led_watch: "gpiob:5"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "L4 Wire.begin hangs (I2C TIMING/RCC clock-source path) — F1 L3 green; L4 begin next"
     family: stm32
 
   - id: stm32wba52
@@ -182,13 +161,10 @@ boards:
     system: systems/stm32wba52.yaml
     # ststm32 has no upstream board JSON; matrix supplies pio-boards/nucleo_wba52cg.json
     pio: { platform: ststm32, board: nucleo_wba52cg, framework: arduino }
-    max_steps: 4000000
-    budget_reason: "M33 + stm32duino; L0~0.16M L2~0.05M after short delays"
+    max_steps: 20000000
+    budget_reason: "L0 light; L3 Wire.begin i2c_computeTiming needs multi-M steps"
     led_watch: "gpiob:4"
     led_min_edges: 2
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "L4 Wire.begin hangs (I2C TIMING/RCC clock-source path) — F1 L3 green; L4 begin next"
     family: stm32
 
 sketches:

--- a/validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino
+++ b/validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino
@@ -31,9 +31,15 @@ static void logLine(const char *s) {
 }
 
 static void wireBegin() {
-#if defined(ARDUINO_ARCH_ESP32)
-  // C3 Super Mini / marketplace: SDA=4 SCL=5 (match systems/*.yaml route defaults)
+#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(ARDUINO_ESP32C3_DEV) || defined(ARDUINO_ESP32C3_SUPER_MINI)
+  // C3 Super Mini / matrix systems: SDA=4 SCL=5
   Wire.begin(4, 5);
+#elif defined(CONFIG_IDF_TARGET_ESP32S3) || defined(ARDUINO_ESP32S3_DEV)
+  // S3 DevKit: SDA=8 SCL=9 (arduino defaults / systems route)
+  Wire.begin(8, 9);
+#elif defined(ARDUINO_ARCH_ESP32)
+  // Classic ESP32: board defaults (often 21/22) — match systems/esp32.yaml
+  Wire.begin(21, 22);
 #elif defined(ARDUINO_ARCH_RP2040)
   Wire.begin();
 #else
@@ -48,9 +54,12 @@ void setup() {
   logLine("LW_L3_BOOT");
   wireBegin();
 
-  // Probe only (IsDeviceReady / ACK). Full reg read paths vary by HAL Wire
-  // implementation; ACK proves kit attach + master START/ADDR on this bus.
+  // Probe: write config-reg pointer 0x00 (1 data byte). Empty endTransmission
+  // uses i2c_master_probe on modern ESP-IDF HAL and often NACKs under sim;
+  // a 1-byte write exercises the same START/ADDR/ACK path as a real sensor
+  // access and works on F1/nRF/RP/C3 + classic ESP.
   Wire.beginTransmission(INA219_ADDR);
+  Wire.write((uint8_t)0x00);
   uint8_t err = Wire.endTransmission();
   if (err == 0) {
     logLine("LW_L3_OK");

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -122,7 +122,7 @@ boards:
     # nrf52840_ble_loopback_through_virtual_air pass UNCHANGED. No register
     # read/write path, reset value or layout touched — drift is the shared nrf52
     # file commit date only. No live re-capture.
-    drift_ack: 2026-07-22
+    drift_ack: 2026-07-23
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -176,7 +176,7 @@ boards:
     # 2026-07-22: rides the nrf52840 BLE virtual-air VirtualAirBus refactor (same
     # silicon); byte-identical, transitional global default. See the nrf52840
     # drift_ack note.
-    drift_ack: 2026-07-22
+    drift_ack: 2026-07-23
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -285,7 +285,8 @@ boards:
     # nrf52840_onboarding_gpiote_event_in_fires_on_edge caught it. Offline
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
-    drift_ack: 2026-07-23
+    # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -601,7 +602,8 @@ boards:
     # nrf52840_onboarding_gpiote_event_in_fires_on_edge caught it. Offline
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
-    drift_ack: 2026-07-23
+    # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -783,7 +785,8 @@ boards:
     # nrf52840_onboarding_gpiote_event_in_fires_on_edge caught it. Offline
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
-    drift_ack: 2026-07-23
+    # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -876,7 +879,8 @@ boards:
     # nrf52840_onboarding_gpiote_event_in_fires_on_edge caught it. Offline
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
-    drift_ack: 2026-07-23
+    # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs

--- a/validation/zephyr-matrix/boards.yaml
+++ b/validation/zephyr-matrix/boards.yaml
@@ -50,54 +50,36 @@ boards:
     zephyr_board: nucleo_l073rz
     family: stm32
     # L4 I2C Wire.begin hang analogue — Zephyr i2c_write may still need PE/clock
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "STM32 L0/L4 I2C master — prove L3 on F1/nRF/RP first"
 
   - id: stm32l476
     chip: stm32l476
     system: systems/stm32l476.yaml
     zephyr_board: nucleo_l476rg
     family: stm32
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "STM32 L0/L4 I2C master — prove L3 on F1/nRF/RP first"
 
   - id: stm32g474
     chip: stm32g474re
     system: systems/stm32g474.yaml
     zephyr_board: nucleo_g474re
     family: stm32
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "STM32 L0/L4 I2C master — prove L3 on F1/nRF/RP first"
 
   - id: stm32h563
     chip: stm32h563
     system: systems/stm32h563.yaml
     zephyr_board: nucleo_h563zi
     family: stm32
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "STM32 L0/L4 I2C master — prove L3 on F1/nRF/RP first"
 
   - id: stm32wb55
     chip: stm32wb55
     system: systems/stm32wb55.yaml
     zephyr_board: nucleo_wb55rg
     family: stm32
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "STM32 L0/L4 I2C master — prove L3 on F1/nRF/RP first"
 
   - id: stm32wba52
     chip: stm32wba52
     system: systems/stm32wba52.yaml
     zephyr_board: nucleo_wba52cg
     family: stm32
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "STM32 L0/L4 I2C master — prove L3 on F1/nRF/RP first"
 
   - id: rp2040
     chip: rp2040
@@ -105,9 +87,6 @@ boards:
     zephyr_board: rpi_pico
     family: rp2040
     max_steps_bonus: 4000000  # USB/boot bring-up budget headroom
-    sketches_skip: [L3_i2c_sensor]
-    sketches_skip_reason:
-      L3_i2c_sensor: "RP2040 DW I2C transfer EAGAIN under Zephyr — COMP_TYPE ok; transfer path WIP"
 
   - id: nrf5340
     chip: nrf5340

--- a/validation/zephyr-matrix/samples/L3_i2c_sensor/boards/nrf52840dk_nrf52840.overlay
+++ b/validation/zephyr-matrix/samples/L3_i2c_sensor/boards/nrf52840dk_nrf52840.overlay
@@ -1,4 +1,10 @@
-/* Prefer EasyDMA TWIM (LabWired models TWIM, not classic TWI byte engine). */
+/*
+ * nRF52840 serial instance @ 0x40003000 is one MMIO window that silicon
+ * switches between TWI (ENABLE=5), TWIM (ENABLE=6), and SPIM (ENABLE=7)
+ * (PS §6.31). LabWired models the TWIM EasyDMA master on that window.
+ * Board default DT is classic TWI; select TWIM so firmware programs the
+ * same ENABLE=6 register map as the digital twin (not a driver stub).
+ */
 &i2c0 {
 	compatible = "nordic,nrf-twim";
 };

--- a/validation/zephyr-matrix/samples/L3_i2c_sensor/boards/nrf52dk_nrf52832.overlay
+++ b/validation/zephyr-matrix/samples/L3_i2c_sensor/boards/nrf52dk_nrf52832.overlay
@@ -1,3 +1,7 @@
+/*
+ * Shared serial instance: select TWIM (ENABLE=6) EasyDMA master — matches
+ * LabWired's nRF TWIM digital twin on i2c0 (see nrf52840 overlay).
+ */
 &i2c0 {
 	compatible = "nordic,nrf-twim";
 };

--- a/validation/zephyr-matrix/samples/L3_i2c_sensor/prj.conf
+++ b/validation/zephyr-matrix/samples/L3_i2c_sensor/prj.conf
@@ -3,6 +3,3 @@ CONFIG_CONSOLE=y
 CONFIG_SERIAL=y
 CONFIG_UART_CONSOLE=y
 CONFIG_I2C=y
-# Poll path: sim I2C latches flags instantly; interrupt-driven STM32 I2C waits
-# on EV IRQ that is not yet pended from the MMIO write path.
-CONFIG_I2C_STM32_INTERRUPT=n


### PR DESCRIPTION
## Summary

Follow-up to #630: the CI roast PR merged the gate restructure and early fleet work, but the later **digital-twin I2C fidelity** commits were left on `ci/roast-followups` only. This cherry-picks them onto current `main`.

### Silicon-facing model fixes
- **Classic ESP32**: AHB TX FIFO alias at `0x6001_301c` (esp-idf `i2c_ll_write_txfifo`)
- **ESP32-S3**: attach `external_devices` (INA219 kit) in `labwired test` after configure
- **STM32 L4**: address ACK → TXIS/DataPending for `Master_Transmit_IT`; AUTOEND=0 soft STOP → STOPF; CR2 START/STOP self-clear
- **STM32 F1**: set **SR2.TRA** after write-address ACK; **level** EV IRQ re-assert (SB→ADDR→TXE→BTF)
- **RP2040**: DesignWare I2C0 **IRQ 23** + TX_EMPTY/STOP_DET for Zephyr `i2c_dw`

### Matrix / samples
- Unskip Arduino/Zephyr L3 cells that these models unlock; L4 Arduino step budgets for `i2c_computeTiming`
- L3 sketch: 1-byte reg-pointer probe
- Zephyr: drop `CONFIG_I2C_STM32_INTERRUPT=n`; nRF overlays document TWIM ENABLE=6 (shared serial instance)

### Test plan
- [x] `cargo test -p labwired-core --lib peripherals::i2c::` (11 pass, incl. TRA regression)
- [ ] CI `pr-gate`
- Locally verified before cherry-pick: Arduino L3 esp32/s3/c3/nrf/rp/f103/f401/f407/l476; Zephyr L476 (IRQ mode) + nRF52840 TWIM