### PR TITLE
fix(bus): keep nonzero-based empty image_env ROM windows in the memory map

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -86,11 +86,19 @@ impl SystemBus {
                     }
                 }
             }
-            // Skip empty image_env regions: a zero-filled window at 0 would
-            // shadow the Cortex-M flash boot alias (breaks RP2040 bare-metal
-            // onboarding ELFs that rely on VTOR=0 → flash). Regions without
-            // image_env (plain RAM holes) are still installed as zeros.
-            if region.image_env.is_some() && !loaded_image {
+            // Skip an empty image_env region *only* when it's based at address
+            // 0: a zero-filled window there would shadow the Cortex-M flash boot
+            // alias (breaks RP2040 bare-metal onboarding ELFs that rely on
+            // VTOR=0 → flash). Nonzero-based ROM windows (e.g. the C3 IROM @
+            // 0x40000000 / DROM @ 0x3FF00000) must stay installed as zeros even
+            // with no on-disk image: on the wasm/browser path there is no
+            // filesystem to preload from, and the ROM arrives later as blobs
+            // that `inject_rom_regions` copies into these slots. Dropping them
+            // here left no slot to fill, which is what surfaced to users as
+            // "C3 flash fast-start: chip YAML declares no IROM region at
+            // 0x40000000". Regions without image_env (plain RAM holes) are
+            // always installed as zeros.
+            if region.image_env.is_some() && !loaded_image && region.base == 0 {
                 tracing::debug!(
                     "skipping empty image_env region '{}' @ {:#010x}",
                     region.name,
@@ -1087,5 +1095,73 @@ impl SystemBus {
             .or_else(|| ext.config.get(alt_key))
             .and_then(|v| v.as_str())?;
         Self::parse_esp32s3_gpio_pin(label).or_else(|| Self::parse_esp32_gpio_pin(label))
+    }
+}
+
+#[cfg(test)]
+mod image_env_region_tests {
+    use super::*;
+
+    /// A nonzero-based `image_env` region with no loadable image must still be
+    /// installed (zero-filled) so a later filler — `inject_rom_regions` on the
+    /// wasm/browser fast-start path — has a slot to copy the ROM blobs into.
+    /// Only a region based at address 0 (the RP2040 bootrom, which would shadow
+    /// the Cortex-M flash boot alias) is dropped when empty.
+    ///
+    /// Regression for the browser "C3 flash fast-start: chip YAML declares no
+    /// IROM region at 0x40000000" failure: with no filesystem to preload from,
+    /// `from_config` used to drop the C3 IROM window entirely, leaving
+    /// `inject_rom_regions` nothing to fill.
+    #[test]
+    fn empty_image_env_region_kept_unless_based_at_zero() {
+        // `LABWIRED_TEST_MISSING_ROM` has no default image path and is never
+        // set, so both regions below fail to load an image — exactly the
+        // wasm/browser condition — without touching any real env var or file.
+        let chip_yaml = r#"
+name: "test-image-env"
+arch: "riscv"
+flash:
+  base: 0x42000000
+  size: "1KB"
+ram:
+  base: 0x3FC80000
+  size: "1KB"
+memory_regions:
+  - name: "irom"
+    base: 0x40000000
+    size: "1KB"
+    image_env: "LABWIRED_TEST_MISSING_ROM"
+  - name: "bootrom_at_zero"
+    base: 0x0
+    size: "1KB"
+    image_env: "LABWIRED_TEST_MISSING_ROM"
+peripherals: []
+"#;
+        let manifest_yaml = r#"
+name: "test-image-env-system"
+chip: "test-image-env"
+"#;
+        let chip: ChipDescriptor = serde_yaml::from_str(chip_yaml).expect("parse chip");
+        let manifest: SystemManifest = serde_yaml::from_str(manifest_yaml).expect("parse manifest");
+
+        // Guard the hermeticity assumption: if some ambient env ever defines
+        // this name, the test would silently stop exercising the empty path.
+        assert!(
+            std::env::var("LABWIRED_TEST_MISSING_ROM").is_err(),
+            "test env var must be unset for this regression to be meaningful"
+        );
+
+        let bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+
+        assert!(
+            bus.extra_mem.iter().any(|m| m.base_addr == 0x4000_0000),
+            "nonzero-based empty image_env region must be installed so \
+             inject_rom_regions can fill it (was dropped → browser IROM error)"
+        );
+        assert!(
+            !bus.extra_mem.iter().any(|m| m.base_addr == 0),
+            "empty image_env region based at 0 must be dropped so it can't \
+             shadow the flash boot alias"
+        );
     }
 }


### PR DESCRIPTION
## Description

The browser ESP32-C3 flash fast-start fails on a curated example with:

> Run failed: C3 flash fast-start: chip YAML declares no IROM region at 0x40000000

**Root cause.** The C3 chip descriptor declares its mask-ROM windows (IROM `0x40000000`, DROM `0x3FF00000`) via `image_env`, since the copyrighted ROM dump isn't committed. On the wasm/browser path, the ROM content is fetched by the frontend and passed in as blobs that `inject_rom_regions` copies into those windows *after* `SystemBus::from_config` builds the bus.

`from_config` dropped **every** empty `image_env` region when no on-disk image loaded:
- **Native** builds find the in-tree ROM dump → window kept → works.
- **Browser** has no filesystem → nothing to preload → IROM/DROM windows dropped → `inject_rom_regions` finds no slot at `0x40000000` → the fast-start error.

The error message proves the blobs were present (the code cleared the earlier "needs ESP32-C3 ROM blobs" guard); the only thing missing was the region slot to copy them into.

**Fix.** That skip exists solely to stop a zero-filled window at address `0` from shadowing the Cortex-M flash boot alias (RP2040 bare-metal onboarding). Narrowing the condition to `region.base == 0` keeps the RP2040 protection unchanged while nonzero-based ROM windows stay installed (zero-filled) so a later filler has a slot. No frontend change was needed — it already supplies the blobs correctly.

## Related Issues
Curated ESP32-C3 0.96" OLED example failing to boot in the web app.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist
- [x] I have run `cargo fmt` and `cargo clippy`. (No new warnings; the one clippy warning present is pre-existing and unrelated to this change.)
- [x] I have added tests that prove my fix is effective — a hermetic regression test covering both sides of the condition (nonzero window kept, base-0 window dropped).
- [ ] I have updated the documentation accordingly. (No doc changes needed; behavior is described in code comments.)
- [x] My changes generate no new warnings.

### Verification
- New regression test `empty_image_env_region_kept_unless_based_at_zero` reproduces the no-filesystem case and passes.
- Full `labwired-core` lib suite: **2305 passed, 0 failed**.
- `rp2040_pio_onboarding` (the flash-alias behavior the skip protects): still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiuaQ9b6vn7vxzFqYmEt4c)_