### PR TITLE
chore(validation): regen VALIDATION_STATUS + ack esp32s3 drift (#644 follow-up)

### DIFF
--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,12 +10,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-23 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-07-18 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
@@ -98,7 +98,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -1041,7 +1041,15 @@ boards:
     # passed), `esp32s3_reset_conformance`/`reset_values_match_silicon` unchanged,
     # full core lib suite 2329 green. No S3 board attached; no live re-capture
     # warranted — the new behaviour is post-reset and outside the anchored window.
-    drift_ack: 2026-07-23
+    # 2026-07-24: central I²C data-ready time drive (#644). Additive-only against
+    # the reset-state silicon anchor: SYSTIMER gained a new `sim_time_us()` `&self`
+    # accessor (UNIT0 ticks ÷ 16, computed fresh — no register, tick, on_event or
+    # reset value touched), and esp32s3/i2c gained `drives_central_i2c_time` +
+    # `advance_attached_i2c_us` (opt-in fan-out that only forwards elapsed µs to
+    # attached slaves). No existing read/write/tick/on_event path changed, so the
+    # anchored reset windows and every observable register value are untouched;
+    # esp32s3_walk_differential covers byte-identity. No live re-capture warranted.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Fast-follow to #644. Editing `esp32c3/i2c.rs` and `esp32s3/systimer.rs` in #644 bumped those models' last-modified date to 2026-07-24, so the auto-generated `docs/boards/VALIDATION_STATUS.md` went stale and esp32s3's `drift_ack` (2026-07-23) no longer covered the model date — the `pr-gate` "Validation status — regen check + drift gate" flagged it. (#644's auto-merge fired on its first commit's passing gate before the rebuilt gate finished, so this landed on main red on that one check.)

The #644 change is additive-only — a new `sim_time_us()` `&self` accessor on the SYSTIMER plus opt-in `drives_central_i2c_time`/`advance_attached_i2c_us` fan-out methods; no reset value, register, tick, on_event, read or write path changed. The anchored silicon reset windows are untouched and `esp32s3_walk_differential` covers byte-identity, so **re-ack** rather than re-capture is the honest resolution.

- Regenerated `VALIDATION_STATUS.md` (esp32c3/esp32s3 model dates → 2026-07-24).
- Bumped esp32s3 `drift_ack` → 2026-07-24 with a dated note.
- Both boards stay 🟢 silicon-verified.

`python3 scripts/generate_validation_status.py --check --drift` and `generate_firmware_exercise_matrix.py --check` both pass locally.