### PR TITLE
style: rustfmt declarative_regs.rs (unblock core-integrity on main)

### DIFF
--- a/crates/core/src/peripherals/components/declarative_regs.rs
+++ b/crates/core/src/peripherals/components/declarative_regs.rs
@@ -101,7 +101,10 @@ pub(crate) fn unpack(bytes: &[u8], endian: Endian) -> u32 {
 }
 
 /// One `scale_from` factor: the value another register's bit-field selects (1.0 if unmapped).
-pub(crate) fn scale_from_one(sf: &labwired_config::ScaleFrom, reg_values: &HashMap<String, u32>) -> f64 {
+pub(crate) fn scale_from_one(
+    sf: &labwired_config::ScaleFrom,
+    reg_values: &HashMap<String, u32>,
+) -> f64 {
     let regval = reg_values.get(&sf.register).copied().unwrap_or(0);
     let field = (regval >> sf.shift as u32) & sf.mask;
     sf.map.get(&field).copied().unwrap_or(1.0)
@@ -109,7 +112,9 @@ pub(crate) fn scale_from_one(sf: &labwired_config::ScaleFrom, reg_values: &HashM
 
 /// Product of a register's `scale_from` factors, folded left-to-right from 1.0.
 pub(crate) fn scale_from_product(reg: &RegisterSpec, reg_values: &HashMap<String, u32>) -> f64 {
-    reg.scale_from.iter().fold(1.0, |acc, sf| acc * scale_from_one(sf, reg_values))
+    reg.scale_from
+        .iter()
+        .fold(1.0, |acc, sf| acc * scale_from_one(sf, reg_values))
 }
 
 /// Divide dual of `encode_raw`: count = round(value / resolution), clamped. A


### PR DESCRIPTION
core-integrity's `cargo fmt --all -- --check` step has been red on main since the SPI-L3 declarative merge (commit `fa5d7a2d`) left two unwrapped signatures/chains in `declarative_regs.rs`. Pre-existing and unrelated to the I2C time-drive work — it was masked until #644/#645 cleared the earlier drift-check failure in the same job. Pure rustfmt line-wrapping, no logic change. Unblocks the walk-differential feature gate that runs right after formatting.