### PR TITLE
fix(ci): repair core-coverage.yml heredoc indentation

### DIFF
--- a/.github/workflows/core-coverage.yml
+++ b/.github/workflows/core-coverage.yml
@@ -63,8 +63,8 @@ jobs:
           import sys
 
           # Weekly floor only (not a PR gate). Keep conservative until main baseline
-      # is measured; PR signal is integrity + onboarding + coverage-matrix + arduino.
-      threshold = 55.0
+          # is measured; PR signal is integrity + onboarding + coverage-matrix + arduino.
+          threshold = 55.0
           p = pathlib.Path("out/coverage/llvm-cov.json")
           data = json.loads(p.read_text())
           nodes = data.get("data", [])


### PR DESCRIPTION
core-coverage has failed with 0 jobs on every main push since yesterday's CI rework: two heredoc lines (the threshold comment + `threshold = 55.0`) were dedented below the literal block's indentation, making the workflow YAML unparsable. Re-indented; `yaml.safe_load` passes. No behavioral change to the gate itself.