### PR TITLE
feat: absorb IR capabilities into i2c_device — tmp102 + pca9685 declarative (phase A of IR retirement)

### DIFF
--- a/configs/devices/pca9685.yaml
+++ b/configs/devices/pca9685.yaml
@@ -1,0 +1,50 @@
+# NXP PCA9685 16-channel 12-bit I²C PWM controller — declarative byte-addressable
+# register-file device. Byte-for-byte twin of the hand-written oracle
+# crates/core/src/peripherals/components/pca9685.rs (now retained only as the
+# parity oracle).
+#
+# Per the PCA9685 datasheet (Rev. 4) the device is a 256-byte register file with
+# a write-pointer (the "control register"). The first byte after a START selects
+# the pointer; subsequent bytes are data. When MODE1 (reg 0x00) bit 5 (`AI`) is
+# set the pointer auto-increments after every data byte read or written — so the
+# firmware's 4-byte `LEDn_ON_L … LEDn_OFF_H` block writes land in consecutive
+# registers. The auto-increment enable is checked LIVE, so the very write that
+# sets the AI bit also advances the pointer. Power-on MODE1 reads back 0x11
+# (SLEEP | ALLCALL) like real silicon.
+#
+# Each channel's 12-bit OFF count (LEDn_OFF_L / LEDn_OFF_H[3:0]) encodes the servo
+# pulse width; the `servo_angle` observable exposes the commanded angle in degrees
+# by linearising the firmware's `off → µs → degree` map. A channel that has never
+# been written (raw OFF = 0) reports no angle.
+type: pca9685
+
+behavior:
+  primitive: i2c_device
+  i2c:
+    default_address: 0x40
+    register_file:
+      size: 256
+      reset:
+        0x00: 0x11   # MODE1 power-on: SLEEP | ALLCALL
+      auto_increment:
+        when_field_set: { addr: 0x00, mask: 0x20 }   # MODE1.AI
+    observables:
+      - name: servo_angle
+        channels: 16
+        base: 0x06       # LED0_ON_L
+        stride: 4
+        value:
+          u12_compose: { lo_rel: 2, hi_rel: 3, hi_mask: 0x0F }   # OFF_L / OFF_H[3:0]
+        map:
+          linear: { scale: 0.46258224, offset: -47.368423, clamp: [0.0, 180.0] }
+          none_when_raw_zero: true
+
+metadata:
+  label: "NXP PCA9685 PWM/Servo"
+  summary: "16-channel 12-bit I²C PWM / servo controller."
+  detail: "NXP PCA9685 at default address 0x40, a 256-byte register-file device with a write-pointer and MODE1.AI auto-increment. Drives up to 16 servo/LED PWM channels; the servo_angle observable reports each channel's commanded angle in degrees. Power-on MODE1 reads back 0x11 (SLEEP | ALLCALL), matching silicon."
+  category: i2c
+  config_keys:
+    - name: i2c_address
+      ty: int
+      doc: "7-bit slave address. Defaults to the PCA9685 address 0x40 (A0..A5 tied low)."

--- a/configs/devices/tmp102.yaml
+++ b/configs/devices/tmp102.yaml
@@ -1,0 +1,44 @@
+# Texas Instruments TMP102 I²C temperature sensor — declarative register-pointer
+# device. Byte-for-byte twin of the hand-written oracle
+# crates/core/src/peripherals/esp32s3/tmp102.rs (now retained only as the
+# parity oracle), including the demo self-drift.
+#
+# Per the TMP102 datasheet (SBOS397) the master writes a 1-byte pointer (only
+# the low two bits are decoded, `pointer_mask: 0x03`) then streams a 16-bit
+# BIG-ENDIAN word (MSB first). The four pointer slots are read-only 16-bit
+# registers; a write of config/T_LOW/T_HIGH bytes is absorbed and ignored
+# (access `r`), so those registers always read back their reset value.
+#
+# The temperature register is left-justified 12-bit, 1 LSB = 0.0625 °C
+# (0x1900 = 25.0 °C). It is **self-driving** for the demo: every full
+# temperature read adds +0.5 °C (0x80) and wraps back to 20.0 °C (0x1400)
+# once it would exceed 35.0 °C (0x2300) — expressed as the generic
+# `read_complete` → `add_wrap` update, not a TMP102 special case.
+type: tmp102
+
+behavior:
+  primitive: i2c_device
+  i2c:
+    default_address: 0x48
+    pointer_mask: 0x03
+    registers:
+      # Temperature: 12-bit left-justified, big-endian, self-drifting (below).
+      - { name: TEMP, addr: 0x00, width: 2, endian: be, access: r, reset: 0x1900 }
+      # Config / T_LOW / T_HIGH: read-only storage; writes are absorbed.
+      - { name: CONFIG, addr: 0x01, width: 2, endian: be, access: r, reset: 0x60A0 }
+      - { name: T_LOW, addr: 0x02, width: 2, endian: be, access: r, reset: 0x4B00 }
+      - { name: T_HIGH, addr: 0x03, width: 2, endian: be, access: r, reset: 0x5000 }
+    updates:
+      # +0.5 °C per full temperature read; wrap to 20 °C once it exceeds 35 °C.
+      - trigger: { read_complete: { pointer: 0x00 } }
+        action:  { add_wrap: { add: 0x80, max: 0x2300, reset: 0x1400 } }
+
+metadata:
+  label: "TI TMP102 Temperature"
+  summary: "12-bit I²C temperature sensor (self-drifting demo)."
+  detail: "Texas Instruments TMP102 at default address 0x48, a register-pointer device with 16-bit big-endian words (pointer decodes only the low two bits). The temperature register starts at 25 °C and self-drifts +0.5 °C per read, wrapping 35 °C → 20 °C — a deterministic demo stimulus that needs no external input. Config / T_LOW / T_HIGH are read-only storage."
+  category: i2c
+  config_keys:
+    - name: i2c_address
+      ty: int
+      doc: "7-bit slave address. Defaults to the TMP102 address 0x48 (ADD0 = GND)."

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -908,6 +908,226 @@ pub struct I2cSpec {
     /// Command set. Present ⇒ this is a command device.
     #[serde(default)]
     pub commands: Vec<I2cCommand>,
+    /// Mask applied to the pointer byte the master writes in **register-pointer**
+    /// mode (`registers:`). Absent ⇒ `0xFF` (no masking). A part whose pointer is
+    /// only a few low bits (TMP102 uses `0x03`) sets it so a write of an
+    /// out-of-range pointer aliases into the register file exactly as silicon does.
+    #[serde(default)]
+    pub pointer_mask: Option<u8>,
+    /// **Byte-addressable register file** mode. Present ⇒ this is a register-file
+    /// device (256 one-byte registers with a write-pointer that walks on
+    /// auto-increment, PCA9685-style). Mutually exclusive with `registers:` and
+    /// `commands:`.
+    #[serde(default)]
+    pub register_file: Option<RegisterFileSpec>,
+    /// Self-driving state updates fired by bus activity (e.g. the TMP102's
+    /// +0.5 °C-per-read drift). Each fires when a full multi-byte read of its
+    /// target register completes. Applies to the `registers:` (wide) mode.
+    #[serde(default)]
+    pub updates: Vec<UpdateRule>,
+    /// Engineering-unit values derived from the register file, readable by Rust
+    /// consumers/tests through the engine's `observable()` API (e.g. the PCA9685
+    /// `servo_angle` per channel). Applies to the `register_file:` mode.
+    #[serde(default)]
+    pub observables: Vec<ObservableSpec>,
+}
+
+/// **Byte-addressable register file** for the `register_file` I²C mode: `size`
+/// one-byte registers, a write-pointer selected by the first post-START byte,
+/// and an auto-increment policy that walks the pointer after each data byte.
+/// This is the datasheet shape for PWM expanders / GPIO expanders (PCA9685)
+/// whose block writes stream consecutive registers. Mutually exclusive with the
+/// named `registers:`/`commands:` shapes.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RegisterFileSpec {
+    /// Number of one-byte registers (typically 256).
+    pub size: usize,
+    /// Sparse non-zero power-on reset values, keyed by register offset.
+    #[serde(default)]
+    pub reset: BTreeMap<u8, u8>,
+    /// Mask applied to the pointer byte. Absent ⇒ `0xFF`.
+    #[serde(default = "default_pointer_mask")]
+    pub pointer_mask: u8,
+    /// The first byte written after START selects the pointer. Default true.
+    #[serde(default = "default_true")]
+    pub first_write_after_start_sets_pointer: bool,
+    /// When the pointer advances after a data byte read/written.
+    #[serde(default)]
+    pub auto_increment: AutoIncrement,
+}
+
+fn default_pointer_mask() -> u8 {
+    0xFF
+}
+
+/// Auto-increment policy for a register-file write-pointer. Checked **live**
+/// (after the enabling byte is stored), so the very write that sets the enable
+/// field also advances the pointer — matching PCA9685 silicon.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum AutoIncrement {
+    /// Pointer never advances automatically.
+    #[default]
+    Never,
+    /// Pointer advances after every data byte.
+    Always,
+    /// Pointer advances while `regs[addr] & mask != 0` (PCA9685 MODE1.AI).
+    WhenFieldSet {
+        /// Register offset holding the enable field.
+        addr: u8,
+        /// Bit mask of the enable field.
+        mask: u8,
+    },
+}
+
+/// Serde helper for the `when_field_set` map form of [`AutoIncrement`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WhenFieldSetFields {
+    addr: u8,
+    mask: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutoIncrementMap {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    when_field_set: Option<WhenFieldSetFields>,
+}
+
+impl Serialize for AutoIncrement {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            AutoIncrement::Never => serializer.serialize_str("never"),
+            AutoIncrement::Always => serializer.serialize_str("always"),
+            AutoIncrement::WhenFieldSet { addr, mask } => AutoIncrementMap {
+                when_field_set: Some(WhenFieldSetFields {
+                    addr: *addr,
+                    mask: *mask,
+                }),
+            }
+            .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AutoIncrement {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+        let value = serde_yaml::Value::deserialize(deserializer)?;
+        match &value {
+            serde_yaml::Value::String(s) => match s.as_str() {
+                "never" => Ok(AutoIncrement::Never),
+                "always" => Ok(AutoIncrement::Always),
+                other => Err(D::Error::unknown_variant(
+                    other,
+                    &["never", "always", "when_field_set"],
+                )),
+            },
+            serde_yaml::Value::Mapping(_) => {
+                let m: AutoIncrementMap =
+                    serde_yaml::from_value(value).map_err(D::Error::custom)?;
+                match m.when_field_set {
+                    Some(f) => Ok(AutoIncrement::WhenFieldSet {
+                        addr: f.addr,
+                        mask: f.mask,
+                    }),
+                    None => Err(D::Error::custom("unknown auto_increment variant")),
+                }
+            }
+            _ => Err(D::Error::custom(
+                "expected string or map for auto_increment",
+            )),
+        }
+    }
+}
+
+/// One self-driving update: a trigger paired with an action. See
+/// [`I2cSpec::updates`].
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateRule {
+    pub trigger: UpdateTrigger,
+    pub action: UpdateAction,
+}
+
+/// What fires an [`UpdateRule`]. Currently only `read_complete` — a full
+/// multi-byte read of the identified register finished.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateTrigger {
+    pub read_complete: ReadComplete,
+}
+
+/// Identify the register a `read_complete` trigger watches: exactly one of a
+/// register `name` or a `pointer` value.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReadComplete {
+    #[serde(default)]
+    pub register: Option<String>,
+    #[serde(default)]
+    pub pointer: Option<u8>,
+}
+
+/// What an [`UpdateRule`] does. Currently only `add_wrap`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UpdateAction {
+    pub add_wrap: AddWrap,
+}
+
+/// `value = value.wrapping_add(add) as i16; if value > max { value = reset }`
+/// applied to the triggering register's stored word (signed i16 semantics).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AddWrap {
+    pub add: i16,
+    pub max: i16,
+    pub reset: i16,
+}
+
+/// A named, channel-indexed engineering-unit value derived from the register
+/// file. See [`I2cSpec::observables`].
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ObservableSpec {
+    pub name: String,
+    /// Number of channels (1 for a scalar observable).
+    pub channels: u8,
+    /// Register offset of channel 0's block.
+    pub base: u8,
+    /// Offset between consecutive channel blocks.
+    pub stride: u8,
+    /// How the raw value is composed from the channel block.
+    pub value: ObservableValue,
+    /// Optional raw → engineering-units mapping.
+    #[serde(default)]
+    pub map: Option<ObservableMap>,
+}
+
+/// Raw-value composition for an [`ObservableSpec`].
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ObservableValue {
+    pub u12_compose: U12Compose,
+}
+
+/// `((regs[base+hi_rel] & hi_mask) << 8) | regs[base+lo_rel]`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct U12Compose {
+    pub lo_rel: u8,
+    pub hi_rel: u8,
+    pub hi_mask: u8,
+}
+
+/// Raw → engineering-units mapping for an [`ObservableSpec`].
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ObservableMap {
+    pub linear: LinearMap,
+    /// Return `None` while the raw value is exactly 0 (channel never written).
+    #[serde(default)]
+    pub none_when_raw_zero: bool,
+}
+
+/// `eng = clamp(raw * scale + offset)`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LinearMap {
+    pub scale: f64,
+    pub offset: f64,
+    /// Optional inclusive `[lo, hi]` clamp.
+    #[serde(default)]
+    pub clamp: Option<(f64, f64)>,
 }
 
 /// The `behavior.spi` section of a declarative `spi_device` — datasheet-shaped
@@ -1310,6 +1530,8 @@ pub fn embedded_device_yaml(device_type: &str) -> Option<&'static str> {
         "max31855" => Some(include_str!("../../../configs/devices/max31855.yaml")),
         "bh1750" => Some(include_str!("../../../configs/devices/bh1750.yaml")),
         "veml7700" => Some(include_str!("../../../configs/devices/veml7700.yaml")),
+        "tmp102" => Some(include_str!("../../../configs/devices/tmp102.yaml")),
+        "pca9685" => Some(include_str!("../../../configs/devices/pca9685.yaml")),
         _ => None,
     }
 }

--- a/crates/core/src/peripherals/components/declarative_i2c.rs
+++ b/crates/core/src/peripherals/components/declarative_i2c.rs
@@ -38,10 +38,11 @@ use std::collections::HashMap;
 
 use anyhow::{bail, Context, Result};
 use labwired_config::{
-    Crc8Spec, DeviceDescriptor, Endian, I2cAccess, I2cCommand, I2cRegister, I2cSpec, ResponseWord,
+    AddWrap, AutoIncrement, Crc8Spec, DeviceDescriptor, Endian, I2cAccess, I2cCommand, I2cRegister,
+    I2cSpec, ObservableSpec, ReadComplete, ResponseWord, UpdateRule,
 };
 
-use super::declarative_regs::{encode_raw, pack, register_read_bytes, unpack};
+use super::declarative_regs::{encode_raw, observe, pack, register_read_bytes, unpack};
 use crate::peripherals::i2c::I2cDevice;
 use crate::sim_input::{InputChannel, SimInput, SimInputError};
 
@@ -100,6 +101,24 @@ pub struct GenericI2cDevice {
     pending: Option<Vec<u8>>,
     ready_at_us: u64,
 
+    /// Register-pointer-mode pointer mask (applied to the pointer byte). 0xFF ⇒
+    /// no masking (the default; TMP102 uses 0x03).
+    reg_pointer_mask: u8,
+    /// Register-pointer-mode self-driving update rules (e.g. TMP102 drift).
+    updates: Vec<UpdateRule>,
+
+    /// **Byte-addressable register-file** mode state. `Some` ⇒ this device is a
+    /// register-file device (PCA9685-style); the register/command fields above
+    /// are unused. `None` ⇒ a register-pointer or command device.
+    file: Option<Vec<u8>>,
+    file_pointer: u8,
+    file_writes_since_frame: u32,
+    file_pointer_mask: u8,
+    file_first_write_sets_pointer: bool,
+    file_auto_increment: AutoIncrement,
+    /// Engineering-unit observables derived from the register file.
+    observables: Vec<ObservableSpec>,
+
     /// Discovery channels (leaked to `'static`; see [`DeclarativeI2cKit`]).
     channels: &'static [InputChannel],
     /// system.yaml `external_devices` id, stamped at attach.
@@ -134,12 +153,33 @@ impl GenericI2cDevice {
             }
         }
         // Seed every register to its reset value so a scale_from / storage read
-        // before any write observes the power-on state.
+        // (or a self-driving `add_wrap` update) before any write observes the
+        // power-on state.
         let reg_values = spec
             .registers
             .iter()
             .map(|r| (r.name.clone(), r.reset))
             .collect();
+
+        // Byte-addressable register-file mode: allocate the file and stamp resets.
+        let file = spec.register_file.as_ref().map(|rf| {
+            let mut regs = vec![0u8; rf.size];
+            for (&off, &v) in &rf.reset {
+                if let Some(slot) = regs.get_mut(off as usize) {
+                    *slot = v;
+                }
+            }
+            regs
+        });
+        let (file_pointer_mask, file_first_write_sets_pointer, file_auto_increment) =
+            match &spec.register_file {
+                Some(rf) => (
+                    rf.pointer_mask,
+                    rf.first_write_after_start_sets_pointer,
+                    rf.auto_increment.clone(),
+                ),
+                None => (0xFF, true, AutoIncrement::Never),
+            };
 
         Ok(Self {
             address,
@@ -158,9 +198,77 @@ impl GenericI2cDevice {
             elapsed_us: 0,
             pending: None,
             ready_at_us: 0,
+            reg_pointer_mask: spec.pointer_mask.unwrap_or(0xFF),
+            updates: spec.updates.clone(),
+            file,
+            file_pointer: 0,
+            file_writes_since_frame: 0,
+            file_pointer_mask,
+            file_first_write_sets_pointer,
+            file_auto_increment,
+            observables: spec.observables.clone(),
             channels,
             component_id: None,
         })
+    }
+
+    /// Read a named observable channel in engineering units (e.g. the PCA9685
+    /// `servo_angle` for a channel). Mirrors `IrCore::observable`; only
+    /// register-file devices declare observables, so this returns `None` for
+    /// register-pointer / command devices.
+    pub fn observable(&self, name: &str, channel: u8) -> Option<f64> {
+        let regs = self.file.as_ref()?;
+        let obs = self.observables.iter().find(|o| o.name == name)?;
+        observe(regs, obs, channel)
+    }
+
+    /// Live auto-increment check for the register-file pointer, reading the
+    /// enable field out of the current register image `regs`.
+    fn file_ai_enabled(auto_increment: &AutoIncrement, regs: &[u8]) -> bool {
+        match auto_increment {
+            AutoIncrement::Always => true,
+            AutoIncrement::Never => false,
+            AutoIncrement::WhenFieldSet { addr, mask } => {
+                regs.get(*addr as usize).is_some_and(|r| r & *mask != 0)
+            }
+        }
+    }
+
+    /// Whether a `read_complete` trigger names the register at `pointer`.
+    fn trigger_matches(&self, rc: &ReadComplete, pointer: u8) -> bool {
+        if rc.pointer == Some(pointer) {
+            return true;
+        }
+        match (&rc.register, self.find_register(pointer)) {
+            (Some(name), Some(reg)) => &reg.name == name,
+            _ => false,
+        }
+    }
+
+    /// Apply every `add_wrap` update whose `read_complete` trigger names the
+    /// just-fully-read register at `pointer`, mutating the register's stored
+    /// word (signed i16 semantics, matching the reference drift model).
+    fn apply_read_complete_updates(&mut self, pointer: u8) {
+        let actions: Vec<AddWrap> = self
+            .updates
+            .iter()
+            .filter(|u| self.trigger_matches(&u.trigger.read_complete, pointer))
+            .map(|u| u.action.add_wrap.clone())
+            .collect();
+        if actions.is_empty() {
+            return;
+        }
+        let Some(name) = self.find_register(pointer).map(|r| r.name.clone()) else {
+            return;
+        };
+        for a in actions {
+            let cur = self.reg_values.get(&name).copied().unwrap_or(0) as u16 as i16;
+            let mut v = cur.wrapping_add(a.add);
+            if v > a.max {
+                v = a.reset;
+            }
+            self.reg_values.insert(name.clone(), (v as u16) as u32);
+        }
     }
 
     /// Convenience for tests / standalone use: parse a descriptor YAML and leak
@@ -253,6 +361,10 @@ impl I2cDevice for GenericI2cDevice {
         self.write_buf.clear();
         self.read_idx = 0;
         self.latched = false;
+        // Register-file mode: the first write after START selects the pointer,
+        // exactly like the hand-written PCA9685 (which resets its write counter
+        // on START only).
+        self.file_writes_since_frame = 0;
     }
 
     fn stop(&mut self) {
@@ -264,6 +376,23 @@ impl I2cDevice for GenericI2cDevice {
     }
 
     fn write(&mut self, data: u8) {
+        // Register-file mode (byte-addressable): first post-START byte selects
+        // the pointer; subsequent bytes are data, and the pointer auto-increments
+        // when its enable field is set. The enable is checked LIVE (after the
+        // store) so the write that sets the field also advances the pointer.
+        if let Some(regs) = self.file.as_mut() {
+            if self.file_first_write_sets_pointer && self.file_writes_since_frame == 0 {
+                self.file_pointer = data & self.file_pointer_mask;
+            } else if !regs.is_empty() {
+                let idx = self.file_pointer as usize % regs.len();
+                regs[idx] = data;
+                if Self::file_ai_enabled(&self.file_auto_increment, regs) {
+                    self.file_pointer = self.file_pointer.wrapping_add(1);
+                }
+            }
+            self.file_writes_since_frame = self.file_writes_since_frame.saturating_add(1);
+            return;
+        }
         self.write_buf.push(data);
         if self.command_mode {
             // A command completes once `code_width` bytes have arrived (a
@@ -278,10 +407,10 @@ impl I2cDevice for GenericI2cDevice {
             }
             return;
         }
-        // Register mode: first byte is the pointer; the rest are a data write
-        // into the pointed rw register.
+        // Register mode: first byte is the pointer (masked); the rest are a data
+        // write into the pointed rw register.
         if self.write_buf.len() == 1 {
-            self.pointer = Some(data);
+            self.pointer = Some(data & self.reg_pointer_mask);
             return;
         }
         let Some(ptr) = self.pointer else { return };
@@ -294,6 +423,18 @@ impl I2cDevice for GenericI2cDevice {
     }
 
     fn read(&mut self) -> u8 {
+        // Register-file mode: return the pointed byte and auto-increment (live).
+        if let Some(regs) = self.file.as_ref() {
+            if regs.is_empty() {
+                return 0;
+            }
+            let idx = self.file_pointer as usize % regs.len();
+            let v = regs[idx];
+            if Self::file_ai_enabled(&self.file_auto_increment, regs) {
+                self.file_pointer = self.file_pointer.wrapping_add(1);
+            }
+            return v;
+        }
         if self.command_mode {
             if self.pending.is_some() && self.elapsed_us >= self.ready_at_us {
                 self.read_buf = self.pending.take().unwrap();
@@ -314,6 +455,17 @@ impl I2cDevice for GenericI2cDevice {
         }
         let byte = self.read_buf.get(self.read_idx).copied().unwrap_or(0xFF);
         self.read_idx += 1;
+        // Self-driving updates: fire when the full multi-byte word has just been
+        // consumed (e.g. the TMP102 +0.5 °C drift after each temperature read).
+        if !self.updates.is_empty() {
+            if let Some(ptr) = self.pointer {
+                if let Some(width) = self.find_register(ptr).map(|r| r.width as usize) {
+                    if self.read_idx == width {
+                        self.apply_read_complete_updates(ptr);
+                    }
+                }
+            }
+        }
         byte
     }
 
@@ -352,15 +504,69 @@ impl SimInput for GenericI2cDevice {
     }
 }
 
-/// A descriptor is exactly one shape, and command devices with CRC framing must
-/// use even-width words (CRC is computed per 16-bit word).
+/// A descriptor is exactly one shape (registers XOR commands XOR register_file),
+/// and command devices with CRC framing must use even-width words (CRC is
+/// computed per 16-bit word).
 fn validate_spec(spec: &I2cSpec) -> Result<()> {
-    match (spec.registers.is_empty(), spec.commands.is_empty()) {
-        (true, true) => bail!("behavior.i2c declares neither registers nor commands"),
-        (false, false) => {
-            bail!("behavior.i2c declares both registers and commands (a device is exactly one)")
+    let has_regs = !spec.registers.is_empty();
+    let has_cmds = !spec.commands.is_empty();
+    let has_file = spec.register_file.is_some();
+    match has_regs as u8 + has_cmds as u8 + has_file as u8 {
+        0 => bail!("behavior.i2c declares none of registers / commands / register_file"),
+        1 => {}
+        _ => bail!(
+            "behavior.i2c declares more than one of registers / commands / register_file \
+             (a device is exactly one shape)"
+        ),
+    }
+    // `observables` read the byte register file; `updates` drive a wide register.
+    if !spec.observables.is_empty() && !has_file {
+        bail!("behavior.i2c declares observables but no register_file (observables read it)");
+    }
+    if !spec.updates.is_empty() && !has_regs {
+        bail!("behavior.i2c declares updates but no registers (updates drive a wide register)");
+    }
+    if let Some(rf) = &spec.register_file {
+        if rf.size == 0 || rf.size > 65536 {
+            bail!("register_file.size {} outside 1..=65536", rf.size);
         }
-        _ => {}
+        for &off in rf.reset.keys() {
+            if off as usize >= rf.size {
+                bail!(
+                    "register_file reset offset {off:#x} outside the file (size {:#x})",
+                    rf.size
+                );
+            }
+        }
+        if let AutoIncrement::WhenFieldSet { addr, .. } = &rf.auto_increment {
+            if *addr as usize >= rf.size {
+                bail!("auto_increment enable register {addr:#x} outside the register file");
+            }
+        }
+        for o in &spec.observables {
+            let span = o.value.u12_compose.lo_rel.max(o.value.u12_compose.hi_rel) as usize;
+            let last =
+                o.base as usize + o.stride as usize * (o.channels.max(1) as usize - 1) + span;
+            if last >= rf.size {
+                bail!(
+                    "observable '{}' channel block ends at {last:#x}, outside register_file (size {:#x})",
+                    o.name,
+                    rf.size
+                );
+            }
+        }
+    }
+    // Every `read_complete` update must name a real register (by pointer or name).
+    for u in &spec.updates {
+        let rc = &u.trigger.read_complete;
+        let ok = match (&rc.pointer, &rc.register) {
+            (Some(p), _) => spec.registers.iter().any(|r| r.addr == *p),
+            (None, Some(name)) => spec.registers.iter().any(|r| &r.name == name),
+            (None, None) => false,
+        };
+        if !ok {
+            bail!("update read_complete trigger does not name a declared register");
+        }
     }
     if !spec.commands.is_empty() && !matches!(spec.code_width, 1 | 2) {
         bail!(
@@ -618,6 +824,28 @@ pub static VEML7700_KIT: LazyLock<DeclarativeI2cKit> = LazyLock::new(|| {
         labwired_config::embedded_device_yaml("veml7700").expect("veml7700 descriptor is embedded"),
     )
     .expect("veml7700.yaml is a valid declarative i2c descriptor")
+});
+
+/// TI TMP102 temperature sensor (declarative `tmp102.yaml`, register-pointer +
+/// self-driving drift). Migrated from the hand-written
+/// [`super::super::esp32s3::tmp102::Tmp102`] model, which now survives only as
+/// the byte-parity oracle (see `pca9685_tmp102_parity.rs`).
+pub static TMP102_KIT: LazyLock<DeclarativeI2cKit> = LazyLock::new(|| {
+    DeclarativeI2cKit::from_yaml(
+        labwired_config::embedded_device_yaml("tmp102").expect("tmp102 descriptor is embedded"),
+    )
+    .expect("tmp102.yaml is a valid declarative i2c descriptor")
+});
+
+/// NXP PCA9685 16-channel PWM controller (declarative `pca9685.yaml`,
+/// byte-addressable register file + `servo_angle` observable). Migrated from the
+/// hand-written [`super::pca9685::Pca9685`] model, which now survives only as the
+/// byte-parity oracle (see `pca9685_tmp102_parity.rs`).
+pub static PCA9685_KIT: LazyLock<DeclarativeI2cKit> = LazyLock::new(|| {
+    DeclarativeI2cKit::from_yaml(
+        labwired_config::embedded_device_yaml("pca9685").expect("pca9685 descriptor is embedded"),
+    )
+    .expect("pca9685.yaml is a valid declarative i2c descriptor")
 });
 
 #[cfg(test)]

--- a/crates/core/src/peripherals/components/declarative_regs.rs
+++ b/crates/core/src/peripherals/components/declarative_regs.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 
-use labwired_config::{Encode, Endian, LabDescriptor, RegisterSpec};
+use labwired_config::{Encode, Endian, LabDescriptor, ObservableSpec, RegisterSpec};
 
 use crate::peripherals::kit::LabRef;
 
@@ -171,6 +171,37 @@ pub(crate) fn register_read_bytes(
         reg_values.get(&reg.name).copied().unwrap_or(reg.reset)
     };
     pack(raw, reg.width, reg.endian)
+}
+
+/// Read a named observable channel from a byte-addressable register file:
+/// compose the 12-bit raw value (`((regs[base+hi_rel] & hi_mask) << 8) |
+/// regs[base+lo_rel]`) and apply the optional linear map (`raw × scale + offset`,
+/// clamped). Returns `None` when the channel is out of range, a composing byte
+/// is out of bounds, or (with `none_when_raw_zero`) the raw value is 0. This is
+/// the shared home for the register→engineering-units math; the I²C
+/// `register_file` engine is its only caller (declarative_spi is unaffected).
+pub(crate) fn observe(regs: &[u8], obs: &ObservableSpec, channel: u8) -> Option<f64> {
+    if channel >= obs.channels {
+        return None;
+    }
+    let base = obs.base as usize + obs.stride as usize * channel as usize;
+    let lo = *regs.get(base + obs.value.u12_compose.lo_rel as usize)?;
+    let hi =
+        *regs.get(base + obs.value.u12_compose.hi_rel as usize)? & obs.value.u12_compose.hi_mask;
+    let raw = ((hi as u16) << 8) | lo as u16;
+    match &obs.map {
+        Some(map) => {
+            if map.none_when_raw_zero && raw == 0 {
+                return None;
+            }
+            let mut eng = raw as f64 * map.linear.scale + map.linear.offset;
+            if let Some((lo_c, hi_c)) = map.linear.clamp {
+                eng = eng.clamp(lo_c, hi_c);
+            }
+            Some(eng)
+        }
+        None => Some(raw as f64),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/peripherals/components/i2c_factory.rs
+++ b/crates/core/src/peripherals/components/i2c_factory.rs
@@ -32,12 +32,45 @@ pub fn build_external_i2c_device(
     Some(dev)
 }
 
+/// Build a declarative [`GenericI2cDevice`] from its embedded
+/// `configs/devices/<type>.yaml` descriptor, honouring an `i2c_address` override.
+/// Used by the factory arms of parts (TMP102, PCA9685) that were migrated off
+/// hand-written models but still need a factory entry so every attach path — not
+/// just the kit pass — wires them.
+fn build_declarative_i2c_device(
+    type_str: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> Option<Box<dyn I2cDevice>> {
+    let yaml = labwired_config::embedded_device_yaml(type_str)?;
+    // 0 tells GenericI2cDevice to use the descriptor's default_address.
+    let address = config
+        .get("i2c_address")
+        .and_then(|v| v.as_u64())
+        .map(|a| a as u8)
+        .unwrap_or(0);
+    match crate::peripherals::components::declarative_i2c::GenericI2cDevice::from_yaml(
+        yaml, address,
+    ) {
+        Ok(dev) => Some(Box::new(dev)),
+        Err(e) => {
+            eprintln!("declarative i2c device '{type_str}': {e}");
+            None
+        }
+    }
+}
+
 pub fn build_i2c_device(
     type_str: &str,
     config: &HashMap<String, serde_yaml::Value>,
 ) -> Option<Box<dyn I2cDevice>> {
     match type_str.to_ascii_lowercase().as_str() {
-        "tmp102" => Some(Box::new(crate::peripherals::esp32s3::tmp102::Tmp102::new())),
+        // TMP102 (register-pointer + drift) and PCA9685 (byte register file +
+        // servo observable) are declarative devices — the model lives entirely in
+        // configs/devices/*.yaml, interpreted by the generic GenericI2cDevice. The
+        // hand-written structs survive only as the byte-parity oracles.
+        "tmp102" | "pca9685" => {
+            build_declarative_i2c_device(&type_str.to_ascii_lowercase(), config)
+        }
         "tmp117" => {
             use crate::peripherals::components::tmp117::{Tmp117, TMP117_ADDR};
             let address = config

--- a/crates/core/src/peripherals/kit/registry.rs
+++ b/crates/core/src/peripherals/kit/registry.rs
@@ -77,6 +77,11 @@ pub static KITS: &[&'static dyn PeripheralKit] = &[
     &components::declarative_i2c::SHT31_KIT,
     &components::declarative_i2c::BH1750_KIT,
     &components::declarative_i2c::VEML7700_KIT,
+    // TMP102 (register-pointer + drift) and PCA9685 (byte register file + servo
+    // observable) were migrated from hand-written models; those survive only as
+    // the byte-parity oracles (pca9685_tmp102_parity.rs).
+    &components::declarative_i2c::TMP102_KIT,
+    &components::declarative_i2c::PCA9685_KIT,
     // Declarative SPI devices — model lives entirely in configs/devices/*.yaml,
     // interpreted by the generic GenericSpiDevice (zero per-part Rust).
     &components::declarative_spi::ADXL345_KIT,

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -41,10 +41,8 @@ fn build_i2c_external_device(
         "oled-ssd1306" => Some(Box::new(crate::peripherals::components::Ssd1306::new(
             addr(0x3C),
         ))),
-        "tmp102" => Some(Box::new(crate::peripherals::esp32s3::tmp102::Tmp102::new())),
-        "pca9685" => Some(Box::new(
-            crate::peripherals::components::pca9685::Pca9685::new(),
-        )),
+        // tmp102 / pca9685 are declarative devices handled by the shared factory
+        // (`build_external_i2c_device`) above — no local arm needed.
         _ => None,
     }
 }

--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -1619,6 +1619,40 @@
       ]
     },
     {
+      "device_type": "tmp102",
+      "label": "TI TMP102 Temperature",
+      "summary": "12-bit I²C temperature sensor (self-drifting demo).",
+      "detail": "Texas Instruments TMP102 at default address 0x48, a register-pointer device with 16-bit big-endian words (pointer decodes only the low two bits). The temperature register starts at 25 °C and self-drifts +0.5 °C per read, wrapping 35 °C → 20 °C — a deterministic demo stimulus that needs no external input. Config / T_LOW / T_HIGH are read-only storage.",
+      "transport": "i2c",
+      "category": "i2c",
+      "config_keys": [
+        {
+          "name": "i2c_address",
+          "ty": "int",
+          "doc": "7-bit slave address. Defaults to the TMP102 address 0x48 (ADD0 = GND)."
+        }
+      ],
+      "labs": [],
+      "inputs": []
+    },
+    {
+      "device_type": "pca9685",
+      "label": "NXP PCA9685 PWM/Servo",
+      "summary": "16-channel 12-bit I²C PWM / servo controller.",
+      "detail": "NXP PCA9685 at default address 0x40, a 256-byte register-file device with a write-pointer and MODE1.AI auto-increment. Drives up to 16 servo/LED PWM channels; the servo_angle observable reports each channel's commanded angle in degrees. Power-on MODE1 reads back 0x11 (SLEEP | ALLCALL), matching silicon.",
+      "transport": "i2c",
+      "category": "i2c",
+      "config_keys": [
+        {
+          "name": "i2c_address",
+          "ty": "int",
+          "doc": "7-bit slave address. Defaults to the PCA9685 address 0x40 (A0..A5 tied low)."
+        }
+      ],
+      "labs": [],
+      "inputs": []
+    },
+    {
       "device_type": "adxl345_spi",
       "label": "ADXL345 accelerometer",
       "summary": "3-axis ±16 g accelerometer over SPI (full-resolution, 256 LSB/g).",

--- a/crates/core/tests/pca9685_tmp102_parity.rs
+++ b/crates/core/tests/pca9685_tmp102_parity.rs
@@ -1,0 +1,275 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! **Byte-parity harness: the declarative PCA9685 / TMP102 vs the hand-written
+//! oracles.**
+//!
+//! The shipping PCA9685 and TMP102 are now the declarative descriptors
+//! `configs/devices/pca9685.yaml` / `configs/devices/tmp102.yaml`, interpreted by
+//! [`GenericI2cDevice`]. The hand-written [`Pca9685`] / [`Tmp102`] models are
+//! retained *only* as the reference this file proves the declarative devices
+//! byte-identical against: every test drives the OLD and NEW devices through the
+//! exact same I²C script and asserts byte-equal reads (and, for PCA9685, equal
+//! `servo_angle` observables).
+//!
+//! This is the declarative-vs-hand-written gate. The sibling
+//! `ir_component_equivalence.rs` (IR-vs-hand-written) stays unchanged — it is a
+//! Phase-B deletion target.
+
+use labwired_core::peripherals::components::{GenericI2cDevice, Pca9685};
+use labwired_core::peripherals::esp32s3::tmp102::Tmp102;
+use labwired_core::peripherals::i2c::I2cDevice;
+
+/// One bus op. Deterministic corpus only — no randomness.
+#[derive(Clone)]
+enum Op {
+    Start,
+    Write(u8),
+    Read,
+}
+
+fn declarative(device_type: &str) -> GenericI2cDevice {
+    let yaml = labwired_config::embedded_device_yaml(device_type)
+        .unwrap_or_else(|| panic!("{device_type} descriptor is embedded"));
+    GenericI2cDevice::from_yaml(yaml, 0)
+        .unwrap_or_else(|e| panic!("{device_type}.yaml is a valid descriptor: {e}"))
+}
+
+/// Drive the oracle and the declarative device through `ops` in lockstep,
+/// asserting every read is byte-identical.
+#[track_caller]
+fn drive_both(oracle: &mut dyn I2cDevice, decl: &mut dyn I2cDevice, ops: &[Op]) {
+    assert_eq!(oracle.address(), decl.address(), "address");
+    for (i, op) in ops.iter().enumerate() {
+        match op {
+            Op::Start => {
+                oracle.start();
+                decl.start();
+            }
+            Op::Write(b) => {
+                oracle.write(*b);
+                decl.write(*b);
+            }
+            Op::Read => assert_eq!(oracle.read(), decl.read(), "read divergence at op {i}"),
+        }
+    }
+}
+
+// ─── PCA9685 ────────────────────────────────────────────────────────────────
+
+fn set_angle_ops(ops: &mut Vec<Op>, ch: u8, deg: f64) {
+    let us = 500.0 + (deg / 180.0) * 1900.0;
+    let ticks = (us / 20000.0 * 4096.0) as u16;
+    ops.push(Op::Start);
+    ops.push(Op::Write(0x06 + 4 * ch));
+    ops.push(Op::Write(0x00));
+    ops.push(Op::Write(0x00));
+    ops.push(Op::Write((ticks & 0xFF) as u8));
+    ops.push(Op::Write(((ticks >> 8) & 0x0F) as u8));
+}
+
+/// After driving `ops` into a fresh declarative PCA9685, assert every channel's
+/// `servo_angle` observable equals the hand-written oracle's `channel_angle_deg`
+/// (presence and value, within the IR-gate tolerance of 0.01°).
+#[track_caller]
+fn assert_observables_equal(oracle: &Pca9685, decl: &GenericI2cDevice) {
+    for ch in 0..16u8 {
+        let a = oracle.channel_angle_deg(ch);
+        let b = decl.observable("servo_angle", ch);
+        match (a, b) {
+            (None, None) => {}
+            (Some(x), Some(y)) => assert!(
+                (x as f64 - y).abs() < 0.01,
+                "ch {ch}: oracle {x} vs declarative {y}"
+            ),
+            _ => panic!("ch {ch}: presence mismatch oracle={a:?} declarative={b:?}"),
+        }
+    }
+}
+
+#[test]
+fn pca9685_dispense_sequence_is_byte_equivalent_with_observables() {
+    let mut oracle = Pca9685::new();
+    let mut decl = declarative("pca9685");
+    let mut ops = vec![Op::Start, Op::Write(0x00), Op::Write(0xA1)]; // AI on
+    set_angle_ops(&mut ops, 8, 15.0); // revolver → compartment 1
+    set_angle_ops(&mut ops, 12, 20.0); // shutter closed
+    set_angle_ops(&mut ops, 12, 90.0); // shutter open
+    set_angle_ops(&mut ops, 8, 135.0); // revolver → compartment 5
+                                       // Read back the channel-8 block through AI.
+    ops.push(Op::Start);
+    ops.push(Op::Write(0x06 + 4 * 8));
+    for _ in 0..4 {
+        ops.push(Op::Read);
+    }
+    drive_both(&mut oracle, &mut decl, &ops);
+    assert_observables_equal(&oracle, &decl);
+}
+
+#[test]
+fn pca9685_pointer_semantics_without_ai_are_byte_equivalent() {
+    // AI off (power-on MODE1=0x11): repeated reads hit the same register; data
+    // writes overwrite the same register.
+    let ops = vec![
+        Op::Start,
+        Op::Write(0x00), // pointer = MODE1
+        Op::Read,
+        Op::Read,
+        Op::Start,
+        Op::Write(0x06),
+        Op::Write(0x55), // data write with AI off
+        Op::Write(0x66), // overwrites the same register
+        Op::Start,
+        Op::Write(0x06),
+        Op::Read,
+    ];
+    drive_both(&mut Pca9685::new(), &mut declarative("pca9685"), &ops);
+}
+
+#[test]
+fn pca9685_full_255_byte_ai_sweep_is_byte_equivalent() {
+    // Walk every register: write a deterministic pattern with AI on, then read
+    // the whole file back and compare byte-for-byte.
+    let mut ops = vec![Op::Start, Op::Write(0x00), Op::Write(0xA1)];
+    ops.push(Op::Start);
+    ops.push(Op::Write(0x01)); // start after MODE1 to keep AI set
+    for i in 1..=255u32 {
+        ops.push(Op::Write((i.wrapping_mul(37) & 0xFF) as u8));
+    }
+    ops.push(Op::Start);
+    ops.push(Op::Write(0x00));
+    for _ in 0..=255 {
+        ops.push(Op::Read);
+    }
+    drive_both(&mut Pca9685::new(), &mut declarative("pca9685"), &ops);
+}
+
+#[test]
+fn pca9685_b2_ai_enable_timing_is_byte_equivalent() {
+    // The Write(0xA1) that sets AI is checked *after* it is stored, so the AI
+    // bit is visible for the auto-increment check on the same write: the pointer
+    // advances 0→1 on the enabling write, and the first Read returns regs[1].
+    let ops = vec![
+        Op::Start,
+        Op::Write(0x00), // pointer = MODE1
+        Op::Write(0xA1), // stores 0xA1 into regs[0]; AI now visible → pointer → 1
+        Op::Read,        // reads regs[1] = 0x00 (MODE2 reset); pointer → 2
+        Op::Read,        // reads regs[2]; pointer → 3
+    ];
+    drive_both(&mut Pca9685::new(), &mut declarative("pca9685"), &ops);
+}
+
+#[test]
+fn pca9685_b3_double_start_is_byte_equivalent() {
+    let ops = vec![
+        Op::Start,
+        Op::Start,       // second consecutive START — must be a no-op
+        Op::Write(0x00), // pointer = MODE1
+        Op::Read,        // returns reset 0x11
+    ];
+    drive_both(&mut Pca9685::new(), &mut declarative("pca9685"), &ops);
+}
+
+#[test]
+fn pca9685_servo_angle_observable_matches_across_duties_including_raw_zero() {
+    // Several duty values across the range, plus a clamp-at-0 (small raw) and a
+    // never-written channel (raw 0 → None on both).
+    let mut oracle = Pca9685::new();
+    let mut decl = declarative("pca9685");
+    let mut ops = vec![Op::Start, Op::Write(0x00), Op::Write(0xA1)]; // AI on
+    set_angle_ops(&mut ops, 0, 0.0);
+    set_angle_ops(&mut ops, 1, 45.0);
+    set_angle_ops(&mut ops, 2, 90.0);
+    set_angle_ops(&mut ops, 4, 135.0);
+    set_angle_ops(&mut ops, 5, 180.0);
+    // Channel 3: raw OFF = 50 (nonzero but maps below 0° → clamps to 0.0).
+    ops.push(Op::Start);
+    ops.push(Op::Write(0x06 + 4 * 3));
+    ops.push(Op::Write(0x00));
+    ops.push(Op::Write(0x00));
+    ops.push(Op::Write(50)); // OFF_L = 50
+    ops.push(Op::Write(0x00)); // OFF_H = 0 → raw = 50
+    drive_both(&mut oracle, &mut decl, &ops);
+    assert_observables_equal(&oracle, &decl);
+    // Channel 3 is nonzero → Some(clamped 0.0); channel 15 never written → None.
+    assert_eq!(decl.observable("servo_angle", 3), Some(0.0));
+    assert_eq!(oracle.channel_angle_deg(3), Some(0.0));
+    assert_eq!(decl.observable("servo_angle", 15), None);
+    assert_eq!(oracle.channel_angle_deg(15), None);
+    // Out-of-range channel and unknown observable are None.
+    assert_eq!(decl.observable("servo_angle", 16), None);
+    assert_eq!(decl.observable("nope", 0), None);
+}
+
+// ─── TMP102 ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn tmp102_temperature_drift_and_wrap_are_byte_equivalent() {
+    let mut oracle = Tmp102::new();
+    let mut decl = declarative("tmp102");
+    assert_eq!(oracle.address(), decl.address(), "tmp102 address 0x48");
+    // 60 full temperature reads (each framed by START + pointer 0x00 + two reads)
+    // crosses the 35 °C wrap at least twice.
+    let mut ops = Vec::new();
+    for _ in 0..60 {
+        ops.push(Op::Start);
+        ops.push(Op::Write(0x00));
+        ops.push(Op::Read);
+        ops.push(Op::Read);
+    }
+    drive_both(&mut oracle, &mut decl, &ops);
+}
+
+#[test]
+fn tmp102_config_tlow_thigh_read_back_identically() {
+    let mut ops = Vec::new();
+    for ptr in 1..=3u8 {
+        ops.push(Op::Start);
+        ops.push(Op::Write(ptr));
+        ops.push(Op::Read); // MSB
+        ops.push(Op::Read); // LSB
+    }
+    drive_both(&mut Tmp102::new(), &mut declarative("tmp102"), &ops);
+}
+
+#[test]
+fn tmp102_config_write_is_absorbed_identically() {
+    // Write pointer 0x01 (config), then a data byte (0x55) — absorbed/ignored by
+    // both models; read back config and assert byte equality (proves absorb, not
+    // just by-construction).
+    let ops = vec![
+        Op::Start,
+        Op::Write(0x01), // pointer → config
+        Op::Write(0x55), // absorbed by both
+        Op::Start,
+        Op::Write(0x01),
+        Op::Read, // config MSB
+        Op::Read, // config LSB
+    ];
+    drive_both(&mut Tmp102::new(), &mut declarative("tmp102"), &ops);
+}
+
+#[test]
+fn tmp102_pointer_masking_is_byte_equivalent() {
+    // Pointer decodes only the low two bits: writing 0x04 aliases to 0x00 (temp),
+    // 0x06 aliases to 0x02 (T_LOW). Both models must agree.
+    let ops = vec![
+        // 0x04 → temp: MSB/LSB then drift.
+        Op::Start,
+        Op::Write(0x04),
+        Op::Read,
+        Op::Read,
+        // 0x06 → T_LOW (0x4B00).
+        Op::Start,
+        Op::Write(0x06),
+        Op::Read,
+        Op::Read,
+        // 0x07 → T_HIGH (0x5000).
+        Op::Start,
+        Op::Write(0x07),
+        Op::Read,
+        Op::Read,
+    ];
+    drive_both(&mut Tmp102::new(), &mut declarative("tmp102"), &ops);
+}


### PR DESCRIPTION
Phase A of retiring the legacy IR declarative engine: fold its three remaining unique capabilities into the modern declarative `i2c_device` stack and port **TMP102 + PCA9685** with **byte-parity**. Both parts now ship as `configs/devices/*.yaml` with zero per-part Rust.

## New `behavior.i2c` capabilities (datasheet-shaped, minimal-flat)
- **`register_file`** — byte-addressable file (`size` / `reset` / `pointer_mask` / `first_write_after_start_sets_pointer` / `auto_increment`). `auto_increment` is `never | always | when_field_set{addr, mask}`, checked **live** so the enabling write itself advances the pointer (PCA9685 MODE1.AI B2 semantics). Mutually exclusive with `registers:` / `commands:` (validated).
- **`updates`** — self-driving `read_complete → add_wrap`, fired when a full multi-byte read of the target register completes (TMP102 +0.5 °C drift). Implemented generically in the engine, not TMP102-special-cased.
- **`observables`** — register-file-derived engineering-unit values (`u12_compose` + linear `map` + `none_when_raw_zero`) with a public `GenericI2cDevice::observable()` API mirroring `IrCore::observable` (PCA9685 `servo_angle`). Shared math added to `declarative_regs.rs`; `declarative_spi` untouched.
- **`pointer_mask`** on the `registers:` mode (TMP102 `0x03`).

## Ports
- `configs/devices/tmp102.yaml` — 4 wide 16-bit BE registers, `pointer_mask 0x03`, config-write-absorbed, `add_wrap` drift (`0x80` / max `0x2300` / reset `0x1400`).
- `configs/devices/pca9685.yaml` — 256-byte register file, reset `{0x00: 0x11}`, AI `when_field_set{0x00, 0x20}`, `servo_angle` observable.
- Registered both as `DeclarativeI2cKit`s; vendored peripherals manifest regenerated (**54 → 56** devices).
- Repointed the tmp102/pca9685 factory + ESP32 attach arms to the kit path. The hand-written `Tmp102`/`Pca9685` structs stay public as **byte-parity oracles only** (hw-oracle keeps `Tmp102` as its ACK stub, unchanged). The hand-written PCA9685 `eprintln` servo log leaves the production path with the demotion.

## Byte-parity harness
`crates/core/tests/pca9685_tmp102_parity.rs` drives the hand-written oracles vs the new `GenericI2cDevice` through identical scripts — full PCA9685 op corpus incl. the B2 AI-enable hardener + 255-byte AI sweep + `servo_angle` observable cross-checks (incl. raw-zero → `None` and clamp-at-0), TMP102 60-read drift/wrap, config-write-absorbed, and pointer masking. Byte-equal streams + equal observables.

The existing `ir_component_equivalence.rs` (IR vs hand-written) is **untouched and still green** — it is Phase B's deletion target.

## Gates
Green: full `cargo test -p labwired-core` (2363 passed) and `-p labwired-config`, kit/manifest gate, `system::xtensa` manifest-attach tmp102, factory tests, veml7700 parity, hw-oracle build, fmt, clippy. Pre-existing failures unrelated to this diff (proven identical on `origin/main`): `e2e_stm32f407_i2c`, `firmware_survival::test_nucleo_f407_i2c_survival`, `test_nucleo_l476rg_i2c_survival` — STM32 I²C firmware getting stuck (aht20/bmp280 / l476rg; no tmp102/pca9685 involvement).