### PR TITLE
chore: ack nrf52840 validation drift from IR retirement (phase B)

### DIFF
--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,8 +7,8 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-22 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
@@ -20,7 +20,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-07-24 | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-22 | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-24 | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-24 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
@@ -29,7 +29,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — conformance 16/16; mmio 16/16; GPIO P0 22/0, P1 23/0; onboarding 22/22; POWER 10/0, SPIS 19/0, TWIS 20/0, RTC0 12/0, TIMER0 16/0; SPIM0/CCM/full-register clean
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -37,7 +37,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — rides the nrf52840 full register sweep (16/16) re-confirmed 2026-06-17
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -122,7 +122,11 @@ boards:
     # nrf52840_ble_loopback_through_virtual_air pass UNCHANGED. No register
     # read/write path, reset value or layout touched — drift is the shared nrf52
     # file commit date only. No live re-capture.
-    drift_ack: 2026-07-23
+    # 2026-07-24: IR-component-engine retirement (phase B) removed the dead
+    # `type: ir` SPI escape-hatch branch from nrf52/factory.rs. No register
+    # read/write path, reset value or layout touched — drift is the shared nrf52
+    # file commit date only. No live re-capture.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -176,7 +180,10 @@ boards:
     # 2026-07-22: rides the nrf52840 BLE virtual-air VirtualAirBus refactor (same
     # silicon); byte-identical, transitional global default. See the nrf52840
     # drift_ack note.
-    drift_ack: 2026-07-23
+    # 2026-07-24: rides the nrf52840 IR-component-engine retirement (dead
+    # `type: ir` SPI escape-hatch removed from nrf52/factory.rs); byte-identical,
+    # same silicon. See the nrf52840 drift_ack note.
+    drift_ack: 2026-07-24
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml


### PR DESCRIPTION
Follow-up to #650. The IR-component-engine retirement removed the dead `type: ir` SPI escape-hatch branch from `crates/core/src/peripherals/nrf52/factory.rs`. That directory is in nrf52840's `models` glob, so the validation-status generator rolled nrf52840 / seeed-xiao-nrf52840-sense "newest model" to 2026-07-24 — past their 2026-07-23 `drift_ack` — flipping `pr-gate` to ✖ DRIFT on main.

The change is pure dead-code removal: no register read/write path, reset value, or layout touched (offline nrf52 conformance / mmio / gpio suites pass unchanged). This bumps both `drift_ack`s to 2026-07-24 with a dated note and regenerates `docs/boards/VALIDATION_STATUS.md`.

`python3 scripts/generate_validation_status.py --check --drift` → exit 0. Restores `pr-gate` green on main.