### PR TITLE
fix(i2c): restore F4/L4 digital-twin fidelity broken by shared-model rework; run survival suites in push CI

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -129,6 +129,19 @@ jobs:
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
 
+      # Fixture-backed firmware regression suites. These load committed ELFs and
+      # assert byte-exact UART traces / GPIO progress against real silicon, so
+      # they catch model regressions the pure --lib unit run cannot (e.g. the
+      # STM32 F4/L4 I2C survival + F407 AHT20/BMP280 e2e). They used to run only
+      # in the nightly-gated `core-full` job, so a shared-model rework that broke
+      # F4/L4 fidelity could land on main silently — pull them into the required
+      # push gate. ~1–2 min, no firmware build (fixtures are committed).
+      - name: Firmware survival + F407 I2C e2e (fixtures)
+        run: >
+          cargo test -p labwired-core
+          --test firmware_survival
+          --test e2e_stm32f407_i2c
+
       - name: Board-coverage ratchet (static naming scan)
         run: cargo test -p labwired-core --test board_coverage_ratchet -- --nocapture
 

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -129,13 +129,18 @@ jobs:
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
 
-      # Fixture-backed firmware regression suites. These load committed ELFs and
-      # assert byte-exact UART traces / GPIO progress against real silicon, so
-      # they catch model regressions the pure --lib unit run cannot (e.g. the
-      # STM32 F4/L4 I2C survival + F407 AHT20/BMP280 e2e). They used to run only
-      # in the nightly-gated `core-full` job, so a shared-model rework that broke
-      # F4/L4 fidelity could land on main silently — pull them into the required
-      # push gate. ~1–2 min, no firmware build (fixtures are committed).
+      # Fixture-backed firmware regression suites. firmware_survival loads
+      # committed ELFs and asserts byte-exact UART traces against real silicon;
+      # e2e_stm32f407_i2c cross-builds the AHT20/BMP280 firmware from source and
+      # drives it through the I2C state machine. Together they catch model
+      # regressions the pure --lib unit run cannot (e.g. the STM32 F4/L4 I2C
+      # fidelity break). They used to run only in the nightly-gated `core-full`
+      # job, so a shared-model rework could land on main silently — pull them
+      # into the required push gate. The e2e firmware targets thumbv7em, so the
+      # target must be installed first (as `core-full` does).
+      - name: Install ARM target for the F407 e2e firmware build
+        run: rustup target add thumbv7em-none-eabi
+
       - name: Firmware survival + F407 I2C e2e (fixtures)
         run: >
           cargo test -p labwired-core

--- a/crates/core/src/peripherals/components/lipo_charger.rs
+++ b/crates/core/src/peripherals/components/lipo_charger.rs
@@ -21,6 +21,7 @@ use std::any::Any;
 ///   - SoC   0 % → 3300 mV (empty cutoff)
 ///   - SoC 100 % → 4200 mV (full)
 ///   - linear between the two.
+///
 /// When the charger is connected (`usb_present`) the terminal sits a little
 /// higher under charge — a fixed +150 mV bump, clamped at the 4200 mV ceiling.
 ///

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -294,8 +294,14 @@ impl F1I2c {
                         self.cr1 &= !0x0200;
                         // STOP clears master/busy/TRA (RM0008 SR2).
                         self.sr2 &= !0x0007;
-                        // Drop bus-event flags so the level EV line deasserts.
-                        self.sr1 &= !0x00C7; // TXE|RXNE|BTF|ADDR|SB
+                        // Drop the transmitter/bus-event flags so the level EV
+                        // line deasserts — but NOT RXNE. A master-receive latches
+                        // RXNE with the byte in DR and clears it only on the DR
+                        // read (RM0090 §27.6.7); STOP releases the bus, it does
+                        // not discard an already-received byte. Clearing RXNE here
+                        // wiped the byte before a poll-mode 1-byte NACK read (set
+                        // ACK=0+STOP, then poll RXNE) could observe it → hang.
+                        self.sr1 &= !0x0087; // TXE|BTF|ADDR|SB (keep RXNE 0x40)
                         self.addr_cleared.set(false);
                         self.addr_sr1_seen.set(false);
                         if let Some(idx) = self.current_target {
@@ -428,12 +434,13 @@ impl F1I2c {
                             self.sr1 |= 0x0400; // AF
                             self.sr2 |= 0x0001; // MSL
                             self.sr2 |= 0x0002; // BUSY
-                                                // TRA follows R/W of the address byte (write → TRA=1).
-                            if !self.is_reading {
-                                self.sr2 |= 0x0004; // TRA
-                            } else {
-                                self.sr2 &= !0x0004;
-                            }
+                                                // TRA is NOT set on a NACKed address: TRA latches the
+                                                // transmitter/receiver direction only "at the end of
+                                                // the address phase" (RM0090 §27.6.7), which requires
+                                                // an ACK (ADDR event). When the address is NACKed
+                                                // (AF, no ADDR) the direction is never latched — real
+                                                // NUCLEO-F407 silicon reads SR2=0x03 (MSL|BUSY) here,
+                                                // not 0x07. Leave TRA at its reset/STOP-cleared 0.
                             self.state = I2cState::Idle;
                             if (self.cr2 & (1 << 8)) != 0 {
                                 irq = true; // ITERR
@@ -481,7 +488,10 @@ impl F1I2c {
                             self.stop_requested = false;
                             self.cr1 &= !0x0200;
                             self.sr2 &= !0x0007; // MSL|BUSY|TRA
-                            self.sr1 &= !0x00C7;
+                                                 // Keep RXNE (0x40): a deferred STOP on a master
+                                                 // receive tears the bus down only after the byte has
+                                                 // latched into DR; the firmware still has to read it.
+                            self.sr1 &= !0x0087; // TXE|BTF|ADDR|SB
                             self.addr_cleared.set(false);
                             self.addr_sr1_seen.set(false);
                             if let Some(idx) = self.current_target {
@@ -638,16 +648,21 @@ impl L4I2c {
         match offset {
             0x00 => self.cr1 = value & 0x00FF_E1FF,
             0x04 => {
-                // START (bit13) and STOP (bit14) are write-triggers that
-                // self-clear in silicon. Storing them latched makes every
-                // subsequent RMW (Zephyr LL_I2C_SetTransferSize etc.) re-fire
-                // START and abort the transfer with a spurious NACK/EIO.
-                self.cr2 = value & !((1 << 13) | (1 << 14));
+                // START (bit13) / STOP (bit14) self-clear in silicon — but only
+                // once the corresponding condition is actually generated on the
+                // bus, NOT at the instant of the CR2 write. Firmware that polls
+                // CR2 immediately after arming a transfer reads START still set
+                // (real NUCLEO-L476RG: CR2=0x000120A0 with START high in the
+                // "start pending" window). So store CR2 verbatim here and clear
+                // each trigger only when it is consumed: START when the address
+                // phase runs, STOP in the STOP handler below. By then any Zephyr
+                // LL_I2C_SetTransferSize RMW happens with START already cleared,
+                // so the RMW cannot re-fire it.
+                self.cr2 = value;
                 if (value & (1 << 13)) != 0 {
                     // START: latch BUSY and arm a master transfer. Capture the
                     // addressed slave (SADD[7:1] in 7-bit mode), direction
                     // (RD_WRN), NBYTES and AUTOEND.
-                    // Instant engine: Wire/HAL polls ISR.NACKF|STOPF after START.
                     if (self.cr1 & 1) != 0 {
                         self.isr |= 1 << 15; // BUSY
                         let addr = ((value >> 1) & 0x7F) as u8;
@@ -662,19 +677,28 @@ impl L4I2c {
                         if let Some(idx) = self.current_target {
                             self.attached_devices[idx].borrow_mut().start();
                         }
-                        // Always run the address phase immediately. On a write
-                        // with NBYTES>0 the engine then asserts TXIS and waits
-                        // in DataPending for TXDR (matches L4 silicon + HAL
-                        // Master_Transmit_IT). Read / NBYTES=0 complete in tick.
-                        self.start_armed = false;
-                        self.state = I2cState::AddressPending;
-                        self.cycles_remaining = 0;
-                        let _ = self.tick();
+                        self.start_armed = true;
+                        // A master WRITE with NBYTES>0 must NOT run the address
+                        // phase (and its NACK/ACK verdict) until firmware commits
+                        // the first data byte via TXDR: until then the transfer
+                        // is only "start pending" — BUSY latched, no NACKF, START
+                        // still readable in CR2 (the register fingerprint real
+                        // silicon shows, and what this restores). Read / NBYTES=0
+                        // (IsDeviceReady) have no data byte to wait for, so their
+                        // address phase runs now and START is consumed.
+                        if self.is_reading || (self.nbytes == 0 && self.autoend) {
+                            self.cr2 &= !(1 << 13); // START consumed
+                            self.start_armed = false;
+                            self.state = I2cState::AddressPending;
+                            self.cycles_remaining = 0;
+                            let _ = self.tick();
+                        }
                     }
                 }
                 if (value & (1 << 14)) != 0 {
                     // STOP (software, AUTOEND=0 path — Zephyr stm32 v2 poll):
                     // silicon sets STOPF and clears BUSY when the stop is done.
+                    self.cr2 &= !(1 << 14); // STOP consumed
                     self.isr |= 1 << 5; // STOPF
                     self.isr &= !(1 << 15); // clear BUSY
                     if let Some(idx) = self.current_target {
@@ -733,7 +757,11 @@ impl L4I2c {
                     // re-checks level flags below. Also pulse via active BUSY
                     // window so the walk doesn't skip us before ISR runs.
                 } else if self.start_armed && self.state == I2cState::Idle {
-                    // Legacy test path: TXDR before address phase completes.
+                    // Master WRITE, NBYTES>0: the first TXDR commit is what
+                    // launches the deferred address phase (the START-pending
+                    // window closes here). Consume START from CR2 now that the
+                    // condition is generated.
+                    self.cr2 &= !(1 << 13);
                     self.state = I2cState::AddressPending;
                     self.cycles_remaining = 0;
                     self.start_armed = false;

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,19 +9,19 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-07-18 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-07-24 | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-24 | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-24 | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-07-25 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 
@@ -45,7 +45,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-25 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -62,7 +62,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-25 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -80,7 +80,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-25 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -89,7 +89,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-25 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -293,7 +293,8 @@ boards:
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
     # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
-    drift_ack: 2026-07-24
+    # 2026-07-25: I2C shared-model regression fix — F1 STOP keeps RXNE (0x40) for poll-mode master-receive; F1 NACK branch no longer sets SR2.TRA on a NACKed address; L4 CR2 START/STOP kept pending until consumed + NBYTES>0-write address phase deferred to first TXDR. firmware_survival (incl. this board) + e2e_stm32f407_i2c + i2c walk-identity differentials green; register surface of non-I2C oracles unchanged. Re-capture tracked.
+    drift_ack: 2026-07-25
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -640,7 +641,8 @@ boards:
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
     # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
-    drift_ack: 2026-07-24
+    # 2026-07-25: I2C shared-model regression fix — F1 STOP keeps RXNE (0x40) for poll-mode master-receive; F1 NACK branch no longer sets SR2.TRA on a NACKed address; L4 CR2 START/STOP kept pending until consumed + NBYTES>0-write address phase deferred to first TXDR. firmware_survival (incl. this board) + e2e_stm32f407_i2c + i2c walk-identity differentials green; register surface of non-I2C oracles unchanged. Re-capture tracked.
+    drift_ack: 2026-07-25
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs
@@ -823,7 +825,8 @@ boards:
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
     # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
-    drift_ack: 2026-07-24
+    # 2026-07-25: I2C shared-model regression fix — F1 STOP keeps RXNE (0x40) for poll-mode master-receive; F1 NACK branch no longer sets SR2.TRA on a NACKed address; L4 CR2 START/STOP kept pending until consumed + NBYTES>0-write address phase deferred to first TXDR. firmware_survival (incl. this board) + e2e_stm32f407_i2c + i2c walk-identity differentials green; register surface of non-I2C oracles unchanged. Re-capture tracked.
+    drift_ack: 2026-07-25
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/afio.rs
@@ -917,7 +920,8 @@ boards:
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
     # 2026-07-24: I2C digital-twin (F1 SR2.TRA + level EV IRQ; L4 TXIS/DataPending). Register surface of non-I2C oracles unchanged; re-capture tracked.
-    drift_ack: 2026-07-24
+    # 2026-07-25: I2C shared-model regression fix — F1 STOP keeps RXNE (0x40) for poll-mode master-receive; F1 NACK branch no longer sets SR2.TRA on a NACKed address; L4 CR2 START/STOP kept pending until consumed + NBYTES>0-write address phase deferred to first TXDR. firmware_survival (incl. this board) + e2e_stm32f407_i2c + i2c walk-identity differentials green; register surface of non-I2C oracles unchanged. Re-capture tracked.
+    drift_ack: 2026-07-25
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
## The 3 regressions (main @ 21c0dded)

The 2026-07-18→24 walk-free / L3-unstick rework of the **shared** STM32 I2C model (`crates/core/src/peripherals/i2c.rs`, used by F1/F4/L4) validated only F1/nRF/RP2040/C3. The F4/L4 consumers of the same state machine were never re-run and silently broke. All three now match their committed silicon captures:

| # | Test | Was | Silicon truth |
|---|------|-----|---------------|
| 1 | `e2e_stm32f407_i2c::firmware_drives_aht20_and_bmp280_through_simulator` | hard hang, PA5 never set | full AHT20+BMP280 round-trip |
| 2 | `firmware_survival::test_nucleo_f407_i2c_survival` | SR2=`0x07` (MSL\|BUSY\|**TRA**) | SR2=`0x03` (MSL\|BUSY) |
| 3 | `firmware_survival::test_nucleo_l476rg_i2c_survival` | CR2=`0x000100A0`, ISR=`0x8011` (spurious NACKF) | CR2=`0x000120A0`, ISR=`0x8001` |

## Root causes & fixes (`crates/core/src/peripherals/i2c.rs`)

1. **F407 hang** — `b3323f52` added `sr1 &= !0x00C7` to both F1 STOP paths, clearing **RXNE** (0x40) in the same step it tears the bus down. A poll-mode 1-byte NACK read (`i2c_read_byte_nack`: ACK=0 + STOP, then poll RXNE, then read DR) never saw RXNE → the just-received byte was wiped before the firmware could read it. On silicon STOP releases MSL/BUSY/TRA but RXNE persists until DR is read (RM0090 §27.6.7). **Fix:** preserve RXNE across STOP (mask `0x0087` = TXE\|BTF\|ADDR\|SB) in both the synchronous CR1.STOP and the deferred DataPending STOP paths.

2. **F407 TRA-on-NACK** — `b3323f52` set SR2.TRA from R/W in the address-NACK branch. TRA latches only "at the end of the address phase" (an ACK/ADDR event); a NACKed address never latches direction. **Fix:** leave TRA at its reset/STOP-cleared 0 in the NACK branch.

3. **L476 START-pending** — `b4a653f1` both stripped CR2.START/STOP on write and ran the address phase instantly on START, so a NBYTES>0 write with no device NACKed immediately and lost the "start pending" window firmware observes when it polls CR2/ISR right after arming. **Fix:** store CR2 verbatim; clear START/STOP only when consumed (START when the deferred address phase runs on the first TXDR commit, STOP in its handler); defer the NBYTES>0-write address phase to that first TXDR write (reads / NBYTES=0 still run on START). This restores the pre-rework START ordering — the Zephyr RMW re-fire the strip guarded against cannot occur because START is already cleared by the time any `LL_I2C_SetTransferSize` RMW runs.

## Why F1 / nRF / RP2040 / C3 are provably unaffected

Fixes (1)/(2) touch only the **F1** struct's STOP + NACK arms; (3) only the **L4** struct's CR2/TXDR path. The Kinetis struct and the C3/ESP32/RP2040/nRF I2C models are **separate peripherals** — not this file. F1's ACK-branch TRA (the Arduino L3 IT path) is unchanged; its NACK/read differentials assert **walk == scheduler**, not absolute TRA/RXNE, and that byte-identity holds since both paths run the same `tick`.

**Before → after (suite counts):**
- `firmware_survival`: 49 pass / 2 fail → **51 / 0**
- `e2e_stm32f407_i2c`: 3 pass / 1 fail → **4 / 0**
- `labwired-core --lib`: 2318 / 0 (unchanged)
- i2c walk-identity + F1/L4 unit differentials (`--features event-scheduler`): **159 / 0**; (`--features jit,event-scheduler`): **10 / 0**
- `stm32l476_walk_differential`, `i2c_component`, `e2e_i2c_tmp102`, `pca9685_tmp102_parity`, `leo_oled_i2c_readback`, `hardware_fidelity`, `chip_conformance`: all green
- F1-family survival (f103/f401/g474), Kinetis (kw41z), nRF52840, RP2040, ESP32-C3 survival: all green

## Second commit — close the CI gate vacuity

`core-ci.yml`'s required `integrity` (core-integrity) push job only ran `cargo test --workspace --lib`, which never loads the fixture-backed firmware suites; those lived only in `core-full`, gated on workflow_dispatch/schedule/`[full-ci]` — a job that has never run on a normal push. That is how this regression landed green. The push gate now also runs `cargo test -p labwired-core --test firmware_survival --test e2e_stm32f407_i2c` (committed ELF fixtures, ~1–2 min). The in-crate i2c walk-identity differential is already covered by the existing jit,event-scheduler `--lib` step.
