### PR TITLE
fix(esp32c3): keep WiFi association alive under CPU idle fast-forward

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -956,13 +956,47 @@ pub(crate) fn run_one_c3_wifi(
     m.bus.refresh_peripheral_index();
 
     let limit = args.max_steps.unwrap_or(u64::MAX);
+    // Measurement/parity path (env LABWIRED_WIFI_FF=1): drive the station via
+    // the authoritative `advance(run)` loop with scheduler-safe idle
+    // fast-forward enabled — exactly what the browser bridge does for a heavy
+    // C3 chip (`isHeavyBrowserChip` → `set_idle_fast_forward_enabled(true)`).
+    // The default `step()` loop stays the faithful per-instruction reference so
+    // the two can be diffed for byte-identical WiFi output.
+    if std::env::var("LABWIRED_WIFI_FF").is_ok() {
+        use labwired_core::AdvanceRequest;
+        m.config.idle_fast_forward_enabled = true;
+        eprintln!("[solo] idle fast-forward ENABLED (advance/run path)");
+        let mut done: u64 = 0;
+        while done < limit {
+            let chunk = (limit - done).min(2_000_000);
+            match m.advance(AdvanceRequest::run(Some(chunk))) {
+                Ok(_report) => {}
+                Err(e) => {
+                    eprintln!("[solo] station halted after {done} cycles: {e}");
+                    break;
+                }
+            }
+            done = done.saturating_add(chunk);
+            if m.total_cycles == 0 {
+                break;
+            }
+        }
+        eprintln!(
+            "[solo] run complete — total_cycles={} idle_ff_cycles_skipped={}",
+            m.total_cycles, m.idle_fast_forward_cycles_skipped
+        );
+        return ExitCode::SUCCESS;
+    }
     for i in 0..limit {
         if let Err(e) = m.step() {
             eprintln!("[solo] station halted at step {i}: {e}");
             break;
         }
     }
-    eprintln!("[solo] run complete");
+    eprintln!(
+        "[solo] run complete — total_cycles={} (no idle-ff)",
+        m.total_cycles
+    );
     ExitCode::SUCCESS
 }
 

--- a/crates/core/src/bus/tick.rs
+++ b/crates/core/src/bus/tick.rs
@@ -210,6 +210,50 @@ impl SystemBus {
         }
     }
 
+    /// Pre-tick bus-aware pass: lend `&mut self` into every `tick_with_bus`
+    /// peripheral (RADIO Easy-DMA, the WiFi descriptor-ring/medium pump). The
+    /// swap dance temporarily removes each peripheral so it can borrow the bus;
+    /// a no-op stub stands in for the duration. Extracted so the CPU idle
+    /// fast-forward path can run exactly the same pump at the poll deadline (via
+    /// [`Self::run_idle_poll_bus_tick`]) instead of duplicating it.
+    pub(crate) fn run_bus_tick_pass(&mut self) {
+        let mut bus_tick_pos = 0;
+        while bus_tick_pos < self.bus_tick_indices.len() {
+            let i = self.bus_tick_indices[bus_tick_pos];
+            let placeholder: Box<dyn Peripheral> =
+                Box::new(crate::peripherals::stub::StubPeripheral::new(0));
+            let mut dev = std::mem::replace(&mut self.peripherals[i].dev, placeholder);
+            dev.tick_with_bus(self);
+            self.peripherals[i].dev = dev;
+            let still_needs_bus_tick = self.refresh_bus_tick_index(i);
+            if self.peripherals[i].dev.legacy_tick_dynamic() {
+                self.refresh_legacy_tick_index(i);
+            }
+            if still_needs_bus_tick {
+                bus_tick_pos += 1;
+            }
+        }
+    }
+
+    /// True when a bus peripheral services an external medium that must keep
+    /// being polled at a bounded cadence through a CPU idle skip (see
+    /// [`Peripheral::idle_poll_bus_tick`]) — currently a medium-mode WiFi MAC.
+    /// Only the tiny `bus_tick_indices` set is scanned (empty on every non-WiFi
+    /// bus, so this is ~free on the idle-fast-forward hot check).
+    pub(crate) fn idle_poll_bus_tick_active(&self) -> bool {
+        self.bus_tick_indices
+            .iter()
+            .any(|&i| self.peripherals[i].dev.idle_poll_bus_tick())
+    }
+
+    /// Run the bus-tick pump once from the CPU idle fast-forward path, after the
+    /// skip has advanced `current_cycle`, so an external medium's inbound frames
+    /// (and device-cycle-keyed beacons) are serviced at the poll deadline
+    /// instead of being starved for the whole idle window.
+    pub(crate) fn run_idle_poll_bus_tick(&mut self) {
+        self.run_bus_tick_pass();
+    }
+
     #[allow(clippy::type_complexity)]
     fn tick_peripherals_phase1(
         &mut self,
@@ -243,22 +287,7 @@ impl SystemBus {
         // `&mut self` into `tick_with_bus`; a no-op stub stands in for the
         // duration. `needs_bus_tick` returning false skips this for
         // everyone else at near-zero cost.
-        let mut bus_tick_pos = 0;
-        while bus_tick_pos < self.bus_tick_indices.len() {
-            let i = self.bus_tick_indices[bus_tick_pos];
-            let placeholder: Box<dyn Peripheral> =
-                Box::new(crate::peripherals::stub::StubPeripheral::new(0));
-            let mut dev = std::mem::replace(&mut self.peripherals[i].dev, placeholder);
-            dev.tick_with_bus(self);
-            self.peripherals[i].dev = dev;
-            let still_needs_bus_tick = self.refresh_bus_tick_index(i);
-            if self.peripherals[i].dev.legacy_tick_dynamic() {
-                self.refresh_legacy_tick_index(i);
-            }
-            if still_needs_bus_tick {
-                bus_tick_pos += 1;
-            }
-        }
+        self.run_bus_tick_pass();
 
         // Plan 3: collect ESP32-S3 explicit_irq source IDs during pass 1 so
         // they can be routed through the intmatrix in a follow-up pass that

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -603,6 +603,20 @@ pub trait Peripheral: std::fmt::Debug + Send {
     fn needs_bus_tick(&self) -> bool {
         false
     }
+    /// True if this peripheral's `tick_with_bus` must keep running at a bounded
+    /// cadence even while the CPU is idle-fast-forwarding — because it services
+    /// an *external* medium (a WiFi station polling a shared-AP inbox and
+    /// beaconing) whose frames would otherwise be starved for the whole skip
+    /// window, breaking association. Idle fast-forward caps its skip to a small
+    /// poll quantum and runs the bus-tick pass at the deadline when any bus
+    /// peripheral returns true here. Default false: every self-contained
+    /// peripheral drives entirely off CPU cycles / scheduler events and never
+    /// needs the idle window shortened. Peripherals that opt in MUST key their
+    /// internal cadence (beacons, timeouts) on device cycles — NOT on
+    /// tick_with_bus call count — since the call frequency now varies.
+    fn idle_poll_bus_tick(&self) -> bool {
+        false
+    }
     /// True if this peripheral needs the legacy per-tick `tick()` walk.
     ///
     /// The conservative default is true: hand-written behavioral peripherals
@@ -1166,6 +1180,15 @@ pub struct StepProfile {
     pub legacy_tick_entries: u64,
 }
 
+/// Maximum cycles CPU idle fast-forward may skip in one step while a bus
+/// peripheral needs bounded external-medium polling (a medium-mode WiFi MAC —
+/// see [`Peripheral::idle_poll_bus_tick`]). Each skip runs the medium pump at
+/// its deadline, so this sets the worst-case frame-delivery latency: ~8192
+/// cycles ≈ 51 µs at 160 MHz, far under any WiFi association/DHCP/socket
+/// timeout, while still collapsing the millions of idle cycles the CPU would
+/// otherwise execute one-by-one. Non-WiFi buses never consult this.
+const WIFI_MEDIUM_IDLE_POLL_QUANTUM: u64 = 8192;
+
 pub struct Machine<C: Cpu> {
     pub cpu: C,
     /// Secondary CPU instance — for dual-core SoCs (ESP32, ESP32-S3).
@@ -1680,6 +1703,17 @@ impl<C: Cpu> Machine<C> {
             }
             budget = budget.min(remaining);
 
+            // A bus peripheral servicing an external medium (a medium-mode WiFi
+            // MAC) must keep being pumped through the idle window or its inbound
+            // frames are starved for the whole skip — breaking WiFi association
+            // under fast-forward. Cap the skip to a small poll quantum and run
+            // the bus-tick pump at the deadline (below, after the skip commits).
+            // Gated on the tiny bus-tick set, so it is free on every other bus.
+            let idle_poll = self.bus.idle_poll_bus_tick_active();
+            if idle_poll {
+                budget = budget.min(WIFI_MEDIUM_IDLE_POLL_QUANTUM);
+            }
+
             if let Some(deadline_cycle) = self.sched.next_event_deadline() {
                 if deadline_cycle <= self.total_cycles {
                     return 0;
@@ -1713,6 +1747,14 @@ impl<C: Cpu> Machine<C> {
             }
             self.sched.advance_to(self.total_cycles);
             self.drain_scheduler_events();
+            // Pump the external-medium bus-tick peripherals at the poll deadline
+            // (current_cycle was published above), so a WiFi station pulls the
+            // AP's queued auth/assoc/data frames and beacons on schedule even
+            // though the CPU skipped the idle window. `idle_poll` bounded the
+            // skip to the quantum, keeping this cadence fine-grained.
+            if idle_poll {
+                self.bus.run_idle_poll_bus_tick();
+            }
             u64::from(skipped)
         }
     }

--- a/crates/core/src/peripherals/esp32c3/wifi_mac.rs
+++ b/crates/core/src/peripherals/esp32c3/wifi_mac.rs
@@ -50,6 +50,14 @@ pub(crate) fn rxbuf_trace_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var("LABWIRED_RXBUF_TRACE").is_ok())
 }
 
+/// Device-cycle interval between medium-mode AP beacons. Matches the previous
+/// call-counter cadence (one beacon per 2,000,000 per-cycle ticks) but is now
+/// expressed in device cycles so it holds under CPU idle fast-forward, where
+/// `tick_with_bus` no longer runs once per cycle. At 160 MHz this is ~12.5 ms —
+/// well inside the STA's beacon-timeout, and far shorter than association /
+/// DHCP / socket timeouts, so association survives fast-forward.
+const MEDIUM_BEACON_INTERVAL_CYCLES: u64 = 2_000_000;
+
 const MAC_READY: u64 = 0xD14; // bit0 polled by hal_init
 const RX_RING_BASE: u64 = 0x88; // driver writes the RX descriptor-list head here
 /// RX descriptor-reload handshake (`hal_mac_rx_*_dscr_reload`): the driver sets
@@ -132,8 +140,12 @@ pub struct Esp32c3WifiMac {
     /// it transmits — so we needn't predict the eFuse byte order. Used to pull
     /// this station's medium inbox and to beacon it.
     medium_mac: Option<[u8; 6]>,
-    /// Tick counter for periodic beacon injection in medium mode.
-    medium_beacon_ctr: u32,
+    /// Next DEVICE cycle at which to inject a periodic beacon in medium mode.
+    /// Keyed on `clock.now()` (not a tick-call counter) so the beacon cadence is
+    /// invariant to how often `tick_with_bus` runs — per cycle in normal
+    /// execution, once per idle-poll quantum under CPU idle fast-forward. 0 means
+    /// "not yet armed"; armed lazily on the first medium tick.
+    medium_next_beacon_cycle: u64,
     /// Bus-published cycle clock (walk-free plan). `Some` once
     /// [`SystemBus::add_peripheral`](crate::bus::SystemBus) attaches it (under
     /// the `event-scheduler` feature); its presence flips the model onto the
@@ -174,7 +186,7 @@ impl Esp32c3WifiMac {
             trace_seq: 0,
             medium_mode: false,
             medium_mac: None,
-            medium_beacon_ctr: 0,
+            medium_next_beacon_cycle: 0,
             clock: None,
             wifi: super::virtual_wifi::default_medium(),
         }
@@ -519,6 +531,17 @@ impl Peripheral for Esp32c3WifiMac {
         self.rx_ring != 0 || !self.pending_tx.is_empty() || self.medium_mode
     }
 
+    /// Medium mode services an EXTERNAL shared-AP inbox and beacons the station;
+    /// its frames would be starved for a whole CPU-idle skip window without a
+    /// bounded poll. Opt in so idle fast-forward caps its skip to a poll quantum
+    /// and runs the bus-tick pass at the deadline. The beacon is device-cycle
+    /// keyed (see [`MEDIUM_BEACON_INTERVAL_CYCLES`]), so the varying tick cadence
+    /// is safe. Non-medium single-device runs (CLI bridge) stay false — their RX
+    /// is driven by explicit `queue_rx_*` calls, not a live medium.
+    fn idle_poll_bus_tick(&self) -> bool {
+        self.medium_mode
+    }
+
     fn tick_with_bus(&mut self, bus: &mut dyn Bus) {
         // Capture any transmitted frame + signal TX-complete (in medium mode this
         // submits to the shared AP), then in medium mode pull any frames the AP
@@ -527,9 +550,21 @@ impl Peripheral for Esp32c3WifiMac {
         if self.medium_mode {
             if let Some(mac) = self.medium_mac {
                 // Periodic beacon so the scanning station keeps seeing the AP.
-                self.medium_beacon_ctr = self.medium_beacon_ctr.wrapping_add(1);
-                if self.medium_beacon_ctr % 2_000_000 == 0 {
+                // Cadence is keyed on the DEVICE cycle (`clock.now()`), not on
+                // tick-call count, so it stays regular even when idle
+                // fast-forward makes this tick run once per poll quantum instead
+                // of once per cycle. The `while` catches up if a single skip
+                // crossed more than one beacon boundary.
+                let now = self.clock.as_ref().map(|c| c.now()).unwrap_or(0);
+                if self.medium_next_beacon_cycle == 0 {
+                    self.medium_next_beacon_cycle =
+                        now.saturating_add(MEDIUM_BEACON_INTERVAL_CYCLES);
+                }
+                while now >= self.medium_next_beacon_cycle {
                     self.wifi.queue_beacon(mac, 1);
+                    self.medium_next_beacon_cycle = self
+                        .medium_next_beacon_cycle
+                        .saturating_add(MEDIUM_BEACON_INTERVAL_CYCLES);
                 }
                 for frame in self.wifi.take_inbox(mac) {
                     self.pending_rx.push_back(frame);
@@ -729,6 +764,66 @@ mod tests {
         assert_eq!(
             mac.tick().explicit_irqs.as_deref(),
             Some(&[MAC_INTR_SOURCE][..])
+        );
+    }
+
+    #[test]
+    fn idle_poll_bus_tick_tracks_medium_mode() {
+        // Only a medium-attached station needs the CPU idle fast-forward path to
+        // keep pumping it (its inbox is fed by an external AP). A single-device
+        // MAC drains RX from explicit `queue_rx_*` calls, so it must NOT shorten
+        // the idle window — doing so would needlessly slow every non-medium run.
+        let mut m = Esp32c3WifiMac::new();
+        assert!(
+            !m.idle_poll_bus_tick(),
+            "single-device MAC must not force bounded idle polling"
+        );
+        m.attach_to_medium();
+        assert!(
+            m.idle_poll_bus_tick(),
+            "medium-mode MAC must opt into bounded idle polling so fast-forward \
+             cannot starve its inbox and break association"
+        );
+    }
+
+    #[test]
+    fn beacon_cadence_is_device_cycle_keyed_not_call_count() {
+        // Regression for the WiFi-under-fast-forward fix: the AP beacon fires on
+        // DEVICE cycles, so the number a station sees over a fixed cycle span is
+        // invariant to how often `tick_with_bus` runs. Idle fast-forward calls it
+        // once per poll quantum instead of once per cycle; if the cadence were
+        // keyed on call count (as it was), beacons would all but stop and the
+        // station would deauth.
+        fn beacons_over(call_stride: u64, total_cycles: u64) -> usize {
+            let wifi = super::super::virtual_wifi::VirtualWifiBus::new();
+            let mut m = Esp32c3WifiMac::with_wifi(wifi);
+            let clock = CycleClock::default();
+            m.medium_mode = true;
+            m.medium_mac = Some([0x02, 0, 0, 0, 0, 0x02]);
+            m.clock = Some(clock.clone());
+            let mut bus = SystemBus::new();
+            // No RX ring configured (rx_ring == 0), so `deliver_one_rx` is a
+            // no-op and every beacon the tick pulls from the medium stays parked
+            // in `pending_rx` — a direct count of beacons injected.
+            let mut cyc = 0u64;
+            while cyc <= total_cycles {
+                clock.publish(cyc);
+                m.tick_with_bus(&mut bus);
+                cyc += call_stride;
+            }
+            m.pending_rx.len()
+        }
+
+        // ~10 beacons expected over 20M cycles at a 2M-cycle interval.
+        let dense = beacons_over(1_000, 20_000_000); // ~per-cycle execution
+        let sparse = beacons_over(8_000, 20_000_000); // ~one idle poll quantum
+        assert_eq!(
+            dense, sparse,
+            "beacon count must depend on device cycles, not tick-call frequency"
+        );
+        assert!(
+            dense >= 9,
+            "expected ~10 beacons over 20M cycles / {MEDIUM_BEACON_INTERVAL_CYCLES}-cycle interval, got {dense}"
         );
     }
 }


### PR DESCRIPTION
## The bug (live in the studio)

Idle fast-forward is **default-ON** for heavy C3/S3 chips in the browser (`isHeavyBrowserChip` → `set_idle_fast_forward_enabled(true)`). But it skips the per-cycle bus ticks that pump the WiFi **medium** inbox, so during association:

- the AP's auth/assoc frames arrive after the station's timeout, and
- the medium **beacon** — fired off a tick-**call** counter — stops entirely.

Result: `auth -> init` → `sta disconnected -> retry`, forever. The WiFi demo associates fine with fast-forward **OFF**, but **never** with it ON — i.e. never as a real user runs it in the studio.

| path | result |
|---|---|
| fast-forward OFF | associates → (systimer freezes without ff; see below) |
| fast-forward ON (before) | **never associates** |
| fast-forward ON (after) | associates → DHCP → HTTP → correct body → done |

## The fix (gated on WiFi-medium presence → cannot regress other chips)

- **Beacon is device-cycle keyed** (`CycleClock::now`) instead of tick-call count, so cadence is invariant to how often `tick_with_bus` runs.
- New `Peripheral::idle_poll_bus_tick()` (default `false`; medium-mode MAC → `true`). When any bus peripheral opts in, idle fast-forward **caps its skip to an 8192-cycle poll quantum** (~51 µs @160 MHz) and runs the bus-tick pump at the deadline.
- Extracted `SystemBus::run_bus_tick_pass` so the idle path and the normal tick share one implementation.

Universal: any medium-attached WiFi station on **any** MCU benefits.

## Validation

Real `wifi_probe` firmware, rom-boot, merged flash:

```
fast-forward ON (after fix):
  STA CONNECTED → sta ip: 192.168.4.2 → HTTP RX 256 bytes
  HTTP BODY: {"boards_supported":9,"parts_supported":82,"labs_opened":69,
              "simulations_run":3200,"active_sessions":4900}
  HTTP done   — deterministic run-to-run, idle_ff skipped 283,616,719 cycles (94.5%)
```

Body matches the real-silicon-validated snapshot.

- ✅ 2413 core lib tests pass (incl. 2 new regressions: `idle_poll_bus_tick_tracks_medium_mode`, `beacon_cadence_is_device_cycle_keyed_not_call_count`)
- ✅ C3 walk-vs-scheduler + batch **byte-identical** differential gates pass (`--ignored --release`)
- ✅ nRF54L15 idle-ff speedup differential passes
- ✅ clippy clean, fmt clean

Also adds a `LABWIRED_WIFI_FF` env path to the solo WiFi harness (drives the station via `advance(run)` + idle-ff, mirroring the browser bridge) so the bug is reproducible from the CLI.