### PR TITLE
ci: move weekly coverage gate to core-coverage-weekly.yml

### DIFF
--- a/.github/workflows/core-coverage-weekly.yml
+++ b/.github/workflows/core-coverage-weekly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: core-coverage
+  group: core-coverage-weekly
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Stale feature branches still carry the old `core-coverage.yml` with a `push:` trigger — 35 zombie Coverage Gate runs (100% failure rate) in the last two days. Triggers are read from the pushed branch's file, so the fix is a new workflow ID: schedules only fire from the default branch, and stale branches don't have this file. After merge, the old `core-coverage.yml` workflow ID gets disabled (`gh workflow disable`), which blocks runs from every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)