### PR TITLE
fix(arduino-matrix): guard Serial0 on ARDUINO_USB_CDC_ON_BOOT

### DIFF
--- a/validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino
+++ b/validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino
@@ -15,9 +15,11 @@
 static void logBegin() {
   Serial.begin(115200);
 #if defined(ARDUINO_USB_CDC_ON_BOOT) && (ARDUINO_USB_CDC_ON_BOOT)
+  // Serial is USB-CDC; the core defines Serial0 as hardware UART0 — dual-print
+  // so the sim (which captures UART0) always sees text. Without CDC-on-boot
+  // (classic ESP32, S3/C3 UART profiles) Serial IS UART0 and Serial0 does not
+  // exist, so guarding on ARDUINO_ARCH_ESP32 alone is a compile error there.
   Serial.setTxTimeoutMs(0);
-#endif
-#if defined(ARDUINO_ARCH_ESP32)
   Serial0.begin(115200);
 #endif
   delay(1);
@@ -25,7 +27,7 @@ static void logBegin() {
 
 static void logLine(const char *s) {
   Serial.println(s);
-#if defined(ARDUINO_ARCH_ESP32)
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && (ARDUINO_USB_CDC_ON_BOOT)
   Serial0.println(s);
 #endif
 }


### PR DESCRIPTION
The L3_i2c_sensor sketch guarded `Serial0` dual-print on `ARDUINO_ARCH_ESP32`, but arduino-esp32 only defines `Serial0` when `ARDUINO_USB_CDC_ON_BOOT` is set. Result: **compile_fail on esp32, esp32c3 and esp32s3** in every Core Arduino Matrix Smoke run since the sketch landed (the L3 column red fleet-wide).

This switches both guards to `ARDUINO_USB_CDC_ON_BOOT`, which is the actual condition under which Serial≠UART0 and dual-print is needed.

Verified locally with `validation/arduino-matrix/run_matrix.py --boards esp32,esp32c3,esp32s3 --sketches L3_i2c_sensor --force-compile`:

| board | before | after |
|---|---|---|
| esp32 | compile_fail | compiles, runs, `LW_L3_FAIL err=2` (I2C addr NACK — pre-existing model gap) |
| esp32c3 | compile_fail | **pass** |
| esp32s3 | compile_fail | compiles, boot_fail (pre-existing S3 boot regression, also fails L0/L2) |

Not fixed here (separate model bugs): esp32 I2C NACK, esp32s3 boot_fail, and stm32l073/h563/g474re L3 oracle_fail (boot prints `LW_L3_BOOT`, I2C transaction never completes).