### PR TITLE
fix(stm32): I2C v2 master-write causality + dedicated G4 RCC layout

### DIFF
--- a/configs/chips/stm32g474re.yaml
+++ b/configs/chips/stm32g474re.yaml
@@ -14,7 +14,7 @@ peripherals:
     type: "rcc"
     base_address: 0x40021000
     config:
-      profile: "stm32v2"
+      profile: "stm32g4"
   - id: "gpioa"
     type: "gpio"
     base_address: 0x48000000
@@ -70,10 +70,11 @@ peripherals:
     type: "pwr"
     base_address: 0x40007000
     size: "1KB"
-  # ── Tier-1 peripherals (RM0440). The RCC model is profile stm32v2, so the
-  # clock-gate `reg:` names resolve to the V2 enable-register offsets
-  # (ahb2enr@0x8C, apb1lenr@0x9C, apb2enr@0xA4); the `bit:` values are the
-  # silicon RM0440 §7.4 enable bits for each block's real bus. ─────────────
+  # ── Tier-1 peripherals (RM0440). The RCC model is profile stm32g4, so the
+  # clock-gate `reg:` names resolve to the RM0440 enable-register offsets
+  # (ahb2enr@0x4C, apb1enr1@0x58, apb2enr@0x60 — the same offsets ST's CMSIS
+  # stm32g474xx.h gives); the `bit:` values are the RM0440 §7.4 enable bits for
+  # each block's real bus. ─────────────────────────────────────────────────
   # TIM2 — 32-bit GP timer (APB1). RCC_APB1ENR1.TIM2EN (bit 0).
   - id: "tim2"
     type: "timer"
@@ -122,10 +123,10 @@ peripherals:
     config:
       profile: "stm32l4"
     clock: { reg: "ahb2enr", bit: 13 }
-  # DMA1 (AHB1, 7-channel + DMAMUX). RM0440 puts DMA1EN on AHB1ENR (bit 0),
-  # which the stm32v2 RCC model does not surface (it exposes only
-  # ahb2enr/apb1lenr/apb2enr), so the channel is declared ungated; the
-  # mem-to-mem round-trip is the truthful proof of the model.
+  # DMA1 (AHB1, 7-channel + DMAMUX). RM0440 puts DMA1EN on AHB1ENR (bit 0). The
+  # stm32g4 RCC model stores AHB1ENR@0x48 but no `clock:` gate is declared for
+  # the channel (left ungated); the mem-to-mem round-trip is the truthful proof
+  # of the model.
   - id: "dma1"
     type: "dma"
     base_address: 0x40020000

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -2012,8 +2012,16 @@ mod tests {
         let cr2: u32 = (0x40 << 1) | (1 << 16) | (1 << 25) | (1 << 13); // NBYTES=1|AUTOEND|START
         i2c.write_u32(0x04, cr2).unwrap(); // CR2/START after the preload
 
-        assert_eq!(writes.load(Ordering::SeqCst), 1, "preloaded byte reaches slave");
-        assert_eq!(i2c.peek(0x18).unwrap() & (1 << 4), 0, "no NACKF (slave present)");
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            1,
+            "preloaded byte reaches slave"
+        );
+        assert_eq!(
+            i2c.peek(0x18).unwrap() & (1 << 4),
+            0,
+            "no NACKF (slave present)"
+        );
         assert_ne!(i2c.peek(0x18).unwrap() & (1 << 6), 0, "TC after transfer");
         assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND");
         assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared");
@@ -2040,8 +2048,16 @@ mod tests {
 
         // Address ACKed → hardware requests the first byte via TXIS (bit 1),
         // nothing sent yet.
-        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 1), 0, "TXIS asserted after address ACK");
-        assert_eq!(writes.load(Ordering::SeqCst), 0, "no byte before TXDR write");
+        assert_ne!(
+            i2c.peek(0x18).unwrap() & (1 << 1),
+            0,
+            "TXIS asserted after address ACK"
+        );
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            0,
+            "no byte before TXDR write"
+        );
 
         i2c.write(0x28, 0x00).unwrap(); // ISR writes TXDR after TXIS
         assert_eq!(writes.load(Ordering::SeqCst), 1, "byte sent on TXDR write");
@@ -2061,9 +2077,21 @@ mod tests {
         i2c.write(0x28, 0xAB).unwrap();
         let cr2: u32 = (0x52 << 1) | (1 << 16) | (1 << 25) | (1 << 13);
         i2c.write_u32(0x04, cr2).unwrap();
-        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 4), 0, "NACKF (preload order)");
-        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND (preload order)");
-        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared (preload order)");
+        assert_ne!(
+            i2c.peek(0x18).unwrap() & (1 << 4),
+            0,
+            "NACKF (preload order)"
+        );
+        assert_ne!(
+            i2c.peek(0x18).unwrap() & (1 << 5),
+            0,
+            "STOPF via AUTOEND (preload order)"
+        );
+        assert_eq!(
+            i2c.peek(0x19).unwrap() & (1 << 7),
+            0,
+            "BUSY cleared (preload order)"
+        );
 
         // IT ordering: START first, absent slave.
         let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
@@ -2071,8 +2099,16 @@ mod tests {
         let cr2: u32 = (0x52 << 1) | (1 << 16) | (1 << 25) | (1 << 13);
         i2c.write_u32(0x04, cr2).unwrap();
         assert_ne!(i2c.peek(0x18).unwrap() & (1 << 4), 0, "NACKF (IT order)");
-        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND (IT order)");
-        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared (IT order)");
+        assert_ne!(
+            i2c.peek(0x18).unwrap() & (1 << 5),
+            0,
+            "STOPF via AUTOEND (IT order)"
+        );
+        assert_eq!(
+            i2c.peek(0x19).unwrap() & (1 << 7),
+            0,
+            "BUSY cleared (IT order)"
+        );
     }
 
     #[test]

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -547,11 +547,12 @@ pub struct L4I2c {
     is_reading: bool,
     #[serde(skip)]
     autoend: bool,
-    /// CR2.START has latched a transfer; the address phase fires once the first
-    /// data byte is loaded into TXDR (write) — mirrors F1's START→DR ordering.
-    /// Exception: NBYTES=0 (IsDeviceReady / empty endTransmission) starts now.
+    /// A byte was written to TXDR before the address phase (the L0/L4/G4 HAL
+    /// preload ordering). TXDR is a real writable holding register: the byte
+    /// waits in `txdr` and is transmitted once the address phase ACKs. Cleared
+    /// when the START handler folds it into `first_tx_loaded` for the transfer.
     #[serde(skip)]
-    start_armed: bool,
+    tx_preloaded: bool,
 
     /// Bus-published cycle clock (walk-free campaign) — see `L4I2c::scheduler_mode`.
     #[serde(skip)]
@@ -583,7 +584,7 @@ impl Default for L4I2c {
             current_target: None,
             is_reading: false,
             autoend: false,
-            start_armed: false,
+            tx_preloaded: false,
             clock: None,
             chain_live: false,
         }
@@ -660,8 +661,8 @@ impl L4I2c {
                 // so the RMW cannot re-fire it.
                 self.cr2 = value;
                 if (value & (1 << 13)) != 0 {
-                    // START: latch BUSY and arm a master transfer. Capture the
-                    // addressed slave (SADD[7:1] in 7-bit mode), direction
+                    // START: latch BUSY and run the addressed transfer. Capture
+                    // the addressed slave (SADD[7:1] in 7-bit mode), direction
                     // (RD_WRN), NBYTES and AUTOEND.
                     if (self.cr1 & 1) != 0 {
                         self.isr |= 1 << 15; // BUSY
@@ -669,7 +670,11 @@ impl L4I2c {
                         self.is_reading = (value & (1 << 10)) != 0; // RD_WRN
                         self.autoend = (value & (1 << 25)) != 0;
                         self.nbytes = ((value >> 16) & 0xFF) as u8;
-                        self.first_tx_loaded = false;
+                        // Carry a pre-START TXDR write (the L0/L4/G4 HAL preload
+                        // ordering) into this transfer as the first data byte;
+                        // the byte already sits in self.txdr.
+                        self.first_tx_loaded = self.tx_preloaded;
+                        self.tx_preloaded = false;
                         self.current_target = self
                             .attached_devices
                             .iter()
@@ -677,22 +682,18 @@ impl L4I2c {
                         if let Some(idx) = self.current_target {
                             self.attached_devices[idx].borrow_mut().start();
                         }
-                        self.start_armed = true;
-                        // A master WRITE with NBYTES>0 must NOT run the address
-                        // phase (and its NACK/ACK verdict) until firmware commits
-                        // the first data byte via TXDR: until then the transfer
-                        // is only "start pending" — BUSY latched, no NACKF, START
-                        // still readable in CR2 (the register fingerprint real
-                        // silicon shows, and what this restores). Read / NBYTES=0
-                        // (IsDeviceReady) have no data byte to wait for, so their
-                        // address phase runs now and START is consumed.
-                        if self.is_reading || (self.nbytes == 0 && self.autoend) {
-                            self.cr2 &= !(1 << 13); // START consumed
-                            self.start_armed = false;
-                            self.state = I2cState::AddressPending;
-                            self.cycles_remaining = 0;
-                            let _ = self.tick();
-                        }
+                        // Real silicon begins the addressed transfer the instant
+                        // START is set — for reads AND writes — and START
+                        // self-clears once the start condition is on the bus. Run
+                        // the address phase now: a write with a preloaded byte
+                        // completes here; a write without preload ACKs, asserts
+                        // ISR.TXIS and parks in DataPending for the firmware's
+                        // post-TXIS TXDR write (Arduino/Zephyr Master_Transmit_IT);
+                        // an absent slave NACKs regardless of the write ordering.
+                        self.cr2 &= !(1 << 13); // START consumed
+                        self.state = I2cState::AddressPending;
+                        self.cycles_remaining = 0;
+                        let _ = self.tick();
                     }
                 }
                 if (value & (1 << 14)) != 0 {
@@ -706,9 +707,9 @@ impl L4I2c {
                     }
                     self.current_target = None;
                     self.state = I2cState::Idle;
-                    self.start_armed = false;
                     self.nbytes = 0;
                     self.first_tx_loaded = false;
+                    self.tx_preloaded = false;
                 }
             }
             0x08 => self.oar1 = value,
@@ -729,9 +730,9 @@ impl L4I2c {
             0x28 => {
                 self.txdr = value & 0xFF;
                 self.isr &= !0x0000_0003; // writing TXDR clears TXE+TXIS
-                                          // After address ACK the engine waits in DataPending with TXIS
-                                          // set; firmware (HAL IT / poll) writes TXDR here.
                 if self.state == I2cState::DataPending {
+                    // Post-TXIS path: the address phase already ACKed and asserted
+                    // TXIS; firmware (HAL IT / poll) commits the data byte here.
                     self.first_tx_loaded = true;
                     if let Some(idx) = self.current_target {
                         self.attached_devices[idx]
@@ -751,22 +752,16 @@ impl L4I2c {
                     self.state = I2cState::Idle;
                     self.nbytes = 0;
                     self.first_tx_loaded = false;
-                    self.start_armed = false;
-                    // Completion IRQ for Master_Transmit_IT (TCIE/STOPIE).
-                    // Note: write_reg cannot return irq; the next tick()
-                    // re-checks level flags below. Also pulse via active BUSY
-                    // window so the walk doesn't skip us before ISR runs.
-                } else if self.start_armed && self.state == I2cState::Idle {
-                    // Master WRITE, NBYTES>0: the first TXDR commit is what
-                    // launches the deferred address phase (the START-pending
-                    // window closes here). Consume START from CR2 now that the
-                    // condition is generated.
-                    self.cr2 &= !(1 << 13);
-                    self.state = I2cState::AddressPending;
-                    self.cycles_remaining = 0;
-                    self.start_armed = false;
-                    self.first_tx_loaded = true;
-                    let _ = self.tick();
+                    // Completion IRQ for Master_Transmit_IT (TCIE/STOPIE): the
+                    // next tick() re-checks the level flags set above.
+                } else {
+                    // TXDR written with no data phase waiting → a preload. Real
+                    // silicon: TXDR is a writable holding register; a byte written
+                    // before START (the L0/L4/G4 HAL ordering) is held and
+                    // transmitted once the address phase ACKs (see the CR2 START
+                    // handler, which carries this into first_tx_loaded). The value
+                    // is already stored in self.txdr above.
+                    self.tx_preloaded = true;
                 }
             }
             _ => {}
@@ -1978,6 +1973,106 @@ mod tests {
             "TC after byte transferred"
         );
         assert_eq!(writes.load(Ordering::SeqCst), 1);
+    }
+
+    /// Minimal ACK-and-count slave for the master-write ordering tests.
+    struct WriteSink {
+        address: u8,
+        writes: Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl I2cDevice for WriteSink {
+        fn address(&self) -> u8 {
+            self.address
+        }
+        fn read(&mut self) -> u8 {
+            0
+        }
+        fn write(&mut self, _data: u8) {
+            self.writes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// PRELOAD ordering (STM32Cube L0/L4/G4/WB `HAL_I2C_Master_Transmit_IT`):
+    /// firmware writes TXDR BEFORE arming CR2/START. TXDR is a real holding
+    /// register — the byte must be transmitted once the address phase ACKs, and
+    /// the 1-byte AUTOEND transfer completes (TC + STOPF) with no tick loop.
+    #[test]
+    fn test_l4_i2c_write_preload_before_start() {
+        use super::I2cRegisterLayout;
+        use std::sync::atomic::AtomicUsize;
+        let writes = Arc::new(AtomicUsize::new(0));
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
+        i2c.push_slave(Box::new(WriteSink {
+            address: 0x40,
+            writes: writes.clone(),
+        }));
+
+        i2c.write(0x00, 1).unwrap(); // CR1.PE
+        i2c.write(0x28, 0x00).unwrap(); // TXDR preloaded FIRST
+        let cr2: u32 = (0x40 << 1) | (1 << 16) | (1 << 25) | (1 << 13); // NBYTES=1|AUTOEND|START
+        i2c.write_u32(0x04, cr2).unwrap(); // CR2/START after the preload
+
+        assert_eq!(writes.load(Ordering::SeqCst), 1, "preloaded byte reaches slave");
+        assert_eq!(i2c.peek(0x18).unwrap() & (1 << 4), 0, "no NACKF (slave present)");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 6), 0, "TC after transfer");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND");
+        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared");
+    }
+
+    /// IT ordering (STM32Cube H5 `HAL_I2C_Master_Transmit_IT`): CR2/START first;
+    /// hardware ACKs the address and asserts ISR.TXIS; only then does the ISR
+    /// write TXDR. The model must set TXIS on the address ACK (park in
+    /// DataPending), then complete the byte on the post-TXIS TXDR write.
+    #[test]
+    fn test_l4_i2c_write_txis_then_txdr() {
+        use super::I2cRegisterLayout;
+        use std::sync::atomic::AtomicUsize;
+        let writes = Arc::new(AtomicUsize::new(0));
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
+        i2c.push_slave(Box::new(WriteSink {
+            address: 0x40,
+            writes: writes.clone(),
+        }));
+
+        i2c.write(0x00, 1).unwrap(); // CR1.PE
+        let cr2: u32 = (0x40 << 1) | (1 << 16) | (1 << 25) | (1 << 13); // NBYTES=1|AUTOEND|START
+        i2c.write_u32(0x04, cr2).unwrap(); // START first — NO preloaded byte
+
+        // Address ACKed → hardware requests the first byte via TXIS (bit 1),
+        // nothing sent yet.
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 1), 0, "TXIS asserted after address ACK");
+        assert_eq!(writes.load(Ordering::SeqCst), 0, "no byte before TXDR write");
+
+        i2c.write(0x28, 0x00).unwrap(); // ISR writes TXDR after TXIS
+        assert_eq!(writes.load(Ordering::SeqCst), 1, "byte sent on TXDR write");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 6), 0, "TC after transfer");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND");
+    }
+
+    /// Address-NACK must set ISR.NACKF (+STOPF via AUTOEND) in BOTH the preload
+    /// and IT orderings, so the HAL returns error rather than hanging.
+    #[test]
+    fn test_l4_i2c_write_nack_both_orderings() {
+        use super::I2cRegisterLayout;
+
+        // Preload ordering: TXDR then START, absent slave.
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
+        i2c.write(0x00, 1).unwrap();
+        i2c.write(0x28, 0xAB).unwrap();
+        let cr2: u32 = (0x52 << 1) | (1 << 16) | (1 << 25) | (1 << 13);
+        i2c.write_u32(0x04, cr2).unwrap();
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 4), 0, "NACKF (preload order)");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND (preload order)");
+        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared (preload order)");
+
+        // IT ordering: START first, absent slave.
+        let mut i2c = I2c::new_with_layout(I2cRegisterLayout::Stm32L4);
+        i2c.write(0x00, 1).unwrap();
+        let cr2: u32 = (0x52 << 1) | (1 << 16) | (1 << 25) | (1 << 13);
+        i2c.write_u32(0x04, cr2).unwrap();
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 4), 0, "NACKF (IT order)");
+        assert_ne!(i2c.peek(0x18).unwrap() & (1 << 5), 0, "STOPF via AUTOEND (IT order)");
+        assert_eq!(i2c.peek(0x19).unwrap() & (1 << 7), 0, "BUSY cleared (IT order)");
     }
 
     #[test]

--- a/crates/core/src/peripherals/rcc.rs
+++ b/crates/core/src/peripherals/rcc.rs
@@ -38,6 +38,12 @@ pub enum RccRegisterLayout {
     Stm32L4,
     /// STM32L0 family (RM0367). Verified on NUCLEO-L073RZ over SWD.
     Stm32L0,
+    /// STM32G4 family (RM0440). The modern-V2 clock tree (CR/CFGR/PLLCFGR/
+    /// BDCR/CSR/CRRCR) with the RM0440 enable/reset register offsets
+    /// (APB1ENR1@0x58, AHB2ENR@0x4C, APB2ENR@0x60) — which differ from the
+    /// H5-style V2 layout (APB1LENR@0x9C). Offsets verified against the
+    /// vendored CMSIS `stm32g474xx.h`.
+    Stm32G4,
 }
 
 impl FromStr for RccRegisterLayout {
@@ -53,8 +59,9 @@ impl FromStr for RccRegisterLayout {
             "h7" | "stm32h7" => Ok(Self::Stm32H7),
             "stm32l4" | "l4" => Ok(Self::Stm32L4),
             "stm32l0" | "l0" => Ok(Self::Stm32L0),
+            "stm32g4" | "g4" => Ok(Self::Stm32G4),
             _ => Err(format!(
-                "unsupported RCC register layout '{}'; supported: stm32f1, stm32f4, stm32v2, stm32h5, stm32h7, stm32l4, stm32l0",
+                "unsupported RCC register layout '{}'; supported: stm32f1, stm32f4, stm32v2, stm32h5, stm32h7, stm32l4, stm32l0, stm32g4",
                 value
             )),
         }
@@ -1226,6 +1233,143 @@ impl RccModel for L0Rcc {
     }
 }
 
+// ── STM32G4 ─────────────────────────────────────────────────────────────────
+// RM0440 register map. Shares the modern-V2 clock-tree IP (CR/CFGR/PLLCFGR with
+// the classic + HSI16 ready rules, BDCR/CSR/CRRCR handshakes), but the
+// enable/reset registers sit at the RM0440 offsets — APB1ENR1@0x58,
+// APB1ENR2@0x5C, AHB1ENR@0x48, AHB2ENR@0x4C, APB2ENR@0x60, reset regs at
+// 0x28/0x2C/0x38/0x3C/0x40. On the H5-style V2 layout those same enables live at
+// 0x9C/0xA4, so I2C1EN (APB1ENR1 bit 21) written by `__HAL_RCC_I2C1_CLK_ENABLE`
+// would be dropped and the clock-gate check would read the wrong register. A
+// dedicated struct keeps G4 and the H5-style V2 families apart. Offsets/bit
+// positions verified against the vendored CMSIS `stm32g474xx.h`.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct G4Rcc {
+    cr: u32,       // 0x00
+    icscr: u32,    // 0x04
+    cfgr: u32,     // 0x08
+    pllcfgr: u32,  // 0x0C
+    ahb1rstr: u32, // 0x28
+    ahb2rstr: u32, // 0x2C
+    apb1rstr: u32, // APB1RSTR1 0x38
+    apb1rstr2: u32,// APB1RSTR2 0x3C
+    apb2rstr: u32, // 0x40
+    ahb1enr: u32,  // 0x48
+    ahb2enr: u32,  // AHB2ENR 0x4C (GPIO ports, ADC12)
+    apb1enr: u32,  // APB1ENR1 0x58 (TIM2, RTCAPB, I2C1)
+    apb1enr2: u32, // APB1ENR2 0x5C
+    apb2enr: u32,  // 0x60 (TIM1, SPI1)
+    bdcr: u32,     // 0x90 — LSEON bit0 → LSERDY bit1
+    csr: u32,      // 0x94 — LSION bit0 → LSIRDY bit1
+    crrcr: u32,    // 0x98 — HSI48ON bit0 → HSI48RDY bit1
+}
+
+impl G4Rcc {
+    fn new() -> Self {
+        Self {
+            cr: Self::ready(1 << 0),
+            ..Default::default()
+        }
+    }
+    /// G4 CR ready rule (matches the V2 model that boots this family): the
+    /// classic HSION(0)/HSERDY(16)/PLLRDY(24) bits plus HSI16 at bit8→bit10 —
+    /// the Arduino G4 core kernel clock gates on HSI16RDY.
+    fn ready(cr: u32) -> u32 {
+        let mut cr = classic_cr_ready(cr);
+        if cr & (1 << 8) != 0 {
+            cr |= 1 << 10;
+        } else {
+            cr &= !(1 << 10);
+        }
+        cr
+    }
+}
+
+impl RccModel for G4Rcc {
+    fn read_reg(&self, offset: u64) -> u32 {
+        match offset {
+            0x00 => self.cr,
+            0x04 => self.icscr,
+            0x08 => self.cfgr,
+            0x0C => self.pllcfgr,
+            0x28 => self.ahb1rstr,
+            0x2C => self.ahb2rstr,
+            0x38 => self.apb1rstr,
+            0x3C => self.apb1rstr2,
+            0x40 => self.apb2rstr,
+            0x48 => self.ahb1enr,
+            0x4C => self.ahb2enr,
+            0x58 => self.apb1enr,
+            0x5C => self.apb1enr2,
+            0x60 => self.apb2enr,
+            0x90 => self.bdcr,
+            0x94 => self.csr,
+            0x98 => self.crrcr,
+            _ => 0,
+        }
+    }
+    fn write_reg(&mut self, offset: u64, value: u32) {
+        match offset {
+            0x00 => self.cr = Self::ready(value),
+            0x04 => self.icscr = value,
+            // RCC_CFGR (0x08): SW[1:0]→SWS[3:2] follows only once the requested
+            // source is ready in CR — 01 HSI16 (bit10), 10 HSE (bit17), 11 PLL
+            // (bit25). Slot 00 (bit1) is the classic-HSI slot the HAL never
+            // selects on G4 but is kept for parity with the V2 model.
+            0x08 => {
+                self.cfgr = cfgr_with_gated_sws(
+                    value,
+                    self.cr,
+                    self.cfgr,
+                    [Some(1), Some(10), Some(17), Some(25)],
+                );
+            }
+            0x0C => {
+                self.pllcfgr = value;
+                self.cr = Self::ready(self.cr); // PLLSRC change can re-gate PLLRDY
+            }
+            0x28 => self.ahb1rstr = value,
+            0x2C => self.ahb2rstr = value,
+            0x38 => self.apb1rstr = value,
+            0x3C => self.apb1rstr2 = value,
+            0x40 => self.apb2rstr = value,
+            0x48 => self.ahb1enr = value,
+            0x4C => self.ahb2enr = value,
+            0x58 => self.apb1enr = value,
+            0x5C => self.apb1enr2 = value,
+            0x60 => self.apb2enr = value,
+            // BDCR: LSEON (bit0) → LSERDY (bit1); rest is RTC/backup storage.
+            0x90 => {
+                self.bdcr = if value & 1 != 0 {
+                    value | (1 << 1)
+                } else {
+                    value & !(1 << 1)
+                };
+            }
+            // CSR: LSION (bit0) → LSIRDY (bit1); reset flags (31:23) are storage.
+            0x94 => {
+                self.csr = if value & 1 != 0 {
+                    value | (1 << 1)
+                } else {
+                    value & !(1 << 1)
+                };
+            }
+            // CRRCR: HSI48ON (bit0) → HSI48RDY (bit1).
+            0x98 => {
+                self.crrcr = if value & 1 != 0 {
+                    value | (1 << 1)
+                } else {
+                    value & !(1 << 1)
+                };
+            }
+            _ => {}
+        }
+    }
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
 // ── Dispatcher ──────────────────────────────────────────────────────────────
 
 /// RCC peripheral — one variant per chip family. Each variant's registers are
@@ -1239,6 +1383,7 @@ pub enum Rcc {
     Stm32H7(H7Rcc),
     Stm32L4(L4Rcc),
     Stm32L0(L0Rcc),
+    Stm32G4(G4Rcc),
 }
 
 impl Default for Rcc {
@@ -1261,6 +1406,7 @@ impl Rcc {
             RccRegisterLayout::Stm32H7 => Self::Stm32H7(H7Rcc::new()),
             RccRegisterLayout::Stm32L4 => Self::Stm32L4(L4Rcc::new()),
             RccRegisterLayout::Stm32L0 => Self::Stm32L0(L0Rcc::new()),
+            RccRegisterLayout::Stm32G4 => Self::Stm32G4(G4Rcc::new()),
         }
     }
 
@@ -1295,6 +1441,16 @@ impl Rcc {
             Self::Stm32L4(_) => match r.as_str() {
                 "ahbenr" | "ahb2enr" => Some(0x4C),
                 "apb1enr" | "apb1enr1" => Some(0x58),
+                "apb2enr" => Some(0x60),
+                _ => None,
+            },
+            // G4: AHB1ENR@0x48, AHB2ENR@0x4C, APB1ENR1@0x58, APB1ENR2@0x5C,
+            // APB2ENR@0x60 (RM0440 §7.4 / CMSIS stm32g474xx.h).
+            Self::Stm32G4(_) => match r.as_str() {
+                "ahbenr" | "ahb1enr" => Some(0x48),
+                "ahb2enr" => Some(0x4C),
+                "apb1enr" | "apb1enr1" => Some(0x58),
+                "apb1enr2" => Some(0x5C),
                 "apb2enr" => Some(0x60),
                 _ => None,
             },
@@ -1363,6 +1519,7 @@ impl Rcc {
             Self::Stm32H7(r) => r,
             Self::Stm32L4(r) => r,
             Self::Stm32L0(r) => r,
+            Self::Stm32G4(r) => r,
         }
     }
 
@@ -1375,6 +1532,7 @@ impl Rcc {
             Self::Stm32H7(r) => r,
             Self::Stm32L4(r) => r,
             Self::Stm32L0(r) => r,
+            Self::Stm32G4(r) => r,
         }
     }
 }
@@ -1605,6 +1763,45 @@ mod tests {
         assert_eq!(rcc.read(0xA4).unwrap(), 0xCC);
         assert_eq!(rcc.read(0x9C).unwrap(), 0x33);
         assert_eq!(rcc.read(0x18).unwrap(), 0x00);
+    }
+
+    /// G4 (RM0440) puts the enable registers at the L4 offsets — APB1ENR1@0x58,
+    /// AHB2ENR@0x4C, APB2ENR@0x60 — NOT the H5-style V2 slots (0x9C/0x8C/0xA4).
+    /// The clock-gate check resolves `clock: { reg }` through `enable_reg_offset`,
+    /// so a wrong offset here silently ungates every I2C1/TIM2 access.
+    #[test]
+    fn test_rcc_g4_offsets() {
+        let rcc = Rcc::new_with_layout(RccRegisterLayout::Stm32G4);
+        assert_eq!(rcc.enable_reg_offset("apb1enr"), Some(0x58), "APB1ENR1 (I2C1EN/TIM2EN)");
+        assert_eq!(rcc.enable_reg_offset("apb1enr1"), Some(0x58));
+        assert_eq!(rcc.enable_reg_offset("ahb2enr"), Some(0x4C), "AHB2ENR (ADC12)");
+        assert_eq!(rcc.enable_reg_offset("apb2enr"), Some(0x60), "APB2ENR (TIM1/SPI1)");
+        assert_eq!(rcc.enable_reg_offset("ahb1enr"), Some(0x48));
+
+        // The V2 (H5-style) slots must NOT be the enable registers on G4 — a
+        // write there is inert storage, proving the two layouts stay apart.
+        let mut rcc = Rcc::new_with_layout(RccRegisterLayout::Stm32G4);
+        rcc.write_u32(0x58, 1 << 21).unwrap(); // APB1ENR1.I2C1EN
+        assert_eq!(rcc.read_u32(0x58).unwrap(), 1 << 21, "I2C1EN round-trips at 0x58");
+        rcc.write_u32(0x4C, 0xF0).unwrap();
+        rcc.write_u32(0x60, 0x1800).unwrap();
+        assert_eq!(rcc.read_u32(0x4C).unwrap(), 0xF0);
+        assert_eq!(rcc.read_u32(0x60).unwrap(), 0x1800);
+        assert_eq!(rcc.read_u32(0x9C).unwrap(), 0x00, "0x9C is not an ENR on G4");
+    }
+
+    /// G4 shares the V2 kernel-clock ready rules the family boots on: HSI16RDY at
+    /// CR bit 10, HSI48RDY via CRRCR (0x98), LSI via CSR (0x94).
+    #[test]
+    fn test_rcc_g4_clock_ready() {
+        let mut rcc = Rcc::new_with_layout(RccRegisterLayout::Stm32G4);
+        let cr = rcc.read_u32(0x00).unwrap();
+        rcc.write_u32(0x00, cr | (1 << 8)).unwrap(); // HSION
+        assert_ne!(rcc.read_u32(0x00).unwrap() & (1 << 10), 0, "HSI16RDY at bit 10");
+        rcc.write_u32(0x98, 1).unwrap(); // HSI48ON
+        assert_eq!(rcc.read_u32(0x98).unwrap() & 0x3, 0x3, "HSI48RDY");
+        rcc.write_u32(0x94, 1).unwrap(); // LSION
+        assert_eq!(rcc.read_u32(0x94).unwrap() & 0x3, 0x3, "LSIRDY");
     }
 
     #[test]

--- a/crates/core/src/peripherals/rcc.rs
+++ b/crates/core/src/peripherals/rcc.rs
@@ -1245,23 +1245,23 @@ impl RccModel for L0Rcc {
 // positions verified against the vendored CMSIS `stm32g474xx.h`.
 #[derive(Debug, Default, serde::Serialize)]
 pub struct G4Rcc {
-    cr: u32,       // 0x00
-    icscr: u32,    // 0x04
-    cfgr: u32,     // 0x08
-    pllcfgr: u32,  // 0x0C
-    ahb1rstr: u32, // 0x28
-    ahb2rstr: u32, // 0x2C
-    apb1rstr: u32, // APB1RSTR1 0x38
-    apb1rstr2: u32,// APB1RSTR2 0x3C
-    apb2rstr: u32, // 0x40
-    ahb1enr: u32,  // 0x48
-    ahb2enr: u32,  // AHB2ENR 0x4C (GPIO ports, ADC12)
-    apb1enr: u32,  // APB1ENR1 0x58 (TIM2, RTCAPB, I2C1)
-    apb1enr2: u32, // APB1ENR2 0x5C
-    apb2enr: u32,  // 0x60 (TIM1, SPI1)
-    bdcr: u32,     // 0x90 — LSEON bit0 → LSERDY bit1
-    csr: u32,      // 0x94 — LSION bit0 → LSIRDY bit1
-    crrcr: u32,    // 0x98 — HSI48ON bit0 → HSI48RDY bit1
+    cr: u32,        // 0x00
+    icscr: u32,     // 0x04
+    cfgr: u32,      // 0x08
+    pllcfgr: u32,   // 0x0C
+    ahb1rstr: u32,  // 0x28
+    ahb2rstr: u32,  // 0x2C
+    apb1rstr: u32,  // APB1RSTR1 0x38
+    apb1rstr2: u32, // APB1RSTR2 0x3C
+    apb2rstr: u32,  // 0x40
+    ahb1enr: u32,   // 0x48
+    ahb2enr: u32,   // AHB2ENR 0x4C (GPIO ports, ADC12)
+    apb1enr: u32,   // APB1ENR1 0x58 (TIM2, RTCAPB, I2C1)
+    apb1enr2: u32,  // APB1ENR2 0x5C
+    apb2enr: u32,   // 0x60 (TIM1, SPI1)
+    bdcr: u32,      // 0x90 — LSEON bit0 → LSERDY bit1
+    csr: u32,       // 0x94 — LSION bit0 → LSIRDY bit1
+    crrcr: u32,     // 0x98 — HSI48ON bit0 → HSI48RDY bit1
 }
 
 impl G4Rcc {
@@ -1772,22 +1772,42 @@ mod tests {
     #[test]
     fn test_rcc_g4_offsets() {
         let rcc = Rcc::new_with_layout(RccRegisterLayout::Stm32G4);
-        assert_eq!(rcc.enable_reg_offset("apb1enr"), Some(0x58), "APB1ENR1 (I2C1EN/TIM2EN)");
+        assert_eq!(
+            rcc.enable_reg_offset("apb1enr"),
+            Some(0x58),
+            "APB1ENR1 (I2C1EN/TIM2EN)"
+        );
         assert_eq!(rcc.enable_reg_offset("apb1enr1"), Some(0x58));
-        assert_eq!(rcc.enable_reg_offset("ahb2enr"), Some(0x4C), "AHB2ENR (ADC12)");
-        assert_eq!(rcc.enable_reg_offset("apb2enr"), Some(0x60), "APB2ENR (TIM1/SPI1)");
+        assert_eq!(
+            rcc.enable_reg_offset("ahb2enr"),
+            Some(0x4C),
+            "AHB2ENR (ADC12)"
+        );
+        assert_eq!(
+            rcc.enable_reg_offset("apb2enr"),
+            Some(0x60),
+            "APB2ENR (TIM1/SPI1)"
+        );
         assert_eq!(rcc.enable_reg_offset("ahb1enr"), Some(0x48));
 
         // The V2 (H5-style) slots must NOT be the enable registers on G4 — a
         // write there is inert storage, proving the two layouts stay apart.
         let mut rcc = Rcc::new_with_layout(RccRegisterLayout::Stm32G4);
         rcc.write_u32(0x58, 1 << 21).unwrap(); // APB1ENR1.I2C1EN
-        assert_eq!(rcc.read_u32(0x58).unwrap(), 1 << 21, "I2C1EN round-trips at 0x58");
+        assert_eq!(
+            rcc.read_u32(0x58).unwrap(),
+            1 << 21,
+            "I2C1EN round-trips at 0x58"
+        );
         rcc.write_u32(0x4C, 0xF0).unwrap();
         rcc.write_u32(0x60, 0x1800).unwrap();
         assert_eq!(rcc.read_u32(0x4C).unwrap(), 0xF0);
         assert_eq!(rcc.read_u32(0x60).unwrap(), 0x1800);
-        assert_eq!(rcc.read_u32(0x9C).unwrap(), 0x00, "0x9C is not an ENR on G4");
+        assert_eq!(
+            rcc.read_u32(0x9C).unwrap(),
+            0x00,
+            "0x9C is not an ENR on G4"
+        );
     }
 
     /// G4 shares the V2 kernel-clock ready rules the family boots on: HSI16RDY at
@@ -1797,7 +1817,11 @@ mod tests {
         let mut rcc = Rcc::new_with_layout(RccRegisterLayout::Stm32G4);
         let cr = rcc.read_u32(0x00).unwrap();
         rcc.write_u32(0x00, cr | (1 << 8)).unwrap(); // HSION
-        assert_ne!(rcc.read_u32(0x00).unwrap() & (1 << 10), 0, "HSI16RDY at bit 10");
+        assert_ne!(
+            rcc.read_u32(0x00).unwrap() & (1 << 10),
+            0,
+            "HSI16RDY at bit 10"
+        );
         rcc.write_u32(0x98, 1).unwrap(); // HSI48ON
         assert_eq!(rcc.read_u32(0x98).unwrap() & 0x3, 0x3, "HSI48RDY");
         rcc.write_u32(0x94, 1).unwrap(); // LSION

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -12,7 +12,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-23 | ⚠ drift acked 2026-07-23 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
@@ -71,7 +71,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-07-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-25 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -736,7 +736,12 @@ boards:
     # nrf52840_onboarding_gpiote_event_in_fires_on_edge caught it. Offline
     # oracle/mmio/conformance suites pass unchanged. No live re-capture.
     # 2026-07-21: shared rcc.rs / pwr.rs gained the ADDITIVE STM32H7 RCC layout + PwrH7 (new enum variants for the stm32h735 onboarding). This board's RCC/PWR family structs are byte-for-byte untouched; the h735 work also added Cortex-M7 double-precision VFP decode (previously Unknown32), which no existing decode path uses. Its conformance/survival gates + 2189 core lib tests pass unchanged. No silicon re-capture.
-    drift_ack: 2026-07-23
+    # 2026-07-25: shared rcc.rs gained the ADDITIVE STM32G4 RCC layout (G4Rcc,
+    # RM0440 enable/reset offsets for the stm32g474re I2C clock-gate fix). This
+    # board's L0Rcc struct is byte-for-byte untouched — same rationale as the
+    # 2026-07-21 H7-layout entry above. l0_mmio_diff/conformance unchanged.
+    # No live re-capture.
+    drift_ack: 2026-07-25
     models:
       - crates/core/src/peripherals/rcc.rs
       - crates/core/src/peripherals/gpio.rs


### PR DESCRIPTION
Fixes the Arduino matrix L3_i2c_sensor hang on stm32l073, stm32h563 and stm32g474re (printed `LW_L3_BOOT` then busy-waited forever in `Wire.endTransmission()`). Two real bugs:

**1. L4I2c address-phase causality was backwards.** The model deferred the address phase of a master write (NBYTES>0) until firmware wrote TXDR. Real I2C v2 silicon starts the addressed transfer the instant CR2.START is set, and TXIS is a hardware-asserted request for data. Real HALs use two orderings the model couldn't handle: L0/L4/G4 **preload** TXDR before START (the early write was silently discarded → armed transfer waits forever), and H5 waits for **TXIS** after START before its ISR writes TXDR (TXIS was never asserted → deadlock). The address phase now runs at START for reads and writes alike; a pre-START TXDR byte is held as a preload (TXDR is a real holding register) and transmitted on address ACK; without preload the ACK asserts TXIS and parks in DataPending. Address-NACK sets NACKF (+STOPF with AUTOEND) in both orderings.

**2. stm32g474re RCC used H5 register offsets.** The yaml's `stm32v2` RCC profile resolves `apb1enr`→0x9C (H5's APB1LENR), but real G474 (RM0440, CMSIS `stm32g474xx.h`) has APB1ENR1 at **0x58** — so `__HAL_RCC_I2C1_CLK_ENABLE()` landed nowhere, `is_peripheral_clocked()` never saw I2C1EN, and every i2c1 access was gated to 0. Added a dedicated `stm32g4` RCC layout with the RM0440 offsets (enables 0x48/0x4C/0x58/0x5C/0x60, resets 0x28–0x40, BDCR/CSR/CRRCR) and pointed the chip yaml at it; all six `clock:` entries verified against CMSIS bit positions.

**New tests:** preload-order write, TXIS-then-TXDR write, NACK in both orderings; G4 RCC offset + clock-ready tests. Existing CR2-then-TXDR tests unchanged.

**Verification:** `cargo test -p labwired-core --lib` 2325 passed / 0 failed. Arduino matrix `--force-compile`: stm32l073 / stm32h563 / stm32g474re now **pass** (`LW_L3_OK`), stm32f103 (I2C v1 guard) stays pass. Conformance: chip_conformance, h563_conformance, and l073/h563/l476 walk-differentials (with `--features event-scheduler`) all pass.

Note for follow-up: `docs/coverage/chip-conformance.md` has pre-existing drift vs its generator (nrf52832 10→16, stm32f407 29→31) unrelated to this change; reverted here to keep the diff scoped.