### PR TITLE
fix(esp32s3): decouple thunk-ROM harness from MMU-XIP flash model

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -479,10 +479,21 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     // Scoped: provision_rom_images checks this once.
                     let _fast = std::env::var_os("LABWIRED_ESP32S3_FASTBOOT");
                     std::env::set_var("LABWIRED_ESP32S3_FASTBOOT", "1");
+                    // The matrix loads the app at the factory partition
+                    // (`factory_flash_base` below) and seeds the flash MMU via
+                    // `seed_factory_mmu_for_cache2phys` so `spi_flash_mmap` /
+                    // `cache2phys` resolve — that requires the MMU-XIP window, so
+                    // request it explicitly (FASTBOOT alone no longer implies it,
+                    // to keep bare fast_boot fixtures on identity XIP).
+                    let _mmu_xip = std::env::var_os("LABWIRED_ESP32S3_MMU_XIP");
+                    std::env::set_var("LABWIRED_ESP32S3_MMU_XIP", "1");
                     let opts = Esp32s3Opts::default();
                     let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
                     if _fast.is_none() {
                         std::env::remove_var("LABWIRED_ESP32S3_FASTBOOT");
+                    }
+                    if _mmu_xip.is_none() {
+                        std::env::remove_var("LABWIRED_ESP32S3_MMU_XIP");
                     }
                     // Matrix L3 kits live in system.yaml external_devices — attach
                     // after the SoC bank is registered (classic path does this in

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -202,8 +202,7 @@ fn configure_esp32s3_memmap(bus: &mut SystemBus, opts: &Esp32s3Opts) -> Esp32s3M
     // return 0 (an early null-jump through a rodata jump-table entry). Such
     // harness fixtures stay on identity XIP; only callers that program/seed the
     // MMU (real-reset boot, or the matrix's factory seed) select the MMU model.
-    let mmu_model = opts.real_reset_boot
-        || std::env::var_os("LABWIRED_ESP32S3_MMU_XIP").is_some();
+    let mmu_model = opts.real_reset_boot || std::env::var_os("LABWIRED_ESP32S3_MMU_XIP").is_some();
     // Shared flash backing for the proper-model path, loaded from the real
     // flash image so XIP reads (and the SPI-flash controller below) return real
     // bytes. In fast-boot this is unused; the legacy per-window backings apply.

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -188,11 +188,21 @@ fn configure_esp32s3_memmap(bus: &mut SystemBus, opts: &Esp32s3Opts) -> Esp32s3M
         .rom_images
         .clone()
         .or_else(crate::boot::esp32s3_rom::provision_rom_images);
-    // Fast-boot also uses MMU XIP so `spi_flash_mmap` / partition-table load
-    // and `cache2phys` share one translation (seeded after `fast_boot`).
-    // Identity-only XIP made mmap of flash 0x8000 read the wrong dcache page.
+    // The real-firmware matrix path (ESP-IDF/Arduino) also opts into MMU XIP so
+    // `spi_flash_mmap` / partition-table load and `cache2phys` share one
+    // translation (the CLI seeds it via `seed_factory_mmu_for_cache2phys` after
+    // `fast_boot`; identity-only XIP made mmap of flash 0x8000 read the wrong
+    // dcache page). It requests this explicitly with `LABWIRED_ESP32S3_MMU_XIP`.
+    //
+    // `LABWIRED_ESP32S3_FASTBOOT` selects the *thunk ROM harness* (see
+    // `esp32s3_rom::provision_rom_images`) and is orthogonal to the XIP model —
+    // it must NOT force MMU XIP. A bare esp-hal fixture that boots via a plain
+    // `fast_boot` never programs DR_REG_MMU_TABLE, so an MMU-XIP window would
+    // translate every `.rodata`/`.text` read through an all-invalid table and
+    // return 0 (an early null-jump through a rodata jump-table entry). Such
+    // harness fixtures stay on identity XIP; only callers that program/seed the
+    // MMU (real-reset boot, or the matrix's factory seed) select the MMU model.
     let mmu_model = opts.real_reset_boot
-        || std::env::var_os("LABWIRED_ESP32S3_FASTBOOT").is_some()
         || std::env::var_os("LABWIRED_ESP32S3_MMU_XIP").is_some();
     // Shared flash backing for the proper-model path, loaded from the real
     // flash image so XIP reads (and the SPI-flash controller below) return real


### PR DESCRIPTION
Fixes the nightly "ESP32-S3 Fixtures E2E" regression (`e2e_blinky` dying with `Exception raised: cause=0 at pc=0x0`), red since 2026-07-24.

**Root cause:** #618 (`41da5d27`) widened the MMU-XIP selector to include `LABWIRED_ESP32S3_FASTBOOT`. FASTBOOT selects the *thunk ROM harness* and is orthogonal to the flash-XIP model: a bare esp-hal fixture boots via plain `fast_boot` and never programs `DR_REG_MMU_TABLE`, so the all-invalid MMU table translated every `.rodata`/`.text` read to 0 — traced to `esp_hal::soc::xtensa::esp32_init` doing `jx a15` through a jump-table entry loaded as 0 from `0x3c000f80` (ELF holds `0x40378787` there). Not a window-spill bug; CPU state was correct.

**Fix:** `mmu_model = real_reset_boot || LABWIRED_ESP32S3_MMU_XIP` — FASTBOOT no longer implies MMU XIP. The Arduino-matrix CLI path (which loads at the factory partition and seeds the MMU via `seed_factory_mmu_for_cache2phys`) now sets `LABWIRED_ESP32S3_MMU_XIP` explicitly, keeping its behavior byte-identical. Harness fixtures return to the pre-#618 identity-XIP path.

**Verification:** e2e_blinky passes in BOTH lanes (faithful + FASTBOOT harness — the failing CI lane); e2e_hello_world and e2e_i2c_tmp102 harness-lane pass; `cargo test -p labwired-core --lib` 2320 passed / 0 failed (incl. `flash_xip_windows_share_mmu_backed_flash`); diag_esp32s3_boot + diag_esp32s3_l2 pass; matrix esp32 L0/L2 unaffected. `xtensa_lx7.rs` untouched.

**Separately diagnosed, not fixed here:** the Arduino-matrix esp32s3 `boot_fail` is the firmware aborting in `load_partitions` (`E (%u) %s: load_partitions returned 0x%x` → `esp_system_abort`, halt at `panic_abort` pc=0x4037705f) — independent of this fix and pre-existing.