### PR TITLE
fix(esp32s3): seed ROM flash descriptor for spi_flash_mmap + Xtensa BT/BF decode

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -479,10 +479,21 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     // Scoped: provision_rom_images checks this once.
                     let _fast = std::env::var_os("LABWIRED_ESP32S3_FASTBOOT");
                     std::env::set_var("LABWIRED_ESP32S3_FASTBOOT", "1");
+                    // The matrix loads the app at the factory partition
+                    // (`factory_flash_base` below) and seeds the flash MMU via
+                    // `seed_factory_mmu_for_cache2phys` so `spi_flash_mmap` /
+                    // `cache2phys` resolve — that requires the MMU-XIP window, so
+                    // request it explicitly (FASTBOOT alone no longer implies it,
+                    // to keep bare fast_boot fixtures on identity XIP).
+                    let _mmu_xip = std::env::var_os("LABWIRED_ESP32S3_MMU_XIP");
+                    std::env::set_var("LABWIRED_ESP32S3_MMU_XIP", "1");
                     let opts = Esp32s3Opts::default();
                     let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
                     if _fast.is_none() {
                         std::env::remove_var("LABWIRED_ESP32S3_FASTBOOT");
+                    }
+                    if _mmu_xip.is_none() {
+                        std::env::remove_var("LABWIRED_ESP32S3_MMU_XIP");
                     }
                     // Matrix L3 kits live in system.yaml external_devices — attach
                     // after the SoC bank is registered (classic path does this in

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -590,6 +590,15 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                     eprintln!(
                         "labwired-cli test: seeded S3 factory MMU for cache2phys (app0 @ 0x10000)"
                     );
+                    // Post-BROM flash-attach state: the ROM's flash-attach fills
+                    // `rom_spiflash_legacy_data->chip.chip_size`; fast-boot skips
+                    // it, so `spi_flash_mmap` (partition-table load) rejects every
+                    // mmap with ESP_ERR_INVALID_ARG (0x102) and `load_partitions`
+                    // aborts. Seed the descriptor with the configured flash size.
+                    labwired_core::boot::esp32s3::seed_esp32s3_rom_flashchip(
+                        &mut bus,
+                        4 * 1024 * 1024,
+                    );
                     // Arduino dual-core: `system_early_init` calls
                     // `ets_set_appcpu_boot_addr(call_start_cpu1)` then spins on
                     // `s_cpu_up[0] & s_cpu_up[1]`. Without APP_CPU the wait is

--- a/crates/core/src/boot/esp32s3.rs
+++ b/crates/core/src/boot/esp32s3.rs
@@ -233,6 +233,39 @@ pub fn seed_factory_mmu_for_cache2phys(bus: &mut SystemBus, irom_pages: u32, dro
     );
 }
 
+/// Seed the ROM SPI-flash chip descriptor that the boot ROM's flash-attach
+/// (`esp_rom_spiflash_attach` / `esp_rom_spiflash_config_param`) normally fills
+/// at reset. Fast-boot / the thunk harness skip that, so the ROM pointer
+/// `rom_spiflash_legacy_data` (@ `0x3FCE_FFE4`) stays NULL and
+/// `spi_flash_mmap` reads `chip.chip_size == 0`. Its flash-bounds guard
+/// (`if (chip_size < src+size) return ESP_ERR_INVALID_ARG`) then rejects EVERY
+/// mmap — including the partition-table mmap in `esp_partition`'s
+/// `load_partitions`, which aborts with `0x102` before any UART output.
+///
+/// Mirrors the classic-ESP32 `g_rom_flashchip` post-BROM seed
+/// (`esp32_boot_state::seed_esp32_post_brom_dram`). On the S3 ROM
+/// `g_rom_flashchip` is `rom_spiflash_legacy_data->chip` (esp-idf
+/// `esp32s3/rom/spi_flash.h`), so we place the `esp_rom_spiflash_chip_t`
+/// (24 B: device_id, chip_size, block_size, sector_size, page_size,
+/// status_mask) in the ROM-reserved DRAM page (`0x3FCEF000..0x3FCF0000`, which
+/// no app section claims) and point the ROM pointer at it. `0x3FCEFF00` is
+/// below the lowest ROM-BSS symbol on that page (`0x3FCEFF48`).
+pub fn seed_esp32s3_rom_flashchip(bus: &mut SystemBus, flash_size: u32) {
+    const ROM_SPIFLASH_LEGACY_DATA: u64 = 0x3FCE_FFE4;
+    const CHIP: u32 = 0x3FCE_FF00;
+    // esp_rom_spiflash_chip_t — Winbond W25Q-class (matches the SPI RDID model).
+    let _ = bus.write_u32(CHIP as u64, 0x0016_40EF); // device_id
+    let _ = bus.write_u32(CHIP as u64 + 4, flash_size); // chip_size
+    let _ = bus.write_u32(CHIP as u64 + 8, 64 * 1024); // block_size
+    let _ = bus.write_u32(CHIP as u64 + 12, 4 * 1024); // sector_size
+    let _ = bus.write_u32(CHIP as u64 + 16, 256); // page_size
+    let _ = bus.write_u32(CHIP as u64 + 20, 0xFFFF); // status_mask
+    let _ = bus.write_u32(ROM_SPIFLASH_LEGACY_DATA, CHIP);
+    tracing::info!(
+        "esp32s3: seeded rom_spiflash_legacy_data -> chip@{CHIP:#010x} (chip_size={flash_size:#x})"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/cpu/xtensa_jit/emit_core.rs
+++ b/crates/core/src/cpu/xtensa_jit/emit_core.rs
@@ -259,6 +259,8 @@ pub fn is_terminator(ins: &Instruction) -> bool {
             | Bnez { .. }
             | Bltz { .. }
             | Bgez { .. }
+            | Bt { .. }
+            | Bf { .. }
             | Beqi { .. }
             | Bnei { .. }
             | Blti { .. }

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -127,9 +127,8 @@ pub struct XtensaLx7 {
     /// rfr/wfr and lsi/ssi. The Xtensa LX7 FPU is single-precision only.
     pub fp: [u32; 16],
     /// Boolean registers b0..b15 (Boolean Option), packed one per bit. FP
-    /// compares (oeq.s/olt.s/…) write a result bit here; movf.s/movt.s read it.
-    /// Modeled minimally: only the FP compare/move instructions touch it (the
-    /// integer BR-consuming branches aren't in the decoded set yet).
+    /// compares (oeq.s/olt.s/…) write a result bit here; movf.s/movt.s and the
+    /// BT/BF branches read it.
     pub br: u16,
     pub pc: u32,
     /// Set by the branch helper when a conditional branch's predicate
@@ -1891,6 +1890,16 @@ impl XtensaLx7 {
             // BGEZ: taken if (as_ as i32) >= 0
             Bgez { as_, offset } => {
                 let cond = (self.regs.read_logical(as_) as i32) >= 0;
+                self.branch(offset, len, cond);
+            }
+            // BT bs: taken if boolean register BR[bs] == 1 (Boolean Option).
+            Bt { bs, offset } => {
+                let cond = (self.br >> (bs & 0xF)) & 1 == 1;
+                self.branch(offset, len, cond);
+            }
+            // BF bs: taken if boolean register BR[bs] == 0 (Boolean Option).
+            Bf { bs, offset } => {
+                let cond = (self.br >> (bs & 0xF)) & 1 == 0;
                 self.branch(offset, len, cond);
             }
             // BEQI: taken if as_ == imm  (decoder resolved B4CONST[r] into imm: i32)

--- a/crates/core/src/decoder/xtensa.rs
+++ b/crates/core/src/decoder/xtensa.rs
@@ -227,6 +227,16 @@ pub enum Instruction {
         as_: u8,
         offset: i32,
     },
+    /// bt bs, target : branch if boolean register BR[bs] == 1 (Boolean Option).
+    Bt {
+        bs: u8,
+        offset: i32,
+    },
+    /// bf bs, target : branch if boolean register BR[bs] == 0 (Boolean Option).
+    Bf {
+        bs: u8,
+        offset: i32,
+    },
     Beqi {
         as_: u8,
         imm: i32,
@@ -1946,15 +1956,27 @@ fn decode_si(w: u32) -> Instruction {
                     Instruction::Entry { as_: s, imm: imm12 }
                 }
                 1 => {
-                    // n=3, m=1: LOOP family (BRI8-shaped, r selects variant).
-                    // Per Xtensa ISA RM §7.4 Zero-Overhead Loop Option:
+                    // n=3, m=1 (BRI8-shaped, r selects variant):
+                    //   r=0  → BF bs, imm8 (Boolean Option, backward-capable)
+                    //   r=1  → BT bs, imm8 (Boolean Option, backward-capable)
                     //   r=8  → LOOP   as_, imm8 (always taken)
                     //   r=9  → LOOPNEZ as_, imm8 (skip body if as_==0)
                     //   r=10 → LOOPGTZ as_, imm8 (skip body if as_<=0 signed)
-                    // imm8 in bits[23:16], offset relative to PC+4.
+                    // imm8 in bits[23:16], offset relative to PC+4. LOOP imm8 is
+                    // an unsigned forward span; BT/BF imm8 is signed (`bf` can
+                    // branch back). HW-oracle (xtensa-esp32s3-elf-as, esp-15.2.0):
+                    //   bt b0,. → 021076 (r=1,s=0); bf b5,. → ff0576 (r=0,s=5).
                     let imm8 = (w >> 16) & 0xFF;
                     let offset = imm8 as i32 + 4;
                     match r {
+                        0 => Instruction::Bf {
+                            bs: s,
+                            offset: sext8(imm8) + 4,
+                        },
+                        1 => Instruction::Bt {
+                            bs: s,
+                            offset: sext8(imm8) + 4,
+                        },
                         8 => Instruction::Loop { as_: s, offset },
                         9 => Instruction::Loopnez { as_: s, offset },
                         10 => Instruction::Loopgtz { as_: s, offset },
@@ -2200,7 +2222,10 @@ impl Instruction {
             | MovgezS { .. }
             | MovfS { .. }
             | MovtS { .. }
-            | CmpS { .. } => 0,
+            | CmpS { .. }
+            // BT/BF read a boolean register (BR[bs]), not a windowed AR.
+            | Bt { .. }
+            | Bf { .. } => 0,
             Rfr { ar, .. } => ar,
             Wfr { as_, .. } => as_,
             FloatS { as_, .. } | UfloatS { as_, .. } => as_,
@@ -2264,5 +2289,17 @@ mod salt_saltu_tests {
                 at: 8
             }
         );
+    }
+
+    #[test]
+    fn decodes_bt_bf() {
+        // Boolean-Option branches (op0=6, n=3, m=1; r=1→BT, r=0→BF).
+        // HW-oracle (xtensa-esp32s3-elf-as, esp-15.2.0_20250920):
+        //   `bt b0, .+6` → 0x021076 (bs=0, imm8=0x02 → offset = 2+4 = 6)
+        //   `bf b5, .+3` → 0xff0576 (bs=5, imm8=0xff → offset = -1+4 = 3)
+        assert_eq!(decode(0x021076), Instruction::Bt { bs: 0, offset: 6 });
+        assert_eq!(decode(0xff0576), Instruction::Bf { bs: 5, offset: 3 });
+        // LOOP variants at the same n/m must still decode (r=8/9/10).
+        assert!(matches!(decode(0x008076), Instruction::Loop { .. }));
     }
 }

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -202,8 +202,7 @@ fn configure_esp32s3_memmap(bus: &mut SystemBus, opts: &Esp32s3Opts) -> Esp32s3M
     // return 0 (an early null-jump through a rodata jump-table entry). Such
     // harness fixtures stay on identity XIP; only callers that program/seed the
     // MMU (real-reset boot, or the matrix's factory seed) select the MMU model.
-    let mmu_model = opts.real_reset_boot
-        || std::env::var_os("LABWIRED_ESP32S3_MMU_XIP").is_some();
+    let mmu_model = opts.real_reset_boot || std::env::var_os("LABWIRED_ESP32S3_MMU_XIP").is_some();
     // Shared flash backing for the proper-model path, loaded from the real
     // flash image so XIP reads (and the SPI-flash controller below) return real
     // bytes. In fast-boot this is unused; the legacy per-window backings apply.

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -188,11 +188,21 @@ fn configure_esp32s3_memmap(bus: &mut SystemBus, opts: &Esp32s3Opts) -> Esp32s3M
         .rom_images
         .clone()
         .or_else(crate::boot::esp32s3_rom::provision_rom_images);
-    // Fast-boot also uses MMU XIP so `spi_flash_mmap` / partition-table load
-    // and `cache2phys` share one translation (seeded after `fast_boot`).
-    // Identity-only XIP made mmap of flash 0x8000 read the wrong dcache page.
+    // The real-firmware matrix path (ESP-IDF/Arduino) also opts into MMU XIP so
+    // `spi_flash_mmap` / partition-table load and `cache2phys` share one
+    // translation (the CLI seeds it via `seed_factory_mmu_for_cache2phys` after
+    // `fast_boot`; identity-only XIP made mmap of flash 0x8000 read the wrong
+    // dcache page). It requests this explicitly with `LABWIRED_ESP32S3_MMU_XIP`.
+    //
+    // `LABWIRED_ESP32S3_FASTBOOT` selects the *thunk ROM harness* (see
+    // `esp32s3_rom::provision_rom_images`) and is orthogonal to the XIP model —
+    // it must NOT force MMU XIP. A bare esp-hal fixture that boots via a plain
+    // `fast_boot` never programs DR_REG_MMU_TABLE, so an MMU-XIP window would
+    // translate every `.rodata`/`.text` read through an all-invalid table and
+    // return 0 (an early null-jump through a rodata jump-table entry). Such
+    // harness fixtures stay on identity XIP; only callers that program/seed the
+    // MMU (real-reset boot, or the matrix's factory seed) select the MMU model.
     let mmu_model = opts.real_reset_boot
-        || std::env::var_os("LABWIRED_ESP32S3_FASTBOOT").is_some()
         || std::env::var_os("LABWIRED_ESP32S3_MMU_XIP").is_some();
     // Shared flash backing for the proper-model path, loaded from the real
     // flash image so XIP reads (and the SPI-flash controller below) return real

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-24 | ⚠ drift acked 2026-07-24 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-25 | ⚠ drift acked 2026-07-25 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-07-18 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-06-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
@@ -98,7 +98,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-07-25 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -1072,7 +1072,17 @@ boards:
     # attached slaves). No existing read/write/tick/on_event path changed, so the
     # anchored reset windows and every observable register value are untouched;
     # esp32s3_walk_differential covers byte-identity. No live re-capture warranted.
-    drift_ack: 2026-07-24
+    # 2026-07-25: three ADDITIVE boot/CPU fixes, no register model touched:
+    # (a) mmu_model selector decoupled from the FASTBOOT harness flag (#662 —
+    # harness fixtures return to identity XIP; matrix path byte-identical via
+    # explicit MMU_XIP); (b) fast-boot seeds rom_spiflash_legacy_data with a real
+    # W25Q descriptor in ROM-reserved DRAM so spi_flash_mmap's chip_size bounds
+    # check passes (mirrors classic-ESP32 g_rom_flashchip seed; BSS the skipped
+    # BROM would have filled); (c) Xtensa decoder gained BT/BF Boolean-option
+    # branches (encodings pinned by xtensa-esp32s3-elf-as HW oracle). Register
+    # maps, reset values and MMIO paths untouched; S3/C3 silicon differentials,
+    # ws2812_rmt, ssd1306 + 316 Xtensa CPU tests pass. No live re-capture.
+    drift_ack: 2026-07-25
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Completes the esp32s3 Arduino-matrix fix (follow-up to #662, which cured the nightly fixture regression). Two more real simulator defects, root-caused from the `load_partitions` abort:

**1. `rom_spiflash_legacy_data` was NULL in fast-boot** → `spi_flash_mmap`'s flash-bounds guard read `chip.chip_size == 0` and rejected every mmap with `ESP_ERR_INVALID_ARG` (0x102, recovered via PC trace) → `load_partitions` aborted before any UART output (the matrix `boot_fail`). The boot ROM fills this descriptor at flash-attach; fast-boot skips that, and it's runtime BSS so no ROM image seeds it. Fix: `seed_esp32s3_rom_flashchip` writes a real W25Q-class `esp_rom_spiflash_chip_t` (4 MiB) into ROM-reserved DRAM and points the ld-anchored pointer at it — the S3 counterpart of the classic-ESP32 `g_rom_flashchip` post-BROM seed. After the fix mmap programs real MMU entries and the table reads back from phys 0x8000.

**2. Xtensa Boolean-option branches `BT`/`BF` were never decoded** — with the mmap fixed, L2 died `IllegalInstruction` at `rmtSetTick`'s `olt.s → bt` sequence. The BR file and FP compares existed; the BR-consuming branches didn't. Added decode (encodings pinned by an `xtensa-esp32s3-elf-as` HW-oracle test: `bt b0,.`=0x021076, `bf b5,.`=0xff0576), executor, JIT terminator handling.

**Verification:** lib suite 2328 passed / 0 failed; Arduino matrix esp32s3 + esp32 × L0/L2/L3 = **6/6 pass** (esp32s3 column fully green for the first time); Xtensa CPU integration tests 316 passed; S3/C3 silicon differentials, ws2812_rmt, ssd1306, dual-core boot diag all pass. Validation drift acked (additive; no register model touched).