### PR TITLE
docs: refresh Arduino scoreboard — 15×4 matrix fully green

### DIFF
--- a/docs/coverage/arduino-scoreboard.md
+++ b/docs/coverage/arduino-scoreboard.md
@@ -1,31 +1,31 @@
 # Arduino × LabWired board matrix
 
-_Generated 2026-07-23 14:49:04 +0200 by `validation/arduino-matrix/run_matrix.py`._
+_Generated 2026-07-25 17:51:57 +0200 by `validation/arduino-matrix/run_matrix.py`._
 
 Legend: ✅ pass · 🔧 compile/build fail · 📦 toolchain missing · 🔴 boot/sim fail · 🟠 oracle miss · 🟣 unmodeled · ⏱️ timeout
 
-| chip | L0_serial_boot | L1_serial_loop | L2_blink_serial | notes |
-|------|------|------|------|-------|
-| `esp32` | ✅ | ✅ | ✅ |  |
-| `esp32c3` | ✅ | ✅ | ✅ |  |
-| `esp32s3` | ✅ | ✅ | ✅ |  |
-| `nrf52832` | ✅ | ✅ | ✅ |  |
-| `nrf52840` | ✅ | ✅ | ✅ |  |
-| `rp2040` | ✅ | ✅ | ✅ |  |
-| `stm32f103` | ✅ | ✅ | ✅ |  |
-| `stm32f401` | ✅ | ✅ | ✅ |  |
-| `stm32f407` | ✅ | ✅ | ✅ |  |
-| `stm32g474re` | ✅ | ✅ | ✅ |  |
-| `stm32h563` | ✅ | ✅ | ✅ |  |
-| `stm32l073` | ✅ | ✅ | ✅ |  |
-| `stm32l476` | ✅ | ✅ | ✅ |  |
-| `stm32wb55` | ✅ | ✅ | ✅ |  |
-| `stm32wba52` | ✅ | ✅ | ✅ |  |
+| chip | L0_serial_boot | L1_serial_loop | L2_blink_serial | L3_i2c_sensor | notes |
+|------|------|------|------|------|-------|
+| `esp32` | ✅ | ✅ | ✅ | ✅ |  |
+| `esp32c3` | ✅ | ✅ | ✅ | ✅ |  |
+| `esp32s3` | ✅ | ✅ | ✅ | ✅ |  |
+| `nrf52832` | ✅ | ✅ | ✅ | ✅ |  |
+| `nrf52840` | ✅ | ✅ | ✅ | ✅ |  |
+| `rp2040` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32f103` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32f401` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32f407` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32g474re` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32h563` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32l073` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32l476` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32wb55` | ✅ | ✅ | ✅ | ✅ |  |
+| `stm32wba52` | ✅ | ✅ | ✅ | ✅ |  |
 
 ## Summary
 
-- Cells: **45**
-- `pass`: 45
+- Cells: **60**
+- `pass`: 60
 
 ## Failures (detail)
 


### PR DESCRIPTION
Regenerated from a full local `run_matrix.py` run (60/60 pass, 753s) against main at the #663 merge. First scoreboard including the L3_i2c_sensor column — every board passes it after #659/#660/#661/#662/#663.