### PR TITLE
fix(matrix): install pio packages before the WBA series patch

### DIFF
--- a/validation/arduino-matrix/run_matrix.py
+++ b/validation/arduino-matrix/run_matrix.py
@@ -266,6 +266,17 @@ def main() -> int:
                 if "wba" in bid.lower() or "wba" in str(board.get("chip", "")).lower():
                     patch = MATRIX_DIR / "scripts" / "patch_stm32duino_wba_series.py"
                     if patch.is_file():
+                        # On a fresh runner the framework package doesn't exist
+                        # until pio fetches it, so the patch would be a no-op and
+                        # the first WBA compile fails on unpatched series
+                        # detection. Force the download before patching.
+                        subprocess.run(
+                            ["pio", "pkg", "install", "-e", "matrix"],
+                            check=False,
+                            capture_output=True,
+                            text=True,
+                            cwd=work,
+                        )
                         subprocess.run(
                             [sys.executable, str(patch)],
                             check=False,


### PR DESCRIPTION
Fixes the last red cell in Core Arduino Matrix Smoke: `arduino-stm32wba52` failed its FIRST sketch compile on every fresh CI runner because `patch_stm32duino_wba_series.py` ran before PlatformIO had downloaded the framework package — the patch was a no-op, the unpatched series detection broke the first compile, and subsequent sketches passed once the framework existed (which is also why warm local caches never reproduced it). Now `pio pkg install -e matrix` forces the download before patching.

Verified locally: stm32wba52 L0 `--force-compile` passes; full 15×4 matrix was 60/60 on the same tree.