### PR TITLE
feat(esp32c3): droppable, configurable virtual WiFi AP (wifi-ap component)

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -71,6 +71,7 @@ pub(crate) fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode 
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         walk_deleted: Some(false),
     };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -927,10 +927,30 @@ pub(crate) fn run_one_c3_wifi(
     manifest: &labwired_config::SystemManifest,
 ) -> ExitCode {
     use labwired_core::bus::SystemBus;
+    use labwired_core::peripherals::esp32c3::virtual_wifi::{ApConfig, VirtualWifiBus};
     use labwired_core::peripherals::esp32c3::{virtual_wifi, wifi_mac::Esp32c3WifiMac};
 
     virtual_wifi::reset();
     eprintln!("[solo] one C3 on VirtualWifi: STA=02:00:00:00:00:02 (AP hosts DHCP + HTTP)");
+
+    // If the manifest declares a `wifi_ap`, host a medium with that config;
+    // otherwise the MACs bind the process-global default AP (byte-identical to
+    // the former hardcoded behaviour).
+    let configured_bus = manifest.wifi_ap.as_ref().map(|ap| {
+        let ip = {
+            let octets: Vec<u8> = ap
+                .ip
+                .split('.')
+                .filter_map(|o| o.parse::<u8>().ok())
+                .collect();
+            (octets.len() == 4).then(|| [octets[0], octets[1], octets[2], octets[3]])
+        };
+        VirtualWifiBus::with_config(ApConfig::from_parts(
+            Some(ap.ssid.clone()),
+            ip,
+            Some(&ap.serves),
+        ))
+    });
 
     let bus = match SystemBus::from_config(chip, manifest) {
         Ok(b) => b,
@@ -948,6 +968,9 @@ pub(crate) fn run_one_c3_wifi(
             continue;
         };
         if let Some(mac) = any.downcast_mut::<Esp32c3WifiMac>() {
+            if let Some(bus) = configured_bus.as_ref() {
+                mac.set_wifi_bus(bus.clone());
+            }
             mac.attach_to_medium();
         } else if let Some(uart) = any.downcast_mut::<labwired_core::peripherals::uart::Uart>() {
             uart.set_stdout_prefix("");

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -262,6 +262,35 @@ pub struct BoardIoBinding {
     pub device_type: Option<String>,
 }
 
+fn default_wifi_ap_ssid() -> String {
+    "labwired-ap".to_string()
+}
+
+fn default_wifi_ap_ip() -> String {
+    "192.168.4.1".to_string()
+}
+
+fn default_wifi_ap_serves() -> String {
+    "labwired-stats".to_string()
+}
+
+/// Manifest opt-in for the per-lab virtual WiFi Access Point. Emitted when a
+/// diagram contains a `wifi-ap` component. Absent ⇒ no AP (WiFi MACs stay
+/// unassociated — honest "no AP present"). Mirrors `debug_uart`'s optional
+/// pattern.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct WifiApManifest {
+    /// Broadcast SSID of the AP.
+    #[serde(default = "default_wifi_ap_ssid")]
+    pub ssid: String,
+    /// AP's IPv4 address (dotted-quad); its /24 is the DHCP pool.
+    #[serde(default = "default_wifi_ap_ip")]
+    pub ip: String,
+    /// What the AP's HTTP origin serves: "labwired-stats" (default) or "none".
+    #[serde(default = "default_wifi_ap_serves")]
+    pub serves: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SystemManifest {
     #[serde(default = "default_schema_version")]
@@ -278,6 +307,10 @@ pub struct SystemManifest {
     pub board_io: Vec<BoardIoBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub debug_uart: Option<String>,
+    /// Per-lab virtual WiFi AP config (present ⇒ a `wifi-ap` component is on the
+    /// diagram). Absent ⇒ no AP. See [`WifiApManifest`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wifi_ap: Option<WifiApManifest>,
     #[serde(default)]
     pub peripherals: Vec<PeripheralConfig>,
     /// Per-cycle peripheral-walk deletion (only consulted in `event-scheduler`

--- a/crates/core/src/bus/pin_map_tests.rs
+++ b/crates/core/src/bus/pin_map_tests.rs
@@ -20,6 +20,7 @@ fn mkw41z4_bus() -> SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -592,6 +592,7 @@ fn test_from_config_attaches_adxl345_external_device_to_i2c() {
         }],
         board_io: Vec::new(),
         debug_uart: None,
+        wifi_ap: None,
         peripherals: Vec::new(),
     };
 
@@ -1010,6 +1011,7 @@ fn test_esp32c3_i2c_gpio_matrix_distinguishes_gpio45_from_gpio67() {
             }],
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
         let mut bus = SystemBus::from_config(&chip, &manifest).expect("construct C3 bus");
@@ -1183,6 +1185,7 @@ fn test_from_config_attaches_bmp280_to_esp32c3_i2c0() {
         }],
         board_io: Vec::new(),
         debug_uart: None,
+        wifi_ap: None,
         peripherals: Vec::new(),
     };
 
@@ -1332,6 +1335,7 @@ fn test_from_config_attaches_mlx90640_to_esp32c3_i2c0_and_reads_eeprom() {
         }],
         board_io: Vec::new(),
         debug_uart: None,
+        wifi_ap: None,
         peripherals: Vec::new(),
     };
 
@@ -2137,6 +2141,7 @@ fn empty_manifest() -> SystemManifest {
         external_devices: Vec::new(),
         board_io: Vec::new(),
         debug_uart: None,
+        wifi_ap: None,
         peripherals: Vec::new(),
     }
 }
@@ -2281,6 +2286,7 @@ fn manifest_with_external_device(
         }],
         board_io: Vec::new(),
         debug_uart: None,
+        wifi_ap: None,
         peripherals: Vec::new(),
     }
 }

--- a/crates/core/src/peripherals/esp32c3/virtual_wifi.rs
+++ b/crates/core/src/peripherals/esp32c3/virtual_wifi.rs
@@ -56,6 +56,78 @@ const STATS_SNAPSHOT: &str = concat!(
     "\"labs_opened\":69,\"simulations_run\":3200,\"active_sessions\":4900}"
 );
 
+/// What the AP's HTTP origin serves. Keeps the AP's L4 surface a small, explicit
+/// choice so a lab can host the baked stats snapshot (the default demo) or an
+/// empty origin (every path 404s).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ApServes {
+    /// Serve the baked `GET /v1/public-stats` snapshot (the default demo).
+    #[default]
+    LabwiredStats,
+    /// Serve nothing; the HTTP origin has no routes (every request 404s).
+    None,
+}
+
+impl ApServes {
+    /// Parse a manifest `serves` string. Unknown values fall back to the default
+    /// (`LabwiredStats`) so a typo degrades to the demo rather than a dead AP.
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "labwired-stats" | "stats" | "public-stats" => ApServes::LabwiredStats,
+            "none" | "" => ApServes::None,
+            _ => ApServes::LabwiredStats,
+        }
+    }
+}
+
+/// Per-lab AP configuration. The former process-global consts (`AP_SSID`,
+/// `AP_IP`, and the stats origin) are the [`Default`], so an unconfigured AP is
+/// byte-identical to the old hardcoded one; a manifest `wifi_ap` overrides SSID,
+/// IP (its /24 is the DHCP pool), and what the HTTP origin serves. BSSID and
+/// netmask stay const (the driver never keys on them).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApConfig {
+    pub ssid: String,
+    pub ip: [u8; 4],
+    pub serves: ApServes,
+}
+
+impl Default for ApConfig {
+    fn default() -> Self {
+        Self {
+            ssid: AP_SSID.to_string(),
+            ip: AP_IP,
+            serves: ApServes::LabwiredStats,
+        }
+    }
+}
+
+impl ApConfig {
+    /// Build a config from optional parts, filling any missing field from
+    /// [`Default`]. `serves` is parsed via [`ApServes::parse`].
+    pub fn from_parts(ssid: Option<String>, ip: Option<[u8; 4]>, serves: Option<&str>) -> Self {
+        let d = ApConfig::default();
+        Self {
+            ssid: ssid.unwrap_or(d.ssid),
+            ip: ip.unwrap_or(d.ip),
+            serves: serves.map(ApServes::parse).unwrap_or(d.serves),
+        }
+    }
+
+    /// The AP's HTTP origin for this config. `LabwiredStats` serves the baked
+    /// `/v1/public-stats` snapshot; `None` is an empty origin (every path 404s).
+    /// One source of truth for the AP's L4 routing.
+    fn http_origin(&self) -> Arc<dyn SimServer> {
+        match self.serves {
+            ApServes::LabwiredStats => Arc::new(HttpServer::new().get(
+                "/v1/public-stats",
+                HttpResponse::json(STATS_SNAPSHOT.as_bytes().to_vec()),
+            )),
+            ApServes::None => Arc::new(HttpServer::new()),
+        }
+    }
+}
+
 /// Minimal per-connection TCP state for the AP's HTTP server. Enough for lwIP's
 /// `esp_http_client` to complete a short in-order GET (no reordering, no SACK).
 #[derive(Debug, Default)]
@@ -89,24 +161,34 @@ struct VirtualWifi {
     next_host: u8,
     /// Deterministic seed for TCP initial sequence numbers.
     next_isn: u32,
+    /// This AP's identity + L4 config (SSID, IP, what it serves).
+    cfg: ApConfig,
     /// The AP's HTTP origin. Reuses the L4 [`HttpServer`] router + HTTP/1.1
     /// encoder so the TCP layer only moves bytes — one source of truth for HTTP.
+    /// Derived from `cfg.serves`.
     http: Arc<dyn SimServer>,
 }
 
-impl Default for VirtualWifi {
-    fn default() -> Self {
-        // Serves the public-stats snapshot; the device GETs /v1/public-stats.
-        let http = HttpServer::new().get(
-            "/v1/public-stats",
-            HttpResponse::json(STATS_SNAPSHOT.as_bytes().to_vec()),
-        );
+impl VirtualWifi {
+    /// Build an AP from an explicit config; its HTTP origin is derived from
+    /// `cfg.serves`.
+    fn with_config(cfg: ApConfig) -> Self {
+        let http = cfg.http_origin();
         Self {
             stas: HashMap::new(),
             next_host: 0,
             next_isn: 0,
-            http: Arc::new(http),
+            cfg,
+            http,
         }
+    }
+}
+
+impl Default for VirtualWifi {
+    fn default() -> Self {
+        // Default cfg = the former hardcoded AP (SSID "labwired-ap",
+        // 192.168.4.1, serving the public-stats snapshot).
+        Self::with_config(ApConfig::default())
     }
 }
 
@@ -125,6 +207,15 @@ pub struct VirtualWifiBus {
 impl VirtualWifiBus {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Build a medium whose AP uses an explicit [`ApConfig`] (SSID, IP, what it
+    /// serves). `new()`/`Default` use [`ApConfig::default`] — the former
+    /// hardcoded AP — so existing behaviour is byte-identical.
+    pub fn with_config(cfg: ApConfig) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VirtualWifi::with_config(cfg))),
+        }
     }
 
     fn with<R>(&self, f: impl FnOnce(&mut VirtualWifi) -> R) -> R {
@@ -160,7 +251,7 @@ impl VirtualWifiBus {
     /// Called periodically by the MAC while not yet associated.
     pub fn queue_beacon(&self, mac: [u8; 6], channel: u8) {
         self.with(|m| {
-            let frame = build_beacon(channel);
+            let frame = build_beacon(&m.cfg.ssid, channel);
             m.enqueue(mac, frame);
         });
     }
@@ -203,7 +294,7 @@ impl VirtualWifi {
         }
         let host = FIRST_HOST + self.next_host;
         self.next_host += 1;
-        let ip = [192, 168, 4, host];
+        let ip = [self.cfg.ip[0], self.cfg.ip[1], self.cfg.ip[2], host];
         self.sta(mac).ip = ip;
         ip
     }
@@ -238,7 +329,7 @@ impl VirtualWifi {
         if ftype == 0 {
             // Management: respond to the transmitting station.
             match subtype {
-                0x4 => self.enqueue(src, build_probe_resp(src, 1)),
+                0x4 => self.enqueue(src, build_probe_resp(&self.cfg.ssid, src, 1)),
                 0xB => self.enqueue(src, build_auth_resp(src)),
                 0x0 | 0x2 => self.enqueue(src, build_assoc_resp(src)),
                 _ => {}
@@ -251,7 +342,7 @@ impl VirtualWifi {
         // Data frame.
         if let Some((xid, mtype)) = parse_dhcp(frame) {
             let ip = self.assign_ip(src);
-            let reply = build_dhcp_reply(src, ip, xid, mtype == 3);
+            let reply = build_dhcp_reply(self.cfg.ip, src, ip, xid, mtype == 3);
             self.enqueue(src, reply);
             return;
         }
@@ -263,7 +354,7 @@ impl VirtualWifi {
             if oper == 1 {
                 let own = self.stas.get(&src).map(|s| s.ip).unwrap_or_default();
                 if tpa != own {
-                    let who = if tpa == AP_IP {
+                    let who = if tpa == self.cfg.ip {
                         AP_MAC_L2
                     } else if let Some(m) = self.mac_for_ip(tpa) {
                         m
@@ -278,12 +369,12 @@ impl VirtualWifi {
         }
         // IPv4: route to the destination station if we know it, else drop.
         if let Some((dst_ip, proto)) = parse_ipv4_dst(frame) {
-            if dst_ip == AP_IP {
+            if dst_ip == self.cfg.ip {
                 // TCP → the AP's HTTP server (real handshake + segments); else a
                 // UDP echo (proves an app-data round-trip). Other traffic dropped.
                 if proto == 6 {
                     self.handle_tcp(src, frame);
-                } else if let Some(echo) = build_udp_echo(src, frame) {
+                } else if let Some(echo) = build_udp_echo(self.cfg.ip, src, frame) {
                     self.enqueue(src, echo);
                 }
                 return;
@@ -304,6 +395,7 @@ impl VirtualWifi {
     /// lwIP's `esp_http_client` to complete a short GET. The station runs the
     /// real TCP stack; the AP is the peer that terminates it (no thunks).
     fn handle_tcp(&mut self, src_mac: [u8; 6], frame: &[u8]) {
+        let ap_ip = self.cfg.ip;
         let ipoff = snap_off(frame);
         if frame.len() < ipoff + 20 {
             return;
@@ -356,6 +448,7 @@ impl VirtualWifi {
                 req: Vec::new(),
             };
             let synack = build_tcp_to_sta(
+                ap_ip,
                 src_mac,
                 src_ip,
                 server_port,
@@ -417,6 +510,7 @@ impl VirtualWifi {
                         eprintln!("[tcp] -> HTTP response {} bytes + FIN", resp.len());
                     }
                     out.push(build_tcp_to_sta(
+                        ap_ip,
                         src_mac,
                         src_ip,
                         server_port,
@@ -428,6 +522,7 @@ impl VirtualWifi {
                     ));
                     conn.snd_nxt = conn.snd_nxt.wrapping_add(resp.len() as u32);
                     out.push(build_tcp_to_sta(
+                        ap_ip,
                         src_mac,
                         src_ip,
                         server_port,
@@ -442,6 +537,7 @@ impl VirtualWifi {
                 } else {
                     // Partial request: acknowledge what we have so far.
                     out.push(build_tcp_to_sta(
+                        ap_ip,
                         src_mac,
                         src_ip,
                         server_port,
@@ -458,6 +554,7 @@ impl VirtualWifi {
             if flags & TCP_FIN != 0 && seq.wrapping_add(payload.len() as u32) == conn.rcv_nxt {
                 conn.rcv_nxt = conn.rcv_nxt.wrapping_add(1);
                 out.push(build_tcp_to_sta(
+                    ap_ip,
                     src_mac,
                     src_ip,
                     server_port,
@@ -582,21 +679,21 @@ fn mgmt_hdr(subtype_fc0: u8, da: [u8; 6]) -> Vec<u8> {
     f
 }
 
-fn build_beacon(channel: u8) -> Vec<u8> {
+fn build_beacon(ssid: &str, channel: u8) -> Vec<u8> {
     let mut f = mgmt_hdr(0x80, [0xFF; 6]);
     f.extend_from_slice(&[0u8; 8]); // timestamp
     f.extend_from_slice(&[0x64, 0x00]); // beacon interval
     f.extend_from_slice(&[0x01, 0x00]); // capability: ESS, OPEN
     f.push(0x00);
-    f.push(AP_SSID.len() as u8);
-    f.extend_from_slice(AP_SSID.as_bytes());
+    f.push(ssid.len() as u8);
+    f.extend_from_slice(ssid.as_bytes());
     f.extend_from_slice(&[0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x0c, 0x12, 0x18, 0x24]);
     f.extend_from_slice(&[0x03, 0x01, channel]);
     f
 }
 
-fn build_probe_resp(da: [u8; 6], channel: u8) -> Vec<u8> {
-    let mut f = build_beacon(channel);
+fn build_probe_resp(ssid: &str, da: [u8; 6], channel: u8) -> Vec<u8> {
+    let mut f = build_beacon(ssid, channel);
     f[0] = 0x50; // probe response
     f[4..10].copy_from_slice(&da);
     f
@@ -645,13 +742,19 @@ fn data_frame(da: [u8; 6], ethertype: u16, l3: &[u8]) -> Vec<u8> {
     f
 }
 
-fn build_dhcp_reply(da: [u8; 6], yiaddr: [u8; 4], xid: [u8; 4], ack: bool) -> Vec<u8> {
+fn build_dhcp_reply(
+    ap_ip: [u8; 4],
+    da: [u8; 6],
+    yiaddr: [u8; 4],
+    xid: [u8; 4],
+    ack: bool,
+) -> Vec<u8> {
     let mut dhcp = vec![0x02, 0x01, 0x06, 0x00];
     dhcp.extend_from_slice(&xid);
     dhcp.extend_from_slice(&[0x00, 0x00, 0x80, 0x00]); // secs, broadcast flag
     dhcp.extend_from_slice(&[0, 0, 0, 0]); // ciaddr
     dhcp.extend_from_slice(&yiaddr);
-    dhcp.extend_from_slice(&AP_IP); // siaddr
+    dhcp.extend_from_slice(&ap_ip); // siaddr
     dhcp.extend_from_slice(&[0, 0, 0, 0]); // giaddr
     dhcp.extend_from_slice(&da); // chaddr (6)
     dhcp.extend_from_slice(&[0u8; 10]);
@@ -659,11 +762,11 @@ fn build_dhcp_reply(da: [u8; 6], yiaddr: [u8; 4], xid: [u8; 4], ack: bool) -> Ve
     dhcp.extend_from_slice(&[0u8; 128]); // file
     dhcp.extend_from_slice(&[0x63, 0x82, 0x53, 0x63]); // magic
     dhcp.extend_from_slice(&[53, 1, if ack { 5 } else { 2 }]);
-    dhcp.extend_from_slice(&[54, 4, AP_IP[0], AP_IP[1], AP_IP[2], AP_IP[3]]);
+    dhcp.extend_from_slice(&[54, 4, ap_ip[0], ap_ip[1], ap_ip[2], ap_ip[3]]);
     dhcp.extend_from_slice(&[51, 4, 0x00, 0x01, 0x51, 0x80]); // lease
     dhcp.extend_from_slice(&[1, 4, NETMASK[0], NETMASK[1], NETMASK[2], NETMASK[3]]);
-    dhcp.extend_from_slice(&[3, 4, AP_IP[0], AP_IP[1], AP_IP[2], AP_IP[3]]);
-    dhcp.extend_from_slice(&[6, 4, AP_IP[0], AP_IP[1], AP_IP[2], AP_IP[3]]);
+    dhcp.extend_from_slice(&[3, 4, ap_ip[0], ap_ip[1], ap_ip[2], ap_ip[3]]);
+    dhcp.extend_from_slice(&[6, 4, ap_ip[0], ap_ip[1], ap_ip[2], ap_ip[3]]);
     dhcp.push(255);
 
     let udp_len = (8 + dhcp.len()) as u16;
@@ -689,7 +792,7 @@ fn build_dhcp_reply(da: [u8; 6], yiaddr: [u8; 4], xid: [u8; 4], ack: bool) -> Ve
         0,
         0,
     ];
-    ip.extend_from_slice(&AP_IP);
+    ip.extend_from_slice(&ap_ip);
     ip.extend_from_slice(&[255, 255, 255, 255]);
     let cks = inet_checksum(&ip);
     ip[10] = (cks >> 8) as u8;
@@ -710,7 +813,7 @@ fn build_arp_reply(da: [u8; 6], who_mac: [u8; 6], who_ip: [u8; 4], target_ip: [u
 
 /// If `frame` is a UDP datagram to the AP's echo port, build the echoed reply
 /// (same payload, src/dst swapped) as a from-DS data frame to the sender `da`.
-fn build_udp_echo(da: [u8; 6], frame: &[u8]) -> Option<Vec<u8>> {
+fn build_udp_echo(ap_ip: [u8; 4], da: [u8; 6], frame: &[u8]) -> Option<Vec<u8>> {
     let ip = snap_off(frame);
     if frame.len() < ip + 20 || frame[ip] >> 4 != 4 || frame[ip + 9] != 17 {
         return None;
@@ -756,7 +859,7 @@ fn build_udp_echo(da: [u8; 6], frame: &[u8]) -> Option<Vec<u8>> {
         0,
         0,
     ];
-    iph.extend_from_slice(&AP_IP);
+    iph.extend_from_slice(&ap_ip);
     iph.extend_from_slice(&src_ip);
     let cks = inet_checksum(&iph);
     iph[10] = (cks >> 8) as u8;
@@ -769,6 +872,7 @@ fn build_udp_echo(da: [u8; 6], frame: &[u8]) -> Option<Vec<u8>> {
 /// IPv4 and TCP checksums computed) from the AP's HTTP port to the station.
 #[allow(clippy::too_many_arguments)]
 fn build_tcp_to_sta(
+    ap_ip: [u8; 4],
     da: [u8; 6],
     client_ip: [u8; 4],
     sport: u16,
@@ -789,7 +893,7 @@ fn build_tcp_to_sta(
     tcp.extend_from_slice(&[0, 0]); // checksum (filled below)
     tcp.extend_from_slice(&[0, 0]); // urgent pointer
     tcp.extend_from_slice(payload);
-    let cks = tcp_checksum(&AP_IP, &client_ip, &tcp);
+    let cks = tcp_checksum(&ap_ip, &client_ip, &tcp);
     tcp[16] = (cks >> 8) as u8;
     tcp[17] = cks as u8;
 
@@ -808,7 +912,7 @@ fn build_tcp_to_sta(
         0x00,
         0x00, // header checksum (filled below)
     ];
-    ip.extend_from_slice(&AP_IP);
+    ip.extend_from_slice(&ap_ip);
     ip.extend_from_slice(&client_ip);
     let ipck = inet_checksum(&ip);
     ip[10] = (ipck >> 8) as u8;
@@ -1111,6 +1215,50 @@ mod tests {
         assert!(
             text.starts_with("HTTP/1.1 404"),
             "unknown path → 404: {text}"
+        );
+    }
+
+    #[test]
+    fn with_config_ssid_carried_in_beacon() {
+        // A configured SSID must appear in the beacon the AP queues. Default cfg
+        // (SSID "labwired-ap") is byte-identical to the old hardcoded AP; here we
+        // override it and confirm the override propagates through the builder.
+        let cfg = ApConfig::from_parts(Some("myap".to_string()), None, None);
+        let bus = VirtualWifiBus::with_config(cfg);
+        let sta = sta_mac(2);
+        bus.queue_beacon(sta, 6);
+        let rx = bus.take_inbox(sta);
+        assert_eq!(rx.len(), 1, "one beacon queued");
+        let f = &rx[0];
+        assert_eq!(f[0], 0x80, "beacon subtype");
+        assert!(
+            f.windows(4).any(|w| w == b"myap"),
+            "beacon carries the configured SSID"
+        );
+    }
+
+    #[test]
+    fn serves_none_returns_404() {
+        // serves = None → the HTTP origin has no routes, so even the demo path
+        // 404s (nothing is served). Proves the L4 config is honored.
+        let cfg = ApConfig::from_parts(None, None, Some("none"));
+        assert_eq!(cfg.serves, ApServes::None);
+        let bus = VirtualWifiBus::with_config(cfg);
+        let sta = sta_mac(2);
+        let (sport, dport) = (45000u16, 80u16);
+        bus.submit(sta, &sta_tcp(sta, sport, dport, 100, 0, TCP_SYN, &[]));
+        let (_, srv_isn, _, _) = reply_tcp(&bus.take_inbox(sta)[0]);
+        let get = b"GET /v1/public-stats HTTP/1.1\r\n\r\n";
+        bus.submit(
+            sta,
+            &sta_tcp(sta, sport, dport, 101, srv_isn + 1, TCP_PSH | TCP_ACK, get),
+        );
+        let rx = bus.take_inbox(sta);
+        let (_, _, _, body) = reply_tcp(&rx[0]);
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            text.starts_with("HTTP/1.1 404"),
+            "serves=none → no /v1/public-stats route → 404: {text}"
         );
     }
 }

--- a/crates/core/src/peripherals/esp32c3/wifi_mac.rs
+++ b/crates/core/src/peripherals/esp32c3/wifi_mac.rs
@@ -227,6 +227,15 @@ impl Esp32c3WifiMac {
         self.medium_mode = true;
     }
 
+    /// Rebind this MAC to an explicit WiFi bus AFTER construction (the browser
+    /// path builds the machine first, then attaches the configured medium once
+    /// the manifest's `wifi_ap` is known). Does not touch medium mode or the
+    /// learned `medium_mac` — pair with [`Self::attach_to_medium`], exactly as
+    /// the CLI's post-build attach loop does.
+    pub fn set_wifi_bus(&mut self, bus: super::virtual_wifi::VirtualWifiBus) {
+        self.wifi = bus;
+    }
+
     /// Record a captured frame in the analyzer ring buffer (oldest dropped at
     /// `TRACE_CAP`). `dir` is `"tx"` or `"rx"` from this device's perspective.
     fn trace_push(&mut self, dir: &'static str, bytes: &[u8], rssi: i8) {

--- a/crates/core/src/system/xtensa/mod.rs
+++ b/crates/core/src/system/xtensa/mod.rs
@@ -482,6 +482,7 @@ mod tests {
             }],
             board_io: vec![],
             debug_uart: None,
+            wifi_ap: None,
         };
         attach_esp32_external_devices(&mut bus, &manifest)
             .expect("attach TMP102 from manifest must succeed");
@@ -575,6 +576,7 @@ mod tests {
             }],
             board_io: vec![],
             debug_uart: None,
+            wifi_ap: None,
         };
 
         let mut bus = SystemBus::new();
@@ -649,6 +651,7 @@ mod tests {
             }],
             board_io: vec![],
             debug_uart: None,
+            wifi_ap: None,
         };
 
         // Register spi3_s3 exactly as the production S3 bring-up does
@@ -703,6 +706,7 @@ mod tests {
             }],
             board_io: vec![],
             debug_uart: None,
+            wifi_ap: None,
         };
 
         let mut bus = SystemBus::new();

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -440,6 +440,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -616,6 +617,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -680,6 +682,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -739,6 +742,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -804,6 +808,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -957,6 +962,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: Some("uart1".to_string()),
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -1017,6 +1023,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -1079,6 +1086,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -1141,6 +1149,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -2356,6 +2365,7 @@ pub mod integration_tests {
             cosim_models: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -2445,6 +2455,7 @@ pub mod integration_tests {
             external_devices: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -2518,6 +2529,7 @@ pub mod integration_tests {
             external_devices: Vec::new(),
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -2739,6 +2751,7 @@ pub mod integration_tests {
             }],
             board_io: Vec::new(),
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -2877,6 +2890,7 @@ pub mod integration_tests {
                 }],
                 board_io: Vec::new(),
                 debug_uart: None,
+                wifi_ap: None,
                 peripherals: Vec::new(),
             };
             crate::bus::SystemBus::from_config(&chip, &manifest).unwrap()

--- a/crates/core/tests/analog_stimulus.rs
+++ b/crates/core/tests/analog_stimulus.rs
@@ -98,6 +98,7 @@ fn two_potentiometers_are_individually_addressable() {
         external_devices: vec![pot("knob", 0), pot("fader", 1)],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/chip_conformance.rs
+++ b/crates/core/tests/chip_conformance.rs
@@ -293,6 +293,7 @@ fn dummy_manifest(path: &str) -> SystemManifest {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     }

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -33,6 +33,7 @@ fn h563_machine() -> Machine<labwired_core::cpu::CortexM> {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/h563_conformance.rs
+++ b/crates/core/tests/h563_conformance.rs
@@ -31,6 +31,7 @@ fn h563_bus() -> labwired_core::bus::SystemBus {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/kw41z_clock_boot.rs
+++ b/crates/core/tests/kw41z_clock_boot.rs
@@ -46,6 +46,7 @@ fn kw41z_bus() -> SystemBus {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/nrf5340_clock_boot.rs
+++ b/crates/core/tests/nrf5340_clock_boot.rs
@@ -50,6 +50,7 @@ fn nrf5340_bus() -> SystemBus {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/nrf54l15_boot.rs
+++ b/crates/core/tests/nrf54l15_boot.rs
@@ -78,6 +78,7 @@ fn nrf54l15_bus() -> SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/pin_map_resolution.rs
+++ b/crates/core/tests/pin_map_resolution.rs
@@ -15,6 +15,7 @@ fn bus_for(chip_file: &str) -> SystemBus {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -55,6 +55,7 @@ fn validate_chip(path: &PathBuf) -> anyhow::Result<()> {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -132,6 +132,7 @@ fn dummy_manifest(path: &str) -> labwired_config::SystemManifest {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     }

--- a/crates/core/tests/rp2040_pio_onboarding.rs
+++ b/crates/core/tests/rp2040_pio_onboarding.rs
@@ -65,6 +65,7 @@ fn rp2040_chip() -> (ChipDescriptor, SystemManifest) {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/stm32f401_conformance.rs
+++ b/crates/core/tests/stm32f401_conformance.rs
@@ -33,6 +33,7 @@ fn f401_bus() -> labwired_core::bus::SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/stm32f407_dma_walk_differential.rs
+++ b/crates/core/tests/stm32f407_dma_walk_differential.rs
@@ -85,6 +85,7 @@ fn f407_bus() -> SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/core/tests/uart_parity_ratchet.rs
+++ b/crates/core/tests/uart_parity_ratchet.rs
@@ -38,6 +38,7 @@ fn dummy_manifest(path: &str) -> SystemManifest {
         peripherals: vec![],
         memory_overrides: Default::default(),
         debug_uart: None,
+        wifi_ap: None,
     }
 }
 

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1150,6 +1150,7 @@ mod tests {
                 i2c_address: None,
             }],
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -1221,6 +1222,7 @@ mod tests {
                 },
             ],
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 
@@ -1281,6 +1283,7 @@ mod tests {
                 i2c_address: None,
             }],
             debug_uart: None,
+            wifi_ap: None,
             peripherals: Vec::new(),
         };
 

--- a/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
@@ -193,6 +193,7 @@ fn build_sim_bus() -> SystemBus {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/foreign_firmware_probe.rs
+++ b/crates/hw-oracle/tests/foreign_firmware_probe.rs
@@ -36,6 +36,7 @@ fn probe_foreign_firmware() {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/h563_mmio_diff.rs
+++ b/crates/hw-oracle/tests/h563_mmio_diff.rs
@@ -996,6 +996,7 @@ fn build_sim_bus() -> SystemBus {
         cosim_models: Vec::new(),
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/rp2040_dma_oracle.rs
+++ b/crates/hw-oracle/tests/rp2040_dma_oracle.rs
@@ -156,6 +156,7 @@ fn rp2040_bus() -> SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/rp2040_reset_conformance.rs
+++ b/crates/hw-oracle/tests/rp2040_reset_conformance.rs
@@ -127,6 +127,7 @@ fn build_sim_bus() -> SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs
+++ b/crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs
@@ -107,6 +107,7 @@ fn rp2040_bus() -> SystemBus {
         external_devices: vec![],
         board_io: vec![],
         debug_uart: None,
+        wifi_ap: None,
         peripherals: vec![],
         memory_overrides: Default::default(),
     };

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -638,16 +638,60 @@ impl WasmSimulator {
         }
         let uart_rx_bufs = bus.attach_uart_rx_source();
 
-        let machine = build_rom_boot_machine(
+        // A station with a zero eFuse MAC associates but does not STAY associated
+        // (hard-won: the driver needs a real RD_MAC to hold the link). So when a
+        // `wifi-ap` is on the diagram, seed the same station MAC the CLI solo path
+        // uses (02:00:00:00:00:02). Absent ⇒ leave None (unchanged non-WiFi boot).
+        let efuse_mac = manifest
+            .wifi_ap
+            .as_ref()
+            .map(|_| [0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
+
+        let mut machine = build_rom_boot_machine(
             bus,
             flash_bytes,
             RomBootOpts {
-                efuse_mac: None,
+                efuse_mac,
                 usb_serial_sink: capture_usb_serial.then(|| uart_sink.clone()),
             },
             // WasmSimulator holds Machine<Box<dyn Cpu>>; box the concrete RiscV.
             |c| Box::new(c) as Box<dyn Cpu>,
         );
+
+        // Per-lab virtual WiFi AP: if the manifest declares `wifi_ap` (a `wifi-ap`
+        // component is on the diagram), build a medium with the configured
+        // ApConfig and attach every WiFi MAC to it — the browser analog of the
+        // CLI's post-build attach loop (`run_one_c3_wifi`). Absent ⇒ do nothing:
+        // the MAC stays non-medium, never associates, and there is honestly no AP.
+        if let Some(ap) = manifest.wifi_ap.as_ref() {
+            use labwired_core::peripherals::esp32c3::virtual_wifi::{ApConfig, VirtualWifiBus};
+            use labwired_core::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac;
+            // Parse "a.b.c.d" → [u8;4]; on any parse failure fall back to the
+            // default AP IP (from_parts fills None from ApConfig::default()).
+            let ip = {
+                let octets: Vec<u8> = ap
+                    .ip
+                    .split('.')
+                    .filter_map(|o| o.parse::<u8>().ok())
+                    .collect();
+                (octets.len() == 4).then(|| [octets[0], octets[1], octets[2], octets[3]])
+            };
+            let cfg = ApConfig::from_parts(Some(ap.ssid.clone()), ip, Some(&ap.serves));
+            let bus = VirtualWifiBus::with_config(cfg);
+            for p in machine.bus.peripherals.iter_mut() {
+                let Some(any) = p.dev.as_any_mut() else {
+                    continue;
+                };
+                if let Some(mac) = any.downcast_mut::<Esp32c3WifiMac>() {
+                    mac.set_wifi_bus(bus.clone());
+                    mac.attach_to_medium();
+                }
+            }
+            // `attach_to_medium` is a non-MMIO toggle that flips the MAC's
+            // `needs_bus_tick()` on; rebuild the tick-index once so the MAC is
+            // resident (mirrors the CLI attach loop).
+            machine.bus.refresh_peripheral_index();
+        }
 
         let board_io = manifest.board_io.clone();
 


### PR DESCRIPTION
Turns the hardcoded, always-on process-global WiFi AP into a **per-lab, configurable** one, enabled by a new optional `SystemManifest.wifi_ap` field (emitted when a diagram contains a `wifi-ap` component). The 802.11/IP/TCP/HTTP AP logic is **parameterized, not rewritten**.

## What
- **virtual_wifi**: `ApConfig { ssid, ip, serves }` + `ApServes`; `Default` = former consts so an unconfigured AP is **byte-identical** to today. SSID/IP threaded through the frame builders; `serves` selects the HTTP origin (`labwired-stats` | `none`).
- **config**: `WifiApManifest` + `SystemManifest.wifi_ap` (mirrors `debug_uart`).
- **wasm**: browser attach path in `new_from_config_riscv_romboot` binds a configured `VirtualWifiBus` and `attach_to_medium()` on each WiFi MAC when `wifi_ap` is present; seeds the station eFuse MAC (a zero MAC won't stay associated).
- **cli**: `run_one_c3_wifi` is `wifi_ap`-config-aware.
- **wifi_mac**: `set_wifi_bus` for post-construction rebind.

## Safety
Absent `wifi_ap` ⇒ no association (honest "no AP present"); **non-WiFi labs and all existing chip behaviour are unchanged** (additive/gated).

## Tests
- virtual_wifi 5/5 (3 existing byte-identical + 2 new: custom-ssid beacon, serves=none 404), wifi_mac 7/7
- labwired-core lib: 2330 passed
- chip_conformance_ratchet, register_compliance (all chips), register_coverage_ratchet, esp32c3_reset_values_match_silicon: all green
- WASM + CLI + hw-oracle build clean

Enables the droppable `wifi-ap` playground component (TS side in the packages repo) so any WiFi MCU lab can associate to a real modeled AP and fetch over TCP/HTTP.