### PR TITLE
fix(scripts): stop the compat-matrix parser fork from drifting silently

### DIFF
--- a/scripts/generate_compat_matrix.py
+++ b/scripts/generate_compat_matrix.py
@@ -20,16 +20,39 @@ except ImportError:
     yaml = None  # type: ignore[assignment]
 
 
-def parse_yaml_simple(path: Path) -> dict:
-    """Minimal YAML parser for chip configs (avoids PyYAML dependency in CI)."""
-    if yaml:
-        return yaml.safe_load(path.read_text()) or {}
+def _strip_inline_comment(value: str) -> str:
+    """Drop a trailing ` # …` comment, but not a `#` inside a quoted scalar."""
+    quote = ""
+    for i, ch in enumerate(value):
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in "\"'":
+            quote = ch
+        elif ch == "#" and (i == 0 or value[i - 1] in " \t"):
+            return value[:i]
+    return value
 
-    # Bare-bones parser: handles flat keys and peripheral lists
+
+def _scalar(raw: str) -> str:
+    return _strip_inline_comment(raw).strip().strip('"').strip("'")
+
+
+def parse_yaml_fallback(text: str) -> dict:
+    """
+    Zero-dependency parser for the handful of chip-config fields this script
+    reads: top-level scalars, and each peripheral's `id` and `type`.
+
+    It deliberately parses NOTHING else. The previous version also read
+    `base_address` and `irq` — neither of which reaches the output — and the
+    `irq` branch did a bare int() on the rest of the line, so the day someone
+    wrote `irq: 39  # FDCAN1_IT0 …` in stm32h563.yaml this crashed. Parsing a
+    field you do not use is all risk and no benefit.
+    """
     result: dict = {"peripherals": []}
-    current_peripheral: dict = {}
+    current: dict = {}
     in_peripherals = False
-    for line in path.read_text().splitlines():
+    for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith("#") or not stripped:
             continue
@@ -39,23 +62,57 @@ def parse_yaml_simple(path: Path) -> dict:
         if not in_peripherals:
             if ":" in stripped and not stripped.startswith("-"):
                 key, _, val = stripped.partition(":")
-                val = val.strip().strip('"').strip("'")
+                val = _scalar(val)
                 if val:
                     result[key.strip()] = val
-        else:
-            if stripped.startswith("- id:"):
-                if current_peripheral:
-                    result["peripherals"].append(current_peripheral)
-                current_peripheral = {"id": stripped.split(":", 1)[1].strip().strip('"')}
-            elif stripped.startswith("type:") and current_peripheral:
-                current_peripheral["type"] = stripped.split(":", 1)[1].strip().strip('"')
-            elif stripped.startswith("base_address:") and current_peripheral:
-                current_peripheral["base_address"] = stripped.split(":", 1)[1].strip()
-            elif stripped.startswith("irq:") and current_peripheral:
-                current_peripheral["irq"] = int(stripped.split(":", 1)[1].strip())
-    if current_peripheral:
-        result["peripherals"].append(current_peripheral)
+        elif stripped.startswith("- id:"):
+            if current:
+                result["peripherals"].append(current)
+            current = {"id": _scalar(stripped.split(":", 1)[1])}
+        elif stripped.startswith("type:") and current:
+            current["type"] = _scalar(stripped.split(":", 1)[1])
+    if current:
+        result["peripherals"].append(current)
     return result
+
+
+def _consumed(config: dict) -> tuple:
+    """The projection this script actually reads. Equivalence is judged on it."""
+    return (
+        config.get("name"),
+        config.get("arch"),
+        tuple(p.get("type") for p in config.get("peripherals", []) or []),
+    )
+
+
+def parse_yaml_simple(path: Path) -> dict:
+    """
+    Parse a chip config, preferring PyYAML.
+
+    The fallback above is load-bearing: the runner that generates this matrix
+    has no pip step, so PyYAML is genuinely absent there. That makes it a
+    second parser with its own bugs, which is how a stray inline comment took
+    CI down while every developer machine — PyYAML installed — stayed green.
+
+    So when PyYAML IS present, run both and fail loudly on disagreement. The
+    fork then cannot drift silently: it is checked on every developer machine
+    and in every CI job that does have PyYAML.
+    """
+    text = path.read_text()
+    fallback = parse_yaml_fallback(text)
+    if yaml is None:
+        return fallback
+
+    real = yaml.safe_load(text) or {}
+    if _consumed(real) != _consumed(fallback):
+        raise SystemExit(
+            f"{path.name}: the zero-dependency parser disagrees with PyYAML.\n"
+            f"  PyYAML:   {_consumed(real)}\n"
+            f"  fallback: {_consumed(fallback)}\n"
+            "Fix parse_yaml_fallback — CI runs it without PyYAML and would "
+            "otherwise emit a wrong matrix, or crash, with no local warning."
+        )
+    return real
 
 
 def find_smoke_tests(examples_dir: Path) -> dict[str, list[str]]:


### PR DESCRIPTION
## What broke

`Core Integration CI / generate-compat-matrix` fails on main:

```
ValueError: invalid literal for int() with base 10:
  '39  # FDCAN1_IT0; line 1 (IT1 = 40) routing via ILS not modeled'
```

## Why it could not be reproduced locally

`generate_compat_matrix.py` prefers PyYAML and silently falls back to a hand-rolled parser:

```python
if yaml:
    return yaml.safe_load(path.read_text()) or {}
# ...otherwise a bare-bones parser
```

The job that runs it has **no pip step**, so the runner always takes the fallback. Every developer machine has PyYAML and always takes the real parser. Two parsers, and the one CI depends on is the one nobody ever exercises — so a stray inline comment in `stm32h563.yaml` took CI down while local runs stayed green.

Note the other four YAML-reading scripts in `scripts/` (`validate_hw_targets`, `board_matrix`, `generate_validation_status`, `generate_firmware_exercise_matrix`) all **require** PyYAML and exit loudly without it. This script is the lone deviant.

## The fix

**1. Stop parsing fields the output never reads.** `base_address` and `irq` were parsed and then discarded — the crashing line was dead code. Parsing a field you don't use is all risk and no benefit.

**2. Strip inline comments** on the fields still parsed, without cutting a `#` inside a quoted scalar.

**3. Make the fork self-verifying.** When PyYAML is available, run both parsers and fail loudly if they disagree on the projection this script consumes (`name`, `arch`, peripheral `type`s):

```
stm32h563.yaml: the zero-dependency parser disagrees with PyYAML.
  PyYAML:   ('stm32h563zi', 'arm', ('uart', …))
  fallback: ('stm32h563zi', 'arm', ('WRONG', …))
Fix parse_yaml_fallback — CI runs it without PyYAML and would otherwise
emit a wrong matrix, or crash, with no local warning.
```

The fork stays (it's load-bearing — no pip on that runner), but it can no longer drift unnoticed: it's now checked on every developer machine and in every job that *does* have PyYAML.

I chose this over adding `pip install pyyaml` to the workflow because I can't verify what that self-hosted runner permits, and over a `tests/` file because **no workflow in this repo runs the Python tests** — `scripts/ci/test_board_matrix.py` is not gated by anything, so a new test file would be a guard nobody executes.

## Verification

- **Byte-identical JSON across all 21 chips**, with and without PyYAML (`diff -q` clean). The no-PyYAML path was simulated with a `sys.meta_path` blocker, not assumed.
- `stm32h563` — the chip that broke CI — parses on the runner's path: 37 peripherals, `fdcan` present.
- **Divergence check proven to fire** by injecting a wrong value (with an `assert` that the injection actually applied, after a first attempt silently substituted nothing and produced a vacuous pass).
- **Inline-comment case proven** by adding `# …` to a parsed `type:` field and confirming both paths still agree.