### PR TITLE
feat(wifi): universal wifi-ap attach in the hosted `test` path

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -128,12 +128,21 @@ fn run_c3_rom_boot_no_elf(
             }
         };
 
+    // Load the manifest once: it drives both the UART sink selection (debug_uart)
+    // and — the universal WiFi adapter — the `wifi_ap` attach below.
+    let manifest_opt =
+        system_path.and_then(|path| labwired_config::SystemManifest::from_file(path).ok());
+    let debug_uart = manifest_opt.as_ref().and_then(|m| m.debug_uart.clone());
+    // Seed the station eFuse MAC when a `wifi_ap` is present so the C3 stays
+    // associated (a zero eFuse MAC associates but drops); None otherwise keeps
+    // non-WiFi rom-boot byte-identical.
+    let wifi_station_mac = manifest_opt
+        .as_ref()
+        .and_then(labwired_core::system::wifi::wifi_ap_station_mac);
+
     // UART capture, mirroring the main flow: honour debug_uart, else all UARTs,
     // plus the IO-Link master log sink.
     let uart_tx = Arc::new(Mutex::new(Vec::new()));
-    let debug_uart = system_path
-        .and_then(|path| labwired_config::SystemManifest::from_file(path).ok())
-        .and_then(|manifest| manifest.debug_uart);
     if let Some(debug_uart) = debug_uart.as_deref() {
         if !bus.attach_uart_tx_sink_named(debug_uart, uart_tx.clone(), !args.no_uart_stdout) {
             warn!(
@@ -201,7 +210,7 @@ fn run_c3_rom_boot_no_elf(
             error!("resume snapshot self-key mismatch ({e}); cold-boot required");
             return ExitCode::from(EXIT_CONFIG_ERROR);
         }
-        let mut machine = match crate::build_c3_rom_boot_machine(bus, None) {
+        let mut machine = match crate::build_c3_rom_boot_machine(bus, wifi_station_mac) {
             Ok(m) => m,
             Err(code) => return code,
         };
@@ -223,11 +232,19 @@ fn run_c3_rom_boot_no_elf(
         // Cold faithful rom-boot. --capture-app-entry (the cache-miss path) is
         // handled inside execute_test_loop; with no ELF the app-entry PC falls
         // back to the XIP app-window detector.
-        match crate::build_c3_rom_boot_machine(bus, None) {
+        match crate::build_c3_rom_boot_machine(bus, wifi_station_mac) {
             Ok(m) => m,
             Err(code) => return code,
         }
     };
+
+    // Universal WiFi adapter: if the diagram carries a `wifi_ap`, attach every
+    // real WiFi MAC to a per-lab virtual-WiFi medium so the device associates →
+    // DHCP → HTTP under the hosted `test` path exactly like the CLI solo path and
+    // the browser. No-op when there is no `wifi_ap`.
+    if let Some(manifest) = manifest_opt.as_ref() {
+        labwired_core::system::wifi::attach_configured_wifi_ap(&mut machine.bus, manifest);
+    }
 
     let metrics = std::sync::Arc::new(labwired_core::metrics::PerformanceMetrics::new());
     apply_matrix_speed_opts(&mut machine);

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -624,6 +624,13 @@ impl ChipDescriptor {
 }
 
 impl SystemManifest {
+    /// Parse a System Manifest from a YAML string. Unlike [`Self::from_file`]
+    /// this does no filesystem-relative `can-player` `path:` inlining (there is
+    /// no base directory), so it is wasm-safe and handy for tests/embedding.
+    pub fn from_yaml(yaml: &str) -> Result<Self> {
+        serde_yaml::from_str(yaml).context("Failed to parse System Manifest")
+    }
+
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
         let f = std::fs::File::open(path)?;

--- a/crates/core/src/system/mod.rs
+++ b/crates/core/src/system/mod.rs
@@ -1,4 +1,5 @@
 pub mod builder;
 pub mod cortex_m;
 pub mod riscv;
+pub mod wifi;
 pub mod xtensa;

--- a/crates/core/src/system/wifi.rs
+++ b/crates/core/src/system/wifi.rs
@@ -77,7 +77,6 @@ pub fn attach_configured_wifi_ap(bus: &mut SystemBus, manifest: &SystemManifest)
 mod tests {
     use super::*;
     use crate::bus::{PeripheralEntry, SystemBus};
-    use crate::Peripheral;
 
     fn bus_with_c3_mac() -> SystemBus {
         let mut bus = SystemBus::new();

--- a/crates/core/src/system/wifi.rs
+++ b/crates/core/src/system/wifi.rs
@@ -1,0 +1,142 @@
+//! Shared virtual-WiFi AP attach — the ONE source of truth every boot path uses
+//! to make a diagram's `wifi-ap` component behave like a real Access Point.
+//!
+//! This is the "universal WiFi adapter" plumbing: drop a `wifi-ap` on any lab
+//! and every *real* WiFi MAC on the bus associates to a modeled AP (802.11 →
+//! DHCP → HTTP). It is universal by construction —
+//!   * it operates on a bare [`SystemBus`], so the same call works from the
+//!     RISC-V CLI, the browser, and any future host regardless of CPU type; and
+//!   * it downcasts to every real WiFi MAC the simulator models in ONE place.
+//!     Today that is the ESP32-C3 MAC (the S3 MAC is still thunked); when a
+//!     second real MAC lands, teach THIS function and every host — CLI `test`,
+//!     CLI `run`, the browser ctors — gets it for free, no drift.
+//!
+//! Absent a `wifi_ap` in the manifest both helpers are inert, so non-WiFi boots
+//! stay byte-identical to before.
+
+use crate::bus::SystemBus;
+use crate::peripherals::esp32c3::virtual_wifi::{ApConfig, VirtualWifiBus};
+use crate::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac;
+use labwired_config::SystemManifest;
+
+/// Station eFuse MAC seeded when a `wifi_ap` is on the diagram. A zero eFuse MAC
+/// associates but does NOT stay associated (hard-won C3 WiFi rule), so every
+/// boot path that can host WiFi seeds the same station MAC. Absent `wifi_ap` ⇒
+/// `None` (unchanged non-WiFi boot). Pass the result as the `build_*` /
+/// `RomBootOpts` eFuse MAC.
+pub fn wifi_ap_station_mac(manifest: &SystemManifest) -> Option<[u8; 6]> {
+    manifest
+        .wifi_ap
+        .as_ref()
+        .map(|_| [0x02, 0x00, 0x00, 0x00, 0x00, 0x02])
+}
+
+/// If the manifest declares a `wifi_ap`, build a per-lab virtual-WiFi medium from
+/// its config and attach every real WiFi MAC on the bus to it, keeping the MAC
+/// resident so association completes. Absent a `wifi_ap` ⇒ no-op (honest "no AP
+/// present": the MAC never associates).
+///
+/// Call this once, after the machine's bus is built and before the run loop.
+pub fn attach_configured_wifi_ap(bus: &mut SystemBus, manifest: &SystemManifest) {
+    let Some(ap) = manifest.wifi_ap.as_ref() else {
+        return;
+    };
+    // Parse "a.b.c.d" → [u8;4]; parse failure falls back to the default AP IP.
+    let ip = {
+        let octets: Vec<u8> = ap
+            .ip
+            .split('.')
+            .filter_map(|o| o.parse::<u8>().ok())
+            .collect();
+        (octets.len() == 4).then(|| [octets[0], octets[1], octets[2], octets[3]])
+    };
+    let cfg = ApConfig::from_parts(Some(ap.ssid.clone()), ip, Some(&ap.serves));
+    let medium = VirtualWifiBus::with_config(cfg);
+    let mut attached = false;
+    for p in bus.peripherals.iter_mut() {
+        let Some(any) = p.dev.as_any_mut() else {
+            continue;
+        };
+        if let Some(mac) = any.downcast_mut::<Esp32c3WifiMac>() {
+            mac.set_wifi_bus(medium.clone());
+            mac.attach_to_medium();
+            attached = true;
+        }
+    }
+    // `attach_to_medium` flips `needs_bus_tick()` on but is a non-MMIO toggle, so
+    // rebuild the tick index once to make the MAC resident (mirrors the CLI solo
+    // attach loop). Only when we actually attached a MAC — a diagram may carry a
+    // `wifi_ap` while the board has no real WiFi MAC (e.g. thunked S3), in which
+    // case there is nothing to make resident.
+    if attached {
+        bus.refresh_peripheral_index();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::{PeripheralEntry, SystemBus};
+    use crate::Peripheral;
+
+    fn bus_with_c3_mac() -> SystemBus {
+        let mut bus = SystemBus::new();
+        bus.peripherals.push(PeripheralEntry {
+            name: "wifi_mac".to_string(),
+            base: 0x6000_3000,
+            size: 0x1000,
+            irq: None,
+            dev: Box::new(Esp32c3WifiMac::new()),
+            ticks_remaining: 0,
+            clock_gate: None,
+        });
+        bus
+    }
+
+    fn mac_needs_bus_tick(bus: &mut SystemBus) -> bool {
+        let idx = bus.find_peripheral_index_by_name("wifi_mac").unwrap();
+        bus.peripherals[idx].dev.needs_bus_tick()
+    }
+
+    fn manifest(wifi_ap: bool) -> SystemManifest {
+        let yaml = if wifi_ap {
+            "name: t\nchip: esp32c3\nwifi_ap:\n  ssid: labwired-ap\n  ip: 192.168.4.1\n  serves: labwired-stats\n"
+        } else {
+            "name: t\nchip: esp32c3\n"
+        };
+        SystemManifest::from_yaml(yaml).expect("valid manifest")
+    }
+
+    #[test]
+    fn attach_makes_c3_mac_resident_when_wifi_ap_present() {
+        let mut bus = bus_with_c3_mac();
+        // A fresh MAC is non-medium: no per-cycle bus tick required.
+        assert!(!mac_needs_bus_tick(&mut bus), "fresh MAC should be idle");
+        attach_configured_wifi_ap(&mut bus, &manifest(true));
+        // After attach the MAC is medium-resident and must tick every cycle, or
+        // association would never complete (the whole point of this fix).
+        assert!(
+            mac_needs_bus_tick(&mut bus),
+            "attached MAC must be resident (needs_bus_tick)"
+        );
+    }
+
+    #[test]
+    fn attach_is_noop_without_wifi_ap() {
+        let mut bus = bus_with_c3_mac();
+        attach_configured_wifi_ap(&mut bus, &manifest(false));
+        assert!(
+            !mac_needs_bus_tick(&mut bus),
+            "no wifi_ap ⇒ MAC stays idle (honest 'no AP present')"
+        );
+    }
+
+    #[test]
+    fn station_mac_seeded_only_with_wifi_ap() {
+        assert_eq!(
+            wifi_ap_station_mac(&manifest(true)),
+            Some([0x02, 0x00, 0x00, 0x00, 0x00, 0x02])
+        );
+        assert_eq!(wifi_ap_station_mac(&manifest(false)), None);
+    }
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -343,54 +343,20 @@ impl WasmSimulator {
         Self::new_from_config_riscv_program_image(chip, manifest, &program_image, blobs)
     }
 
-    /// Station eFuse MAC seeded when a `wifi_ap` is on the diagram. A zero eFuse
-    /// MAC associates but does NOT stay associated (hard-won C3 WiFi rule), so
-    /// every C3 boot path that can host WiFi seeds the same station MAC the CLI
-    /// solo path uses. Absent `wifi_ap` ⇒ None (unchanged non-WiFi boot).
-    /// ONE source of truth shared by the rom-boot and flash-fast-start ctors.
+    /// Station eFuse MAC seeded when a `wifi_ap` is on the diagram. Delegates to
+    /// the shared core helper so the browser ctors, CLI `test`, and CLI `run`
+    /// all seed the identical station MAC (one source of truth). Absent
+    /// `wifi_ap` ⇒ None (unchanged non-WiFi boot).
     fn wifi_ap_efuse_mac(manifest: &SystemManifest) -> Option<[u8; 6]> {
-        manifest
-            .wifi_ap
-            .as_ref()
-            .map(|_| [0x02, 0x00, 0x00, 0x00, 0x00, 0x02])
+        labwired_core::system::wifi::wifi_ap_station_mac(manifest)
     }
 
-    /// If the manifest declares a `wifi_ap`, build a per-lab virtual-WiFi medium
-    /// from its config and attach every WiFi MAC on the bus to it (the browser
-    /// analog of the CLI `run_one_c3_wifi` attach loop). Absent ⇒ no-op (the MAC
-    /// stays non-medium, never associates — honest "no AP present"). ONE source
-    /// of truth so BOTH C3 browser ctors (rom-boot AND flash-fast-start) attach
-    /// identically — the fast-start path lacking this is exactly why the browser
-    /// timed out while the rom-boot CLI associated.
+    /// Attach every real WiFi MAC to a per-lab virtual-WiFi medium built from the
+    /// manifest's `wifi_ap`. Delegates to the shared, CPU-generic core helper so
+    /// the browser ctors and the CLI `test`/`run` paths attach identically — the
+    /// universal-WiFi-adapter plumbing lives in exactly one place.
     fn attach_wifi_ap(machine: &mut Machine<Box<dyn Cpu>>, manifest: &SystemManifest) {
-        let Some(ap) = manifest.wifi_ap.as_ref() else {
-            return;
-        };
-        use labwired_core::peripherals::esp32c3::virtual_wifi::{ApConfig, VirtualWifiBus};
-        use labwired_core::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac;
-        // Parse "a.b.c.d" → [u8;4]; parse failure falls back to the default AP IP.
-        let ip = {
-            let octets: Vec<u8> = ap
-                .ip
-                .split('.')
-                .filter_map(|o| o.parse::<u8>().ok())
-                .collect();
-            (octets.len() == 4).then(|| [octets[0], octets[1], octets[2], octets[3]])
-        };
-        let cfg = ApConfig::from_parts(Some(ap.ssid.clone()), ip, Some(&ap.serves));
-        let bus = VirtualWifiBus::with_config(cfg);
-        for p in machine.bus.peripherals.iter_mut() {
-            let Some(any) = p.dev.as_any_mut() else {
-                continue;
-            };
-            if let Some(mac) = any.downcast_mut::<Esp32c3WifiMac>() {
-                mac.set_wifi_bus(bus.clone());
-                mac.attach_to_medium();
-            }
-        }
-        // `attach_to_medium` flips `needs_bus_tick()` on; rebuild the tick index
-        // once so the MAC is resident (mirrors the CLI attach loop).
-        machine.bus.refresh_peripheral_index();
+        labwired_core::system::wifi::attach_configured_wifi_ap(&mut machine.bus, manifest);
     }
 
     fn new_from_config_riscv_flash_fastboot(


### PR DESCRIPTION
## Why
The `wifi-ap` component makes any WiFi MCU associate to a modeled AP (802.11 → DHCP → HTTP) in the **browser**, but the hosted **MCP proving path** — `labwired test` on the ELF-less C3 rom-boot path, which is exactly what the builder invokes for agents — never attached the AP nor seeded the station eFuse MAC. An external agent running a WiFi device headlessly saw it spin and never associate. Association worked only where users *don't* prove devices (browser, CLI `run` solo harness).

## What
Extract the proven browser attach into **one shared, CPU-agnostic core helper** and call it from every host:

- **core** — new `crates/core/src/system/wifi.rs`:
  - `attach_configured_wifi_ap(&mut SystemBus, &SystemManifest)` — builds the per-lab virtual-WiFi medium from `wifi_ap`, attaches every real WiFi MAC, and `refresh_peripheral_index()` so the MAC stays **resident** (the whole reason the CLI solo harness needed its own loop).
  - `wifi_ap_station_mac(&SystemManifest)` — seeds `02:00:00:00:00:02` when `wifi_ap` is present (a zero eFuse MAC associates but drops).
  - Unit tests: MAC becomes medium-resident iff `wifi_ap` present; no-op otherwise; seed only with `wifi_ap`.
- **wasm** — both C3 ctors delegate to the shared helper (removes the hand-synced wasm-local copy).
- **cli** — the ELF-less rom-boot `test` path loads the manifest once, seeds the station MAC at build, and attaches the AP before the run loop.
- **config** — `SystemManifest::from_yaml` (wasm-safe string parse) for the new tests.

**Universal by construction:** the downcast to every real WiFi MAC lives in one place, so an S3 de-thunk teaches this one function and every host (CLI `test`/`run`, browser) gets it for free — no drift.

## Safety
Absent a `wifi_ap` on the diagram, every boot path is byte-identical to before. The existing browser e2e guard `browser_c3_fast_start_wifi_associates` now runs through the shared helper and still asserts the full STA CONNECTED → `boards_supported:9` pipeline.