### PR TITLE
feat(config): built-in chips and inputs.chip

### DIFF
--- a/crates/cli/src/asset_validation.rs
+++ b/crates/cli/src/asset_validation.rs
@@ -188,13 +188,14 @@ fn validate_system(path: &PathBuf) -> ExitCode {
 
     // 2. Load Referenced Chip
     // Resolving chip path relative to system file
-    let chip_path_resolved = if let Some(parent) = path.parent() {
-        parent.join(&system.chip)
-    } else {
+    let chip_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let chip_path_resolved = if labwired_config::is_builtin_chip_spec(&system.chip) {
         PathBuf::from(&system.chip)
+    } else {
+        chip_dir.join(&system.chip)
     };
 
-    let chip = match ChipDescriptor::from_file(&chip_path_resolved) {
+    let chip = match ChipDescriptor::resolve(&system.chip, chip_dir) {
         Ok(c) => c,
         Err(e) => {
             result.add_error(

--- a/crates/cli/src/commands/machine.rs
+++ b/crates/cli/src/commands/machine.rs
@@ -42,13 +42,26 @@ pub(crate) fn run_machine_load(args: LoadArgs) -> ExitCode {
     };
 
     // Reconstruct bus
-    let mut bus = match labwired_core::system::builder::build_system_bus(config.system.as_deref()) {
-        Ok(bus) => bus,
+    let reconstructed_system = match config
+        .system
+        .as_deref()
+        .map(labwired_config::ResolvedSystem::from_manifest_file)
+        .transpose()
+    {
+        Ok(s) => s,
         Err(e) => {
-            error!("Failed to reconstruct bus: {:#}", e);
+            error!("Failed to load system manifest: {:#}", e);
             return ExitCode::from(EXIT_CONFIG_ERROR);
         }
     };
+    let mut bus =
+        match labwired_core::system::builder::build_system_bus(reconstructed_system.as_ref()) {
+            Ok(bus) => bus,
+            Err(e) => {
+                error!("Failed to reconstruct bus: {:#}", e);
+                return ExitCode::from(EXIT_CONFIG_ERROR);
+            }
+        };
 
     // Load original firmware (required for memory content that isn't in snapshot yet)
     // Note: Our snapshot currently doesn't include full RAM/Flash dumps to keep it small.

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -982,7 +982,24 @@ pub(crate) fn run_interactive(cli: Cli) -> ExitCode {
     };
 
     let system_path = cli.system.clone();
-    let bus = match labwired_core::system::builder::build_system_bus(system_path.as_deref()) {
+    let resolved_system = match system_path
+        .as_deref()
+        .map(labwired_config::ResolvedSystem::from_manifest_file)
+        .transpose()
+    {
+        Ok(s) => s,
+        Err(e) => {
+            emit_error(
+                cli.json,
+                "ConfigError",
+                format!("Failed to load system manifest: {e:#}"),
+                None,
+                EXIT_CONFIG_ERROR,
+            );
+            return ExitCode::from(EXIT_CONFIG_ERROR);
+        }
+    };
+    let bus = match labwired_core::system::builder::build_system_bus(resolved_system.as_ref()) {
         Ok(bus) => bus,
         Err(e) => {
             emit_error(
@@ -1023,11 +1040,8 @@ pub(crate) fn run_interactive(cli: Cli) -> ExitCode {
     let cpu_arch = if let Some(sys_path) = &system_path {
         match labwired_config::SystemManifest::from_file(sys_path) {
             Ok(manifest) => {
-                let chip_path = sys_path
-                    .parent()
-                    .unwrap_or_else(|| Path::new("."))
-                    .join(&manifest.chip);
-                match labwired_config::ChipDescriptor::from_file(&chip_path) {
+                let chip_dir = sys_path.parent().unwrap_or_else(|| Path::new("."));
+                match labwired_config::ChipDescriptor::resolve(&manifest.chip, chip_dir) {
                     Ok(c) => c.arch,
                     Err(e) => {
                         emit_error(
@@ -1035,7 +1049,7 @@ pub(crate) fn run_interactive(cli: Cli) -> ExitCode {
                             "ConfigError",
                             format!("Failed to parse chip descriptor: {:#}", e),
                             Some(serde_json::json!({
-                                "chip_path": chip_path.display().to_string(),
+                                "chip": manifest.chip.clone(),
                             })),
                             EXIT_CONFIG_ERROR,
                         );

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -70,19 +70,8 @@ use super::esp32_boot_state::resolve_esp_partitions_bin;
 /// chip family with an ELF-less faithful rom-boot machine). Reads the manifest
 /// and its referenced chip descriptor; any load failure → false (fall back to
 /// requiring firmware). Mirrors the C3 detection used on the fast-boot path.
-fn system_manifest_is_esp32c3(sys_path: &std::path::Path) -> bool {
-    labwired_config::SystemManifest::from_file(sys_path)
-        .ok()
-        .and_then(|m| {
-            let chip_path = sys_path
-                .parent()
-                .unwrap_or_else(|| std::path::Path::new("."))
-                .join(&m.chip);
-            labwired_config::ChipDescriptor::from_file(&chip_path)
-                .ok()
-                .map(|c| c.name == "esp32c3")
-        })
-        == Some(true)
+fn system_is_esp32c3(system: &labwired_config::ResolvedSystem) -> bool {
+    system.chip().map(|c| c.name == "esp32c3").unwrap_or(false)
 }
 
 /// Faithful ESP32-C3 (RISC-V) rom-boot with NO debug ELF. The flash image
@@ -103,6 +92,7 @@ fn run_c3_rom_boot_no_elf(
     args: &TestArgs,
     resolved_limits: &TestLimits,
     system_path: Option<&std::path::PathBuf>,
+    system: Option<&labwired_config::ResolvedSystem>,
     assertions: &[TestAssertion],
     faults: &[labwired_config::FaultSpec],
     require_fault_fired: bool,
@@ -111,28 +101,19 @@ fn run_c3_rom_boot_no_elf(
 ) -> ExitCode {
     // Build the from_config bus (peripherals + external devices) exactly as the
     // ELF rom-boot path does before build_c3_rom_boot_machine.
-    let mut bus =
-        match labwired_core::system::builder::build_system_bus(system_path.map(|p| p.as_path())) {
-            Ok(bus) => bus,
-            Err(e) => {
-                let msg = format!("{:#}", e);
-                error!("{}", msg);
-                write_config_error_outputs(
-                    args,
-                    None,
-                    system_path,
-                    None,
-                    Some(resolved_limits),
-                    msg,
-                );
-                return ExitCode::from(EXIT_CONFIG_ERROR);
-            }
-        };
+    let mut bus = match labwired_core::system::builder::build_system_bus(system) {
+        Ok(bus) => bus,
+        Err(e) => {
+            let msg = format!("{:#}", e);
+            error!("{}", msg);
+            write_config_error_outputs(args, None, system_path, None, Some(resolved_limits), msg);
+            return ExitCode::from(EXIT_CONFIG_ERROR);
+        }
+    };
 
     // Load the manifest once: it drives both the UART sink selection (debug_uart)
     // and — the universal WiFi adapter — the `wifi_ap` attach below.
-    let manifest_opt =
-        system_path.and_then(|path| labwired_config::SystemManifest::from_file(path).ok());
+    let manifest_opt = system.map(|s| s.manifest.clone());
     let debug_uart = manifest_opt.as_ref().and_then(|m| m.debug_uart.clone());
     // Seed the station eFuse MAC when a `wifi_ap` is present so the C3 stays
     // associated (a zero eFuse MAC associates but drops); None otherwise keeps
@@ -336,6 +317,13 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
         }
     };
 
+    // `inputs.chip` names a built-in chip for firmware with nothing wired to it.
+    // It is read before the destructuring match because only the 1.0 schema has it.
+    let script_chip = match &loaded {
+        LoadedTestScript::V1_0(script) => script.inputs.chip.clone(),
+        _ => None,
+    };
+
     let (
         script_firmware,
         script_system,
@@ -493,6 +481,31 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             .map(|s| resolve_script_path(&args.script, s))
     });
 
+    // Resolve the system once, from either a manifest file or an `inputs.chip`
+    // name. Every site below that needs the chip, the debug UART, or the wifi
+    // AP reads it from here instead of re-parsing the manifest.
+    let resolved_system = match (&system_path, &script_chip) {
+        (Some(path), _) => match labwired_config::ResolvedSystem::from_manifest_file(path) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                let msg = format!("Failed to load system manifest {path:?}: {e:#}");
+                error!("{}", msg);
+                write_config_error_outputs(&args, None, Some(path), None, None, msg);
+                return ExitCode::from(EXIT_CONFIG_ERROR);
+            }
+        },
+        (None, Some(chip)) => match labwired_config::ResolvedSystem::from_builtin_chip(chip) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                let msg = format!("{e:#}");
+                error!("{}", msg);
+                write_config_error_outputs(&args, None, None, None, None, msg);
+                return ExitCode::from(EXIT_CONFIG_ERROR);
+            }
+        },
+        (None, None) => None,
+    };
+
     // Resolve the firmware source. Normally an ELF is required (via --firmware or
     // inputs.firmware). The ONE exception is the faithful ESP32-C3 (RISC-V)
     // rom-boot path: the flash image (LABWIRED_ESP32C3_FLASH) is the program the
@@ -514,9 +527,9 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     let no_elf_rom_boot = firmware_path_opt.is_none()
         && (args.rom_boot || args.resume_snapshot.is_some())
         && std::env::var("LABWIRED_ESP32C3_FLASH").is_ok()
-        && system_path
-            .as_deref()
-            .map(system_manifest_is_esp32c3)
+        && resolved_system
+            .as_ref()
+            .map(system_is_esp32c3)
             .unwrap_or(false);
 
     if no_elf_rom_boot {
@@ -528,6 +541,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             &args,
             &resolved_limits,
             system_path.as_ref(),
+            resolved_system.as_ref(),
             &assertions,
             &faults,
             require_fault_fired,
@@ -594,22 +608,14 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     // `build_esp32_system_from_manifest` path that calls configure + attach
     // together, before falling through to `build_system_bus` for all other
     // architectures. The parsed manifest is reused so the file is read only once.
-    let esp32_manifest: Option<labwired_config::SystemManifest> =
-        if let Some(sys_path) = system_path.as_deref() {
-            labwired_config::SystemManifest::from_file(sys_path)
-                .ok()
-                .filter(|m| {
-                    let chip_path = sys_path
-                        .parent()
-                        .unwrap_or_else(|| std::path::Path::new("."))
-                        .join(&m.chip);
-                    labwired_config::ChipDescriptor::from_file(&chip_path)
-                        .map(|c| c.arch == labwired_config::Arch::Xtensa)
-                        .unwrap_or(false)
-                })
-        } else {
-            None
-        };
+    let esp32_manifest: Option<labwired_config::SystemManifest> = resolved_system
+        .as_ref()
+        .filter(|s| {
+            s.chip()
+                .map(|c| c.arch == labwired_config::Arch::Xtensa)
+                .unwrap_or(false)
+        })
+        .map(|s| s.manifest.clone());
     let is_xtensa = esp32_manifest.is_some();
 
     // For Xtensa, short-circuit: build bus + CPU together via build_esp32_system_from_manifest.
@@ -666,11 +672,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             // classic ESP32 stays on the legacy fast-boot (its rom-boot is a
             // separate task).
             let is_esp32s3 = {
-                let chip_path = sys_path
+                let chip_dir = sys_path
                     .parent()
-                    .unwrap_or_else(|| std::path::Path::new("."))
-                    .join(&manifest.chip);
-                labwired_config::ChipDescriptor::from_file(&chip_path)
+                    .unwrap_or_else(|| std::path::Path::new("."));
+                labwired_config::ChipDescriptor::resolve(&manifest.chip, chip_dir)
                     .map(|c| c.name == "esp32s3")
                     .unwrap_or(false)
             };
@@ -1133,7 +1138,7 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
         }
     }
 
-    let mut bus = match labwired_core::system::builder::build_system_bus(system_path.as_deref()) {
+    let mut bus = match labwired_core::system::builder::build_system_bus(resolved_system.as_ref()) {
         Ok(bus) => bus,
         Err(e) => {
             let msg = format!("{:#}", e);
@@ -1172,11 +1177,10 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
             labwired_config::SystemManifest::from_file(sys_path)
                 .ok()
                 .and_then(|m| {
-                    let chip_path = sys_path
+                    let chip_dir = sys_path
                         .parent()
-                        .unwrap_or_else(|| std::path::Path::new("."))
-                        .join(&m.chip);
-                    labwired_config::ChipDescriptor::from_file(&chip_path)
+                        .unwrap_or_else(|| std::path::Path::new("."));
+                    labwired_config::ChipDescriptor::resolve(&m.chip, chip_dir)
                         .ok()
                         .map(|c| c.name == "esp32c3")
                 })
@@ -1331,11 +1335,11 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
                 }
                 if let Some(sys_path) = system_path.as_ref() {
                     if let Ok(manifest) = labwired_config::SystemManifest::from_file(sys_path) {
-                        let chip_path = sys_path
+                        let chip_dir = sys_path
                             .parent()
                             .unwrap_or_else(|| std::path::Path::new("."))
-                            .join(&manifest.chip);
-                        if let Ok(chip) = labwired_config::ChipDescriptor::from_file(&chip_path) {
+                            ;
+                        if let Ok(chip) = labwired_config::ChipDescriptor::resolve(&manifest.chip, chip_dir) {
                             if let Ok(ram_sz) = labwired_config::parse_size(&chip.ram.size) {
                                 let mut sp_top = (chip.ram.base + ram_sz) as u32;
                                 // ESP32-C3 boot stack placement:

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -120,6 +120,10 @@ enum Commands {
     /// Deterministic, CI-friendly runner mode driven by a test script (YAML).
     Test(TestArgs),
 
+    /// List the chips bundled with this CLI, usable as `inputs.chip` in a test
+    /// script or as a manifest's `chip:` field without copying any YAML.
+    Chips,
+
     /// Machine control operations (load, etc.)
     Machine(MachineArgs),
 
@@ -728,6 +732,12 @@ fn main() -> ExitCode {
     }
 
     match cli.command {
+        Some(Commands::Chips) => {
+            for name in labwired_config::BUILTIN_CHIP_NAMES {
+                println!("{name}");
+            }
+            ExitCode::SUCCESS
+        }
         Some(Commands::Test(args)) => commands::test::run_test(args),
         Some(Commands::Machine(args)) => run_machine(args),
         Some(Commands::Asset(args)) => run_asset(args),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Canonical device config v1 — the single JSON shape the agent builds and both
 /// engines load directly (Phase 1: parse + structural validation; resolve() is
@@ -291,7 +291,7 @@ pub struct WifiApManifest {
     pub serves: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SystemManifest {
     #[serde(default = "default_schema_version")]
     pub schema_version: String,
@@ -621,6 +621,94 @@ impl ChipDescriptor {
             serde_yaml::from_str(&content).context("Failed to parse Chip Descriptor YAML")
         }
     }
+
+    /// Resolve a `chip:` field. A bare name (`stm32f103`) is one of the chips
+    /// bundled with the CLI; anything containing a separator or a YAML
+    /// extension is a path relative to `base_dir`, for custom silicon.
+    ///
+    /// Built-in names exist so a project onboarding LabWired does not have to
+    /// vendor a copy of our chip descriptor — a copy that silently keeps the
+    /// bugs we have since fixed.
+    pub fn resolve(spec: &str, base_dir: &Path) -> Result<Self> {
+        if is_builtin_chip_spec(spec) {
+            let yaml = embedded_chip_yaml(spec).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "unknown built-in chip '{spec}'. Available: {}. \
+                     To use your own descriptor, give a path such as './chip.yaml'.",
+                    BUILTIN_CHIP_NAMES.join(", ")
+                )
+            })?;
+            return serde_yaml::from_str(yaml)
+                .with_context(|| format!("Failed to parse built-in chip descriptor '{spec}'"));
+        }
+        Self::from_file(base_dir.join(spec))
+    }
+}
+
+/// True when `spec` names a built-in chip rather than a descriptor file.
+pub fn is_builtin_chip_spec(spec: &str) -> bool {
+    !spec.contains('/')
+        && !spec.contains('\\')
+        && !spec.ends_with(".yaml")
+        && !spec.ends_with(".yml")
+        && !spec.ends_with(".json")
+}
+
+/// The chips bundled with the CLI, in the spelling a `chip:` field accepts.
+pub const BUILTIN_CHIP_NAMES: &[&str] = &[
+    "esp32",
+    "esp32c3",
+    "esp32s3",
+    "esp32s3-zero",
+    "mkw41z4",
+    "nrf52832",
+    "nrf52840",
+    "nrf5340",
+    "nrf54l15",
+    "rp2040",
+    "stm32f103",
+    "stm32f401",
+    "stm32f401cdu6",
+    "stm32f407",
+    "stm32f411ceu6",
+    "stm32g474re",
+    "stm32h563",
+    "stm32h735",
+    "stm32l073",
+    "stm32l476",
+    "stm32wb55",
+    "stm32wba52",
+];
+
+/// The embedded `configs/chips/*.yaml` descriptors, keyed by built-in name.
+/// `include_str!` bundles them so a released binary carries them and wasm
+/// builds (no `std::fs`) resolve them too.
+pub fn embedded_chip_yaml(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "esp32" => include_str!("../../../configs/chips/esp32.yaml"),
+        "esp32c3" => include_str!("../../../configs/chips/esp32c3.yaml"),
+        "esp32s3" => include_str!("../../../configs/chips/esp32s3.yaml"),
+        "esp32s3-zero" => include_str!("../../../configs/chips/esp32s3-zero.yaml"),
+        "mkw41z4" => include_str!("../../../configs/chips/mkw41z4.yaml"),
+        "nrf52832" => include_str!("../../../configs/chips/nrf52832.yaml"),
+        "nrf52840" => include_str!("../../../configs/chips/nrf52840.yaml"),
+        "nrf5340" => include_str!("../../../configs/chips/nrf5340.yaml"),
+        "nrf54l15" => include_str!("../../../configs/chips/nrf54l15.yaml"),
+        "rp2040" => include_str!("../../../configs/chips/rp2040.yaml"),
+        "stm32f103" => include_str!("../../../configs/chips/stm32f103.yaml"),
+        "stm32f401" => include_str!("../../../configs/chips/stm32f401.yaml"),
+        "stm32f401cdu6" => include_str!("../../../configs/chips/stm32f401cdu6.yaml"),
+        "stm32f407" => include_str!("../../../configs/chips/stm32f407.yaml"),
+        "stm32f411ceu6" => include_str!("../../../configs/chips/stm32f411ceu6.yaml"),
+        "stm32g474re" => include_str!("../../../configs/chips/stm32g474re.yaml"),
+        "stm32h563" => include_str!("../../../configs/chips/stm32h563.yaml"),
+        "stm32h735" => include_str!("../../../configs/chips/stm32h735.yaml"),
+        "stm32l073" => include_str!("../../../configs/chips/stm32l073.yaml"),
+        "stm32l476" => include_str!("../../../configs/chips/stm32l476.yaml"),
+        "stm32wb55" => include_str!("../../../configs/chips/stm32wb55.yaml"),
+        "stm32wba52" => include_str!("../../../configs/chips/stm32wba52.yaml"),
+        _ => return None,
+    })
 }
 
 impl SystemManifest {
@@ -1755,6 +1843,71 @@ impl From<labwired_ir::IrDevice> for ChipDescriptor {
 pub struct TestInputs {
     pub firmware: String,
     pub system: Option<String>,
+    /// A bare chip name (`stm32f103`), for firmware with no external devices
+    /// or board I/O. Mutually exclusive with `system`; it saves authoring a
+    /// manifest whose entire content would be a chip pointer and two empty
+    /// lists. Anything with a device attached needs `system`.
+    pub chip: Option<String>,
+}
+
+/// A system, resolved once: the manifest plus the directory that relative
+/// paths inside it (chip descriptor, firmware, peripheral schemas) resolve
+/// against.
+///
+/// Runners take this rather than a manifest path so a run described only by
+/// `inputs.chip` — a built-in chip with nothing attached — is a first-class
+/// case instead of a file that has to be conjured on disk. It also means the
+/// manifest is parsed once per run rather than re-read at every site that
+/// needs to know the chip.
+#[derive(Debug, Clone)]
+pub struct ResolvedSystem {
+    pub manifest: SystemManifest,
+    base_dir: PathBuf,
+    /// The manifest file this came from, if any. `None` for a built-in chip,
+    /// where no such file exists — artifacts report it that way rather than
+    /// inventing a path.
+    source_path: Option<PathBuf>,
+}
+
+impl ResolvedSystem {
+    pub fn from_manifest_file(path: &Path) -> Result<Self> {
+        let manifest = SystemManifest::from_file(path)?;
+        Ok(Self {
+            manifest,
+            base_dir: path.parent().unwrap_or(Path::new(".")).to_path_buf(),
+            source_path: Some(path.to_path_buf()),
+        })
+    }
+
+    /// A bare MCU: the named built-in chip, no external devices, no board I/O.
+    pub fn from_builtin_chip(chip: &str) -> Result<Self> {
+        // Fail here rather than at first use, so an unknown name is a config
+        // error before the run starts.
+        ChipDescriptor::resolve(chip, Path::new("."))?;
+        Ok(Self {
+            manifest: SystemManifest {
+                schema_version: default_schema_version(),
+                name: chip.to_string(),
+                chip: chip.to_string(),
+                ..SystemManifest::default()
+            },
+            base_dir: PathBuf::from("."),
+            source_path: None,
+        })
+    }
+
+    /// The chip descriptor this system runs on.
+    pub fn chip(&self) -> Result<ChipDescriptor> {
+        ChipDescriptor::resolve(&self.manifest.chip, &self.base_dir)
+    }
+
+    pub fn base_dir(&self) -> &Path {
+        &self.base_dir
+    }
+
+    pub fn source_path(&self) -> Option<&Path> {
+        self.source_path.as_deref()
+    }
 }
 
 /// Inputs for a multi-node environment test. Environment scripts are selected
@@ -2239,6 +2392,27 @@ impl TestScript {
 
         if self.limits.max_steps == 0 {
             anyhow::bail!("Limit 'max_steps' must be greater than zero");
+        }
+
+        if self.inputs.system.is_some() && self.inputs.chip.is_some() {
+            anyhow::bail!(
+                "inputs may set 'system' or 'chip', not both. Use 'chip' for a bare MCU \
+                 and 'system' when external devices or board I/O are wired up."
+            );
+        }
+        if let Some(chip) = &self.inputs.chip {
+            if !is_builtin_chip_spec(chip) {
+                anyhow::bail!(
+                    "inputs.chip takes a built-in chip name such as 'stm32f103', not a path. \
+                     Use 'system' with a manifest to point at your own descriptor."
+                );
+            }
+            if embedded_chip_yaml(chip).is_none() {
+                anyhow::bail!(
+                    "unknown built-in chip '{chip}'. Available: {}",
+                    BUILTIN_CHIP_NAMES.join(", ")
+                );
+            }
         }
 
         reject_explicit_memory_nodes(&self.assertions, "single-node")?;
@@ -4518,5 +4692,108 @@ metadata:
             signed: false,
             fields: vec![],
         };
+    }
+}
+
+#[cfg(test)]
+mod builtin_chip_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn a_bare_name_resolves_to_the_bundled_descriptor() {
+        let chip = ChipDescriptor::resolve("stm32f103", Path::new("/nonexistent"))
+            .expect("built-in chip resolves without touching the filesystem");
+        assert_eq!(chip.name, "stm32f103c8");
+    }
+
+    /// Guards the drift between `BUILTIN_CHIP_NAMES` and the `include_str!`
+    /// arms: a name advertised in an error message must actually load.
+    #[test]
+    fn every_advertised_builtin_name_loads_and_parses() {
+        for name in BUILTIN_CHIP_NAMES {
+            ChipDescriptor::resolve(name, Path::new("/nonexistent"))
+                .unwrap_or_else(|e| panic!("built-in chip '{name}' failed to load: {e:#}"));
+        }
+    }
+
+    #[test]
+    fn a_path_still_resolves_relative_to_the_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("custom.yaml"),
+            embedded_chip_yaml("stm32f103").unwrap(),
+        )
+        .unwrap();
+        let chip = ChipDescriptor::resolve("./custom.yaml", dir.path()).unwrap();
+        assert_eq!(chip.name, "stm32f103c8");
+    }
+
+    #[test]
+    fn an_unknown_builtin_names_the_available_ones() {
+        let err = ChipDescriptor::resolve("stm32f999", Path::new(".")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unknown built-in chip 'stm32f999'"), "{msg}");
+        assert!(msg.contains("stm32f103"), "{msg}");
+    }
+
+    #[test]
+    fn a_yaml_extension_is_treated_as_a_path_not_a_builtin() {
+        assert!(!is_builtin_chip_spec("stm32f103.yaml"));
+        assert!(!is_builtin_chip_spec("chips/stm32f103"));
+        assert!(is_builtin_chip_spec("stm32f103"));
+    }
+
+    fn script_with_inputs(inputs: &str) -> Result<TestScript> {
+        let yaml = format!(
+            "schema_version: \"1.2\"\ninputs:\n{inputs}limits:\n  max_steps: 10\nassertions: []\n"
+        );
+        let script: TestScript = serde_yaml::from_str(&yaml)?;
+        script.validate()?;
+        Ok(script)
+    }
+
+    #[test]
+    fn chip_alone_is_accepted() {
+        let script = script_with_inputs("  firmware: \"fw.elf\"\n  chip: \"stm32f103\"\n").unwrap();
+        assert_eq!(script.inputs.chip.as_deref(), Some("stm32f103"));
+        assert!(script.inputs.system.is_none());
+    }
+
+    #[test]
+    fn chip_and_system_together_are_rejected() {
+        let err = script_with_inputs(
+            "  firmware: \"fw.elf\"\n  chip: \"stm32f103\"\n  system: \"./system.yaml\"\n",
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("not both"), "{err:#}");
+    }
+
+    #[test]
+    fn a_path_in_inputs_chip_is_rejected() {
+        let err =
+            script_with_inputs("  firmware: \"fw.elf\"\n  chip: \"./chip.yaml\"\n").unwrap_err();
+        assert!(format!("{err:#}").contains("built-in chip name"), "{err:#}");
+    }
+
+    #[test]
+    fn an_unknown_chip_in_inputs_is_rejected_before_the_run() {
+        let err =
+            script_with_inputs("  firmware: \"fw.elf\"\n  chip: \"stm32f999\"\n").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("unknown built-in chip"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn the_synthetic_manifest_has_nothing_attached() {
+        let m = ResolvedSystem::from_builtin_chip("stm32f103")
+            .unwrap()
+            .manifest;
+        assert_eq!(m.chip, "stm32f103");
+        assert!(m.external_devices.is_empty());
+        assert!(m.board_io.is_empty());
+        assert!(!m.schema_version.is_empty());
     }
 }

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -24,7 +24,7 @@ mod can_devices;
 mod construct;
 mod declarative_device;
 mod device_hooks;
-mod embedded_descriptors;
+pub(crate) mod embedded_descriptors;
 mod faults;
 mod from_config;
 mod mmio_activity;

--- a/crates/core/src/system/builder.rs
+++ b/crates/core/src/system/builder.rs
@@ -9,19 +9,25 @@ use crate::cpu::xtensa_lx7::XtensaLx7;
 use std::path::Path;
 use tracing::info;
 
-/// Builds a SystemBus from a given system manifest path.
-/// If no path is provided, returns a default (empty/default) SystemBus.
-pub fn build_system_bus(system_path: Option<&Path>) -> anyhow::Result<SystemBus> {
-    let bus = if let Some(sys_path) = system_path {
-        info!("Loading system manifest: {:?}", sys_path);
-        let mut manifest = labwired_config::SystemManifest::from_file(sys_path)?;
-        let chip_path = sys_path
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join(&manifest.chip);
-        manifest.chip = chip_path.to_string_lossy().into_owned();
-        info!("Loading chip descriptor: {:?}", chip_path);
-        let chip = labwired_config::ChipDescriptor::from_file(&chip_path)?;
+/// Builds a SystemBus from an already-resolved system.
+/// If none is provided, returns a default (empty/default) SystemBus.
+pub fn build_system_bus(
+    system: Option<&labwired_config::ResolvedSystem>,
+) -> anyhow::Result<SystemBus> {
+    let bus = if let Some(system) = system {
+        info!("Loading chip descriptor: {}", system.manifest.chip);
+        let chip = system.chip()?;
+        let mut manifest = system.manifest.clone();
+        // Peripheral descriptor paths inside a chip file are resolved relative
+        // to it, so a file-backed chip keeps its full path. A built-in name has
+        // no directory and is left as the name — its descriptors are embedded.
+        if !labwired_config::is_builtin_chip_spec(&manifest.chip) {
+            manifest.chip = system
+                .base_dir()
+                .join(&manifest.chip)
+                .to_string_lossy()
+                .into_owned();
+        }
         SystemBus::from_config(&chip, &manifest)?
     } else {
         info!("Using default hardware configuration");
@@ -62,12 +68,9 @@ pub fn build_esp32_system_from_manifest(
     manifest: &labwired_config::SystemManifest,
     system_path: &Path,
 ) -> anyhow::Result<(SystemBus, XtensaLx7, XtensaLx7)> {
-    let chip_path = system_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join(&manifest.chip);
-    info!("Loading chip descriptor: {:?}", chip_path);
-    let _chip = labwired_config::ChipDescriptor::from_file(&chip_path)?;
+    let chip_dir = system_path.parent().unwrap_or_else(|| Path::new("."));
+    info!("Loading chip descriptor: {}", manifest.chip);
+    let _chip = labwired_config::ChipDescriptor::resolve(&manifest.chip, chip_dir)?;
 
     let mut bus = SystemBus::new();
     let pro_cpu = crate::system::xtensa::configure_xtensa_esp32(&mut bus);

--- a/crates/core/src/tests/builtin_chip_self_contained.rs
+++ b/crates/core/src/tests/builtin_chip_self_contained.rs
@@ -1,0 +1,79 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+//
+// A built-in chip (`chip: "stm32f103"`) is resolved from the binary, so it has
+// no directory on disk to resolve relative paths against. Any peripheral
+// `debug_schema` it names must therefore come from the embedded descriptor
+// registry — otherwise `resolve_peripheral_path` falls back to a path that
+// does not exist in the consumer's repo and the schema is silently dropped.
+//
+// These two tests are the drift guards for that contract. Without them, adding
+// a chip file or a `debug_schema:` line degrades built-in chips quietly.
+
+use labwired_config::{embedded_chip_yaml, ChipDescriptor, BUILTIN_CHIP_NAMES};
+use std::path::PathBuf;
+
+fn configs_chips_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../configs/chips")
+}
+
+/// Every chip descriptor we ship is offered as a built-in name. A new
+/// `configs/chips/*.yaml` that nobody added to `BUILTIN_CHIP_NAMES` would be
+/// invisible to `chip: "<name>"` while looking supported.
+#[test]
+fn every_shipped_chip_file_is_offered_as_a_builtin() {
+    let mut missing = Vec::new();
+    for entry in std::fs::read_dir(configs_chips_dir()).expect("read configs/chips") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().is_none_or(|e| e != "yaml") {
+            continue;
+        }
+        let stem = path.file_stem().unwrap().to_string_lossy().into_owned();
+        // `ci-fixture-*` are internal harness fixtures, not silicon we offer.
+        if stem.starts_with("ci-fixture-") {
+            continue;
+        }
+        if !BUILTIN_CHIP_NAMES.contains(&stem.as_str()) {
+            missing.push(stem);
+        }
+    }
+    missing.sort();
+    assert!(
+        missing.is_empty(),
+        "these chip descriptors ship but are not reachable as `chip: \"<name>\"`. \
+         Add them to BUILTIN_CHIP_NAMES and embedded_chip_yaml: {missing:?}"
+    );
+}
+
+/// A built-in chip must not depend on a file next to it, because there is no
+/// "next to it" once it is compiled into the binary.
+#[test]
+fn no_builtin_chip_depends_on_a_file_beside_it() {
+    let mut unresolvable = Vec::new();
+    for name in BUILTIN_CHIP_NAMES {
+        let yaml = embedded_chip_yaml(name).expect("advertised name is embedded");
+        let chip: ChipDescriptor =
+            serde_yaml::from_str(yaml).unwrap_or_else(|e| panic!("parse '{name}': {e}"));
+        for peripheral in &chip.peripherals {
+            let Some(schema) = peripheral
+                .config
+                .get("debug_schema")
+                .and_then(|v| v.as_str())
+            else {
+                continue;
+            };
+            if crate::bus::embedded_descriptors::lookup(schema).is_none() {
+                unresolvable.push(format!("{name}: {} -> {schema}", peripheral.id));
+            }
+        }
+    }
+    assert!(
+        unresolvable.is_empty(),
+        "these built-in chips reference peripheral descriptors that are not embedded, so \
+         they resolve to a path that will not exist for a consumer of the released binary. \
+         Embed them in bus::embedded_descriptors: {unresolvable:#?}"
+    );
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+pub mod builtin_chip_self_contained;
+#[cfg(test)]
 pub mod esp32;
 #[cfg(test)]
 pub mod esp32c3_i2c_waveform;

--- a/crates/core/tests/diag_c3_yield.rs
+++ b/crates/core/tests/diag_c3_yield.rs
@@ -44,7 +44,8 @@ fn diag_c3_first_yield() {
     let elf = core.join("validation/arduino-matrix/out/esp32c3/L0_serial_boot/firmware.elf");
     let syms = load_syms(&elf);
 
-    let mut bus = build_system_bus(Some(&sys)).expect("bus");
+    let resolved = labwired_config::ResolvedSystem::from_manifest_file(&sys).expect("system");
+    let mut bus = build_system_bus(Some(&resolved)).expect("bus");
     let mut flash_img = vec![0xFFu8; 4 * 1024 * 1024];
     for p in [
         core.join("validation/arduino-matrix/out/_pio_work/esp32c3__L0_serial_boot/.pio/build/matrix/partitions.bin"),

--- a/crates/core/tests/diag_esp32c3_boot.rs
+++ b/crates/core/tests/diag_esp32c3_boot.rs
@@ -45,7 +45,8 @@ fn diag_c3_boot_progress() {
     assert!(elf.exists(), "missing {elf:?}");
     let syms = load_syms(&elf);
 
-    let mut bus = build_system_bus(Some(&sys)).expect("bus");
+    let resolved = labwired_config::ResolvedSystem::from_manifest_file(&sys).expect("system");
+    let mut bus = build_system_bus(Some(&resolved)).expect("bus");
     let mut flash_img = vec![0xFFu8; 4 * 1024 * 1024];
     for p in [
         core.join("validation/arduino-matrix/out/_pio_work/esp32c3__L0_serial_boot/.pio/build/matrix/partitions.bin"),

--- a/crates/core/tests/diag_esp32c3_panic.rs
+++ b/crates/core/tests/diag_esp32c3_panic.rs
@@ -11,7 +11,8 @@ fn diag_c3_panic_message() {
     let sys = core.join("validation/arduino-matrix/systems/esp32c3.yaml");
     let elf = core.join("validation/arduino-matrix/out/esp32c3/L0_serial_boot/firmware.elf");
     assert!(elf.exists(), "missing {elf:?}");
-    let mut bus = build_system_bus(Some(&sys)).expect("bus");
+    let resolved = labwired_config::ResolvedSystem::from_manifest_file(&sys).expect("system");
+    let mut bus = build_system_bus(Some(&resolved)).expect("bus");
     let flash = Arc::new(Mutex::new(vec![0xFFu8; 4 * 1024 * 1024]));
     bus.add_peripheral(
         "spimem1_flash",

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -210,11 +210,10 @@ impl LabwiredAdapter {
         let mut resolved_board_io_bindings = Vec::new();
         let mut bus = if let Some(sys_path) = &system_path {
             let manifest = labwired_config::SystemManifest::from_file(sys_path)?;
-            let chip_path = sys_path
+            let chip_dir = sys_path
                 .parent()
-                .unwrap_or_else(|| std::path::Path::new("."))
-                .join(&manifest.chip);
-            let chip = labwired_config::ChipDescriptor::from_file(&chip_path)?;
+                .unwrap_or_else(|| std::path::Path::new("."));
+            let chip = labwired_config::ChipDescriptor::resolve(&manifest.chip, chip_dir)?;
             resolved_board_io_bindings = resolve_board_io_bindings(&chip, &manifest);
             labwired_core::bus::SystemBus::from_config(&chip, &manifest)?
         } else {

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -23,12 +23,31 @@ labwired test --firmware path/to/fw.elf --system system.yaml --script test.yaml
 schema_version: "1.0"
 inputs:
   firmware: "relative/or/absolute/path/to/fw.elf"
-  system: "optional/path/to/system.yaml"
+  chip: "stm32f103"
 limits:
   max_steps: 100000
 assertions:
   - uart_contains: "Hello"
 ```
+
+`inputs.chip` names one of the chips bundled with the CLI, for firmware with
+nothing wired to it. This is the whole configuration — there is no manifest to
+write and no chip descriptor to copy into your repository, so your test tracks
+our silicon model instead of freezing a copy of it. Run `labwired chips` for
+the available names.
+
+Firmware with external devices or board I/O uses `inputs.system` instead,
+pointing at a manifest:
+
+```yaml
+inputs:
+  firmware: "path/to/fw.elf"
+  system: "path/to/system.yaml"
+```
+
+A manifest's `chip:` field takes the same two forms: a built-in name, or a path
+to your own descriptor for silicon we do not ship. Setting both `inputs.chip`
+and `inputs.system` is an error.
 
 `--firmware` and `--system` are single-machine overrides only. They are not
 valid with an environment script.


### PR DESCRIPTION
Onboarding a project meant copying a chip descriptor out of `configs/chips/` into its repository. That copy is a fork of our silicon model — it keeps the bugs we later fix — and it puts ~200 lines of vendored YAML in front of a maintainer whose actual ask was "add a workflow file". The stm32f1xx-hal PR needed three files, two of them pure ceremony.

Chips are now bundled in the binary and addressable by name, the way external device descriptors already were:

```yaml
inputs:
  firmware: "target/thumbv7m-none-eabi/release/examples/serial"
  chip: "stm32f103"
```

That is the whole configuration for firmware with nothing wired to it. A manifest's `chip:` field accepts the same bare names; anything with a separator or a YAML extension is still a path, so existing scripts are untouched. `labwired chips` lists the 22 available.

Systems now resolve once into a `ResolvedSystem` (manifest + base dir + optional source path) that the runners take directly, replacing five sites in `test.rs` that each re-read and re-parsed the manifest to answer one question about the chip. A built-in-chip run reports `system: null` in its artifacts, because there is no system file.

### Two drift guards

Both cover failures that are silent today:

- Every `configs/chips/*.yaml` must be reachable as a built-in name, so a new chip file cannot ship while being unusable by name.
- No built-in chip may reference a peripheral `debug_schema` that is not itself embedded. A built-in chip has no directory on disk, so such a reference resolves to a path that will not exist in a consumer's repo — and `resolve_peripheral_path` falls back silently rather than erroring, dropping the schema. `nrf52840.yaml` has ten of these. They all resolve today; now they stay that way.

### Verification

Against the real stm32f1xx-hal fork, which drops from three files to two:

| script | result |
| --- | --- |
| `blinky` (`chip: stm32f103`) | pass, `max_steps` |
| `serial` (`chip: stm32f103`) | pass, `halt` |
| `serial`, injecting `Q` not `X` | fail, `max_steps` |
| `serial`, injection removed | fail, `max_steps` |
| `chip: stm32f999` | config error listing the available names |

Path-based manifests unchanged. `labwired-config`, `labwired-cli`, `labwired-core` and `labwired-dap` suites pass; fmt and clippy clean on all touched crates.