### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -10,13 +10,13 @@ intentionally documents the action beside its implementation rather than
 choosing its own source SHA: every immutable revision therefore carries its own
 matching input and report contract.
 
-The `version` input defaults to `v0.20.0` and independently selects the
+The `version` input defaults to `v0.21.0` and independently selects the
 immutable Core CLI release archive named
-`labwired-v0.20.0-<platform>.tar.gz`. The action downloads that public archive
+`labwired-v0.21.0-<platform>.tar.gz`. The action downloads that public archive
 from the `w1ne/labwired-core` GitHub release with `curl`; it does not build Core
 on the consumer runner.
 
-Its inputs are exactly `script` (required), `version` (default `v0.20.0`),
+Its inputs are exactly `script` (required), `version` (default `v0.21.0`),
 `output-dir`, and `args`. `args` is whitespace-separated extra CLI flags; shell
 quoting inside this input is not interpreted.
 

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: "Immutable LabWired Core release tag to install."
     required: false
-    default: "v0.20.0"
+    default: "v0.21.0"
   output-dir:
     description: "Directory for run artifacts (result.json, uart.log, junit.xml, and reports)."
     required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-27
+
+### Added
+- **Built-in chips**: the chip descriptors in `configs/chips/` are bundled with
+  the CLI and addressable by name, so a project no longer copies one into its
+  repository. `inputs.chip: "stm32f103"` is the whole configuration for firmware
+  with nothing wired to it — no manifest, no descriptor copy — and a manifest's
+  `chip:` field accepts the same bare names. Anything with a separator or a YAML
+  extension is still a path, so existing scripts are unaffected.
+- **`labwired chips`** lists the bundled chips.
+
+### Changed
+- Systems resolve once into a `ResolvedSystem` passed to the runners, replacing
+  five sites that each re-read and re-parsed the manifest. A built-in-chip run
+  reports `system: null` in its artifacts, because there is no system file.
+
 ## [0.20.0] - 2026-07-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1039,56 +1039,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-perf-spin"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cortex-m-rt",
  "panic-halt",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-uart-echo-fixture"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1760,7 +1760,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-egress-relay"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "labwired-core",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -1927,11 +1927,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.20.0"
+version = "0.21.0"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3428,7 +3428,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ examples. Check the per-board docs before assuming a peripheral is modeled:
 Pinned release:
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.20.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh
 labwired --version
 ```
 
@@ -41,7 +41,7 @@ Prefer to inspect the installer first:
 ```sh
 curl -fsSL https://labwired.com/install.sh -o install.sh
 # review install.sh, then:
-LABWIRED_VERSION=v0.20.0 sh install.sh
+LABWIRED_VERSION=v0.21.0 sh install.sh
 ```
 
 Supported host environments:
@@ -52,7 +52,7 @@ Supported host environments:
 
 Install options:
 
-- `LABWIRED_VERSION=v0.20.0` pins the current documented release for a
+- `LABWIRED_VERSION=v0.21.0` pins the current documented release for a
   reproducible install.
 - `LABWIRED_FROM_SOURCE=1` forces a source build.
 - `LABWIRED_INSTALL_DIR=~/.local/bin` changes the install directory.

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -1,7 +1,7 @@
 # CI Integration
 
 LabWired CI runs the same labwired test command locally, in GitHub Actions, and
-in GitLab. Pin the runner release to v0.20.0 so a firmware change is tested
+in GitLab. Pin the runner release to v0.21.0 so a firmware change is tested
 against a reproducible simulator version.
 
 ## GitHub Actions
@@ -25,10 +25,10 @@ jobs:
 
       - id: labwired
         name: Run LabWired
-        uses: w1ne/labwired-core/.github/actions/labwired-test@02952bd33b18dd6527a2ad4875157fe4d94f0a79
+        uses: w1ne/labwired-core/.github/actions/labwired-test@bfd879522914b586223081c4c89ba315db4a97ed
         with:
           script: tests/firmware-test.yaml
-          version: v0.20.0
+          version: v0.21.0
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -38,8 +38,8 @@ jobs:
 ~~~
 
 The public action reference is an immutable action-source pin to
-`02952bd33b18dd6527a2ad4875157fe4d94f0a79`. Its only inputs are `script`
-(required), `version` (default `v0.20.0`), `output-dir`, and `args`; it downloads
+`bfd879522914b586223081c4c89ba315db4a97ed`. Its only inputs are `script`
+(required), `version` (default `v0.21.0`), `output-dir`, and `args`; it downloads
 the selected public CLI release archive with `curl`. The action writes JUnit to
 `output-dir/junit.xml`, appends `summary.md` to the job summary, and always
 uploads the entire output directory, even when the test fails. Its `status`,
@@ -56,7 +56,7 @@ docker run --rm \
   --user "$(id -u):$(id -g)" \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
-  ghcr.io/w1ne/labwired:v0.20.0 \
+  ghcr.io/w1ne/labwired:v0.21.0 \
   test --script tests/firmware-test.yaml \
        --output-dir out/labwired \
        --no-uart-stdout
@@ -76,7 +76,7 @@ uses the pinned image and then invokes labwired test.
 ~~~yaml
 test:firmware:
   image:
-    name: ghcr.io/w1ne/labwired:v0.20.0
+    name: ghcr.io/w1ne/labwired:v0.21.0
     entrypoint: [""]
   script:
     - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -415,21 +415,21 @@ configuration; these produce `status: "error"` with `stop_reason:
 
 ## CI release runners
 
-Use the pinned v0.20.0 release runner in CI. It runs the same `labwired test`
+Use the pinned v0.21.0 release runner in CI. It runs the same `labwired test`
 command described above and writes the same artifact contract.
 
 ### GitHub Actions
 
 Use the public Core action and pin the Core CLI with its version input. Its
 only inputs are required `script`, optional `version` (default
-`v0.20.0`), `output-dir`, and `args`:
+`v0.21.0`), `output-dir`, and `args`:
 
 ~~~yaml
 - id: labwired
   name: Run LabWired tests
-  uses: w1ne/labwired-core/.github/actions/labwired-test@02952bd33b18dd6527a2ad4875157fe4d94f0a79
+  uses: w1ne/labwired-core/.github/actions/labwired-test@bfd879522914b586223081c4c89ba315db4a97ed
   with:
-    version: v0.20.0
+    version: v0.21.0
     script: examples/ci/dummy-max-steps.yaml
     output-dir: out/artifacts
     args: --no-uart-stdout
@@ -440,7 +440,7 @@ only inputs are required `script`, optional `version` (default
 ~~~
 
 The Core action is an immutable action-source pin to
-`02952bd33b18dd6527a2ad4875157fe4d94f0a79`; `version: v0.20.0` independently
+`bfd879522914b586223081c4c89ba315db4a97ed`; `version: v0.21.0` independently
 pins the immutable Core CLI release. It downloads that public release archive
 with `curl`, creates `output-dir/junit.xml` plus Markdown and HTML reports,
 appends the Markdown report to the job summary, and always uploads the entire
@@ -456,7 +456,7 @@ use either a single-machine script or an `inputs.env` world script.
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.20.0 \
+  ghcr.io/w1ne/labwired:v0.21.0 \
   test --script examples/ci/dummy-max-steps.yaml \
        --output-dir out/artifacts \
        --no-uart-stdout
@@ -466,7 +466,7 @@ GitLab should clear that entrypoint and invoke labwired from its job shell:
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.20.0
+  name: ghcr.io/w1ne/labwired:v0.21.0
   entrypoint: [""]
 script:
   - labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -1,14 +1,14 @@
 # CI workflow templates
 
-These templates run a pinned LabWired Core v0.20.0 release and preserve the
+These templates run a pinned LabWired Core v0.21.0 release and preserve the
 result.json, uart.log, snapshot.json, and junit.xml artifacts.
 
 ## GitHub Actions
 
 [github-actions.yml](github-actions.yml) is the primary GitHub template. It
 uses the public Core action at
-w1ne/labwired-core/.github/actions/labwired-test@02952bd33b18dd6527a2ad4875157fe4d94f0a79
-as an immutable action-source pin, while `version: v0.20.0` independently pins
+w1ne/labwired-core/.github/actions/labwired-test@bfd879522914b586223081c4c89ba315db4a97ed
+as an immutable action-source pin, while `version: v0.21.0` independently pins
 the Core CLI. Its only inputs are `script` (required), `version`, `output-dir`,
 and whitespace-separated `args`. The action downloads the public release archive
 with `curl`, writes JUnit at `output-dir/junit.xml`, renders the GitHub report,
@@ -27,7 +27,7 @@ cp docs/integration-templates/github-actions.yml .github/workflows/firmware-test
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.20.0
+  name: ghcr.io/w1ne/labwired:v0.21.0
   entrypoint: [""]
 ~~~
 
@@ -42,7 +42,7 @@ entrypoint:
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.20.0 \
+  ghcr.io/w1ne/labwired:v0.21.0 \
   test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
 ~~~
 

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -23,10 +23,10 @@ jobs:
       - id: labwired
         name: Run LabWired test
         # This immutable action-source pin is separate from the CLI version below.
-        uses: w1ne/labwired-core/.github/actions/labwired-test@02952bd33b18dd6527a2ad4875157fe4d94f0a79
+        uses: w1ne/labwired-core/.github/actions/labwired-test@bfd879522914b586223081c4c89ba315db4a97ed
         with:
           script: tests/firmware-test.yaml
-          version: v0.20.0
+          version: v0.21.0
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -36,4 +36,4 @@ jobs:
 
 # Advanced alternative: build LabWired from a source checkout only when testing
 # an unreleased LabWired change. For normal firmware CI, keep the pinned release
-# selected by version: v0.20.0 above.
+# selected by version: v0.21.0 above.

--- a/docs/integration-templates/gitlab-ci.yml
+++ b/docs/integration-templates/gitlab-ci.yml
@@ -17,7 +17,7 @@ build:firmware:
 test:labwired:
   stage: test
   image:
-    name: ghcr.io/w1ne/labwired:v0.20.0
+    name: ghcr.io/w1ne/labwired:v0.21.0
     entrypoint: [""]
   dependencies:
     - build:firmware

--- a/docs/reference_client_flows.md
+++ b/docs/reference_client_flows.md
@@ -37,16 +37,16 @@ jobs:
       # Step 2: Run the public immutable Core action
       - id: labwired
         name: Run LabWired CLI
-        uses: w1ne/labwired-core/.github/actions/labwired-test@02952bd33b18dd6527a2ad4875157fe4d94f0a79
+        uses: w1ne/labwired-core/.github/actions/labwired-test@bfd879522914b586223081c4c89ba315db4a97ed
         with:
           script: tests/hardware_validation.yaml
-          version: v0.20.0
+          version: v0.21.0
           output-dir: out/labwired
           args: --no-uart-stdout
 ```
 
 The action source is an immutable action-source pin. It has exactly four inputs:
-`script` (required), `version` (default `v0.20.0`), `output-dir`, and
+`script` (required), `version` (default `v0.21.0`), `output-dir`, and
 `args`. It downloads the selected public release
 with `curl`; callers do not need to add a token, repository, JUnit, or artifact
 upload setting. It automatically uploads `out/labwired/`, including

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -503,10 +503,10 @@ require_literal docs/configuration_reference.md 'including `{}` and `null`' 'con
 require_literal docs/configuration_reference.md 'stop_when_assertions_pass' 'configuration reference documents world assertion completion'
 require_literal examples/egress-demo/README.md 'config` is a closed mapping' 'egress example documents its closed config mapping'
 require_literal examples/egress-demo/README.md 'positive integer' 'egress example documents buffer_max type validation'
-require_literal Cargo.toml 'version = "0.20.0"' 'workspace metadata uses the current release version'
-require_literal CHANGELOG.md '## [0.20.0] - 2026-07-27' 'changelog records the current release version'
-require_literal README.md 'LABWIRED_VERSION=v0.20.0' 'public README pins the current release version'
-require_absent_literal README.md 'LABWIRED_VERSION=v0.19.2' 'public README does not retain the superseded release version'
+require_literal Cargo.toml 'version = "0.21.0"' 'workspace metadata uses the current release version'
+require_literal CHANGELOG.md '## [0.21.0] - 2026-07-27' 'changelog records the current release version'
+require_literal README.md 'LABWIRED_VERSION=v0.21.0' 'public README pins the current release version'
+require_absent_literal README.md 'LABWIRED_VERSION=v0.20.0' 'public README does not retain the superseded release version'
 
 if (( failures > 0 )); then
   printf 'Release runner contract failed with %d issue(s).\n' "$failures" >&2

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -254,7 +254,7 @@ if [[ -f "$dockerignore" ]]; then
   done
 fi
 
-require_literal "$action" 'default: "v0.20.0"' 'core action defaults to the supported public release'
+require_literal "$action" 'default: "v0.21.0"' 'core action defaults to the supported public release'
 action_inputs=$(awk '
   /^inputs:$/ { inside = 1; next }
   inside && /^[^[:space:]]/ { exit }
@@ -383,8 +383,8 @@ require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner 
 require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
 require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
 
-safe_action_sha=02952bd33b18dd6527a2ad4875157fe4d94f0a79
-safe_action_version=v0.20.0
+safe_action_sha=bfd879522914b586223081c4c89ba315db4a97ed
+safe_action_version=v0.21.0
 safe_action_ref="w1ne/labwired-core/.github/actions/labwired-test@${safe_action_sha}"
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md docs/reference_client_flows.md .github/actions/labwired-test/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
@@ -394,7 +394,7 @@ for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templa
   require_absent_literal "$doc" 'fda6a7bfb0328d9909ee07ba53ed05c84901f627' "$doc does not retain the superseded action pin"
   require_absent_literal "$doc" 'version: v0.18.0' "$doc does not retain the superseded Core release version"
   require_absent_literal "$doc" 'version: v0.19.0' "$doc does not retain the superseded Core release version"
-  require_absent_literal "$doc" 'v0.19.2' "$doc does not retain the superseded Core release version"
+  require_absent_literal "$doc" 'v0.20.0' "$doc does not retain the superseded Core release version"
 done
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/README.md; do
   require_literal "$doc" '--user "$(id -u):$(id -g)"' "$doc keeps bind-mounted container artifacts writable by the caller"
@@ -436,7 +436,7 @@ else
     fail "immutable action-source commit $safe_action_sha contains its action README"
   fi
   if [[ -n "$pinned_action" ]]; then
-    require_block_literal "$pinned_action" 'default: "v0.20.0"' 'pinned action defaults to the supported public release'
+    require_block_literal "$pinned_action" 'default: "v0.21.0"' 'pinned action defaults to the supported public release'
     require_block_literal "$pinned_action" 'https://github.com/w1ne/labwired-core/releases/download/${version}/${asset}' 'pinned action downloads the public release archive'
     pinned_action_inputs=$(awk '
       /^inputs:$/ { inside = 1; next }
@@ -457,7 +457,7 @@ else
     require_block_literal "$pinned_action" 'name: labwired-${{ github.job }}-${{ github.run_id }}-${{ github.action }}' 'pinned action gives each invocation a unique artifact name'
   fi
   if [[ -n "$pinned_action_readme" ]]; then
-    require_block_literal "$pinned_action_readme" 'defaults to `v0.20.0`' 'pinned action README states the supported public release'
+    require_block_literal "$pinned_action_readme" 'defaults to `v0.21.0`' 'pinned action README states the supported public release'
     require_block_literal "$pinned_action_readme" '[CI integration guide](../../../docs/ci_integration.md)' 'pinned action README links the canonical consumer guide'
     require_block_literal "$pinned_action_readme" 'intentionally documents the action beside its implementation' 'pinned action README explains its source-local contract'
     require_block_absent_literal "$pinned_action_readme" 'uses: w1ne/labwired-core/.github/actions/labwired-test@' 'pinned action README does not recursively choose its own SHA'


### PR DESCRIPTION
Version bump and changelog for v0.21.0.

Headline: built-in chips and `inputs.chip` (#690). A project onboarding LabWired no longer copies a chip descriptor into its repository — `chip: "stm32f103"` resolves from the binary, so its test tracks our silicon model instead of freezing a copy.

Pins move atomically as the release-runner-contract gate requires: workspace version, changelog, README, action default, docs, and the gate's own literals.