### PR TITLE
fix: repair and gate the esp32c3-blinky example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ ARM Cortex-M and RISC-V have the deepest coverage. Selected ESP32/Xtensa paths e
 specific examples. Per-board status is in [docs/boards](docs/boards/) and the
 [validation status matrix](docs/boards/VALIDATION_STATUS.md). Check it before assuming a
 peripheral is modeled. The browsable catalog of chips, boards, and peripherals is at
-[labwired.com/library](https://labwired.com/library.html).
+[app.labwired.com/validation](https://app.labwired.com/validation).
 
 | To see | Run |
 | --- | --- |
@@ -196,7 +196,7 @@ throughput ([`core-perf.yml`](.github/workflows/core-perf.yml)). For release mec
 [labwired.com](https://labwired.com/) ·
 [Playground](https://app.labwired.com/) ·
 [Docs](https://docs.labwired.com/) ·
-[Library](https://labwired.com/library.html) ·
+[Validation](https://app.labwired.com/validation) ·
 [For CI](https://labwired.com/ci.html) ·
 [Blog](https://labwired.com/blog/) ·
 [Pricing](https://labwired.com/pricing.html)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ claude mcp add labwired --transport http https://api.labwired.com/mcp
 codex   mcp add labwired --url https://api.labwired.com/mcp
 ```
 
-Other MCP clients take the standard block:
+On first use your client opens a browser to sign in. Other MCP clients take the standard
+block:
 
 ```json
 { "mcpServers": { "labwired": { "type": "http", "url": "https://api.labwired.com/mcp" } } }

--- a/configs/ci/boards.yml
+++ b/configs/ci/boards.yml
@@ -28,3 +28,9 @@ boards:
     path: examples/nucleo-h563zi
     rust_targets: [thumbv7m-none-eabi]
     gate: false
+  # Committed ELF, no cross-toolchain, runs in seconds — cheap enough to gate on
+  # every PR. It went ungated long enough for its own assertions to stop passing.
+  - id: esp32c3-blinky
+    kind: sim-validate
+    path: examples/esp32c3-blinky
+    gate: true

--- a/examples/esp32c3-blinky/ci/build.sh
+++ b/examples/esp32c3-blinky/ci/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# The ESP32-C3 blinky ELF is committed under firmware/, so there is no firmware
+# build step here. Build the simulator instead, which is what ci/test.sh runs.
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+cargo build -q -p labwired-cli

--- a/examples/esp32c3-blinky/ci/test.sh
+++ b/examples/esp32c3-blinky/ci/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Runs the committed ESP32-C3 blinky ELF and asserts the UART blink log plus the
+# GPIO_ENABLE readback. This example shipped ungated and its max_steps budget
+# silently stopped matching its own assertions; this script keeps that from
+# recurring.
+set -euo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+OUT=out/boards/esp32c3-blinky
+cargo run -q -p labwired-cli -- test \
+  --script examples/esp32c3-blinky/test-blink.yaml \
+  --output-dir "$OUT/blink" \
+  --no-uart-stdout

--- a/examples/esp32c3-blinky/test-blink.yaml
+++ b/examples/esp32c3-blinky/test-blink.yaml
@@ -8,7 +8,10 @@ inputs:
   system: "./system.yaml"
   firmware: "./firmware/esp32c3_blinky.elf"
 limits:
-  max_steps: 400000
+  # The blink loop needs ~500k steps to emit a complete "LED OFF"; 400000 cut
+  # the capture off mid-word at "LED OF" and the assertion below never matched.
+  # 800000 leaves headroom for timing changes while keeping the run short.
+  max_steps: 800000
 assertions:
   - uart_contains: "C3 BLINKY BOOT"
   - uart_contains: "LED ON"


### PR DESCRIPTION
Follow-up to #700, which found this while verifying README commands.

## The bug

`examples/esp32c3-blinky/test-blink.yaml` asserts `LED OFF`, but ran with `max_steps: 400000`. The blink loop needs roughly 500k steps to emit a complete `LED OFF`, so the UART capture stopped at 28 bytes, mid-word:

```
C3 BLINKY BOOT
LED ON
LED OF
```

```
Assertion failed: UartContains("LED OFF") (captured len=28)
```

Nothing referenced this example — not `configs/ci/boards.yml`, not any workflow, not any test under `crates/core/tests/` — so it failed silently for however long the budget has been too tight.

## The fix

- `max_steps` raised to `800000`. Verified passing at 500k; 800k leaves headroom for timing changes and still finishes in seconds.
- Added `ci/build.sh` and `ci/test.sh`. The ELF is committed, so `build.sh` only builds the simulator.
- Registered the example in `configs/ci/boards.yml` with `gate: true`. It needs no cross-toolchain, no apt packages, and no device pack, so gating it on every PR is cheap — and being ungated is why this rotted.

Also points the two README "Library" links at `app.labwired.com/validation` directly, since `labwired.com/library.html` is only a redirect to it now that the Library page was retired, and notes that the MCP connector sends you through a browser sign-in on first use.

## Verification

```
$ labwired test --script examples/esp32c3-blinky/test-blink.yaml
status: pass | steps: 800000 | stop: max_steps

C3 BLINKY BOOT
LED ON
LED OFF
LED ON
LED OFF
...
```

```
$ python3 scripts/ci/board_matrix.py --event pull_request
['iolink-station-l476', 'esp32c3-blinky']
```

`api.labwired.com/mcp` — flagged as unverified in #700 — is live. It answers unauthenticated requests with a 401 plus a `WWW-Authenticate: Bearer ... resource_metadata=...` challenge, and all three OAuth discovery endpoints return 200, so the documented `claude mcp add` flow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fmZwKry4MoPnaBrktb2Xa

---
_Generated by [Claude Code](https://claude.ai/code/session_016fmZwKry4MoPnaBrktb2Xa)_