### PR TITLE
docs: restore the labwired.com install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Clone the repo, install the CLI, run a firmware. No cross-toolchain needed.
 
 ```sh
 git clone https://github.com/w1ne/labwired-core && cd labwired-core
-curl -fsSL https://raw.githubusercontent.com/w1ne/labwired-core/main/scripts/install.sh | LABWIRED_VERSION=v0.21.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh
 labwired test --script examples/nrf54l15-dk/io-smoke.yaml
 ```
 
@@ -47,8 +47,7 @@ compiled on your machine.
 Linux, macOS, and Windows via WSL2. `LABWIRED_VERSION=` pins a release,
 `LABWIRED_INSTALL_DIR=` sets the install directory, `LABWIRED_FROM_SOURCE=1` builds from
 source. To read the installer first:
-`curl -fsSL https://raw.githubusercontent.com/w1ne/labwired-core/main/scripts/install.sh -o install.sh`, review it, then
-`sh install.sh`.
+`curl -fsSL https://labwired.com/install.sh -o install.sh`, review it, then `sh install.sh`.
 
 ## Three ways to drive it
 


### PR DESCRIPTION
w1ne/labwired-landing#187 is merged and deployed, so `https://labwired.com/install.sh` resolves again. Switches the README's two install references back from the raw.githubusercontent.com fallback #700 introduced.

Verified end to end with the README command exactly as written:

```
$ curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 LABWIRED_INSTALL_DIR=/tmp/lwtest sh
→  Downloading prebuilt binary: labwired-v0.21.0-linux-x86_64.tar.gz
✓  Installed prebuilt labwired-dap v0.21.0 → /tmp/lwtest/labwired-dap
✓  Installed prebuilt labwired v0.21.0 → /tmp/lwtest/labwired

$ /tmp/lwtest/labwired --version
labwired-cli 0.21.0

$ /tmp/lwtest/labwired test --script examples/nrf54l15-dk/io-smoke.yaml
nRF54L15 boot OK
core=cortex-m33 rram=1524K ram=256K
uarte20@0x500C6000 gpio2@0x50050400
regs from MDK/SVD, not nRF52
```

So the quickstart works verbatim on a released binary, not just a source build.

## Unrelated finding, not fixed here

The same released v0.21.0 binary cannot run `examples/esp32c3-blinky` from a `main` checkout:

```
ERROR UART type 'esp32c3_uart' (peripheral 'uart0') has no register layout
modelled yet and no `config.profile` set
```

The ESP32-C3 UART model landed after v0.21.0, so that example needs `main`. It is a general skew between a `main` checkout and the pinned release the quickstart installs, not specific to that example, and it does not affect the quickstart itself. Flagging rather than fixing, since the remedy is a product decision — cut a release, or document which examples need `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fmZwKry4MoPnaBrktb2Xa

---
_Generated by [Claude Code](https://claude.ai/code/session_016fmZwKry4MoPnaBrktb2Xa)_