### PR TITLE
feat(wifi-ap): every host via client internet (IP→name)

### DIFF
--- a/crates/core/src/peripherals/esp32c3/virtual_wifi_host_net.rs
+++ b/crates/core/src/peripherals/esp32c3/virtual_wifi_host_net.rs
@@ -34,6 +34,9 @@ struct HostNetState {
     http_pending: VecDeque<PendingHttp>,
     /// Filled HTTP responses (id → raw HTTP/1.1 response bytes).
     http_answers: HashMap<u32, Vec<u8>>,
+    /// Reverse map: resolved A → hostname (client DNS used the real name;
+    /// later TCP to the IP must reconstruct `https://name/...` for host fetch).
+    ip_to_name: HashMap<[u8; 4], String>,
 }
 
 #[derive(Clone, Debug)]
@@ -123,6 +126,14 @@ pub fn poll_dns_requests() -> Vec<PendingDns> {
 pub fn fulfill_dns(id: u32, ips: Vec<[u8; 4]>) {
     let mut s = state().lock().unwrap();
     if let Some(ctx) = s.dns_ctx.remove(&id) {
+        // Remember IP → name so TCP NAT to that A can build a proper URL
+        // (client's own browser then fetches that host — any host, not one API).
+        let name = dns_qname(&ctx.query).unwrap_or_default();
+        if !name.is_empty() {
+            for ip in &ips {
+                s.ip_to_name.insert(*ip, name.clone());
+            }
+        }
         let udp_payload = build_dns_response_from_query(&ctx.query, &ips);
         s.dns_replies.push_back(DnsReplyOut {
             sta_mac: ctx.sta_mac,
@@ -134,6 +145,23 @@ pub fn fulfill_dns(id: u32, ips: Vec<[u8; 4]>) {
     } else {
         s.dns_answers.insert(id, ips);
     }
+}
+
+/// Look up a hostname previously resolved for this IP (browser client DNS).
+pub fn name_for_ip(ip: [u8; 4]) -> Option<String> {
+    state().lock().unwrap().ip_to_name.get(&ip).cloned()
+}
+
+/// Record a name→IP binding (also used when the station uses Host: name).
+pub fn remember_ip_name(ip: [u8; 4], name: &str) {
+    if name.is_empty() {
+        return;
+    }
+    state()
+        .lock()
+        .unwrap()
+        .ip_to_name
+        .insert(ip, name.to_string());
 }
 
 /// DNS replies ready to inject into station inboxes.
@@ -293,6 +321,10 @@ mod tests {
         let replies = take_dns_replies();
         assert_eq!(replies.len(), 1);
         assert!(replies[0].udp_payload.len() > 12);
+        assert_eq!(
+            name_for_ip([93, 184, 216, 34]).as_deref(),
+            Some("example.com")
+        );
         set_bridge_active(false);
     }
 

--- a/crates/core/src/peripherals/esp32c3/virtual_wifi_inet.rs
+++ b/crates/core/src/peripherals/esp32c3/virtual_wifi_inet.rs
@@ -142,23 +142,19 @@ impl EgressTcp {
             } => {
                 req_buf.extend_from_slice(data);
                 if pending_id.is_none() && http_req_complete(req_buf) {
-                    if let Some((method, path, host)) = parse_http_request_line_host(req_buf) {
-                        let scheme = if self.remote_port == 443 {
-                            "https"
-                        } else {
-                            "http"
-                        };
-                        let host = host.split(':').next().unwrap_or(&host);
-                        let url = if path.starts_with("http://") || path.starts_with("https://") {
-                            path.clone()
-                        } else {
-                            format!("{scheme}://{host}{path}")
-                        };
+                    // Build a fetch URL for **whatever host** the station is
+                    // talking to — using Host header, then DNS reverse map,
+                    // then dotted IP. Client browser performs the fetch on the
+                    // user's own network (no LabWired-only allowlist).
+                    if let Some((method, path, url)) =
+                        browser_fetch_target(req_buf, self.remote_ip, self.remote_port)
+                    {
                         *pending_id = Some(virtual_wifi_host_net::enqueue_http(
                             url,
                             method,
                             req_buf.clone(),
                         ));
+                        let _ = path;
                     }
                 }
                 true
@@ -232,7 +228,78 @@ impl EgressTcp {
 
 #[cfg(target_arch = "wasm32")]
 fn http_req_complete(req: &[u8]) -> bool {
-    req.windows(4).any(|w| w == b"\r\n\r\n")
+    // Headers done; for POST/PUT also wait for Content-Length body if present.
+    let Some(sep) = req.windows(4).position(|w| w == b"\r\n\r\n") else {
+        return false;
+    };
+    let head = &req[..sep];
+    let body = &req[sep + 4..];
+    let head_txt = std::str::from_utf8(head).unwrap_or("");
+    let mut content_len: Option<usize> = None;
+    for line in head_txt.split("\r\n") {
+        if let Some(rest) = line
+            .strip_prefix("Content-Length:")
+            .or_else(|| line.strip_prefix("content-length:"))
+        {
+            content_len = rest.trim().parse().ok();
+            break;
+        }
+    }
+    match content_len {
+        Some(n) => body.len() >= n,
+        None => true, // GET/HEAD or unknown length
+    }
+}
+
+/// Resolve method + path + absolute URL for browser `fetch` from a raw request
+/// and the TCP peer the station connected to.
+#[cfg(target_arch = "wasm32")]
+fn browser_fetch_target(
+    req: &[u8],
+    remote_ip: [u8; 4],
+    remote_port: u16,
+) -> Option<(String, String, String)> {
+    let (method, path, host_hdr) = match parse_http_request_line_host(req) {
+        Some(t) => t,
+        None => {
+            // No Host header — still proxy using DNS reverse map / IP.
+            let text = std::str::from_utf8(req).ok()?;
+            let mut parts = text.lines().next()?.split_whitespace();
+            let method = parts.next()?.to_string();
+            let path = parts.next()?.to_string();
+            (method, path, String::new())
+        }
+    };
+    let scheme = if remote_port == 443 { "https" } else { "http" };
+    if path.starts_with("http://") || path.starts_with("https://") {
+        return Some((method, path.clone(), path));
+    }
+    let host_from_hdr = host_hdr.split(':').next().unwrap_or("").trim();
+    let host = if !host_from_hdr.is_empty()
+        && !host_from_hdr
+            .chars()
+            .all(|c| c.is_ascii_digit() || c == '.')
+    {
+        // Prefer hostname from Host: so the browser uses SNI/CORS origin of that host.
+        virtual_wifi_host_net::remember_ip_name(remote_ip, host_from_hdr);
+        host_from_hdr.to_string()
+    } else if let Some(name) = virtual_wifi_host_net::name_for_ip(remote_ip) {
+        name
+    } else if !host_from_hdr.is_empty() {
+        host_from_hdr.to_string()
+    } else {
+        format!(
+            "{}.{}.{}.{}",
+            remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]
+        )
+    };
+    let authority = if remote_port == 80 || remote_port == 443 {
+        host
+    } else {
+        format!("{host}:{remote_port}")
+    };
+    let url = format!("{scheme}://{authority}{path}");
+    Some((method, path, url))
 }
 
 /// Resolve a hostname (or dotted-quad) to IPv4 addresses via the host resolver.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -129,21 +129,53 @@ pub fn wifi_host_fulfill_dns(id: u32, ips_json: &str) {
 }
 
 /// Pending HTTP proxy requests. JSON array of
-/// `{ "id", "url", "method" }`.
+/// `{ "id", "url", "method", "body_b64" }` — any host URL; body is the
+/// request entity after headers (client-side `fetch` uses the user's network).
 #[wasm_bindgen]
 pub fn wifi_host_poll_http_requests() -> String {
     let reqs = labwired_core::peripherals::esp32c3::virtual_wifi_host_net::poll_http_requests();
     let v: Vec<serde_json::Value> = reqs
         .into_iter()
         .map(|r| {
+            let body = r
+                .raw_request
+                .windows(4)
+                .position(|w| w == b"\r\n\r\n")
+                .map(|i| r.raw_request[i + 4..].to_vec())
+                .unwrap_or_default();
             serde_json::json!({
                 "id": r.id,
                 "url": r.url,
                 "method": r.method,
+                "body_b64": b64_encode(&body),
             })
         })
         .collect();
     serde_json::to_string(&v).unwrap_or_else(|_| "[]".into())
+}
+
+fn b64_encode(data: &[u8]) -> String {
+    const T: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(T[((n >> 18) & 63) as usize] as char);
+        out.push(T[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            T[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            T[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
 }
 
 /// Fulfill an HTTP proxy request with a raw HTTP/1.1 response body (status


### PR DESCRIPTION
## Summary
Virtual AP uses the **client's own network** for **every host**:

- DNS A→hostname reverse map so TCP-to-IP rebuilds real URLs for browser fetch
- Full HTTP body wait (Content-Length) before proxy
- body_b64 in host-net poll for POST/PUT

Not limited to api.labwired.com / public-stats.