### PR TITLE
fix(esp32c3): USB-CDC Serial → uart_contains (universal Arduino)

### DIFF
--- a/crates/cli/src/commands/esp32_boot_state.rs
+++ b/crates/cli/src/commands/esp32_boot_state.rs
@@ -168,6 +168,17 @@ pub fn install_esp32c3_fast_boot(bus: &mut SystemBus, firmware_path: &Path) {
             MMU_FMT_C3,
         )),
     );
+    // USB-Serial-JTAG (0x6004_3000): Arduino `Serial` with USB_CDC_ON_BOOT
+    // prints here, not UART0. Without this, uart_contains stays empty for
+    // stock USB-CDC sketches. Sink is attached later by the test runner so
+    // capture shares the same buffer as UART0.
+    bus.replace_or_add_peripheral(
+        "usb_serial_jtag",
+        0x6004_3000,
+        0x100,
+        None,
+        Box::new(labwired_core::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag::new()),
+    );
     bus.config.optimized_bus_access = false;
     // FreeRTOS first yield needs FROM_CPU matrix → riscv_irq_lines.
     bus.esp32c3_irq_routing = true;

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -1211,6 +1211,21 @@ pub(crate) fn run_test(args: TestArgs) -> ExitCode {
     } else {
         bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
     }
+    // ESP32-C3 / S3: Arduino USB-CDC `Serial` writes USB_SERIAL_JTAG, not UART0.
+    // Mirror those bytes into the same uart_tx buffer so uart_contains works for
+    // stock sketches (no dual Serial0 prints required).
+    {
+        use labwired_core::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag;
+        for p in bus.peripherals.iter_mut() {
+            if p.name == "usb_serial_jtag" {
+                if let Some(any) = p.dev.as_any_mut() {
+                    if let Some(jtag) = any.downcast_mut::<UsbSerialJtag>() {
+                        jtag.set_sink(Some(uart_tx.clone()), !args.no_uart_stdout);
+                    }
+                }
+            }
+        }
+    }
     // Let any attached IO-Link master record what it received over IO-Link into
     // the same captured buffer, so `uart_contains` can assert on the MASTER
     // side (MASTER PD= / MASTER VERDICT / MASTER EVENT), not just the device


### PR DESCRIPTION
## Summary
Arduino-on-C3 with `USB_CDC_ON_BOOT` uses **USB_SERIAL_JTAG** for `Serial`, not UART0. Twin `uart_contains` only saw UART0, so stock sketches failed on twin while desk USB worked.

### Changes
- `install_esp32c3_fast_boot`: add `usb_serial_jtag` peripheral
- `labwired test`: attach JTAG TX to the same capture sink as UART0

## Why
Universal same-binary loop: normal `Serial.println` only — no `Serial0` dual-print, no bare-metal demo ELF.

## Test plan
- [x] Build labwired-cli with this change
- [ ] `validation/arduino-matrix` esp32c3 L0 with CDC sketch / agent c3-dev-cycle twin path
- [ ] Confirm L0–L2 matrix still green