### PR TITLE
fix(nrf52840): map Nordic errata probe window at 0xF0000000

### DIFF
--- a/configs/chips/nrf52840.yaml
+++ b/configs/chips/nrf52840.yaml
@@ -7,6 +7,16 @@ flash:
 ram:
   base: 0x20000000
   size: "256KB"
+# Nordic nRF5 SDK / ArduinoCore-nRF5 errata probes read a reserved silicon
+# fingerprint window at 0xF0000FE0 (nrf52_errata_16 etc.). On real die this
+# returns a package/rev code; unmapped, the sim records unmapped_mmio and the
+# hosted verify classifier refuses proven:true even when UART acceptance
+# already passed. Map a tiny zero-filled window so "not this rev" is honest —
+# same pattern as configs/chips/nrf52832.yaml.
+memory_regions:
+  - name: "nrf_errata_probe"
+    base: 0xF0000000
+    size: "4KB"
 peripherals:
   - id: "uart0"
     type: "nrf52840_uart"


### PR DESCRIPTION
## Summary
Hosted multi-chip prove for nRF52840 was getting serial `LED ON` and `assertions_passed`, but `classifyModelVerification` failed with `unmapped_mmio` at `0xF0000FE0` (ArduinoCore-nRF5 errata probe).

## Fix
Map the same zero-filled `memory_regions` window nRF52832 already has so the probe is not an unmapped gap.

## Test plan
- [ ] Rebuild builder image with this core pin
- [ ] Hosted nRF LED starter → Verified live