### PR TITLE
feat(config): optional wifi_ap password field

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -289,6 +289,12 @@ pub struct WifiApManifest {
     /// What the AP's HTTP origin serves: "labwired-stats" (default) or "none".
     #[serde(default = "default_wifi_ap_serves")]
     pub serves: String,
+    /// Optional network password (PSK). Empty / absent = open AP.
+    /// Stored so labs can record credentials that match firmware
+    /// `WiFi.begin(ssid, password)`; the frame-level virtual AP does not
+    /// model a WPA handshake yet — association still behaves as open.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub password: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/crates/core/src/system/wifi.rs
+++ b/crates/core/src/system/wifi.rs
@@ -138,4 +138,21 @@ mod tests {
         );
         assert_eq!(wifi_ap_station_mac(&manifest(false)), None);
     }
+
+    #[test]
+    fn optional_password_parses_and_is_ignored_by_attach() {
+        // Password is stored for people to match firmware credentials; attach
+        // still succeeds (no WPA modelling). Empty/absent password remains open.
+        let with_pw = SystemManifest::from_yaml(
+            "name: t\nchip: esp32c3\nwifi_ap:\n  ssid: home\n  password: s3cret\n  ip: 192.168.4.1\n  serves: none\n",
+        )
+        .expect("valid manifest with password");
+        assert_eq!(with_pw.wifi_ap.as_ref().unwrap().password, "s3cret");
+        let mut bus = bus_with_c3_mac();
+        attach_configured_wifi_ap(&mut bus, &with_pw);
+        assert!(mac_needs_bus_tick(&mut bus), "password does not block attach");
+
+        let open = manifest(true);
+        assert_eq!(open.wifi_ap.as_ref().unwrap().password, "");
+    }
 }


### PR DESCRIPTION
Adds an optional `password` (PSK) to the `wifi_ap:` manifest block so a lab can record credentials matching its firmware's `WiFi.begin(ssid, password)`.

**Explicitly not a WPA model.** The frame-level virtual AP associates without a handshake, so `attach_configured_wifi_ap` succeeds regardless of the value — the new test asserts exactly that, so nobody later mistakes it for enforcement.

- `#[serde(default, skip_serializing_if = "String::is_empty")]` keeps existing open-AP manifests byte-identical.
- Empty / absent ⇒ open AP, unchanged behaviour.

Tests: `cargo test -p labwired-config -p labwired-core --lib wifi` → 24 passed, 0 failed.