### PR TITLE
Correct the weather-station build docs: GxEPD2 must be declared

### DIFF
--- a/examples/esp32c3-weather-station/README.md
+++ b/examples/esp32c3-weather-station/README.md
@@ -80,5 +80,27 @@ in core (2026-06-28); this lab must use the same lock.
 
 ## Build
 
-Arduino-ESP32 + `zinggjm/GxEPD2` (inferred from `#include <GxEPD2_3C.h>` on hosted compile).
-Or paste `src/main.ino` into the LabWired weather-station project and flash.
+Arduino-ESP32 + `zinggjm/GxEPD2`. The library is **not** inferred from the
+`#include` — you have to declare it, or the build stops at
+`GxEPD2_3C.h: No such file or directory`.
+
+Hosted compile — pass it in `lib_deps`:
+
+```json
+{ "board": "esp32-c3-supermini", "language": "arduino",
+  "entryPath": "src/main.ino", "lib_deps": ["zinggjm/GxEPD2"] }
+```
+
+Locally with PlatformIO:
+
+```ini
+[env:esp32c3]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+lib_deps = zinggjm/GxEPD2
+```
+
+That pulls Adafruit GFX and BusIO as dependencies and builds clean (~780 KB
+flash, 60% of a 4 MB part). Or paste `src/main.ino` into the LabWired
+weather-station project and flash.


### PR DESCRIPTION
The README claimed `zinggjm/GxEPD2` was "inferred from `#include <GxEPD2_3C.h>` on hosted compile". It isn't — that line was carried over from the older stats-display README and is wrong.

Verified against the running builder. Without `lib_deps` the compile fails in ~2 seconds:

```
src/main.ino:2:10: fatal error: GxEPD2_3C.h: No such file or directory
========================== [FAILED] Took 2.05 seconds ==========================
```

With `lib_deps: ["zinggjm/GxEPD2"]` it returns HTTP 200 and valid flash images.

So anyone following the old text hit a confusing failure on their first build. This gives both working recipes: the `lib_deps` field for a hosted compile, and a `platformio.ini` for a local one (verified locally — clean build, ~780 KB flash).