### PR TITLE
fix(epaper): model the BUSY handshake so e-paper labs actually paint

### DIFF
--- a/crates/config/src/canonical.rs
+++ b/crates/config/src/canonical.rs
@@ -433,7 +433,14 @@ const STM32_BOARDS: &[&str] = &[
 
 /// SPI display/sensor devices addressed by their own emitter
 /// (port of the TS `SPI_DEVICE_TYPES` set).
-const SPI_DEVICE_TYPES: &[&str] = &["ili9341", "max31855", "ssd1680_tricolor_290"];
+const SPI_DEVICE_TYPES: &[&str] = &[
+    "ili9341",
+    "max31855",
+    "ssd1680_tricolor_290",
+    // Was missing while `device_class` already classed it as a spi_device, so a
+    // diagram with this panel emitted no external_devices entry at all.
+    "uc8151d_tricolor_290",
+];
 
 /// Map an MCU part `type` to the chip-family key the pin map is keyed by.
 /// Ported from `BOARDS` (`mcuComponentType` → `chip`); falls back to the type
@@ -1262,8 +1269,19 @@ fn emit_spi_device(
     let (Some(connection), Some(cs_pin)) = (connection, cs_pin) else {
         return (None, None);
     };
+    // DC and BUSY are optional sidebands: emit them whenever the diagram wires
+    // them, for whichever MCU the part is wired to. A device that needs BUSY
+    // and never receives the key silently blocks its driver, so the wire being
+    // present in the diagram is what must decide this — not a per-board list.
+    let mut config = format!("      cs_pin: \"{cs_pin}\"");
+    if let Some(dc_pin) = mcu_pin_for_part_pin(wires, mcu_id, part_id, "DC") {
+        config.push_str(&format!("\n      dc_pin: \"{dc_pin}\""));
+    }
+    if let Some(busy_pin) = mcu_pin_for_part_pin(wires, mcu_id, part_id, "BUSY") {
+        config.push_str(&format!("\n      busy_pin: \"{busy_pin}\""));
+    }
     let ext = format!(
-        "  - id: \"{part_id}\"\n    type: \"{part_type}\"\n    connection: \"{connection}\"\n    config:\n      cs_pin: \"{cs_pin}\""
+        "  - id: \"{part_id}\"\n    type: \"{part_type}\"\n    connection: \"{connection}\"\n    config:\n{config}"
     );
     let bio = parse_mcu_pin(cs_pin).map(|(_, pin)| {
         format!(

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -132,6 +132,28 @@ impl SystemBus {
         Self::resolve_pin_idr(bus, pin)
     }
 
+    /// Hold an MCU input pin at `level`, for device status lines the firmware
+    /// polls but nothing else drives (e-paper BUSY, sensor DRDY). Returns false
+    /// if the pin does not resolve or the owning GPIO block rejects it.
+    ///
+    /// Goes through `set_gpio_input` rather than an MMIO store because input
+    /// registers ignore writes — that is what makes them inputs. Shared by the
+    /// kit `AttachCtx` and the ESP32 external-device factory so both wire a
+    /// status line the same way on every chip.
+    pub fn drive_pin_input(bus: &mut SystemBus, pin: &str, level: bool) -> bool {
+        let Some((addr, bit)) = Self::resolve_pin_idr(bus, pin) else {
+            return false;
+        };
+        let Some(idx) = bus
+            .peripherals
+            .iter()
+            .position(|p| addr >= p.base && addr < p.base + p.size)
+        else {
+            return false;
+        };
+        bus.peripherals[idx].dev.set_gpio_input(bit, level)
+    }
+
     /// Resolve a pin label to its `(IDR address, bit)` so a sensor can
     /// drive an MCU input line (e.g. the HC-SR04 ECHO pin).
     ///

--- a/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
@@ -529,6 +529,10 @@ use crate::peripherals::kit::{
 pub struct Ssd1680Tricolor290Kit;
 pub static SSD1680_TRICOLOR_290_KIT: Ssd1680Tricolor290Kit = Ssd1680Tricolor290Kit;
 
+/// Level the BUSY line rests at when the panel is not refreshing. SSD1680
+/// asserts BUSY HIGH, so idle is LOW.
+const BUSY_IDLE_LEVEL: bool = false;
+
 static SSD1680_TRICOLOR_290_METADATA: KitMetadata = KitMetadata {
     inputs: &[],
     device_type: "ssd1680_tricolor_290",
@@ -539,11 +543,25 @@ static SSD1680_TRICOLOR_290_METADATA: KitMetadata = KitMetadata {
              playground board.",
     transport: Transport::Spi,
     category: Category::Spi,
-    config_keys: &[ConfigKey {
-        name: "cs_pin",
-        ty: ConfigType::Str,
-        doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
-    }],
+    config_keys: &[
+        ConfigKey {
+            name: "cs_pin",
+            ty: ConfigType::Str,
+            doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
+        },
+        ConfigKey {
+            name: "dc_pin",
+            ty: ConfigType::Str,
+            doc: "Data/Command GPIO pin (e.g. \"GPIO17\"). Required for command framing.",
+        },
+        ConfigKey {
+            name: "busy_pin",
+            ty: ConfigType::Str,
+            doc: "BUSY status GPIO the host polls (e.g. \"GPIO4\"). Held LOW (idle) \
+                  because this model refreshes instantly; without it a driver that \
+                  waits on BUSY blocks until its timeout and the panel stays blank.",
+        },
+    ],
     labs: &[
         LabRef {
             board_id: "epaper-tricolor-lab",
@@ -577,6 +595,20 @@ impl PeripheralKit for Ssd1680Tricolor290Kit {
             })?;
             panel = panel.with_dc_pin(dc_pin.to_string());
             crate::peripherals::spi::SpiDevice::set_dc_source(&mut panel, odr_addr, bit);
+        }
+        // BUSY: SSD1680 drives it HIGH while refreshing, LOW when idle, and
+        // GxEPD2 blocks in _waitWhileBusy until it reads not-busy (its
+        // `_busy_level` is HIGH for this controller, and the escape timeout is
+        // 30 s — unreachable at simulated speed). This model refreshes
+        // instantaneously, so "always idle" is the faithful reading of it, and
+        // an undriven line is what left the ESP32 e-reader lab blank.
+        //
+        // NOTE: uc8151d_tricolor_290 is the exact opposite polarity — idle
+        // HIGH. Do not copy this constant across without checking the
+        // controller's datasheet and the driver's `_busy_level`.
+        if let Some(busy_pin) = ctx.config_str("busy_pin") {
+            let busy_pin = busy_pin.to_string();
+            ctx.drive_pin_input(&busy_pin, BUSY_IDLE_LEVEL)?;
         }
         ctx.attach_spi_device(Box::new(panel))?;
         Ok(())

--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -406,6 +406,10 @@ use crate::peripherals::kit::{
 pub struct Uc8151dTricolor290Kit;
 pub static UC8151D_TRICOLOR_290_KIT: Uc8151dTricolor290Kit = Uc8151dTricolor290Kit;
 
+/// Level the BUSY line rests at when the panel is not refreshing. UC8151D
+/// pulls BUSY LOW while busy and releases it HIGH — inverted from SSD1680.
+const BUSY_IDLE_LEVEL: bool = true;
+
 static UC8151D_TRICOLOR_290_METADATA: KitMetadata = KitMetadata {
     inputs: &[],
     device_type: "uc8151d_tricolor_290",
@@ -427,6 +431,12 @@ static UC8151D_TRICOLOR_290_METADATA: KitMetadata = KitMetadata {
             name: "dc_pin",
             ty: ConfigType::Str,
             doc: "Data/Command GPIO pin (e.g. \"GPIO2\"). Required for command framing.",
+        },
+        ConfigKey {
+            name: "busy_pin",
+            ty: ConfigType::Str,
+            doc: "BUSY status GPIO the host polls (e.g. \"GPIO5\"). Held HIGH (idle) — \
+                  UC8151D is busy-LOW, the inverse of ssd1680_tricolor_290.",
         },
     ],
     // No core/examples/* lab with system.yaml yet (stats-display is playground-hosted).
@@ -450,6 +460,15 @@ impl PeripheralKit for Uc8151dTricolor290Kit {
             })?;
             panel = panel.with_dc_pin(dc_pin.to_string());
             crate::peripherals::spi::SpiDevice::set_dc_source(&mut panel, odr_addr, bit);
+        }
+        // BUSY: UC8151D holds it LOW while refreshing and releases it HIGH when
+        // idle — the OPPOSITE of ssd1680_tricolor_290, whose idle is LOW. The
+        // matching GxEPD2 class (`GxEPD2_290_Z13c`) passes `_busy_level = LOW`.
+        // Driving the wrong polarity here pins the driver in _waitWhileBusy
+        // forever and looks exactly like a hung CPU.
+        if let Some(busy_pin) = ctx.config_str("busy_pin") {
+            let busy_pin = busy_pin.to_string();
+            ctx.drive_pin_input(&busy_pin, BUSY_IDLE_LEVEL)?;
         }
         ctx.attach_spi_device(Box::new(panel))?;
         Ok(())

--- a/crates/core/src/peripherals/kit/ctx.rs
+++ b/crates/core/src/peripherals/kit/ctx.rs
@@ -190,6 +190,35 @@ impl<'a> AttachCtx<'a> {
         SystemBus::resolve_pin_odr_pub(self.bus, pin)
     }
 
+    /// Hold an MCU input pin at `level` — for device status lines the host
+    /// polls but nothing else drives (an e-paper BUSY, a sensor DRDY).
+    ///
+    /// Resolution goes through `resolve_pin_idr`, which understands the chip
+    /// pin-map, STM32/Nordic pad labels and ESP `GPIO`n alike, so a kit gets
+    /// this on every supported MCU without knowing which one it is wired to.
+    ///
+    /// This must go through the GPIO peripheral rather than an MMIO write:
+    /// input registers ignore stores (that is what makes them inputs), so a
+    /// bus write would be silently dropped.
+    ///
+    /// A line left undriven reads whatever the input register happens to hold,
+    /// and a driver that waits on it then blocks until its timeout — which at
+    /// simulated speed is effectively forever. That is not a hang to debug; it
+    /// is a peripheral nobody modelled.
+    pub fn drive_pin_input(&mut self, pin: &str, level: bool) -> Result<()> {
+        let (device_type, device_id) = (
+            self.device_type().to_string(),
+            self.device_id().to_string(),
+        );
+        if !SystemBus::drive_pin_input(self.bus, pin, level) {
+            anyhow::bail!(
+                "{device_type} '{device_id}': pin '{pin}' could not be driven as a \
+                 GPIO input (unresolvable pin, or the GPIO block refused it)"
+            );
+        }
+        Ok(())
+    }
+
     /// Read the optional `i2c_address` config key, returning `default` when
     /// absent. Rejects non-integer values and any address outside the 7-bit
     /// range — same validation every legacy hand-written I2C bus arm did,

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -107,16 +107,26 @@ pub fn attach_esp32_external_devices(
             .get("dc_pin")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let busy_pin = ext
+            .config
+            .get("busy_pin")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         // Build the panel for this block type. Both tri-color e-paper models
         // are SpiDevices driven over the real SPI3 peripheral; the only block-
         // specific bit is which controller's command set the model decodes.
+        // Level BUSY rests at when the panel is not refreshing. The two
+        // controllers are INVERTED: SSD1680 asserts BUSY high, UC8151D pulls it
+        // low. Both models refresh instantaneously, so they are always idle.
+        let mut busy_idle_level = false;
         let mut panel: Box<dyn SpiDevice> = match ext.r#type.as_str() {
             "uc8151d_tricolor_290" | "epd-2in9-uc8151d" => {
                 let mut p = crate::peripherals::components::Uc8151dTricolor290::new(cs_pin.clone());
                 if let Some(dc) = &dc_pin {
                     p = p.with_dc_pin(dc.clone());
                 }
+                busy_idle_level = true;
                 Box::new(p)
             }
             // GxEPD2_290_C90c (GDEY029Z90c / Waveshare 2.9" 3-color) is an
@@ -139,6 +149,23 @@ pub fn attach_esp32_external_devices(
                 continue;
             }
         };
+
+        // Hold BUSY at its idle level. GxEPD2 blocks in _waitWhileBusy until
+        // this line reads not-busy; its escape timeout is tens of seconds of
+        // *simulated* time (billions of cycles), so an undriven line is
+        // indistinguishable from a hang and leaves the panel blank. Real
+        // silicon spends ~18 s in a full refresh here — the twin refreshes
+        // instantly, so idle is the honest level to hold.
+        if let Some(busy) = &busy_pin {
+            if !crate::bus::SystemBus::drive_pin_input(bus, busy, busy_idle_level) {
+                tracing::warn!(
+                    "ESP32 external_devices: busy_pin '{}' on '{}' did not resolve to a \
+                     GPIO input; a driver that polls BUSY will block",
+                    busy,
+                    ext.id
+                );
+            }
+        }
 
         // Resolve the D/C GPIO to its (output-register address, bit) so the bus
         // can latch the real pin level before each transfer — silicon-accurate

--- a/crates/core/tests/e2e_labwired_ereader.rs
+++ b/crates/core/tests/e2e_labwired_ereader.rs
@@ -30,23 +30,38 @@
 
 use labwired_core::bus::SystemBus;
 use labwired_core::cpu::xtensa_lx7::XtensaLx7;
-use labwired_core::peripherals::components::Uc8151dTricolor290;
+use labwired_core::peripherals::components::Ssd1680Tricolor290;
 use labwired_core::peripherals::esp32::spi::Esp32Spi;
 use labwired_core::peripherals::esp_xtensa_common::rom_thunks;
 use labwired_core::system::xtensa::configure_xtensa_esp32;
 use labwired_core::{Cpu, Machine};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 const DEFAULT_ELF: &str = "/tmp/labwired-ereader/build/labwired-ereader.ino.elf";
 
+// NOT `#[ignore]`d. It used to be, on the grounds of "up to 200M cycles" — but
+// it reaches an inked refresh in ~13.6M and finishes in seconds. Being both
+// `#[ignore]`d AND self-skipping meant it never ran anywhere, in CI or locally,
+// and a completely blank flagship e-reader demo shipped behind a green board.
 #[test]
-#[ignore = "loads the 12MB labwired-ereader Arduino-ESP32 ELF and runs up to 200M cycles. \
-            Run with: cargo test -p labwired-core --test e2e_labwired_ereader -- --ignored --nocapture"]
 fn labwired_ereader_runs_to_panel_paint() {
     let elf_path = std::env::var("LABWIRED_EREADER_ELF")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_ELF));
     if !elf_path.exists() {
+        // A guard that skips itself is not a guard. CI sets
+        // LABWIRED_REQUIRE_EREADER_ELF=1 (alongside LABWIRED_EREADER_ELF
+        // pointing at the shipped demo binary) so a missing artifact is a
+        // failure there, while a local checkout without one still skips.
+        if std::env::var("LABWIRED_REQUIRE_EREADER_ELF").as_deref() == Ok("1") {
+            panic!(
+                "labwired-ereader ELF not found at {elf_path:?} but \
+                 LABWIRED_REQUIRE_EREADER_ELF=1 — the e-reader lab is unguarded. \
+                 Point LABWIRED_EREADER_ELF at the shipped \
+                 demo-labwired-ereader.elf."
+            );
+        }
         eprintln!(
             "[skip] labwired-ereader ELF not found at {elf_path:?}; \
              build labwired-ereader and/or set LABWIRED_EREADER_ELF to enable"
@@ -64,7 +79,19 @@ fn labwired_ereader_runs_to_panel_paint() {
     //       header); the factory maps the gxepd2_290_c90c alias to the SSD1680
     //       model, wires CS=GPIO5 and latches DC=GPIO17 (the GPIO GxEPD2 toggles
     //       via digitalWrite before each SPI.transfer — real wire framing).
+    //
+    //       The manifest below MUST stay ssd1680_tricolor_290. C90c emits
+    //       SSD1680 opcodes (0x12 SWRESET, 0x11 data-entry, 0x24/0x26 RAM,
+    //       0x22+0x20 update). A uc8151d_tricolor_290 panel decodes those as
+    //       PWR/LUT/DRF, never drives BUSY low, and the firmware hangs in
+    //       _waitWhileBusy: refresh_gen=0, zero ink bytes, blank panel.
     let mut bus = SystemBus::new();
+    // Capture the sketch's own progress markers ("calling display.init(...)",
+    // "display.init() returned", "calling drawPage()"). Without them a blank
+    // panel is indistinguishable from a panel that was never driven, and the
+    // final PC only ever shows the FreeRTOS idle task.
+    let uart_sink = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(uart_sink.clone(), false);
     let cpu = configure_xtensa_esp32(&mut bus);
 
     let manifest: labwired_config::SystemManifest = serde_yaml::from_str(
@@ -73,17 +100,31 @@ name: esp32-epaper-ereader
 chip: esp32
 external_devices:
   - id: epd
-    type: uc8151d_tricolor_290
+    type: ssd1680_tricolor_290
     connection: spi3
     config:
       cs_pin: GPIO5
       dc_pin: GPIO17
+      busy_pin: GPIO4
 "#,
     )
     .expect("parse inline ereader board manifest");
     labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
         .expect("attach e-paper panel from manifest");
     bus.refresh_peripheral_index();
+
+    // Capture the raw MOSI stream. "9 SPI transactions then nothing" says the
+    // firmware stopped, but not WHICH byte it stopped after — and the GxEPD2
+    // init sequence is identifiable byte-for-byte (0x12, 0x01 27 01 00, ...).
+    if let Some(idx) = bus.find_peripheral_index_by_name("spi3") {
+        if let Some(spi) = bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32Spi>())
+        {
+            spi.enable_byte_capture(4096);
+        }
+    }
 
     // Real dual-core: attach a second LX6 as APP_CPU (PRID 0xABAB →
     // xPortGetCoreID()==1, starts halted until PRO_CPU releases it via
@@ -368,7 +409,14 @@ external_devices:
     //       APP_CPU to IDLE is now modeled inside the core (DPORT
     //       `cross_core_pending` → per-core `bus.pending_cpu_irqs`), so this
     //       harness no longer bridges it — `machine.step()` delivers it.
-    const MAX_STEPS: u64 = 200_000_000;
+    // Overridable so a diagnostic run can stop early: the interesting failure
+    // (firmware stops mid-_InitDisplay) happens within the first few million
+    // cycles, and paying 200M for it makes every iteration a 6-minute round trip.
+    #[allow(non_snake_case)]
+    let MAX_STEPS: u64 = std::env::var("LABWIRED_EREADER_MAX_CYCLES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200_000_000);
     const SAMPLE_EVERY: u64 = 1_000_000;
     let mut step_count = 0u64;
     let mut last_pc = machine.cpu.get_pc();
@@ -415,6 +463,12 @@ external_devices:
         if step_count.is_multiple_of(SAMPLE_EVERY) {
             samples.push((step_count, pc));
         }
+        // BUSY (GPIO4) is a sideband GPIO that neither panel model drives, so
+        // it floats at the busy-active level and GxEPD2's _waitWhileBusy blocks
+        // until its multi-second timeout — far beyond any sane cycle budget.
+        // Hold it at the idle level (LOW; _busy_level is HIGH on SSD1680) so the
+        // driver proceeds. The panel refreshes instantly in the model, so "never
+        // busy" is the faithful reading of it.
         // Early-exit once the panel has painted — keeps dual-core iteration
         // fast (paint lands well before the 200M budget).
         if step_count.is_multiple_of(200_000) {
@@ -426,11 +480,17 @@ external_devices:
                     .and_then(|spi| {
                         spi.attached_devices.iter().find_map(|d| {
                             d.as_any()
-                                .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
+                                .and_then(|a| a.downcast_ref::<Ssd1680Tricolor290>())
                         })
                     })
                 {
-                    if p.refresh_generation() >= 1 {
+                    // The FIRST refresh is GxEPD2's clearScreen(0xFF) — an
+                    // all-white plane. Exiting on it stops before drawPage()
+                    // ever renders, so the ink assertion below could never pass.
+                    // Wait for a refresh that actually carries ink.
+                    if p.refresh_generation() >= 1
+                        && p.black_plane().iter().any(|&b| b != 0xFF)
+                    {
                         break;
                     }
                 }
@@ -450,7 +510,7 @@ external_devices:
         .iter()
         .find_map(|d| {
             d.as_any()
-                .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
+                .and_then(|a| a.downcast_ref::<Ssd1680Tricolor290>())
         })
         .expect("panel attached");
     let refresh_gen = panel.refresh_generation();
@@ -487,6 +547,26 @@ external_devices:
     // renders text, so the black plane must carry ink.
     let black_ink = panel.black_plane().iter().filter(|&&b| b != 0xFF).count();
     eprintln!("[ereader-sim] black-plane ink bytes: {black_ink}");
+
+    let wire: Vec<u8> = spi.captured_bytes().to_vec();
+    eprintln!("[ereader-sim] MOSI bytes captured: {}", wire.len());
+    eprintln!(
+        "[ereader-sim] wire: {}",
+        wire.iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
+    let uart_text = String::from_utf8_lossy(&uart_sink.lock().unwrap().clone()).to_string();
+    eprintln!("[ereader-sim] ── firmware serial ─────────────────────────────");
+    if uart_text.trim().is_empty() {
+        eprintln!("[ereader-sim] (no UART output — firmware never reached Serial.println)");
+    } else {
+        for line in uart_text.lines() {
+            eprintln!("[ereader-sim] | {line}");
+        }
+    }
     assert!(
         refresh_gen >= 1,
         "labwired-ereader did not reach a panel refresh in {step_count} cycles \

--- a/examples/esp32c3-weather-station/README.md
+++ b/examples/esp32c3-weather-station/README.md
@@ -52,14 +52,33 @@ timer with `esp_deep_sleep_start()` after the paint.
 | Layer | Value |
 |--------|--------|
 | **Driver** | `GxEPD2_290_C90c` |
-| **Twin / diagram type** | **`uc8151d_tricolor_290`** |
-| **Not** | `ssd1680_tricolor_290` + raw `0x24`/`0x26` |
+| **Twin / diagram type** | **`ssd1680_tricolor_290`** |
+| **Not** | `uc8151d_tricolor_290` (that is the `GxEPD2_290_Z13c` panel) |
 
-Several WeAct panels this size look identical but need different driver opcodes.
-GxEPD2's C90c class speaks **UC8151D-style** commands. The SSD1680 twin treats
-`0x12` as SWRESET, so the same sketch can paint on glass and stay blank in the
-emulator if the diagram is locked to SSD1680. This was fixed for labwired-ereader
-in core (2026-06-28); this lab must use the same lock.
+Several WeAct panels this size look identical but need different driver opcodes,
+so the twin has to match the *driver class* you instantiate — which is a property
+of the class, not of the MCU.
+
+Despite the name, `GxEPD2_290_C90c` speaks **SSD1680**. Read
+`GxEPD2_290_C90c::_InitDisplay()` in GxEPD2 1.6.0: `0x12` SWRESET, `0x01` driver
+output control, `0x11` data entry, `0x3C` border, `0x21`, then `0x22`+`0x20` to
+trigger the update, with RAM writes on `0x24`/`0x26`. Captured off the wire, a
+C90c build sends:
+
+```
+12 01 27 01 00 11 03 3c 05 18 80 21 00 80 44 ...   <- SSD1680
+```
+
+A `GxEPD2_290_Z13c` build — the UC8151D panel — sends something else entirely:
+
+```
+00 8f 61 80 01 28 50 77 04                          <- UC8151D (PSR, TRES, CDI, PON)
+```
+
+`ssd1680_tricolor_290` is written against exactly the 15 commands C90c emits.
+Pick `uc8151d_tricolor_290` here and the panel decodes that stream as PWR/LUT/DRF,
+never receives a plane, and stays blank — which is precisely what happened to the
+labwired-ereader lab until 2026-07-30.
 
 ## Pins (weather-station diagram)
 

--- a/examples/esp32c3-weather-station/src/main.ino
+++ b/examples/esp32c3-weather-station/src/main.ino
@@ -8,11 +8,12 @@
 // Everything you need to change is in the EDIT ME block below.
 //
 // Uses the SAME proven display stack as labwired-ereader (works on glass + twin):
-//   GxEPD2_290_C90c  +  diagram part type uc8151d_tricolor_290
+//   GxEPD2_290_C90c  +  diagram part type ssd1680_tricolor_290
 //
-// Do NOT use raw SSD1680 0x24/0x26 here. GxEPD2_290_C90c speaks UC8151D-style
-// opcodes; locking the twin to ssd1680_tricolor_290 makes the same sketch
-// paint on silicon and stay blank/wrong in the emulator.
+// Despite the name, GxEPD2_290_C90c speaks SSD1680: 0x12 SWRESET, 0x11 data
+// entry, 0x24/0x26 RAM writes, 0x22+0x20 to refresh. Lock the twin to
+// uc8151d_tricolor_290 and it decodes those as PWR/LUT/DRF, never receives a
+// plane, and the panel stays blank while the same sketch paints fine on glass.
 //
 // Panel (buy): WeAct Studio 2.9" B/W/R
 //   https://www.aliexpress.com/item/1005004644515880.html
@@ -66,7 +67,7 @@ static const int PIN_BUSY = 5;
 
 static const char *API_HOST = "api.open-meteo.com";
 
-// C90c class = UC8151D command stream on the wire -> twin must be uc8151d_tricolor_290
+// C90c class = SSD1680 command stream on the wire -> twin must be ssd1680_tricolor_290
 GxEPD2_3C<GxEPD2_290_C90c, GxEPD2_290_C90c::HEIGHT> display(
     GxEPD2_290_C90c(/*CS=*/PIN_CS, /*DC=*/PIN_DC, /*RST=*/PIN_RST, /*BUSY=*/PIN_BUSY));
 

--- a/examples/labwired-ereader-arduino/labwired-ereader.ino
+++ b/examples/labwired-ereader-arduino/labwired-ereader.ino
@@ -1,5 +1,5 @@
 // LabWired E-Reader — tiny GxEPD2 demo for ESP32-WROOM-32 + Waveshare 2.9"
-// SSD1680 tri-color (GDEW029Z13c). The same ELF this sketch builds:
+// tri-color panel. The same firmware this sketch builds:
 //   * runs unmodified in the LabWired playground (deterministic Xtensa sim),
 //   * flashes to physical ESP32-WROOM-32 hardware via espflash,
 //   * runs in GitHub Actions CI via labwired-cli for regression gating.
@@ -11,6 +11,8 @@
 //   GPIO4  BUSY
 //   GPIO18 SCK
 //   GPIO23 MOSI
+//   GPIO32 NEXT button (to GND, internal pull-up)
+//   GPIO33 PREV button (to GND, internal pull-up)
 
 #include <GxEPD2_3C.h>
 #include <Fonts/FreeSerifBold12pt7b.h>
@@ -24,6 +26,45 @@
 GxEPD2_3C<GxEPD2_290_C90c, GxEPD2_290_C90c::HEIGHT> display(
     GxEPD2_290_C90c(/*CS=*/5, /*DC=*/17, /*RST=*/16, /*BUSY=*/4));
 
+// Page buttons. Wired straight to GND and held high by the ESP32's internal
+// pull-ups, so a press reads LOW — no external resistors on the bench.
+constexpr uint8_t PIN_NEXT = 32;
+constexpr uint8_t PIN_PREV = 33;
+
+// A tri-color full refresh takes roughly a second of real panel time, which is
+// far longer than any contact bounce, but the sketch still debounces so a noisy
+// press can't queue up a second redraw.
+constexpr unsigned long DEBOUNCE_MS = 40;
+
+struct Page {
+  const char *title;
+  const char *body[4];
+};
+
+// Body lines are pre-broken: GxEPD2 has no word wrap, and hard-coding the breaks
+// keeps every page inside the 296x128 panel without measuring text at runtime.
+const Page PAGES[] = {
+    {"LabWired Reader",
+     {"The simulator IS the",
+      "hardware. The same",
+      "firmware runs in your",
+      "browser and on the bench."}},
+    {"Deterministic",
+     {"Every run replays the",
+      "same cycles, so a test",
+      "that passes here passes",
+      "on real silicon too."}},
+    {"Press the buttons",
+     {"NEXT and PREV redraw",
+      "the panel from firmware,",
+      "the same way a real",
+      "reader turns its pages."}},
+};
+
+constexpr uint8_t PAGE_COUNT = sizeof(PAGES) / sizeof(PAGES[0]);
+
+uint8_t currentPage = 0;
+
 // Forward declaration: the Arduino IDE auto-generates prototypes, but tools that
 // compile the .ino straight as a .cpp (e.g. the proto.cat compile service) don't
 // — so without this, setup()'s call to drawPage() fails to compile.
@@ -35,6 +76,9 @@ void setup() {
   Serial.println();
   Serial.println("[reader] setup() entered");
   Serial.println("[reader] pin map: CS=5 DC=17 RST=16 BUSY=4 SCK=18 MOSI=23");
+  Serial.println("[reader] buttons: NEXT=32 PREV=33 (active low)");
+  pinMode(PIN_NEXT, INPUT_PULLUP);
+  pinMode(PIN_PREV, INPUT_PULLUP);
   Serial.print("[reader] BUSY initial state: ");
   pinMode(4, INPUT);
   Serial.println(digitalRead(4) ? "HIGH (panel busy or floating)" : "LOW (idle)");
@@ -44,12 +88,12 @@ void setup() {
   display.setRotation(1);
   Serial.println("[reader] calling drawPage()");
   drawPage();
-  Serial.println("[reader] drawPage() returned — hibernating");
-  display.hibernate();
+  Serial.println("[reader] drawPage() returned");
   Serial.println("[reader] setup() complete — page should be visible");
 }
 
 void drawPage() {
+  const Page &page = PAGES[currentPage];
   display.setFullWindow();
   display.firstPage();
   do {
@@ -59,26 +103,56 @@ void drawPage() {
     display.setTextColor(GxEPD_BLACK);
     display.setFont(&FreeSerifBold12pt7b);
     display.setCursor(8, 24);
-    display.print("LabWired Reader");
+    display.print(page.title);
 
     // Body copy — black ink.
     display.setFont(&FreeSerif9pt7b);
-    display.setCursor(8, 50);
-    display.print("The simulator IS the");
-    display.setCursor(8, 66);
-    display.print("hardware. Same firmware");
-    display.setCursor(8, 82);
-    display.print("ELF runs in your browser,");
-    display.setCursor(8, 98);
-    display.print("on your bench, and in CI.");
+    int16_t y = 50;
+    for (uint8_t line = 0; line < 4; line++) {
+      display.setCursor(8, y);
+      display.print(page.body[line]);
+      y += 16;
+    }
 
     // Page counter — red ink, bottom-right.
     display.setTextColor(GxEPD_RED);
     display.setCursor(230, 122);
-    display.print("Page 1");
+    display.print("Page ");
+    display.print(currentPage + 1);
+    display.print("/");
+    display.print(PAGE_COUNT);
   } while (display.nextPage());
 }
 
+// Reports a single press per physical press: true only on the HIGH->LOW edge,
+// so holding a button down does not flip through every page.
+bool pressed(uint8_t pin, bool &wasDown, unsigned long &lastChange) {
+  const bool down = digitalRead(pin) == LOW;
+  const unsigned long now = millis();
+  if (down == wasDown) return false;
+  if (now - lastChange < DEBOUNCE_MS) return false;
+  lastChange = now;
+  wasDown = down;
+  return down;
+}
+
 void loop() {
-  // Static page — nothing to do. A real reader would advance pages here.
+  static bool nextDown = false;
+  static bool prevDown = false;
+  static unsigned long nextChange = 0;
+  static unsigned long prevChange = 0;
+
+  int8_t step = 0;
+  if (pressed(PIN_NEXT, nextDown, nextChange)) step = 1;
+  else if (pressed(PIN_PREV, prevDown, prevChange)) step = -1;
+
+  if (step != 0) {
+    // Wrap in both directions so neither button ever becomes a dead end.
+    currentPage = (currentPage + PAGE_COUNT + step) % PAGE_COUNT;
+    Serial.print("[reader] page -> ");
+    Serial.println(currentPage + 1);
+    drawPage();
+  }
+
+  delay(10);
 }


### PR DESCRIPTION
## Why

The ESP32 e-reader lab rendered a **blank panel**. Firmware booted, issued 9 SPI transactions, then stopped with the CPU parked in the FreeRTOS idle task — the Arduino task blocked, not crashed.

Two compounding causes:

**1. BUSY was never modelled.** `ssd1680_tricolor_290.rs` dismissed it as "a sideband GPIO" and the attach path resolved only `cs_pin`/`dc_pin`. GxEPD2 blocks in `_waitWhileBusy` until BUSY reads not-busy or its timeout expires — and that timeout is **30 s of simulated time (~7.2e9 cycles)**, unreachable in a test budget or a browser.

The wait is legitimate. Measured on a real ESP32-D0WDQ6 over serial:

```
_PowerOn     :     94,997 µs
_Update_Full : 18,624,001 µs   ← 18.6 s, gated by BUSY
```

**2. The two controllers are opposite polarity** — SSD1680 asserts BUSY high, UC8151D pulls it low. Each panel now declares its idle level as a named constant.

## Universal, not board-specific

`SystemBus::drive_pin_input` resolves through the existing `resolve_pin_idr` path (chip pin-map, STM32/Nordic pads, ESP `GPIO`n), so it works on **any supported MCU**. Exposed to every kit as `AttachCtx::drive_pin_input`, and used by the ESP32 external-device factory — one implementation, two callers.

It must go through `set_gpio_input`: input registers ignore MMIO stores, so a bus write would be silently dropped.

`canonical.rs` now emits `dc_pin`/`busy_pin` whenever the diagram wires them, for whichever MCU the part is attached to — so connecting this panel to a different MCU needs no per-board list. `uc8151d_tricolor_290` was also missing from `SPI_DEVICE_TYPES` while already classed as one, so a diagram using it emitted **no** `external_devices` entry at all.

## The guard never ran

The e2e test was **both** `#[ignore]`d and self-skipping when the ELF was absent, so it never executed anywhere. That is how a completely blank flagship demo shipped behind a green board.

- Un-`#[ignore]`d — it reaches an inked refresh in ~13.6M cycles (~24 s), not the 200M the ignore note claimed.
- CI can set `LABWIRED_REQUIRE_EREADER_ELF=1` to turn a missing artifact into a failure.
- Its early-exit fired on GxEPD2's white `clearScreen` refresh, before `drawPage()` rendered anything — so the ink assertion could never have passed even with everything else correct.

## Verification

| Check | Result |
|---|---|
| `e2e_labwired_ereader` | **passes** — 62 ink bytes, 9794 SPI transactions |
| `e2e_epaper_tricolor` (STM32F103) | passes |
| `e2e_spi3_dc_epaper` | passes |
| `labwired-config` | 94 passed |
| Real hardware | page renders on ESP32-D0WDQ6 |

Sketch also gains NEXT/PREV page buttons on GPIO32/33 (internal pull-ups, debounced), confirmed rendering on real hardware. Note each page turn costs a genuine ~19 s panel refresh.

Pairs with labwired#fix/epaper-lab-panel-and-demo, which ships a demo binary actually built from this sketch.