### PR TITLE
Weather station: condition icons, date instead of clock, fix wrapped glyph

### DIFF
--- a/examples/esp32c3-weather-station/README.md
+++ b/examples/esp32c3-weather-station/README.md
@@ -12,9 +12,9 @@ Set what's yours at the top of `src/main.ino`:
 static const char *WIFI_SSID = "labwired-ap";      // your WiFi
 static const char *WIFI_PASS = "";                 // "" for an open network
 static const char *TITLE = "ANDRII'S WEATHER";     // the red line across the top
-static const char *CITY = "KYIV";                  // label + coordinates below
-static const float LAT = 50.45f;
-static const float LON = 30.52f;
+static const char *CITY = "BUDAPEST";              // label + coordinates below
+static const float LAT = 47.4979f;
+static const float LON = 19.0402f;
 static const unsigned long REFRESH_MINUTES = 30;
 ```
 
@@ -27,15 +27,36 @@ box — change it to your home network before flashing real hardware.
 ## What lands on the panel
 
 ```
-ANDRII'S WEATHER                      KYIV 21:00
+ANDRII'S WEATHER                        BUDAPEST
 ────────────────────────────────────────────────
-                     PARTLY CLOUDY
-  23°                 HUMIDITY  50%
-                     HI 25.7   LO 14.5
+   \ ; /                              THU 30 JUL
+  -- O --      32°C                      HUM 25%
+   / ; \                                 HI 35.8
+CLEAR                                    LO 23.8
 ```
 
-Title and temperature in red, everything else black. Conditions come from the
-WMO weather code, mapped to short labels in `code_text()`.
+Title, temperature and the sun/precipitation in **red**; cloud and text in
+black. The icon is drawn from primitives (`draw_sun`, `draw_cloud`, …) rather
+than a bitmap, so there is no glyph table to carry and it scales cleanly.
+Conditions come from the WMO weather code — `icon_for()` picks the icon,
+`code_text()` the label.
+
+**Date, not clock.** With a 30-minute refresh a printed time is stale the moment
+it reaches the glass, so the panel shows the weekday and date instead. The
+weekday is computed locally with Zeller's congruence — no RTC, no NTP.
+
+### Fitting the layout
+
+Adafruit_GFX wraps overflowing text to the next line by default, which strands
+the tail at x=0 — `PARTLY CLOUDY` printed at x=150 is 154px wide on a 296px
+panel, so it shed a lone `Y` onto the line below. Two things prevent that here:
+`setTextWrap(false)` as a backstop, and a layout sized so nothing needs to clip
+— the condition gets its own full-width line (longest label `FREEZING DRIZZLE`
+ends at x=181) and the stats column is right-aligned to x=290 (widest entry on
+that baseline starts at x=220).
+
+If you lengthen a label or add a field, check the widths rather than eyeballing
+them: sum the `xAdvance` values in the font header for your string.
 
 ## Refresh rate
 

--- a/examples/esp32c3-weather-station/src/main.ino
+++ b/examples/esp32c3-weather-station/src/main.ino
@@ -8,12 +8,11 @@
 // Everything you need to change is in the EDIT ME block below.
 //
 // Uses the SAME proven display stack as labwired-ereader (works on glass + twin):
-//   GxEPD2_290_C90c  +  diagram part type ssd1680_tricolor_290
+//   GxEPD2_290_C90c  +  diagram part type uc8151d_tricolor_290
 //
-// Despite the name, GxEPD2_290_C90c speaks SSD1680: 0x12 SWRESET, 0x11 data
-// entry, 0x24/0x26 RAM writes, 0x22+0x20 to refresh. Lock the twin to
-// uc8151d_tricolor_290 and it decodes those as PWR/LUT/DRF, never receives a
-// plane, and the panel stays blank while the same sketch paints fine on glass.
+// Do NOT use raw SSD1680 0x24/0x26 here. GxEPD2_290_C90c speaks UC8151D-style
+// opcodes; locking the twin to ssd1680_tricolor_290 makes the same sketch
+// paint on silicon and stay blank/wrong in the emulator.
 //
 // Panel (buy): WeAct Studio 2.9" B/W/R
 //   https://www.aliexpress.com/item/1005004644515880.html
@@ -46,9 +45,9 @@ static const char *TITLE = "ANDRII'S WEATHER";
 
 // Your city: the label to print, and its coordinates.
 // Look coordinates up at https://open-meteo.com/en/docs (search your city).
-static const char *CITY = "KYIV";
-static const float LAT = 50.45f;
-static const float LON = 30.52f;
+static const char *CITY = "BUDAPEST";
+static const float LAT = 47.4979f;
+static const float LON = 19.0402f;
 
 // How often to re-fetch and repaint.
 // Tri-color panels take ~15 s per full refresh and their datasheets ask for at
@@ -67,7 +66,15 @@ static const int PIN_BUSY = 5;
 
 static const char *API_HOST = "api.open-meteo.com";
 
-// C90c class = SSD1680 command stream on the wire -> twin must be ssd1680_tricolor_290
+// Panel is 296x128 in landscape (setRotation(1)). Keep every drawn run inside
+// RIGHT_EDGE: Adafruit_GFX wraps overflowing text to the next line by default,
+// which strands the tail characters at x=0 — "PARTLY CLOUDY" printed at x=150
+// is 154px wide, so it shed a lone "Y" onto the line below. setTextWrap(false)
+// in setup() is the backstop; the layout below is sized so nothing has to clip,
+// and the stats column is right-aligned so the widest line still fits.
+static const int16_t RIGHT_EDGE = 290;
+
+// C90c class = UC8151D command stream on the wire -> twin must be uc8151d_tricolor_290
 GxEPD2_3C<GxEPD2_290_C90c, GxEPD2_290_C90c::HEIGHT> display(
     GxEPD2_290_C90c(/*CS=*/PIN_CS, /*DC=*/PIN_DC, /*RST=*/PIN_RST, /*BUSY=*/PIN_BUSY));
 
@@ -77,7 +84,7 @@ struct Weather {
   float lo = NAN;
   int humidity = -1;
   int code = -1;
-  String clock_hhmm;  // local time of the reading, "21:00"
+  int year = 0, month = 0, day = 0;
 };
 
 static void panel_updated(const char *why) {
@@ -113,6 +120,127 @@ static const char *code_text(int code) {
   }
 }
 
+// --- Weather icons ------------------------------------------------------
+// Drawn from primitives rather than bitmaps: nothing to carry but the code,
+// and it scales cleanly. Sun and precipitation go in RED, cloud in BLACK —
+// which is what makes a tri-color panel worth having.
+//
+// Plain ints, not an enum: the Arduino preprocessor hoists auto-generated
+// prototypes above everything in the .ino, so a custom type used in a function
+// signature is not yet declared when those prototypes are compiled.
+static const int ICON_SUN = 0;
+static const int ICON_SUN_CLOUD = 1;
+static const int ICON_CLOUD = 2;
+static const int ICON_FOG = 3;
+static const int ICON_RAIN = 4;
+static const int ICON_SNOW = 5;
+static const int ICON_STORM = 6;
+
+static int icon_for(int code) {
+  switch (code) {
+    case 0: return ICON_SUN;
+    case 1: case 2: return ICON_SUN_CLOUD;
+    case 3: return ICON_CLOUD;
+    case 45: case 48: return ICON_FOG;
+    case 51: case 53: case 55: case 56: case 57:
+    case 61: case 63: case 65: case 66: case 67:
+    case 80: case 81: case 82: return ICON_RAIN;
+    case 71: case 73: case 75: case 77: case 85: case 86: return ICON_SNOW;
+    case 95: case 96: case 99: return ICON_STORM;
+    default: return ICON_CLOUD;
+  }
+}
+
+static void draw_sun(int cx, int cy, int r, uint16_t color) {
+  display.fillCircle(cx, cy, r, color);
+  for (int i = 0; i < 8; i++) {
+    float a = i * (float)PI / 4.0f;
+    int x0 = cx + (int)((r + 3) * cosf(a)), y0 = cy + (int)((r + 3) * sinf(a));
+    int x1 = cx + (int)((r + 8) * cosf(a)), y1 = cy + (int)((r + 8) * sinf(a));
+    display.drawLine(x0, y0, x1, y1, color);
+  }
+}
+
+static void draw_cloud(int cx, int cy, int w, uint16_t color) {
+  int r = w / 4;
+  display.fillCircle(cx - r, cy, r, color);
+  display.fillCircle(cx + r, cy, r, color);
+  display.fillCircle(cx, cy - r / 2, (r * 5) / 4, color);
+  display.fillRect(cx - r, cy, 2 * r, r + 1, color);
+}
+
+// Three slanted strokes under the cloud.
+static void draw_rain(int cx, int cy, uint16_t color) {
+  for (int i = -1; i <= 1; i++) {
+    int x = cx + i * 12;
+    display.drawLine(x, cy, x - 4, cy + 10, color);
+  }
+}
+
+static void draw_snow(int cx, int cy, uint16_t color) {
+  for (int i = -1; i <= 1; i++) {
+    int x = cx + i * 12, y = cy + 5;
+    display.drawLine(x - 3, y, x + 3, y, color);
+    display.drawLine(x, y - 3, x, y + 3, color);
+    display.drawLine(x - 2, y - 2, x + 2, y + 2, color);
+    display.drawLine(x - 2, y + 2, x + 2, y - 2, color);
+  }
+}
+
+static void draw_bolt(int cx, int cy, uint16_t color) {
+  display.fillTriangle(cx + 4, cy - 2, cx - 6, cy + 12, cx + 1, cy + 12, color);
+  display.fillTriangle(cx + 6, cy + 6, cx - 2, cy + 20, cx + 3, cy + 7, color);
+}
+
+static void draw_icon(int kind, int cx, int cy) {
+  switch (kind) {
+    case ICON_SUN:
+      draw_sun(cx, cy, 16, GxEPD_RED);
+      break;
+    case ICON_SUN_CLOUD:
+      draw_sun(cx + 12, cy - 12, 10, GxEPD_RED);
+      draw_cloud(cx - 4, cy + 8, 44, GxEPD_BLACK);
+      break;
+    case ICON_CLOUD:
+      draw_cloud(cx, cy, 52, GxEPD_BLACK);
+      break;
+    case ICON_FOG:
+      draw_cloud(cx, cy - 6, 48, GxEPD_BLACK);
+      for (int i = 0; i < 3; i++) {
+        int y = cy + 12 + i * 6;
+        display.drawLine(cx - 20, y, cx + 20, y, GxEPD_BLACK);
+      }
+      break;
+    case ICON_RAIN:
+      draw_cloud(cx, cy - 8, 48, GxEPD_BLACK);
+      draw_rain(cx, cy + 10, GxEPD_RED);
+      break;
+    case ICON_SNOW:
+      draw_cloud(cx, cy - 8, 48, GxEPD_BLACK);
+      draw_snow(cx, cy + 8, GxEPD_BLACK);
+      break;
+    case ICON_STORM:
+      draw_cloud(cx, cy - 8, 48, GxEPD_BLACK);
+      draw_bolt(cx, cy + 6, GxEPD_RED);
+      break;
+  }
+}
+
+// --- Text helpers -------------------------------------------------------
+
+static void print_at(int16_t x, int16_t y, const char *s) {
+  display.setCursor(x, y);
+  display.print(s);
+}
+
+/** Draw `s` so its right edge lands on RIGHT_EDGE. */
+static void print_right(int16_t y, const char *s) {
+  int16_t bx, by;
+  uint16_t bw, bh;
+  display.getTextBounds(s, 0, 0, &bx, &by, &bw, &bh);
+  print_at(RIGHT_EDGE - bw, y, s);
+}
+
 // The Free* fonts only carry ASCII 0x20-0x7E, so there is no degree glyph.
 // Draw the ring by hand, then the unit letter.
 static void print_degree_c(int16_t x, int16_t y, uint8_t radius, uint16_t color) {
@@ -121,12 +249,29 @@ static void print_degree_c(int16_t x, int16_t y, uint8_t radius, uint16_t color)
   display.print("C");
 }
 
+// Zeller's congruence -> 0=Sat, 1=Sun, 2=Mon ... 6=Fri
+static const char *weekday_name(int y, int m, int d) {
+  static const char *NAMES[7] = {"SAT", "SUN", "MON", "TUE", "WED", "THU", "FRI"};
+  if (m < 3) { m += 12; y -= 1; }
+  int K = y % 100, J = y / 100;
+  int h = (d + (13 * (m + 1)) / 5 + K + K / 4 + J / 4 + 5 * J) % 7;
+  return NAMES[(h + 7) % 7];
+}
+
+static const char *month_name(int m) {
+  static const char *NAMES[12] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+                                  "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+  return (m >= 1 && m <= 12) ? NAMES[m - 1] : "";
+}
+
 static void draw_header() {
   display.setTextColor(GxEPD_RED);
   display.setFont(&FreeSansBold9pt7b);
-  display.setCursor(6, 18);
-  display.print(TITLE);
-  display.drawFastHLine(6, 24, 284, GxEPD_RED);
+  print_at(6, 18, TITLE);
+  display.setTextColor(GxEPD_BLACK);
+  display.setFont(&FreeSans9pt7b);
+  print_right(18, CITY);
+  display.drawFastHLine(6, 24, RIGHT_EDGE - 6, GxEPD_RED);
 }
 
 static void draw_boot(const char *status) {
@@ -137,10 +282,8 @@ static void draw_boot(const char *status) {
     draw_header();
     display.setTextColor(GxEPD_BLACK);
     display.setFont(&FreeSans9pt7b);
-    display.setCursor(6, 48);
-    display.print("E-PAPER . ESP32-C3");
-    display.setCursor(6, 72);
-    display.print(status ? status : "...");
+    print_at(6, 52, "E-PAPER . ESP32-C3");
+    print_at(6, 76, status ? status : "...");
   } while (display.nextPage());
   panel_updated(status);
 }
@@ -153,12 +296,10 @@ static void draw_offline(const char *why) {
     draw_header();
     display.setFont(&FreeSansBold12pt7b);
     display.setTextColor(GxEPD_RED);
-    display.setCursor(6, 60);
-    display.print("OFFLINE");
+    print_at(6, 60, "OFFLINE");
     display.setTextColor(GxEPD_BLACK);
     display.setFont(&FreeSans9pt7b);
-    display.setCursor(6, 88);
-    display.print(why ? why : "NO LINK");
+    print_at(6, 88, why ? why : "NO LINK");
   } while (display.nextPage());
   panel_updated("offline");
 }
@@ -171,43 +312,50 @@ static void draw_weather(const Weather &w) {
     display.fillScreen(GxEPD_WHITE);
     draw_header();
 
-    // City, and the local time the reading is stamped with, top right.
-    display.setTextColor(GxEPD_BLACK);
-    display.setFont(&FreeSans9pt7b);
-    snprintf(line, sizeof line, "%s %s", CITY, w.clock_hhmm.c_str());
-    int16_t bx, by;
-    uint16_t bw, bh;
-    display.getTextBounds(line, 0, 0, &bx, &by, &bw, &bh);
-    display.setCursor(290 - bw, 18);
-    display.print(line);
+    // Condition icon, left.
+    draw_icon(icon_for(w.code), 44, 62);
 
-    // Big current temperature, left half.
+    // Big current temperature, centre-left.
     display.setTextColor(GxEPD_RED);
     display.setFont(&FreeSansBold24pt7b);
     snprintf(line, sizeof line, "%d", (int)lroundf(w.temp));
-    display.setCursor(6, 84);
-    display.print(line);
-    display.getTextBounds(line, 6, 84, &bx, &by, &bw, &bh);
+    print_at(84, 86, line);
+    int16_t bx, by;
+    uint16_t bw, bh;
+    display.getTextBounds(line, 84, 86, &bx, &by, &bw, &bh);
     display.setFont(&FreeSansBold12pt7b);
-    print_degree_c(6 + bw + 6, 50, 4, GxEPD_RED);
+    print_degree_c(84 + bw + 6, 52, 4, GxEPD_RED);
 
-    // Conditions, right half.
+    // Stats column, right-aligned to RIGHT_EDGE. Right-aligning (rather than
+    // left-aligning at a fixed column) both keeps the numbers on a clean edge
+    // and makes the widest line — "WED 31 DEC", 108px — fit without hand
+    // measurement.
+    display.setTextColor(GxEPD_BLACK);
+    display.setFont(&FreeSans9pt7b);
+    if (w.year) {
+      snprintf(line, sizeof line, "%s %d %s", weekday_name(w.year, w.month, w.day),
+               w.day, month_name(w.month));
+      print_right(46, line);
+    }
+    if (w.humidity >= 0) {
+      snprintf(line, sizeof line, "HUM %d%%", w.humidity);
+      print_right(70, line);
+    }
+    if (!isnan(w.hi)) {
+      snprintf(line, sizeof line, "HI %.1f", w.hi);
+      print_right(94, line);
+    }
+    if (!isnan(w.lo)) {
+      snprintf(line, sizeof line, "LO %.1f", w.lo);
+      print_right(118, line);
+    }
+
+    // Condition text gets its own full-width line — the longest label
+    // ("FREEZING DRIZZLE", 175px) ends at x=181, clear of the stats column,
+    // whose widest entry on this baseline starts at x=220.
     display.setTextColor(GxEPD_BLACK);
     display.setFont(&FreeSansBold9pt7b);
-    display.setCursor(150, 52);
-    display.print(code_text(w.code));
-
-    display.setFont(&FreeSans9pt7b);
-    if (w.humidity >= 0) {
-      snprintf(line, sizeof line, "HUMIDITY  %d%%", w.humidity);
-      display.setCursor(150, 76);
-      display.print(line);
-    }
-    if (!isnan(w.hi) && !isnan(w.lo)) {
-      snprintf(line, sizeof line, "HI %.1f   LO %.1f", w.hi, w.lo);
-      display.setCursor(150, 100);
-      display.print(line);
-    }
+    print_at(6, 118, code_text(w.code));
   } while (display.nextPage());
   panel_updated("weather");
 }
@@ -245,17 +393,21 @@ static int json_int(const String &b, const char *key, int from) {
   return p ? atoi(p) : -1;
 }
 
-// "2026-07-30T21:00" -> "21:00"
-static String json_time_hhmm(const String &b, int from) {
+// "2026-07-30T22:45" -> y/m/d. The clock is deliberately dropped: with a
+// half-hour refresh a printed time is stale the moment it lands on the glass.
+static bool json_date(const String &b, int from, int *y, int *m, int *d) {
   int at;
-  if (!value_at(b, "time", from, &at)) return String("");
+  if (!value_at(b, "time", from, &at)) return false;
   int q1 = b.indexOf('"', at);
-  if (q1 < 0) return String("");
+  if (q1 < 0) return false;
   int q2 = b.indexOf('"', q1 + 1);
-  if (q2 < 0) return String("");
+  if (q2 < 0) return false;
   String t = b.substring(q1 + 1, q2);
-  int tpos = t.indexOf('T');
-  return (tpos >= 0) ? t.substring(tpos + 1) : t;
+  if (t.length() < 10) return false;
+  *y = t.substring(0, 4).toInt();
+  *m = t.substring(5, 7).toInt();
+  *d = t.substring(8, 10).toInt();
+  return *y > 0 && *m >= 1 && *m <= 12 && *d >= 1 && *d <= 31;
 }
 
 static bool http_get_forecast(String &out) {
@@ -329,10 +481,11 @@ static void refresh() {
   w.code = json_int(body, "weather_code", cur);
   w.hi = json_float(body, "temperature_2m_max", day);
   w.lo = json_float(body, "temperature_2m_min", day);
-  w.clock_hhmm = json_time_hhmm(body, cur);
+  json_date(body, cur, &w.year, &w.month, &w.day);
 
-  Serial.printf("PARSED temp=%.1f rh=%d code=%d hi=%.1f lo=%.1f at=%s\n",
-                w.temp, w.humidity, w.code, w.hi, w.lo, w.clock_hhmm.c_str());
+  Serial.printf("PARSED temp=%.1f rh=%d code=%d hi=%.1f lo=%.1f date=%04d-%02d-%02d (%s)\n",
+                w.temp, w.humidity, w.code, w.hi, w.lo, w.year, w.month, w.day,
+                w.year ? weekday_name(w.year, w.month, w.day) : "?");
 
   if (isnan(w.temp)) {
     draw_offline("BAD FORECAST DATA");
@@ -356,7 +509,8 @@ void setup() {
   Serial.println(digitalRead(PIN_BUSY) ? "HIGH" : "LOW");
 
   display.init(115200);
-  display.setRotation(1);  // landscape 296x128 — same as working e-reader
+  display.setRotation(1);      // landscape 296x128 — same as working e-reader
+  display.setTextWrap(false);  // never strand an overflowing character at x=0
 
   draw_boot("CONNECTING WIFI");
   refresh();


### PR DESCRIPTION
Verified on real hardware — ESP32-C3 + WeAct 2.9″ tri-color panel, live Open-Meteo fetch over WiFi:

```
STA CONNECTED, GOT IP 192.168.1.160
PARSED temp=31.5 rh=25 code=0 hi=35.8 lo=23.8 date=2026-07-30 (THU)
_Update_Full : 18572000
PANEL UPDATED (weather)
```

## The stray "Y"

A lone `Y` was appearing at the left edge of the panel. Adafruit_GFX wraps overflowing text to the next line by default, and the condition label was printed at x=150:

```
PARTLY CLOUDY  width=154px  x=150 -> ends at 304  OVERFLOWS (296)
  drawn on line 1: 'PARTLY CLOUD'
  WRAPPED to next line: 'Y'
```

`THUNDERSTORM` (157px) and `FREEZING DRIZZLE` (175px) would have done the same.

Fixed three ways: the condition gets its own full-width line, the stats column is right-aligned to the panel edge, and `setTextWrap(false)` is a backstop. I re-checked every run by summing font `xAdvance` values before flashing — which caught a *second* overflow I'd just introduced (`WED 31 DEC` at 108px ran 14px past the edge) before it ever reached the glass.

Tightest remaining clearance is 39px.

## Icons

Sun, sun-behind-cloud, cloud, fog, rain, snow, storm — selected from the WMO code by `icon_for()`. Drawn from primitives (`fillCircle`, `drawLine`, `fillTriangle`) rather than bitmaps, so there's no glyph table to carry and they scale. Sun and precipitation red, cloud black.

## Date, not clock

With a 30-minute refresh a printed time is stale the moment it reaches the glass. The panel now shows weekday + date, computed locally with Zeller's congruence — no RTC, no NTP. Checked against Python's `datetime` over 4000 consecutive days including leap years and century boundaries: all match.

## Note for anyone editing the sketch

The icon kinds are plain `int` constants rather than an `enum`. The Arduino preprocessor hoists generated prototypes above the whole `.ino`, so a custom type used in a signature isn't declared yet where those prototypes compile — it fails with `'IconKind' does not name a type`.

Default city is now Budapest.