### PR TITLE
fix(kit): regenerate stale peripherals manifest + guard the core/overlay boundary

### DIFF
--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -824,6 +824,16 @@
           "name": "cs_pin",
           "ty": "str",
           "doc": "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4."
+        },
+        {
+          "name": "dc_pin",
+          "ty": "str",
+          "doc": "Data/Command GPIO pin (e.g. \"GPIO17\"). Required for command framing."
+        },
+        {
+          "name": "busy_pin",
+          "ty": "str",
+          "doc": "BUSY status GPIO the host polls (e.g. \"GPIO4\"). Held LOW (idle) because this model refreshes instantly; without it a driver that waits on BUSY blocks until its timeout and the panel stays blank."
         }
       ],
       "labs": [
@@ -859,6 +869,11 @@
           "name": "dc_pin",
           "ty": "str",
           "doc": "Data/Command GPIO pin (e.g. \"GPIO2\"). Required for command framing."
+        },
+        {
+          "name": "busy_pin",
+          "ty": "str",
+          "doc": "BUSY status GPIO the host polls (e.g. \"GPIO5\"). Held HIGH (idle) — UC8151D is busy-LOW, the inverse of ssd1680_tricolor_290."
         }
       ],
       "labs": [],

--- a/crates/core/tests/peripheral_kit_gate.rs
+++ b/crates/core/tests/peripheral_kit_gate.rs
@@ -213,3 +213,72 @@ fn lab_example_dirs_exist_on_disk() {
         }
     }
 }
+
+/// Architectural boundary: **core is the simulation engine; commercial overlays
+/// live in the web app.**
+///
+/// A kit describes silicon — what bus it sits on, what registers it decodes,
+/// what config pins wire it up. It must NOT carry the product layer: vendor
+/// names, manufacturer part numbers, SKUs, prices, distributor/buy links. That
+/// data belongs to the overlay in the web app, keyed by `device_type`, where it
+/// can differ per vendor for the same silicon and change without touching the
+/// engine.
+///
+/// The pressure to inline "just the MPN" here is constant and each instance
+/// looks harmless, which is exactly why this is a test and not a convention:
+/// once commerce data is embedded in the engine, the same chip sold by two
+/// vendors needs two kits, and the overlay stops being a separable layer.
+///
+/// Widen the allow-list only for genuinely engine-level fields. If you are
+/// reaching for one of the banned terms, the value almost certainly belongs in
+/// the overlay instead.
+#[test]
+fn kit_metadata_carries_no_commercial_overlay_data() {
+    // Substrings that indicate product/commerce data rather than silicon.
+    const BANNED: &[&str] = &[
+        "mpn",
+        "sku",
+        "product_url",
+        "buy_url",
+        "purchase",
+        "distributor",
+        "price",
+        "vendor",
+        "manufacturer",
+        "aliexpress",
+        "digikey",
+        "mouser",
+    ];
+
+    for kit in registry::kits() {
+        let md = kit.metadata();
+        // Config keys are the machine-readable surface: a banned key name here
+        // would put commerce data into system.yaml itself.
+        for key in md.config_keys {
+            let name = key.name.to_ascii_lowercase();
+            for bad in BANNED {
+                assert!(
+                    !name.contains(bad),
+                    "kit '{}' declares config key '{}', which is overlay data, not \
+                     silicon. Vendor/SKU/commerce fields belong in the web app's \
+                     part overlay keyed by device_type — core stays the simulation \
+                     engine.",
+                    md.device_type,
+                    key.name
+                );
+            }
+        }
+        // Storefront links in prose are the other way this leaks in.
+        let prose = format!("{} {} {}", md.label, md.summary, md.detail).to_ascii_lowercase();
+        for bad in ["aliexpress", "digikey", "mouser", "buy_url", "product_url"] {
+            assert!(
+                !prose.contains(bad),
+                "kit '{}' mentions '{}' in its description. Storefront and vendor \
+                 links belong in the web app's part overlay, not in the engine's \
+                 kit metadata.",
+                md.device_type,
+                bad
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 1. The vendored manifest went stale (regression from #714)

#714 added `dc_pin`/`busy_pin` config keys to the two tri-color e-paper kits without re-running `gen-peripherals-manifest`, so `peripheral_kit_gate::manifest_json_matches_registry` fails:

```
peripherals-manifest.json is stale.
```

It didn't fire on #714 because the job carrying it is excluded from the PR set by design, so it would have landed on the per-merge/nightly run. Verified both directions locally: **fails** on the old fixture, **passes** on the regenerated one. The diff is exactly the two kits' new keys — 15 lines, no unrelated churn.

The parent repo's copy (`packages/ui/src/peripherals/manifest.json`) needs the same regeneration; that's a companion PR.

## 2. Guard: core is the engine, overlays are the moat

A kit describes **silicon** — bus, registers, config pins. It must not carry vendor names, MPNs, SKUs, prices, or storefront links. Those belong to the **overlay in the web app**, keyed by `device_type`, where the same silicon sold by two vendors is two overlay entries and *zero* extra kits.

The pressure to inline "just the MPN" is constant and every instance looks harmless — which is exactly why this is a test and not a convention. Once commerce data is embedded in the engine, one chip sold by two vendors needs two kits and the overlay stops being separable.

Fails on banned config-key names and on storefront links in kit prose. **Verified it bites**: injecting a `vendor_mpn` key produces

```
kit 'ssd1680_tricolor_290' declares config key 'vendor_mpn', which is overlay data,
not silicon. Vendor/SKU/commerce fields belong in the web app's part overlay keyed
by device_type — core stays the simulation engine.
```

and reverting returns green (8/8).

## Architectural note, not fixed here

This data now exists in **three** places: the `KitMetadata` structs (real source of truth), a vendored fixture in core, and a second vendored copy in the parent. Only the fixture is gated; the TS side validates `schema_version` but never content, so the parent copy can drift silently — which is precisely what just happened.

`KitMetadata` also still carries presentation and product coupling: `label`/`summary`/`detail`, plus `LabRef { board_id, example_dir, demo_elf }` — playground lab ids and demo asset filenames living inside the simulation engine. That is the same boundary this guard defends, and worth a follow-up.