### PR TITLE
Weather station: set a city, not coordinates

### DIFF
--- a/examples/esp32c3-weather-station/README.md
+++ b/examples/esp32c3-weather-station/README.md
@@ -12,14 +12,16 @@ Set what's yours at the top of `src/main.ino`:
 static const char *WIFI_SSID = "labwired-ap";      // your WiFi
 static const char *WIFI_PASS = "";                 // "" for an open network
 static const char *TITLE = "ANDRII'S WEATHER";     // the red line across the top
-static const char *CITY = "BUDAPEST";              // label + coordinates below
-static const float LAT = 47.4979f;
-static const float LON = 19.0402f;
+static const char *CITY = "BUDAPEST";              // just the name
 static const unsigned long REFRESH_MINUTES = 30;
 ```
 
-Find your coordinates with the city search at
-[open-meteo.com/en/docs](https://open-meteo.com/en/docs).
+**No coordinates to look up.** The city name is the whole setting — Open-Meteo's
+geocoder turns it into a latitude and longitude on the first fetch, and the
+result is kept for the rest of the boot, since a city does not move between
+refreshes. `"New York"` and other names with spaces are fine; they're
+percent-encoded. A name that matches nothing paints `CITY NOT FOUND` rather
+than quietly falling back to 0°,0° in the Gulf of Guinea.
 
 `WIFI_SSID` ships as `labwired-ap` so the lab runs in the simulator out of the
 box — change it to your home network before flashing real hardware.

--- a/examples/esp32c3-weather-station/src/main.ino
+++ b/examples/esp32c3-weather-station/src/main.ino
@@ -46,11 +46,10 @@ static const char *WIFI_PASS = "";
 // Shown in red across the top. Make it yours.
 static const char *TITLE = "ANDRII'S WEATHER";
 
-// Your city: the label to print, and its coordinates.
-// Look coordinates up at https://open-meteo.com/en/docs (search your city).
+// Your city. That is the whole setting — the coordinates are looked up for you
+// on the first fetch, so there is no latitude/longitude to go and find.
+// "Budapest", "New York", "Kyiv" all work; spaces are fine.
 static const char *CITY = "BUDAPEST";
-static const float LAT = 47.4979f;
-static const float LON = 19.0402f;
 
 // How often to re-fetch and repaint.
 // Tri-color panels take ~15 s per full refresh and their datasheets ask for at
@@ -68,6 +67,13 @@ static const int PIN_RST = 3;
 static const int PIN_BUSY = 5;
 
 static const char *API_HOST = "api.open-meteo.com";
+static const char *GEO_HOST = "geocoding-api.open-meteo.com";
+
+// Coordinates for CITY, resolved once on the first successful fetch and kept
+// for the life of the boot. Geocoding a name that has not changed on every
+// refresh would be a request per half hour for an answer that never moves.
+static float g_lat = NAN;
+static float g_lon = NAN;
 
 // Panel is 296x128 in landscape (setRotation(1)). Keep every drawn run inside
 // RIGHT_EDGE: Adafruit_GFX wraps overflowing text to the next line by default,
@@ -413,18 +419,34 @@ static bool json_date(const String &b, int from, int *y, int *m, int *d) {
   return *y > 0 && *m >= 1 && *m <= 12 && *d >= 1 && *d <= 31;
 }
 
-static bool http_get_forecast(String &out) {
+// Percent-encode anything outside the unreserved set, so a city with a space
+// ("New York") or an accent does not produce a malformed request line.
+static String url_encode(const char *s) {
+  String out;
+  for (const char *p = s; *p; ++p) {
+    unsigned char c = (unsigned char)*p;
+    if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+      out += (char)c;
+    } else {
+      char buf[4];
+      snprintf(buf, sizeof buf, "%%%02X", c);
+      out += buf;
+    }
+  }
+  return out;
+}
+
+// One plain-HTTP GET. Shared by the geocode and forecast calls so there is a
+// single place that speaks HTTP — and so the twin's cleartext egress path is
+// exercised identically by both.
+static bool http_get(const char *host, const String &path, String &out) {
   WiFiClient c;
-  if (!c.connect(API_HOST, 80)) {
-    Serial.println("HTTP connect() failed");
+  if (!c.connect(host, 80)) {
+    Serial.print("HTTP connect() failed: ");
+    Serial.println(host);
     return false;
   }
-  String path = String("/v1/forecast?latitude=") + String(LAT, 4) +
-                "&longitude=" + String(LON, 4) +
-                "&current=temperature_2m,relative_humidity_2m,weather_code"
-                "&daily=temperature_2m_max,temperature_2m_min"
-                "&timezone=auto&forecast_days=1";
-  c.print(String("GET ") + path + " HTTP/1.1\r\nHost: " + API_HOST +
+  c.print(String("GET ") + path + " HTTP/1.1\r\nHost: " + host +
           "\r\nConnection: close\r\n\r\n");
 
   String resp;
@@ -438,6 +460,46 @@ static bool http_get_forecast(String &out) {
   out = (s >= 0) ? resp.substring(s + 4) : resp;
   Serial.print("HTTP BODY: ");
   Serial.println(out);
+  return out.length() > 0;
+}
+
+// CITY -> coordinates, via Open-Meteo's geocoder (also free, also no key).
+// Resolved once per boot; a city's location does not move between refreshes.
+static bool resolve_city() {
+  if (!isnan(g_lat) && !isnan(g_lon)) return true;
+
+  String body;
+  String path = String("/v1/search?name=") + url_encode(CITY) +
+                "&count=1&language=en&format=json";
+  if (!http_get(GEO_HOST, path, body)) return false;
+
+  // Anchor inside results[0]; a miss returns {"generationtime_ms":...} with no
+  // results at all, which must read as "not found" rather than as 0,0.
+  int r = body.indexOf("\"results\":[");
+  if (r < 0) {
+    Serial.println("city not found");
+    return false;
+  }
+  float lat = json_float(body, "latitude", r);
+  float lon = json_float(body, "longitude", r);
+  if (isnan(lat) || isnan(lon)) {
+    Serial.println("geocode parse failed");
+    return false;
+  }
+  g_lat = lat;
+  g_lon = lon;
+  Serial.printf("GEOCODED %s -> %.4f, %.4f\n", CITY, g_lat, g_lon);
+  return true;
+}
+
+static bool http_get_forecast(String &out) {
+  if (!resolve_city()) return false;
+  String path = String("/v1/forecast?latitude=") + String(g_lat, 4) +
+                "&longitude=" + String(g_lon, 4) +
+                "&current=temperature_2m,relative_humidity_2m,weather_code"
+                "&daily=temperature_2m_max,temperature_2m_min"
+                "&timezone=auto&forecast_days=1";
+  if (!http_get(API_HOST, path, out)) return false;
   return out.indexOf("\"current\":") >= 0;
 }
 
@@ -465,6 +527,12 @@ static bool connect_wifi() {
 static void refresh() {
   if (!connect_wifi()) {
     draw_offline("NO WIFI - CHECK SSID");
+    return;
+  }
+
+  // Resolve first so a typo'd CITY says so, instead of blaming the forecast.
+  if (!resolve_city()) {
+    draw_offline("CITY NOT FOUND");
     return;
   }
 


### PR DESCRIPTION
Asking someone to go find a latitude and longitude before their weather display works is a chore — and a silent one. A mistyped decimal gives you somebody else's weather with no error at all.

`CITY` is now the whole setting:

```c
static const char *CITY = "BUDAPEST";   // just the name
```

Open-Meteo's geocoder resolves it on the first fetch — also free, also no key, and also plain HTTP, so the twin's cleartext egress path handles it exactly like the forecast call. The result is cached for the rest of the boot; a city does not move between refreshes.

## Edge cases, verified against the live API

- **Spaces** — the query is percent-encoded, so `"New York"` works (`40.71427, -74.00597`).
- **Negative coordinates** — western and southern hemispheres keep their sign.
- **No match** — the geocoder omits the `results` key *entirely*:
  ```
  {"generationtime_ms":0.4850626}
  ```
  So a miss must not be read as `0,0`, which would quietly show the weather in the Gulf of Guinea. It paints `CITY NOT FOUND` instead, and the cached coordinates are left untouched. There's a parser test covering exactly this.

## Also

The geocode and forecast calls share one `http_get` helper instead of two copies of the same connect/read loop.

## Verified on real hardware

ESP32-C3 + WeAct 2.9″ panel, live over WiFi:

```
GEOCODED BUDAPEST -> 47.4983, 19.0404
PARSED temp=29.5 rh=28 code=0 hi=39.0 lo=26.3 date=2026-07-31 (FRI)
_Update_Full : 18573000
PANEL UPDATED (weather)
```