### PR TITLE
fix(example): boot banner named the wrong e-paper twin

### DIFF
--- a/examples/esp32c3-weather-station/src/main.ino
+++ b/examples/esp32c3-weather-station/src/main.ino
@@ -568,7 +568,7 @@ static void refresh() {
 void setup() {
   Serial.begin(115200);
   delay(100);
-  Serial.println("E-Paper Weather Station boot (GxEPD2_290_C90c / UC8151D twin)");
+  Serial.println("E-Paper Weather Station boot (GxEPD2_290_C90c / ssd1680_tricolor_290 twin)");
 
   // ESP32-C3: bind SPI to the diagram pins before GxEPD2 init.
   SPI.begin(PIN_SCK, /*MISO*/ -1, PIN_MOSI, PIN_CS);


### PR DESCRIPTION
`examples/esp32c3-weather-station/src/main.ino:571` printed:

```
E-Paper Weather Station boot (GxEPD2_290_C90c / UC8151D twin)
```

…while the sketch 485 lines above it correctly instantiates `GxEPD2_290_C90c` against the **`ssd1680_tricolor_290`** twin, and the example's own README documents that lock explicitly ("**Not** `uc8151d_tricolor_290` (that is the `GxEPD2_290_Z13c` panel)") with the captured wire trace to prove it:

```
12 01 27 01 00 11 03 3c 05 18 80 21 00 80 44 ...   <- SSD1680 (C90c)
00 8f 61 80 01 28 50 77 04                          <- UC8151D (Z13c)
```

I independently confirmed the C90c→SSD1680 lock against WeAct Studio's own reference driver for the 2.9" B/W/R module (`YRD0290RWS800F6HP.c`): `0x12` SWRESET → `0x01` driver output control → `0x11` data entry → `0x44/0x45` RAM window → `0x4E/0x4F` counters → `0x24/0x26` plane writes, with `ALLSCREEN_BYTES 4736` matching our model's plane size exactly.

Picking the wrong twin for a 2.9" tri-color panel is the easiest way to end up with a blank display, and this banner was telling anyone reading the serial log to pick the wrong one.

No test asserts on the string (verified by a full-tree scan, not just grep).