### PR TITLE
fix: loopTask repin for wide movi, and real D/C framing for ILI9341

### DIFF
--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -146,10 +146,21 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // Handles both legacy and IDF-5.x app_main layouts. See
     // rom_thunks::repin_loop_task.
     if let Some(&app_main_addr) = symbol_addrs.get("app_main") {
-        if let Some((addr, shape)) = rom_thunks::repin_loop_task(&mut machine.bus, app_main_addr) {
-            eprintln!(
+        match rom_thunks::repin_loop_task(&mut machine.bus, app_main_addr) {
+            Some((addr, shape)) => eprintln!(
                 "labwired-cli snapshot: repinned loopTask xCoreID at 0x{addr:08x} (1→0, {shape}; runs on PRO_CPU)"
-            );
+            ),
+            // Not benign. An unrecognised layout leaves loopTask pinned to
+            // APP_CPU, where the sketch deadlocks the first time it contends a
+            // FreeRTOS portMUX with PRO_CPU — parking in `spinlock_acquire`
+            // partway through setup(). That reads as a firmware hang, so say
+            // plainly that it was us. A silently-skipped repin cost a real
+            // customer rig a mid-setup() stall that looked like their bug.
+            None => eprintln!(
+                "labwired-cli snapshot: warn: app_main at 0x{app_main_addr:08x} matched no known \
+                 xCoreID layout — loopTask stays on APP_CPU and setup() may deadlock in \
+                 spinlock_acquire. This is a simulator gap, not a firmware fault."
+            ),
         }
     }
 

--- a/crates/core/src/peripherals/components/ili9341.rs
+++ b/crates/core/src/peripherals/components/ili9341.rs
@@ -11,12 +11,38 @@ const WIDTH: usize = 240;
 const HEIGHT: usize = 320;
 const FB_BYTES: usize = WIDTH * HEIGHT * 2; // RGB565, 2 bytes per pixel
 
+/// MADCTL bits (datasheet §8.2.29). MV swaps the addressing axes — that is what
+/// `setRotation(1)`/`(3)` sets, so ignoring it clamps a landscape window to
+/// portrait width and silently draws the wrong picture.
+const MADCTL_MY: u8 = 0x80;
+const MADCTL_MX: u8 = 0x40;
+const MADCTL_MV: u8 = 0x20;
+
 /// Protocol state machine for the ILI9341 SPI command/data stream.
 ///
-/// The ILI9341 uses a separate D/C GPIO pin to distinguish command vs data bytes.
-/// Since the simulator cannot observe arbitrary GPIO state, we use a self-contained
-/// state machine driven by command semantics: each command specifies how many parameter
-/// bytes it needs, and RAMWR (0x2C) opens a pixel data stream.
+/// Framing comes from the **D/C line**, exactly as on silicon: D/C low marks a
+/// command byte, D/C high marks a data byte. The bus latches the configured
+/// GPIO's output level into [`SpiDevice::set_dc_level`] before each transfer.
+///
+/// This used to infer framing from the byte values instead — a table of "how
+/// many parameters does this command take", with unknown commands assumed to
+/// take none. That could not survive a real driver's init sequence: Adafruit's
+/// stock table sends the undocumented power-control command 0xCB with five
+/// parameters, the model treated 0xCB as unknown/zero-parameter, and its second
+/// parameter 0x2C was then decoded as RAMWR. The pixel stream opened mid-init
+/// and every remaining init byte — including SLPOUT and DISPON — was written
+/// into the framebuffer as pixel data. The panel never turned on, and the
+/// firmware was blameless.
+///
+/// With D/C wired, a parameter byte can never be mistaken for a command, so
+/// unknown and undocumented commands are harmless: their parameters are
+/// consumed as data and ignored. The per-command byte counts below now decide
+/// only WHEN a command's parameters are complete enough to apply, never where
+/// one command ends and the next begins.
+///
+/// `Ili9341::new` leaves D/C unwired for backward compatibility with callers
+/// that never supplied a pin; that path keeps the old inference and its limits.
+/// Prefer [`Ili9341::with_dc_pin`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum ProtoState {
     Idle,
@@ -69,6 +95,23 @@ pub struct Ili9341 {
     /// Command/data state machine.
     #[serde(skip_serializing)]
     state: ProtoState,
+    /// D/C GPIO label, when the manifest wired one.
+    dc_pin: Option<String>,
+    /// Latched D/C level at transfer time: false = command, true = data.
+    dc_level: bool,
+    /// MADCTL (0x36) value — orientation and mirroring.
+    madctl: u8,
+    /// Command byte currently collecting parameters (D/C-framed path).
+    cur_cmd: u8,
+    /// Parameters gathered for `cur_cmd`. Sized for the longest command we
+    /// interpret; longer ones (gamma tables) are consumed and ignored.
+    #[serde(skip_serializing)]
+    param_buf: [u8; 4],
+    param_len: usize,
+    /// True while a RAMWR (0x2C) / RAMWR-continue (0x3C) pixel stream is open.
+    in_ramwr: bool,
+    /// High byte of a pixel awaiting its low byte.
+    pixel_hi: Option<u8>,
 }
 
 impl Default for Ili9341 {
@@ -90,7 +133,58 @@ impl Ili9341 {
             row_end: (HEIGHT as u16) - 1,
             framebuffer: vec![0u8; FB_BYTES],
             state: ProtoState::Idle,
+            dc_pin: None,
+            dc_level: false,
+            madctl: 0,
+            cur_cmd: 0,
+            param_buf: [0; 4],
+            param_len: 0,
+            in_ramwr: false,
+            pixel_hi: None,
         }
+    }
+
+    /// Wire the D/C line, which is what makes framing real rather than inferred.
+    pub fn with_dc_pin(mut self, dc_pin: impl Into<String>) -> Self {
+        self.dc_pin = Some(dc_pin.into());
+        self
+    }
+
+    /// Addressable extent in the CURRENT orientation. MADCTL's MV bit swaps the
+    /// axes, so a landscape driver legitimately sets columns to 0..=319.
+    /// Clamping those to 239 (the panel's physical width) silently folded a
+    /// correct landscape image into portrait.
+    fn addressable_width(&self) -> u16 {
+        if self.madctl & MADCTL_MV != 0 {
+            HEIGHT as u16
+        } else {
+            WIDTH as u16
+        }
+    }
+
+    fn addressable_height(&self) -> u16 {
+        if self.madctl & MADCTL_MV != 0 {
+            WIDTH as u16
+        } else {
+            HEIGHT as u16
+        }
+    }
+
+    /// Map a logical (column, row) in the current orientation onto the physical
+    /// 240×320 frame memory, which does not rotate.
+    fn to_physical(&self, col: u16, row: u16) -> (usize, usize) {
+        let (mut x, mut y) = if self.madctl & MADCTL_MV != 0 {
+            (row, col)
+        } else {
+            (col, row)
+        };
+        if self.madctl & MADCTL_MX != 0 {
+            x = (WIDTH as u16).saturating_sub(1).saturating_sub(x);
+        }
+        if self.madctl & MADCTL_MY != 0 {
+            y = (HEIGHT as u16).saturating_sub(1).saturating_sub(y);
+        }
+        (x as usize, y as usize)
     }
 
     /// Return the raw RGB565 framebuffer (153,600 bytes: row-major, 2 bytes per pixel).
@@ -111,16 +205,96 @@ impl Ili9341 {
 
     // ---- Internal command dispatch ----
 
+    /// Number of parameter bytes a command must gather before it is applied.
+    /// With D/C framing this is a semantic threshold only — it no longer
+    /// decides where one command ends and the next begins, so an unlisted
+    /// command is harmless rather than stream-corrupting.
+    fn param_count(cmd: u8) -> usize {
+        match cmd {
+            0x2A | 0x2B => 4, // CASET / PASET
+            0x36 | 0x3A => 1, // MADCTL / COLMOD
+            _ => 0,
+        }
+    }
+
+    /// A byte arriving with D/C low: a command.
+    fn dc_command(&mut self, cmd: u8) {
+        self.cur_cmd = cmd;
+        self.param_len = 0;
+        self.param_buf = [0; 4];
+        // Any command other than a RAMWR continue closes an open pixel stream.
+        match cmd {
+            0x2C => {
+                // RAMWR — restart the pixel pointer at the window origin.
+                self.cur_col = self.col_start;
+                self.cur_row = self.row_start;
+                self.in_ramwr = true;
+                self.pixel_hi = None;
+            }
+            0x3C => {
+                // RAMWR continue (§8.2.34): resume WITHOUT resetting the
+                // pointer, which is how drivers chunk a large blit across
+                // transactions. Previously undecoded, so those pixel bytes were
+                // read as commands.
+                self.in_ramwr = true;
+            }
+            _ => {
+                self.in_ramwr = false;
+                self.pixel_hi = None;
+                self.apply_simple_command(cmd);
+            }
+        }
+    }
+
+    /// Commands that act immediately and take no parameters.
+    fn apply_simple_command(&mut self, cmd: u8) {
+        match cmd {
+            0x01 => {
+                // SWRESET. Datasheet §8.2.2 is explicit: "the Frame Memory
+                // contents are unaffected by this command". Clearing it here
+                // let firmware that relies on SWRESET to blank the screen pass
+                // in the twin and show stale pixels on silicon.
+                self.col_start = 0;
+                self.col_end = self.addressable_width() - 1;
+                self.row_start = 0;
+                self.row_end = self.addressable_height() - 1;
+                self.display_on = false;
+                self.madctl = 0;
+            }
+            0x28 => self.display_on = false,
+            0x29 => self.display_on = true,
+            _ => {}
+        }
+    }
+
+    /// A byte arriving with D/C high: parameter or pixel data.
+    fn dc_data(&mut self, byte: u8) {
+        if self.in_ramwr {
+            match self.pixel_hi.take() {
+                None => self.pixel_hi = Some(byte),
+                Some(hi) => self.write_pixel(hi, byte),
+            }
+            return;
+        }
+        if self.param_len < self.param_buf.len() {
+            self.param_buf[self.param_len] = byte;
+        }
+        self.param_len += 1;
+        let want = Self::param_count(self.cur_cmd);
+        if want > 0 && self.param_len == want {
+            let (cmd, params) = (self.cur_cmd, self.param_buf);
+            self.handle_params_complete(cmd, &params);
+        }
+    }
+
     fn handle_command(&mut self, cmd: u8) {
         match cmd {
             0x01 => {
-                // SWRESET — software reset: clear framebuffer and reset window
-                self.framebuffer.iter_mut().for_each(|b| *b = 0);
-                self.col_start = 0;
-                self.col_end = (WIDTH as u16) - 1;
-                self.row_start = 0;
-                self.row_end = (HEIGHT as u16) - 1;
-                self.display_on = false;
+                // SWRESET. Frame memory is deliberately NOT cleared — see
+                // `apply_simple_command`. Both framing paths must agree, or the
+                // same command would mean two things depending on whether a D/C
+                // pin happened to be wired.
+                self.apply_simple_command(0x01);
                 self.state = ProtoState::Idle;
             }
             0x11 => {
@@ -206,13 +380,35 @@ impl Ili9341 {
                     want: 2,
                 };
             }
-            0xB1 | 0xB6 => {
-                // FRMCTR / DFUNCTR — variable, consume up to 3 params; ignored
+            // Datasheet parameter counts: FRMCTR1 (B1h) §8.3.2 takes 2,
+            // DISCTRL (B6h) §8.3.7 takes 4. Both were 3 here, so B1h ate the
+            // following command byte and B6h left one to be decoded as a
+            // command. Only reachable on the legacy no-D/C path now, but wrong
+            // is wrong.
+            0xB1 => {
                 self.state = ProtoState::AwaitingParams {
                     cmd,
                     params: [0; 4],
                     have: 0,
-                    want: 3,
+                    want: 2,
+                };
+            }
+            0xB6 => {
+                self.state = ProtoState::AwaitingParams {
+                    cmd,
+                    params: [0; 4],
+                    have: 0,
+                    want: 4,
+                };
+            }
+            // Single-parameter commands a stock driver sends: VMCTR2 (C7h),
+            // GAMMASET (26h), VSCRSADD (37h).
+            0xC7 | 0x26 | 0x37 => {
+                self.state = ProtoState::AwaitingParams {
+                    cmd,
+                    params: [0; 4],
+                    have: 0,
+                    want: 1,
                 };
             }
             _ => {
@@ -225,27 +421,36 @@ impl Ili9341 {
     fn handle_params_complete(&mut self, cmd: u8, params: &[u8; 4]) {
         match cmd {
             0x2A => {
-                // CASET: set column window
+                // CASET: set column window, clamped to the CURRENT orientation.
                 let start = ((params[0] as u16) << 8) | (params[1] as u16);
                 let end = ((params[2] as u16) << 8) | (params[3] as u16);
-                self.col_start = start.min((WIDTH as u16) - 1);
-                self.col_end = end.min((WIDTH as u16) - 1);
+                let limit = self.addressable_width() - 1;
+                self.col_start = start.min(limit);
+                self.col_end = end.min(limit);
             }
             0x2B => {
-                // PASET: set row window
+                // PASET: set row window, clamped to the current orientation.
                 let start = ((params[0] as u16) << 8) | (params[1] as u16);
                 let end = ((params[2] as u16) << 8) | (params[3] as u16);
-                self.row_start = start.min((HEIGHT as u16) - 1);
-                self.row_end = end.min((HEIGHT as u16) - 1);
+                let limit = self.addressable_height() - 1;
+                self.row_start = start.min(limit);
+                self.row_end = end.min(limit);
             }
-            // All other commands' parameters are consumed silently
+            0x36 => {
+                // MADCTL — orientation. Previously consumed and dropped, which
+                // is why a landscape sketch drew a portrait image.
+                self.madctl = params[0];
+            }
+            // Other commands' parameters are consumed and ignored. With D/C
+            // framing that is safe: they can never be read as commands.
             _ => {}
         }
     }
 
     fn write_pixel(&mut self, hi: u8, lo: u8) {
-        let idx = (self.cur_row as usize * WIDTH + self.cur_col as usize) * 2;
-        if idx + 1 < self.framebuffer.len() {
+        let (x, y) = self.to_physical(self.cur_col, self.cur_row);
+        let idx = (y * WIDTH + x) * 2;
+        if x < WIDTH && idx + 1 < self.framebuffer.len() {
             self.framebuffer[idx] = hi;
             self.framebuffer[idx + 1] = lo;
         }
@@ -281,7 +486,24 @@ impl SpiDevice for Ili9341 {
         // The next cs_select() will reset state for the following command.
     }
 
+    fn dc_pin(&self) -> Option<&str> {
+        self.dc_pin.as_deref()
+    }
+
+    fn set_dc_level(&mut self, level: bool) {
+        self.dc_level = level;
+    }
+
     fn transfer(&mut self, mosi: u8) -> u8 {
+        // With a D/C line wired, framing is the wire's, not a guess.
+        if self.dc_pin.is_some() {
+            if self.dc_level {
+                self.dc_data(mosi);
+            } else {
+                self.dc_command(mosi);
+            }
+            return 0;
+        }
         let state = self.state;
         match state {
             ProtoState::Idle => {
@@ -347,11 +569,21 @@ static ILI9341_METADATA: KitMetadata = KitMetadata {
              the display verbatim.",
     transport: Transport::Spi,
     category: Category::Spi,
-    config_keys: &[ConfigKey {
-        name: "cs_pin",
-        ty: ConfigType::Str,
-        doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
-    }],
+    config_keys: &[
+        ConfigKey {
+            name: "cs_pin",
+            ty: ConfigType::Str,
+            doc: "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4.",
+        },
+        ConfigKey {
+            name: "dc_pin",
+            ty: ConfigType::Str,
+            doc: "Data/command GPIO pin (e.g. \"GPIO33\"). Strongly recommended: \
+                  with it, command/data framing is read from the wire like real \
+                  silicon. Without it the model must infer framing from byte \
+                  values, which a real driver's init sequence desynchronises.",
+        },
+    ],
     labs: &[LabRef {
         board_id: "ili9341-tft-lab",
         chip: "stm32f103",
@@ -366,7 +598,12 @@ impl PeripheralKit for Ili9341Kit {
     }
     fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
         let cs_pin = ctx.config_str("cs_pin").unwrap_or("PA4").to_string();
-        ctx.attach_spi_device(Box::new(Ili9341::new(cs_pin)))?;
+        let dc_pin = ctx.config_str("dc_pin").map(|s| s.to_string());
+        let mut dev = Ili9341::new(cs_pin);
+        if let Some(dc) = dc_pin {
+            dev = dev.with_dc_pin(dc);
+        }
+        ctx.attach_spi_device(Box::new(dev))?;
         Ok(())
     }
 }
@@ -389,6 +626,124 @@ mod tests {
             dev.transfer(b);
         }
         dev.cs_release();
+    }
+
+    /// Drive a D/C-wired panel the way the bus does: latch the level, then
+    /// clock the byte.
+    fn dc_send(dev: &mut Ili9341, dc_high: bool, bytes: &[u8]) {
+        dev.set_dc_level(dc_high);
+        for &b in bytes {
+            dev.transfer(b);
+        }
+    }
+
+    fn cmd(dev: &mut Ili9341, c: u8, params: &[u8]) {
+        dc_send(dev, false, &[c]);
+        if !params.is_empty() {
+            dc_send(dev, true, params);
+        }
+    }
+
+    // Adafruit_ILI9341's stock init table, run through the model exactly as the
+    // bus delivers it. This is the sequence that used to destroy the model:
+    // 0xCB is undocumented, the old value-inference treated it as taking no
+    // parameters, and its second parameter 0x2C was decoded as RAMWR — opening
+    // the pixel stream mid-init so SLPOUT and DISPON were written into the
+    // framebuffer as pixel data and the display never came on.
+    #[test]
+    fn adafruit_init_sequence_leaves_the_display_on_and_the_framebuffer_clean() {
+        let mut dev = Ili9341::new("PA4").with_dc_pin("PB0");
+        cmd(&mut dev, 0xEF, &[0x03, 0x80, 0x02]);
+        cmd(&mut dev, 0xCF, &[0x00, 0xC1, 0x30]);
+        cmd(&mut dev, 0xED, &[0x64, 0x03, 0x12, 0x81]);
+        cmd(&mut dev, 0xE8, &[0x85, 0x00, 0x78]);
+        cmd(&mut dev, 0xCB, &[0x39, 0x2C, 0x00, 0x34, 0x02]); // the killer
+        cmd(&mut dev, 0xF7, &[0x20]);
+        cmd(&mut dev, 0xEA, &[0x00, 0x00]);
+        cmd(&mut dev, 0xC0, &[0x23]);
+        cmd(&mut dev, 0xC1, &[0x10]);
+        cmd(&mut dev, 0xC5, &[0x3E, 0x28]);
+        cmd(&mut dev, 0xC7, &[0x86]);
+        cmd(&mut dev, 0x36, &[0x48]);
+        cmd(&mut dev, 0x3A, &[0x55]);
+        cmd(&mut dev, 0xB1, &[0x00, 0x18]);
+        cmd(&mut dev, 0xB6, &[0x08, 0x82, 0x27]);
+        cmd(&mut dev, 0x11, &[]); // SLPOUT
+        cmd(&mut dev, 0x29, &[]); // DISPON
+
+        assert!(
+            dev.display_on(),
+            "DISPON must be seen as a command, not swallowed as pixel data"
+        );
+        assert!(
+            dev.framebuffer().iter().all(|&b| b == 0),
+            "init must not write a single pixel"
+        );
+    }
+
+    // A landscape sketch (`setRotation(1)`) sets MADCTL MV and then addresses
+    // columns 0..=319. Dropping MADCTL and clamping columns to 239 folded that
+    // into portrait: a correct firmware, the wrong picture, no diagnostic.
+    #[test]
+    fn madctl_landscape_allows_the_full_320_column_window() {
+        let mut dev = Ili9341::new("PA4").with_dc_pin("PB0");
+        cmd(&mut dev, 0x36, &[MADCTL_MV]);
+        cmd(&mut dev, 0x2A, &[0x00, 0x00, 0x01, 0x3F]); // columns 0..=319
+        assert_eq!(dev.col_end, 319, "landscape column window must not clamp");
+
+        // The pixel at logical (319, 0) is physical (x=0, y=319) once MV swaps
+        // the axes — inside the 240x320 frame memory, not discarded.
+        cmd(&mut dev, 0x2B, &[0x00, 0x00, 0x00, 0x00]);
+        dc_send(&mut dev, false, &[0x2C]);
+        dev.cur_col = 319;
+        dev.cur_row = 0;
+        dc_send(&mut dev, true, &[0xF8, 0x00]);
+        let idx = (319 * WIDTH) * 2;
+        assert_eq!(
+            (dev.framebuffer()[idx], dev.framebuffer()[idx + 1]),
+            (0xF8, 0x00),
+            "landscape pixel must land in frame memory"
+        );
+    }
+
+    // Datasheet 8.2.2: "the Frame Memory contents are unaffected by this
+    // command". Clearing on SWRESET let firmware that relies on it to blank the
+    // screen pass here and show stale pixels on real hardware.
+    #[test]
+    fn swreset_does_not_clear_frame_memory() {
+        let mut dev = Ili9341::new("PA4").with_dc_pin("PB0");
+        cmd(&mut dev, 0x2A, &[0, 0, 0, 0]);
+        cmd(&mut dev, 0x2B, &[0, 0, 0, 0]);
+        dc_send(&mut dev, false, &[0x2C]);
+        dc_send(&mut dev, true, &[0xAB, 0xCD]);
+        assert_eq!((dev.framebuffer()[0], dev.framebuffer()[1]), (0xAB, 0xCD));
+
+        cmd(&mut dev, 0x01, &[]); // SWRESET
+        assert_eq!(
+            (dev.framebuffer()[0], dev.framebuffer()[1]),
+            (0xAB, 0xCD),
+            "SWRESET must leave frame memory untouched"
+        );
+        assert!(!dev.display_on(), "but it does turn the display off");
+    }
+
+    // RAMWR-continue (0x3C) resumes the pixel stream WITHOUT resetting the
+    // pointer — how drivers chunk a large blit. Undecoded before, so those
+    // pixel bytes were interpreted as commands.
+    #[test]
+    fn ramwr_continue_resumes_without_restarting_the_window() {
+        let mut dev = Ili9341::new("PA4").with_dc_pin("PB0");
+        cmd(&mut dev, 0x2A, &[0x00, 0x00, 0x00, 0x03]);
+        cmd(&mut dev, 0x2B, &[0x00, 0x00, 0x00, 0x00]);
+        dc_send(&mut dev, false, &[0x2C]);
+        dc_send(&mut dev, true, &[0x11, 0x11, 0x22, 0x22]);
+        dc_send(&mut dev, false, &[0x3C]);
+        dc_send(&mut dev, true, &[0x33, 0x33]);
+        assert_eq!(
+            &dev.framebuffer()[0..6],
+            &[0x11, 0x11, 0x22, 0x22, 0x33, 0x33],
+            "continue must append at the third pixel, not restart at the first"
+        );
     }
 
     #[test]
@@ -450,18 +805,30 @@ mod tests {
     }
 
     #[test]
-    fn test_swreset_clears_framebuffer() {
+    // Datasheet §8.2.2: "the Frame Memory contents are unaffected by this
+    // command". This test previously asserted the opposite, pinning a model
+    // behaviour that let firmware relying on SWRESET to blank the screen pass
+    // in the twin and show stale pixels on silicon. The no-D/C path must agree
+    // with the D/C path (see `swreset_does_not_clear_frame_memory`) — one
+    // command cannot mean two things depending on how it was framed.
+    #[test]
+    fn test_swreset_preserves_framebuffer_and_turns_display_off() {
         let mut dev = Ili9341::new("PA4");
-        // Write a pixel
+        send_cmd(&mut dev, 0x29);
         dev.cs_select();
         dev.transfer(0x2C);
         dev.transfer(0xFF);
         dev.transfer(0xFF);
         dev.cs_release();
         assert_ne!(dev.framebuffer()[0], 0);
-        // Software reset
+
         send_cmd(&mut dev, 0x01);
-        assert_eq!(dev.framebuffer()[0], 0, "SWRESET should clear framebuffer");
+        assert_eq!(
+            dev.framebuffer()[0],
+            0xFF,
+            "SWRESET must leave frame memory untouched"
+        );
+        assert!(!dev.display_on(), "SWRESET does turn the display off");
     }
 
     #[test]

--- a/crates/core/src/peripherals/components/ili9341.rs
+++ b/crates/core/src/peripherals/components/ili9341.rs
@@ -804,7 +804,6 @@ mod tests {
         assert_eq!(fb[3], 0xE0);
     }
 
-    #[test]
     // Datasheet §8.2.2: "the Frame Memory contents are unaffected by this
     // command". This test previously asserted the opposite, pinning a model
     // behaviour that let firmware relying on SWRESET to blank the screen pass

--- a/crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs
@@ -550,11 +550,20 @@ pub fn set_appcpu_up_flags(addrs: Vec<u32>) {
 ///
 ///  * Legacy: the 4-byte sequence `E9 01 0C 0D` → `0C 0D D9 01`.
 ///  * IDF 5.x: `xCoreID` is `xTaskCreateUniversal`'s 7th (stack) arg —
-///    `movi.n aT, 1` whose value is stored via `s32i.n aT, a1, 0`. Recover
-///    `T` from the store (`[0x09|(T<<4), 0x01]`) and zero the `movi.n aT, 1`
-///    immediate (`[0x0C, 0x10|T]` → `[0x0C, T]`).
+///    a `movi` of 1 whose value is stored via `s32i.n aT, a1, 0`. Recover `T`
+///    from the store (`[0x09|(T<<4), 0x01]`), then zero whichever `movi` form
+///    the compiler picked:
+///      - narrow `movi.n aT, 1` = `[0x0C, 0x10|T]` → `[0x0C, T]`
+///      - wide   `movi aT, 1`   = `[(T<<4)|0x02, 0xA0, 0x01]` → `…, 0x00`
 ///
-/// Returns `(patched_addr, which_shape)`, or `None` if neither matches
+/// Both forms must be handled. A build that used the WIDE encoding matched
+/// neither shape and silently returned `None`, leaving `loopTask` pinned to
+/// APP_CPU. That does not fail cleanly: the sketch runs on the wrong core and
+/// deadlocks the first time it contends a FreeRTOS portMUX with PRO_CPU,
+/// parking forever in `spinlock_acquire` — which reads as a firmware hang, not
+/// as an unrecognised layout. Callers should treat `None` as loud.
+///
+/// Returns `(patched_addr, which_shape)`, or `None` if none matches
 /// (firmware already targets core 0, or an unrecognized layout).
 pub fn repin_loop_task(bus: &mut dyn Bus, app_main_addr: u32) -> Option<(u32, &'static str)> {
     const SCAN: u32 = 96;
@@ -575,18 +584,34 @@ pub fn repin_loop_task(bus: &mut dyn Bus, app_main_addr: u32) -> Option<(u32, &'
         }
         return Some((addr, "legacy"));
     }
-    // IDF 5.x: locate `s32i.n aT, a1, 0`, recover T, zero its movi.n source.
+    // IDF 5.x: locate `s32i.n aT, a1, 0`, recover T, zero whichever `movi`
+    // form loaded it. The compiler picks narrow or wide freely, so BOTH must
+    // be recognised — see the note above on why missing one is not a benign
+    // no-op but a cross-core deadlock.
     for k in 0..w.len().saturating_sub(1) {
-        if (w[k] & 0x0F) == 0x09 && w[k + 1] == 0x01 {
-            let t = w[k] >> 4;
-            let movi_hi = 0x10 | t;
-            if let Some(mi) =
-                (0..w.len().saturating_sub(1)).find(|&m| w[m] == 0x0C && w[m + 1] == movi_hi)
-            {
-                let addr = app_main_addr + mi as u32 + 1;
-                let _ = bus.write_u8(addr as u64, t); // movi.n aT, 0
-                return Some((addr, "idf5"));
-            }
+        if (w[k] & 0x0F) != 0x09 || w[k + 1] != 0x01 {
+            continue;
+        }
+        let t = w[k] >> 4;
+        // Narrow: `movi.n aT, 1` = [0x0C, 0x10|T]. Zero the immediate nibble.
+        let movi_n_hi = 0x10 | t;
+        if let Some(mi) =
+            (0..w.len().saturating_sub(1)).find(|&m| w[m] == 0x0C && w[m + 1] == movi_n_hi)
+        {
+            let addr = app_main_addr + mi as u32 + 1;
+            let _ = bus.write_u8(addr as u64, t); // movi.n aT, 0
+            return Some((addr, "idf5"));
+        }
+        // Wide: `movi aT, 1` = [(T<<4)|0x02, 0xA0, 0x01] (imm12 = 1, so the
+        // high nibble of the immediate is 0 and the whole value lives in the
+        // third byte). Zero that byte.
+        let movi_lo = (t << 4) | 0x02;
+        if let Some(mi) = (0..w.len().saturating_sub(2))
+            .find(|&m| w[m] == movi_lo && w[m + 1] == 0xA0 && w[m + 2] == 0x01)
+        {
+            let addr = app_main_addr + mi as u32 + 2;
+            let _ = bus.write_u8(addr as u64, 0x00); // movi aT, 0
+            return Some((addr, "idf5-wide"));
         }
     }
     None
@@ -2117,6 +2142,94 @@ mod tests {
     use crate::bus::SystemBus;
     use crate::cpu::xtensa_lx7::XtensaLx7;
     use crate::Cpu;
+
+    /// A bus with writable RAM at `APP_MAIN`, holding `code`.
+    fn bus_with_app_main(code: &[u8]) -> SystemBus {
+        use crate::system::xtensa::RamPeripheral;
+        let mut bus = SystemBus::empty();
+        bus.add_peripheral(
+            "ram",
+            APP_MAIN as u64,
+            0x1000,
+            None,
+            Box::new(RamPeripheral::new(0x1000)),
+        );
+        for (i, b) in code.iter().enumerate() {
+            bus.write_u8(APP_MAIN as u64 + i as u64, *b).unwrap();
+        }
+        bus
+    }
+
+    const APP_MAIN: u32 = 0x400D_0000;
+
+    // `xTaskCreateUniversal`'s xCoreID arg is loaded with a `movi` the compiler
+    // picks in either width. Recognising only the narrow one is not a benign
+    // miss: loopTask stays pinned to APP_CPU and the sketch deadlocks partway
+    // through setup() in `spinlock_acquire`, which looks like a firmware hang.
+    // A real customer build used the WIDE form and stalled mid-setup().
+    #[test]
+    fn repin_loop_task_handles_the_wide_movi_form() {
+        // movi a14, 1        = E2 A0 01
+        // s32i.n a14, a1, 0  = E9 01
+        let code = [0x36, 0x61, 0x00, 0xE2, 0xA0, 0x01, 0xE9, 0x01, 0x1D, 0xF0];
+        let mut bus = bus_with_app_main(&code);
+        let (addr, shape) =
+            repin_loop_task(&mut bus, APP_MAIN).expect("wide movi must be repinned");
+        assert_eq!(shape, "idf5-wide");
+        assert_eq!(addr, APP_MAIN + 5, "patches the immediate byte");
+        assert_eq!(
+            bus.read_u8(addr as u64).unwrap(),
+            0x00,
+            "xCoreID immediate must become 0 (PRO_CPU)"
+        );
+        // The opcode and register selector must be untouched.
+        assert_eq!(bus.read_u8(APP_MAIN as u64 + 3).unwrap(), 0xE2);
+        assert_eq!(bus.read_u8(APP_MAIN as u64 + 4).unwrap(), 0xA0);
+    }
+
+    #[test]
+    fn repin_loop_task_handles_the_narrow_movi_form() {
+        // movi.n a14, 1      = 0C 1E
+        // s32i.n a14, a1, 0  = E9 01
+        let code = [0x36, 0x61, 0x00, 0x0C, 0x1E, 0xE9, 0x01, 0x1D, 0xF0];
+        let mut bus = bus_with_app_main(&code);
+        let (addr, shape) = repin_loop_task(&mut bus, APP_MAIN).expect("narrow movi repinned");
+        assert_eq!(shape, "idf5");
+        assert_eq!(
+            bus.read_u8(addr as u64).unwrap(),
+            0x0E,
+            "movi.n a14, 0 keeps the register and zeroes the immediate"
+        );
+    }
+
+    #[test]
+    fn repin_loop_task_handles_the_legacy_form() {
+        let code = [0x36, 0x61, 0x00, 0xE9, 0x01, 0x0C, 0x0D, 0x1D, 0xF0];
+        let mut bus = bus_with_app_main(&code);
+        let (addr, shape) = repin_loop_task(&mut bus, APP_MAIN).expect("legacy repinned");
+        assert_eq!(shape, "legacy");
+        let mut got = [0u8; 4];
+        for (i, b) in got.iter_mut().enumerate() {
+            *b = bus.read_u8(addr as u64 + i as u64).unwrap();
+        }
+        assert_eq!(got, [0x0C, 0x0D, 0xD9, 0x01]);
+    }
+
+    // Firmware already targeting core 0 has nothing to patch, and must not be
+    // corrupted by a loose pattern match.
+    #[test]
+    fn repin_loop_task_leaves_an_unrecognised_layout_alone() {
+        let code = [0x36, 0x61, 0x00, 0x1D, 0xF0, 0x00, 0x00, 0x00];
+        let mut bus = bus_with_app_main(&code);
+        assert!(repin_loop_task(&mut bus, APP_MAIN).is_none());
+        for (i, b) in code.iter().enumerate() {
+            assert_eq!(
+                bus.read_u8(APP_MAIN as u64 + i as u64).unwrap(),
+                *b,
+                "byte {i} must be untouched"
+            );
+        }
+    }
 
     #[test]
     fn registered_thunk_address_holds_break_bytes() {

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,12 +10,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-01 | ⚠ drift acked 2026-08-01 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-01 | ⚠ drift acked 2026-08-01 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-07-28 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-07-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
@@ -60,7 +60,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-07-31 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-01 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -105,7 +105,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-07-31 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-01 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -750,7 +750,17 @@ boards:
     # coverage bit-clocks a real transaction through this controller and covers the
     # `SLAVE_ADDR` fallback specifically; passes unchanged. No live USB-JTAG
     # re-capture this session.
-    drift_ack: 2026-07-31
+    # 2026-08-01: shared-path changes only, none of them a C3 peripheral.
+    # (a) The classic-ESP32 boot ROM's UART console routines are now loaded as
+    # real ROM code instead of nop thunks, and (b) `repin_loop_task` learned the
+    # wide `movi` encoding. Both live on the Xtensa side; the C3 is RISC-V and
+    # ROM-boots its own image. (c) The ILI9341 SPI panel now frames on its D/C
+    # line — an external device model on the far side of the wire, not a chip
+    # peripheral. No C3 register layout, base address or reset value moved, so
+    # the 2026-06-17 reset-state oracle (1123/1123 static registers) cannot
+    # move. Evidence: full `cargo test -p labwired-core --lib` green, 2509
+    # tests. No live USB-JTAG re-capture this session.
+    drift_ack: 2026-08-01
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -1479,7 +1489,18 @@ boards:
     # bus the resolution is byte-identical to the code it replaces. Register map,
     # reset values and the 9-reg reset-state anchor are untouched; esp32s3 reset
     # conformance passes. No S3 board attached; no live re-capture.
-    drift_ack: 2026-07-31
+    # 2026-08-01: two shared-path changes, neither an S3 peripheral.
+    # `crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs` gained the
+    # wide-`movi` shape in `repin_loop_task` (a classic-ESP32 firmware-image
+    # patch that rewrites an xCoreID immediate; the S3 path never calls it) and
+    # lost its ROM console thunks in favour of the classic-ESP32 boot ROM's real
+    # code, installed only by `configure_xtensa_esp32`. The S3's own
+    # `ets_printf` registration at 0x4000_05d0 is untouched. Separately the
+    # ILI9341 SPI panel now frames on its D/C line — an external device, not a
+    # chip peripheral. Register map, reset values and the 9-reg reset-state
+    # anchor are untouched; esp32s3 reset conformance passes. No S3 board
+    # attached; no live re-capture.
+    drift_ack: 2026-08-01
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Two defects found by running a customer's rig end to end. Both were silent, and both made a *correct* firmware look broken.

## 1. loopTask stayed pinned to APP_CPU — mid-`setup()` deadlock

Arduino-ESP32 pins `loopTask` to APP_CPU; the snapshot path rewrites that `xCoreID` immediate to 0. The IDF-5.x matcher only recognised the **narrow** `movi.n aT, 1`. Compilers pick the width freely, and a current arduino-esp32 build emits the **wide** `movi aT, 1` instead.

Missing it is not a benign no-op: `loopTask` stays on APP_CPU and the sketch deadlocks the first time it contends a FreeRTOS portMUX with PRO_CPU, parking forever in `spinlock_acquire` (whose retry loop spins while the lock owner is the *other* core, `PRID ^ 0x6666`). It reads as a firmware hang with no hint the simulator caused it.

The customer rig stalled after 6 of its 12 tests. With the wide form matched it completes all 12. `None` is now warned about loudly instead of skipped silently — the failure mode is a deadlock, so it must never be quiet again.

## 2. ILI9341 inferred command framing from byte values

Adafruit's stock init sends undocumented `0xCB` with 5 parameters; the model assumed unknown commands take none, so parameter `0x2C` was decoded as **RAMWR**. The pixel stream opened mid-init and every remaining byte — `SLPOUT` and `DISPON` included — landed in the framebuffer as pixel data. Display never turned on.

Both directions at once: correct firmware looks broken, and any firmware that *did* light the sim was one whose byte stream happened to dodge a stray opcode — so the sim was not testing the init at all. The shipped lab sends only `01/11/3A/29` and never collides, which is why it stayed green.

The engine already had `SpiDevice::dc_pin`/`set_dc_level` (PCD8544 uses it). ILI9341 now does too. Also fixed against the datasheet: MADCTL orientation (a `setRotation(1)` window was clamped to portrait), SWRESET no longer clears frame memory (§8.2.2), RAMWR-continue `0x3C`, and the B1h/B6h parameter counts.

## Verification

2509 lib tests pass. The customer rig now reports 12/12 over serial with the panel driven through real D/C framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)