### PR TITLE
ci(pr-gate): lint and test the default-members, not just core + CLI

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -89,15 +89,31 @@ jobs:
       - name: Check Formatting
         run: cargo fmt --all -- --check
 
-      # Clippy + lib tests for the merge surface only (core + CLI). Full
-      # workspace + feature lanes run in nightly integrity-full.
-      - name: Clippy (core + CLI)
-        run: >
-          cargo clippy -p labwired-core -p labwired-cli
-          --all-targets -- -D warnings
+      # Clippy + lib tests over the workspace's default-members — cli, core,
+      # dap, loader, labwired-fuzz. Feature lanes and the firmware/matrix
+      # crates stay in nightly integrity-full.
+      #
+      # These two steps used to narrow to `-p labwired-core -p labwired-cli`,
+      # which left `dap`, `loader` and `labwired-fuzz` compiled by NO pre-merge
+      # gate at all: `core-integrity` lints them (its bare `cargo clippy
+      # --all-targets` resolves to default-members) but it runs only on push to
+      # main, so the first thing to notice a break was main itself, after the
+      # merge. `channel: Option<String>` on `BoardIoBinding` reached main
+      # exactly that way — it stranded four `BoardIoBinding` literals in the
+      # DAP adapter's tests, and because those literals are `#[cfg(test)]` the
+      # break was invisible to anything short of `--all-targets`. pr-gate was
+      # green, main went red on the merge.
+      #
+      # `pull_request` CI builds the merge commit, not the branch tip, so
+      # linting the default-members here catches that class of semantic
+      # conflict against the tree the merge will actually produce — before it
+      # lands rather than after. Keep this scope in step with the `Run Clippy`
+      # step in core-integrity; if they drift apart the hole reopens.
+      - name: Clippy (default-members)
+        run: cargo clippy --all-targets -- -D warnings
 
-      - name: Unit tests (core + CLI lib)
-        run: cargo test -p labwired-core -p labwired-cli --lib
+      - name: Unit tests (default-members lib)
+        run: cargo test --lib
 
   # ── Main-branch integrity (push to main) — fuller than PR, still no matrices ─
   integrity:


### PR DESCRIPTION
## Description

`pr-gate` is the only required pre-merge check, and it narrowed its two cargo steps to `-p labwired-core -p labwired-cli`. `core-integrity` does not narrow — its bare `cargo clippy --all-targets` resolves to the workspace `default-members`:

```
default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
```

So `dap`, `loader` and `labwired-fuzz` were linted **only on push to main**. Anything that broke them passed the merge gate green and turned main red on landing. The required gate was reporting on a strictly smaller tree than the branch it was gating.

`channel: Option<String>` on `BoardIoBinding` (#727) is the worked example. It stranded four `BoardIoBinding` literals in the DAP adapter's tests, and because those literals live behind `#[cfg(test)]` nothing short of `--all-targets` sees them: `cargo build` stays green, and `pr-gate` never built the crate at all. main failed `core-integrity` and `core-full` from that single root cause from the moment it merged until #727 landed.

**Reproduced** against main at `7570e7c` (pre-#727) on the toolchain CI pins:

| command | result |
|---|---|
| `cargo clippy -p labwired-core -p labwired-cli --all-targets -- -D warnings` | **exit 0** — break slips through |
| `cargo clippy --all-targets -- -D warnings` | **exit 101**, 5× E0063 in `crates/dap/src/adapter.rs` |

The widening is close to free. `labwired-core` dominates the compile and is shared, so adding `dap` and `loader` at `--all-targets` is **3.46s** of incremental work (79s → 82s cold). For scale, `pr-gate` on #727 ran 4m16s. Feature lanes and the firmware/matrix crates are untouched and stay nightly.

`pull_request` CI builds the merge commit rather than the branch tip, so this lints the tree the merge will actually produce — which is what makes it catch a semantic conflict between two independently-green branches *before* it lands rather than after.

## Related Issues

Follow-up to #727, which fixed the symptom (the four stranded literals). This fixes the gate that let it through.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt` and `cargo clippy`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

On the second box: the change *is* test surface rather than something with a test of its own, so it is verified by the before/after table above — the old scope exits 0 on the broken tree, the new scope exits 101. Widening `cargo test --lib` to the default-members also newly runs **23 dap + 13 loader** lib tests that no pre-merge gate has ever executed.

Verified green on this branch rebased onto `f866a78` (main with #727 merged):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib` — **2576 passed, 0 failed** (40 cli, 2500 core, 23 dap, 13 loader, 0 fuzz)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs1ZpwvVfeaUDzdZcDPKFi)_