### PR TITLE
fix(xtensa): shadow-mode RETW must never vector to the firmware underflow handler

### DIFF
--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -1742,15 +1742,33 @@ impl XtensaLx7 {
                 let wb_cur = self.regs.windowbase();
                 let wb_dest = wb_cur.wrapping_sub(n) & 0x0F;
 
-                // Shadow hybrid: if we still have a preserve entry for this RETW,
-                // force the dest frame live and skip UF — restore_call_preserve
-                // below reloads a0..a7 (including ipc_task a5/a6). Stack UF is
-                // unreliable after FreeRTOS task switch (save areas get reused).
-                if !self.faithful_windows
-                    && !self.call_preserve_stack.is_empty()
-                    && !self.regs.windowstart_bit(wb_dest)
-                    && n > 0
-                {
+                // Shadow mode owns window save/restore END TO END, so it must
+                // never hand a RETW to the firmware's underflow vector.
+                //
+                // The two halves have to agree. In shadow mode the per-access
+                // WINDOW OVERFLOW vector is disabled (see the F5 block in
+                // `execute`) because the sim-level spill on CALL{n} preserves
+                // the caller's registers itself — which means the firmware's
+                // `_WindowOverflow{4,8,12}` handlers never run and the on-stack
+                // save areas at a1-16.. are never written. Vectoring to
+                // `_WindowUnderflow8` then restores a0 from a save area nobody
+                // populated: a0 comes back 0 and the RETW lands at pc=0x0,
+                // surfacing as an illegal-instruction fault inside
+                // _KernelExceptionVector with no hint of where it came from.
+                //
+                // This guard used to additionally require a non-empty
+                // `call_preserve_stack`, so it only masked the asymmetry while
+                // that stack happened to be primed. A deep enough call chain
+                // drained it and the next wrapped RETW fell through to the
+                // firmware handler. Adafruit's stock `graphicstest` reproduces
+                // it during its first benchmark, where real silicon (verified
+                // on an ESP32-D0WDQ6) completes all twelve.
+                //
+                // With the stack empty there is nothing to reload, but forcing
+                // the frame live is still strictly better: the physical
+                // registers hold the most recent values, whereas the firmware
+                // path is guaranteed to read zeros.
+                if !self.faithful_windows && !self.regs.windowstart_bit(wb_dest) && n > 0 {
                     self.regs.set_windowstart_bit(wb_dest, true);
                     for k in 1..n {
                         let s = wb_dest.wrapping_add(k) & 0x0F;


### PR DESCRIPTION
Found by running Adafruit's stock `graphicstest_featherwing.ino` **unmodified**, and confirmed against real hardware.

| | result |
|---|---|
| **Real silicon** (ESP32-D0WDQ6 DevKit V1) | completes all 12 benchmarks, `Done!` |
| **Twin** (before this) | faults during the *first* benchmark |

## Root cause: the two halves of window handling disagreed

In shadow mode the per-access **window overflow** vector is disabled — the sim-level spill on `CALL{n}` preserves the caller's registers itself — so the firmware's `_WindowOverflow{4,8,12}` handlers never run and the on-stack save areas at `a1-16..` are never written.

But `RETW` still vectored to **`_WindowUnderflow8`** whenever the destination frame was not live. That handler restores `a0` from a save area nobody populated: `a0` comes back `0`, the `RETW` lands at `pc=0x0`, and it surfaces as an illegal-instruction fault inside `_KernelExceptionVector` — with no hint of where it came from.

The guard that masked this additionally required a non-empty `call_preserve_stack`, so it only held while that stack happened to be primed. A deep enough call chain drained it and the next wrapped `RETW` fell through.

## This is NOT a complete fix

It removes a path that can only ever read zeros. The sketch now gets through "Screen fill" and several more benchmarks before failing differently — `Memory access violation at 0xffffffbc`, a negative offset off a **zero** `a1`, because with the preserve stack drained there is genuinely nothing to reload.

The underlying gap: shadow-mode spills live only in `call_preserve_stack`, which is also `.clear()`ed on several paths and popped by ROM thunks without a matching push. Once drained, a wrapped frame cannot be reconstructed. Fixing it properly means either making those spills durable, or enabling `faithful_windows` so the firmware's own symmetric handlers own the save chain. Tracked with the full diagnosis and both candidate routes.

## Not a regression, and no regressions caused

Reproduces on `9695546b`, before any of today's work. With this change: **2509 lib tests pass**, the customer rig still reports **12/12** with the panel painting `0x07E0`, and the ereader capture is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)