### PR TITLE
Revert "chore(esp32c3-weather-station): retitle the panel to PETER'S WEATHER"

### DIFF
--- a/examples/esp32c3-weather-station/README.md
+++ b/examples/esp32c3-weather-station/README.md
@@ -11,7 +11,7 @@ Set what's yours at the top of `src/main.ino`:
 ```c
 static const char *WIFI_SSID = "labwired-ap";      // your WiFi
 static const char *WIFI_PASS = "";                 // "" for an open network
-static const char *TITLE = "PETER'S WEATHER";      // the red line across the top
+static const char *TITLE = "ANDRII'S WEATHER";     // the red line across the top
 static const char *CITY = "BUDAPEST";              // just the name
 static const unsigned long REFRESH_MINUTES = 30;
 ```
@@ -29,7 +29,7 @@ box — change it to your home network before flashing real hardware.
 ## What lands on the panel
 
 ```
-PETER'S WEATHER                         BUDAPEST
+ANDRII'S WEATHER                        BUDAPEST
 ────────────────────────────────────────────────
    \ ; /                              THU 30 JUL
   -- O --      32°C                      HUM 25%

--- a/examples/esp32c3-weather-station/src/main.ino
+++ b/examples/esp32c3-weather-station/src/main.ino
@@ -44,7 +44,7 @@ static const char *WIFI_SSID = "labwired-ap";
 static const char *WIFI_PASS = "";
 
 // Shown in red across the top. Make it yours.
-static const char *TITLE = "PETER'S WEATHER";
+static const char *TITLE = "ANDRII'S WEATHER";
 
 // Your city. That is the whole setting — the coordinates are looked up for you
 // on the first fetch, so there is no latitude/longitude to go and find.


### PR DESCRIPTION
Reverts #738. The rename was never wanted — "PETER'S WEATHER" was a *prompt to give the in-canvas agent* as a test that it can edit firmware, not an instruction to edit the repo. I misread it.

Example is back to `ANDRII'S WEATHER` in all three places (`src/main.ino`, and the config block + panel art in the README).