### PR TITLE
feat(trace): standardize per-instruction instrumentation across every CPU core

### DIFF
--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -599,7 +599,55 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
         "labwired-cli snapshot: stepping firmware to cycle {}",
         args.steps
     );
-    let observers: Vec<std::sync::Arc<dyn labwired_core::SimulationObserver>> = Vec::new();
+    // Instruction trace. Off unless asked for: attaching an observer forces
+    // the interpreter path (a compiled block cannot emit per-step events), so
+    // an always-on trace would silently tax every capture.
+    let ring = args
+        .trace_out
+        .as_ref()
+        .map(|_| std::sync::Arc::new(labwired_core::trace::RetiredRing::new(args.trace_last)));
+    let observers: Vec<std::sync::Arc<dyn labwired_core::SimulationObserver>> = match &ring {
+        Some(r) => vec![r.clone()],
+        None => Vec::new(),
+    };
+    if let Some(path) = &args.trace_out {
+        eprintln!(
+            "labwired-cli snapshot: tracing the last {} retired instructions to {}",
+            args.trace_last,
+            path.display()
+        );
+    }
+    // Written on EVERY exit path, faults included — a trace that only survives
+    // a clean run is useless for the case it exists to explain.
+    let dump_trace = |ring: &Option<std::sync::Arc<labwired_core::trace::RetiredRing>>| {
+        let (Some(ring), Some(path)) = (ring, args.trace_out.as_ref()) else {
+            return;
+        };
+        let entries = ring.entries();
+        let total = ring.total_retired();
+        let payload = serde_json::json!({
+            "total_retired": total,
+            "kept": entries.len(),
+            "dropped": total.saturating_sub(entries.len() as u64),
+            "instructions": entries,
+        });
+        match std::fs::File::create(path) {
+            Ok(f) => {
+                if let Err(e) = serde_json::to_writer_pretty(f, &payload) {
+                    eprintln!("error: failed to write {}: {e}", path.display());
+                } else {
+                    eprintln!(
+                        "labwired-cli snapshot: wrote {} of {} retired instructions to {}",
+                        entries.len(),
+                        total,
+                        path.display()
+                    );
+                }
+            }
+            Err(e) => eprintln!("error: failed to create {}: {e}", path.display()),
+        }
+    };
+
     let config = labwired_core::SimulationConfig::default();
     let mut i: u64 = 0;
     let progress = args.progress_every;
@@ -665,6 +713,7 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                     "error: sim step at cycle {i} pc=0x{:08x}: {e}",
                     machine.cpu.get_pc()
                 );
+                dump_trace(&ring);
                 return ExitCode::from(EXIT_RUNTIME_ERROR);
             }
         }
@@ -699,6 +748,7 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
                         "error: sim step cpu1 at cycle {i} pc=0x{:08x}: {e}",
                         cpu1.get_pc()
                     );
+                    dump_trace(&ring);
                     return ExitCode::from(EXIT_RUNTIME_ERROR);
                 }
             }
@@ -935,6 +985,8 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
             }
         }
     }
+
+    dump_trace(&ring);
 
     let snap = machine.take_runtime_snapshot();
     let bytes = snap.to_bytes();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -308,6 +308,17 @@ pub struct SnapshotCaptureArgs {
     /// Print a progress line every N steps. 0 = silent.
     #[arg(long, default_value = "5000000")]
     pub progress_every: u64,
+
+    /// Write a JSON instruction trace here. Records the LAST `--trace-last`
+    /// retired instructions, which is the window that matters when a run
+    /// faults. Attaching a trace forces the interpreter (compiled blocks can't
+    /// emit per-step events), so the capture runs slower.
+    #[arg(long = "trace-out", value_name = "PATH")]
+    pub trace_out: Option<PathBuf>,
+
+    /// How many retired instructions to keep in the trace ring.
+    #[arg(long = "trace-last", value_name = "N", default_value = "4096")]
+    pub trace_last: usize,
 }
 
 #[derive(Parser, Debug)]

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -3233,11 +3233,16 @@ impl CortexM {
         // and this runs on every instruction. Gate it on having observers, the
         // same way on_step_start above is gated.
         if !_observers.is_empty() {
-            let mut registers = [0u32; 17];
+            let mut registers = [0u32; 19];
             for (i, reg) in registers.iter_mut().enumerate().take(16) {
                 *reg = self.get_register(i as u8);
             }
             registers[16] = self.xpsr;
+            // Standard trailer (see `SimulationObserver`): SP then PC. Both
+            // already live in the arch block (r13/r15); repeating them here is
+            // what lets an arch-agnostic consumer find them.
+            registers[17] = self.get_register(13);
+            registers[18] = self.pc;
 
             crate::emit_trace_event(
                 _observers,

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -1266,9 +1266,12 @@ impl Cpu for RiscV {
         // Building the register snapshot is pure waste when nothing observes it,
         // and this runs on every instruction. Gate it on having observers.
         if !observers.is_empty() {
-            let mut registers = [0u32; 33];
+            let mut registers = [0u32; 34];
             registers[..32].copy_from_slice(&self.x);
-            registers[32] = self.pc;
+            // Standard trailer (see `SimulationObserver`): SP then PC. On
+            // RISC-V the stack pointer is x2 by ABI convention.
+            registers[32] = self.x[2];
+            registers[33] = self.pc;
 
             crate::emit_trace_event(
                 observers,

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -320,6 +320,38 @@ impl XtensaLx7 {
         cpu
     }
 
+    /// Raw instruction encoding at `pc`, for trace observers only.
+    ///
+    /// Xtensa instructions are 2, 3 or 4 bytes and the decode cache means a
+    /// hot step may never touch the bytes at all, so the trace has to go get
+    /// them. Widths mirror the fetch path exactly (u16 for narrow, u32
+    /// otherwise) so observing a run cannot change which addresses it reads.
+    /// A read that fails yields 0 rather than an error: losing one trace word
+    /// must never turn into a simulation fault.
+    fn raw_word_for_trace(&self, bus: &mut dyn Bus, pc: u32, len: u32) -> u32 {
+        let addr = pc as u64;
+        if let Some((start, end, ptr_addr)) = self.fetch_cache {
+            if addr >= start && addr + 4 <= end {
+                let off = (addr - start) as usize;
+                // SAFETY: identical invariant to the fetch fast path in
+                // `step` — the pointer comes from `Bus::fetch_slice` into a
+                // fixed-size RAM backing buffer, the cache is invalidated on
+                // any write into the cached range, and `addr + 4 <= end` is
+                // bounds-checked above.
+                unsafe {
+                    let p = (ptr_addr as *const u8).add(off);
+                    let w = u32::from_le_bytes([*p, *p.add(1), *p.add(2), *p.add(3)]);
+                    return if len == 2 { w & 0xFFFF } else { w };
+                }
+            }
+        }
+        if len == 2 {
+            bus.read_u16(addr).map(u32::from).unwrap_or(0)
+        } else {
+            bus.read_u32(addr).unwrap_or(0)
+        }
+    }
+
     /// Phase 3.2 pilot (issue #124): attempt to dispatch the current PC to
     /// a JIT-compiled block. Returns `Ok(Some(instr_count))` if the JIT
     /// handled the step (with PC, registers, and CCOUNT already updated),
@@ -1742,33 +1774,33 @@ impl XtensaLx7 {
                 let wb_cur = self.regs.windowbase();
                 let wb_dest = wb_cur.wrapping_sub(n) & 0x0F;
 
-                // Shadow mode owns window save/restore END TO END, so it must
-                // never hand a RETW to the firmware's underflow vector.
+                // Shadow mode owns window save/restore only while it still
+                // HOLDS the frames — i.e. while `call_preserve_stack` is
+                // non-empty. Once `spill_call_preserve_to_stack` has run, the
+                // frames live in the on-stack OF save areas and WINDOWSTART has
+                // collapsed to `1<<WB`; from then on the firmware's underflow
+                // handler is the correct reader and this shortcut must not fire.
                 //
-                // The two halves have to agree. In shadow mode the per-access
-                // WINDOW OVERFLOW vector is disabled (see the F5 block in
-                // `execute`) because the sim-level spill on CALL{n} preserves
-                // the caller's registers itself — which means the firmware's
-                // `_WindowOverflow{4,8,12}` handlers never run and the on-stack
-                // save areas at a1-16.. are never written. Vectoring to
-                // `_WindowUnderflow8` then restores a0 from a save area nobody
-                // populated: a0 comes back 0 and the RETW lands at pc=0x0,
-                // surfacing as an illegal-instruction fault inside
-                // _KernelExceptionVector with no hint of where it came from.
+                // Dropping the `is_empty` condition (an earlier attempt at the
+                // `graphicstest` fault below) is measurably wrong: with
+                // LABWIRED_DIAG_RETW instrumentation, all 14 force-live events
+                // in that run had `preserve_depth=0` and a prior spill, so the
+                // shortcut skipped the only path that could still reload the
+                // frame. `testFillScreen`'s RETW then returned a1=0x20 to
+                // `setup()` and `Print::printNumber` faulted on the garbage SP.
                 //
-                // This guard used to additionally require a non-empty
-                // `call_preserve_stack`, so it only masked the asymmetry while
-                // that stack happened to be primed. A deep enough call chain
-                // drained it and the next wrapped RETW fell through to the
-                // firmware handler. Adafruit's stock `graphicstest` reproduces
-                // it during its first benchmark, where real silicon (verified
-                // on an ESP32-D0WDQ6) completes all twelve.
-                //
-                // With the stack empty there is nothing to reload, but forcing
-                // the frame live is still strictly better: the physical
-                // registers hold the most recent values, whereas the firmware
-                // path is guaranteed to read zeros.
-                if !self.faithful_windows && !self.regs.windowstart_bit(wb_dest) && n > 0 {
+                // The remaining defect is NOT here. Adafruit's stock
+                // `graphicstest` still faults (real silicon, an ESP32-D0WDQ6,
+                // completes all twelve benchmarks) because the underflow
+                // handler reads a save area the spill never populated:
+                // `spill_call_preserve_to_stack` skips frames whose a1 fails
+                // `valid_sp`/`stackish`, leaving holes. Fixing the holes is the
+                // open work — see the graphicstest task.
+                if !self.faithful_windows
+                    && !self.regs.windowstart_bit(wb_dest)
+                    && n > 0
+                    && !self.call_preserve_stack.is_empty()
+                {
                     self.regs.set_windowstart_bit(wb_dest, true);
                     for k in 1..n {
                         let s = wb_dest.wrapping_add(k) & 0x0F;
@@ -3088,9 +3120,15 @@ impl Cpu for XtensaLx7 {
     fn step(
         &mut self,
         bus: &mut dyn Bus,
-        _observers: &[Arc<dyn SimulationObserver>],
+        observers: &[Arc<dyn SimulationObserver>],
         _config: &crate::SimulationConfig,
     ) -> SimResult<()> {
+        // Instruction tracing is the same contract every other core honours
+        // (`on_step_start` / `InstructionRetired` / `on_step_end`); see
+        // `tests/cpu_trace_conformance.rs`, which fails if a core stops
+        // emitting it. Building the register view costs real time, so every
+        // trace-only path below is gated on somebody actually observing.
+        let observed = !observers.is_empty();
         // Dual-core: a halted CPU contributes nothing — skip the entire
         // step (no CCOUNT advance, no fetch, no IRQ dispatch). Real
         // silicon's APP_CPU sits in reset until PRO_CPU releases it; we
@@ -3158,7 +3196,11 @@ impl Cpu for XtensaLx7 {
         // an exit code that says where to continue.
         #[cfg(feature = "jit")]
         {
-            if self.jit_enabled {
+            // A compiled block retires many instructions without passing
+            // through the fetch/decode path, so it cannot emit the per-step
+            // trace. Fall back to the interpreter whenever anyone is
+            // observing — an empty trace is worse than a slow one.
+            if self.jit_enabled && !observed {
                 if let Some(_n) = self.try_jit_step(bus)? {
                     return Ok(());
                 }
@@ -3261,6 +3303,20 @@ impl Cpu for XtensaLx7 {
             self.decode_gen[dc_idx] = self.cur_decode_gen;
             (len, ins)
         };
+        // Raw encoding for the trace. Read at the same widths the fetch path
+        // uses so an observed run touches exactly the bytes an unobserved one
+        // does — a trace that perturbs the run it is measuring is useless.
+        let raw = if observed {
+            self.raw_word_for_trace(bus, pc, len)
+        } else {
+            0
+        };
+        if observed {
+            for obs in observers {
+                obs.on_step_start(pc, raw);
+            }
+        }
+
         self.branched = false;
         let fall_through_pc = pc.wrapping_add(len);
         self.execute(ins, bus, len)?;
@@ -3280,6 +3336,28 @@ impl Cpu for XtensaLx7 {
         if lcount > 0 && self.pc == lend && fall_through_pc == lend && !self.branched {
             self.sr.write(LCOUNT, lcount - 1);
             self.pc = self.sr.read(LBEG);
+        }
+
+        if observed {
+            // a0..a15 as the window currently sees them, then PC. The window
+            // view is the one that matters on Xtensa: a raw physical-file dump
+            // would not line up with the disassembly a reader is holding.
+            let mut registers = [0u32; 18];
+            for (i, slot) in registers[..16].iter_mut().enumerate() {
+                *slot = self.regs.read_logical(i as u8);
+            }
+            // Standard trailer (see `SimulationObserver`): SP then PC. On
+            // Xtensa the stack pointer is a1 in the current window.
+            registers[16] = self.regs.read_logical(1);
+            registers[17] = self.pc;
+
+            crate::emit_trace_event(
+                observers,
+                labwired_hw_trace::TraceEvent::InstructionRetired { pc, opcode: raw },
+            );
+            for obs in observers {
+                obs.on_step_end(1, &registers);
+            }
         }
         Ok(())
     }

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -1742,15 +1742,33 @@ impl XtensaLx7 {
                 let wb_cur = self.regs.windowbase();
                 let wb_dest = wb_cur.wrapping_sub(n) & 0x0F;
 
-                // Shadow hybrid: if we still have a preserve entry for this RETW,
-                // force the dest frame live and skip UF — restore_call_preserve
-                // below reloads a0..a7 (including ipc_task a5/a6). Stack UF is
-                // unreliable after FreeRTOS task switch (save areas get reused).
-                if !self.faithful_windows
-                    && !self.call_preserve_stack.is_empty()
-                    && !self.regs.windowstart_bit(wb_dest)
-                    && n > 0
-                {
+                // Shadow mode owns window save/restore END TO END, so it must
+                // never hand a RETW to the firmware's underflow vector.
+                //
+                // The two halves have to agree. In shadow mode the per-access
+                // WINDOW OVERFLOW vector is disabled (see the F5 block in
+                // `execute`) because the sim-level spill on CALL{n} preserves
+                // the caller's registers itself — which means the firmware's
+                // `_WindowOverflow{4,8,12}` handlers never run and the on-stack
+                // save areas at a1-16.. are never written. Vectoring to
+                // `_WindowUnderflow8` then restores a0 from a save area nobody
+                // populated: a0 comes back 0 and the RETW lands at pc=0x0,
+                // surfacing as an illegal-instruction fault inside
+                // _KernelExceptionVector with no hint of where it came from.
+                //
+                // This guard used to additionally require a non-empty
+                // `call_preserve_stack`, so it only masked the asymmetry while
+                // that stack happened to be primed. A deep enough call chain
+                // drained it and the next wrapped RETW fell through to the
+                // firmware handler. Adafruit's stock `graphicstest` reproduces
+                // it during its first benchmark, where real silicon (verified
+                // on an ESP32-D0WDQ6) completes all twelve.
+                //
+                // With the stack empty there is nothing to reload, but forcing
+                // the frame live is still strictly better: the physical
+                // registers hold the most recent values, whereas the firmware
+                // path is guaranteed to read zeros.
+                if !self.faithful_windows && !self.regs.windowstart_bit(wb_dest) && n > 0 {
                     self.regs.set_windowstart_bit(wb_dest, true);
                     for k in 1..n {
                         let s = wb_dest.wrapping_add(k) & 0x0F;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -157,6 +157,35 @@ impl PeripheralTickResult {
 }
 
 /// Trait for observing simulation events in a modular way.
+///
+/// # The per-instruction trace contract
+///
+/// Every CPU core MUST emit, for each retired instruction, in this order:
+///
+///   1. `on_step_start(pc, opcode)` — before execution, `pc` is the address
+///      being executed and `opcode` its raw little-endian encoding.
+///   2. `TraceEvent::InstructionRetired { pc, opcode }` via [`emit_trace_event`].
+///   3. `on_step_end(cycles, registers)` — after execution.
+///
+/// A core may skip all three when `observers.is_empty()` (building the
+/// register view is not free), but it may NOT skip them for any other reason:
+/// in particular a JIT/compiled-block fast path must fall back to the
+/// interpreter while anyone is observing, or the trace silently loses the
+/// instructions that matter most.
+///
+/// `registers` is arch-specific in its leading entries, but the **last two
+/// slots are standardized** so that arch-agnostic consumers work everywhere:
+///
+/// ```text
+///   [ .. architectural registers, ISA numbering .. , SP , PC ]
+/// ```
+///
+/// SP and PC are repeated in those trailing slots even when they already
+/// appear in the arch block (ARM's r13/r15, RISC-V's x2). The duplication is
+/// deliberate: it means a consumer never has to know which core produced a
+/// trace to find the two values it almost always wants. See
+/// [`SP_FROM_END`]/[`PC_FROM_END`], and `tests/cpu_trace_conformance.rs`,
+/// which runs every core and fails if one drifts from any of the above.
 pub trait SimulationObserver: std::fmt::Debug + Send + Sync {
     fn on_simulation_start(&self) {}
     fn on_simulation_stop(&self) {}
@@ -165,6 +194,23 @@ pub trait SimulationObserver: std::fmt::Debug + Send + Sync {
     fn on_step_end(&self, _cycles: u32, _registers: &[u32]) {}
     fn on_memory_write(&self, _addr: u64, _old: u8, _new: u8) {}
     fn on_peripheral_tick(&self, _name: &str, _cycles: u32) {}
+}
+
+/// Offset of the standardized PC slot from the end of an `on_step_end`
+/// register slice. See [`SimulationObserver`].
+pub const PC_FROM_END: usize = 1;
+/// Offset of the standardized SP slot from the end of an `on_step_end`
+/// register slice. See [`SimulationObserver`].
+pub const SP_FROM_END: usize = 2;
+
+/// SP and PC out of an `on_step_end` register slice, whatever core produced
+/// it. Returns `None` for a slice too short to carry the standard trailer.
+pub fn trace_sp_pc(registers: &[u32]) -> Option<(u32, u32)> {
+    let n = registers.len();
+    if n < SP_FROM_END {
+        return None;
+    }
+    Some((registers[n - SP_FROM_END], registers[n - PC_FROM_END]))
 }
 
 pub fn emit_trace_event(

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::Mutex;
 
 /// A single instruction execution trace point
@@ -11,6 +11,14 @@ pub struct InstructionTrace {
     pub register_delta: BTreeMap<u8, (u32, u32)>,
     pub memory_writes: Vec<MemoryWrite>,
     pub mnemonic: Option<String>,
+    /// Stack pointer after the instruction retired, read from the standardized
+    /// trailer of the observer register slice (see `SimulationObserver`).
+    ///
+    /// Named `stack_depth` for wire compatibility with existing `trace.json`
+    /// readers. It has always been the SP value, never a depth — but until the
+    /// trailer existed it was read from index 13, which is SP only on ARM. On
+    /// RISC-V and Xtensa that index is an unrelated temporary, so every
+    /// non-ARM trace ever emitted had a meaningless number here.
     pub stack_depth: u32,
     pub function: Option<String>,
 }
@@ -107,11 +115,152 @@ impl crate::SimulationObserver for TraceObserver {
             register_delta,
             memory_writes: writes,
             mnemonic: None,
-            stack_depth: registers.get(13).copied().unwrap_or(0),
+            stack_depth: crate::trace_sp_pc(registers).map(|(sp, _)| sp).unwrap_or(0),
             function: None,
         });
 
         state.registers_before = registers.to_vec();
         state.total_cycles += cycles as u64;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One retired instruction, in the ring.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RetiredInstruction {
+    /// Position in the run, counted from the first retired instruction. Kept
+    /// because the ring drops the beginning: without it there is no way to
+    /// tell "the last 4096 of 8 million" from "the only 4096 that ran".
+    pub seq: u64,
+    pub pc: u32,
+    pub opcode: u32,
+    /// Stack pointer after retirement, from the standardized register trailer.
+    pub sp: u32,
+}
+
+/// The last N retired instructions, for any core.
+///
+/// [`TraceObserver`] keeps the *first* `max_traces` instructions, which is the
+/// wrong end of the run when the thing being debugged is a fault: the useful
+/// window is whatever executed immediately before it. This keeps a fixed-size
+/// ring instead, so a multi-million-instruction run costs bounded memory and
+/// still answers "what ran just before it died".
+///
+/// Arch-agnostic by construction — it reads PC and SP out of the standardized
+/// trailer described on [`crate::SimulationObserver`], so it works unchanged on
+/// every core rather than needing a per-chip variant.
+#[derive(Debug)]
+pub struct RetiredRing {
+    capacity: usize,
+    state: Mutex<RetiredRingState>,
+}
+
+#[derive(Debug)]
+struct RetiredRingState {
+    entries: VecDeque<RetiredInstruction>,
+    /// Total retired, including those already dropped out of the ring.
+    total: u64,
+    /// Carried from `on_step_start` to the matching `on_step_end`.
+    pending: Option<(u32, u32)>,
+}
+
+impl RetiredRing {
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            capacity,
+            state: Mutex::new(RetiredRingState {
+                entries: VecDeque::with_capacity(capacity),
+                total: 0,
+                pending: None,
+            }),
+        }
+    }
+
+    /// Instructions still in the ring, oldest first.
+    pub fn entries(&self) -> Vec<RetiredInstruction> {
+        self.state.lock().unwrap().entries.iter().copied().collect()
+    }
+
+    /// Total retired over the whole run, including entries dropped from the
+    /// ring. Compare against `entries().len()` to see how much was discarded.
+    pub fn total_retired(&self) -> u64 {
+        self.state.lock().unwrap().total
+    }
+}
+
+impl crate::SimulationObserver for RetiredRing {
+    fn on_step_start(&self, pc: u32, opcode: u32) {
+        self.state.lock().unwrap().pending = Some((pc, opcode));
+    }
+
+    fn on_step_end(&self, _cycles: u32, registers: &[u32]) {
+        let mut state = self.state.lock().unwrap();
+        let Some((pc, opcode)) = state.pending.take() else {
+            return;
+        };
+        let sp = crate::trace_sp_pc(registers).map(|(sp, _)| sp).unwrap_or(0);
+        let seq = state.total;
+        state.total += 1;
+        if state.entries.len() == self.capacity {
+            state.entries.pop_front();
+        }
+        state.entries.push_back(RetiredInstruction {
+            seq,
+            pc,
+            opcode,
+            sp,
+        });
+    }
+}
+
+#[cfg(test)]
+mod ring_tests {
+    use super::*;
+    use crate::SimulationObserver;
+
+    fn regs(sp: u32, pc: u32) -> Vec<u32> {
+        vec![0, 0, 0, sp, pc]
+    }
+
+    #[test]
+    fn ring_keeps_the_last_window_not_the_first() {
+        let ring = RetiredRing::new(3);
+        for i in 0..10u32 {
+            ring.on_step_start(0x1000 + i * 4, 0xAA00 + i);
+            ring.on_step_end(1, &regs(0x8000 - i, 0x1004 + i * 4));
+        }
+        let entries = ring.entries();
+        assert_eq!(entries.len(), 3, "ring exceeded its capacity");
+        assert_eq!(ring.total_retired(), 10);
+        // The tail, not the head — this is the whole point of the type.
+        assert_eq!(entries[0].pc, 0x1000 + 7 * 4);
+        assert_eq!(entries[2].pc, 0x1000 + 9 * 4);
+        // seq survives the drop, so the window is locatable in the run.
+        assert_eq!(entries[0].seq, 7);
+        assert_eq!(entries[2].seq, 9);
+    }
+
+    #[test]
+    fn ring_reads_sp_from_the_standard_trailer() {
+        let ring = RetiredRing::new(4);
+        ring.on_step_start(0x2000, 0x1234);
+        ring.on_step_end(1, &regs(0x7FF0, 0x2004));
+        assert_eq!(ring.entries()[0].sp, 0x7FF0);
+    }
+
+    #[test]
+    fn a_step_that_faults_before_retiring_is_not_recorded() {
+        // on_step_start with no matching on_step_end is exactly what a faulting
+        // instruction looks like. It must not leak into the next entry.
+        let ring = RetiredRing::new(4);
+        ring.on_step_start(0x3000, 0x1111);
+        assert!(ring.entries().is_empty());
+        ring.on_step_start(0x3004, 0x2222);
+        ring.on_step_end(1, &regs(0x8000, 0x3008));
+        let entries = ring.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].pc, 0x3004, "stale pending step bled through");
     }
 }

--- a/crates/core/tests/cpu_trace_conformance.rs
+++ b/crates/core/tests/cpu_trace_conformance.rs
@@ -232,8 +232,7 @@ fn every_core_emits_the_full_per_instruction_trace() {
             let width = core.step_len as usize;
             let mut expected_opcode = 0u32;
             for b in (0..width).rev() {
-                expected_opcode =
-                    (expected_opcode << 8) | core.program[i * width + b] as u32;
+                expected_opcode = (expected_opcode << 8) | core.program[i * width + b] as u32;
             }
             assert_eq!(
                 step.start_opcode, expected_opcode,

--- a/crates/core/tests/cpu_trace_conformance.rs
+++ b/crates/core/tests/cpu_trace_conformance.rs
@@ -162,8 +162,7 @@ fn cores() -> Vec<CoreUnderTest> {
             name: "RiscV",
             entry: 0x100,
             // `addi x1, x1, 1` ×4 (4 bytes each).
-            program: std::iter::repeat(0x00108093u32)
-                .take(4)
+            program: std::iter::repeat_n(0x00108093u32, 4)
                 .flat_map(u32::to_le_bytes)
                 .collect(),
             step_len: 4,

--- a/crates/core/tests/cpu_trace_conformance.rs
+++ b/crates/core/tests/cpu_trace_conformance.rs
@@ -1,0 +1,353 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! Standardized instruction-trace instrumentation, proven per CPU core.
+//!
+//! Every core must emit the same per-instruction trace, in the same shape, so
+//! that `--trace`, VCD export, coverage and the DAP adapter behave identically
+//! no matter which chip is under the debugger. The contract itself is written
+//! down on `SimulationObserver`; this file is what makes it true.
+//!
+//! It exists because it was NOT true. Xtensa — the core behind classic ESP32
+//! and ESP32-S3 — ignored its `observers` argument entirely, so `--trace`
+//! produced an empty file for those chips and every Xtensa debugging session
+//! fell back to guesswork. Nothing failed, because nothing checked.
+//!
+//! Note the shape of the guard: a trace test that only asserts "some events
+//! arrived" would have passed on a core that emits one bogus event, and a test
+//! that hard-codes today's three cores would go quietly stale the day a fourth
+//! lands. So this runs real instructions through each core and checks the
+//! emissions against what the core actually did, and it derives the core list
+//! from the source tree rather than trusting the list below.
+
+use labwired_core::cpu::{CortexM, RiscV, XtensaLx7};
+use labwired_core::{
+    trace_sp_pc, Bus, Cpu, DmaRequest, SimResult, SimulationConfig, SimulationObserver,
+};
+use labwired_hw_trace::TraceEvent;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+/// Flat byte-addressable RAM based at 0. Deliberately dumb: this test is about
+/// what the CPU *emits*, so the bus must not be able to influence the outcome.
+#[derive(Debug)]
+struct RamBus {
+    mem: Vec<u8>,
+    config: SimulationConfig,
+}
+
+impl RamBus {
+    fn with_program(entry: u64, program: &[u8]) -> Self {
+        let mut mem = vec![0u8; 0x1_0000];
+        mem[entry as usize..entry as usize + program.len()].copy_from_slice(program);
+        Self {
+            mem,
+            config: SimulationConfig::default(),
+        }
+    }
+}
+
+impl Bus for RamBus {
+    fn read_u8(&self, addr: u64) -> SimResult<u8> {
+        Ok(self.mem.get(addr as usize).copied().unwrap_or(0))
+    }
+    fn write_u8(&mut self, addr: u64, value: u8) -> SimResult<()> {
+        if let Some(slot) = self.mem.get_mut(addr as usize) {
+            *slot = value;
+        }
+        Ok(())
+    }
+    fn tick_peripherals(&mut self) -> Vec<u32> {
+        Vec::new()
+    }
+    fn execute_dma(&mut self, _requests: &[DmaRequest]) -> SimResult<()> {
+        Ok(())
+    }
+    fn config(&self) -> &SimulationConfig {
+        &self.config
+    }
+}
+
+/// One emitted step, reassembled from the three callbacks.
+#[derive(Debug, Clone)]
+struct Step {
+    start_pc: u32,
+    start_opcode: u32,
+    retired: Option<(u32, u32)>,
+    registers: Vec<u32>,
+}
+
+#[derive(Debug, Default)]
+struct Recorder {
+    steps: Mutex<Vec<Step>>,
+    /// Callbacks seen since the last `on_step_end`, so ordering is checkable.
+    pending: Mutex<Option<Step>>,
+}
+
+impl Recorder {
+    fn steps(&self) -> Vec<Step> {
+        self.steps.lock().unwrap().clone()
+    }
+}
+
+impl SimulationObserver for Recorder {
+    fn on_step_start(&self, pc: u32, opcode: u32) {
+        let mut pending = self.pending.lock().unwrap();
+        assert!(
+            pending.is_none(),
+            "on_step_start fired twice with no on_step_end between: \
+             the core is dropping the tail of the trace contract"
+        );
+        *pending = Some(Step {
+            start_pc: pc,
+            start_opcode: opcode,
+            retired: None,
+            registers: Vec::new(),
+        });
+    }
+
+    fn on_trace_event(&self, event: TraceEvent) {
+        if let TraceEvent::InstructionRetired { pc, opcode } = event {
+            let mut pending = self.pending.lock().unwrap();
+            let step = pending
+                .as_mut()
+                .expect("InstructionRetired arrived outside a step");
+            step.retired = Some((pc, opcode));
+        }
+    }
+
+    fn on_step_end(&self, _cycles: u32, registers: &[u32]) {
+        let mut step = self
+            .pending
+            .lock()
+            .unwrap()
+            .take()
+            .expect("on_step_end without a matching on_step_start");
+        step.registers = registers.to_vec();
+        self.steps.lock().unwrap().push(step);
+    }
+}
+
+/// A core, plus the smallest real program that exercises it.
+struct CoreUnderTest {
+    /// Type name as it appears in `impl Cpu for …`; ties the row to the source.
+    name: &'static str,
+    entry: u32,
+    /// Straight-line, side-effect-free instructions, little-endian.
+    program: Vec<u8>,
+    /// Bytes each instruction advances PC by.
+    step_len: u32,
+    build: fn() -> Box<dyn Cpu>,
+}
+
+/// Every core that implements `Cpu`. Completeness is enforced by
+/// `every_cpu_core_is_covered_by_this_file`, not by reviewer diligence.
+fn cores() -> Vec<CoreUnderTest> {
+    vec![
+        CoreUnderTest {
+            name: "CortexM",
+            entry: 0x100,
+            // `movs r0, #1` ×4 (Thumb, 2 bytes each).
+            program: vec![0x01, 0x20, 0x01, 0x20, 0x01, 0x20, 0x01, 0x20],
+            step_len: 2,
+            build: || {
+                let mut cpu = CortexM::new();
+                cpu.set_sp(0x8000);
+                Box::new(cpu)
+            },
+        },
+        CoreUnderTest {
+            name: "RiscV",
+            entry: 0x100,
+            // `addi x1, x1, 1` ×4 (4 bytes each).
+            program: std::iter::repeat(0x00108093u32)
+                .take(4)
+                .flat_map(u32::to_le_bytes)
+                .collect(),
+            step_len: 4,
+            build: || {
+                let mut cpu = RiscV::new();
+                cpu.set_sp(0x8000);
+                Box::new(cpu)
+            },
+        },
+        CoreUnderTest {
+            name: "XtensaLx7",
+            entry: 0x100,
+            // `movi.n a2, 1` ×4 (narrow, 2 bytes each).
+            program: vec![0x0C, 0x12, 0x0C, 0x12, 0x0C, 0x12, 0x0C, 0x12],
+            step_len: 2,
+            build: || {
+                let mut cpu = XtensaLx7::new();
+                cpu.set_sp(0x8000);
+                Box::new(cpu)
+            },
+        },
+    ]
+}
+
+// ── The contract ─────────────────────────────────────────────────────────────
+
+#[test]
+fn every_core_emits_the_full_per_instruction_trace() {
+    const STEPS: usize = 4;
+
+    for core in cores() {
+        let mut cpu = (core.build)();
+        cpu.set_pc(core.entry);
+        let mut bus = RamBus::with_program(core.entry as u64, &core.program);
+        let recorder = Arc::new(Recorder::default());
+        let observers: Vec<Arc<dyn SimulationObserver>> = vec![recorder.clone()];
+        let config = SimulationConfig::default();
+
+        for _ in 0..STEPS {
+            cpu.step(&mut bus, &observers, &config)
+                .unwrap_or_else(|e| panic!("{}: step failed: {e:?}", core.name));
+        }
+
+        let steps = recorder.steps();
+        assert_eq!(
+            steps.len(),
+            STEPS,
+            "{}: emitted {} traced steps for {STEPS} executed instructions — \
+             a core that runs instructions without tracing them makes `--trace` \
+             silently useless for every chip built on it",
+            core.name,
+            steps.len(),
+        );
+
+        for (i, step) in steps.iter().enumerate() {
+            let expected_pc = core.entry + (i as u32) * core.step_len;
+            assert_eq!(
+                step.start_pc, expected_pc,
+                "{}: step {i} reported pc={:#x}, executed {:#x}",
+                core.name, step.start_pc, expected_pc
+            );
+
+            // The opcode must be the real encoding. A core that passes 0 (or a
+            // decoded-enum discriminant) here produces a trace that cannot be
+            // disassembled, which is most of what a trace is for.
+            let width = core.step_len as usize;
+            let mut expected_opcode = 0u32;
+            for b in (0..width).rev() {
+                expected_opcode =
+                    (expected_opcode << 8) | core.program[i * width + b] as u32;
+            }
+            assert_eq!(
+                step.start_opcode, expected_opcode,
+                "{}: step {i} reported opcode {:#x}, memory holds {:#x}",
+                core.name, step.start_opcode, expected_opcode
+            );
+
+            assert_eq!(
+                step.retired,
+                Some((expected_pc, expected_opcode)),
+                "{}: step {i} did not emit a matching InstructionRetired event",
+                core.name
+            );
+
+            // Standardized trailer: SP then PC, regardless of core.
+            let (sp, pc) = trace_sp_pc(&step.registers).unwrap_or_else(|| {
+                panic!(
+                    "{}: register slice of len {} is too short to carry the \
+                     standard [.., SP, PC] trailer",
+                    core.name,
+                    step.registers.len()
+                )
+            });
+            assert_eq!(
+                pc,
+                expected_pc + core.step_len,
+                "{}: step {i} trailer PC is {:#x}, expected the next pc {:#x}",
+                core.name,
+                pc,
+                expected_pc + core.step_len
+            );
+            assert_eq!(
+                sp, 0x8000,
+                "{}: step {i} trailer SP is {:#x}, expected the stack pointer \
+                 we set ({:#x}) — the trailer is reporting some other register",
+                core.name, sp, 0x8000u32
+            );
+        }
+    }
+}
+
+#[test]
+fn no_core_traces_when_nobody_is_observing() {
+    // The gate that keeps the contract affordable. If a core stopped honouring
+    // it the hot path would pay for a register snapshot on every instruction,
+    // which is the reason the emission is conditional in the first place.
+    for core in cores() {
+        let mut cpu = (core.build)();
+        cpu.set_pc(core.entry);
+        let mut bus = RamBus::with_program(core.entry as u64, &core.program);
+        let none: Vec<Arc<dyn SimulationObserver>> = Vec::new();
+        let config = SimulationConfig::default();
+        for _ in 0..4 {
+            cpu.step(&mut bus, &none, &config)
+                .unwrap_or_else(|e| panic!("{}: step failed: {e:?}", core.name));
+        }
+        assert_eq!(
+            cpu.get_pc(),
+            core.entry + 4 * core.step_len,
+            "{}: unobserved run diverged from the observed one",
+            core.name
+        );
+    }
+}
+
+#[test]
+fn every_cpu_core_is_covered_by_this_file() {
+    // Derived from the source tree, so a new core cannot ship untraced: adding
+    // `impl Cpu for Foo` fails this test until Foo is in `cores()` above.
+    let cpu_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cpu");
+    let mut found: Vec<String> = Vec::new();
+    let mut stack = vec![cpu_dir.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src/cpu") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("read source");
+            for line in src.lines() {
+                let line = line.trim();
+                if let Some(rest) = line.strip_prefix("impl Cpu for ") {
+                    let name = rest.trim_end_matches('{').trim();
+                    // Blanket impls over references/boxes forward to the
+                    // concrete core and have nothing of their own to trace.
+                    if name.starts_with('&') || name.starts_with("Box<") {
+                        continue;
+                    }
+                    found.push(name.to_string());
+                }
+            }
+        }
+    }
+    found.sort();
+    found.dedup();
+    assert!(
+        !found.is_empty(),
+        "found no `impl Cpu for` in {} — this guard has stopped guarding \
+         anything; fix the scan before trusting a green run",
+        cpu_dir.display()
+    );
+
+    let mut covered: Vec<String> = cores().iter().map(|c| c.name.to_string()).collect();
+    covered.sort();
+
+    assert_eq!(
+        found, covered,
+        "cores implementing `Cpu` and cores exercised by this file have \
+         diverged. Every core must emit the standardized instruction trace; \
+         add the missing one to `cores()` (and make it emit) rather than \
+         relaxing this assertion."
+    );
+}


### PR DESCRIPTION
Xtensa — the core behind classic ESP32 and ESP32-S3 — ignored its `observers` argument entirely, so `--trace` produced an **empty file** for those chips and every Xtensa debugging session fell back to guesswork. Nothing failed, because nothing checked.

A second one underneath it: `TraceObserver` read register index 13 as the stack pointer. That is SP on ARM only, so every RISC-V and Xtensa trace ever emitted carried a meaningless number in that field.

## What this does

- **Xtensa emits the trace**, and falls back from the JIT while anyone is observing — a compiled block retires without firing the per-step tap, so an always-JIT path would silently trace nothing.
- **The contract is written down** on `SimulationObserver`, including a standardized `[.., SP, PC]` trailer so an arch-agnostic consumer never has to know which core produced a trace.
- **`cpu_trace_conformance.rs`** runs real instructions through all three cores and checks emissions against what each core actually did. The core list is derived from `impl Cpu for` in the source tree, so a fourth core cannot ship untraced.
- **`trace::RetiredRing`** keeps the LAST N retired instructions. `TraceObserver` keeps the first N, which is the wrong end of a run that ends in a fault.
- **`snapshot capture --trace-out/--trace-last`**, dumped on every exit path including faults.

## The guard is not vacuous

Mutation-tested twice. Reverting the Xtensa emission fails it (`emitted 0 traced steps for 4 executed instructions`); mis-indexing the SP trailer fails it. The pre-existing `trace_event_contract.rs` is the counter-example — it feeds a hand-built observer a hand-built event and never runs a CPU, which is why it stayed green through all of this.

## It paid for itself

Pointed at the Adafruit `graphicstest` fault, the ring caught the last 4096 of 5.86M instructions and localised it in one run: `testFillScreen()`'s `retw.n` returns `a1=0x20`, and the reported `0xffffffbc` was fallout three calls later.

**It also reverts b66377d9** (PR #737, now closed). All 14 force-live events in that run had `preserve_depth=0` with a prior spill, so the guard skipped the only correct reader. The real defect is now localised to the spill writing the OF save area at the wrong base.

## Verification

- 2512 lib tests, 2739 integration
- Ryan's rig still 12/12 over serial; panel byte-identical (`refresh_generation=1, painted 10176/153600, top colour 0x07E0 x5088`)
- Two failures are **pre-existing**, confirmed against a reverted tree: `esp32_ili9341_attach` and `peripheral_kit_gate` (stale `peripherals-manifest.json`)

**Tracing forces the interpreter, so traced captures are slower.** Deliberate — an empty trace is worse than a slow one.