### PR TITLE
Spill window panes at the callee's SP, not their own

### DIFF
--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -850,6 +850,10 @@ impl XtensaLx7 {
         // Leftover WS panes: CALL4 a0..a3 only for 16B-aligned known frame SPs.
         let ws = self.regs.windowstart();
         let wb = self.regs.windowbase();
+
+        // Gather the panes first: the OF base for a pane is its *callee's* SP,
+        // which we can only pick once every frame SP in this window is known.
+        let mut panes: Vec<(u32, u32, u32, u32)> = Vec::new();
         for slot in 0..16u8 {
             if (ws >> slot) & 1 == 0 {
                 continue;
@@ -872,13 +876,37 @@ impl XtensaLx7 {
             if !valid_sp(a1) {
                 continue;
             }
+            panes.push((a0, a1, a2, a3));
+        }
+
+        // Every SP we know about in this call chain, ascending. The stack grows
+        // down, so a frame's callee is the next SP *below* it.
+        let mut all_sps = frame_sps.clone();
+        all_sps.extend(panes.iter().map(|&(_, a1, _, _)| a1));
+        all_sps.sort_unstable();
+        all_sps.dedup();
+
+        for &(a0, a1, a2, a3) in &panes {
             let a1_ok = frame_sps.contains(&a1)
                 || frame_sps
                     .iter()
                     .any(|&f| a1 < f && f.wrapping_sub(a1) < 0x80);
-            if a1_ok && stackish(a1, current_a1) {
-                write4(bus, a1, 16, a0, a1, a2, a3);
+            if !a1_ok || !stackish(a1, current_a1) {
+                continue;
             }
+            // WindowOverflow4 (window_vectors.S) saves a0..a3 at `call[j+1]`'s
+            // stack frame — the CALLEE's sp − 16, never the frame's own sp.
+            // Using the frame's own sp lands the record in the callee's save
+            // area and destroys what the callee legitimately stored there:
+            // graphicstest_featherwing overwrote a correct a1=0x3ffb2240 at
+            // 0x3ffb2214 with 0x3ffb2220, so the firmware's WindowUnderflow
+            // restored a bogus frame and RETW'd to pc=0. There is no safe
+            // fallback: with no known callee we cannot place the record, and
+            // guessing is what corrupted the stack, so skip the pane instead.
+            let Some(&callee_sp) = all_sps.iter().rev().find(|&&s| s < a1) else {
+                continue;
+            };
+            write4(bus, callee_sp, 16, a0, a1, a2, a3);
         }
 
         self.regs.set_windowstart(1u16 << (wb & 0x0F));


### PR DESCRIPTION
Adafruit's **stock, unmodified** `graphicstest_featherwing.ino` completes all 12 benchmarks on real ESP32-D0WDQ6 silicon but faulted in the twin at cycle **3,821,618** with `Exception raised: cause=0 at pc=0x0`.

## The bug

`spill_call_preserve_to_stack` writes register windows to their stack save areas in two loops.

Loop 1 (preserve frames) correctly places each frame's `a0..a3` at the **callee's** `sp-16` — what `WindowOverflow4` does in `window_vectors.S`:

```
s32e a0, a5, -16     /* save a0 to call[j+1]'s stack frame */
```

where `a5` is the callee's stack pointer.

Loop 2 (leftover `WINDOWSTART` panes) used the pane's **own** `sp`. That lands the record inside the *callee's* save area and destroys what the callee legitimately stored there.

## The evidence

A watchpoint on the disputed address caught both writes hitting the same 16 bytes, in order:

```
base_sp=0x3ffb2220 off=16 -> [0x3ffb2210..)  r1=0x3ffb2240   <- loop 1, correct
base_sp=0x3ffb2220 off=16 -> [0x3ffb2210..)  r1=0x3ffb2220   <- loop 2, clobber
```

The firmware's `WindowUnderflow` handler then read `0x3ffb2220` back out of `0x3ffb2214` where `0x3ffb2240` belonged, restored a bogus frame, and `RETW`'d to `pc=0`. The clobbering value is a pane's own `sp` — the signature of a wrong *base*, not a wrong *value*.

## The fix

Loop 2 resolves each pane's callee from the sorted set of every known frame SP. Where no callee is known the pane is **skipped** rather than guessed: guessing a base is what corrupted the stack, so a missing record (recoverable) beats a wrong one (not).

## On process

Three earlier hypotheses were disproven by measurement and are recorded in the task rather than retried. Worth noting: instrumentation reporting *"103 of 103 spills take the callee_sp branch"* was **true** and still missed this — it only covered the first loop.

## Verification

- Real **ESP32-D0WDQ6** flashed with the identical ELF: **12/12** benchmarks, `Done!`
- Twin: no fault through **900,000,000** cycles (was dying at 3.8M)
- Ryan's bay-occupancy lab: **12/12 PASS**, UART **byte-identical** to pristine
- `labwired-core`: **3146 passed**; the 3 failures (`esp32_ili9341_attach`, `peripheral_kit_gate` stale manifest, `register_coverage_ratchet`) are **byte-identical on a tree with this change stashed** — pre-existing, not caused here