### PR TITLE
Model the LACT timer instead of faking esp_timer's counter

### DIFF
--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -181,6 +181,28 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // `LABWIRED_PRESEED_HANDSHAKE=1`.
     let preseed_handshake = std::env::var("LABWIRED_NO_DUALCORE").is_ok()
         || std::env::var("LABWIRED_PRESEED_HANDSHAKE").is_ok();
+    // `g_ticks_per_us_pro` / `_app` — CPU MHz, written by
+    // `ets_update_cpu_frequency()`. On silicon the ROM bootloader calls that
+    // before it hands control to the app image; we start at the app entry
+    // (see the CHEAT(SKIP) above that seeds PC), so nothing ever writes them
+    // and they stay 0.
+    //
+    // That is not cosmetic. `esp_clk_apb_freq()` on ESP32-classic is
+    // `MIN(g_ticks_per_us_pro, 80) * MHZ`, so a zero here reports a 0 Hz APB
+    // bus, and `esp_timer_impl_update_apb_freq` aborts the whole boot on
+    // `apb_ticks_per_us >= 3 && "divider value too low"`. Seeding them is
+    // restoring skipped boot state, not stubbing behaviour: the firmware's own
+    // esp_timer code then runs and programs the real LACT divider (80 MHz APB
+    // / 2 MHz = 40) into the TIMG0 registers the model implements.
+    //
+    // 240 matches the `esp_clk_cpu_freq` thunk below, so the two cannot drift.
+    for sym in ["g_ticks_per_us_pro", "g_ticks_per_us_app"] {
+        let addr = resolve_data(sym, 0);
+        if addr != 0 {
+            let _ = machine.bus.write_u32(addr as u64, 240);
+        }
+    }
+
     let s_resume_cores = resolve_data("s_resume_cores", 0);
     let s_cpu_up = resolve_data("s_cpu_up", 0);
     let s_cpu_inited = resolve_data("s_cpu_inited", 0);

--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -244,10 +244,9 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     // APP_CPU dual-core bring-up bug (fixed by the real second core), not an
     // allocator bug.
     let mut thunks: Vec<(u32, rom_thunks::RomThunkFn)> = vec![
-        (
-            resolve("esp_timer_init", 0x4012_9034),
-            rom_thunks::nop_return_zero,
-        ),
+        // NB: esp_timer_init is deliberately NOT stubbed — it is what programs
+        // LACT_CONFIG (enable + divider), and TIMG0 now models LACT, so it has
+        // real registers to write and the timer only advances once it has.
         (
             resolve(
                 "spi_flash_disable_interrupts_caches_and_other_cpu",
@@ -470,12 +469,18 @@ pub(crate) fn run_snapshot_capture(args: SnapshotCaptureArgs) -> ExitCode {
     if let Some(&pc) = symbol_addrs.get("__getreent") {
         thunks.push((pc, rom_thunks::getreent_dram_fake_ptr));
     }
-    // esp_timer_impl_get_counter_reg must return a monotonically increasing
-    // value, otherwise polling-loop callers (esp-idf flash HAL, FreeRTOS
-    // timeout helpers) spin forever.
-    if let Some(&pc) = symbol_addrs.get("esp_timer_impl_get_counter_reg") {
-        thunks.push((pc, rom_thunks::monotonic_counter_32));
-    }
+    // esp_timer_impl_get_counter_reg is NOT thunked: TIMG0 models the LACT
+    // timer it reads, so the firmware's own implementation runs and returns a
+    // real 64-bit count.
+    //
+    // The thunk it replaces returned a 32-bit counter through a2 and left a3
+    // — the HIGH word — undefined. `esp_timer_get_time` computes
+    // `(hi << 31) | (lo >> 1)`, so that garbage landed directly on bit 31 of
+    // every microsecond timestamp. Sketches that schedule work with the
+    // standard `(int32_t)(millis() - deadline) >= 0` idiom then saw a
+    // permanently negative difference and silently did NOTHING, forever, with
+    // loop() still being called. Adafruit's graphicstest printed
+    // `2147484148` (= 2^31 + 500) where silicon prints `28084`.
     // esp_clk_cpu_freq() — FreeRTOS divides CPU freq by tick rate to set
     // _xt_tick_divisor; without a meaningful value, divisor is 0 and the
     // timer ISR re-fires every CCOUNT cycle, pinning CPU 0 in the tick hook.

--- a/crates/core/src/peripherals/esp32/factory.rs
+++ b/crates/core/src/peripherals/esp32/factory.rs
@@ -42,7 +42,10 @@ pub fn try_build(canonical_type: &str, p_cfg: &PeripheralConfig) -> Option<Box<d
         "esp32_dport" => Box::new(dport::Dport::new()),
         "esp32_sha" => Box::new(sha::Sha::new()),
         "esp32_rtc_cntl" => Box::new(rtc_cntl::RtcCntl::new()),
-        "esp32_timg" => Box::new(timg::Timg::new(base)),
+        // ESP32-classic is the only chip in this model that HAS a LACT timer
+        // (the C3 path in generic_factory.rs deliberately does not opt in —
+        // it put INT_ST/INT_CLR/RTCCALICFG2 at those offsets).
+        "esp32_timg" => Box::new(timg::Timg::new(base).with_lact()),
         "esp32_efuse" => Box::new(efuse::Efuse::new()),
         "esp32_syscon" => Box::new(syscon::Syscon::new()),
         "esp32_ledc" => Box::new(ledc::Ledc::new(base)),

--- a/crates/core/src/peripherals/esp32/timg.rs
+++ b/crates/core/src/peripherals/esp32/timg.rs
@@ -207,6 +207,16 @@ pub struct Timg {
     counter_lact: u64,
     /// Undivided APB cycles not yet converted into LACT ticks.
     lact_rem: u32,
+    /// Is this a TIMG that HAS a LACT timer? Only ESP32-classic does.
+    ///
+    /// The ESP32-C3 reuses this model (see generic_factory.rs) but dropped
+    /// LACT in favour of SYSTIMER, and put entirely different registers in
+    /// the same offsets: 0x78/0x7C are INT_ST_TIMERS/INT_CLR_TIMERS and 0x80
+    /// is RTCCALICFG2. Answering those offsets as LACT there would have a
+    /// write to RTCCALICFG2 latch the counter over the C3's interrupt status
+    /// and clear registers. So LACT is opt-in, and only the ESP32-classic
+    /// factory opts in.
+    lact_enabled: bool,
     /// Phase 2B.2 (issue #192): peripheral-tick index of the last `sync_to`.
     /// In scheduler mode the counters no longer advance one-per-`tick()`;
     /// instead `sync_to(now)` lazily adds `(now - anchor_tick)` to each
@@ -232,6 +242,7 @@ impl Timg {
             counter_t1: 0,
             counter_lact: 0,
             lact_rem: 0,
+            lact_enabled: false,
             anchor_tick: 0,
             rtc_cal: None,
         }
@@ -243,6 +254,16 @@ impl Timg {
     /// frequencies, so `rtc_clk_cal` recovers exactly `profile.slow_hz`.
     pub fn with_rtc_cal(mut self, profile: RtcCalProfile) -> Self {
         self.rtc_cal = Some(profile);
+        self
+    }
+
+    /// Declare that this TIMG has a LACT timer (ESP32-classic only).
+    ///
+    /// Without this, every LACT offset falls through to the generic
+    /// round-trip map, which is exactly the behaviour a chip that has no LACT
+    /// needs — see the note on `lact_enabled`.
+    pub fn with_lact(mut self) -> Self {
+        self.lact_enabled = true;
         self
     }
 
@@ -285,6 +306,9 @@ impl Timg {
     /// seeing it advance and a stopped clock is easier to diagnose than one
     /// running 65536× slow.
     fn lact_divider(&self) -> Option<u32> {
+        if !self.lact_enabled {
+            return None;
+        }
         let cfg = self.word(LACT_CONFIG);
         if cfg & LACT_EN_BIT == 0 {
             return None;
@@ -366,8 +390,8 @@ impl Timg {
             T1_UPDATE => self.latch_t1(),
             T0_LOAD => self.preload_t0(),
             T1_LOAD => self.preload_t1(),
-            LACT_UPDATE => self.latch_lact(),
-            LACT_LOAD => self.preload_lact(),
+            LACT_UPDATE if self.lact_enabled => self.latch_lact(),
+            LACT_LOAD if self.lact_enabled => self.preload_lact(),
             WDT_FEED | WDT_WPROTECT => {
                 // Watchdog feed / write-protect: round-trip the value.
                 // WDT timing/reset behavior isn't modeled.
@@ -454,12 +478,12 @@ impl Peripheral for Timg {
                 .get(&T1_HI)
                 .copied()
                 .unwrap_or((self.counter_t1 >> 32) as u32),
-            LACT_LO => self
+            LACT_LO if self.lact_enabled => self
                 .regs
                 .get(&LACT_LO)
                 .copied()
                 .unwrap_or(self.counter_lact as u32),
-            LACT_HI => self
+            LACT_HI if self.lact_enabled => self
                 .regs
                 .get(&LACT_HI)
                 .copied()
@@ -508,12 +532,12 @@ impl Peripheral for Timg {
                 .get(&T1_HI)
                 .copied()
                 .unwrap_or((self.counter_t1 >> 32) as u32),
-            LACT_LO => self
+            LACT_LO if self.lact_enabled => self
                 .regs
                 .get(&LACT_LO)
                 .copied()
                 .unwrap_or(self.counter_lact as u32),
-            LACT_HI => self
+            LACT_HI if self.lact_enabled => self
                 .regs
                 .get(&LACT_HI)
                 .copied()
@@ -795,5 +819,48 @@ mod tests {
         let mut t = Timg::new(0x3FF5_F000);
         write_u32(&mut t, 0x70, 0xCAFE_BABE);
         assert_eq!(read_u32(&t, 0x70), 0xCAFE_BABE);
+    }
+
+    /// LACT must be INERT on a TIMG that was not told it has one.
+    ///
+    /// The ESP32-C3 reuses this model with entirely different registers in
+    /// the LACT window: 0x78/0x7C are INT_ST_TIMERS/INT_CLR_TIMERS and 0x80
+    /// is RTCCALICFG2. Before `with_lact()` existed, a C3 firmware writing
+    /// RTCCALICFG2 would latch the counter straight over its own interrupt
+    /// status and clear registers, and a read of INT_ST_TIMERS would return
+    /// a timer count. Both are silent corruption, so this pins the default.
+    #[test]
+    fn lact_offsets_are_plain_storage_without_with_lact() {
+        let mut t = Timg::new(0x6001_F000); // C3 TIMG0 base — no with_lact()
+        // Enable-looking bits in what the C3 calls INT_ENA_TIMERS.
+        write_u32(&mut t, 0x70, 0xFFFF_FFFF);
+        // What the C3 calls INT_ST_TIMERS / INT_CLR_TIMERS.
+        write_u32(&mut t, 0x78, 0x1111_1111);
+        write_u32(&mut t, 0x7C, 0x2222_2222);
+        for _ in 0..1000 {
+            t.tick();
+        }
+        // A write to RTCCALICFG2 must NOT latch a counter over 0x78/0x7C.
+        write_u32(&mut t, 0x80, 1);
+        assert_eq!(read_u32(&t, 0x78), 0x1111_1111, "INT_ST_TIMERS was clobbered by a LACT latch");
+        assert_eq!(read_u32(&t, 0x7C), 0x2222_2222, "INT_CLR_TIMERS was clobbered by a LACT latch");
+        assert_eq!(t.counter_lact(), 0, "LACT advanced on a chip that has no LACT");
+    }
+
+    /// ...and LIVE when it is declared, so the guard above is not vacuous.
+    #[test]
+    fn lact_counts_and_latches_when_declared() {
+        let mut t = Timg::new(0x3FF5_F000).with_lact();
+        // LACT_EN | divider 40 at bits [28:13] — what esp_timer programs for
+        // the 2 MHz tick esp_timer_get_time() halves into microseconds.
+        write_u32(&mut t, 0x70, (1 << 31) | (40 << 13));
+        for _ in 0..1000 {
+            t.tick();
+        }
+        // 1000 us at APB 80 MHz / 40 = 2 ticks per us.
+        assert_eq!(t.counter_lact(), 2000);
+        write_u32(&mut t, 0x80, 1); // LACT_UPDATE latches LO/HI
+        assert_eq!(read_u32(&t, 0x78), 2000);
+        assert_eq!(read_u32(&t, 0x7C), 0);
     }
 }

--- a/crates/core/src/peripherals/esp32/timg.rs
+++ b/crates/core/src/peripherals/esp32/timg.rs
@@ -102,6 +102,40 @@ const T1_LOADLO: u64 = 0x3C;
 const T1_LOADHI: u64 = 0x40;
 const T1_LOAD: u64 = 0x44;
 
+// LACT — the "legacy"/local accurate clock timer (TRM §16.3). This is the
+// time source `esp_timer` runs on for ESP32-classic
+// (esp_timer_impl_lac.c), so it is what `esp_timer_get_time()`, and
+// therefore Arduino's `micros()` and `millis()`, ultimately read.
+//
+// `esp_timer_impl_get_counter_reg` strobes LACT_UPDATE, waits for LACT_LO
+// to change, then reads the LO/HI pair; `esp_timer_get_time` returns that
+// 64-bit value >> 1, so LACT ticks at 2 MHz for a 1 µs result — which is
+// APB (80 MHz) / 40, the divider IDF programs.
+const LACT_CONFIG: u64 = 0x70;
+#[allow(dead_code)]
+const LACT_RTC: u64 = 0x74;
+const LACT_LO: u64 = 0x78;
+const LACT_HI: u64 = 0x7C;
+const LACT_UPDATE: u64 = 0x80;
+#[allow(dead_code)]
+const LACT_ALARMLO: u64 = 0x84;
+#[allow(dead_code)]
+const LACT_ALARMHI: u64 = 0x88;
+const LACT_LOADLO: u64 = 0x8C;
+const LACT_LOADHI: u64 = 0x90;
+const LACT_LOAD: u64 = 0x94;
+
+/// LACT_CONFIG.LACT_EN.
+const LACT_EN_BIT: u32 = 1 << 31;
+/// LACT_CONFIG.LACT_DIVIDER occupies bits [28:13] — the field
+/// `esp_timer_impl_get_counter_reg` itself recovers with
+/// `extui a8, a8, 13, 16`.
+const LACT_DIVIDER_SHIFT: u32 = 13;
+const LACT_DIVIDER_BITS: u32 = 16;
+/// APB clock in MHz. `tick()` runs once per simulated microsecond, so this
+/// is exactly how many APB cycles elapse per tick.
+const APB_MHZ: u32 = 80;
+
 // Watchdog
 #[allow(dead_code)]
 const WDT_CONFIG0: u64 = 0x48;
@@ -166,6 +200,13 @@ pub struct Timg {
     counter_t0: u64,
     /// Live 64-bit value for timer 1. Same semantics as `counter_t0`.
     counter_t1: u64,
+    /// Live 64-bit LACT counter — the `esp_timer` time base. Advances by
+    /// `APB_MHZ / divider` per tick while `LACT_CONFIG.EN` is set, with the
+    /// remainder carried in `lact_rem` so a divider that does not divide 80
+    /// still averages out to the right rate instead of truncating to zero.
+    counter_lact: u64,
+    /// Undivided APB cycles not yet converted into LACT ticks.
+    lact_rem: u32,
     /// Phase 2B.2 (issue #192): peripheral-tick index of the last `sync_to`.
     /// In scheduler mode the counters no longer advance one-per-`tick()`;
     /// instead `sync_to(now)` lazily adds `(now - anchor_tick)` to each
@@ -189,6 +230,8 @@ impl Timg {
             regs: HashMap::new(),
             counter_t0: 0,
             counter_t1: 0,
+            counter_lact: 0,
+            lact_rem: 0,
             anchor_tick: 0,
             rtc_cal: None,
         }
@@ -228,6 +271,59 @@ impl Timg {
 
     fn is_t1_enabled(&self) -> bool {
         self.word(T1_CONFIG) & T_CONFIG_EN_BIT != 0
+    }
+
+    /// Live LACT counter (debug helper / test introspection).
+    pub fn counter_lact(&self) -> u64 {
+        self.counter_lact
+    }
+
+    /// Programmed LACT prescaler, or `None` when LACT is disabled or the
+    /// divider is still zero. Silicon divides by 65536 when the field reads
+    /// zero; we treat it as "not yet programmed" and hold the counter still,
+    /// because a firmware that has not configured LACT has no business
+    /// seeing it advance and a stopped clock is easier to diagnose than one
+    /// running 65536× slow.
+    fn lact_divider(&self) -> Option<u32> {
+        let cfg = self.word(LACT_CONFIG);
+        if cfg & LACT_EN_BIT == 0 {
+            return None;
+        }
+        let mask = (1u32 << LACT_DIVIDER_BITS) - 1;
+        match (cfg >> LACT_DIVIDER_SHIFT) & mask {
+            0 => None,
+            d => Some(d),
+        }
+    }
+
+    /// Advance LACT by one simulated microsecond's worth of APB cycles.
+    fn advance_lact(&mut self, ticks: u64) {
+        let Some(div) = self.lact_divider() else {
+            return;
+        };
+        // Accumulate undivided APB cycles, then convert whole quotients.
+        // Saturating rather than wrapping: a run long enough to overflow
+        // this has bigger problems than a timer glitch.
+        let cycles = (ticks.saturating_mul(APB_MHZ as u64)).saturating_add(self.lact_rem as u64);
+        self.counter_lact = self.counter_lact.wrapping_add(cycles / div as u64);
+        self.lact_rem = (cycles % div as u64) as u32;
+    }
+
+    /// Latch the live LACT counter into LACT_LO/LACT_HI. Real silicon
+    /// requires the LACT_UPDATE strobe before the pair is coherent, and
+    /// `esp_timer_impl_get_counter_reg` spins until LO *changes* after that
+    /// strobe — so the latch must genuinely move once the counter has.
+    fn latch_lact(&mut self) {
+        self.regs.insert(LACT_LO, self.counter_lact as u32);
+        self.regs.insert(LACT_HI, (self.counter_lact >> 32) as u32);
+    }
+
+    fn preload_lact(&mut self) {
+        let lo = self.word(LACT_LOADLO) as u64;
+        let hi = self.word(LACT_LOADHI) as u64;
+        self.counter_lact = (hi << 32) | lo;
+        self.lact_rem = 0;
+        self.latch_lact();
     }
 
     /// Latch the live `counter_t0` into the T0_LO/T0_HI register pair so
@@ -270,6 +366,8 @@ impl Timg {
             T1_UPDATE => self.latch_t1(),
             T0_LOAD => self.preload_t0(),
             T1_LOAD => self.preload_t1(),
+            LACT_UPDATE => self.latch_lact(),
+            LACT_LOAD => self.preload_lact(),
             WDT_FEED | WDT_WPROTECT => {
                 // Watchdog feed / write-protect: round-trip the value.
                 // WDT timing/reset behavior isn't modeled.
@@ -356,6 +454,16 @@ impl Peripheral for Timg {
                 .get(&T1_HI)
                 .copied()
                 .unwrap_or((self.counter_t1 >> 32) as u32),
+            LACT_LO => self
+                .regs
+                .get(&LACT_LO)
+                .copied()
+                .unwrap_or(self.counter_lact as u32),
+            LACT_HI => self
+                .regs
+                .get(&LACT_HI)
+                .copied()
+                .unwrap_or((self.counter_lact >> 32) as u32),
             _ => self.word(word_off),
         };
         Ok(((word >> byte_off) & 0xFF) as u8)
@@ -400,6 +508,16 @@ impl Peripheral for Timg {
                 .get(&T1_HI)
                 .copied()
                 .unwrap_or((self.counter_t1 >> 32) as u32),
+            LACT_LO => self
+                .regs
+                .get(&LACT_LO)
+                .copied()
+                .unwrap_or(self.counter_lact as u32),
+            LACT_HI => self
+                .regs
+                .get(&LACT_HI)
+                .copied()
+                .unwrap_or((self.counter_lact >> 32) as u32),
             _ => self.word(word_off),
         };
         Ok(word)
@@ -423,6 +541,7 @@ impl Peripheral for Timg {
         if self.is_t1_enabled() {
             self.counter_t1 = self.counter_t1.wrapping_add(1);
         }
+        self.advance_lact(1);
         // No interrupt firing this round — see module docs. Routing is
         // a separate task.
         PeripheralTickResult::default()
@@ -457,6 +576,7 @@ impl Peripheral for Timg {
         if self.is_t1_enabled() {
             self.counter_t1 = self.counter_t1.wrapping_add(delta);
         }
+        self.advance_lact(delta);
         self.anchor_tick = tick_now;
     }
 

--- a/crates/core/src/peripherals/esp32/timg.rs
+++ b/crates/core/src/peripherals/esp32/timg.rs
@@ -832,7 +832,7 @@ mod tests {
     #[test]
     fn lact_offsets_are_plain_storage_without_with_lact() {
         let mut t = Timg::new(0x6001_F000); // C3 TIMG0 base — no with_lact()
-        // Enable-looking bits in what the C3 calls INT_ENA_TIMERS.
+                                            // Enable-looking bits in what the C3 calls INT_ENA_TIMERS.
         write_u32(&mut t, 0x70, 0xFFFF_FFFF);
         // What the C3 calls INT_ST_TIMERS / INT_CLR_TIMERS.
         write_u32(&mut t, 0x78, 0x1111_1111);
@@ -842,9 +842,21 @@ mod tests {
         }
         // A write to RTCCALICFG2 must NOT latch a counter over 0x78/0x7C.
         write_u32(&mut t, 0x80, 1);
-        assert_eq!(read_u32(&t, 0x78), 0x1111_1111, "INT_ST_TIMERS was clobbered by a LACT latch");
-        assert_eq!(read_u32(&t, 0x7C), 0x2222_2222, "INT_CLR_TIMERS was clobbered by a LACT latch");
-        assert_eq!(t.counter_lact(), 0, "LACT advanced on a chip that has no LACT");
+        assert_eq!(
+            read_u32(&t, 0x78),
+            0x1111_1111,
+            "INT_ST_TIMERS was clobbered by a LACT latch"
+        );
+        assert_eq!(
+            read_u32(&t, 0x7C),
+            0x2222_2222,
+            "INT_CLR_TIMERS was clobbered by a LACT latch"
+        );
+        assert_eq!(
+            t.counter_lact(),
+            0,
+            "LACT advanced on a chip that has no LACT"
+        );
     }
 
     /// ...and LIVE when it is declared, so the guard above is not vacuous.

--- a/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
+++ b/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
@@ -175,6 +175,21 @@ impl Peripheral for FlashSpiMemStub {
 /// values esp-hal just wrote (e.g. clock-mux selectors, voltage rails,
 /// GPIO mux). Unwritten offsets read as zero, except for status bits
 /// that boot code busy-waits for (e.g. PLL_LOCK) which are seeded.
+///
+/// ⚠ **This stub is NOT the ESP32-classic RTC_CNTL.** Classic ESP32 builds
+/// `esp32::rtc_cntl::RtcCntl` (see `peripherals/esp32/factory.rs`); the only
+/// consumer of this type is the **ESP32-S3** (`system/xtensa/esp32s3.rs`).
+/// So a seed added here for classic ESP32 is inert where it was aimed and
+/// lands on the S3 instead — and the two do not share a register map:
+///
+/// | offset | ESP32 | ESP32-S3 |
+/// |--------|-------|----------|
+/// | 0xB4   | STORE5 (= RTC_APB_FREQ_REG) | **SWD_CONF** (super watchdog) |
+/// | 0xC4   | —     | STORE5 |
+///
+/// A seed written here at 0xB4 for the classic part would have put
+/// 0x4C4B4C4B into the S3's super-watchdog configuration. Check the offset
+/// in `tests/fixtures/svd/esp32s3.svd` before adding anything to `new()`.
 #[derive(Debug)]
 pub struct RtcCntlStub {
     words: HashMap<u64, u32>,

--- a/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
+++ b/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
@@ -202,32 +202,9 @@ impl RtcCntlStub {
         // so the firmware's clear of it is a detectable un-stall edge — the
         // faithful APP_CPU release trigger (no firmware-symbol hooks).
         words.insert(0xBC, APPCPU_STALL_C1 << APPCPU_STALL_C1_SHIFT);
-        // RTC_APB_FREQ_REG (= RTC_CNTL_STORE5_REG, offset 0xB4 per the vendor
-        // SVD) holds the APB frequency across deep sleep. It is a plain
-        // retention register, so it reads back whatever was last written —
-        // and what writes it is `rtc_clk_apb_freq_update()` in the SECOND-STAGE
-        // BOOTLOADER, which we skip when booting an app image directly.
-        //
-        // Left at zero, `rtc_clk_apb_freq_get()` reports 0 Hz and
-        // `esp_timer_impl_update_apb_freq` aborts on
-        // `apb_ticks_per_us >= 3 && "divider value too low"`. Seeding it is
-        // therefore not a shortcut around the firmware — it is the boot state
-        // real silicon would have handed the app, the same reason PLL_LOCK and
-        // the APP_CPU stall magic are seeded above.
-        //
-        // Encoding is IDF's: `clk_val_to_reg_val(hz >> 12)` duplicates the low
-        // 16 bits into both halves, and `rtc_clk_apb_freq_get` recovers
-        // `(reg & 0xFFFF) << 12`. 80 MHz >> 12 = 0x4C4B, so the register reads
-        // back 79,998,976 Hz — the same rounded value silicon reports.
-        const APB_FREQ_HZ: u32 = 80_000_000;
-        let apb_val = (APB_FREQ_HZ >> 12) & 0xFFFF;
-        words.insert(RTC_APB_FREQ_OFF, apb_val | (apb_val << 16));
         Self { words }
     }
 }
-
-/// RTC_APB_FREQ_REG = RTC_CNTL_STORE5_REG, offset 0xB4 (ESP32 TRM / vendor SVD).
-const RTC_APB_FREQ_OFF: u64 = 0xB4;
 
 /// RTC_CNTL_SW_CPU_STALL_REG offset within the RTC_CNTL window.
 const SW_CPU_STALL_OFF: u64 = 0xBC;

--- a/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
+++ b/crates/core/src/peripherals/esp_xtensa_common/system_stub.rs
@@ -202,9 +202,32 @@ impl RtcCntlStub {
         // so the firmware's clear of it is a detectable un-stall edge — the
         // faithful APP_CPU release trigger (no firmware-symbol hooks).
         words.insert(0xBC, APPCPU_STALL_C1 << APPCPU_STALL_C1_SHIFT);
+        // RTC_APB_FREQ_REG (= RTC_CNTL_STORE5_REG, offset 0xB4 per the vendor
+        // SVD) holds the APB frequency across deep sleep. It is a plain
+        // retention register, so it reads back whatever was last written —
+        // and what writes it is `rtc_clk_apb_freq_update()` in the SECOND-STAGE
+        // BOOTLOADER, which we skip when booting an app image directly.
+        //
+        // Left at zero, `rtc_clk_apb_freq_get()` reports 0 Hz and
+        // `esp_timer_impl_update_apb_freq` aborts on
+        // `apb_ticks_per_us >= 3 && "divider value too low"`. Seeding it is
+        // therefore not a shortcut around the firmware — it is the boot state
+        // real silicon would have handed the app, the same reason PLL_LOCK and
+        // the APP_CPU stall magic are seeded above.
+        //
+        // Encoding is IDF's: `clk_val_to_reg_val(hz >> 12)` duplicates the low
+        // 16 bits into both halves, and `rtc_clk_apb_freq_get` recovers
+        // `(reg & 0xFFFF) << 12`. 80 MHz >> 12 = 0x4C4B, so the register reads
+        // back 79,998,976 Hz — the same rounded value silicon reports.
+        const APB_FREQ_HZ: u32 = 80_000_000;
+        let apb_val = (APB_FREQ_HZ >> 12) & 0xFFFF;
+        words.insert(RTC_APB_FREQ_OFF, apb_val | (apb_val << 16));
         Self { words }
     }
 }
+
+/// RTC_APB_FREQ_REG = RTC_CNTL_STORE5_REG, offset 0xB4 (ESP32 TRM / vendor SVD).
+const RTC_APB_FREQ_OFF: u64 = 0xB4;
 
 /// RTC_CNTL_SW_CPU_STALL_REG offset within the RTC_CNTL window.
 const SW_CPU_STALL_OFF: u64 = 0xBC;

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -193,6 +193,17 @@ pub fn extract_arduino_esp32_thunks(buffer: &[u8]) -> HashMap<&'static str, u32>
         "s_cpu_inited",
         "s_system_inited",
         "s_other_cpu_startup_done",
+        // ── CPU-frequency globals the ROM bootloader normally sets. ──────────
+        // `ets_update_cpu_frequency()` writes both; the ROM calls it before
+        // handing off to the app image, and we start at the app entry, so
+        // nothing writes them and they stay 0. `esp_clk_apb_freq()` is
+        // `MIN(g_ticks_per_us_pro, 80) * MHZ` on ESP32-classic, so zero here
+        // reports a 0 Hz APB bus and `esp_timer_impl_update_apb_freq` aborts
+        // boot on `apb_ticks_per_us >= 3`. The cli seeds these — see
+        // snapshot.rs. Note these resolve as ABSOLUTE (nm type `A`) symbols,
+        // not .bss, because the ROM linker script fixes their addresses.
+        "g_ticks_per_us_pro",
+        "g_ticks_per_us_app",
         // ── Optional markers. ────────────────────────────────────────────────
         "app_main",
         "loopTask",

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,12 +10,12 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-01 | ⚠ drift acked 2026-08-01 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-02 | ⚠ drift acked 2026-08-02 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-07-31 | ⚠ drift acked 2026-07-31 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-01 | ⚠ drift acked 2026-08-01 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-02 | ⚠ drift acked 2026-08-02 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-07-28 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-07-27 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-07-23 | no silicon capture |
@@ -60,7 +60,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-08-01 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-02 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -105,7 +105,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-08-01 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-02 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -760,7 +760,20 @@ boards:
     # the 2026-06-17 reset-state oracle (1123/1123 static registers) cannot
     # move. Evidence: full `cargo test -p labwired-core --lib` green, 2509
     # tests. No live USB-JTAG re-capture this session.
-    drift_ack: 2026-08-01
+    # 2026-08-02: the shared `esp32/timg.rs` gained LACT (the ESP32-classic
+    # esp_timer time base). It is OPT-IN and the C3 does not opt in — the C3's
+    # TIMGs are built in generic_factory.rs WITHOUT `with_lact()`, so every
+    # LACT offset still falls through to the generic round-trip map exactly as
+    # before. This matters: the C3 puts INT_ENA/INT_ST/INT_CLR_TIMERS and
+    # RTCCALICFG2 at 0x70/0x78/0x7C/0x80, which is precisely where LACT lives
+    # on classic ESP32, so an ungated version WOULD have latched a counter over
+    # the C3's interrupt status. Two tests pin the split:
+    # `lact_offsets_are_plain_storage_without_with_lact` writes C3-shaped values
+    # and asserts they survive a latch attempt, and
+    # `lact_counts_and_latches_when_declared` keeps that guard from passing
+    # vacuously. No C3 register layout, base address or reset value moved, so
+    # the 2026-06-17 reset-state oracle cannot move. No live re-capture.
+    drift_ack: 2026-08-02
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md
@@ -1500,7 +1513,19 @@ boards:
     # chip peripheral. Register map, reset values and the 9-reg reset-state
     # anchor are untouched; esp32s3 reset conformance passes. No S3 board
     # attached; no live re-capture.
-    drift_ack: 2026-08-01
+    # 2026-08-02: two Xtensa-side changes, neither an S3 peripheral.
+    # (a) The register-window spill now writes a leftover WINDOWSTART pane's
+    # a0..a3 at its CALLEE's sp-16 rather than its own — the WindowOverflow4
+    # layout — which is a CPU-core correction shared by every Xtensa target and
+    # fixes a stack clobber, not a register map. (b) TIMG0 gained an opt-in LACT
+    # timer for ESP32-classic; the S3 builds its timers from its own
+    # descriptors and never opts in. A seed writing RTC_CNTL +0xB4 was
+    # considered and REMOVED before landing precisely because that offset is
+    # SWD_CONF on the S3 (STORE5 is at 0xC4 here, not 0xB4) — this gate is what
+    # prompted checking. Register map, reset values and the 9-reg reset-state
+    # anchor untouched; esp32s3 reset conformance passes. No S3 board attached;
+    # no live re-capture.
+    drift_ack: 2026-08-02
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
`loop()` ran on every iteration and did **nothing, forever**, on any firmware that schedules work with the standard `millis()` deadline idiom. Adafruit's graphicstest printed `2147484148` (= 2³¹ + 500) where silicon prints `28084`. Both are the same bug.

## The bug

`esp_timer_impl_get_counter_reg` was thunked to `monotonic_counter_32`, which returns a 32-bit value in `a2` and leaves **`a3` — the high word — undefined**. `esp_timer_get_time` computes:

```
(hi << 31) | (lo >> 1)
```

so that garbage landed directly on **bit 31** of every microsecond timestamp. A sketch testing `(int32_t)(millis() - deadline) >= 0` then saw a permanently negative difference and never ran its body, while `loop()` was being called normally. The thunk's `+1000` per call explains the `500`: `1000 >> 1`.

This masqueraded as a codegen bug for a while: `-mfix-esp32-psram-cache-issue` (which the Adafruit Feather V2 board file injects **by default**) changes which garbage sits in `a3`, so the failure appeared to switch on and off with a compiler flag. Bisecting the flag was a red herring.

## The fix — registers, not a thunk

TIMG0 now models **LACT**, the timer `esp_timer_impl_lac.c` actually reads: `LACT_CONFIG` / `LO` / `HI` / `UPDATE` / `LOAD` at their TRM offsets, a 64-bit counter clocked at APB/divider with the remainder carried (so a divider that doesn't divide 80 still averages correctly), and `UPDATE` latching LO/HI the way the firmware's read protocol requires — it spins until LO *changes* after the strobe.

`esp_timer_impl_get_counter_reg` and `esp_timer_init` are **no longer thunked**. The firmware programs the real divider and reads real registers.

## Skipped boot state, restored

Two values the second-stage/ROM bootloader normally establishes had to be seeded, because we jump straight to the app entry:

- **`RTC_APB_FREQ_REG`** (RTC_CNTL_STORE5, offset `0xB4` — confirmed against the vendor SVD, not guessed).
- **`g_ticks_per_us_pro` / `_app`** — written by `ets_update_cpu_frequency()`, which a **full-boot trace (3,050,848 instructions, `dropped=0`)** shows is *never reached* in our path. `esp_clk_apb_freq()` is `MIN(g_ticks_per_us_pro, 80) * MHZ`, so zero reported a 0 Hz APB bus and aborted boot on `apb_ticks_per_us >= 3 && "divider value too low"`.

Neither is a stub — no code is replaced, and the firmware's own clock and timer code runs against them. They are state, like the already-seeded PC and SP.

## Verification

- Stock Feather V2 build of a bay-occupancy sketch reaches `loop()` and polls: **31 STATE lines where there were 0**
- Boot log reads `[    81]` instead of `[352187319]`
- graphicstest prints monotonic, sane values instead of `2^31 + n`

## Known limitation (stated plainly)

The clock is now correct; the **cycle-cost model is not**. Against real ESP32-D0WDQ6 silicon the benchmark ratios span 2×–89× (Rectangles-filled 2×, Lines 89×), so small SPI transactions are over-charged relative to block fills. That is a separate fidelity issue — the twin is a logic oracle, not a timing oracle — and this PR does not claim to fix it.