### PR TITLE
fix(peripherals): re-vendor the manifest fixture the registry actually emits

### DIFF
--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -775,6 +775,11 @@
           "name": "cs_pin",
           "ty": "str",
           "doc": "Chip-select GPIO pin (e.g. \"PA4\"). Defaults to PA4."
+        },
+        {
+          "name": "dc_pin",
+          "ty": "str",
+          "doc": "Data/command GPIO pin (e.g. \"GPIO33\"). Strongly recommended: with it, command/data framing is read from the wire like real silicon. Without it the model must infer framing from byte values, which a real driver's init sequence desynchronises."
         }
       ],
       "labs": [


### PR DESCRIPTION
`manifest_json_matches_registry` is **failing on main** as of #743.

The merge kept main's older vendored `crates/core/tests/fixtures/peripherals/manifest.json` while the registry it is checked against had gained the SPI `dc_pin` config key. So the gate whose entire job is to stop the TS/browser layer drifting from the Rust source of truth is itself red:

```
peripherals-manifest.json is stale.
(Committed bytes: 62091, expected: 62426.)
```

Regenerated with `gen-peripherals-manifest`. **No registry change** — this only re-vendors what the generator emits today (+5 lines, the `dc_pin` key).

Found while bumping the submodule pointer for labwired#1166, whose `part-simulation-coverage` gate reads this same fixture and went red against a freshly generated manifest.

Verified: `cargo test -p labwired-core --test peripheral_kit_gate` → 8 passed.