### PR TITLE
1.39x on classic ESP32: stop SipHashing register offsets

### DIFF
--- a/crates/core/src/fidelity.rs
+++ b/crates/core/src/fidelity.rs
@@ -161,8 +161,20 @@ thread_local! {
 }
 
 /// True when strict mode is on: the first gap panics instead of accumulating.
+///
+/// Read ONCE per process. This used to call `env::var_os` on every
+/// `record_*` — and those sit on per-tick paths, so a profile of a classic
+/// ESP32 run had `getenv`/`__findenv_locked` as the TOP frame in the whole
+/// simulator, above the peripheral tick and the CPU interpreter: 1046 of the
+/// 1290 samples inside `Esp32Uart::tick` were this lookup. `getenv` also takes
+/// a process-wide read lock, so it does not even scale.
+///
+/// Same fix and same reason as `cortex_m::trace_insn_enabled` — see the note
+/// there. The environment cannot change mid-run, so caching is
+/// behaviour-preserving.
 fn strict() -> bool {
-    std::env::var_os("LABWIRED_STRICT_FIDELITY").is_some()
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("LABWIRED_STRICT_FIDELITY").is_some())
 }
 
 /// Record an undecoded/unhandled instruction. In strict mode this panics with

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2672,3 +2672,53 @@ impl<C: Cpu> DebugControl for Machine<C> {
         self.apply_snapshot(snapshot.clone())
     }
 }
+
+/// A fast, dependency-free hasher for small integer keys (register offsets).
+///
+/// Peripheral register banks are `HashMap<u64, u32>` keyed by offset and are
+/// read on nearly every tick — `UartCore::int_raw` alone walks several. With
+/// std's default SipHash, `sip::Hasher::write` profiled as the SECOND heaviest
+/// frame in a whole classic-ESP32 run, behind only the peripheral-walk loop.
+/// SipHash is a DoS-resistant hash for adversarial keys; a register offset the
+/// firmware chose is not that.
+///
+/// This is the same finding, and the same fix, that took the ESP32-C3 labs
+/// 2.343s -> 1.955s (see the scheduler-hash work). Multiply-xor, i.e. the FxHash
+/// construction, without taking a new dependency.
+#[derive(Default, Clone, Copy)]
+pub struct FastHasher(u64);
+
+impl std::hash::Hasher for FastHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.write_u8(b);
+        }
+    }
+    #[inline]
+    fn write_u8(&mut self, n: u8) {
+        self.write_u64(u64::from(n));
+    }
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.write_u64(u64::from(n));
+    }
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        // FxHash: rotate, xor, multiply by a large odd constant.
+        const SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+        self.0 = (self.0.rotate_left(5) ^ n).wrapping_mul(SEED);
+    }
+    #[inline]
+    fn write_usize(&mut self, n: usize) {
+        self.write_u64(n as u64);
+    }
+}
+
+/// Drop-in replacement for `HashMap` on integer keys. Same semantics, same
+/// iteration-order guarantees (i.e. none), just a cheaper hash.
+pub type FastMap<K, V> = std::collections::HashMap<K, V, std::hash::BuildHasherDefault<FastHasher>>;

--- a/crates/core/src/peripherals/esp32/i2c.rs
+++ b/crates/core/src/peripherals/esp32/i2c.rs
@@ -57,6 +57,13 @@ use std::collections::BTreeMap;
 use crate::peripherals::i2c::I2cDevice;
 use crate::{Peripheral, PeripheralTickResult, SimResult};
 
+/// Read once per process — this sits on the I2C command path. See
+/// `fidelity::strict` for why a per-call `env::var` is a real cost.
+fn i2c_trace_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("LABWIRED_I2C_TRACE").is_ok())
+}
+
 pub const I2C0_BASE: u32 = 0x3FF5_3000;
 pub const I2C0_SIZE: u64 = 0x1000;
 
@@ -294,7 +301,7 @@ impl Peripheral for Esp32I2c {
             }
             other => self.other.get(&other).copied().unwrap_or(0),
         };
-        if std::env::var("LABWIRED_I2C_TRACE").is_ok() {
+        if i2c_trace_enabled() {
             eprintln!("ESP32 I2C R [0x{offset:02x}] = 0x{v:08x}");
         }
         Ok(v)
@@ -307,7 +314,7 @@ impl Peripheral for Esp32I2c {
     }
 
     fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
-        if std::env::var("LABWIRED_I2C_TRACE").is_ok() {
+        if i2c_trace_enabled() {
             eprintln!("ESP32 I2C W [0x{offset:02x}] = 0x{value:08x}");
         }
         match offset {

--- a/crates/core/src/peripherals/esp32/ledc.rs
+++ b/crates/core/src/peripherals/esp32/ledc.rs
@@ -162,7 +162,7 @@ pub struct Ledc {
     base: u32,
     /// Word-aligned register backing store. Every offset round-trips
     /// here; side-effecting offsets are intercepted before storing.
-    regs: HashMap<u64, u32>,
+    regs: crate::FastMap<u64, u32>,
     /// Actuators driven by this controller's PWM output, notified on each
     /// duty latch. Runtime wiring — not part of the register snapshot.
     duty_observers: Vec<Arc<dyn LedcDutyObserver>>,
@@ -181,7 +181,7 @@ impl Ledc {
     /// Construct a freshly-powered LEDC block. Seeds only LEDC_DATE with
     /// its silicon constant; every other register resets to zero.
     pub fn new(base: u32) -> Self {
-        let mut regs = HashMap::new();
+        let mut regs: crate::FastMap<u64, u32> = crate::FastMap::default();
         regs.insert(DATE, DATE_RESET);
         Self {
             base,

--- a/crates/core/src/peripherals/esp32/ledc.rs
+++ b/crates/core/src/peripherals/esp32/ledc.rs
@@ -69,7 +69,6 @@
 //! waveform UI actually consume.
 
 use crate::{Peripheral, PeripheralTickResult, SimResult};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Notified when a channel commits a new duty via the `CONF1.DUTY_START`

--- a/crates/core/src/peripherals/esp32/mcpwm.rs
+++ b/crates/core/src/peripherals/esp32/mcpwm.rs
@@ -31,7 +31,6 @@
 //! frequency/duty a controller actually commands.
 
 use crate::{Peripheral, PeripheralTickResult, SimResult};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Notified when an operator commits a new compare-A (duty) value, i.e. on

--- a/crates/core/src/peripherals/esp32/mcpwm.rs
+++ b/crates/core/src/peripherals/esp32/mcpwm.rs
@@ -67,7 +67,7 @@ const PWM_CLK_HZ: u64 = 160_000_000;
 pub struct Mcpwm {
     base: u32,
     /// Word-aligned register backing store; round-trips every write.
-    regs: HashMap<u64, u32>,
+    regs: crate::FastMap<u64, u32>,
     /// Actuators driven by this controller, notified on each duty commit.
     duty_observers: Vec<Arc<dyn McpwmDutyObserver>>,
 }
@@ -80,7 +80,7 @@ impl Mcpwm {
     pub fn new(base: u32) -> Self {
         Self {
             base,
-            regs: HashMap::new(),
+            regs: crate::FastMap::default(),
             duty_observers: Vec::new(),
         }
     }

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -41,7 +41,6 @@
 
 use crate::peripherals::spi::SpiDevice;
 use crate::{Peripheral, PeripheralTickResult, SimResult};
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// Read once per process — this sits on the SPI transfer path.

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -44,6 +44,12 @@ use crate::{Peripheral, PeripheralTickResult, SimResult};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+/// Read once per process — this sits on the SPI transfer path.
+fn spi_debug_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var("LABWIRED_SPI_DEBUG").is_ok())
+}
+
 const REG_CMD: u64 = 0x00;
 const REG_ADDR: u64 = 0x04;
 /// Classic SPI_RD_STATUS_REG — dedicated FLASH_RDID / FLASH_RDSR land here.
@@ -127,7 +133,7 @@ pub struct Esp32Spi {
     miso_dlen: u32,
     fifo: [u32; 16],
     /// Round-trip every other offset so firmware RMW sequences observe their writes.
-    other: HashMap<u64, u32>,
+    other: crate::FastMap<u64, u32>,
 
     /// Modeled flash status register 1 (WIP/WEL). Instant-complete model:
     /// WIP never stays set; WEL tracks WREN/WRDI.
@@ -286,7 +292,7 @@ impl Esp32Spi {
         if cmd & FLASH_RES != 0 {
             // Resume-from-powerdown: no data the boot path consumes.
         }
-        if std::env::var("LABWIRED_SPI_DEBUG").is_ok() {
+        if spi_debug_enabled() {
             eprintln!(
                 "esp32_spi: dedicated cmd=0x{cmd:08x} status=0x{:04x} rd_status=0x{:08x}",
                 self.flash_status, self.rd_status
@@ -337,7 +343,7 @@ impl Esp32Spi {
         let read_bytes = (((self.miso_dlen & 0x7FF) + 1) / 8) as usize;
         let addr = (self.addr >> 8) as usize;
 
-        if std::env::var("LABWIRED_SPI_DEBUG").is_ok() {
+        if spi_debug_enabled() {
             eprintln!(
                 "esp32_spi: USR miso op=0x{opcode:02x} addr=0x{addr:06x} bytes={read_bytes} user2=0x{:08x}",
                 self.user2

--- a/crates/core/src/peripherals/esp32/timg.rs
+++ b/crates/core/src/peripherals/esp32/timg.rs
@@ -71,7 +71,6 @@
 //! probes from firmware still see their own writes.
 
 use crate::{Peripheral, PeripheralTickResult, SimResult};
-use std::collections::HashMap;
 
 // Per-timer register offsets (T0 block starts at 0x00, T1 block at 0x24).
 // Some entries (`*_ALARM*`, `WDT_CONFIG0`, `INT_ENA`, `INT_ST`) aren't

--- a/crates/core/src/peripherals/esp32/timg.rs
+++ b/crates/core/src/peripherals/esp32/timg.rs
@@ -192,7 +192,7 @@ pub struct Timg {
     base: u32,
     /// Word-aligned register backing store. Any offset not explicitly
     /// computed in `read()` falls through to this map (or zero).
-    regs: HashMap<u64, u32>,
+    regs: crate::FastMap<u64, u32>,
     /// Live 64-bit value for timer 0. Advances on every `tick()` while
     /// `T0CONFIG.EN` is set. Latched into `T0_LO`/`T0_HI` on a write to
     /// `T0_UPDATE` (and on read of LO/HI as a safety net so firmware that
@@ -237,7 +237,7 @@ impl Timg {
     pub fn new(base: u32) -> Self {
         Self {
             base,
-            regs: HashMap::new(),
+            regs: crate::FastMap::default(),
             counter_t0: 0,
             counter_t1: 0,
             counter_lact: 0,

--- a/crates/core/src/peripherals/esp32/uart.rs
+++ b/crates/core/src/peripherals/esp32/uart.rs
@@ -89,7 +89,7 @@ const CONFIG_REGS: &[(u64, u32, u32)] = &[
 #[derive(Default)]
 struct UartCore {
     sink: Option<Arc<Mutex<Vec<u8>>>>,
-    regs: HashMap<u64, u32>,
+    regs: crate::FastMap<u64, u32>,
     tx_fifo: VecDeque<u8>,
     rx_fifo: VecDeque<u8>,
     int_raw_sticky: u32,
@@ -135,7 +135,7 @@ impl Esp32Uart {
     /// console (use for UART0, the typical `Serial`); false keeps it
     /// capture-only. `source_id` is the intr-matrix source (34/35/36).
     pub fn new(echo_stdout: bool, source_id: u32) -> Self {
-        let mut regs = HashMap::new();
+        let mut regs = crate::FastMap::default();
         for &(off, reset, _mask) in CONFIG_REGS {
             regs.insert(off, reset);
         }

--- a/crates/core/src/peripherals/esp32/uart.rs
+++ b/crates/core/src/peripherals/esp32/uart.rs
@@ -35,7 +35,7 @@
 //! routes it through the per-core interrupt matrix.
 
 use crate::{Peripheral, PeripheralTickResult, SimResult};
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
Classic ESP32 ran at **~2M cycles/s (RTF ~0.008)** — about 120× slower than the real chip, and ~150× behind the optimised ESP32-C3 (RTF 1.098/1.769, *above* real time). That is the root cause behind the hosted `verify` timeout, Ryan's test needing 3,000,000,000 steps, and the 2×–89× benchmark spread vs silicon.

## The win

```
interleaved, 6 rounds:
  base 9.82 9.88 9.89 9.87 9.86 9.96 s
  fast 7.06 7.29 7.10 7.11 7.11 7.06 s
  -> 1.36x - 1.41x, median 1.39x
```

Both binaries built and `cmp`-proven different, run interleaved, on a machine whose load was checked.

**Fidelity held:** Ryan's lab **12/12**, UART **byte-identical** to a binary built from `main`, `spi3=9202` and `painted=8984` unchanged, 747 esp32 peripheral unit tests green.

## What it was

Peripheral register banks are `HashMap<u64, u32>` keyed by register offset, read on nearly every tick — `UartCore::int_raw` alone walks several. std's default hasher is **SipHash**, and a clean profile put `sip::Hasher::write` as the **second heaviest frame in the whole simulator**, behind only the peripheral-walk loop.

SipHash is DoS-resistance for adversarial keys. A register offset the firmware chose is not that.

Same finding and same fix as the ESP32-C3 scheduler-hash work (2.343s → 1.955s there). `FastMap` is FxHash's multiply-xor construction, **no new dependency**. Map semantics are unchanged — including the absence of any iteration-order guarantee — so nothing that was correct before can break. Applied to the banks that profiled hot: `uart`, `timg`, `spi`, `ledc`, `mcpwm`.

## Also included

Three per-call `env::var` gates hoisted into `OnceLock` (`fidelity::strict`, `LABWIRED_I2C_TRACE`, `LABWIRED_SPI_DEBUG`), matching `cortex_m::trace_insn_enabled` which already documents why.

**Stated plainly: that part measured NO win on its own** (1.00× over 5 interleaved rounds). It is kept because it is strictly correct and cheap, not because it bought anything. It is not part of the 1.39×.

## Measurement note

The profile that first sent me at env lookups was **invalid**. I had spiked `uart`/`i2c`/`spi` `tick()` with an `env::var_os` probe, reverted the source, and profiled **without rebuilding** — so `sample` showed my own instrumentation as the top frame. Rebuilding first gave the real profile. Recorded so it is not repeated.

## Not in this PR, and why

Five other hypotheses were killed by measurement (I²C cadence, walk bodies, dual-core lockstep, per-tick allocation, caching the static `legacy_tick_dynamic` virtual calls — that last one was implemented in full and measured **exactly 1.00×**, then reverted rather than ship a cache needing sync for zero gain).

The remaining ~45% is `tick_peripherals_phase1`, and it is a frequency problem: `peripheral_tick_interval` defaults to **1** for this chip. Widening it gives 1.77×–8.8× but **breaks fidelity at the first step**, because `Peripheral::tick_elapsed(_cycles)` discards its argument — modelled time then runs N× slow and every firmware `millis()` deadline is wrong by N. Full detail, including the attempted-and-reverted `Timg::tick_elapsed` fix, is in the task.