### PR TITLE
ci: make the runner a variable instead of 31 hardcoded literals

### DIFF
--- a/.github/workflows/core-arduino-matrix-smoke.yml
+++ b/.github/workflows/core-arduino-matrix-smoke.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   arduino-matrix:
     name: arduino-${{ matrix.board }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -117,7 +117,7 @@ jobs:
 
   arduino-matrix-gate:
     name: arduino-matrix-gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     needs: arduino-matrix
     if: always()

--- a/.github/workflows/core-backfill-runner-image.yml
+++ b/.github/workflows/core-backfill-runner-image.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   publish:
     name: Publish an existing release runner image
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - name: Validate release tag
         shell: bash

--- a/.github/workflows/core-board-ci.yml
+++ b/.github/workflows/core-board-ci.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
@@ -52,7 +52,7 @@ jobs:
 
   board:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -118,7 +118,7 @@ jobs:
   # auto-committing to protected main: regenerate here and fail if it drifted, so
   # whoever changed the matrix must commit the regenerated scoreboard.
   coverage-staleness:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -20,7 +20,7 @@ jobs:
   # ── Static contract (always on PR; seconds) ────────────────────────────────
   release-runner-contract:
     name: release-runner-contract
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   pr-gate:
     name: pr-gate
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     steps:
       # Full history required: generate_validation_status.py uses
@@ -122,7 +122,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -253,7 +253,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -275,7 +275,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'push' && contains(github.event.head_commit.message, '[full-ci]'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   coverage-matrix-smoke:
     name: coverage-matrix-${{ matrix.id }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
 
   coverage-matrix-scoreboard:
     name: coverage-matrix-scoreboard
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     needs: coverage-matrix-smoke
     if: always()

--- a/.github/workflows/core-coverage-weekly.yml
+++ b/.github/workflows/core-coverage-weekly.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core-hil.yml
+++ b/.github/workflows/core-hil.yml
@@ -28,7 +28,7 @@ jobs:
   # Read hil/boards.json on a hosted runner and emit the matrix of ACTIVE boards.
   # Planned boards are listed in the manifest for visibility but make no jobs.
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
       count: ${{ steps.set.outputs.count }}

--- a/.github/workflows/core-iolink-native.yml
+++ b/.github/workflows/core-iolink-native.yml
@@ -54,7 +54,7 @@ concurrency:
 jobs:
   iolink-native:
     name: iolink-native-c-master
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - name: Checkout LabWired core
         uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
   # bump fail this workflow instead of the example.
   thermal-firmware-build:
     name: esp32c3-mlx90640-thermal firmware build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - name: Checkout LabWired core
         uses: actions/checkout@v4

--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   validation:
     name: Advanced Validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
 
   example-smokes:
     name: Example Smokes (real-output autochecks)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
 
   esp32s3-fixtures-e2e:
     name: ESP32-S3 Fixtures E2E (espup)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -187,7 +187,7 @@ jobs:
 
   tier1-fixture-drift:
     name: Tier-1 Fixture Drift Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 60
     steps:
       # Gate to Sundays only for scheduled runs; workflow_dispatch always proceeds.

--- a/.github/workflows/core-onboarding-smoke.yml
+++ b/.github/workflows/core-onboarding-smoke.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   onboarding-smoke:
     name: onboarding-${{ matrix.id }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -88,7 +88,7 @@ jobs:
 
   onboarding-scoreboard:
     name: onboarding-scoreboard
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 5
     needs: onboarding-smoke
     if: always()

--- a/.github/workflows/core-perf.yml
+++ b/.github/workflows/core-perf.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   board-throughput:
     name: board-throughput
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -87,7 +87,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -121,7 +121,7 @@ jobs:
   publish:
     name: Publish CI runner image
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -152,7 +152,7 @@ jobs:
   release-smoke:
     name: Smoke released archives and runner image
     needs: [release, publish]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-unsupported-audit.yml
+++ b/.github/workflows/core-unsupported-audit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   unsupported-audit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-validate-hw-targets.yml
+++ b/.github/workflows/core-validate-hw-targets.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   validate-targets:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
 
     steps:
       - name: Checkout core

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/labwired-ci-dogfood.yml
+++ b/.github/workflows/labwired-ci-dogfood.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   dogfood:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["ubuntu-latest"]') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Every job in this repo pinned `runs-on: ubuntu-latest` directly. When GitHub-hosted runners went unavailable on 2026-08-02 (account billing block), there was no way to move this repo's CI without editing **31 job definitions**.

**Nothing changes today.** The default is still `ubuntu-latest`, so routing is byte-identical and hosted runners keep being used. This only adds the switch: setting the `CI_RUNNER` repo variable now redirects the whole repo at once — the same pattern the superproject already uses.

## Deliberately not converted

- `core-release.yml` → `runs-on: ${{ matrix.runner }}` — the cross-platform release matrix. Forcing it onto one Linux pool would break the macOS/Windows builds.
- `core-hil.yml` → `["self-hosted","hil","${{ matrix.runner_label }}"]` — HIL rigs are physical hardware and already correct.

## Verification

- `scripts/ci/verify-release-runner-contract.sh` **executed against this tree and passes** — it greps `core-release.yml` for literals, so it was the one gate that could plausibly break. 13 tests, OK.
- `actionlint 1.7.7` clean on every file I changed. It does warn about the custom `hil` label in `core-hil.yml:59`, but that is **pre-existing** — identical on `origin/main`, on a line this PR does not touch, and this repo has no actionlint gate.

## ⚠️ For whoever flips the switch

This repo currently has **one** self-hosted runner registered (`pluto-labwired-core-ci`). Setting `CI_RUNNER` serializes all 31 jobs onto it. That's an outage lever, not a steady state.

The billing block has since cleared — hosted runs succeeded at 19:06 and 20:07 — so there is no need to flip it now. This is so that next time it takes one variable rather than a 31-file PR.