### PR TITLE
Fix millis() in the browser: the WASM path never got core#742

### DIFF
--- a/crates/wasm/src/install.rs
+++ b/crates/wasm/src/install.rs
@@ -105,6 +105,23 @@ impl WasmSimulator {
             }
         }
 
+        // `g_ticks_per_us_pro` / `_app` — CPU MHz, normally written by
+        // `ets_update_cpu_frequency()` in the ROM bootloader, which this path
+        // skips. `esp_clk_apb_freq()` on ESP32-classic is
+        // `MIN(g_ticks_per_us_pro, 80) * MHZ`, so leaving them zero reports a
+        // 0 Hz APB bus and `esp_timer_impl_update_apb_freq` aborts boot.
+        //
+        // Without this the browser had the SAME defect the CLI had until
+        // core#742: millis() came back with bit 31 set, so every
+        // `(int32_t)(millis() - deadline) >= 0` in a sketch compared negative
+        // and loop() ran forever doing NOTHING. A bay-occupancy lab showed a
+        // blank panel and no serial for as long as you cared to wait.
+        for sym in ["g_ticks_per_us_pro", "g_ticks_per_us_app"] {
+            if let Some(&addr) = symbol_addrs.get(sym) {
+                let _ = machine.bus.write_u32(addr as u64, 240);
+            }
+        }
+
         // pxCurrentTCB pointer seed for xTaskGetCurrentTaskHandle thunk.
         if let Some(&addr) = symbol_addrs.get("pxCurrentTCB") {
             rom_thunks::PX_CURRENT_TCB_ADDR.with(|s| s.set(Some(addr)));
@@ -132,8 +149,9 @@ impl WasmSimulator {
         // with the real heap: refresh_gen=1, 1429 ink bytes).
 
         // No-op stubs for ESP-IDF / Arduino-ESP32 init paths we don't model.
+        // NB: esp_timer_init is deliberately absent — it is what programs
+        // LACT_CONFIG (enable + divider), and TIMG0 models LACT.
         for sym in &[
-            "esp_timer_init",
             "spi_flash_disable_interrupts_caches_and_other_cpu",
             "spi_flash_enable_interrupts_caches_and_other_cpu",
             "__retarget_lock_init_recursive",
@@ -266,11 +284,11 @@ impl WasmSimulator {
             "__getreent",
             rom_thunks::getreent_dram_fake_ptr,
         );
-        push_named(
-            &mut thunks,
-            "esp_timer_impl_get_counter_reg",
-            rom_thunks::monotonic_counter_32,
-        );
+        // esp_timer_impl_get_counter_reg is NOT thunked: TIMG0 models the LACT
+        // timer it reads. The thunk it replaces returned 32 bits through a2 and
+        // left a3 — the HIGH word — undefined, and `esp_timer_get_time` computes
+        // `(hi << 31) | (lo >> 1)`, putting garbage on bit 31 of every
+        // microsecond timestamp. See core#742.
         push_named(
             &mut thunks,
             "esp_clk_cpu_freq",


### PR DESCRIPTION
A published lab showed a **blank panel and no serial, indefinitely**, while reporting "Running". Waiting did not help and never would have.

## Cause

The browser runs a **third copy** of the Arduino-ESP32 boot setup (`crates/wasm/src/install.rs`). When `snapshot` and `test` were unified onto the shared profile (#746), that commit noted the WASM bridge should converge too — and then didn't. So the browser kept all three defects #742 removed:

| defect | consequence |
|---|---|
| `esp_timer_impl_get_counter_reg` → `monotonic_counter_32` | returns 32 bits in `a2`, leaves `a3` (the **high** word) undefined; `esp_timer_get_time` computes `(hi << 31) \| (lo >> 1)`, so garbage lands on **bit 31** of every timestamp |
| `esp_timer_init` stubbed | the LACT divider is never programmed |
| `g_ticks_per_us_pro`/`_app` never seeded | `esp_clk_apb_freq()` reports a **0 Hz** APB bus |

In a sketch this means every `(int32_t)(millis() - deadline) >= 0` compares **negative**, so `loop()` runs forever and does **nothing**. A bay-occupancy lab polled no sensors and painted no pixels.

This is the browser half of a bug already fixed for the CLI. TIMG0 models LACT, so the firmware's own timer code now runs against real registers.

## Deliberately NOT done here

Making this path **call** the shared profile. The two thunk sets differ by **41 symbols**:

- 7 only in wasm — `esp_flash_read_chip_id`, `spi_flash_op_lock`, `esp_flash_app_disable_protect`, …
- 34 only in the profile — the newlib `__s*` family, the `spi_flash_chip_generic*` family, `vListInsert`, …

A swap would therefore **change** browser behaviour rather than unify it. That convergence deserves its own change with its own before/after evidence. This one restores a broken product path.