### PR TITLE
feat(parts): connect parts from any source via labwired.part/v1 packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Build output
 /target/
 target/
+# ...and `target` as a SYMLINK: the patterns above end in `/`, so they match
+# a directory only. Pointing target/ at another disk (a full internal drive)
+# otherwise makes the link itself show up as an untracked file to commit.
+/target
 examples/*/target/
 # Generated test fixtures (build artifacts) — but allow committed reference
 # binaries like the Espressif ESP32 BROM ELF in crates/*/tests/fixtures/

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -63,6 +63,7 @@ pub(crate) fn run_firmware_riscv(args: RunArgs, _chip_yaml: String) -> ExitCode 
     // Minimal system manifest: no external devices, no extra peripherals.
     // All peripherals come from the chip descriptor.
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         schema_version: "1.0".to_string(),
         name: chip.name.clone(),
         chip: args.chip.to_string_lossy().into_owned(),

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -104,13 +104,6 @@ fn test_asset_init() {
         std::fs::remove_dir_all(output_dir).ok();
     }
 
-    let root = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_path_buf();
-
     // `CARGO_BIN_EXE_labwired` is cargo's own path to the built binary. A
     // hardcoded `target/debug/labwired` is wrong whenever the target dir is
     // not the default — a `CARGO_TARGET_DIR` env var or a `[build] target-dir`

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -10,7 +10,12 @@ fn test_cli_json_metrics() {
         .unwrap()
         .to_path_buf();
 
-    let bin_path = root.join("target/debug/labwired");
+    // `CARGO_BIN_EXE_labwired` is cargo's own path to the built binary. A
+    // hardcoded `target/debug/labwired` is wrong whenever the target dir is
+    // not the default — a `CARGO_TARGET_DIR` env var or a `[build] target-dir`
+    // in .cargo/config.toml, both of which are ordinary things to set when the
+    // build tree lives on another disk.
+    let bin_path = PathBuf::from(env!("CARGO_BIN_EXE_labwired"));
     let elf_path = root.join("tests/fixtures/uart-ok-thumbv7m.elf");
 
     let mut cmd = Command::new(bin_path);
@@ -49,7 +54,12 @@ fn test_cli_vcd_generation() {
         .unwrap()
         .to_path_buf();
 
-    let bin_path = root.join("target/debug/labwired");
+    // `CARGO_BIN_EXE_labwired` is cargo's own path to the built binary. A
+    // hardcoded `target/debug/labwired` is wrong whenever the target dir is
+    // not the default — a `CARGO_TARGET_DIR` env var or a `[build] target-dir`
+    // in .cargo/config.toml, both of which are ordinary things to set when the
+    // build tree lives on another disk.
+    let bin_path = PathBuf::from(env!("CARGO_BIN_EXE_labwired"));
     let elf_path = root.join("tests/fixtures/uart-ok-thumbv7m.elf");
 
     let mut cmd = Command::new(bin_path);
@@ -101,7 +111,12 @@ fn test_asset_init() {
         .unwrap()
         .to_path_buf();
 
-    let bin_path = root.join("target/debug/labwired");
+    // `CARGO_BIN_EXE_labwired` is cargo's own path to the built binary. A
+    // hardcoded `target/debug/labwired` is wrong whenever the target dir is
+    // not the default — a `CARGO_TARGET_DIR` env var or a `[build] target-dir`
+    // in .cargo/config.toml, both of which are ordinary things to set when the
+    // build tree lives on another disk.
+    let bin_path = PathBuf::from(env!("CARGO_BIN_EXE_labwired"));
 
     let mut cmd = Command::new(bin_path);
     cmd.args(["asset", "init", "-o", output_dir]);

--- a/crates/cli/tests/demo_blinky.rs
+++ b/crates/cli/tests/demo_blinky.rs
@@ -11,9 +11,20 @@ fn test_demo_blinky_gpio_toggle() {
         .with_test_writer()
         .try_init();
 
-    // Load the demo-blinky firmware
-    let firmware_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../target/thumbv7m-none-eabi/release/demo-blinky");
+    // Load the demo-blinky firmware. The target dir is not always
+    // `<workspace>/target`: a `CARGO_TARGET_DIR` env var or a `[build]
+    // target-dir` in .cargo/config.toml moves it, which is an ordinary thing to
+    // do when the build tree lives on another disk. Ask the environment first
+    // and fall back to the default layout.
+    // `CARGO_TARGET_TMPDIR` is `<target-dir>/tmp`, and cargo sets it for every
+    // integration test — so its parent is the target dir wherever it lives,
+    // including when a `[build] target-dir` in .cargo/config.toml moved it
+    // (which never reaches the test as an env var).
+    let target_dir = std::env::var("CARGO_TARGET_TMPDIR")
+        .ok()
+        .and_then(|tmp| PathBuf::from(tmp).parent().map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target"));
+    let firmware_path = target_dir.join("thumbv7m-none-eabi/release/demo-blinky");
 
     if !firmware_path.exists() {
         panic!(

--- a/crates/cli/tests/e2e_stimulus_reporting.rs
+++ b/crates/cli/tests/e2e_stimulus_reporting.rs
@@ -31,6 +31,7 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
@@ -65,10 +66,22 @@ impl Run {
 /// and system paths are absolute, so the script's location does not matter.
 fn run_script(script_body: &str) -> Run {
     let root = repo_root();
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    // Timestamp PLUS a process-wide counter. `as_nanos()` is not actually
+    // nanosecond-granular on macOS, so sibling tests starting in the same
+    // microsecond used to land in the SAME directory and overwrite each
+    // other's script.yaml/result.json — a random subset of this file failed
+    // on every parallel run, a different subset each time, while
+    // `--test-threads=1` always passed. The counter makes the name unique
+    // regardless of what the clock resolves to.
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nonce = format!(
+        "{}-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    );
     let dir = std::env::temp_dir().join(format!("labwired-stimulus-report-{nonce}"));
     std::fs::create_dir_all(&dir).expect("create temp dir");
     let script = dir.join("script.yaml");

--- a/crates/cli/tests/e2e_uart_injection.rs
+++ b/crates/cli/tests/e2e_uart_injection.rs
@@ -15,6 +15,7 @@
 
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
@@ -60,10 +61,22 @@ struct InjectionRun {
 }
 
 fn run_script(root: &std::path::Path, script_yaml: &str) -> InjectionRun {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    // Timestamp PLUS a process-wide counter. `as_nanos()` is not actually
+    // nanosecond-granular on macOS, so sibling tests starting in the same
+    // microsecond used to land in the SAME directory and overwrite each
+    // other's script.yaml/result.json — a random subset of this file failed
+    // on every parallel run, a different subset each time, while
+    // `--test-threads=1` always passed. The counter makes the name unique
+    // regardless of what the clock resolves to.
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nonce = format!(
+        "{}-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    );
     let out_dir = std::env::temp_dir().join(format!("labwired-uart-injection-{nonce}"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let script_path = out_dir.join("script.yaml");

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -331,6 +331,17 @@ pub struct SystemManifest {
     pub memory_overrides: HashMap<String, String>,
     #[serde(default)]
     pub external_devices: Vec<ExternalDevice>,
+    /// Part packs this system carries — the parts that are NOT built into the
+    /// engine. An `external_devices` entry whose `type:` names a pack here is
+    /// modelled from that pack, so a private/vendor/customer catalog connects
+    /// with no code in this repository and nothing published. See
+    /// `docs/part-packs.md` for the `labwired.part/v1` contract.
+    ///
+    /// Packs ride in the manifest so every transport that already carries a
+    /// manifest carries them too: the CLI, the browser wasm build, and the
+    /// hosted builder's `/run`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<PartPack>,
     #[serde(default)]
     pub cosim_models: Vec<CosimModelConfig>,
     #[serde(default)]
@@ -782,7 +793,73 @@ impl SystemManifest {
                 }
             }
         }
+        // `parts: [- path: ./acme.yaml]` is the same CLI convenience: read it
+        // here so the core only ever sees an inline pack (wasm has no fs).
+        for entry in &mut manifest.parts {
+            let rel = match entry {
+                PartPack::Path(p) => p.path.clone(),
+                PartPack::Inline(_) => continue,
+            };
+            let full = base.join(&rel);
+            let text = std::fs::read_to_string(&full)
+                .map_err(|e| anyhow::anyhow!("part pack {:?}: cannot read {e}", full))?;
+            let origin = full.display().to_string();
+            *entry = PartPack::Inline(Box::new(parse_part_pack(&text, &origin)?));
+        }
+        manifest.validate_parts()?;
         Ok(manifest)
+    }
+
+    /// The ONE lookup for a manifest-carried part. Returns the pack whose
+    /// `type:` matches, or `None` when this system carries no such part (the
+    /// caller then falls through to the built-in registries).
+    ///
+    /// Call [`Self::validate_parts`] before relying on this — it is what
+    /// guarantees the match is unambiguous.
+    pub fn resolve_part(&self, device_type: &str) -> Option<&DeviceDescriptor> {
+        self.parts
+            .iter()
+            .filter_map(PartPack::descriptor)
+            .find(|d| d.r#type == device_type)
+    }
+
+    /// Enforce the contract across the whole `parts:` list: every entry is a
+    /// resolved, well-formed pack, and no two packs claim the same `type`.
+    ///
+    /// Two packs for one type is the failure this exists to prevent. Picking a
+    /// winner would mean a customer's firmware silently runs against whichever
+    /// catalog happened to load last — so it is an error, named, with both
+    /// sources in the message.
+    pub fn validate_parts(&self) -> Result<()> {
+        let mut seen: HashMap<&str, Option<&str>> = HashMap::new();
+        for entry in &self.parts {
+            let pack = match entry {
+                PartPack::Inline(d) => d.as_ref(),
+                PartPack::Path(p) => anyhow::bail!(
+                    "part pack '{}' was never loaded. `path:` is a CLI convenience that \
+                     SystemManifest::from_file inlines; a manifest handed to the engine \
+                     directly (browser, hosted runner) must carry the pack inline.",
+                    p.path
+                ),
+            };
+            let origin = pack
+                .source
+                .as_deref()
+                .map(|s| format!("source: {s}"))
+                .unwrap_or_else(|| "no declared source".to_string());
+            validate_part_pack(pack, &origin)?;
+            if let Some(prev) = seen.insert(pack.r#type.as_str(), pack.source.as_deref()) {
+                anyhow::bail!(
+                    "two part packs both define '{}' (sources: {} and {}). \
+                     One part is one document — rename one, or namespace them \
+                     `vendor:part`.",
+                    pack.r#type,
+                    prev.unwrap_or("undeclared"),
+                    pack.source.as_deref().unwrap_or("undeclared"),
+                );
+            }
+        }
+        Ok(())
     }
 
     pub fn validate_cosim_models(&self) -> Vec<String> {
@@ -960,6 +1037,111 @@ pub struct DeviceDescriptor {
     /// schema still parse.
     #[serde(default)]
     pub metadata: Option<DeviceMetadata>,
+    /// Contract version, `labwired.part/v1`. Required of a pack that arrives
+    /// through a manifest's `parts:`; absent on the descriptors bundled in
+    /// `configs/devices/` (they predate the contract and are validated by
+    /// being in-tree). Declaring it is what lets us change the schema later
+    /// without guessing at what an out-of-tree file meant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    /// Provenance: which catalog/vendor/customer shipped this pack. Carried so
+    /// an error message and a bug report can name where the model came from —
+    /// "which model ran?" must never be answered by a shrug.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// The built-in part `type` this pack deliberately replaces. Shadowing a
+    /// built-in is otherwise a hard error, so a replacement is always explicit
+    /// and attributable rather than a silent win for whoever loaded last.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<String>,
+    /// The app-layer catalog record (pin declarations, device class, ref
+    /// prefix). Opaque here — the simulation core has no use for it — but
+    /// carried so one pack file describes the part end to end instead of
+    /// splitting into a half that simulates and a half that draws.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<serde_yaml::Value>,
+}
+
+/// The contract version a manifest-carried part pack must declare.
+pub const PART_PACK_SCHEMA: &str = "labwired.part/v1";
+
+/// One entry in a manifest's `parts:` list.
+///
+/// `path:` is a `labwired` CLI convenience — [`SystemManifest::from_file`]
+/// reads the file and replaces the entry with its contents, exactly as it
+/// already does for a `can-player`'s `path:`. The simulation core only ever
+/// sees [`PartPack::Inline`]: it has no filesystem under wasm, and a contract
+/// that works on only one of our three runtimes is not a contract.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum PartPack {
+    /// A path to a pack file, relative to the manifest. CLI-only; inlined on load.
+    Path(PartPackPath),
+    /// The pack itself, verbatim.
+    Inline(Box<DeviceDescriptor>),
+}
+
+/// The `- path: ./acme-tmp999.yaml` spelling of a [`PartPack`].
+///
+/// `deny_unknown_fields` is load-bearing: it is what stops serde's untagged
+/// matching from swallowing a malformed inline pack into this variant and
+/// reporting "missing field: path" for a file that plainly has `type:` and
+/// `behavior:` in it.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct PartPackPath {
+    pub path: String,
+}
+
+impl PartPack {
+    /// The pack body, or `None` for a still-unresolved `path:` entry.
+    pub fn descriptor(&self) -> Option<&DeviceDescriptor> {
+        match self {
+            PartPack::Inline(d) => Some(d),
+            PartPack::Path(_) => None,
+        }
+    }
+}
+
+/// Parse a part pack from YAML and enforce the `labwired.part/v1` contract.
+///
+/// Unlike [`DeviceDescriptor::from_yaml`] (which also parses the in-tree
+/// `configs/devices/*.yaml` bodies) this REQUIRES the `schema:` declaration,
+/// because an out-of-tree file is the one case where we cannot tell by
+/// inspection which schema its author was writing against.
+pub fn parse_part_pack(yaml: &str, origin: &str) -> Result<DeviceDescriptor> {
+    let pack = DeviceDescriptor::from_yaml(yaml)
+        .with_context(|| format!("part pack {origin} is not a valid descriptor"))?;
+    validate_part_pack(&pack, origin)?;
+    Ok(pack)
+}
+
+/// Enforce the parts of the contract that are true of every pack, wherever it
+/// came from: the schema declaration, a non-empty type, and a `behavior` that
+/// names a primitive.
+pub fn validate_part_pack(pack: &DeviceDescriptor, origin: &str) -> Result<()> {
+    match pack.schema.as_deref() {
+        Some(PART_PACK_SCHEMA) => {}
+        Some(other) => anyhow::bail!(
+            "part pack {origin} declares unknown schema '{other}'; \
+             this engine speaks '{PART_PACK_SCHEMA}'"
+        ),
+        None => anyhow::bail!(
+            "part pack {origin} is missing `schema: {PART_PACK_SCHEMA}`. \
+             Declaring the contract version is what lets the schema change \
+             later without guessing what your file meant."
+        ),
+    }
+    if pack.r#type.trim().is_empty() {
+        anyhow::bail!("part pack {origin} has an empty `type:`");
+    }
+    if pack.behavior.primitive.trim().is_empty() {
+        anyhow::bail!(
+            "part pack '{}' ({origin}) has an empty `behavior.primitive:`",
+            pack.r#type
+        );
+    }
+    Ok(())
 }
 
 /// Display + runtime metadata for a declarative device. Only `inputs` is
@@ -2148,6 +2330,7 @@ impl ResolvedSystem {
         ChipDescriptor::resolve(chip, Path::new("."))?;
         Ok(Self {
             manifest: SystemManifest {
+                parts: Vec::new(),
                 schema_version: default_schema_version(),
                 name: chip.to_string(),
                 chip: chip.to_string(),

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -120,6 +120,11 @@ impl SystemBus {
     }
 
     pub fn from_config(chip: &ChipDescriptor, manifest: &SystemManifest) -> anyhow::Result<Self> {
+        // Part-pack contract, enforced HERE rather than in the manifest loader:
+        // `from_file` is the CLI's path, and the browser and hosted runners
+        // parse with `from_yaml`. Validating at load time only would mean two
+        // of our three runtimes silently accept documents the third rejects.
+        manifest.validate_parts()?;
         let flash_size = parse_size(&chip.flash.size)?;
         let ram_size = parse_size(&chip.ram.size)?;
 
@@ -734,6 +739,23 @@ impl SystemBus {
             // to the generic arms — it is handled, so re-processing it here
             // would emit a spurious "Unsupported external device" WARN.
             if attached_i2c_ext_ids.contains(ext.id.as_str()) {
+                continue;
+            }
+            // Zeroth-pass: parts this manifest CARRIES (`parts:`), i.e. parts
+            // that are not built into the engine at all — a private catalog, a
+            // vendor library, a customer's own sensor. They resolve first
+            // because they are the most specific thing anyone said about this
+            // system; shadowing a built-in is rejected inside `lookup` rather
+            // than silently allowed here. See `super::part_pack`.
+            if let Some(pack) = super::part_pack::lookup(manifest, &ext.r#type)? {
+                if let Some(kit) = super::part_pack::kit_for(pack)? {
+                    let mut ctx = crate::peripherals::kit::AttachCtx::new(&mut bus, ext);
+                    kit.attach(&mut ctx)?;
+                } else {
+                    // Not bus-resident: the GPIO / pin-timing primitives, which
+                    // take the same path an embedded descriptor takes.
+                    bus.attach_declarative_device(ext, pack)?;
+                }
                 continue;
             }
             // First-pass: peripherals that have migrated to the unified

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -29,6 +29,7 @@ mod faults;
 mod from_config;
 mod mmio_activity;
 mod mmio_words;
+pub(crate) mod part_pack;
 mod policy;
 mod profiles;
 mod resident_device;

--- a/crates/core/src/bus/part_pack.rs
+++ b/crates/core/src/bus/part_pack.rs
@@ -114,14 +114,12 @@ pub(crate) fn kit_for(pack: &DeviceDescriptor) -> Result<Option<&'static dyn Per
     }
 
     let kit: &'static dyn PeripheralKit = match transport {
-        Transport::I2c => Box::leak(Box::new(
-            DeclarativeI2cKit::from_yaml(&key)
-                .with_context(|| format!("part pack '{}' is not a valid i2c_device", pack.r#type))?,
-        )),
-        Transport::Spi => Box::leak(Box::new(
-            DeclarativeSpiKit::from_yaml(&key)
-                .with_context(|| format!("part pack '{}' is not a valid spi_device", pack.r#type))?,
-        )),
+        Transport::I2c => Box::leak(Box::new(DeclarativeI2cKit::from_yaml(&key).with_context(
+            || format!("part pack '{}' is not a valid i2c_device", pack.r#type),
+        )?)),
+        Transport::Spi => Box::leak(Box::new(DeclarativeSpiKit::from_yaml(&key).with_context(
+            || format!("part pack '{}' is not a valid spi_device", pack.r#type),
+        )?)),
     };
     interned.insert(key, kit);
     Ok(Some(kit))

--- a/crates/core/src/bus/part_pack.rs
+++ b/crates/core/src/bus/part_pack.rs
@@ -1,0 +1,174 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Attach path for **manifest-carried part packs** — parts that are not built
+//! into this engine.
+//!
+//! A system manifest may carry `parts:`, each a `labwired.part/v1` document (see
+//! `docs/part-packs.md`). An `external_devices` entry whose `type:` names one is
+//! modelled from that pack, so a private, vendor, or customer catalog connects
+//! with no code in this repository and nothing published.
+//!
+//! The pack body is the same schema as the in-tree `configs/devices/*.yaml`
+//! descriptors, which is the point: built-in parts and private parts are the
+//! same kind of object, interpreted by the same primitives, so the private path
+//! is the one we exercise every day rather than a side door that rots.
+//!
+//! What is NOT here is any new modelling. A pack names one of the irreducible
+//! primitives (`i2c_device`, `spi_device`, `quadrature`, `matrix`, `one_wire`,
+//! `pulse_echo`) and this module routes it to the same construction the built-in
+//! parts use. A part with a genuinely new wire protocol needs a new primitive,
+//! which is a change to this crate — that boundary is real and worth being
+//! straight about.
+//!
+//! ## Which door each primitive uses
+//!
+//! Built-in parts reach the bus by two different routes, and packs follow the
+//! same ones rather than inventing a third:
+//!
+//! - **I²C** — [`i2c_device`] is called from `build_i2c_tree`, the single place
+//!   every controller family (generic, ESP32-C3, the Xtensa glue, nRF52/nRF54L
+//!   TWIM) turns a `type:` into a model. One hook there means a private sensor
+//!   works on every MCU, not just the one we happened to try it on.
+//! - **SPI** — SPI devices only ever attach through the `PeripheralKit`
+//!   registry, so [`kit_for`] interns the pack as a kit and `from_config`
+//!   attaches it exactly as it attaches a built-in.
+//! - **GPIO / pin-timing** — no factory at all; `from_config` hands the
+//!   descriptor to `attach_declarative_device`, the same call the embedded
+//!   `configs/devices/*.yaml` descriptors take.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use anyhow::{Context, Result};
+use labwired_config::{DeviceDescriptor, SystemManifest};
+
+use crate::peripherals::components::{DeclarativeI2cKit, DeclarativeSpiKit};
+use crate::peripherals::kit::PeripheralKit;
+use crate::sim_input::SimInput;
+
+/// Interned dynamic kits, keyed by the pack's canonical serialisation.
+///
+/// The registry contract is `&'static dyn PeripheralKit`, and a pack arrives at
+/// runtime — so building one means leaking it. Keying on the pack's own bytes
+/// makes that leak bounded and idempotent: re-running the same system reuses the
+/// same kit, and editing a pack interns the edited one rather than serving a
+/// stale model under the same `type:` (which would be the worst of both).
+static INTERNED: LazyLock<Mutex<HashMap<String, &'static (dyn PeripheralKit + 'static)>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Built-in `type:` strings a pack would shadow. Both built-in registries are
+/// consulted, because "already built in" must mean the same thing to a pack
+/// author regardless of which of our two internal paths happens to own the part.
+fn builtin_owns(device_type: &str) -> bool {
+    crate::peripherals::kit::registry::lookup(device_type).is_some()
+        || labwired_config::embedded_device_yaml(device_type).is_some()
+}
+
+/// Resolve `device_type` against the manifest's `parts:`, enforcing the
+/// shadowing rule.
+///
+/// Returns `Ok(None)` when this system carries no such pack — the caller then
+/// falls through to the built-in registries, which is the ordinary case.
+pub(crate) fn lookup<'m>(
+    manifest: &'m SystemManifest,
+    device_type: &str,
+) -> Result<Option<&'m DeviceDescriptor>> {
+    let Some(pack) = manifest.resolve_part(device_type) else {
+        return Ok(None);
+    };
+    if builtin_owns(device_type) && pack.overrides.as_deref() != Some(device_type) {
+        anyhow::bail!(
+            "part pack '{device_type}' ({}) shadows a built-in part. \
+             Set `overrides: {device_type}` to replace it deliberately, or rename the pack. \
+             Which model ran is not something a bug report should have to guess at.",
+            pack.source
+                .as_deref()
+                .map(|s| format!("source: {s}"))
+                .unwrap_or_else(|| "no declared source".to_string()),
+        );
+    }
+    Ok(Some(pack))
+}
+
+/// Intern a pack as a `PeripheralKit` for the bus-resident (I²C / SPI)
+/// primitives. Returns `Ok(None)` for a primitive that is not bus-resident —
+/// the GPIO / pin-timing family, which attaches through
+/// [`super::declarative_device`] instead.
+pub(crate) fn kit_for(pack: &DeviceDescriptor) -> Result<Option<&'static dyn PeripheralKit>> {
+    let transport = match pack.behavior.primitive.as_str() {
+        "i2c_device" => Transport::I2c,
+        "spi_device" => Transport::Spi,
+        _ => return Ok(None),
+    };
+
+    let key = serde_yaml::to_string(pack)
+        .with_context(|| format!("part pack '{}' could not be canonicalised", pack.r#type))?;
+
+    let mut interned = INTERNED
+        .lock()
+        .map_err(|_| anyhow::anyhow!("part-pack registry lock poisoned"))?;
+    if let Some(kit) = interned.get(&key) {
+        return Ok(Some(*kit));
+    }
+
+    let kit: &'static dyn PeripheralKit = match transport {
+        Transport::I2c => Box::leak(Box::new(
+            DeclarativeI2cKit::from_yaml(&key)
+                .with_context(|| format!("part pack '{}' is not a valid i2c_device", pack.r#type))?,
+        )),
+        Transport::Spi => Box::leak(Box::new(
+            DeclarativeSpiKit::from_yaml(&key)
+                .with_context(|| format!("part pack '{}' is not a valid spi_device", pack.r#type))?,
+        )),
+    };
+    interned.insert(key, kit);
+    Ok(Some(kit))
+}
+
+enum Transport {
+    I2c,
+    Spi,
+}
+
+/// Build the I²C model for `ext` from a manifest-carried pack, if one claims
+/// its `type:`.
+///
+/// This is called from [`build_i2c_tree`](crate::peripherals::components::build_i2c_tree)
+/// — the one place every I²C attach path (generic `from_config`, ESP32-C3, the
+/// Xtensa glue, nRF52/nRF54L TWIM) turns a `type:` into a model. Resolving here
+/// rather than in each caller is what makes "my private sensor works" mean the
+/// same thing on every MCU instead of on whichever one we happened to test.
+pub(crate) fn i2c_device(
+    manifest: &SystemManifest,
+    ext: &labwired_config::ExternalDevice,
+) -> Result<Option<Box<dyn crate::peripherals::i2c::I2cDevice>>> {
+    let Some(pack) = lookup(manifest, &ext.r#type)? else {
+        return Ok(None);
+    };
+    if pack.behavior.primitive != "i2c_device" {
+        return Ok(None);
+    }
+    let yaml = serde_yaml::to_string(pack)
+        .with_context(|| format!("part pack '{}' could not be canonicalised", pack.r#type))?;
+    // 0 tells GenericI2cDevice to use the pack's `default_address`.
+    let address = ext
+        .config
+        .get("i2c_address")
+        .and_then(|v| v.as_u64())
+        .map(|a| a as u8)
+        .unwrap_or(0);
+    let mut device = crate::peripherals::components::GenericI2cDevice::from_yaml(&yaml, address)
+        .with_context(|| {
+            format!(
+                "part pack '{}' ({}) is not a valid i2c_device",
+                pack.r#type,
+                pack.source.as_deref().unwrap_or("no declared source")
+            )
+        })?;
+    // Same identity stamping the built-in factory does, so a pack's stimulus
+    // channels are addressable by the id the manifest author wrote.
+    device.set_component_id(ext.id.clone());
+    Ok(Some(Box::new(device)))
+}

--- a/crates/core/src/bus/pin_map_tests.rs
+++ b/crates/core/src/bus/pin_map_tests.rs
@@ -12,6 +12,7 @@ fn mkw41z4_bus() -> SystemBus {
         .join("../../configs/chips/mkw41z4.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load mkw41z4");
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -577,6 +577,7 @@ fn test_from_config_attaches_adxl345_external_device_to_i2c() {
         serde_yaml::Value::Number(0x53.into()),
     );
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
@@ -997,6 +998,7 @@ fn test_esp32c3_i2c_gpio_matrix_distinguishes_gpio45_from_gpio67() {
             serde_yaml::Value::Number(0x3C.into()),
         );
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -1216,6 +1218,7 @@ fn test_from_config_attaches_bmp280_to_esp32c3_i2c0() {
         serde_yaml::Value::Number(0x76.into()),
     );
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
@@ -1367,6 +1370,7 @@ fn test_from_config_attaches_mlx90640_to_esp32c3_i2c0_and_reads_eeprom() {
         serde_yaml::Value::Number(25.0.into()),
     );
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
@@ -2183,6 +2187,7 @@ peripherals:
 
 fn empty_manifest() -> SystemManifest {
     SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
@@ -2322,6 +2327,7 @@ fn manifest_with_external_device(
     config: std::collections::HashMap<String, serde_yaml::Value>,
 ) -> labwired_config::SystemManifest {
     labwired_config::SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/src/peripherals/components/i2c_factory.rs
+++ b/crates/core/src/peripherals/components/i2c_factory.rs
@@ -169,6 +169,13 @@ pub fn build_i2c_tree(
     manifest: &labwired_config::SystemManifest,
     ext: &labwired_config::ExternalDevice,
 ) -> anyhow::Result<Option<Box<dyn I2cDevice>>> {
+    // A part this manifest CARRIES outranks the built-in factory: it is the most
+    // specific thing anyone said about this system. A pack can only reach here
+    // for a type we already ship by declaring `overrides:`; otherwise
+    // `bus::part_pack::lookup` refuses it rather than picking a winner.
+    if let Some(device) = crate::bus::part_pack::i2c_device(manifest, ext)? {
+        return Ok(Some(device));
+    }
     let Some(mut device) = build_external_i2c_device(&ext.r#type, &ext.id, &ext.config) else {
         return Ok(None);
     };

--- a/crates/core/src/system/xtensa/mod.rs
+++ b/crates/core/src/system/xtensa/mod.rs
@@ -470,6 +470,7 @@ mod tests {
         // manifest's external_devices through the generic factory, exactly as the
         // app/CLI do. Declare it, attach it, then probe below.
         let manifest = labwired_config::SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -565,6 +566,7 @@ mod tests {
             serde_yaml::Value::String("GPIO5".to_string()),
         );
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -641,6 +643,7 @@ mod tests {
             serde_yaml::Value::String("GPIO10".to_string()),
         );
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -697,6 +700,7 @@ mod tests {
         use labwired_config::{ExternalDevice, SystemManifest};
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -431,6 +431,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
@@ -608,6 +609,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-2".to_string(),
@@ -673,6 +675,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-3".to_string(),
@@ -733,6 +736,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-gpio-v2".to_string(),
@@ -799,6 +803,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-uart-v2".to_string(),
@@ -953,6 +958,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-two-uarts".to_string(),
@@ -1014,6 +1020,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-rcc-v2".to_string(),
@@ -1077,6 +1084,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-rcc-f4".to_string(),
@@ -1140,6 +1148,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system-gpio-v2-alias".to_string(),
@@ -2356,6 +2365,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
@@ -2446,6 +2456,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -2520,6 +2531,7 @@ pub mod integration_tests {
         };
 
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -2733,6 +2745,7 @@ pub mod integration_tests {
             serde_yaml::Value::Number(0x3C.into()),
         );
         let manifest = SystemManifest {
+            parts: Vec::new(),
             cosim_models: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
@@ -2873,6 +2886,7 @@ pub mod integration_tests {
                 serde_yaml::Value::Number(0x3C.into()),
             );
             let manifest = SystemManifest {
+                parts: Vec::new(),
                 cosim_models: Vec::new(),
                 walk_deleted: Some(false),
                 schema_version: "1.0".to_string(),

--- a/crates/core/src/tests/peripheral_reachability.rs
+++ b/crates/core/src/tests/peripheral_reachability.rs
@@ -126,6 +126,7 @@ fn report(system: &str, bus: &SystemBus) -> Option<String> {
 
 fn dummy_manifest(chip_path: &str) -> SystemManifest {
     SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "peripheral-reachability".to_string(),

--- a/crates/core/tests/analog_stimulus.rs
+++ b/crates/core/tests/analog_stimulus.rs
@@ -90,6 +90,7 @@ fn two_potentiometers_are_individually_addressable() {
     let chip_path = root("configs/chips/stm32f103.yaml");
     let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/tests/chip_conformance.rs
+++ b/crates/core/tests/chip_conformance.rs
@@ -295,6 +295,7 @@ fn root(rel: &str) -> PathBuf {
 
 fn dummy_manifest(path: &str) -> SystemManifest {
     SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "chip-conformance".to_string(),

--- a/crates/core/tests/fixtures/emitted-part-pack-manifest.yaml
+++ b/crates/core/tests/fixtures/emitted-part-pack-manifest.yaml
@@ -1,0 +1,48 @@
+name: "playground-board"
+chip: "inline"
+cpu_hz: 160_000_000
+parts:
+  - schema: labwired.part/v1
+    type: acme:tmp999
+    source: acme-private
+    behavior:
+      primitive: i2c_device
+      i2c:
+        default_address: 74
+        pointer_mask: 3
+        registers:
+          - name: TEMP
+            addr: 0
+            width: 2
+            endian: be
+            access: r
+            reset: 4660
+    catalog:
+      deviceClass: i2c_device
+      defaultI2cAddress: 74
+      pins:
+        - name: SDA
+          etype: bidirectional
+          role: i2c_sda
+        - name: SCL
+          etype: input
+          role: i2c_scl
+external_devices:
+  - id: "dev"
+    type: "acme:tmp999"
+    connection: "i2c0"
+    route:
+      sda: "GPIO4"
+      scl: "GPIO5"
+    config:
+      i2c_address: 0x4a
+board_io:
+  - id: "dev"
+    kind: "i2c_device"
+    peripheral: "i2c0"
+    pin: 0
+    signal: "input"
+    active_high: true
+    i2c_address: 0x4a
+    device_type: "acme:tmp999"
+

--- a/crates/core/tests/flash_h5_ops.rs
+++ b/crates/core/tests/flash_h5_ops.rs
@@ -25,6 +25,7 @@ fn h563_machine() -> Machine<labwired_core::cpu::CortexM> {
         .join("../../configs/chips/stm32h563.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load stm32h563.yaml");
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "flash-h5-ops".to_string(),

--- a/crates/core/tests/h563_conformance.rs
+++ b/crates/core/tests/h563_conformance.rs
@@ -23,6 +23,7 @@ fn h563_bus() -> labwired_core::bus::SystemBus {
         .join("../../configs/chips/stm32h563.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load chip");
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "h563-conformance".to_string(),

--- a/crates/core/tests/i2c_mux_tca9548a.rs
+++ b/crates/core/tests/i2c_mux_tca9548a.rs
@@ -518,6 +518,7 @@ channel: 3
 
 fn manifest_with(devices: Vec<labwired_config::ExternalDevice>) -> labwired_config::SystemManifest {
     labwired_config::SystemManifest {
+        parts: Vec::new(),
         external_devices: devices,
         ..manifest_skeleton()
     }

--- a/crates/core/tests/kw41z_clock_boot.rs
+++ b/crates/core/tests/kw41z_clock_boot.rs
@@ -38,6 +38,7 @@ fn kw41z_bus() -> SystemBus {
         .join("../../configs/chips/mkw41z4.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load mkw41z4 chip");
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "kw41z-clock-boot".to_string(),

--- a/crates/core/tests/nrf5340_clock_boot.rs
+++ b/crates/core/tests/nrf5340_clock_boot.rs
@@ -42,6 +42,7 @@ fn nrf5340_bus() -> SystemBus {
         .join("../../configs/chips/nrf5340.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load nrf5340 chip");
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "nrf5340-clock-boot".to_string(),

--- a/crates/core/tests/nrf54l15_boot.rs
+++ b/crates/core/tests/nrf54l15_boot.rs
@@ -70,6 +70,7 @@ fn nrf54l15_bus() -> SystemBus {
     let path = nrf54l15_chip_path();
     let chip = ChipDescriptor::from_file(&path).expect("load nrf54l15 chip");
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/tests/part_pack_contract.rs
+++ b/crates/core/tests/part_pack_contract.rs
@@ -1,0 +1,312 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! **The `labwired.part/v1` contract, asserted from outside the engine.**
+//!
+//! Everything here is derived from `docs/part-packs.md` and the TMP102/TMP1075
+//! datasheet shape it borrows — not from reading the implementation. A pack
+//! author who has only the contract document should be able to predict every
+//! assertion below; where they could not, the contract is under-specified and
+//! that is the bug.
+//!
+//! The three negative controls matter as much as the positive case. A test that
+//! only asserts "the private part reads 0x1234" passes just as well if the
+//! device attached for some unrelated reason, so each positive case is paired
+//! with the same manifest minus the one thing under test.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
+use labwired_core::peripherals::i2c::I2cDevice;
+use std::path::PathBuf;
+
+/// A private I²C temperature sensor that exists nowhere in this repository.
+///
+/// Wire protocol is the register-pointer shape every such datasheet describes:
+/// the master writes a one-byte pointer, then streams a 16-bit big-endian word.
+/// `reset: 0x1234` therefore reads back as the two bytes `0x12, 0x34` — that is
+/// a datasheet fact about big-endian framing, not an implementation detail.
+const ACME_PACK: &str = r#"
+schema: labwired.part/v1
+type: "acme:tmp999"
+source: acme-private
+behavior:
+  primitive: i2c_device
+  i2c:
+    default_address: 0x4a
+    pointer_mask: 0x03
+    registers:
+      - { name: TEMP, addr: 0x00, width: 2, endian: be, access: r, reset: 0x1234 }
+"#;
+
+/// Build a manifest carrying `packs`, wiring one device of `device_type` to the
+/// C3's I²C0. Composed through `serde_yaml::Value` so the test says what it
+/// means instead of depending on the indentation of a string literal.
+fn manifest_yaml(packs: &[&str], device_type: &str) -> String {
+    let mut root: serde_yaml::Mapping = serde_yaml::from_str(&format!(
+        r#"
+schema_version: "1.0"
+name: "part-pack-contract"
+chip: "esp32c3"
+external_devices:
+  - id: t1
+    type: "{device_type}"
+    connection: i2c0
+    route: {{ sda: "GPIO4", scl: "GPIO5" }}
+"#
+    ))
+    .expect("harness manifest is valid YAML");
+
+    if !packs.is_empty() {
+        let parts: Vec<serde_yaml::Value> = packs
+            .iter()
+            .map(|p| serde_yaml::from_str(p).expect("harness pack is valid YAML"))
+            .collect();
+        root.insert("parts".into(), serde_yaml::Value::Sequence(parts));
+    }
+    serde_yaml::to_string(&root).expect("harness manifest serialises")
+}
+
+/// Parse and build exactly as the browser does — `from_yaml`, not `from_file`.
+///
+/// That is deliberate: `from_file` is the CLI path, and validating there only
+/// would mean the hosted and browser runtimes accept manifests the CLI rejects.
+/// Every contract rule asserted in this file must be enforced by the engine
+/// itself, so the harness does nothing but hand it the document.
+fn build_bus(manifest_src: &str) -> anyhow::Result<SystemBus> {
+    let manifest: SystemManifest = SystemManifest::from_yaml(manifest_src)?;
+    // The C3 descriptor references relative peripheral sub-YAMLs, so it must be
+    // loaded from its real path rather than the embedded copy.
+    let chip_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../configs/chips/esp32c3.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path)?;
+    SystemBus::from_config(&chip, &manifest)
+}
+
+/// The error a rejected manifest produces. `SystemBus` is not `Debug`, and the
+/// negative cases only ever care about what the engine said.
+fn build_error(manifest_src: &str, why: &str) -> String {
+    match build_bus(manifest_src) {
+        Ok(_) => panic!("{why}"),
+        Err(e) => format!("{e:#}"),
+    }
+}
+
+/// Point at `reg`, repeated-START, read `n` bytes — the datasheet's read framing.
+fn read_reg(d: &mut dyn I2cDevice, reg: u8, n: usize) -> Vec<u8> {
+    d.start();
+    d.write(reg);
+    d.start();
+    let out: Vec<u8> = (0..n).map(|_| d.read()).collect();
+    d.stop();
+    out
+}
+
+fn slave_bytes_at(bus: &mut SystemBus, address: u8, reg: u8, n: usize) -> Option<Vec<u8>> {
+    let idx = bus.find_peripheral_index_by_name("i2c0")?;
+    let any = bus.peripherals[idx].dev.as_any_mut()?;
+    let c3 = any.downcast_mut::<Esp32c3I2c>()?;
+    let slave = c3
+        .attached_slaves_mut()
+        .iter_mut()
+        .find(|d| d.address() == address)?;
+    Some(read_reg(slave.as_mut(), reg, n))
+}
+
+// ─── the part connects ─────────────────────────────────────────────────────
+
+#[test]
+fn a_part_the_engine_has_never_seen_attaches_and_answers() {
+    let src = manifest_yaml(&[ACME_PACK], "acme:tmp999");
+    let mut bus = build_bus(&src).expect("a manifest carrying its own part must build");
+
+    let bytes = slave_bytes_at(&mut bus, 0x4a, 0x00, 2)
+        .expect("the pack's device must be attached at its declared address");
+    assert_eq!(
+        bytes,
+        vec![0x12, 0x34],
+        "a 16-bit big-endian register with reset 0x1234 reads MSB first"
+    );
+}
+
+/// The negative control for the test above: without `parts:`, the very same
+/// manifest must NOT quietly produce a working device. If this ever passes, the
+/// test above has stopped proving that the pack is what made the part work.
+#[test]
+fn the_same_part_without_its_pack_attaches_nothing() {
+    let src = manifest_yaml(&[], "acme:tmp999");
+    let mut bus = build_bus(&src).expect("an unknown device type is skipped, not fatal");
+
+    assert!(
+        slave_bytes_at(&mut bus, 0x4a, 0x00, 2).is_none(),
+        "an unknown `type:` must not attach a device — otherwise the pack proves nothing"
+    );
+}
+
+// ─── shadowing a built-in is deliberate or it is an error ──────────────────
+
+#[test]
+fn shadowing_a_builtin_without_declaring_it_is_refused() {
+    let pack = ACME_PACK.replace("\"acme:tmp999\"", "tmp102");
+    let src = manifest_yaml(&[&pack], "tmp102");
+
+    let msg = build_error(&src, "silently replacing a built-in model must not be possible");
+    assert!(
+        msg.contains("shadows a built-in"),
+        "the error must say what happened, got: {msg}"
+    );
+    assert!(
+        msg.contains("overrides: tmp102"),
+        "the error must name the way out, got: {msg}"
+    );
+    assert!(
+        msg.contains("acme-private"),
+        "the error must name the source that shipped the pack, got: {msg}"
+    );
+}
+
+#[test]
+fn declaring_the_override_replaces_the_builtin_model() {
+    let pack = ACME_PACK
+        .replace("\"acme:tmp999\"", "tmp102")
+        .replace("source: acme-private", "source: acme-private\noverrides: tmp102");
+    let src = manifest_yaml(&[&pack], "tmp102");
+    let mut bus = build_bus(&src).expect("a declared override must build");
+
+    // 0x4a, not the built-in TMP102's 0x48: the pack's address proves the pack's
+    // model is the one on the bus, not merely that nothing errored.
+    let bytes = slave_bytes_at(&mut bus, 0x4a, 0x00, 2)
+        .expect("the overriding pack's device must be the one attached");
+    assert_eq!(bytes, vec![0x12, 0x34], "the pack's register map must win");
+    assert!(
+        slave_bytes_at(&mut bus, 0x48, 0x00, 2).is_none(),
+        "the built-in TMP102 must be gone, not merely outvoted"
+    );
+}
+
+// ─── the contract's own rules ──────────────────────────────────────────────
+
+#[test]
+fn two_packs_for_one_type_is_an_error_not_a_race() {
+    let other = ACME_PACK.replace("source: acme-private", "source: someone-else");
+    let src = manifest_yaml(&[ACME_PACK, &other], "acme:tmp999");
+
+    let msg = build_error(&src, "one part is one document");
+    assert!(msg.contains("acme-private") && msg.contains("someone-else"), "both sources must be named, got: {msg}");
+}
+
+#[test]
+fn a_pack_without_a_schema_declaration_is_refused() {
+    let pack = ACME_PACK.replace("schema: labwired.part/v1\n", "");
+    let src = manifest_yaml(&[&pack], "acme:tmp999");
+
+    let msg = build_error(&src, "an out-of-tree file must say which schema it obeys");
+    assert!(
+        msg.contains("labwired.part/v1"),
+        "the error must name the contract version"
+    );
+}
+
+#[test]
+fn an_unresolved_path_entry_reaching_the_engine_is_refused() {
+    let src = manifest_yaml(&["path: ./acme.yaml"], "acme:tmp999");
+
+    let msg = build_error(&src, "`path:` is a CLI convenience, not an engine feature");
+    assert!(
+        msg.contains("never loaded"),
+        "the error must explain that the CLI inlines it, got: {msg}"
+    );
+}
+
+// ─── the two halves actually meet ──────────────────────────────────────────
+
+/// The manifest the APP emits, parsed by the ENGINE.
+///
+/// The fixture is `compile()` output captured verbatim from
+/// `@labwired/board-config` — not hand-written to look like it. Both halves of
+/// this contract can be individually correct and still not meet: the app's YAML
+/// writer emits a namespaced `type: acme:tmp999` as an unquoted plain scalar
+/// with a colon in it, and whether that survives the engine's parser is a fact
+/// about two libraries, not a fact either side can assert alone.
+///
+/// Regenerate with the snippet in `core/docs/part-packs.md` if the emitter
+/// changes; a diff here is a real cross-boundary change and wants reading.
+#[test]
+fn the_manifest_the_app_emits_is_one_the_engine_can_run() {
+    let src = include_str!("fixtures/emitted-part-pack-manifest.yaml");
+    let mut bus = build_bus(src).expect("compile() output must build on the engine");
+
+    let bytes = slave_bytes_at(&mut bus, 0x4a, 0x00, 2)
+        .expect("the emitted pack's device must be attached at its declared address");
+    assert_eq!(
+        bytes,
+        vec![0x12, 0x34],
+        "the register map survived the app → manifest → engine round trip"
+    );
+}
+
+// ─── the other primitive that carries its own transport ────────────────────
+
+/// SPI packs travel a different road than I²C ones: I²C devices are built by
+/// the shared `build_i2c_tree` factory, while SPI devices only ever attach
+/// through the `PeripheralKit` registry. So "packs work" proved on I²C alone
+/// would be a claim about one of the two doors.
+///
+/// Framing and expected bytes are datasheet facts about a 4-wire register
+/// device: the master sends `[R/W | MB | addr]` then clocks the register out.
+/// A read of DEVID (0x00) is therefore command byte 0x80 followed by the
+/// register's reset value.
+#[test]
+fn an_spi_pack_attaches_through_the_kit_door() {
+    const SPI_PACK: &str = r#"
+schema: labwired.part/v1
+type: "acme:acc999"
+source: acme-private
+behavior:
+  primitive: spi_device
+  spi:
+    framing: { command_bytes: 1, rw_bit: 7, rw_read_high: true, addr_mask: 0x3F, auto_increment: true }
+    registers:
+      - { name: DEVID, addr: 0x00, width: 1, endian: le, access: r, reset: 0xE5 }
+"#;
+    let mut root: serde_yaml::Mapping = serde_yaml::from_str(
+        r#"
+schema_version: "1.0"
+name: "part-pack-spi"
+chip: "esp32c3"
+external_devices:
+  - id: acc
+    type: "acme:acc999"
+    connection: spi2
+    config: { cs_pin: "GPIO7" }
+"#,
+    )
+    .unwrap();
+    root.insert(
+        "parts".into(),
+        serde_yaml::Value::Sequence(vec![serde_yaml::from_str(SPI_PACK).unwrap()]),
+    );
+    let src = serde_yaml::to_string(&root).unwrap();
+
+    let mut bus = build_bus(&src).expect("an SPI pack must build");
+    let idx = bus
+        .find_peripheral_index_by_name("spi2")
+        .expect("the C3 declares spi2");
+    let any = bus.peripherals[idx]
+        .dev
+        .as_any_mut()
+        .expect("spi2 must downcast");
+    let spi = any
+        .downcast_mut::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
+        .expect("spi2 is the C3 controller");
+    let devices = spi.attached_devices_mut();
+    assert_eq!(devices.len(), 1, "the pack's device must be on the SPI bus");
+
+    let dev = &mut devices[0];
+    dev.cs_select();
+    dev.transfer(0x80); // read, address 0x00
+    let devid = dev.transfer(0x00);
+    dev.cs_release();
+    assert_eq!(devid, 0xE5, "the pack's declared reset value must clock out");
+}

--- a/crates/core/tests/part_pack_contract.rs
+++ b/crates/core/tests/part_pack_contract.rs
@@ -151,7 +151,10 @@ fn shadowing_a_builtin_without_declaring_it_is_refused() {
     let pack = ACME_PACK.replace("\"acme:tmp999\"", "tmp102");
     let src = manifest_yaml(&[&pack], "tmp102");
 
-    let msg = build_error(&src, "silently replacing a built-in model must not be possible");
+    let msg = build_error(
+        &src,
+        "silently replacing a built-in model must not be possible",
+    );
     assert!(
         msg.contains("shadows a built-in"),
         "the error must say what happened, got: {msg}"
@@ -168,9 +171,10 @@ fn shadowing_a_builtin_without_declaring_it_is_refused() {
 
 #[test]
 fn declaring_the_override_replaces_the_builtin_model() {
-    let pack = ACME_PACK
-        .replace("\"acme:tmp999\"", "tmp102")
-        .replace("source: acme-private", "source: acme-private\noverrides: tmp102");
+    let pack = ACME_PACK.replace("\"acme:tmp999\"", "tmp102").replace(
+        "source: acme-private",
+        "source: acme-private\noverrides: tmp102",
+    );
     let src = manifest_yaml(&[&pack], "tmp102");
     let mut bus = build_bus(&src).expect("a declared override must build");
 
@@ -193,7 +197,10 @@ fn two_packs_for_one_type_is_an_error_not_a_race() {
     let src = manifest_yaml(&[ACME_PACK, &other], "acme:tmp999");
 
     let msg = build_error(&src, "one part is one document");
-    assert!(msg.contains("acme-private") && msg.contains("someone-else"), "both sources must be named, got: {msg}");
+    assert!(
+        msg.contains("acme-private") && msg.contains("someone-else"),
+        "both sources must be named, got: {msg}"
+    );
 }
 
 #[test]
@@ -308,5 +315,8 @@ external_devices:
     dev.transfer(0x80); // read, address 0x00
     let devid = dev.transfer(0x00);
     dev.cs_release();
-    assert_eq!(devid, 0xE5, "the pack's declared reset value must clock out");
+    assert_eq!(
+        devid, 0xE5,
+        "the pack's declared reset value must clock out"
+    );
 }

--- a/crates/core/tests/pin_map_resolution.rs
+++ b/crates/core/tests/pin_map_resolution.rs
@@ -7,6 +7,7 @@ fn bus_for(chip_file: &str) -> SystemBus {
         .join(chip_file);
     let chip = ChipDescriptor::from_file(&path).expect("load chip");
     let manifest = SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "pinmap".to_string(),

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -47,6 +47,7 @@ fn validate_chip(path: &PathBuf) -> anyhow::Result<()> {
 
     // Create Manual System Manifest
     let dummy_manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "test-bench".to_string(),

--- a/crates/core/tests/register_coverage.rs
+++ b/crates/core/tests/register_coverage.rs
@@ -129,6 +129,7 @@ fn root(rel: &str) -> PathBuf {
 
 fn dummy_manifest(path: &str) -> labwired_config::SystemManifest {
     labwired_config::SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "coverage".to_string(),

--- a/crates/core/tests/rp2040_pio_onboarding.rs
+++ b/crates/core/tests/rp2040_pio_onboarding.rs
@@ -57,6 +57,7 @@ fn rp2040_chip() -> (ChipDescriptor, SystemManifest) {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load rp2040 chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/tests/stm32f401_conformance.rs
+++ b/crates/core/tests/stm32f401_conformance.rs
@@ -25,6 +25,7 @@ fn f401_bus() -> labwired_core::bus::SystemBus {
         .join("../../configs/chips/stm32f401.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load chip");
     let manifest = labwired_config::SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/tests/stm32f407_dma_walk_differential.rs
+++ b/crates/core/tests/stm32f407_dma_walk_differential.rs
@@ -77,6 +77,7 @@ fn f407_bus() -> SystemBus {
         .join("../../configs/chips/stm32f407.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load stm32f407.yaml");
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/core/tests/uart_parity_ratchet.rs
+++ b/crates/core/tests/uart_parity_ratchet.rs
@@ -28,6 +28,7 @@ const UNMODELLED_UART_TYPES: &[&str] = &[];
 
 fn dummy_manifest(path: &str) -> SystemManifest {
     SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".into(),
         name: "uart-parity".into(),

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1183,6 +1183,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
@@ -1244,6 +1245,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),
@@ -1319,6 +1321,7 @@ mod tests {
         };
 
         let manifest = labwired_config::SystemManifest {
+            parts: Vec::new(),
             walk_deleted: Some(false),
             schema_version: "1.0".to_string(),
             name: "test-system".to_string(),

--- a/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
@@ -185,6 +185,7 @@ fn build_sim_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "esp32c3-reset-conformance".to_string(),

--- a/crates/hw-oracle/tests/foreign_firmware_probe.rs
+++ b/crates/hw-oracle/tests/foreign_firmware_probe.rs
@@ -28,6 +28,7 @@ fn probe_foreign_firmware() {
     let chip_path = root.join("configs/chips/stm32h563.yaml");
     let chip = ChipDescriptor::from_file(&chip_path).expect("load chip");
     let manifest = SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "foreign-probe".to_string(),

--- a/crates/hw-oracle/tests/h563_mmio_diff.rs
+++ b/crates/hw-oracle/tests/h563_mmio_diff.rs
@@ -988,6 +988,7 @@ fn build_sim_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
+        parts: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),
         name: "h563-mmio-diff".to_string(),

--- a/crates/hw-oracle/tests/rp2040_dma_oracle.rs
+++ b/crates/hw-oracle/tests/rp2040_dma_oracle.rs
@@ -148,6 +148,7 @@ fn rp2040_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/hw-oracle/tests/rp2040_reset_conformance.rs
+++ b/crates/hw-oracle/tests/rp2040_reset_conformance.rs
@@ -119,6 +119,7 @@ fn build_sim_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs
+++ b/crates/hw-oracle/tests/rp2040_timer_exec_oracle.rs
@@ -99,6 +99,7 @@ fn rp2040_bus() -> SystemBus {
     let chip = ChipDescriptor::from_file(&chip_path)
         .unwrap_or_else(|e| panic!("load chip {chip_path:?}: {e}"));
     let manifest = SystemManifest {
+        parts: Vec::new(),
         cosim_models: Vec::new(),
         walk_deleted: Some(false),
         schema_version: "1.0".to_string(),

--- a/docs/part-packs.md
+++ b/docs/part-packs.md
@@ -1,0 +1,208 @@
+# Part packs — `labwired.part/v1`
+
+A **part pack** is one file describing one part, completely. It is the only
+thing you need to connect a part LabWired has never seen — from a private
+catalog, a customer's internal library, a vendor's own repo, or a directory on
+your laptop — without a line of code in this repository and without publishing
+anything.
+
+The contract exists because the alternative had already grown four places to
+edit per part: a descriptor in `configs/devices/`, a `KITS` entry, a catalog
+record in the app, and a hand-mirrored emitter. All four are derivable from one
+document, so this is that document.
+
+## Why one file and not four
+
+A part is one physical thing. Splitting its description across repos means the
+halves drift, and drift in this domain is silent: a catalog record claiming 6
+pins against a model with 4 does not fail a build, it fails a customer's
+firmware at 3am with a wiring error that reads like their bug. One file, one
+part, one source of truth — and the loader refuses a second definition of the
+same `type` rather than picking a winner.
+
+## The document
+
+```yaml
+schema: labwired.part/v1       # required — the contract version this file obeys
+type: acme:tmp999              # required — globally unique id, `vendor:part`
+source: acme-private           # optional — provenance; who shipped this pack
+overrides: tmp102              # optional — the ONLY way to shadow a built-in
+
+behavior:                      # required — how it behaves on the wire (the sim)
+  primitive: i2c_device
+  i2c:
+    default_address: 0x4A
+    registers: [ ... ]
+
+emit:                          # optional — canvas wiring → system-manifest entry
+  connection: i2c
+  config: [ ... ]
+
+metadata:                      # optional — label, summary, stimulus channels
+  label: "ACME TMP999"
+  inputs: [ ... ]
+
+catalog:                       # optional — the app-layer record (pins, class)
+  deviceClass: i2c_device
+  refPrefix: U
+  pins: [ ... ]
+```
+
+`behavior`, `emit` and `metadata` are the existing `configs/devices/*.yaml`
+schema, unchanged — every shipped descriptor is already a valid pack body, which
+is deliberate: the built-in parts and your private parts are the same kind of
+object, so the private path is the one we dogfood daily rather than a bolted-on
+side door.
+
+`catalog` is ignored by this crate. It is carried through for the app layer
+(`@labwired/board-config`), so a pack stays one file end to end. Its fields are
+the `CatalogPart` fields, spelled exactly as TypeScript spells them
+(`deviceClass`, `refPrefix`, `defaultI2cAddress`, `pins`) — the block is handed
+over verbatim, and a rename step here would only be one more thing to get wrong.
+
+### `type` must be namespaced
+
+Use `vendor:part`. A bare `tmp999` is accepted but risks colliding with a
+built-in we add later; a collision is a hard error at load, so an un-namespaced
+private pack is a future build break you have chosen to schedule.
+
+### `overrides` is the only way to shadow a built-in
+
+If a pack's `type` names a part the engine already ships, loading fails:
+
+```
+part pack 'tmp102' (source: acme-private) shadows a built-in part.
+Set `overrides: tmp102` to replace it deliberately, or rename the pack.
+```
+
+Setting `overrides:` to the same string makes the replacement explicit and
+attributable in a bug report. Silence is never the answer to "which model ran?".
+
+## Connecting a pack
+
+Packs travel in the system manifest, so every transport that already carries a
+manifest carries packs too — the CLI, the browser wasm build, and the hosted
+builder's `/run`. There is no new endpoint and no new file the runtime has to
+find on disk.
+
+```yaml
+# system.yaml
+chip: "esp32c3"
+parts:
+  - path: "./private/acme-tmp999.yaml"    # CLI-only convenience, inlined on load
+  - schema: labwired.part/v1              # or the pack inline, verbatim
+    type: acme:hum1
+    behavior: { ... }
+
+external_devices:
+  - id: t1
+    type: acme:tmp999                     # resolves against `parts:` above
+    connection: i2c0
+    route: { sda: "GPIO4", scl: "GPIO5" }
+```
+
+`path:` is a `labwired` CLI convenience: `SystemManifest::from_file` reads the
+file and replaces the entry with its contents, exactly as it already does for a
+`can-player`'s `path:`. The simulation core never sees a `path:` — it has no
+filesystem in wasm, and a contract that only works on one of our three runtimes
+is not a contract.
+
+## Resolution order
+
+For an `external_devices[].type`, in order:
+
+1. `parts:` in this manifest
+2. the built-in `PeripheralKit` registry (`peripherals::kit::registry`)
+3. the embedded declarative descriptors (`configs/devices/*.yaml`)
+4. the legacy hand-written attach arms
+
+A pack at step 1 that also exists at step 2 or 3 is the collision error above,
+not a silent win.
+
+## Connecting a source to the app
+
+The engine reads packs out of a manifest. The app is what puts them there:
+
+```ts
+import { registerPartSource } from '@labwired/board-config';
+
+registerPartSource({
+  id: 'acme-private',
+  packs: await fetchEntitledCatalog(orgId),   // any origin: HTTP, file, bundle
+});
+```
+
+From that call on, the part behaves like any other:
+
+- `getCatalogPart('acme:tmp999')` resolves it, so ERC, wiring, netlist export
+  and the compiler treat it as a first-class part.
+- `listCatalogParts()` includes it, so the palette offers it. (Enumerate with
+  that, never `Object.values(CATALOG)` — the latter sees only parts we ship,
+  which is how a connected part ends up simulating correctly while being
+  invisible in the palette meant to offer it.)
+- `compile()` inlines the packs the diagram actually uses into the manifest's
+  `parts:`, so the lab runs on an engine that has never heard of your catalog —
+  and keeps running after the source that supplied the part is gone.
+- The canvas draws it from its declared `pins` via the generic renderer. Shipping
+  hand-drawn artwork is an improvement, never a prerequisite.
+
+Registration enforces the same rules the engine does, and one more: the app's
+built-in set is not the engine's. A part can be catalogued in the app and
+modelled in the engine, or modelled in the engine and absent from the app
+catalog (`tmp102` is). Each side therefore checks its own set, and a pack has to
+clear both.
+
+## What a pack cannot do
+
+A pack is data interpreted by a **primitive** — `i2c_device`, `spi_device`,
+`quadrature`, `matrix`, `one_wire`, `pulse_echo`. Those primitives are the
+irreducible timing algorithms, and they live in Rust in this repository.
+
+So: a part whose datasheet behaviour is a register map, a command/response
+protocol, or one of the pin-timing shapes above is pure data and needs nothing
+from us. A part with a genuinely new wire protocol needs a new primitive, which
+is a change to this crate. That boundary is honest and worth stating to a
+customer up front: we can onboard your sensor catalogue without seeing it, but a
+novel protocol is engineering, not configuration.
+
+The same split applies to silicon. A private MCU is a chip descriptor —
+`chip: "./acme-soc.yaml"` on the CLI, or the `chipYaml` field on the hosted
+builder's `/run` — and needs no code here as long as its peripheral blocks are
+ones the engine models. A novel peripheral block does not.
+
+## Regenerating the cross-boundary fixture
+
+`crates/core/tests/fixtures/emitted-part-pack-manifest.yaml` is `compile()`
+output captured verbatim, so the engine test proves it can run the manifest the
+app actually writes. Regenerate it from `packages/board-config`:
+
+```sh
+npx tsx -e "
+import { compile } from './src/compile';
+import { registerPartSource } from './src/part-sources';
+registerPartSource({ id: 'acme-private', packs: [/* the pack in the test */] });
+console.log(compile(/* the diagram in the test */).systemYaml);
+" > ../../core/crates/core/tests/fixtures/emitted-part-pack-manifest.yaml
+```
+
+A diff there is a real cross-boundary change and wants reading, not blessing.
+
+## Not yet covered
+
+Named so nobody discovers them by surprise:
+
+- **Private boards.** A private *chip* runs today through the paths above, but
+  the app's `BOARDS` and `CHIP_YAMLS` are still build-time constants, so a
+  private board cannot be offered in the picker the way a private part can be
+  offered in the palette. Extending this contract to boards is the natural next
+  increment — it carries more than a part does (pin map, renderer, compile
+  toolchains, PlatformIO profile), which is why it is not folded in here.
+- **Reverse mapping.** `system-to-diagram.ts` turns a manifest back into a
+  canvas from `CATALOG` alone, so a shared lab containing a pack part will not
+  round-trip into a diagram until that reads through `getCatalogPart` too.
+- **Legacy compat maps.** `component-meta.ts` derives `COMPONENT_META` from
+  `CATALOG` at module-init, so a pack declaring `boardIoKind` is not seen by the
+  wire-derived board_io path. Same for `partSeedIntent.ts` and the ERC
+  "did you mean" suggestions.
+- **Entitlement.** Nothing here decides WHO may load which catalog. A pack is
+  data; deciding that an org may fetch it is the API's job, not this contract's.


### PR DESCRIPTION
Lets a private, vendor, or customer parts catalog connect with no code in this repository and nothing published.

## The contract

One `labwired.part/v1` document describes one part completely — wire behaviour (`behavior`), canvas→manifest lowering (`emit`), display/stimulus metadata, and the app-layer catalog record. The body is the **existing** `configs/devices/*.yaml` schema, so built-in and private parts are the same kind of object interpreted by the same primitives; the private path is the one we exercise daily rather than a side door that rots.

Packs ride in the manifest's new `parts:`, so every transport that already carries a manifest carries them: the CLI, the browser wasm build, and the hosted builder's `/run`. `path:` is a CLI convenience `from_file` inlines — the core only ever sees an inline pack, because it has no filesystem under wasm.

## Nothing resolves ambiguity silently

- shadowing a built-in requires `overrides: <type>`
- two packs claiming one type errors, naming both sources
- a pack without `schema:` is refused

Validation runs in `SystemBus::from_config`, **not** the manifest loader: `from_file` is the CLI's path while the browser and hosted runner use `from_yaml`, so validating at load time would let two of three runtimes accept documents the third rejects.

## Attach doors

I²C via `build_i2c_tree` (one hook covers generic, ESP32-C3, Xtensa, nRF52/nRF54L at once), SPI via the `PeripheralKit` registry, pin-timing via `attach_declarative_device`.

## Tests

Derived from `docs/part-packs.md`, not from the implementation. Every positive case is paired with the same manifest minus the one thing under test, so green cannot come from the part having worked for another reason. One test feeds verbatim `compile()` output from `@labwired/board-config` to the engine — whether an unquoted namespaced `type: acme:tmp999` survives both YAML libraries is a fact neither side can assert alone.

`part_pack_contract.rs` 9/9.

## Boundaries, stated in the doc

A register-map / command-response / pin-timing part is pure data. A novel wire protocol needs a new primitive — that is engineering, not configuration. Same split for silicon: a private MCU is a chip descriptor; a novel peripheral block is not. Private *boards* and four app-side integration points are named as not-yet-covered.

## Second commit

Unrelated to part packs, found while diagnosing a red suite: a temp-dir nonce collision that made `e2e_uart_injection` / `e2e_stimulus_reporting` fail a random different subset on every parallel run, plus two hardcoded `target/` paths. Easy to review separately.