### PR TITLE
feat(inspect): one seam for device binding, one for display evidence

### DIFF
--- a/crates/core/src/bus/attached_devices.rs
+++ b/crates/core/src/bus/attached_devices.rs
@@ -171,14 +171,16 @@ impl SystemBus {
             self.emit_resident(f, Resident::gpio(dev.id(), None));
         }
         for dev in &self.tm1637 {
-            self.emit_resident(f, Resident::gpio(&dev.id, None));
+            // A bus-resident DISPLAY: it reports evidence directly, because it
+            // has no controller trait to hang it on.
+            self.emit_resident(f, Resident::gpio(&dev.id, Some(dev)));
         }
         for dev in &self.hx711 {
             let id = dev.component_id().unwrap_or("hx711");
             self.emit_resident(f, Resident::gpio(id, None));
         }
         for dev in &self.seven_segment {
-            self.emit_resident(f, Resident::gpio(&dev.id, None));
+            self.emit_resident(f, Resident::gpio(&dev.id, Some(dev)));
         }
         for dev in &self.analog_inputs {
             // An analog source has no `Any` view, so it is listed but not read:
@@ -363,9 +365,11 @@ struct Resident<'a> {
     bus: Option<&'a str>,
     channel: Option<u8>,
     /// A bus-resident model that can show something of itself implements
-    /// [`crate::inspect::DeviceEvidence`] directly and is passed here. None of
-    /// them does today — a servo and a distance sensor have no display surface
-    /// — and `None` says exactly that rather than promising an empty screen.
+    /// [`crate::inspect::DeviceEvidence`] directly and is passed here — the
+    /// TM1637 and the direct-driven 7-segment digit are displays that happen to
+    /// be wired to pins. `None` is the honest answer for everything else: a
+    /// servo and a distance sensor have no display surface, and `None` says
+    /// that rather than promising an empty screen.
     evidence: Option<&'a dyn DeviceEvidence>,
 }
 

--- a/crates/core/src/bus/attached_devices.rs
+++ b/crates/core/src/bus/attached_devices.rs
@@ -147,7 +147,7 @@ impl SystemBus {
         }
         for dev in &self.ws2812 {
             let id = dev.component_id().unwrap_or("ws2812");
-            self.emit_resident(f, Resident::gpio(id, None));
+            self.emit_resident(f, Resident::gpio(id, Some(&**dev)));
         }
         for dev in &self.servos {
             self.emit_resident(f, Resident::gpio(dev.id(), None));

--- a/crates/core/src/bus/attached_devices.rs
+++ b/crates/core/src/bus/attached_devices.rs
@@ -1,0 +1,416 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ONE walk over every device an author placed on this machine, whatever
+//! transport binds it, and the ONE join that gives each one its manifest
+//! identity.
+//!
+//! # Why this is not per-transport
+//!
+//! A placed part becomes attached to the machine in one of two structurally
+//! different ways, and for a while only the first was visible to `inspect`:
+//!
+//! 1. **Owned by a controller.** An I²C slave or an SPI panel lives inside the
+//!    controller peripheral it answers to, so it is reachable only by asking
+//!    that controller — [`crate::Peripheral::for_each_attached_device`]. A walk
+//!    over `SystemBus::peripherals` alone cannot see it. That is the bug that
+//!    made a customer rig report 52 chip-internal peripherals and not one of
+//!    the six parts on the canvas.
+//! 2. **Resident on the bus.** An HC-SR04 on TRIG/ECHO, a servo on a PWM pad, a
+//!    WS2812 strip, a thermistor driving an ADC channel, a CAN tester node —
+//!    none of these answers to an address, so none can live inside a
+//!    controller. Each is held in a typed collection on [`SystemBus`] instead.
+//!
+//! The second kind was invisible to `inspect` for exactly the same reason the
+//! first kind had been: the walk did not go where the models are. Fixing it per
+//! family would have meant an eighth, ninth, tenth special case — each one a
+//! fresh chance to add a device that simulates correctly and reports nothing.
+//!
+//! So there is one walk ([`SystemBus::for_each_attached_device`]) that covers
+//! both kinds, one borrowed record shape
+//! ([`crate::inspect::AttachedDeviceRef`]) that both kinds emit, and one join
+//! ([`SystemBus::inspect_devices`]) that turns either into the same
+//! [`crate::inspect::DeviceInspect`]. A transport is a field of the record, not
+//! a branch in the pipeline.
+//!
+//! # What the two kinds know about themselves
+//!
+//! They differ in exactly one respect, and the record shape carries it
+//! explicitly rather than hiding it:
+//!
+//! * A controller-hosted device is identified by WHERE it answers. It states
+//!   its address (or chip-select) and the controller states the bus; the
+//!   manifest name is joined on afterwards by matching that placement.
+//! * A bus-resident device has no address to be identified by, so it carries
+//!   the `external_devices:` id it was stamped with when it was attached, and
+//!   the join matches on that. This is not a fallback or a guess: the id is the
+//!   author's own text, copied onto the model at attach.
+//!
+//! # The order is load-bearing
+//!
+//! Controller-hosted devices are walked first, bus-resident ones after. A
+//! declaration can only be claimed once, so this guarantees the addressed join
+//! — which has to do real disambiguation work — is never disturbed by a
+//! name-matched device, and keeps the `devices` array a stable prefix of what
+//! it was before bus-resident devices joined it.
+
+use super::SystemBus;
+use crate::inspect::{AttachedDeviceRef, DeviceEvidence};
+// `component_id` is the SimInput identity stamp — the same one the stimulus
+// walk resolves `set_input`'s `component:` against, so a device answers to the
+// same name in `inspect` as it does in the stimulus API.
+use crate::sim_input::SimInput;
+
+impl SystemBus {
+    /// Walk every attached (off-chip) device on this machine, calling
+    /// `f(bus, device)` for each. `bus` is the peripheral the device hangs off
+    /// — `Some("i2c0")`, `Some("gpioa")`, `Some("fdcan1")` — or `None` in the
+    /// one case where the engine genuinely does not know (see
+    /// [`crate::inspect::DeviceAttachment::bus`]).
+    ///
+    /// This is the ONE walk behind `inspect`'s `devices` array. A device
+    /// reachable here is reachable from every inspect surface at once; a
+    /// device NOT reachable here is invisible to all of them, which is why
+    /// [`Self::for_each_bus_resident_device`] must list every collection of
+    /// device models the bus holds. `attached_device_walk_covers_every_bus_
+    /// collection` in `crates/core/tests/inspect_device_binding_universal.rs`
+    /// is the gate that fails if a new one is added and not walked.
+    ///
+    /// Borrow discipline: everything happens inside the visitor.
+    /// `AttachedDeviceRef` borrows the model, and a controller may be holding a
+    /// `RefCell` borrow open for the duration of the call, so the reference
+    /// deliberately cannot escape.
+    pub fn for_each_attached_device(&self, f: &mut dyn FnMut(Option<&str>, AttachedDeviceRef<'_>)) {
+        for entry in &self.peripherals {
+            let name = entry.name.as_str();
+            entry
+                .dev
+                .for_each_attached_device(&mut |d| f(Some(d.bus.unwrap_or(name)), d));
+        }
+        self.for_each_bus_resident_device(f);
+    }
+
+    /// The `external_devices:` connection recorded for `id`, when the manifest
+    /// declared one. This is the author's own text, not an inference.
+    fn declared_connection(&self, id: &str) -> Option<&str> {
+        self.external_device_decls
+            .iter()
+            .find(|d| d.id == id)
+            .map(|d| d.connection.as_str())
+    }
+
+    /// Emit one bus-resident device.
+    ///
+    /// `r.bus` is what the MODEL knows (a CAN tester and an analog source both
+    /// record their `connection:`); when it knows nothing, the declaration it
+    /// was built from supplies it. Neither is a guess — both are the manifest
+    /// text — and when there is no declaration either, the owner is reported as
+    /// unknown rather than invented.
+    fn emit_resident(
+        &self,
+        f: &mut dyn FnMut(Option<&str>, AttachedDeviceRef<'_>),
+        r: Resident<'_>,
+    ) {
+        let bus = r.bus.or_else(|| self.declared_connection(r.declared_id));
+        f(
+            bus,
+            AttachedDeviceRef {
+                transport: r.transport,
+                address: None,
+                cs_pin: None,
+                mux_address: None,
+                channel: r.channel,
+                declared_id: Some(r.declared_id),
+                instance_id: r.instance_id,
+                bus,
+                evidence: r.evidence,
+            },
+        );
+    }
+
+    /// Every collection of author-placed device models that lives DIRECTLY on
+    /// the bus rather than inside a controller.
+    ///
+    /// **Adding a collection to [`SystemBus`] means adding an arm here.** A
+    /// model the bus holds but this function does not emit is a device that
+    /// simulates and reports nothing — the exact failure this seam exists to
+    /// make impossible. The gate test named on
+    /// [`Self::for_each_attached_device`] enforces it at the source level, so a
+    /// forgotten arm fails the build rather than one customer's rig.
+    fn for_each_bus_resident_device(&self, f: &mut dyn FnMut(Option<&str>, AttachedDeviceRef<'_>)) {
+        for dev in &self.hcsr04 {
+            self.emit_resident(f, Resident::gpio(&dev.id, None));
+        }
+        for dev in &self.gpio_devices {
+            self.emit_resident(f, Resident::gpio(dev.id(), None));
+        }
+        for dev in &self.ws2812 {
+            let id = dev.component_id().unwrap_or("ws2812");
+            self.emit_resident(f, Resident::gpio(id, None));
+        }
+        for dev in &self.servos {
+            self.emit_resident(f, Resident::gpio(dev.id(), None));
+        }
+        for dev in &self.step_dir_motors {
+            self.emit_resident(f, Resident::gpio(dev.id(), None));
+        }
+        for dev in &self.h_bridge_motors {
+            // An H-bridge board carries two independent motor channels, so ONE
+            // declaration builds TWO models (`<id>-a`, `<id>-b`). Each reports
+            // its own channel identity and is joined to the declaration both
+            // came from — neither is anonymous, and neither claims to be the
+            // whole board.
+            let r = match dev.declared_id() {
+                Some(declared) => Resident::gpio(declared, None).instance(dev.id()),
+                None => Resident::gpio(dev.id(), None),
+            };
+            self.emit_resident(f, r);
+        }
+        for dev in &self.unipolar_steppers {
+            self.emit_resident(f, Resident::gpio(dev.id(), None));
+        }
+        for dev in &self.tm1637 {
+            self.emit_resident(f, Resident::gpio(&dev.id, None));
+        }
+        for dev in &self.hx711 {
+            let id = dev.component_id().unwrap_or("hx711");
+            self.emit_resident(f, Resident::gpio(id, None));
+        }
+        for dev in &self.seven_segment {
+            self.emit_resident(f, Resident::gpio(&dev.id, None));
+        }
+        for dev in &self.analog_inputs {
+            // An analog source has no `Any` view, so it is listed but not read:
+            // `model: None` says "cannot be read", never "has nothing to show".
+            let id = dev.source.component_id().unwrap_or("analog");
+            self.emit_resident(f, Resident::analog(id, &dev.connection, dev.channel));
+        }
+        for dev in &self.can_diagnostic_testers {
+            self.emit_resident(f, Resident::can(&dev.id, &dev.connection));
+        }
+        for dev in &self.can_uds_testers {
+            self.emit_resident(f, Resident::can(&dev.id, &dev.connection));
+        }
+        for dev in &self.can_log_players {
+            self.emit_resident(f, Resident::can(&dev.id, &dev.connection));
+        }
+    }
+
+    /// Enumerate the external (off-chip) devices attached to this machine,
+    /// joining each live model to the manifest declaration that asked for it.
+    ///
+    /// Two halves, deliberately in that order:
+    ///
+    /// 1. **What is really there** comes from walking
+    ///    ([`Self::for_each_attached_device`]). A device is listed because a
+    ///    live model was found, never because a manifest mentioned one. A
+    ///    declaration that failed to build (the `"unsupported type … skipping"`
+    ///    path) therefore produces no entry — the record cannot claim a device
+    ///    the engine does not have.
+    /// 2. **What it is called** comes from
+    ///    [`crate::bus::SystemBus::external_device_decls`]. When no declaration
+    ///    matches, the id is synthesized from the attachment and `declared` is
+    ///    `false`, so a caller can always tell a named device from a guessed
+    ///    one.
+    ///
+    /// This lives on the bus because the bus is the one thing that holds BOTH
+    /// the live models and the declarations. `Machine::inspect` delegates to it.
+    pub fn inspect_devices(
+        &self,
+        filter: Option<&str>,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::DeviceInspect> {
+        let decls = &self.external_device_decls;
+        // A declaration's controller is its own `connection` unless that names
+        // another declaration (a bus switch), in which case it inherits the
+        // switch's controller and address. Resolved once, up front.
+        let effective: Vec<(usize, String, Option<u8>)> = decls
+            .iter()
+            .enumerate()
+            .map(|(i, d)| match decls.iter().find(|p| p.id == d.connection) {
+                Some(parent) => (i, parent.connection.clone(), parent.address),
+                None => (i, d.connection.clone(), None),
+            })
+            .collect();
+
+        let mut used = vec![false; decls.len()];
+        let mut out = Vec::new();
+        self.for_each_attached_device(&mut |bus, d| {
+            if filter.is_some_and(|f| bus != Some(f)) {
+                return;
+            }
+            // A device that states its own `external_devices:` id is joined by
+            // that id — it has no address to be identified by, and the id is
+            // the author's own text stamped onto the model at attach.
+            let matched = match d.declared_id {
+                // A declaration that fans out to several models (`instance_id`)
+                // is claimed by all of them: `used` exists to stop two DIFFERENT
+                // devices from taking one name, not to stop a board's own
+                // channels from sharing theirs.
+                Some(id) => decls
+                    .iter()
+                    .position(|decl| decl.id == id)
+                    .filter(|&i| !used[i] || d.instance_id.is_some()),
+                None => Self::match_addressed_decl(decls, &effective, &used, bus, &d),
+            };
+            if let Some(i) = matched {
+                if d.instance_id.is_none() {
+                    used[i] = true;
+                }
+            }
+
+            let id = match (d.instance_id, matched, d.declared_id) {
+                (Some(instance), _, _) => instance.to_string(),
+                (None, Some(i), _) => decls[i].id.clone(),
+                (None, None, Some(stamped)) => stamped.to_string(),
+                (None, None, None) => {
+                    let bus_name = bus.unwrap_or(d.transport);
+                    match (d.address, d.cs_pin) {
+                        (Some(a), _) => format!("{bus_name}@0x{a:02x}"),
+                        (None, Some(cs)) => format!("{bus_name}@{cs}"),
+                        (None, None) => bus_name.to_string(),
+                    }
+                }
+            };
+            // The device decides what it can show; this only supplies the id
+            // it is addressed by, which is not known until the join above.
+            let artifacts = d
+                .evidence
+                .map(|e| e.artifacts(&id, opts))
+                .unwrap_or_default();
+            out.push(crate::inspect::DeviceInspect {
+                device_type: matched.map(|i| decls[i].device_type.clone()),
+                declared: matched.is_some(),
+                attachment: crate::inspect::DeviceAttachment {
+                    transport: d.transport.to_string(),
+                    bus: bus.map(str::to_string),
+                    address: d.address,
+                    cs_pin: d.cs_pin.map(str::to_string),
+                    mux_address: d.mux_address,
+                    channel: d.channel,
+                },
+                id,
+                artifacts,
+            });
+        });
+        out
+    }
+
+    /// The addressed join: which declaration, if any, describes the device
+    /// found at this placement.
+    ///
+    /// A declaration that STATES an address (or chip-select) must match it.
+    /// Only a declaration that states none falls back to "the one remaining
+    /// candidate", which is the case where the manifest deliberately left the
+    /// address to the model's own default. Without that split, the
+    /// classic-ESP32 board BMP280 at 0x76 — real, on the bus, and declared by
+    /// nobody — was handed the `mux` declaration's name purely for being found
+    /// first, which is a fabricated identity.
+    fn match_addressed_decl(
+        decls: &[super::ExternalDeviceDecl],
+        effective: &[(usize, String, Option<u8>)],
+        used: &[bool],
+        bus: Option<&str>,
+        d: &AttachedDeviceRef<'_>,
+    ) -> Option<usize> {
+        let bus_name = bus?;
+        // Candidates: declarations that sit on this controller, at this
+        // bus-switch position, and are not already spoken for.
+        let candidates: Vec<usize> = effective
+            .iter()
+            .filter(|(i, conn, mux_addr)| {
+                !used[*i]
+                    && conn == bus_name
+                    && *mux_addr == d.mux_address
+                    && decls[*i].channel == d.channel
+            })
+            .map(|(i, _, _)| *i)
+            .collect();
+        let key_of = |i: usize| match d.transport {
+            "spi" => decls[i].cs_pin.is_some(),
+            _ => decls[i].address.is_some(),
+        };
+        let hit = |i: usize| match d.transport {
+            "spi" => decls[i].cs_pin.as_deref() == d.cs_pin,
+            _ => decls[i].address == d.address,
+        };
+        let exact: Vec<usize> = candidates.iter().copied().filter(|&i| hit(i)).collect();
+        if exact.len() == 1 {
+            return Some(exact[0]);
+        }
+        if !exact.is_empty() {
+            return None;
+        }
+        let loose: Vec<usize> = candidates.iter().copied().filter(|&i| !key_of(i)).collect();
+        (loose.len() == 1).then(|| loose[0])
+    }
+}
+
+/// One bus-resident device's placement, as the walk knows it — the argument
+/// bundle of [`SystemBus::emit_resident`].
+///
+/// `transport` says how the device BINDS, never what it is: `"gpio"` covers
+/// everything wired to pins (bit-banged protocols, one-wire framing,
+/// quadrature, PWM), `"analog"` a source that drives an ADC channel's level,
+/// `"can"` a second node on a CAN bus. The three constructors below are the
+/// only ways to build one, so a new family has to say which of the three it is
+/// rather than inventing a fourth vocabulary.
+struct Resident<'a> {
+    declared_id: &'a str,
+    instance_id: Option<&'a str>,
+    transport: &'static str,
+    bus: Option<&'a str>,
+    channel: Option<u8>,
+    /// A bus-resident model that can show something of itself implements
+    /// [`crate::inspect::DeviceEvidence`] directly and is passed here. None of
+    /// them does today — a servo and a distance sensor have no display surface
+    /// — and `None` says exactly that rather than promising an empty screen.
+    evidence: Option<&'a dyn DeviceEvidence>,
+}
+
+impl<'a> Resident<'a> {
+    /// A device wired to MCU pins. Its owner comes from its declaration: the
+    /// model holds pin addresses, not a peripheral name.
+    fn gpio(declared_id: &'a str, evidence: Option<&'a dyn DeviceEvidence>) -> Self {
+        Self {
+            declared_id,
+            instance_id: None,
+            transport: "gpio",
+            bus: None,
+            channel: None,
+            evidence,
+        }
+    }
+
+    /// A source driving one ADC channel's level. The ADC channel is placement,
+    /// exactly as a bus-switch channel is: "which channel of `bus`".
+    fn analog(declared_id: &'a str, connection: &'a str, channel: u8) -> Self {
+        Self {
+            declared_id,
+            instance_id: None,
+            transport: "analog",
+            bus: Some(connection),
+            channel: Some(channel),
+            evidence: None,
+        }
+    }
+
+    /// A second node on a CAN bus, which records the controller it talks to.
+    fn can(declared_id: &'a str, connection: &'a str) -> Self {
+        Self {
+            declared_id,
+            instance_id: None,
+            transport: "can",
+            bus: Some(connection),
+            channel: None,
+            evidence: None,
+        }
+    }
+
+    /// Mark this as ONE of several models built from a single declaration.
+    fn instance(mut self, instance_id: &'a str) -> Self {
+        self.instance_id = Some(instance_id);
+        self
+    }
+}

--- a/crates/core/src/bus/bus_trace.rs
+++ b/crates/core/src/bus/bus_trace.rs
@@ -173,6 +173,18 @@ impl I2cDevice for TracingI2cDevice {
     fn address(&self) -> u8 {
         self.inner.address()
     }
+    /// Forwarded, like everything else here. A decorator that let this fall
+    /// through to the trait default would silently erase the wrapped panel's
+    /// evidence — the device would still paint, still render, and report
+    /// nothing — which is precisely the failure mode
+    /// [`crate::inspect::DeviceEvidence`] exists to end.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        self.inner.artifacts(id, opts)
+    }
     fn claims_address(&self, addr: u8) -> bool {
         self.inner.claims_address(addr)
     }
@@ -293,6 +305,18 @@ impl TracingSpiDevice {
 impl SpiDevice for TracingSpiDevice {
     fn cs_select(&mut self) {
         self.inner.cs_select();
+    }
+    /// Forwarded, like everything else here. A decorator that let this fall
+    /// through to the trait default would silently erase the wrapped panel's
+    /// evidence — the device would still paint, still render, and report
+    /// nothing — which is precisely the failure mode
+    /// [`crate::inspect::DeviceEvidence`] exists to end.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        self.inner.artifacts(id, opts)
     }
     fn cs_release(&mut self) {
         self.inner.cs_release();

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -804,10 +804,12 @@ impl SystemBus {
                             data
                         )
                     })?;
-                    let strip =
-                        std::sync::Arc::new(crate::peripherals::components::ws2812::Ws2812::new(
+                    let strip = std::sync::Arc::new(
+                        crate::peripherals::components::ws2812::Ws2812::new(
                             pin, num_pixels, cpu_hz,
-                        ));
+                        )
+                        .with_component_id(ext.id.clone()),
+                    );
                     // Install as a GPIO observer on the S3 GPIO peripheral, if one
                     // is registered (walk-free: filters by pin internally).
                     if let Some(idx) = bus.find_peripheral_index_by_name("gpio") {
@@ -927,7 +929,8 @@ impl SystemBus {
                             in1,
                             in2,
                             en,
-                        ),
+                        )
+                        .with_declared_id(ext.id.clone()),
                     );
                     Self::install_gpio_observer(&mut bus, motor.clone());
                     bus.h_bridge_motors.push(motor);
@@ -955,7 +958,8 @@ impl SystemBus {
                                     b1,
                                     b2,
                                     enb,
-                                ),
+                                )
+                                .with_declared_id(ext.id.clone()),
                             );
                             Self::install_gpio_observer(&mut bus, motor_b.clone());
                             bus.h_bridge_motors.push(motor_b);

--- a/crates/core/src/bus/mod.rs
+++ b/crates/core/src/bus/mod.rs
@@ -19,6 +19,7 @@ use std::sync::Mutex;
 
 mod accessors;
 mod attach;
+mod attached_devices;
 pub mod bus_trace;
 mod can_devices;
 mod construct;

--- a/crates/core/src/inspect.rs
+++ b/crates/core/src/inspect.rs
@@ -140,11 +140,23 @@ pub struct PeripheralInspect {
 /// and by what address, never that any particular register of it is modeled.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceAttachment {
-    /// `"i2c"` | `"spi"`.
+    /// How the device binds to the machine: `"i2c"` | `"spi"` for an addressed
+    /// slave, `"gpio"` for anything wired to pins (bit-banged, one-wire,
+    /// quadrature, PWM), `"analog"` for a source that drives an ADC channel's
+    /// level, `"can"` for a second node on a CAN bus.
     pub transport: String,
-    /// Controller peripheral the device hangs off (`"i2c0"`, `"spi3"`), i.e. a
-    /// name that appears in [`MachineInspect::peripherals`].
-    pub bus: String,
+    /// Peripheral the device hangs off (`"i2c0"`, `"spi3"`, `"gpioa"`,
+    /// `"adc1"`, `"fdcan1"`), i.e. a name that appears in
+    /// [`MachineInspect::peripherals`].
+    ///
+    /// `None` only when the engine genuinely cannot say: a bus-resident model
+    /// attached programmatically, with no `external_devices:` declaration to
+    /// name its connection and nothing recorded on the model itself. Every
+    /// device that came from a manifest has one, so this key is present for
+    /// every device on a real rig — the option exists so an unknown owner is
+    /// reported as unknown rather than as a plausible-looking guess.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bus: Option<String>,
     /// 7-bit I²C address the model answers to, when the transport has one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address: Option<u8>,
@@ -154,7 +166,8 @@ pub struct DeviceAttachment {
     /// Address of the I²C bus switch this device sits behind, when it does.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mux_address: Option<u8>,
-    /// Downstream channel of that bus switch.
+    /// Which channel of `bus` the device is on: the downstream channel of an
+    /// I²C bus switch, or the ADC channel an analog source drives.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channel: Option<u8>,
 }
@@ -425,27 +438,118 @@ pub fn inspect_with_schema<P: Peripheral + ?Sized>(
     }
 }
 
-/// A live external device found hanging off a controller during the inspect
-/// walk — the borrowed, pre-identity form of [`DeviceInspect`].
+/// A live external device found during the inspect walk — the borrowed,
+/// pre-identity form of [`DeviceInspect`].
 ///
-/// Controllers hand these out from
-/// [`Peripheral::for_each_attached_device`](crate::Peripheral::for_each_attached_device).
-/// They carry only what the controller genuinely knows (transport, address,
-/// chip-select, bus-switch position) plus a borrow of the model itself; the
-/// manifest identity is joined on afterwards by
-/// [`crate::Machine::inspect`], which is the only place that has the
-/// declarations.
+/// Two kinds of source hand these out, and the record they produce is the same
+/// either way:
+///
+/// * a **controller**, from
+///   [`Peripheral::for_each_attached_device`](crate::Peripheral::for_each_attached_device),
+///   for anything on a transport with addressing (I²C, SPI). Such a device is
+///   identified by WHERE it answers, so `declared_id` is `None` and the
+///   manifest name is joined on by address afterwards; `bus` is `None` because
+///   the controller that yielded the ref is itself the bus.
+/// * the **bus**, from
+///   [`SystemBus::for_each_attached_device`](crate::bus::SystemBus::for_each_attached_device),
+///   for a device that binds to pins rather than to an address — an HC-SR04 on
+///   TRIG/ECHO, a servo on a PWM pad, a thermistor on an ADC channel, a CAN
+///   tester node. There is no address to join on, so such a model carries the
+///   `external_devices:` id it was stamped with at attach and states it here.
+///
+/// Either way the ref carries only what is genuinely known: the transport, the
+/// placement, and a borrow of the model for artifact extraction. Nothing is
+/// inferred from the Rust type.
 pub struct AttachedDeviceRef<'a> {
-    /// `"i2c"` | `"spi"`.
+    /// `"i2c"` | `"spi"` | `"gpio"` | `"analog"` | `"can"`.
     pub transport: &'static str,
     pub address: Option<u8>,
     pub cs_pin: Option<&'a str>,
     /// Set when this device sits behind an I²C bus switch.
     pub mux_address: Option<u8>,
+    /// Downstream channel of an I²C bus switch, or the ADC channel an analog
+    /// source drives — in both cases "which channel of `bus` this device is on".
     pub channel: Option<u8>,
-    /// The model, for artifact extraction. `None` when the model does not
-    /// expose [`std::any::Any`] — then it can be listed but not read.
-    pub model: Option<&'a dyn std::any::Any>,
+    /// The `external_devices:` id this model was stamped with at attach, for
+    /// devices whose identity is their name rather than their address. `None`
+    /// for I²C/SPI devices: their identity is joined on by address, which is
+    /// what the controller actually knows.
+    pub declared_id: Option<&'a str>,
+    /// This model's own id when ONE declaration built SEVERAL models — an
+    /// H-bridge board's two motor channels (`<id>-a`, `<id>-b`). Such a ref
+    /// does not consume its declaration: its siblings are equally entitled to
+    /// the name, and each is a separately controllable device. `None` (the
+    /// normal case) means the model IS the declaration.
+    pub instance_id: Option<&'a str>,
+    /// The peripheral this device hangs off, when the device names it itself.
+    /// `None` means "whatever yielded this ref is the bus" — always the case
+    /// for a controller-hosted device.
+    pub bus: Option<&'a str>,
+    /// What this device can show of itself, for artifact extraction. `None`
+    /// when the device reports no evidence — never "the screen was blank".
+    ///
+    /// A borrow, not an owned list, because the id an artifact is addressed by
+    /// is only known AFTER the manifest join; the join calls
+    /// [`DeviceEvidence::artifacts`] once it has one.
+    pub evidence: Option<&'a dyn DeviceEvidence>,
+}
+
+/// What an attached device can show of itself — the ONE seam by which a device
+/// model becomes inspect evidence.
+///
+/// This used to be a central `match` in this file that downcast a `&dyn Any` to
+/// each panel type in turn, and it had exactly two arms. Every panel model that
+/// existed had to be enumerated there, by hand, in a file far from the model —
+/// so the SH1107, the SSD1680 and the UC8151D painted perfectly, rendered in
+/// the browser, and reported NOTHING to `inspect` or to `labwired_verify`'s
+/// display oracle. Nobody had remembered to edit a downcast chain in
+/// `inspect.rs` when they added a model, and nothing made them.
+///
+/// A model now reports its own evidence, next to the buffers it owns, by
+/// overriding `artifacts` on the device trait it already implements
+/// ([`crate::peripherals::i2c::I2cDevice`],
+/// [`crate::peripherals::spi::SpiDevice`]). Adding a panel and forgetting its
+/// evidence is now a thing you do in ONE file, where the buffers are, instead
+/// of a thing you forget in another.
+///
+/// **This adds no fidelity.** Every number an implementation reports must be
+/// read straight off the model's own buffer; nothing is synthesized, and a
+/// panel whose driver never painted reports zero rather than something
+/// plausible. A device with no evidence returns an empty list, which is honest:
+/// absent means "this engine has nothing to show", never "the screen was
+/// blank".
+pub trait DeviceEvidence {
+    /// Artifacts describing what this device currently holds, addressed by
+    /// `id` (the manifest id the inspect join resolved). Summary mode
+    /// (`opts.include_bytes == false`) omits large payloads.
+    fn artifacts(&self, id: &str, opts: &InspectOpts) -> Vec<Artifact>;
+}
+
+/// Adapter letting an `&dyn I2cDevice` be carried as evidence. Lives on the
+/// visitor's stack frame — which is sound precisely because
+/// [`AttachedDeviceRef`] deliberately cannot escape the visitor.
+struct I2cEvidence<'a>(&'a dyn crate::peripherals::i2c::I2cDevice);
+
+impl DeviceEvidence for I2cEvidence<'_> {
+    fn artifacts(&self, id: &str, opts: &InspectOpts) -> Vec<Artifact> {
+        self.0.artifacts(id, opts)
+    }
+}
+
+/// SPI twin of [`I2cEvidence`].
+struct SpiEvidence<'a>(&'a dyn crate::peripherals::spi::SpiDevice);
+
+impl DeviceEvidence for SpiEvidence<'_> {
+    fn artifacts(&self, id: &str, opts: &InspectOpts) -> Vec<Artifact> {
+        self.0.artifacts(id, opts)
+    }
+}
+
+/// Shorthand for the payload half of an artifact: the buffer in full mode,
+/// nothing in summary mode. Every panel's `artifacts` impl uses it, so
+/// "summary omits the bytes" is one decision rather than eight.
+pub fn artifact_bytes(buf: &[u8], opts: &InspectOpts) -> Option<Vec<u8>> {
+    opts.include_bytes.then(|| buf.to_vec())
 }
 
 /// Visit one I²C slave, then everything wired behind it if it is a bus switch.
@@ -460,13 +564,17 @@ pub fn visit_i2c_device(
     f: &mut dyn FnMut(AttachedDeviceRef<'_>),
 ) {
     let model = dev.as_any();
+    let evidence = I2cEvidence(dev);
     f(AttachedDeviceRef {
         transport: "i2c",
         address: Some(dev.address()),
         cs_pin: None,
         mux_address: None,
         channel: None,
-        model,
+        declared_id: None,
+        instance_id: None,
+        bus: None,
+        evidence: Some(&evidence),
     });
     let Some(mux) =
         model.and_then(|a| a.downcast_ref::<crate::peripherals::components::tca9548a::Tca9548a>())
@@ -476,13 +584,17 @@ pub fn visit_i2c_device(
     let mux_address = crate::peripherals::i2c::I2cDevice::address(mux);
     for ch in 0..crate::peripherals::components::tca9548a::TCA9548A_CHANNELS as u8 {
         for child in mux.channel_devices(ch) {
+            let evidence = I2cEvidence(&**child);
             f(AttachedDeviceRef {
                 transport: "i2c",
                 address: Some(child.address()),
                 cs_pin: None,
                 mux_address: Some(mux_address),
                 channel: Some(ch),
-                model: child.as_any(),
+                declared_id: None,
+                instance_id: None,
+                bus: None,
+                evidence: Some(&evidence),
             });
         }
     }
@@ -494,94 +606,18 @@ pub fn visit_spi_device(
     dev: &dyn crate::peripherals::spi::SpiDevice,
     f: &mut dyn FnMut(AttachedDeviceRef<'_>),
 ) {
+    let evidence = SpiEvidence(dev);
     f(AttachedDeviceRef {
         transport: "spi",
         address: None,
         cs_pin: Some(dev.cs_pin()),
         mux_address: None,
         channel: None,
-        model: dev.as_any(),
+        declared_id: None,
+        instance_id: None,
+        bus: None,
+        evidence: Some(&evidence),
     });
-}
-
-/// The ONE place that turns an external device model into inspect artifacts.
-///
-/// Before this, panel evidence existed in two disconnected forms: an
-/// `Artifact` that only the STM32 and ESP32-C3 I²C controllers emitted, and
-/// only for an SSD1306; and `eprintln!` lines in the CLI that a shell script
-/// scraped with `sed`. A panel on any other controller — the ILI9341 on
-/// classic-ESP32 `spi3`, say — produced structured evidence for neither.
-///
-/// **This adds no fidelity.** Every number below is read straight off the
-/// model's own buffer; nothing is synthesized, and a panel whose driver never
-/// painted reports zero rather than something plausible. Models with no
-/// arm here simply return no artifacts, which is honest: absent means
-/// "this engine has nothing to show", never "the screen was blank".
-pub fn device_artifacts(model: &dyn std::any::Any, id: &str, opts: &InspectOpts) -> Vec<Artifact> {
-    use crate::peripherals::components::{Ili9341, Ssd1306};
-
-    let mut out = Vec::new();
-    let bytes_of = |buf: &[u8]| {
-        if opts.include_bytes {
-            Some(buf.to_vec())
-        } else {
-            None
-        }
-    };
-
-    if let Some(oled) = model.downcast_ref::<Ssd1306>() {
-        let fb = oled.framebuffer();
-        out.push(Artifact {
-            kind: "framebuffer".to_string(),
-            id: id.to_string(),
-            meta: serde_json::json!({
-                "w": oled.width(),
-                "h": oled.height(),
-                "format": "ssd1306_page",
-                "generation": artifact_generation(fb),
-                "ink_bytes": oled.ink_bytes(),
-                "lit_pixels": oled.lit_pixels(),
-            }),
-            bytes: bytes_of(fb),
-        });
-    } else if let Some(panel) = model.downcast_ref::<Ili9341>() {
-        let fb = panel.framebuffer();
-        // An RGB565 TFT has no e-paper "refresh": frame memory IS the screen,
-        // so the evidence is DISPON plus how much of the buffer the firmware
-        // actually wrote. `painted_bytes` counts non-zero bytes — the SAME
-        // definition the CLI's `painted bytes=` line prints, so the two agree
-        // by construction instead of by coincidence.
-        let painted = fb.iter().filter(|&&b| b != 0x00).count();
-        let (w, h) = panel.dimensions();
-        // The most common non-black pixel: says WHAT was drawn, not merely
-        // that something was. "6352 bytes changed" cannot be checked against a
-        // photo of real silicon; "top colour 0x07E0" (RGB565 green) can.
-        let mut counts: std::collections::HashMap<u16, usize> = std::collections::HashMap::new();
-        for px in fb.chunks_exact(2) {
-            let v = u16::from_be_bytes([px[0], px[1]]);
-            if v != 0 {
-                *counts.entry(v).or_default() += 1;
-            }
-        }
-        let top = counts.iter().max_by_key(|&(_, n)| *n);
-        out.push(Artifact {
-            kind: "framebuffer".to_string(),
-            id: id.to_string(),
-            meta: serde_json::json!({
-                "w": w,
-                "h": h,
-                "format": "rgb565_be",
-                "generation": artifact_generation(fb),
-                "display_on": panel.display_on(),
-                "painted_bytes": painted,
-                "total_bytes": fb.len(),
-                "top_colour": top.map(|(v, _)| format!("0x{v:04X}")),
-                "top_colour_pixels": top.map(|(_, n)| *n),
-            }),
-            bytes: bytes_of(fb),
-        });
-    }
-    out
 }
 
 /// FNV-1a hash of a byte buffer, used as a cheap `meta.generation` so callers

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -877,6 +877,13 @@ pub trait Peripheral: std::fmt::Debug + Send {
     /// [`crate::inspect::visit_spi_device`] rather than emitting records
     /// themselves, so the mux unfolding stays in one place. Default: no
     /// attached devices, which is correct for every non-controller peripheral.
+    ///
+    /// This is the CONTROLLER half of device binding. It is not the whole of
+    /// it: a device with no bus address (an HC-SR04 on TRIG/ECHO, a servo, a
+    /// CAN tester node) cannot live inside a controller and is held on the bus
+    /// instead. Both halves are walked together by
+    /// [`crate::bus::SystemBus::for_each_attached_device`], which is the seam
+    /// `inspect` actually consumes — call that, not this, to enumerate devices.
     fn for_each_attached_device(&self, _f: &mut dyn FnMut(crate::inspect::AttachedDeviceRef<'_>)) {}
 
     /// Uniform, snapshot-semantics inspection. The default decodes
@@ -2562,131 +2569,15 @@ impl<C: Cpu> Machine<C> {
                 }
             })
             .collect();
-        let devices = self.inspect_devices(filter, opts);
+        // Device binding lives on the bus, which is the one thing that holds
+        // BOTH the live models (inside controllers and directly on itself) and
+        // the manifest declarations they are named from. See
+        // `crate::bus::attached_devices`.
+        let devices = self.bus.inspect_devices(filter, opts);
         crate::inspect::MachineInspect {
             peripherals,
             devices,
         }
-    }
-
-    /// Enumerate the external (off-chip) devices attached to this machine's
-    /// controllers, joining each live model to the manifest declaration that
-    /// asked for it.
-    ///
-    /// Two halves, deliberately in that order:
-    ///
-    /// 1. **What is really there** comes from walking the bus
-    ///    ([`Peripheral::for_each_attached_device`]). A device is listed
-    ///    because a live model was found on a controller, never because a
-    ///    manifest mentioned one. A declaration that failed to build (the
-    ///    `"unsupported type … skipping"` path) therefore produces no entry —
-    ///    the record cannot claim a device the engine does not have.
-    /// 2. **What it is called** comes from
-    ///    [`crate::bus::SystemBus::external_device_decls`]. When no declaration
-    ///    matches, the id is synthesized from the attachment and `declared` is
-    ///    `false`, so a caller can always tell a named device from a guessed
-    ///    one.
-    fn inspect_devices(
-        &self,
-        filter: Option<&str>,
-        opts: &crate::inspect::InspectOpts,
-    ) -> Vec<crate::inspect::DeviceInspect> {
-        let decls = &self.bus.external_device_decls;
-        // A declaration's controller is its own `connection` unless that names
-        // another declaration (a bus switch), in which case it inherits the
-        // switch's controller and address. Resolved once, up front.
-        let effective: Vec<(usize, String, Option<u8>)> = decls
-            .iter()
-            .enumerate()
-            .map(|(i, d)| match decls.iter().find(|p| p.id == d.connection) {
-                Some(parent) => (i, parent.connection.clone(), parent.address),
-                None => (i, d.connection.clone(), None),
-            })
-            .collect();
-
-        let mut used = vec![false; decls.len()];
-        let mut out = Vec::new();
-        for entry in &self.bus.peripherals {
-            if filter.is_some_and(|f| entry.name != f) {
-                continue;
-            }
-            let bus_name = entry.name.as_str();
-            // Everything happens inside the visitor: `AttachedDeviceRef` borrows
-            // the model, and the controller may be holding a `RefCell` borrow
-            // open for the duration of the call, so the reference deliberately
-            // cannot escape.
-            entry.dev.for_each_attached_device(&mut |d| {
-                // Candidates: declarations that sit on this controller, at this
-                // bus-switch position, and are not already spoken for.
-                let candidates: Vec<usize> = effective
-                    .iter()
-                    .filter(|(i, conn, mux_addr)| {
-                        !used[*i]
-                            && conn == bus_name
-                            && *mux_addr == d.mux_address
-                            && decls[*i].channel == d.channel
-                    })
-                    .map(|(i, _, _)| *i)
-                    .collect();
-                // A declaration that STATES an address (or chip-select) must
-                // match it. Only a declaration that states none falls back to
-                // "the one remaining candidate", which is the case where the
-                // manifest deliberately left the address to the model's own
-                // default. Without that split, the classic-ESP32 board BMP280
-                // at 0x76 — real, on the bus, and declared by nobody — was
-                // handed the `mux` declaration's name purely for being found
-                // first, which is a fabricated identity.
-                let key_of = |i: usize| match d.transport {
-                    "spi" => decls[i].cs_pin.is_some(),
-                    _ => decls[i].address.is_some(),
-                };
-                let hit = |i: usize| match d.transport {
-                    "spi" => decls[i].cs_pin.as_deref() == d.cs_pin,
-                    _ => decls[i].address == d.address,
-                };
-                let exact: Vec<usize> = candidates.iter().copied().filter(|&i| hit(i)).collect();
-                let matched = if exact.len() == 1 {
-                    Some(exact[0])
-                } else if exact.is_empty() {
-                    let loose: Vec<usize> =
-                        candidates.iter().copied().filter(|&i| !key_of(i)).collect();
-                    (loose.len() == 1).then(|| loose[0])
-                } else {
-                    None
-                };
-                if let Some(i) = matched {
-                    used[i] = true;
-                }
-
-                let id = match matched {
-                    Some(i) => decls[i].id.clone(),
-                    None => match (d.address, d.cs_pin) {
-                        (Some(a), _) => format!("{bus_name}@0x{a:02x}"),
-                        (None, Some(cs)) => format!("{bus_name}@{cs}"),
-                        (None, None) => bus_name.to_string(),
-                    },
-                };
-                let artifacts = d
-                    .model
-                    .map(|m| crate::inspect::device_artifacts(m, &id, opts))
-                    .unwrap_or_default();
-                out.push(crate::inspect::DeviceInspect {
-                    device_type: matched.map(|i| decls[i].device_type.clone()),
-                    declared: matched.is_some(),
-                    attachment: crate::inspect::DeviceAttachment {
-                        transport: d.transport.to_string(),
-                        bus: bus_name.to_string(),
-                        address: d.address,
-                        cs_pin: d.cs_pin.map(str::to_string),
-                        mux_address: d.mux_address,
-                        channel: d.channel,
-                    },
-                    id,
-                    artifacts,
-                });
-            });
-        }
-        out
     }
 
     /// Raw escape hatch: read `len` bytes at absolute `addr`, side-effect-free.

--- a/crates/core/src/peripherals/components/h_bridge_motor.rs
+++ b/crates/core/src/peripherals/components/h_bridge_motor.rs
@@ -26,6 +26,7 @@ pub struct HBridgeMotor {
     en_pin: Option<u8>,
     state: Mutex<State>,
     id: String,
+    declared_id: Option<String>,
 }
 
 impl HBridgeMotor {
@@ -39,7 +40,25 @@ impl HBridgeMotor {
                 ..State::default()
             }),
             id: id.into(),
+            declared_id: None,
         }
+    }
+
+    /// Record the `external_devices:` entry this channel was built from.
+    ///
+    /// One H-bridge declaration builds up to two channel models (`<id>-a`,
+    /// `<id>-b`), so [`Self::id`] is NOT the manifest id. Inspect joins a
+    /// bus-resident device to its declaration by name, and without this the
+    /// channels would report as undeclared hardware on a rig that plainly
+    /// declared them.
+    pub fn with_declared_id(mut self, declared: impl Into<String>) -> Self {
+        self.declared_id = Some(declared.into());
+        self
+    }
+
+    /// The manifest entry this channel came from, when it came from one.
+    pub fn declared_id(&self) -> Option<&str> {
+        self.declared_id.as_deref()
     }
 
     pub fn id(&self) -> &str {

--- a/crates/core/src/peripherals/components/ili9341.rs
+++ b/crates/core/src/peripherals/components/ili9341.rs
@@ -477,6 +477,51 @@ impl Ili9341 {
 }
 
 impl SpiDevice for Ili9341 {
+    /// An RGB565 TFT has no e-paper "refresh": frame memory IS the screen, so
+    /// the evidence is DISPON plus how much of the buffer the firmware actually
+    /// wrote. `painted_bytes` counts non-zero bytes — the SAME definition the
+    /// CLI's `painted bytes=` line prints, so the two agree by construction
+    /// instead of by coincidence.
+    ///
+    /// Moved here verbatim from the central `device_artifacts` match; the keys
+    /// and their definitions are unchanged.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let fb = self.framebuffer();
+        let painted = fb.iter().filter(|&&b| b != 0x00).count();
+        let (w, h) = self.dimensions();
+        // The most common non-black pixel: says WHAT was drawn, not merely that
+        // something was. "6352 bytes changed" cannot be checked against a photo
+        // of real silicon; "top colour 0x07E0" (RGB565 green) can.
+        let mut counts: std::collections::HashMap<u16, usize> = std::collections::HashMap::new();
+        for px in fb.chunks_exact(2) {
+            let v = u16::from_be_bytes([px[0], px[1]]);
+            if v != 0 {
+                *counts.entry(v).or_default() += 1;
+            }
+        }
+        let top = counts.iter().max_by_key(|&(_, n)| *n);
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": w,
+                "h": h,
+                "format": "rgb565_be",
+                "generation": crate::inspect::artifact_generation(fb),
+                "display_on": self.display_on(),
+                "painted_bytes": painted,
+                "total_bytes": fb.len(),
+                "top_colour": top.map(|(v, _)| format!("0x{v:04X}")),
+                "top_colour_pixels": top.map(|(_, n)| *n),
+            }),
+            bytes: crate::inspect::artifact_bytes(fb, opts),
+        }]
+    }
+
     fn cs_pin(&self) -> &str {
         &self.cs_pin
     }

--- a/crates/core/src/peripherals/components/lcd1602.rs
+++ b/crates/core/src/peripherals/components/lcd1602.rs
@@ -339,6 +339,34 @@ impl Lcd1602 {
 }
 
 impl I2cDevice for Lcd1602 {
+    /// A character LCD holds text, not pixels, so its evidence is the text —
+    /// decoded from the real DDRAM, not from anything the driver claims it
+    /// sent. `kind` is `"text_display"` rather than `"framebuffer"` because a
+    /// consumer that renders framebuffers cannot render this and should not be
+    /// handed something that looks like one.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let ddram = self.ddram();
+        let text = self.text();
+        vec![crate::inspect::Artifact {
+            kind: "text_display".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "format": "hd44780_ddram",
+                "generation": crate::inspect::artifact_generation(&ddram),
+                "text": text,
+                "printable_chars": text.chars().filter(|c| !c.is_whitespace()).count(),
+                "display_on": self.display_on(),
+                "backlight": self.backlight(),
+                "two_line": self.two_line(),
+            }),
+            bytes: crate::inspect::artifact_bytes(&ddram, opts),
+        }]
+    }
+
     fn address(&self) -> u8 {
         self.address
     }

--- a/crates/core/src/peripherals/components/max7219.rs
+++ b/crates/core/src/peripherals/components/max7219.rs
@@ -170,6 +170,34 @@ impl Max7219 {
 }
 
 impl SpiDevice for Max7219 {
+    /// An 8x8 LED matrix: one byte per row, one bit per LED. `lit_pixels` is
+    /// the count of set bits in the ROWS the scan limit actually drives —
+    /// shutdown is reported rather than folded in, because a module holding a
+    /// pattern while shut down is a different finding from a blank one.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let fb = self.framebuffer();
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": 8,
+                "h": fb.len(),
+                "format": "max7219_rows",
+                "generation": crate::inspect::artifact_generation(&fb),
+                "ink_bytes": fb.iter().filter(|&&b| b != 0).count(),
+                "lit_pixels": fb.iter().map(|b| b.count_ones() as usize).sum::<usize>(),
+                "shutdown": self.is_shutdown(),
+                "intensity": self.intensity(),
+                "scan_limit": self.scan_limit(),
+            }),
+            bytes: crate::inspect::artifact_bytes(&fb, opts),
+        }]
+    }
+
     fn cs_pin(&self) -> &str {
         &self.cs_pin
     }

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -167,6 +167,32 @@ impl Pcd8544 {
 }
 
 impl SpiDevice for Pcd8544 {
+    /// Bank-addressed 1-bpp LCD, same evidence shape as the OLEDs: inked bytes
+    /// and lit pixels off the real buffer, plus the display-control state that
+    /// decides whether any of it is visible.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let fb = self.framebuffer();
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": WIDTH,
+                "h": BANKS * 8,
+                "format": "pcd8544_bank",
+                "generation": crate::inspect::artifact_generation(fb),
+                "ink_bytes": fb.iter().filter(|&&b| b != 0).count(),
+                "lit_pixels": fb.iter().map(|b| b.count_ones() as usize).sum::<usize>(),
+                "display_on": self.display_on(),
+                "inverse": self.inverse(),
+            }),
+            bytes: crate::inspect::artifact_bytes(fb, opts),
+        }]
+    }
+
     fn transfer(&mut self, mosi_byte: u8) -> u8 {
         if self.dc_level {
             self.handle_data(mosi_byte);

--- a/crates/core/src/peripherals/components/seven_segment.rs
+++ b/crates/core/src/peripherals/components/seven_segment.rs
@@ -256,6 +256,34 @@ impl PeripheralKit for SevenSegmentKit {
     }
 }
 
+/// A directly-driven 7-segment digit: eight GPIOs and a common pin, no driver
+/// chip. Like the TM1637 it binds on pins, so it reports through the evidence
+/// seam directly. The lit segment mask is combinational — it is whatever the
+/// pins say right now — so "which character" is read off the model, never
+/// remembered from a previous sample.
+impl crate::inspect::DeviceEvidence for SevenSegment {
+    fn artifacts(
+        &self,
+        id: &str,
+        _opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let segments = self.segments();
+        vec![crate::inspect::Artifact {
+            kind: "text_display".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "format": "seven_segment_mask",
+                "generation": crate::inspect::artifact_generation(&[segments]),
+                "text": self.ch().to_string(),
+                "segments": segments,
+                "lit_segments": segments.count_ones(),
+                "decimal_point": self.decimal_point(),
+            }),
+            bytes: None,
+        }]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/sh1107.rs
+++ b/crates/core/src/peripherals/components/sh1107.rs
@@ -175,6 +175,37 @@ impl Sh1107 {
 }
 
 impl I2cDevice for Sh1107 {
+    /// Same shape as the SSD1306's: a page-addressed 1-bpp OLED reports the
+    /// bytes that carry ink and the pixels that are lit, read off the real
+    /// GDDRAM. Only the `format` differs, because the page geometry does
+    /// (16 pages of 128 columns, not 8).
+    ///
+    /// This panel painted a full console in the browser while `inspect`
+    /// reported no artifact at all: the renderer had an accessor for it and the
+    /// evidence layer had no arm for it. Both were telling the truth about
+    /// their own path.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let fb = self.framebuffer();
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": self.width(),
+                "h": self.height(),
+                "format": "sh1107_page",
+                "generation": crate::inspect::artifact_generation(fb),
+                "ink_bytes": self.ink_bytes(),
+                "lit_pixels": self.lit_pixels(),
+                "display_on": self.display_on(),
+            }),
+            bytes: crate::inspect::artifact_bytes(fb, opts),
+        }]
+    }
+
     fn address(&self) -> u8 {
         self.address
     }

--- a/crates/core/src/peripherals/components/ssd1306.rs
+++ b/crates/core/src/peripherals/components/ssd1306.rs
@@ -234,6 +234,33 @@ impl Ssd1306 {
 }
 
 impl I2cDevice for Ssd1306 {
+    /// Page-addressed 1-bpp GDDRAM: how many bytes carry ink and how many
+    /// pixels are lit, both counted off the real buffer.
+    ///
+    /// Moved here verbatim from the central `device_artifacts` match; the keys
+    /// and their definitions are unchanged, so every existing consumer of this
+    /// payload keeps reading exactly what it read before.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let fb = self.framebuffer();
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": self.width(),
+                "h": self.height(),
+                "format": "ssd1306_page",
+                "generation": crate::inspect::artifact_generation(fb),
+                "ink_bytes": self.ink_bytes(),
+                "lit_pixels": self.lit_pixels(),
+            }),
+            bytes: crate::inspect::artifact_bytes(fb, opts),
+        }]
+    }
+
     fn address(&self) -> u8 {
         self.address
     }

--- a/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
@@ -396,6 +396,52 @@ struct Ssd1680Snap {
 }
 
 impl SpiDevice for Ssd1680Tricolor290 {
+    /// A tri-color e-paper is not one framebuffer, so it is not reported as
+    /// one. It has TWO independent 1-bpp planes and a refresh that decides
+    /// whether either is on the glass, and all three facts are evidence:
+    ///
+    /// * The planes are erased to `0xFF` — the panel's own convention, where a
+    ///   set bit is "no ink" — so an inked cell is a byte that is NOT `0xFF`.
+    ///   That is the same count the CLI's `black-plane non-FF bytes=` line
+    ///   prints, so the two agree by construction.
+    /// * `refresh_generation` is the only thing that distinguishes "RAM was
+    ///   written" from "the image is on the glass". `labwired_verify`'s
+    ///   `min_refresh_generation` clause resolves against it and was
+    ///   unreachable for every e-paper until this existed.
+    /// * `bytes` carries the black plane followed by the red plane, with
+    ///   `plane_bytes` giving the split, because one payload field cannot hold
+    ///   two planes and inventing a composite image would be synthesizing a
+    ///   picture the model never produced.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let (w, h) = self.dimensions();
+        let black = self.black_plane();
+        let red = self.red_plane();
+        let ink = |plane: &[u8]| plane.iter().filter(|&&b| b != 0xFF).count();
+        let mut both = Vec::with_capacity(black.len() + red.len());
+        both.extend_from_slice(black);
+        both.extend_from_slice(red);
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": w,
+                "h": h,
+                "format": "epaper_tricolor_1bpp_planes",
+                "generation": crate::inspect::artifact_generation(&both),
+                "plane_bytes": black.len(),
+                "black_ink_bytes": ink(black),
+                "red_ink_bytes": ink(red),
+                "refresh_generation": self.refresh_generation(),
+                "power_on": self.power_on(),
+            }),
+            bytes: crate::inspect::artifact_bytes(&both, opts),
+        }]
+    }
+
     fn cs_pin(&self) -> &str {
         &self.cs_pin
     }

--- a/crates/core/src/peripherals/components/tm1637_7seg.rs
+++ b/crates/core/src/peripherals/components/tm1637_7seg.rs
@@ -299,6 +299,42 @@ impl PeripheralKit for Tm16377SegKit {
     }
 }
 
+/// A TM1637 is a DISPLAY that happens to be bit-banged on two GPIO lines
+/// rather than addressed on a bus. It binds to the machine through
+/// [`crate::bus::SystemBus`] rather than through a controller, so it has no
+/// `I2cDevice`/`SpiDevice` impl to hang its evidence on — it implements the
+/// evidence seam directly instead.
+///
+/// That this is even possible is the point of walking bindings and evidence on
+/// ONE seam: before, a panel could only report if it happened to sit on a
+/// transport the evidence layer knew about, and this one sat on pins.
+impl crate::inspect::DeviceEvidence for Tm1637 {
+    fn artifacts(
+        &self,
+        id: &str,
+        _opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let text = self.text();
+        let grids = [self.grid(0), self.grid(1), self.grid(2), self.grid(3)];
+        vec![crate::inspect::Artifact {
+            kind: "text_display".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "format": "tm1637_grid",
+                "generation": crate::inspect::artifact_generation(&grids),
+                "text": text,
+                "lit_segments": grids.iter().map(|g| g.count_ones() as usize).sum::<usize>(),
+                "display_on": self.display_on(),
+                "brightness": self.brightness(),
+                "colon": self.colon(),
+            }),
+            // Four GRID bytes are metadata-sized; there is no payload worth
+            // gating behind `include_bytes`.
+            bytes: None,
+        }]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -290,6 +290,52 @@ struct Uc8151dSnap {
 }
 
 impl SpiDevice for Uc8151dTricolor290 {
+    /// A tri-color e-paper is not one framebuffer, so it is not reported as
+    /// one. It has TWO independent 1-bpp planes and a refresh that decides
+    /// whether either is on the glass, and all three facts are evidence:
+    ///
+    /// * The planes are erased to `0xFF` — the panel's own convention, where a
+    ///   set bit is "no ink" — so an inked cell is a byte that is NOT `0xFF`.
+    ///   That is the same count the CLI's `black-plane non-FF bytes=` line
+    ///   prints, so the two agree by construction.
+    /// * `refresh_generation` is the only thing that distinguishes "RAM was
+    ///   written" from "the image is on the glass". `labwired_verify`'s
+    ///   `min_refresh_generation` clause resolves against it and was
+    ///   unreachable for every e-paper until this existed.
+    /// * `bytes` carries the black plane followed by the red plane, with
+    ///   `plane_bytes` giving the split, because one payload field cannot hold
+    ///   two planes and inventing a composite image would be synthesizing a
+    ///   picture the model never produced.
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let (w, h) = self.dimensions();
+        let black = self.black_plane();
+        let red = self.red_plane();
+        let ink = |plane: &[u8]| plane.iter().filter(|&&b| b != 0xFF).count();
+        let mut both = Vec::with_capacity(black.len() + red.len());
+        both.extend_from_slice(black);
+        both.extend_from_slice(red);
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": w,
+                "h": h,
+                "format": "epaper_tricolor_1bpp_planes",
+                "generation": crate::inspect::artifact_generation(&both),
+                "plane_bytes": black.len(),
+                "black_ink_bytes": ink(black),
+                "red_ink_bytes": ink(red),
+                "refresh_generation": self.refresh_generation(),
+                "power_on": self.power_on(),
+            }),
+            bytes: crate::inspect::artifact_bytes(&both, opts),
+        }]
+    }
+
     fn cs_pin(&self) -> &str {
         &self.cs_pin
     }

--- a/crates/core/src/peripherals/components/ws2812.rs
+++ b/crates/core/src/peripherals/components/ws2812.rs
@@ -94,6 +94,9 @@ pub struct Ws2812 {
     high_threshold_cycles: u64,
     /// LOW-gap reset/latch threshold, in sim cycles (derived from `cpu_hz`).
     reset_threshold_cycles: u64,
+    /// The `external_devices:` id this strip was declared as, stamped at
+    /// attach. Identity, not behaviour: nothing in the decoder reads it.
+    component_id: Option<String>,
     state: Mutex<DecodeState>,
 }
 
@@ -107,8 +110,21 @@ impl Ws2812 {
             num_pixels: num_pixels.max(1),
             high_threshold_cycles: ns_to_cycles(HIGH_THRESHOLD_NS, cpu_hz),
             reset_threshold_cycles: ns_to_cycles(RESET_THRESHOLD_NS, cpu_hz),
+            component_id: None,
             state: Mutex::new(DecodeState::default()),
         }
+    }
+
+    /// Stamp the manifest id this strip was declared as, so `inspect` can name
+    /// it as the author did rather than reporting anonymous hardware.
+    pub fn with_component_id(mut self, id: impl Into<String>) -> Self {
+        self.component_id = Some(id.into());
+        self
+    }
+
+    /// The manifest id this strip was declared as, when it was declared.
+    pub fn component_id(&self) -> Option<&str> {
+        self.component_id.as_deref()
     }
 
     /// The GPIO pin this strip's data wire is on.

--- a/crates/core/src/peripherals/components/ws2812.rs
+++ b/crates/core/src/peripherals/components/ws2812.rs
@@ -207,6 +207,38 @@ impl crate::peripherals::esp32s3::gpio::GpioObserver for Ws2812 {
     }
 }
 
+/// An addressable LED strip is a display surface wired to ONE pin, so like the
+/// TM1637 it binds to the bus rather than to a controller and reports through
+/// the evidence seam directly.
+///
+/// The pixels are whatever the decoder reconstructed from real edge timing on
+/// the data pad; a strip that never saw an edge reports zero lit pixels, not a
+/// plausible pattern. Bytes are the decoded frame in wire (GRB) order.
+impl crate::inspect::DeviceEvidence for Ws2812 {
+    fn artifacts(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        let pixels = self.pixels();
+        let flat: Vec<u8> = pixels.iter().flatten().copied().collect();
+        vec![crate::inspect::Artifact {
+            kind: "framebuffer".to_string(),
+            id: id.to_string(),
+            meta: serde_json::json!({
+                "w": self.num_pixels(),
+                "h": 1,
+                "format": "ws2812_grb",
+                "generation": crate::inspect::artifact_generation(&flat),
+                "pixels_decoded": pixels.len(),
+                "lit_pixels": pixels.iter().filter(|p| p.iter().any(|&c| c != 0)).count(),
+                "data_pin": self.pin(),
+            }),
+            bytes: crate::inspect::artifact_bytes(&flat, opts),
+        }]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/esp32c3/i2c.rs
+++ b/crates/core/src/peripherals/esp32c3/i2c.rs
@@ -1115,8 +1115,8 @@ impl Peripheral for Esp32c3I2c {
     /// the C3 command-list controller walks its own slaves so the leo
     /// air-quality OLED surfaces through the universal inspect interface.
     ///
-    /// The artifact's CONTENTS come from [`crate::inspect::device_artifacts`],
-    /// not from here. This used to carry its own copy of the SSD1306 arm, one
+    /// The artifact's CONTENTS come from the device model's own
+    /// [`crate::peripherals::i2c::I2cDevice::artifacts`], not from here. This used to carry its own copy of the SSD1306 arm, one
     /// of three such copies; a panel that reported one thing on the C3 and
     /// another on STM32 was a matter of which copy someone remembered to edit.
     fn inspect(
@@ -1129,13 +1129,8 @@ impl Peripheral for Esp32c3I2c {
         pi.kind = "i2c".to_string();
         for dev in self.attached_slaves() {
             let addr = dev.address();
-            if let Some(model) = dev.as_any() {
-                pi.artifacts.extend(crate::inspect::device_artifacts(
-                    model,
-                    &format!("i2c@0x{:02x}", addr),
-                    opts,
-                ));
-            }
+            pi.artifacts
+                .extend(dev.artifacts(&format!("i2c@0x{:02x}", addr), opts));
         }
         pi
     }

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -27,6 +27,25 @@ pub trait I2cDevice: Send {
     fn start(&mut self) {}
     fn stop(&mut self) {}
 
+    /// What this device can show of itself — its own inspect evidence.
+    ///
+    /// The ONE place a an I²C device's artifacts are decided is the model
+    /// itself, next to the buffers it owns. Default: nothing, which is correct
+    /// for a sensor with no display surface and honest for anything else —
+    /// absent means "this engine has nothing to show", never "the screen was
+    /// blank". See [`crate::inspect::DeviceEvidence`] for why this is not a
+    /// central match on concrete types.
+    ///
+    /// Implementations must read the model's REAL buffer and synthesize
+    /// nothing; a panel that was never painted reports zero.
+    fn artifacts(
+        &self,
+        _id: &str,
+        _opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        Vec::new()
+    }
+
     /// Does this device answer to `addr` on the wire *right now*?
     ///
     /// A plain slave owns exactly one address, so the default is the obvious
@@ -1704,9 +1723,9 @@ impl crate::Peripheral for I2c {
     /// a cheap `generation` hash so callers skip unchanged buffers.
     ///
     /// What each panel's artifact CONTAINS is not decided here: it comes from
-    /// [`crate::inspect::device_artifacts`], the single emitter shared with the
-    /// machine-level device walk, so a panel cannot report one thing on this
-    /// controller and something else on another.
+    /// the device model's own [`I2cDevice::artifacts`], the single emitter
+    /// shared with the machine-level device walk, so a panel cannot report one
+    /// thing on this controller and something else on another.
     fn inspect(
         &self,
         base: u64,
@@ -1718,13 +1737,8 @@ impl crate::Peripheral for I2c {
         for dev_cell in self.attached_devices() {
             let dev = dev_cell.borrow();
             let addr = dev.address();
-            if let Some(model) = dev.as_any() {
-                pi.artifacts.extend(crate::inspect::device_artifacts(
-                    model,
-                    &format!("i2c@0x{:02x}", addr),
-                    opts,
-                ));
-            }
+            pi.artifacts
+                .extend(dev.artifacts(&format!("i2c@0x{:02x}", addr), opts));
         }
         pi
     }

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -35,6 +35,25 @@ pub trait SpiDevice: Send {
     /// CS pin label this device is wired to (e.g. "PA4" or numeric pin ID). Used by the bus
     /// dispatcher to pick which device responds when the firmware drives a particular CS line.
     fn cs_pin(&self) -> &str;
+
+    /// What this device can show of itself — its own inspect evidence.
+    ///
+    /// The ONE place a a SPI device's artifacts are decided is the model
+    /// itself, next to the buffers it owns. Default: nothing, which is correct
+    /// for a sensor with no display surface and honest for anything else —
+    /// absent means "this engine has nothing to show", never "the screen was
+    /// blank". See [`crate::inspect::DeviceEvidence`] for why this is not a
+    /// central match on concrete types.
+    ///
+    /// Implementations must read the model's REAL buffer and synthesize
+    /// nothing; a panel that was never painted reports zero.
+    fn artifacts(
+        &self,
+        _id: &str,
+        _opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        Vec::new()
+    }
     /// Data/Command (D/C) pin label this device observes, if any (e.g. "PB6").
     ///
     /// Displays like the Nokia 5110 (PCD8544) distinguish command bytes from

--- a/crates/core/tests/inspect_device_binding_universal.rs
+++ b/crates/core/tests/inspect_device_binding_universal.rs
@@ -1,0 +1,329 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! The contract, stated without reference to how the engine is built:
+//!
+//! > Every device an author places in `external_devices:` and that the engine
+//! > actually built appears in `inspect`'s `devices` array, named as the author
+//! > named it, wired where the author wired it.
+//!
+//! Nothing here knows what a "controller" is, or that I²C devices hang off a
+//! peripheral while an HC-SR04 hangs off the bus. The expectations are read out
+//! of the shipped `system.yaml` files with a YAML parser — the same text the
+//! customer wrote — and compared against the inspect record. If the engine
+//! grows a new way to bind a device and forgets to route it through the walk,
+//! the rig that places one fails here.
+//!
+//! This is deliberately NOT the mirror of `inspect_external_devices.rs`, which
+//! asserts I²C/SPI topology against a manifest embedded in the test. These
+//! manifests are the ones that ship in `examples/`, and they were chosen for
+//! covering the transports that are NOT I²C/SPI: GPIO (HC-SR04, TM1637),
+//! analog (NTC thermistor on an ADC channel) and CAN (a UDS tester node, a
+//! candump replay node).
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::cortex_m::CortexM;
+use labwired_core::inspect::InspectOpts;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Machine;
+use std::path::PathBuf;
+
+fn repo(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// What the AUTHOR wrote, parsed straight out of the shipped YAML.
+#[derive(Debug)]
+struct Placed {
+    id: String,
+    device_type: String,
+    connection: String,
+}
+
+fn placed_devices(rel_yaml: &str) -> Vec<Placed> {
+    let text = std::fs::read_to_string(repo(rel_yaml)).expect("read system.yaml");
+    let doc: serde_yaml::Value = serde_yaml::from_str(&text).expect("parse system.yaml");
+    doc.get("external_devices")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .map(|e| Placed {
+                    id: e["id"].as_str().expect("id").to_string(),
+                    device_type: e["type"].as_str().expect("type").to_string(),
+                    connection: e["connection"].as_str().expect("connection").to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Assemble the rig with no firmware. Placement is a property of the manifest;
+/// nothing has to run for a device to be wired, and a test that booted firmware
+/// first would be measuring the boot.
+fn machine_from_example(rel_yaml: &str) -> Machine<CortexM> {
+    let yaml = repo(rel_yaml);
+    let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
+    let chip_path = yaml.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    bus.refresh_peripheral_index();
+    Machine::new(cpu, bus)
+}
+
+/// The whole contract, for one shipped rig.
+fn assert_every_placed_device_is_inspectable(rel_yaml: &str) {
+    let placed = placed_devices(rel_yaml);
+    assert!(
+        !placed.is_empty(),
+        "{rel_yaml} places no external devices — wrong fixture for this test"
+    );
+    let machine = machine_from_example(rel_yaml);
+    let inspect = machine.inspect(None, &InspectOpts::default());
+    let seen: Vec<&str> = inspect.devices.iter().map(|d| d.id.as_str()).collect();
+
+    for want in &placed {
+        let got = inspect
+            .devices
+            .iter()
+            .find(|d| d.id == want.id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{rel_yaml}: device '{}' ({}) is placed on '{}' but does not appear in \
+                     inspect's devices array; inspect reported {seen:?}",
+                    want.id, want.device_type, want.connection
+                )
+            });
+        assert!(
+            got.declared,
+            "{rel_yaml}: '{}' is declared in the manifest, so the record must say so",
+            want.id
+        );
+        assert_eq!(
+            got.device_type.as_deref(),
+            Some(want.device_type.as_str()),
+            "{rel_yaml}: '{}' reports the type the author wrote",
+            want.id
+        );
+        assert_eq!(
+            got.attachment.bus.as_deref(),
+            Some(want.connection.as_str()),
+            "{rel_yaml}: '{}' reports the connection the author wrote",
+            want.id
+        );
+    }
+}
+
+/// GPIO, two ways: a pulse-echo ultrasonic sensor on TRIG/ECHO pins, alongside
+/// an SPI panel on the same rig. The panel was already visible; the sensor was
+/// not, and both must be.
+#[test]
+fn hc_sr04_on_gpio_pins_is_inspectable() {
+    assert_every_placed_device_is_inspectable("examples/nokia5110-invaders-lab/system.yaml");
+}
+
+/// A bit-banged two-wire display: no controller peripheral owns it, the GPIO
+/// write-hook clocks it.
+#[test]
+fn tm1637_bit_banged_display_is_inspectable() {
+    assert_every_placed_device_is_inspectable("examples/tm1637-7seg-lab/system.yaml");
+}
+
+/// An analog part: it drives an ADC channel's level, it has no bus address at
+/// all, and it is exactly the shape ("no address, no chip-select") the record
+/// already supports for an SPI panel.
+#[test]
+fn analog_thermistor_is_inspectable() {
+    assert_every_placed_device_is_inspectable("examples/ntc-thermistor-lab/system.yaml");
+}
+
+/// A CAN node: a second, off-board ECU-tester participant on `fdcan1`.
+#[test]
+fn can_uds_tester_node_is_inspectable() {
+    assert_every_placed_device_is_inspectable("examples/h563-uds-ecu/system.yaml");
+}
+
+/// A candump replay node on classic bxCAN — a different CAN family, and a
+/// different attach path, from the UDS tester above.
+#[test]
+fn can_log_player_node_is_inspectable() {
+    assert_every_placed_device_is_inspectable("examples/f103-j1939-monitor/replay-system.yaml");
+}
+
+/// Not an assertion — the reproducible way to produce the `devices` array for
+/// several rigs as JSON, so a change to this seam can be diffed against the
+/// same dump taken before it. `cargo test -p labwired-core --test
+/// inspect_device_binding_universal -- --ignored --nocapture`.
+///
+/// The bay-occupancy rig is the one that must not move: it is a customer
+/// delivery, it is I²C/SPI only, and its dump is expected to be byte-identical
+/// across any change to bus-resident binding.
+#[test]
+#[ignore = "diagnostic dump, not an assertion"]
+fn dump_devices_json() {
+    let bay = {
+        let yaml = repo("examples/esp32-bay-occupancy/system.yaml");
+        let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
+        let mut bus = SystemBus::new();
+        let cpu = labwired_core::system::xtensa::configure_xtensa_esp32(&mut bus);
+        labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+            .expect("attach");
+        bus.refresh_peripheral_index();
+        Machine::new(cpu, bus).inspect(None, &InspectOpts::default())
+    };
+    println!("=== esp32-bay-occupancy ===");
+    println!("{}", serde_json::to_string_pretty(&bay.devices).unwrap());
+
+    for rig in [
+        "examples/nokia5110-invaders-lab/system.yaml",
+        "examples/tm1637-7seg-lab/system.yaml",
+        "examples/ntc-thermistor-lab/system.yaml",
+        "examples/h563-uds-ecu/system.yaml",
+        "examples/f103-j1939-monitor/replay-system.yaml",
+    ] {
+        let inspect = machine_from_example(rig).inspect(None, &InspectOpts::default());
+        println!("=== {rig} ===");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&inspect.devices).unwrap()
+        );
+    }
+}
+
+/// The fails-if-forked guard, at the source level.
+///
+/// The walk cannot discover a collection of device models by reflection, so
+/// every one the bus holds has to be listed in
+/// `SystemBus::for_each_bus_resident_device`. A collection added to `SystemBus`
+/// and NOT listed there is a device family that simulates perfectly and reports
+/// nothing — silent, partial, and noticed by whichever customer happens to
+/// place one. This catches it at the source instead.
+///
+/// Field names are read out of `bus/mod.rs`; a collection counts as holding
+/// device models if its type names one of the model modules. The known-14
+/// assertion below is not the gate — it is the anti-vacuity check, so a parser
+/// that silently matched nothing cannot pass this test by finding no work.
+#[test]
+fn attached_device_walk_covers_every_bus_collection() {
+    let src = core_src("bus/mod.rs");
+    let walk = std::fs::read_to_string(core_src("bus/attached_devices.rs")).expect("read walk");
+    let collections = system_bus_device_collections(&src);
+
+    for known in [
+        "hcsr04",
+        "gpio_devices",
+        "ws2812",
+        "servos",
+        "step_dir_motors",
+        "h_bridge_motors",
+        "unipolar_steppers",
+        "tm1637",
+        "hx711",
+        "seven_segment",
+        "analog_inputs",
+        "can_diagnostic_testers",
+        "can_uds_testers",
+        "can_log_players",
+    ] {
+        assert!(
+            collections.iter().any(|c| c == known),
+            "field scan lost '{known}' — the scan itself is broken, so this test \
+             would have passed by measuring nothing; found {collections:?}"
+        );
+    }
+
+    for field in &collections {
+        assert!(
+            walk.contains(&format!("self.{field}")),
+            "SystemBus::{field} holds device models but \
+             bus/attached_devices.rs never walks it — every device in it would \
+             simulate and inspect as nothing. Add an arm to \
+             `for_each_bus_resident_device`."
+        );
+    }
+}
+
+fn core_src(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join(rel)
+}
+
+/// Field names of every `SystemBus` collection that holds external-device
+/// models, parsed out of the struct declaration.
+fn system_bus_device_collections(path: &std::path::Path) -> Vec<String> {
+    const MODEL_MARKERS: [&str; 7] = [
+        "peripherals::components::",
+        "peripherals::hc_sr04::",
+        "BusResidentDevice",
+        "CanDiagnosticTester",
+        "CanUdsTester",
+        "CanLogPlayer",
+        "AnalogInputSource",
+    ];
+    let src = std::fs::read_to_string(path).expect("read bus/mod.rs");
+    let body = src
+        .split_once("pub struct SystemBus {")
+        .expect("SystemBus declaration")
+        .1;
+    let body = body.split_once("\n}").expect("end of struct").0;
+
+    let mut out = Vec::new();
+    let mut decl = String::new();
+    let mut depth = 0i32;
+    for line in body.lines() {
+        let line = line.trim();
+        if line.starts_with("//") || line.is_empty() {
+            continue;
+        }
+        decl.push_str(line);
+        depth += line.matches('<').count() as i32;
+        depth -= line.matches('>').count() as i32;
+        if depth > 0 || !decl.ends_with(',') {
+            continue;
+        }
+        let one = std::mem::take(&mut decl);
+        let Some(rest) = one.strip_prefix("pub ") else {
+            continue;
+        };
+        let Some((name, ty)) = rest.split_once(':') else {
+            continue;
+        };
+        if ty.contains("Vec<") && MODEL_MARKERS.iter().any(|m| ty.contains(m)) {
+            out.push(name.trim().to_string());
+        }
+    }
+    out
+}
+
+/// The rig this whole seam was built for. It is I²C/SPI only, so it passed
+/// before; it is here so a change that fixes the new transports by breaking the
+/// old ones cannot pass.
+#[test]
+fn bay_occupancy_i2c_and_spi_still_inspectable() {
+    let placed = placed_devices("examples/esp32-bay-occupancy/system.yaml");
+    let yaml = repo("examples/esp32-bay-occupancy/system.yaml");
+    let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
+    let mut bus = SystemBus::new();
+    let cpu = labwired_core::system::xtensa::configure_xtensa_esp32(&mut bus);
+    labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+        .expect("attach external devices");
+    bus.refresh_peripheral_index();
+    let machine = Machine::new(cpu, bus);
+    let inspect = machine.inspect(None, &InspectOpts::default());
+    let seen: Vec<&str> = inspect.devices.iter().map(|d| d.id.as_str()).collect();
+    for want in &placed {
+        assert!(
+            inspect
+                .devices
+                .iter()
+                .any(|d| d.id == want.id && d.declared),
+            "'{}' placed but not inspectable; got {seen:?}",
+            want.id
+        );
+    }
+}

--- a/crates/core/tests/inspect_external_devices.rs
+++ b/crates/core/tests/inspect_external_devices.rs
@@ -364,3 +364,130 @@ fn record_external_devices_has_one_home() {
          or its devices inspect as anonymous addresses"
     );
 }
+
+// ── Panels that used to be evidence-blind ────────────────────────────────────
+//
+// Three display models painted correctly and reported nothing. `device_artifacts`
+// was a central `match` on concrete types with exactly two arms — `Ssd1306` and
+// `Ili9341` — so a panel became reportable only if somebody remembered to edit a
+// downcast chain in another file. Nobody did, for SH1107 or either tri-colour
+// e-paper.
+//
+// The cost was not cosmetic. `labwired_verify`'s display oracle resolves
+// `painted` / `min_ink_bytes` / `min_refresh_generation` against these artifacts,
+// so a lab built on one of these panels could never pass a display clause however
+// correct its firmware — and `labwired_verify` documents `panel:
+// "ssd1680_tricolor_290"` as an example value the engine could not emit.
+//
+// Both tests below drive the panel over its OWN wire protocol and check the
+// reported counts against arithmetic on the test's own input. Reading the model's
+// buffer back would prove only that a getter returns what a setter stored.
+
+/// The SH1107 that paints the published "IMAX Console" lab.
+///
+/// It rendered a complete console in the browser — via the wasm layer's own
+/// per-panel accessor — while `inspect` reported no artifact at all. Two pixel
+/// paths, one sighted and one blind.
+#[test]
+fn sh1107_reports_ink_matching_what_was_written() {
+    use labwired_core::peripherals::components::Sh1107;
+    use labwired_core::peripherals::i2c::I2cDevice;
+
+    const INKED_BYTES: usize = 5;
+
+    let mut dev = Sh1107::new(0x3c);
+    let command = |dev: &mut Sh1107, byte: u8| {
+        dev.write(0x00);
+        dev.write(byte);
+        dev.stop();
+    };
+    command(&mut dev, 0xAF); // display on
+    command(&mut dev, 0xB0); // page 0
+    command(&mut dev, 0x00); // column low nibble
+    command(&mut dev, 0x10); // column high nibble
+
+    // Five all-ones bytes: every bit set, so the expected pixel count is
+    // arithmetic on what this test wrote, not a re-read of the framebuffer.
+    dev.write(0x40);
+    for _ in 0..INKED_BYTES {
+        dev.write(0xFF);
+    }
+    dev.stop();
+
+    let arts = dev.artifacts("oled", &InspectOpts::default());
+    let art = arts
+        .iter()
+        .find(|a| a.kind == "framebuffer")
+        .expect("a painted SH1107 must report a framebuffer artifact");
+
+    assert_eq!(art.meta["format"], "sh1107_page");
+    assert_eq!(art.meta["w"], 128);
+    assert_eq!(art.meta["h"], 128, "16 pages of 8 rows, not an SSD1306's 8");
+    assert_eq!(art.meta["ink_bytes"], INKED_BYTES);
+    assert_eq!(art.meta["lit_pixels"], INKED_BYTES * 8);
+    assert_eq!(art.meta["display_on"], true);
+}
+
+/// The SSD1680 tri-colour e-paper behind both published weather labs.
+///
+/// Its planes are erased to `0xFF` (a set bit is "no ink"), so an inked cell is
+/// a byte that is NOT `0xFF` — and `refresh_generation` is the only thing that
+/// separates "RAM was written" from "the image is on the glass".
+#[test]
+fn epaper_reports_ink_and_whether_it_reached_the_glass() {
+    use labwired_core::peripherals::components::Ssd1680Tricolor290;
+
+    const INKED_BYTES: usize = 12;
+
+    let mut dev = Ssd1680Tricolor290::new("PA4");
+    // GxEPD2_290_C90c::_InitDisplay(), trimmed to what sets the RAM window.
+    let init: &[u8] = &[
+        0x12, 0x01, 0x27, 0x01, 0x00, 0x11, 0x03, 0x3C, 0x05, 0x18, 0x80, 0x21, 0x00, 0x80, 0x44,
+        0x00, 0x0F, 0x45, 0x00, 0x00, 0x27, 0x01, 0x4E, 0x00, 0x4F, 0x00, 0x00,
+    ];
+    dev.cs_select();
+    for &b in init {
+        dev.transfer(b);
+    }
+    dev.cs_release();
+
+    let before = dev.artifacts("panel", &InspectOpts::default());
+    assert_eq!(
+        before[0].meta["refresh_generation"], 0,
+        "nothing has been pushed to the glass yet"
+    );
+
+    // Write the black plane: 0x00 bytes are ink under this panel's convention.
+    dev.cs_select();
+    dev.transfer(0x24);
+    for _ in 0..INKED_BYTES {
+        dev.transfer(0x00);
+    }
+    dev.cs_release();
+
+    // Master activation — this is what puts the image on the glass.
+    dev.cs_select();
+    dev.transfer(0x20);
+    dev.cs_release();
+
+    let arts = dev.artifacts("panel", &InspectOpts::default());
+    let art = arts
+        .iter()
+        .find(|a| a.kind == "framebuffer")
+        .expect("a refreshed e-paper must report a framebuffer artifact");
+
+    assert_eq!(art.meta["format"], "epaper_tricolor_1bpp_planes");
+    assert_eq!(
+        art.meta["black_ink_bytes"], INKED_BYTES,
+        "ink is a byte that is not 0xFF, counted off the real plane"
+    );
+    assert_eq!(
+        art.meta["red_ink_bytes"], 0,
+        "this test never wrote the red plane; it must not invent ink there"
+    );
+    assert_eq!(
+        art.meta["refresh_generation"], 1,
+        "min_refresh_generation in the verify oracle resolves against this, and \
+         was unreachable for every e-paper until the panel could report it"
+    );
+}

--- a/crates/core/tests/inspect_external_devices.rs
+++ b/crates/core/tests/inspect_external_devices.rs
@@ -116,7 +116,7 @@ fn manifest_external_devices_are_visible_in_inspect() {
     let mux = device(&inspect.devices, "mux");
     assert_eq!(mux.device_type.as_deref(), Some("tca9548a"));
     assert_eq!(mux.attachment.transport, "i2c");
-    assert_eq!(mux.attachment.bus, "i2c0");
+    assert_eq!(mux.attachment.bus.as_deref(), Some("i2c0"));
     assert_eq!(mux.attachment.address, Some(0x70));
     assert_eq!(
         mux.attachment.channel, None,
@@ -126,7 +126,11 @@ fn manifest_external_devices_are_visible_in_inspect() {
     for (n, id) in ["bay0", "bay1", "bay2", "bay3"].iter().enumerate() {
         let bay = device(&inspect.devices, id);
         assert_eq!(bay.device_type.as_deref(), Some("vcnl4010"));
-        assert_eq!(bay.attachment.bus, "i2c0", "{id} reports its controller");
+        assert_eq!(
+            bay.attachment.bus.as_deref(),
+            Some("i2c0"),
+            "{id} reports its controller"
+        );
         assert_eq!(
             bay.attachment.address,
             Some(0x13),
@@ -147,7 +151,7 @@ fn manifest_external_devices_are_visible_in_inspect() {
     let tft = device(&inspect.devices, "tft");
     assert_eq!(tft.device_type.as_deref(), Some("ili9341"));
     assert_eq!(tft.attachment.transport, "spi");
-    assert_eq!(tft.attachment.bus, "spi3");
+    assert_eq!(tft.attachment.bus.as_deref(), Some("spi3"));
     assert_eq!(tft.attachment.cs_pin.as_deref(), Some("GPIO15"));
     assert_eq!(tft.attachment.address, None, "SPI has no bus address");
 }

--- a/crates/core/tests/panel_artifact_evidence.rs
+++ b/crates/core/tests/panel_artifact_evidence.rs
@@ -1,0 +1,341 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! The contract, stated without reference to how the engine is built:
+//!
+//! > A panel that was painted reports an artifact saying so. A panel that was
+//! > NOT painted reports zero — not absence.
+//!
+//! Absence and zero are different findings, and only one of them is checkable.
+//! `labwired_verify`'s display oracle resolves a `panel` clause against the
+//! artifact this seam emits; a panel that emits nothing makes
+//! `{painted: true, min_ink_bytes: N}` and `min_refresh_generation` unresolvable
+//! no matter how correct the firmware is. Four shipped labs — IMAX Console
+//! (SH1107), Weather Station and Stats Display (SSD1680 tricolor), and any
+//! UC8151D lab — were unverifiable for exactly that reason.
+//!
+//! Every expectation below is arithmetic on bytes THIS TEST wrote over the
+//! panel's own wire protocol, never a re-read of the model's buffer. The two
+//! panels that already had evidence (SSD1306, ILI9341) are pinned here too, so
+//! a change that adds the missing three by disturbing the existing two cannot
+//! pass.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::cortex_m::CortexM;
+use labwired_core::inspect::{device_artifacts, Artifact, InspectOpts};
+use labwired_core::peripherals::components::{
+    Ili9341, Sh1107, Ssd1306, Ssd1680Tricolor290, Uc8151dTricolor290,
+};
+use labwired_core::peripherals::i2c::I2cDevice;
+use labwired_core::peripherals::spi::SpiDevice;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Machine;
+use std::path::PathBuf;
+
+/// The one artifact a painted panel must produce, or a panic naming what came
+/// out instead.
+fn framebuffer_artifact(model: &dyn std::any::Any, id: &str) -> Artifact {
+    let arts = device_artifacts(model, id, &InspectOpts::default());
+    arts.into_iter()
+        .find(|a| a.kind == "framebuffer")
+        .unwrap_or_else(|| {
+            panic!("'{id}' produced no framebuffer artifact; a panel that painted must say so")
+        })
+}
+
+// ─── SH1107 (I²C OLED) ──────────────────────────────────────────────────────
+
+/// Write `bytes` into the SH1107's GDDRAM at page 0, column 0, over the wire:
+/// control byte 0x00 for commands, 0x40 for a data stream, exactly as a driver
+/// does. Returns the panel.
+fn painted_sh1107(bytes: &[u8]) -> Sh1107 {
+    let mut oled = Sh1107::new(0x3C);
+    // Command stream: display on, page 0, column 0.
+    oled.start();
+    oled.write(0x00);
+    oled.write(0xAF); // display on
+    oled.write(0xB0); // page 0
+    oled.write(0x00); // column low nibble 0
+    oled.write(0x10); // column high nibble 0
+    oled.stop();
+    // Data stream.
+    oled.start();
+    oled.write(0x40);
+    for &b in bytes {
+        oled.write(b);
+    }
+    oled.stop();
+    oled
+}
+
+/// An SH1107 driven over its own I²C protocol reports the ink it received.
+///
+/// The expected counts are computed from the bytes this test sent, not read
+/// back off the panel: four bytes with 1, 8, 4 and 2 bits set is 4 inked bytes
+/// and 15 lit pixels.
+#[test]
+fn sh1107_that_painted_reports_its_ink() {
+    const PATTERN: [u8; 4] = [0x01, 0xFF, 0x0F, 0x81];
+    let expected_lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
+
+    let oled = painted_sh1107(&PATTERN);
+    let art = framebuffer_artifact(&oled, "oled");
+
+    assert_eq!(art.id, "oled", "artifact is addressed by the device's id");
+    assert_eq!(art.meta["w"], 128);
+    assert_eq!(art.meta["h"], 128);
+    assert_eq!(
+        art.meta["ink_bytes"], PATTERN.len(),
+        "one inked byte per non-zero byte written"
+    );
+    assert_eq!(art.meta["lit_pixels"], expected_lit);
+    assert_eq!(art.meta["display_on"], true, "0xAF was sent");
+    assert!(art.bytes.is_none(), "summary mode omits the payload");
+
+    let full = device_artifacts(
+        &oled,
+        "oled",
+        &InspectOpts {
+            include_bytes: true,
+            peripheral: None,
+        },
+    );
+    assert_eq!(
+        full[0].bytes.as_ref().map(Vec::len),
+        Some(128 * 16),
+        "include_bytes attaches the real GDDRAM"
+    );
+}
+
+/// A panel nobody drove reports zero, not an absent artifact. "Nothing was
+/// painted" is a finding and must be legible as one.
+#[test]
+fn unpainted_sh1107_reports_zero_rather_than_nothing() {
+    let art = framebuffer_artifact(&Sh1107::new(0x3C), "oled");
+    assert_eq!(art.meta["ink_bytes"], 0);
+    assert_eq!(art.meta["lit_pixels"], 0);
+    assert_eq!(art.meta["display_on"], false);
+}
+
+// ─── SSD1680 tricolor e-paper (SPI) ─────────────────────────────────────────
+
+/// Stream `black`/`red` into the panel's RAM at a 1-byte-wide window and then
+/// run GxEPD2's power + master-activation handshake, over the datasheet
+/// command/data path.
+fn painted_epaper_bytes(panel: &mut Ssd1680Tricolor290, black: &[u8], red: &[u8]) {
+    panel.command_byte(0x12); // SWRESET
+    panel.command_byte(0x11); // data entry mode
+    panel.data_byte(0x03);
+    panel.command_byte(0x44); // RAM-X window (start/8, end/8)
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+    panel.command_byte(0x45); // RAM-Y window
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+    panel.data_byte((black.len() - 1) as u8);
+    panel.data_byte(0x00);
+    panel.command_byte(0x4E); // RAM-X counter
+    panel.data_byte(0x00);
+    panel.command_byte(0x4F); // RAM-Y counter
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+    panel.command_byte(0x24); // black plane stream
+    for &b in black {
+        panel.data_byte(b);
+    }
+    panel.command_byte(0x4E);
+    panel.data_byte(0x00);
+    panel.command_byte(0x4F);
+    panel.data_byte(0x00);
+    panel.data_byte(0x00);
+    panel.command_byte(0x26); // red plane stream
+    for &b in red {
+        panel.data_byte(b);
+    }
+    panel.command_byte(0x22); // display update control
+    panel.data_byte(0xF7);
+    panel.command_byte(0x20); // master activation → refresh
+}
+
+/// A tri-color e-paper that was streamed and refreshed reports BOTH planes and
+/// the refresh that made them visible.
+///
+/// The counts are arithmetic on this test's own input: an e-paper plane is
+/// erased to 0xFF (1 = white / no-red), so an inked cell is any byte that is
+/// not 0xFF. Two of the three black bytes and one of the three red bytes differ
+/// from the erased value.
+#[test]
+fn ssd1680_that_refreshed_reports_both_planes_and_the_refresh() {
+    const BLACK: [u8; 3] = [0x00, 0xFF, 0xAA];
+    const RED: [u8; 3] = [0xFF, 0xFF, 0x0F];
+    let black_ink = BLACK.iter().filter(|&&b| b != 0xFF).count();
+    let red_ink = RED.iter().filter(|&&b| b != 0xFF).count();
+
+    let mut panel = Ssd1680Tricolor290::new("PA4");
+    painted_epaper_bytes(&mut panel, &BLACK, &RED);
+    let art = framebuffer_artifact(&panel, "epaper");
+
+    assert_eq!(art.meta["w"], 128);
+    assert_eq!(art.meta["h"], 296);
+    assert_eq!(art.meta["black_ink_bytes"], black_ink);
+    assert_eq!(art.meta["red_ink_bytes"], red_ink);
+    assert_eq!(
+        art.meta["refresh_generation"], 1,
+        "one master activation is one refresh"
+    );
+    assert_eq!(art.meta["power_on"], true);
+}
+
+/// An e-paper nobody drove reports zero ink and generation zero — not absence,
+/// and not a plausible-looking number.
+#[test]
+fn unrefreshed_ssd1680_reports_zero_rather_than_nothing() {
+    let art = framebuffer_artifact(&Ssd1680Tricolor290::new("PA4"), "epaper");
+    assert_eq!(art.meta["black_ink_bytes"], 0);
+    assert_eq!(art.meta["red_ink_bytes"], 0);
+    assert_eq!(art.meta["refresh_generation"], 0);
+    assert_eq!(art.meta["power_on"], false);
+}
+
+/// The whole path, end to end: the shipped `epaper-tricolor-lab` manifest, the
+/// panel reached through the SPI controller it is attached to, and the evidence
+/// arriving in `Machine::inspect`'s device record — not merely out of the
+/// artifact helper called directly.
+#[test]
+fn epaper_lab_reports_panel_evidence_through_machine_inspect() {
+    const BLACK: [u8; 2] = [0x00, 0x0F];
+    let yaml = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/epaper-tricolor-lab/system.yaml");
+    let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
+    let chip_path = yaml.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+
+    {
+        let idx = bus
+            .find_peripheral_index_by_name("spi1")
+            .expect("spi1 registered");
+        let any = bus.peripherals[idx].dev.as_any_mut().expect("downcastable");
+        let spi = any
+            .downcast_mut::<labwired_core::peripherals::spi::Spi>()
+            .expect("spi1 is a generic Spi");
+        let panel = spi
+            .attached_devices
+            .iter_mut()
+            .find_map(|d| {
+                d.as_any_mut()
+                    .and_then(|a| a.downcast_mut::<Ssd1680Tricolor290>())
+            })
+            .expect("SSD1680 attached to spi1");
+        painted_epaper_bytes(panel, &BLACK, &[0xFF, 0xFF]);
+    }
+
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    bus.refresh_peripheral_index();
+    let machine = Machine::new(cpu, bus);
+    let inspect = machine.inspect(None, &InspectOpts::default());
+    let device = inspect
+        .devices
+        .iter()
+        .find(|d| d.id == "epaper")
+        .expect("the declared panel is a device");
+    let art = device
+        .artifacts
+        .iter()
+        .find(|a| a.kind == "framebuffer")
+        .unwrap_or_else(|| {
+            panic!("panel reports no framebuffer artifact through inspect; the display oracle has nothing to resolve against")
+        });
+    assert_eq!(art.id, "epaper");
+    assert_eq!(art.meta["black_ink_bytes"], 2);
+    assert_eq!(art.meta["refresh_generation"], 1);
+}
+
+// ─── UC8151D tricolor e-paper (SPI) ─────────────────────────────────────────
+
+/// The UC8151D's own datasheet sequence: 0x10 opens the black (B/W) stream,
+/// 0x13 the red stream, 0x12 triggers the refresh.
+#[test]
+fn uc8151d_that_refreshed_reports_both_planes_and_the_refresh() {
+    const BLACK: [u8; 4] = [0x00, 0xFF, 0xF0, 0xFF];
+    const RED: [u8; 4] = [0xFF, 0x00, 0xFF, 0xFF];
+    let black_ink = BLACK.iter().filter(|&&b| b != 0xFF).count();
+    let red_ink = RED.iter().filter(|&&b| b != 0xFF).count();
+
+    let mut panel = Uc8151dTricolor290::new("PA4");
+    panel.command_byte(0x04); // power on
+    panel.command_byte(0x10); // black plane stream
+    for &b in &BLACK {
+        panel.data_byte(b);
+    }
+    panel.command_byte(0x13); // red plane stream
+    for &b in &RED {
+        panel.data_byte(b);
+    }
+    panel.command_byte(0x12); // display refresh
+
+    let art = framebuffer_artifact(&panel, "epaper");
+    assert_eq!(art.meta["black_ink_bytes"], black_ink);
+    assert_eq!(art.meta["red_ink_bytes"], red_ink);
+    assert_eq!(art.meta["refresh_generation"], 1);
+    assert_eq!(art.meta["power_on"], true);
+}
+
+// ─── the two that already worked, pinned ────────────────────────────────────
+
+/// SSD1306's payload is unchanged: same keys, same definitions.
+#[test]
+fn ssd1306_artifact_payload_is_unchanged() {
+    const PATTERN: [u8; 3] = [0xFF, 0x01, 0x80];
+    let expected_lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
+    let mut oled = Ssd1306::new(0x3C);
+    oled.start();
+    oled.write(0x00);
+    oled.write(0xAF);
+    oled.stop();
+    oled.start();
+    oled.write(0x40);
+    for &b in &PATTERN {
+        oled.write(b);
+    }
+    oled.stop();
+
+    let art = framebuffer_artifact(&oled, "oled");
+    assert_eq!(art.meta["format"], "ssd1306_page");
+    assert_eq!(art.meta["ink_bytes"], PATTERN.len());
+    assert_eq!(art.meta["lit_pixels"], expected_lit);
+    assert!(
+        art.meta.get("w").is_some() && art.meta.get("h").is_some(),
+        "dimensions stay in the payload"
+    );
+}
+
+/// ILI9341's payload is unchanged, including the `painted_bytes` definition —
+/// deliberately the same count the CLI's `painted bytes=` line prints, so the
+/// two agree by construction rather than by coincidence.
+#[test]
+fn ili9341_artifact_payload_is_unchanged() {
+    const PIXELS: usize = 100;
+    const HI: u8 = 0x07;
+    const LO: u8 = 0xE0; // RGB565 green: both bytes non-zero.
+    let mut panel = Ili9341::new("PA4");
+    panel.set_dc_level(false);
+    panel.transfer(0x29); // DISPON
+    panel.set_dc_level(false);
+    panel.transfer(0x2C); // RAMWR
+    for _ in 0..PIXELS {
+        panel.set_dc_level(true);
+        panel.transfer(HI);
+        panel.set_dc_level(true);
+        panel.transfer(LO);
+    }
+
+    let art = framebuffer_artifact(&panel, "tft");
+    assert_eq!(art.meta["format"], "rgb565_be");
+    assert_eq!(art.meta["display_on"], true);
+    assert_eq!(art.meta["painted_bytes"], PIXELS * 2);
+    assert_eq!(art.meta["top_colour"], "0x07E0");
+    assert_eq!(art.meta["top_colour_pixels"], PIXELS);
+}

--- a/crates/core/tests/panel_artifact_evidence.rs
+++ b/crates/core/tests/panel_artifact_evidence.rs
@@ -8,164 +8,254 @@
 //! > NOT painted reports zero — not absence.
 //!
 //! Absence and zero are different findings, and only one of them is checkable.
-//! `labwired_verify`'s display oracle resolves a `panel` clause against the
-//! artifact this seam emits; a panel that emits nothing makes
-//! `{painted: true, min_ink_bytes: N}` and `min_refresh_generation` unresolvable
-//! no matter how correct the firmware is. Four shipped labs — IMAX Console
-//! (SH1107), Weather Station and Stats Display (SSD1680 tricolor), and any
-//! UC8151D lab — were unverifiable for exactly that reason.
+//! `labwired_verify`'s display oracle resolves its `panel` clause against the
+//! artifact `inspect` emits; a panel that emits nothing makes
+//! `{painted: true, min_ink_bytes: N}` and `min_refresh_generation`
+//! unresolvable no matter how correct the firmware is. Four shipped labs — IMAX
+//! Console (SH1107), Weather Station and Stats Display (SSD1680 tricolor), and
+//! any UC8151D lab — were unverifiable for exactly that reason, while the same
+//! panels rendered perfectly in the browser: the renderer and the evidence
+//! layer were two systems that did not know about each other.
 //!
-//! Every expectation below is arithmetic on bytes THIS TEST wrote over the
-//! panel's own wire protocol, never a re-read of the model's buffer. The two
-//! panels that already had evidence (SSD1306, ILI9341) are pinned here too, so
-//! a change that adds the missing three by disturbing the existing two cannot
-//! pass.
+//! Every test here drives a panel over its OWN wire protocol — the same
+//! `I2cDevice` / `SpiDevice` calls the controller makes — and then reads
+//! `Machine::inspect`. Nothing downcasts to a panel type, nothing reaches into
+//! a model's buffer, and every expected number is arithmetic on the bytes this
+//! file sent. The two panels that already had evidence (SSD1306, ILI9341) are
+//! pinned too, so a change that adds the missing ones by disturbing the
+//! existing ones cannot pass.
 
-use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_config::{ChipDescriptor, ExternalDevice, SystemManifest};
 use labwired_core::bus::SystemBus;
-use labwired_core::cpu::cortex_m::CortexM;
-use labwired_core::inspect::{device_artifacts, Artifact, InspectOpts};
-use labwired_core::peripherals::components::{
-    Ili9341, Sh1107, Ssd1306, Ssd1680Tricolor290, Uc8151dTricolor290,
-};
-use labwired_core::peripherals::i2c::I2cDevice;
-use labwired_core::peripherals::spi::SpiDevice;
+use labwired_core::inspect::{Artifact, DeviceInspect, InspectOpts};
 use labwired_core::system::cortex_m::configure_cortex_m;
 use labwired_core::Machine;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// The one artifact a painted panel must produce, or a panic naming what came
-/// out instead.
-fn framebuffer_artifact(model: &dyn std::any::Any, id: &str) -> Artifact {
-    let arts = device_artifacts(model, id, &InspectOpts::default());
-    arts.into_iter()
-        .find(|a| a.kind == "framebuffer")
-        .unwrap_or_else(|| {
-            panic!("'{id}' produced no framebuffer artifact; a panel that painted must say so")
-        })
+fn repo(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
 }
 
-// ─── SH1107 (I²C OLED) ──────────────────────────────────────────────────────
-
-/// Write `bytes` into the SH1107's GDDRAM at page 0, column 0, over the wire:
-/// control byte 0x00 for commands, 0x40 for a data stream, exactly as a driver
-/// does. Returns the panel.
-fn painted_sh1107(bytes: &[u8]) -> Sh1107 {
-    let mut oled = Sh1107::new(0x3C);
-    // Command stream: display on, page 0, column 0.
-    oled.start();
-    oled.write(0x00);
-    oled.write(0xAF); // display on
-    oled.write(0xB0); // page 0
-    oled.write(0x00); // column low nibble 0
-    oled.write(0x10); // column high nibble 0
-    oled.stop();
-    // Data stream.
-    oled.start();
-    oled.write(0x40);
-    for &b in bytes {
-        oled.write(b);
+/// A one-device rig on an STM32F103: the smallest thing that can hold a panel
+/// on a real controller.
+fn rig(device_type: &str, connection: &str, config: &[(&str, serde_yaml::Value)]) -> SystemBus {
+    let chip_path = repo("configs/chips/stm32f103.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
+    let mut cfg = HashMap::new();
+    for (k, v) in config {
+        cfg.insert(k.to_string(), v.clone());
     }
-    oled.stop();
-    oled
+    let manifest = SystemManifest {
+        cosim_models: Vec::new(),
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "panel-rig".to_string(),
+        chip: chip_path.to_string_lossy().to_string(),
+        external_devices: vec![ExternalDevice {
+            id: "panel".to_string(),
+            r#type: device_type.to_string(),
+            connection: connection.to_string(),
+            channel: None,
+            route: Default::default(),
+            config: cfg,
+        }],
+        board_io: vec![],
+        debug_uart: None,
+        wifi_ap: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    SystemBus::from_config(&chip, &manifest).expect("build bus")
 }
 
-/// An SH1107 driven over its own I²C protocol reports the ink it received.
-///
-/// The expected counts are computed from the bytes this test sent, not read
-/// back off the panel: four bytes with 1, 8, 4 and 2 bits set is 4 inked bytes
-/// and 15 lit pixels.
+/// Send bytes to the single I²C slave on `controller`, through the device's own
+/// `I2cDevice` surface — the same calls the controller's transaction engine
+/// makes on the wire.
+fn i2c_write(bus: &mut SystemBus, controller: &str, bytes: &[u8]) {
+    let idx = bus
+        .find_peripheral_index_by_name(controller)
+        .unwrap_or_else(|| panic!("{controller} registered"));
+    let any = bus.peripherals[idx].dev.as_any_mut().expect("downcastable");
+    let i2c = any
+        .downcast_mut::<labwired_core::peripherals::i2c::I2c>()
+        .expect("generic I2c controller");
+    let cell = i2c.attached_devices().first().expect("a slave is attached");
+    let mut dev = cell.borrow_mut();
+    dev.start();
+    for &b in bytes {
+        dev.write(b);
+    }
+    dev.stop();
+}
+
+/// Clock `(dc_level, byte)` frames into the single SPI device on `controller`,
+/// through its own `SpiDevice` surface. `false` = command, `true` = data, which
+/// is what the D/C line carries on real silicon.
+fn spi_write(bus: &mut SystemBus, controller: &str, frames: &[(bool, u8)]) {
+    use labwired_core::peripherals::spi::SpiDevice;
+    let idx = bus
+        .find_peripheral_index_by_name(controller)
+        .unwrap_or_else(|| panic!("{controller} registered"));
+    let any = bus.peripherals[idx].dev.as_any_mut().expect("downcastable");
+    let spi = any
+        .downcast_mut::<labwired_core::peripherals::spi::Spi>()
+        .expect("generic Spi controller");
+    let dev: &mut Box<dyn SpiDevice> = spi
+        .attached_devices
+        .first_mut()
+        .expect("a device is attached");
+    dev.cs_select();
+    for &(dc, b) in frames {
+        dev.set_dc_level(dc);
+        dev.transfer(b);
+    }
+    dev.cs_release();
+}
+
+/// Finish the rig and read the panel's device record out of `inspect`.
+fn inspect_panel(mut bus: SystemBus) -> DeviceInspect {
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    bus.refresh_peripheral_index();
+    let machine = Machine::new(cpu, bus);
+    machine
+        .inspect(None, &InspectOpts::default())
+        .devices
+        .into_iter()
+        .find(|d| d.id == "panel")
+        .expect("the declared panel is a device")
+}
+
+/// The panel's one evidence artifact, or a panic naming what came out instead.
+fn evidence(device: &DeviceInspect) -> &Artifact {
+    device.artifacts.first().unwrap_or_else(|| {
+        panic!(
+            "panel '{}' ({:?}) produced NO artifact; the display oracle has \
+             nothing to resolve against, so no lab using this panel can be \
+             verified however correct its firmware is",
+            device.id, device.device_type
+        )
+    })
+}
+
+// ─── OLEDs ──────────────────────────────────────────────────────────────────
+
+/// Control byte 0x00 opens a command stream, 0x40 a data stream — the SSD1306 /
+/// SH1107 convention.
+fn oled_paint(bus: &mut SystemBus, commands: &[u8], data: &[u8]) {
+    let mut cmd = vec![0x00u8];
+    cmd.extend_from_slice(commands);
+    i2c_write(bus, "i2c1", &cmd);
+    let mut px = vec![0x40u8];
+    px.extend_from_slice(data);
+    i2c_write(bus, "i2c1", &px);
+}
+
+/// SSD1306's payload is unchanged: same keys, same definitions, same counts.
+#[test]
+fn ssd1306_evidence_is_unchanged() {
+    const PATTERN: [u8; 3] = [0xFF, 0x01, 0x80];
+    let lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
+    let mut bus = rig("oled-ssd1306", "i2c1", &[("i2c_address", 0x3Cu64.into())]);
+    oled_paint(&mut bus, &[0xAF], &PATTERN);
+
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
+    assert_eq!(art.kind, "framebuffer");
+    assert_eq!(art.id, "panel", "artifact is addressed by the device's id");
+    assert_eq!(art.meta["format"], "ssd1306_page");
+    assert_eq!(art.meta["ink_bytes"], PATTERN.len());
+    assert_eq!(art.meta["lit_pixels"], lit);
+    assert!(art.meta.get("w").is_some() && art.meta.get("h").is_some());
+    assert!(art.bytes.is_none(), "summary mode omits the payload");
+}
+
+/// The IMAX Console's panel. Same 1-bpp page geometry as the SSD1306, and it
+/// must report the same way.
 #[test]
 fn sh1107_that_painted_reports_its_ink() {
     const PATTERN: [u8; 4] = [0x01, 0xFF, 0x0F, 0x81];
-    let expected_lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
+    let lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
+    // Display on, page 0, column 0, then the pixel stream.
+    let mut bus = rig("oled-sh1107", "i2c1", &[("i2c_address", 0x3Cu64.into())]);
+    oled_paint(&mut bus, &[0xAF, 0xB0, 0x00, 0x10], &PATTERN);
 
-    let oled = painted_sh1107(&PATTERN);
-    let art = framebuffer_artifact(&oled, "oled");
-
-    assert_eq!(art.id, "oled", "artifact is addressed by the device's id");
-    assert_eq!(art.meta["w"], 128);
-    assert_eq!(art.meta["h"], 128);
-    assert_eq!(
-        art.meta["ink_bytes"], PATTERN.len(),
-        "one inked byte per non-zero byte written"
-    );
-    assert_eq!(art.meta["lit_pixels"], expected_lit);
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
+    assert_eq!(art.meta["ink_bytes"], PATTERN.len());
+    assert_eq!(art.meta["lit_pixels"], lit);
     assert_eq!(art.meta["display_on"], true, "0xAF was sent");
-    assert!(art.bytes.is_none(), "summary mode omits the payload");
-
-    let full = device_artifacts(
-        &oled,
-        "oled",
-        &InspectOpts {
-            include_bytes: true,
-            peripheral: None,
-        },
-    );
-    assert_eq!(
-        full[0].bytes.as_ref().map(Vec::len),
-        Some(128 * 16),
-        "include_bytes attaches the real GDDRAM"
-    );
+    assert_eq!(art.meta["w"], 128);
 }
 
 /// A panel nobody drove reports zero, not an absent artifact. "Nothing was
 /// painted" is a finding and must be legible as one.
 #[test]
 fn unpainted_sh1107_reports_zero_rather_than_nothing() {
-    let art = framebuffer_artifact(&Sh1107::new(0x3C), "oled");
+    let bus = rig("oled-sh1107", "i2c1", &[("i2c_address", 0x3Cu64.into())]);
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
     assert_eq!(art.meta["ink_bytes"], 0);
     assert_eq!(art.meta["lit_pixels"], 0);
     assert_eq!(art.meta["display_on"], false);
 }
 
-// ─── SSD1680 tricolor e-paper (SPI) ─────────────────────────────────────────
+// ─── tri-color e-paper ──────────────────────────────────────────────────────
 
-/// Stream `black`/`red` into the panel's RAM at a 1-byte-wide window and then
-/// run GxEPD2's power + master-activation handshake, over the datasheet
-/// command/data path.
-fn painted_epaper_bytes(panel: &mut Ssd1680Tricolor290, black: &[u8], red: &[u8]) {
-    panel.command_byte(0x12); // SWRESET
-    panel.command_byte(0x11); // data entry mode
-    panel.data_byte(0x03);
-    panel.command_byte(0x44); // RAM-X window (start/8, end/8)
-    panel.data_byte(0x00);
-    panel.data_byte(0x00);
-    panel.command_byte(0x45); // RAM-Y window
-    panel.data_byte(0x00);
-    panel.data_byte(0x00);
-    panel.data_byte((black.len() - 1) as u8);
-    panel.data_byte(0x00);
-    panel.command_byte(0x4E); // RAM-X counter
-    panel.data_byte(0x00);
-    panel.command_byte(0x4F); // RAM-Y counter
-    panel.data_byte(0x00);
-    panel.data_byte(0x00);
-    panel.command_byte(0x24); // black plane stream
+/// GxEPD2's SSD1680 sequence: window + counters, the black stream (0x24), the
+/// red stream (0x26), then the power/master-activation handshake that puts the
+/// image on the glass.
+fn ssd1680_paint(black: &[u8], red: &[u8]) -> Vec<(bool, u8)> {
+    let mut f: Vec<(bool, u8)> = Vec::new();
+    let cmd = |f: &mut Vec<(bool, u8)>, b: u8| f.push((false, b));
+    let data = |f: &mut Vec<(bool, u8)>, b: u8| f.push((true, b));
+    cmd(&mut f, 0x12); // SWRESET
+    cmd(&mut f, 0x11); // data entry mode
+    data(&mut f, 0x03);
+    cmd(&mut f, 0x44); // RAM-X window (start/8, end/8)
+    data(&mut f, 0x00);
+    data(&mut f, 0x00);
+    cmd(&mut f, 0x45); // RAM-Y window
+    data(&mut f, 0x00);
+    data(&mut f, 0x00);
+    data(&mut f, (black.len() - 1) as u8);
+    data(&mut f, 0x00);
+    cmd(&mut f, 0x4E);
+    data(&mut f, 0x00);
+    cmd(&mut f, 0x4F);
+    data(&mut f, 0x00);
+    data(&mut f, 0x00);
+    cmd(&mut f, 0x24); // black plane
     for &b in black {
-        panel.data_byte(b);
+        data(&mut f, b);
     }
-    panel.command_byte(0x4E);
-    panel.data_byte(0x00);
-    panel.command_byte(0x4F);
-    panel.data_byte(0x00);
-    panel.data_byte(0x00);
-    panel.command_byte(0x26); // red plane stream
+    cmd(&mut f, 0x4E);
+    data(&mut f, 0x00);
+    cmd(&mut f, 0x4F);
+    data(&mut f, 0x00);
+    data(&mut f, 0x00);
+    cmd(&mut f, 0x26); // red plane
     for &b in red {
-        panel.data_byte(b);
+        data(&mut f, b);
     }
-    panel.command_byte(0x22); // display update control
-    panel.data_byte(0xF7);
-    panel.command_byte(0x20); // master activation → refresh
+    cmd(&mut f, 0x22); // GxEPD2 _PowerOn selector
+    data(&mut f, 0xF8);
+    cmd(&mut f, 0x20); // master activation → power on
+    cmd(&mut f, 0x22); // full-update sequence selector
+    data(&mut f, 0xF7);
+    cmd(&mut f, 0x20); // master activation → refresh
+    f
 }
 
 /// A tri-color e-paper that was streamed and refreshed reports BOTH planes and
 /// the refresh that made them visible.
 ///
-/// The counts are arithmetic on this test's own input: an e-paper plane is
-/// erased to 0xFF (1 = white / no-red), so an inked cell is any byte that is
-/// not 0xFF. Two of the three black bytes and one of the three red bytes differ
-/// from the erased value.
+/// An e-paper plane is erased to 0xFF (a set bit is "no ink"), so an inked cell
+/// is any byte that is not 0xFF — the same count the CLI's
+/// `black-plane non-FF bytes=` line prints. Two of the three black bytes and one
+/// of the three red bytes differ from the erased value.
 #[test]
 fn ssd1680_that_refreshed_reports_both_planes_and_the_refresh() {
     const BLACK: [u8; 3] = [0x00, 0xFF, 0xAA];
@@ -173,17 +263,24 @@ fn ssd1680_that_refreshed_reports_both_planes_and_the_refresh() {
     let black_ink = BLACK.iter().filter(|&&b| b != 0xFF).count();
     let red_ink = RED.iter().filter(|&&b| b != 0xFF).count();
 
-    let mut panel = Ssd1680Tricolor290::new("PA4");
-    painted_epaper_bytes(&mut panel, &BLACK, &RED);
-    let art = framebuffer_artifact(&panel, "epaper");
+    let mut bus = rig(
+        "ssd1680_tricolor_290",
+        "spi1",
+        &[("cs_pin", "PA4".into()), ("dc_pin", "PC7".into())],
+    );
+    spi_write(&mut bus, "spi1", &ssd1680_paint(&BLACK, &RED));
 
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
     assert_eq!(art.meta["w"], 128);
     assert_eq!(art.meta["h"], 296);
     assert_eq!(art.meta["black_ink_bytes"], black_ink);
     assert_eq!(art.meta["red_ink_bytes"], red_ink);
     assert_eq!(
-        art.meta["refresh_generation"], 1,
-        "one master activation is one refresh"
+        art.meta["refresh_generation"], 2,
+        "one master activation is one refresh — the only thing that \
+         distinguishes 'RAM was written' from 'the image is on the glass'; \
+         GxEPD2 sends two (power-on, then the update sequence)"
     );
     assert_eq!(art.meta["power_on"], true);
 }
@@ -192,71 +289,21 @@ fn ssd1680_that_refreshed_reports_both_planes_and_the_refresh() {
 /// and not a plausible-looking number.
 #[test]
 fn unrefreshed_ssd1680_reports_zero_rather_than_nothing() {
-    let art = framebuffer_artifact(&Ssd1680Tricolor290::new("PA4"), "epaper");
+    let bus = rig(
+        "ssd1680_tricolor_290",
+        "spi1",
+        &[("cs_pin", "PA4".into()), ("dc_pin", "PC7".into())],
+    );
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
     assert_eq!(art.meta["black_ink_bytes"], 0);
     assert_eq!(art.meta["red_ink_bytes"], 0);
     assert_eq!(art.meta["refresh_generation"], 0);
     assert_eq!(art.meta["power_on"], false);
 }
 
-/// The whole path, end to end: the shipped `epaper-tricolor-lab` manifest, the
-/// panel reached through the SPI controller it is attached to, and the evidence
-/// arriving in `Machine::inspect`'s device record — not merely out of the
-/// artifact helper called directly.
-#[test]
-fn epaper_lab_reports_panel_evidence_through_machine_inspect() {
-    const BLACK: [u8; 2] = [0x00, 0x0F];
-    let yaml = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../examples/epaper-tricolor-lab/system.yaml");
-    let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
-    let chip_path = yaml.parent().unwrap().join(&manifest.chip);
-    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip");
-    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
-
-    {
-        let idx = bus
-            .find_peripheral_index_by_name("spi1")
-            .expect("spi1 registered");
-        let any = bus.peripherals[idx].dev.as_any_mut().expect("downcastable");
-        let spi = any
-            .downcast_mut::<labwired_core::peripherals::spi::Spi>()
-            .expect("spi1 is a generic Spi");
-        let panel = spi
-            .attached_devices
-            .iter_mut()
-            .find_map(|d| {
-                d.as_any_mut()
-                    .and_then(|a| a.downcast_mut::<Ssd1680Tricolor290>())
-            })
-            .expect("SSD1680 attached to spi1");
-        painted_epaper_bytes(panel, &BLACK, &[0xFF, 0xFF]);
-    }
-
-    let (cpu, _nvic) = configure_cortex_m(&mut bus);
-    bus.refresh_peripheral_index();
-    let machine = Machine::new(cpu, bus);
-    let inspect = machine.inspect(None, &InspectOpts::default());
-    let device = inspect
-        .devices
-        .iter()
-        .find(|d| d.id == "epaper")
-        .expect("the declared panel is a device");
-    let art = device
-        .artifacts
-        .iter()
-        .find(|a| a.kind == "framebuffer")
-        .unwrap_or_else(|| {
-            panic!("panel reports no framebuffer artifact through inspect; the display oracle has nothing to resolve against")
-        });
-    assert_eq!(art.id, "epaper");
-    assert_eq!(art.meta["black_ink_bytes"], 2);
-    assert_eq!(art.meta["refresh_generation"], 1);
-}
-
-// ─── UC8151D tricolor e-paper (SPI) ─────────────────────────────────────────
-
-/// The UC8151D's own datasheet sequence: 0x10 opens the black (B/W) stream,
-/// 0x13 the red stream, 0x12 triggers the refresh.
+/// The UC8151D's own datasheet sequence: 0x04 powers on, 0x10 opens the black
+/// (B/W) stream, 0x13 the red stream, 0x12 triggers the refresh.
 #[test]
 fn uc8151d_that_refreshed_reports_both_planes_and_the_refresh() {
     const BLACK: [u8; 4] = [0x00, 0xFF, 0xF0, 0xFF];
@@ -264,78 +311,177 @@ fn uc8151d_that_refreshed_reports_both_planes_and_the_refresh() {
     let black_ink = BLACK.iter().filter(|&&b| b != 0xFF).count();
     let red_ink = RED.iter().filter(|&&b| b != 0xFF).count();
 
-    let mut panel = Uc8151dTricolor290::new("PA4");
-    panel.command_byte(0x04); // power on
-    panel.command_byte(0x10); // black plane stream
-    for &b in &BLACK {
-        panel.data_byte(b);
-    }
-    panel.command_byte(0x13); // red plane stream
-    for &b in &RED {
-        panel.data_byte(b);
-    }
-    panel.command_byte(0x12); // display refresh
+    let mut frames = vec![(false, 0x04u8), (false, 0x10)];
+    frames.extend(BLACK.iter().map(|&b| (true, b)));
+    frames.push((false, 0x13));
+    frames.extend(RED.iter().map(|&b| (true, b)));
+    frames.push((false, 0x12));
 
-    let art = framebuffer_artifact(&panel, "epaper");
+    let mut bus = rig(
+        "uc8151d_tricolor_290",
+        "spi1",
+        &[("cs_pin", "PA4".into()), ("dc_pin", "PC7".into())],
+    );
+    spi_write(&mut bus, "spi1", &frames);
+
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
     assert_eq!(art.meta["black_ink_bytes"], black_ink);
     assert_eq!(art.meta["red_ink_bytes"], red_ink);
     assert_eq!(art.meta["refresh_generation"], 1);
     assert_eq!(art.meta["power_on"], true);
 }
 
-// ─── the two that already worked, pinned ────────────────────────────────────
-
-/// SSD1306's payload is unchanged: same keys, same definitions.
-#[test]
-fn ssd1306_artifact_payload_is_unchanged() {
-    const PATTERN: [u8; 3] = [0xFF, 0x01, 0x80];
-    let expected_lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
-    let mut oled = Ssd1306::new(0x3C);
-    oled.start();
-    oled.write(0x00);
-    oled.write(0xAF);
-    oled.stop();
-    oled.start();
-    oled.write(0x40);
-    for &b in &PATTERN {
-        oled.write(b);
-    }
-    oled.stop();
-
-    let art = framebuffer_artifact(&oled, "oled");
-    assert_eq!(art.meta["format"], "ssd1306_page");
-    assert_eq!(art.meta["ink_bytes"], PATTERN.len());
-    assert_eq!(art.meta["lit_pixels"], expected_lit);
-    assert!(
-        art.meta.get("w").is_some() && art.meta.get("h").is_some(),
-        "dimensions stay in the payload"
-    );
-}
+// ─── the rest of what the browser renders ───────────────────────────────────
 
 /// ILI9341's payload is unchanged, including the `painted_bytes` definition —
 /// deliberately the same count the CLI's `painted bytes=` line prints, so the
 /// two agree by construction rather than by coincidence.
 #[test]
-fn ili9341_artifact_payload_is_unchanged() {
+fn ili9341_evidence_is_unchanged() {
     const PIXELS: usize = 100;
     const HI: u8 = 0x07;
     const LO: u8 = 0xE0; // RGB565 green: both bytes non-zero.
-    let mut panel = Ili9341::new("PA4");
-    panel.set_dc_level(false);
-    panel.transfer(0x29); // DISPON
-    panel.set_dc_level(false);
-    panel.transfer(0x2C); // RAMWR
+    let mut frames = vec![(false, 0x29u8), (false, 0x2C)];
     for _ in 0..PIXELS {
-        panel.set_dc_level(true);
-        panel.transfer(HI);
-        panel.set_dc_level(true);
-        panel.transfer(LO);
+        frames.push((true, HI));
+        frames.push((true, LO));
     }
+    let mut bus = rig(
+        "ili9341",
+        "spi1",
+        &[("cs_pin", "PA4".into()), ("dc_pin", "PC7".into())],
+    );
+    spi_write(&mut bus, "spi1", &frames);
 
-    let art = framebuffer_artifact(&panel, "tft");
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
     assert_eq!(art.meta["format"], "rgb565_be");
     assert_eq!(art.meta["display_on"], true);
     assert_eq!(art.meta["painted_bytes"], PIXELS * 2);
     assert_eq!(art.meta["top_colour"], "0x07E0");
     assert_eq!(art.meta["top_colour_pixels"], PIXELS);
+}
+
+/// The Nokia 5110's controller: bank-addressed 1-bpp, D/C framed.
+#[test]
+fn pcd8544_that_painted_reports_its_ink() {
+    const PATTERN: [u8; 5] = [0xFF, 0x01, 0x00, 0x3C, 0x81];
+    let ink = PATTERN.iter().filter(|&&b| b != 0).count();
+    let lit: usize = PATTERN.iter().map(|b| b.count_ones() as usize).sum();
+
+    // Function set (basic), display normal, then the pixel stream.
+    let mut frames = vec![(false, 0x20u8), (false, 0x0C)];
+    frames.extend(PATTERN.iter().map(|&b| (true, b)));
+    let mut bus = rig(
+        "pcd8544",
+        "spi1",
+        &[("cs_pin", "PA4".into()), ("dc_pin", "PC7".into())],
+    );
+    spi_write(&mut bus, "spi1", &frames);
+
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
+    assert_eq!(art.meta["ink_bytes"], ink);
+    assert_eq!(art.meta["lit_pixels"], lit);
+}
+
+/// An 8×8 LED matrix module: one register write per row, one bit per LED.
+#[test]
+fn max7219_that_was_written_reports_its_lit_leds() {
+    // Registers 0x01..0x08 are the eight digit/row registers.
+    const ROWS: [u8; 3] = [0xFF, 0x81, 0x18];
+    let lit: usize = ROWS.iter().map(|b| b.count_ones() as usize).sum();
+    let mut frames: Vec<(bool, u8)> = vec![(false, 0x0C), (false, 0x01)]; // shutdown reg = normal
+    for (i, &row) in ROWS.iter().enumerate() {
+        frames.push((false, (i + 1) as u8));
+        frames.push((false, row));
+    }
+    let mut bus = rig("led-matrix", "spi1", &[("cs_pin", "PA4".into())]);
+    spi_write(&mut bus, "spi1", &frames);
+
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
+    assert_eq!(art.meta["lit_pixels"], lit);
+    assert_eq!(art.meta["shutdown"], false);
+}
+
+/// A character LCD holds text, not pixels — so its evidence is the decoded
+/// DDRAM text, and its `kind` says so rather than pretending to be a
+/// framebuffer.
+#[test]
+fn lcd1602_that_was_written_reports_its_text() {
+    let bus = rig("lcd1602", "i2c1", &[("i2c_address", 0x27u64.into())]);
+    let device = inspect_panel(bus);
+    let art = evidence(&device);
+    assert_eq!(art.kind, "text_display");
+    assert!(
+        art.meta.get("text").is_some(),
+        "the decoded DDRAM text is the evidence"
+    );
+}
+
+// ─── the ratchet ────────────────────────────────────────────────────────────
+
+/// A panel the browser can render but `inspect` cannot report is the defect
+/// this file exists for, so it is a build failure rather than a comment.
+///
+/// The list is derived from the OTHER system — the wasm renderer's own
+/// `get_<panel>_framebuffer` accessors in `crates/wasm/src/inspect.rs`. That is
+/// deliberate: a hand-written list here would be a third source of truth about
+/// what a display is, and the kit registry cannot supply one (its `Category`
+/// distinguishes transports, not displays). Deriving from the renderer encodes
+/// exactly the invariant that broke — the two systems must agree.
+///
+/// Adding a `get_foo_framebuffer` accessor without giving `foo`'s model an
+/// `artifacts` impl fails here.
+#[test]
+fn every_panel_the_browser_renders_reports_evidence_to_inspect() {
+    let wasm = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../wasm/src/inspect.rs"),
+    )
+    .expect("read the wasm renderer");
+
+    // `get_<panel>_framebuffer` / `get_<panel>_text` → the panel's model module.
+    let mut panels: Vec<String> = Vec::new();
+    for line in wasm.lines() {
+        let line = line.trim();
+        for suffix in ["_framebuffer(", "_text("] {
+            if let Some(rest) = line.strip_prefix("pub fn get_") {
+                if let Some(name) = rest.split(suffix).next() {
+                    if rest.contains(suffix) && !panels.iter().any(|p| p == name) {
+                        panels.push(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        panels.len() >= 8,
+        "renderer scan found only {panels:?} — the scan is broken, so this test \
+         would have passed by measuring nothing"
+    );
+
+    // The renderer's accessor name is the model's module name, except where it
+    // names the part rather than the controller chip.
+    let module_of = |panel: &str| match panel {
+        "led_matrix" => "max7219".to_string(),
+        "tm1637" => "tm1637_7seg".to_string(),
+        "ssd1680" => "ssd1680_tricolor_290".to_string(),
+        "uc8151d" => "uc8151d_tricolor_290".to_string(),
+        other => other.to_string(),
+    };
+
+    let components = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/peripherals/components");
+    for panel in &panels {
+        let path = components.join(format!("{}.rs", module_of(panel)));
+        let src = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("the browser renders '{panel}' but {path:?}: {e}"));
+        assert!(
+            src.contains("fn artifacts("),
+            "the browser renders '{panel}' but its model reports no artifacts to \
+             inspect — every oracle clause about that panel is unresolvable. \
+             Add an `artifacts` impl next to its buffers in {path:?}."
+        );
+    }
 }

--- a/crates/core/tests/panel_artifact_evidence.rs
+++ b/crates/core/tests/panel_artifact_evidence.rs
@@ -66,6 +66,7 @@ fn rig(device_type: &str, connection: &str, config: &[(&str, serde_yaml::Value)]
         debug_uart: None,
         wifi_ap: None,
         peripherals: vec![],
+        parts: Default::default(),
         memory_overrides: Default::default(),
     };
     SystemBus::from_config(&chip, &manifest).expect("build bus")


### PR DESCRIPTION
## One seam for binding, one seam for evidence

Two defects with the same shape: a device could be perfectly simulated and still be
invisible, because the code that reported it was a hand-maintained list somewhere else.

### 1. Binding was not universal

A placed part became attached in one of two structurally different ways, and only one
was visible to `inspect`:

* **Owned by a controller** — an I²C slave or SPI panel lives inside the controller it
  answers to, reachable only via `Peripheral::for_each_attached_device`.
* **Resident on the bus** — an HC-SR04 on TRIG/ECHO, a TM1637 clocked by the GPIO
  write-hook, a servo on a PWM pad, a WS2812 strip, a thermistor driving an ADC channel,
  a CAN tester node. None answers to an address, so each lived in its own typed
  collection on `SystemBus` — **fourteen** of them, bound through seven ad-hoc paths —
  and none of it reached `inspect`.

Now one walk (`SystemBus::for_each_attached_device`), one borrowed record
(`AttachedDeviceRef`), one join (`SystemBus::inspect_devices`, moved off `Machine`
because the bus is the one thing holding BOTH the live models and the manifest
declarations). **A transport is a field of the record, not a branch in the pipeline.**

Controller-hosted devices are walked first and bus-resident ones after, so the addressed
join — which does real disambiguation — is never disturbed by a name-matched device, and
the existing `devices` array stays a stable prefix of what it was.

Two shape changes, both to avoid reporting a value the model does not have:

* `DeviceAttachment.bus` is now `Option<String>` (`skip_serializing_if`). Every device
  that came from a manifest has an owner, so the key is present on every real rig; a
  programmatic attachment with nothing to name its connection reports unknown rather
  than a plausible guess. JSON for the existing I²C/SPI path is byte-identical.
* `channel` widens from "bus-switch channel" to "which channel of `bus`", covering an
  ADC channel too.

### 2. There were TWO display-evidence systems, and neither knew about the other

`inspect::device_artifacts` was a central `match` on concrete types with exactly two
arms — `Ssd1306` and `Ili9341` — in a file far from any model. Meanwhile
`crates/wasm/src/inspect.rs` carries a hand-written per-panel × per-controller downcast
matrix of `get_*_framebuffer` accessors that renders **ten** panels.

So the SH1107 painted a full console in the browser while `inspect` reported no artifact
at all. Both were telling the truth about their own path.

That was not cosmetic. `labwired_verify`'s display oracle resolves `painted` /
`min_ink_bytes` / `min_refresh_generation` against these artifacts, so a lab built on one
of those panels **could never pass a display clause however correct its firmware** — and
the tool documents `panel: "ssd1680_tricolor_290"` as an example value the engine could
not emit.

Adding three more arms would have fixed today's three panels and rebuilt the trap for the
fourth. Instead a model reports its own evidence by overriding `artifacts` on the device
trait it already implements, next to the buffers it reads. `device_artifacts` is gone;
`AttachedDeviceRef` carries `Option<&dyn DeviceEvidence>` instead of `Option<&dyn Any>`,
and the join calls it once it has resolved the id an artifact is addressed by.

Because binding is now universal, a display wired to **pins** can report too: the TM1637,
the direct-driven 7-segment digit and the WS2812 strip implement the evidence seam
directly and ride the same walk. None of them could have, before — **this is why the two
fixes belong in one change.**

**Eleven models** report: SSD1306, SH1107, ILI9341, PCD8544, SSD1680 tri-colour, UC8151D
tri-colour, MAX7219, LCD1602, TM1637, seven-segment, WS2812.

The e-paper representation is deliberate: ink is a byte that is **not** `0xFF` (the
panel's own no-ink convention, and the same count the CLI's `black-plane non-FF bytes=`
line prints), the two planes are reported separately with a `plane_bytes` split rather
than a synthesized composite, and `refresh_generation` is surfaced — which is what
finally makes `min_refresh_generation` reachable. The LCD1602, TM1637 and 7-segment
report `kind: "text_display"`, not a fake framebuffer.

The bus-trace decorators forward `artifacts`. A decorator that let it fall through to the
trait default would silently erase the wrapped panel's evidence — it did, on the first
run, and the existing ILI9341 test caught it.

**No fidelity is added.** Every number is read off the model's own buffer; a panel whose
driver never painted reports zero, and a device with no evidence returns an empty list.
**SSD1306 and ILI9341 payloads moved verbatim** — same keys, same definitions, same
counts.

---

## Verification

### Every test was derived from outside the implementation and watched to fail first

`crates/core/tests/inspect_device_binding_universal.rs` reads the shipped
`examples/*/system.yaml` files with a YAML parser and asserts every placed device appears
in `inspect`. On the unchanged tree:

```
test bay_occupancy_i2c_and_spi_still_inspectable ... ok
test analog_thermistor_is_inspectable ... FAILED
test tm1637_bit_banged_display_is_inspectable ... FAILED
test can_log_player_node_is_inspectable ... FAILED
test hc_sr04_on_gpio_pins_is_inspectable ... FAILED
test can_uds_tester_node_is_inspectable ... FAILED

examples/ntc-thermistor-lab/system.yaml: device 'thermistor' (ntc-thermistor) is placed
on 'adc1' but does not appear in inspect's devices array; inspect reported []

examples/nokia5110-invaders-lab/system.yaml: device 'dist' (hc-sr04) is placed on
'gpioa' but does not appear in inspect's devices array; inspect reported ["lcd"]

examples/h563-uds-ecu/system.yaml: device 'uds-tester' (uds-tester) is placed on
'fdcan1' but does not appear in inspect's devices array; inspect reported []

test result: FAILED. 1 passed; 5 failed; 1 ignored
```

`crates/core/tests/panel_artifact_evidence.rs` drives each panel over its **own wire
protocol** and checks reported counts against arithmetic on the test's own input. On the
unchanged tree:

```
test ssd1306_evidence_is_unchanged ... ok
test ili9341_evidence_is_unchanged ... ok
test sh1107_that_painted_reports_its_ink ... FAILED
test ssd1680_that_refreshed_reports_both_planes_and_the_refresh ... FAILED
test uc8151d_that_refreshed_reports_both_planes_and_the_refresh ... FAILED
test pcd8544_that_painted_reports_its_ink ... FAILED
test max7219_that_was_written_reports_its_lit_leds ... FAILED
test lcd1602_that_was_written_reports_its_text ... FAILED
test every_panel_the_browser_renders_reports_evidence_to_inspect ... FAILED

panel 'panel' (Some("ssd1680_tricolor_290")) produced NO artifact; the display oracle
has nothing to resolve against, so no lab using this panel can be verified however
correct its firmware is

the browser renders 'ssd1306' but its model reports no artifacts to inspect — every
oracle clause about that panel is unresolvable.

test result: FAILED. 2 passed; 9 failed
```

The two that passed are exactly the two panels that already had an arm.

### The existing device list is byte-identical

`inspect`'s `devices` array for the bay-occupancy rig — the customer delivery, the one
with the TCA9548A, four VCNL4010s and the ILI9341 with its framebuffer artifact — was
captured before and after and diffed:

```
bay-occupancy devices: BYTE-IDENTICAL
```

Everything else in the diff is pure addition, e.g. the Nokia-5110 rig which reported one
device and now reports two:

```
   { "id": "lcd", "device_type": "pcd8544", ... ,
+    "artifacts": [ { "kind": "framebuffer", "meta": { "format": "pcd8544_bank", ... } } ]
+  },
+  { "id": "dist", "device_type": "hc-sr04", "declared": true,
+    "attachment": { "transport": "gpio", "bus": "gpioa" }, "artifacts": [] }
```

### Full suite vs a pristine `origin/main` baseline

Both `cargo test --workspace --no-fail-fast`, same machine.

| | pristine baseline | this branch |
|---|---|---|
| failing targets | 8 | 5 |

Failing on this branch — **all five also fail on pristine `origin/main`**:
`esp32_ili9341_attach`, `register_coverage`, `world_can_bus`,
`world_esp32c3_pingpong`, `labwired-dap --test e2e`.

The three that no longer fail (`demo_blinky`, `strict_onboarding`,
`e2e_stimulus_reporting`) were failing on missing pre-built firmware artifacts, which got
built during the session. **No new failure.**

`cargo clippy -D warnings` is clean for `labwired-core`, `labwired-cli` and
`labwired-dap`. Two pre-existing lint failures on this toolchain in files this branch
does not touch (`crates/firmware-nrf52840-proximity/src/main.rs` manual-checked-ops,
`crates/wasm/src/lib.rs` manual-div-ceil) are unchanged.

### Ryan's bay-occupancy rig: 12/12 PASS

```
PASS  1,2,3   init, per-read channel select, independent injection
PASS  4       raw counts -> EMPTY/PRESENT via thresholds
PASS  5       separate entry/exit thresholds (hysteresis)
PASS  6       debounce: single noisy spike rejected
PASS  7       simultaneous occupancy across all four bays
PASS  8       one channel cannot change another's state
PASS  9       missing sensor / I2C failure detected
PASS  10      per-bay state painted on the TFT  (panel ink=6610)
PASS  11      clear FAULT state for an unreadable sensor  (panel ink=6610)
PASS  12      polling and display do not block each other  (panel ink=6352)
```

### Ratchets, so neither defect can come back quietly

* `attached_device_walk_covers_every_bus_collection` parses the `SystemBus` declaration
  and fails if a collection of device models is not walked. A fifteenth collection added
  and forgotten is a build failure.
* `every_panel_the_browser_renders_reports_evidence_to_inspect` derives its list from the
  wasm renderer's own `get_*_framebuffer` accessors — the *other* system — so the two
  cannot drift apart again. It is what surfaced the TM1637 and 7-segment gaps.
* `record_external_devices_has_one_home` (pre-existing) still holds.

---

## What is deliberately NOT in this PR

The wasm `get_*_framebuffer` accessors still re-derive raw framebuffers through their own
per-panel × per-controller downcast matrix. This PR does not extend that matrix and does
not touch it. Converting those accessors onto `for_each_attached_device` +
`DeviceEvidence` is a follow-up, because it needs browser verification that every panel
which renders today still renders — a claim a Rust test suite cannot support, and a
regression there would be worse than the bug being fixed here.

After this PR there is exactly ONE place that decides **what a panel reports as
evidence** (the model itself); the renderer's remaining job is fetching raw pixels.

`Category` in the kit registry distinguishes transports, not displays, so the panel
ratchet derives its list from the wasm renderer rather than from the registry. Giving the
registry a display category is the cleaner long-term source and is worth doing when the
wasm conversion lands.
