### PR TITLE
feat(inspect): ONE door for every display, whatever bound it

### DIFF
--- a/crates/core/src/bus/attached_devices.rs
+++ b/crates/core/src/bus/attached_devices.rs
@@ -223,6 +223,67 @@ impl SystemBus {
         filter: Option<&str>,
         opts: &crate::inspect::InspectOpts,
     ) -> Vec<crate::inspect::DeviceInspect> {
+        self.join_devices(filter, None, opts)
+    }
+
+    /// What the device the author called `id` is currently showing — THE door
+    /// for reading a display, whatever bound it.
+    ///
+    /// One call, one argument: the name in the manifest. Not the model, not the
+    /// transport, not the controller, and above all not a `board_io` binding.
+    ///
+    /// Each of those used to be a clause a panel could fail. The accessors this
+    /// replaces began by looking the display up in `board_io`, so a display
+    /// declared only under `external_devices:` — which is a perfectly ordinary
+    /// way to place one, and what several shipped rigs do — had no placement for
+    /// the renderer to query and painted nothing. Not for one model: for every
+    /// model, on every chip. Then, having found a binding, each accessor
+    /// re-enumerated by downcast the controllers it believed that panel could
+    /// hang off, so a chip whose SPI block was missing from one list rendered
+    /// blank there and only there.
+    ///
+    /// This asks the same walk `inspect` asks and joins on the same manifest
+    /// name, so it reaches a bus-resident TM1637 on GPIO pads and an I²C slave
+    /// behind a bus switch by the same code path that reaches an SPI panel. A
+    /// display the walk cannot reach is invisible to `inspect` too — which is a
+    /// bug with one home and one fix, instead of a surface that silently
+    /// disagrees with its sibling.
+    ///
+    /// The answer carries geometry and packing as DATA (`meta.w`, `meta.h`,
+    /// `meta.format`), because a caller must be able to render a panel it has
+    /// never heard of. A per-accessor doc contract — "153,600 bytes, 240×320,
+    /// big-endian RGB565" — is lore that lives in the reader; a new model
+    /// cannot supply it, so every new model needed a new accessor and a new
+    /// renderer branch.
+    ///
+    /// Evidence is extracted for the matched device ONLY: the join computes an
+    /// id before it asks anything to describe itself, so polling one panel does
+    /// not build every other panel's framebuffer.
+    pub fn display_artifact(
+        &self,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Option<crate::inspect::Artifact> {
+        self.join_devices(None, Some(id), opts)
+            .into_iter()
+            .next()?
+            .artifacts
+            .into_iter()
+            .find(|a| crate::inspect::is_display_artifact(a))
+    }
+
+    /// The join behind [`Self::inspect_devices`] and [`Self::display_artifact`].
+    ///
+    /// `only_id` restricts the result to the single device that resolves to that
+    /// id. It is applied AFTER the id is resolved and BEFORE evidence is asked
+    /// for, which is what keeps a single-panel poll cheap without giving the
+    /// one-device path its own, subtly different, copy of the join.
+    fn join_devices(
+        &self,
+        filter: Option<&str>,
+        only_id: Option<&str>,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::DeviceInspect> {
         let decls = &self.external_device_decls;
         // A declaration's controller is its own `connection` unless that names
         // another declaration (a bus switch), in which case it inherits the
@@ -275,6 +336,9 @@ impl SystemBus {
                     }
                 }
             };
+            if only_id.is_some_and(|want| want != id) {
+                return;
+            }
             // The device decides what it can show; this only supplies the id
             // it is addressed by, which is not known until the join above.
             let artifacts = d
@@ -371,6 +435,38 @@ impl SystemBus {
                     .and_then(serde_json::Value::as_str)
                     .is_some_and(|f| formats.contains(&f))
             });
+        });
+        found
+    }
+
+    /// [`Self::device_artifact_at`] without a format filter: whatever DISPLAY
+    /// sits at this placement, whichever model it turns out to be.
+    ///
+    /// The second key of the one door — used only when the manifest join could
+    /// not name the device (a model attached programmatically), where the
+    /// caller's binding still knows the wire.
+    pub fn device_artifact_at_any(
+        &self,
+        bus: &str,
+        address: Option<u8>,
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Option<crate::inspect::Artifact> {
+        let mut found: Option<crate::inspect::Artifact> = None;
+        self.for_each_attached_device(&mut |on, d| {
+            if found.is_some() || on != Some(bus) {
+                return;
+            }
+            if address.is_some() && d.address != address {
+                return;
+            }
+            let Some(evidence) = d.evidence else {
+                return;
+            };
+            found = evidence
+                .artifacts(id, opts)
+                .into_iter()
+                .find(crate::inspect::is_display_artifact);
         });
         found
     }

--- a/crates/core/src/bus/attached_devices.rs
+++ b/crates/core/src/bus/attached_devices.rs
@@ -269,7 +269,7 @@ impl SystemBus {
             .next()?
             .artifacts
             .into_iter()
-            .find(|a| crate::inspect::is_display_artifact(a))
+            .find(crate::inspect::is_display_artifact)
     }
 
     /// The join behind [`Self::inspect_devices`] and [`Self::display_artifact`].

--- a/crates/core/src/bus/attached_devices.rs
+++ b/crates/core/src/bus/attached_devices.rs
@@ -299,6 +299,82 @@ impl SystemBus {
         out
     }
 
+    /// What the device at a given PLACEMENT is currently showing.
+    ///
+    /// [`Self::inspect_devices`] answers "what is attached to this machine, and
+    /// what is each one called". This answers the different question a renderer
+    /// asks sixty times a second: "the panel the author placed on THIS
+    /// controller, at THIS address — what is on its screen right now?"
+    ///
+    /// Both are joins over the same [`Self::for_each_attached_device`] walk and
+    /// both read pixels through [`DeviceEvidence::artifacts`], which is the
+    /// entire point of this existing. `crates/wasm` used to carry a SECOND
+    /// display-evidence system: one bespoke accessor per panel, each
+    /// re-enumerating by downcast every controller that panel might hang off.
+    /// A controller missing from one of those hand-written lists did not fail
+    /// loudly — it rendered a working, actively-painted panel blank. The lists
+    /// did not even agree with each other: the ILI9341 could be read off an
+    /// ESP32-C3 but not off a classic ESP32, for no reason but which arm
+    /// somebody had remembered to write. Controller coverage is now a property
+    /// of the walk, so a controller it reaches is readable from `inspect` and
+    /// from the renderer at the same instant, and one it does not reach is
+    /// invisible to both rather than to one.
+    ///
+    /// Matching is on PLACEMENT and on what the device says it is — never on a
+    /// Rust type and never on a declared type string:
+    ///
+    /// * `bus` — the controller peripheral name, as the caller's binding states
+    ///   it, compared against the name the walk reports for the device.
+    /// * `address` — the I²C address the device answers to. `None` does not
+    ///   constrain, which is what an SPI caller wants: the accessors this
+    ///   replaces never compared chip-selects either.
+    /// * `formats` — accepted `meta.format` values. A model names its own
+    ///   format next to the buffer that format describes, so this asks the
+    ///   DEVICE what it is instead of the caller downcasting to a concrete
+    ///   struct. Panels that genuinely share a wire format share an entry: the
+    ///   SSD1680 and the UC8151D both emit `epaper_tricolor_1bpp_planes`, and
+    ///   treating them as interchangeable is what the UC8151D accessor already
+    ///   did by hand — precisely because the DECLARED type is not reliable
+    ///   (system YAMLs written before the split still say `ssd1680_*` for a
+    ///   panel the ESP32 builder attaches as a `Uc8151dTricolor290`).
+    ///
+    /// `id` is stamped onto the returned artifact exactly as the manifest join
+    /// stamps a declaration id in [`Self::inspect_devices`]; the caller passes
+    /// the id it addressed the device by.
+    ///
+    /// The first matching device wins, in walk order. Evidence is asked for
+    /// only AFTER `bus` and `address` have failed to exclude a device, so a
+    /// panel's (sometimes expensive) artifact is never built to answer a query
+    /// about a different device on a different controller.
+    pub fn device_artifact_at(
+        &self,
+        bus: &str,
+        address: Option<u8>,
+        formats: &[&str],
+        id: &str,
+        opts: &crate::inspect::InspectOpts,
+    ) -> Option<crate::inspect::Artifact> {
+        let mut found: Option<crate::inspect::Artifact> = None;
+        self.for_each_attached_device(&mut |on, d| {
+            if found.is_some() || on != Some(bus) {
+                return;
+            }
+            if address.is_some() && d.address != address {
+                return;
+            }
+            let Some(evidence) = d.evidence else {
+                return;
+            };
+            found = evidence.artifacts(id, opts).into_iter().find(|a| {
+                a.meta
+                    .get("format")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|f| formats.contains(&f))
+            });
+        });
+        found
+    }
+
     /// The addressed join: which declaration, if any, describes the device
     /// found at this placement.
     ///

--- a/crates/core/src/inspect.rs
+++ b/crates/core/src/inspect.rs
@@ -545,6 +545,35 @@ impl DeviceEvidence for SpiEvidence<'_> {
     }
 }
 
+/// The `meta.format` string each display model stamps on its own artifact —
+/// the ONE name for "how are these bytes packed".
+///
+/// A format is how a device says WHAT it is, in its own words, so that a reader
+/// can find it without downcasting to a concrete Rust type. That makes these
+/// strings load-bearing in two places at once: the model writes one, and
+/// [`crate::bus::SystemBus::device_artifact_at`]'s callers match on it. Two
+/// string literals that must agree and are edited in different crates is the
+/// same hazard this whole seam exists to remove, so there is one symbol per
+/// format and a typo is a compile error rather than a blank panel.
+///
+/// Two models sharing a constant is deliberate, not a collision: the SSD1680
+/// and the UC8151D differ in which opcodes they decode, not in how the planes
+/// are packed, so a reader that wants "a tri-color e-paper's pixels" genuinely
+/// does not care which one answered.
+pub mod artifact_format {
+    pub const SSD1306_PAGE: &str = "ssd1306_page";
+    pub const SH1107_PAGE: &str = "sh1107_page";
+    pub const RGB565_BE: &str = "rgb565_be";
+    pub const PCD8544_BANK: &str = "pcd8544_bank";
+    pub const MAX7219_ROWS: &str = "max7219_rows";
+    pub const HD44780_DDRAM: &str = "hd44780_ddram";
+    /// Emitted by BOTH tri-color e-paper models — see the module doc.
+    pub const EPAPER_TRICOLOR_PLANES: &str = "epaper_tricolor_1bpp_planes";
+    pub const TM1637_GRID: &str = "tm1637_grid";
+    pub const SEVEN_SEGMENT_MASK: &str = "seven_segment_mask";
+    pub const WS2812_GRB: &str = "ws2812_grb";
+}
+
 /// Shorthand for the payload half of an artifact: the buffer in full mode,
 /// nothing in summary mode. Every panel's `artifacts` impl uses it, so
 /// "summary omits the bytes" is one decision rather than eight.

--- a/crates/core/src/inspect.rs
+++ b/crates/core/src/inspect.rs
@@ -545,6 +545,18 @@ impl DeviceEvidence for SpiEvidence<'_> {
     }
 }
 
+/// Is this artifact something a display surface can paint?
+///
+/// Kind, not model. `"framebuffer"` is packed pixels and `"text_display"` is
+/// decoded characters (an HD44780 panel, a TM1637 module, one 7-segment digit) —
+/// between them that is every way this engine has of saying "a human can see
+/// this". A reader asks the question once, here, instead of each caller keeping
+/// a list of the models it believes are screens; a new panel that reports either
+/// kind is renderable the day its model lands.
+pub fn is_display_artifact(artifact: &Artifact) -> bool {
+    matches!(artifact.kind.as_str(), "framebuffer" | "text_display")
+}
+
 /// The `meta.format` string each display model stamps on its own artifact —
 /// the ONE name for "how are these bytes packed".
 ///

--- a/crates/core/src/peripherals/components/ili9341.rs
+++ b/crates/core/src/peripherals/components/ili9341.rs
@@ -510,7 +510,7 @@ impl SpiDevice for Ili9341 {
             meta: serde_json::json!({
                 "w": w,
                 "h": h,
-                "format": "rgb565_be",
+                "format": crate::inspect::artifact_format::RGB565_BE,
                 "generation": crate::inspect::artifact_generation(fb),
                 "display_on": self.display_on(),
                 "painted_bytes": painted,

--- a/crates/core/src/peripherals/components/lcd1602.rs
+++ b/crates/core/src/peripherals/components/lcd1602.rs
@@ -355,7 +355,7 @@ impl I2cDevice for Lcd1602 {
             kind: "text_display".to_string(),
             id: id.to_string(),
             meta: serde_json::json!({
-                "format": "hd44780_ddram",
+                "format": crate::inspect::artifact_format::HD44780_DDRAM,
                 "generation": crate::inspect::artifact_generation(&ddram),
                 "text": text,
                 "printable_chars": text.chars().filter(|c| !c.is_whitespace()).count(),

--- a/crates/core/src/peripherals/components/max7219.rs
+++ b/crates/core/src/peripherals/components/max7219.rs
@@ -186,7 +186,7 @@ impl SpiDevice for Max7219 {
             meta: serde_json::json!({
                 "w": 8,
                 "h": fb.len(),
-                "format": "max7219_rows",
+                "format": crate::inspect::artifact_format::MAX7219_ROWS,
                 "generation": crate::inspect::artifact_generation(&fb),
                 "ink_bytes": fb.iter().filter(|&&b| b != 0).count(),
                 "lit_pixels": fb.iter().map(|b| b.count_ones() as usize).sum::<usize>(),

--- a/crates/core/src/peripherals/components/pcd8544.rs
+++ b/crates/core/src/peripherals/components/pcd8544.rs
@@ -182,7 +182,7 @@ impl SpiDevice for Pcd8544 {
             meta: serde_json::json!({
                 "w": WIDTH,
                 "h": BANKS * 8,
-                "format": "pcd8544_bank",
+                "format": crate::inspect::artifact_format::PCD8544_BANK,
                 "generation": crate::inspect::artifact_generation(fb),
                 "ink_bytes": fb.iter().filter(|&&b| b != 0).count(),
                 "lit_pixels": fb.iter().map(|b| b.count_ones() as usize).sum::<usize>(),

--- a/crates/core/src/peripherals/components/seven_segment.rs
+++ b/crates/core/src/peripherals/components/seven_segment.rs
@@ -272,7 +272,7 @@ impl crate::inspect::DeviceEvidence for SevenSegment {
             kind: "text_display".to_string(),
             id: id.to_string(),
             meta: serde_json::json!({
-                "format": "seven_segment_mask",
+                "format": crate::inspect::artifact_format::SEVEN_SEGMENT_MASK,
                 "generation": crate::inspect::artifact_generation(&[segments]),
                 "text": self.ch().to_string(),
                 "segments": segments,

--- a/crates/core/src/peripherals/components/sh1107.rs
+++ b/crates/core/src/peripherals/components/sh1107.rs
@@ -196,7 +196,7 @@ impl I2cDevice for Sh1107 {
             meta: serde_json::json!({
                 "w": self.width(),
                 "h": self.height(),
-                "format": "sh1107_page",
+                "format": crate::inspect::artifact_format::SH1107_PAGE,
                 "generation": crate::inspect::artifact_generation(fb),
                 "ink_bytes": self.ink_bytes(),
                 "lit_pixels": self.lit_pixels(),

--- a/crates/core/src/peripherals/components/ssd1306.rs
+++ b/crates/core/src/peripherals/components/ssd1306.rs
@@ -252,7 +252,7 @@ impl I2cDevice for Ssd1306 {
             meta: serde_json::json!({
                 "w": self.width(),
                 "h": self.height(),
-                "format": "ssd1306_page",
+                "format": crate::inspect::artifact_format::SSD1306_PAGE,
                 "generation": crate::inspect::artifact_generation(fb),
                 "ink_bytes": self.ink_bytes(),
                 "lit_pixels": self.lit_pixels(),

--- a/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/ssd1680_tricolor_290.rs
@@ -430,7 +430,7 @@ impl SpiDevice for Ssd1680Tricolor290 {
             meta: serde_json::json!({
                 "w": w,
                 "h": h,
-                "format": "epaper_tricolor_1bpp_planes",
+                "format": crate::inspect::artifact_format::EPAPER_TRICOLOR_PLANES,
                 "generation": crate::inspect::artifact_generation(&both),
                 "plane_bytes": black.len(),
                 "black_ink_bytes": ink(black),

--- a/crates/core/src/peripherals/components/tm1637_7seg.rs
+++ b/crates/core/src/peripherals/components/tm1637_7seg.rs
@@ -320,7 +320,7 @@ impl crate::inspect::DeviceEvidence for Tm1637 {
             kind: "text_display".to_string(),
             id: id.to_string(),
             meta: serde_json::json!({
-                "format": "tm1637_grid",
+                "format": crate::inspect::artifact_format::TM1637_GRID,
                 "generation": crate::inspect::artifact_generation(&grids),
                 "text": text,
                 "lit_segments": grids.iter().map(|g| g.count_ones() as usize).sum::<usize>(),

--- a/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
+++ b/crates/core/src/peripherals/components/uc8151d_tricolor_290.rs
@@ -324,7 +324,7 @@ impl SpiDevice for Uc8151dTricolor290 {
             meta: serde_json::json!({
                 "w": w,
                 "h": h,
-                "format": "epaper_tricolor_1bpp_planes",
+                "format": crate::inspect::artifact_format::EPAPER_TRICOLOR_PLANES,
                 "generation": crate::inspect::artifact_generation(&both),
                 "plane_bytes": black.len(),
                 "black_ink_bytes": ink(black),

--- a/crates/core/src/peripherals/components/ws2812.rs
+++ b/crates/core/src/peripherals/components/ws2812.rs
@@ -228,7 +228,7 @@ impl crate::inspect::DeviceEvidence for Ws2812 {
             meta: serde_json::json!({
                 "w": self.num_pixels(),
                 "h": 1,
-                "format": "ws2812_grb",
+                "format": crate::inspect::artifact_format::WS2812_GRB,
                 "generation": crate::inspect::artifact_generation(&flat),
                 "pixels_decoded": pixels.len(),
                 "lit_pixels": pixels.iter().filter(|p| p.iter().any(|&c| c != 0)).count(),

--- a/crates/core/src/tests/device_identity_one_home.rs
+++ b/crates/core/src/tests/device_identity_one_home.rs
@@ -207,36 +207,6 @@ fn registry_aliases() -> BTreeMap<String, String> {
     aliases
 }
 
-/// How many places the browser layer still READS `device_type` at all.
-///
-/// The anti-vacuity floor is derived from this rather than fixed, and the
-/// reason is a real event: the display accessors used to contribute a dozen
-/// identity literals, and the one-door change removed every one of them — not
-/// by hiding them from the scanner, but by making display resolution stop
-/// consulting `device_type`. A constant floor calls that progress a broken
-/// scanner and goes red; worse, the obvious "fix" is to lower the constant,
-/// which is a number nobody can justify next time.
-///
-/// Tying the floor to the access sites keeps the property the constant was
-/// reaching for — every site that reads `device_type` must yield at least one
-/// literal, so a scanner that stops parsing still trips it — while letting the
-/// honest answer (a subsystem stopped keying on strings) pass. When the sensor
-/// accessors follow the panels, both numbers reach zero together and the
-/// scanner's own positive/negative controls in `scanner_controls` remain the
-/// guard against a parser that silently finds nothing.
-fn device_type_access_sites() -> usize {
-    WASM_SOURCES
-        .iter()
-        .map(|rel| {
-            std::fs::read_to_string(repo_root(rel))
-                .unwrap_or_default()
-                .lines()
-                .filter(|l| !l.trim_start().starts_with("//") && l.contains(".device_type"))
-                .count()
-        })
-        .sum()
-}
-
 #[test]
 fn every_device_type_the_browser_keys_on_is_known_to_the_registry() {
     let per_file = wasm_identity_literals();
@@ -244,13 +214,10 @@ fn every_device_type_the_browser_keys_on_is_known_to_the_registry() {
 
     // Anti-vacuity. If the scan stops finding literals the gate proves nothing,
     // and a silent zero is exactly how a green suite covers broken behaviour.
-    // Derived from the access sites, not fixed — see `device_type_access_sites`.
-    let sites = device_type_access_sites();
     assert!(
-        all.len() >= sites,
-        "the device-type scan found only {} literals across {:?}, but those files read \
-         `.device_type` at {sites} sites; the scanner is broken or the browser layer \
-         moved. A vacuous gate is worse than none.",
+        all.len() >= 12,
+        "the device-type scan found only {} literals across {:?}; it is broken or \
+         the browser layer moved. A vacuous gate is worse than none.",
         all.len(),
         WASM_SOURCES
     );
@@ -290,7 +257,7 @@ fn the_browser_does_not_re_implement_the_device_type_alias_table() {
     );
     let per_file = wasm_identity_literals();
     assert!(
-        per_file.values().flatten().count() >= device_type_access_sites(),
+        per_file.values().flatten().count() >= 12,
         "the device-type scan went vacuous; see the sibling test."
     );
 

--- a/crates/core/src/tests/device_identity_one_home.rs
+++ b/crates/core/src/tests/device_identity_one_home.rs
@@ -207,6 +207,36 @@ fn registry_aliases() -> BTreeMap<String, String> {
     aliases
 }
 
+/// How many places the browser layer still READS `device_type` at all.
+///
+/// The anti-vacuity floor is derived from this rather than fixed, and the
+/// reason is a real event: the display accessors used to contribute a dozen
+/// identity literals, and the one-door change removed every one of them — not
+/// by hiding them from the scanner, but by making display resolution stop
+/// consulting `device_type`. A constant floor calls that progress a broken
+/// scanner and goes red; worse, the obvious "fix" is to lower the constant,
+/// which is a number nobody can justify next time.
+///
+/// Tying the floor to the access sites keeps the property the constant was
+/// reaching for — every site that reads `device_type` must yield at least one
+/// literal, so a scanner that stops parsing still trips it — while letting the
+/// honest answer (a subsystem stopped keying on strings) pass. When the sensor
+/// accessors follow the panels, both numbers reach zero together and the
+/// scanner's own positive/negative controls in `scanner_controls` remain the
+/// guard against a parser that silently finds nothing.
+fn device_type_access_sites() -> usize {
+    WASM_SOURCES
+        .iter()
+        .map(|rel| {
+            std::fs::read_to_string(repo_root(rel))
+                .unwrap_or_default()
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//") && l.contains(".device_type"))
+                .count()
+        })
+        .sum()
+}
+
 #[test]
 fn every_device_type_the_browser_keys_on_is_known_to_the_registry() {
     let per_file = wasm_identity_literals();
@@ -214,10 +244,13 @@ fn every_device_type_the_browser_keys_on_is_known_to_the_registry() {
 
     // Anti-vacuity. If the scan stops finding literals the gate proves nothing,
     // and a silent zero is exactly how a green suite covers broken behaviour.
+    // Derived from the access sites, not fixed — see `device_type_access_sites`.
+    let sites = device_type_access_sites();
     assert!(
-        all.len() >= 12,
-        "the device-type scan found only {} literals across {:?}; it is broken or \
-         the browser layer moved. A vacuous gate is worse than none.",
+        all.len() >= sites,
+        "the device-type scan found only {} literals across {:?}, but those files read \
+         `.device_type` at {sites} sites; the scanner is broken or the browser layer \
+         moved. A vacuous gate is worse than none.",
         all.len(),
         WASM_SOURCES
     );
@@ -257,7 +290,7 @@ fn the_browser_does_not_re_implement_the_device_type_alias_table() {
     );
     let per_file = wasm_identity_literals();
     assert!(
-        per_file.values().flatten().count() >= 12,
+        per_file.values().flatten().count() >= device_type_access_sites(),
         "the device-type scan went vacuous; see the sibling test."
     );
 

--- a/crates/core/tests/display_evidence_one_seam.rs
+++ b/crates/core/tests/display_evidence_one_seam.rs
@@ -1,0 +1,271 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! The contract, stated without reference to how the engine is built:
+//!
+//! > A panel that `inspect` can show pixels for is a panel the renderer can
+//! > show pixels for, and they are the SAME pixels.
+//!
+//! This is the property the browser lost for a year. `crates/wasm` reached its
+//! panels through a hand-written matrix of controller downcasts; `inspect`
+//! reached them through the device walk. Two systems, one sighted, one blind —
+//! and which one was blind depended on which arm somebody had remembered to add.
+//! The SH1107 painted a full console in the browser while `inspect` reported no
+//! artifact at all.
+//!
+//! The two surfaces are keyed DIFFERENTLY on purpose, and that is what makes
+//! this test worth writing rather than a mirror of the implementation:
+//!
+//! * [`SystemBus::inspect_devices`] joins on the manifest — "the device the
+//!   author called `epaper`".
+//! * [`SystemBus::device_artifact_at`] joins on placement — "the tri-color
+//!   e-paper on `spi1`", which is all a `board_io` binding actually knows.
+//!
+//! Different keys, and the answer must be byte-identical. Nothing below
+//! downcasts to a panel type, names a controller, or restates the lookup: the
+//! fixtures are the `system.yaml` files that ship in `examples/`, and the
+//! expectation is read out of the OTHER surface.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::cortex_m::CortexM;
+use labwired_core::inspect::{artifact_format as fmt, Artifact, InspectOpts};
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::Machine;
+use std::path::PathBuf;
+
+fn repo(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Assemble the rig with no firmware. Placement is a property of the manifest;
+/// nothing has to run for a panel to be wired, and a test that booted firmware
+/// first would be measuring the boot.
+fn machine_from_example(rel_yaml: &str) -> Machine<CortexM> {
+    let yaml = repo(rel_yaml);
+    let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
+    let chip_path = yaml.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    bus.refresh_peripheral_index();
+    Machine::new(cpu, bus)
+}
+
+/// Every artifact `inspect` reports for a device that has a `format`, with the
+/// placement it was found at — i.e. everything the renderer would need to ask
+/// the other question.
+struct Reported {
+    id: String,
+    bus: String,
+    address: Option<u8>,
+    artifact: Artifact,
+}
+
+fn reported_displays(machine: &Machine<CortexM>, opts: &InspectOpts) -> Vec<Reported> {
+    machine
+        .inspect(None, opts)
+        .devices
+        .into_iter()
+        .flat_map(|d| {
+            let bus = d.attachment.bus.clone();
+            let address = d.attachment.address;
+            let id = d.id.clone();
+            d.artifacts.into_iter().filter_map(move |a| {
+                let bus = bus.clone()?;
+                a.meta.get("format")?.as_str()?;
+                Some(Reported {
+                    id: id.clone(),
+                    bus,
+                    address,
+                    artifact: a,
+                })
+            })
+        })
+        .collect()
+}
+
+/// Every shipped rig that places a display, across the transports and
+/// controller families the deleted wasm accessors enumerated by hand: a
+/// generic-I²C OLED, an ESP32-C3 I²C OLED, an ESP32-S3 I²C SH1107, a
+/// generic-SPI TFT, a generic-SPI e-paper, and an ESP32 SPI e-paper.
+const DISPLAY_LABS: &[&str] = &[
+    "examples/ssd1306-hello-lab/system.yaml",
+    "examples/ssd1306-128x32-lab/system.yaml",
+    "examples/ili9341-tft-lab/system.yaml",
+    "examples/epaper-tricolor-lab/system.yaml",
+    "configs/systems/esp32c3-oled-demo.yaml",
+    "configs/systems/esp32c3-oled-128x32-workshop.yaml",
+    "configs/systems/esp32s3-oled-demo.yaml",
+    "configs/systems/esp32c3-epaper-workshop.yaml",
+    "configs/systems/esp32-wroom-epaper.yaml",
+    "configs/systems/nucleo-f103rb-epaper.yaml",
+];
+
+/// The whole contract, for every shipped rig that has a panel.
+///
+/// Asking by placement must return, byte for byte, what asking by manifest id
+/// returned. A controller the walk cannot reach fails BOTH halves and so shows
+/// up as "this lab reported no display at all"; a controller the placement
+/// query mishandles fails only the second half.
+#[test]
+fn placement_query_returns_what_inspect_reports_for_every_shipped_panel() {
+    let opts = InspectOpts {
+        include_bytes: true,
+        peripheral: None,
+    };
+    let mut panels_checked = 0;
+
+    for lab in DISPLAY_LABS {
+        let machine = machine_from_example(lab);
+        let reported = reported_displays(&machine, &opts);
+        assert!(
+            !reported.is_empty(),
+            "{lab} places a display but inspect reports no artifact for any device — \
+             the walk cannot reach this lab's panel, so nothing can render it"
+        );
+
+        for r in &reported {
+            let format = r.artifact.meta["format"].as_str().expect("format");
+            // Ask the OTHER question, with only what a `board_io` binding
+            // knows: which controller, and (for an addressed transport) which
+            // address.
+            let by_placement = machine
+                .bus
+                .device_artifact_at(&r.bus, r.address, &[format], &r.id, &opts)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{lab}: inspect reports a '{format}' artifact for '{}' on '{}' \
+                         (address {:?}), but the placement query finds nothing there",
+                        r.id, r.bus, r.address
+                    )
+                });
+
+            assert_eq!(
+                by_placement.kind, r.artifact.kind,
+                "{lab}: '{}' — same device, so same artifact kind",
+                r.id
+            );
+            assert_eq!(
+                by_placement.id, r.artifact.id,
+                "{lab}: '{}' — the artifact is stamped with the id it was addressed by",
+                r.id
+            );
+            assert_eq!(
+                by_placement.meta, r.artifact.meta,
+                "{lab}: '{}' — the renderer and inspect must not disagree about the \
+                 panel's dimensions, format, or ink",
+                r.id
+            );
+            assert_eq!(
+                by_placement.bytes, r.artifact.bytes,
+                "{lab}: '{}' — the renderer and inspect must paint the SAME pixels",
+                r.id
+            );
+            panels_checked += 1;
+        }
+    }
+
+    assert!(
+        panels_checked >= DISPLAY_LABS.len(),
+        "every listed lab must contribute at least one panel; only {panels_checked} were checked, \
+         which means a fixture stopped placing a display and this test went quiet"
+    );
+}
+
+/// The negative direction, which is what makes the positive one mean something.
+///
+/// A query is only as good as its ability to say no. If `device_artifact_at`
+/// answered regardless of the placement it was handed, the assertions above
+/// would pass with the lookup deleted.
+#[test]
+fn placement_query_refuses_the_wrong_placement() {
+    let opts = InspectOpts {
+        include_bytes: true,
+        peripheral: None,
+    };
+    let machine = machine_from_example("examples/ssd1306-hello-lab/system.yaml");
+    let reported = reported_displays(&machine, &opts);
+    let panel = reported.first().expect("the lab places an OLED");
+    let format = panel.artifact.meta["format"].as_str().expect("format");
+
+    assert!(
+        machine
+            .bus
+            .device_artifact_at(&panel.bus, panel.address, &[format], &panel.id, &opts)
+            .is_some(),
+        "control: the real placement answers"
+    );
+    assert!(
+        machine
+            .bus
+            .device_artifact_at("i2c99", panel.address, &[format], &panel.id, &opts)
+            .is_none(),
+        "a controller the panel is not on must not answer for it"
+    );
+    assert!(
+        machine
+            .bus
+            .device_artifact_at(&panel.bus, Some(0x77), &[format], &panel.id, &opts)
+            .is_none(),
+        "an address the panel does not answer to must not answer for it"
+    );
+    assert!(
+        machine
+            .bus
+            .device_artifact_at(
+                &panel.bus,
+                panel.address,
+                &[fmt::RGB565_BE],
+                &panel.id,
+                &opts
+            )
+            .is_none(),
+        "a panel must not be handed to a caller asking for a different format — \
+         that is what stops an OLED being painted as a TFT framebuffer"
+    );
+}
+
+/// Summary mode must still identify the panel and still carry the cheap `meta`
+/// the UI polls, because that is the whole reason the e-paper refresh counter
+/// does not have to drag 9472 bytes across the wasm boundary sixty times a
+/// second.
+#[test]
+fn summary_mode_keeps_the_metadata_and_drops_only_the_payload() {
+    let machine = machine_from_example("examples/epaper-tricolor-lab/system.yaml");
+    let full = InspectOpts {
+        include_bytes: true,
+        peripheral: None,
+    };
+    let summary = InspectOpts {
+        include_bytes: false,
+        peripheral: None,
+    };
+    let reported = reported_displays(&machine, &full);
+    let panel = reported.first().expect("the lab places an e-paper panel");
+
+    let lean = machine
+        .bus
+        .device_artifact_at(
+            &panel.bus,
+            panel.address,
+            &[fmt::EPAPER_TRICOLOR_PLANES],
+            &panel.id,
+            &summary,
+        )
+        .expect("summary mode still finds the panel");
+
+    assert!(lean.bytes.is_none(), "summary mode drops the payload");
+    assert_eq!(
+        lean.meta, panel.artifact.meta,
+        "summary mode changes nothing but the payload — the UI's refresh_generation \
+         poll reads the same number the full read would report"
+    );
+    assert!(
+        lean.meta.get("refresh_generation").is_some(),
+        "the counter the renderer polls before re-fetching pixels must survive summary mode"
+    );
+}

--- a/crates/core/tests/display_evidence_one_seam.rs
+++ b/crates/core/tests/display_evidence_one_seam.rs
@@ -29,10 +29,7 @@
 
 use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
-use labwired_core::cpu::cortex_m::CortexM;
 use labwired_core::inspect::{artifact_format as fmt, Artifact, InspectOpts};
-use labwired_core::system::cortex_m::configure_cortex_m;
-use labwired_core::Machine;
 use std::path::PathBuf;
 
 fn repo(rel: &str) -> PathBuf {
@@ -44,15 +41,35 @@ fn repo(rel: &str) -> PathBuf {
 /// Assemble the rig with no firmware. Placement is a property of the manifest;
 /// nothing has to run for a panel to be wired, and a test that booted firmware
 /// first would be measuring the boot.
-fn machine_from_example(rel_yaml: &str) -> Machine<CortexM> {
+fn bus_from_example(rel_yaml: &str) -> SystemBus {
     let yaml = repo(rel_yaml);
     let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
     let chip_path = yaml.parent().unwrap().join(&manifest.chip);
     let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
-    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
-    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    let mut bus = match chip.arch {
+        // The classic ESP32 builds its peripherals from the CPU configuration
+        // rather than from the chip's peripheral list, so its external devices
+        // are attached afterwards — see `WasmSimulator::new_from_config`.
+        labwired_config::Arch::Xtensa => {
+            let mut bus = SystemBus::new();
+            let _ = labwired_core::system::xtensa::configure_xtensa_esp32(&mut bus);
+            labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+                .expect("attach external devices");
+            bus
+        }
+        labwired_config::Arch::RiscV => {
+            let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+            let _ = labwired_core::system::riscv::configure_riscv(&mut bus);
+            bus
+        }
+        _ => {
+            let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+            let _ = labwired_core::system::cortex_m::configure_cortex_m(&mut bus);
+            bus
+        }
+    };
     bus.refresh_peripheral_index();
-    Machine::new(cpu, bus)
+    bus
 }
 
 /// Every artifact `inspect` reports for a device that has a `format`, with the
@@ -65,10 +82,8 @@ struct Reported {
     artifact: Artifact,
 }
 
-fn reported_displays(machine: &Machine<CortexM>, opts: &InspectOpts) -> Vec<Reported> {
-    machine
-        .inspect(None, opts)
-        .devices
+fn reported_displays(bus: &SystemBus, opts: &InspectOpts) -> Vec<Reported> {
+    bus.inspect_devices(None, opts)
         .into_iter()
         .flat_map(|d| {
             let bus = d.attachment.bus.clone();
@@ -120,8 +135,8 @@ fn placement_query_returns_what_inspect_reports_for_every_shipped_panel() {
     let mut panels_checked = 0;
 
     for lab in DISPLAY_LABS {
-        let machine = machine_from_example(lab);
-        let reported = reported_displays(&machine, &opts);
+        let bus = bus_from_example(lab);
+        let reported = reported_displays(&bus, &opts);
         assert!(
             !reported.is_empty(),
             "{lab} places a display but inspect reports no artifact for any device — \
@@ -133,8 +148,7 @@ fn placement_query_returns_what_inspect_reports_for_every_shipped_panel() {
             // Ask the OTHER question, with only what a `board_io` binding
             // knows: which controller, and (for an addressed transport) which
             // address.
-            let by_placement = machine
-                .bus
+            let by_placement = bus
                 .device_artifact_at(&r.bus, r.address, &[format], &r.id, &opts)
                 .unwrap_or_else(|| {
                     panic!(
@@ -187,35 +201,31 @@ fn placement_query_refuses_the_wrong_placement() {
         include_bytes: true,
         peripheral: None,
     };
-    let machine = machine_from_example("examples/ssd1306-hello-lab/system.yaml");
-    let reported = reported_displays(&machine, &opts);
+    let bus = bus_from_example("examples/ssd1306-hello-lab/system.yaml");
+    let reported = reported_displays(&bus, &opts);
     let panel = reported.first().expect("the lab places an OLED");
     let format = panel.artifact.meta["format"].as_str().expect("format");
 
     assert!(
-        machine
-            .bus
+        bus
             .device_artifact_at(&panel.bus, panel.address, &[format], &panel.id, &opts)
             .is_some(),
         "control: the real placement answers"
     );
     assert!(
-        machine
-            .bus
+        bus
             .device_artifact_at("i2c99", panel.address, &[format], &panel.id, &opts)
             .is_none(),
         "a controller the panel is not on must not answer for it"
     );
     assert!(
-        machine
-            .bus
+        bus
             .device_artifact_at(&panel.bus, Some(0x77), &[format], &panel.id, &opts)
             .is_none(),
         "an address the panel does not answer to must not answer for it"
     );
     assert!(
-        machine
-            .bus
+        bus
             .device_artifact_at(
                 &panel.bus,
                 panel.address,
@@ -235,7 +245,7 @@ fn placement_query_refuses_the_wrong_placement() {
 /// second.
 #[test]
 fn summary_mode_keeps_the_metadata_and_drops_only_the_payload() {
-    let machine = machine_from_example("examples/epaper-tricolor-lab/system.yaml");
+    let bus = bus_from_example("examples/epaper-tricolor-lab/system.yaml");
     let full = InspectOpts {
         include_bytes: true,
         peripheral: None,
@@ -244,11 +254,10 @@ fn summary_mode_keeps_the_metadata_and_drops_only_the_payload() {
         include_bytes: false,
         peripheral: None,
     };
-    let reported = reported_displays(&machine, &full);
+    let reported = reported_displays(&bus, &full);
     let panel = reported.first().expect("the lab places an e-paper panel");
 
-    let lean = machine
-        .bus
+    let lean = bus
         .device_artifact_at(
             &panel.bus,
             panel.address,

--- a/crates/core/tests/display_evidence_one_seam.rs
+++ b/crates/core/tests/display_evidence_one_seam.rs
@@ -207,33 +207,29 @@ fn placement_query_refuses_the_wrong_placement() {
     let format = panel.artifact.meta["format"].as_str().expect("format");
 
     assert!(
-        bus
-            .device_artifact_at(&panel.bus, panel.address, &[format], &panel.id, &opts)
+        bus.device_artifact_at(&panel.bus, panel.address, &[format], &panel.id, &opts)
             .is_some(),
         "control: the real placement answers"
     );
     assert!(
-        bus
-            .device_artifact_at("i2c99", panel.address, &[format], &panel.id, &opts)
+        bus.device_artifact_at("i2c99", panel.address, &[format], &panel.id, &opts)
             .is_none(),
         "a controller the panel is not on must not answer for it"
     );
     assert!(
-        bus
-            .device_artifact_at(&panel.bus, Some(0x77), &[format], &panel.id, &opts)
+        bus.device_artifact_at(&panel.bus, Some(0x77), &[format], &panel.id, &opts)
             .is_none(),
         "an address the panel does not answer to must not answer for it"
     );
     assert!(
-        bus
-            .device_artifact_at(
-                &panel.bus,
-                panel.address,
-                &[fmt::RGB565_BE],
-                &panel.id,
-                &opts
-            )
-            .is_none(),
+        bus.device_artifact_at(
+            &panel.bus,
+            panel.address,
+            &[fmt::RGB565_BE],
+            &panel.id,
+            &opts
+        )
+        .is_none(),
         "a panel must not be handed to a caller asking for a different format — \
          that is what stops an OLED being painted as a TFT framebuffer"
     );

--- a/crates/core/tests/display_one_door.rs
+++ b/crates/core/tests/display_one_door.rs
@@ -114,7 +114,11 @@ fn every_placed_display_answers_the_one_door() {
         // what a per-accessor doc contract ("153,600 bytes = 240x320x2,
         // big-endian RGB565") cannot give it.
         assert!(
-            artifact.meta.get("format").and_then(|v| v.as_str()).is_some(),
+            artifact
+                .meta
+                .get("format")
+                .and_then(|v| v.as_str())
+                .is_some(),
             "{lab}: '{id}' must say how its bytes are packed"
         );
         assert!(
@@ -269,7 +273,9 @@ fn every_display_in_every_shipped_rig_answers_the_one_door() {
         }
     }
 
-    println!("one door served {displays_checked} displays across {rigs_with_a_display} shipped rigs");
+    println!(
+        "one door served {displays_checked} displays across {rigs_with_a_display} shipped rigs"
+    );
     // Without this the test passes just as happily if the scan finds nothing,
     // which is the shape of every gate that was green while broken.
     assert!(

--- a/crates/core/tests/display_one_door.rs
+++ b/crates/core/tests/display_one_door.rs
@@ -1,0 +1,239 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! The contract, stated without reference to how the engine is built:
+//!
+//! > A display the author placed answers ONE call, by the name the author gave
+//! > it, and tells the caller enough to render it sight-unseen.
+//!
+//! Not "an SSD1306 answers `get_ssd1306_framebuffer` if a `board_io` binding
+//! names it and the caller's controller list happens to include this chip's SPI
+//! block". Every clause of that sentence was a way for a working, painting panel
+//! to render blank, and each one had to be discovered by a customer.
+//!
+//! # Where the fixtures come from
+//!
+//! Not from the accessor's own match arms — a list built that way agrees with
+//! the code by construction and proves nothing. They are the shipped
+//! `system.yaml` files, scanned for the shape that broke: a display declared
+//! under `external_devices:` that NO `board_io:` entry names. Every accessor
+//! this replaces began by looking that display up in `board_io`, so on these
+//! rigs the browser had no placement to query and painted nothing — whatever the
+//! model, whatever the chip.
+//!
+//! Deliberately not one model and not one transport, so the fix cannot be
+//! shaped like any single panel: an SPI TFT, an I²C OLED, and a GPIO-bit-banged
+//! 7-segment module that has no controller to hang off at all.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::inspect::InspectOpts;
+use std::path::PathBuf;
+
+fn repo(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Shipped rigs that place a display under `external_devices:` with no
+/// `board_io:` entry naming it, paired with the id the author gave it.
+///
+/// Found by scanning every `system.yaml` in the tree for that shape, not by
+/// reading any accessor.
+const BOARD_IO_LESS_DISPLAYS: &[(&str, &str, &str)] = &[
+    // Ryan's bay-occupancy rig: an ILI9341 on the classic-ESP32 SPI3.
+    ("examples/esp32-bay-occupancy/system.yaml", "tft", "ili9341"),
+    // The same shape with a different model on a different transport and a
+    // different chip — so a fix that only works for the TFT fails here.
+    (
+        "examples/esp32c3-leo-airquality/system.yaml",
+        "oled",
+        "oled-ssd1306",
+    ),
+    // And one with no controller at all: bit-banged on GPIO pins, held in a
+    // bus-resident collection rather than inside a peripheral.
+    ("examples/tm1637-7seg-lab/system.yaml", "seg", "tm1637-7seg"),
+];
+
+/// Assemble the rig with no firmware, by the same route the browser assembles
+/// it for this chip family. Placement is a property of the manifest; nothing has
+/// to run for a display to be wired, and a test that booted firmware first would
+/// be measuring the boot.
+fn bus_from_example(rel_yaml: &str) -> SystemBus {
+    let yaml = repo(rel_yaml);
+    let manifest = SystemManifest::from_file(&yaml).expect("load system.yaml");
+    let chip_path = yaml.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
+    let mut bus = match chip.arch {
+        // The classic ESP32 builds its peripherals from the CPU configuration
+        // rather than from the chip's peripheral list, so its external devices
+        // are attached afterwards — see `WasmSimulator::new_from_config`.
+        labwired_config::Arch::Xtensa => {
+            let mut bus = SystemBus::new();
+            let _ = labwired_core::system::xtensa::configure_xtensa_esp32(&mut bus);
+            labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+                .expect("attach external devices");
+            bus
+        }
+        labwired_config::Arch::RiscV => {
+            let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+            let _ = labwired_core::system::riscv::configure_riscv(&mut bus);
+            bus
+        }
+        _ => {
+            let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus");
+            let _ = labwired_core::system::cortex_m::configure_cortex_m(&mut bus);
+            bus
+        }
+    };
+    bus.refresh_peripheral_index();
+    bus
+}
+
+/// The one door answers for every shipped display, whatever bound it.
+#[test]
+fn every_placed_display_answers_the_one_door() {
+    let opts = InspectOpts {
+        include_bytes: true,
+        peripheral: None,
+    };
+
+    for (lab, id, device_type) in BOARD_IO_LESS_DISPLAYS {
+        let bus = bus_from_example(lab);
+        let artifact = bus.display_artifact(id, &opts).unwrap_or_else(|| {
+            panic!(
+                "{lab}: the author placed a {device_type} called '{id}', and the engine built \
+                 it — but the one door returns nothing, so nothing can render it"
+            )
+        });
+
+        // Geometry and packing must come back as DATA. A caller that has never
+        // heard of this model must still be able to paint it, which is exactly
+        // what a per-accessor doc contract ("153,600 bytes = 240x320x2,
+        // big-endian RGB565") cannot give it.
+        assert!(
+            artifact.meta.get("format").and_then(|v| v.as_str()).is_some(),
+            "{lab}: '{id}' must say how its bytes are packed"
+        );
+        assert!(
+            !artifact.id.is_empty(),
+            "{lab}: '{id}' must come back stamped with the id it was addressed by"
+        );
+    }
+}
+
+/// The ratchet: **every** display this engine can see, in every rig that ships,
+/// answers the one door.
+///
+/// The enumeration is the FILESYSTEM — every `system.yaml` under `examples/`
+/// and `configs/systems/` — and the set of displays inside each one is whatever
+/// reports a display-kind artifact through the walk. Nothing here names a model,
+/// a controller, a transport, or a device_type. That matters: a list built by
+/// reading the accessor's own arms agrees with the accessor by construction and
+/// would pass with the door deleted.
+///
+/// So the failure this makes impossible is the one that keeps happening — a new
+/// display model lands, ships in a lab, and nobody remembers the second place it
+/// had to be registered. There is no second place left to forget, and if one
+/// grows back this test is what notices.
+///
+/// What it does NOT catch, stated so nobody reads more into a green run than is
+/// there: a model that reports no evidence AT ALL is invisible to the walk and
+/// therefore invisible here too. That direction — "this part is a screen, so its
+/// model owes us pixels" — belongs to the part-simulation ratchet in the
+/// superproject catalog, which is where the claim "this part is a display"
+/// actually lives.
+#[test]
+fn every_display_in_every_shipped_rig_answers_the_one_door() {
+    let opts = InspectOpts {
+        include_bytes: true,
+        peripheral: None,
+    };
+    let mut rigs_with_a_display = 0;
+    let mut displays_checked = 0;
+
+    for yaml in shipped_system_manifests() {
+        // A rig this test harness cannot assemble (a chip family with a
+        // bespoke boot path, a fixture that needs blobs) is skipped rather
+        // than failed — it is not evidence about the door either way.
+        let Some(bus) = try_bus_from_example(&yaml) else {
+            continue;
+        };
+        let mut found_here = false;
+
+        for device in bus.inspect_devices(None, &opts) {
+            for artifact in device
+                .artifacts
+                .iter()
+                .filter(|a| labwired_core::inspect::is_display_artifact(a))
+            {
+                found_here = true;
+                displays_checked += 1;
+                let through_the_door =
+                    bus.display_artifact(&device.id, &opts).unwrap_or_else(|| {
+                        panic!(
+                            "{yaml}: the walk can see a '{}' display for '{}', but the one door \
+                             returns nothing for that id — the browser would paint it blank",
+                            artifact.kind, device.id
+                        )
+                    });
+                assert_eq!(
+                    &through_the_door.bytes, &artifact.bytes,
+                    "{yaml}: '{}' — the door and the walk must return the SAME pixels",
+                    device.id
+                );
+                assert_eq!(
+                    &through_the_door.meta, &artifact.meta,
+                    "{yaml}: '{}' — and the same geometry and packing",
+                    device.id
+                );
+            }
+        }
+        if found_here {
+            rigs_with_a_display += 1;
+        }
+    }
+
+    println!("one door served {displays_checked} displays across {rigs_with_a_display} shipped rigs");
+    // Without this the test passes just as happily if the scan finds nothing,
+    // which is the shape of every gate that was green while broken.
+    assert!(
+        rigs_with_a_display >= 8 && displays_checked >= 8,
+        "the scan found only {displays_checked} displays across {rigs_with_a_display} rigs; \
+         the repo ships far more than that, so the enumeration has silently stopped working"
+    );
+}
+
+/// Every `system.yaml` the repo ships, found by walking the tree — not by
+/// reading a list that some other file also has to be told about.
+fn shipped_system_manifests() -> Vec<String> {
+    let mut out = Vec::new();
+    for dir in ["examples", "configs/systems"] {
+        collect_manifests(&repo(dir), dir, &mut out);
+    }
+    out.sort();
+    out
+}
+
+fn collect_manifests(dir: &std::path::Path, rel: &str, out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if path.is_dir() {
+            collect_manifests(&path, &format!("{rel}/{name}"), out);
+        } else if name.ends_with(".yaml") || name.ends_with(".yml") {
+            out.push(format!("{rel}/{name}"));
+        }
+    }
+}
+
+/// [`bus_from_example`] for a file that may not be a system manifest at all, or
+/// may need a boot path this harness does not have.
+fn try_bus_from_example(rel_yaml: &str) -> Option<SystemBus> {
+    std::panic::catch_unwind(|| bus_from_example(rel_yaml)).ok()
+}

--- a/crates/core/tests/display_resolution_ignores_board_io_type.rs
+++ b/crates/core/tests/display_resolution_ignores_board_io_type.rs
@@ -1,0 +1,152 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! `board_io` describes PINS. `external_devices:` declares PARTS. No display
+//! resolution path may confuse the two again.
+//!
+//! # The duplicate that caused all of it
+//!
+//! [`labwired_config::SystemManifest`] has two surfaces that can describe the
+//! same physical part. `external_devices:` says what a part IS and what it is
+//! wired to — it is what attaches a real model to a bus. `board_io:` describes a
+//! contact asserting a level, which is a genuinely different thing (a button, an
+//! LED, a PIR or hall output), except that it also carries `device_type:` and
+//! `i2c_address:` — restating what `external_devices` already said.
+//!
+//! Nothing forced the two to agree, and the engine only reads one of them. It
+//! attaches the panel from `external_devices:`, while every wasm framebuffer
+//! accessor searched `board_io` for a matching `device_type`. So a lab that
+//! declared its display correctly in ONE of the two got a panel that was fully
+//! driven, painting every frame, and completely invisible. Declared in both, it
+//! painted. That is not a bug about a model or a chip — it is a bug about which
+//! surface the author happened to write in.
+//!
+//! # What this guards
+//!
+//! Display resolution now goes through the attached-device seam, which sees a
+//! device attached by ANY route, so `board_io.device_type` has no consumer left
+//! on that path. The field is not deleted — 47 files read `board_io` and the
+//! rest of it is load-bearing — it is made **non-load-bearing**, which is the
+//! win. This test is what stops it becoming load-bearing again in six months,
+//! quietly, in one accessor, for one model.
+//!
+//! Deliberately a SOURCE-level check. The behavioural gates
+//! (`display_one_door.rs`) prove the door answers today; only reading the source
+//! can prove that no future path resolves a display the old way — a behavioural
+//! test passes just as happily when a second, `board_io`-keyed lookup is added
+//! beside the working one, which is exactly how the fork appeared the first time.
+
+use std::path::PathBuf;
+
+fn wasm_inspect_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../wasm/src/inspect.rs")
+        .canonicalize()
+        .expect("crates/wasm/src/inspect.rs exists");
+    std::fs::read_to_string(path).expect("read crates/wasm/src/inspect.rs")
+}
+
+/// Function bodies whose job is resolving or serving a DISPLAY.
+///
+/// Named individually rather than pattern-matched, so adding a display accessor
+/// means adding it here — a two-second edit that puts the new code under the
+/// guard, versus a regex that silently stops covering whatever it stops
+/// matching.
+const DISPLAY_RESOLUTION_FNS: &[&str] = &[
+    "fn display_artifact(",
+    "fn panel_artifact(",
+    "fn panel_bytes(",
+    "fn panel_meta(",
+    "fn refresh_generation(",
+    "pub fn get_display(",
+    "pub fn get_ssd1306_framebuffer(",
+    "pub fn get_sh1107_framebuffer(",
+    "pub fn get_ili9341_framebuffer(",
+    "pub fn get_pcd8544_framebuffer(",
+    "pub fn get_ssd1680_framebuffer(",
+    "pub fn get_uc8151d_framebuffer(",
+    "pub fn get_led_matrix_framebuffer(",
+    "pub fn get_lcd1602_text(",
+    "pub fn get_ssd1680_refresh_generation(",
+    "pub fn get_uc8151d_refresh_generation(",
+];
+
+/// The body of `signature`, brace-matched from its opening `{`. Comments are
+/// stripped first: this is about what the code READS, and a doc comment that
+/// mentions the field by name is documentation, not a dependency.
+fn body_of(source: &str, signature: &str) -> String {
+    let start = source
+        .find(signature)
+        .unwrap_or_else(|| panic!("crates/wasm/src/inspect.rs no longer defines `{signature}` — \
+             if it was renamed, rename it here; if it was deleted, delete it here. \
+             A guard that silently stops covering its subject is worse than no guard."));
+    let open = source[start..]
+        .find('{')
+        .map(|i| start + i)
+        .expect("function has a body");
+    let bytes = source.as_bytes();
+    let mut depth = 0usize;
+    let mut end = open;
+    for (i, b) in bytes.iter().enumerate().skip(open) {
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    source[open..=end]
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// No display path may decide what a device IS from `board_io`.
+#[test]
+fn no_display_path_resolves_a_device_by_board_io_device_type() {
+    let source = wasm_inspect_source();
+    for signature in DISPLAY_RESOLUTION_FNS {
+        let body = body_of(&source, signature);
+        assert!(
+            !body.contains("device_type"),
+            "`{signature}` reads `device_type`. A display's identity comes from the model's \
+             own artifact (`meta.format`), never from a `board_io` row restating what \
+             `external_devices:` already declared — that duplicate is why a correctly \
+             declared, actively painting panel could be invisible to the browser. If a new \
+             display genuinely cannot be resolved without it, that is a missing \
+             `DeviceEvidence` impl, not a reason to reopen this."
+        );
+    }
+}
+
+/// And the one door itself must not need `board_io` at all.
+///
+/// The per-model shims may still consult a binding for PLACEMENT (which
+/// controller, which address) when the manifest join could not name a
+/// programmatically attached model. The door may not: a display declared in
+/// `external_devices:` alone — Ryan's shape, and the shape that never worked —
+/// has no row for it to read.
+#[test]
+fn the_one_door_resolves_without_a_board_io_row() {
+    let source = wasm_inspect_source();
+    let door = body_of(&source, "pub fn get_display(");
+    assert!(
+        !door.contains("board_io"),
+        "`get_display` reads `board_io`. The door's whole point is that a display \
+         author writes ONE `external_devices:` entry and it paints — in the CLI, in the \
+         browser, in `inspect`, in the 3D view — with no second declaration anywhere."
+    );
+    // Not vacuous: the door must actually go through the seam, or an empty
+    // function would satisfy the assertion above.
+    assert!(
+        door.contains("display_artifact"),
+        "`get_display` must resolve through the attached-device seam"
+    );
+}

--- a/crates/core/tests/display_resolution_ignores_board_io_type.rs
+++ b/crates/core/tests/display_resolution_ignores_board_io_type.rs
@@ -94,11 +94,13 @@ fn body_of_opt(source: &str, signature: &str) -> Option<String> {
 
 /// The body of `signature`, brace-matched from its opening `{`.
 fn body_of(source: &str, signature: &str) -> String {
-    let start = source
-        .find(signature)
-        .unwrap_or_else(|| panic!("crates/wasm/src/inspect.rs no longer defines `{signature}` — \
+    let start = source.find(signature).unwrap_or_else(|| {
+        panic!(
+            "crates/wasm/src/inspect.rs no longer defines `{signature}` — \
              if it was renamed, rename it here; if it was deleted, delete it here. \
-             A guard that silently stops covering its subject is worse than no guard."));
+             A guard that silently stops covering its subject is worse than no guard."
+        )
+    });
     let open = source[start..]
         .find('{')
         .map(|i| start + i)

--- a/crates/core/tests/display_resolution_ignores_board_io_type.rs
+++ b/crates/core/tests/display_resolution_ignores_board_io_type.rs
@@ -47,19 +47,19 @@ fn wasm_inspect_source() -> String {
     std::fs::read_to_string(path).expect("read crates/wasm/src/inspect.rs")
 }
 
-/// Function bodies whose job is resolving or serving a DISPLAY.
+/// The display accessors the UI calls. Every one of these exists on `main` too,
+/// which is what makes this guard's red a REAL one: run it against unmodified
+/// `main` and it fails naming `get_ssd1306_framebuffer` and its six siblings,
+/// each of which opens by matching a `board_io` row's `device_type`. It does not
+/// fail because its subject is missing.
 ///
-/// Named individually rather than pattern-matched, so adding a display accessor
-/// means adding it here — a two-second edit that puts the new code under the
-/// guard, versus a regex that silently stops covering whatever it stops
-/// matching.
-const DISPLAY_RESOLUTION_FNS: &[&str] = &[
-    "fn display_artifact(",
-    "fn panel_artifact(",
-    "fn panel_bytes(",
-    "fn panel_meta(",
-    "fn refresh_generation(",
-    "pub fn get_display(",
+/// That distinction is the whole point. A guard whose only pre-fix failure is
+/// "the function I guard does not exist yet" passes vacuously the day someone
+/// deletes the thing it guards and updates the guard to match. These names are
+/// the stable, pre-existing surface; [`NEW_RESOLUTION_FNS`] holds the ones this
+/// change introduced, checked separately so their absence can never be mistaken
+/// for the defect.
+const SHIPPED_DISPLAY_ACCESSORS: &[&str] = &[
     "pub fn get_ssd1306_framebuffer(",
     "pub fn get_sh1107_framebuffer(",
     "pub fn get_ili9341_framebuffer(",
@@ -72,9 +72,27 @@ const DISPLAY_RESOLUTION_FNS: &[&str] = &[
     "pub fn get_uc8151d_refresh_generation(",
 ];
 
-/// The body of `signature`, brace-matched from its opening `{`. Comments are
-/// stripped first: this is about what the code READS, and a doc comment that
-/// mentions the field by name is documentation, not a dependency.
+/// The resolution helpers this change introduced. Absent on `main` by
+/// definition, so a missing one here is reported as "not applicable on this
+/// tree", never as the defect.
+const NEW_RESOLUTION_FNS: &[&str] = &[
+    "fn display_artifact(",
+    "fn panel_artifact(",
+    "fn panel_bytes(",
+    "fn panel_meta(",
+    "fn refresh_generation(",
+    "pub fn get_display(",
+];
+
+/// The body of `signature`, or `None` when this tree does not define it.
+/// Comments are stripped first: this is about what the code READS, and a doc
+/// comment that mentions the field by name is documentation, not a dependency.
+fn body_of_opt(source: &str, signature: &str) -> Option<String> {
+    source.find(signature)?;
+    Some(body_of(source, signature))
+}
+
+/// The body of `signature`, brace-matched from its opening `{`.
 fn body_of(source: &str, signature: &str) -> String {
     let start = source
         .find(signature)
@@ -109,11 +127,31 @@ fn body_of(source: &str, signature: &str) -> String {
 }
 
 /// No display path may decide what a device IS from `board_io`.
+///
+/// **This test fails on unmodified `main`, for the real reason.** Every one of
+/// the ten accessors below exists there and opens by matching a `board_io`
+/// row's `device_type`, so `main` reports:
+///
+/// ```text
+/// `pub fn get_ssd1306_framebuffer(` reads `device_type`. …
+/// ```
+///
+/// which is exactly the defect: a display's identity taken from a `board_io`
+/// row restating what `external_devices:` already declared, on a surface that
+/// only reads one of the two.
 #[test]
 fn no_display_path_resolves_a_device_by_board_io_device_type() {
     let source = wasm_inspect_source();
-    for signature in DISPLAY_RESOLUTION_FNS {
-        let body = body_of(&source, signature);
+    let subjects = SHIPPED_DISPLAY_ACCESSORS
+        .iter()
+        .map(|s| (*s, body_of(&source, s)))
+        // A helper this tree does not have is not evidence either way.
+        .chain(
+            NEW_RESOLUTION_FNS
+                .iter()
+                .filter_map(|s| body_of_opt(&source, s).map(|b| (*s, b))),
+        );
+    for (signature, body) in subjects {
         assert!(
             !body.contains("device_type"),
             "`{signature}` reads `device_type`. A display's identity comes from the model's \
@@ -136,6 +174,20 @@ fn no_display_path_resolves_a_device_by_board_io_device_type() {
 #[test]
 fn the_one_door_resolves_without_a_board_io_row() {
     let source = wasm_inspect_source();
+    // Deliberately a hard failure, not a skip: a guard that goes quiet when its
+    // subject disappears is how the thing it guards gets deleted unnoticed. On a
+    // tree that predates the door this is a "not implemented here" red, NOT a
+    // demonstration of the board_io defect — that one is
+    // `no_display_path_resolves_a_device_by_board_io_device_type`, which fails
+    // on unmodified main naming `get_ssd1306_framebuffer`.
+    assert!(
+        source.contains("pub fn get_display("),
+        "crates/wasm/src/inspect.rs defines no `get_display` — there is no one door on this \
+         tree. If you are running this against a checkout that predates it, that is expected \
+         and this test is not the defect demonstration; see \
+         `no_display_path_resolves_a_device_by_board_io_device_type`. If the door was deleted, \
+         restore it: without it a display declared only in `external_devices:` cannot render."
+    );
     let door = body_of(&source, "pub fn get_display(");
     assert!(
         !door.contains("board_io"),

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -216,13 +216,8 @@ impl WasmSimulator {
     /// Both tri-color panels report it under the same `meta` key, so there is
     /// one implementation rather than two that must be kept in step.
     fn refresh_generation(&self, device_id: &str, what: &str) -> Result<u32, JsValue> {
-        let value = self.panel_meta(
-            device_id,
-            EPAPER_TRICOLOR,
-            None,
-            what,
-            "refresh_generation",
-        )?;
+        let value =
+            self.panel_meta(device_id, EPAPER_TRICOLOR, None, what, "refresh_generation")?;
         value
             .as_u64()
             .and_then(|v| u32::try_from(v).ok())

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -7,12 +7,13 @@
 //! A second #[wasm_bindgen] impl block, split out of lib.rs.
 
 use crate::*;
+use labwired_core::inspect::artifact_format as F;
 use wasm_bindgen::prelude::*;
 
 /// Both tri-color e-paper models emit this format. They are interchangeable to
 /// a reader on purpose — see [`WasmSimulator::panel_artifact`] and
 /// [`labwired_core::bus::SystemBus::device_artifact_at`].
-const EPAPER_TRICOLOR: &[&str] = &["epaper_tricolor_1bpp_planes"];
+const EPAPER_TRICOLOR: &[&str] = &[F::EPAPER_TRICOLOR_PLANES];
 
 /// How this crate reads a display: through the ONE device-evidence seam
 /// `inspect` walks, never through a downcast chain of its own.
@@ -539,7 +540,7 @@ impl WasmSimulator {
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_ssd1306_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        self.panel_bytes(device_id, &["ssd1306_page"], Some(0x3C), "SSD1306")
+        self.panel_bytes(device_id, &[F::SSD1306_PAGE], Some(0x3C), "SSD1306")
     }
 
     /// Return the visible text of the LCD1602 identified by `device_id`.
@@ -557,7 +558,7 @@ impl WasmSimulator {
     pub fn get_lcd1602_text(&self, device_id: &str) -> Result<String, JsValue> {
         let text = self.panel_meta(
             device_id,
-            &["hd44780_ddram"],
+            &[F::HD44780_DDRAM],
             Some(0x27),
             "LCD1602",
             "text",
@@ -574,7 +575,7 @@ impl WasmSimulator {
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_sh1107_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        self.panel_bytes(device_id, &["sh1107_page"], Some(0x3C), "SH1107")
+        self.panel_bytes(device_id, &[F::SH1107_PAGE], Some(0x3C), "SH1107")
     }
 
     /// Return the ILI9341 RGB565 framebuffer for the device identified by `device_id`.
@@ -583,7 +584,7 @@ impl WasmSimulator {
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_ili9341_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        self.panel_bytes(device_id, &["rgb565_be"], None, "ILI9341")
+        self.panel_bytes(device_id, &[F::RGB565_BE], None, "ILI9341")
     }
 
     /// Return the PCD8544 (Nokia 5110) framebuffer for the device identified
@@ -593,7 +594,7 @@ impl WasmSimulator {
     /// bit `(y % 8)` of byte `[(y / 8) * 84 + x]` (1 = on/dark).
     #[wasm_bindgen]
     pub fn get_pcd8544_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        self.panel_bytes(device_id, &["pcd8544_bank"], None, "PCD8544")
+        self.panel_bytes(device_id, &[F::PCD8544_BANK], None, "PCD8544")
     }
 
     /// Return the decoded four-character text currently latched into a TM1637
@@ -703,7 +704,7 @@ impl WasmSimulator {
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_led_matrix_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        self.panel_bytes(device_id, &["max7219_rows"], None, "MAX7219")
+        self.panel_bytes(device_id, &[F::MAX7219_ROWS], None, "MAX7219")
     }
 
     /// Read back the current state of each SPI sensor declared in `board_io`.

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -9,6 +9,139 @@
 use crate::*;
 use wasm_bindgen::prelude::*;
 
+/// Both tri-color e-paper models emit this format. They are interchangeable to
+/// a reader on purpose — see [`WasmSimulator::panel_artifact`] and
+/// [`labwired_core::bus::SystemBus::device_artifact_at`].
+const EPAPER_TRICOLOR: &[&str] = &["epaper_tricolor_1bpp_planes"];
+
+/// How this crate reads a display: through the ONE device-evidence seam
+/// `inspect` walks, never through a downcast chain of its own.
+///
+/// # What this replaces
+///
+/// Every `get_*_framebuffer` below used to re-enumerate, by hand, each I²C or
+/// SPI controller its panel might hang off — `I2c`, `Esp32c3I2c`, `Esp32s3I2c`
+/// for the OLEDs; `Spi`, `Esp32Spi`, `Esp32c3Spi` for the SPI panels — and then
+/// downcast every attached device to one concrete model type. That is an N×M
+/// matrix maintained by hand in a file far from any model, and the lists did not
+/// even agree with each other: the ILI9341 accessor knew about the ESP32-C3 but
+/// not the classic ESP32, the SSD1306 accessor knew about neither ESP32 SPI nor
+/// the nRF52, and nothing knew about the ESP32-S3's GPSPI. A controller missing
+/// from one of those lists did not fail loudly — it rendered a working,
+/// actively-painted panel blank, which is exactly how the SH1107 painted a full
+/// console in the browser while `inspect` reported no artifact at all.
+///
+/// [`labwired_core::bus::SystemBus::device_artifact_at`] is the same walk
+/// `inspect` uses, so controller coverage stops being a list here and becomes a
+/// property of the walk: adding a controller makes every panel readable through
+/// it at once, and no panel can be visible to one surface and blind to the
+/// other.
+///
+/// # Two identity models, reconciled deliberately
+///
+/// The UI addresses a panel by its `board_io` id; the seam addresses a device by
+/// where it was FOUND, joining a manifest name on afterwards. Those two need not
+/// agree, so only the parts of the binding that are facts about the WIRE are
+/// used:
+///
+/// * `peripheral` and `i2c_address` — the placement — are matched against the
+///   placement the walk reports. (The board_io id and the `external_devices:`
+///   id are written from one placement by the compiler and are in practice the
+///   same string, but nothing here depends on that: the id is only carried
+///   through to stamp the artifact it addresses.)
+/// * `device_type:` is deliberately NOT consulted. It is the field already
+///   known to lie — a binding can say `ssd1680_tricolor_290` for a panel the
+///   ESP32 builder attaches as a `Uc8151dTricolor290`, which is why
+///   `get_uc8151d_framebuffer` already ignored it. What the device IS comes from
+///   `meta.format`, which the model writes next to the buffer it describes.
+impl WasmSimulator {
+    /// The artifact of the display bound to `device_id`, read through the seam.
+    fn panel_artifact(
+        &self,
+        device_id: &str,
+        formats: &[&str],
+        default_address: Option<u8>,
+        include_bytes: bool,
+        what: &str,
+    ) -> Result<labwired_core::inspect::Artifact, JsValue> {
+        let machine = self.machine.as_ref().unwrap();
+        let binding = self
+            .board_io
+            .iter()
+            .find(|b| b.id == device_id)
+            .ok_or_else(|| JsValue::from_str(&format!("No board_io binding '{device_id}'")))?;
+        // `Some(default)` is an I²C caller saying "this transport is addressed,
+        // and here is the address the model defaults to when the manifest left
+        // it out". `None` is an SPI caller: chip-selects were never compared.
+        let address = default_address.map(|d| binding.i2c_address.unwrap_or(d));
+        let opts = labwired_core::inspect::InspectOpts {
+            include_bytes,
+            peripheral: None,
+        };
+        machine
+            .bus
+            .device_artifact_at(&binding.peripheral, address, formats, device_id, &opts)
+            .ok_or_else(|| {
+                JsValue::from_str(&format!(
+                    "{what} device not found on '{}'",
+                    binding.peripheral
+                ))
+            })
+    }
+
+    /// The payload half of [`Self::panel_artifact`], for accessors that return
+    /// raw pixels.
+    fn panel_bytes(
+        &self,
+        device_id: &str,
+        formats: &[&str],
+        default_address: Option<u8>,
+        what: &str,
+    ) -> Result<Box<[u8]>, JsValue> {
+        let artifact = self.panel_artifact(device_id, formats, default_address, true, what)?;
+        artifact
+            .bytes
+            .map(Vec::into_boxed_slice)
+            .ok_or_else(|| JsValue::from_str(&format!("{what} '{device_id}' reported no payload")))
+    }
+
+    /// One `meta` value of the panel's artifact, for accessors that return a
+    /// decoded scalar or string rather than pixels. `include_bytes` stays off:
+    /// nothing on this path needs the payload.
+    fn panel_meta(
+        &self,
+        device_id: &str,
+        formats: &[&str],
+        default_address: Option<u8>,
+        what: &str,
+        key: &str,
+    ) -> Result<serde_json::Value, JsValue> {
+        let artifact = self.panel_artifact(device_id, formats, default_address, false, what)?;
+        artifact
+            .meta
+            .get(key)
+            .cloned()
+            .ok_or_else(|| JsValue::from_str(&format!("{what} '{device_id}' reports no '{key}'")))
+    }
+
+    /// The e-paper refresh counter the UI polls before re-fetching 9472 bytes.
+    /// Both tri-color panels report it under the same `meta` key, so there is
+    /// one implementation rather than two that must be kept in step.
+    fn refresh_generation(&self, device_id: &str, what: &str) -> Result<u32, JsValue> {
+        let value = self.panel_meta(
+            device_id,
+            EPAPER_TRICOLOR,
+            None,
+            what,
+            "refresh_generation",
+        )?;
+        value
+            .as_u64()
+            .and_then(|v| u32::try_from(v).ok())
+            .ok_or_else(|| JsValue::from_str("refresh_generation is not a u32"))
+    }
+}
+
 #[wasm_bindgen]
 impl WasmSimulator {
     /// Legacy LED state query (hardcoded GPIOB pin 5 for backward compat).
@@ -399,105 +532,14 @@ impl WasmSimulator {
 
     /// Return the SSD1306 GDDRAM framebuffer for the device identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type: "oled-ssd1306"`.
-    /// Returns a 1024-byte `Uint8Array` (128 columns × 8 pages, page-major).
+    /// Returns a 1024-byte `Uint8Array` (128 columns × 8 pages, page-major) for
+    /// the 128×64 panel. Both SSD1306 form factors surface through this one
+    /// accessor: the framebuffer length (1024 vs 512 bytes) is what tells the
+    /// renderer the panel height, so one readback path serves both.
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_ssd1306_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        // Find the board_io binding for this device. Both SSD1306 form factors
-        // (128×64 and the 0.91″ 128×32) surface through the same accessor — the
-        // framebuffer length (1024 vs 512 bytes) tells the renderer the panel
-        // height, so one readback path serves both.
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| {
-                b.id == device_id
-                    && matches!(
-                        b.device_type.as_deref(),
-                        Some("oled-ssd1306") | Some("oled-ssd1306-128x32")
-                    )
-            })
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("No oled-ssd1306 board_io binding '{}'", device_id))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "I2C peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        let address = binding.i2c_address.unwrap_or(0x3C);
-
-        // The framebuffer readback has to understand every I²C controller a
-        // supported board can attach an SSD1306 to. STM32 boards use the generic
-        // `I2c`; the ESP32-C3 (leo air-quality lab) uses the command-list
-        // `Esp32c3I2c`; the ESP32-S3 uses its own command-list `Esp32s3I2c`.
-        // All attach the OLED via the bus I²C choke point, so all must be
-        // enumerable here — otherwise `get_ssd1306_framebuffer` returns "not an
-        // I2C controller" and the OLED renders blank in the playground/embed even
-        // though the device is present and being drawn to.
-        if let Some(i2c) = any.downcast_ref::<labwired_core::peripherals::i2c::I2c>() {
-            for device in i2c.attached_devices() {
-                let device = device.borrow();
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(oled) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Ssd1306>()
-                }) {
-                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else if let Some(c3) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c>()
-        {
-            for device in c3.attached_slaves() {
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(oled) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Ssd1306>()
-                }) {
-                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else if let Some(s3) =
-            any.downcast_ref::<labwired_core::peripherals::esp32s3::i2c::Esp32s3I2c>()
-        {
-            for device in s3.attached_slaves() {
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(oled) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Ssd1306>()
-                }) {
-                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an I2C controller",
-                binding.peripheral
-            )));
-        }
-
-        Err(JsValue::from_str(&format!(
-            "SSD1306 device at address 0x{:02x} not found on '{}'",
-            address, binding.peripheral
-        )))
+        self.panel_bytes(device_id, &["ssd1306_page"], Some(0x3C), "SSD1306")
     }
 
     /// Return the visible text of the LCD1602 identified by `device_id`.
@@ -507,308 +549,51 @@ impl WasmSimulator {
     /// caller slices `[0..16]` and `[16..32]`. A display the firmware has not
     /// switched on reads as all spaces, matching the dark panel.
     /// Returns a JS error if the device is not found.
+    ///
+    /// The panel's evidence carries this text in `meta.text`, so this reads the
+    /// same string the CLI and `inspect` print rather than a second decode.
+    /// The default address matches the kit's own: 0x27, the PCF8574T backpack.
     #[wasm_bindgen]
     pub fn get_lcd1602_text(&self, device_id: &str) -> Result<String, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id && b.device_type.as_deref() == Some("lcd1602"))
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("No lcd1602 board_io binding '{}'", device_id))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "I2C peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        // Default matches the kit's own default: 0x27, the PCF8574T backpack.
-        let address = binding.i2c_address.unwrap_or(0x27);
-
-        // Same controller coverage as `get_ssd1306_framebuffer`: STM32 boards use
-        // the generic `I2c`, the ESP32-C3 and ESP32-S3 use their own command-list
-        // controllers. All attach character LCDs through the bus I²C choke point,
-        // so all three must be enumerable here — otherwise the panel renders blank
-        // in the playground even though the device is present and being written to.
-        if let Some(i2c) = any.downcast_ref::<labwired_core::peripherals::i2c::I2c>() {
-            for device in i2c.attached_devices() {
-                let device = device.borrow();
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(lcd) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Lcd1602>()
-                }) {
-                    return Ok(lcd.text());
-                }
-            }
-        } else if let Some(c3) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c>()
-        {
-            for device in c3.attached_slaves() {
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(lcd) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Lcd1602>()
-                }) {
-                    return Ok(lcd.text());
-                }
-            }
-        } else if let Some(s3) =
-            any.downcast_ref::<labwired_core::peripherals::esp32s3::i2c::Esp32s3I2c>()
-        {
-            for device in s3.attached_slaves() {
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(lcd) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Lcd1602>()
-                }) {
-                    return Ok(lcd.text());
-                }
-            }
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an I2C controller",
-                binding.peripheral
-            )));
-        }
-
-        Err(JsValue::from_str(&format!(
-            "LCD1602 device at address 0x{:02x} not found on '{}'",
-            address, binding.peripheral
-        )))
+        let text = self.panel_meta(
+            device_id,
+            &["hd44780_ddram"],
+            Some(0x27),
+            "LCD1602",
+            "text",
+        )?;
+        text.as_str()
+            .map(str::to_string)
+            .ok_or_else(|| JsValue::from_str("LCD1602 text is not a string"))
     }
 
     /// Return the SH1107 GDDRAM framebuffer for the device identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type: "oled-sh1107"`.
     /// Returns a 2048-byte `Uint8Array` (128 columns × 16 pages, page-major) — the
     /// same bit layout as the SSD1306, just twice as tall (128 rows).
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_sh1107_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id && b.device_type.as_deref() == Some("oled-sh1107"))
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("No oled-sh1107 board_io binding '{}'", device_id))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "I2C peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        let address = binding.i2c_address.unwrap_or(0x3C);
-
-        // Same multi-controller enumeration as the SSD1306 accessor: the SH1107
-        // can sit on the generic STM32 `I2c` or either ESP32 command-list bus, so
-        // all three must be walked or the panel renders blank in the playground.
-        if let Some(i2c) = any.downcast_ref::<labwired_core::peripherals::i2c::I2c>() {
-            for device in i2c.attached_devices() {
-                let device = device.borrow();
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(oled) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Sh1107>()
-                }) {
-                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else if let Some(c3) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c>()
-        {
-            for device in c3.attached_slaves() {
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(oled) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Sh1107>()
-                }) {
-                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else if let Some(s3) =
-            any.downcast_ref::<labwired_core::peripherals::esp32s3::i2c::Esp32s3I2c>()
-        {
-            for device in s3.attached_slaves() {
-                if device.address() != address {
-                    continue;
-                }
-                if let Some(oled) = device.as_any().and_then(|any| {
-                    any.downcast_ref::<labwired_core::peripherals::components::Sh1107>()
-                }) {
-                    return Ok(oled.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an I2C controller",
-                binding.peripheral
-            )));
-        }
-
-        Err(JsValue::from_str(&format!(
-            "SH1107 device at address 0x{:02x} not found on '{}'",
-            address, binding.peripheral
-        )))
+        self.panel_bytes(device_id, &["sh1107_page"], Some(0x3C), "SH1107")
     }
 
     /// Return the ILI9341 RGB565 framebuffer for the device identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type: "ili9341"`.
     /// Returns a 153,600-byte `Uint8Array` (240×320 pixels × 2 bytes, row-major, big-endian RGB565).
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_ili9341_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id && b.device_type.as_deref() == Some("ili9341"))
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("No ili9341 board_io binding '{}'", device_id))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-            for device in &spi.attached_devices {
-                if let Some(tft) = device.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ili9341>()
-                }) {
-                    let fb = tft.framebuffer().to_vec().into_boxed_slice();
-                    return Ok(fb);
-                }
-            }
-        } else if let Some(spi) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
-        {
-            for device in spi.attached_devices() {
-                if let Some(tft) = device.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ili9341>()
-                }) {
-                    let fb = tft.framebuffer().to_vec().into_boxed_slice();
-                    return Ok(fb);
-                }
-            }
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an SPI controller",
-                binding.peripheral
-            )));
-        }
-
-        Err(JsValue::from_str(&format!(
-            "ILI9341 device not found on SPI peripheral '{}'",
-            binding.peripheral
-        )))
+        self.panel_bytes(device_id, &["rgb565_be"], None, "ILI9341")
     }
 
     /// Return the PCD8544 (Nokia 5110) framebuffer for the device identified
     /// by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type:
-    /// "pcd8544"`. Returns 504 bytes: 84 columns × 6 banks, bank-major. Pixel
-    /// (x, y) is bit `(y % 8)` of byte `[(y / 8) * 84 + x]` (1 = on/dark).
+    /// Returns 504 bytes: 84 columns × 6 banks, bank-major. Pixel (x, y) is
+    /// bit `(y % 8)` of byte `[(y / 8) * 84 + x]` (1 = on/dark).
     #[wasm_bindgen]
     pub fn get_pcd8544_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id && b.device_type.as_deref() == Some("pcd8544"))
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("No pcd8544 board_io binding '{}'", device_id))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-            for device in &spi.attached_devices {
-                if let Some(lcd) = device.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Pcd8544>()
-                }) {
-                    return Ok(lcd.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else if let Some(spi) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
-        {
-            for device in spi.attached_devices() {
-                if let Some(lcd) = device.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Pcd8544>()
-                }) {
-                    return Ok(lcd.framebuffer().to_vec().into_boxed_slice());
-                }
-            }
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an SPI controller",
-                binding.peripheral
-            )));
-        }
-
-        Err(JsValue::from_str(&format!(
-            "PCD8544 device not found on SPI peripheral '{}'",
-            binding.peripheral
-        )))
+        self.panel_bytes(device_id, &["pcd8544_bank"], None, "PCD8544")
     }
 
     /// Return the decoded four-character text currently latched into a TM1637
@@ -870,7 +655,6 @@ impl WasmSimulator {
 
     /// Return the SSD1680 tri-color e-paper framebuffer for the device identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type: "ssd1680_tricolor_290"`.
     /// Returns a 9472-byte `Uint8Array`: first 4736 bytes are the black plane
     /// (1 = white / 0 = black), next 4736 bytes are the red plane on the wire
     /// (1 = no-red / 0 = red — see GxEPD2 inversion in writeImage). Row-major,
@@ -878,288 +662,40 @@ impl WasmSimulator {
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_ssd1680_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| {
-                b.id == device_id
-                    && matches!(
-                        b.device_type.as_deref(),
-                        Some("ssd1680_tricolor_290") | Some("epd-2in9-tricolor")
-                    )
-            })
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "No ssd1680_tricolor_290 board_io binding '{}'",
-                    device_id
-                ))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        // The SSD1680 panel attaches to either the generic STM32-shape Spi
-        // peripheral or the Esp32Spi controller (same SpiDevice trait,
-        // different controller models). Try both downcasts.
-        let panel_bytes =
-            if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-                spi.attached_devices.iter().find_map(|dev| {
-                    dev.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
-                }).map(|panel| (panel.black_plane().to_vec(), panel.red_plane().to_vec()))
-                })
-            } else if let Some(spi) =
-                any.downcast_ref::<labwired_core::peripherals::esp32::spi::Esp32Spi>()
-            {
-                spi.attached_devices.iter().find_map(|dev| {
-                    dev.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
-                }).map(|panel| (panel.black_plane().to_vec(), panel.red_plane().to_vec()))
-                })
-            } else if let Some(spi) =
-                any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
-            {
-                spi.attached_devices().iter().find_map(|dev| {
-                    dev.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
-                }).map(|panel| (panel.black_plane().to_vec(), panel.red_plane().to_vec()))
-                })
-            } else {
-                return Err(JsValue::from_str(&format!(
-                    "Peripheral '{}' is not an SPI controller",
-                    binding.peripheral
-                )));
-            };
-
-        let (black, red) = panel_bytes.ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "SSD1680 device not found on SPI peripheral '{}'",
-                binding.peripheral
-            ))
-        })?;
-        let mut combined = Vec::with_capacity(black.len() + red.len());
-        combined.extend_from_slice(&black);
-        combined.extend_from_slice(&red);
-        Ok(combined.into_boxed_slice())
+        self.panel_bytes(device_id, EPAPER_TRICOLOR, None, "SSD1680")
     }
 
     /// Cheap accessor returning just the SSD1680 refresh-generation counter.
     /// UI uses this to decide whether to re-fetch the (larger) framebuffer.
     #[wasm_bindgen]
     pub fn get_ssd1680_refresh_generation(&self, device_id: &str) -> Result<u32, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| {
-                b.id == device_id
-                    && matches!(
-                        b.device_type.as_deref(),
-                        Some("ssd1680_tricolor_290") | Some("epd-2in9-tricolor")
-                    )
-            })
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "No ssd1680_tricolor_290 board_io binding '{}'",
-                    device_id
-                ))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        let gen = if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-            spi.attached_devices.iter().find_map(|dev| {
-                dev.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
-                }).map(|panel| panel.refresh_generation())
-            })
-        } else if let Some(spi) =
-            any.downcast_ref::<labwired_core::peripherals::esp32::spi::Esp32Spi>()
-        {
-            spi.attached_devices.iter().find_map(|dev| {
-                dev.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
-                }).map(|panel| panel.refresh_generation())
-            })
-        } else if let Some(spi) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
-        {
-            spi.attached_devices().iter().find_map(|dev| {
-                dev.as_any().and_then(|a| {
-                    a.downcast_ref::<labwired_core::peripherals::components::Ssd1680Tricolor290>()
-                }).map(|panel| panel.refresh_generation())
-            })
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an SPI controller",
-                binding.peripheral
-            )));
-        };
-        gen.ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "SSD1680 device not found on SPI peripheral '{}'",
-                binding.peripheral
-            ))
-        })
+        self.refresh_generation(device_id, "SSD1680")
     }
 
-    /// Same shape as [`get_ssd1680_framebuffer`] but for the UC8151D-family
-    /// tri-color panel attached by [`install_arduino_esp32_quirks`]. The
-    /// board_io binding type may say `ssd1680_tricolor_290` (since system
-    /// YAMLs were authored before the UC8151D split); we ignore that and
-    /// just find a `Uc8151dTricolor290` on the named SPI peripheral.
+    /// Same shape as [`Self::get_ssd1680_framebuffer`], kept as a separate name
+    /// because the UI selects an accessor by the diagram part's type.
+    ///
+    /// It resolves to the SAME query: a tri-color e-paper on the bound
+    /// controller, whichever of the two controller models the builder attached.
+    /// That is not a shortcut — it is the honest reading of a `board_io`
+    /// `device_type:` that says `ssd1680_tricolor_290` for a panel the ESP32
+    /// builder attaches as a `Uc8151dTricolor290`. This accessor already ignored
+    /// the declared type for exactly that reason; now its twin does too, so a
+    /// lab can no longer render blank purely because the UI picked the accessor
+    /// named after the type string rather than the one named after the model.
     #[wasm_bindgen]
     pub fn get_uc8151d_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        use labwired_core::peripherals::components::Uc8151dTricolor290;
-        use labwired_core::peripherals::esp32::spi::Esp32Spi;
-        use labwired_core::peripherals::esp32c3::spi::Esp32c3Spi;
-        let machine = self.machine.as_ref().unwrap();
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id)
-            .ok_or_else(|| JsValue::from_str(&format!("No board_io binding '{}'", device_id)))?;
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-        // Same controller set as get_ssd1680_*: STM32 Spi, classic Esp32Spi,
-        // and Esp32c3Spi. Missing the C3 arm made stats-display attach the
-        // panel (kit registry) but never surface planes to the UI.
-        let panel_bytes =
-            if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-                spi.attached_devices.iter().find_map(|dev| {
-                    dev.as_any()
-                        .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
-                        .map(|p| (p.black_plane().to_vec(), p.red_plane().to_vec()))
-                })
-            } else if let Some(spi) = any.downcast_ref::<Esp32Spi>() {
-                spi.attached_devices.iter().find_map(|dev| {
-                    dev.as_any()
-                        .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
-                        .map(|p| (p.black_plane().to_vec(), p.red_plane().to_vec()))
-                })
-            } else if let Some(spi) = any.downcast_ref::<Esp32c3Spi>() {
-                spi.attached_devices().iter().find_map(|dev| {
-                    dev.as_any()
-                        .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
-                        .map(|p| (p.black_plane().to_vec(), p.red_plane().to_vec()))
-                })
-            } else {
-                return Err(JsValue::from_str(&format!(
-                    "Peripheral '{}' is not an SPI controller",
-                    binding.peripheral
-                )));
-            };
-        let (black, red) = panel_bytes.ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "UC8151D device not found on SPI peripheral '{}'",
-                binding.peripheral
-            ))
-        })?;
-        let mut combined = Vec::with_capacity(black.len() + red.len());
-        combined.extend_from_slice(&black);
-        combined.extend_from_slice(&red);
-        Ok(combined.into_boxed_slice())
+        self.panel_bytes(device_id, EPAPER_TRICOLOR, None, "UC8151D")
     }
 
     /// Cheap accessor returning just the UC8151D refresh-generation counter.
     #[wasm_bindgen]
     pub fn get_uc8151d_refresh_generation(&self, device_id: &str) -> Result<u32, JsValue> {
-        use labwired_core::peripherals::components::Uc8151dTricolor290;
-        use labwired_core::peripherals::esp32::spi::Esp32Spi;
-        use labwired_core::peripherals::esp32c3::spi::Esp32c3Spi;
-        let machine = self.machine.as_ref().unwrap();
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id)
-            .ok_or_else(|| JsValue::from_str(&format!("No board_io binding '{}'", device_id)))?;
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-        let gen = if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-            spi.attached_devices.iter().find_map(|dev| {
-                dev.as_any()
-                    .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
-                    .map(|p| p.refresh_generation())
-            })
-        } else if let Some(spi) = any.downcast_ref::<Esp32Spi>() {
-            spi.attached_devices.iter().find_map(|dev| {
-                dev.as_any()
-                    .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
-                    .map(|p| p.refresh_generation())
-            })
-        } else if let Some(spi) = any.downcast_ref::<Esp32c3Spi>() {
-            spi.attached_devices().iter().find_map(|dev| {
-                dev.as_any()
-                    .and_then(|a| a.downcast_ref::<Uc8151dTricolor290>())
-                    .map(|p| p.refresh_generation())
-            })
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an SPI controller",
-                binding.peripheral
-            )));
-        };
-        gen.ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "UC8151D device not found on SPI peripheral '{}'",
-                binding.peripheral
-            ))
-        })
+        self.refresh_generation(device_id, "UC8151D")
     }
 
     /// Return the MAX7219 LED-matrix framebuffer for the device identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type: "led-matrix"`.
     /// Returns an 8-byte `Uint8Array`: one byte per matrix row, row 0 first,
     /// bit 7 = the leftmost column (`SEG A` on the driver). The bytes already
     /// account for shutdown (all zero) and display test (all `0xFF`), so the
@@ -1167,78 +703,7 @@ impl WasmSimulator {
     /// Returns a JS error if the device is not found.
     #[wasm_bindgen]
     pub fn get_led_matrix_framebuffer(&self, device_id: &str) -> Result<Box<[u8]>, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
-
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id && b.device_type.as_deref() == Some("led-matrix"))
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("No led-matrix board_io binding '{}'", device_id))
-            })?;
-
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "SPI peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any()
-            .ok_or_else(|| JsValue::from_str("Peripheral does not support downcasting"))?;
-
-        // Cover every SPI controller a supported board can hang a MAX7219 off:
-        // the generic STM32-shape `Spi`, the ESP32 `Esp32Spi` and the ESP32-C3
-        // `Esp32c3Spi` — the same set the SSD1680 readback enumerates. Missing
-        // one here renders the matrix blank even though the device is present
-        // and being driven.
-        let rows = if let Some(spi) = any.downcast_ref::<labwired_core::peripherals::spi::Spi>() {
-            spi.attached_devices.iter().find_map(|dev| {
-                dev.as_any()
-                    .and_then(|a| {
-                        a.downcast_ref::<labwired_core::peripherals::components::Max7219>()
-                    })
-                    .map(|m| m.framebuffer())
-            })
-        } else if let Some(spi) =
-            any.downcast_ref::<labwired_core::peripherals::esp32::spi::Esp32Spi>()
-        {
-            spi.attached_devices.iter().find_map(|dev| {
-                dev.as_any()
-                    .and_then(|a| {
-                        a.downcast_ref::<labwired_core::peripherals::components::Max7219>()
-                    })
-                    .map(|m| m.framebuffer())
-            })
-        } else if let Some(spi) =
-            any.downcast_ref::<labwired_core::peripherals::esp32c3::spi::Esp32c3Spi>()
-        {
-            spi.attached_devices().iter().find_map(|dev| {
-                dev.as_any()
-                    .and_then(|a| {
-                        a.downcast_ref::<labwired_core::peripherals::components::Max7219>()
-                    })
-                    .map(|m| m.framebuffer())
-            })
-        } else {
-            return Err(JsValue::from_str(&format!(
-                "Peripheral '{}' is not an SPI controller",
-                binding.peripheral
-            )));
-        };
-
-        let rows = rows.ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "MAX7219 device not found on SPI peripheral '{}'",
-                binding.peripheral
-            ))
-        })?;
-        Ok(rows.to_vec().into_boxed_slice())
+        self.panel_bytes(device_id, &["max7219_rows"], None, "MAX7219")
     }
 
     /// Read back the current state of each SPI sensor declared in `board_io`.

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -686,7 +686,6 @@ impl WasmSimulator {
 
     /// Return the visible text of the LCD1602 identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type: "lcd1602"`.
     /// Returns exactly 32 characters — row 0 then row 1, no separator — so the
     /// caller slices `[0..16]` and `[16..32]`. A display the firmware has not
     /// switched on reads as all spaces, matching the dark panel.
@@ -765,8 +764,7 @@ impl WasmSimulator {
     /// Return the character shown on the direct-drive 7-segment digit
     /// identified by `device_id`.
     ///
-    /// `device_id` must match a `board_io` binding with `device_type:
-    /// "seven-segment"`. Returns the single decoded character, with `'.'`
+    /// Returns the single decoded character, with `'.'`
     /// appended when the decimal point is lit — so a blank digit is `" "`,
     /// a lit `0` is `"0"`, and `0` with the dp is `"0."`. An unrecognised
     /// segment pattern decodes to `"?"` rather than silently blanking.

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -15,6 +15,36 @@ use wasm_bindgen::prelude::*;
 /// [`labwired_core::bus::SystemBus::device_artifact_at`].
 const EPAPER_TRICOLOR: &[&str] = &[F::EPAPER_TRICOLOR_PLANES];
 
+/// Rewrite integers that JavaScript cannot hold exactly as decimal STRINGS.
+///
+/// `serde_wasm_bindgen` does not truncate a `u64` past 2^53 — it fails the whole
+/// serialization, and `to_value(..).unwrap_or(JsValue::NULL)` then hands the UI
+/// a silent `null`. `meta.generation` is a 64-bit FNV hash, so it trips this
+/// essentially always: `WasmSimulator::inspect` returns `null` for every machine
+/// that has a device with an artifact, which is every machine with a panel.
+///
+/// A string keeps the value exact and keeps it comparable (`!==` is all a
+/// change-detector needs), where an `f64` would silently alias two different
+/// buffers to one generation and a `BigInt` would make `JSON.stringify` throw.
+fn js_safe_meta(meta: &serde_json::Value) -> serde_json::Value {
+    const MAX_EXACT: u64 = 1 << 53;
+    match meta {
+        serde_json::Value::Number(n) => match n.as_u64() {
+            Some(v) if v >= MAX_EXACT => serde_json::Value::String(v.to_string()),
+            _ => meta.clone(),
+        },
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(js_safe_meta).collect())
+        }
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), js_safe_meta(v)))
+                .collect(),
+        ),
+        _ => meta.clone(),
+    }
+}
+
 /// How this crate reads a display: through the ONE device-evidence seam
 /// `inspect` walks, never through a downcast chain of its own.
 ///
@@ -56,7 +86,51 @@ const EPAPER_TRICOLOR: &[&str] = &[F::EPAPER_TRICOLOR_PLANES];
 ///   `get_uc8151d_framebuffer` already ignored it. What the device IS comes from
 ///   `meta.format`, which the model writes next to the buffer it describes.
 impl WasmSimulator {
+    /// THE door: whatever the display called `device_id` is showing.
+    ///
+    /// One resolution, tried in the order the two id registries are authoritative:
+    ///
+    /// 1. **The manifest name.** [`labwired_core::bus::SystemBus::display_artifact`]
+    ///    joins the walk to `external_devices:`, so this reaches a display
+    ///    however it was bound — I²C slave, SPI panel, a slave behind a bus
+    ///    switch, or a bit-banged module that has no controller at all. This is
+    ///    the step that was missing: every accessor this replaces started from
+    ///    `board_io`, so a display declared only under `external_devices:` had
+    ///    no placement to query and painted nothing on every chip, for every
+    ///    model.
+    /// 2. **The `board_io` placement**, when and only when the manifest join did
+    ///    not produce this id — a model attached programmatically rather than
+    ///    from a declaration (the ESP32 quirks path) has a synthesized id, and
+    ///    the binding still states the wire it is on. Not a parallel system: it
+    ///    is a second key into the SAME walk and the SAME
+    ///    [`labwired_core::inspect::DeviceEvidence::artifacts`] call.
+    fn display_artifact(
+        &self,
+        device_id: &str,
+        include_bytes: bool,
+    ) -> Option<labwired_core::inspect::Artifact> {
+        let machine = self.machine.as_ref()?;
+        let opts = labwired_core::inspect::InspectOpts {
+            include_bytes,
+            peripheral: None,
+        };
+        if let Some(found) = machine.bus.display_artifact(device_id, &opts) {
+            return Some(found);
+        }
+        let binding = self.board_io.iter().find(|b| b.id == device_id)?;
+        machine.bus.device_artifact_at_any(
+            &binding.peripheral,
+            binding.i2c_address,
+            device_id,
+            &opts,
+        )
+    }
+
     /// The artifact of the display bound to `device_id`, read through the seam.
+    ///
+    /// Kept for the per-model shims, which pass a `formats` filter so that two
+    /// panels on one controller cannot be handed to each other. The door above
+    /// needs no such filter: it is keyed by the id the author gave the device.
     fn panel_artifact(
         &self,
         device_id: &str,
@@ -65,6 +139,19 @@ impl WasmSimulator {
         include_bytes: bool,
         what: &str,
     ) -> Result<labwired_core::inspect::Artifact, JsValue> {
+        // The one door first, so a per-model accessor inherits every route the
+        // door can resolve — including the `external_devices:`-only rigs that
+        // have no binding at all.
+        if let Some(found) = self.display_artifact(device_id, include_bytes) {
+            if found
+                .meta
+                .get("format")
+                .and_then(|f| f.as_str())
+                .is_some_and(|f| formats.contains(&f))
+            {
+                return Ok(found);
+            }
+        }
         let machine = self.machine.as_ref().unwrap();
         let binding = self
             .board_io
@@ -531,6 +618,60 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&states).unwrap_or(JsValue::NULL)
     }
 
+    /// **THE door.** Whatever the display called `device_id` is showing — any
+    /// model, any transport, any chip, however it was bound.
+    ///
+    /// Returns `null` when there is no such display, otherwise:
+    ///
+    /// ```text
+    /// { id, kind, format, width, height, bytes, text, meta }
+    /// ```
+    ///
+    /// * `kind` — `"framebuffer"` (packed pixels) or `"text_display"` (decoded
+    ///   characters). Between them, every way this engine has of saying "a human
+    ///   can see this".
+    /// * `format` — how `bytes` are packed (`"rgb565_be"`, `"ssd1306_page"`,
+    ///   `"epaper_tricolor_1bpp_planes"`, …).
+    /// * `width` / `height` — the panel's own geometry, in pixels (or in
+    ///   characters, for a text display), `null` when the model reports none.
+    /// * `bytes` — the payload, present only when `include_bytes`.
+    /// * `text` — the decoded string, for a `text_display`.
+    /// * `meta` — everything else the model chose to report (ink counts, power
+    ///   state, `generation`, `refresh_generation`), so a caller can poll for
+    ///   change without pulling pixels.
+    ///
+    /// **Geometry and packing are DATA, deliberately.** The accessors this
+    /// replaces carried them as prose in a doc comment — "153,600 bytes =
+    /// 240×320×2, big-endian RGB565" — which is lore that lives in the reader.
+    /// A model that arrives tomorrow cannot put anything into last year's doc
+    /// comment, so every new panel needed a new accessor AND a new renderer
+    /// branch before it could show a single pixel. Here a caller can paint a
+    /// display it has never heard of, and a new model is renderable the day its
+    /// own `artifacts()` lands.
+    ///
+    /// `generation` is stringified: it is a 64-bit FNV hash, and a `u64` past
+    /// 2^53 makes `serde_wasm_bindgen` refuse the WHOLE payload. That is not
+    /// hypothetical — it is why [`Self::inspect`] currently returns `null` for
+    /// every machine that has a device with an artifact.
+    #[wasm_bindgen]
+    pub fn get_display(&self, device_id: &str, include_bytes: bool) -> JsValue {
+        let Some(artifact) = self.display_artifact(device_id, include_bytes) else {
+            return JsValue::NULL;
+        };
+        let meta = js_safe_meta(&artifact.meta);
+        let out = serde_json::json!({
+            "id": artifact.id,
+            "kind": artifact.kind,
+            "format": meta.get("format").cloned().unwrap_or(serde_json::Value::Null),
+            "width": meta.get("w").cloned().unwrap_or(serde_json::Value::Null),
+            "height": meta.get("h").cloned().unwrap_or(serde_json::Value::Null),
+            "text": meta.get("text").cloned().unwrap_or(serde_json::Value::Null),
+            "bytes": artifact.bytes,
+            "meta": meta,
+        });
+        serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
+    }
+
     /// Return the SSD1306 GDDRAM framebuffer for the device identified by `device_id`.
     ///
     /// Returns a 1024-byte `Uint8Array` (128 columns × 8 pages, page-major) for
@@ -850,7 +991,17 @@ impl WasmSimulator {
             peripheral: None,
         };
         let mi = machine.inspect(name.as_deref(), &opts);
-        serde_wasm_bindgen::to_value(&mi).unwrap_or(JsValue::NULL)
+        // Round-trip through `serde_json` so `js_safe_meta` can reach the
+        // artifact `generation` values. Without it this returned `null` — not
+        // for a filtered peripheral, but for the WHOLE payload, on every
+        // machine that has a panel: a 64-bit FNV hash is past 2^53 and
+        // `serde_wasm_bindgen` refuses the entire document rather than the
+        // field. Every inspect surface in the browser has been blind to
+        // exactly the machines it exists to describe.
+        let Ok(value) = serde_json::to_value(&mi) else {
+            return JsValue::NULL;
+        };
+        serde_wasm_bindgen::to_value(&js_safe_meta(&value)).unwrap_or(JsValue::NULL)
     }
 
     /// Raw escape hatch: read `len` bytes at absolute `addr`, side-effect-free.


### PR DESCRIPTION
## ONE door for every display

`crates/wasm/src/inspect.rs` carried a second, parallel display-evidence system next to the seam core#757 landed: **seven** per-model framebuffer accessors, **51** `downcast_ref` arms across **16** concrete types, each accessor re-enumerating by hand every controller its panel might hang off.

The lists did not agree with each other. `get_ili9341_framebuffer` knew about the ESP32-C3 but not the classic ESP32. None of them knew about the ESP32-S3's GPSPI or the nRF52's SPIM. A controller missing from a list did not fail loudly — it rendered a working, actively-painted panel blank.

**And all seven began by looking the display up in `board_io`.** So a display declared only under `external_devices:` — an ordinary way to place one — had no placement for the renderer to query and painted nothing. Not for one model: **for every model, on every chip.** Ryan is simply the first person who reported it.

### The door

```rust
get_display(device_id, include_bytes)
  -> { id, kind, format, width, height, bytes, text, meta } | null
```

One call. Any model, any transport, any chip, however the author placed it. Backed by `SystemBus::display_artifact`, which joins the same `for_each_attached_device` walk `inspect` walks to the manifest name — so it reaches an I²C slave, an SPI panel, a slave behind a bus switch, and a bit-banged TM1637 with no controller at all, by one code path.

**Geometry and packing are DATA.** The old accessors carried them as prose in a doc comment (*"153,600 bytes = 240×320×2, big-endian RGB565"*) — lore that lives in the reader. A model arriving tomorrow cannot put anything into last year's doc comment, so every new panel needed a new accessor **and** a new renderer branch before it could show one pixel. A caller can now paint a display it has never heard of.

The seven per-model accessors remain as one-line shims over the door (the UI still selects one by part type), and they inherit its resolution — so they work on `external_devices`-only rigs too. **No third path was added.**

### Watched it fail first

Three shipped rigs, found by scanning the tree for "display under `external_devices:` that no `board_io:` entry names" — deliberately three models, three transports, three chips, so the fix cannot be ILI9341-shaped:

```
BLIND examples/esp32-bay-occupancy/system.yaml:   ili9341     'tft' ...
BLIND examples/esp32c3-leo-airquality/system.yaml: oled-ssd1306 'oled' ...
BLIND examples/tm1637-7seg-lab/system.yaml:       tm1637-7seg 'seg' ...
  ... is placed and built, but no board_io binding names it — the renderer has
      no placement to query, so the panel paints nothing
assertion `left == right` failed: 3 shipped displays cannot be rendered at all
```

All three pass after.

### Browser evidence (real engine, real firmware)

Deterministic harness: fixed cycle schedule, engine rebuilt, framebuffers FNV-hashed and compared against a hash baseline captured from **origin/main before any edit**.

**11/11 already-working panels byte-identical.** SSD1306 on generic-I²C / ESP32-C3 / ESP32-S3, SH1107 on ESP32-S3, ILI9341, SSD1680 e-paper on generic-SPI and ESP32-SPI, UC8151D e-reader, PCD8544 ×2 — every payload and every `refresh_generation` unchanged.

**And the rig that could never render, now renders.** `esp32c3-leo-airquality` has *zero* `board_io` bindings; every per-model accessor returns nothing; the door returns `framebuffer ssd1306_page 128x64 len=1024` with live pixels.

### Gates

* `display_one_door.rs::every_display_in_every_shipped_rig_answers_the_one_door` — enumerates from the **filesystem** (every `system.yaml` under `examples/` and `configs/systems/`) and takes the displays in each from whatever reports a display-kind artifact through the walk. It names no model, controller, transport or device_type, so it cannot agree with the accessor by construction. **21 displays across 21 rigs.**
* `display_evidence_one_seam.rs` — the placement query and the manifest query must return byte-identical artifacts, plus the negative direction (wrong bus, wrong address, wrong format must all refuse).

### Also fixed

`WasmSimulator::inspect` returned `null` for **every machine that has a panel**: `meta.generation` is a 64-bit FNV hash, and `serde_wasm_bindgen` refuses the *whole* document for a `u64` past 2^53 rather than the one field. Integers JavaScript cannot hold exactly now cross as decimal strings — exact, still comparable, where an `f64` would alias two buffers to one generation.

Artifact `meta.format` literals became one symbol (`labwired_core::inspect::artifact_format`), shared by the models that write them and the readers that match them, so a typo is a compile error rather than a blank panel.

### Not in this PR

* **The UI still selects an accessor by part type.** `SimHost` has a per-kind `if/else` chain and `displayDecoders.ts` switches on `kind`. Making "add a display model, edit no UI" true end-to-end means driving both off `format`/`width`/`height` from the door — that data now exists; the UI change does not. It is where the "no panel may stop rendering" risk concentrates (e-paper red-plane inversion, synthesised generations), so it wants its own change and its own browser pass.
* `get_iolink_master_state` and the UART/GPS accessors have the same disease. The seam generalises to them — they are `DeviceEvidence` implementations waiting to be written, and the door's `kind` filter is the only thing that would need widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
