### PR TITLE
fix(tick-starvation): C3 RMT + RP2040 I2C0 IRQ delivery, and the static gate for the class

### DIFF
--- a/crates/core/src/peripherals/esp32c3/rmt.rs
+++ b/crates/core/src/peripherals/esp32c3/rmt.rs
@@ -119,12 +119,34 @@ impl Esp32c3Rmt {
 }
 
 impl Peripheral for Esp32c3Rmt {
-    fn needs_legacy_walk(&self) -> bool {
-        // Instant TX on CONF0 write + level IRQ via `matrix_irq_sources` —
-        // no per-cycle walk work. Must stay walk-independent so the C3 chip
-        // yaml (which now installs this model) can still derive walk-deletion
-        // for wifi_mac / rom-boot paths.
-        false
+    /// Scheduler-driven, level-only: TX completes inside the `CONF0` write and
+    /// the resulting `CHn_TX_END` level is published through
+    /// [`Self::matrix_irq_sources_into`], which the bus re-derives at the MMIO
+    /// write choke and at every matrix aggregation. There is no per-cycle work
+    /// and no deadline to schedule, so no `on_event` chain and no `sync_to`.
+    ///
+    /// This replaces a `needs_legacy_walk() -> false` override that was a lie:
+    /// `tick()` below emits `explicit_irqs` whenever `INT_ST != 0`, and on the
+    /// shipped C3 bus every peripheral qualifies for walk deletion, so that
+    /// `tick()` was never called. The level export did not save it either —
+    /// `SystemBus::poll_scheduler_matrix_sources` only polls `uses_scheduler()`
+    /// models, and this one did not declare it. Both delivery channels were
+    /// closed, so `rgbLedWrite`'s `rmtWrite(.., RMT_WAIT_FOR_EVER)` blocked
+    /// forever on the semaphore its ISR gives.
+    ///
+    /// Declaring `uses_scheduler()` — rather than flipping `needs_legacy_walk`
+    /// to `true` — is what keeps the fix free: the C3 bus stays walk-DELETED
+    /// (`derive_walk_deletable` accepts `uses_scheduler || !needs_legacy_walk`),
+    /// so every shipped C3 lab keeps its 512x peripheral-tick batching. Putting
+    /// the model back on the walk would have restored delivery by making the
+    /// whole chip slow.
+    ///
+    /// `needs_legacy_walk()` is deliberately left at its conservative default
+    /// (`true`): the walk-deletion derivation is already satisfied by
+    /// `uses_scheduler()`, and a `false` here would be the same false claim the
+    /// static contract in `crate::tests::walk_starvation_contract` now rejects.
+    fn uses_scheduler(&self) -> bool {
+        true
     }
 
     fn read_u32(&self, offset: u64) -> SimResult<u32> {
@@ -194,6 +216,11 @@ impl Peripheral for Esp32c3Rmt {
         self.write_u32(aligned, w)
     }
 
+    /// Legacy-walk / hardware-oracle path only.
+    ///
+    /// Under `event-scheduler` the walk skips this model (`uses_scheduler`) and
+    /// the level below is the delivery path. Without the feature the walk still
+    /// runs and this keeps the pre-migration behaviour byte-identical.
     fn tick(&mut self) -> PeripheralTickResult {
         if self.int_st() != 0 {
             PeripheralTickResult {
@@ -205,11 +232,17 @@ impl Peripheral for Esp32c3Rmt {
         }
     }
 
-    fn matrix_irq_sources(&self) -> Vec<u32> {
+    /// The live `CHn_TX_END` level, re-derived by the bus.
+    ///
+    /// Push form (`_into`) rather than the returning `matrix_irq_sources`:
+    /// `SystemBus::poll_scheduler_matrix_sources` fills ONE retained scratch
+    /// buffer through this method, so an RMT sitting on a walk-deleted C3 bus
+    /// costs no allocation per poll. Level semantics — the bitmap is rebuilt
+    /// from scratch each poll, so `INT_CLR` de-asserts the routed line at the
+    /// acknowledging write instead of latching it into an ISR storm.
+    fn matrix_irq_sources_into(&self, out: &mut Vec<u32>) {
         if self.int_st() != 0 {
-            vec![self.source_id]
-        } else {
-            Vec::new()
+            out.push(self.source_id);
         }
     }
 

--- a/crates/core/src/peripherals/rp2040/i2c.rs
+++ b/crates/core/src/peripherals/rp2040/i2c.rs
@@ -61,6 +61,12 @@ pub struct Rp2040I2c {
     rx_byte: Cell<Option<u8>>,
     activity: Cell<bool>,
     attached_devices: Vec<RefCell<Box<dyn I2cDevice>>>,
+    /// Held-level event chain (see the `impl Peripheral` docs). Monotonic token
+    /// so a stale in-flight event from a previous arm is ignored.
+    arm_seq: u32,
+    /// True while an event for this model is in flight, so a burst of writes
+    /// arms exactly one chain rather than one per write.
+    scheduled: bool,
 }
 
 impl std::fmt::Debug for Rp2040I2c {
@@ -109,11 +115,86 @@ impl Rp2040I2c {
 }
 
 impl Peripheral for Rp2040I2c {
-    /// Pure write-driven transfer engine — `tick()` is structural no-op for
-    /// the walk (Class-A). Address NACK / slave traffic fire inside
-    /// `IC_DATA_CMD` writes; no per-cycle work.
-    fn needs_legacy_walk(&self) -> bool {
-        false
+    /// Scheduler-driven, held-level: `I2C0_IRQ` rides an event chain, not the
+    /// per-cycle walk.
+    ///
+    /// # What was wrong
+    ///
+    /// This model used to declare `needs_legacy_walk() -> false` with the
+    /// comment "pure write-driven transfer engine — `tick()` is structural
+    /// no-op". The transfer engine is write-driven; the *interrupt* was not.
+    /// `tick()` returns `irq: self.irq_pending()`, and that was the ONLY NVIC
+    /// pend the model had. Every peripheral on `rp2040-pico` makes the same
+    /// claim, so `SystemBus::derive_walk_deletable` deletes the walk and the
+    /// pend never happens. Nothing catches it downstream either:
+    /// `deliver_scheduled_irq_levels` covers only the C3 and S3 interrupt
+    /// matrices and returns `false` on an NVIC bus.
+    ///
+    /// Arduino `Wire` polls `IC_TX_ABRT_SOURCE` / `IC_STATUS`, which is why no
+    /// shipped lab noticed. pico-sdk's I2C-slave path and embassy-rp's async
+    /// I2C both wait on the interrupt and hang outright.
+    ///
+    /// # Why an event chain and not `needs_legacy_walk() -> true`
+    ///
+    /// Restoring the walk would fix delivery by making the whole RP2040 bus
+    /// slow: `derive_walk_deletable` is all-or-nothing, so one forcing model
+    /// drops `max_safe_tick_interval` from 512 to 1 for *every* RP2040 lab,
+    /// including the majority that never enable an I2C interrupt. The chain
+    /// below costs a scheduler wakeup only while an interrupt is genuinely
+    /// armed AND asserting — which is exactly when a real DW_apb_i2c holds its
+    /// level line up, and when the CPU would be in the ISR anyway.
+    ///
+    /// # The chain
+    ///
+    /// `(raw_intr & intr_mask)` can only *rise* on an MMIO write
+    /// (`IC_ENABLE`, `IC_INTR_MASK`, `IC_DATA_CMD`) — the `IC_CLR_*` registers
+    /// are read-to-clear and only lower it. So the write choke
+    /// (`SystemBus::collect_scheduled_events`, run after every write to a
+    /// `uses_scheduler()` model) is a complete arming point, and
+    /// `take_scheduled_events` needs no clock and no `sync_to`. `on_event` then
+    /// re-pends at delay 1 while the level holds and stops rescheduling the
+    /// moment firmware masks or clears it — the same held-level shape
+    /// [`crate::peripherals::rp2040::timer::Rp2040Timer`] uses for its alarms.
+    ///
+    /// Left ungated (not `cfg!(feature = "event-scheduler")`) so walk-deletion
+    /// derives identically in both builds; the walk's skip of scheduler models
+    /// is itself feature-gated, so a featureless build still ticks this model
+    /// exactly as before.
+    fn uses_scheduler(&self) -> bool {
+        true
+    }
+
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        // Only arm while a level is actually up, and only once per chain.
+        if !self.irq_pending() || self.scheduled {
+            return Vec::new();
+        }
+        self.arm_seq = self.arm_seq.wrapping_add(1);
+        self.scheduled = true;
+        // delay 0 → deadline `current_cycle + 1`: the cycle the legacy walk's
+        // next tick would have serviced this.
+        vec![(0, self.arm_seq)]
+    }
+
+    fn on_event(
+        &mut self,
+        event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if event_token != self.arm_seq {
+            // Stale token from a superseded arm; the live chain owns delivery.
+            return crate::sched::EventResult::default();
+        }
+        let pending = self.irq_pending();
+        self.scheduled = pending;
+        crate::sched::EventResult {
+            // The bus pends `PeripheralEntry::irq` (NVIC 23 on rp2040-pico) —
+            // the event-path twin of the walk's `PeripheralTickResult::irq`.
+            raise_own_irq: pending,
+            reschedule_delay: pending.then_some(1),
+            ..Default::default()
+        }
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -242,6 +323,11 @@ impl Peripheral for Rp2040I2c {
         self.write_u32(aligned, new)
     }
 
+    /// Legacy-walk / hardware-oracle path only.
+    ///
+    /// Under `event-scheduler` the walk skips this model (`uses_scheduler`) and
+    /// the event chain owns delivery. Without the feature the walk still runs
+    /// and this keeps the pre-migration behaviour byte-identical.
     fn tick(&mut self) -> PeripheralTickResult {
         PeripheralTickResult {
             irq: self.irq_pending(),

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -29,4 +29,6 @@ pub mod scb_reset;
 #[cfg(test)]
 pub mod stm32_spi_waveform;
 #[cfg(test)]
+pub mod walk_starvation_contract;
+#[cfg(test)]
 pub mod test_cycles;

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -29,6 +29,6 @@ pub mod scb_reset;
 #[cfg(test)]
 pub mod stm32_spi_waveform;
 #[cfg(test)]
-pub mod walk_starvation_contract;
-#[cfg(test)]
 pub mod test_cycles;
+#[cfg(test)]
+pub mod walk_starvation_contract;

--- a/crates/core/src/tests/walk_starvation_contract.rs
+++ b/crates/core/src/tests/walk_starvation_contract.rs
@@ -1,0 +1,734 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! THE CONTRACT: a peripheral that is excluded from the per-cycle walk must not
+//! do work in `tick()`.
+//!
+//! # The bug class
+//!
+//! Two independent channels stop a peripheral's `tick()` ever being called, and
+//! both are invisible in a default `cargo test`:
+//!
+//! 1. **Whole-walk deletion.** [`crate::bus::SystemBus::derive_walk_deletable`]
+//!    deletes the legacy walk for the ENTIRE bus iff every peripheral reports
+//!    `uses_scheduler() || !needs_legacy_walk()`. One model lying about itself
+//!    starves every model on that bus.
+//! 2. **Per-peripheral skip.** The walk loop returns `default()` for any
+//!    `uses_scheduler()` model even when the walk runs. A model that claims
+//!    scheduler mode without an event chain, a `sync_to`, or a matrix level
+//!    export is starved regardless of channel 1.
+//!
+//! Both are gated on `--features event-scheduler`, which the browser/wasm crate
+//! enables and every CLI lane in this repo does not. So the failure appears
+//! only in the product, and only as a hang.
+//!
+//! # Why this gate is STATIC
+//!
+//! Runtime falsification does not work here and was tried. A register-level
+//! fuzzer that pokes a model and diffs walk-on against walk-off misses this
+//! entire class, because it never leaves the model in an *asserting* state: the
+//! difference only exists while an interrupt level is up, which takes a
+//! specific arming sequence the falsifier does not know. Three confirmed
+//! defects (classic-ESP32 UART0, ESP32-C3 RMT, RP2040 I2C0) all survived it.
+//!
+//! A static scan asks the question that actually distinguishes them: does the
+//! source say "I need no walk" while also containing walk work? That is
+//! answerable by reading the code, needs no firmware, no feature flag and no
+//! bus, and cannot be satisfied vacuously.
+//!
+//! # The three rules
+//!
+//! * **A.** An `impl Peripheral` whose `needs_legacy_walk()` is literally
+//!   `false` must have a literally-default `tick()` / `tick_elapsed()`.
+//!   Caught: ESP32-C3 RMT, RP2040 I2C0.
+//! * **B.** An `impl Peripheral` that can report `uses_scheduler() == true`
+//!   while having a non-default `tick()` must ALSO declare a delivery hook
+//!   (`on_event`, `take_scheduled_events`, `sync_to`, `matrix_irq_sources_into`
+//!   / `matrix_irq_sources`, or `tick_with_bus`) — otherwise the walk skip in
+//!   channel 2 silently drops its work on the floor.
+//! * **C.** No production source may hand-assign `legacy_walk_disabled = true`.
+//!   Walk deletion is DERIVED (`recompute_walk_deletable`) or opted into per
+//!   config (`manifest.walk_deleted`); a hand assert claims a property about
+//!   peripherals it never inspects. Caught: classic ESP32
+//!   (`system/xtensa/esp32.rs`), where the comment named `uart0` as migrated
+//!   and `uart0` never was.
+//!
+//! # Conditional forms
+//!
+//! `needs_legacy_walk()` bodies that are the textual negation of the same
+//! impl's `uses_scheduler()` body (`!self.scheduler_mode()`,
+//! `!self.uses_scheduler()`) are self-consistent by construction: the model
+//! leaves the walk exactly when it joins the scheduler, so channel 1's OR can
+//! never starve it. Those are accepted automatically. Every OTHER conditional
+//! shape needs an entry in [`CONDITIONAL_ALLOWLIST`] with a justification.
+//!
+//! # Allowlists shrink, never grow
+//!
+//! Each allowlist entry is re-checked: an entry that no longer violates fails
+//! the gate, so a fixed model cannot leave a stale exemption behind for the
+//! next offender to hide under.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Frozen allowlists. Adding a line here is a deliberate act; read the rule
+// docs above before you do it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Rule A exemptions: models that declare `needs_legacy_walk() == false` while
+/// their `tick()` still does work.
+///
+/// EVERY entry is a live instance of the same defect class as the two fixed in
+/// this PR, found by this gate on its first run. They are recorded rather than
+/// fixed because each needs its own delivery-path design (an event chain, or a
+/// per-fabric IRQ route) and its own behavioural proof — a blanket
+/// `needs_legacy_walk() -> true` would trade the starvation for a whole-bus
+/// throughput regression, which is the trade this codebase keeps making by
+/// accident.
+///
+/// Format: `(path relative to crates/core/src, impl type, why it is still here)`.
+const RULE_A_ALLOWLIST: &[(&str, &str, &str)] = &[
+    (
+        "peripherals/rp2040/usb.rs",
+        "Rp2040Usb",
+        "tick() runs host_poll() and emits USBCTRL_IRQ. Needs the same delay-1 \
+         event chain as Rp2040I2c, plus a decision about host_poll cadence.",
+    ),
+    (
+        "peripherals/nrf52/clock.rs",
+        "Nrf52Clock",
+        "tick() re-pends a held HFCLKSTARTED/LFCLKSTARTED level (irq: true).",
+    ),
+    (
+        "peripherals/nrf52/ecb.rs",
+        "Nrf52Ecb",
+        "tick() latches ENDECB and pends the AES ECB line.",
+    ),
+    (
+        "peripherals/nrf52/egu.rs",
+        "Nrf52Egu",
+        "tick() drains software-triggered EGU events into IRQs.",
+    ),
+    (
+        "peripherals/nrf52/gpiote.rs",
+        "Nrf52Gpiote",
+        "tick() drains pending PORT/IN events into IRQs.",
+    ),
+    (
+        "peripherals/nrf52/radio.rs",
+        "Nrf52Radio",
+        "tick() advances the TX/RX cycle countdown and fires ADDRESS/END.",
+    ),
+    (
+        "peripherals/nrf52/serial_instance.rs",
+        "Nrf52SerialInstance",
+        "tick() delegates to the active TWIM/SPIM sub-model, both of which tick.",
+    ),
+    (
+        "peripherals/nrf52/twim.rs",
+        "Nrf52Twim",
+        "tick() converts latched TWIM events into the instance IRQ.",
+    ),
+    (
+        "peripherals/esp32s3/gpio.rs",
+        "Esp32s3Gpio",
+        "tick() advances an internal cycle counter used for edge timestamps; no \
+         IRQ, but the counter is observable state mutated from the walk.",
+    ),
+];
+
+/// Rule A/B conditional-shape exemptions: `needs_legacy_walk()` bodies that are
+/// not literal and not the textual negation of the impl's own
+/// `uses_scheduler()`.
+const CONDITIONAL_ALLOWLIST: &[(&str, &str, &str)] = &[
+    (
+        "peripherals/bxcan.rs",
+        "BxCan",
+        "`self.bus_rx.is_some()`: the only thing tick() does is drain the CanBus \
+         mpsc interconnect, so with no interconnect attached the tick is a \
+         genuine structural no-op. State-dependent but exhaustive.",
+    ),
+    (
+        "peripherals/declarative.rs",
+        "GenericPeripheral",
+        "`has_read_trigger() || has_write_trigger() || !inflight_events.is_empty()`: \
+         a descriptor with no triggers and no seeded periodic events has an \
+         inert tick. new() seeds the inflight set, so the predicate covers the \
+         whole reachable space.",
+    ),
+    (
+        "peripherals/esp_uart.rs",
+        "EspUart",
+        "`!uses_scheduler() || !attached_streams.is_empty()`: strictly STRONGER \
+         than the auto-accepted negation — a cross-linked UART stays on the walk \
+         even under the scheduler because its peer is polled from tick_elapsed.",
+    ),
+    (
+        "peripherals/nrf52/rng.rs",
+        "Nrf52Rng",
+        "`self.clock.is_none()` is the semantic negation of \
+         `uses_scheduler() = self.clock.is_some()`; only the spelling differs.",
+    ),
+    (
+        "peripherals/nrf52/wdt.rs",
+        "Nrf52Wdt",
+        "`self.clock.is_none()` is the semantic negation of \
+         `uses_scheduler() = self.clock.is_some()`; only the spelling differs.",
+    ),
+];
+
+/// Rule C exemptions: production sites that hand-assign
+/// `legacy_walk_disabled = true`.
+///
+/// Marked `pending_external_fix` because a hand assert is never correct — it is
+/// waiting on someone else's landing, not justified. Unlike the other two
+/// lists, a stale entry here does NOT fail the gate: it is expected to
+/// disappear from under us when that fix merges, and a cross-PR shrink check
+/// would just make two correct branches conflict.
+const RULE_C_PENDING_FIX: &[(&str, &str)] = &[(
+    "system/xtensa/esp32.rs",
+    "classic-ESP32 asserts walk deletion under a comment claiming uart0 was \
+     migrated to the scheduler; Esp32Uart never was, so uart0's tx_fifo is \
+     never drained and arduino-esp32 spins in uart_ll_write_txfifo. Fix in \
+     flight on fix/esp32-uart-event-scheduler-starvation, which replaces the \
+     assert with recompute_walk_deletable(). Delete this entry when it lands.",
+)];
+
+/// Delivery hooks that make a `uses_scheduler()` model's work observable.
+const DELIVERY_HOOKS: &[&str] = &[
+    "on_event",
+    "take_scheduled_events",
+    "sync_to",
+    "matrix_irq_sources_into",
+    "matrix_irq_sources",
+    "tick_with_bus",
+];
+
+/// Bodies that count as a literally-default `tick()`.
+const DEFAULT_TICK_BODIES: &[&str] = &[
+    "PeripheralTickResult::default()",
+    "crate::PeripheralTickResult::default()",
+    "Default::default()",
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scanner
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn src_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+    paths.sort();
+    for p in paths {
+        if p.is_dir() {
+            rust_files(&p, out);
+        } else if p.extension().is_some_and(|e| e == "rs") {
+            out.push(p);
+        }
+    }
+}
+
+/// Replace comments and string literals with spaces so brace matching and
+/// keyword search never trip over `"{"` or a doc comment. Length-preserving, so
+/// byte offsets stay usable for line numbers.
+fn blank_comments_and_strings(src: &str) -> String {
+    let b = src.as_bytes();
+    let mut out = vec![b' '; b.len()];
+    let mut i = 0;
+    while i < b.len() {
+        // Keep newlines so line numbers survive.
+        if b[i] == b'\n' {
+            out[i] = b'\n';
+            i += 1;
+        } else if b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'/' {
+            while i < b.len() && b[i] != b'\n' {
+                i += 1;
+            }
+        } else if b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'*' {
+            let mut depth = 1;
+            i += 2;
+            while i + 1 < b.len() && depth > 0 {
+                if b[i] == b'/' && b[i + 1] == b'*' {
+                    depth += 1;
+                    i += 2;
+                } else if b[i] == b'*' && b[i + 1] == b'/' {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    if b[i] == b'\n' {
+                        out[i] = b'\n';
+                    }
+                    i += 1;
+                }
+            }
+        } else if b[i] == b'"' {
+            i += 1;
+            while i < b.len() && b[i] != b'"' {
+                if b[i] == b'\\' {
+                    i += 1;
+                }
+                if i < b.len() && b[i] == b'\n' {
+                    out[i] = b'\n';
+                }
+                i += 1;
+            }
+            i += 1;
+        } else {
+            out[i] = b[i];
+            i += 1;
+        }
+    }
+    String::from_utf8(out).expect("ascii-preserving blanking")
+}
+
+/// End index (exclusive) of the block whose opening `{` is at `open`.
+fn block_end(s: &str, open: usize) -> Option<usize> {
+    let b = s.as_bytes();
+    let mut depth = 0usize;
+    for (i, &c) in b.iter().enumerate().skip(open) {
+        if c == b'{' {
+            depth += 1;
+        } else if c == b'}' {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Blank out every `#[cfg(test)] mod ... { .. }` body. Test scaffolding builds
+/// deliberately unrealistic peripherals and buses; the contract is about
+/// production models only.
+fn blank_cfg_test_modules(s: &str) -> String {
+    let mut out = s.to_string();
+    let mut from = 0usize;
+    while let Some(rel) = out[from..].find("#[cfg(test)]") {
+        let at = from + rel;
+        // Only a `mod` immediately after the attribute encloses a block.
+        let rest = &out[at + "#[cfg(test)]".len()..];
+        let trimmed = rest.trim_start();
+        if trimmed.starts_with("mod ") || trimmed.starts_with("pub mod ") {
+            if let Some(open_rel) = rest.find('{') {
+                let open = at + "#[cfg(test)]".len() + open_rel;
+                if let Some(end) = block_end(&out, open) {
+                    let blanked: String = out[open..=end]
+                        .chars()
+                        .map(|c| if c == '\n' { '\n' } else { ' ' })
+                        .collect();
+                    out.replace_range(open..=end, &blanked);
+                    from = end;
+                    continue;
+                }
+            }
+        }
+        from = at + "#[cfg(test)]".len();
+    }
+    out
+}
+
+/// One parsed `impl Peripheral for T` block.
+struct PeripheralImpl {
+    file: String,
+    ty: String,
+    /// Method name → single-line-normalised body.
+    methods: Vec<(String, String)>,
+}
+
+impl PeripheralImpl {
+    fn body(&self, name: &str) -> Option<&str> {
+        self.methods
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, b)| b.as_str())
+    }
+    fn has(&self, name: &str) -> bool {
+        self.body(name).is_some()
+    }
+    /// True when `tick()` or `tick_elapsed()` is overridden with anything other
+    /// than the trait default.
+    fn does_walk_work(&self) -> bool {
+        let tick_bad = self
+            .body("tick")
+            .is_some_and(|b| !DEFAULT_TICK_BODIES.contains(&b));
+        let te_bad = self
+            .body("tick_elapsed")
+            .is_some_and(|b| !DEFAULT_TICK_BODIES.contains(&b) && b != "self.tick()");
+        tick_bad || te_bad
+    }
+}
+
+fn normalise(body: &str) -> String {
+    body.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Find every `impl Peripheral for T { .. }` in production source.
+fn parse_peripheral_impls() -> Vec<PeripheralImpl> {
+    let root = src_root();
+    let mut files = Vec::new();
+    rust_files(&root, &mut files);
+    let mut impls = Vec::new();
+    for path in files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        // `src/tests/` is this crate's lib-test tree — scaffolding, not models.
+        if rel.starts_with("tests/") || rel.ends_with("tests_main.rs") {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path).expect("read source");
+        let clean = blank_cfg_test_modules(&blank_comments_and_strings(&raw));
+        let mut search = 0usize;
+        while let Some(rel_at) = clean[search..].find("impl ") {
+            let at = search + rel_at;
+            search = at + 5;
+            // `impl [<generics>] Peripheral for <Type> {`
+            let tail = &clean[at..];
+            let Some(for_at) = tail.find(" for ") else {
+                continue;
+            };
+            let head = &tail[..for_at];
+            if !head.contains("Peripheral") || head.contains('{') {
+                continue;
+            }
+            // Reject `impl I2cDevice for`, `impl PeripheralExt for`, etc.
+            let last_token = head.rsplit(|c: char| !c.is_alphanumeric() && c != '_');
+            if last_token.into_iter().next() != Some("Peripheral") {
+                continue;
+            }
+            let Some(open_rel) = tail.find('{') else {
+                continue;
+            };
+            let open = at + open_rel;
+            let Some(end) = block_end(&clean, open) else {
+                continue;
+            };
+            let ty = tail[for_at + 5..open_rel].trim().to_string();
+            let body = &clean[open + 1..end];
+
+            let mut methods = Vec::new();
+            let mut fsearch = 0usize;
+            while let Some(fn_rel) = body[fsearch..].find("fn ") {
+                let fat = fsearch + fn_rel;
+                fsearch = fat + 3;
+                let after = &body[fat + 3..];
+                let name: String = after
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                if name.is_empty() {
+                    continue;
+                }
+                let Some(bopen_rel) = body[fat..].find('{') else {
+                    continue;
+                };
+                let bopen = fat + bopen_rel;
+                let Some(bend) = block_end(body, bopen) else {
+                    continue;
+                };
+                methods.push((name, normalise(&body[bopen + 1..bend])));
+                fsearch = bend;
+            }
+            impls.push(PeripheralImpl {
+                file: rel.clone(),
+                ty,
+                methods,
+            });
+            search = end;
+        }
+    }
+    impls
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rule A + conditional shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A peripheral that says it needs no walk must genuinely do nothing in the
+/// walk. See the module docs: this is the whole-walk-deletion channel, and it
+/// is how ESP32-C3 RMT and RP2040 I2C0 both went silent in the browser.
+#[test]
+fn walk_free_peripherals_have_a_default_tick() {
+    let impls = parse_peripheral_impls();
+    assert!(
+        impls.len() > 100,
+        "scanner found only {} `impl Peripheral` blocks — it is broken, and a \
+         broken scanner is a vacuously green gate",
+        impls.len()
+    );
+
+    let allow: BTreeSet<(&str, &str)> = RULE_A_ALLOWLIST
+        .iter()
+        .map(|(f, t, _)| (*f, *t))
+        .collect();
+    let mut violations = Vec::new();
+    let mut hit: BTreeSet<(String, String)> = BTreeSet::new();
+
+    for i in &impls {
+        let Some(nlw) = i.body("needs_legacy_walk") else {
+            continue;
+        };
+        if nlw != "false" || !i.does_walk_work() {
+            continue;
+        }
+        if allow.contains(&(i.file.as_str(), i.ty.as_str())) {
+            hit.insert((i.file.clone(), i.ty.clone()));
+            continue;
+        }
+        violations.push(format!(
+            "  {}::{}\n      needs_legacy_walk() -> false, but tick() = {}",
+            i.file,
+            i.ty,
+            i.body("tick").or_else(|| i.body("tick_elapsed")).unwrap_or("")
+        ));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "\nWALK-STARVATION CONTRACT (rule A) violated by {} model(s):\n{}\n\n\
+         `needs_legacy_walk() == false` asserts that this model's \
+         tick()/tick_elapsed() cannot change observable state in ANY reachable \
+         firmware state. A tick() that pends an IRQ, drains a FIFO or advances a \
+         counter is not that. Once every peripheral on a bus makes this claim, \
+         SystemBus::derive_walk_deletable deletes the walk and the model is never \
+         ticked again — under --features event-scheduler, which is what the \
+         browser runs and no CLI lane here does.\n\n\
+         Fix it by putting the model on the event scheduler (uses_scheduler() + \
+         an event chain, a sync_to, or a matrix level export), NOT by flipping \
+         needs_legacy_walk() to true — that un-deletes the whole bus's walk and \
+         trades a hang for a slowdown.\n",
+        violations.len(),
+        violations.join("\n")
+    );
+
+    // Shrink-only: a fixed model must not leave its exemption behind.
+    let stale: Vec<&str> = RULE_A_ALLOWLIST
+        .iter()
+        .filter(|(f, t, _)| !hit.contains(&(f.to_string(), t.to_string())))
+        .map(|(t, _, _)| *t)
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "RULE_A_ALLOWLIST has stale entries (these no longer violate — delete \
+         the lines): {stale:?}"
+    );
+}
+
+/// Conditional `needs_legacy_walk()` bodies must either be the textual negation
+/// of the same impl's `uses_scheduler()` (self-consistent by construction) or
+/// carry a written justification.
+#[test]
+fn conditional_walk_predicates_are_self_consistent_or_justified() {
+    let impls = parse_peripheral_impls();
+    let allow: BTreeSet<(&str, &str)> = CONDITIONAL_ALLOWLIST
+        .iter()
+        .map(|(f, t, _)| (*f, *t))
+        .collect();
+    let mut violations = Vec::new();
+    let mut hit: BTreeSet<(String, String)> = BTreeSet::new();
+
+    for i in &impls {
+        let Some(nlw) = i.body("needs_legacy_walk") else {
+            continue;
+        };
+        if nlw == "true" || nlw == "false" {
+            continue;
+        }
+        let self_consistent = nlw == "!self.uses_scheduler()"
+            || i.body("uses_scheduler")
+                .is_some_and(|us| nlw == format!("!{us}"));
+        if self_consistent {
+            continue;
+        }
+        if allow.contains(&(i.file.as_str(), i.ty.as_str())) {
+            hit.insert((i.file.clone(), i.ty.clone()));
+            continue;
+        }
+        violations.push(format!("  {}::{}  =>  {}", i.file, i.ty, nlw));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "\nWALK-STARVATION CONTRACT (rule A, conditional shape) — \
+         unreviewed predicate(s):\n{}\n\n\
+         A state-dependent needs_legacy_walk() is only sound if it is false \
+         exactly when the model is genuinely inert. If it is simply \
+         `!uses_scheduler()` (any spelling of the same body) it is accepted \
+         automatically; anything else needs a line in CONDITIONAL_ALLOWLIST \
+         saying why the false branch covers every reachable state.\n",
+        violations.join("\n")
+    );
+
+    let stale: Vec<&str> = CONDITIONAL_ALLOWLIST
+        .iter()
+        .filter(|(f, t, _)| !hit.contains(&(f.to_string(), t.to_string())))
+        .map(|(t, _, _)| *t)
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "CONDITIONAL_ALLOWLIST has stale entries (delete the lines): {stale:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rule B
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A scheduler-driven model's work must have somewhere to come out.
+///
+/// The walk loop hands back `default()` for every `uses_scheduler()` model, so
+/// a model that claims scheduler mode and keeps doing its work in `tick()` —
+/// with no `on_event` chain, no `sync_to`, and no matrix level export — is
+/// starved even on a bus whose walk is still running. This is the channel that
+/// would have made the "fix" for rule A silently useless.
+#[test]
+fn scheduler_driven_peripherals_declare_a_delivery_path() {
+    let impls = parse_peripheral_impls();
+    let mut violations = Vec::new();
+
+    for i in &impls {
+        let Some(us) = i.body("uses_scheduler") else {
+            continue;
+        };
+        if us == "false" || !i.does_walk_work() {
+            continue;
+        }
+        if DELIVERY_HOOKS.iter().any(|h| i.has(h)) {
+            continue;
+        }
+        violations.push(format!(
+            "  {}::{}  uses_scheduler() = {us}  (no {DELIVERY_HOOKS:?})",
+            i.file, i.ty
+        ));
+    }
+
+    assert!(
+        violations.is_empty(),
+        "\nWALK-STARVATION CONTRACT (rule B) violated by {} model(s):\n{}\n\n\
+         The per-cycle walk SKIPS uses_scheduler() models (bus/tick.rs, the \
+         `p.dev.uses_scheduler() && !force_scheduler_walk` early return), so \
+         their tick() work never runs in production. Declare at least one of \
+         {DELIVERY_HOOKS:?} so the work has a route to the CPU.\n",
+        violations.len(),
+        violations.join("\n")
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rule C
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Walk deletion is DERIVED from the peripheral set, never asserted by hand.
+///
+/// `bus.legacy_walk_disabled = true` is a claim about every peripheral on the
+/// bus made by code that inspects none of them. On classic ESP32 that claim sat
+/// under a comment naming `uart0` as migrated to the scheduler; `Esp32Uart`
+/// never was, so its `tx_fifo` was never drained,
+/// `UART_STATUS.TXFIFO_CNT` pinned at its high-water mark, and arduino-esp32's
+/// wait-for-space loop spun forever. Use `recompute_walk_deletable()` (which
+/// asks each peripheral) or the per-config `manifest.walk_deleted` opt-in.
+#[test]
+fn walk_deletion_is_derived_not_asserted() {
+    let root = src_root();
+    let mut files = Vec::new();
+    rust_files(&root, &mut files);
+    let pending: BTreeSet<&str> = RULE_C_PENDING_FIX.iter().map(|(f, _)| *f).collect();
+    let mut violations = Vec::new();
+    let mut scanned_any = false;
+
+    for path in files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if rel.starts_with("tests/") || rel.ends_with("tests_main.rs") {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path).expect("read source");
+        let clean = blank_cfg_test_modules(&blank_comments_and_strings(&raw));
+        scanned_any = true;
+        for (n, line) in clean.lines().enumerate() {
+            let l = normalise(line);
+            if !l.contains("legacy_walk_disabled") {
+                continue;
+            }
+            // Only literal `= true` assignments; `= derive_walk_deletable()`,
+            // `= match manifest.walk_deleted { .. }` and reads are fine.
+            let is_hand_assert = l.contains("legacy_walk_disabled = true")
+                && !l.contains("==")
+                && !l.contains("!=");
+            if is_hand_assert && !pending.contains(rel.as_str()) {
+                violations.push(format!("  {rel}:{}  {l}", n + 1));
+            }
+        }
+    }
+
+    assert!(scanned_any, "rule C scanned no files — the gate is vacuous");
+    assert!(
+        violations.is_empty(),
+        "\nWALK-STARVATION CONTRACT (rule C) — walk deletion asserted by \
+         hand:\n{}\n\n\
+         Replace with `bus.recompute_walk_deletable()` AFTER the final \
+         peripheral is registered, or set `walk_deleted: true` in the system \
+         manifest if this is a firmware-specific byte-identity claim no \
+         config-time predicate can prove.\n",
+        violations.join("\n")
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The gate's own falsifiability
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The scanner must actually see a non-default tick and a literal `false`.
+///
+/// A source-scanning gate fails open the moment its parser drifts (a rename, a
+/// formatting change, a macro). This pins the parse on two models whose shapes
+/// are known and opposite, so a scanner that silently stops matching turns red
+/// here instead of turning every other test in this file vacuously green.
+#[test]
+fn the_scanner_actually_parses_known_shapes() {
+    let impls = parse_peripheral_impls();
+
+    let timer = impls
+        .iter()
+        .find(|i| i.file == "peripherals/rp2040/timer.rs" && i.ty == "Rp2040Timer")
+        .expect("Rp2040Timer impl Peripheral must be found by the scanner");
+    assert_eq!(
+        timer.body("needs_legacy_walk"),
+        Some("!self.scheduler_mode()"),
+        "scanner mis-parsed a known conditional predicate"
+    );
+    assert!(
+        timer.does_walk_work(),
+        "Rp2040Timer::tick() advances the counter — the scanner must see that"
+    );
+    assert!(
+        timer.has("on_event") && timer.has("take_scheduled_events"),
+        "scanner must see the delivery hooks it keys rule B on"
+    );
+
+    let stub = impls
+        .iter()
+        .find(|i| i.file == "peripherals/stub.rs")
+        .expect("the stub peripheral must be found");
+    assert!(
+        !stub.does_walk_work(),
+        "the stub peripheral does no walk work; a scanner that thinks it does \
+         is over-matching"
+    );
+}

--- a/crates/core/src/tests/walk_starvation_contract.rs
+++ b/crates/core/src/tests/walk_starvation_contract.rs
@@ -631,6 +631,43 @@ fn scheduler_driven_peripherals_declare_a_delivery_path() {
 // Rule C
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// True for a literal `legacy_walk_disabled = true` assignment.
+///
+/// Deliberately narrow: `= self.derive_walk_deletable()`,
+/// `= match manifest.walk_deleted { .. }` and every comparison / read are the
+/// legitimate forms. Split out so it can be falsified directly — see
+/// [`rule_c_detector_is_not_vacuous`], which matters because rule C's only
+/// current subject is exempted while its fix is in flight, and an
+/// always-passing detector would look identical.
+fn is_hand_walk_assert(normalised_line: &str) -> bool {
+    normalised_line.contains("legacy_walk_disabled = true")
+        && !normalised_line.contains("==")
+        && !normalised_line.contains("!=")
+}
+
+/// Rule C's detector must fire on the shape it exists to catch.
+#[test]
+fn rule_c_detector_is_not_vacuous() {
+    // The exact classic-ESP32 line (crates/core/src/system/xtensa/esp32.rs).
+    assert!(is_hand_walk_assert("bus.legacy_walk_disabled = true;"));
+    assert!(is_hand_walk_assert("self.legacy_walk_disabled = true;"));
+    // Legitimate forms must NOT fire.
+    assert!(!is_hand_walk_assert(
+        "bus.legacy_walk_disabled = bus.derive_walk_deletable();"
+    ));
+    assert!(!is_hand_walk_assert(
+        "self.legacy_walk_disabled = self.derive_walk_deletable();"
+    ));
+    assert!(!is_hand_walk_assert(
+        "bus.legacy_walk_disabled = match manifest.walk_deleted {"
+    ));
+    assert!(!is_hand_walk_assert(
+        "if self.legacy_walk_disabled == true {"
+    ));
+    assert!(!is_hand_walk_assert("legacy_walk_disabled: false,"));
+    assert!(!is_hand_walk_assert("return self.legacy_walk_disabled;"));
+}
+
 /// Walk deletion is DERIVED from the peripheral set, never asserted by hand.
 ///
 /// `bus.legacy_walk_disabled = true` is a claim about every peripheral on the
@@ -646,6 +683,7 @@ fn walk_deletion_is_derived_not_asserted() {
     let mut files = Vec::new();
     rust_files(&root, &mut files);
     let pending: BTreeSet<&str> = RULE_C_PENDING_FIX.iter().map(|(f, _)| *f).collect();
+    let mut pending_seen: BTreeSet<String> = BTreeSet::new();
     let mut violations = Vec::new();
     let mut scanned_any = false;
 
@@ -666,14 +704,25 @@ fn walk_deletion_is_derived_not_asserted() {
             if !l.contains("legacy_walk_disabled") {
                 continue;
             }
-            // Only literal `= true` assignments; `= derive_walk_deletable()`,
-            // `= match manifest.walk_deleted { .. }` and reads are fine.
-            let is_hand_assert = l.contains("legacy_walk_disabled = true")
-                && !l.contains("==")
-                && !l.contains("!=");
-            if is_hand_assert && !pending.contains(rel.as_str()) {
-                violations.push(format!("  {rel}:{}  {l}", n + 1));
+            if is_hand_walk_assert(&l) {
+                if pending.contains(rel.as_str()) {
+                    pending_seen.insert(rel.clone());
+                } else {
+                    violations.push(format!("  {rel}:{}  {l}", n + 1));
+                }
             }
+        }
+    }
+
+    // A pending entry that no longer fires is not a failure — it is expected to
+    // stop firing when the in-flight fix lands, and failing here would make two
+    // correct branches conflict. Say so loudly instead.
+    for (f, _) in RULE_C_PENDING_FIX {
+        if !pending_seen.contains(*f) {
+            println!(
+                "NOTE: RULE_C_PENDING_FIX entry `{f}` no longer hand-asserts \
+                 walk deletion — the in-flight fix has landed. Delete the entry."
+            );
         }
     }
 

--- a/crates/core/src/tests/walk_starvation_contract.rs
+++ b/crates/core/src/tests/walk_starvation_contract.rs
@@ -470,10 +470,7 @@ fn walk_free_peripherals_have_a_default_tick() {
         impls.len()
     );
 
-    let allow: BTreeSet<(&str, &str)> = RULE_A_ALLOWLIST
-        .iter()
-        .map(|(f, t, _)| (*f, *t))
-        .collect();
+    let allow: BTreeSet<(&str, &str)> = RULE_A_ALLOWLIST.iter().map(|(f, t, _)| (*f, *t)).collect();
     let mut violations = Vec::new();
     let mut hit: BTreeSet<(String, String)> = BTreeSet::new();
 
@@ -492,7 +489,9 @@ fn walk_free_peripherals_have_a_default_tick() {
             "  {}::{}\n      needs_legacy_walk() -> false, but tick() = {}",
             i.file,
             i.ty,
-            i.body("tick").or_else(|| i.body("tick_elapsed")).unwrap_or("")
+            i.body("tick")
+                .or_else(|| i.body("tick_elapsed"))
+                .unwrap_or("")
         ));
     }
 

--- a/crates/core/tests/esp32c3_rmt_irq_delivery.rs
+++ b/crates/core/tests/esp32c3_rmt_irq_delivery.rs
@@ -1,0 +1,199 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ESP32-C3 RMT TX_END must reach the CPU on the SHIPPED (walk-deleted) bus.
+//!
+//! ## What this asserts, and why it is not the existing RMT test
+//!
+//! `Esp32c3Rmt`'s own unit test (`logic_tap_sees_tx_start_pulse`) and the
+//! matrix L2 oracle both observe `tx_start_count` / the LogicTap edge. Both of
+//! those are produced *inside the `CONF0` write*, so they are walk-independent
+//! by construction: they are green whether or not the model is ever ticked.
+//! No test in this repo asserted RMT **interrupt delivery**, which was the one
+//! thing that depended on the walk.
+//!
+//! The observable here is therefore `SystemBus::riscv_irq_lines` — the routed
+//! CPU interrupt-line mask the RISC-V core reads at its instruction boundary.
+//! Not `legacy_walk_disabled`, not `matrix_irq_sources()`, not the model's own
+//! `INT_ST`: the bit that actually reaches the CPU.
+//!
+//! ## The defect this pins
+//!
+//! `Esp32c3Rmt` declared `needs_legacy_walk() == false` while its `tick()`
+//! emitted `explicit_irqs: [28]` whenever `INT_ST != 0`, and it exported its
+//! level through the *returning* `matrix_irq_sources()` without ever declaring
+//! `uses_scheduler()`. On the shipped C3 bus every peripheral qualifies, so
+//! `derive_walk_deletable()` deletes the legacy walk — and then:
+//!
+//!   * the walk never calls `tick()`, so `explicit_irqs` never fires, and
+//!   * `poll_scheduler_matrix_sources()` only polls `uses_scheduler()` models,
+//!     so the level export is never read either.
+//!
+//! Both delivery channels closed. `rgbLedWrite` →
+//! `rmtWrite(..., RMT_WAIT_FOR_EVER)` blocks on a semaphore given from that
+//! ISR, so the firmware livelocks — the same shape as the classic-ESP32 UART
+//! TX-FIFO defect.
+//!
+//! Runs in every feature configuration: with the walk ON (no
+//! `event-scheduler`) delivery must work through `tick()`, and with the walk
+//! DELETED it must work through the scheduler matrix export. A fix that only
+//! satisfies one of the two is not a fix.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
+use std::path::PathBuf;
+
+/// ETS_RMT_INTR_SOURCE on ESP32-C3.
+const RMT_SOURCE: u32 = 28;
+/// CPU interrupt line firmware binds RMT to (esp-idf `intr_alloc` picks a free
+/// one; the number is arbitrary, only the routing matters).
+const LINE: u32 = 1;
+const INTC: u64 = 0x600C_2000;
+
+// RMT register offsets (C3 map — see `peripherals::esp32c3::rmt`).
+const RMT_CH0_TX_CONF0: u64 = 0x10;
+const RMT_INT_ST: u64 = 0x3C;
+const RMT_INT_ENA: u64 = 0x40;
+const RMT_INT_CLR: u64 = 0x44;
+const TX_START: u32 = 1 << 0;
+
+fn root(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// The shipped `esp32c3-devkit` bus with walk-deletion AUTO-DERIVED (never the
+/// hand `walk_deleted` hatch), plus the C3 interrupt-matrix routing the browser
+/// rom-boot entry turns on.
+fn bus_esp32c3_devkit() -> SystemBus {
+    let chip = ChipDescriptor::from_file(root("configs/chips/esp32c3.yaml")).expect("chip yaml");
+    let system_path = root("configs/systems/esp32c3-devkit.yaml");
+    let mut manifest = SystemManifest::from_file(&system_path).expect("system yaml");
+    let anchored = system_path.parent().expect("parent").join(&manifest.chip);
+    manifest.chip = anchored.to_string_lossy().into_owned();
+    manifest.walk_deleted = None;
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build c3 bus");
+    let _ = labwired_core::system::riscv::configure_riscv(&mut bus);
+    // `build_rom_boot_machine` (the browser C3 entry) enables matrix routing and
+    // then re-derives walk deletion over the final peripheral set. Mirror both.
+    bus.esp32c3_irq_routing = true;
+    bus.recompute_walk_deletable();
+    bus
+}
+
+/// Bind matrix source `RMT_SOURCE` to CPU line `LINE` at priority 15 and enable
+/// it — exactly what esp-idf's `intr_alloc` writes.
+fn route_rmt_to_cpu(bus: &mut SystemBus) {
+    bus.write_u32(INTC + u64::from(RMT_SOURCE) * 4, LINE).unwrap();
+    bus.write_u32(INTC + 0x114 + u64::from(LINE) * 4, 15).unwrap();
+    bus.write_u32(INTC + 0x104, 1 << LINE).unwrap();
+    bus.write_u32(INTC + 0x194, 1).unwrap();
+}
+
+fn rmt_base(bus: &SystemBus) -> u64 {
+    let idx = bus.find_peripheral_index_by_name("rmt").expect("rmt present");
+    bus.peripherals[idx].base
+}
+
+/// TX_END must raise the routed CPU line under the ORDINARY production tick.
+#[test]
+fn rmt_tx_end_reaches_the_cpu_on_the_shipped_c3_bus() {
+    let mut bus = bus_esp32c3_devkit();
+    let base = rmt_base(&bus);
+    route_rmt_to_cpu(&mut bus);
+
+    // Arm CH0/CH1 TX_END, then kick a transmission. The model completes TX
+    // inside the CONF0 write and latches INT_RAW bit 0.
+    bus.write_u32(base + RMT_INT_ENA, 0x3).unwrap();
+    bus.write_u32(base + RMT_CH0_TX_CONF0, TX_START).unwrap();
+    assert_ne!(
+        bus.read_u32(base + RMT_INT_ST).unwrap(),
+        0,
+        "precondition: RMT TX_END must be asserting after TX_START"
+    );
+
+    // Whatever the browser runs: the ordinary production tick. 64 of them is
+    // three orders of magnitude more than any delivery path needs.
+    for _ in 0..64 {
+        let _ = bus.tick_peripherals_with_costs();
+    }
+
+    assert_ne!(
+        bus.riscv_irq_lines & (1 << LINE),
+        0,
+        "STARVED: RMT TX_END (source {RMT_SOURCE}) never reached CPU line {LINE}. \
+         riscv_irq_lines={:#x}, legacy_walk_disabled={}, INT_ST={:#x}. \
+         rgbLedWrite blocks forever on the semaphore this IRQ gives.",
+        bus.riscv_irq_lines,
+        bus.legacy_walk_disabled,
+        bus.read_u32(base + RMT_INT_ST).unwrap(),
+    );
+}
+
+/// The level must DE-ASSERT when firmware acknowledges via `INT_CLR`.
+///
+/// A fix that latches the line forever swaps a livelock for an ISR storm, so
+/// the de-assert direction is asserted too — a level export is only correct if
+/// it is re-derived in both directions.
+#[test]
+fn rmt_tx_end_de_asserts_after_int_clr() {
+    let mut bus = bus_esp32c3_devkit();
+    let base = rmt_base(&bus);
+    route_rmt_to_cpu(&mut bus);
+
+    bus.write_u32(base + RMT_INT_ENA, 0x3).unwrap();
+    bus.write_u32(base + RMT_CH0_TX_CONF0, TX_START).unwrap();
+    for _ in 0..8 {
+        let _ = bus.tick_peripherals_with_costs();
+    }
+    assert_ne!(
+        bus.riscv_irq_lines & (1 << LINE),
+        0,
+        "precondition: line must be asserted before the acknowledge"
+    );
+
+    // The ISR acknowledges CH0 TX_END.
+    bus.write_u32(base + RMT_INT_CLR, 0x3).unwrap();
+    assert_eq!(
+        bus.read_u32(base + RMT_INT_ST).unwrap(),
+        0,
+        "precondition: INT_CLR must clear the model's own status"
+    );
+    for _ in 0..8 {
+        let _ = bus.tick_peripherals_with_costs();
+    }
+
+    assert_eq!(
+        bus.riscv_irq_lines & (1 << LINE),
+        0,
+        "LATCHED: RMT line {LINE} stayed asserted after INT_CLR \
+         (riscv_irq_lines={:#x}) — the ISR would re-enter forever",
+        bus.riscv_irq_lines,
+    );
+}
+
+/// The C3 walk must STILL be deleted after the fix.
+///
+/// This is the throughput half of the contract: the honest-but-wrong repair for
+/// the starvation above is `needs_legacy_walk() -> true`, which un-deletes the
+/// whole C3 walk and costs the 512x peripheral-tick batching every shipped C3
+/// lab depends on. Pinning walk-deletion here makes that repair fail its own
+/// test instead of silently shipping as a slowdown.
+#[cfg(feature = "event-scheduler")]
+#[test]
+fn c3_devkit_walk_stays_deleted() {
+    let bus = bus_esp32c3_devkit();
+    let forcers: Vec<&str> = bus
+        .peripherals
+        .iter()
+        .filter(|p| !p.dev.uses_scheduler() && p.dev.needs_legacy_walk())
+        .map(|p| p.name.as_str())
+        .collect();
+    assert!(
+        bus.legacy_walk_disabled,
+        "esp32c3-devkit must keep auto-deriving walk deletion; forcers: {forcers:?}"
+    );
+}

--- a/crates/core/tests/esp32c3_rmt_irq_delivery.rs
+++ b/crates/core/tests/esp32c3_rmt_irq_delivery.rs
@@ -87,14 +87,18 @@ fn bus_esp32c3_devkit() -> SystemBus {
 /// Bind matrix source `RMT_SOURCE` to CPU line `LINE` at priority 15 and enable
 /// it — exactly what esp-idf's `intr_alloc` writes.
 fn route_rmt_to_cpu(bus: &mut SystemBus) {
-    bus.write_u32(INTC + u64::from(RMT_SOURCE) * 4, LINE).unwrap();
-    bus.write_u32(INTC + 0x114 + u64::from(LINE) * 4, 15).unwrap();
+    bus.write_u32(INTC + u64::from(RMT_SOURCE) * 4, LINE)
+        .unwrap();
+    bus.write_u32(INTC + 0x114 + u64::from(LINE) * 4, 15)
+        .unwrap();
     bus.write_u32(INTC + 0x104, 1 << LINE).unwrap();
     bus.write_u32(INTC + 0x194, 1).unwrap();
 }
 
 fn rmt_base(bus: &SystemBus) -> u64 {
-    let idx = bus.find_peripheral_index_by_name("rmt").expect("rmt present");
+    let idx = bus
+        .find_peripheral_index_by_name("rmt")
+        .expect("rmt present");
     bus.peripherals[idx].base
 }
 

--- a/crates/core/tests/rp2040_i2c_irq_delivery.rs
+++ b/crates/core/tests/rp2040_i2c_irq_delivery.rs
@@ -1,0 +1,330 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! RP2040 I2C0 must pend `I2C0_IRQ` on the SHIPPED (walk-deleted) Pico bus.
+//!
+//! ## The observable
+//!
+//! `NVIC.ISPR[0]` bit 23 — I2C0_IRQ per RP2040 datasheet §2.3.2, the value the
+//! Cortex-M0+ core samples at its instruction boundary. Not `legacy_walk_disabled`,
+//! not the model's own `IC_INTR_STAT`: the bit that reaches the CPU.
+//!
+//! ## The defect this pins
+//!
+//! `Rp2040I2c` declared `needs_legacy_walk() == false` while its `tick()`
+//! returned `irq: self.irq_pending()` — the ONLY NVIC pend the model had. Every
+//! peripheral on `rp2040-pico` qualifies for walk deletion, so
+//! `derive_walk_deletable()` deletes the walk and that `tick()` is never called
+//! again. There is no matrix fabric to fall back on either:
+//! `deliver_scheduled_irq_levels()` handles only the C3 and S3 interrupt
+//! matrices and returns `false` on an NVIC bus.
+//!
+//! Arduino `Wire` polls `IC_TX_ABRT_SOURCE` / `IC_STATUS` and is unaffected,
+//! which is why no lab caught this. pico-sdk I2C-slave and embassy-rp's async
+//! I2C are interrupt-driven and hang outright.
+//!
+//! ## Why this drives a `Machine`, not a bare bus
+//!
+//! The repair is a held-level delay-1 event chain (the shape `Rp2040Timer`
+//! already uses), NOT putting the model back on the per-cycle walk — the walk
+//! would cost `rp2040-pico` its 512x peripheral-tick batching for every lab,
+//! including the majority that never enable an I2C interrupt. An event chain is
+//! only observable through the scheduler drain, which lives in `Machine`.
+//! So the test drives the real `Machine::advance` loop at the recommended tick
+//! interval, exactly like `rp2040_timer_machine_gate`.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::{SystemBus, RECOMMENDED_TICK_INTERVAL};
+use labwired_core::snapshot::{ArmCpuSnapshot, CpuSnapshot};
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{
+    AdvanceRequest, BreakpointPolicy, Bus, Cpu, Machine, SimResult, SimulationConfig,
+    SimulationObserver,
+};
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+/// RP2040 datasheet §4.3 — I2C0 base, and the DesignWare register offsets.
+const I2C0: u64 = 0x4004_4000;
+const IC_INTR_MASK: u64 = I2C0 + 0x30;
+const IC_RAW_INTR_STAT: u64 = I2C0 + 0x34;
+const IC_CLR_STOP_DET: u64 = I2C0 + 0x60;
+const IC_ENABLE: u64 = I2C0 + 0x6c;
+const INTR_TX_EMPTY: u32 = 1 << 4;
+
+/// RP2040 datasheet §2.3.2 — I2C0_IRQ = 23.
+const I2C0_IRQ: u32 = 23;
+
+fn root(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Minimal cycle-advancing CPU: one cycle per step, so `Machine` drains the
+/// event scheduler without real Thumb firmware. Same stand-in as
+/// `rp2040_timer_machine_gate`.
+#[derive(Debug, Default)]
+struct CycleCpu {
+    pc: u32,
+    steps: u32,
+}
+
+impl Cpu for CycleCpu {
+    fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
+        self.pc = 0;
+        self.steps = 0;
+        Ok(())
+    }
+    fn step(
+        &mut self,
+        _bus: &mut dyn Bus,
+        _observers: &[Arc<dyn SimulationObserver>],
+        _config: &SimulationConfig,
+    ) -> SimResult<()> {
+        self.steps = self.steps.wrapping_add(1);
+        self.pc = self.pc.wrapping_add(2);
+        Ok(())
+    }
+    fn set_pc(&mut self, val: u32) {
+        self.pc = val;
+    }
+    fn get_pc(&self) -> u32 {
+        self.pc
+    }
+    fn set_sp(&mut self, _val: u32) {}
+    fn set_exception_pending(&mut self, _exception_num: u32) {}
+    fn get_register(&self, id: u8) -> u32 {
+        match id {
+            0 => self.steps,
+            15 => self.pc,
+            _ => 0,
+        }
+    }
+    fn set_register(&mut self, id: u8, val: u32) {
+        match id {
+            0 => self.steps = val,
+            15 => self.pc = val,
+            _ => {}
+        }
+    }
+    fn snapshot(&self) -> CpuSnapshot {
+        let mut registers = vec![0; 16];
+        registers[0] = self.steps;
+        registers[15] = self.pc;
+        CpuSnapshot::Arm(ArmCpuSnapshot {
+            registers,
+            pc: self.pc,
+            xpsr: 0,
+            primask: false,
+            pending_exceptions: 0,
+            pending_exceptions_hi: Vec::new(),
+            vtor: 0,
+        })
+    }
+    fn apply_snapshot(&mut self, snapshot: &CpuSnapshot) {
+        if let CpuSnapshot::Arm(s) = snapshot {
+            self.steps = s.registers.first().copied().unwrap_or(0);
+            self.pc = s.pc;
+        }
+    }
+    fn get_register_names(&self) -> Vec<String> {
+        (0..=12)
+            .map(|id| format!("R{id}"))
+            .chain(["SP", "LR", "PC"].into_iter().map(String::from))
+            .collect()
+    }
+    fn index_of_register(&self, name: &str) -> Option<u8> {
+        if name.eq_ignore_ascii_case("PC") {
+            return Some(15);
+        }
+        let id = name
+            .strip_prefix('R')
+            .or_else(|| name.strip_prefix('r'))?
+            .parse::<u8>()
+            .ok()?;
+        (id <= 12).then_some(id)
+    }
+}
+
+/// The shipped `rp2040-pico` bus with walk-deletion AUTO-DERIVED.
+fn bus_rp2040_pico() -> SystemBus {
+    // Match the inventory / production peripheral set (bootrom is not a forcer).
+    std::env::set_var("LABWIRED_RP2040_BOOTROM", "");
+    let chip = ChipDescriptor::from_file(root("configs/chips/rp2040.yaml")).expect("chip yaml");
+    let system_path = root("configs/systems/rp2040-pico.yaml");
+    let mut manifest = SystemManifest::from_file(&system_path).expect("system yaml");
+    let anchored = system_path.parent().expect("parent").join(&manifest.chip);
+    manifest.chip = anchored.to_string_lossy().into_owned();
+    manifest.walk_deleted = None;
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build rp2040 bus");
+    let _ = configure_cortex_m(&mut bus);
+    bus
+}
+
+fn ispr0(bus: &SystemBus) -> u32 {
+    bus.nvic
+        .as_ref()
+        .map(|n| n.ispr[0].load(Ordering::SeqCst))
+        .unwrap_or(0)
+}
+
+/// An armed, asserting I2C0 interrupt must pend `I2C0_IRQ` in the NVIC.
+#[test]
+fn i2c0_pends_its_nvic_line_on_the_shipped_pico_bus() {
+    let bus = bus_rp2040_pico();
+    assert!(
+        bus.legacy_walk_disabled,
+        "precondition: rp2040-pico must auto-derive walk deletion"
+    );
+    let mut machine = Machine::new(CycleCpu::default(), bus);
+    machine.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+    machine.bus.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+
+    // The DW controller holds TX_EMPTY from reset (empty FIFO). Firmware
+    // enabling the controller and unmasking TX_EMPTY is all it takes — this is
+    // the pico-sdk / embassy-rp arming sequence, minus the transfer.
+    machine.bus.write_u32(IC_ENABLE, 1).unwrap();
+    machine.bus.write_u32(IC_INTR_MASK, INTR_TX_EMPTY).unwrap();
+    let raw = machine.bus.read_u32(IC_RAW_INTR_STAT).unwrap();
+    assert_ne!(
+        raw & INTR_TX_EMPTY,
+        0,
+        "precondition: TX_EMPTY raw must be asserting ({raw:#x})"
+    );
+
+    const CYCLE_BUDGET: u64 = 8_192;
+    let mut pended = false;
+    while machine.total_cycles < CYCLE_BUDGET {
+        machine
+            .advance(AdvanceRequest::run(Some(512)).with_breakpoints(BreakpointPolicy::Ignore))
+            .expect("Machine::advance");
+        if ispr0(&machine.bus) & (1 << I2C0_IRQ) != 0 {
+            pended = true;
+            break;
+        }
+    }
+
+    assert!(
+        pended,
+        "STARVED: I2C0_IRQ ({I2C0_IRQ}) never pended within {CYCLE_BUDGET} cycles. \
+         ISPR[0]={:#x}, IC_INTR_STAT={:#x}, legacy_walk_disabled={}. \
+         pico-sdk I2C-slave and embassy-rp async I2C hang on exactly this.",
+        ispr0(&machine.bus),
+        machine.bus.read_u32(I2C0 + 0x2c).unwrap_or(0),
+        machine.bus.legacy_walk_disabled,
+    );
+}
+
+/// A MASKED I2C0 interrupt must NOT pend — the negative direction.
+///
+/// Without this the test above is satisfied by anything that pends
+/// unconditionally, which would be a different bug (a spurious ISR entry on
+/// every RP2040 lab). Both directions or neither.
+#[test]
+fn i2c0_does_not_pend_while_masked() {
+    let bus = bus_rp2040_pico();
+    let mut machine = Machine::new(CycleCpu::default(), bus);
+    machine.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+    machine.bus.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+
+    // Controller enabled (TX_EMPTY raw asserts) but IC_INTR_MASK left at 0 —
+    // the Arduino `Wire` configuration, which polls instead.
+    machine.bus.write_u32(IC_ENABLE, 1).unwrap();
+    assert_ne!(
+        machine.bus.read_u32(IC_RAW_INTR_STAT).unwrap() & INTR_TX_EMPTY,
+        0,
+        "precondition: raw TX_EMPTY asserts even while masked"
+    );
+
+    for _ in 0..16 {
+        machine
+            .advance(AdvanceRequest::run(Some(512)).with_breakpoints(BreakpointPolicy::Ignore))
+            .expect("Machine::advance");
+    }
+
+    assert_eq!(
+        ispr0(&machine.bus) & (1 << I2C0_IRQ),
+        0,
+        "SPURIOUS: I2C0_IRQ pended with IC_INTR_MASK = 0 (ISPR[0]={:#x})",
+        ispr0(&machine.bus),
+    );
+}
+
+/// Acknowledging must stop the chain — no ISR storm, no runaway event chain.
+///
+/// A held-level chain that never notices the de-assert would peg the scheduler
+/// at one wakeup per cycle forever, collapsing mean batch width to 1. This
+/// asserts the level drops AND that the bus stops scheduling for it.
+#[test]
+fn i2c0_level_drops_when_firmware_masks_the_source() {
+    let bus = bus_rp2040_pico();
+    let mut machine = Machine::new(CycleCpu::default(), bus);
+    machine.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+    machine.bus.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+
+    machine.bus.write_u32(IC_ENABLE, 1).unwrap();
+    machine.bus.write_u32(IC_INTR_MASK, INTR_TX_EMPTY).unwrap();
+    for _ in 0..4 {
+        machine
+            .advance(AdvanceRequest::run(Some(512)).with_breakpoints(BreakpointPolicy::Ignore))
+            .expect("Machine::advance");
+    }
+    assert_ne!(
+        ispr0(&machine.bus) & (1 << I2C0_IRQ),
+        0,
+        "precondition: line must pend before the acknowledge"
+    );
+
+    // ISR path: mask the source (what the pico-sdk TX_EMPTY handler does once
+    // the FIFO is refilled) and clear the NVIC pend.
+    machine.bus.write_u32(IC_INTR_MASK, 0).unwrap();
+    let _ = machine.bus.read_u32(IC_CLR_STOP_DET);
+    if let Some(nvic) = &machine.bus.nvic {
+        nvic.ispr[0].fetch_and(!(1 << I2C0_IRQ), Ordering::SeqCst);
+    }
+
+    for _ in 0..16 {
+        machine
+            .advance(AdvanceRequest::run(Some(512)).with_breakpoints(BreakpointPolicy::Ignore))
+            .expect("Machine::advance");
+    }
+
+    assert_eq!(
+        ispr0(&machine.bus) & (1 << I2C0_IRQ),
+        0,
+        "LATCHED: I2C0_IRQ re-pended after the source was masked (ISPR[0]={:#x})",
+        ispr0(&machine.bus),
+    );
+}
+
+/// The Pico bus must STILL derive walk deletion after the fix.
+///
+/// The alternative repair — `needs_legacy_walk() -> true` — would put the whole
+/// RP2040 bus back on the per-cycle walk and drop `max_safe_tick_interval` from
+/// 512 to 1 for every RP2040 lab, the overwhelming majority of which never
+/// enable an I2C interrupt. This makes that repair fail rather than ship as a
+/// silent slowdown.
+#[test]
+fn rp2040_pico_walk_stays_deleted_and_tick_512() {
+    let bus = bus_rp2040_pico();
+    let forcers: Vec<&str> = bus
+        .peripherals
+        .iter()
+        .filter(|p| !p.dev.uses_scheduler() && p.dev.needs_legacy_walk())
+        .map(|p| p.name.as_str())
+        .collect();
+    assert!(
+        bus.legacy_walk_disabled,
+        "rp2040-pico must keep auto-deriving walk deletion; forcers: {forcers:?}"
+    );
+    assert_eq!(
+        bus.max_safe_tick_interval(),
+        RECOMMENDED_TICK_INTERVAL,
+        "rp2040-pico must keep max_safe_tick_interval = {RECOMMENDED_TICK_INTERVAL}"
+    );
+}

--- a/crates/core/tests/rp2040_i2c_irq_delivery.rs
+++ b/crates/core/tests/rp2040_i2c_irq_delivery.rs
@@ -302,6 +302,104 @@ fn i2c0_level_drops_when_firmware_masks_the_source() {
     );
 }
 
+/// THROUGHPUT: what the event chain actually costs, in mean batch width.
+///
+/// Mean batch width (`cpu_instructions / cpu_batches`) is a pure function of
+/// the model — bit-deterministic and machine-independent — which is why
+/// `esp32c3_shipped_lab_batch_gate` asserts on it rather than on wall clock.
+/// It is also the direct proxy for this failure class in both directions: a
+/// per-cycle scheduler wakeup pins every batch to width 1.
+///
+/// Two configurations, both on the shipped Pico bus at
+/// `peripheral_tick_interval = 512`:
+///
+/// * **masked** — `IC_INTR_MASK = 0`. Every shipped RP2040 lab (Arduino `Wire`
+///   polls). The chain never arms, so this must stay at the full 512.
+/// * **armed** — `IC_INTR_MASK = TX_EMPTY` with the level up. The chain fires
+///   at delay 1, so the batch narrows — by design, and only here. Real
+///   DW_apb_i2c silicon holds its level line up in exactly this state and the
+///   CPU would be in the ISR, so a wide batch would be the wrong answer.
+///
+/// Caveat on the printed numbers: `CycleCpu` retires exactly one instruction
+/// per `step()` and never signals idle, so `cpu_batches` tracks
+/// `cpu_instructions` and the mean-batch figure is pinned at 1.00 by the
+/// HARNESS, identically before and after this change. The deterministic
+/// quantity that does move on this bus is `peripheral_ticks` (64 ticks per
+/// 32768 cycles = interval 512, masked and armed alike), printed alongside.
+/// A real mean-batch instrument needs real firmware, which the RP2040 side of
+/// the repo does not have a shipped-flash harness for — the C3 side does, and
+/// `esp32c3_shipped_lab_batch_gate` is where that number comes from.
+///
+/// So the cost claim below is made STRUCTURALLY instead of statistically: with
+/// the source masked the chain provably schedules nothing, therefore it cannot
+/// narrow any batch. That is a stronger statement than a measurement on a
+/// harness whose batch width is fixed by construction.
+#[test]
+fn i2c0_event_chain_batch_width_cost_is_confined_to_the_armed_case() {
+    fn measure(arm: bool) -> (f64, u64, bool) {
+        let bus = bus_rp2040_pico();
+        let mut machine = Machine::new(CycleCpu::default(), bus);
+        machine.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+        machine.bus.config.peripheral_tick_interval = RECOMMENDED_TICK_INTERVAL;
+        machine.bus.write_u32(IC_ENABLE, 1).unwrap();
+        if arm {
+            machine.bus.write_u32(IC_INTR_MASK, INTR_TX_EMPTY).unwrap();
+        }
+        let cycle_accurate = machine.bus.requires_cycle_accurate();
+        machine.reset_step_profile();
+        for _ in 0..64 {
+            machine
+                .advance(AdvanceRequest::run(Some(512)).with_breakpoints(BreakpointPolicy::Ignore))
+                .expect("Machine::advance");
+        }
+        let p = machine.step_profile();
+        (
+            p.cpu_instructions as f64 / p.cpu_batches.max(1) as f64,
+            p.peripheral_ticks,
+            cycle_accurate,
+        )
+    }
+
+    let (masked, masked_ticks, ca) = measure(false);
+    let (armed, armed_ticks, _) = measure(true);
+    println!(
+        "rp2040-pico: mean_batch masked={masked:.2} armed={armed:.2}  \
+         peripheral_ticks masked={masked_ticks} armed={armed_ticks}  \
+         requires_cycle_accurate={ca}"
+    );
+
+    // THE COST STATEMENT, structural rather than statistical: with the source
+    // masked — every shipped RP2040 lab, because Arduino `Wire` polls — the
+    // chain never arms, so it schedules nothing and can cost nothing. A wakeup
+    // here would be the regression that collapses batch width for labs that
+    // never touch an I2C interrupt.
+    let mut i2c = crate_i2c_masked();
+    assert!(
+        labwired_core::Peripheral::take_scheduled_events(&mut i2c).is_empty(),
+        "REGRESSION: masked I2C0 armed a scheduler event; the chain must be \
+         inert while (IC_RAW_INTR_STAT & IC_INTR_MASK) == 0"
+    );
+    let mut i2c = crate_i2c_armed();
+    assert!(
+        !labwired_core::Peripheral::take_scheduled_events(&mut i2c).is_empty(),
+        "the chain must arm when the level IS up, or the gate above is vacuous"
+    );
+}
+
+/// A standalone enabled `Rp2040I2c` with interrupts MASKED (Arduino `Wire`).
+fn crate_i2c_masked() -> labwired_core::peripherals::rp2040::i2c::Rp2040I2c {
+    let mut i2c = labwired_core::peripherals::rp2040::i2c::Rp2040I2c::new();
+    labwired_core::Peripheral::write_u32(&mut i2c, 0x6c, 1).unwrap();
+    i2c
+}
+
+/// The same model with TX_EMPTY unmasked (pico-sdk / embassy-rp).
+fn crate_i2c_armed() -> labwired_core::peripherals::rp2040::i2c::Rp2040I2c {
+    let mut i2c = crate_i2c_masked();
+    labwired_core::Peripheral::write_u32(&mut i2c, 0x30, INTR_TX_EMPTY).unwrap();
+    i2c
+}
+
 /// The Pico bus must STILL derive walk deletion after the fix.
 ///
 /// The alternative repair — `needs_legacy_walk() -> true` — would put the whole

--- a/crates/core/tests/tick_interval_inventory.rs
+++ b/crates/core/tests/tick_interval_inventory.rs
@@ -236,6 +236,64 @@ fn bus_esp32s3() -> SystemBus {
     bus
 }
 
+/// Classic ESP32 — the family this inventory was missing.
+///
+/// Production path (`configure_xtensa_esp32`), not `from_config`: the classic
+/// bus is assembled in code, and `from_config` on the chip YAML stubs the
+/// models with generic placeholders, which would report a false walk-free
+/// roster (the same trap `bus_esp32s3` documents).
+///
+/// `configure_xtensa_esp32` sets `legacy_walk_disabled` itself; re-derive over
+/// the final peripheral set so the inventory reports the DERIVED property
+/// rather than whatever the assembler latched. That difference is the whole
+/// point of listing this family — see `esp32_classic_walk_forcers_are_named`.
+fn bus_esp32_classic() -> SystemBus {
+    let mut bus = SystemBus::new();
+    let _ = labwired_core::system::xtensa::configure_xtensa_esp32(&mut bus);
+    bus.recompute_walk_deletable();
+    bus
+}
+
+/// Classic ESP32 is NOT walk-free, and this pins which models hold the walk.
+///
+/// It is the only shipped family absent from this inventory, and it is also the
+/// family with the first confirmed tick-starvation defect: `configure_xtensa_
+/// esp32` asserted `legacy_walk_disabled = true` under a comment claiming
+/// `uart0` had migrated to the event scheduler. `Esp32Uart` never did — it
+/// drains `tx_fifo` from `tick()` and nowhere else — so under `event-scheduler`
+/// the hand flag deleted the walk out from under it and arduino-esp32 spun
+/// forever in `uart_ll_write_txfifo`.
+///
+/// This test asserts the honest derived state: the forcer set is NON-empty and
+/// contains the UARTs. It is deliberately not a "should be walk-free" gate —
+/// asserting a property this bus does not have is how the defect got in.
+#[test]
+fn esp32_classic_walk_forcers_are_named() {
+    let bus = bus_esp32_classic();
+    let inv = inventory("esp32-classic", &bus);
+    print_inventory(&inv);
+
+    let forcing: Vec<&str> = inv.forcers.iter().map(|f| f.name.as_str()).collect();
+    assert!(
+        !forcing.is_empty(),
+        "classic ESP32 reported an EMPTY walk-forcer set. Either a model was \
+         genuinely migrated (update this test and the docs) or one is lying \
+         about `needs_legacy_walk` — check `Esp32Uart` first."
+    );
+    assert!(
+        forcing.iter().any(|n| n.starts_with("uart")),
+        "expected a classic-ESP32 UART among the walk-forcers, got {forcing:?}. \
+         `Esp32Uart::tick_elapsed` is the only thing that drains `tx_fifo`; if \
+         it stops forcing the walk it must have gained a real event chain."
+    );
+    assert_eq!(
+        inv.walk_deletable, inv.legacy_walk_disabled,
+        "classic ESP32: derived walk_deletable ({}) != legacy_walk_disabled \
+         ({}) after recompute — the derivation and the latch disagree",
+        inv.walk_deletable, inv.legacy_walk_disabled
+    );
+}
+
 /// PR-B gate: nRF52840 DK auto-derives walk deletion under `event-scheduler`
 /// with `walk_deleted = None` and reaches `RECOMMENDED_TICK_INTERVAL` (512).
 ///

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -628,6 +628,14 @@ impl WasmSimulator {
                     Box::new(labwired_core::peripherals::esp32c3::ana_i2c::Esp32c3AnaI2c::new()),
                 );
                 bus.refresh_peripheral_index();
+                // A peripheral added AFTER bus assembly changes the input to
+                // `derive_walk_deletable`, which the boot path already ran. It
+                // is correct today only because this model happens to be inert
+                // — the walk-deletion flag would silently disagree with the
+                // live peripheral set the moment it stopped being. Re-derive
+                // rather than rely on that. (Cheap: one pass over the roster,
+                // once per simulator construction.)
+                bus.recompute_walk_deletable();
                 true
             } else {
                 false
@@ -654,6 +662,10 @@ impl WasmSimulator {
                 Box::new(usb_serial),
             );
             bus.refresh_peripheral_index();
+            // Same reason as the `rtc_i2c_ana` addition above: re-derive
+            // walk-deletion over the peripheral set that actually exists, not
+            // the one the boot path saw.
+            bus.recompute_walk_deletable();
         }
         if let Some(debug_uart) = manifest.debug_uart.as_deref() {
             if !bus.attach_uart_tx_sink_named(debug_uart, uart_sink.clone(), false) {

--- a/docs/performance/2026-07-27-tick1-walk-inventory.md
+++ b/docs/performance/2026-07-27-tick1-walk-inventory.md
@@ -122,7 +122,8 @@ Notes:
 | i2c0 | scheduler | true | true |
 | spi2 | scheduler | true | true |
 | ledc | scheduler | false | true |
-| rmt, spi0/1, gpio_sd, efuse, uhci0/1, bb, twai0, i2s0 | inert | false | false |
+| rmt | scheduler | true | true |
+| spi0/1, gpio_sd, efuse, uhci0/1, bb, twai0, i2s0 | inert | false | false |
 | aes, sha, rsa, ds, hmac, dma | inert | false | false |
 | apb_saradc | scheduler | true | true |
 | usb_device, sensitive, extmem, xts_aes, assist_debug | inert | false | false |
@@ -236,8 +237,8 @@ Featureless builds still report `max_safe=1` (honest). Gates:
 
 | Class | Models | Mechanism |
 |-------|--------|-----------|
-| **Class-A inert** | `spi0`, `i2c0`, `sio`, `xip_ssi` | `needs_legacy_walk = false` — pure MMIO engines; `tick()` is the default no-op (loopback/abort/SSI shift complete inside register writes). **Walk-free Class-A is green intentional**; not a paced-SPI/I2C@512 EasyDMA certificate |
-| **Class-B scheduler** | `timer`, `dma`, `pio0`, `usbctrl` | `uses_scheduler` + `take_scheduled_events` / `on_event` (CycleClock on timer/dma; delay-1 SM/host chains on pio/usb) |
+| **Class-A inert** | `spi0`, `sio`, `xip_ssi` | `needs_legacy_walk = false` — pure MMIO engines; `tick()` is the default no-op (loopback/SSI shift complete inside register writes). **Walk-free Class-A is green intentional**; not a paced-SPI/I2C@512 EasyDMA certificate |
+| **Class-B scheduler** | `timer`, `dma`, `pio0`, `usbctrl`, `i2c0` | `uses_scheduler` + `take_scheduled_events` / `on_event` (CycleClock on timer/dma; delay-1 SM/host/level chains on pio/usb/i2c0) |
 | **Class-B / thin** | `uart0` | scheduler on the pico bus; baud / paced-transfer tick-512 fidelity is **interim** only (no EasyDMA-style differential gate) |
 
 Featureless builds still report `max_safe=1` (honest). Gates:
@@ -261,6 +262,14 @@ Featureless builds still report `max_safe=1` (honest). Gates:
 - **USB**: attach debounce / enumeration / bulk service + held `USBCTRL_IRQ`
   ride a delay-1 chain; attach countdown still counts host_poll steps (not
   wall-clock µs) — same model as pre-migration, now event-paced.
+- **I2C0**: held level `(IC_RAW_INTR_STAT & IC_INTR_MASK)` rides a delay-1
+  chain, armed from the MMIO write choke (the level can only RISE on a write;
+  the `IC_CLR_*` registers are read-to-clear). `on_event` returns
+  `raise_own_irq` — the event-path twin of the walk's `irq: true` — so
+  `I2C0_IRQ` (NVIC 23) pends on an NVIC bus, where
+  `deliver_scheduled_irq_levels` cannot help (it covers only the C3/S3
+  matrices). Costs a wakeup only while an interrupt is armed AND asserting.
+  Gate: `rp2040_i2c_irq_delivery.rs`.
 
 ### Full peripheral status
 
@@ -274,7 +283,7 @@ Featureless builds still report `max_safe=1` (honest). Gates:
 | rosc, watchdog | inert | false | false |
 | timer | scheduler | false | true |
 | spi0 | inert | false | false |
-| i2c0 | inert | false | false |
+| i2c0 | scheduler | true | true |
 | systick | scheduler | true | true |
 | sio | inert | false | false |
 | xip_ssi | inert | false | false |


### PR DESCRIPTION
## Two proven tick-starvation defects, plus the static gate that stops the class

Two peripherals declared `needs_legacy_walk() == false` while their `tick()` did the only interrupt-delivery work they had. Once every peripheral on a bus makes that claim, `SystemBus::derive_walk_deletable` deletes the legacy walk and the model is never ticked again — under `--features event-scheduler`, which the browser/wasm crate enables and no CLI lane in this repo does. So both defects were invisible to every green gate and visible only in the product, as a hang.

### Fix 1 — ESP32-C3 RMT (highest blast radius)

`tick()` emitted `explicit_irqs: [28]` while `INT_ST != 0` — the only live delivery path for `CHn_TX_END`. The level export did not save it: it used the *returning* `matrix_irq_sources`, and `poll_scheduler_matrix_sources` only polls `uses_scheduler()` models. Both channels closed, so arduino-esp32's `rgbLedWrite` → `rmtWrite(.., RMT_WAIT_FOR_EVER)` blocks forever on the semaphore its ISR gives — a livelock of the same shape as the classic-ESP32 UART TX-FIFO defect.

Blast radius: 7 shipped ESP32-C3 systems including `esp32c3-devkit` and all four workshop labs; three of the four published community labs are C3.

**Pre-change failure, verbatim** (`crates/core/tests/esp32c3_rmt_irq_delivery.rs`, run on the unchanged models):

```
test rmt_tx_end_reaches_the_cpu_on_the_shipped_c3_bus ... FAILED
test rmt_tx_end_de_asserts_after_int_clr ... FAILED
test c3_devkit_walk_stays_deleted ... ok

---- rmt_tx_end_reaches_the_cpu_on_the_shipped_c3_bus stdout ----
assertion `left != right` failed: STARVED: RMT TX_END (source 28) never reached
CPU line 1. riscv_irq_lines=0x0, legacy_walk_disabled=true, INT_ST=0x1.
rgbLedWrite blocks forever on the semaphore this IRQ gives.
  left: 0
 right: 0
```

**Change:** `uses_scheduler() -> true` plus `matrix_irq_sources` renamed to `matrix_irq_sources_into`, which routes the live level through the bus's scheduler poll and its MMIO write choke. The `needs_legacy_walk` override is dropped back to the conservative default — the derivation is satisfied by `uses_scheduler()`, so the C3 bus stays walk-DELETED. `tick()` is kept for the featureless build and the hardware-oracle forced walk.

**Proof it now delivers:** the same three tests pass. The observable is `SystemBus::riscv_irq_lines` — the routed CPU interrupt-line mask, not the engine's walk bookkeeping — and the de-assert direction is asserted too, so the fix cannot be an ISR storm.

### Fix 2 — RP2040 I2C0

`tick()` returned `irq: self.irq_pending()`, the only NVIC pend for `I2C0_IRQ` (23). Nothing catches it downstream: `deliver_scheduled_irq_levels` covers only the C3 and S3 interrupt matrices and returns `false` on an NVIC bus. Arduino `Wire` polls, which is why no shipped lab noticed; pico-sdk I2C-slave and embassy-rp async I2C wait on the interrupt and hang.

**Pre-change failure, verbatim** (`crates/core/tests/rp2040_i2c_irq_delivery.rs`):

```
test i2c0_does_not_pend_while_masked ... ok
test i2c0_level_drops_when_firmware_masks_the_source ... FAILED
test rp2040_pico_walk_stays_deleted_and_tick_512 ... ok
test i2c0_pends_its_nvic_line_on_the_shipped_pico_bus ... FAILED

---- i2c0_pends_its_nvic_line_on_the_shipped_pico_bus stdout ----
STARVED: I2C0_IRQ (23) never pended within 8192 cycles. ISPR[0]=0x0,
IC_INTR_STAT=0x10, legacy_walk_disabled=true. pico-sdk I2C-slave and
embassy-rp async I2C hang on exactly this.
```

Note the two negative-direction tests were green *before* the fix — they are not mirrors of it.

**Change:** a held-level delay-1 event chain, the shape `Rp2040Timer` already uses. `(raw_intr & intr_mask)` can only *rise* on an MMIO write (the `IC_CLR_*` registers are read-to-clear), so the write choke is a complete arming point and no clock or `sync_to` is needed. `on_event` returns `raise_own_irq` — the event-path twin of the walk's `irq: true` — and reschedules at delay 1 while the level holds.

**Chosen over `needs_legacy_walk() -> true` deliberately.** Walk-deletion is all-or-nothing, so that repair drops `max_safe_tick_interval` from 512 to 1 for *every* RP2040 lab, the majority of which never enable an I2C interrupt. Nothing blocked the event chain, so the throughput cost is not paid. Both delivery test files also pin walk-deletion itself, so the wrong repair fails its own test rather than shipping as a silent slowdown.

### Fix 3 — the static gate

`crates/core/src/tests/walk_starvation_contract.rs`. A source scan, derived from outside the models:

* **Rule A** — an `impl Peripheral` whose `needs_legacy_walk()` is literally `false` must have a literally-default `tick()` / `tick_elapsed()`. Caught both defects above.
* **Rule B** — an impl that can report `uses_scheduler() == true` with a non-default `tick()` must declare a delivery hook (`on_event`, `take_scheduled_events`, `sync_to`, `matrix_irq_sources_into` / `matrix_irq_sources`, `tick_with_bus`). This is the second exclusion channel: the walk loop returns `default()` for scheduler models even when the walk runs.
* **Rule C** — no production source may hand-assign `legacy_walk_disabled = true`. This is the classic-ESP32 defect: the assert sat under a comment naming `uart0` as migrated, and `Esp32Uart` never was.

Conditional `needs_legacy_walk()` bodies that are the textual negation of the same impl's `uses_scheduler()` are accepted automatically (self-consistent by construction); every other shape needs a written justification in `CONDITIONAL_ALLOWLIST`. Rule A and the conditional list are **shrink-only** — an entry that no longer violates fails the gate, so a fixed model cannot leave a stale exemption behind.

**Why static and not fuzzing.** A register-level falsifier that diffs walk-on against walk-off misses this entire class because it never leaves a model in an *asserting* state; all three confirmed defects survived it. The gate also carries `the_scanner_actually_parses_known_shapes` and `rule_c_detector_is_not_vacuous` so a parser that silently stops matching turns red instead of turning the rest vacuously green.

**Its lane.** `crates/core/src/tests/` is the crate's lib-test tree, so the gate runs under `cargo test --lib` — the "Unit tests (default-members lib)" step of `core-ci.yml`'s `pr-gate` job, which is `if: github.event_name == 'pull_request'`. No workflow change, and nothing parked in a heavy lane. Confirmed locally by running the exact pr-gate command:

```
$ cargo test --lib          # featureless, default-members
  labwired_core: test result: ok. 2552 passed; 0 failed
  (walk_starvation_contract's six tests among them)
```

Integration tests under `crates/core/tests/` are *not* in pr-gate (`board_coverage_ratchet`, `svd_conformance` etc. run only on push to main), which is exactly why the gate is a lib test.

**Nine more instances found.** Rule A's first run flagged 11 models; two are fixed here. The other nine are recorded in `RULE_A_ALLOWLIST` with per-entry notes — `Rp2040Usb`, six nRF52 models, and `Esp32s3Gpio`. Each needs its own delivery-path design and its own behavioural proof, and a blanket `needs_legacy_walk() -> true` would trade the starvation for a whole-bus throughput regression. They are tracked, not hidden: the list can only shrink.

`system/xtensa/esp32.rs` is in `RULE_C_PENDING_FIX` because its fix is in flight on `fix/esp32-uart-event-scheduler-starvation`. That one list is deliberately *not* shrink-enforced, so the two branches do not conflict; it prints a delete-me note once the fix lands.

### Throughput — measured, not asserted

Mean batch width (`cpu_instructions / cpu_batches`), the deterministic metric `esp32c3_shipped_lab_batch_gate` uses. Run against the shipped browser flash images with `LABWIRED_WASM_DIR` pointed at `packages/playground/public/wasm`:

| lab | before | after | floor |
|---|---|---|---|
| `esp32c3-oled-lab` | **125.716** | **125.716** | 8.0 |
| `esp32c3-oled-128x32-lab` | **115.033** | **115.033** | 8.0 |

Byte-identical, down to the batch counts (27122 / 26489) and `lit_px` (782 / 442). The C3 bus stays walk-deleted, so nothing about the fast-start policy changed. (These two labs do not drive RMT; a lab that did would previously have hung outright.)

RP2040: `rp2040-pico` keeps `legacy_walk_disabled` and `max_safe_tick_interval = 512` (asserted). The event chain's cost is pinned **structurally** rather than statistically — with `IC_INTR_MASK = 0` (Arduino `Wire`, i.e. every shipped RP2040 lab) `take_scheduled_events` provably returns empty, so the chain cannot narrow a batch; the paired positive assertion keeps that from being vacuous. `peripheral_ticks` is 64 per 32768 cycles (interval 512) masked and armed alike. The `CycleCpu` harness pins mean batch at 1.00 by construction, identically before and after, so that number is reported with the caveat rather than leaned on.

### Related gaps closed

* `crates/core/tests/tick_interval_inventory.rs` covered f103/c3/h563/rp2040/nrf52840/s3 — classic ESP32, the family with the first confirmed defect, was the one absent. Added via the production `configure_xtensa_esp32` path, asserting the **honest** state (walk NOT free, a UART among the forcers), not an aspirational one.
* `crates/wasm/src/lib.rs`: the two post-assembly `add_peripheral` sites (`Esp32c3AnaI2c`, `UsbSerialJtag`) called `refresh_peripheral_index()` but not `recompute_walk_deletable()` — correct today only because both models happen to be inert. Now re-derived.
* `docs/performance/2026-07-27-tick1-walk-inventory.md` claimed i2c0's "`tick()` is the default no-op". It was not. Reclassified with the other Class-B scheduler models, same for C3 `rmt`.

### Verification

* **Full core suite** (`cargo test -p labwired-core --features event-scheduler --no-fail-fast`): **3404 passed, 6 failed**, in exactly the four known-red-on-main binaries — `esp32_ili9341_attach`, `register_coverage`, `world_can_bus` (3), `world_esp32c3_pingpong`. No new failure.
* **pr-gate locally**: `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean; `cargo test --lib` green; `generate_validation_status.py --check --drift` and `generate_firmware_exercise_matrix.py --check` pass; `./scripts/regen-all.sh` leaves the tree clean.
* **Ryan bay-occupancy**: **12/12**, panel ink **6610 / 6610 / 6352**.
