### PR TITLE
ci: run the observable walk-deletion arm pre-merge, not on main

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -152,7 +152,8 @@ jobs:
   # WHY A SEPARATE JOB RATHER THAN A STEP IN `pr-gate` (measured, not guessed):
   #   * the feature-variant recompile of `labwired-core` costs ~45s on a warm
   #     cache (measured: the `Feature gate — scheduler IRQ delivery` step in
-  #     `core-integrity`, run 30838517438, `Finished ... in 44.79s`);
+  #     `core-integrity`, run 30838517438, `Finished ... in 44.79s`; this job
+  #     builds it COLD in 46.32s, so ~45-50s either way);
   #   * a PASSING observable arm exits on the first 500k-step batch, but a
   #     FAILING one burns the whole 20M-step budget — locally 15s pass vs 129s
   #     fail, ~8x. `pr-gate` has `timeout-minutes: 5` and already runs 3.0-4.5
@@ -178,21 +179,21 @@ jobs:
       # (`tests/fixtures/tier1/esp32.elf`) is a plain committed binary, not LFS.
       - uses: actions/checkout@v4
 
+      # No rustfmt/clippy components: this job lints nothing.
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.95.0
 
-      # Deliberately shares `core-integrity`'s cache key and never writes to it:
-      # that cache is rebuilt on every push to main and already contains the
-      # third-party deps for this toolchain, so this job starts warm on its very
-      # first run. A private `shared-key` would instead be branch-scoped, which
-      # means a cold full build on every new PR branch.
-      - name: Cache dependencies (read-only, from core-integrity)
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: core-ci
-          save-if: false
-          workspaces: |
-            . -> target
+      # NO CACHE STEP, ON PURPOSE — measured, not assumed. The first cut of this
+      # job used `Swatinem/rust-cache@v2` with `shared-key: core-ci` +
+      # `save-if: false`, on the theory that it would restore `core-integrity`'s
+      # warm target dir. Run 30842338316 reported `... Restoring cache ... No
+      # cache found.`: rust-cache's key folds in the installed toolchain
+      # components, and `core-integrity` installs rustfmt + clippy, so the two
+      # jobs never share a key. The cold build cost 46.32s and the whole job 71s
+      # — while `core-integrity`'s WARM feature-variant compile of the same
+      # crate is 44.79s. The cache was buying ~0s and would have cost an ~18s
+      # restore plus repo cache storage, so it is gone. Keep it that way unless
+      # a measurement says otherwise.
 
       # `--nocapture` on purpose: on PASS the arm prints
       # `uart0: CLKDIV=... TXFIFO_CNT=... sink_bytes=N`, which is the evidence

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -119,8 +119,11 @@ jobs:
       # needs no firmware, no `event-scheduler` recompile and no fixtures — it
       # only asserts that a chip's `legacy_walk_disabled` is what the
       # conservative derivation proves rather than a hand-written claim, and
-      # that check compiles under default features. Its observable twin (which
-      # does need `event-scheduler`) stays in `core-integrity`.
+      # that check compiles under default features. Under DEFAULT features the
+      # file's observable twin is `#[cfg]`-ed out entirely, so this command
+      # runs exactly ONE test; its twin needs an `event-scheduler` build and
+      # lives in the `pr-scheduler-observable` job below (which runs in
+      # PARALLEL with this job, so it costs this lane nothing).
       #
       # It is here because the bug it covers shipped precisely BECAUSE the only
       # lanes that could see it were nightly: a classic-ESP32 lab was 12/12 on
@@ -129,6 +132,77 @@ jobs:
       # class walks back through.
       - name: Walk-deletion derivation (PR-fast structural arm)
         run: cargo test -p labwired-core --test esp32_classic_walk_differential
+
+  # ── Browser-configuration observable gate (PR; parallel with pr-gate) ──────
+  #
+  # THE LANE THAT DID NOT EXIST PRE-MERGE.
+  #
+  # `esp32_classic_walk_differential` has two arms. `pr-gate` carries the
+  # STRUCTURAL one, which is cheap because it compiles under default features.
+  # The OBSERVABLE one — the arm that boots the committed classic-ESP32 ELF
+  # under the browser's own scheduling policy and asserts that serial bytes
+  # actually reach the UART sink — is `#[cfg(feature = "event-scheduler")]`,
+  # because with the feature off `legacy_walk_disabled` is never read and the
+  # defect is unobservable by construction. Until this job existed that arm ran
+  # ONLY in `core-integrity` (push to main), i.e. AFTER the merge — which is
+  # exactly how the defect it covers shipped: a classic-ESP32 lab was 12/12
+  # green on the CLI and livelocked in the browser, and main was the first
+  # thing to notice.
+  #
+  # WHY A SEPARATE JOB RATHER THAN A STEP IN `pr-gate` (measured, not guessed):
+  #   * the feature-variant recompile of `labwired-core` costs ~45s on a warm
+  #     cache (measured: the `Feature gate — scheduler IRQ delivery` step in
+  #     `core-integrity`, run 30838517438, `Finished ... in 44.79s`);
+  #   * a PASSING observable arm exits on the first 500k-step batch, but a
+  #     FAILING one burns the whole 20M-step budget — locally 15s pass vs 129s
+  #     fail, ~8x. `pr-gate` has `timeout-minutes: 5` and already runs 3.0-4.5
+  #     min, so a failing arm inside it would hit the job timeout and kill the
+  #     lane WITHOUT printing the CLKDIV / TXFIFO_CNT / sink_bytes diagnostic
+  #     that makes this gate worth having.
+  # As its own job it runs concurrently with `pr-gate`, so the PR's critical
+  # path is unchanged, and it can afford a timeout sized for the failing case.
+  #
+  # `--features event-scheduler` WITHOUT `jit`: that is what `crates/wasm/
+  # Cargo.toml` pins, so this is the browser's exact feature set.
+  # `core-integrity` runs the same test with `jit,event-scheduler`, which the
+  # browser never builds — this lane is the faithful one. It does not replace
+  # the integrity run; both stay.
+  pr-scheduler-observable:
+    name: pr-scheduler-observable
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Shallow checkout is fine here: unlike `pr-gate` this job runs no
+      # git-history-dependent gate. The fixture it needs
+      # (`tests/fixtures/tier1/esp32.elf`) is a plain committed binary, not LFS.
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      # Deliberately shares `core-integrity`'s cache key and never writes to it:
+      # that cache is rebuilt on every push to main and already contains the
+      # third-party deps for this toolchain, so this job starts warm on its very
+      # first run. A private `shared-key` would instead be branch-scoped, which
+      # means a cold full build on every new PR branch.
+      - name: Cache dependencies (read-only, from core-integrity)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-ci
+          save-if: false
+          workspaces: |
+            . -> target
+
+      # `--nocapture` on purpose: on PASS the arm prints
+      # `uart0: CLKDIV=... TXFIFO_CNT=... sink_bytes=N`, which is the evidence
+      # that the lane actually observed bytes rather than merely existing in
+      # the YAML. A gate whose log cannot distinguish "ran and saw bytes" from
+      # "was skipped" is the failure mode this job was added to remove.
+      - name: Observable arm — classic-ESP32 serial reaches the sink (browser policy)
+        run: >
+          cargo test -p labwired-core --features event-scheduler
+          --test esp32_classic_walk_differential -- --nocapture
 
   # ── Main-branch integrity (push to main) — fuller than PR, still no matrices ─
   integrity:
@@ -228,13 +302,21 @@ jobs:
           cargo test --release -p labwired-core --features event-scheduler
           --lib --test event_scheduler --test release_only_cfg_ratchet
 
-      # `esp32_classic_walk_differential` is here and NOT in `pr-gate` for the
-      # same structural reason the rest of this step is: the defect it covers is
-      # only reachable in an `event-scheduler` build, and the CLI (which every
-      # PR-fast lane exercises) deliberately compiles that feature OFF. A
-      # classic-ESP32 lab was 12/12 green on the CLI while livelocked in the
-      # browser because NO lane ran classic ESP32 under the browser's own
-      # feature set. This step is that lane.
+      # `esp32_classic_walk_differential` is BOTH arms here, and both arms are
+      # covered pre-merge as well — do not read this step as their only lane.
+      # `pr-gate` runs the structural arm under default features, and
+      # `pr-scheduler-observable` runs the observable arm under
+      # `event-scheduler` on every PR. This step keeps the push-to-main copy
+      # (with `jit` on, which no PR lane exercises).
+      #
+      # The original note here said the test was "NOT in pr-gate" because the
+      # defect is only reachable in an `event-scheduler` build and the CLI
+      # deliberately compiles that feature OFF. The premise is still true; the
+      # conclusion no longer is. A classic-ESP32 lab was 12/12 green on the CLI
+      # while livelocked in the browser because no lane ran classic ESP32 under
+      # the browser's own feature set BEFORE THE MERGE — a push-to-main lane
+      # reports that after the fact. See the comment on
+      # `pr-scheduler-observable`.
       - name: Feature gate — scheduler IRQ delivery (jit + event-scheduler)
         run: >
           cargo test -p labwired-core --features jit,event-scheduler


### PR DESCRIPTION
## The hole

`crates/core/tests/esp32_classic_walk_differential.rs` has two arms:

| arm | needs | ran where (before) | when |
|---|---|---|---|
| structural (`..._flag_is_derived_not_asserted`) | default features | `pr-gate` | pre-merge |
| **observable** (`..._serial_reaches_sink_under_browser_policy`) | `--features event-scheduler` | **`core-integrity` only** | **post-merge (push to main)** |

So a regression that stops serial bytes reaching the UART sink **merges green** and is discovered on main. That is precisely how the defect it covers shipped: a classic-ESP32 lab was 12/12 on the CLI and livelocked in the browser, because the only lane that could observe it ran after the merge.

Confirmed from the real log of PR run 30838734631, step `Walk-deletion derivation (PR-fast structural arm)`:

```
running 1 test
test esp32_classic_walk_flag_is_derived_not_asserted ... ok
test result: ok. 1 passed; 0 failed; ...
```

One test. The observable arm is `#[cfg]`-ed out of that build entirely.

## The change

New PR-triggered job `pr-scheduler-observable`, running **in parallel with `pr-gate`**:

```
cargo test -p labwired-core --features event-scheduler \
  --test esp32_classic_walk_differential -- --nocapture
```

`event-scheduler` **without `jit`** — that is exactly what `crates/wasm/Cargo.toml` pins, so this is the browser's own feature set. `core-integrity` runs the same test with `jit,event-scheduler`, which the browser never builds; that run stays as-is. **No existing gate is weakened.**

## Proof it actually executes in the lane (run 30842648130)

```
Finished `test` profile [unoptimized + debuginfo] target(s) in 47.92s
     Running tests/esp32_classic_walk_differential.rs
running 2 tests
test esp32_classic_walk_flag_is_derived_not_asserted ... ok
browser policy: tick_interval=1 legacy_walk_disabled=false steps=500000 cycles=500000
uart0: CLKDIV=694 (0x2b6) TXFIFO_CNT=128 sink_bytes=18
test esp32_classic_serial_reaches_sink_under_browser_policy ... ok
test result: ok. 2 passed; 0 failed;
```

Two tests, and `sink_bytes=18` — the log distinguishes "ran and observed bytes" from "was skipped". That is what `-- --nocapture` is there for.

## Cost, measured on the real runner

| | |
|---|---|
| `pr-scheduler-observable` wall clock | **70s** (18:45:15 → 18:46:25) |
| `pr-gate` wall clock, same run | **4m37s** (18:45:08 → 18:49:45) |
| PR critical path | **unchanged** — the new job finishes 3m20s before `pr-gate` |
| feature-variant compile | 47.92s cold here; 44.79s warm in `core-integrity` (run 30838517438) |
| observable arm runtime | 4.21s passing |

**Why not a step inside `pr-gate`:** it would add ~50s to a job that is already 3.0-4.6 min against `timeout-minutes: 5` — and a *failing* observable arm burns the full 20M-step budget instead of exiting on the first 500k batch (15s pass vs 129s fail locally, ~8x), so the failure case would trip the job timeout and lose the `CLKDIV / TXFIFO_CNT / sink_bytes` diagnostic that makes this gate worth having. As its own job it costs the critical path nothing and gets a timeout sized for the failing case.

**No cache step, on measurement:** the first cut used `Swatinem/rust-cache@v2` with `shared-key: core-ci` + `save-if: false`. Run 30842338316 logged `... Restoring cache ... No cache found.` — rust-cache folds installed toolchain components into its key and `core-integrity` installs rustfmt + clippy, so the keys never match. Cold build was 46.32s vs `core-integrity`'s warm 44.79s: the cache bought ~0s and would have cost an ~18s restore. Removed, and the comment records the measurement rather than the theory (2nd commit).

## Proof the arm actually detects the regression

Reinstating the hand-written `bus.legacy_walk_disabled = true` in `crates/core/src/system/xtensa/esp32.rs` (the original bug), under `--features event-scheduler`:

```
browser policy: tick_interval=512 legacy_walk_disabled=true steps=20000000 cycles=20000000
uart0: CLKDIV=694 (0x2b6) TXFIFO_CNT=128 sink_bytes=0
tick profile: peripheral_ticks=39062 legacy_tick_entries=0 ticked_entries=0
test result: FAILED. 0 passed; 2 failed;
```

byte-identical to the pre-fix signature. Restored:

```
browser policy: tick_interval=1 legacy_walk_disabled=false steps=500000 cycles=500000
uart0: CLKDIV=694 (0x2b6) TXFIFO_CNT=128 sink_bytes=18
test result: ok. 2 passed; 0 failed;
```

The same mutation under **default** features fails only the structural arm — the observable arm is not compiled at all. That is the whole reason it needs its own build.

## Also

Fixes the stale comment in `core-integrity` claiming the test is "here and NOT in `pr-gate`" — half-false since the structural arm moved.

> Note for branch protection: `pr-scheduler-observable` is a new check name. It only blocks merges once it is added to the required-checks list.