### PR TITLE
One bus trace for every wired bus (and the 4-of-5 UARTs it un-silenced)

### DIFF
--- a/crates/cli/src/bus_vcd.rs
+++ b/crates/cli/src/bus_vcd.rs
@@ -13,7 +13,9 @@
 //!   bus, so the capture opens directly in GTKWave, PulseView/sigrok, or any
 //!   other waveform viewer. Each event becomes one value-change at `#<seq>`
 //!   carrying the transacted byte (I²C: the `byte` field, already covering
-//!   the address frame via `I2cSym::AddrWrite`/`AddrRead`; SPI: `mosi`).
+//!   the address frame via `I2cSym::AddrWrite`/`AddrRead`; SPI: `mosi`; UART:
+//!   the octet). CAN is frame-oriented and has no 8-bit wire sample, so it
+//!   appears in the JSON export but not the VCD — see `event_byte`.
 
 use labwired_core::bus::bus_trace::{BusPayload, BusTraceEvent};
 use std::collections::BTreeMap;
@@ -25,11 +27,23 @@ pub fn write_bus_trace_json<W: Write>(events: &[BusTraceEvent], w: W) -> io::Res
     serde_json::to_writer_pretty(w, events).map_err(io::Error::other)
 }
 
-/// The byte a `BusTraceEvent` carries on the wire, for the VCD vector signal.
-fn event_byte(payload: &BusPayload) -> u8 {
+/// The byte a `BusTraceEvent` carries on the wire, for the VCD vector signal —
+/// or `None` when the event is not a single-byte wire symbol at all.
+///
+/// CAN is the `None` case, and deliberately so. A CAN event is a whole FRAME
+/// (arbitration id, DLC, up to 64 payload bytes); there is no one octet that
+/// represents it on an 8-bit vector. Emitting its first data byte, or a zero,
+/// would put a value in a waveform viewer that never existed on the wire —
+/// worse than omitting it, because a waveform is read as measurement. A
+/// frame-oriented bus wants its own VCD representation, which is a separate
+/// piece of work; until then the JSON export carries CAN losslessly and the VCD
+/// says nothing rather than something false.
+fn event_byte(payload: &BusPayload) -> Option<u8> {
     match payload {
-        BusPayload::I2c { byte, .. } => *byte,
-        BusPayload::Spi { mosi, .. } => *mosi,
+        BusPayload::I2c { byte, .. } => Some(*byte),
+        BusPayload::Spi { mosi, .. } => Some(*mosi),
+        BusPayload::Uart { byte, .. } => Some(*byte),
+        BusPayload::Can { .. } => None,
     }
 }
 
@@ -51,9 +65,13 @@ fn byte_to_bits(byte: u8) -> [Value; 8] {
 /// `#<seq>` / `b<binary> <id>` pair per event.
 pub fn write_bus_trace_vcd<W: Write>(events: &[BusTraceEvent], sink: W) -> io::Result<()> {
     // Distinct bus names, first-seen order (stable, deterministic output).
+    // Only buses that actually produce a wire sample get a signal — declaring a
+    // `wire 8` for a CAN controller and then never writing to it shows up in
+    // GTKWave as a channel stuck at its initial value, which reads as "this bus
+    // was idle" rather than "this bus is not representable here".
     let mut bus_order: Vec<String> = Vec::new();
     for e in events {
-        if !bus_order.contains(&e.bus) {
+        if event_byte(&e.payload).is_some() && !bus_order.contains(&e.bus) {
             bus_order.push(e.bus.clone());
         }
     }
@@ -70,9 +88,12 @@ pub fn write_bus_trace_vcd<W: Write>(events: &[BusTraceEvent], sink: W) -> io::R
     writer.enddefinitions()?;
 
     for e in events {
+        let Some(byte) = event_byte(&e.payload) else {
+            continue; // frame-oriented bus, no 8-bit wire sample — see `event_byte`
+        };
         let id = ids[&e.bus];
         writer.timestamp(e.seq)?;
-        writer.change_vector(id, byte_to_bits(event_byte(&e.payload)))?;
+        writer.change_vector(id, byte_to_bits(byte))?;
     }
     writer.flush()
 }

--- a/crates/cli/tests/bus_trace_export.rs
+++ b/crates/cli/tests/bus_trace_export.rs
@@ -121,7 +121,8 @@ fn vcd_carries_uart_octets_and_omits_frame_oriented_can() {
     // The JSON export is lossless, so nothing is actually lost by the omission.
     let mut json = Vec::new();
     labwired_cli::bus_vcd::write_bus_trace_json(&events, &mut json).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&String::from_utf8(json).unwrap()).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(json).unwrap()).unwrap();
     assert_eq!(parsed[0]["payload"]["protocol"], "uart");
     assert_eq!(parsed[0]["payload"]["direction"], "tx");
     assert_eq!(parsed[1]["payload"]["protocol"], "can");

--- a/crates/cli/tests/bus_trace_export.rs
+++ b/crates/cli/tests/bus_trace_export.rs
@@ -65,3 +65,66 @@ fn json_export_round_trips_events() {
     assert_eq!(parsed[0]["bus"], "spi0");
     assert_eq!(parsed[0]["payload"]["mosi"], 16);
 }
+
+/// UART octets belong in the VCD; CAN frames deliberately do not.
+///
+/// A UART event is one octet on a wire, which is exactly what a `wire 8`
+/// signal represents. A CAN event is a whole frame — arbitration id, DLC, up
+/// to 64 payload bytes — and no single octet of it was ever on the wire as a
+/// byte-wide sample. Emitting one anyway (the first data byte, or a zero) would
+/// put a value in a waveform viewer that never existed, and a waveform is read
+/// as measurement. So CAN is absent from the VCD entirely — not even a declared
+/// signal, because a `wire 8` that is never written renders in GTKWave as a
+/// channel sitting at its initial value, i.e. "this bus was idle" rather than
+/// "this bus is not representable here".
+#[test]
+fn vcd_carries_uart_octets_and_omits_frame_oriented_can() {
+    use labwired_core::bus::bus_trace::{BusDir, BusPayload, BusTraceEvent};
+    let events = vec![
+        BusTraceEvent {
+            seq: 1,
+            cycle: 10,
+            bus: "uart0".into(),
+            payload: BusPayload::Uart {
+                direction: BusDir::Tx,
+                byte: 0xAF,
+            },
+        },
+        BusTraceEvent {
+            seq: 2,
+            cycle: 20,
+            bus: "fdcan1".into(),
+            payload: BusPayload::Can {
+                direction: BusDir::Tx,
+                id: 0x7E0,
+                data: vec![0x03, 0x22],
+                extended: false,
+                fd: false,
+                bitrate_switch: false,
+                remote: false,
+            },
+        },
+    ];
+
+    let mut out = Vec::new();
+    labwired_cli::bus_vcd::write_bus_trace_vcd(&events, &mut out).unwrap();
+    let text = String::from_utf8(out).unwrap();
+
+    assert!(text.contains("uart0"), "the UART bus gets a signal");
+    assert!(text.contains("b10101111"), "and its octet 0xAF is encoded");
+    assert!(
+        !text.contains("fdcan1"),
+        "a frame-oriented bus must not be declared as a wire-8 signal it can \
+         never write to — that reads as an idle channel, not an absent one:\n{text}"
+    );
+
+    // The JSON export is lossless, so nothing is actually lost by the omission.
+    let mut json = Vec::new();
+    labwired_cli::bus_vcd::write_bus_trace_json(&events, &mut json).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&String::from_utf8(json).unwrap()).unwrap();
+    assert_eq!(parsed[0]["payload"]["protocol"], "uart");
+    assert_eq!(parsed[0]["payload"]["direction"], "tx");
+    assert_eq!(parsed[1]["payload"]["protocol"], "can");
+    assert_eq!(parsed[1]["payload"]["id"], 0x7E0);
+    assert_eq!(parsed[1]["payload"]["data"][1], 0x22);
+}

--- a/crates/core/src/bus/bus_trace.rs
+++ b/crates/core/src/bus/bus_trace.rs
@@ -23,7 +23,18 @@ use std::sync::{Arc, Mutex};
 use crate::peripherals::i2c::I2cDevice;
 use crate::peripherals::spi::SpiDevice;
 
-const BUS_TRACE_LIMIT: usize = 1024;
+/// How many events the one shared ring holds before the oldest is evicted.
+///
+/// Raised from 1024 when UART and CAN moved in here. Before, each bus had its
+/// own budget — 1024 shared by I²C+SPI, 512 per UART instance, 200 per CAN
+/// controller — so a chatty UART could not evict an I²C address phase. With one
+/// ring it can, and eviction is silent: an instrument that reconstructs
+/// transactions from address phases just sees fewer transactions, not an error.
+/// The budget therefore has to cover the busiest plausible lab (a display SPI
+/// burst concurrent with sensor polling and console output), not one bus in
+/// isolation. 4096 events is ≈330 KB worst case with 64-byte CAN-FD payloads,
+/// which is affordable in wasm.
+const BUS_TRACE_LIMIT: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -33,11 +44,52 @@ pub enum I2cSym {
     Data,
 }
 
+/// Which way a byte or frame moved, from the MCU peripheral's point of view.
+///
+/// Serializes to `"tx"` / `"rx"` — byte-identical to the `&'static str` and
+/// `String` direction fields this replaced on the per-peripheral UART and CAN
+/// traces, so the browser sees no change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BusDir {
+    Tx,
+    Rx,
+}
+
+/// What transacted. The ENVELOPE ([`BusTraceEvent`]) is universal — one seq,
+/// one cycle stamp, one bus name — while the payload stays honest about the
+/// protocol: an I²C symbol is genuinely not a CAN frame, and flattening them
+/// into a common struct would model neither well.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "protocol", rename_all = "lowercase")]
 pub enum BusPayload {
-    I2c { kind: I2cSym, byte: u8, ack: bool },
-    Spi { mosi: u8, miso: u8 },
+    I2c {
+        kind: I2cSym,
+        byte: u8,
+        ack: bool,
+    },
+    Spi {
+        mosi: u8,
+        miso: u8,
+    },
+    /// One octet on a UART's TX or RX line, recorded by the UART model itself
+    /// (there is no attachable "slave" to wrap, unlike I²C/SPI).
+    Uart {
+        direction: BusDir,
+        byte: u8,
+    },
+    /// One CAN / CAN-FD frame, from either the FDCAN (H5) or bxCAN (F1/F4)
+    /// controller — both feed this one variant so instruments work across
+    /// controller families.
+    Can {
+        direction: BusDir,
+        id: u32,
+        data: Vec<u8>,
+        extended: bool,
+        fd: bool,
+        bitrate_switch: bool,
+        remote: bool,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -91,6 +143,22 @@ impl Default for BusTrace {
     }
 }
 
+/// Deliberately does NOT lock the ring.
+///
+/// Peripherals that hold a handle derive `Debug`, and those `Debug` impls are
+/// reached from panic paths and from `inspect`. Taking the trace mutex there
+/// would let a formatter deadlock against a peripheral that is mid-`push` —
+/// turning a diagnostic into a hang. The identity of the ring is what is
+/// diagnostically interesting anyway; the contents are available via
+/// `snapshot()`.
+impl std::fmt::Debug for BusTrace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BusTrace")
+            .field("ring", &Arc::as_ptr(&self.ring))
+            .finish_non_exhaustive()
+    }
+}
+
 impl BusTrace {
     pub fn new() -> Self {
         Self {
@@ -114,6 +182,18 @@ impl BusTrace {
 
     pub fn snapshot(&self) -> Vec<BusTraceEvent> {
         self.ring.lock().unwrap().snapshot()
+    }
+
+    /// Whether two handles name the SAME ring — identity, not equal contents.
+    ///
+    /// This is what makes the one-home property checkable. A peripheral that
+    /// was never handed the bus's handle keeps the orphan ring it was born
+    /// with: it records happily, nobody reads it, and the instrument shows an
+    /// empty panel with no error — the silent failure this module exists to
+    /// prevent. Comparing snapshots could not tell that apart (two empty rings
+    /// are equal); comparing `Arc` identity can.
+    pub fn same_ring(&self, other: &BusTrace) -> bool {
+        Arc::ptr_eq(&self.ring, &other.ring)
     }
 }
 

--- a/crates/core/src/bus/construct.rs
+++ b/crates/core/src/bus/construct.rs
@@ -229,6 +229,7 @@ impl SystemBus {
         dev.attach_cycle_clock(self.cycle_clock.clone());
         // Twin of the `push_peripheral` attach — see there.
         dev.attach_irq_line(irq);
+        dev.attach_bus_trace(name, &self.bus_trace);
         self.peripherals.push(PeripheralEntry {
             name: name.to_string(),
             base,
@@ -258,6 +259,7 @@ impl SystemBus {
     ) {
         dev.attach_cycle_clock(self.cycle_clock.clone());
         dev.attach_irq_line(irq);
+        dev.attach_bus_trace(name, &self.bus_trace);
         if let Some(idx) = self.peripherals.iter().position(|p| p.name == name) {
             let e = &mut self.peripherals[idx];
             e.base = base;
@@ -664,6 +666,10 @@ impl SystemBus {
         // wired, so one whose only per-cycle wakeup holds a level-triggered IRQ
         // can stop scheduling itself on a bus where that pend is dropped.
         dev.attach_irq_line(p_cfg.irq);
+        // Same choke point again: the ONE universal bus trace. A UART or CAN
+        // model has no attachable slave to wrap, so it records for itself —
+        // being registered is what gets it the shared ring.
+        dev.attach_bus_trace(&p_cfg.id, &self.bus_trace);
         self.peripherals.push(PeripheralEntry {
             name: p_cfg.id.clone(),
             base: p_cfg.base_address,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1012,6 +1012,38 @@ pub trait Peripheral: std::fmt::Debug + Send {
     /// that bypass the choke points keep the old exact semantics.
     fn attach_irq_line(&mut self, _irq: Option<u32>) {}
 
+    /// Hand the peripheral the machine's ONE universal bus trace, plus the name
+    /// it should stamp events with. Called from the same registration choke
+    /// points as [`Peripheral::attach_cycle_clock`] and
+    /// [`Peripheral::attach_irq_line`] (`add_peripheral`,
+    /// `replace_or_add_peripheral`, `push_peripheral`), so a model reaches it by
+    /// being registered at all rather than by a per-family call site.
+    ///
+    /// I²C and SPI do NOT use this: their traffic is recorded by wrapping the
+    /// attached slave (`bus_trace::wrap_i2c` / `wrap_spi`), which is structurally
+    /// unbypassable. It exists for the buses with nothing to wrap — a UART or a
+    /// CAN controller transacts against a wire, not against an attachable
+    /// device, so the model itself has to record.
+    ///
+    /// Default no-op: the vast majority of peripherals carry no bus traffic.
+    /// A model that DOES carry traffic and ignores this is exactly the fork
+    /// `crate::tests::bus_trace_one_home` fails on.
+    fn attach_bus_trace(&mut self, _name: &str, _trace: &crate::bus::bus_trace::BusTrace) {}
+
+    /// The trace handle this model records into, if it records at all — `None`
+    /// for the vast majority, which carry no bus traffic.
+    ///
+    /// Exists so the one-home gate can prove by `Arc` identity that a model
+    /// which DOES record is recording into the machine's ring rather than into
+    /// the private handle it was born with. That distinction is invisible from
+    /// the outside: an orphaned ring accepts every write and simply is never
+    /// read, so the instrument shows an empty panel and no error. Comparing
+    /// snapshots cannot detect it (two empty rings are equal); comparing
+    /// identity can.
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        None
+    }
+
     /// Classify an MMIO access at `offset` for host idle/coalesce policy.
     /// Default [`MmioAccessClass::SideEffecting`] — only models that are
     /// proven poll-safe (or proven side-effect-free) override this.

--- a/crates/core/src/peripherals/bxcan.rs
+++ b/crates/core/src/peripherals/bxcan.rs
@@ -132,12 +132,13 @@ pub struct BxCan {
     /// Frames transmitted with loopback off and no bus attached. Bounded.
     #[serde(skip)]
     pub tx_frames: VecDeque<CanFrame>,
-    /// Frame-level CAN trace for the logic analyzer (tx + loopback rx), shared
-    /// `FdcanTraceFrame` shape so the existing UDS/CAN decoder consumes it.
+    /// The machine's ONE bus trace, and this controller's name in it. Private
+    /// until `attach_bus_trace` hands over the shared handle at registration,
+    /// so a bare `BxCan::new()` in a unit test still records somewhere.
     #[serde(skip)]
-    trace_seq: u64,
+    trace: crate::bus::bus_trace::BusTrace,
     #[serde(skip)]
-    trace: VecDeque<FdcanTraceFrame>,
+    trace_name: String,
     /// `CanBus` interconnect endpoints (`new_with_bus`). Transmitted frames go
     /// out on `bus_tx`; frames arriving on `bus_rx` are delivered (subject to
     /// the acceptance filter) on each tick while the controller is running.
@@ -170,8 +171,8 @@ impl BxCan {
             extra: HashMap::new(),
             rx_fifo0: VecDeque::new(),
             tx_frames: VecDeque::new(),
-            trace_seq: 0,
-            trace: VecDeque::new(),
+            trace: crate::bus::bus_trace::BusTrace::new(),
+            trace_name: String::new(),
             bus_tx: None,
             bus_rx: None,
         }
@@ -190,32 +191,11 @@ impl BxCan {
     /// Frame-level trace for the logic analyzer; mirrors the FDCAN shape so the
     /// shared CAN/UDS decoder works for both controllers.
     pub fn trace_snapshot(&self, peripheral: &str) -> Vec<FdcanTraceFrame> {
-        self.trace
-            .iter()
-            .cloned()
-            .map(|mut frame| {
-                frame.peripheral = peripheral.to_string();
-                frame
-            })
-            .collect()
+        crate::peripherals::can_trace_snapshot(&self.trace, &self.trace_name, peripheral)
     }
 
     fn push_trace(&mut self, direction: &'static str, frame: &CanFrame) {
-        self.trace_seq = self.trace_seq.wrapping_add(1);
-        if self.trace.len() >= 200 {
-            self.trace.pop_front();
-        }
-        self.trace.push_back(FdcanTraceFrame {
-            seq: self.trace_seq,
-            peripheral: String::new(),
-            direction: direction.to_string(),
-            id: frame.id,
-            data: frame.data.clone(),
-            extended: frame.extended,
-            fd: frame.fd,
-            bitrate_switch: frame.bitrate_switch,
-            remote: frame.remote,
-        });
+        crate::peripherals::push_can_trace(&self.trace, &self.trace_name, direction, frame);
     }
 
     fn running(&self) -> bool {
@@ -528,6 +508,16 @@ impl Default for BxCan {
 }
 
 impl Peripheral for BxCan {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.trace.clone())
+    }
+
+    /// Join the machine's one bus trace; see [`crate::bus::bus_trace`].
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        self.trace = trace.clone();
+        self.trace_name = name.to_string();
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word = Peripheral::read_u32(self, offset & !3)?;
         Ok(((word >> ((offset % 4) * 8)) & 0xFF) as u8)

--- a/crates/core/src/peripherals/esp32/uart.rs
+++ b/crates/core/src/peripherals/esp32/uart.rs
@@ -89,6 +89,12 @@ const CONFIG_REGS: &[(u64, u32, u32)] = &[
 #[derive(Default)]
 struct UartCore {
     sink: Option<Arc<Mutex<Vec<u8>>>>,
+    /// The machine's ONE bus trace, and the name to stamp with. Lives on the
+    /// CORE, not on either window, for the same reason the FIFO does: the APB
+    /// and AHB aliases are two doors onto one UART, and a byte must be traced
+    /// once whichever door pushed it.
+    trace: crate::bus::bus_trace::BusTrace,
+    trace_name: String,
     regs: crate::FastMap<u64, u32>,
     tx_fifo: VecDeque<u8>,
     rx_fifo: VecDeque<u8>,
@@ -142,6 +148,8 @@ impl Esp32Uart {
         Self {
             core: Arc::new(Mutex::new(UartCore {
                 sink: None,
+                trace: crate::bus::bus_trace::BusTrace::new(),
+                trace_name: String::new(),
                 regs,
                 tx_fifo: VecDeque::new(),
                 rx_fifo: VecDeque::new(),
@@ -171,6 +179,16 @@ impl Esp32Uart {
         let mut core = self.core.lock().unwrap();
         if core.rx_fifo.len() < FIFO_LEN {
             core.rx_fifo.push_back(byte);
+            // Only a byte that landed is traced — a byte dropped into a full
+            // FIFO never reaches the firmware, and tracing it would make the
+            // analyzer disagree with the model about what arrived.
+            core.trace.push(
+                &core.trace_name,
+                crate::bus::bus_trace::BusPayload::Uart {
+                    direction: crate::bus::bus_trace::BusDir::Rx,
+                    byte,
+                },
+            );
             core.int_raw_sticky |= INT_RXFIFO_TOUT;
         } else {
             core.int_raw_sticky |= INT_RXFIFO_OVF;
@@ -268,6 +286,23 @@ impl UartCore {
 }
 
 impl Peripheral for Esp32Uart {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.core.lock().unwrap().trace.clone())
+    }
+
+    /// Join the machine's one bus trace, on behalf of the shared core.
+    ///
+    /// Deliberately NOT implemented on [`Esp32UartAhbFifo`]: that window is an
+    /// alias onto this same core, and if it also stamped a name the events for
+    /// one physical UART would be split across two bus names depending on
+    /// registration order. One UART, one name — the AHB door pushes into the
+    /// core and the core traces under the APB peripheral's id.
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        let mut core = self.core.lock().unwrap();
+        core.trace = trace.clone();
+        core.trace_name = name.to_string();
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let mut core = self.core.lock().unwrap();
         if offset & !3 == OFF_FIFO {
@@ -360,6 +395,13 @@ impl Peripheral for Esp32Uart {
             while core.drain_accum >= per_byte && !core.tx_fifo.is_empty() {
                 core.drain_accum -= per_byte;
                 if let Some(byte) = core.tx_fifo.pop_front() {
+                    core.trace.push(
+                        &core.trace_name,
+                        crate::bus::bus_trace::BusPayload::Uart {
+                            direction: crate::bus::bus_trace::BusDir::Tx,
+                            byte,
+                        },
+                    );
                     if let Some(sink) = &core.sink {
                         if let Ok(mut g) = sink.lock() {
                             g.push(byte);

--- a/crates/core/src/peripherals/esp_uart.rs
+++ b/crates/core/src/peripherals/esp_uart.rs
@@ -240,6 +240,12 @@ const READONLY_REGS: &[(u64, u32)] = &[
 pub struct EspUart {
     sink: Option<Arc<Mutex<Vec<u8>>>>,
     echo_stdout: bool,
+    /// The machine's ONE bus trace and this instance's name in it. Handed over
+    /// at registration by `Peripheral::attach_bus_trace`; private until then so
+    /// a bare `EspUart::new` still records somewhere. See
+    /// [`crate::bus::bus_trace`].
+    trace: crate::bus::bus_trace::BusTrace,
+    trace_name: String,
     /// Interrupt-matrix source ID (UART0=27, UART1=28, UART2=29).
     source_id: u32,
     /// Config register storage: keyed by word offset, stores masked value.
@@ -313,6 +319,8 @@ impl EspUart {
         Self {
             sink: None,
             attached_streams: Vec::new(),
+            trace: crate::bus::bus_trace::BusTrace::new(),
+            trace_name: String::new(),
             echo_stdout,
             source_id,
             regs,
@@ -358,6 +366,13 @@ impl EspUart {
             match src.pop_front() {
                 Some(b) => {
                     rx.push_back(b);
+                    self.trace.push(
+                        &self.trace_name,
+                        crate::bus::bus_trace::BusPayload::Uart {
+                            direction: crate::bus::bus_trace::BusDir::Rx,
+                            byte: b,
+                        },
+                    );
                     moved += 1;
                 }
                 None => break,
@@ -418,6 +433,17 @@ impl EspUart {
         let mut rx = self.rx_fifo.borrow_mut();
         if rx.len() < FIFO_LEN {
             rx.push_back(byte);
+            // Only a byte that actually landed is traced. A byte dropped into a
+            // full FIFO never existed as far as the firmware is concerned, and
+            // tracing it would make the analyzer disagree with the model about
+            // what arrived.
+            self.trace.push(
+                &self.trace_name,
+                crate::bus::bus_trace::BusPayload::Uart {
+                    direction: crate::bus::bus_trace::BusDir::Rx,
+                    byte,
+                },
+            );
             self.int_raw_sticky |= INT_RXFIFO_TOUT;
         } else {
             self.int_raw_sticky |= INT_RXFIFO_OVF;
@@ -554,6 +580,15 @@ impl EspUart {
         while self.drain_accum >= per_byte && !self.tx_fifo.is_empty() {
             self.drain_accum -= per_byte;
             if let Some(byte) = self.tx_fifo.pop_front() {
+                // Same choke point as the sink, for the same reason: a byte
+                // leaves the shift register exactly once.
+                self.trace.push(
+                    &self.trace_name,
+                    crate::bus::bus_trace::BusPayload::Uart {
+                        direction: crate::bus::bus_trace::BusDir::Tx,
+                        byte,
+                    },
+                );
                 if let Some(sink) = &self.sink {
                     if let Ok(mut g) = sink.lock() {
                         g.push(byte);
@@ -620,6 +655,20 @@ impl crate::peripherals::uart::UartStreamHost for EspUart {
 }
 
 impl Peripheral for EspUart {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.trace.clone())
+    }
+
+    /// Join the machine's one bus trace. Before this existed, an ESP32-C3 or
+    /// ESP32 UART recorded nothing anywhere: the browser found UARTs by
+    /// `downcast_ref::<Uart>()`, which this model is not, so the logic
+    /// analyzer's UART panel was permanently empty on every ESP lab — with no
+    /// error to say so.
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        self.trace = trace.clone();
+        self.trace_name = name.to_string();
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         self.ingest_rx_source();
         if offset & !3 == OFF_FIFO {

--- a/crates/core/src/peripherals/fdcan.rs
+++ b/crates/core/src/peripherals/fdcan.rs
@@ -225,10 +225,13 @@ pub struct Fdcan {
     /// attached. Bounded: oldest dropped past 64.
     #[serde(skip)]
     pub tx_frames: VecDeque<CanFrame>,
+    /// The machine's ONE bus trace, and this controller's name in it. Private
+    /// until `attach_bus_trace` hands over the shared handle at registration,
+    /// so a bare `Fdcan::new()` in a unit test still records somewhere.
     #[serde(skip)]
-    trace_seq: u64,
+    trace: crate::bus::bus_trace::BusTrace,
     #[serde(skip)]
-    trace: VecDeque<FdcanTraceFrame>,
+    trace_name: String,
     /// `CanBus` interconnect endpoints (`new_with_bus` / `attach_bus`).
     #[serde(skip)]
     bus_tx: Option<Sender<CanFrame>>,
@@ -275,8 +278,8 @@ impl Fdcan {
             bus_active: false,
             message_ram: vec![0; RAM_WORDS],
             tx_frames: VecDeque::new(),
-            trace_seq: 0,
-            trace: VecDeque::new(),
+            trace: crate::bus::bus_trace::BusTrace::new(),
+            trace_name: String::new(),
             bus_tx: None,
             bus_rx: None,
             pending_tx: VecDeque::new(),
@@ -339,33 +342,16 @@ impl Fdcan {
         Ok(())
     }
 
+    /// This controller's frames from the shared trace, oldest first. Derived
+    /// per call — a projection of the one ring, not a second store. `seq` is
+    /// therefore the GLOBAL sequence, which is what makes CAN frames orderable
+    /// against I²C/SPI/UART traffic on the same machine.
     pub fn trace_snapshot(&self, peripheral: &str) -> Vec<FdcanTraceFrame> {
-        self.trace
-            .iter()
-            .cloned()
-            .map(|mut frame| {
-                frame.peripheral = peripheral.to_string();
-                frame
-            })
-            .collect()
+        crate::peripherals::can_trace_snapshot(&self.trace, &self.trace_name, peripheral)
     }
 
     fn push_trace(&mut self, direction: &'static str, frame: &CanFrame) {
-        self.trace_seq = self.trace_seq.wrapping_add(1);
-        if self.trace.len() >= 200 {
-            self.trace.pop_front();
-        }
-        self.trace.push_back(FdcanTraceFrame {
-            seq: self.trace_seq,
-            peripheral: String::new(),
-            direction: direction.to_string(),
-            id: frame.id,
-            data: frame.data.clone(),
-            extended: frame.extended,
-            fd: frame.fd,
-            bitrate_switch: frame.bitrate_switch,
-            remote: frame.remote,
-        });
+        crate::peripherals::push_can_trace(&self.trace, &self.trace_name, direction, frame);
     }
 
     fn config_unlocked(&self) -> bool {
@@ -673,6 +659,16 @@ impl Default for Fdcan {
 }
 
 impl Peripheral for Fdcan {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.trace.clone())
+    }
+
+    /// Join the machine's one bus trace; see [`crate::bus::bus_trace`].
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        self.trace = trace.clone();
+        self.trace_name = name.to_string();
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let word = Peripheral::read_u32(self, offset & !3)?;
         Ok(((word >> ((offset % 4) * 8)) & 0xFF) as u8)

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -64,3 +64,124 @@ pub mod tsc;
 pub mod uart;
 pub mod usb_otg;
 pub mod wwdg;
+
+/// Record one CAN/CAN-FD frame into the machine's ONE bus trace.
+///
+/// Shared by [`fdcan::Fdcan`] (H5) and [`bxcan::BxCan`] (F1/F4) so the two
+/// controller families cannot drift in how a frame is represented. They used to
+/// hold a `VecDeque<FdcanTraceFrame>` each, with a hand-copied 200-entry
+/// eviction rule and a private `trace_seq` — two homes for one concept, which
+/// is exactly what this module's trace unification exists to end.
+pub fn push_can_trace(
+    trace: &crate::bus::bus_trace::BusTrace,
+    bus: &str,
+    direction: &'static str,
+    frame: &crate::network::CanFrame,
+) {
+    use crate::bus::bus_trace::{BusDir, BusPayload};
+    let direction = match direction {
+        "tx" => BusDir::Tx,
+        "rx" => BusDir::Rx,
+        other => unreachable!("CAN trace direction is tx or rx, got {other:?}"),
+    };
+    trace.push(
+        bus,
+        BusPayload::Can {
+            direction,
+            id: frame.id,
+            data: frame.data.clone(),
+            extended: frame.extended,
+            fd: frame.fd,
+            bitrate_switch: frame.bitrate_switch,
+            remote: frame.remote,
+        },
+    );
+}
+
+/// The frames one CAN controller recorded, projected back into the
+/// [`fdcan::FdcanTraceFrame`] shape the UDS/CAN decoders already consume.
+///
+/// `bus` selects this controller's rows in the shared ring; `peripheral` is the
+/// name stamped onto the returned rows (the caller's display id). They are
+/// separate arguments because a bare controller built in a unit test has no bus
+/// name yet, and must still see its own frames.
+pub fn can_trace_snapshot(
+    trace: &crate::bus::bus_trace::BusTrace,
+    bus: &str,
+    peripheral: &str,
+) -> Vec<fdcan::FdcanTraceFrame> {
+    use crate::bus::bus_trace::{BusDir, BusPayload};
+    trace
+        .snapshot()
+        .into_iter()
+        .filter(|e| e.bus == bus)
+        .filter_map(|e| match e.payload {
+            BusPayload::Can {
+                direction,
+                id,
+                data,
+                extended,
+                fd,
+                bitrate_switch,
+                remote,
+            } => Some(fdcan::FdcanTraceFrame {
+                seq: e.seq,
+                peripheral: peripheral.to_string(),
+                direction: match direction {
+                    BusDir::Tx => "tx",
+                    BusDir::Rx => "rx",
+                }
+                .to_string(),
+                id,
+                data,
+                extended,
+                fd,
+                bitrate_switch,
+                remote,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every CAN frame in a bus-trace snapshot, from every controller, in one flat
+/// list — the shape the CAN/UDS instruments consume.
+///
+/// The browser used to build this by walking peripherals and downcasting to
+/// each concrete controller type in turn, so a new CAN family was invisible
+/// until someone remembered to add an arm. Reading the shared ring makes
+/// membership a consequence of recording.
+pub fn can_trace_snapshot_all(
+    events: &[crate::bus::bus_trace::BusTraceEvent],
+) -> Vec<fdcan::FdcanTraceFrame> {
+    use crate::bus::bus_trace::{BusDir, BusPayload};
+    events
+        .iter()
+        .filter_map(|e| match &e.payload {
+            BusPayload::Can {
+                direction,
+                id,
+                data,
+                extended,
+                fd,
+                bitrate_switch,
+                remote,
+            } => Some(fdcan::FdcanTraceFrame {
+                seq: e.seq,
+                peripheral: e.bus.clone(),
+                direction: match direction {
+                    BusDir::Tx => "tx",
+                    BusDir::Rx => "rx",
+                }
+                .to_string(),
+                id: *id,
+                data: data.clone(),
+                extended: *extended,
+                fd: *fd,
+                bitrate_switch: *bitrate_switch,
+                remote: *remote,
+            }),
+            _ => None,
+        })
+        .collect()
+}

--- a/crates/core/src/peripherals/nrf52/uarte.rs
+++ b/crates/core/src/peripherals/nrf52/uarte.rs
@@ -129,6 +129,11 @@ pub struct Nrf52Uarte {
     sink: Option<Arc<Mutex<Vec<u8>>>>,
     /// Echo transmitted bytes to the process stdout (console behaviour).
     echo_stdout: bool,
+    /// The machine's ONE bus trace and this instance's name in it; see
+    /// [`crate::bus::bus_trace`]. Private until `attach_bus_trace` hands over
+    /// the shared handle at registration.
+    trace: crate::bus::bus_trace::BusTrace,
+    trace_name: String,
 }
 
 impl std::fmt::Debug for Nrf52Uarte {
@@ -167,6 +172,16 @@ impl Nrf52Uarte {
     }
 
     fn emit_byte(&mut self, byte: u8) {
+        // The one place a TX byte leaves this UARTE, so the one place it is
+        // traced. See `attach_bus_trace` for what this model recorded before:
+        // nothing, anywhere.
+        self.trace.push(
+            &self.trace_name,
+            crate::bus::bus_trace::BusPayload::Uart {
+                direction: crate::bus::bus_trace::BusDir::Tx,
+                byte,
+            },
+        );
         if let Some(sink) = &self.sink {
             if let Ok(mut guard) = sink.lock() {
                 guard.push(byte);
@@ -183,6 +198,19 @@ impl Nrf52Uarte {
 }
 
 impl Peripheral for Nrf52Uarte {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.trace.clone())
+    }
+
+    /// Join the machine's one bus trace. This model previously recorded no
+    /// trace at all — the browser located UARTs by `downcast_ref::<Uart>()`,
+    /// which a UARTE is not, so every nRF52 lab's UART analyzer was silently
+    /// empty.
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        self.trace = trace.clone();
+        self.trace_name = name.to_string();
+    }
+
     /// Dual-path EasyDMA: scheduler delay-0 (`on_event`) under Machine +
     /// walk-free + batched `peripheral_tick_interval`, and `tick_with_bus`
     /// (`bus_tick_indices`) for bare-bus unit tests / feature-off. No

--- a/crates/core/src/peripherals/nrf54l/uarte.rs
+++ b/crates/core/src/peripherals/nrf54l/uarte.rs
@@ -174,6 +174,11 @@ pub struct Nrf54lUarte {
     sink: Option<Arc<Mutex<Vec<u8>>>>,
     /// Echo transmitted bytes to the process stdout (console behaviour).
     echo_stdout: bool,
+    /// The machine's ONE bus trace and this instance's name in it; see
+    /// [`crate::bus::bus_trace`]. Private until `attach_bus_trace` hands over
+    /// the shared handle at registration.
+    trace: crate::bus::bus_trace::BusTrace,
+    trace_name: String,
 }
 
 impl std::fmt::Debug for Nrf54lUarte {
@@ -212,6 +217,15 @@ impl Nrf54lUarte {
     }
 
     fn emit_byte(&mut self, byte: u8) {
+        // The one place a TX byte leaves this UARTE, so the one place it is
+        // traced. See `attach_bus_trace`.
+        self.trace.push(
+            &self.trace_name,
+            crate::bus::bus_trace::BusPayload::Uart {
+                direction: crate::bus::bus_trace::BusDir::Tx,
+                byte,
+            },
+        );
         if let Some(sink) = &self.sink {
             if let Ok(mut guard) = sink.lock() {
                 guard.push(byte);
@@ -246,6 +260,17 @@ impl Nrf54lUarte {
 }
 
 impl Peripheral for Nrf54lUarte {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.trace.clone())
+    }
+
+    /// Join the machine's one bus trace. Like its nRF52 sibling, this model
+    /// previously recorded no trace at all.
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        self.trace = trace.clone();
+        self.trace_name = name.to_string();
+    }
+
     fn read(&self, _offset: u64) -> SimResult<u8> {
         Ok(0)
     }

--- a/crates/core/src/peripherals/uart.rs
+++ b/crates/core/src/peripherals/uart.rs
@@ -15,8 +15,18 @@ use std::sync::{Arc, Mutex};
 /// token — it has only one kind of wakeup ("do one tick of work"), so the
 /// value is arbitrary and never disambiguated in `on_event`.
 const UART_WAKE_TOKEN: u32 = 0;
-const UART_TRACE_LIMIT: usize = 512;
 
+/// A projection of this UART's rows in the machine's ONE bus trace — NOT a
+/// second home.
+///
+/// It holds no state: [`Uart::trace_snapshot`] computes it on demand by
+/// filtering the shared ring (see [`crate::bus::bus_trace`]). It survives the
+/// move off the old per-instance `VecDeque` only because the tests written
+/// against it are what prove that move changed no observable behaviour.
+///
+/// `seq` is therefore the GLOBAL sequence number, not a per-UART counter. That
+/// is the point: one counter across every wired bus is what makes "did this
+/// UART byte precede that I²C address phase?" answerable at all.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct UartTraceEvent {
     pub seq: u64,
@@ -701,10 +711,18 @@ pub struct Uart {
     /// Stream devices attached to the RX path (e.g. GPS modules).
     #[serde(skip)]
     pub attached_streams: Vec<Box<dyn UartStreamDevice>>,
+    /// The machine's ONE bus trace, and the name to stamp events with.
+    ///
+    /// Born as a private handle so a hand-built `Uart::new()` (unit tests,
+    /// fixtures) still records into something; `attach_bus_trace` REPLACES it
+    /// with the bus's shared handle at registration. A model that never got
+    /// registered keeps the orphan — which is what
+    /// `crate::tests::bus_trace_one_home` asserts cannot happen on a real
+    /// machine, by `Arc` identity rather than by contents.
     #[serde(skip)]
-    trace: VecDeque<UartTraceEvent>,
+    trace: crate::bus::bus_trace::BusTrace,
     #[serde(skip)]
-    trace_seq: u64,
+    trace_name: String,
     /// Microseconds accumulated since last stream tick.
     elapsed_us: u32,
     /// Phase 2B.3b (issue #192): whether a self-perpetuating scheduler WAKE
@@ -784,8 +802,8 @@ impl Uart {
             cr3_mask,
             dma_tx_pending: false,
             attached_streams: Vec::new(),
-            trace: VecDeque::new(),
-            trace_seq: 0,
+            trace: crate::bus::bus_trace::BusTrace::new(),
+            trace_name: String::new(),
             elapsed_us: 0,
             scheduled: false,
             // Conservative until the bus says otherwise (see `attach_irq_line`).
@@ -1045,19 +1063,36 @@ impl Uart {
     }
 
     fn record_trace(&mut self, direction: &'static str, byte: u8) {
-        self.trace_seq = self.trace_seq.wrapping_add(1);
-        if self.trace.len() >= UART_TRACE_LIMIT {
-            self.trace.pop_front();
-        }
-        self.trace.push_back(UartTraceEvent {
-            seq: self.trace_seq,
-            direction,
-            byte,
-        });
+        use crate::bus::bus_trace::{BusDir, BusPayload};
+        let direction = match direction {
+            "tx" => BusDir::Tx,
+            "rx" => BusDir::Rx,
+            other => unreachable!("UART trace direction is tx or rx, got {other:?}"),
+        };
+        self.trace
+            .push(&self.trace_name, BusPayload::Uart { direction, byte });
     }
 
+    /// This UART's rows in the shared trace, oldest first. Derived per call —
+    /// see [`UartTraceEvent`] for why this is a view and not a second home.
     pub fn trace_snapshot(&self) -> Vec<UartTraceEvent> {
-        self.trace.iter().cloned().collect()
+        use crate::bus::bus_trace::{BusDir, BusPayload};
+        self.trace
+            .snapshot()
+            .into_iter()
+            .filter(|e| e.bus == self.trace_name)
+            .filter_map(|e| match e.payload {
+                BusPayload::Uart { direction, byte } => Some(UartTraceEvent {
+                    seq: e.seq,
+                    direction: match direction {
+                        BusDir::Tx => "tx",
+                        BusDir::Rx => "rx",
+                    },
+                    byte,
+                }),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Set a prefix emitted before each echoed stdout line, to label this UART's
@@ -1084,6 +1119,10 @@ impl UartStreamHost for Uart {
 }
 
 impl crate::Peripheral for Uart {
+    fn bus_trace_handle(&self) -> Option<crate::bus::bus_trace::BusTrace> {
+        Some(self.trace.clone())
+    }
+
     fn read(&self, offset: u64) -> SimResult<u8> {
         let status = self.status_offset();
         if offset >= status && offset < status + self.layout.regmap().status_width {
@@ -1191,6 +1230,13 @@ impl crate::Peripheral for Uart {
     /// will drop on the floor. See the field docs on `irq_wired`.
     fn attach_irq_line(&mut self, irq: Option<u32>) {
         self.irq_wired = irq.is_some();
+    }
+
+    /// Join the machine's one bus trace, replacing the private handle this
+    /// model was born with. See the `trace` field docs.
+    fn attach_bus_trace(&mut self, name: &str, trace: &crate::bus::bus_trace::BusTrace) {
+        self.trace = trace.clone();
+        self.trace_name = name.to_string();
     }
 
     /// Hand the bus a single self-perpetuating WAKE event when the UART has

--- a/crates/core/src/tests/bus_trace_one_home.rs
+++ b/crates/core/src/tests/bus_trace_one_home.rs
@@ -1,0 +1,352 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! THE BUS TRACE HAS ONE HOME.
+//!
+//! Why this file exists
+//! ====================
+//! `crate::bus::bus_trace` calls itself the *universal* bus-transaction trace.
+//! For a long time it was universal over exactly two buses. I²C and SPI
+//! recorded into its shared ring; UART kept a `VecDeque<UartTraceEvent>` per
+//! instance with its own 512-entry limit and its own `trace_seq`; FDCAN and
+//! bxCAN each kept a `VecDeque<FdcanTraceFrame>` with a hand-copied 200-entry
+//! limit and a third `trace_seq`. Three homes, three event shapes, three
+//! sequence counters.
+//!
+//! That is the same shape as the seven bugs catalogued in
+//! [`super::device_identity_one_home`], and unlike device identity it was
+//! already broken, in three separate ways:
+//!
+//! 1. **Four of five UART models traced nothing at all.** The browser found
+//!    UARTs with `downcast_ref::<Uart>()`. `EspUart` (ESP32-C3/S3), `Esp32Uart`,
+//!    `Nrf52Uarte` and `Nrf54lUarte` are all UARTs and none of them IS a `Uart`,
+//!    so on every ESP and nRF lab the analyzer's UART panel was permanently
+//!    empty — with no error, because "no UART found" and "a UART that sent
+//!    nothing" are the same empty array. This is the identical mistake
+//!    `uart::UartStreamHost` was introduced to fix for cross-chip links; the
+//!    trace path simply never got the same treatment.
+//! 2. **No cycle stamp on UART or CAN.** `BusTraceEvent::cycle` promises the UI
+//!    can "time-align protocol decode with sampled waveforms on one cycle axis".
+//!    Only I²C and SPI could.
+//! 3. **Three sequence counters ⇒ no cross-bus order.** Nothing could answer
+//!    "did this UART byte precede that I²C address phase?", because the two
+//!    numbers came from different counters.
+//!
+//! What this file gates
+//! ====================
+//! Two properties, one behavioural and one structural. Both are derived — the
+//! expected side from live Rust data or from the source itself, never from a
+//! list a person maintains and forgets.
+//!
+//! (1) `every_recording_peripheral_shares_the_machines_ring` — for every chip
+//!     descriptor we ship, every registered peripheral that admits to recording
+//!     ([`crate::Peripheral::bus_trace_handle`]) must hold the SAME ring as the
+//!     bus, by `Arc` identity. This is the fails-CLOSED half. A model whose
+//!     `attach_bus_trace` is never reached keeps the private handle it was born
+//!     with: it records happily, nothing reads it, and the instrument shows an
+//!     empty panel. Comparing contents cannot see that — two empty rings are
+//!     equal — so the gate compares identity.
+//!
+//! (2) `no_peripheral_keeps_a_private_trace_ring` — no file under
+//!     `peripherals/` may declare its own trace ring or trace-limit constant.
+//!     This is the fails-if-FORKED half: it catches the next model that solves
+//!     "I need a trace" by growing a `VecDeque` instead of recording into the
+//!     one ring, which is how all three of the above started.
+//!
+//! Why a source scan for (2)
+//! ========================
+//! A private ring is invisible at runtime — that is the entire problem. A model
+//! with its own `VecDeque<FooTraceEvent>` behaves correctly, tests green, and
+//! is simply absent from the universal trace. There is no value to assert on,
+//! so the gate reads the declaration instead. Same reasoning as
+//! [`super::device_identity_one_home`], which reads the browser's source
+//! because the lane that blocks a merge never links that crate.
+
+use crate::bus::SystemBus;
+use labwired_config::{ChipDescriptor, SystemManifest};
+use std::path::PathBuf;
+
+/// `crates/core` → repo root.
+fn repo_root(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+fn dummy_manifest(chip_path: &str) -> SystemManifest {
+    SystemManifest {
+        parts: Vec::new(),
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "bus-trace-one-home".to_string(),
+        chip: chip_path.to_string(),
+        external_devices: vec![],
+        cosim_models: Vec::new(),
+        board_io: vec![],
+        debug_uart: None,
+        wifi_ap: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    }
+}
+
+/// Every chip descriptor we ship, enumerated FROM DISK so a chip added later
+/// cannot escape the gate by not being listed here.
+#[test]
+fn every_recording_peripheral_shares_the_machines_ring() {
+    let dir = repo_root("configs/chips");
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {dir:?}: {e}"))
+        .map(|e| e.expect("dir entry").path())
+        .filter(|p| p.extension().is_some_and(|e| e == "yaml"))
+        .collect();
+    paths.sort();
+
+    let mut failures = Vec::new();
+    let mut recorders = 0usize;
+    let mut chips = 0usize;
+
+    for path in paths {
+        let stem = path.file_stem().unwrap().to_string_lossy().into_owned();
+        // Internal harness fixtures, not silicon we ship.
+        if stem.starts_with("ci-fixture-") {
+            continue;
+        }
+        let Ok(chip) = ChipDescriptor::from_file(&path) else {
+            continue; // loading is another gate's job
+        };
+        let abs = path.to_string_lossy().to_string();
+        let Ok(bus) = SystemBus::from_config(&chip, &dummy_manifest(&abs)) else {
+            continue;
+        };
+        chips += 1;
+
+        for p in &bus.peripherals {
+            let Some(handle) = p.dev.bus_trace_handle() else {
+                continue; // carries no bus traffic
+            };
+            recorders += 1;
+            if !handle.same_ring(&bus.bus_trace) {
+                failures.push(format!(
+                    "{stem}: peripheral '{}' records into a ring that is NOT the \
+                     machine's. It kept the private handle it was constructed \
+                     with, so everything it traces is written to a buffer nobody \
+                     reads — the instrument will show an empty panel and no \
+                     error. Its registration path must call \
+                     `Peripheral::attach_bus_trace` (see the three funnels in \
+                     `bus/construct.rs`).",
+                    p.name
+                ));
+            }
+        }
+    }
+
+    assert!(
+        chips > 0,
+        "no chip descriptors were built — the gate is vacuous"
+    );
+    assert!(
+        recorders > 0,
+        "no peripheral reported a trace handle across {chips} chips — either \
+         `bus_trace_handle` was removed from every model, or the gate is \
+         looking in the wrong place. Either way it is no longer proving \
+         anything."
+    );
+    assert!(failures.is_empty(), "\n{}", failures.join("\n\n"));
+}
+
+/// Files allowed to own a trace ring, each with the reason.
+///
+/// Most are AIR traces, not wired buses, and they are outside this unification
+/// on purpose: an over-the-air frame has no wire, no bus name and no place in a
+/// wired-bus analyzer, and they already share their own one home
+/// (`VirtualAirBus`). Wired and air are two honest axes; collapsing them would
+/// make the model worse, not better. The IO-Link entry is different and is
+/// flagged as debt in its own reason string.
+const ALLOWED_PRIVATE_RINGS: &[(&str, &str)] = &[
+    (
+        "peripherals/ble_air.rs",
+        "air trace (BLE/proprietary frames), shared via VirtualAirBus",
+    ),
+    (
+        "peripherals/esp32c3/wifi_mac.rs",
+        "air trace (802.11 frames), the WiFi analog of the BLE air bus",
+    ),
+    (
+        "peripherals/nrf52/radio.rs",
+        "air trace (VirtualAirBus itself lives here)",
+    ),
+    (
+        "peripherals/components/iolink_master.rs",
+        "IO-Link transfers are a DECODE of UART octets that are themselves in \
+         the one ring, not a fourth wired bus — derivable, kept for now",
+    ),
+];
+
+/// Every `.rs` file under `crates/core/src/peripherals`, recursively.
+fn peripheral_sources() -> Vec<(String, String)> {
+    fn walk(dir: &PathBuf, root: &PathBuf, out: &mut Vec<(String, String)>) {
+        for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read {dir:?}: {e}")) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, root, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("under root")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                let src = std::fs::read_to_string(&path).expect("read source");
+                out.push((format!("peripherals/{rel}"), src));
+            }
+        }
+    }
+    let root = repo_root("crates/core/src/peripherals");
+    let mut out = Vec::new();
+    walk(&root, &root, &mut out);
+    out.sort();
+    out
+}
+
+/// Does this line DECLARE a private trace ring or its eviction budget?
+///
+/// Two shapes, both taken from the three real forks this gate ends:
+///   `trace: VecDeque<UartTraceEvent>,`   — the ring itself
+///   `const UART_TRACE_LIMIT: usize = 512;` — its private budget
+///
+/// Deliberately not matched: `trace_seq`, which is meaningless on its own, and
+/// any use of `BusTrace`, which is the one home and the thing we want models to
+/// hold. Comment lines are skipped — prose describing a ring is not a ring.
+fn declares_a_private_ring(line: &str) -> bool {
+    let t = line.trim();
+    if t.starts_with("//") {
+        return false;
+    }
+    let ring = t.contains("VecDeque<") && {
+        let after = t.split("VecDeque<").nth(1).unwrap_or("");
+        let inner = after.split('>').next().unwrap_or("");
+        inner.contains("Trace") || inner.contains("trace")
+    };
+    let budget = t.starts_with("const ") && t.contains("TRACE_LIMIT");
+    ring || budget
+}
+
+#[test]
+fn no_peripheral_keeps_a_private_trace_ring() {
+    let allowed: std::collections::HashMap<&str, &str> =
+        ALLOWED_PRIVATE_RINGS.iter().copied().collect();
+
+    let sources = peripheral_sources();
+    assert!(
+        !sources.is_empty(),
+        "no peripheral sources were scanned — the gate is vacuous"
+    );
+
+    let mut failures = Vec::new();
+    for (rel, src) in &sources {
+        if allowed.contains_key(rel.as_str()) {
+            continue;
+        }
+        for (i, line) in src.lines().enumerate() {
+            if declares_a_private_ring(line) {
+                failures.push(format!(
+                    "{rel}:{}: declares a private trace ring\n    {}\n  \
+                     A peripheral must record into the machine's ONE bus trace \
+                     (`Peripheral::attach_bus_trace` + `BusTrace::push`), not \
+                     into a buffer of its own. A private ring is invisible to \
+                     every instrument and to `bus_trace_snapshot`, and nothing \
+                     at runtime can tell it apart from a bus that was simply \
+                     quiet — which is how the UART and CAN traces stayed \
+                     missing. If this really is an AIR trace and not a wired \
+                     bus, add it to ALLOWED_PRIVATE_RINGS with the reason.",
+                    i + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n\n"));
+}
+
+/// The gate above must actually be able to fail. A scanner that matches nothing
+/// passes every file for free, which is the vacuous-green pattern this codebase
+/// has been bitten by before — so pin the detector against the exact three
+/// declarations that used to exist, and against shapes it must NOT flag.
+#[test]
+fn the_private_ring_detector_is_not_vacuous() {
+    // The three real forks, verbatim from the code this change removed.
+    assert!(declares_a_private_ring(
+        "    trace: VecDeque<UartTraceEvent>,"
+    ));
+    assert!(declares_a_private_ring(
+        "    trace: VecDeque<FdcanTraceFrame>,"
+    ));
+    assert!(declares_a_private_ring(
+        "const UART_TRACE_LIMIT: usize = 512;"
+    ));
+
+    // The one home, and things that merely mention tracing, must stay clean.
+    assert!(!declares_a_private_ring(
+        "    trace: crate::bus::bus_trace::BusTrace,"
+    ));
+    assert!(!declares_a_private_ring("    trace_name: String,"));
+    assert!(!declares_a_private_ring(
+        "    /// trace: VecDeque<UartTraceEvent>, (how it used to work)"
+    ));
+    assert!(!declares_a_private_ring("    rx_fifo: VecDeque<u8>,"));
+}
+
+/// The bug, end to end: an ESP-family UART must appear in the machine's trace.
+///
+/// This is the property that was broken for every ESP and nRF lab. It is
+/// asserted on the SHARED ring — the same array `bus_trace_snapshot` hands the
+/// browser — rather than on any per-model accessor, because "the model recorded
+/// it somewhere" was never the problem. The problem was that what it recorded
+/// never reached the one place the instruments read.
+#[test]
+fn an_esp_uart_reaches_the_shared_trace() {
+    use crate::bus::bus_trace::BusPayload;
+
+    let path = repo_root("configs/chips/esp32c3.yaml");
+    let chip = ChipDescriptor::from_file(&path).expect("load esp32c3 chip yaml");
+    let abs = path.to_string_lossy().to_string();
+    let mut bus = SystemBus::from_config(&chip, &dummy_manifest(&abs)).expect("build c3 bus");
+
+    assert!(
+        bus.bus_trace_snapshot().is_empty(),
+        "a freshly built machine has transacted nothing"
+    );
+
+    // Push a byte through UART0's FIFO and let it shift out at baud.
+    let idx = bus
+        .find_peripheral_index_by_name("uart0")
+        .expect("the C3 carries uart0");
+    bus.peripherals[idx]
+        .dev
+        .write_u32(0x00, b'K' as u32)
+        .expect("FIFO write");
+    for _ in 0..200_000 {
+        bus.peripherals[idx].dev.tick();
+        if !bus.bus_trace_snapshot().is_empty() {
+            break;
+        }
+    }
+
+    let events = bus.bus_trace_snapshot();
+    let uart: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e.payload, BusPayload::Uart { .. }))
+        .collect();
+    assert!(
+        !uart.is_empty(),
+        "the C3's UART0 shifted a byte out and the machine's trace stayed \
+         empty. This is the original defect: an `EspUart` is not a `Uart`, so \
+         nothing recorded it and the analyzer had nothing to show."
+    );
+    assert_eq!(uart[0].bus, "uart0", "stamped with the peripheral's own id");
+    match uart[0].payload {
+        BusPayload::Uart { byte, .. } => assert_eq!(byte, b'K'),
+        _ => unreachable!(),
+    }
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -20,6 +20,7 @@ pub mod integration;
 pub mod logic_capture;
 #[cfg(test)]
 pub mod logic_capture_differential;
+#[cfg(test)]
 pub mod machine_advance;
 #[cfg(test)]
 pub mod nrf52;

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 pub mod builtin_chip_self_contained;
 #[cfg(test)]
+pub mod bus_trace_one_home;
+#[cfg(test)]
 pub mod device_identity_one_home;
 #[cfg(test)]
 pub mod esp32;
@@ -18,7 +20,6 @@ pub mod integration;
 pub mod logic_capture;
 #[cfg(test)]
 pub mod logic_capture_differential;
-#[cfg(test)]
 pub mod machine_advance;
 #[cfg(test)]
 pub mod nrf52;

--- a/crates/wasm/src/traces.rs
+++ b/crates/wasm/src/traces.rs
@@ -35,24 +35,51 @@ impl WasmSimulator {
     }
 
     /// Non-consuming UART trace snapshot for instruments such as the logic analyzer.
+    ///
+    /// Reads the machine's ONE bus trace and groups by bus name. It does NOT
+    /// walk peripherals looking for a concrete type, and that is the whole
+    /// point: this used to be `downcast_ref::<Uart>()`, which silently found
+    /// only the generic STM32-family model. `EspUart` (ESP32-C3 / ESP32-S3),
+    /// `Esp32Uart`, `Nrf52Uarte` and `Nrf54lUarte` are all UARTs and none of
+    /// them is a `Uart`, so on every ESP and nRF lab this returned `[]` — the
+    /// analyzer's UART panel sat empty forever with nothing to indicate an
+    /// error. Asking the trace what it recorded, rather than asking the type
+    /// system what a UART is, is what makes the answer complete.
     #[wasm_bindgen]
     pub fn uart_trace_snapshot(&self) -> JsValue {
+        use labwired_core::bus::bus_trace::{BusDir, BusPayload};
+
         let Some(machine) = self.machine.as_ref() else {
             return serde_wasm_bindgen::to_value(&Vec::<serde_json::Value>::new())
                 .unwrap_or(JsValue::NULL);
         };
 
-        let snapshots = machine
-            .bus
-            .peripherals
-            .iter()
-            .filter_map(|p| {
-                let any = p.dev.as_any()?;
-                let uart = any.downcast_ref::<labwired_core::peripherals::uart::Uart>()?;
-                Some(serde_json::json!({
-                    "peripheral": p.name,
-                    "events": uart.trace_snapshot(),
-                }))
+        // Bus name → its UART events, in first-seen order so the panel's
+        // instrument list is stable across polls.
+        let mut order: Vec<String> = Vec::new();
+        let mut by_bus: std::collections::HashMap<String, Vec<serde_json::Value>> =
+            std::collections::HashMap::new();
+        for e in machine.bus.bus_trace_snapshot() {
+            let BusPayload::Uart { direction, byte } = e.payload else {
+                continue;
+            };
+            let events = by_bus.entry(e.bus.clone()).or_insert_with(|| {
+                order.push(e.bus.clone());
+                Vec::new()
+            });
+            events.push(serde_json::json!({
+                "seq": e.seq,
+                "cycle": e.cycle,
+                "direction": match direction { BusDir::Tx => "tx", BusDir::Rx => "rx" },
+                "byte": byte,
+            }));
+        }
+
+        let snapshots = order
+            .into_iter()
+            .map(|bus| {
+                let events = by_bus.remove(&bus).unwrap_or_default();
+                serde_json::json!({ "peripheral": bus, "events": events })
             })
             .collect::<Vec<_>>();
 
@@ -97,27 +124,11 @@ impl WasmSimulator {
                 .unwrap_or(JsValue::NULL);
         };
 
-        let snapshots = machine
-            .bus
-            .peripherals
-            .iter()
-            .flat_map(|p| {
-                let Some(any) = p.dev.as_any() else {
-                    return Vec::new();
-                };
-                // FDCAN (H5) and bxCAN (F1/F4) both feed the same CAN/UDS
-                // trace so the logic analyzer works across controllers.
-                if let Some(fdcan) = any.downcast_ref::<labwired_core::peripherals::fdcan::Fdcan>()
-                {
-                    return fdcan.trace_snapshot(&p.name);
-                }
-                if let Some(bxcan) = any.downcast_ref::<labwired_core::peripherals::bxcan::BxCan>()
-                {
-                    return bxcan.trace_snapshot(&p.name);
-                }
-                Vec::new()
-            })
-            .collect::<Vec<_>>();
+        // One ring, one read. FDCAN (H5) and bxCAN (F1/F4) both record into it,
+        // so a third CAN controller family joins by recording — not by adding a
+        // downcast arm here that someone has to remember to write.
+        let snapshots =
+            labwired_core::peripherals::can_trace_snapshot_all(&machine.bus.bus_trace_snapshot());
 
         serde_wasm_bindgen::to_value(&snapshots).unwrap_or(JsValue::NULL)
     }


### PR DESCRIPTION
## The defect, measured

`bus/bus_trace.rs` calls itself the *universal* bus-transaction trace. It was universal over two buses.

| Bus | Ring | Limit | Seq | Cycle |
|---|---|---|---|---|
| I²C / SPI | shared `BusTrace` | 1024 | shared | ✅ |
| UART | per-instance `VecDeque` | 512 | own | ❌ |
| CAN | per-instance `VecDeque` | 200 | own | ❌ |

`grep -c bus_trace` was **0** in `uart.rs`, `fdcan.rs`, `bxcan.rs`, `can.rs`.

That fork was already broken, three ways:

1. **Four of five UART models traced nothing at all.** `wasm/traces.rs` located UARTs with `downcast_ref::<Uart>()`. `EspUart` (C3/S3), `Esp32Uart`, `Nrf52Uarte` and `Nrf54lUarte` are all UARTs and none of them **is** a `Uart` — so on every ESP and nRF lab the analyzer's UART panel was permanently empty, silently, because *"no UART found"* and *"a UART that sent nothing"* are the same empty array. This is the identical mistake `UartStreamHost` was introduced to fix for cross-chip links; the trace path never got the same treatment.
2. **No cycle stamp on UART or CAN**, so `BusTraceEvent::cycle`'s documented promise to "time-align protocol decode with sampled waveforms on one cycle axis" held for only half the buses.
3. **Three sequence counters** ⇒ cross-bus ordering unrecoverable. Nothing could answer "did this UART byte precede that I²C address phase?"

## One ring, one envelope, one door

- `BusPayload` gains `Uart { direction, byte }` and `Can { .. }`. The **envelope** is universal (one seq, one cycle, one bus name); the **payload** stays honest about the protocol — an I²C symbol genuinely is not a CAN frame.
- `Peripheral::attach_bus_trace` joins `attach_cycle_clock` / `attach_irq_line` at the three registration funnels in `bus/construct.rs`. A model reaches the trace by *being registered*, not via a per-family call site. I²C/SPI keep the wrapper funnel — structurally unbypassable, no hook needed.
- All seven models record into the shared ring. Private rings, `UART_TRACE_LIMIT` and both `trace_seq` counters deleted. The per-model accessors survive as **derived projections**, which is why the pre-existing UART/CAN trace tests pass untouched — they are the byte-identity proof, written before this refactor.
- The bridge stops downcasting. A new UART or CAN family now joins by **recording**, not by someone remembering to add a `downcast_ref` arm.

## Ring capacity: 1024 → 4096

Each bus used to have its own budget, so a chatty UART could not evict an I²C address phase. With one ring it can, and eviction is silent — an instrument reconstructing transactions from address phases just sees fewer, not an error. `firmware_survival.rs:1741` already documents this exact hazard for SPI redraws vs I²C. ≈330 KB worst case with 64-byte CAN-FD payloads.

## Guards — each watched failing before it was kept

- **`every_recording_peripheral_shares_the_machines_ring`** — fails **closed**. For every chip descriptor on disk, a peripheral that admits to recording must hold the bus's ring by `Arc` identity. An un-injected model keeps its private handle and writes to a buffer nobody reads; comparing *contents* cannot detect that (two empty rings are equal), comparing *identity* can. Deliberate break (unwiring one funnel) fails it across `esp32`, `esp32c3`, `esp32s3`, `mkw41z4`, `nrf52832`, `nrf52840`.
- **`no_peripheral_keeps_a_private_trace_ring`** — fails if **forked**. A source scan, because a private ring is invisible at runtime by construction: the model behaves correctly, tests green, and is simply absent from the trace. Allowlist carries the air traces (different medium, already one home behind `VirtualAirBus`) and IO-Link (a decode of UART octets now in the ring), each with its reason.
- **`the_private_ring_detector_is_not_vacuous`** pins the detector against the three declarations this PR removes, so the scan cannot rot into always-green.
- **`an_esp_uart_reaches_the_shared_trace`** — the end-to-end property that was broken: a C3 UART0 byte must appear in `bus_trace_snapshot()`.

## Scope

Air traces (BLE / WiFi / radio) are deliberately **out**: an over-the-air frame has no wire and no bus name, and they already share their own one home. Wired and air are two honest axes; collapsing them would make the model worse. IO-Link is out for now and flagged as debt in the allowlist — it is a decode layer above UART octets, which are now in the ring, so it is derivable.

## Verification

- **2612 tests across 30 targets, 0 failures** (`cargo test -p labwired-core`, all targets incl. `firmware_survival`).
- `cargo clippy` clean for both `labwired-core` and `labwired-wasm`. Note `crates/wasm` is not a workspace default-member, so it was built explicitly for `wasm32-unknown-unknown` — the core PR lane never links it.

Follow-up (separate PR, monorepo): bump the submodule pointer and collapse `traceSnapshot(kind)` plus the four per-protocol converters in `wireActivity.ts` into one, now that the engine speaks one dialect.