### PR TITLE
fix(nrf52): GPIOTE port-1 wrote into gpio0 — and guard the class: peripheral bases belong to the chip YAML

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -351,6 +351,7 @@ impl SystemBus {
                             p_cfg,
                             manifest,
                             &bus.bus_trace,
+                            crate::peripherals::chip_map::ChipMap::new(&merged_peripherals),
                         )
                     })
                     .or_else(|| {

--- a/crates/core/src/peripherals/chip_map.rs
+++ b/crates/core/src/peripherals/chip_map.rs
@@ -1,0 +1,116 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! The resolved peripheral memory map, handed to peripheral models at build
+//! time so a model never has to hardcode a sibling peripheral's base address.
+//!
+//! # Why this exists
+//!
+//! A peripheral's **base address** is a property of the chip's memory map,
+//! which the chip YAML owns. A **register offset within** that peripheral
+//! (`+0x510`) is a silicon fact of the peripheral itself and legitimately
+//! belongs with the model. The line is drawn there, deliberately: mass-moving
+//! offsets into YAML would be worse than the disease.
+//!
+//! Most models only ever need their *own* base, and the peripheral factories
+//! already read that straight off `p_cfg.base_address`. The gap this type
+//! closes is the model that must address a **different** peripheral — nRF52
+//! GPIOTE drives pads that live in the GPIO ports' windows, so it emits MMIO
+//! writes at `gpio0`/`gpio1` bases it does not own.
+//!
+//! # The bug that motivated it
+//!
+//! `Nrf52Gpiote` hardcoded `GPIO1_BASE = 0x5000_0300`, the real-silicon P1
+//! base. The nRF52840 chip YAML deliberately remaps `gpio1` to `0x5000_1000`,
+//! because Nordic's real P1 base sits *inside* GPIO0's 4 KB window and the two
+//! would collide on a flat bus. So every port-1 GPIOTE task wrote
+//! `0x5000_0810` — a perfectly valid address, inside **gpio0's** window, where
+//! it was swallowed. No error, no warning, no fault: a wrong address is still
+//! a valid address. That is what makes this class silent.
+//!
+//! Reading the base from here instead means the model cannot disagree with the
+//! YAML, because it has no second copy of the fact to disagree with.
+
+use labwired_config::PeripheralConfig;
+
+/// Read-only view of the peripheral memory map a bus is being built from —
+/// the chip descriptor's peripherals with the system manifest's overrides
+/// already merged in, i.e. exactly the addresses the bus will route.
+#[derive(Copy, Clone, Debug)]
+pub struct ChipMap<'a> {
+    entries: &'a [PeripheralConfig],
+}
+
+impl<'a> ChipMap<'a> {
+    /// Wrap the merged peripheral list. Built once in
+    /// [`crate::bus::SystemBus::from_config`] and passed down to the family
+    /// factories.
+    pub fn new(entries: &'a [PeripheralConfig]) -> Self {
+        Self { entries }
+    }
+
+    /// An empty map, for unit tests and callers that construct a model outside
+    /// a bus. Every lookup misses, so callers must supply their own fallback
+    /// and cannot silently get a wrong address from a stub.
+    pub fn empty() -> Self {
+        Self { entries: &[] }
+    }
+
+    /// Base address of the peripheral with this exact `id`, as declared.
+    /// `None` when the chip does not declare it — callers decide whether that
+    /// is a fallback or a hard error, since a chip may legitimately lack a
+    /// peripheral (nRF52832 has no P1 at all).
+    pub fn base_of(&self, id: &str) -> Option<u64> {
+        self.entries
+            .iter()
+            .find(|p| p.id == id)
+            .map(|p| p.base_address)
+    }
+
+    /// Every declared peripheral id, in map order. Used by the sibling-lookup
+    /// diagnostics and by tests.
+    pub fn ids(&self) -> impl Iterator<Item = &'a str> {
+        self.entries.iter().map(|p| p.id.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(id: &str, base: u64) -> PeripheralConfig {
+        PeripheralConfig {
+            id: id.to_string(),
+            r#type: "gpio".to_string(),
+            base_address: base,
+            size: None,
+            irq: None,
+            clock: None,
+            config: Default::default(),
+        }
+    }
+
+    #[test]
+    fn base_of_returns_the_declared_address() {
+        let entries = vec![cfg("gpio0", 0x5000_0000), cfg("gpio1", 0x5000_1000)];
+        let map = ChipMap::new(&entries);
+        assert_eq!(map.base_of("gpio0"), Some(0x5000_0000));
+        // The remapped port-1 base, NOT Nordic's raw-silicon 0x5000_0300.
+        assert_eq!(map.base_of("gpio1"), Some(0x5000_1000));
+    }
+
+    #[test]
+    fn base_of_misses_for_an_undeclared_peripheral() {
+        let entries = vec![cfg("gpio0", 0x5000_0000)];
+        assert_eq!(ChipMap::new(&entries).base_of("gpio1"), None);
+    }
+
+    #[test]
+    fn empty_map_misses_everything() {
+        assert_eq!(ChipMap::empty().base_of("gpio0"), None);
+        assert_eq!(ChipMap::empty().ids().count(), 0);
+    }
+}

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -9,6 +9,7 @@ pub mod afio;
 pub mod ble_air;
 pub mod bxcan;
 pub mod can;
+pub mod chip_map;
 pub mod comp;
 pub mod components;
 pub mod crc;

--- a/crates/core/src/peripherals/nrf52/factory.rs
+++ b/crates/core/src/peripherals/nrf52/factory.rs
@@ -16,12 +16,16 @@ use labwired_config::{PeripheralConfig, SystemManifest};
 /// Build an nRF52 peripheral model for `canonical_type`, or `None` if this
 /// family does not own that type (so `from_config` falls through to the
 /// generic match). `manifest` is consulted for external I²C devices attached to
-/// a TWIM controller.
+/// a TWIM controller. `chip_map` is the resolved peripheral memory map, for the
+/// models that must address a *sibling* peripheral (GPIOTE → the GPIO ports)
+/// and so would otherwise keep a second, unenforced copy of the chip YAML's
+/// base addresses in Rust.
 pub fn try_build(
     canonical_type: &str,
     p_cfg: &PeripheralConfig,
     manifest: &SystemManifest,
     bus_trace: &crate::bus::bus_trace::BusTrace,
+    chip_map: crate::peripherals::chip_map::ChipMap<'_>,
 ) -> Option<Box<dyn Peripheral>> {
     let dev: Box<dyn Peripheral> = match canonical_type {
         "nrf52840_uart" => Box::new(crate::peripherals::nrf52::uarte::Nrf52Uarte::new()),
@@ -44,7 +48,14 @@ pub fn try_build(
         "nrf52840_ppi" | "nrf52_ppi" => Box::new(crate::peripherals::nrf52::ppi::Nrf52Ppi::new()),
         "nrf52840_pdm" | "nrf52_pdm" => Box::new(crate::peripherals::nrf52::pdm::Nrf52Pdm::new()),
         "nrf52_gpiote" | "nrf52840_gpiotasksevents" => {
-            Box::new(crate::peripherals::nrf52::gpiote::Nrf52Gpiote::new())
+            // GPIOTE drives pads that live in the GPIO ports' MMIO windows, so
+            // it needs its siblings' base addresses. They come from the chip
+            // descriptor via `chip_map`, never from a constant in this crate:
+            // the nRF52840 YAML remaps `gpio1` off its raw-silicon base and a
+            // hardcoded copy silently wrote into gpio0's window instead.
+            Box::new(crate::peripherals::nrf52::gpiote::Nrf52Gpiote::new(
+                chip_map,
+            ))
         }
         "nrf52840_ecb" | "nrf52_ecb" => Box::new(crate::peripherals::nrf52::ecb::Nrf52Ecb::new()),
         "nrf52_clock" => Box::new(crate::peripherals::nrf52::clock::Nrf52Clock::new()),

--- a/crates/core/src/peripherals/nrf52/gpiote.rs
+++ b/crates/core/src/peripherals/nrf52/gpiote.rs
@@ -64,12 +64,18 @@ const POLARITY_LO_TO_HI: u32 = 1;
 const POLARITY_HI_TO_LO: u32 = 2;
 const POLARITY_TOGGLE: u32 = 3;
 
-// GPIO port bases on nRF52840 (PS §6.10).
-const GPIO0_BASE: u32 = 0x5000_0000;
-const GPIO1_BASE: u32 = 0x5000_0300;
 /// Offset of the IN register within a GPIO port (nRF52840 PS §6.10).
 /// GPIOTE drives the pad level here; GPIO.OUT (0x504) is left untouched.
+///
+/// This is an offset *within* the GPIO peripheral, so it is a silicon fact of
+/// that peripheral and stays with the model. The port **base** addresses are a
+/// property of the chip memory map and come from the chip YAML via
+/// [`crate::peripherals::chip_map::ChipMap`] — see [`Nrf52Gpiote::new`].
 const GPIO_IN_OFFSET: u32 = 0x510;
+
+/// Chip-YAML peripheral ids for the two GPIO ports GPIOTE can drive.
+/// CONFIG[i].PORT selects the index.
+const GPIO_PORT_IDS: [&str; 2] = ["gpio0", "gpio1"];
 
 #[derive(Debug, Default)]
 pub struct Nrf52Gpiote {
@@ -110,11 +116,38 @@ pub struct Nrf52Gpiote {
     idr_shadow: [u32; 2],
     /// Scheduler delay-0 drain chain armed.
     chain_live: bool,
+
+    /// Base address of each GPIO port, read from the chip descriptor at build
+    /// time — index 0 = `gpio0`, index 1 = `gpio1`. `None` means the chip does
+    /// not declare that port (nRF52832 has no P1), in which case a task
+    /// targeting it drives nothing and says so, rather than writing a guessed
+    /// address into whatever peripheral happens to own that window.
+    port_bases: [Option<u32>; 2],
 }
 
 impl Nrf52Gpiote {
-    pub fn new() -> Self {
-        Self::default()
+    /// Build the model against the chip's declared memory map.
+    ///
+    /// The GPIO port bases are looked up by chip-YAML id, so the model cannot
+    /// disagree with the descriptor it was built from. There is deliberately no
+    /// `new()` without a map: the previous hardcoded `GPIO1_BASE` produced a
+    /// valid-but-wrong address that the bus swallowed silently, and a default
+    /// constructor is exactly how that constant would grow back.
+    pub fn new(map: crate::peripherals::chip_map::ChipMap<'_>) -> Self {
+        let mut port_bases = [None; 2];
+        for (idx, id) in GPIO_PORT_IDS.iter().enumerate() {
+            port_bases[idx] = map.base_of(id).map(|b| b as u32);
+            if port_bases[idx].is_none() {
+                tracing::debug!(
+                    "nRF52 GPIOTE: chip declares no '{id}'; \
+                     tasks targeting PORT={idx} will drive nothing"
+                );
+            }
+        }
+        Self {
+            port_bases,
+            ..Self::default()
+        }
     }
 
     /// Drive the target pin's pad level (reflected in `GPIO.IN` at offset 0x510).
@@ -135,10 +168,18 @@ impl Nrf52Gpiote {
         } else {
             0usize
         };
-        let port_base = if port_idx == 1 {
-            GPIO1_BASE
-        } else {
-            GPIO0_BASE
+        // The port base comes from the chip descriptor. If the chip does not
+        // declare this port there is no correct address to write, so drop the
+        // drive loudly instead of picking one — a wrong address is still a
+        // valid address, and the bus would absorb it without complaint.
+        let Some(port_base) = self.port_bases[port_idx] else {
+            tracing::warn!(
+                "nRF52 GPIOTE ch{channel}: CONFIG selects PORT={port_idx} ('{}'), \
+                 which this chip does not declare; pin {pin} drive dropped",
+                GPIO_PORT_IDS[port_idx]
+            );
+            self.channel_out_level[channel] = high as u32;
+            return;
         };
         let bit_mask = 1u32 << pin;
         // Read-modify-write against the per-port idr shadow so we drive only
@@ -368,6 +409,37 @@ impl Peripheral for Nrf52Gpiote {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::peripherals::chip_map::ChipMap;
+    use labwired_config::PeripheralConfig;
+
+    // Test fixture memory map. These are the addresses the nRF52840 chip YAML
+    // declares (note gpio1 = 0x5000_1000, the remap — NOT Nordic's raw-silicon
+    // P1 base 0x5000_0300, which sits inside gpio0's 4 KB window). They live
+    // here as test *inputs*, so the model has no base address of its own to be
+    // wrong about.
+    const T_GPIO0_BASE: u32 = 0x5000_0000;
+    const T_GPIO1_BASE: u32 = 0x5000_1000;
+
+    fn port_cfg(id: &str, base: u64) -> PeripheralConfig {
+        PeripheralConfig {
+            id: id.to_string(),
+            r#type: "gpio".to_string(),
+            base_address: base,
+            size: Some("4KB".to_string()),
+            irq: None,
+            clock: None,
+            config: Default::default(),
+        }
+    }
+
+    /// A GPIOTE built against a two-port map, as `from_config` would build it.
+    fn gpiote() -> Nrf52Gpiote {
+        let entries = vec![
+            port_cfg("gpio0", T_GPIO0_BASE as u64),
+            port_cfg("gpio1", T_GPIO1_BASE as u64),
+        ];
+        Nrf52Gpiote::new(ChipMap::new(&entries))
+    }
 
     fn cfg_task(pin: u32, port: u32, polarity: u32, outinit: u32) -> u32 {
         CONFIG_MODE_TASK
@@ -379,7 +451,7 @@ mod tests {
 
     #[test]
     fn config0_round_trips_writable_bits() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         g.write_u32(OFF_CONFIG_0, 0x0003_0D03).unwrap();
         assert_eq!(g.read_u32(OFF_CONFIG_0).unwrap() & 0x0007_1F03, 0x0003_0D03);
     }
@@ -392,7 +464,7 @@ mod tests {
 
     #[test]
     fn task_set_drives_in_register_not_out() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         // Channel 0: pin 26, port 0 — TASKS_SET should drive GPIO0.IN bit 26 high.
         g.write_u32(OFF_CONFIG_0, cfg_task(26, 0, POLARITY_NONE, 0))
             .unwrap();
@@ -401,13 +473,13 @@ mod tests {
         // Target: GPIO0.IN (0x510) written with bit 26 set; OUT (0x504/0x508/0x50C) untouched.
         assert_eq!(
             res.mmio_writes,
-            vec![(GPIO0_BASE + GPIO_IN_OFFSET, 1 << 26)]
+            vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 1 << 26)]
         );
     }
 
     #[test]
     fn task_clr_drives_in_register_low_on_port1() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         // Channel 1: pin 5, port 1 — start with bit 5 high in the shadow, then CLR.
         // First SET to put the pin high.
         g.write_u32(OFF_CONFIG_0 + 4, cfg_task(5, 1, POLARITY_NONE, 0))
@@ -418,12 +490,15 @@ mod tests {
         // Now CLR: idr_shadow[1] has bit 5 set → clearing should produce 0.
         g.write_u32(OFF_TASKS_CLR_0 + 4, 1).unwrap();
         let res = g.tick();
-        assert_eq!(res.mmio_writes, vec![(GPIO1_BASE + GPIO_IN_OFFSET, 0)]);
+        // The write must target the port-1 base the nRF52840 chip YAML declares
+        // (0x5000_1000), NOT the raw-silicon P1 base (0x5000_0300) — the latter
+        // lands inside gpio0's 4 KB window and is silently swallowed.
+        assert_eq!(res.mmio_writes, vec![(T_GPIO1_BASE + GPIO_IN_OFFSET, 0)]);
     }
 
     #[test]
     fn task_out_toggle_alternates_in_register() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         // Channel 0: pin 13, port 0, POLARITY=TOGGLE, OUTINIT=0.
         // Shadow starts at 0. Toggles: 0→1→0→1.
         g.write_u32(OFF_CONFIG_0, cfg_task(13, 0, POLARITY_TOGGLE, 0))
@@ -433,24 +508,24 @@ mod tests {
         let res1 = g.tick();
         assert_eq!(
             res1.mmio_writes,
-            vec![(GPIO0_BASE + GPIO_IN_OFFSET, 1 << 13)]
+            vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 1 << 13)]
         );
 
         g.write_u32(OFF_TASKS_OUT_0, 1).unwrap();
         let res2 = g.tick();
-        assert_eq!(res2.mmio_writes, vec![(GPIO0_BASE + GPIO_IN_OFFSET, 0)]);
+        assert_eq!(res2.mmio_writes, vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 0)]);
 
         g.write_u32(OFF_TASKS_OUT_0, 1).unwrap();
         let res3 = g.tick();
         assert_eq!(
             res3.mmio_writes,
-            vec![(GPIO0_BASE + GPIO_IN_OFFSET, 1 << 13)]
+            vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 1 << 13)]
         );
     }
 
     #[test]
     fn task_in_event_mode_is_noop() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         // MODE = Event (not Task) → tasks should not drive pins.
         let cfg = 1 // MODE = Event
             | ((26 & CONFIG_PSEL_MASK) << CONFIG_PSEL_SHIFT)
@@ -463,18 +538,18 @@ mod tests {
 
     #[test]
     fn task_with_polarity_lo_to_hi_drives_in_high() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         g.write_u32(OFF_CONFIG_0, cfg_task(7, 0, POLARITY_LO_TO_HI, 0))
             .unwrap();
         g.write_u32(OFF_TASKS_OUT_0, 1).unwrap();
         let res = g.tick();
         // POLARITY=LoToHi forces high on TASKS_OUT: GPIO0.IN bit 7 set.
-        assert_eq!(res.mmio_writes, vec![(GPIO0_BASE + GPIO_IN_OFFSET, 1 << 7)]);
+        assert_eq!(res.mmio_writes, vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 1 << 7)]);
     }
 
     #[test]
     fn outinit_seeds_initial_toggle_direction() {
-        let mut g = Nrf52Gpiote::new();
+        let mut g = gpiote();
         // OUTINIT=1 → channel_out_level starts at 1, first Toggle goes low.
         // idr_shadow[0] starts at 0 (default) but channel_out_level is 1.
         // Toggle: current level = 1 → new level = 0.  idr_shadow[0] stays 0 after clear.
@@ -483,6 +558,6 @@ mod tests {
         g.write_u32(OFF_TASKS_OUT_0, 1).unwrap();
         let res = g.tick();
         // Pin 2 cleared: new_in = 0 & !4 = 0 (shadow was 0, bit 2 already 0).
-        assert_eq!(res.mmio_writes, vec![(GPIO0_BASE + GPIO_IN_OFFSET, 0)]);
+        assert_eq!(res.mmio_writes, vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 0)]);
     }
 }

--- a/crates/core/src/peripherals/nrf52/gpiote.rs
+++ b/crates/core/src/peripherals/nrf52/gpiote.rs
@@ -544,7 +544,10 @@ mod tests {
         g.write_u32(OFF_TASKS_OUT_0, 1).unwrap();
         let res = g.tick();
         // POLARITY=LoToHi forces high on TASKS_OUT: GPIO0.IN bit 7 set.
-        assert_eq!(res.mmio_writes, vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 1 << 7)]);
+        assert_eq!(
+            res.mmio_writes,
+            vec![(T_GPIO0_BASE + GPIO_IN_OFFSET, 1 << 7)]
+        );
     }
 
     #[test]

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -34,3 +34,5 @@ pub mod stm32_spi_waveform;
 pub mod test_cycles;
 #[cfg(test)]
 pub mod walk_starvation_contract;
+#[cfg(test)]
+pub mod yaml_owned_base_contract;

--- a/crates/core/src/tests/nrf52.rs
+++ b/crates/core/src/tests/nrf52.rs
@@ -988,3 +988,83 @@ fn xiao_nrf52840_spim0_start_sets_end_event_and_amount() {
         "RXD.AMOUNT should be 0 when RXD.MAXCNT=0"
     );
 }
+
+/// GPIOTE task-mode drive must land in the port the chip YAML declares — for
+/// **both** ports.
+///
+/// The nRF52840 chip YAML deliberately remaps P1/`gpio1` from its silicon base
+/// (0x5000_0300) to 0x5000_1000, because the real P1 base sits *inside* GPIO0's
+/// 4 KB window and the two peripherals would otherwise collide on the bus. A
+/// GPIOTE model that hardcodes the silicon base therefore writes 0x5000_0810,
+/// which lands in gpio0's window and is swallowed with no error and no warning.
+///
+/// This asserts both ports so a "fix" that merely moves the breakage from
+/// port 1 to port 0 fails here.
+#[test]
+fn gpiote_task_drive_reaches_the_port_the_chip_yaml_declares() {
+    let mut chip_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    chip_path.push("../../configs/chips/onboarding/nrf52840.yaml");
+    let mut system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    system_path.push("../../configs/systems/onboarding/nrf52840.yaml");
+
+    let chip = ChipDescriptor::from_file(&chip_path).unwrap();
+    let mut manifest = SystemManifest::from_file(&system_path).unwrap();
+    let anchored = system_path.parent().unwrap().join(&manifest.chip);
+    manifest.chip = anchored.to_str().unwrap().to_string();
+
+    // The bases under test come from the chip descriptor, not from this test's
+    // own opinion about Nordic silicon: if the YAML remap ever changes, this
+    // test follows it instead of encoding a second copy of the memory map.
+    let base_of = |id: &str| -> u64 {
+        chip.peripherals
+            .iter()
+            .find(|p| p.id == id)
+            .unwrap_or_else(|| panic!("chip yaml declares no peripheral '{id}'"))
+            .base_address
+    };
+    let gpio0_base = base_of("gpio0");
+    let gpio1_base = base_of("gpio1");
+    let gpiote_base = base_of("gpiote");
+    assert_ne!(
+        gpio0_base, gpio1_base,
+        "the two GPIO ports must not share a base"
+    );
+
+    const IN_OFFSET: u64 = 0x510;
+    const CONFIG_0: u64 = 0x510;
+    const TASKS_SET_0: u64 = 0x030;
+    const PIN: u32 = 5;
+
+    // MODE=Task(3), PSEL=PIN, PORT=<port>, POLARITY=None.
+    let cfg = |port: u32| 3u32 | (PIN << 8) | ((port & 1) << 13);
+
+    for (port, target_base, other_base, target, other) in [
+        (0u32, gpio0_base, gpio1_base, "gpio0", "gpio1"),
+        (1u32, gpio1_base, gpio0_base, "gpio1", "gpio0"),
+    ] {
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("onboarding bus");
+
+        bus.write_u32(gpiote_base + CONFIG_0, cfg(port)).unwrap();
+        bus.write_u32(gpiote_base + TASKS_SET_0, 1).unwrap();
+        for _ in 0..4 {
+            bus.tick_peripherals_fully_forced();
+        }
+
+        let target_in = bus.read_u32(target_base + IN_OFFSET).unwrap();
+        let other_in = bus.read_u32(other_base + IN_OFFSET).unwrap();
+
+        assert_eq!(
+            target_in & (1 << PIN),
+            1 << PIN,
+            "PORT={port}: GPIOTE TASKS_SET must drive {target}.IN bit {PIN} high \
+             ({target} base {target_base:#010x}); got {target}.IN = {target_in:#010x}, \
+             {other}.IN = {other_in:#010x}"
+        );
+        assert_eq!(
+            other_in & (1 << PIN),
+            0,
+            "PORT={port}: the drive must NOT leak into {other}.IN bit {PIN} \
+             ({other} base {other_base:#010x}); got {other}.IN = {other_in:#010x}"
+        );
+    }
+}

--- a/crates/core/src/tests/yaml_owned_base_contract.rs
+++ b/crates/core/src/tests/yaml_owned_base_contract.rs
@@ -899,11 +899,7 @@ fn scan_chip_collisions() -> Vec<Collision> {
                 if !overlap {
                     continue;
                 }
-                let (a, b) = if x.id <= y.id {
-                    (x, y)
-                } else {
-                    (y, x)
-                };
+                let (a, b) = if x.id <= y.id { (x, y) } else { (y, x) };
                 let detail = format!(
                     "{} @ {:#010x} (size {}) vs {} @ {:#010x} (size {})",
                     a.id,
@@ -1189,7 +1185,10 @@ mod scanner_unit_tests {
             !code.contains("X_BASE"),
             "test-module const leaked: {code:?}"
         );
-        assert!(code.contains("Y_BASE"), "production const was eaten: {code:?}");
+        assert!(
+            code.contains("Y_BASE"),
+            "production const was eaten: {code:?}"
+        );
     }
 
     #[test]

--- a/crates/core/src/tests/yaml_owned_base_contract.rs
+++ b/crates/core/src/tests/yaml_owned_base_contract.rs
@@ -1,0 +1,1202 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! THE CONTRACT: a peripheral's **base address** belongs to the chip YAML.
+//! A peripheral model may not keep a second copy of it in Rust.
+//!
+//! # The bug class
+//!
+//! A base address hardcoded in a model is a second home for a fact the chip
+//! descriptor already owns, with nothing forcing the two to agree. When they
+//! disagree the failure is **silent**, because a wrong address is still a
+//! *valid* address: it lands in some other peripheral's MMIO window and is
+//! absorbed without a fault, a log line, or a test failure.
+//!
+//! Two confirmed instances, both of which cost real time:
+//!
+//! * **nRF52 GPIOTE** hardcoded `GPIO1_BASE = 0x5000_0300`, Nordic's
+//!   real-silicon P1 base. Every nRF52840 chip YAML deliberately remaps `gpio1`
+//!   to `0x5000_1000`, because the silicon base sits *inside* GPIO0's 4 KB
+//!   window and a flat bus cannot host both. So a port-1 GPIOTE task wrote
+//!   `0x5000_0810` — inside **gpio0's** window, where it vanished. The model's
+//!   own unit test asserted the wrong base, so it passed while the behaviour
+//!   was broken.
+//! * **classic ESP32 `apb_ctrl` vs SYSCON** resolved to the same base. Bus
+//!   routing ties are won by the LAST peripheral registered, so `apb_ctrl`
+//!   shadowed SYSCON, `SYSCLK_CONF` read `0xFFFF_FFFF`, `getApbFrequency()`
+//!   returned 78125 Hz and the Arduino baud divisor blew up. "Serial does not
+//!   work on classic ESP32" was accepted as a property of the product for
+//!   about a year. It was never a UART bug — it was an address-map
+//!   disagreement that failed silently.
+//!
+//! # Where the line is drawn — deliberately
+//!
+//! * A peripheral's **BASE address** comes from the memory map. That is the
+//!   chip YAML's job. → **Rule 1** below.
+//! * A **register OFFSET within** a peripheral (`+0x510` for GPIO.IN) is a
+//!   silicon fact of that peripheral and legitimately lives with the model.
+//!   Offsets are NOT checked and must not be mass-migrated to YAML: that would
+//!   scatter one peripheral's register map across two files and be worse than
+//!   the disease.
+//! * Memory **regions** (flash/RAM/ROM/XIP windows, DMA scratch buffers) are
+//!   not peripherals and are out of scope here.
+//!
+//! # The two rules
+//!
+//! * **Rule 1 — no hardcoded base in a model.** No production source under
+//!   `crates/core/src/peripherals/` may bind a `const`/`static` whose *name*
+//!   says it is a base or an address (`*BASE*`, `*ADDR*`) to an absolute MMIO
+//!   literal (`>= 0x1000_0000`). Models that need an address must read it from
+//!   the chip descriptor — their own via `p_cfg.base_address`, a sibling's via
+//!   [`crate::peripherals::chip_map::ChipMap`].
+//!
+//!   Note this rule keys on the **shape of the binding**, not on whether the
+//!   value matches a YAML entry — on purpose. The GPIOTE constant
+//!   `0x5000_0300` matched *no* declared base anywhere in the repo; that
+//!   disagreement was the entire bug. A rule of the form "flag literals equal
+//!   to a declared base" would have missed it completely.
+//!
+//! * **Rule 2 — a chip YAML may not disagree with itself.** Within one chip
+//!   descriptor, no two peripherals may share a `base_address`, and no two
+//!   `[base, base + size)` windows may overlap. An overlap is resolved
+//!   silently by registration order, which is how `apb_ctrl` ate SYSCON.
+//!
+//! # What this gate does NOT catch
+//!
+//! Stated plainly so nobody reads a green run as more than it is:
+//!
+//! * **Inline literals.** `bus.write_u32(0x6000_0000 + 0x1C, v)` with no named
+//!   binding is invisible to Rule 1. Covering those means flagging ~265 sites,
+//!   the large majority of which are doc comments, test fixtures and
+//!   `base + offset` composites — an allowlist of that size stops being read.
+//!   Rule 1 targets the shape both confirmed defects actually had.
+//! * **Wrong-but-consistent maps.** If the YAML itself declares the wrong
+//!   address, everything here is green and the model is still wrong. This gate
+//!   enforces *one home*, not correctness of the value in that home.
+//! * **Cross-chip register-map assumptions.** Rule 2 is per-chip-file by
+//!   design. The same offset does NOT mean the same register across ESP32-C3
+//!   and S3, and this repo has already been burned by an inherited shared map.
+//!   Nothing here should be read as licence to share one.
+//!
+//! # Allowlists shrink, never grow
+//!
+//! Every entry is re-checked: an entry that no longer violates fails the gate,
+//! so a converted model cannot leave a stale exemption behind for the next
+//! offender to hide under.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Frozen allowlists. Adding a line here is a deliberate act; read the rule
+// docs above before you do it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Rule 1 exemptions: production `*BASE*` / `*ADDR*` constants still holding an
+/// absolute MMIO literal.
+///
+/// Every entry below is a live instance of the same class as the nRF52 GPIOTE
+/// defect this contract was written for. They are recorded rather than
+/// converted because each needs its own plumbing decision and its own
+/// behavioural proof, and because several sit on the ESP32-C3/S3 throughput
+/// paths where a byte-identical result has to be demonstrated, not assumed.
+///
+/// Severity note: the dangerous shape is a model addressing a **different**
+/// peripheral (what GPIOTE did). A model naming its **own** base is a
+/// duplicated fact but a far less explosive one — it is normally also passed
+/// `p_cfg.base_address`, so the two can be reconciled without new plumbing.
+/// Entries are annotated with which kind they are.
+///
+/// Format: `(path relative to crates/core/src, const name, why it is still here)`.
+const HARDCODED_BASE_ALLOWLIST: &[(&str, &str, &str)] = &[
+    // ── cross-peripheral emitters: same shape as the GPIOTE defect ──────────
+    (
+        "peripherals/esp32s3/gdma.rs",
+        "UART0_BASE",
+        "CROSS-PERIPHERAL, highest-value next conversion. GDMA/UHCI0 reads and \
+         writes UART0's FIFO (+0x00) and STATUS (+0x1C) at a hardcoded base — \
+         exactly the shape that broke GPIOTE. Both esp32s3 YAMLs happen to \
+         declare uart0 at 0x6000_0000 so it is currently correct, and nothing \
+         enforces that. Converting needs ChipMap threaded through \
+         esp32s3::factory (two callers, one of which builds no chip YAML) and \
+         touches ~70 Esp32s3Gdma::new call sites.",
+    ),
+    (
+        "peripherals/esp32s3/crosscore_ipi.rs",
+        "BASE",
+        "CROSS-PERIPHERAL. 0x600C_0030 is an offset INTO the `system` window, \
+         not a peripheral base of its own — no chip YAML declares it, so there \
+         is no id to resolve. Needs the system base from ChipMap plus a named \
+         offset; left alone rather than guessed at.",
+    ),
+    // ── models naming their own base ────────────────────────────────────────
+    (
+        "peripherals/esp32c3/apb_saradc.rs",
+        "APB_SARADC_BASE",
+        "OWN BASE (esp32c3.yaml: apb_saradc). Exported for the C3 system \
+         builder's registration call; reconciling it means having that builder \
+         read the descriptor. C3 throughput is a byte-identical gate, so this \
+         needs its own proof run.",
+    ),
+    (
+        "peripherals/esp32c3/bt.rs",
+        "BT_BASE",
+        "OWN BASE (esp32c3.yaml: bt). The C3 BT block is on the validated BLE \
+         path; touching its registration without a live BLE re-run is not worth \
+         the risk for a duplicated constant.",
+    ),
+    (
+        "peripherals/esp32c3/i2c.rs",
+        "I2C0_BASE",
+        "OWN BASE (esp32c3.yaml: i2c0). On the C3 shipped-lab throughput path.",
+    ),
+    (
+        "peripherals/esp32c3/ledc.rs",
+        "LEDC_BASE",
+        "OWN BASE (esp32c3.yaml: ledc).",
+    ),
+    (
+        "peripherals/esp32c3/spi.rs",
+        "SPI2_BASE",
+        "OWN BASE (esp32c3.yaml: spi2).",
+    ),
+    (
+        "peripherals/esp32c3/uart.rs",
+        "UART0_BASE",
+        "OWN BASE (esp32c3.yaml: uart0). Used by `default_source_id` to pick an \
+         interrupt-matrix source when the descriptor names none — i.e. the \
+         constant is a lookup KEY, not an address that is ever written. \
+         Converting it means changing how the default is selected, not just \
+         where the number comes from.",
+    ),
+    (
+        "peripherals/esp32c3/uart.rs",
+        "UART1_BASE",
+        "OWN BASE (esp32c3.yaml: uart1). Same interrupt-source lookup key as \
+         UART0_BASE above.",
+    ),
+    (
+        "peripherals/esp32/dport.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: dport). Classic-ESP32 registration constant. \
+         This is the family where apb_ctrl shadowed SYSCON, so its address map \
+         should be moved wholesale and proven, not one constant at a time.",
+    ),
+    (
+        "peripherals/esp32/efuse.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: efuse). Classic-ESP32 registration constant.",
+    ),
+    (
+        "peripherals/esp32/i2c.rs",
+        "I2C0_BASE",
+        "OWN BASE (esp32.yaml: i2c0). Classic-ESP32 registration constant.",
+    ),
+    (
+        "peripherals/esp32/ledc.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: ledc). Classic-ESP32 registration constant.",
+    ),
+    (
+        "peripherals/esp32/mcpwm.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: mcpwm0). Classic-ESP32 registration constant.",
+    ),
+    (
+        "peripherals/esp32/rtc_cntl.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: rtc_cntl). Classic-ESP32 registration constant.",
+    ),
+    (
+        "peripherals/esp32/sar_adc.rs",
+        "SENS_BASE",
+        "OWN BASE (esp32.yaml: sens_sar_adc). Note esp32.yaml declares `rtcio` \
+         as 4 KB from 0x3FF4_8400, which swallows this window whole — see the \
+         Rule 2 allowlist entry.",
+    ),
+    (
+        "peripherals/esp32/sha.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: sha). Classic-ESP32 registration constant.",
+    ),
+    (
+        "peripherals/esp32/syscon.rs",
+        "BASE",
+        "OWN BASE (esp32.yaml: syscon). This is the exact peripheral apb_ctrl \
+         shadowed. The base is now correct and Rule 2 below enforces that \
+         nothing re-collides with it; the duplicated constant remains.",
+    ),
+    (
+        "peripherals/esp32s3/ds.rs",
+        "DS_BASE",
+        "OWN BASE. Declared by esp32c3.yaml as `ds`; no esp32s3 YAML declares a \
+         `ds` at all, so there is currently no S3 id to resolve it from. \
+         Resolving it against the C3 entry would be the shared-register-map \
+         mistake this repo has already paid for — C3 and S3 do not share \
+         offsets by default. Left as-is and flagged.",
+    ),
+    (
+        "peripherals/esp32s3/hmac.rs",
+        "HMAC_BASE",
+        "OWN BASE. Same C3-declared/S3-undeclared split as ds.rs above.",
+    ),
+    (
+        "peripherals/esp32s3/i2c.rs",
+        "I2C0_BASE",
+        "OWN BASE (esp32s3.yaml: i2c0).",
+    ),
+    (
+        "peripherals/esp32s3/i2c.rs",
+        "I2C1_BASE",
+        "NO YAML OWNER — no esp32s3 chip YAML declares an `i2c1`. The model is \
+         reachable at an address the descriptor never mentions, which is the \
+         same one-home defect pointing the other way. The fix is a YAML entry, \
+         not a code change, and adding peripherals to a shipped chip map needs \
+         its own review.",
+    ),
+    (
+        "peripherals/esp32s3/i2s.rs",
+        "I2S0_BASE",
+        "NO YAML OWNER — esp32s3 YAMLs declare no `i2s0`. Same as I2C1_BASE.",
+    ),
+    (
+        "peripherals/esp32s3/i2s.rs",
+        "I2S1_BASE",
+        "NO YAML OWNER on S3; the value matches esp32c3.yaml's `i2s0`. \
+         Resolving S3 against a C3 entry is the shared-map trap. Flagged, not \
+         converted.",
+    ),
+    (
+        "peripherals/esp32s3/lcd_cam.rs",
+        "LCD_CAM_BASE",
+        "NO YAML OWNER — no chip YAML declares `lcd_cam`. Same as I2C1_BASE.",
+    ),
+    (
+        "peripherals/esp32s3/ledc.rs",
+        "LEDC_BASE",
+        "OWN BASE; matches esp32c3.yaml `ledc`, no S3 YAML entry. Same \
+         C3/S3 split as ds.rs.",
+    ),
+    (
+        "peripherals/esp32s3/mcpwm.rs",
+        "MCPWM0_BASE",
+        "OWN BASE (esp32s3.yaml: mcpwm0).",
+    ),
+    (
+        "peripherals/esp32s3/mcpwm.rs",
+        "MCPWM1_BASE",
+        "NO YAML OWNER — no chip YAML declares `mcpwm1`. Same as I2C1_BASE.",
+    ),
+    // ── memory-region prefixes, not peripheral bases ────────────────────────
+    (
+        "peripherals/esp32c3/wifi_mac.rs",
+        "DRAM_BASE",
+        "NOT A PERIPHERAL BASE. 0x3FC0_0000 is the C3 DRAM window, used to \
+         translate DMA descriptor pointers. Memory regions live under a chip \
+         YAML's `memory_regions`, not `peripherals`, so ChipMap cannot resolve \
+         it. Caught only because the constant is named *_BASE. Kept listed \
+         rather than name-mangled around the rule.",
+    ),
+    (
+        "peripherals/esp32s3/gdma.rs",
+        "DRAM_ADDR_PREFIX",
+        "NOT A PERIPHERAL BASE. S3 DRAM window prefix for DMA descriptor \
+         address translation, same as wifi_mac.rs DRAM_BASE.",
+    ),
+];
+
+/// Rule 2 exemptions: chip YAMLs whose declared peripheral windows overlap.
+///
+/// An overlap is decided silently by registration order. Each of these is a
+/// real ambiguity in a shipped memory map; they are recorded because changing a
+/// shipped chip's address map is a behavioural change that needs its own
+/// firmware proof, not a drive-by edit.
+///
+/// Format: `(chip yaml file name, peripheral id A, peripheral id B, why)`.
+/// Ids are stored sorted so the entry does not depend on YAML ordering.
+const WINDOW_OVERLAP_ALLOWLIST: &[(&str, &str, &str, &str)] = &[
+    (
+        "esp32.yaml",
+        "rtcio",
+        "sens_sar_adc",
+        "`rtcio` is declared 4 KB from 0x3FF4_8400 but really owns only 0x400, \
+         so its declared window swallows `sens_sar_adc` (0x3FF4_8800) whole. \
+         Narrowing rtcio to its true extent is the fix; it changes what answers \
+         in 0x3FF4_8800..0x3FF4_9400 on classic ESP32 and needs a firmware run.",
+    ),
+    (
+        "esp32.yaml",
+        "io_mux",
+        "rtcio",
+        "Same over-declared `rtcio` 4 KB window, overlapping `io_mux` at \
+         0x3FF4_9000 for 0x400 bytes.",
+    ),
+    (
+        "nrf5340.yaml",
+        "gpio0",
+        "gpio1",
+        "HIGHEST RISK ENTRY. `gpio1` sits at 0x5084_2300, i.e. 0x300 INSIDE \
+         gpio0's declared 4 KB window — the exact collision nrf52840.yaml \
+         documents avoiding by remapping P1 to 0x5000_1000. nRF5340 never got \
+         that remap, so P1 accesses are decided by registration order. This is \
+         the nRF52 GPIOTE defect waiting on a second chip; recorded here so it \
+         cannot be rediscovered as novel.",
+    ),
+    (
+        "nrf54l15.yaml",
+        "gpio1",
+        "temp",
+        "nRF54L15 uses documented negative-offset remaps (MDK base - 0x504) to \
+         line up Zephyr's register views; the side effect is 0x504 bytes of \
+         gpio1 landing inside `temp`'s window.",
+    ),
+    (
+        "nrf54l15.yaml",
+        "gpio0",
+        "wdt31",
+        "Same documented -0x504 remap, gpio0 into `wdt31`'s window.",
+    ),
+    (
+        "stm32l476.yaml",
+        "comp",
+        "syscfg",
+        "The classic STM32 0x4001_0000 block: SYSCFG/COMP/EXTI are one silicon \
+         block declared as three 1 KB peripherals at 0x200 spacing, so each \
+         declared window runs into the next. Correct fix is to declare their \
+         true 0x200 extents.",
+    ),
+    (
+        "stm32l476.yaml",
+        "comp",
+        "exti",
+        "Same STM32 0x4001_0000 SYSCFG/COMP/EXTI block.",
+    ),
+    // ── imported descriptor with genuinely identical bases ──────────────────
+    // `configs/chips/onboarding/atsamd21j17d-aft.yaml` collapses seven
+    // peripherals onto two addresses: gpio_a/gpio_b both at 0x4100, and
+    // tc4/tc6/usart0/usart1/usart2 ALL at 0x4200. This is the apb_ctrl-vs-SYSCON
+    // shape exactly — four of those five are unreachable, and which one answers
+    // is decided by registration order. Found by this gate on its first run.
+    // Not fixed here because the real base addresses have to come from the SAMD21
+    // datasheet, which is a datasheet task, not a refactor.
+    (
+        "atsamd21j17d-aft.yaml",
+        "gpio_a",
+        "gpio_b",
+        "IDENTICAL BASE 0x4100. Imported descriptor never got real per-instance \
+         addresses; needs SAMD21 datasheet values.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc4",
+        "tc6",
+        "IDENTICAL BASE 0x4200, part of the five-way tc4/tc6/usart0-2 tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc4",
+        "usart0",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc4",
+        "usart1",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc4",
+        "usart2",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc6",
+        "usart0",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc6",
+        "usart1",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "tc6",
+        "usart2",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "usart0",
+        "usart1",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "usart0",
+        "usart2",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+    (
+        "atsamd21j17d-aft.yaml",
+        "usart1",
+        "usart2",
+        "IDENTICAL BASE 0x4200, part of the five-way tie.",
+    ),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Source scanning
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Anything at or above this is treated as an absolute MMIO address rather than
+/// a register offset. Every peripheral window on every chip in `configs/chips/`
+/// sits above it (lowest is the RP2040 XIP SSI at 0x1800_0000); every register
+/// offset within a peripheral sits far below.
+const MMIO_FLOOR: u64 = 0x1000_0000;
+
+/// Rule 2 floor. Lower than [`MMIO_FLOOR`] because a real peripheral window can
+/// legitimately sit low (some imported descriptors map peripherals from
+/// 0x4000), but high enough to reject the non-MMIO bus-slot indices
+/// (`base_address: 1`, `0xf`) used by the imported Renode-style platform files.
+const MIN_MMIO_WINDOW_BASE: u64 = 0x1000;
+
+fn core_src_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn configs_chips_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../configs/chips")
+}
+
+fn rust_sources_under(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for p in paths {
+        if p.is_dir() {
+            rust_sources_under(&p, out);
+        } else if p.extension().is_some_and(|e| e == "rs") {
+            out.push(p);
+        }
+    }
+}
+
+fn yaml_files_under(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for p in paths {
+        if p.is_dir() {
+            yaml_files_under(&p, out);
+        } else if p.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+            out.push(p);
+        }
+    }
+}
+
+/// Blank out comments and string/char literals, preserving byte length and line
+/// structure, so brace matching and literal scanning only ever see real code.
+///
+/// Without this the scanner miscounts: a `"{:#x}"` format string inside a test
+/// module throws the brace depth off and leaks test code into the production
+/// scan. That is not hypothetical — it produced two false positives on the
+/// first run of this gate.
+fn blank_noncode(src: &str) -> String {
+    let b: Vec<char> = src.chars().collect();
+    let mut out = b.clone();
+    let n = b.len();
+    let blank = |out: &mut Vec<char>, a: usize, z: usize| {
+        for c in out.iter_mut().take(z.min(n)).skip(a) {
+            if *c != '\n' {
+                *c = ' ';
+            }
+        }
+    };
+    let mut i = 0usize;
+    while i < n {
+        let c = b[i];
+        if c == '/' && i + 1 < n && b[i + 1] == '/' {
+            let mut j = i;
+            while j < n && b[j] != '\n' {
+                j += 1;
+            }
+            blank(&mut out, i, j);
+            i = j;
+        } else if c == '/' && i + 1 < n && b[i + 1] == '*' {
+            let mut depth = 1usize;
+            let mut j = i + 2;
+            while j < n && depth > 0 {
+                if b[j] == '/' && j + 1 < n && b[j + 1] == '*' {
+                    depth += 1;
+                    j += 2;
+                } else if b[j] == '*' && j + 1 < n && b[j + 1] == '/' {
+                    depth -= 1;
+                    j += 2;
+                } else {
+                    j += 1;
+                }
+            }
+            blank(&mut out, i, j);
+            i = j;
+        } else if c == 'r' && i + 1 < n && (b[i + 1] == '#' || b[i + 1] == '"') {
+            let mut k = i + 1;
+            let mut hashes = 0usize;
+            while k < n && b[k] == '#' {
+                hashes += 1;
+                k += 1;
+            }
+            if k < n && b[k] == '"' {
+                // Find the closing `"` followed by `hashes` `#`.
+                let mut j = k + 1;
+                loop {
+                    if j >= n {
+                        break;
+                    }
+                    if b[j] == '"' {
+                        let mut h = 0usize;
+                        while h < hashes && j + 1 + h < n && b[j + 1 + h] == '#' {
+                            h += 1;
+                        }
+                        if h == hashes {
+                            j = j + 1 + hashes;
+                            break;
+                        }
+                    }
+                    j += 1;
+                }
+                blank(&mut out, i, j);
+                i = j;
+            } else {
+                i += 1;
+            }
+        } else if c == '"' {
+            let mut j = i + 1;
+            while j < n {
+                if b[j] == '\\' {
+                    j += 2;
+                    continue;
+                }
+                if b[j] == '"' {
+                    j += 1;
+                    break;
+                }
+                j += 1;
+            }
+            blank(&mut out, i, j);
+            i = j;
+        } else if c == '\'' {
+            // A char literal is `'x'` or `'\x'`; anything else is a lifetime.
+            let end = if i + 2 < n && b[i + 1] == '\\' {
+                let mut j = i + 2;
+                while j < n && b[j] != '\'' {
+                    j += 1;
+                }
+                if j < n {
+                    Some(j + 1)
+                } else {
+                    None
+                }
+            } else if i + 2 < n && b[i + 2] == '\'' {
+                Some(i + 3)
+            } else {
+                None
+            };
+            match end {
+                Some(j) => {
+                    blank(&mut out, i, j);
+                    i = j;
+                }
+                None => i += 1,
+            }
+        } else {
+            i += 1;
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Blank out `#[cfg(test)] mod NAME { ... }` bodies. Input must already be
+/// [`blank_noncode`]'d so brace depth is trustworthy.
+fn blank_test_modules(code: &str) -> String {
+    let b: Vec<char> = code.chars().collect();
+    let mut out = b.clone();
+    let n = b.len();
+    let s: String = code.to_string();
+    let mut search_from = 0usize;
+    while let Some(rel) = s[search_from..].find("#[cfg(test)]") {
+        let start = search_from + rel;
+        // Accept `#[cfg(test)]` followed by optional whitespace, optional
+        // `pub`, `mod NAME {`.
+        let tail = &s[start..];
+        let Some(brace_rel) = tail.find('{') else {
+            break;
+        };
+        let header = &tail[..brace_rel];
+        if !header.contains("mod ") {
+            search_from = start + "#[cfg(test)]".len();
+            continue;
+        }
+        let open = start + brace_rel;
+        let mut depth = 0usize;
+        let mut j = open;
+        while j < n {
+            if b[j] == '{' {
+                depth += 1;
+            } else if b[j] == '}' {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            j += 1;
+        }
+        for c in out.iter_mut().take((j + 1).min(n)).skip(start) {
+            if *c != '\n' {
+                *c = ' ';
+            }
+        }
+        search_from = (j + 1).min(n);
+    }
+    out.into_iter().collect()
+}
+
+/// One Rule 1 violation.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct BaseConst {
+    /// Path relative to `crates/core/src`.
+    file: String,
+    line: usize,
+    name: String,
+    value: u64,
+}
+
+/// Find `const|static NAME: uNN = 0x…;` where NAME mentions BASE or ADDR and
+/// the literal is an absolute MMIO address.
+fn scan_hardcoded_bases() -> Vec<BaseConst> {
+    let root = core_src_dir();
+    let scan_root = root.join("peripherals");
+    let mut files = Vec::new();
+    rust_sources_under(&scan_root, &mut files);
+
+    let mut found = Vec::new();
+    for path in files {
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let code = blank_test_modules(&blank_noncode(&raw));
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        for (idx, line) in code.lines().enumerate() {
+            if let Some(hit) = parse_base_const(line) {
+                let (name, value) = hit;
+                if value >= MMIO_FLOOR && value <= u32::MAX as u64 {
+                    found.push(BaseConst {
+                        file: rel.clone(),
+                        line: idx + 1,
+                        name,
+                        value,
+                    });
+                }
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+/// Parse a single line for `const|static NAME: <int ty> = 0x…;`.
+/// Returns `(name, value)` when NAME contains BASE or ADDR.
+fn parse_base_const(line: &str) -> Option<(String, u64)> {
+    let t = line.trim_start();
+    let t = t.strip_prefix("pub ").unwrap_or(t).trim_start();
+    // `pub(crate)` etc.
+    let t = if t.starts_with("pub(") {
+        let close = t.find(')')?;
+        t[close + 1..].trim_start()
+    } else {
+        t
+    };
+    let rest = t
+        .strip_prefix("const ")
+        .or_else(|| t.strip_prefix("static "))?;
+    let colon = rest.find(':')?;
+    let name = rest[..colon].trim();
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    let upper = name.to_ascii_uppercase();
+    if !upper.contains("BASE") && !upper.contains("ADDR") {
+        return None;
+    }
+    let after = &rest[colon + 1..];
+    let eq = after.find('=')?;
+    let ty = after[..eq].trim();
+    if !matches!(ty, "u32" | "u64" | "usize") {
+        return None;
+    }
+    let val = after[eq + 1..].trim().trim_end_matches(';').trim();
+    let hex = val.strip_prefix("0x").or_else(|| val.strip_prefix("0X"))?;
+    let digits: String = hex.chars().filter(|c| *c != '_').collect();
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(&digits, 16)
+        .ok()
+        .map(|v| (name.to_string(), v))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chip YAML scanning
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct Window {
+    id: String,
+    base: u64,
+    size: Option<u64>,
+}
+
+/// `"4KB"`, `"1024"`, `0x1000` → bytes.
+fn parse_size_str(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let lower = s.to_ascii_lowercase();
+    let (num, mult) = if let Some(p) = lower.strip_suffix("kb") {
+        (p, 1024)
+    } else if let Some(p) = lower.strip_suffix("mb") {
+        (p, 1024 * 1024)
+    } else if let Some(p) = lower.strip_suffix('k') {
+        (p, 1024)
+    } else if let Some(p) = lower.strip_suffix('m') {
+        (p, 1024 * 1024)
+    } else if let Some(p) = lower.strip_suffix('b') {
+        (p, 1)
+    } else {
+        (lower.as_str(), 1)
+    };
+    let num = num.trim();
+    let v = if let Some(h) = num.strip_prefix("0x") {
+        u64::from_str_radix(h, 16).ok()?
+    } else {
+        num.parse::<u64>().ok()?
+    };
+    Some(v * mult)
+}
+
+fn value_to_u64(v: &serde_yaml::Value) -> Option<u64> {
+    match v {
+        serde_yaml::Value::Number(n) => n.as_u64(),
+        serde_yaml::Value::String(s) => {
+            let s = s.trim();
+            if let Some(h) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                u64::from_str_radix(&h.replace('_', ""), 16).ok()
+            } else {
+                s.parse::<u64>().ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Every chip YAML's declared peripheral windows, keyed by file name.
+fn chip_windows() -> Vec<(String, Vec<Window>)> {
+    let dir = configs_chips_dir();
+    let mut files = Vec::new();
+    yaml_files_under(&dir, &mut files);
+    let mut out = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(doc) = serde_yaml::from_str::<serde_yaml::Value>(&text) else {
+            continue;
+        };
+        let Some(list) = doc.get("peripherals").and_then(|p| p.as_sequence()) else {
+            continue;
+        };
+        let mut wins = Vec::new();
+        for item in list {
+            let Some(id) = item.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(base) = item.get("base_address").and_then(value_to_u64) else {
+                continue;
+            };
+            // Only system-bus MMIO windows can collide in the way this rule is
+            // about. The 200-odd auto-imported descriptors under
+            // `configs/chips/onboarding/` carry Renode-style entries where
+            // `base_address` is a slot index on a non-MMIO parent bus
+            // (`bus: pci`, `bus: usbEhci`, `base_address: 1`); those share a
+            // "base" by construction and mean nothing here.
+            if base < MIN_MMIO_WINDOW_BASE {
+                continue;
+            }
+            if item
+                .get("bus")
+                .and_then(|v| v.as_str())
+                .is_some_and(|b| b != "sysbus")
+            {
+                continue;
+            }
+            let size = item.get("size").and_then(|v| match v {
+                serde_yaml::Value::String(s) => parse_size_str(s),
+                other => value_to_u64(other),
+            });
+            wins.push(Window {
+                id: id.to_string(),
+                base,
+                size,
+            });
+        }
+        // Key by path relative to configs/chips so `onboarding/nrf52840.yaml`
+        // stays distinguishable from `nrf52840.yaml`.
+        let rel = path
+            .strip_prefix(&dir)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        out.push((rel, wins));
+    }
+    out
+}
+
+/// A Rule 2 violation: two peripherals in one chip YAML whose windows collide.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct Collision {
+    chip: String,
+    a: String,
+    b: String,
+    same_base: bool,
+    detail: String,
+}
+
+fn scan_chip_collisions() -> Vec<Collision> {
+    let mut out = Vec::new();
+    for (chip, wins) in chip_windows() {
+        for i in 0..wins.len() {
+            for j in (i + 1)..wins.len() {
+                let (x, y) = (&wins[i], &wins[j]);
+                let same_base = x.base == y.base;
+                let overlap = match (x.size, y.size) {
+                    (Some(sx), Some(sy)) => x.base < y.base + sy && y.base < x.base + sx,
+                    // A window with no declared size cannot be shown to
+                    // overlap; only an exact base tie is provable.
+                    _ => same_base,
+                };
+                if !overlap {
+                    continue;
+                }
+                let (a, b) = if x.id <= y.id {
+                    (x, y)
+                } else {
+                    (y, x)
+                };
+                let detail = format!(
+                    "{} @ {:#010x} (size {}) vs {} @ {:#010x} (size {})",
+                    a.id,
+                    a.base,
+                    a.size.map(|s| format!("{s:#x}")).unwrap_or("?".into()),
+                    b.id,
+                    b.base,
+                    b.size.map(|s| format!("{s:#x}")).unwrap_or("?".into()),
+                );
+                out.push(Collision {
+                    chip: chip.clone(),
+                    a: a.id.clone(),
+                    b: b.id.clone(),
+                    same_base,
+                    detail,
+                });
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The gates
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Rule 1: no production peripheral model may hardcode an absolute base.
+#[test]
+fn rule1_no_hardcoded_peripheral_base_in_models() {
+    let found = scan_hardcoded_bases();
+    let allowed: BTreeSet<(&str, &str)> = HARDCODED_BASE_ALLOWLIST
+        .iter()
+        .map(|(f, n, _)| (*f, *n))
+        .collect();
+
+    let mut violations = Vec::new();
+    for hit in &found {
+        if !allowed.contains(&(hit.file.as_str(), hit.name.as_str())) {
+            violations.push(format!(
+                "  {}:{}  `{}` = {:#010x}",
+                hit.file, hit.line, hit.name, hit.value
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "\n\nA peripheral model hardcodes an absolute MMIO base address.\n\
+         A base address belongs to the chip YAML; a copy in Rust is a second \
+         home for the same fact with nothing forcing the two to agree, and the \
+         disagreement fails SILENTLY (a wrong address is still a valid address \
+         — it lands in another peripheral's window and is swallowed).\n\n\
+         Read the base from the chip descriptor instead:\n\
+           * the model's OWN base  → `p_cfg.base_address` in the family factory\n\
+           * a SIBLING's base      → `peripherals::chip_map::ChipMap::base_of(id)`\n\n\
+         Register offsets WITHIN a peripheral are fine and are not checked.\n\n\
+         New hardcoded bases ({}):\n{}\n\n\
+         If it genuinely cannot be converted, add it to HARDCODED_BASE_ALLOWLIST \
+         in crates/core/src/tests/yaml_owned_base_contract.rs with a real \
+         reason.\n",
+        violations.len(),
+        violations.join("\n")
+    );
+}
+
+/// Rule 1, shrink-only: an allowlist entry that no longer violates must be
+/// deleted, so a converted model cannot leave a stale exemption behind for the
+/// next offender to hide under.
+#[test]
+fn rule1_allowlist_shrinks_only() {
+    let found = scan_hardcoded_bases();
+    let live: BTreeSet<(&str, &str)> = found
+        .iter()
+        .map(|h| (h.file.as_str(), h.name.as_str()))
+        .collect();
+
+    let mut stale = Vec::new();
+    for (file, name, _) in HARDCODED_BASE_ALLOWLIST {
+        if !live.contains(&(*file, *name)) {
+            stale.push(format!("  {file} :: {name}"));
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "\n\nStale HARDCODED_BASE_ALLOWLIST entries — these no longer hardcode a \
+         base, so their exemption must be deleted.\n\
+         An allowlist that only grows stops being a ratchet.\n\n{}\n",
+        stale.join("\n")
+    );
+}
+
+/// Rule 1 self-check: the scanner must see production code and must NOT see
+/// `#[cfg(test)]` modules. A scanner that silently reads nothing would make
+/// Rule 1 vacuously green forever.
+#[test]
+fn rule1_scanner_is_not_vacuous() {
+    let root = core_src_dir().join("peripherals");
+    let mut files = Vec::new();
+    rust_sources_under(&root, &mut files);
+    assert!(
+        files.len() > 100,
+        "expected the peripherals tree to hold >100 .rs files, found {} — \
+         the scanner is looking in the wrong place and Rule 1 is vacuous",
+        files.len()
+    );
+
+    // The allowlist is non-empty, so the scanner must be finding those.
+    let found = scan_hardcoded_bases();
+    assert!(
+        !found.is_empty(),
+        "the scanner found zero base constants while HARDCODED_BASE_ALLOWLIST \
+         lists {} — the scan is broken and Rule 1 is vacuous",
+        HARDCODED_BASE_ALLOWLIST.len()
+    );
+
+    // Test-module constants must be invisible. `nrf52/gpiote.rs` keeps
+    // `T_GPIO0_BASE`/`T_GPIO1_BASE` inside `#[cfg(test)] mod tests`; if the
+    // brace matcher regresses (e.g. miscounting braces inside a format string)
+    // they leak into the production scan and this catches it.
+    let leaked: Vec<_> = found
+        .iter()
+        .filter(|h| h.name.starts_with("T_GPIO"))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "test-module constants leaked into the production scan: {leaked:?}"
+    );
+}
+
+/// Rule 2: a chip YAML may not disagree with itself about its own memory map.
+#[test]
+fn rule2_chip_yaml_peripheral_windows_do_not_collide() {
+    let found = scan_chip_collisions();
+    let allowed: BTreeSet<(&str, &str, &str)> = WINDOW_OVERLAP_ALLOWLIST
+        .iter()
+        .map(|(c, a, b, _)| (*c, *a, *b))
+        .collect();
+
+    let mut violations = Vec::new();
+    for c in &found {
+        // Allowlist keys on the bare file name so `onboarding/x.yaml` and
+        // `x.yaml` both match a single entry only if they genuinely share the
+        // defect; the file name is carried in the message either way.
+        let leaf = c.chip.rsplit('/').next().unwrap_or(&c.chip);
+        if !allowed.contains(&(leaf, c.a.as_str(), c.b.as_str())) {
+            violations.push(format!(
+                "  {} :: {}{}",
+                c.chip,
+                c.detail,
+                if c.same_base {
+                    "  [IDENTICAL BASE]"
+                } else {
+                    ""
+                }
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "\n\nA chip YAML declares two peripherals whose MMIO windows collide.\n\
+         Bus routing ties are resolved by REGISTRATION ORDER, silently. This is \
+         how classic-ESP32 `apb_ctrl` shadowed SYSCON: SYSCLK_CONF read \
+         0xFFFF_FFFF, getApbFrequency() returned 78125 Hz, and \"Serial doesn't \
+         work on classic ESP32\" was believed for about a year.\n\n\
+         Fix the chip YAML: give each peripheral a base and a `size:` that \
+         describe the window it actually owns.\n\n\
+         New collisions ({}):\n{}\n\n\
+         If a shipped map genuinely cannot change yet, add it to \
+         WINDOW_OVERLAP_ALLOWLIST in \
+         crates/core/src/tests/yaml_owned_base_contract.rs with a real reason.\n",
+        violations.len(),
+        violations.join("\n")
+    );
+}
+
+/// Rule 2, shrink-only.
+#[test]
+fn rule2_allowlist_shrinks_only() {
+    let found = scan_chip_collisions();
+    let live: BTreeSet<(String, String, String)> = found
+        .iter()
+        .map(|c| {
+            (
+                c.chip.rsplit('/').next().unwrap_or(&c.chip).to_string(),
+                c.a.clone(),
+                c.b.clone(),
+            )
+        })
+        .collect();
+
+    let mut stale = Vec::new();
+    for (chip, a, b, _) in WINDOW_OVERLAP_ALLOWLIST {
+        if !live.contains(&(chip.to_string(), a.to_string(), b.to_string())) {
+            stale.push(format!("  {chip} :: {a} vs {b}"));
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "\n\nStale WINDOW_OVERLAP_ALLOWLIST entries — these chip YAMLs no longer \
+         collide, so their exemption must be deleted.\n\n{}\n",
+        stale.join("\n")
+    );
+}
+
+/// Rule 2 self-check: the YAML scanner must actually be reading chip files.
+#[test]
+fn rule2_scanner_is_not_vacuous() {
+    let windows = chip_windows();
+    assert!(
+        windows.len() >= 20,
+        "expected >=20 chip YAMLs under configs/chips, found {} — \
+         Rule 2 is vacuous",
+        windows.len()
+    );
+    let total: usize = windows.iter().map(|(_, w)| w.len()).sum();
+    assert!(
+        total > 400,
+        "expected >400 declared peripheral windows across all chips, found \
+         {total} — Rule 2 is vacuous"
+    );
+    // nRF52840 is the chip the GPIOTE defect lived on; its remapped gpio1 must
+    // be visible to the scanner, otherwise the fix's premise is unverified.
+    let (_, nrf) = windows
+        .iter()
+        .find(|(f, _)| f == "nrf52840.yaml")
+        .expect("configs/chips/nrf52840.yaml must be scanned");
+    let gpio1 = nrf
+        .iter()
+        .find(|w| w.id == "gpio1")
+        .expect("nrf52840.yaml must declare gpio1");
+    assert_eq!(
+        gpio1.base, 0x5000_1000,
+        "nrf52840.yaml gpio1 is remapped off Nordic's silicon P1 base; if this \
+         ever changes, Nrf52Gpiote follows it via ChipMap and this contract's \
+         premise needs revisiting"
+    );
+}
+
+#[cfg(test)]
+mod scanner_unit_tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_base_const() {
+        assert_eq!(
+            parse_base_const("const GPIO1_BASE: u32 = 0x5000_0300;"),
+            Some(("GPIO1_BASE".to_string(), 0x5000_0300))
+        );
+        assert_eq!(
+            parse_base_const("pub const BT_BASE: u64 = 0x6003_1000;"),
+            Some(("BT_BASE".to_string(), 0x6003_1000))
+        );
+    }
+
+    #[test]
+    fn ignores_offsets_and_masks() {
+        // Not BASE/ADDR-named → not a base claim.
+        assert_eq!(parse_base_const("const OFF_CONFIG_0: u64 = 0x510;"), None);
+        assert_eq!(
+            parse_base_const("const CONFIG_WRITE_MASK: u32 = 0x0013_3F03;"),
+            None
+        );
+        // BASE-named but below the MMIO floor — filtered by the caller, so the
+        // parser still returns it; assert the value so the floor is testable.
+        assert_eq!(
+            parse_base_const("const GPIO_IN_BASE: u32 = 0x510;"),
+            Some(("GPIO_IN_BASE".to_string(), 0x510))
+        );
+        assert!(0x510 < MMIO_FLOOR);
+    }
+
+    #[test]
+    fn blanks_braces_inside_string_literals() {
+        // The exact shape that broke the first version of this scanner.
+        let src = "#[cfg(test)]\nmod tests {\n let s = \"{\";\n const X_BASE: u32 = 0x6000_0000;\n}\nconst Y_BASE: u32 = 0x6001_0000;\n";
+        let code = blank_test_modules(&blank_noncode(src));
+        assert!(
+            !code.contains("X_BASE"),
+            "test-module const leaked: {code:?}"
+        );
+        assert!(code.contains("Y_BASE"), "production const was eaten: {code:?}");
+    }
+
+    #[test]
+    fn parses_sizes() {
+        assert_eq!(parse_size_str("4KB"), Some(4096));
+        assert_eq!(parse_size_str("0x1000"), Some(4096));
+        assert_eq!(parse_size_str("256"), Some(256));
+        assert_eq!(parse_size_str("1MB"), Some(1024 * 1024));
+    }
+}

--- a/crates/core/src/tests/yaml_owned_base_contract.rs
+++ b/crates/core/src/tests/yaml_owned_base_contract.rs
@@ -1177,7 +1177,7 @@ mod scanner_unit_tests {
             parse_base_const("const GPIO_IN_BASE: u32 = 0x510;"),
             Some(("GPIO_IN_BASE".to_string(), 0x510))
         );
-        assert!(0x510 < MMIO_FLOOR);
+        const { assert!(0x510 < MMIO_FLOOR) };
     }
 
     #[test]


### PR DESCRIPTION
Fixes a silent nRF52 GPIOTE defect, then guards the class it belongs to.

## The instance

`nrf52/gpiote.rs` hardcoded `GPIO1_BASE = 0x5000_0300` — Nordic's real-silicon P1 base. Every nRF52840 chip YAML deliberately remaps `gpio1` to `0x5000_1000`, because the silicon base sits *inside* GPIO0's 4 KB window and a flat bus cannot host both. So every port-1 GPIOTE task wrote `0x5000_0810`: a valid address, inside **gpio0's** window, where the bus swallowed it. No error, no warning, no fault.

**Reproduced on unmodified `origin/main` before fixing:**

```
PORT=1: GPIOTE TASKS_SET must drive gpio1.IN bit 5 high (gpio1 base 0x50001000);
        got gpio1.IN = 0x00000000, gpio0.IN = 0x00000000
  left: 0   right: 32
```

The `PORT=0` case passed in the same run — the loop reached `PORT=1` before failing. So this was port-1-specific, exactly as reported.

**The second casualty.** `task_clr_drives_in_register_low_on_port1` asserted the wrong base, so it passed while the behaviour was broken. Corrected, it fails on unmodified main:

```
  left: [(1342179344, 0)]   // 0x5000_0810 — lands in gpio0
 right: [(1342182672, 0)]   // 0x5000_1510 — where gpio1 actually is
```

Both pass after the fix.

## The fix — plumbing, not a swapped constant

Changing the constant to `0x5000_1000` would swap one hardcoded address for another and leave the model lying the next time the YAML moves. The plumbing to reach the descriptor did not exist: `nrf52::factory::try_build` received the `SystemManifest`, but a chip's peripherals live in the `ChipDescriptor`, and the resolved map (descriptor + manifest overrides) existed only as a local inside `from_config`.

**That plumbing is the deliverable.** New `peripherals::chip_map::ChipMap` — a read-only view of the resolved peripheral memory map, built once in `from_config` and passed into the family factory. `Nrf52Gpiote::new` takes it and resolves `gpio0`/`gpio1` by chip-YAML id.

There is deliberately **no constructor without a map**. A default constructor is exactly how the constant would grow back. A port the chip does not declare (nRF52832 has no P1) drives nothing and warns, rather than writing a guessed address into whichever peripheral owns that window.

**Both ports are asserted, and so is the non-target port**, so a fix that moved the breakage from port 1 to port 0 — or that leaked the drive into the wrong port — fails.

### Where the line is drawn

- A peripheral's **BASE address** comes from the memory map → the YAML's job. Converted.
- A **register OFFSET within** a peripheral (`GPIO_IN_OFFSET = 0x510`) is a silicon fact of that peripheral → stays with the model. **Not** converted, and the guard deliberately does not check offsets. Mass-migrating them would scatter one peripheral's register map across two files and be worse than the disease.
- **Memory regions** (flash/RAM/ROM/XIP windows, DMA scratch) are not peripherals → out of scope.

## The class guard

`crates/core/src/tests/yaml_owned_base_contract.rs`. Two rules, both chip-agnostic — nRF52/nRF54, all STM32 families, RP2040, ESP32 classic/C3/S3, MKW41Z and every other `configs/chips/` descriptor.

**Rule 1 — no hardcoded base in a model.** No production source under `crates/core/src/peripherals/` may bind a `const`/`static` whose *name* says base or address (`*BASE*`, `*ADDR*`) to an absolute MMIO literal (`>= 0x1000_0000`).

It keys on the **shape of the binding**, not on whether the value matches a YAML entry — on purpose. `0x5000_0300` matched *no* declared base anywhere in the repo; that disagreement *was* the bug. A "flag literals equal to a declared base" rule would have missed it completely.

**Rule 2 — a chip YAML may not disagree with itself.** No two peripherals in one descriptor may share a `base_address`, and no two `[base, base+size)` windows may overlap. Ties are resolved silently by registration order — which is how classic-ESP32 `apb_ctrl` shadowed SYSCON, `SYSCLK_CONF` read `0xFFFF_FFFF`, `getApbFrequency()` returned 78125 Hz, and "Serial doesn't work on classic ESP32" was believed for about a year.

Both allowlists are **shrink-only**: an entry that no longer violates fails the gate, so a converted model cannot leave a stale exemption for the next offender to hide under. Three anti-vacuity tests assert the scanners are actually reading source and YAML (`>100` .rs files, `>=20` chip YAMLs, `>400` declared windows), and one asserts nRF52840's `gpio1` really is remapped — the fix's premise.

### Both rules proven by deliberate reintroduction

Rule 1, re-adding the original constant:
```
New hardcoded bases (1):
  peripherals/nrf52/gpiote.rs:81  `GPIO1_BASE` = 0x50000300
```

Rule 2, pointing `syscon` at `dport`'s base — the apb_ctrl/SYSCON shape:
```
New collisions (1):
  esp32.yaml :: dport @ 0x3ff00000 (size 0x1000) vs syscon @ 0x3ff00000 (size 0x100)  [IDENTICAL BASE]
```
Both restored afterwards; `git diff origin/main -- configs/` is empty.

## What the guard found on its first run

**`configs/chips/onboarding/atsamd21j17d-aft.yaml` collapses seven peripherals onto two addresses**: `gpio_a`/`gpio_b` both at `0x4100`, and `tc4`/`tc6`/`usart0`/`usart1`/`usart2` **all at `0x4200`**. Four of those five are unreachable; which one answers is decided by registration order. This is the apb_ctrl/SYSCON defect, live, on another chip. Recorded, not fixed — the real addresses have to come from the SAMD21 datasheet, which is a datasheet task, not a refactor.

**`nrf5340.yaml` declares `gpio1` at `0x5084_2300`, i.e. `0x300` inside `gpio0`'s window** — the exact collision `nrf52840.yaml` documents avoiding by remapping P1. nRF5340 never got that remap. This is the bug in this PR waiting on a second chip; recorded so it cannot be rediscovered as novel.

Plus `esp32.yaml` (`rtcio` over-declared at 4 KB, swallowing `sens_sar_adc` whole and half of `io_mux`), `nrf54l15.yaml` (documented `-0x504` remaps pushing gpio0/gpio1 into `wdt31`/`temp`), and `stm32l476.yaml` (the SYSCFG/COMP/EXTI 0x200-spacing block). Seven overlaps + eleven identical-base pairs, each allowlisted with a reason.

## Sweep: the size of the problem

Full sweep of `crates/core/src/peripherals/` (two independent counting methods, agreeing exactly — no silent grep misses):

| | count |
|---|---|
| Hex literals in the tree | 3917 |
| **(A) absolute peripheral bases matching a chip YAML** | **265** |
| (B) register offsets (`< 0x10000`) — correctly model-owned | 1040 |
| (C) bitmasks / reset values / magic / crypto constants | 2062 |
| (D) ambiguous — RAM/ROM/flash windows, range bounds, no YAML owner | 550 |

Of those 265, **30 are named `*BASE*`/`*ADDR*` constants in production code** — the shape both confirmed defects actually had, and what Rule 1 gates. All 30 are in `HARDCODED_BASE_ALLOWLIST` with a per-entry reason and a severity annotation.

## What I did NOT do

Stated plainly.

- **Converted one model, not thirty.** Only GPIOTE — the proven defect, with a failing-first test. An honest ratchet beats a rushed mass edit, and the guard is what stops the list growing.
- **Did not convert `esp32s3/gdma.rs::UART0_BASE`**, the highest-value next one and the same cross-peripheral shape as GPIOTE (GDMA writes UART0's FIFO at a hardcoded base). Both S3 YAMLs happen to declare `uart0` at `0x6000_0000`, so it is currently correct and nothing enforces that. Converting needs `ChipMap` threaded through `esp32s3::factory` (two callers, one of which builds no chip YAML) and touches ~70 `Esp32s3Gdma::new` call sites — too much unproven churn for one PR.
- **Did not touch the ESP32-C3 constants.** They sit on the byte-identical throughput gate; each needs its own proof run.
- **Resisted the shared-register-map instinct, and flagged it instead.** Several S3 models (`ds.rs`, `hmac.rs`, `i2s.rs`, `ledc.rs`) hold bases that only *`esp32c3.yaml`* declares — no S3 YAML declares them at all. Resolving S3 against a C3 entry is exactly the trap this project has already paid for: the same offset does not mean the same register across C3 and S3. Left alone and annotated as such in the allowlist.
- **Did not mass-convert offsets.** By design.
- **Did not fix the seven YAML overlaps or the SAMD21 tie.** Changing a shipped chip's address map is a behavioural change needing its own firmware proof.

### What the guard does not catch

- **Inline literals.** `bus.write_u32(0x6000_0000 + 0x1C, v)` with no named binding is invisible to Rule 1. Covering those means flagging ~265 sites, most of them doc comments, test fixtures and `base + offset` composites — an allowlist that size stops being read.
- **Wrong-but-consistent maps.** If the YAML itself is wrong, everything is green. This enforces *one home*, not correctness of the value in that home.
- Rule 2 is per-chip-file by design, and skips non-MMIO bus-slot entries (`bus: pci`, `base_address: 1`) in the ~200 imported Renode-style descriptors under `configs/chips/onboarding/`.

## Verification

- `cargo test -p labwired-core --lib` — **2571 passed, 0 failed** (baseline 2557 + 14 new: 10 guard, 3 `ChipMap`, 1 GPIOTE integration).
- `--lib --features event-scheduler` — **2687 passed, 0 failed**.
- nRF52/53/54 integration tests green.
- **Real firmware, non-vacuously**: built `thumbv7em-none-eabi` and confirmed `nrf52840_onboarding_real_firmware_toggles_led` and `..._isr_firmware_toggles_led` actually loaded the ELF (`Loading firmware from …` in output) rather than taking the silent-skip path. Both pass, alongside `nrf52840_onboarding_ppi_routes_timer_to_gpiote_pin`, which drives GPIOTE via PPI end to end.
- **C3 shipped-lab throughput byte-identical** — all five numbers unchanged:
  ```
  esp32c3-oled-lab        mean_batch=125.716  lit_px=782  batches=27122
  esp32c3-oled-128x32-lab mean_batch=115.033  lit_px=442  batches=26489
  ```
- `cargo clippy -p labwired-core --all-targets -- -D warnings` — clean.
- `cargo clippy -p labwired-wasm --all-targets -- -D warnings` — one `manual_div_ceil` at `crates/wasm/src/lib.rs:159`. Pre-existing, from the newer local toolchain (1.96 vs CI's pinned 1.95); `git diff origin/main -- crates/wasm/` is empty.
