### PR TITLE
Per-chip UART/SPI/I²C bus-proof matrix, gated in pr-gate

### DIFF
--- a/crates/core/src/tests/bus_proof_matrix.rs
+++ b/crates/core/src/tests/bus_proof_matrix.rs
@@ -502,3 +502,32 @@ fn cell_ordering_detects_a_downgrade() {
     deleted.remove(&cell("esp32", "uart"));
     assert_eq!(downgrades(&base, &deleted).len(), 1);
 }
+
+/// The ratchet's git plumbing must work BEFORE it has anything to compare.
+///
+/// `bus_proof_matrix_never_regresses` cannot bite until this file exists on
+/// `main`: until then `git_show` legitimately returns `None` and the arm skips.
+/// That is a window in which a broken `merge-base` or `git show` would look
+/// exactly like "no baseline yet", so this test closes it by resolving the
+/// merge base and reading a file that has been there all along.
+#[test]
+fn baseline_plumbing_can_read_the_merge_base() {
+    let Some(base) = merge_base_with_trunk() else {
+        assert!(
+            std::env::var("CI").is_err(),
+            "no `git merge-base HEAD origin/main` under CI — the lane needs \
+             fetch-depth: 0 and an origin/main ref"
+        );
+        eprintln!("SKIP: shallow/detached checkout with no origin/main");
+        return;
+    };
+    assert_eq!(base.len(), 40, "merge base is not a full sha: {base:?}");
+    let anchor = git_show(&base, "Cargo.toml")
+        .unwrap_or_else(|| panic!("`git show {base}:Cargo.toml` returned nothing"));
+    assert!(
+        anchor.contains("[workspace]"),
+        "read something from the merge base, but it is not the workspace manifest"
+    );
+    // And a path that has never existed must be reported as absent, not as "".
+    assert!(git_show(&base, "validation/definitely_not_a_file.json").is_none());
+}

--- a/crates/core/src/tests/bus_proof_matrix.rs
+++ b/crates/core/src/tests/bus_proof_matrix.rs
@@ -1,0 +1,504 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! BUS-PROOF MATRIX — per-chip UART / SPI / I²C evidence, gated.
+//!
+//! Why this file exists
+//! ====================
+//! "Does UART work on this chip?" had no answer you could read off anything.
+//! The registers accept writes on every chip, the boot lanes are green on every
+//! chip, and neither fact says a byte ever left the controller. The three
+//! places that came closest each answer a different question:
+//!
+//! - `tier1` (`crates/cli/src/tier1.rs`) has `uart`/`spi`/`i2c` columns, but the
+//!   `spi` and `i2c` cells are the FIXTURE's self-report about its own
+//!   registers (`examples/tier1-fixture/*/src/main.rs`: write DR, poll BSY;
+//!   START an absent address, require NACK). No device ever receives a byte.
+//! - `validation/arduino-matrix` DOES put a real device on the wire (INA219 on
+//!   `Wire`) and DOES read the verdict back over a real UART — but it needs
+//!   PlatformIO, so it runs nightly, never on a PR.
+//! - `board_coverage_ratchet.rs` ratchets reset/exec/display classes, and
+//!   deliberately says nothing about buses.
+//!
+//! So this file records, per chip and per bus, what evidence EXISTS — in three
+//! states, with the difference between them enforced rather than trusted:
+//!
+//! - `proven` — a test drives real firmware and asserts observable data moved:
+//!   bytes at a UART sink, a modelled device answering with its real
+//!   identity/payload, or a panel's own framebuffer painting. It must run
+//!   somewhere, unguarded.
+//! - `shallow` — evidence exists but does not carry that weight: it asserts
+//!   register state only, or it moves real bytes but drives the controller from
+//!   a harness instead of firmware, or it is `#[ignore]`d / self-skips on a
+//!   missing fixture and therefore passes VACUOUSLY wherever it is invoked.
+//! - `none` — nothing.
+//!
+//! ONE source of truth
+//! ===================
+//! `validation/bus_proof_matrix.json` is it. This file does NOT keep a second
+//! copy of the verdicts (that is how a ratchet allowlist drifts from the thing
+//! it ratchets); it keeps the RULES the JSON must satisfy.
+//!
+//! The two arms
+//! ============
+//! 1. STRUCTURAL (`bus_proof_matrix_is_complete_and_not_fabricated`) — needs no
+//!    git and no fixtures, so it runs everywhere `cargo test --lib` runs, which
+//!    is `pr-gate` on every PR:
+//!      - the chip set is DERIVED from `configs/chips/*.yaml` (minus
+//!        `ci-fixture-*`), exactly like `builtin_chip_self_contained.rs`. A new
+//!        chip — including a new `BOARDS` chip in the superproject, which
+//!        cannot ship without its `configs/chips/<id>.yaml` — has no row and
+//!        FAILS. A row for a chip that no longer ships also fails.
+//!      - a cell that is not `none` must cite a file that EXISTS and a test
+//!        name that literally appears in it. A `proven` cell must additionally
+//!        name the observable (`signal`) and the lane that runs it. You cannot
+//!        make a cell green by typing `"proven"`.
+//! 2. RATCHET (`bus_proof_matrix_never_regresses`) — compares every cell to the
+//!    same file at `git merge-base HEAD origin/main`. `proven` may not become
+//!    `shallow` or `none`; `shallow` may not become `none`. The baseline comes
+//!    from OUTSIDE the change, so an author cannot move it by editing the JSON
+//!    in the same commit. Under CI this is fatal if the baseline cannot be
+//!    resolved — a ratchet that shrugs and passes is the bug it exists to stop.
+//!
+//! `cell_ordering_detects_a_downgrade` proves the comparator is not vacuous by
+//! watching it reject each downgrade direction, the way
+//! `walk_starvation_contract::rule_c_detector_is_not_vacuous` does.
+
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+/// `validation/bus_proof_matrix.json`, relative to the workspace root.
+pub const MATRIX_PATH: &str = "validation/bus_proof_matrix.json";
+
+/// The three buses every row must answer for.
+const BUSES: [&str; 3] = ["uart", "spi", "i2c"];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The data
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum State {
+    /// Ordering matters: `None < Shallow < Proven`, and the ratchet is a `>=`.
+    None,
+    Shallow,
+    Proven,
+}
+
+impl State {
+    fn label(self) -> &'static str {
+        match self {
+            State::None => "none",
+            State::Shallow => "shallow",
+            State::Proven => "proven",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Cell {
+    pub state: State,
+    /// Repo-relative path of the test file backing this cell. Required unless
+    /// `state == none`.
+    #[serde(default)]
+    pub file: String,
+    /// A string that must literally appear in `file` — normally the test fn
+    /// name, or the assertion line for a YAML-driven lab script.
+    #[serde(default)]
+    pub test: String,
+    /// What is actually observed. Required for `proven`.
+    #[serde(default)]
+    pub signal: String,
+    /// Where it runs. Required for `proven`; `"none"` is a legal value for a
+    /// `shallow` cell and is exactly how a vacuous test is recorded.
+    #[serde(default)]
+    pub lane: String,
+    /// Why this is not `proven`. Required for `shallow` and `none`.
+    #[serde(default)]
+    pub gap: String,
+    /// Free-form caveat that does NOT change the verdict — e.g. "the proof is a
+    /// one-byte write plus the device's ACK, not a payload readback". Optional
+    /// everywhere; a `proven` cell may carry one, which is how a cell records
+    /// the limits of its own proof without pretending to be `shallow`.
+    #[serde(default)]
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Row {
+    /// True when some board in the superproject's `packages/board-config`
+    /// `BOARDS` declares `chip: "<this>"`. Informational: the gate derives its
+    /// chip set from `configs/chips/`, which is a superset.
+    #[serde(default)]
+    pub in_boards: bool,
+    #[serde(flatten)]
+    pub buses: BTreeMap<String, Cell>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Matrix {
+    pub chips: BTreeMap<String, Row>,
+}
+
+impl Matrix {
+    fn parse(text: &str) -> Result<Self, String> {
+        serde_json::from_str(text).map_err(|e| format!("parse {MATRIX_PATH}: {e}"))
+    }
+
+    fn cells(&self) -> BTreeMap<(String, String), State> {
+        let mut out = BTreeMap::new();
+        for (chip, row) in &self.chips {
+            for (bus, cell) in &row.buses {
+                out.insert((chip.clone(), bus.clone()), cell.state);
+            }
+        }
+        out
+    }
+}
+
+fn load_committed() -> Matrix {
+    let path = workspace_root().join(MATRIX_PATH);
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    Matrix::parse(&text).unwrap_or_else(|e| panic!("{e}"))
+}
+
+/// Every chip descriptor we ship, derived — never hand-listed. Same rule as
+/// `builtin_chip_self_contained::every_shipped_chip_file_is_offered_as_a_builtin`,
+/// which is what keeps this set honest: a chip file that is not offered as a
+/// built-in already fails there.
+fn shipped_chips() -> BTreeSet<String> {
+    let dir = workspace_root().join("configs/chips");
+    let mut out = BTreeSet::new();
+    for entry in std::fs::read_dir(&dir).expect("read configs/chips") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().is_none_or(|e| e != "yaml") {
+            continue;
+        }
+        let stem = path.file_stem().unwrap().to_string_lossy().into_owned();
+        // Internal harness fixtures, not silicon we offer.
+        if stem.starts_with("ci-fixture-") {
+            continue;
+        }
+        out.insert(stem);
+    }
+    out
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Arm 1 — structural: complete, well-formed, and not fabricated
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn bus_proof_matrix_is_complete_and_not_fabricated() {
+    let matrix = load_committed();
+    let shipped = shipped_chips();
+    let root = workspace_root();
+    let mut failures: Vec<String> = Vec::new();
+
+    // Derived chip set — a new chip cannot slip in unrated.
+    let rows: BTreeSet<String> = matrix.chips.keys().cloned().collect();
+    let missing: Vec<&String> = shipped.difference(&rows).collect();
+    if !missing.is_empty() {
+        failures.push(format!(
+            "these chips ship (configs/chips/<id>.yaml) but have NO row in {MATRIX_PATH}: \
+             {missing:?}.\n  Add a row. A chip whose UART/SPI/I²C evidence nobody has \
+             written down is a chip nobody has checked — `none` is a legal, honest answer."
+        ));
+    }
+    let extra: Vec<&String> = rows.difference(&shipped).collect();
+    if !extra.is_empty() {
+        failures.push(format!(
+            "{MATRIX_PATH} has rows for chips that no longer ship: {extra:?}. Delete them."
+        ));
+    }
+
+    for (chip, row) in &matrix.chips {
+        let present: BTreeSet<&str> = row.buses.keys().map(String::as_str).collect();
+        for bus in BUSES {
+            if !present.contains(bus) {
+                failures.push(format!("{chip}: missing `{bus}` cell"));
+            }
+        }
+        for bus in present {
+            if !BUSES.contains(&bus) {
+                failures.push(format!(
+                    "{chip}: unknown bus `{bus}` (expected exactly {BUSES:?})"
+                ));
+            }
+        }
+
+        for (bus, cell) in &row.buses {
+            let at = format!("{chip}/{bus}");
+            match cell.state {
+                State::None => {
+                    if cell.gap.trim().is_empty() {
+                        failures.push(format!("{at}: `none` must say why in `gap`"));
+                    }
+                    if !cell.file.trim().is_empty() {
+                        failures.push(format!(
+                            "{at}: `none` cites {}: if a test exists this is not `none`",
+                            cell.file
+                        ));
+                    }
+                    if !cell.note.trim().is_empty() {
+                        failures.push(format!(
+                            "{at}: `none` has nothing to caveat — put it in `gap`"
+                        ));
+                    }
+                }
+                State::Shallow | State::Proven => {
+                    // Anti-fabrication: the cited evidence must exist, and the
+                    // cited test name must literally be in it.
+                    if cell.file.trim().is_empty() || cell.test.trim().is_empty() {
+                        failures.push(format!(
+                            "{at}: `{}` must cite both `file` and `test`",
+                            cell.state.label()
+                        ));
+                        continue;
+                    }
+                    let path = root.join(&cell.file);
+                    match std::fs::read_to_string(&path) {
+                        Err(e) => failures.push(format!(
+                            "{at}: cites `{}` which cannot be read ({e}). \
+                             A cell may not cite evidence that is not there.",
+                            cell.file
+                        )),
+                        Ok(text) => {
+                            if !text.contains(&cell.test) {
+                                failures.push(format!(
+                                    "{at}: `{}` does not appear in `{}`. Either the test was \
+                                     renamed or deleted (fix the row, or downgrade the cell) \
+                                     or the citation was invented.",
+                                    cell.test, cell.file
+                                ));
+                            }
+                        }
+                    }
+                    if cell.state == State::Proven {
+                        if cell.signal.trim().is_empty() {
+                            failures.push(format!(
+                                "{at}: `proven` must name the observable in `signal` \
+                                 (bytes at a sink / a device's own payload / painted pixels). \
+                                 'the registers looked right' is `shallow`."
+                            ));
+                        }
+                        if cell.lane.trim().is_empty() || cell.lane == "none" {
+                            failures.push(format!(
+                                "{at}: `proven` must name the lane that RUNS it. A test that \
+                                 runs nowhere proves nothing — that is `shallow`."
+                            ));
+                        }
+                        if !cell.gap.trim().is_empty() {
+                            failures.push(format!(
+                                "{at}: `proven` must not carry a `gap` (it has none)"
+                            ));
+                        }
+                    } else if cell.gap.trim().is_empty() {
+                        failures.push(format!(
+                            "{at}: `shallow` must say in `gap` what it fails to prove"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "\nBUS-PROOF MATRIX ({MATRIX_PATH}) is not honest:\n\n  {}\n",
+        failures.join("\n  ")
+    );
+
+    // Print the table. `--nocapture` in a lane turns this into the evidence that
+    // the gate READ something, rather than merely existing — the same reason
+    // `pr-scheduler-observable` prints `sink_bytes=N`.
+    eprintln!("bus-proof matrix ({} chips)", matrix.chips.len());
+    eprintln!(
+        "  {:<16} {:<7} {:<8} {:<8} {:<8}",
+        "chip", "BOARDS", "uart", "spi", "i2c"
+    );
+    let mut proven = 0usize;
+    for (chip, row) in &matrix.chips {
+        let get = |b: &str| row.buses[b].state.label();
+        eprintln!(
+            "  {:<16} {:<7} {:<8} {:<8} {:<8}",
+            chip,
+            if row.in_boards { "yes" } else { "-" },
+            get("uart"),
+            get("spi"),
+            get("i2c")
+        );
+        proven += row
+            .buses
+            .values()
+            .filter(|c| c.state == State::Proven)
+            .count();
+    }
+    eprintln!(
+        "  proven {}/{} cells",
+        proven,
+        matrix.chips.len() * BUSES.len()
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Arm 2 — the ratchet: cells improve, never regress
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The comparison itself, factored out so it can be tested against synthetic
+/// input rather than only against whatever the tree happens to contain.
+fn downgrades(
+    baseline: &BTreeMap<(String, String), State>,
+    live: &BTreeMap<(String, String), State>,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for (cell, was) in baseline {
+        match live.get(cell) {
+            None => out.push(format!(
+                "{}/{}: {} -> row DELETED. Deleting a cell is a downgrade.",
+                cell.0,
+                cell.1,
+                was.label()
+            )),
+            Some(now) if now < was => out.push(format!(
+                "{}/{}: {} -> {}",
+                cell.0,
+                cell.1,
+                was.label(),
+                now.label()
+            )),
+            Some(_) => {}
+        }
+    }
+    out
+}
+
+/// `git show <rev>:<path>`, or `None` when the rev/path is not there.
+fn git_show(rev: &str, path: &str) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["show", &format!("{rev}:{path}")])
+        .current_dir(workspace_root())
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn merge_base_with_trunk() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["merge-base", "HEAD", "origin/main"])
+        .current_dir(workspace_root())
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}
+
+#[test]
+fn bus_proof_matrix_never_regresses() {
+    let live = load_committed().cells();
+
+    // `CI` is set by GitHub Actions. There, an unresolvable baseline is fatal:
+    // the whole point is that the author cannot move it.
+    let required = std::env::var("CI").is_ok();
+
+    let Some(base_rev) = merge_base_with_trunk() else {
+        assert!(
+            !required,
+            "bus-proof ratchet: cannot resolve `git merge-base HEAD origin/main`. \
+             The lane needs fetch-depth: 0 and an origin/main ref. Refusing to pass \
+             without a baseline."
+        );
+        eprintln!(
+            "SKIP(baseline): no `git merge-base HEAD origin/main` in this checkout. \
+             The structural arm still ran; the ratchet arm did not."
+        );
+        return;
+    };
+
+    let Some(text) = git_show(&base_rev, MATRIX_PATH) else {
+        // The very first commit that adds the file has no baseline, by
+        // construction. Every later one does.
+        eprintln!("SKIP(baseline): {MATRIX_PATH} does not exist at {base_rev} (new file).");
+        return;
+    };
+
+    let baseline = Matrix::parse(&text)
+        .unwrap_or_else(|e| panic!("bus-proof ratchet: baseline at {base_rev} is unparsable: {e}"))
+        .cells();
+
+    eprintln!(
+        "bus-proof baseline: {base_rev} ({} cells) vs live ({} cells)",
+        baseline.len(),
+        live.len()
+    );
+
+    let bad = downgrades(&baseline, &live);
+    assert!(
+        bad.is_empty(),
+        "\nBUS-PROOF RATCHET: {} cell(s) got WORSE than the merge base:\n\n  {}\n\n\
+         A cell may improve or hold. If a test really was deleted or made vacuous, \
+         that is a coverage regression to argue for in review — not a JSON edit to \
+         slip past a gate.\n",
+        bad.len(),
+        bad.join("\n  ")
+    );
+}
+
+/// The comparator must actually reject downgrades. A ratchet whose detector is
+/// broken is a green gate that guards nothing.
+#[test]
+fn cell_ordering_detects_a_downgrade() {
+    assert!(State::None < State::Shallow && State::Shallow < State::Proven);
+
+    let cell = |c: &str, b: &str| (c.to_string(), b.to_string());
+    let base: BTreeMap<_, _> = [
+        (cell("esp32", "uart"), State::Proven),
+        (cell("esp32", "spi"), State::Shallow),
+        (cell("esp32", "i2c"), State::None),
+    ]
+    .into_iter()
+    .collect();
+
+    // Holding, and improving, are fine.
+    assert!(downgrades(&base, &base).is_empty());
+    let better: BTreeMap<_, _> = base.keys().map(|k| (k.clone(), State::Proven)).collect();
+    assert!(downgrades(&base, &better).is_empty());
+
+    // Every downgrade direction is caught.
+    for (bus, to) in [
+        ("uart", State::Shallow),
+        ("uart", State::None),
+        ("spi", State::None),
+    ] {
+        let mut worse = base.clone();
+        worse.insert(cell("esp32", bus), to);
+        let hits = downgrades(&base, &worse);
+        assert_eq!(
+            hits.len(),
+            1,
+            "downgrade esp32/{bus} -> {} missed",
+            to.label()
+        );
+        assert!(hits[0].starts_with(&format!("esp32/{bus}: ")), "{hits:?}");
+    }
+
+    // Deleting a cell is a downgrade, not a way out.
+    let mut deleted = base.clone();
+    deleted.remove(&cell("esp32", "uart"));
+    assert_eq!(downgrades(&base, &deleted).len(), 1);
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 pub mod builtin_chip_self_contained;
 #[cfg(test)]
+pub mod bus_proof_matrix;
+#[cfg(test)]
 pub mod device_identity_one_home;
 #[cfg(test)]
 pub mod esp32;
@@ -26,6 +28,8 @@ pub mod nrf52;
 pub mod peripheral_reachability;
 #[cfg(test)]
 pub mod rp2040;
+#[cfg(test)]
+pub mod rp2040_spi_carries_a_byte;
 #[cfg(test)]
 pub mod scb_reset;
 #[cfg(test)]

--- a/crates/core/src/tests/rp2040_spi_carries_a_byte.rs
+++ b/crates/core/src/tests/rp2040_spi_carries_a_byte.rs
@@ -1,0 +1,172 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! RP2040 SPI: a byte goes into the shift engine and the same byte comes back.
+//!
+//! Why this file exists
+//! ====================
+//! `validation/bus_proof_matrix.json` recorded `rp2040/spi` as `shallow`, and
+//! the reason was not that the evidence was weak — it was that the evidence ran
+//! nowhere. `examples/tier1-fixture/rp2040/src/main.rs::check_spi` already does
+//! the real thing: put the PL022 in internal loopback (`CR1.LBM`), write `0xA5`
+//! to `SSPDR`, wait for `SR.RNE`, and require the byte read back to be `0xA5`.
+//! Its ELF is committed and sha256-pinned (`tests/fixtures/tier1/MANIFEST.json`).
+//!
+//! But the only things that read its verdict were `tier1_matrix` (which asserts
+//! the row has the right NUMBER of cells, not that `spi` passed) and
+//! `tier1_matrix_ratchet` (`#[cfg_attr(debug_assertions, ignore)]`, invoked only
+//! by `core-full` — nightly / `workflow_dispatch` / `[full-ci]`). An RP2040 SPI
+//! regression could not fail a PR.
+//!
+//! This test closes that: it lives under `crates/core/src/tests/`, so
+//! `cargo test --lib` picks it up and it runs in `pr-gate` on EVERY pull
+//! request. It needs no toolchain, no `--release`, and no env var.
+//!
+//! Not vacuous, by construction
+//! ============================
+//! Three ways this could have been a green gate over nothing, all closed:
+//!
+//! 1. A missing fixture would make it silently pass. It does not: the ELF is
+//!    committed, and its absence is an `assert!`, not a `return`.
+//! 2. `TIER1 spi PASS` could be printed by a fixture whose `check_spi` had been
+//!    weakened to a register poke. So the test also reads the fixture's SOURCE
+//!    and requires the `0xA5` comparison to still be in it. Weakening the check
+//!    breaks this test even if the stale ELF keeps printing PASS.
+//! 3. `contains("TIER1 spi PASS")` would also be satisfied by an empty-ish
+//!    transcript in a future where the marker changed. So the test additionally
+//!    requires `TIER1 spi FAIL` to be absent AND the transcript to be non-empty,
+//!    and prints the captured bytes so a lane log can tell "ran and saw the
+//!    transcript" from "was skipped".
+
+use crate::bus::SystemBus;
+use crate::Machine;
+use labwired_config::{ChipDescriptor, SystemManifest};
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+/// Minimal PT_LOAD walk. Deliberately does NOT use `labwired-loader`: that
+/// crate depends on `labwired-core`, so calling it from inside core's own lib
+/// tests pulls a second copy of `ProgramImage` into the graph and the types no
+/// longer unify. `tests::nrf52` bypasses it the same way, for the same reason.
+fn load_elf_image(path: &Path) -> crate::memory::ProgramImage {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let elf = goblin::elf::Elf::parse(&bytes).expect("parse ELF");
+    let mut image = crate::memory::ProgramImage::new(elf.entry, crate::Arch::Arm);
+    for ph in &elf.program_headers {
+        if ph.p_type != goblin::elf::program_header::PT_LOAD || ph.p_filesz == 0 {
+            continue;
+        }
+        let off = ph.p_offset as usize;
+        let size = ph.p_filesz as usize;
+        image.add_segment(ph.p_paddr, bytes[off..off + size].to_vec());
+    }
+    image
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+/// Budget. `check_spi` is the FOURTH check the fixture runs (clock, timer,
+/// gpio, then spi), so the verdict lands early; the loop below stops the moment
+/// the line arrives, so this is a ceiling, not a cost.
+const MAX_STEPS: u64 = 4_000_000;
+
+#[test]
+fn rp2040_spi_loopback_carries_a_real_byte_under_firmware() {
+    let root = repo_root();
+
+    // ── the claim's other half: the fixture must still MAKE the comparison ──
+    let fixture_src = root.join("examples/tier1-fixture/rp2040/src/main.rs");
+    let src = std::fs::read_to_string(&fixture_src)
+        .unwrap_or_else(|e| panic!("read {}: {e}", fixture_src.display()));
+    let spi_body = src
+        .split_once("fn check_spi()")
+        .map(|(_, rest)| rest.split_once("\n}").map(|(b, _)| b).unwrap_or(rest))
+        .expect("examples/tier1-fixture/rp2040/src/main.rs has no check_spi");
+    for needed in ["CR1_LBM", "0xA5", "SR_RNE", "spi-data"] {
+        assert!(
+            spi_body.contains(needed),
+            "rp2040 tier-1 check_spi no longer contains `{needed}`. This test asserts that \
+             `TIER1 spi PASS` means a byte round-tripped through the PL022 shift engine; if \
+             check_spi has been reduced to a register poke, that claim is no longer true. \
+             Fix check_spi, or downgrade rp2040/spi in validation/bus_proof_matrix.json."
+        );
+    }
+
+    // ── run the committed firmware ──────────────────────────────────────────
+    // The tier-1 rp2040 target is a fast-boot ELF-entry target (see
+    // `TIER1_TARGETS` in crates/cli/src/tier1.rs), so the mask ROM at address 0
+    // must not shadow flash — same opt-out as `tests::rp2040::rp2040_bus()`.
+    std::env::set_var("LABWIRED_RP2040_BOOTROM", "");
+
+    let elf = root.join("tests/fixtures/tier1/rp2040.elf");
+    assert!(
+        elf.exists(),
+        "committed fixture missing: {}. It is a plain binary in git (sha256 in \
+         tests/fixtures/tier1/MANIFEST.json), not LFS — a checkout without it is broken, \
+         and this test refuses to pass over the gap.",
+        elf.display()
+    );
+
+    let system_path = root.join("configs/systems/rp2040-pico.yaml");
+    let mut manifest = SystemManifest::from_file(&system_path)
+        .unwrap_or_else(|e| panic!("load {}: {e}", system_path.display()));
+    let chip_path = system_path.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path)
+        .unwrap_or_else(|e| panic!("load {}: {e}", chip_path.display()));
+    manifest.chip = chip_path.to_str().unwrap().to_string();
+
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build rp2040 bus");
+    let sink = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(sink.clone(), false);
+
+    let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+    let image = load_elf_image(&elf);
+    machine.load_firmware(&image).expect("load firmware");
+
+    let mut steps = 0u64;
+    while steps < MAX_STEPS {
+        if machine.step().is_err() {
+            break;
+        }
+        steps += 1;
+        // Poll cheaply; the verdict line is short and lands early.
+        if steps % 20_000 == 0 {
+            let seen = String::from_utf8_lossy(&sink.lock().unwrap()).into_owned();
+            if seen.contains("TIER1 spi PASS") || seen.contains("TIER1 spi FAIL") {
+                break;
+            }
+        }
+    }
+
+    let uart = String::from_utf8_lossy(&sink.lock().unwrap()).into_owned();
+    eprintln!(
+        "rp2040 tier-1 fixture: steps={steps} uart_bytes={} transcript:\n{}",
+        uart.len(),
+        uart.trim()
+    );
+
+    assert!(
+        !uart.is_empty(),
+        "no UART bytes at all after {steps} steps — the fixture did not run, so a `PASS` \
+         check below would have been vacuous"
+    );
+    assert!(
+        !uart.contains("TIER1 spi FAIL"),
+        "rp2040 SPI loopback FAILED in firmware. `spi-no-rx` = the byte never reached the RX \
+         FIFO; `spi-data` = it arrived corrupted. Transcript:\n{uart}"
+    );
+    assert!(
+        uart.contains("TIER1 spi PASS"),
+        "the rp2040 tier-1 fixture never reported an SPI verdict within {MAX_STEPS} steps. \
+         Transcript:\n{uart}"
+    );
+}

--- a/validation/bus_proof_matrix.json
+++ b/validation/bus_proof_matrix.json
@@ -1,0 +1,534 @@
+{
+  "$schema_note": "Per-chip UART/SPI/I2C evidence. THE GATE for this file is crates/core/src/tests/bus_proof_matrix.rs, which runs in core-ci's `pr-gate` job (cargo test --lib) on every pull request. Read that file's module docs before editing this one. States: proven | shallow | none. proven = real firmware moved observable data. shallow = evidence exists but asserts register state only, OR moves bytes without firmware, OR is #[ignore]d / self-skips and therefore passes vacuously. none = nothing.",
+  "chip_set_derived_from": "configs/chips/*.yaml minus ci-fixture-* (same rule as crates/core/src/tests/builtin_chip_self_contained.rs). This is a SUPERSET of the `chip:` values in the superproject's packages/board-config/src/boards.ts BOARDS array, which is why a new BOARDS chip cannot dodge this gate: it cannot ship without its chip yaml. `in_boards` records BOARDS membership as of 2026-08-03 and is informational only.",
+  "surveyed": "2026-08-03",
+  "chips": {
+    "esp32": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/esp32_classic_walk_differential.rs",
+        "test": "esp32_classic_serial_reaches_sink_under_browser_policy",
+        "signal": "the committed tests/fixtures/tier1/esp32.elf runs under the BROWSER's event-scheduler policy and the test asserts the UART TX sink is non-empty, printing sink_bytes=N as evidence",
+        "lane": "core-ci / pr-scheduler-observable - EVERY PULL REQUEST (cargo test -p labwired-core --features event-scheduler --test esp32_classic_walk_differential -- --nocapture)"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/esp32/src/main.rs",
+        "test": "check_spi",
+        "gap": "the fixture's own comment says it: 'No SPI device is attached in the tier-1 setup; the streamed bytes go nowhere'. Asserts FIFO word storage + CMD.USR self-clear. The real device-level SPI proofs exist but run in NO lane: examples/esp32-bay-occupancy (ILI9341 over SPI3, panel ink 6610/6610/6352) has no committed ELF and no workflow, and crates/core/tests/e2e_labwired_ereader.rs silently `return`s at line 69 unless LABWIRED_EREADER_ELF points at an ELF - grep over .github/workflows/ finds neither that var nor LABWIRED_REQUIRE_EREADER_ELF anywhere.",
+        "lane": "none"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "examples/tier1-fixture/esp32/src/main.rs",
+        "test": "check_i2c",
+        "signal": "phase 2 of the fixture does a full write-pointer / repeated-start / read against the board-level BMP280 model that configure_xtensa_esp32 attaches at 0x76 (crates/core/src/system/xtensa/esp32.rs:565), and requires the byte back to be the real CHIP_ID 0x58; phase 1 requires an absent 0x20 to NACK. Reported as TIER1 i2c PASS over the real UART.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC) via tier1_matrix; also core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the arduino-matrix INA219 cell is a second, independent proof on this chip."
+      }
+    },
+    "esp32c3": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_esp32c3_demo_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'ESP OK\\\\n' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/esp32c3/src/main.rs",
+        "test": "check_spi",
+        "gap": "fixture comment: 'With no device on the bus the controller shifts in an idle (pulled-high) MISO line'. Asserts USR self-clear, TRANS_DONE and W0 == 0xFFFFFFFF. No configs/systems/*.yaml attaches an SPI device to an esp32c3 bus anywhere in the repo.",
+        "lane": "core-ci / core-full (nightly) via tier1_matrix"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "crates/cli/tests/e2e_leo_airquality.rs",
+        "test": "leo_normal_scenario_boots_all_sensors_and_flips_verdict",
+        "signal": "a committed ELF running UNMODIFIED Sensirion vendor drivers (SCD41/SGP41/SPS30) plus VEML7700 and an SSD1306 decodes real sensor values over the C3 I2C0 command-list engine; the test asserts the decoded values drive a verdict state machine and that assert_oled_rendered counts >200 lit pixels in the panel's own framebuffer",
+        "lane": "core-nightly (cron 03:05 UTC): cargo test --release -p labwired-cli --test e2e_leo_airquality",
+        "note": "tier1 check_i2c (BMP280 CHIP_ID 0x58) and the arduino-matrix INA219 cell are two further independent proofs on this chip."
+      }
+    },
+    "esp32s3": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L0_serial_boot/src/main.ino",
+        "test": "LW_L0_OK",
+        "signal": "real PlatformIO-compiled Arduino firmware; the sim captures hardware UART0/USARTx bytes and a uart_contains oracle matches the LW_L0_OK marker printed from setup()",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "crates/core/tests/esp32s3_gpspi_oracle.rs",
+        "test": "gpspi_cpu_transfer_executes_and_latches_done",
+        "gap": "a synthetic register-level CPU-mode transfer with NO device attached (MISO reads the 0xFFFFFFFF idle); asserts USR auto-clear, TRANS_DONE latch and length-bounded fill. Not firmware-driven. examples/tier1-fixture/esp32s3 has no check_spi at all and docs/coverage/tier1-matrix.json records esp32s3/spi as 'na'; no manifest attaches an SPI device to an esp32s3 bus.",
+        "lane": "core-ci / core-full (nightly) via cargo test --workspace"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "crates/core/tests/e2e_i2c_tmp102.rs",
+        "test": "i2c_tmp102_firmware_runs_and_prints_temperature",
+        "signal": "real esp-hal firmware from examples/esp32s3-i2c-tmp102 talks to a real TMP102 model through the production manifest/factory path; the test asserts monotonically-drifting decoded 'T = ...' lines over the USB-Serial-JTAG sink AND a GPIO2 threshold crossing once the decoded temperature passes 30 C",
+        "lane": "core-nightly / esp32s3-fixtures-e2e (cron 03:05 UTC, --features esp32s3-fixtures)",
+        "note": "ensure_firmware_built() panics loudly if the +esp toolchain is absent - it does not skip. The arduino-matrix INA219 cell is a second, independent proof on this chip."
+      }
+    },
+    "esp32s3-zero": {
+      "in_boards": false,
+      "uart": {
+        "state": "none",
+        "gap": "no test loads configs/chips/esp32s3-zero.yaml and moves a byte. strict_onboarding.rs explicitly SKIPs the stem ('Xtensa covered by hw-oracle / e2e fixture tests'), and crates/cli/src/tier1.rs folds the board variant into the esp32s3 row ('one row per SILICON'). The esp32s3 evidence does not transfer: every one of those tests loads configs/chips/esp32s3.yaml."
+      },
+      "spi": {
+        "state": "none",
+        "gap": "same as uart: nothing loads this chip descriptor and drives a bus."
+      },
+      "i2c": {
+        "state": "none",
+        "gap": "same as uart: nothing loads this chip descriptor and drives a bus."
+      }
+    },
+    "mkw41z4": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_kw41z_smoke_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'KW41Z_SMOKE_OK\\\\n' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_kw41z_lcd_renders_screen",
+        "signal": "boots the unmodified kw41z-lcd-activity.elf, then reads the PCD8544 panel MODEL's own framebuffer back and confirms the display was turned on and real pixels were drawn - i.e. the DSPI master actually clocked the bytes into the panel. kw41z_lcd_bus_trace_captures_i2c_and_spi in the same file independently asserts a BusPayload::Spi frame on spi0.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "kw41z_lcd_bus_trace_captures_i2c_and_spi",
+        "signal": "the universal bus-trace logic analyzer captures, from unmodified firmware, an I2C address frame for the FXOS8700 at 0x1f AND at least one I2cSym::Data event on i2c1; test_kw41z_zephyr_fxos8700_survival additionally asserts the decoded 'AX=' reading reaches UART",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      }
+    },
+    "nrf52832": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L0_serial_boot/src/main.ino",
+        "test": "LW_L0_OK",
+        "signal": "real PlatformIO-compiled Arduino firmware; the sim captures hardware UART0/USARTx bytes and a uart_contains oracle matches the LW_L0_OK marker printed from setup()",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "firmware_survival.rs also has an nrf52832_demo case, but its expected_uart_output is b\"\" and assert_uart_contains short-circuits on an empty expectation - that case proves nothing about UART."
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/nrf52832/src/main.rs",
+        "test": "check_spi",
+        "gap": "SPIM EasyDMA is STARTed and EVENTS_END/TXD.AMOUNT/RXD.AMOUNT are checked - counts, not content. It never compares SPI_RX_BUF against SPI_TX_BUF, so it cannot tell a transferred byte from garbage.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "nrf52840": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_nrf52840_demo_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'NRF52840_SMOKE_OK\\\\n' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/nrf52840/src/main.rs",
+        "test": "check_spi",
+        "gap": "SPIM EasyDMA is STARTed and EVENTS_END/TXD.AMOUNT/RXD.AMOUNT are checked - counts, not content. crates/core/tests/nrf52_spim_easydma_executing.rs DOES prove real RAM byte movement, but from a hand-built SystemBus with no chip config and no firmware.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03. sim_input_reachability.rs attaches a real ADXL345 to the Nrf52Twim but reads it back by calling the Rust device object directly, bypassing the TWIM TASKS/EasyDMA registers entirely."
+      }
+    },
+    "nrf5340": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_nrf5340_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nrf5340dk/nrf5340/cpuapp' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "none",
+        "gap": "no SPI/SPIM test, example, firmware crate or system manifest references nrf5340 SPI anywhere."
+      },
+      "i2c": {
+        "state": "none",
+        "gap": "no TWIM/I2C test, example, firmware crate or system manifest references nrf5340 I2C anywhere. The chip is also not in the arduino matrix."
+      }
+    },
+    "nrf54l15": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_nrf54l15_smoke_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'nRF54L15 boot OK' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "none",
+        "gap": "no SPI/SPIM test, example or manifest references nrf54l15 SPI. configs/systems/nrf54l15dk.yaml, smart-ring.yaml and examples/nrf54l15-dk wire GPIO and TWIM devices only."
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "crates/core/tests/nrf54l15_smart_ring_probe.rs",
+        "test": "smart_ring_firmware_reads_all_four_sensor_ids_over_i2c",
+        "signal": "the committed nrf54l15-smart-ring.elf does WHO_AM_I reads of four device models on TWIM21 and the test asserts each returned that model's REAL datasheet identity (BMI270 0x24, MAX30102 0x15, TMP117 0x0117, DRV2605 0xE0), that nothing NACKed, and that the firmware's 0xEE RX-buffer poison sentinel did not survive - a stub or a no-op cannot pass",
+        "lane": "core-ci / core-full (nightly 02:30 UTC): cargo test --workspace",
+        "note": "the strongest single bus proof in the repo. Fixture absence is a hard assert!, not a skip. It runs nightly only: core-integrity's push gate runs --lib plus four named --test targets, and this is not one of them."
+      }
+    },
+    "rp2040": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_rp2040_demo_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'RP2040_SMOKE_OK\\\\n' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "proven",
+        "file": "crates/core/src/tests/rp2040_spi_carries_a_byte.rs",
+        "test": "rp2040_spi_loopback_carries_a_real_byte_under_firmware",
+        "signal": "the committed tests/fixtures/tier1/rp2040.elf runs in-sim; its check_spi puts the PL022 in internal loopback (CR1.LBM), writes 0xA5 to SSPDR, waits for SR.RNE and requires the byte read back to be 0xA5. The test asserts 'TIER1 spi PASS' on the real UART sink, asserts 'TIER1 spi FAIL' is absent, asserts the transcript is non-empty, and separately re-reads the fixture SOURCE to require the 0xA5 comparison still exists so a weakened check cannot keep the claim alive on a stale ELF.",
+        "lane": "core-ci / pr-gate - EVERY PULL REQUEST (cargo test --lib over default-members)",
+        "note": "watched fail first: forcing the loopback path off in peripherals/rp2040/spi.rs makes the firmware print 'TIER1 spi FAIL code=spi-data' and the test go red. It is internal loopback, not an external device - the byte round-trips through the shift engine, nothing on the board receives it."
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03. rp2040_i2c_irq_delivery.rs drives the real shipped chip through Machine::advance but asserts only NVIC.ISPR bits; the byte-content proof in peripherals/rp2040/i2c.rs is a bare unit test with no chip and no firmware."
+      }
+    },
+    "stm32f103": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32f103_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_f103rb' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32f103/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "stm32f401": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32f401_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_f401re' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival",
+        "note": "the sibling stm32f401_blinky case sets expected_uart_output: b\"\" with the comment 'F401 board model does not yet produce deterministic UART bytes end-to-end' - that case is a no-op; the zephyr case is the real one."
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32f401/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "stm32f401cdu6": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "examples/stm32f401cdu6/uart-smoke.yaml",
+        "test": "uart_contains: \"OK\"",
+        "signal": "firmware-f401-demo writes 'O','K','\\n' straight to USART2->DR and the script runner's uart_contains oracle matches them on the captured sink, against configs/systems/stm32f401cdu6.yaml",
+        "lane": "core-onboarding-smoke / onboarding-stm32f401cdu6 (push to main + schedule; NOT on PRs)",
+        "note": "thin but real: a 3-byte bare DR write inside a 64-step budget, and it runs the GENERIC firmware-f401-demo crate, not the chip-specific firmware-f401cdu6-blackpill-demo."
+      },
+      "spi": {
+        "state": "none",
+        "gap": "nothing exercises SPI on this chip descriptor. It has no tier-1 fixture (absent from TIER1_TARGETS), is not in the arduino matrix, and is named in strict_onboarding.rs's SMOKE_LESS_ALLOWLIST so the generic onboarding gate skips it."
+      },
+      "i2c": {
+        "state": "none",
+        "gap": "crates/firmware-f401cdu6-blackpill-demo/src/i2c_smoke.rs and examples/stm32f401cdu6-blackpill/i2c-smoke.yaml exist and do a real address+data write expecting an ACK - but that yaml is referenced by NO workflow and NO test, and its own system.yaml declares external_devices: [], so if it ever ran it would NACK. Dead code, not coverage."
+      }
+    },
+    "stm32f407": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_nucleo_f407_smoke_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'the F407 smoke transcript' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32f407/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "crates/core/tests/e2e_stm32f407_i2c.rs",
+        "test": "firmware_drives_aht20_and_bmp280_through_simulator",
+        "signal": "real cross-built firmware drives the AHT20 and BMP280 models through the F407 I2C1 state machine; the test asserts GPIOA.ODR bit 5 goes high, a branch the firmware only takes once AHT20 BUSY has cleared AND the BMP280 returned chip-ID 0x58",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test e2e_stm32f407_i2c",
+        "note": "the arduino-matrix INA219 cell is a second, independent proof on this chip."
+      }
+    },
+    "stm32f411ceu6": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/cli/src/tier1.rs",
+        "test": "\"stm32f411\"",
+        "signal": "the committed tests/fixtures/tier1/stm32f411.elf boots against configs/chips/stm32f411ceu6.yaml and the harness parses the real TIER1 protocol transcript out of the captured UART; parse_tier1_uart treats 'TIER1 done' arriving at all as the UART proof",
+        "lane": "core-ci / core-full (nightly 02:30 UTC): cargo test --release -p labwired-cli --test tier1_matrix --test tier1_matrix_ratchet",
+        "note": "this chip is NOT in the arduino matrix and has no firmware_survival case, so tier-1 is its only bus evidence of any kind."
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32f411/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32f411/src/main.rs",
+        "test": "check_i2c",
+        "gap": "firmware-driven, but it only addresses an ABSENT slave and requires the NACK. That proves the arbitration path, not that any device ever received or returned data.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      }
+    },
+    "stm32g474re": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32g474_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_g474re' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32g474re/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "stm32h563": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32h563_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_h563zi' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32h563/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "stm32h735": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "examples/stm32h735-smoke/io-smoke.yaml",
+        "test": "uart_contains: \"TIER1 done\"",
+        "signal": "the committed tests/fixtures/tier1/stm32h735.elf runs against examples/stm32h735-smoke/system.yaml and the script runner's uart_contains oracles match the real TIER1 transcript lines on the captured UART - no cross-compile needed",
+        "lane": "core-ci / core-full (nightly 02:30 UTC): cargo test --workspace runs crates/core/tests/strict_onboarding.rs; also tier1_matrix in the same job",
+        "note": "this chip has NO firmware_survival case and is NOT in the arduino matrix."
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32h735/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32h735/src/main.rs",
+        "test": "check_i2c",
+        "gap": "firmware-driven, but it only addresses an ABSENT slave and requires the NACK. That proves the arbitration path, not that any device ever received or returned data.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      }
+    },
+    "stm32l073": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32l073_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_l073rz' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32l073/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "stm32l476": {
+      "in_boards": true,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32l476_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_l476rg' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "proven",
+        "file": "crates/core/tests/world_multichip.rs",
+        "test": "master_chip_reaches_operate_with_real_sensor_chip",
+        "signal": "two independent L476 chip instances run real firmware; a real SN74HC165 shift register is attached on spi1 (examples/iolink-station/sensor/system.yaml) and its 0xA5 preset is read over SPI by the sensor chip, sent across the modelled C/Q UART wire, and read back out of the master chip's RAM by ELF symbol (g_master_pd0). A specific payload byte survives the whole path.",
+        "lane": "core-board-ci / iolink-station-l476 (gate: true in configs/ci/boards.yml, runs on pull_request; path-filtered to configs|examples|hil|platformio)",
+        "note": "VACUITY WATCH: skip_or_fail_missing_elfs() returns silently unless LABWIRED_REQUIRE_IOLINK_ELFS is set. Only examples/iolink-station/ci/test.sh sets it. In any OTHER lane that runs cargo test --workspace this same file silently skips."
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03. firmware_survival's nucleo_l476rg_i2c case and firmware-l476-demo's 'I2C1 OK' are register/status fingerprints only - no device ever ACKs there. The nokia5110 PCD8544 framebuffer tests would be strong SPI evidence but every test in those three files is #[ignore]d and no workflow passes --ignored."
+      }
+    },
+    "stm32wb55": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32wb55_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_wb55rg' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32wb55/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    },
+    "stm32wba52": {
+      "in_boards": false,
+      "uart": {
+        "state": "proven",
+        "file": "crates/core/tests/firmware_survival.rs",
+        "test": "test_stm32wba52_zephyr_survival",
+        "signal": "committed ELF fixture booted in-sim; assert_uart_contains matches 'Hello World! nucleo_wba52cg' on a real bus.attach_uart_tx_sink capture. Fixture absence is a hard assert!, not a skip.",
+        "lane": "core-ci / core-integrity (push to main): cargo test -p labwired-core --test firmware_survival"
+      },
+      "spi": {
+        "state": "shallow",
+        "file": "examples/tier1-fixture/stm32wba52/src/main.rs",
+        "test": "check_spi",
+        "gap": "firmware-driven, but nothing is on the far end of the bus: the fixture writes the data register and then asserts BSY/TXE/EOT flags. No device receives a byte, so this cannot distinguish a working shift engine from one that only moves status bits.",
+        "lane": "core-ci / core-full (nightly 02:30 UTC + workflow_dispatch + '[full-ci]') via tier1_matrix + tier1_matrix_ratchet"
+      },
+      "i2c": {
+        "state": "proven",
+        "file": "validation/arduino-matrix/sketches/L3_i2c_sensor/src/main.ino",
+        "test": "LW_L3_OK",
+        "signal": "real Arduino firmware writes a register-pointer byte to the INA219 model attached at 0x40 in validation/arduino-matrix/systems/<chip>.yaml and Wire.endTransmission() returns 0 (the device ACKed); the verdict LW_L3_OK then comes back as real bytes on the modelled UART, matched by a uart_contains oracle",
+        "lane": "core-arduino-matrix-smoke / arduino-matrix-gate (nightly 02:20 UTC + push to main)",
+        "note": "the ACK is meaningful because the same chips' tier-1 fixtures show an UNMATCHED address NACKs (esp32 check_i2c addr 0x20, stm32 NACKF, rp2040 ABRT_7B_ADDR_NOACK) - the bus does not blanket-ACK. LIMIT: this proves address+data out and the device's ACK back, not a payload readback. Evidence: run 30842505709, 'cells=45 expected>=45 fails=0', 2026-08-03."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## The honest picture first

22 shipped chips × 3 buses = 66 cells. **41 proven, 17 shallow, 8 none.**

| chip | BOARDS | UART | SPI | I2C |
|---|---|---|---|---|
| esp32 | yes | proven | **shallow** | proven |
| esp32c3 | yes | proven | **shallow** | proven |
| esp32s3 | yes | proven | **shallow** | proven |
| esp32s3-zero | – | **none** | **none** | **none** |
| mkw41z4 | – | proven | proven | proven |
| nrf52832 | – | proven | **shallow** | proven |
| nrf52840 | yes | proven | **shallow** | proven |
| nrf5340 | – | proven | **none** | **none** |
| nrf54l15 | yes | proven | **none** | proven |
| rp2040 | yes | proven | proven ← *closed in this PR* | proven |
| stm32f103 | yes | proven | **shallow** | proven |
| stm32f401 | yes | proven | **shallow** | proven |
| stm32f401cdu6 | yes | proven | **none** | **none** |
| stm32f407 | – | proven | **shallow** | proven |
| stm32f411ceu6 | – | proven | **shallow** | **shallow** |
| stm32g474re | – | proven | **shallow** | proven |
| stm32h563 | yes | proven | **shallow** | proven |
| stm32h735 | yes | proven | **shallow** | **shallow** |
| stm32l073 | – | proven | **shallow** | proven |
| stm32l476 | yes | proven | proven | proven |
| stm32wb55 | – | proven | **shallow** | proven |
| stm32wba52 | – | proven | **shallow** | proven |

Every cell's citation, observable, CI lane and gap is in `validation/bus_proof_matrix.json`.

**UART is genuinely solid. SPI is the hole: 16 of 22 chips have no proof a byte reaches anything.**

## What "shallow" means here, concretely

The tier-1 `spi` and `i2c` cells that read ✅ in `docs/coverage/tier1-scoreboard.md` are, on most chips, the fixture's self-report about its **own registers**: SPI writes `DR` and polls `BSY` with nothing on MISO; I²C STARTs an **absent** address and requires the NACK. `examples/tier1-fixture/*/src/main.rs` says so outright — *"No SPI device is attached in the tier-1 setup; the streamed bytes go nowhere."*

The exceptions, which are real: classic-ESP32 and C3 tier-1 `check_i2c` reads BMP280 `CHIP_ID = 0x58` back from a board-level device model; RP2040 `check_spi` does a genuine `0xA5` PL022 loopback compare.

## Two of the three "known-good anchors" are vacuous in CI

Verified by grep over `.github/workflows/`, rechecked in Python:

- `e2e_labwired_ereader` `return`s at line 69 unless `LABWIRED_EREADER_ELF` is set. **No workflow sets it, or `LABWIRED_REQUIRE_EREADER_ELF`.** It is not `#[ignore]`d, so `cargo test --workspace` runs it every time and it silently no-ops every time.
- `esp32c3_shipped_lab_batch_gate` is `#[ignore]`d **and** needs `LABWIRED_WASM_DIR`. Neither is ever set here.
- `examples/esp32-bay-occupancy` (12/12, ILI9341 + TCA9548A) has **no committed ELF and no workflow** — absent from `configs/ci/boards.yml` and outside `scripts/example_smokes.sh`'s glob.

Also dormant: every test in `e2e_nokia5110_invaders.rs` / `capture_nokia5110_frames.rs` / `nokia5110_pcd8544_differential.rs` is `#[ignore]`d and nothing passes `--ignored`; `openai_deck_s3_boot.rs` (the best-designed S3 I²C proof in the tree) is referenced by zero workflows.

## The strongest evidence nobody had written down

`validation/arduino-matrix` is the real cross-chip I²C proof: 15 chips × real PlatformIO Arduino firmware × a real INA219 model on `Wire`, with the verdict returning as real UART bytes matched by a `uart_contains` oracle. It ran **today** and is green:

```
arduino-matrix-gate  cells=45 expected>=45 fails=0
arduino-matrix-gate  arduino matrix gate: full fleet pass (pass|skipped ok)
```
(run 30842505709, 2026-08-03T18:47Z — 45 real passes, zero `skipped`)

The ACK is meaningful because the same chips' tier-1 fixtures show an **unmatched** address NACKs, so the bus does not blanket-ACK. Limit, recorded in the cell's `note`: it proves address+data out and the device's ACK back, not a payload readback.

## `arduino-matrix-gate` — the required-check hazard is NOT real

`core-arduino-matrix-smoke.yml` says `# Required status: arduino-matrix-gate (branch protection)` and never triggers on `pull_request`. But branch protection actually requires only:

```
$ gh api repos/w1ne/labwired-core/branches/main/protection --jq '.required_status_checks.contexts'
["pr-gate","release-runner-contract"]
```

So no branch can be blocked by it. **The comment is stale, not the config.** Reported, not silently fixed.

## The gate

`crates/core/src/tests/bus_proof_matrix.rs` — under `crates/core/src/tests/`, so `cargo test --lib` picks it up and it runs in **`pr-gate` on every PR**.

One source of truth: the JSON. The Rust keeps no second copy of the verdicts, only the rules.

- **Structural arm** (no git, no fixtures): chip set DERIVED from `configs/chips/*.yaml` minus `ci-fixture-*` — the same rule as `builtin_chip_self_contained.rs`, and a superset of the superproject's `BOARDS` chips, so a new `BOARDS` chip cannot ship without a row. A non-`none` cell must cite a file that **exists** and a test name that literally appears in it; a `proven` cell must also name the observable and the lane. Typing `"proven"` does not make a cell green.
- **Ratchet arm**: every cell compared to the same file at `git merge-base HEAD origin/main`. `proven` may not become `shallow` or `none`; deleting a cell counts as a downgrade. The baseline is outside the change. Fatal under `CI` if it cannot be resolved.
- `cell_ordering_detects_a_downgrade` watches the comparator reject each downgrade direction; `baseline_plumbing_can_read_the_merge_base` closes the window before the file exists on main, where broken git plumbing would look identical to "no baseline yet".

### Watched it fail first

```
### fabricate a PROVEN citation ###
  stm32h735/spi: `test_h735_spi_definitely_exists` does not appear in
  `crates/core/tests/firmware_survival.rs`. … or the citation was invented.

### delete a chip row ###
  these chips ship (configs/chips/<id>.yaml) but have NO row: ["nrf54l15"].

### a NEW chip ships with no row ###
  these chips ship (configs/chips/<id>.yaml) but have NO row: ["zzz-new-silicon"].
```

## The one gap closed: rp2040/spi

`examples/tier1-fixture/rp2040/check_spi` already did the real thing — PL022 internal loopback, write `0xA5`, wait `SR.RNE`, require `0xA5` back — with a committed, sha256-pinned ELF. Nothing read the verdict: `tier1_matrix` only checks the row has the right *number* of cells, and `tier1_matrix_ratchet` is `#[cfg_attr(debug_assertions, ignore)]` and only invoked by `core-full`. An RP2040 SPI regression could not fail a PR.

`crates/core/src/tests/rp2040_spi_carries_a_byte.rs` runs that firmware in `pr-gate` — 0.2 s, no toolchain, no env var:

```
rp2040 tier-1 fixture: steps=20000 uart_bytes=177 transcript:
TIER1 clock PASS
TIER1 timer PASS
TIER1 gpio PASS
TIER1 spi PASS
…
TIER1 done
```

Non-vacuous by construction: missing fixture is an `assert!` not a `return`; it asserts `FAIL` is absent and the transcript non-empty; and it re-reads the fixture **source** to require the `0xA5` comparison still exists, so a weakened `check_spi` cannot keep the claim alive on a stale ELF.

**Watched it fail first** — disabling the loopback path in `peripherals/rp2040/spi.rs`:

```
TIER1 spi FAIL code=spi-data
rp2040 SPI loopback FAILED in firmware. `spi-no-rx` = the byte never reached
the RX FIFO; `spi-data` = it arrived corrupted.
test result: FAILED. 0 passed; 1 failed
```

## Verification

- `cargo test -p labwired-core --lib` — **2562 passed, 0 failed** (pristine baseline on `origin/main` 97ddb7c6: 2557 passed, 0 failed; +5 new tests).
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --all` clean.
- No existing lab touched. This PR adds one JSON file and two test files and changes nothing an engine reads — no throughput or byte-identity surface is in the diff.

## Not done, deliberately

- **SPI on 16 chips.** The honest fix is an `L4_spi_device` sketch in the arduino matrix mirroring L3 (a real SPI device in each `validation/arduino-matrix/systems/*.yaml`, verdict over UART). That is a fleet-wide firmware+manifest job, not a follow-on to this one.
- `esp32s3-zero`, `stm32f401cdu6`, `nrf5340` are the thinnest rows. `stm32f401cdu6` is the cheapest: `crates/firmware-f401cdu6-blackpill-demo/src/i2c_smoke.rs` and `examples/stm32f401cdu6-blackpill/i2c-smoke.yaml` already exist and do a real address+data write expecting an ACK — but the yaml is referenced by no workflow and no test, and its `system.yaml` declares `external_devices: []`, so it would NACK if it ever ran. Add a device, wire the yaml, and the cell moves.