### PR TITLE
Give each test a scratch directory it provably owns

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9,4 +9,5 @@ pub mod coverage;
 pub mod faults;
 pub mod manifest;
 pub mod pc_coverage_report;
+pub mod test_support;
 pub mod tier1;

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1,0 +1,125 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! ONE way for a test to name a scratch directory it owns exclusively.
+//!
+//! # The bug this ends
+//!
+//! Integration tests here named their output directory from a wall-clock
+//! reading:
+//!
+//! ```ignore
+//! let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+//! let out_dir = std::env::temp_dir().join(format!("labwired-cow-{nonce}"));
+//! ```
+//!
+//! `as_nanos()` returns nanoseconds but the clock does not *tick* in
+//! nanoseconds. Measured on the macOS dev host: the smallest non-zero delta
+//! between consecutive readings is **1000 ns**, and 80 000 samples taken across
+//! four threads yielded 6 270 distinct values — a **92 % collision rate**.
+//!
+//! `cargo test` runs a binary's tests in parallel by default, so two tests that
+//! start in the same microsecond get the same "nonce", the same directory, and
+//! then race over one set of files. The observed symptom was
+//! `e2e_kw41z_cow_stimulus` failing with
+//! `parse result.json: expected ',' or '}' at line 616` — line 616 of a
+//! 14 492-line file, i.e. a TRUNCATED read, because the sibling test's
+//! `remove_dir_all` ran while this one was still reading. It is intermittent and
+//! load-dependent, which is what made it read as an unrelated regression when it
+//! surfaced during an unrelated change.
+//!
+//! `std::process::id()` is not a fix either, and several tests use it: every
+//! test inside one integration binary shares a pid, so parallel siblings still
+//! collide. It only separates *binaries*.
+//!
+//! # Why a counter and not a better clock
+//!
+//! Uniqueness here should not be a probability. A process-local
+//! [`AtomicUsize`] cannot repeat within a process no matter how fast tests
+//! start, and the pid separates processes. The timestamp is kept only so a
+//! leftover directory can be dated by a human; nothing depends on it being
+//! distinct.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+/// A temp-directory path unique to this call, for the lifetime of this machine.
+///
+/// Unique by CONSTRUCTION — pid (separates concurrent `cargo test` binaries)
+/// plus a process-local counter (separates parallel tests inside one binary).
+/// Neither can repeat, so there is no collision probability to reason about.
+///
+/// Does not create the directory; the caller decides whether it wants
+/// `create_dir_all`, and remains responsible for cleanup.
+///
+/// ```ignore
+/// let out_dir = labwired_cli::test_support::unique_temp_dir("labwired-cow");
+/// std::fs::create_dir_all(&out_dir).expect("create out dir");
+/// ```
+pub fn unique_temp_dir(prefix: &str) -> PathBuf {
+    std::env::temp_dir().join(unique_name(prefix))
+}
+
+/// The bare directory name [`unique_temp_dir`] would use — for the few callers
+/// that build a file name rather than a directory.
+pub fn unique_name(prefix: &str) -> String {
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{prefix}-{}-{seq}-{stamp}", std::process::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// The property the old timestamp nonce did not have.
+    ///
+    /// Asserted at a rate no wall clock on this host can satisfy: the measured
+    /// granularity is 1 µs, so 10 000 back-to-back timestamp reads would yield
+    /// on the order of tens of distinct values. A counter yields 10 000.
+    #[test]
+    fn names_are_unique_under_back_to_back_calls() {
+        let names: HashSet<String> = (0..10_000).map(|_| unique_name("probe")).collect();
+        assert_eq!(
+            names.len(),
+            10_000,
+            "unique_name must not repeat; this is the collision that made \
+             parallel tests share a scratch directory"
+        );
+    }
+
+    /// Uniqueness must not depend on the caller being single-threaded — the
+    /// failing case was two tests started by the harness at the same instant.
+    #[test]
+    fn names_are_unique_across_threads() {
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                std::thread::spawn(|| (0..2_000).map(|_| unique_name("t")).collect::<Vec<_>>())
+            })
+            .collect();
+        let all: Vec<String> = handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect();
+        let unique: HashSet<&String> = all.iter().collect();
+        assert_eq!(unique.len(), all.len(), "collision across threads");
+    }
+
+    #[test]
+    fn paths_live_under_the_temp_dir_and_carry_the_prefix() {
+        let p = unique_temp_dir("labwired-example");
+        assert!(p.starts_with(std::env::temp_dir()));
+        assert!(p
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("labwired-example-"));
+    }
+}

--- a/crates/cli/tests/breakpoints.rs
+++ b/crates/cli/tests/breakpoints.rs
@@ -7,18 +7,16 @@
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn write_temp_file(prefix: &str, contents: &str) -> PathBuf {
     let mut dir = std::env::temp_dir();
     dir.push("labwired-tests");
     let _ = std::fs::create_dir_all(&dir);
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let path = dir.join(format!("{}-{}.yaml", prefix, nonce));
+    let path = dir.join(format!(
+        "{}.yaml",
+        labwired_cli::test_support::unique_name(prefix)
+    ));
     std::fs::write(&path, contents).expect("Failed to write temp file");
     path
 }
@@ -49,11 +47,7 @@ assertions: []
         ),
     );
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let output_dir = std::env::temp_dir().join(format!("labwired-tests-breakpoint-{}", nonce));
+    let output_dir = labwired_cli::test_support::unique_temp_dir("labwired-tests-breakpoint");
     let _ = std::fs::remove_dir_all(&output_dir);
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))

--- a/crates/cli/tests/e2e_esp32c3_blinky.rs
+++ b/crates/cli/tests/e2e_esp32c3_blinky.rs
@@ -18,7 +18,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -30,11 +29,7 @@ fn repo_root() -> PathBuf {
 #[test]
 fn esp32c3_blinky_blinks_gpio8_and_narrates_over_uart() {
     let root = repo_root();
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let out_dir = std::env::temp_dir().join(format!("labwired-c3-blinky-{nonce}"));
+    let out_dir = labwired_cli::test_support::unique_temp_dir("labwired-c3-blinky");
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))

--- a/crates/cli/tests/e2e_kw41z_cow_stimulus.rs
+++ b/crates/cli/tests/e2e_kw41z_cow_stimulus.rs
@@ -22,7 +22,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -42,11 +41,7 @@ struct CowRun {
 /// `labwired test` CLI and collect its result + UART log.
 fn run_cow(script_rel: &str) -> CowRun {
     let root = repo_root();
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let out_dir = std::env::temp_dir().join(format!("labwired-cow-{nonce}"));
+    let out_dir = labwired_cli::test_support::unique_temp_dir("labwired-cow");
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))

--- a/crates/cli/tests/e2e_leo_airquality.rs
+++ b/crates/cli/tests/e2e_leo_airquality.rs
@@ -19,7 +19,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -39,10 +38,6 @@ struct LeoRun {
 /// `labwired test` CLI and collect its result + UART log.
 fn run_leo(script_rel: &str) -> LeoRun {
     let root = repo_root();
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
     // Scenario name in the dir: the two tests run in parallel threads, and a
     // clock-tick nonce collision would make them share one result.json
     // (interleaved writes -> unparseable JSON).
@@ -51,7 +46,7 @@ fn run_leo(script_rel: &str) -> LeoRun {
         .next()
         .unwrap_or(script_rel)
         .replace(['.', '/'], "-");
-    let out_dir = std::env::temp_dir().join(format!("labwired-leo-{scenario}-{nonce}"));
+    let out_dir = labwired_cli::test_support::unique_temp_dir(&format!("labwired-leo-{scenario}"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))

--- a/crates/cli/tests/e2e_stimulus_reporting.rs
+++ b/crates/cli/tests/e2e_stimulus_reporting.rs
@@ -31,8 +31,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -73,16 +71,7 @@ fn run_script(script_body: &str) -> Run {
     // on every parallel run, a different subset each time, while
     // `--test-threads=1` always passed. The counter makes the name unique
     // regardless of what the clock resolves to.
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let nonce = format!(
-        "{}-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    );
-    let dir = std::env::temp_dir().join(format!("labwired-stimulus-report-{nonce}"));
+    let dir = labwired_cli::test_support::unique_temp_dir("labwired-stimulus-report");
     std::fs::create_dir_all(&dir).expect("create temp dir");
     let script = dir.join("script.yaml");
     std::fs::write(&script, script_body).expect("write script");

--- a/crates/cli/tests/e2e_uart_injection.rs
+++ b/crates/cli/tests/e2e_uart_injection.rs
@@ -15,8 +15,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -68,16 +66,7 @@ fn run_script(root: &std::path::Path, script_yaml: &str) -> InjectionRun {
     // on every parallel run, a different subset each time, while
     // `--test-threads=1` always passed. The counter makes the name unique
     // regardless of what the clock resolves to.
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let nonce = format!(
-        "{}-{}",
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
-    );
-    let out_dir = std::env::temp_dir().join(format!("labwired-uart-injection-{nonce}"));
+    let out_dir = labwired_cli::test_support::unique_temp_dir("labwired-uart-injection");
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let script_path = out_dir.join("script.yaml");
     std::fs::write(&script_path, script_yaml).expect("write script");

--- a/crates/cli/tests/golden_examples.rs
+++ b/crates/cli/tests/golden_examples.rs
@@ -6,7 +6,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -16,11 +15,7 @@ fn repo_root() -> PathBuf {
 }
 
 fn temp_artifacts_dir(prefix: &str) -> PathBuf {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("labwired-golden-{}-{}", prefix, nonce));
+    let dir = labwired_cli::test_support::unique_temp_dir(&format!("labwired-golden-{prefix}"));
     let _ = std::fs::create_dir_all(&dir);
     dir
 }

--- a/crates/cli/tests/interactive_snapshot.rs
+++ b/crates/cli/tests/interactive_snapshot.rs
@@ -5,18 +5,15 @@
 // See the LICENSE file in the project root for full license information.
 
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
 fn test_cli_interactive_writes_snapshot() {
     let firmware = std::fs::canonicalize("../../tests/fixtures/uart-ok-thumbv7m.elf").unwrap();
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let snapshot_path =
-        std::env::temp_dir().join(format!("labwired-interactive-snapshot-{}.json", nonce));
+    let snapshot_path = std::env::temp_dir().join(format!(
+        "{}.json",
+        labwired_cli::test_support::unique_name("labwired-interactive-snapshot")
+    ));
     let _ = std::fs::remove_file(&snapshot_path);
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))

--- a/crates/cli/tests/legacy_schema.rs
+++ b/crates/cli/tests/legacy_schema.rs
@@ -6,7 +6,6 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -20,11 +19,10 @@ fn write_temp_file(prefix: &str, contents: &str) -> PathBuf {
     dir.push("labwired-tests");
     let _ = std::fs::create_dir_all(&dir);
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let path = dir.join(format!("{}-{}.yaml", prefix, nonce));
+    let path = dir.join(format!(
+        "{}.yaml",
+        labwired_cli::test_support::unique_name(prefix)
+    ));
     std::fs::write(&path, contents).expect("Failed to write temp file");
     path
 }

--- a/crates/cli/tests/outputs.rs
+++ b/crates/cli/tests/outputs.rs
@@ -6,18 +6,16 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn write_temp_file(prefix: &str, contents: &str) -> PathBuf {
     let mut dir = std::env::temp_dir();
     dir.push("labwired-tests");
     let _ = std::fs::create_dir_all(&dir);
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let path = dir.join(format!("{}-{}.yaml", prefix, nonce));
+    let path = dir.join(format!(
+        "{}.yaml",
+        labwired_cli::test_support::unique_name(prefix)
+    ));
     std::fs::write(&path, contents).expect("Failed to write temp file");
     path
 }
@@ -123,11 +121,7 @@ bad_field: 123
 "#,
     );
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let output_dir = std::env::temp_dir().join(format!("labwired-tests-config-error-{}", nonce));
+    let output_dir = labwired_cli::test_support::unique_temp_dir("labwired-tests-config-error");
     let _ = std::fs::remove_dir_all(&output_dir);
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
@@ -195,12 +189,7 @@ assertions:
 "#,
     );
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let output_dir =
-        std::env::temp_dir().join(format!("labwired-tests-env-config-error-{}", nonce));
+    let output_dir = labwired_cli::test_support::unique_temp_dir("labwired-tests-env-config-error");
     let _ = std::fs::remove_dir_all(&output_dir);
 
     let output = Command::new(env!("CARGO_BIN_EXE_labwired"))

--- a/crates/cli/tests/runner.rs
+++ b/crates/cli/tests/runner.rs
@@ -6,18 +6,16 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn write_temp_file(prefix: &str, contents: &str) -> PathBuf {
     let mut dir = std::env::temp_dir();
     dir.push("labwired-tests");
     let _ = std::fs::create_dir_all(&dir);
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let path = dir.join(format!("{}-{}.yaml", prefix, nonce));
+    let path = dir.join(format!(
+        "{}.yaml",
+        labwired_cli::test_support::unique_name(prefix)
+    ));
     std::fs::write(&path, contents).expect("Failed to write temp file");
     path
 }

--- a/crates/cli/tests/script_validation.rs
+++ b/crates/cli/tests/script_validation.rs
@@ -6,18 +6,16 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn write_temp_file(prefix: &str, contents: &str) -> PathBuf {
     let mut dir = std::env::temp_dir();
     dir.push("labwired-tests");
     let _ = std::fs::create_dir_all(&dir);
 
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let path = dir.join(format!("{}-{}.yaml", prefix, nonce));
+    let path = dir.join(format!(
+        "{}.yaml",
+        labwired_cli::test_support::unique_name(prefix)
+    ));
     std::fs::write(&path, contents).expect("Failed to write temp file");
     path
 }


### PR DESCRIPTION
## The flake

`e2e_kw41z_cow_stimulus` fails intermittently with:

```
parse result.json: Error("expected `,` or `}`", line: 616, column: 7)
```

Line 616 of a **14,492-line** file — a *truncated read*, not corrupted content. `result.json` contains no trace data, no `bus_trace`, nothing exotic; the reader simply got a partial file. Because it is load-dependent, it presents as a regression in whatever change happens to be in flight when it fires. It did exactly that to #767, where I initially mistook it for my own.

## Cause, measured

Tests name their scratch directory from a wall-clock reading:

```rust
let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
let out_dir = temp_dir().join(format!("labwired-cow-{nonce}"));
```

`as_nanos()` *reports* nanoseconds. The clock does not *tick* in nanoseconds. On the macOS dev host:

| measurement | value |
|---|---|
| smallest non-zero delta between reads | **1000 ns** |
| distinct values in 80,000 samples (4 threads) | **6,270** |
| collision rate | **92%** |

`cargo test` runs a binary's tests in parallel, so two tests starting in the same microsecond get the same directory and race over one set of files — the sibling's `remove_dir_all` lands mid-read.

## Scope: 14 files, two shapes, and two prior private workarounds

- **Per-test output directories** — `labwired-cow-{nonce}` and friends.
- **`write_temp_file`** — writes `{prefix}-{nonce}.yaml` into a **shared** `labwired-tests` directory, so parallel tests could overwrite each other's config outright. This one I only found because removing the first shape broke compilation.

Two files (`e2e_uart_injection.rs`, `e2e_stimulus_reporting.rs`) had **already hand-rolled a private `static SEQ: AtomicU64`** against this exact race — a fix that helped those two and was invisible to the other twelve. Both deleted in favour of one home.

## The fix

`labwired_cli::test_support::unique_temp_dir` makes uniqueness **structural, not probabilistic**:

- **pid** separates concurrent `cargo test` binaries;
- a **process-local `AtomicUsize`** separates parallel tests inside one binary.

Neither can repeat, so there is no collision probability left to reason about. `std::process::id()` alone is *not* sufficient and several call sites relied on it — every test in one integration binary shares a pid, so parallel siblings still collide; it only separates binaries. The timestamp survives purely so a human can date a leftover directory.

Three unit tests pin it, including 10,000 back-to-back names being distinct — a rate no wall clock on this host can satisfy, so that test fails against the scheme it replaces rather than merely passing against the new one.

## Verification

- `cargo test -p labwired-cli` — **183 tests / 40 targets, 0 failures**.
- `cargo clippy -p labwired-cli --all-targets -- -D warnings` — clean.
- Independent of #767; branches off `main`.