### PR TITLE
fix(chips): nRF5340 P0 was entirely shadowed by P1, and SAMD21's bases were truncated on import

### DIFF
--- a/configs/chips/nrf5340.yaml
+++ b/configs/chips/nrf5340.yaml
@@ -13,6 +13,8 @@
 #   the NON-secure alias base 0x50000000 (DT `peripheral@50000000`,
 #   `ranges = <0x0 0x50000000 0x10000000>`), so e.g. UARTE0 = 0x50008000,
 #   CLOCK = 0x50005000, GPIO P0 = 0x50842500.
+# - Peripheral bases cross-checked against tests/fixtures/real_world/nrf5340.svd
+#   (NordicSemiconductor/nrfx v3.12.0, mdk/nrf5340_application.svd).
 # - IRQ numbers are the DT `interrupts` cell (UARTE0=8, CLOCK=5, TIMER0..2=15..17,
 #   RTC0=20, RTC1=21).
 #
@@ -98,37 +100,53 @@ peripherals:
     config:
       debug_schema: "../peripherals/nrf5340/timer2_s.yaml"
 
-  # GPIO P0/P1 — the nRF5340 GPIO block sits at 0x5084_2000, far from the rest
+  # GPIO P0/P1 — the nRF5340 GPIO block sits at 0x5084_2500, far from the rest
   # of the peripheral window.
   #
-  # The devicetree says gpio0@50842500 / gpio1@50842800, but a Nordic GPIO DT
-  # node points at the OUT register, which is peripheral_base + 0x500 — so the
-  # bases below are the DT addresses minus 0x500. The gpio model uses
-  # peripheral-relative offsets (OUT 0x504, OUTSET 0x508, DIRSET 0x518), so
-  # mapping the DT address directly would put every GPIO register 0x500 too
-  # high. That is a silent failure: UART still works and the boot still
-  # completes, only the pins never move. Found while onboarding the nRF54L15,
-  # which has the identical layout quirk.
+  # These two used to be declared at 0x5084_2000 / 0x5084_2300 — the vendor
+  # bases minus 0x500 — because the shared nRF52 GPIO model counts registers
+  # from the block start (OUT at +0x504) while Nordic bases an nRF53 port at
+  # OUT itself (P0_S = 0x5084_2500, OUT at +0x004). Both describe the same
+  # silicon and the same absolute addresses, but the two ports are only 0x300
+  # apart, so a window anchored 0x500 low starts INSIDE its neighbour's. With
+  # both declared 4 KB wide, gpio1's window covered every gpio0 register, and
+  # the router's greatest-start-wins rule handed all of them to gpio1: P0.OUT
+  # (0x5084_2504) was answered by gpio1 at its offset 0x204, which is not a
+  # register, so P0 writes vanished and P0 reads returned 0. Every P0 pin on
+  # the nRF5340-DK — the LEDs and the buttons — was dead, silently. No size or
+  # ordering change can fix that; the window has to move.
   #
-  # For the SAME reason these two carry NO `debug_schema`: the SVD's P0_S/P1_S
-  # descriptors are written against the MDK base (0x50842500 / 0x50842800), so
-  # attaching one here would name every register 0x500 off — a debugger
-  # confidently labelling the wrong address is worse than no names at all.
-  # A shifted-offset descriptor would have to be authored by hand; do not
-  # "fix" this by pointing at p0_s.yaml.
+  # So the windows are now declared where the vendor puts them, and
+  # `reg_offset: 0x500` tells the model how far into its register map each
+  # window starts (the SVD `addressBlock.offset` idea). Sources, both in-tree:
+  # tests/fixtures/real_world/nrf5340.svd (nrfx v3.12.0 mdk) gives P0_S
+  # 0x5084_2500 / P1_S 0x5084_2800 with a 0x300 addressBlock, and the Zephyr
+  # `nrf5340dk/nrf5340/cpuapp` devicetree agrees: gpio0@50842500 /
+  # gpio1@50842800, reg length 0x300.
+  #
+  # These two still carry no `debug_schema`, but the reason has changed. It was
+  # that the SVD's P0_S/P1_S names are written against the MDK base, so on the
+  # old anchor a debugger would have labelled every register 0x500 off. That is
+  # fixed — the window IS the MDK base now, and p0_s.yaml / p1_s.yaml would line
+  # up exactly. What stops it is only cost: they are 48 KB each and every
+  # referenced descriptor is `include_str!`d into the wasm download, so wiring
+  # them is a 96 KB change to the browser bundle and belongs in its own commit,
+  # not in a collision fix.
   - id: "gpio0"
     type: "gpio"
-    base_address: 0x50842000
-    size: "4KB"
+    base_address: 0x50842500
+    size: "768B"
     config:
       profile: "nrf52"
+      reg_offset: 0x500
   - id: "gpio1"
     type: "gpio"
-    base_address: 0x50842300
-    size: "4KB"
+    base_address: 0x50842800
+    size: "768B"
     config:
       profile: "nrf52"
       num_pins: 16
+      reg_offset: 0x500
 
   # ── Benign stub windows (trim/config blocks: write-only or never polled) ──
   # These are poked by SystemInit / soc-level errata + DCDC/regulator setup but

--- a/configs/chips/onboarding/atsamd21j17d-aft.yaml
+++ b/configs/chips/onboarding/atsamd21j17d-aft.yaml
@@ -3,7 +3,51 @@
 #
 # This software is released under the MIT License.
 # See the LICENSE file in the project root for full license information.
-
+#
+# Microchip ATSAMD21J17D (Cortex-M0+).
+#
+# ── Why every peripheral base in this file changed ──────────────────────────
+# This descriptor was machine-imported from Renode's
+# `platforms/cpus/atsamd21j17d-aft.repl`. That file writes addresses as
+# underscore-grouped hex (`0x4200_0800`); the import kept only the digits
+# BEFORE the underscore, so every base landed as its top 16 bits:
+#
+#     0x4200_0800 -> 0x4200      0x4100_4400 -> 0x4100
+#     0x4000_1400 -> 0x4000      0xE000_1000 -> 0xE000
+#
+# `gclk` survived intact only because upstream happens to spell it
+# `0x40000C00`, with no underscore. The result was seven peripherals collapsed
+# onto two addresses: gpio_a/gpio_b both at 0x4100, and tc4/tc6/usart0/usart1/
+# usart2 ALL at 0x4200. Bus routing resolves an equal-base tie silently, by
+# registration order, so four of those five and one of those two answered
+# nothing — the same shape as the classic-ESP32 apb_ctrl/SYSCON shadow.
+#
+# Sources for the corrected values, in order of authority:
+#   1. `ATSAMD21J17D.svd` (Microchip, via cmsis-svd-data `data/Atmel/`) — the
+#      part-exact peripheral base addresses and addressBlock extents.
+#   2. renode/renode `platforms/cpus/atsamd21j17d-aft.repl` — which SERCOM/TC
+#      instance each `usartN` id refers to. This matters: `usart2` is SERCOM3
+#      (0x4200_1400), NOT SERCOM2. Upstream's NVIC wiring confirms it
+#      (usart0->9, usart1->10, usart2->12 = SERCOM0/SERCOM1/SERCOM3 on SAM D21).
+#
+# `size:` is now declared on every peripheral, for the same reason the bases
+# are fixed: an undeclared size defaults to 4 KB, which on APB-C (0x400 slot
+# spacing) would put each peripheral's window over the next three. The values
+# below are the peripheral's APB slot — 1 KB — except PORT, whose two GROUPs
+# are 0x80 apart (SVD register-cluster dimIncrement), and DWT, the 4 KB
+# Cortex-M debug block.
+#
+# ── Still wrong, deliberately NOT changed here ─────────────────────────────
+# `flash.base` is 0x08000000; upstream says 0x0000_0000, and SAM D21 flash is
+# at 0. Almost certainly the same truncation (`0x0000_0000` -> 0) with a
+# non-zero default substituted afterwards. Not corrected in this commit
+# because `scripts/validate_hw_targets.py` treats `flash.base > 0` as "flash
+# present", so writing the true value would flip this board's onboarding
+# status — that gate has to be fixed first (nrf5340 and nrf52840 legitimately
+# base flash at 0). `ram.base` 8192 is the truncation of 0x2000_0000, and the
+# flash/ram sizes (256 KB / 32 KB) are J18A geometry, not the J17D's
+# 128 KB / 16 KB. All three are import artifacts; none is a window collision,
+# so they are recorded rather than fixed in a collision commit.
 name: atsamd21j17d-aft
 arch: arm
 flash:
@@ -13,43 +57,58 @@ ram:
   base: 8192
   size: 32768B
 peripherals:
+# Cortex-M DWT on the private peripheral bus — not a SAM D21 block.
 - id: dwt
   type: dwt
   bus: sysbus
-  base_address: 57344
-- id: rtc
-  type: samd21_rtc
-  bus: sysbus
-  base_address: 16384
-- id: gpio_a
-  type: samd21_gpio
-  bus: sysbus
-  base_address: 16640
-- id: gpio_b
-  type: samd21_gpio
-  bus: sysbus
-  base_address: 16640
-- id: usart0
-  type: samd5_uart
-  bus: sysbus
-  base_address: 16896
-- id: tc4
-  type: samd21_timer
-  bus: sysbus
-  base_address: 16896
-- id: tc6
-  type: samd21_timer
-  bus: sysbus
-  base_address: 16896
+  base_address: 0xE0001000
+  size: 4KB
+# APB-A: GCLK 0x40000C00 (SVD addressBlock 0x10), RTC 0x40001400 (0x40).
 - id: gclk
   type: arraymemory
   bus: sysbus
-  base_address: 1073744896
+  base_address: 0x40000C00
+  size: 1KB
+- id: rtc
+  type: samd21_rtc
+  bus: sysbus
+  base_address: 0x40001400
+  size: 1KB
+# APB-B: PORT 0x41004400, addressBlock 0x200, two GROUPs at 0x80 increments —
+# GROUP[0] = PA @ 0x41004400, GROUP[1] = PB @ 0x41004480.
+- id: gpio_a
+  type: samd21_gpio
+  bus: sysbus
+  base_address: 0x41004400
+  size: 128B
+- id: gpio_b
+  type: samd21_gpio
+  bus: sysbus
+  base_address: 0x41004480
+  size: 128B
+# APB-C, 0x400 per slot. usart0/1/2 = SERCOM0 / SERCOM1 / SERCOM3.
+- id: usart0
+  type: samd5_uart
+  bus: sysbus
+  base_address: 0x42000800
+  size: 1KB
 - id: usart1
   type: samd5_uart
   bus: sysbus
-  base_address: 16896
+  base_address: 0x42000C00
+  size: 1KB
 - id: usart2
   type: samd5_uart
   bus: sysbus
-  base_address: 16896
+  base_address: 0x42001400
+  size: 1KB
+- id: tc4
+  type: samd21_timer
+  bus: sysbus
+  base_address: 0x42003000
+  size: 1KB
+- id: tc6
+  type: samd21_timer
+  bus: sysbus
+  base_address: 0x42003800
+  size: 1KB

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -577,6 +577,17 @@ impl SystemBus {
                     // silently defaulted onto STM32F1 (which would move the ODR
                     // offset and blank a display's D/C line — the KW41Z "cow" bug).
                     let layout: GpioRegisterLayout = Self::gpio_layout_for(p_cfg)?;
+                    // Optional `reg_offset`: the window's offset inside the
+                    // family register map (the SVD `addressBlock.offset`).
+                    // nRF53/nRF54 GPIO ports declare 0x500, because Nordic
+                    // bases those at OUT rather than at the block start and
+                    // two ports are only 0x300 apart — see
+                    // `GpioPort::window_offset`.
+                    let window_offset: u64 = p_cfg
+                        .config
+                        .get("reg_offset")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
                     // For nRF52 ports, an optional `num_pins` config key caps the
                     // valid-pin range (e.g. 16 for nRF52840 P1 which has P1.0–P1.15).
                     // Writes outside that range are discarded; reads return 0.
@@ -587,7 +598,10 @@ impl SystemBus {
                             .and_then(|v| v.as_u64())
                             .map(|n| n as u32)
                             .unwrap_or(32);
-                        Box::new(crate::peripherals::gpio::GpioPort::new_nrf52(num_pins))
+                        Box::new(
+                            crate::peripherals::gpio::GpioPort::new_nrf52(num_pins)
+                                .with_window_offset(window_offset),
+                        )
                     } else if layout == GpioRegisterLayout::Stm32V2
                         && p_cfg.config.contains_key("reset_moder")
                     {
@@ -601,13 +615,19 @@ impl SystemBus {
                                 .map(|n| n as u32)
                                 .unwrap_or(0)
                         };
-                        Box::new(crate::peripherals::gpio::GpioPort::new_stm32v2_with_resets(
-                            cfg_u32("reset_moder"),
-                            cfg_u32("reset_ospeedr"),
-                            cfg_u32("reset_pupdr"),
-                        ))
+                        Box::new(
+                            crate::peripherals::gpio::GpioPort::new_stm32v2_with_resets(
+                                cfg_u32("reset_moder"),
+                                cfg_u32("reset_ospeedr"),
+                                cfg_u32("reset_pupdr"),
+                            )
+                            .with_window_offset(window_offset),
+                        )
                     } else {
-                        Box::new(crate::peripherals::gpio::GpioPort::new_with_layout(layout))
+                        Box::new(
+                            crate::peripherals::gpio::GpioPort::new_with_layout(layout)
+                                .with_window_offset(window_offset),
+                        )
                     }
                 }
                 // ESP32-C3 behavioral GP-SPI2 controller (CPU/W-buffer

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -540,6 +540,23 @@ pub struct GpioPort {
     /// without a wired STM32 SPI.
     spi_cells: Vec<std::sync::Arc<crate::peripherals::spi::SpiLineLevels>>,
     spi_routes: Vec<SpiPadRoute>,
+    /// Offset of this port's MMIO window inside the family's register space,
+    /// i.e. the SVD `addressBlock.offset`. Zero for every port whose window
+    /// starts where its register map starts, which is all of them except the
+    /// nRF53/nRF54 GPIO ports.
+    ///
+    /// Nordic describes an nRF52 GPIO port from the block start, with `OUT` at
+    /// +0x504 and 0x500 of reserved space in front of it. From the nRF5340 on,
+    /// the MDK and the SVD instead base a port at `OUT` (P0_S = 0x5084_2500,
+    /// `OUT` at +0x004) and give it a 0x300 `addressBlock`. Same silicon, same
+    /// absolute addresses — but the ports are only 0x300 apart, so a window
+    /// anchored 0x500 low is necessarily 0x300 deep inside its neighbour's.
+    /// That is not a fixable overlap: whichever anchor loses the router's
+    /// greatest-start-wins tie-break has ALL of its registers served by the
+    /// other port. Declaring the window where the vendor puts it and telling
+    /// the model how far in it starts is the only arrangement in which both
+    /// ports are addressable at once.
+    window_offset: u64,
 }
 
 impl Default for GpioPort {
@@ -555,7 +572,15 @@ impl GpioPort {
             tap: None,
             spi_cells: Vec::new(),
             spi_routes: Vec::new(),
+            window_offset: 0,
         }
+    }
+
+    /// Anchor this port's MMIO window `offset` bytes into its register map.
+    /// See [`GpioPort::window_offset`]. Chip yaml: `config: { reg_offset: … }`.
+    pub fn with_window_offset(mut self, offset: u64) -> Self {
+        self.window_offset = offset;
+        self
     }
 
     pub fn new() -> Self {
@@ -591,34 +616,43 @@ impl GpioPort {
         }))
     }
 
+    /// Window-relative offset -> family register offset. The only place the
+    /// two coordinate systems meet; every `Peripheral` entry point below goes
+    /// through here, so a port with a non-zero window offset cannot be reached
+    /// by one path and missed by another.
     fn read_reg(&self, offset: u64) -> u32 {
-        self.family.read_reg(offset)
+        self.family.read_reg(offset + self.window_offset)
     }
 
     fn write_reg(&mut self, offset: u64, value: u32) {
-        self.family.write_reg(offset, value);
+        self.family.write_reg(offset + self.window_offset, value);
     }
 
-    /// Register offset of the output data register (ODR) for this family.
+    /// Register offset of the output data register (ODR) for this family,
+    /// relative to the port's MMIO window (so `base + odr_offset()` is an
+    /// address the bus can route).
     /// Used by the bus to resolve a display's D/C line to a concrete address.
     pub fn odr_offset(&self) -> u64 {
-        match &self.family {
+        let family: u64 = match &self.family {
             GpioFamily::Stm32F1(_) => 0x0C,
             GpioFamily::Stm32V2(_) => 0x14,
             GpioFamily::Nrf52(_) => 0x504,
             GpioFamily::Kinetis(_) => 0x00,
-        }
+        };
+        family.saturating_sub(self.window_offset)
     }
 
-    /// Register offset of the input data register (IDR) for this family.
+    /// Register offset of the input data register (IDR) for this family,
+    /// relative to the port's MMIO window (see [`GpioPort::odr_offset`]).
     /// Used by the bus to resolve a sensor's input line (e.g. HC-SR04 ECHO).
     pub fn idr_offset(&self) -> u64 {
-        match &self.family {
+        let family: u64 = match &self.family {
             GpioFamily::Stm32F1(_) => 0x08,
             GpioFamily::Stm32V2(_) => 0x10,
             GpioFamily::Nrf52(_) => 0x510,
             GpioFamily::Kinetis(_) => 0x10,
-        }
+        };
+        family.saturating_sub(self.window_offset)
     }
 
     /// Register layout of this port (used by the SPI pad-wiring helper to
@@ -1084,6 +1118,43 @@ mod routing_tests {
         g.write_u32(0x14, 1 << 3).unwrap(); // PDDR: pin3 output
         assert_eq!(g.gpio_routing(3).unwrap().mode, GpioMode::Output);
         assert_eq!(g.gpio_routing(4).unwrap().mode, GpioMode::Input);
+    }
+
+    /// A window offset shifts EVERY door into the model by the same amount —
+    /// the MMIO reads/writes and the `odr_offset`/`idr_offset` the bus uses to
+    /// resolve a pin to an address. If those two disagreed, a pin-bound device
+    /// would be wired to an address the register path never serves.
+    #[test]
+    fn window_offset_shifts_mmio_and_the_pin_address_helpers_together() {
+        // nRF53/nRF54 anchor: the window starts at OUT, 0x500 into the map.
+        let mut g = GpioPort::new_with_layout(GpioRegisterLayout::Nrf52).with_window_offset(0x500);
+
+        assert_eq!(
+            g.odr_offset(),
+            0x004,
+            "OUT is 0x504 - 0x500 into the window"
+        );
+        assert_eq!(g.idr_offset(), 0x010, "IN is 0x510 - 0x500 into the window");
+
+        // PIN_CNF[7].DIR = Output, then OUTSET pin 7 — all at window-relative
+        // offsets (0x700-0x500, 0x508-0x500).
+        g.write_u32(0x200 + 7 * 4, 1).unwrap();
+        g.write_u32(0x008, 1 << 7).unwrap();
+        assert_eq!(g.read_gpio_pad(7), Some(true));
+        assert_eq!(
+            g.read_u32(g.odr_offset()).unwrap() & (1 << 7),
+            1 << 7,
+            "reading OUT through odr_offset() must see the same bit the MMIO \
+             write set — the bus resolves pin addresses through this helper"
+        );
+
+        // And the un-offset default is untouched: same port, same registers,
+        // at the block-start offsets every other Nordic part uses.
+        let mut plain = GpioPort::new_with_layout(GpioRegisterLayout::Nrf52);
+        assert_eq!(plain.odr_offset(), 0x504);
+        plain.write_u32(0x700 + 7 * 4, 1).unwrap();
+        plain.write_u32(0x508, 1 << 7).unwrap();
+        assert_eq!(plain.read_gpio_pad(7), Some(true));
     }
 }
 

--- a/crates/core/src/tests/peripheral_reachability.rs
+++ b/crates/core/src/tests/peripheral_reachability.rs
@@ -35,6 +35,7 @@
 //! layered over a broad catch-all). Being *entirely* covered is the defect.
 
 use crate::bus::SystemBus;
+use crate::Bus;
 use labwired_config::{ChipDescriptor, SystemManifest};
 use std::path::PathBuf;
 
@@ -372,4 +373,163 @@ fn equal_base_tiebreak_is_last_registered_and_order_independent() {
         Some("narrow"),
         "equal starts must resolve to the LAST registered entry"
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Register-level regressions: two shipped chip maps whose windows collided.
+//
+// The gate above asks "does the router dispatch to this peripheral ANYWHERE in
+// its window". That is necessary but not sufficient: a window can own an
+// address that holds no register while every address that DOES hold one is
+// served by its neighbour. nRF5340 `gpio0` passed the gate that way — it owned
+// its own base (0x5084_2000, dead space under the -0x500 remap) while all 0x280
+// bytes of its actual registers were served by `gpio1`.
+//
+// So these two tests address the peripherals the way SILICON does, at addresses
+// taken from the vendor descriptor rather than from the chip YAML, and check
+// that two instances are TELLABLE APART. A shadowed peripheral is silent by
+// definition; only a differential read/write shows the shadow is gone.
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn bus_for_chip(rel: &str) -> SystemBus {
+    let path = repo_root(rel);
+    let chip = ChipDescriptor::from_file(&path).unwrap_or_else(|e| panic!("load {rel}: {e}"));
+    let abs = path.to_string_lossy().to_string();
+    SystemBus::from_config(&chip, &dummy_manifest(&abs))
+        .unwrap_or_else(|e| panic!("assemble {rel}: {e}"))
+}
+
+/// nRF5340: P0 and P1 must each answer at their own silicon addresses.
+///
+/// Register facts from the vendored Nordic descriptor
+/// `tests/fixtures/real_world/nrf5340.svd` (nrfx v3.12.0 `mdk/nrf5340_application.svd`):
+/// `P0_S` @ 0x5084_2500, `P1_S` @ 0x5084_2800, `addressBlock` size 0x300, with
+/// `OUT` at offset +0x004 and `DIR` at +0x014. The Zephyr `nrf5340dk/nrf5340/cpuapp`
+/// devicetree agrees: `gpio0@50842500` / `gpio1@50842800`, `reg` length 0x300.
+///
+/// Before the fix, both ports were remapped 0x500 low (0x5084_2000 / 0x5084_2300)
+/// and declared 4 KB wide, so gpio1's window covered EVERY gpio0 register.
+/// Under the router's greatest-start-wins rule, P0.OUT (0x5084_2504) was served
+/// by gpio1 at its offset 0x204 — not a register in the nRF GPIO map, so the
+/// write vanished and the read returned 0. P0 is where the nRF5340-DK's LEDs
+/// and buttons live; every one of them was dead and nothing said so.
+#[test]
+fn nrf5340_gpio_ports_answer_at_their_own_silicon_addresses() {
+    const P0: u64 = 0x5084_2500;
+    const P1: u64 = 0x5084_2800;
+    const OUT: u64 = 0x004;
+
+    let mut bus = bus_for_chip("configs/chips/nrf5340.yaml");
+
+    assert_eq!(bus.read_u32(P0 + OUT).unwrap(), 0, "P0.OUT resets to 0");
+    assert_eq!(bus.read_u32(P1 + OUT).unwrap(), 0, "P1.OUT resets to 0");
+
+    // Write P0 only. It must land in P0 and be invisible from P1.
+    bus.write_u32(P0 + OUT, 0x0F0F_0F0F).unwrap();
+    assert_eq!(
+        bus.read_u32(P0 + OUT).unwrap(),
+        0x0F0F_0F0F,
+        "P0.OUT (0x{:08X}) must read back what was written to it — if this is 0, \
+         P0 is shadowed by P1 and every P0 pin on the board is dead",
+        P0 + OUT
+    );
+    assert_eq!(
+        bus.read_u32(P1 + OUT).unwrap(),
+        0,
+        "writing P0.OUT must not disturb P1.OUT — the two ports are separate silicon"
+    );
+
+    // Now write P1 only. P1 has 16 pins (P1.0–P1.15), so stay in range.
+    bus.write_u32(P1 + OUT, 0x0000_1234).unwrap();
+    assert_eq!(
+        bus.read_u32(P1 + OUT).unwrap(),
+        0x0000_1234,
+        "P1.OUT must read back its own value"
+    );
+    assert_eq!(
+        bus.read_u32(P0 + OUT).unwrap(),
+        0x0F0F_0F0F,
+        "writing P1.OUT must not disturb P0.OUT"
+    );
+}
+
+/// ATSAMD21J17D: the three SERCOM USART instances must be separately addressable.
+///
+/// Addresses from the Microchip-published `ATSAMD21J17D.svd` (cmsis-svd-data,
+/// `data/Atmel/ATSAMD21J17D.svd`): SERCOM0 @ 0x4200_0800, SERCOM1 @ 0x4200_0C00,
+/// SERCOM3 @ 0x4200_1400, 0x400 apart on APB-C. Which SERCOM each `usartN` id
+/// means comes from the upstream descriptor this chip YAML was imported from,
+/// `renode/renode` `platforms/cpus/atsamd21j17d-aft.repl`, which maps
+/// usart0→0x4200_0800, usart1→0x4200_0C00, usart2→0x4200_1400 (and whose NVIC
+/// lines 9/10/12 are SERCOM0/1/3, confirming the third is SERCOM3, not SERCOM2).
+/// SERCOM USART `DATA` is at +0x28.
+///
+/// Before the fix all five of tc4/tc6/usart0/usart1/usart2 sat at 0x4200 —
+/// the top 16 bits of their real addresses, because the importer truncated
+/// Renode's underscore-separated hex literals at the underscore. Four of the
+/// five were unreachable; the router handed every access to the last registered.
+#[test]
+fn atsamd21_sercom_usarts_are_separately_addressable() {
+    use std::sync::{Arc, Mutex};
+
+    const SERCOM0: u64 = 0x4200_0800;
+    const SERCOM1: u64 = 0x4200_0C00;
+    const SERCOM3: u64 = 0x4200_1400;
+    const DATA: u64 = 0x28;
+
+    let mut bus = bus_for_chip("configs/chips/onboarding/atsamd21j17d-aft.yaml");
+
+    // Tap usart1's transmitter. Only bytes that reach THAT model may appear.
+    let sink = Arc::new(Mutex::new(Vec::new()));
+    assert!(
+        bus.attach_uart_tx_sink_named("usart1", sink.clone(), false),
+        "usart1 must exist as a UART model"
+    );
+
+    bus.write_u8(SERCOM0 + DATA, b'0').unwrap();
+    assert!(
+        sink.lock().unwrap().is_empty(),
+        "a byte written to SERCOM0 must not come out of usart1 (=SERCOM1)"
+    );
+
+    bus.write_u8(SERCOM1 + DATA, b'1').unwrap();
+    assert_eq!(
+        &*sink.lock().unwrap(),
+        b"1",
+        "a byte written to SERCOM1's DATA must come out of usart1 — if the sink \
+         is empty, usart1 is shadowed and unreachable at its own address"
+    );
+
+    bus.write_u8(SERCOM3 + DATA, b'2').unwrap();
+    assert_eq!(
+        &*sink.lock().unwrap(),
+        b"1",
+        "a byte written to SERCOM3 must not come out of usart1"
+    );
+}
+
+/// ATSAMD21J17D PORT: GROUP0 (PA) and GROUP1 (PB) are 0x80 apart, not identical.
+///
+/// `ATSAMD21J17D.svd` gives PORT @ 0x4100_4400 with a 0x200 `addressBlock` and a
+/// two-element register cluster at 0x80 increments; the upstream Renode
+/// descriptor spells the same thing out as gpio_a @ 0x4100_4400,
+/// gpio_b @ 0x4100_4480. Both were imported as 0x4100.
+///
+/// `samd21_gpio` has no model in this engine (it builds a stub), so the two
+/// ports cannot be told apart by a read/write — a stub answers 0 either way.
+/// What CAN be checked, and is the whole content of the defect, is that the
+/// router dispatches each port's own address to that port.
+#[test]
+fn atsamd21_port_groups_route_to_their_own_instances() {
+    let bus = bus_for_chip("configs/chips/onboarding/atsamd21j17d-aft.yaml");
+    for (id, addr) in [("gpio_a", 0x4100_4400u64), ("gpio_b", 0x4100_4480u64)] {
+        let owner = bus
+            .find_peripheral_index(addr)
+            .map(|i| bus.peripherals[i].name.clone());
+        assert_eq!(
+            owner.as_deref(),
+            Some(id),
+            "{addr:#010x} must be served by `{id}`, not by {owner:?}"
+        );
+    }
 }

--- a/crates/core/src/tests/yaml_owned_base_contract.rs
+++ b/crates/core/src/tests/yaml_owned_base_contract.rs
@@ -335,17 +335,6 @@ const WINDOW_OVERLAP_ALLOWLIST: &[(&str, &str, &str, &str)] = &[
          0x3FF4_9000 for 0x400 bytes.",
     ),
     (
-        "nrf5340.yaml",
-        "gpio0",
-        "gpio1",
-        "HIGHEST RISK ENTRY. `gpio1` sits at 0x5084_2300, i.e. 0x300 INSIDE \
-         gpio0's declared 4 KB window — the exact collision nrf52840.yaml \
-         documents avoiding by remapping P1 to 0x5000_1000. nRF5340 never got \
-         that remap, so P1 accesses are decided by registration order. This is \
-         the nRF52 GPIOTE defect waiting on a second chip; recorded here so it \
-         cannot be rediscovered as novel.",
-    ),
-    (
         "nrf54l15.yaml",
         "gpio1",
         "temp",
@@ -373,81 +362,6 @@ const WINDOW_OVERLAP_ALLOWLIST: &[(&str, &str, &str, &str)] = &[
         "comp",
         "exti",
         "Same STM32 0x4001_0000 SYSCFG/COMP/EXTI block.",
-    ),
-    // ── imported descriptor with genuinely identical bases ──────────────────
-    // `configs/chips/onboarding/atsamd21j17d-aft.yaml` collapses seven
-    // peripherals onto two addresses: gpio_a/gpio_b both at 0x4100, and
-    // tc4/tc6/usart0/usart1/usart2 ALL at 0x4200. This is the apb_ctrl-vs-SYSCON
-    // shape exactly — four of those five are unreachable, and which one answers
-    // is decided by registration order. Found by this gate on its first run.
-    // Not fixed here because the real base addresses have to come from the SAMD21
-    // datasheet, which is a datasheet task, not a refactor.
-    (
-        "atsamd21j17d-aft.yaml",
-        "gpio_a",
-        "gpio_b",
-        "IDENTICAL BASE 0x4100. Imported descriptor never got real per-instance \
-         addresses; needs SAMD21 datasheet values.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc4",
-        "tc6",
-        "IDENTICAL BASE 0x4200, part of the five-way tc4/tc6/usart0-2 tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc4",
-        "usart0",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc4",
-        "usart1",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc4",
-        "usart2",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc6",
-        "usart0",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc6",
-        "usart1",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "tc6",
-        "usart2",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "usart0",
-        "usart1",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "usart0",
-        "usart2",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
-    ),
-    (
-        "atsamd21j17d-aft.yaml",
-        "usart1",
-        "usart2",
-        "IDENTICAL BASE 0x4200, part of the five-way tie.",
     ),
 ];
 

--- a/crates/core/tests/nrf54l15_boot.rs
+++ b/crates/core/tests/nrf54l15_boot.rs
@@ -208,31 +208,56 @@ fn timer_and_temp_and_grtc_windows_are_reachable() {
     let _ = bus.read_u32(GRTC);
 }
 
-/// Regression probe for a PRE-EXISTING nRF5340 profile bug found while
-/// onboarding the nRF54L15 (kept here because this is where the reasoning
-/// lives; move it if the nRF5340 profile is fixed).
+/// Companion probe for the nRF5340, which has the identical Nordic GPIO layout
+/// quirk (kept here because this is where the reasoning lives).
 ///
-/// `configs/chips/nrf5340.yaml` maps GPIO P0 at 0x5084_2500, which is the
-/// DEVICETREE address — i.e. the OUT register — not the peripheral base. By
-/// the same +0x500 rule this file documents, the base should be 0x5084_2000.
-/// If this test fails, the nRF5340 GPIO registers are all 0x500 too high and
-/// its LEDs cannot be driven either.
+/// This used to assert the *convention*: that `gpio0.base_address` was the
+/// devicetree address minus 0x500. That is a mirror of whatever the yaml
+/// happens to say, and it was green throughout the whole time nRF5340 P0 was
+/// unreachable — the -0x500 anchor put gpio0's window 0x300 inside gpio1's, and
+/// under greatest-start-wins gpio1 answered every P0 register. nRF5340 now
+/// anchors its ports at the vendor bases with `reg_offset: 0x500`.
+///
+/// So assert the thing the convention was only ever a means to: whatever anchor
+/// and offset the yaml chooses, P0.OUT must come out at the devicetree address.
+/// That holds under both conventions and fails for a chip that picks one and
+/// forgets the other. Whether the two ports are also *distinguishable* is
+/// checked behaviourally by
+/// `peripheral_reachability::nrf5340_gpio_ports_answer_at_their_own_silicon_addresses`.
 #[test]
-fn nrf5340_gpio_base_follows_the_same_plus_0x500_rule() {
+fn nrf5340_gpio_out_lands_on_the_devicetree_address() {
+    // Zephyr nrf5340dk/nrf5340/cpuapp DT: gpio0@50842500 / gpio1@50842800, and
+    // a Nordic GPIO DT node points at OUT. Nordic's SVD agrees (P0_S/P1_S).
+    const DT_P0_OUT: u64 = 0x5084_2500 + 0x004;
+    const DT_P1_OUT: u64 = 0x5084_2800 + 0x004;
+    // OUT in the shared nRF52 GPIO register map, counted from the block start.
+    const OUT_IN_BLOCK: u64 = 0x504;
+
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../configs/chips/nrf5340.yaml");
     let chip = ChipDescriptor::from_file(&path).expect("load nrf5340 chip");
-    let gpio0 = chip
-        .peripherals
-        .iter()
-        .find(|p| p.id == "gpio0")
-        .expect("nrf5340 gpio0");
 
-    assert_eq!(
-        gpio0.base_address, 0x5084_2000,
-        "nRF5340 GPIO P0 base should be the DT address 0x5084_2500 minus 0x500; \
-         mapping the DT address directly puts every GPIO register 0x500 too high"
-    );
+    for (id, want) in [("gpio0", DT_P0_OUT), ("gpio1", DT_P1_OUT)] {
+        let p = chip
+            .peripherals
+            .iter()
+            .find(|p| p.id == id)
+            .unwrap_or_else(|| panic!("nrf5340 {id}"));
+        let reg_offset = p
+            .config
+            .get("reg_offset")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        assert_eq!(
+            p.base_address + (OUT_IN_BLOCK - reg_offset),
+            want,
+            "nRF5340 {id}: base {:#x} with reg_offset {:#x} puts OUT at {:#x}, \
+             but the devicetree and the SVD both say {want:#x}",
+            p.base_address,
+            reg_offset,
+            p.base_address + (OUT_IN_BLOCK - reg_offset)
+        );
+    }
 }
 
 // ── CLOCK ────────────────────────────────────────────────────────────────

--- a/crates/core/tests/svd_conformance.rs
+++ b/crates/core/tests/svd_conformance.rs
@@ -76,20 +76,16 @@ const ALLOWED: &[(&str, &str, Deviation, &str)] = &[
     // nRF-family GPIO model uses the block start with OUT at +0x504 (the
     // classic nRF52 layout it shares with every other Nordic part). The config
     // back-offsets the base by 0x504 so the two agree on where OUT lands. This
-    // is uniform across all Nordic ports and is load-bearing: "correcting" the
-    // base to the SVD's number would move every GPIO register by 0x504.
-    (
-        "nrf5340",
-        "gpio0",
-        Deviation::Base,
-        "Nordic SVD bases a port at its OUT register; model uses block start.",
-    ),
-    (
-        "nrf5340",
-        "gpio1",
-        Deviation::Base,
-        "Nordic SVD bases a port at its OUT register; model uses block start.",
-    ),
+    // is load-bearing WHERE IT IS STILL USED: "correcting" such a base to the
+    // SVD's number, without telling the model the window moved, would shift
+    // every GPIO register by 0x500.
+    //
+    // nRF5340's two ports are no longer among them. On that part the back-offset
+    // was not merely a bookkeeping convention: P0 and P1 are 0x300 apart, so a
+    // window anchored 0x500 low sits inside its neighbour's and one port's
+    // registers were entirely served by the other. They now sit at the SVD bases
+    // with `reg_offset: 0x500` in the chip yaml, so no deviation is claimed.
+    // nRF54L15 still uses the remap and still needs these entries.
     (
         "nrf54l15",
         "gpio0",


### PR DESCRIPTION
Rule 2 of the address guard that landed in #768 found two shipped chip maps whose
peripheral windows collide. Both were recorded in `WINDOW_OVERLAP_ALLOWLIST`
rather than fixed. This fixes them from the silicon and deletes the entries.

A colliding window is not a cosmetic YAML defect. Routing is greatest-start-wins
(equal starts resolve to the last registered), silently — the same shape that let
`apb_ctrl` shadow SYSCON on classic ESP32.

## What was actually broken

**nRF5340 — P0 was completely dead.** `gpio0` was anchored at 0x5084_2000 and
`gpio1` at 0x5084_2300 (the vendor bases minus 0x500, so the shared nRF52 GPIO
model's `OUT`@+0x504 lands on the real address), both declared 4 KB wide. gpio1's
window therefore covered every gpio0 register, and greatest-start-wins handed all
of them to gpio1: `P0.OUT` (0x5084_2504) was answered by gpio1 at its offset
0x204, which is not a register. P0 writes vanished; P0 reads returned 0. P0 is
where the nRF5340-DK's LEDs and buttons are.

No size or ordering change can fix that — the ports are 0x300 apart and a port's
register block runs 0x780 from the -0x500 anchor, so the two windows are
structurally interleaved. The window has to move.

**ATSAMD21J17D — an import bug, not a datasheet gap.** The descriptor was
machine-imported from Renode's `platforms/cpus/atsamd21j17d-aft.repl`, which
writes addresses as underscore-grouped hex. The import kept only the digits
before the underscore, so every base became its top 16 bits (`0x4200_0800` →
`0x4200`, `0xE000_1000` → `0xE000`). `gclk` survived only because upstream spells
it `0x40000C00`, with no underscore. Seven peripherals collapsed onto two
addresses.

## The fixes

**`configs/chips/nrf5340.yaml`** — ports declared where the vendor puts them:
`gpio0` @ 0x5084_2500, `gpio1` @ 0x5084_2800, `size: 768B`, with a new
`config: { reg_offset: 0x500 }` telling the model the window starts 0x500 into
its register map (the SVD `addressBlock.offset` idea). Absolute register
addresses are unchanged; the windows are now disjoint and both ports work.

Source: `tests/fixtures/real_world/nrf5340.svd` (in-tree, nrfx v3.12.0
`mdk/nrf5340_application.svd`) — `P0_S` 0x5084_2500, `P1_S` 0x5084_2800,
addressBlock 0x300. The Zephyr `nrf5340dk/nrf5340/cpuapp` devicetree agrees, and
so does `docs/boards/nrf5340.md`, which already documented these addresses while
the YAML did not.

`GpioPort::window_offset` (new, defaults to 0) is applied at the single
`read_reg`/`write_reg` choke point and subtracted from `odr_offset()` /
`idr_offset()`, so the MMIO path and the pin→address helpers cannot disagree.
Every other port on every other chip is unaffected.

**`configs/chips/onboarding/atsamd21j17d-aft.yaml`** — real addresses, plus a
`size:` on every entry (an undeclared size defaults to 4 KB, which on APB-C's
0x400 spacing would put each window over the next three):

| id | was | now | source |
|----|-----|-----|--------|
| `dwt` | 0xE000 | 0xE000_1000 | Cortex-M debug block |
| `gclk` | 0x4000_0C00 | unchanged | already correct |
| `rtc` | 0x4000 | 0x4000_1400 | SVD `RTC` |
| `gpio_a` | 0x4100 | 0x4100_4400 | SVD `PORT` GROUP[0] |
| `gpio_b` | 0x4100 | 0x4100_4480 | SVD `PORT` GROUP[1] (cluster dimIncrement 0x80) |
| `usart0` | 0x4200 | 0x4200_0800 | SVD `SERCOM0` |
| `usart1` | 0x4200 | 0x4200_0C00 | SVD `SERCOM1` |
| `usart2` | 0x4200 | 0x4200_1400 | SVD `SERCOM3` — **not** SERCOM2 |
| `tc4` | 0x4200 | 0x4200_3000 | SVD `TC4` |
| `tc6` | 0x4200 | 0x4200_3800 | SVD `TC6` |

Addresses from the Microchip-published `ATSAMD21J17D.svd` (cmsis-svd-data
`data/Atmel/`). Which SERCOM/TC each `usartN`/`tcN` id means comes from the
upstream Renode descriptor the file was imported from; its NVIC wiring
(usart0→9, usart1→10, usart2→12 = SERCOM0/SERCOM1/SERCOM3) confirms the third is
SERCOM3. Nothing was removed — every id is a real block on this part.

## Proof

**Rule 2 red then green.** Deleted the 12 allowlist entries first and ran the
guard against the unmodified YAMLs: 12 collisions, naming both files. After the
fix: green, with `rule2_allowlist_shrinks_only` and
`rule2_scanner_is_not_vacuous` also green.

**Behavioural, not structural.** Three new register-level tests in
`peripheral_reachability.rs`, written before the fix and watched to fail:

- `nrf5340_gpio_ports_answer_at_their_own_silicon_addresses` — writes P0.OUT at
  0x5084_2504 and P1.OUT at 0x5084_2804 and checks each reads back its own value
  and does not disturb the other. Pre-fix it failed `left: 0, right: 252645135`
  — P0.OUT swallowed, exactly the shadow.
- `atsamd21_sercom_usarts_are_separately_addressable` — taps usart1's
  transmitter, writes a byte to each of SERCOM0/1/3's `DATA`, checks only the
  SERCOM1 byte comes out. Pre-fix it faulted: SERCOM1's address was not mapped.
- `atsamd21_port_groups_route_to_their_own_instances` — routing identity for the
  two PORT groups. `samd21_gpio` has no model (it builds a stub), so the two
  cannot be told apart by a read/write; the test says so rather than dressing
  itself up as behavioural.

Plus a unit test on the model itself
(`window_offset_shifts_mmio_and_the_pin_address_helpers_together`) — an offset
port and a plain one, so a future edit cannot shift one door and not the other.

**A mirror test replaced.**
`nrf54l15_boot::nrf5340_gpio_base_follows_the_same_plus_0x500_rule` asserted that
gpio0's base was the DT address minus 0x500 — a mirror of whatever the YAML said,
green for the entire time P0 was unreachable. It now asserts the outcome the
convention was only ever a means to: `base + (0x504 - reg_offset)` must equal the
devicetree OUT address, which holds under either anchor.

**`svd_conformance`** — the two `nrf5340` gpio `ALLOWED` entries are deleted;
those bases now match the SVD outright. The `nrf54l15` entries stay; that part
still uses the remap.

## What this does not fix

- **nRF54L15 has the same quirk** and two Rule 2 entries left (`gpio1`/`temp`,
  `gpio0`/`wdt31`). `reg_offset` is the mechanism to close them, but that chip's
  ports are remapped by 0x504 against a different register map and it has its own
  firmware to re-verify. Separate change.
- **nRF52840 `gpio1`** is still parked at a fabricated 0x5000_1000
  (`svd_conformance` records it as a KNOWN GAP). `reg_offset` does not help
  there: on nRF52840 the vendor base *is* the block start, so the two ports
  genuinely share one 4 KB page. Closing it needs sub-page port windows.
- **SAM D21 `flash.base`, `ram.base` and both sizes are still wrong** —
  documented in the YAML with the upstream values. `flash.base` is deliberately
  left alone: `scripts/validate_hw_targets.py` treats `flash.base > 0` as "flash
  present", so the true value (0) would flip this board's onboarding status. That
  gate needs fixing first — nrf5340 and nrf52840 legitimately base flash at 0.
- **The nRF5340 GPIO ports still carry no `debug_schema`.** They now *could* —
  the reason recorded in the YAML (names would be 0x500 off) is gone. What stops
  it is that `p0_s.yaml`/`p1_s.yaml` are 48 KB each and every referenced
  descriptor is `include_str!`d into the wasm bundle. Its own commit.

## Gaps this exposed in the existing gates

- `peripheral_reachability::no_declarative_chip_registers_a_shadowed_peripheral`
  was **green** on nRF5340 the whole time. gpio0 owned exactly one address — its
  own base, 0x5084_2000, dead space under the -0x500 anchor — while every address
  that held a register was served by gpio1. Owning an address is not owning a
  register.
- That gate also reads `configs/chips` non-recursively, so
  `configs/chips/onboarding/` — 200+ descriptors, this one included — is outside
  it entirely.
- Nothing in-tree exercises the SAM D21 at all: no lab, no firmware, no test. The
  only mention of `atsamd21j17d-aft` outside its own config files was the
  allowlist entry.
- `crates/config`'s `parse_size` rejects hex (`"0x80"`) while the guard's own
  `parse_size_str` accepts it, so a hex `size:` would pass the gate and fail the
  engine. Not hit here (the new sizes are `1KB`/`128B`/`4KB`/`768B`), but worth
  knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
