### PR TITLE
fix(nrf52): TWIM MAXCNT is 16-bit on silicon, not 8

### DIFF
--- a/crates/core/src/peripherals/nrf52/twim.rs
+++ b/crates/core/src/peripherals/nrf52/twim.rs
@@ -119,7 +119,11 @@ const ERRORSRC_MASK: u32 = ERRORSRC_ANACK | ERRORSRC_DNACK;
 
 // ── Misc masks ────────────────────────────────────────────────────────────────
 const ENABLE_MASK: u32 = 0xF;
-const MAXCNT_MASK: u32 = 0xFF;
+// nRF52840 TWIM MAXCNT is 16 bits (PS §6.31: TXD.MAXCNT/RXD.MAXCNT are
+// 0xFFFF-wide) — the slave peripherals (SPIS/TWIS) are 8-bit, the master is
+// not. Capping this at 0xFF truncated >255-byte EasyDMA transfers (e.g. a
+// full-frame SSD1306 flush) to `len & 0xFF` bytes.
+const MAXCNT_MASK: u32 = 0xFFFF;
 const ADDRESS_MASK: u32 = 0x7F;
 const SHORTS_MASK: u32 = SHORT_LASTTX_STARTRX
     | SHORT_LASTTX_SUSPEND
@@ -933,12 +937,15 @@ mod tests {
     }
 
     #[test]
-    fn maxcnt_mask_8_bits() {
+    fn maxcnt_mask_16_bits() {
+        // TWIM master MAXCNT is 16-bit on silicon (0xFFFF); only the SPIS/
+        // TWIS slaves are 8-bit. A full-frame SSD1306 flush (1025 bytes)
+        // must round-trip.
         let mut t = Nrf52Twim::new();
-        write32(&mut t, OFF_TXD_MAXCNT, 0x1FF);
-        assert_eq!(read32(&t, OFF_TXD_MAXCNT), 0xFF);
-        write32(&mut t, OFF_RXD_MAXCNT, 0x1FF);
-        assert_eq!(read32(&t, OFF_RXD_MAXCNT), 0xFF);
+        write32(&mut t, OFF_TXD_MAXCNT, 0x1FFFF);
+        assert_eq!(read32(&t, OFF_TXD_MAXCNT), 0xFFFF);
+        write32(&mut t, OFF_RXD_MAXCNT, 0x401);
+        assert_eq!(read32(&t, OFF_RXD_MAXCNT), 0x401);
     }
 
     #[test]

--- a/examples/nrf52840-secure-boot-lab/secure-boot-smoke.yaml
+++ b/examples/nrf52840-secure-boot-lab/secure-boot-smoke.yaml
@@ -43,7 +43,7 @@ inputs:
   system: "./system.yaml"
   firmware: "../../target/thumbv7em-none-eabi/release/firmware-nrf52840-secure-boot"
 limits:
-  max_steps: 4000000
+  max_steps: 30000000
 
 # ── The OTA server: three packages queued to uart0 RX at run start ────────
 # The firmware consumes them in order — one per boot phase — so no pacing is


### PR DESCRIPTION
The master TWIM model masked MAXCNT to 0xFF, silently truncating any EasyDMA transfer over 255 bytes to `len & 0xFF` — a 1025-byte SSD1306 full-frame flush delivered exactly 1 byte (found via the secure-boot lab's garbled OLED in the playground).

- nRF52840 PS §6.31: TWIM TXD.MAXCNT/RXD.MAXCNT are 16-bit. The 8-bit mask was right for SPIS/TWIS slaves only; those models keep it.
- Test `maxcnt_mask_8_bits` encoded the wrong mask; now `maxcnt_mask_16_bits`.
- secure-boot-smoke.yaml: 4M → 30M steps — with the full 1025-byte flush actually transferring, the (correct) realistic-latency TWIM path needs the headroom. Lab passes 45/45 locally.

Evidence: nrf52 suite 263/263, secure-boot lab 45/45 with the full flush on the wire.