### PR TITLE
refactor: kill residual bus board_io duals; pot via external_devices

### DIFF
--- a/configs/systems/esp32c3-mlx90640-thermal.yaml
+++ b/configs/systems/esp32c3-mlx90640-thermal.yaml
@@ -34,7 +34,5 @@ external_devices:
       cooling_fault_at_s: 30.0 # at t=30 s cooling collapses → hotspot climbs
       frame_period_s: 0.5      # simulated time advanced per captured frame (2 Hz)
 
-board_io:
-  - id: "thermal_cam"
-    kind: "i2c_device"
-    peripheral: "i2c0"
+# Identity is external_devices only — no board_io twin for bus modules.
+board_io: []

--- a/configs/systems/frdm-kw41z.yaml
+++ b/configs/systems/frdm-kw41z.yaml
@@ -15,6 +15,5 @@ external_devices:
     connection: "i2c1"
     config:
       i2c_address: 0x1f
-board_io:
-  # Temporary dual graph for UI sensor readback (get_i2c_sensor_states still
-  # walks board_io). Display-only duals have been removed; sensors next.
+# FXOS8700 is external_devices only (no board_io twin).
+board_io: []

--- a/configs/systems/seeed-xiao-nrf52840-sense.yaml
+++ b/configs/systems/seeed-xiao-nrf52840-sense.yaml
@@ -20,9 +20,3 @@ board_io:
     pin: 6
     signal: "output"
     active_high: false
-  - id: "spi0_bus"
-    kind: "spi_device"
-    peripheral: "spi0"
-    pin: 5
-    signal: "output"
-    active_high: false

--- a/crates/core/src/tests/device_identity_one_home.rs
+++ b/crates/core/src/tests/device_identity_one_home.rs
@@ -216,15 +216,14 @@ fn every_device_type_the_browser_keys_on_is_known_to_the_registry() {
     // and a silent zero is exactly how a green suite covers broken behaviour.
     //
     // The floor was 12 when every display accessor keyed on a `board_io`
-    // device_type string. The one-door change deleted those: a display's
-    // identity now comes from the model's own artifact, so there is no spelling
-    // for the browser to get wrong on that path. Six literals remain, all in
-    // sensor accessors (ntc-thermistor, max31855, neo6m-gps) that still resolve
-    // by type — they are what this gate now guards. Lowering the floor to match
-    // a REMOVED fork is correct; lowering it to silence a scan that broke is
-    // not, which is why the number moves in the same commit that removed them.
+    // device_type string, then 6 after displays went one-door. Potentiometer
+    // joined NTC on `set_input_on(external_devices id, …)` and no longer
+    // matches `board_io.device_type == "potentiometer"`, so the remaining
+    // scan set is five type strings (adxl345/mpu6050/ntc/…). Lowering the
+    // floor to match a REMOVED fork is correct; lowering it to silence a scan
+    // that broke is not — same commit rule as the display one-door.
     assert!(
-        all.len() >= 6,
+        all.len() >= 5,
         "the device-type scan found only {} literals across {:?}; it is broken or \
          the browser layer moved. A vacuous gate is worse than none.",
         all.len(),
@@ -266,10 +265,9 @@ fn the_browser_does_not_re_implement_the_device_type_alias_table() {
     );
     let per_file = wasm_identity_literals();
     assert!(
-        // Same floor move as the sibling, same reason: the one-door change
-        // removed the display device_type literals rather than the scan losing
-        // them. Keep the two numbers in step.
-        per_file.values().flatten().count() >= 6,
+        // Same floor as the sibling (unique set size ≥ 5). flatten().count()
+        // can be higher when a type is spelled in both files — keep floor at 5.
+        per_file.values().flatten().count() >= 5,
         "the device-type scan went vacuous; see the sibling test."
     );
 

--- a/crates/core/tests/no_bus_device_board_io_dual.rs
+++ b/crates/core/tests/no_bus_device_board_io_dual.rs
@@ -27,32 +27,20 @@ fn scan_yaml(path: &std::path::Path, offenders: &mut Vec<String>) {
         return;
     };
     let bio = &text[bio_start..];
-    // Only flag bus-controller twins (i2c_device / spi_device / uart_device).
-    // adc_input + device_type for NTC is a separate temporary dual (stimulus
-    // still keys board_io) — not the same bug class as I²C OLED twins.
-    let mut current_kind: Option<String> = None;
+    // Bus-controller kinds in board_io are always dual debt — with or without
+    // device_type. Onboard led/button/adc_input/pwm stay allowed.
     for line in bio.lines() {
         let t = line.trim();
-        if let Some(rest) = t.strip_prefix("kind:") {
-            current_kind = Some(
-                rest.trim()
-                    .trim_matches('"')
-                    .trim_matches('\'')
-                    .to_string(),
-            );
-            continue;
-        }
-        let Some(rest) = t.strip_prefix("device_type:") else {
+        let Some(rest) = t.strip_prefix("kind:") else {
             continue;
         };
-        let rest = rest.trim().trim_matches('"').trim_matches('\'');
-        if rest.is_empty() || rest.starts_with('#') {
-            continue;
-        }
-        let kind = current_kind.as_deref().unwrap_or("");
+        let kind = rest
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'');
         if matches!(kind, "i2c_device" | "spi_device" | "uart_device") {
             offenders.push(format!(
-                "{}: board_io kind={kind} device_type='{rest}' (use external_devices only)",
+                "{}: board_io kind={kind} (use external_devices only)",
                 path.file_name().unwrap().to_string_lossy(),
             ));
         }

--- a/crates/wasm/src/inputs.rs
+++ b/crates/wasm/src/inputs.rs
@@ -344,67 +344,26 @@ impl WasmSimulator {
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
-    /// Set the simulated wiper position on a potentiometer attached to an ADC channel.
+    /// Set the simulated wiper position on a potentiometer kit.
     ///
-    /// All divider math lives in Rust core (Potentiometer::wiper_output_mv).
-    /// This function only validates the position, recomputes wiper_mv via core,
-    /// and injects the result into the ADC peripheral's channel.
-    ///
-    /// `device_id` must match a `board_io` binding with `device_type: "potentiometer"`.
+    /// Thin wrapper over [`Machine::set_input_on`] — identity is the
+    /// `external_devices` id (no board_io twin). Kit math drives the ADC.
     /// `position_pct` must be in 0..=100.
     #[wasm_bindgen]
     pub fn set_potentiometer(&mut self, device_id: &str, position_pct: f32) -> Result<(), JsValue> {
-        use labwired_core::peripherals::components::Potentiometer;
-
         if !(0.0..=100.0).contains(&position_pct) {
             return Err(JsValue::from_str(&format!(
                 "potentiometer position {} out of range (0..=100)",
                 position_pct
             )));
         }
-
-        // Find the board_io binding for this device.
-        let binding = self
-            .board_io
-            .iter()
-            .find(|b| b.id == device_id && b.device_type.as_deref() == Some("potentiometer"))
-            .cloned()
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "No potentiometer board_io binding '{}'",
-                    device_id
-                ))
-            })?;
-
-        let channel = binding.pin;
-
-        // Build a temporary pot model to compute the millivolt output — all math in core.
-        let mv = Potentiometer::new(channel, position_pct).wiper_output_mv();
-
-        // Inject the computed millivolt value into the matching ADC peripheral's channel.
-        let machine = self.machine.as_mut().unwrap();
-        let idx = machine
-            .bus
-            .find_peripheral_index_by_name(&binding.peripheral)
-            .ok_or_else(|| {
-                JsValue::from_str(&format!(
-                    "ADC peripheral '{}' not found",
-                    binding.peripheral
-                ))
-            })?;
-        let any = machine.bus.peripherals[idx]
-            .dev
-            .as_any_mut()
-            .ok_or_else(|| JsValue::from_str("ADC peripheral does not support downcasting"))?;
-        let adc = any.downcast_mut::<Adc>().ok_or_else(|| {
-            JsValue::from_str(&format!(
-                "Peripheral '{}' is not an ADC",
-                binding.peripheral
-            ))
-        })?;
-
-        adc.set_channel_input(channel, mv);
-        Ok(())
+        let machine = self
+            .machine
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("simulator not initialized"))?;
+        machine
+            .set_input_on(device_id, "position", f64::from(position_pct))
+            .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Read the 74HC165's live input byte (bit `i` = channel `i`), or `-1` if
@@ -877,6 +836,46 @@ board_io: []
                 .iter()
                 .any(|a| a.source.component_id() == Some("thermistor")),
             "NTC kit must be stamped with external_devices id"
+        );
+    }
+
+    #[test]
+    fn potentiometer_uses_external_devices_sim_input() {
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let chip_yaml =
+            std::fs::read_to_string(root.join("../../configs/chips/stm32f103.yaml"))
+                .expect("chip");
+        let chip: ChipDescriptor = serde_yaml::from_str(&chip_yaml).expect("parse chip");
+        let manifest: SystemManifest = serde_yaml::from_str(
+            r#"
+name: "pot-only"
+chip: "../chips/stm32f103.yaml"
+external_devices:
+  - id: "pot1"
+    type: "potentiometer"
+    connection: "adc1"
+    config:
+      channel: 0
+board_io: []
+"#,
+        )
+        .expect("manifest");
+        let mut bus = SystemBus::from_config(&chip, &manifest).expect("bus");
+        bus.refresh_peripheral_index();
+        let mut machine = Machine::new(
+            Box::new(labwired_core::cpu::cortex_m::CortexM::new()) as Box<dyn Cpu>,
+            bus,
+        );
+        machine
+            .set_input_on("pot1", "position", 75.0)
+            .expect("drive pot via external_devices id");
+        assert!(
+            machine
+                .bus
+                .analog_inputs
+                .iter()
+                .any(|a| a.source.component_id() == Some("pot1")),
+            "pot kit must be stamped with external_devices id"
         );
     }
 

--- a/examples/seeed-xiao-nrf52840-sense/system.yaml
+++ b/examples/seeed-xiao-nrf52840-sense/system.yaml
@@ -20,9 +20,3 @@ board_io:
     pin: 6
     signal: "output"
     active_high: false
-  - id: "spi0_bus"
-    kind: "spi_device"
-    peripheral: "spi0"
-    pin: 5
-    signal: "output"
-    active_high: false


### PR DESCRIPTION
## Summary
Follow-up cleanup after #784 (universal kits). Removes leftover bus duals and dead board_io paths.

- Drop dual stubs: MLX thermal `i2c_device`, Seeed `spi0_bus`, FRDM empty dual comments
- Strengthen `no_bus_device_board_io_dual` to flag any bus kind (not only `device_type` twins)
- `set_potentiometer` → `set_input_on(id, position)` on external_devices (same as NTC)
- Unit test for pot external_devices path

## Test plan
- [x] `cargo test -p labwired-core --test no_bus_device_board_io_dual`
- [x] `cargo test -p labwired-wasm external_devices`
- [ ] CI pr-gate green