### PR TITLE
docs: agent path, fidelity hub, and board page template

### DIFF
--- a/docs/agent/first-run.md
+++ b/docs/agent/first-run.md
@@ -1,0 +1,98 @@
+# First agent run
+
+Goal: in one session, **describe a board → run firmware → verify** with the oracle.  
+If the model says “it works” without `labwired_verify` (or an explicit oracle green), treat that as **unproven**.
+
+---
+
+## 0. Connect
+
+Follow [Connect an agent (MCP)](mcp.md) — hosted or stdio.  
+Smoke: `labwired_list` returns boards.
+
+---
+
+## 1. Discover hardware
+
+Prompt the agent:
+
+```text
+Using LabWired MCP:
+1) labwired_list kind=board (or list everything)
+2) labwired_describe id=esp32-c3-supermini
+Summarize pins, flash/artifact expectations, and any limitations from the description.
+Do not invent pins not returned by describe.
+```
+
+Prefer ids from `labwired_list` / `labwired_describe`. Example C3 page: [ESP32-C3](../boards/esp32c3.md).
+
+---
+
+## 2. Compile or attach an artifact
+
+**Hosted (easiest):**
+
+```text
+Compile a minimal blink (or my project) for board esp32-c3-supermini
+with labwired_compile. Keep the firmware_ref.
+```
+
+**Stdio:** build with your normal toolchain (ESP-IDF, PlatformIO, …), then pass the ELF / flash image path or a `firmware_ref` the local cache understands. There is **no** `labwired_compile` on stdio.
+
+ESP32-C3 note: many IDF apps need a **merged flash `.bin`**, not a lone app ELF — see the board page.
+
+---
+
+## 3. Run on the twin
+
+```text
+labwired_run with the firmware_ref (and diagram/board if required).
+Return serial output, any faults, and snapshot_id.
+```
+
+Optional: `labwired_inspect` with that `snapshot_id` for GPIO / registers.
+
+---
+
+## 4. Verify (the dispose step)
+
+```text
+labwired_verify against the same board/system and firmware_ref
+with assertions appropriate to the demo (UART token, GPIO level, etc.).
+Report only the oracle result — pass or fail with reason.
+```
+
+**Green** = LabWired oracle accepted the run.  
+**Red** = fix firmware or expectations; do not “reinterpret” as success.
+
+---
+
+## 5. Optional: share with a human
+
+On hosted:
+
+```text
+labwired_lab — open a Studio lab for this board/diagram and give me the share URL.
+```
+
+Or open [app.labwired.com](https://app.labwired.com) yourself.
+
+---
+
+## Good agent habits
+
+| Do | Don’t |
+|----|--------|
+| Call `labwired_describe` before wiring | Guess pin maps from training data |
+| Use `labwired_verify` for claims | “Looks correct from the log” without oracle |
+| Respect ✅/⚠️/❌ on [board pages](../boards/esp32c3.md) | Assert BLE/analog if marked ❌ |
+| Keep firmware as refs | Paste multi‑MB binaries into chat |
+
+---
+
+## Next
+
+- [Tool reference](tools.md)  
+- [CLI path](../getting_started_firmware.md)  
+- [CI / oracle](../ci_integration.md)  
+- [Fidelity](../fidelity.md)  

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -1,0 +1,113 @@
+# Connect an agent (MCP)
+
+LabWired exposes a **Model Context Protocol** server so coding agents can **describe hardware, run firmware on the digital twin, and verify** — without grading their own homework.
+
+The agent **proposes**. The **oracle disposes**.
+
+!!! tip "Product vs engine"
+    This page is for **using** LabWired from Claude Code, Codex, Cursor, and friends.  
+    For contributing to the simulator engine itself, see [Core agents manual](../agents.md).
+
+---
+
+## Two surfaces
+
+| Surface | Endpoint / install | Compile from source | Best for |
+|---------|-------------------|---------------------|----------|
+| **Hosted** | `https://api.labwired.com/mcp` | Yes (`labwired_compile`) | Cloud agents, zero local sim install |
+| **Stdio (local)** | `npx -y @labwired/mcp` | No — flash **artifacts** only | Offline / on-box CLI + `labwired` binary |
+
+Tool names are the same family (`labwired_<verb>`). Stdio **does not** advertise `labwired_compile` — build locally or use hosted, then pass `firmware_ref` / ELF paths. Registry SoT: monorepo `@labwired/board-config` (`mcp-tools.ts`).
+
+---
+
+## Hosted (recommended)
+
+### Claude Code
+
+```bash
+claude mcp add labwired --transport http https://api.labwired.com/mcp
+```
+
+### Codex
+
+```bash
+codex mcp add labwired --url https://api.labwired.com/mcp
+```
+
+Sign in / OAuth when the client prompts — same account as [app.labwired.com](https://app.labwired.com).
+
+### Other HTTP MCP clients
+
+Point the client at:
+
+```text
+https://api.labwired.com/mcp
+```
+
+Use the client’s “remote MCP / HTTP / SSE” flow and complete auth.
+
+---
+
+## Stdio (local)
+
+### Prerequisites
+
+1. **Node ≥ 20**
+2. **`labwired` CLI on `PATH`** (local runs):
+
+```bash
+curl -fsSL https://labwired.com/install.sh | sh
+labwired --help
+```
+
+### Claude Code
+
+```bash
+claude mcp add labwired -- npx -y @labwired/mcp
+```
+
+### Cursor
+
+`~/.cursor/mcp.json` (or project `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "labwired": {
+      "command": "npx",
+      "args": ["-y", "@labwired/mcp"]
+    }
+  }
+}
+```
+
+### Global binary
+
+```bash
+npm install -g @labwired/mcp
+labwired-mcp
+```
+
+---
+
+## Smoke check
+
+Ask the agent:
+
+> List LabWired boards with `labwired_list`, then describe `esp32-c3-supermini` (or `esp32c3`).
+
+You should see catalog entries and pin/toolchain metadata — not a hallucinated pinout.
+
+Next: [First agent run](first-run.md) · [Tool reference](tools.md)
+
+---
+
+## Related
+
+| | |
+|--|--|
+| [Playground](https://app.labwired.com) | Human visual lab |
+| [CLI — running firmware](../getting_started_firmware.md) | Non-agent path |
+| [CI integration](../ci_integration.md) | Oracle in pipelines |
+| [Fidelity](../fidelity.md) | What a green pass means |

--- a/docs/agent/tools.md
+++ b/docs/agent/tools.md
@@ -1,0 +1,86 @@
+# MCP tool reference
+
+Canonical names are `labwired_<verb>`. Both **hosted** (`https://api.labwired.com/mcp`) and **stdio** (`@labwired/mcp`) load tools from the same registry; surface tags decide what each client advertises.
+
+!!! note "Living contract"
+    Shapes live in monorepo `packages/board-config/src/mcp-tools.ts`. If this page and the live server disagree, **the server wins** — file a docs fix.
+
+---
+
+## Core loop (use these first)
+
+| Tool | Hosted | Stdio | Role |
+|------|:------:|:-----:|------|
+| `labwired_search` | ✅ | ✅ | Search the tool catalog by keyword |
+| `labwired_list` | ✅ | ✅ | List boards / MCUs / components (`kind` optional) |
+| `labwired_describe` | ✅ | ✅ | Pins, buses, attrs for any catalog id |
+| `labwired_validate` | ✅ | ✅ | ERC / diagram checks before run |
+| `labwired_compile` | ✅ | ❌ | Source → `firmware_ref` (+ ESP flash images) |
+| `labwired_run` | ✅ | ✅ | Execute firmware on the twin; observe serial/GPIO/… |
+| `labwired_inspect` | ✅ | ✅ | Deeper state from a prior `snapshot_id` |
+| `labwired_verify` | ✅ | ✅ | **Oracle** — pass/fail, not model self-report |
+| `labwired_lab` | ✅ | ❌ | Open / share a Studio lab widget + URL |
+
+**Rule for agents:** never claim success until `labwired_verify` (or an explicit oracle assertion in the run result) is green.
+
+---
+
+## Discovery & parts
+
+| Tool | Hosted | Stdio | Role |
+|------|:------:|:-----:|------|
+| `labwired_catalog` | ✅ | — | Versioned Circuit V1 catalog snapshot |
+| `labwired_resolve_circuit` | ✅ | — | Resolve CircuitRequestV1 → validated graph |
+| `labwired_part` | ✅ | ✅* | Lookup part by MPN / alias / catalog id |
+| `labwired_part_citation` | ✅ | ✅* | Evidence behind a knowledge claim |
+| `labwired_datasheet` | ✅ | ✅* | Read manufacturer datasheet text (paged) |
+| `labwired_export` | ✅ | ✅ | Export diagram (KiCad netlist / schematic / BOM / …) |
+
+\*Advertisement may follow registry `surfaces`; if a tool is missing on stdio, use hosted or the CLI.
+
+---
+
+## Power / advanced
+
+| Tool | Hosted | Stdio | Role |
+|------|:------:|:-----:|------|
+| `labwired_put_source` | ✅ | — | Store source tree as content-addressed refs |
+| `labwired_debug` | ✅ | ✅* | Scripted breakpoints / probe on the twin |
+| `labwired_fuzz` | — | ✅ | Coverage-guided fuzz; crashes are replayable |
+| `labwired_ingest_svd` | — | ✅ | SVD → declarative peripheral YAML |
+| `labwired_validate_device` | — | ✅ | Validate declarative device YAML (no persist) |
+| `labwired_project` | ✅ | — | Create / update / publish Studio projects |
+
+---
+
+## Currency: firmware refs
+
+Hosted `labwired_compile` returns a **`firmware_ref`** (`sha256:<hex>`).  
+`labwired_run` / `labwired_verify` / fuzz accept that ref (or a lab document’s artifact ref).
+
+Stdio resolves refs from the **local artifact cache**, then the hosted blob API when needed. Prefer refs over stuffing multi‑MB binaries through the model context.
+
+---
+
+## Stdio vs hosted run/verify
+
+| | Hosted | Stdio |
+|--|--------|-------|
+| Input | Source compile-then-run **or** `firmware_ref` | **Artifact-only** (`firmware_ref` / path + target) |
+| Diagram | Supported on run/lab paths | Diagram validate + local system yaml patterns |
+| Stimuli | Supported on `labwired_run` | Supported |
+| Snapshot | `snapshot_id` for `labwired_inspect` | In-proc snapshot store |
+
+---
+
+## Deprecated names (do not use)
+
+Old names (`labwired_list_boards`, `labwired_run_device`, `labwired_inspect_run`, `search_tools`, …) are **removed**. Hard rename only — no aliases.
+
+---
+
+## Next
+
+- [Connect MCP](mcp.md)  
+- [First agent run](first-run.md)  
+- Board fidelity: [ESP32-C3](../boards/esp32c3.md)  

--- a/docs/boards/_TEMPLATE.md
+++ b/docs/boards/_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Board page template
+
+**Do not publish this file as a board.** Copy the section order from the exemplar:
+
+→ **[ESP32-C3](esp32c3.md)** (board page v2)
+
+Required sections:
+
+1. Title + one-line summary
+2. Live status tip → scoreboards + rubric
+3. Status at a glance
+4. Flash / firmware artifact
+5. Pins (board label → GPIO)
+6. Support matrix (✅ / ⚠️ / ❌)
+7. What it catches vs bench
+8. How to run (CLI · Playground · MCP)
+9. Related systems & examples
+
+Public docs rules: no competitor names, no pricing strategy, no internal roadmap. Fidelity only.

--- a/docs/boards/esp32c3.md
+++ b/docs/boards/esp32c3.md
@@ -1,43 +1,177 @@
 # ESP32-C3
 
-The Espressif ESP32-C3 (single-core RISC-V RV32IMC, 400 KB SRAM, external
-QSPI flash, Wi-Fi + BLE) is LabWired's reference RISC-V Espressif target.
-All declared peripherals are **declarative** — the chip yaml references
-external YAML descriptors under `configs/peripherals/esp32c3/`.
+Espressif **ESP32-C3** — single-core **RISC-V (RV32IMC)**, ~400 KB SRAM, external QSPI flash, **Wi-Fi** (+ BLE on silicon; see matrix). LabWired's reference **RISC-V / Espressif** target: run the **same binary** you flash to hardware in the oracle, CI, and playground.
+
+This page is the **board-page template** for public docs: status → artifact → pins → support matrix → how to run → honest limits. Copy the section order for other boards.
+
+!!! tip "Live status"
+    The tables below are a maintained snapshot. Authoritative automation:
+
+    - [Chip conformance scoreboard](../coverage/chip-conformance.md) — level · modelled peripherals · register-match
+    - [Tier-1 matrix](../coverage/tier1-scoreboard.md) — per-peripheral pass/fail
+    - [Target support rubric](../target_support_rubric.md) — modeled / stub / silicon-verified
+
+---
 
 ## Status at a glance
 
+| Aspect | Status |
+|--------|--------|
+| Chip descriptor | [`configs/chips/esp32c3.yaml`](../../configs/chips/esp32c3.yaml) |
+| Example system | [`configs/systems/esp32c3-devkit.yaml`](../../configs/systems/esp32c3-devkit.yaml) |
+| Playground board id | `esp32-c3-supermini` (labs such as `esp32c3-oled-lab`) |
+| Reference firmware | [`crates/firmware-esp32c3-demo/`](../../crates/firmware-esp32c3-demo/) |
+| Examples | `examples/esp32c3-blinky`, `esp32c3-oled-demo`, weather / thermal workshops under `examples/` |
+| Wi-Fi path | Register-level MAC + bridge — [ESP32-C3 Wi-Fi MAC bridge](../esp32c3_wifi_mac_bridge.md) |
+| Tier (snapshot) | Full documented SVD estate wired; behavioral depth varies by block (matrix below) |
 
-> **Live status:** the table below is a hand-maintained snapshot. For the authoritative, auto-generated view see the [chip conformance scoreboard](../coverage/chip-conformance.md) (level · modelled peripherals · register-match vs silicon) and the [tier-1 matrix](../coverage/tier1-scoreboard.md) (per-peripheral pass/fail).
+---
 
-| Aspect              | Status                                                                            |
-|---------------------|-----------------------------------------------------------------------------------|
-| Chip yaml           | [`configs/chips/esp32c3.yaml`](../../configs/chips/esp32c3.yaml)                  |
-| System yaml         | [`configs/systems/esp32c3-devkit.yaml`](../../configs/systems/esp32c3-devkit.yaml) |
-| Reference firmware  | [`crates/firmware-esp32c3-demo/`](../../crates/firmware-esp32c3-demo/) (RISC-V `riscv32imc` demo) |
-| Validation          | reset-state conformance vs silicon |
-| WiFi/lwIP           | full association → DHCP → UDP over the register-level MAC — see [`docs/esp32c3_wifi_mac_bridge.md`](../esp32c3_wifi_mac_bridge.md) |
-| Tier                | full documented SVD estate wired + reset-state validated                          |
+## Flash / firmware artifact
 
-## Peripherals (from chip yaml)
+| Use | Artifact | Notes |
+|-----|----------|--------|
+| **ESP-IDF / esptool path** | Merged flash **`.bin`** (bootloader + partition table + app) | Same image you would write to silicon |
+| **Bare / demo crates** | **ELF** where the example links for the C3 map | Demo crates under `crates/firmware-esp32c3-*` |
+| **Arduino / PlatformIO** | Build output for the board's compile profile | Hosted compile: board id `esp32-c3-supermini` |
 
-The chip yaml now wires the **full documented SVD estate** — ~35 peripheral
-descriptors. Behaviorally modeled blocks (RV32IMC core, UART0/1, GPIO, the WiFi
-MAC + radio front-end) drive real firmware; the remainder are declarative
-register windows validated for reset-state conformance and clean mapping (no
-bus faults). Wired blocks include:
+!!! warning "Not STM32-shaped"
+    Do not assume a single `0x0800_0000` ELF like Cortex-M. C3 apps use **IROM/DROM/IRAM** windows and often a **flash image**. See chip yaml `memory_regions` and [Running firmware](../getting_started_firmware.md).
 
-- **Core / console:** RV32IMC core, UART0/1
-  (`crates/core/src/peripherals/esp32c3/uart.rs` — the Espressif register map
-  with real 128-byte TX/RX FIFOs and the `TXFIFO_EMPTY`/`TX_DONE` interrupts
-  ESP-IDF's blocking `uart_tx_all()` waits on), GPIO + `io_mux`, `gpio_sd`
-- **Timers / clocks:** TIMG0/1, `systimer`, `system`, `apb_ctrl`, `rtc_cntl`
-- **Buses:** SPI0/1/2, I²C0, I²S0, `rmt`, `ledc`, `twai0`, `uhci0/1`, GDMA (`dma`)
-- **Radio:** `wifi_mac`, `radio_fe`, `radio_nrx`, `bb` (register-level MAC; see WiFi link above)
-- **Crypto / security:** AES, SHA, RSA, HMAC, DS, XTS-AES, `sensitive`, `assist_debug`
-- **Misc:** `efuse`, `apb_saradc`, `usb_device` (USB-Serial/JTAG), `extmem`
+**ROM dumps (optional):** mask ROM via `LABWIRED_ESP32C3_ROM` / `LABWIRED_ESP32C3_ROM_DATA` (see `esp32c3.yaml`). Without them those windows stay zero; many user apps still boot.
 
-Authoritative bases come from the ESP32-C3 SVD
-(`tests/fixtures/real_world/esp32c3.svd`).
-See [`docs/declarative_registers.md`](../declarative_registers.md) for how
-declarative peripheral descriptors work.
+---
+
+## Pins (Super Mini / common playground mapping)
+
+Canonical playground MCU: **ESP32-C3 Super Mini** (`esp32-c3-supermini`). Silkscreen **D0–D10** map to GPIO; firmware should use the **GPIO matrix**.
+
+| Board label | GPIO | Typical default | Notes |
+|-------------|------|-----------------|--------|
+| D0 | GPIO2 | A0 / GPIO | |
+| D1 | GPIO3 | A1 / GPIO | |
+| D2 | GPIO4 | A2 / GPIO | |
+| D3 | GPIO5 | A3 / GPIO | |
+| D4 | GPIO6 | I2C SDA (common) | Remappable via matrix |
+| D5 | GPIO7 | I2C SCL (common) | Remappable |
+| D6 | GPIO21 | UART TX | |
+| D7 | GPIO20 | UART RX | |
+| D8 | GPIO8 | SPI SCK / **user LED** (active-low on Super Mini) | |
+| D9 | GPIO9 | SPI MISO | |
+| D10 | GPIO10 | SPI MOSI | |
+| 3V3 / 5V / GND | — | Power | Digital levels in sim — not SPICE |
+
+---
+
+## Support matrix
+
+| Mark | Meaning |
+|------|---------|
+| ✅ | Modeled well enough for real drivers / demos we ship |
+| ⚠️ | Present but partial, stubbed, or easy to misuse |
+| ❌ | Not simulated — use the bench |
+
+### Core & boot
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| RV32IMC CPU | ✅ | Instruction-level; unsupported ops audited |
+| Memory map (SRAM, IROM, DROM, IRAM, RTC FAST) | ✅ | Matches IDF link layout |
+| Mask ROM | ⚠️ | Optional image via env |
+| Reset / clocks | ✅ / ⚠️ | Enough for boot + timers |
+
+### Console, GPIO, timers
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| UART0 / UART1 | ✅ | Espressif UART IP + FIFOs (`esp32c3_uart`) — not STM32 UART |
+| GPIO + IO MUX | ✅ | Super Mini LED on GPIO8 active-low |
+| TIMG0 / TIMG1 | ✅ | |
+| SYSTIMER | ✅ | FreeRTOS-style tick source |
+| USB device (USB-Serial/JTAG) | ⚠️ | Do not assume full USB enumeration |
+
+### Buses
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| I2C0 | ✅ | Wire external sensors in system yaml / playground |
+| SPI0 / SPI1 / SPI2 | ⚠️ | Controller modeled; not every external SPI device fully bridged |
+| I2S0, RMT, LEDC, TWAI, UHCI, GDMA | ⚠️ | Wired in yaml; check tier-1 scoreboard |
+
+### Radio & network
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| Wi-Fi (MAC + FE path) | ✅ / ⚠️ | [Wi-Fi MAC bridge](../esp32c3_wifi_mac_bridge.md); sim network, not RF PHY cert |
+| BLE / BT | ❌ | On silicon; not a C3 LabWired deliverable today |
+| Packet-level multi-node RF room | ⚠️ | Separate product work; do not over-claim here |
+
+### ADC, crypto, misc
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| SAR ADC | ⚠️ | No full analog conversion from graph voltage |
+| Crypto blocks / eFuse | ⚠️ | Present in map; verify scoreboard before CI reliance |
+
+---
+
+## What it catches vs what needs a bench
+
+**Sim is strong for:** logic/state-machine bugs; UART/GPIO/timer/I2C bring-up; deterministic CI; Wi-Fi **stack** along the documented bridge.
+
+**Still use silicon for:** analog, power, antenna/EMI, BLE, USB edge cases, flash wear, production sign-off.
+
+See [Fidelity](../fidelity.md), [Hardware-sim parity](../golden_reference.md), [Run limits](../limits.md).
+
+---
+
+## How to run
+
+### CLI (oracle / CI)
+
+```bash
+cargo run -p labwired-cli -- test \
+  --script path/to/esp32c3-test.yaml \
+  --output-dir out/esp32c3-run
+```
+
+```bash
+cargo run -p labwired-cli -- run \
+  --firmware path/to/firmware.elf \
+  --system configs/systems/esp32c3-devkit.yaml
+```
+
+### Playground
+
+1. Open a C3 lab on [app.labwired.com](https://app.labwired.com).
+2. Board: **ESP32-C3 Super Mini**.
+3. Build or upload the correct artifact.
+4. Assert on GPIO / UART / display / oracle — not on ❌ features.
+
+### Agent (MCP)
+
+1. [Connect MCP](../agent/mcp.md).
+2. `labwired_describe` → `esp32-c3-supermini` or `esp32c3`.
+3. `labwired_compile` (hosted) / artifact (stdio) → `labwired_run` → **`labwired_verify`**.
+
+Details: [First agent run](../agent/first-run.md) · [Tools](../agent/tools.md).
+
+---
+
+## Related systems & examples
+
+| Path | What |
+|------|------|
+| `configs/systems/esp32c3-devkit.yaml` | Baseline system |
+| `configs/systems/esp32c3-oled-demo.yaml` | Display lab |
+| `examples/esp32c3-blinky` | Minimal bring-up |
+| `docs/esp32c3_wifi_mac_bridge.md` | Wi-Fi fidelity |
+| [Parts index](../parts/index.md) | External components |
+
+---
+
+## Template checklist (other board pages)
+
+1. Status at a glance · 2. Flash/artifact · 3. Pins · 4. Support matrix · 5. Catch vs bench · 6. CLI · Playground · MCP · 7. Related
+
+No competitor names, pricing strategy, or internal roadmap on board pages.

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -1,0 +1,56 @@
+# Fidelity — what a green pass means
+
+LabWired is a **deterministic digital twin**: same firmware, same system, same seed → same result. A **pass** is an oracle decision, not a model opinion.
+
+---
+
+## What we claim
+
+| Claim | Meaning |
+|-------|---------|
+| **Register-accurate where modeled** | Firmware sees MMIO like silicon for supported blocks |
+| **Same binary** | No special LabWired HAL; vendor SDK binaries |
+| **Replayable** | CI and agents can re-run and get the same dispose |
+| **Honest matrix** | Per-board ✅ / ⚠️ / ❌ — stubs are labeled |
+
+Per-target detail: [Boards](boards/esp32c3.md) and [Target support rubric](target_support_rubric.md).
+
+---
+
+## What we do **not** claim
+
+- Full **analog / SPICE** board physics (unless a page says otherwise)  
+- **RF certification** or perfect PHY  
+- Every peripheral on every chip at silicon depth  
+- That an **unmodeled** access is “fine” — expect faults or stuck polls  
+
+When firmware hits unmapped or stubbed behavior, prefer **fail loud** over silent success.
+
+---
+
+## Live evidence (not marketing)
+
+| Scoreboard | URL on this site |
+|------------|------------------|
+| Chip conformance | [coverage/chip-conformance](coverage/chip-conformance.md) |
+| Tier-1 peripheral matrix | [coverage/tier1-scoreboard](coverage/tier1-scoreboard.md) |
+| Hardware–sim parity | [golden_reference](golden_reference.md) |
+| Run limits | [limits](limits.md) |
+
+Silicon-verified boards cite dates and harnesses on their board page (example: [nRF52840](boards/nrf52840.md)).
+
+---
+
+## Agent rule
+
+> No correctness claim without **`labwired_verify`** (or an explicit oracle assertion result).
+
+See [First agent run](agent/first-run.md).
+
+---
+
+## Deeper engineering
+
+- [Architecture](architecture.md)  
+- [Hardware–sim parity](golden_reference.md)  
+- [Peripheral modeling](peripherals.md)  

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,56 +1,62 @@
 # LabWired Core Documentation
 
-Welcome to the **LabWired Core** documentation. LabWired is a deterministic firmware simulation platform designed to replace physical hardware in CI pipelines.
+**Deterministic firmware simulation** — the same binary in the browser, in CI, and under an agent. The agent proposes; the **oracle disposes**.
 
-## 🚀 Getting Started
+---
 
-If you are new to LabWired, start here:
+## Three doors (start here)
 
-- **[Running Your Firmware](getting_started_firmware.md)**: Learn how to load ELF binaries and execute them in the simulator.
-- **[Per-Board Coverage](boards/)**: What's modeled per chip — see e.g.
-  [`stm32f401`](boards/stm32f401.md),
-  [`stm32f407` (I²C onboarding-in-flight)](boards/stm32f407.md),
-  [`stm32h563`](boards/stm32h563.md),
-  [`stm32l476` (gold reference)](boards/nucleo-l476rg.md),
-  [`nrf52840`](boards/nrf52840.md),
-  [`seeed-xiao-nrf52840-sense`](boards/seeed-xiao-nrf52840-sense.md),
-  [`rp2040`](boards/rp2040.md),
-  [`esp32c3`](boards/esp32c3.md).
-  Check here before pointing firmware at a new chip.
-- **[Board Onboarding](board_onboarding_playbook.md)**: Steps to add support for a new microcontroller or board.
+| Path | For | Start |
+|------|-----|--------|
+| **Playground** | Humans, zero install | [Playground first run](tutorials/playground.md) · [app.labwired.com](https://app.labwired.com) |
+| **Agent (MCP)** | Claude Code, Codex, Cursor, … | [Connect MCP](agent/mcp.md) · [First agent run](agent/first-run.md) · [Tools](agent/tools.md) |
+| **CLI / CI** | Local sim, pipelines, oracle scripts | [Running firmware](getting_started_firmware.md) · [CI integration](ci_integration.md) |
 
-## 🧠 Core Concepts
+**Fidelity:** [What a green pass means](fidelity.md) · [Scoreboards](coverage/chip-conformance.md)
 
-Understand how LabWired achieves deterministic simulation:
+---
 
-- **[Architecture Overview](architecture.md)**: Explains the split between the CPU Core, System Bus, and Peripherals.
-- **[Configuration Reference](configuration_reference.md)**: Detailed schema for defining chips and systems (YAML).
+## Boards & parts
 
-## 🛠 Developer Guides
+- **[Boards](boards/esp32c3.md)** — per-MCU pins, artifact format, ✅/⚠️/❌ matrix (template: [ESP32-C3](boards/esp32c3.md))
+- **[Parts](parts/index.md)** — external components (sensors, displays, …)
+- **[Board onboarding](board_onboarding_playbook.md)** — add a new chip (contributors)
 
-For contributors extending the core engine or adding new peripherals:
+Popular boards: [ESP32-C3](boards/esp32c3.md) · [nRF52840](boards/nrf52840.md) · [RP2040](boards/rp2040.md) · [STM32F401](boards/stm32f401.md)
 
-- **[Peripheral Modeling](peripherals.md)**: How to model and validate a peripheral — declarative YAML and Rust paths, the silicon-validation loop, and the merge bar.
-- **[Declarative Registers](declarative_registers.md)**: The register-map YAML schema.
-- **[CI Integration](ci_integration.md)**: How to run LabWired in GitHub Actions or GitLab CI.
-- **[Coverage Scoreboard](coverage_scoreboard.md)**: Top-target smoke coverage and deterministic status tracking.
-- **Onboarding Smoke CI**: `core-onboarding-smoke.yml` publishes time-to-first-smoke metrics and scoreboard artifacts.
-- **[Catalog Validation Structure](catalog_validation.md)**: Separation of PR smoke vs full target sweep and catalog metadata ownership.
-- **[Target Support Rubric](target_support_rubric.md)**: Objective support levels and promotion criteria.
+---
 
-## 🔍 Debugging
+## Core concepts
 
-- **[VS Code Debugging](vscode_debugging.md)**: Recipes for `launch.json`.
-- **[Native DAP](debugging.md)**: Architecture of the built-in Debug Adapter.
-- **[GDB Integration](gdb_integration.md)**: Using standard GDB clients.
+- [Architecture overview](architecture.md) — CPU, bus, peripherals
+- [Hardware–sim parity](golden_reference.md)
+- [Configuration (YAML)](configuration_reference.md)
+- [Target support rubric](target_support_rubric.md)
 
-## 🤖 AI Agents
+---
 
-- **[Core Agents Manual](./agents.md)**: Essential onboarding for AI coding agents working in this repository.
+## Tutorials & examples
 
-## 📚 Examples and Case Studies
+- [Simulating sensors (I²C)](examples/i2c_sensor_example.md)
+- [DMA & interrupts](examples/dma_exti_example.md)
+- [Integrated test walkthrough](examples/integrated_test_walkthrough.md)
 
-Practical walkthroughs and technical deep-dives:
+---
 
-- **[I2C Sensor Simulation](examples/i2c_sensor_example.md)**: Verify driver code against a mock I2C device.
-- **[DMA & Interrupts](examples/dma_exti_example.md)**: Understanding the two-phase execution model.
+## Debugging
+
+- [VS Code](vscode_debugging.md) · [Native DAP](debugging.md) · [GDB](gdb_integration.md)
+
+---
+
+## Contributing (engine)
+
+- [Core agents manual](agents.md) — AI agents working **in this repository**
+- [Peripheral modeling](peripherals.md) · [Declarative registers](declarative_registers.md)
+- [Release strategy](release_strategy.md)
+
+---
+
+## Product
+
+Simulation for registered users is not cycle-metered on the product side; hosted agent tokens follow your plan on [labwired.com](https://labwired.com). This site documents **how the twin works** and **how to drive it**.

--- a/docs/parts/_TEMPLATE.md
+++ b/docs/parts/_TEMPLATE.md
@@ -1,0 +1,40 @@
+# Part page template (external component)
+
+**Do not publish this file as a part.** Create `parts/<id>.md` and add it under **Parts** in `mkdocs.yml`.
+
+## Title
+
+One line: what it is (e.g. "SSD1306 128×64 I2C OLED").
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Device descriptor | `configs/devices/<id>.yaml` or Rust kit path |
+| Buses | I2C / SPI / GPIO — addresses, CS |
+| Playground type id | catalog id |
+| Example system | `configs/systems/...` |
+| Tier | modeled / partial / stub |
+
+## Pins / bus attachment
+
+Table: component pin → typical MCU pin / net.
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Register map / protocol | ✅/⚠️/❌ | |
+| Visual in playground | ✅/⚠️/❌ | |
+| Noise / SimInput | ✅/⚠️/❌ | |
+| Power / analog | ❌ | usually bench |
+
+## How to run
+
+Minimal system yaml or playground steps + MCP `labwired_describe` id.
+
+## Related boards
+
+Link board pages that demos use (e.g. [ESP32-C3](../boards/esp32c3.md)).
+
+Exemplar board shape: [ESP32-C3](../boards/esp32c3.md).

--- a/docs/parts/index.md
+++ b/docs/parts/index.md
@@ -1,0 +1,42 @@
+# Parts (external components)
+
+External devices you wire to an MCU in the Playground or system YAML — sensors, displays, actuators, and (when documented) network helpers.
+
+**Board pages** describe the MCU. **Part pages** describe everything else.
+
+!!! tip "Template"
+    Authors: copy [parts/_TEMPLATE.md](_TEMPLATE.md). Tone and matrix style match [ESP32-C3](../boards/esp32c3.md).
+
+---
+
+## How to use parts from an agent
+
+1. `labwired_list` with `kind=component` (or search)
+2. `labwired_describe` with the catalog id
+3. Wire in a diagram → `labwired_validate` → `labwired_run` / `labwired_verify`
+
+Do not invent I2C addresses or pin names — use describe / part pages.
+
+---
+
+## Catalog (v1 pages)
+
+Full device models live in engine configs (`configs/devices/`, Rust kits) and the product catalog. **Public part pages** land here as they are written.
+
+| Category | Planned public pages (parity / playground) |
+|----------|--------------------------------------------|
+| Sensors | MCP9808, BMP280, MPU6050, MMA8451Q, … |
+| Displays | SSD1306, LCD1602, seven-segment, … |
+| Actuators | SG90, LED / RGB, APA102, buzzer, … |
+| Inputs | Button, switch |
+| Network | RF / Wi-Fi helpers when product-ready |
+
+Until a part page exists: use `labwired_describe`, board examples under `examples/`, and [I2C sensor tutorial](../examples/i2c_sensor_example.md).
+
+---
+
+## Related
+
+- [Boards](../boards/esp32c3.md)
+- [MCP tools](../agent/tools.md)
+- [Simulating sensors (I2C)](../examples/i2c_sensor_example.md)

--- a/docs/tutorials/playground.md
+++ b/docs/tutorials/playground.md
@@ -1,0 +1,54 @@
+# Playground first run
+
+No Rust install. Open a lab, run firmware on a virtual board, share a link.
+
+---
+
+## 1. Open Studio
+
+Go to **[app.labwired.com](https://app.labwired.com)** and sign in (or use the guest path if offered).
+
+---
+
+## 2. Pick a board / starter lab
+
+Start from a starter (LED, OLED, …) or an empty lab and add an MCU from the catalog.
+
+Examples:
+
+- **ESP32-C3 Super Mini** — see [ESP32-C3 board docs](../boards/esp32c3.md)  
+- **nRF52840** — see [nRF52840](../boards/nrf52840.md)  
+
+Check the board page for **flash artifact** (ELF vs merged `.bin`) and the support matrix before expecting a peripheral to work.
+
+---
+
+## 3. Build or upload firmware
+
+- Use the in-lab build when the board’s compile profile is available, **or**  
+- Upload the artifact you would flash to silicon  
+
+If serial/oracle checks fail, confirm you are not asserting on a **❌ / ⚠️ stub** feature.
+
+---
+
+## 4. Run and observe
+
+Hit run. Watch serial, pins, and any display widgets.  
+Deterministic twin: re-run with the same inputs should match.
+
+---
+
+## 5. Share
+
+Use the lab share URL for humans or hand the same board id to an agent via [MCP](../agent/mcp.md).
+
+---
+
+## Next
+
+| Path | Doc |
+|------|-----|
+| Agent does the loop | [First agent run](../agent/first-run.md) |
+| CLI / CI | [Running firmware](../getting_started_firmware.md), [CI](../ci_integration.md) |
+| What “pass” means | [Fidelity](../fidelity.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,11 +55,18 @@ plugins:
 
 nav:
   - Home: index.md
+  - Fidelity: fidelity.md
   - Architecture Overview: architecture.md
   - Hardware-Sim Parity: golden_reference.md
-  - AI Agent Manual: agents.md
+
+  - Agent:
+    - Connect MCP: agent/mcp.md
+    - Tool reference: agent/tools.md
+    - First agent run: agent/first-run.md
+    - Contributing (engine agents): agents.md
 
   - Tutorials:
+    - Playground first run: tutorials/playground.md
     - Running Firmware: getting_started_firmware.md
     - Simulating Sensors (I2C): examples/i2c_sensor_example.md
     - Mastering DMA & Interrupts: examples/dma_exti_example.md
@@ -90,22 +97,29 @@ nav:
     - Target Support Rubric: target_support_rubric.md
 
   - Boards:
+    - ESP32-C3: boards/esp32c3.md
+    - ESP32-S3: boards/esp32s3.md
+    - nRF52840: boards/nrf52840.md
+    - XIAO nRF52840 Sense: boards/seeed-xiao-nrf52840-sense.md
+    - RP2040: boards/rp2040.md
+    - RP2350: boards/rp2350.md
     - STM32F103: boards/stm32f103.md
     - STM32F401: boards/stm32f401.md
+    - STM32F405: boards/stm32f405.md
     - STM32F407: boards/stm32f407.md
+    - STM32F411: boards/stm32f411.md
+    - STM32F767: boards/stm32f767.md
     - NUCLEO-L476RG: boards/nucleo-l476rg.md
+    - NUCLEO-L073RZ: boards/nucleo-l073rz.md
     - STM32H563: boards/stm32h563.md
     - STM32H735: boards/stm32h735.md
     - STM32WBA52: boards/stm32wba52.md
     - nRF52832: boards/nrf52832.md
-    - nRF52840: boards/nrf52840.md
-    - RP2040: boards/rp2040.md
-    - ESP32-C3: boards/esp32c3.md
-    - ESP32-S3: boards/esp32s3.md
     - nRF5340: boards/nrf5340.md
     - nRF54L15: boards/nrf54l15.md
-    - NUCLEO-L073RZ: boards/nucleo-l073rz.md
-    - XIAO nRF52840 Sense: boards/seeed-xiao-nrf52840-sense.md
+
+  - Parts:
+    - Overview: parts/index.md
 
   - Operations:
     - Release Strategy: release_strategy.md


### PR DESCRIPTION
## Summary
- Public Agent docs: MCP connect, tool reference, first agent run
- Fidelity hub, playground tutorial, parts index
- ESP32-C3 board page v2 (artifact / pins / support matrix / run paths)
- Home three doors + mkdocs nav (Agent, Parts, Fidelity)

Triggers **Deploy Docs** on merge to main → docs.labwired.com.

## Test plan
- [ ] PR checks green
- [ ] After merge: Deploy Docs workflow succeeds
- [ ] Spot-check https://docs.labwired.com/agent/mcp/ and https://docs.labwired.com/boards/esp32c3/