### PR TITLE
docs: parts catalog, nRF52840/RP2040 templates, llms map

### DIFF
--- a/docs/boards/nrf52840.md
+++ b/docs/boards/nrf52840.md
@@ -1,25 +1,85 @@
 # nRF52840
 
-The Nordic nRF52840 (Cortex-M4F, 1 MB flash, 256 KB SRAM, 2.4 GHz radio,
-USB) is a popular Nordic part used by the
-[nRF52840-DK](../../configs/systems/nrf52840-dk.yaml) and the
-[XIAO nRF52840](https://wiki.seeedstudio.com/XIAO_BLE/) family. The LabWired
-model declares 47 peripherals, verified register-by-register against real
-silicon (Seeed XIAO nRF52840 Sense, SWD via ST-LINK V2 + OpenOCD, 2026-06-09).
+Nordic **nRF52840** — Cortex-M4F, 1 MB flash, 256 KB SRAM, 2.4 GHz radio, USB. LabWired models a full peripheral estate with **silicon-verified** register sweeps (Seeed XIAO nRF52840 Sense).
+
+!!! tip "Live status"
+    - [Chip conformance](../coverage/chip-conformance.md)
+    - [Tier-1 matrix](../coverage/tier1-scoreboard.md)
+    - [Target support rubric](../target_support_rubric.md)
+
+---
 
 ## Status at a glance
 
+| Aspect | Status |
+|--------|--------|
+| Chip descriptor | [`configs/chips/nrf52840.yaml`](../../configs/chips/nrf52840.yaml) — 47 peripherals |
+| Example system | [`configs/systems/nrf52840-dk.yaml`](../../configs/systems/nrf52840-dk.yaml) |
+| Playground / form factor | nRF52840-DK; [XIAO nRF52840 Sense](seeed-xiao-nrf52840-sense.md) |
+| Reference firmware | [`crates/firmware-nrf52840-demo`](../../crates/firmware-nrf52840-demo) |
+| Conformance | [`crates/firmware-nrf52840-conformance`](../../crates/firmware-nrf52840-conformance) |
+| Tier | **silicon-verified** (see below) |
 
-> **Live status:** the table below is a hand-maintained snapshot. For the authoritative, auto-generated view see the [chip conformance scoreboard](../coverage/chip-conformance.md) (level · modelled peripherals · register-match vs silicon) and the [tier-1 matrix](../coverage/tier1-scoreboard.md) (per-peripheral pass/fail).
+---
 
-| Aspect              | Status                                                                          |
-|---------------------|---------------------------------------------------------------------------------|
-| Chip yaml           | [`configs/chips/nrf52840.yaml`](../../configs/chips/nrf52840.yaml) — 47 peripherals |
-| System yaml         | [`configs/systems/nrf52840-dk.yaml`](../../configs/systems/nrf52840-dk.yaml)    |
-| Reference firmware  | [`crates/firmware-nrf52840-demo`](../../crates/firmware-nrf52840-demo)          |
-| Conformance firmware| [`crates/firmware-nrf52840-conformance`](../../crates/firmware-nrf52840-conformance) |
-| Validation          | [`examples/seeed-xiao-nrf52840-sense/VALIDATION.md`](../../examples/seeed-xiao-nrf52840-sense/VALIDATION.md) |
-| Tier                | silicon-verified — full peripheral register sweep + behavioral conformance gate |
+## Flash / firmware artifact
+
+| Use | Artifact | Notes |
+|-----|----------|--------|
+| Zephyr / bare-metal | **ELF** | Vector table at flash base per Nordic map |
+| Arduino / PlatformIO | Board compile profile output | Hosted compile when board id registered |
+| UF2 / SoftDevice | — | SoftDevice stacks: check whether your image expects radio stack blobs |
+
+---
+
+## Pins (nRF52840-DK / common)
+
+Nordic pins are **P0.xx / P1.xx**. Playground and board-config map DK silkscreen to GPIO — always `labwired_describe` the board id you use.
+
+| Bank | Role |
+|------|------|
+| P0.0–P0.31 | GPIO0 |
+| P1.0–P1.15 | GPIO1 (sim may remap base; see silicon notes below) |
+| UART / SPI / TWI | Via PSEL registers (not fixed Arduino pins only) |
+
+---
+
+## Support matrix (summary)
+
+| Block | Status | Notes |
+|-------|--------|-------|
+| Cortex-M4F + FPU | ✅ | Thumb-2 + VFPv4 |
+| GPIO P0/P1 | ✅ silicon-verified | Strict register match |
+| UART / SPIM / TIMER / RTC / WDT / RNG | ✅ silicon-verified | See harness table |
+| RADIO / BLE air | ✅ / ⚠️ | RADIO registers + air model; not full BLE stack cert |
+| USB | ✅ / ⚠️ | Modelled; edge cases may differ |
+| CRYPTOCELL / NFC / QSPI / … | ✅ modelled / verified subsets | Scoreboard is authority |
+
+---
+
+## What it catches vs bench
+
+**Strong:** GPIO/UART/SPI drivers, deterministic CI, register-level regressions vs silicon captures.  
+**Bench:** RF certification, analog SAADC accuracy, USB host edge cases, SoftDevice-only bugs.
+
+---
+
+## How to run
+
+### CLI
+```bash
+cargo run -p labwired-cli -- run \
+  --firmware path/to/zephyr.elf \
+  --system configs/systems/nrf52840-dk.yaml
+```
+
+### Playground
+Open an nRF52840 / XIAO lab on [app.labwired.com](https://app.labwired.com).
+
+### Agent
+[Connect MCP](../agent/mcp.md) → `labwired_describe` → `labwired_run` / **`labwired_verify`**.
+
+---
 
 ## Silicon verification (2026-06-09, Seeed XIAO nRF52840 Sense, ST-LINK V2)
 

--- a/docs/boards/rp2040.md
+++ b/docs/boards/rp2040.md
@@ -1,54 +1,87 @@
-# RP2040 (Raspberry Pi Pico)
+# RP2040
 
-The RP2040 (dual Cortex-M0+, 264 KB SRAM, external QSPI flash, PIO state
-machines) is a Tier 1 LabWired target. The current model
-declares UART0 plus PIO0; the second core, SIO, and the rest of the
-silicon are not yet declared in the chip yaml.
+Raspberry Pi **RP2040** (dual Cortex-M0+, 264 KB SRAM, external QSPI flash, PIO). LabWired **Tier-1** target — useful for bring-up, with honest gaps below.
+
+!!! tip "Live status"
+    - [Chip conformance](../coverage/chip-conformance.md)
+    - [Tier-1 matrix](../coverage/tier1-scoreboard.md)
+    - [Target support rubric](../target_support_rubric.md)
+
+---
 
 ## Status at a glance
 
+| Aspect | Status |
+|--------|--------|
+| Chip descriptor | [`configs/chips/rp2040.yaml`](../../configs/chips/rp2040.yaml) |
+| Systems | `configs/systems/pico.yaml`, `configs/systems/rp2040-pico.yaml` |
+| Playground | Raspberry Pi Pico / related board ids in board-config |
+| Reference firmware | `crates/firmware-rp2040-pio-onboarding/` |
+| Tier | Structural / growing — **read matrix** before CI claims |
 
-> **Live status:** the table below is a hand-maintained snapshot. For the authoritative, auto-generated view see the [chip conformance scoreboard](../coverage/chip-conformance.md) (level · modelled peripherals · register-match vs silicon) and the [tier-1 matrix](../coverage/tier1-scoreboard.md) (per-peripheral pass/fail).
+---
 
-| Aspect              | Status                                                                  |
-|---------------------|-------------------------------------------------------------------------|
-| Chip yaml           | [`configs/chips/rp2040.yaml`](../../configs/chips/rp2040.yaml)          |
-| System yamls        | `configs/systems/pico.yaml`, `configs/systems/rp2040-pico.yaml`         |
-| Reference firmware  | `crates/firmware-rp2040-pio-onboarding/`                                |
-| Validation          | No `VALIDATION.md` checked in                                           |
-| Tier                | structural — UART0 + PIO0 declared, no in-tree validation runbook       |
+## Flash / firmware artifact
 
-## Peripherals (from chip yaml)
+| Use | Artifact | Notes |
+|-----|----------|--------|
+| Pico SDK / bare-metal | **ELF** or UF2-derived image as supported by loader | Match memory map in chip yaml |
+| Arduino-Pico | Compile profile output | Hosted compile when registered |
 
-| Peripheral | Base       | Status       | Notes                                                  |
-|------------|------------|--------------|--------------------------------------------------------|
-| Cortex-M0+ | —          | ✅ modeled   | Single core only — second core not modeled             |
-| UART0      | 0x40034000 | ✅ modeled   | `stm32v2` profile (note: not RP2040-native register layout) |
-| PIO0       | 0x50200000 | ⚙ yaml-listed| Programmable I/O state machine block                   |
+---
 
-## Not yet modeled (commonly expected on RP2040)
+## Pins (Raspberry Pi Pico)
 
-The chip yaml does not declare: **Core 1** (second Cortex-M0+), **SIO**
-(single-cycle I/O, including hardware spinlocks and FIFOs), **RESETS**,
-**CLOCKS**, **PLL_SYS / PLL_USB**, **XOSC**, **ROSC**, **WATCHDOG**,
-**TIMER**, **GPIO** bank (IO_BANK0 / PADS_BANK0), **PIO1**, **DMA**,
-**UART1**, **SPI0/1**, **I²C0/1**, **PWM**, **ADC**, **USB**, **SSI /
-XIP** (external flash interface), **TBMAN**, **VREG_AND_CHIP_RESET**.
+| Silk | GPIO | Notes |
+|------|------|--------|
+| GP0–GP28 | GPIO0–28 | Standard Pico header map |
+| 3V3 / GND | Power | Digital twin |
+| ADC GPIOs | GP26–29 | ADC modelling may be partial |
 
-PIO firmware specifically: PIO0 is yaml-listed but full PIO program
-execution / state-machine semantics are not part of the
-`firmware-rp2040-pio-onboarding` survival path yet — see that crate for
-the current scope.
+Always confirm with `labwired_describe` for the exact board id.
 
-Firmware that touches any unmodeled register will hit
-`MemoryAccessViolation` or stall in a polling loop. See
-[`docs/getting_started_firmware.md`](../getting_started_firmware.md).
+---
 
-## Roadmap notes
+## Support matrix
 
-RP2040 is a Tier 1 target (see
-[`docs/coverage_scoreboard.md`](../coverage_scoreboard.md)). Closing the gap
-to a full Tier 1 model requires at minimum: Core 1, SIO, RESETS, CLOCKS,
-TIMER, IO_BANK0/PADS_BANK0, and full PIO state-machine execution. The
-hardware-validation playbook to follow once peripherals are added is
-[`docs/boards/nucleo-l476rg.md`](nucleo-l476rg.md).
+| Block | Status | Notes |
+|-------|--------|-------|
+| Cortex-M0+ core 0 | ✅ | Instruction path |
+| Core 1 (second M0+) | ❌ / ⚠️ | Not a complete dual-core product story yet |
+| UART0 | ✅ | Modelled (check register profile notes in chip yaml) |
+| PIO0 | ⚠️ | Yaml-listed; full SM execution depth limited |
+| GPIO / SIO / DMA / USB / ADC / SPI / I²C / PWM | ⚠️ / ❌ | Many blocks incomplete — unmodeled access → fault or stall |
+| External QSPI XIP | ⚠️ | Flash load path depends on image |
+
+Firmware that touches unmodeled MMIO will hit `MemoryAccessViolation` or poll forever — that is intentional honesty.
+
+---
+
+## What it catches vs bench
+
+**Strong:** Single-core logic demos that stay on modelled peripherals; agent/CLI oracle loops when assertions match reality.  
+**Bench / later:** Full PIO programs, dual-core + SIO FIFOs, USB device stack, timing-sensitive bit-banging on incomplete GPIO.
+
+---
+
+## How to run
+
+### CLI
+```bash
+cargo run -p labwired-cli -- run \
+  --firmware path/to/firmware.elf \
+  --system configs/systems/pico.yaml
+```
+
+### Playground
+Pico-class lab on [app.labwired.com](https://app.labwired.com).
+
+### Agent
+[MCP](../agent/mcp.md) → describe board → run → **verify**. Do not claim PIO/USB success if the matrix says otherwise.
+
+---
+
+## Related
+
+- [ESP32-C3 template](esp32c3.md) · [Parts](../parts/index.md) · [Fidelity](../fidelity.md)
+- Roadmap / scoreboard: [coverage_scoreboard](../coverage_scoreboard.md)

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1,0 +1,34 @@
+# llms.txt — LabWired for agents
+
+```
+# LabWired
+> Deterministic firmware digital twin. Agent proposes; oracle disposes.
+
+## Product
+- Studio / Playground: https://app.labwired.com
+- Docs: https://docs.labwired.com
+- Hosted MCP: https://api.labwired.com/mcp
+- Stdio MCP: npx -y @labwired/mcp
+
+## Install MCP
+- Claude Code (hosted): claude mcp add labwired --transport http https://api.labwired.com/mcp
+- Claude Code (stdio): claude mcp add labwired -- npx -y @labwired/mcp
+- Codex: codex mcp add labwired --url https://api.labwired.com/mcp
+
+## Core tools (labwired_*)
+- labwired_search, labwired_list, labwired_describe
+- labwired_validate, labwired_compile (hosted only)
+- labwired_run, labwired_inspect, labwired_verify
+- labwired_lab (hosted), labwired_fuzz (stdio), labwired_debug
+
+## Rule
+Never claim firmware success without labwired_verify (or explicit oracle green).
+
+## Docs map
+- Agent: /agent/mcp/ /agent/tools/ /agent/first-run/
+- Fidelity: /fidelity/
+- Boards: /boards/esp32c3/ /boards/nrf52840/ /boards/rp2040/
+- Parts: /parts/
+```
+
+Human pages: [Connect MCP](agent/mcp.md) · [Tools](agent/tools.md) · [First run](agent/first-run.md).

--- a/docs/parts/apa102.md
+++ b/docs/parts/apa102.md
@@ -1,0 +1,42 @@
+# APA102 / DotStar
+
+APA102 addressable RGB LED strip (SPI clock + data).
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `apa102` |
+| Bus | SPI-like (data + clock) |
+| Address / select | n/a |
+| Source | Rust kit `apa102.rs` |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| DI | Data |
+| CI | Clock |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Frame stream / brightness | ✅ | Configurable LED count |
+| Power / daisy electrical | ❌ | Not modelled |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=apa102` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `labwired_describe id=apa102`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/bmp280.md
+++ b/docs/parts/bmp280.md
@@ -1,0 +1,43 @@
+# BMP280
+
+Bosch BMP280 pressure + temperature (I²C/SPI).
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `bmp280` |
+| Bus | I²C (primary in playground) |
+| Address / select | 0x76 / 0x77 |
+| Source | Rust kit `bmp280.rs` |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| SDA/SDI | Data |
+| SCL/SCK | Clock |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Pressure / temp reads | ✅ | Digital twin |
+| Compensation formulas | ⚠️ | Check demo fidelity |
+| SPI mode | ⚠️ | Prefer I²C unless wired SPI kit |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=bmp280` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. Weather-station style labs.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/button.md
+++ b/docs/parts/button.md
@@ -1,0 +1,41 @@
+# Button
+
+Momentary push button for GPIO input stimuli.
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `button` |
+| Bus | GPIO |
+| Address / select | n/a |
+| Source | `button` component |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| A/B | To GPIO / GND |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Click / level to GPIO | ✅ | Agent stimuli + UI |
+| Bounce physics | ⚠️ | Idealized |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=button` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. Drive with playground click or `labwired_run` stimuli.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/buzzer.md
+++ b/docs/parts/buzzer.md
@@ -1,0 +1,41 @@
+# Buzzer
+
+Simple active/passive buzzer driven from GPIO.
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `buzzer` |
+| Bus | GPIO |
+| Address / select | n/a |
+| Source | catalog `buzzer` |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| Signal | GPIO |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| On/off / tone indication | ✅ | Digital |
+| Acoustic fidelity | ❌ | Not audio SPICE |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=buzzer` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `labwired_describe id=buzzer`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/index.md
+++ b/docs/parts/index.md
@@ -1,42 +1,34 @@
 # Parts (external components)
 
-External devices you wire to an MCU in the Playground or system YAML — sensors, displays, actuators, and (when documented) network helpers.
-
-**Board pages** describe the MCU. **Part pages** describe everything else.
+External devices you wire to an MCU in the Playground or system YAML.
 
 !!! tip "Template"
-    Authors: copy [parts/_TEMPLATE.md](_TEMPLATE.md). Tone and matrix style match [ESP32-C3](../boards/esp32c3.md).
+    Authors: [parts/_TEMPLATE.md](_TEMPLATE.md). Board tone: [ESP32-C3](../boards/esp32c3.md).
 
----
+## Agent path
 
-## How to use parts from an agent
+1. `labwired_list` (`kind=component` if supported)
+2. `labwired_describe` with catalog id
+3. `labwired_validate` → `labwired_run` / `labwired_verify`
 
-1. `labwired_list` with `kind=component` (or search)
-2. `labwired_describe` with the catalog id
-3. Wire in a diagram → `labwired_validate` → `labwired_run` / `labwired_verify`
+## Catalog (documented)
 
-Do not invent I2C addresses or pin names — use describe / part pages.
+| Part | Catalog id | Bus |
+|------|------------|-----|
+| [MCP9808](mcp9808.md) | `mcp9808` | I²C |
+| [MMA8451Q](mma8451q.md) | `mma8451q` | I²C |
+| [MPU-6050](mpu6050.md) | `mpu6050` | I²C |
+| [BMP280](bmp280.md) | `bmp280` | I²C (primary in playground) |
+| [SSD1306 OLED](ssd1306.md) | `oled-ssd1306 / oled-ssd1306-128x32` | I²C |
+| [LCD1602](lcd1602.md) | `lcd1602` | GPIO parallel / I²C backpack variants |
+| [APA102 / DotStar](apa102.md) | `apa102` | SPI-like (data + clock) |
+| [SG90 / hobby servo](servo.md) | `servo` | GPIO PWM / pulse |
+| [Button](button.md) | `button` | GPIO |
+| [Buzzer](buzzer.md) | `buzzer` | GPIO |
+| [Seven-segment display](seven-segment.md) | `seven-segment` | GPIO / SPI shift |
 
----
-
-## Catalog (v1 pages)
-
-Full device models live in engine configs (`configs/devices/`, Rust kits) and the product catalog. **Public part pages** land here as they are written.
-
-| Category | Planned public pages (parity / playground) |
-|----------|--------------------------------------------|
-| Sensors | MCP9808, BMP280, MPU6050, MMA8451Q, … |
-| Displays | SSD1306, LCD1602, seven-segment, … |
-| Actuators | SG90, LED / RGB, APA102, buzzer, … |
-| Inputs | Button, switch |
-| Network | RF / Wi-Fi helpers when product-ready |
-
-Until a part page exists: use `labwired_describe`, board examples under `examples/`, and [I2C sensor tutorial](../examples/i2c_sensor_example.md).
-
----
+More devices exist in engine configs and the product catalog — if a part is missing here, describe still works when the id is in the live catalog.
 
 ## Related
 
-- [Boards](../boards/esp32c3.md)
-- [MCP tools](../agent/tools.md)
-- [Simulating sensors (I2C)](../examples/i2c_sensor_example.md)
+- [Boards](../boards/esp32c3.md) · [MCP tools](../agent/tools.md) · [I²C tutorial](../examples/i2c_sensor_example.md)

--- a/docs/parts/lcd1602.md
+++ b/docs/parts/lcd1602.md
@@ -1,0 +1,41 @@
+# LCD1602
+
+HD44780-class 16×2 character LCD.
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `lcd1602` |
+| Bus | GPIO parallel / I²C backpack variants |
+| Address / select | backpack-dependent |
+| Source | Rust kit `lcd1602.rs` |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| RS/E/D4–D7 or I²C | Per wiring |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Character write / visual | ✅ | Playground |
+| Full HD44780 timing | ⚠️ | Functional not SPICE |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=lcd1602` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `labwired_describe id=lcd1602`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/mcp9808.md
+++ b/docs/parts/mcp9808.md
@@ -1,0 +1,45 @@
+# MCP9808
+
+Microchip MCP9808 ±0.25 °C I²C temperature sensor.
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `mcp9808` |
+| Bus | I²C |
+| Address / select | 0x18–0x1F (A0–A2 straps; default 0x18) |
+| Source | `configs/devices/mcp9808.yaml` (declarative) |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| SDA | I²C SDA |
+| SCL | I²C SCL |
+| VDD/GND | Power (digital twin) |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| TA temperature read | ✅ | Seeded noise σ≈0.0625 °C + thermal lag τ≈1 s |
+| CONFIG / limits regs | ⚠️ | Storage; alert IRQ not modelled |
+| Conversion timing by resolution | ❌ | Always ready |
+| Analog / power | ❌ | Bench |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=mcp9808` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. Wire to any MCU I²C; agent: `labwired_describe id=mcp9808`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/mma8451q.md
+++ b/docs/parts/mma8451q.md
@@ -1,0 +1,44 @@
+# MMA8451Q
+
+NXP MMA8451Q 3-axis accelerometer (I²C).
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `mma8451q` |
+| Bus | I²C |
+| Address / select | 0x1C / 0x1D (SA0) |
+| Source | device/kit under core peripherals (parity pack) |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| SDA | I²C SDA |
+| SCL | I²C SCL |
+| SA0 | Address select |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| XYZ data + WHO_AM_I | ✅ | Parity scope |
+| Standby/active gating | ✅/⚠️ | See scoreboard |
+| Tap / freefall / FIFO | ❌ | Out of parity scope |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=mma8451q` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `labwired_describe id=mma8451q`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/mpu6050.md
+++ b/docs/parts/mpu6050.md
@@ -1,0 +1,44 @@
+# MPU-6050
+
+TDK InvenSense MPU-6050 6-axis IMU (I²C).
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `mpu6050` |
+| Bus | I²C |
+| Address / select | 0x68 / 0x69 |
+| Source | Rust kit `peripherals/components/mpu6050` |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| SDA | I²C SDA |
+| SCL | I²C SCL |
+| AD0 | Address |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Accel/gyro registers | ✅ | SimInput channels + noise option |
+| I²C read path | ✅ | Common demos |
+| DMP / full FIFO | ⚠️/❌ | Not full silicon feature set |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=mpu6050` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. OLED tilt labs; `labwired_describe id=mpu6050`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/servo.md
+++ b/docs/parts/servo.md
@@ -1,0 +1,42 @@
+# SG90 / hobby servo
+
+Hobby servo angle via PWM-style control.
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `servo` |
+| Bus | GPIO PWM / pulse |
+| Address / select | n/a |
+| Source | Servo kit in catalog |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| Signal | GPIO PWM |
+| V+/GND | Power |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Angle / visual | ✅ | Playground |
+| Torque / analog load | ❌ | Bench |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=servo` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `labwired_describe id=servo`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/seven-segment.md
+++ b/docs/parts/seven-segment.md
@@ -1,0 +1,41 @@
+# Seven-segment display
+
+Seven-segment digit display (GPIO or shift-register driven).
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `seven-segment` |
+| Bus | GPIO / SPI shift |
+| Address / select | n/a |
+| Source | catalog + kits (e.g. HC595 paths) |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| Segments / DIG | Per board wiring |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| Digit visual | ✅ | Playground |
+| Multiplex timing edge cases | ⚠️ | Check demos |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=seven-segment` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `labwired_describe id=seven-segment`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/docs/parts/ssd1306.md
+++ b/docs/parts/ssd1306.md
@@ -1,0 +1,44 @@
+# SSD1306 OLED
+
+Solomon SSD1306 128×64 (and 128×32) monochrome OLED.
+
+!!! tip "Live catalog"
+    Prefer `labwired_describe` with the catalog id over guessing pins or addresses.
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Catalog id | `oled-ssd1306 / oled-ssd1306-128x32` |
+| Bus | I²C |
+| Address / select | 0x3C / 0x3D |
+| Source | Display kit + playground visual |
+| Tier | See matrix below |
+
+## Pins / attachment
+
+| Pin / net | Role |
+|-----------|------|
+| SDA | I²C SDA |
+| SCL | I²C SCL |
+| VCC | 3.3–5 V module (digital) |
+
+## Support matrix
+
+| Behavior | Status | Notes |
+|----------|--------|-------|
+| I²C framebuffer / paint | ✅ | Playground visual |
+| 128×32 variant | ✅ | catalog `oled-ssd1306-128x32` |
+| SPI SSD1306 | ⚠️ | I²C is the main path |
+
+## How to run
+
+1. Place part + MCU in Playground (or system YAML).
+2. Agent: `labwired_list` → `labwired_describe id=oled-ssd1306` → wire → `labwired_validate` → `labwired_run` / `labwired_verify`.
+3. `examples` OLED demos; `labwired_describe id=oled-ssd1306`.
+
+## Related
+
+- [Parts index](index.md)
+- Board example: [ESP32-C3](../boards/esp32c3.md)
+- [Fidelity](../fidelity.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
 nav:
   - Home: index.md
   - Fidelity: fidelity.md
+  - llms.txt (agents): llms.md
   - Architecture Overview: architecture.md
   - Hardware-Sim Parity: golden_reference.md
 
@@ -120,6 +121,17 @@ nav:
 
   - Parts:
     - Overview: parts/index.md
+    - MCP9808: parts/mcp9808.md
+    - MMA8451Q: parts/mma8451q.md
+    - MPU-6050: parts/mpu6050.md
+    - BMP280: parts/bmp280.md
+    - SSD1306 OLED: parts/ssd1306.md
+    - LCD1602: parts/lcd1602.md
+    - APA102: parts/apa102.md
+    - Servo: parts/servo.md
+    - Button: parts/button.md
+    - Buzzer: parts/buzzer.md
+    - Seven-segment: parts/seven-segment.md
 
   - Operations:
     - Release Strategy: release_strategy.md


### PR DESCRIPTION
## Summary
- Top-N part pages (MCP9808, MPU6050, SSD1306, …) + Parts nav
- nRF52840 and RP2040 board pages on the v2 template
- `llms.md` for agent discovery

## Test plan
- [ ] PR checks green
- [ ] Deploy Docs after merge
- [ ] Spot-check /parts/mcp9808/ /boards/nrf52840/ /llms/