### PR TITLE
docs: pin CNAME for docs.labwired.com

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.labwired.com


### PR DESCRIPTION
MkDocs deploys wiped the Pages CNAME. Commit docs/CNAME so gh-deploy keeps docs.labwired.com.