### PR TITLE
feat(motors): configurable BLDC advanced timer name

### DIFF
--- a/configs/devices/bldc_motor.yaml
+++ b/configs/devices/bldc_motor.yaml
@@ -61,7 +61,7 @@ emit:
     - { key: overcurrent_fault_pin, from_part_pin: [OVERCURRENT_FAULT], required: false }
     - { key: undervoltage_fault_pin, from_part_pin: [UNDERVOLTAGE_FAULT], required: false }
     - { key: simulation_clock_hz, from: sim_cpu_hz }
-    - { key: timer_name, from_attr: timer_name, default: tim1 }
+    - { key: timer_name, from_attr: timer_name, default_str: tim1 }
     - { key: resistance_ohm, from_attr: resistance_ohm, default: 0.35 }
     - { key: inductance_h, from_attr: inductance_h, default: 0.00018 }
     - { key: torque_constant_nm_per_a, from_attr: torque_constant_nm_per_a, default: 0.04 }

--- a/configs/devices/bldc_motor.yaml
+++ b/configs/devices/bldc_motor.yaml
@@ -61,6 +61,7 @@ emit:
     - { key: overcurrent_fault_pin, from_part_pin: [OVERCURRENT_FAULT], required: false }
     - { key: undervoltage_fault_pin, from_part_pin: [UNDERVOLTAGE_FAULT], required: false }
     - { key: simulation_clock_hz, from: sim_cpu_hz }
+    - { key: timer_name, from_attr: timer_name, default: tim1 }
     - { key: resistance_ohm, from_attr: resistance_ohm, default: 0.35 }
     - { key: inductance_h, from_attr: inductance_h, default: 0.00018 }
     - { key: torque_constant_nm_per_a, from_attr: torque_constant_nm_per_a, default: 0.04 }

--- a/crates/config/src/canonical.rs
+++ b/crates/config/src/canonical.rs
@@ -1031,12 +1031,21 @@ fn emit_from_descriptor(
                 }
             }
         } else if let Some(attr) = &c.from_attr {
-            let default = c.default.unwrap_or(0.0);
-            let n = attr_string(part, attr)
-                .and_then(|s| s.trim().parse::<f64>().ok())
-                .filter(|d| d.is_finite())
-                .unwrap_or(default);
-            format_js_number(n)
+            if let Some(default_str) = &c.default_str {
+                // String attr path (e.g. BLDC timer_name). Emit a quoted YAML string.
+                let raw = attr_string(part, attr)
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| default_str.clone());
+                format!("\"{}\"", raw.replace('\\', "\\\\").replace('"', "\\\""))
+            } else {
+                let default = c.default.unwrap_or(0.0);
+                let n = attr_string(part, attr)
+                    .and_then(|s| s.trim().parse::<f64>().ok())
+                    .filter(|d| d.is_finite())
+                    .unwrap_or(default);
+                format_js_number(n)
+            }
         } else {
             ext_ok = false;
             break;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2437,12 +2437,17 @@ pub struct EmitConfig {
     /// clock) or `"echo_pacing_cpu_hz"` (the HC-SR04 echo-pacing override).
     #[serde(default)]
     pub from: Option<String>,
-    /// Source: a numeric part attribute of this name, parsed as f64.
+    /// Source: a part attribute of this name. When `default_str` is set the
+    /// value is emitted as a quoted string; otherwise it is parsed as f64.
     #[serde(default)]
     pub from_attr: Option<String>,
-    /// Fallback for `from_attr` when the attribute is absent or non-numeric.
+    /// Fallback for numeric `from_attr` when the attribute is absent or non-numeric.
     #[serde(default)]
     pub default: Option<f64>,
+    /// Fallback for string `from_attr` when the attribute is absent or blank.
+    /// Presence of this field selects the string emission path.
+    #[serde(default)]
+    pub default_str: Option<String>,
     /// Whether a missing pin binding suppresses the whole device. Defaults to
     /// true; optional feedback signals such as encoder index set this false.
     #[serde(default = "default_true")]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -266,6 +266,10 @@ pub struct BldcMotorConfig {
     pub overcurrent_trip_steps: u32,
     #[serde(default = "default_motor_simulation_clock_hz")]
     pub simulation_clock_hz: u64,
+    /// Chip-descriptor peripheral name for the advanced timer that owns the
+    /// six complementary PWM legs (default `tim1` for STM32 advanced timers).
+    #[serde(default = "default_bldc_timer_name")]
+    pub timer_name: String,
     pub phase_a_high_pin: String,
     pub phase_a_low_pin: String,
     pub phase_b_high_pin: String,
@@ -292,6 +296,10 @@ pub struct BldcMotorConfig {
 
 fn default_motor_simulation_clock_hz() -> u64 {
     80_000_000
+}
+
+fn default_bldc_timer_name() -> String {
+    "tim1".to_owned()
 }
 
 fn default_overcurrent_trip_steps() -> u32 {
@@ -405,6 +413,12 @@ impl MotorModelConfig {
                 if config.pole_pairs == 0 {
                     issues.push(format!(
                         "motor_models[{}].pole_pairs must be between 1 and 255 inclusive",
+                        config.id
+                    ));
+                }
+                if config.timer_name.trim().is_empty() {
+                    issues.push(format!(
+                        "motor_models[{}].timer_name must be nonblank",
                         config.id
                     ));
                 }

--- a/crates/config/tests/config_tests.rs
+++ b/crates/config/tests/config_tests.rs
@@ -242,6 +242,80 @@ undervoltage_fault_pin: PB5
 }
 
 #[test]
+fn motor_model_bldc_accepts_non_tim1_timer_name() {
+    let yaml = r#"
+kind: bldc
+id: spindle_tim8
+resistance_ohm: 0.35
+inductance_h: 0.00018
+torque_constant_nm_per_a: 0.04
+back_emf_constant_v_per_rad_s: 0.04
+rotor_inertia_kg_m2: 0.00002
+viscous_friction_nm_per_rad_s: 0.000003
+supply_voltage_v: 24.0
+load_torque_nm: 0.015
+encoder_cpr: 2048
+pole_pairs: 7
+timer_name: tim8
+phase_a_high_pin: PA8
+phase_a_low_pin: PA7
+phase_b_high_pin: PA9
+phase_b_low_pin: PB0
+phase_c_high_pin: PA10
+phase_c_low_pin: PB1
+enable_pin: PB2
+hall_a_pin: PC0
+hall_b_pin: PC1
+hall_c_pin: PC2
+encoder_a_pin: PC6
+encoder_b_pin: PC7
+"#;
+    let model: MotorModelConfig = serde_yaml::from_str(yaml).unwrap();
+    let MotorModelConfig::Bldc(cfg) = &model else {
+        panic!("expected bldc motor");
+    };
+    assert_eq!(cfg.timer_name, "tim8");
+    assert!(model.validate().is_empty());
+}
+
+#[test]
+fn motor_model_bldc_rejects_blank_timer_name() {
+    let yaml = r#"
+kind: bldc
+id: spindle
+resistance_ohm: 0.35
+inductance_h: 0.00018
+torque_constant_nm_per_a: 0.04
+back_emf_constant_v_per_rad_s: 0.04
+rotor_inertia_kg_m2: 0.00002
+viscous_friction_nm_per_rad_s: 0.000003
+supply_voltage_v: 24.0
+load_torque_nm: 0.015
+encoder_cpr: 2048
+pole_pairs: 7
+timer_name: "   "
+phase_a_high_pin: PA8
+phase_a_low_pin: PA7
+phase_b_high_pin: PA9
+phase_b_low_pin: PB0
+phase_c_high_pin: PA10
+phase_c_low_pin: PB1
+enable_pin: PB2
+hall_a_pin: PC0
+hall_b_pin: PC1
+hall_c_pin: PC2
+encoder_a_pin: PC6
+encoder_b_pin: PC7
+"#;
+    let model: MotorModelConfig = serde_yaml::from_str(yaml).unwrap();
+    let issues = model.validate();
+    assert!(
+        issues.iter().any(|issue| issue.contains("timer_name")),
+        "expected blank timer_name issue, got {issues:?}"
+    );
+}
+
+#[test]
 fn motor_model_validation_issues_are_field_qualified() {
     let mut model: MotorModelConfig = serde_yaml::from_str(valid_dc_motor_yaml()).unwrap();
     let MotorModelConfig::Dc(dc) = &mut model else {

--- a/crates/config/tests/config_tests.rs
+++ b/crates/config/tests/config_tests.rs
@@ -225,6 +225,7 @@ undervoltage_fault_pin: PB5
     };
     assert_eq!(cfg.id, "spindle");
     assert_eq!(cfg.pole_pairs, 7);
+    assert_eq!(cfg.timer_name, "tim1");
     assert_eq!(cfg.encoder_index_pin, None);
     assert_eq!(cfg.simulation_clock_hz, 80_000_000);
     assert_eq!(cfg.motor_fault_pin, None);

--- a/crates/core/src/bus/motors.rs
+++ b/crates/core/src/bus/motors.rs
@@ -196,16 +196,29 @@ impl SystemBus {
         ] {
             self.resolve_motor_pin(&c.id, role, pin)?;
         }
-        let timer = self.find_peripheral_index_by_name("tim1").ok_or_else(|| {
-            anyhow::anyhow!("motor '{}': BLDC requires advanced timer 'tim1'", c.id)
-        })?;
+        let timer_name = if c.timer_name.trim().is_empty() {
+            "tim1"
+        } else {
+            c.timer_name.trim()
+        };
+        let timer = self
+            .find_peripheral_index_by_name(timer_name)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "motor '{}': BLDC requires advanced timer '{timer_name}' (set timer_name in motor config)",
+                    c.id
+                )
+            })?;
         let is_timer = self.peripherals[timer]
             .dev
             .as_any()
             .and_then(|a| a.downcast_ref::<crate::peripherals::timer::Timer>())
             .is_some();
         if !is_timer {
-            anyhow::bail!("motor '{}': peripheral 'tim1' is not an STM32 timer", c.id);
+            anyhow::bail!(
+                "motor '{}': peripheral '{timer_name}' is not an STM32 timer",
+                c.id
+            );
         }
         let plant = BldcMotor::new(BldcMotorParams {
             resistance_ohm: c.resistance_ohm,


### PR DESCRIPTION
## Summary
- Add `timer_name` on `BldcMotorConfig` (default `tim1`) instead of hard-coding the peripheral in the bus
- Wire device DSL emit via `default_str` for string attrs (timer names are not f64)
- Validate nonblank `timer_name`; errors name the configured timer
- Tests: default `tim1`, accept `tim8`, reject blank

Closes #792

## Test plan
- [x] `cargo test -p labwired-config --test config_tests motor_model`
- [ ] CI on this PR