### PR TITLE
test(config): drop bus board_io duals from TS-oracle expecteds

### DIFF
--- a/crates/config/src/canonical.rs
+++ b/crates/config/src/canonical.rs
@@ -1699,14 +1699,7 @@ external_devices:
     config:
       i2c_address: 0x3c
 board_io:
-  - id: "oled"
-    kind: "i2c_device"
-    peripheral: "i2c1"
-    pin: 0
-    signal: "input"
-    active_high: true
-    i2c_address: 0x3c
-    device_type: "oled-ssd1306"
+  []
 "#;
 
     const FIXTURE_GPIO_LED: &str = r#"{
@@ -1760,14 +1753,6 @@ external_devices:
     config:
       i2c_address: 0x3c
 board_io:
-  - id: "oled"
-    kind: "i2c_device"
-    peripheral: "i2c1"
-    pin: 0
-    signal: "input"
-    active_high: true
-    i2c_address: 0x3c
-    device_type: "oled-ssd1306"
   - id: "led1"
     kind: "led"
     peripheral: "gpioa"
@@ -1807,13 +1792,7 @@ external_devices:
     config:
       cs_pin: "PA4"
 board_io:
-  - id: "disp"
-    kind: "spi_device"
-    peripheral: "spi1"
-    pin: 4
-    signal: "input"
-    active_high: true
-    device_type: "ili9341"
+  []
 "#;
 
     const FIXTURE_SPI_MAX31855: &str = r#"{
@@ -1840,13 +1819,7 @@ external_devices:
     config:
       cs_pin: "PA4"
 board_io:
-  - id: "tc"
-    kind: "spi_device"
-    peripheral: "spi1"
-    pin: 4
-    signal: "input"
-    active_high: true
-    device_type: "max31855"
+  []
 "#;
 
     const FIXTURE_SPI_SSD1680: &str = r#"{
@@ -1873,13 +1846,7 @@ external_devices:
     config:
       cs_pin: "PA4"
 board_io:
-  - id: "epd"
-    kind: "spi_device"
-    peripheral: "spi1"
-    pin: 4
-    signal: "input"
-    active_high: true
-    device_type: "ssd1680_tricolor_290"
+  []
 "#;
 
     const FIXTURE_ULTRASONIC: &str = r#"{
@@ -2241,13 +2208,7 @@ external_devices:
       cs_pin: "PA4"
       dc_pin: "PA3"
 board_io:
-  - id: "lcd"
-    kind: "spi_device"
-    peripheral: "spi1"
-    pin: 4
-    signal: "input"
-    active_high: true
-    device_type: "pcd8544"
+  []
 "#;
 
     const FIXTURE_SN74HC165: &str = r#"{

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -807,7 +807,6 @@ pub struct InterconnectConfig {
 }
 
 impl EnvironmentManifest {
-
     /// Test/helper constructor with no RF block.
     pub fn bare(
         name: impl Into<String>,

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -697,11 +697,19 @@ impl SystemBus {
         use crate::peripherals::esp32c3::bt::Esp32c3Bt;
         use crate::peripherals::nrf52::radio::Nrf52Radio;
         for entry in &mut self.peripherals {
-            if let Some(radio) = entry.dev.as_any_mut().and_then(|a| a.downcast_mut::<Nrf52Radio>()) {
+            if let Some(radio) = entry
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Nrf52Radio>())
+            {
                 radio.set_air(nrf_air.clone());
                 radio.set_node_id(node_id);
             }
-            if let Some(bt) = entry.dev.as_any_mut().and_then(|a| a.downcast_mut::<Esp32c3Bt>()) {
+            if let Some(bt) = entry
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Esp32c3Bt>())
+            {
                 bt.set_air(ble_air.clone());
             }
         }

--- a/crates/core/src/peripherals/nrf52/radio.rs
+++ b/crates/core/src/peripherals/nrf52/radio.rs
@@ -190,12 +190,7 @@ impl VirtualAirBus {
     /// `Some(rssi_dbm)` if delivered, `None` if the medium drops the frame.
     /// When no medium is attached, always delivers with `None` RSSI (caller
     /// keeps PRNG sample).
-    fn medium_try_deliver(
-        &self,
-        tx_node: &str,
-        rx_node: &str,
-        tx_power_dbm: f64,
-    ) -> MediumVerdict {
+    fn medium_try_deliver(&self, tx_node: &str, rx_node: &str, tx_power_dbm: f64) -> MediumVerdict {
         let Ok(slot) = self.medium.lock() else {
             return MediumVerdict::NoMedium;
         };
@@ -1307,11 +1302,10 @@ impl Peripheral for Nrf52Radio {
                         if f.mode != self.mode || !self.matches_address(f) {
                             continue;
                         }
-                        match self.air.medium_try_deliver(
-                            &f.tx_node,
-                            &self.node_id,
-                            f.tx_power_dbm,
-                        ) {
+                        match self
+                            .air
+                            .medium_try_deliver(&f.tx_node, &self.node_id, f.tx_power_dbm)
+                        {
                             MediumVerdict::Drop => continue,
                             MediumVerdict::Deliver { rssi_dbm } => {
                                 medium_rssi = Some(rssi_dbm);
@@ -2118,14 +2112,12 @@ mod tests {
         use crate::Bus;
 
         let air = VirtualAirBus::new();
-        air.attach_medium(
-            RfMedium::new(7).with_params(PathLossParams {
-                rssi_floor_dbm: -55.0,
-                ref_loss_db: 40.0,
-                exponent: 2.0,
-                ..PathLossParams::default()
-            }),
-        );
+        air.attach_medium(RfMedium::new(7).with_params(PathLossParams {
+            rssi_floor_dbm: -55.0,
+            ref_loss_db: 40.0,
+            exponent: 2.0,
+            ..PathLossParams::default()
+        }));
         air.set_node_position("tx", NodePosition { x: 0.0, y: 0.0 });
         // 50 m → path loss ≈ 40 + 20*log10(50) ≈ 74 dB → RSSI ≈ -74 at 0 dBm TX
         air.set_node_position("rx_far", NodePosition { x: 50.0, y: 0.0 });

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -26,7 +26,8 @@ pub struct World {
     /// Shared RF medium built from optional env-manifest `rf:` (path loss / RSSI).
     /// Radios attach via their air bus when product wiring is enabled; always
     /// available for inspect / tests when the manifest declared `rf:`.
-    pub rf_medium: Option<std::sync::Arc<std::sync::Mutex<crate::peripherals::rf_medium::RfMedium>>>,
+    pub rf_medium:
+        Option<std::sync::Arc<std::sync::Mutex<crate::peripherals::rf_medium::RfMedium>>>,
 }
 
 /// One point-to-point serial link between two nodes, as carried on the world's
@@ -426,13 +427,7 @@ fn build_world_rf_medium(
     }
     let mut medium = RfMedium::new(rf.seed).with_params(params);
     for (id, pos) in &rf.nodes {
-        medium.set_node(
-            id.clone(),
-            NodePosition {
-                x: pos.x,
-                y: pos.y,
-            },
-        );
+        medium.set_node(id.clone(), NodePosition { x: pos.x, y: pos.y });
     }
     Some(std::sync::Arc::new(std::sync::Mutex::new(medium)))
 }

--- a/crates/core/tests/world_multichip.rs
+++ b/crates/core/tests/world_multichip.rs
@@ -76,7 +76,7 @@ fn from_manifest_builds_two_cortexm_nodes_and_uart_link() {
             nodes: vec!["n1".into(), "n2".into()],
             config: HashMap::new(),
         }],
-            rf: None,
+        rf: None,
     };
 
     let mut world = World::from_manifest(env, &station_root()).expect("build world from manifest");

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1574,8 +1574,7 @@ impl AirBus {
     #[wasm_bindgen]
     pub fn set_node_position(&self, node_id: &str, x: f64, y: f64) {
         use labwired_core::peripherals::rf_medium::NodePosition;
-        self.nrf
-            .set_node_position(node_id, NodePosition { x, y });
+        self.nrf.set_node_position(node_id, NodePosition { x, y });
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
## Summary
- Main `core-integrity` failed `resolve_matches_ts_oracle` (i2c-oled) after #798 unblocked fmt.
- Root cause: #784 dual-kill for I2C/SPI modules left EXPECTED fixtures with `board_io` twins.
- Update expected snapshots for oled / SPI panels / pcd8544; keep GPIO LED + neo6m UART as emitted.

## Test plan
- [x] `cargo test -p labwired-config resolve_matches_ts_oracle --lib`
- [ ] Rust Core CI green on this PR
- [ ] Merge unblocks main core-integrity unit tests