### PR TITLE
feat: STEP/DIR + H-bridge + unipolar stepper PeripheralKits

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -841,92 +841,9 @@ impl SystemBus {
                 // super::declarative_device.
                 // neopixel / ws2812 → PeripheralKit registry (`WS2812_KIT`).
                 // servo / sg90 / mg996r → PeripheralKit registry (`SERVO_KIT`).
-                "a4988" | "drv8825" | "tmc2209" => {
-                    let step = Self::gpio_from_config(ext, "step_pin", "STEP", "GPIO16")?;
-                    let dir = Self::gpio_from_config(ext, "dir_pin", "DIR", "GPIO17")?;
-                    let en = Self::optional_gpio_from_config(ext, "en_pin", "EN");
-                    let mut motor =
-                        crate::peripherals::components::step_dir_motor::StepDirMotor::new(
-                            &ext.id, step, dir, en,
-                        );
-                    if ext.r#type == "tmc2209" {
-                        // SilentStepStick often 1/16 microstep default → treat as 1.8/16
-                        motor = motor.with_config(
-                            crate::peripherals::components::step_dir_motor::StepDirConfig {
-                                degrees_per_step: 1.8 / 16.0,
-                                enable_active_low: true,
-                            },
-                        );
-                    }
-                    let motor = std::sync::Arc::new(motor);
-                    Self::install_gpio_observer(&mut bus, motor.clone());
-                    bus.step_dir_motors.push(motor);
-                }
-                "l298n" | "tb6612" | "l293d" => {
-                    // First motor channel (A)
-                    let in1 = Self::gpio_from_config(ext, "in1_pin", "IN1", "GPIO16")
-                        .or_else(|_| Self::gpio_from_config(ext, "ain1_pin", "AIN1", "GPIO16"))?;
-                    let in2 = Self::gpio_from_config(ext, "in2_pin", "IN2", "GPIO17")
-                        .or_else(|_| Self::gpio_from_config(ext, "ain2_pin", "AIN2", "GPIO17"))?;
-                    let en = Self::optional_gpio_from_config(ext, "en_pin", "ENA")
-                        .or_else(|| Self::optional_gpio_from_config(ext, "pwma_pin", "PWMA"));
-                    let motor = std::sync::Arc::new(
-                        crate::peripherals::components::h_bridge_motor::HBridgeMotor::new(
-                            format!("{}-a", ext.id),
-                            in1,
-                            in2,
-                            en,
-                        )
-                        .with_declared_id(ext.id.clone()),
-                    );
-                    Self::install_gpio_observer(&mut bus, motor.clone());
-                    bus.h_bridge_motors.push(motor);
-                    // Optional B channel when IN3/IN4 (or BIN*) are configured.
-                    let has_b = ext.config.contains_key("in3_pin")
-                        || ext.config.contains_key("IN3")
-                        || ext.config.contains_key("bin1_pin")
-                        || ext.config.contains_key("BIN1");
-                    if has_b {
-                        if let (Ok(b1), Ok(b2)) = (
-                            Self::gpio_from_config(ext, "in3_pin", "IN3", "GPIO18").or_else(|_| {
-                                Self::gpio_from_config(ext, "bin1_pin", "BIN1", "GPIO18")
-                            }),
-                            Self::gpio_from_config(ext, "in4_pin", "IN4", "GPIO19").or_else(|_| {
-                                Self::gpio_from_config(ext, "bin2_pin", "BIN2", "GPIO19")
-                            }),
-                        ) {
-                            let enb = Self::optional_gpio_from_config(ext, "enb_pin", "ENB")
-                                .or_else(|| {
-                                    Self::optional_gpio_from_config(ext, "pwmb_pin", "PWMB")
-                                });
-                            let motor_b = std::sync::Arc::new(
-                                crate::peripherals::components::h_bridge_motor::HBridgeMotor::new(
-                                    format!("{}-b", ext.id),
-                                    b1,
-                                    b2,
-                                    enb,
-                                )
-                                .with_declared_id(ext.id.clone()),
-                            );
-                            Self::install_gpio_observer(&mut bus, motor_b.clone());
-                            bus.h_bridge_motors.push(motor_b);
-                        }
-                    }
-                }
-                "uln2003" | "stepper-28byj48" => {
-                    let p1 = Self::gpio_from_config(ext, "in1_pin", "IN1", "GPIO16")?;
-                    let p2 = Self::gpio_from_config(ext, "in2_pin", "IN2", "GPIO17")?;
-                    let p3 = Self::gpio_from_config(ext, "in3_pin", "IN3", "GPIO18")?;
-                    let p4 = Self::gpio_from_config(ext, "in4_pin", "IN4", "GPIO19")?;
-                    let motor = std::sync::Arc::new(
-                        crate::peripherals::components::unipolar_stepper::UnipolarStepper::new_28byj48(
-                            &ext.id,
-                            [p1, p2, p3, p4],
-                        ),
-                    );
-                    Self::install_gpio_observer(&mut bus, motor.clone());
-                    bus.unipolar_steppers.push(motor);
-                }
+                // a4988 / drv8825 / tmc2209 → `STEP_DIR_MOTOR_KIT`.
+                // l298n / tb6612 / l293d → `H_BRIDGE_MOTOR_KIT`.
+                // uln2003 / stepper-28byj48 → `UNIPOLAR_STEPPER_KIT`.
                 // ili9341-16bit / ili9341_16bit: PeripheralKit registry
                 // (`Ili9341ParallelKit`, Transport::GpioGroup) — see
                 // peripherals::kit and ili9341_parallel.rs.
@@ -1210,6 +1127,7 @@ impl SystemBus {
         }
     }
 
+    #[allow(dead_code)] // residual GPIO helpers kept for CAN/tester arms that may re-use them
     fn gpio_from_config(
         ext: &labwired_config::ExternalDevice,
         key: &str,
@@ -1235,6 +1153,7 @@ impl SystemBus {
             })
     }
 
+    #[allow(dead_code)]
     fn optional_gpio_from_config(
         ext: &labwired_config::ExternalDevice,
         key: &str,

--- a/crates/core/src/peripherals/components/h_bridge_motor.rs
+++ b/crates/core/src/peripherals/components/h_bridge_motor.rs
@@ -109,6 +109,100 @@ impl crate::peripherals::esp32::gpio::GpioObserver for HBridgeMotor {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
+};
+use std::sync::Arc;
+
+/// Dual H-bridge motor kit (L298N / TB6612 / L293D-class).
+pub struct HBridgeMotorKit;
+pub static H_BRIDGE_MOTOR_KIT: HBridgeMotorKit = HBridgeMotorKit;
+
+static H_BRIDGE_METADATA: KitMetadata = KitMetadata {
+    inputs: &[],
+    device_type: "l298n",
+    label: "H-bridge motor driver",
+    summary: "L298N/TB6612/L293D-class dual H-bridge twin (direction + enable effort).",
+    detail: "Channel A from IN1/IN2/ENA (or AIN1/AIN2/PWMA). Optional channel B when \
+             IN3/IN4 or BIN* keys are present. Aliases: tb6612, l293d.",
+    transport: Transport::GpioGroup,
+    category: Category::Gpio,
+    config_keys: &[
+        ConfigKey {
+            name: "in1_pin",
+            ty: ConfigType::Str,
+            doc: "Channel A input 1 (or ain1_pin).",
+        },
+        ConfigKey {
+            name: "in2_pin",
+            ty: ConfigType::Str,
+            doc: "Channel A input 2 (or ain2_pin).",
+        },
+        ConfigKey {
+            name: "en_pin",
+            ty: ConfigType::Str,
+            doc: "Channel A enable (or pwma_pin).",
+        },
+    ],
+    labs: &[],
+};
+
+impl PeripheralKit for HBridgeMotorKit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &H_BRIDGE_METADATA
+    }
+
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let in1 = ctx
+            .config_gpio_pin("in1_pin", "AIN1", "GPIO16")
+            .or_else(|_| ctx.config_gpio_pin("ain1_pin", "IN1", "GPIO16"))?;
+        let in2 = ctx
+            .config_gpio_pin("in2_pin", "AIN2", "GPIO17")
+            .or_else(|_| ctx.config_gpio_pin("ain2_pin", "IN2", "GPIO17"))?;
+        let en = ctx
+            .config_str("en_pin")
+            .or_else(|| ctx.config_str("ENA"))
+            .or_else(|| ctx.config_str("pwma_pin"))
+            .or_else(|| ctx.config_str("PWMA"))
+            .and_then(|l| ctx.parse_gpio_pin(l));
+        let motor = Arc::new(
+            HBridgeMotor::new(format!("{}-a", ctx.device_id()), in1, in2, en)
+                .with_declared_id(ctx.device_id().to_string()),
+        );
+        ctx.install_gpio_observer(motor.clone());
+        ctx.bus.h_bridge_motors.push(motor);
+
+        let has_b = ctx.ext.config.contains_key("in3_pin")
+            || ctx.ext.config.contains_key("IN3")
+            || ctx.ext.config.contains_key("bin1_pin")
+            || ctx.ext.config.contains_key("BIN1");
+        if has_b {
+            if let (Ok(b1), Ok(b2)) = (
+                ctx.config_gpio_pin("in3_pin", "BIN1", "GPIO18")
+                    .or_else(|_| ctx.config_gpio_pin("bin1_pin", "IN3", "GPIO18")),
+                ctx.config_gpio_pin("in4_pin", "BIN2", "GPIO19")
+                    .or_else(|_| ctx.config_gpio_pin("bin2_pin", "IN4", "GPIO19")),
+            ) {
+                let enb = ctx
+                    .config_str("enb_pin")
+                    .or_else(|| ctx.config_str("ENB"))
+                    .or_else(|| ctx.config_str("pwmb_pin"))
+                    .or_else(|| ctx.config_str("PWMB"))
+                    .and_then(|l| ctx.parse_gpio_pin(l));
+                let motor_b = Arc::new(
+                    HBridgeMotor::new(format!("{}-b", ctx.device_id()), b1, b2, enb)
+                        .with_declared_id(ctx.device_id().to_string()),
+                );
+                ctx.install_gpio_observer(motor_b.clone());
+                ctx.bus.h_bridge_motors.push(motor_b);
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/step_dir_motor.rs
+++ b/crates/core/src/peripherals/components/step_dir_motor.rs
@@ -128,6 +128,72 @@ impl crate::peripherals::esp32::gpio::GpioObserver for StepDirMotor {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
+};
+use std::sync::Arc;
+
+/// STEP/DIR driver kit (A4988 / DRV8825 / TMC2209-class).
+pub struct StepDirMotorKit;
+pub static STEP_DIR_MOTOR_KIT: StepDirMotorKit = StepDirMotorKit;
+
+static STEP_DIR_METADATA: KitMetadata = KitMetadata {
+    inputs: &[],
+    device_type: "a4988",
+    label: "STEP/DIR stepper driver",
+    summary: "A4988/DRV8825/TMC2209-class STEP/DIR twin (step count + angle).",
+    detail: "Counts rising STEP edges while EN is active; DIR selects direction. \
+             Type aliases drv8825 and tmc2209 map here (tmc2209 uses 1/16 microstep cal).",
+    transport: Transport::GpioGroup,
+    category: Category::Gpio,
+    config_keys: &[
+        ConfigKey {
+            name: "step_pin",
+            ty: ConfigType::Str,
+            doc: "STEP pin (default GPIO16).",
+        },
+        ConfigKey {
+            name: "dir_pin",
+            ty: ConfigType::Str,
+            doc: "DIR pin (default GPIO17).",
+        },
+        ConfigKey {
+            name: "en_pin",
+            ty: ConfigType::Str,
+            doc: "Optional EN pin.",
+        },
+    ],
+    labs: &[],
+};
+
+impl PeripheralKit for StepDirMotorKit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &STEP_DIR_METADATA
+    }
+
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let step = ctx.config_gpio_pin("step_pin", "STEP", "GPIO16")?;
+        let dir = ctx.config_gpio_pin("dir_pin", "DIR", "GPIO17")?;
+        let en = ctx
+            .config_str("en_pin")
+            .or_else(|| ctx.config_str("EN"))
+            .and_then(|l| ctx.parse_gpio_pin(l));
+        let mut motor = StepDirMotor::new(ctx.device_id(), step, dir, en);
+        if ctx.device_type() == "tmc2209" {
+            motor = motor.with_config(StepDirConfig {
+                degrees_per_step: 1.8 / 16.0,
+                enable_active_low: true,
+            });
+        }
+        let motor = Arc::new(motor);
+        ctx.install_gpio_observer(motor.clone());
+        ctx.bus.step_dir_motors.push(motor);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/components/unipolar_stepper.rs
+++ b/crates/core/src/peripherals/components/unipolar_stepper.rs
@@ -112,6 +112,67 @@ impl crate::peripherals::esp32::gpio::GpioObserver for UnipolarStepper {
     }
 }
 
+// ─── PeripheralKit registration ────────────────────────────────────────────
+
+use crate::peripherals::kit::{
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
+};
+use std::sync::Arc;
+
+/// 28BYJ-48 unipolar stepper via ULN2003-style IN1..IN4.
+pub struct UnipolarStepperKit;
+pub static UNIPOLAR_STEPPER_KIT: UnipolarStepperKit = UnipolarStepperKit;
+
+static UNIPOLAR_METADATA: KitMetadata = KitMetadata {
+    inputs: &[],
+    device_type: "uln2003",
+    label: "ULN2003 / 28BYJ-48 stepper",
+    summary: "Four-phase unipolar stepper twin (IN1..IN4).",
+    detail: "Alias stepper-28byj48 maps to this kit. Half-step sequencing from GPIO edges.",
+    transport: Transport::GpioGroup,
+    category: Category::Gpio,
+    config_keys: &[
+        ConfigKey {
+            name: "in1_pin",
+            ty: ConfigType::Str,
+            doc: "Phase 1 pin (default GPIO16).",
+        },
+        ConfigKey {
+            name: "in2_pin",
+            ty: ConfigType::Str,
+            doc: "Phase 2 pin (default GPIO17).",
+        },
+        ConfigKey {
+            name: "in3_pin",
+            ty: ConfigType::Str,
+            doc: "Phase 3 pin (default GPIO18).",
+        },
+        ConfigKey {
+            name: "in4_pin",
+            ty: ConfigType::Str,
+            doc: "Phase 4 pin (default GPIO19).",
+        },
+    ],
+    labs: &[],
+};
+
+impl PeripheralKit for UnipolarStepperKit {
+    fn metadata(&self) -> &'static KitMetadata {
+        &UNIPOLAR_METADATA
+    }
+
+    fn attach(&self, ctx: &mut AttachCtx<'_>) -> anyhow::Result<()> {
+        let p1 = ctx.config_gpio_pin("in1_pin", "IN1", "GPIO16")?;
+        let p2 = ctx.config_gpio_pin("in2_pin", "IN2", "GPIO17")?;
+        let p3 = ctx.config_gpio_pin("in3_pin", "IN3", "GPIO18")?;
+        let p4 = ctx.config_gpio_pin("in4_pin", "IN4", "GPIO19")?;
+        let motor = Arc::new(UnipolarStepper::new_28byj48(ctx.device_id(), [p1, p2, p3, p4]));
+        ctx.install_gpio_observer(motor.clone());
+        ctx.bus.unipolar_steppers.push(motor);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/peripherals/kit/registry.rs
+++ b/crates/core/src/peripherals/kit/registry.rs
@@ -110,6 +110,9 @@ pub static KITS: &[&'static dyn PeripheralKit] = &[
     // GPIO-group actuators migrated off from_config residual arms.
     &components::servo::SERVO_KIT,
     &components::ws2812::WS2812_KIT,
+    &components::step_dir_motor::STEP_DIR_MOTOR_KIT,
+    &components::h_bridge_motor::H_BRIDGE_MOTOR_KIT,
+    &components::unipolar_stepper::UNIPOLAR_STEPPER_KIT,
 ];
 
 /// Borrow the registry slice.
@@ -137,6 +140,14 @@ const TYPE_ALIASES: &[(&str, &str)] = &[
     ("mg996r", "servo"),
     // WS2812 synonym for neopixel kit.
     ("ws2812", "neopixel"),
+    // STEP/DIR driver family.
+    ("drv8825", "a4988"),
+    ("tmc2209", "a4988"),
+    // H-bridge family.
+    ("tb6612", "l298n"),
+    ("l293d", "l298n"),
+    // Unipolar stepper.
+    ("stepper-28byj48", "uln2003"),
 ];
 
 /// Resolve a `device_type` spelling to its canonical form.

--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -2394,6 +2394,92 @@
       ],
       "labs": [],
       "inputs": []
+    },
+    {
+      "device_type": "a4988",
+      "label": "STEP/DIR stepper driver",
+      "summary": "A4988/DRV8825/TMC2209-class STEP/DIR twin (step count + angle).",
+      "detail": "Counts rising STEP edges while EN is active; DIR selects direction. Type aliases drv8825 and tmc2209 map here (tmc2209 uses 1/16 microstep cal).",
+      "transport": "gpio_group",
+      "category": "gpio",
+      "config_keys": [
+        {
+          "name": "step_pin",
+          "ty": "str",
+          "doc": "STEP pin (default GPIO16)."
+        },
+        {
+          "name": "dir_pin",
+          "ty": "str",
+          "doc": "DIR pin (default GPIO17)."
+        },
+        {
+          "name": "en_pin",
+          "ty": "str",
+          "doc": "Optional EN pin."
+        }
+      ],
+      "labs": [],
+      "inputs": []
+    },
+    {
+      "device_type": "l298n",
+      "label": "H-bridge motor driver",
+      "summary": "L298N/TB6612/L293D-class dual H-bridge twin (direction + enable effort).",
+      "detail": "Channel A from IN1/IN2/ENA (or AIN1/AIN2/PWMA). Optional channel B when IN3/IN4 or BIN* keys are present. Aliases: tb6612, l293d.",
+      "transport": "gpio_group",
+      "category": "gpio",
+      "config_keys": [
+        {
+          "name": "in1_pin",
+          "ty": "str",
+          "doc": "Channel A input 1 (or ain1_pin)."
+        },
+        {
+          "name": "in2_pin",
+          "ty": "str",
+          "doc": "Channel A input 2 (or ain2_pin)."
+        },
+        {
+          "name": "en_pin",
+          "ty": "str",
+          "doc": "Channel A enable (or pwma_pin)."
+        }
+      ],
+      "labs": [],
+      "inputs": []
+    },
+    {
+      "device_type": "uln2003",
+      "label": "ULN2003 / 28BYJ-48 stepper",
+      "summary": "Four-phase unipolar stepper twin (IN1..IN4).",
+      "detail": "Alias stepper-28byj48 maps to this kit. Half-step sequencing from GPIO edges.",
+      "transport": "gpio_group",
+      "category": "gpio",
+      "config_keys": [
+        {
+          "name": "in1_pin",
+          "ty": "str",
+          "doc": "Phase 1 pin (default GPIO16)."
+        },
+        {
+          "name": "in2_pin",
+          "ty": "str",
+          "doc": "Phase 2 pin (default GPIO17)."
+        },
+        {
+          "name": "in3_pin",
+          "ty": "str",
+          "doc": "Phase 3 pin (default GPIO18)."
+        },
+        {
+          "name": "in4_pin",
+          "ty": "str",
+          "doc": "Phase 4 pin (default GPIO19)."
+        }
+      ],
+      "labs": [],
+      "inputs": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
Continue residual kit migration after servo/neopixel (#801):

- \`STEP_DIR_MOTOR_KIT\` (a4988; aliases drv8825, tmc2209)
- \`H_BRIDGE_MOTOR_KIT\` (l298n; aliases tb6612, l293d)
- \`UNIPOLAR_STEPPER_KIT\` (uln2003; alias stepper-28byj48)

Removes matching \`from_config\` hand arms. Labs attach via \`external_devices\` → universal kit path.

## Test plan
- [x] cargo clippy -p labwired-core -D warnings
- [x] gen-peripherals-manifest fixture
- [ ] CI pr-gate