### PR TITLE
style: cargo fmt for servo/ws2812/unipolar stepper kits

### DIFF
--- a/crates/core/src/peripherals/components/servo.rs
+++ b/crates/core/src/peripherals/components/servo.rs
@@ -375,9 +375,7 @@ impl PeripheralKit for ServoKit {
                 pin_label
             )
         })?;
-        let model = ctx
-            .config_str("model")
-            .unwrap_or(ctx.device_type());
+        let model = ctx.config_str("model").unwrap_or(ctx.device_type());
         let cal = match model {
             "sg90" => ServoCal::sg90(),
             "mg996r" => ServoCal::mg996r(),

--- a/crates/core/src/peripherals/components/unipolar_stepper.rs
+++ b/crates/core/src/peripherals/components/unipolar_stepper.rs
@@ -166,7 +166,10 @@ impl PeripheralKit for UnipolarStepperKit {
         let p2 = ctx.config_gpio_pin("in2_pin", "IN2", "GPIO17")?;
         let p3 = ctx.config_gpio_pin("in3_pin", "IN3", "GPIO18")?;
         let p4 = ctx.config_gpio_pin("in4_pin", "IN4", "GPIO19")?;
-        let motor = Arc::new(UnipolarStepper::new_28byj48(ctx.device_id(), [p1, p2, p3, p4]));
+        let motor = Arc::new(UnipolarStepper::new_28byj48(
+            ctx.device_id(),
+            [p1, p2, p3, p4],
+        ));
         ctx.install_gpio_observer(motor.clone());
         ctx.bus.unipolar_steppers.push(motor);
         Ok(())

--- a/crates/core/src/peripherals/components/ws2812.rs
+++ b/crates/core/src/peripherals/components/ws2812.rs
@@ -245,7 +245,6 @@ impl crate::inspect::DeviceEvidence for Ws2812 {
     }
 }
 
-
 // ─── PeripheralKit registration ────────────────────────────────────────────
 
 use crate::peripherals::kit::{


### PR DESCRIPTION
## Summary
Main Rust Core CI fails `cargo fmt --check` after #801/#803:
- `servo.rs`, `ws2812.rs` (#801)
- `unipolar_stepper.rs` (#803)

## Test plan
- [x] local `cargo fmt --all -- --check` clean on current main tip
- [ ] CI green; merge unblocks main core-integrity formatting