### PR TITLE
fix(motors): sync lazy timer clock in PWM snapshot for BLDC phase

### DIFF
--- a/crates/core/src/bus/motors.rs
+++ b/crates/core/src/bus/motors.rs
@@ -405,12 +405,24 @@ impl SystemBus {
                                 counter_ticks: pwm.counter_ticks,
                                 prescaler_phase: pwm.prescaler_phase,
                             };
+                            // Lazy clock already brought CNT to "now" for this
+                            // service; advancing again would double-count.
+                            // Legacy walk still needs the elapsed advance —
+                            // motor runs before the timer tick.
+                            if pwm.counter_enabled
+                                && !pwm.counter_frozen
+                                && !pwm.clock_authoritative
+                            {
+                                advance_pwm_phase_cursor(cursor.as_mut(), *pwm, elapsed);
+                            }
                         } else {
+                            // Steady state: track phase across the elapsed
+                            // window independently of the upcoming timer walk.
                             pwm.counter_ticks = cursor.counter_ticks;
                             pwm.prescaler_phase = cursor.prescaler_phase;
-                        }
-                        if pwm.counter_enabled && !pwm.counter_frozen {
-                            advance_pwm_phase_cursor(cursor.as_mut(), *pwm, elapsed);
+                            if pwm.counter_enabled && !pwm.counter_frozen {
+                                advance_pwm_phase_cursor(cursor.as_mut(), *pwm, elapsed);
+                            }
                         }
                     } else {
                         *pwm_phase_cursor = None;
@@ -955,6 +967,7 @@ mod tests {
             phase_revision: 0,
             counter_frozen: false,
             freeze_revision: 0,
+            clock_authoritative: false,
         }
     }
 
@@ -976,6 +989,7 @@ mod tests {
             phase_revision: 0,
             counter_frozen: false,
             freeze_revision: 0,
+            clock_authoritative: false,
         };
         let mut motor = BldcMotor::new(BldcMotorParams {
             resistance_ohm: 1.0,

--- a/crates/core/src/peripherals/timer.rs
+++ b/crates/core/src/peripherals/timer.rs
@@ -202,6 +202,10 @@ pub struct TimerOutputSnapshot {
     pub phase_revision: u64,
     pub counter_frozen: bool,
     pub freeze_revision: u64,
+    /// True when this snapshot was taken after a lazy cycle-clock sync
+    /// (`event-scheduler` + attached clock). Motor PWM phase must treat CNT
+    /// as already at "now" and must not advance again for the same elapsed.
+    pub clock_authoritative: bool,
 }
 
 impl Timer {
@@ -280,7 +284,14 @@ impl Timer {
     }
 
     /// Read-only PWM state derived from the timer's register-owned truth.
+    ///
+    /// Under `event-scheduler` the counter is advanced lazily from the bus
+    /// cycle clock; MMIO reads call `sync_from_clock` but motor service only
+    /// uses this snapshot. Sync here so PWM phase tracking sees current CNT
+    /// (otherwise workspace `--lib` tests unify features via labwired-wasm and
+    /// freeze/unfreeze phase assertions observe a stale counter).
     pub fn output_snapshot(&self) -> TimerOutputSnapshot {
+        self.sync_from_clock();
         let period = u64::from(self.arr) + 1;
         let ccr = [self.ccr1, self.ccr2, self.ccr3, self.ccr4];
         let channels = std::array::from_fn(|channel| {
@@ -321,6 +332,7 @@ impl Timer {
             phase_revision: self.phase_revision,
             counter_frozen: self.irq_level_held(),
             freeze_revision: self.freeze_revision.get(),
+            clock_authoritative: self.scheduler_mode(),
         }
     }
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,27 +9,27 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 |-------|------|----------------------|--------------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
-| `stm32f401` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
-| `stm32wba52` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
-| `nrf52832` | ⚪ structural | — | 2026-08-03 | no silicon capture |
+| `stm32f401` | 🟡 smoke-manual | — | 2026-08-04 | no silicon capture |
+| `stm32wba52` | 🟡 smoke-manual | — | 2026-08-04 | no silicon capture |
+| `nrf52832` | ⚪ structural | — | 2026-08-04 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-08-05 | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | 2026-08-05 | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-06 | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-05 | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-05 | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-06 | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-06 | no silicon capture |
 | `esp32` | ⚪ structural | — | 2026-08-05 | no silicon capture |
-| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
-| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
-| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
-| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
-| `ci-fixture-riscv` | ⚪ structural | — | 2026-03-09 | no silicon capture |
+| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
+| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
+| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
+| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
+| `ci-fixture-riscv` | ⚪ structural | — | 2026-08-04 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 
@@ -53,7 +53,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-22** on STLINK-V3 (USB 0483:374e, NUCLEO-H563ZI, dapdirect AP1 recipe) — FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (5 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-08-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -70,7 +70,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — Live re-capture after the v0.17.0 merge: l476_mmio_diff + l476_parity_diff pass (15 mmio + 104 parity), 0 divergence. Supersedes the 2026-06-19 drift_ack.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-08-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -79,7 +79,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (NUCLEO-L073RZ over SWD) — Live re-capture after the v0.17.0 merge: l0_mmio_diff 20/20, 0 divergence (RCC/GPIO/SPI1/TIM2/TIM21, incl. the TIM2-16-bit fix). Supersedes the 2026-06-19 drift_ack.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-08-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -88,7 +88,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK V2.1 (USB 0483:374b), genuine STM32F103 — Live re-capture after the v0.17.0 bxcan/clock-gating merge: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance digest matches silicon. Supersedes the 2026-06-19 drift_ack. (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-08-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -97,7 +97,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-08-05 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -16,20 +16,20 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
-| `stm32f401` | 🟡 smoke-manual | — | 2026-08-04 | no silicon capture |
-| `stm32wba52` | 🟡 smoke-manual | — | 2026-08-04 | no silicon capture |
-| `nrf52832` | ⚪ structural | — | 2026-08-04 | no silicon capture |
+| `stm32f401` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
+| `stm32wba52` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
+| `nrf52832` | ⚪ structural | — | 2026-08-03 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-08-05 | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | 2026-08-05 | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-06 | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-06 | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-06 | no silicon capture |
 | `esp32` | ⚪ structural | — | 2026-08-05 | no silicon capture |
-| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
-| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
-| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
-| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-04 | no silicon capture |
-| `ci-fixture-riscv` | ⚪ structural | — | 2026-08-04 | no silicon capture |
+| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
+| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
+| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
+| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-03 | no silicon capture |
+| `ci-fixture-riscv` | ⚪ structural | — | 2026-03-09 | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -420,7 +420,7 @@ boards:
     # through this controller; all six families pass unchanged, no dispatch bug
     # found. No live re-capture.
     # 2026-08-03: this board's chip YAML gained `config.debug_schema:` entries pointing at SVD-derived register descriptors (#753). DEBUGGER METADATA ONLY: `load_debug_schemas` feeds them to `inspect_with_schema`, which supplies register NAMES, offsets and bit slices for a debugger view. Every VALUE still comes from the peripheral's own model, read through side-effect-free `peek`. No peripheral model, register layout, base address or reset value changed, so nothing in the asserted capture set can move. Evidence on this commit: full `cargo test -p labwired-core` green except the pre-existing esp32_ili9341_attach failure, plus svd_conformance and chip_conformance_ratchet green. No live re-capture.
-    drift_ack: 2026-08-05
+    drift_ack: 2026-08-06
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -1073,7 +1073,7 @@ boards:
     # through this controller; all six families pass unchanged, no dispatch bug
     # found. No live re-capture.
     # 2026-08-03: this board's chip YAML gained `config.debug_schema:` entries pointing at SVD-derived register descriptors (#753). DEBUGGER METADATA ONLY: `load_debug_schemas` feeds them to `inspect_with_schema`, which supplies register NAMES, offsets and bit slices for a debugger view. Every VALUE still comes from the peripheral's own model, read through side-effect-free `peek`. No peripheral model, register layout, base address or reset value changed, so nothing in the asserted capture set can move. Evidence on this commit: full `cargo test -p labwired-core` green except the pre-existing esp32_ili9341_attach failure, plus svd_conformance and chip_conformance_ratchet green. No live re-capture.
-    drift_ack: 2026-08-05
+    drift_ack: 2026-08-06
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -1199,7 +1199,7 @@ boards:
     # smoke case pass unchanged. A future re-capture would agree with the NEW model,
     # not the old one. Re-capture of GPIOC IDR readback is owed and tracked.
     # 2026-08-03: this board's chip YAML gained `config.debug_schema:` entries pointing at SVD-derived register descriptors (#753). DEBUGGER METADATA ONLY: `load_debug_schemas` feeds them to `inspect_with_schema`, which supplies register NAMES, offsets and bit slices for a debugger view. Every VALUE still comes from the peripheral's own model, read through side-effect-free `peek`. No peripheral model, register layout, base address or reset value changed, so nothing in the asserted capture set can move. Evidence on this commit: full `cargo test -p labwired-core` green except the pre-existing esp32_ili9341_attach failure, plus svd_conformance and chip_conformance_ratchet green. No live re-capture.
-    drift_ack: 2026-08-05
+    drift_ack: 2026-08-06
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -1343,7 +1343,7 @@ boards:
     # through this controller; all six families pass unchanged, no dispatch bug
     # found. No live re-capture.
     # 2026-08-03: this board's chip YAML gained `config.debug_schema:` entries pointing at SVD-derived register descriptors (#753). DEBUGGER METADATA ONLY: `load_debug_schemas` feeds them to `inspect_with_schema`, which supplies register NAMES, offsets and bit slices for a debugger view. Every VALUE still comes from the peripheral's own model, read through side-effect-free `peek`. No peripheral model, register layout, base address or reset value changed, so nothing in the asserted capture set can move. Evidence on this commit: full `cargo test -p labwired-core` green except the pre-existing esp32_ili9341_attach failure, plus svd_conformance and chip_conformance_ratchet green. No live re-capture.
-    drift_ack: 2026-08-05
+    drift_ack: 2026-08-06
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -1480,7 +1480,7 @@ boards:
     # through this controller; all six families pass unchanged, no dispatch bug
     # found. No live re-capture.
     # 2026-08-03: this board's chip YAML gained `config.debug_schema:` entries pointing at SVD-derived register descriptors (#753). DEBUGGER METADATA ONLY: `load_debug_schemas` feeds them to `inspect_with_schema`, which supplies register NAMES, offsets and bit slices for a debugger view. Every VALUE still comes from the peripheral's own model, read through side-effect-free `peek`. No peripheral model, register layout, base address or reset value changed, so nothing in the asserted capture set can move. Evidence on this commit: full `cargo test -p labwired-core` green except the pre-existing esp32_ili9341_attach failure, plus svd_conformance and chip_conformance_ratchet green. No live re-capture.
-    drift_ack: 2026-08-05
+    drift_ack: 2026-08-06
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs


### PR DESCRIPTION
## Summary
Main `core-integrity` failed `bus_motor_bldc_samples_tim1_six_gates_and_is_deterministic` after fmt was fixed: phase stayed `(0,0)` while CNT was `1`.

**Root cause:** `cargo test --workspace --lib` feature-unifies `event-scheduler` through `labwired-wasm`. Under that mode the timer advances lazily from the cycle clock on MMIO reads, but `Timer::output_snapshot` (used by motor service) did not sync — so PWM phase tracking used a stale counter.

## Fix
- Sync the cycle clock in `output_snapshot`
- `clock_authoritative` on the snapshot; skip a second cursor advance on freeze/phase resync when the timer is already at "now"

## Test plan
- [x] `cargo test -p labwired-core --lib bus_motor_bldc` (legacy)
- [x] same with `--features event-scheduler` (workspace-unified path)
- [ ] Rust Core CI green on main after merge