### PR TITLE
fix(kit): drop empty demo_elf lab on ili9341-16bit

### DIFF
--- a/crates/core/src/peripherals/components/ili9341_parallel.rs
+++ b/crates/core/src/peripherals/components/ili9341_parallel.rs
@@ -391,7 +391,7 @@ impl crate::peripherals::esp32::gpio::GpioObserver for Ili9341Parallel {
 // ─── PeripheralKit (universal attach) ──────────────────────────────────────
 
 use crate::peripherals::kit::{
-    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, LabRef, PeripheralKit, Transport,
+    AttachCtx, Category, ConfigKey, ConfigType, KitMetadata, PeripheralKit, Transport,
 };
 
 /// Kit for the 16-bit parallel ILI9341 (`ili9341-16bit`). Distinct device_type
@@ -442,12 +442,9 @@ static ILI9341_PARALLEL_METADATA: KitMetadata = KitMetadata {
             doc: "Data bus bit 0 (LSB). Also db1_pin..db15_pin. Defaults GPIO10..GPIO25.",
         },
     ],
-    labs: &[LabRef {
-        board_id: "ili9341-16bit-lab",
-        chip: "esp32",
-        example_dir: "ili9341-16bit-lab",
-        demo_elf: "",
-    }],
+    // Example system lives at examples/ili9341-16bit-lab; keep labs empty until
+    // a non-empty demo_elf ships (UI kitsWithLabs requires demo_elf length > 0).
+    labs: &[],
 };
 
 impl PeripheralKit for Ili9341ParallelKit {

--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -902,14 +902,7 @@
           "doc": "Data bus bit 0 (LSB). Also db1_pin..db15_pin. Defaults GPIO10..GPIO25."
         }
       ],
-      "labs": [
-        {
-          "board_id": "ili9341-16bit-lab",
-          "chip": "esp32",
-          "example_dir": "ili9341-16bit-lab",
-          "demo_elf": ""
-        }
-      ],
+      "labs": [],
       "inputs": []
     },
     {


### PR DESCRIPTION
## Summary
- `ili9341-16bit` registered a LabRef with `demo_elf: \"\"`, which fails the super UI gate `kitsWithLabs` (demo_elf length > 0).
- Clear `labs` until a real demo binary exists; example remains at `examples/ili9341-16bit-lab`.
- Regenerate fixtures peripherals manifest.

## Test plan
- [x] gen-peripherals-manifest: ili9341-16bit labs []
- [ ] core pr-gate