### PR TITLE
fix(cli): stamp run-manifest nondeterminism for seeded sensor noise

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2894,11 +2894,19 @@ fn write_outputs<C: labwired_core::Cpu>(
                 if let Some(sys) = system_path {
                     configs.push(hash_file(sys));
                 }
+                // Stamp honestly: `any_noise_enabled` matches kit config keys
+                // and declarative noise inputs. Seeded noise is bit-identical
+                // across runs, but it is not the absence of variation.
+                let nondeterminism = system_path
+                    .and_then(|sys| std::fs::read_to_string(sys).ok())
+                    .filter(|yaml| manifest::any_noise_enabled(yaml))
+                    .map(|_| "seeded(sensor-noise)".to_string())
+                    .unwrap_or_else(|| "none".to_string());
                 let mut man = manifest::RunManifest {
                     manifest_schema_version: manifest::MANIFEST_SCHEMA_VERSION.to_string(),
                     engine_version: env!("CARGO_PKG_VERSION").to_string(),
                     seed: 0,
-                    nondeterminism: "none".to_string(),
+                    nondeterminism,
                     firmware: manifest::HashedFile {
                         path: basename(firmware_path),
                         sha256: result.firmware_hash.clone(),


### PR DESCRIPTION
## Problem
Scheduled **Rust Core CI** / `core-full` failed:
`noise_enabled_run_declares_seeded_nondeterminism` expected `seeded(sensor-noise)`, got `none`.

## Cause
`manifest::any_noise_enabled` was implemented and unit-tested but never used when writing `run-manifest.json`.

## Fix
When building the run manifest, read the system YAML and stamp
`nondeterminism: "seeded(sensor-noise)"` if any external device carries noise config keys or a declarative noise input.

## Test
`cargo test -p labwired-cli --test manifest_reproducible` — 3/3 pass