### PR TITLE
ci(core-full): install thumbv7em-none-eabihf for L476 BLDC tests

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -661,10 +661,15 @@ jobs:
             . -> target
 
       - name: Install ARM targets
+        # thumbv7em-none-eabihf is required by nucleo_l476rg BLDC tests
+        # (firmware-l476-demo / six-step). Soft-float eabi alone is not enough;
+        # without the hard-float target, cargo test --workspace fails mid-suite
+        # with E0463 can't find crate for `core`. Nightly already installs it.
         run: |
           rustup target add thumbv6m-none-eabi
           rustup target add thumbv7m-none-eabi
           rustup target add thumbv7em-none-eabi
+          rustup target add thumbv7em-none-eabihf
 
       - name: Build test firmware fixture
         run: |


### PR DESCRIPTION
## Summary
- `core-full` Install ARM targets now includes `thumbv7em-none-eabihf` (same as nightly)
- Unblocks `nucleo_l476rg` BLDC firmware builds inside `cargo test --workspace`

## Context
core-full failed on main after #812: `can't find crate for core` / target not installed when building `firmware-l476-demo`.

## Test plan
- [ ] CI pr-gate
- [ ] core-full workspace tests after merge