### PR TITLE
test(coverage): re-baseline register-modeling after F411 proxy drop

### DIFF
--- a/docs/coverage/register-modeling.json
+++ b/docs/coverage/register-modeling.json
@@ -1,10 +1,10 @@
 {
   "esp32": {
-    "modeled": 2333,
+    "modeled": 2336,
     "total": 2997
   },
   "esp32c3": {
-    "modeled": 333,
+    "modeled": 2545,
     "total": 2606
   },
   "esp32s3": {
@@ -12,55 +12,55 @@
     "total": 4283
   },
   "nrf52832": {
-    "modeled": 2,
+    "modeled": 397,
     "total": 1690
   },
   "nrf52840": {
-    "modeled": 946,
+    "modeled": 968,
     "total": 2142
   },
   "rp2040": {
-    "modeled": 67,
+    "modeled": 739,
     "total": 1182
   },
   "stm32f103": {
-    "modeled": 221,
+    "modeled": 273,
     "total": 722
   },
   "stm32f401": {
-    "modeled": 52,
+    "modeled": 223,
     "total": 660
   },
   "stm32f407": {
-    "modeled": 254,
+    "modeled": 364,
     "total": 1540
   },
   "stm32f411ceu6": {
-    "modeled": 279,
+    "modeled": 273,
     "total": 669
   },
   "stm32g474re": {
-    "modeled": 80,
+    "modeled": 230,
     "total": 1585
   },
   "stm32h563": {
-    "modeled": 339,
+    "modeled": 382,
     "total": 4426
   },
   "stm32l073": {
-    "modeled": 297,
+    "modeled": 308,
     "total": 524
   },
   "stm32l476": {
-    "modeled": 721,
+    "modeled": 734,
     "total": 1485
   },
   "stm32wb55": {
-    "modeled": 44,
+    "modeled": 204,
     "total": 799
   },
   "stm32wba52": {
-    "modeled": 44,
+    "modeled": 227,
     "total": 1713
   }
 }


### PR DESCRIPTION
## Summary
- `stm32f411ceu6` modeled 279 → 273 (write-protect probe under-count; see `register_coverage.rs` docs)
- Full baseline refresh from live measure so other chips reflect current modeled counts

## Test plan
- [x] `cargo test -p labwired-core --test register_coverage`
- [ ] core-full after merge