### PR TITLE
test(rp2350): add pico2 io-smoke + thumbv8m for core-full

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -668,11 +668,14 @@ jobs:
         # (firmware-l476-demo / six-step). Soft-float eabi alone is not enough;
         # without the hard-float target, cargo test --workspace fails mid-suite
         # with E0463 can't find crate for `core`. Nightly already installs it.
+        # thumbv8m.main-none-eabi is required by firmware-rp2350-demo for the
+        # pico2 strict-onboarding io-smoke (RP2350 / Cortex-M33).
         run: |
           rustup target add thumbv6m-none-eabi
           rustup target add thumbv7m-none-eabi
           rustup target add thumbv7em-none-eabi
           rustup target add thumbv7em-none-eabihf
+          rustup target add thumbv8m.main-none-eabi
 
       - name: Build test firmware fixture
         run: |

--- a/examples/pico2/io-smoke.yaml
+++ b/examples/pico2/io-smoke.yaml
@@ -1,0 +1,11 @@
+# LabWired - Pico 2 (RP2350) UART smoke test
+# Firmware: firmware-rp2350-demo (bare-metal, targets RP2350 UART0 @0x40070000).
+schema_version: "1.0"
+inputs:
+  firmware: "../../target/thumbv8m.main-none-eabi/release/firmware-rp2350-demo"
+  system: "./system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "RP2350_SMOKE_OK"
+  - expected_stop_reason: max_steps


### PR DESCRIPTION
## Summary
- Add `examples/pico2/io-smoke.yaml` (same contract as existing `uart-smoke.yaml`)
- Install `thumbv8m.main-none-eabi` in core-full so `firmware-rp2350-demo` builds

## Context
core-full failed: `rp2350 (missing io-smoke.yaml, not in allowlist)` after board pack RP2350 landed with only `uart-smoke.yaml`.

## Test plan
- [x] `cargo build -p firmware-rp2350-demo --release --target thumbv8m.main-none-eabi`
- [ ] CI pr-gate / core-full