### PR TITLE
fix(can): recompute walk after CanBus attach under event-scheduler

### DIFF
--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -771,7 +771,16 @@ impl SystemBus {
         let fdcan = any
             .downcast_mut::<crate::peripherals::fdcan::Fdcan>()
             .ok_or_else(|| anyhow::anyhow!("peripheral '{can_id}' is not an FDCAN"))?;
-        fdcan.attach_bus(tx, rx)
+        fdcan.attach_bus(tx, rx)?;
+        // FDCAN is walk-free under `event-scheduler` until a CanBus endpoint is
+        // attached (`scheduler_mode` is `event-scheduler && bus_rx.is_none()`).
+        // from_config latches `legacy_walk_disabled` over the pre-attach set, so
+        // without a recompute the multi-node bus stays walk-deleted and mpsc RX
+        // never drains — world_can_bus / CanBus paths under cargo test --workspace
+        // (feature-unified event-scheduler) receive zero frames.
+        self.rebuild_peripheral_ranges();
+        self.recompute_walk_deletable();
+        Ok(())
     }
 
     /// Detach a single UART (by peripheral id) from the shared console TX sink.


### PR DESCRIPTION
## Summary
- After `attach_can_bus_by_id`, rebuild peripheral ranges/tick indices and recompute `legacy_walk_disabled`
- Unblocks multi-node FDCAN under `event-scheduler` (workspace feature unification)

## Context
core-full failed `world_can_bus` (0 frames received) only with event-scheduler; default features passed.

## Test plan
- [x] `cargo test -p labwired-core --features event-scheduler --test world_can_bus`
- [x] same without features
- [ ] core-full