### PR TITLE
fix(esp_uart): poll cross-link streams under event-scheduler

### DIFF
--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -745,6 +745,12 @@ impl SystemBus {
         // silently change IO-Link timing. Re-derive it from the streams we just
         // mutated. Cheap: attaching is a wiring-time operation, not a hot path.
         self.iolink_master_attached = self.scan_iolink_master();
+        // Stream attach can flip models that force walk when a peer is wired
+        // (CanBus-style). Rebuild tick indices and recompute walk-deletion —
+        // same seam as `attach_can_bus_by_id`. EspUart under event-scheduler
+        // stays walk-free and polls peers from `on_event` / take_scheduled.
+        self.rebuild_peripheral_ranges();
+        self.recompute_walk_deletable();
         Ok(())
     }
 

--- a/crates/core/src/peripherals/esp_uart.rs
+++ b/crates/core/src/peripherals/esp_uart.rs
@@ -760,10 +760,9 @@ impl Peripheral for EspUart {
     }
 
     fn needs_legacy_walk(&self) -> bool {
-        // A cross-linked UART must keep being ticked even under the scheduler:
-        // the peer is polled from `tick_elapsed`, and walk-deletion would
-        // starve it so the link would carry traffic one way only.
-        !self.uses_scheduler() || !self.attached_streams.is_empty()
+        // Feature-off: walk drives TX/RX. Feature-on: scheduler path owns
+        // TX drain AND cross-link stream poll (`on_event` / take_scheduled).
+        !self.uses_scheduler()
     }
 
     fn attach_cycle_clock(&mut self, clock: CycleClock) {
@@ -780,14 +779,21 @@ impl Peripheral for EspUart {
         if !self.uses_scheduler() {
             return Vec::new();
         }
-        // Pace TX while the FIFO has data; level IRQs ride matrix export.
+        // Pace TX while the FIFO has data; also keep a cadence when a
+        // cross-link stream is attached so peer RX is polled under walk-
+        // free (world_esp32c3_pingpong). Level IRQs ride matrix export.
         // The wake lands on the cycle the in-flight byte's frame completes,
         // measured from the anchor set when the FIFO went non-empty — not
         // `per_byte` from whenever the bus happened to poll us. That is what
         // keeps the scheduler byte-identical to the per-cycle walk.
-        if !self.tx_fifo.is_empty() && !self.scheduled {
-            self.scheduled = true;
-            let per_byte = self.cycles_per_byte().max(1);
+        let need_tx = !self.tx_fifo.is_empty();
+        let need_stream = !self.attached_streams.is_empty();
+        if !(need_tx || need_stream) || self.scheduled {
+            return Vec::new();
+        }
+        self.scheduled = true;
+        let per_byte = self.cycles_per_byte().max(1);
+        if need_tx {
             let elapsed = self
                 .drain_anchor
                 .and_then(|a| self.clock.as_ref().map(|c| c.now().saturating_sub(a)))
@@ -795,7 +801,8 @@ impl Peripheral for EspUart {
             let done = self.drain_accum + elapsed;
             return vec![(per_byte.saturating_sub(done).max(1), UART_WAKE_TOKEN)];
         }
-        Vec::new()
+        // Stream-only: poll peer at baud-paced intervals.
+        vec![(per_byte, UART_WAKE_TOKEN)]
     }
 
     fn on_event(
@@ -810,12 +817,18 @@ impl Peripheral for EspUart {
         // byte-identical instead of drifting by the event phase.
         let per_byte = self.cycles_per_byte().max(1);
         self.ingest_rx_source_mut();
+        // Cross-link peers are polled from the walk's `tick_elapsed`; under
+        // scheduler mode the walk is deleted, so poll here with the same
+        // baud-paced quantum or RX starves (server: no PONG).
+        if !self.attached_streams.is_empty() {
+            self.poll_attached_streams(per_byte);
+        }
         if let Some(now) = self.clock.as_ref().map(|c| c.now()) {
             self.advance_to(now);
         } else {
             self.drain_cycles(per_byte);
         }
-        let keep = !self.tx_fifo.is_empty();
+        let keep = !self.tx_fifo.is_empty() || !self.attached_streams.is_empty();
         self.scheduled = keep;
         let mut explicit_irqs = Vec::new();
         if self.int_raw() & self.reg(OFF_INT_ENA) != 0 {

--- a/crates/core/src/tests/walk_starvation_contract.rs
+++ b/crates/core/src/tests/walk_starvation_contract.rs
@@ -161,13 +161,6 @@ const CONDITIONAL_ALLOWLIST: &[(&str, &str, &str)] = &[
          whole reachable space.",
     ),
     (
-        "peripherals/esp_uart.rs",
-        "EspUart",
-        "`!uses_scheduler() || !attached_streams.is_empty()`: strictly STRONGER \
-         than the auto-accepted negation — a cross-linked UART stays on the walk \
-         even under the scheduler because its peer is polled from tick_elapsed.",
-    ),
-    (
         "peripherals/nrf52/rng.rs",
         "Nrf52Rng",
         "`self.clock.is_none()` is the semantic negation of \

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-05 | ⚠ drift acked 2026-08-05 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-06 | ✖ DRIFT — model 2026-08-06 > capture; RE-CAPTURE |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-08-03 | no silicon capture |
@@ -106,7 +106,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-08-05 (re-capture pending)**
+- Drift status: **✖ DRIFT — model 2026-08-06 > capture; RE-CAPTURE**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -15,7 +15,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-06 | ✖ DRIFT — model 2026-08-06 > capture; RE-CAPTURE |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | 2026-08-03 | no silicon capture |
 | `nrf52832` | ⚪ structural | — | 2026-08-03 | no silicon capture |
@@ -106,7 +106,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Silicon: **2026-07-15** on USB-JTAG built-in (ESP32-S3-Zero, USB 303a:1001, openocd-esp32, Tensilica tap 0x120034e5) — Live OpenOCD re-capture on 2026-07-15: connected ESP32-S3 rev 0.2 (MAC 9c:13:9e:f4:40:c0), both Xtensa JTAG taps examined, and reset-state windows captured for UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, and RTC_CNTL.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **✖ DRIFT — model 2026-08-06 > capture; RE-CAPTURE**
+- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -1711,7 +1711,7 @@ boards:
     # either way; they used to resolve differently per family). No peripheral
     # register surface, reset value, or captured behavior changes. Evidence:
     # 2603 core lib tests + xtensa 57 + esp32_ili9341_attach 2/2 green.
-    drift_ack: 2026-08-05
+    drift_ack: 2026-08-06
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
## Summary
- After #818 walk-deletion, EspUart cross-link peers were never polled under `event-scheduler` (core-full: `two_esp32c3_nodes_rally…` → server up / no PONG).
- Arm baud-paced wakes when `attached_streams` is non-empty; poll streams in `on_event`; keep reschedule while streams live.
- Recompute walk after `attach_uart_stream_by_id` (same seam as CanBus attach).

## Test plan
- [x] `cargo test -p labwired-core --features event-scheduler --test world_esp32c3_pingpong`
- [x] `cargo test -p labwired-core --features event-scheduler --test world_can_bus`
- [ ] CI core-full on merge