### PR TITLE
fix(ci): cargo fmt after H735 telematics merge

### DIFF
--- a/crates/core/src/network/sim_mqtt_fabric.rs
+++ b/crates/core/src/network/sim_mqtt_fabric.rs
@@ -87,8 +87,7 @@ impl SimMqttFabric {
     pub fn open(&self, endpoint: &str, client_id: u8, host: &str, port: u16) {
         self.with_mut(|inner| {
             let ep = inner.endpoints.entry(endpoint.to_string()).or_default();
-            ep.brokers
-                .insert(client_id, (host.to_string(), port));
+            ep.brokers.insert(client_id, (host.to_string(), port));
         });
     }
 
@@ -119,13 +118,7 @@ impl SimMqttFabric {
     }
 
     /// Publish from `endpoint`. Returns number of subscriber deliveries queued.
-    pub fn publish(
-        &self,
-        endpoint: &str,
-        client_id: u8,
-        topic: &str,
-        payload: &[u8],
-    ) -> usize {
+    pub fn publish(&self, endpoint: &str, client_id: u8, topic: &str, payload: &[u8]) -> usize {
         self.with_mut(|inner| {
             let (host, port) = inner
                 .endpoints
@@ -209,13 +202,7 @@ impl SimMqttFabric {
                 .log
                 .iter()
                 .take(limit)
-                .map(|m| {
-                    format!(
-                        "{}\t{}",
-                        m.topic,
-                        String::from_utf8_lossy(&m.payload)
-                    )
-                })
+                .map(|m| format!("{}\t{}", m.topic, String::from_utf8_lossy(&m.payload)))
                 .collect()
         })
     }

--- a/crates/core/src/peripherals/components/bg770a.rs
+++ b/crates/core/src/peripherals/components/bg770a.rs
@@ -1404,8 +1404,7 @@ impl QuectelBg770a {
                         self.mqtt[id as usize].state = MqttState::Initialized;
                         self.mqtt[id as usize].broker_host = host.to_string();
                         self.mqtt[id as usize].broker_port = port;
-                        self.mqtt_net
-                            .open(&self.mqtt_endpoint_id(), id, host, port);
+                        self.mqtt_net.open(&self.mqtt_endpoint_id(), id, host, port);
                     }
                     let urc = format!("\r\n+QMTOPEN: {},{}\r\n", id, result);
                     self.deferred_urcs
@@ -3782,7 +3781,10 @@ mod tests {
         m.set_input("range_m", 10_000.0).unwrap();
         let csq = m.effective_csq().0;
         // Weakened CSQ step or no-service (99) if below the floor — not CSQ 31.
-        assert_ne!(csq, 31, "10 km path loss should not stay max CSQ, got {csq}");
+        assert_ne!(
+            csq, 31,
+            "10 km path loss should not stay max CSQ, got {csq}"
+        );
         assert!(
             air.medium_slot().lock().unwrap().is_some(),
             "shared slot still holds the medium"

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -356,12 +356,7 @@ impl World {
                 let ble = BleAirBus::new();
                 let fabric = SimMqttFabric::new();
                 for (id, machine) in world.machines.iter_mut() {
-                    machine.attach_lab_air(
-                        id.as_str(),
-                        nrf.clone(),
-                        ble.clone(),
-                        fabric.clone(),
-                    );
+                    machine.attach_lab_air(id.as_str(), nrf.clone(), ble.clone(), fabric.clone());
                 }
             }
         }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1609,9 +1609,7 @@ impl AirBus {
     /// Latest payload bytes for an exact topic, or empty if none.
     #[wasm_bindgen]
     pub fn cellular_last_payload(&self, topic: &str) -> Vec<u8> {
-        self.cellular
-            .last_payload_on(topic)
-            .unwrap_or_default()
+        self.cellular.last_payload_on(topic).unwrap_or_default()
     }
 
     /// Inspect fabric: up to `limit` lines of `topic\\tpayload` (most recent first).

--- a/examples/h735-telematics-lab/src/main.rs
+++ b/examples/h735-telematics-lab/src/main.rs
@@ -207,7 +207,7 @@ fn spi_enable() {
     let moder = rd32(GPIOA_BASE);
     wr32(GPIOA_BASE, (moder & !(0x3 << 8)) | (0x1 << 8)); // PA4 MODER=01
     wr32(GPIOA_BASE + 0x18, 1 << 4); // CS high
-    // SPI master, SSM, SSI, 8-bit default CFG1, endless TSIZE=0
+                                     // SPI master, SSM, SSI, 8-bit default CFG1, endless TSIZE=0
     wr32(SPI1_BASE, H5_SSI); // CR1 SSI first
     wr32(SPI1_BASE + 0x0C, H5_MASTER | H5_SSM); // CFG2
     wr32(SPI1_BASE + 0x04, 0); // CR2 TSIZE=0 endless
@@ -305,7 +305,7 @@ fn tft_init_compact() {
     spin(5_000);
     tft_cmd1(0x3A, 0x55); // COLMOD RGB565
     tft_cmd(0x29); // DISPON
-    // Compact header only: 240×16 navy
+                   // Compact header only: 240×16 navy
     tft_fill_rect(0, 0, 240, 16, 0x0010);
 }
 
@@ -430,7 +430,13 @@ fn main() -> ! {
     // (those cost 150s of model time and blow the smoke step budget).
 
     send_at("AT+QGPS=1", &mut resp, &mut resp_len);
-    send_at_until("AT+QGPSLOC=0", &mut resp, &mut resp_len, b"+QGPSLOC:", 200_000);
+    send_at_until(
+        "AT+QGPSLOC=0",
+        &mut resp,
+        &mut resp_len,
+        b"+QGPSLOC:",
+        200_000,
+    );
 
     let (lat, lon) = parse_qgpsloc(&resp, resp_len).unwrap_or((37.7749, -122.4194));
     let mut lat_buf = [0u8; 16];


### PR DESCRIPTION
## Summary
- `core-integrity` on main failed `cargo fmt --check` after #820 (H735 telematics / SimMqttFabric).
- Ran `cargo fmt --all` on the affected files only.

## Files
- `sim_mqtt_fabric.rs`, `bg770a.rs`, `world.rs`, wasm `lib.rs`, `h735-telematics-lab` main

## Test plan
- [x] local `cargo fmt --all -- --check`
- CI core-integrity should pass