### PR TITLE
fix(telematics): harden AirBus MQTT fabric send/collect

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1555,6 +1555,10 @@ fn assertion_currently_passes(
                     .as_ref()
                     .is_none_or(|fault| motor.faults.contains(fault))
         }),
+        TestAssertion::MqttFabric(a) => machine.bus.mqtt_fabric_matches(
+            &a.mqtt_fabric.topic,
+            a.mqtt_fabric.payload_contains.as_deref(),
+        ),
         // This assertion requires immutable event-cycle evidence collected by
         // the runner; accumulated text alone is deliberately insufficient.
         TestAssertion::ShutdownLatency(_) => false,
@@ -2416,7 +2420,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         let passed = match assertion {
             TestAssertion::UartContains(a) => uart_text.contains(&a.uart_contains),
             TestAssertion::UartRegex(a) => simple_regex_is_match(&a.uart_regex, &uart_text),
-            TestAssertion::UartOrdered(_) | TestAssertion::MotorState(_) => {
+            TestAssertion::UartOrdered(_)
+            | TestAssertion::MotorState(_)
+            | TestAssertion::MqttFabric(_) => {
                 assertion_currently_passes(assertion, &uart_text, machine)
             }
             TestAssertion::MotorSpeedReached(_) => {
@@ -2484,7 +2490,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         false
                     }
                 }
-            }
+            } // MqttFabric is handled above via assertion_currently_passes.
         };
 
         if matches!(assertion, TestAssertion::ExpectedStopReason(_)) && passed {
@@ -3397,6 +3403,13 @@ fn assertion_short_name(assertion: &TestAssertion) -> String {
             "memory_value: @{:#x}={:#x}",
             a.memory_value.address, a.memory_value.expected_value
         ),
+        TestAssertion::MqttFabric(a) => {
+            let mut s = format!("mqtt_fabric: topic={}", a.mqtt_fabric.topic);
+            if let Some(p) = &a.mqtt_fabric.payload_contains {
+                s.push_str(&format!(" payload_contains={p}"));
+            }
+            s
+        }
         TestAssertion::UdsTester(a) => {
             format!(
                 "uds_tester: {} result={:?}",

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3225,6 +3225,23 @@ pub struct UdsTesterAssertion {
     pub uds_tester: UdsTesterDetails,
 }
 
+/// Assert SimMqttFabric collected a publish (send→collect), not only UART text.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct MqttFabricDetails {
+    /// Exact topic that must appear on the fabric.
+    pub topic: String,
+    /// Optional substring that must appear in the latest payload for that topic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_contains: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct MqttFabricAssertion {
+    pub mqtt_fabric: MqttFabricDetails,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum TestAssertion {
@@ -3237,6 +3254,7 @@ pub enum TestAssertion {
     ExpectedStopReason(StopReasonAssertion),
     MemoryValue(MemoryValueAssertion),
     UdsTester(UdsTesterAssertion),
+    MqttFabric(MqttFabricAssertion),
 }
 
 /// Where a fault is applied. Either a peripheral (by `id`, optionally narrowed

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -898,9 +898,10 @@ impl SystemBus {
             None => bus.derive_walk_deletable(),
         };
 
-        // One attach API: attach_lab_air. CLI/single-board mints a private lab
-        // air here; browser multi-chip later rebinds the same API with a shared
-        // AirBus (deliberate replace, not a second fabric).
+        // One bind API only: attach_lab_air. Single-board CLI mints a private
+        // lab air here so MQTT/CSQ work without a browser. Multi-node World and
+        // the playground rebind via attach_lab_air with a *shared* air (same
+        // method — deliberate replace of the private fabric, not double-bind).
         if bus.has_cellular_modem() {
             let node = if manifest.name.is_empty() {
                 "lab"

--- a/crates/core/src/bus/routing.rs
+++ b/crates/core/src/bus/routing.rs
@@ -704,7 +704,6 @@ impl SystemBus {
         use crate::peripherals::esp32c3::bt::Esp32c3Bt;
         use crate::peripherals::nrf52::radio::Nrf52Radio;
         use crate::peripherals::uart::Uart;
-        use crate::sim_input::SimInput;
         let medium = nrf_air.medium_slot();
         for entry in &mut self.peripherals {
             if let Some(radio) = entry
@@ -735,9 +734,9 @@ impl SystemBus {
                         // One AirBus story: path-loss medium + cellular MQTT fabric.
                         modem.share_medium_slot(medium.clone());
                         modem.set_mqtt_net(cellular.clone());
-                        if SimInput::component_id(modem).is_none() {
-                            modem.set_rf_node_id(node_id);
-                        }
+                        // Always label the UE with the lab node id so multi-node
+                        // fabric endpoints differ (device id is often both "modem").
+                        modem.set_rf_node_id(node_id);
                     }
                 }
             }
@@ -768,6 +767,44 @@ impl SystemBus {
         false
     }
 
+    /// True if any modem's SimMqttFabric has a publish on `topic`, optionally
+    /// requiring `payload_contains` as a UTF-8 substring of the latest payload.
+    pub fn mqtt_fabric_matches(&self, topic: &str, payload_contains: Option<&str>) -> bool {
+        use crate::peripherals::components::QuectelBg770a;
+        use crate::peripherals::uart::Uart;
+        for entry in &self.peripherals {
+            let Some(any) = entry.dev.as_any() else {
+                continue;
+            };
+            let Some(uart) = any.downcast_ref::<Uart>() else {
+                continue;
+            };
+            for stream in &uart.attached_streams {
+                let Some(modem) = stream
+                    .as_any()
+                    .and_then(|a| a.downcast_ref::<QuectelBg770a>())
+                else {
+                    continue;
+                };
+                let fabric = modem.mqtt_net();
+                if !fabric.has_publish_on(topic) {
+                    continue;
+                }
+                match payload_contains {
+                    None => return true,
+                    Some(needle) => {
+                        if let Some(payload) = fabric.last_payload_on(topic) {
+                            if String::from_utf8_lossy(&payload).contains(needle) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
     /// Mint a private lab AirBus trio and bind via [`Self::attach_lab_air`].
     /// Used by `from_config` (CLI) and multi-node `World` so there is exactly
     /// one bind API: `attach_lab_air`.
@@ -781,17 +818,6 @@ impl SystemBus {
         let ble = BleAirBus::new();
         let cellular = SimMqttFabric::new();
         self.attach_lab_air(node_id, nrf, ble, cellular);
-    }
-
-    /// Bind to an existing lab air (shared across World nodes or browser chips).
-    pub fn attach_shared_lab_air(
-        &mut self,
-        node_id: &str,
-        nrf_air: crate::peripherals::nrf52::radio::VirtualAirBus,
-        ble_air: crate::peripherals::ble_air::BleAirBus,
-        cellular: crate::network::SimMqttFabric,
-    ) {
-        self.attach_lab_air(node_id, nrf_air, ble_air, cellular);
     }
 
     /// Attach a UART stream device (e.g. an inter-chip wire endpoint) to the

--- a/crates/core/src/peripherals/components/bg770a.rs
+++ b/crates/core/src/peripherals/components/bg770a.rs
@@ -505,10 +505,18 @@ impl QuectelBg770a {
         self.schedule(URC_DELAY_QMTPUB_US, urc.into_bytes());
     }
 
-    /// Update the seed / override reported by `AT+CSQ` (defaults to 99,99).
-    /// RSSI is 0..=31 (or 99), BER is 0..=7 (or 99). Sets a CSQ override so
-    /// scripted values win until `range_m` re-enables path-loss.
+    /// Seed CSQ values (0..=31 or 99). Does **not** force an override —
+    /// path-loss wins when an RfMedium is attached. Prefer `range_m` SimInput.
     pub fn set_signal(&mut self, rssi: u8, ber: u8) {
+        self.csq_rssi = rssi;
+        self.csq_ber = ber;
+    }
+
+    /// Force CSQ steps until the next `range_m` drive.
+    ///
+    /// Used by system-yaml `config.rssi` seed and unit tests — **not** a
+    /// playground SimInput channel (UI drives `range_m` only).
+    pub fn set_csq_override(&mut self, rssi: u8, ber: u8) {
         self.csq_rssi = rssi;
         self.csq_ber = ber;
         self.csq_override = Some(rssi);
@@ -559,9 +567,12 @@ impl QuectelBg770a {
     }
 
     fn mqtt_endpoint_id(&self) -> String {
-        self.component_id
+        // Prefer lab node id (multi-UE World / attach_lab_air) so two boards
+        // that both declare external_devices id "modem" still get distinct
+        // fabric endpoints for pub/sub fan-out.
+        self.rf_node_id
             .clone()
-            .or_else(|| self.rf_node_id.clone())
+            .or_else(|| self.component_id.clone())
             .unwrap_or_else(|| "modem".into())
     }
 
@@ -2810,8 +2821,7 @@ impl UartStreamDevice for QuectelBg770a {
 }
 
 /// Radio-quality channels. ONE table backs BOTH the `SimInput` impl and kit
-/// metadata. Prefer `range_m` (shared RfMedium path loss, same story as air);
-/// `rssi` is an optional CSQ override for scripts.
+/// metadata. Drive `range_m` (path loss) — no free-floating CSQ override in UI.
 pub const INPUT_CHANNELS: &[crate::sim_input::InputChannel] = &[
     crate::sim_input::InputChannel {
         key: "range_m",
@@ -2820,14 +2830,6 @@ pub const INPUT_CHANNELS: &[crate::sim_input::InputChannel] = &[
         // UE ↔ cell distance for path loss. 0 = co-located (strong CSQ).
         min: 0.0,
         max: 50_000.0,
-    },
-    crate::sim_input::InputChannel {
-        key: "rssi",
-        label: "RSSI override",
-        unit: "CSQ",
-        // Optional force of AT+CSQ steps; clears when range_m is driven.
-        min: 0.0,
-        max: 99.0,
     },
     crate::sim_input::InputChannel {
         key: "ber",
@@ -2847,10 +2849,6 @@ impl crate::sim_input::SimInput for QuectelBg770a {
         self.require_channel(key, value)?;
         match key {
             "range_m" => self.set_range_m(value),
-            "rssi" => {
-                let v = value.round().clamp(0.0, 99.0) as u8;
-                self.set_signal(v, self.csq_ber);
-            }
             "ber" => {
                 self.csq_ber = value.round().clamp(0.0, 99.0) as u8;
             }
@@ -2890,7 +2888,7 @@ static BG770A_METADATA: KitMetadata = KitMetadata {
              validated against real BG770A-GL hardware captures. Firmware sends AT commands, \
              modem replies stream back over UART. Radio quality (AT+CSQ / AT+QCSQ) uses the \
              same RfMedium path-loss geometry as VirtualAirBus: drive `range_m` (metres to \
-             cell) or share the lab AirBus medium; optional `rssi` CSQ override for scripts.",
+             cell). Seed CSQ via config `rssi` only when no medium is attached.",
     transport: Transport::Uart,
     category: Category::Uart,
     config_keys: &[
@@ -2902,8 +2900,8 @@ static BG770A_METADATA: KitMetadata = KitMetadata {
         ConfigKey {
             name: "rssi",
             ty: ConfigType::Int,
-            doc: "Initial CSQ override (0..99). Prefer runtime `range_m` so quality tracks \
-                  path loss; this forces AT+CSQ until range_m is driven.",
+            doc: "YAML seed CSQ (0..99) until `range_m` is driven. Not a UI SimInput — \
+                  playground radio quality is path-loss only (`range_m`).",
         },
         ConfigKey {
             name: "ber",
@@ -2959,7 +2957,8 @@ impl PeripheralKit for QuectelBg770aKit {
         }
         if let Some(rssi) = rssi {
             let ber = ber.unwrap_or(99);
-            modem.set_signal(rssi.clamp(0, 99) as u8, ber.clamp(0, 99) as u8);
+            // Config seed only — not exposed as a free-floating SimInput.
+            modem.set_csq_override(rssi.clamp(0, 99) as u8, ber.clamp(0, 99) as u8);
         }
         if auto_attach {
             modem.complete_network_attach();
@@ -3752,9 +3751,8 @@ mod tests {
             !far.contains("+CSQ: 31,"),
             "5 km should not stay CSQ 31, got {far:?}"
         );
-        // Override forces CSQ regardless of range.
-        m.set_input("rssi", 15.0).expect("rssi");
-        m.set_input("ber", 3.0).expect("ber");
+        // YAML/test override (not a SimInput channel) forces CSQ.
+        m.set_csq_override(15, 3);
         let r = exchange(&mut m, "AT+CSQ");
         assert!(r.contains("+CSQ: 15,3"), "got {r:?}");
         // range_m clears override and physics resume.

--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -5,7 +5,7 @@
       "device_type": "bg770a-cellular",
       "label": "Quectel BG770A Cellular",
       "summary": "LTE-M / NB-IoT cellular modem with the full Quectel AT command surface.",
-      "detail": "Byte-exact V.250 + Quectel +QI*/+QMT*/+QHTTP*/+QGPS*/+QSSL* state machines, validated against real BG770A-GL hardware captures. Firmware sends AT commands, modem replies stream back over UART. Radio quality (AT+CSQ / AT+QCSQ) uses the same RfMedium path-loss geometry as VirtualAirBus: drive `range_m` (metres to cell) or share the lab AirBus medium; optional `rssi` CSQ override for scripts.",
+      "detail": "Byte-exact V.250 + Quectel +QI*/+QMT*/+QHTTP*/+QGPS*/+QSSL* state machines, validated against real BG770A-GL hardware captures. Firmware sends AT commands, modem replies stream back over UART. Radio quality (AT+CSQ / AT+QCSQ) uses the same RfMedium path-loss geometry as VirtualAirBus: drive `range_m` (metres to cell). Seed CSQ via config `rssi` only when no medium is attached.",
       "transport": "uart",
       "category": "uart",
       "config_keys": [
@@ -17,7 +17,7 @@
         {
           "name": "rssi",
           "ty": "int",
-          "doc": "Initial CSQ override (0..99). Prefer runtime `range_m` so quality tracks path loss; this forces AT+CSQ until range_m is driven."
+          "doc": "YAML seed CSQ (0..99) until `range_m` is driven. Not a UI SimInput — playground radio quality is path-loss only (`range_m`)."
         },
         {
           "name": "ber",
@@ -56,13 +56,6 @@
           "unit": "m",
           "min": 0.0,
           "max": 50000.0
-        },
-        {
-          "key": "rssi",
-          "label": "RSSI override",
-          "unit": "CSQ",
-          "min": 0.0,
-          "max": 99.0
         },
         {
           "key": "ber",

--- a/crates/core/tests/sim_input.rs
+++ b/crates/core/tests/sim_input.rs
@@ -250,7 +250,6 @@ fn lists_channels_across_all_transports() {
         ("gps", "lat"),             // NEO-6M (UART stream)
         ("gps", "fix"),
         ("modem", "range_m"), // BG770A — path-loss range (shared RfMedium story)
-        ("modem", "rssi"),
         ("modem", "ber"),
         ("sonar", "distance"), // HC-SR04 (bus-direct)
     ] {
@@ -298,10 +297,12 @@ fn drives_each_transport_through_the_generic_api() {
         near.contains("+CSQ: 31,"),
         "co-located path loss should be CSQ 31, got {near:?}"
     );
-    bus.set_input(Some("modem"), "rssi", 12.0)
-        .expect("drive modem rssi override");
+    // ber is a SimInput channel (path-loss still owns RSSI steps).
     bus.set_input(Some("modem"), "ber", 2.0)
         .expect("drive modem ber");
+    // Far range should drop CSQ steps while ber sticks.
+    bus.set_input(Some("modem"), "range_m", 5_000.0)
+        .expect("drive modem far");
     let csq = with_device::<QuectelBg770a, _>(&mut bus, "uart2", |modem| {
         for b in b"AT+CSQ\r" {
             modem.on_tx_byte(*b);
@@ -313,8 +314,8 @@ fn drives_each_transport_through_the_generic_api() {
         out
     });
     assert!(
-        csq.contains("+CSQ: 12,2"),
-        "CSQ override should be visible on AT+CSQ, got {csq:?}"
+        csq.contains(",2") && !csq.contains("+CSQ: 31,"),
+        "path-loss CSQ + ber channel should show, got {csq:?}"
     );
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1596,31 +1596,49 @@ impl AirBus {
 
     /// Drop SimMqttFabric state (publish log + subscriptions).
     #[wasm_bindgen]
-    pub fn clear_cellular(&self) {
+    pub fn mqtt_fabric_clear(&self) {
         self.cellular.clear();
     }
 
     /// True if any modem on this air published to `topic` (exact match).
     #[wasm_bindgen]
-    pub fn cellular_has_publish(&self, topic: &str) -> bool {
+    pub fn mqtt_fabric_has_publish(&self, topic: &str) -> bool {
         self.cellular.has_publish_on(topic)
     }
 
     /// Latest payload bytes for an exact topic, or empty if none.
     #[wasm_bindgen]
-    pub fn cellular_last_payload(&self, topic: &str) -> Vec<u8> {
+    pub fn mqtt_fabric_last_payload(&self, topic: &str) -> Vec<u8> {
         self.cellular.last_payload_on(topic).unwrap_or_default()
     }
 
     /// Inspect fabric: up to `limit` lines of `topic\\tpayload` (most recent first).
     #[wasm_bindgen]
-    pub fn cellular_inspect(&self, limit: f64) -> String {
+    pub fn mqtt_fabric_inspect(&self, limit: f64) -> String {
         let n = if limit.is_finite() && limit > 0.0 {
             limit as usize
         } else {
             16
         };
         self.cellular.inspect_lines(n.min(64)).join("\n")
+    }
+
+    // --- deprecated aliases (wasm keeps old names working one release) ---
+    #[wasm_bindgen]
+    pub fn clear_cellular(&self) {
+        self.mqtt_fabric_clear();
+    }
+    #[wasm_bindgen]
+    pub fn cellular_has_publish(&self, topic: &str) -> bool {
+        self.mqtt_fabric_has_publish(topic)
+    }
+    #[wasm_bindgen]
+    pub fn cellular_last_payload(&self, topic: &str) -> Vec<u8> {
+        self.mqtt_fabric_last_payload(topic)
+    }
+    #[wasm_bindgen]
+    pub fn cellular_inspect(&self, limit: f64) -> String {
+        self.mqtt_fabric_inspect(limit)
     }
 }
 

--- a/docs/howto/multi-node.md
+++ b/docs/howto/multi-node.md
@@ -222,14 +222,16 @@ before deliver. nRF optional attach is step 1; BLE + Wi‑Fi frame path next.
 **Cellular (shipped):** BG770A shares the VirtualAirBus medium slot via
 `attach_lab_air` (or spins a local medium for single-board labs). `AT+CSQ` /
 `AT+QCSQ` map UE↔`cell` distance to CSQ steps; SimInput `range_m` moves the
-UE. Optional `rssi` CSQ override is for scripts only.
+UE. YAML `config.rssi` seeds CSQ until `range_m` is driven — **not** a UI channel.
 
 **SimMqttFabric (shipped on AirBus):** topic fabric for BG770A AT MQTT — **not**
 a wire broker or EPC. Lives on lab `AirBus` next to nRF/BLE. **One bind API:**
-`attach_lab_air` (CLI private mint via `attach_private_lab_air` / browser shared
-rebind). Path-loss CSQ **gates** `QMTOPEN`/`CONN`/`PUB` (no RF → open fails,
-publish result ≠ 0). Multi-node `World` rebinds all cellular nodes onto one
-fabric. Inspect: `cellular_inspect` / playground fabric strip.
+`attach_lab_air` (CLI mints private air via `attach_private_lab_air`; browser /
+multi-node World **rebind** the same API with a shared air — deliberate replace,
+not a second fabric). Path-loss CSQ **gates** `QMTOPEN`/`CONN`/`PUB` (no RF →
+open fails, publish result ≠ 0). Inspect: `mqtt_fabric_inspect` (wasm aliases
+`cellular_*` still work one release) / playground fabric strip. Smoke:
+`mqtt_fabric: { topic, payload_contains }`.
 
 Do **not** force one bit layout across RADIO / BLE / Wi‑Fi.
 

--- a/examples/h735-telematics-lab/Cargo.toml
+++ b/examples/h735-telematics-lab/Cargo.toml
@@ -14,6 +14,12 @@ path = "src/main.rs"
 test = false
 bench = false
 
+[[bin]]
+name = "h735-telematics-subscriber"
+path = "src/subscriber.rs"
+test = false
+bench = false
+
 [profile.release]
 debug = true
 opt-level = "s"

--- a/examples/h735-telematics-lab/README.md
+++ b/examples/h735-telematics-lab/README.md
@@ -18,19 +18,20 @@ CLM-style telematics story for demos (e.g. Proemion):
 | Modem | **BG770A AT stand-in**, not production telematics module |
 | GPS | Simulator default coordinates from `+QGPSLOC` |
 | MQTT | Happy-path Quectel AT model, not a real broker |
-| Radio quality | Same **RfMedium** path-loss as VirtualAirBus / lab AirBus. Drag **Range (m)** on the modem (UE ↔ cell). Optional **RSSI override** (CSQ) for scripts. |
-| Messages | **SimMqttFabric** on AirBus: **send** (`QMTPUB`) + **collect** (log / playground strip). Not a full network or real broker. RF path-loss can gate open/pub when range is bad. |
+| Radio quality | Same **RfMedium** path-loss as VirtualAirBus / lab AirBus. Drag **Range (m)** on the modem (UE ↔ cell). YAML `config.rssi` is a seed only (not a UI SimInput). |
+| Messages | **SimMqttFabric** on AirBus: **send** (`QMTPUB`) + **collect** (log / fabric strip / `mqtt_fabric` smoke). Not a full network or real broker. RF path-loss can gate open/pub when range is bad. |
 
-Drag **Range** if you care about CSQ. After Run, the fabric strip shows published `topic` + payload (collect). Optional two-UE: `env-two-ue.yaml`.
+Drag **Range** if you care about CSQ. After Run, the fabric strip shows published `topic` + payload (collect). Two-UE pub/sub: `env-two-ue.yaml` (publisher + subscriber ELFs).
 
 ## Build
 
 ```bash
-cd core/examples/h735-telematics-lab
-cargo build --release --target thumbv7em-none-eabi
+# from core/
+cargo build -p h735-telematics-lab --release --target thumbv7em-none-eabi \
+  --bin h735-telematics-lab --bin h735-telematics-subscriber
 ```
 
-Copy ELF into playground assets as `demo-h735-telematics-lab.elf` when packaging.
+Copy publisher ELF into playground assets as `demo-h735-telematics-lab.elf` when packaging.
 
 ## Run in sim (CLI)
 
@@ -47,6 +48,18 @@ Expect UART log lines containing:
 - `> AT`
 - `QGPSLOC` / `GPS fix`
 - `location published`
+
+Plus a **`mqtt_fabric`** assertion that topic `telematics/location` collected payload with `"src":"qgpsloc"`.
+
+### Dual-UE (publisher + subscriber)
+
+```bash
+cargo run -q -p labwired-cli -- test \
+  --script examples/h735-telematics-lab/env-two-ue-smoke.yaml \
+  --output-dir /tmp/h735-two-ue-out --no-uart-stdout
+```
+
+`ue_a` runs the publisher; `ue_b` runs `h735-telematics-subscriber` (`QMTSUB` → `+QMTRECV` / `location received` in `uart.log`).
 
 ## Playground
 

--- a/examples/h735-telematics-lab/env-two-ue-smoke.yaml
+++ b/examples/h735-telematics-lab/env-two-ue-smoke.yaml
@@ -1,0 +1,10 @@
+# Multi-node runner: publisher + subscriber on shared SimMqttFabric.
+# Requires both ELFs built (see env-two-ue.yaml header).
+schema_version: "1.0"
+inputs:
+  env: "./env-two-ue.yaml"
+limits:
+  # Single-UE publish ~0.8M steps; dual interleave + sub needs headroom.
+  max_steps: 5000000
+  # No durable assertions (env runner only allows memory_value). Artifacts
+  # under --output-dir include per-node UART (`location received` on ue_b).

--- a/examples/h735-telematics-lab/env-two-ue.yaml
+++ b/examples/h735-telematics-lab/env-two-ue.yaml
@@ -1,17 +1,20 @@
 # Two H735 telematics UEs on one lab AirBus (shared SimMqttFabric + path-loss).
-# Not a full multi-board CI matrix — demonstrates proper World rebind of air.
+# Real pub/sub: ue_a publishes location; ue_b QMTSUBs and collects via fabric
+# fan-out (+QMTRECV). Not a full multi-board CI matrix — World rebind of air.
 #
-# Build firmware first:
-#   cargo build -p h735-telematics-lab --release --target thumbv7em-none-eabi
+# Build firmwares first:
+#   cargo build -p h735-telematics-lab --release --target thumbv7em-none-eabi \
+#     --bin h735-telematics-lab --bin h735-telematics-subscriber
 #
 # Run (from core/):
 #   cargo run -q -p labwired-cli -- environment-test \
 #     --env examples/h735-telematics-lab/env-two-ue.yaml \
 #     --max-steps 50000000
 #
-# Honesty: both nodes run the same demo firmware (each publishes its fix).
-# Shared fabric means publishes land on one SimMqttFabric; RF positions
-# differ so CSQ can diverge with path loss.
+# Honesty: publisher + subscriber ELFs share one SimMqttFabric; RF positions
+# differ so CSQ can diverge with path loss. Environment-test only allows
+# node-qualified memory_value assertions — collect is proven by subscriber
+# UART (`location received`) and by unit/io-smoke mqtt_fabric asserts.
 schema_version: "1.0"
 name: "h735-two-ue-telematics"
 nodes:
@@ -20,7 +23,7 @@ nodes:
     firmware: "../../target/thumbv7em-none-eabi/release/h735-telematics-lab"
   - id: ue_b
     system: "system.yaml"
-    firmware: "../../target/thumbv7em-none-eabi/release/h735-telematics-lab"
+    firmware: "../../target/thumbv7em-none-eabi/release/h735-telematics-subscriber"
 rf:
   seed: 7
   rssi_floor_dbm: -95.0

--- a/examples/h735-telematics-lab/io-smoke.yaml
+++ b/examples/h735-telematics-lab/io-smoke.yaml
@@ -15,4 +15,8 @@ assertions:
   - uart_contains: "GPS fix"
   - uart_contains: "location published"
   - uart_contains: "+QMTPUB:"
+  # Collect path: payload must land on SimMqttFabric, not only the UART log.
+  - mqtt_fabric:
+      topic: "telematics/location"
+      payload_contains: "\"src\":\"qgpsloc\""
   - expected_stop_reason: assertions_passed

--- a/examples/h735-telematics-lab/src/subscriber.rs
+++ b/examples/h735-telematics-lab/src/subscriber.rs
@@ -1,0 +1,186 @@
+//! H735 telematics **subscriber** UE — pairs with `main.rs` publisher on shared fabric.
+//!
+//! Opens MQTT AT, subscribes to `telematics/#`, waits for fabric fan-out
+//! (`+QMTRECV`), prints `location received`. No TFT / GPS path — keeps the
+//! dual-UE story honest: one node **sends**, one node **collects**.
+
+#![no_std]
+#![no_main]
+
+use core::ptr::{read_volatile, write_volatile};
+use cortex_m_rt::entry;
+use panic_halt as _;
+
+const RCC_BASE: u32 = 0x5802_4400;
+const RCC_APB1LENR: u32 = RCC_BASE + 0xE8;
+const RCC_APB2ENR: u32 = RCC_BASE + 0xF0;
+
+const USART3_BASE: u32 = 0x4000_4800; // console
+const USART1_BASE: u32 = 0x4001_1000; // modem
+
+const ISR_TXE: u32 = 1 << 7;
+const ISR_RXNE: u32 = 1 << 5;
+
+#[inline(always)]
+fn rd32(addr: u32) -> u32 {
+    unsafe { read_volatile(addr as *const u32) }
+}
+#[inline(always)]
+fn wr32(addr: u32, value: u32) {
+    unsafe { write_volatile(addr as *mut u32, value) }
+}
+
+fn console_byte(b: u8) {
+    for _ in 0..10_000 {
+        if rd32(USART3_BASE + 0x1C) & ISR_TXE != 0 {
+            break;
+        }
+    }
+    unsafe { write_volatile((USART3_BASE + 0x28) as *mut u8, b) };
+}
+
+fn console_str(s: &str) {
+    for b in s.bytes() {
+        console_byte(b);
+    }
+}
+
+fn modem_byte(b: u8) {
+    for _ in 0..10_000 {
+        if rd32(USART1_BASE + 0x1C) & ISR_TXE != 0 {
+            break;
+        }
+    }
+    unsafe { write_volatile((USART1_BASE + 0x28) as *mut u8, b) };
+}
+
+fn modem_str(s: &str) {
+    for b in s.bytes() {
+        modem_byte(b);
+    }
+}
+
+fn modem_has_rx() -> bool {
+    rd32(USART1_BASE + 0x1C) & ISR_RXNE != 0
+}
+
+fn modem_read() -> u8 {
+    (rd32(USART1_BASE + 0x24) & 0xFF) as u8
+}
+
+fn drain_modem(buf: &mut [u8], len: &mut usize) {
+    for _ in 0..8192 {
+        if !modem_has_rx() {
+            return;
+        }
+        let b = modem_read();
+        console_byte(b);
+        if *len < buf.len() {
+            buf[*len] = b;
+            *len += 1;
+        } else {
+            buf.copy_within(1.., 0);
+            buf[buf.len() - 1] = b;
+        }
+    }
+}
+
+fn buf_contains(buf: &[u8], n: usize, needle: &[u8]) -> bool {
+    if needle.is_empty() || n < needle.len() {
+        return false;
+    }
+    'outer: for i in 0..=(n - needle.len()) {
+        for j in 0..needle.len() {
+            if buf[i + j] != needle[j] {
+                continue 'outer;
+            }
+        }
+        return true;
+    }
+    false
+}
+
+fn send_at_until(line: &str, buf: &mut [u8], len: &mut usize, needle: &[u8], iters: u32) {
+    *len = 0;
+    console_str("> ");
+    console_str(line);
+    console_str("\r\n");
+    modem_str(line);
+    modem_str("\r\n");
+    for _ in 0..iters {
+        drain_modem(buf, len);
+        if !needle.is_empty() && buf_contains(buf, *len, needle) {
+            break;
+        }
+    }
+}
+
+fn send_at(line: &str, buf: &mut [u8], len: &mut usize) {
+    send_at_until(line, buf, len, b"OK", 200_000);
+}
+
+#[entry]
+fn main() -> ! {
+    wr32(RCC_APB1LENR, rd32(RCC_APB1LENR) | (1 << 18));
+    wr32(RCC_APB2ENR, rd32(RCC_APB2ENR) | (1 << 4));
+
+    console_str("LabWired telematics subscriber / H735 + modem\r\n");
+    console_str("Collect: QMTSUB telematics/# → wait +QMTRECV from fabric\r\n\r\n");
+
+    let mut resp = [0u8; 512];
+    let mut resp_len = 0usize;
+
+    send_at("AT", &mut resp, &mut resp_len);
+    send_at("ATE0", &mut resp, &mut resp_len);
+    send_at("AT+CMEE=2", &mut resp, &mut resp_len);
+    send_at("AT+CSQ", &mut resp, &mut resp_len);
+    send_at("AT+CGATT?", &mut resp, &mut resp_len);
+
+    send_at_until(
+        "AT+QMTOPEN=0,\"broker.labwired.local\",1883",
+        &mut resp,
+        &mut resp_len,
+        b"+QMTOPEN: 0,0",
+        2_000_000,
+    );
+    send_at_until(
+        "AT+QMTCONN=0,\"labwired-subscriber\"",
+        &mut resp,
+        &mut resp_len,
+        b"+QMTCONN:",
+        500_000,
+    );
+    send_at_until(
+        "AT+QMTSUB=0,1,\"telematics/#\",0",
+        &mut resp,
+        &mut resp_len,
+        b"+QMTSUB:",
+        500_000,
+    );
+
+    console_str("subscribed — waiting for fabric delivery\r\n");
+
+    // World interleaves both UEs; peer publishes after GPS/TFT. Drain until
+    // +QMTRECV or a generous spin budget elapses.
+    resp_len = 0;
+    let mut got = false;
+    for _ in 0..8_000_000 {
+        drain_modem(&mut resp, &mut resp_len);
+        if buf_contains(&resp, resp_len, b"+QMTRECV:") {
+            got = true;
+            break;
+        }
+    }
+
+    if got {
+        console_str("location received\r\n");
+    } else {
+        console_str("location timeout (no +QMTRECV)\r\n");
+    }
+
+    loop {
+        for _ in 0..500_000 {
+            drain_modem(&mut resp, &mut resp_len);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Roast follow-up for H735 telematics / SimMqttFabric (#820):

- **Rename** wasm APIs `cellular_*` → `mqtt_fabric_*` (deprecated aliases kept one release)
- **Drop free-floating RSSI SimInput** — UI drives `range_m` only; YAML `config.rssi` uses `set_csq_override` seed
- **One attach path** — `attach_lab_air` only; private mint is CLI convenience that World/browser rebinds
- **Real dual-UE pub/sub** — publisher ELF + `h735-telematics-subscriber` on shared fabric (`env-two-ue.yaml`)
- **Smoke asserts fabric** — `mqtt_fabric: { topic, payload_contains }` in `io-smoke.yaml`, not only UART text
- **Bugfix** multi-UE fan-out: fabric endpoint prefers lab `node_id` so two `"modem"` devices do not collide

## Verify

- `cargo test -p labwired-core --lib peripherals::components::bg770a` (51 ok)
- `cargo test -p labwired-core --test sim_input --test peripheral_kit_gate` (ok)
- io-smoke: all assertions pass including `mqtt_fabric`
- dual-UE: `location published` + `+QMTRECV` / `location received` on subscriber

## Follow-up (monorepo)

- Playground strip: call `mqtt_fabric_inspect` (aliases work until wasm rebuild)
- Regenerate `packages/ui/src/peripherals/manifest.json` after pin (rssi channel removed from inputs)
- PR #1381 ship path stays independent for demo assets/blog