### PR TITLE
fix(arch): fill bare Pico + nRF52840-DK board_io from product profiles

### DIFF
--- a/configs/systems/nrf52840-dk.yaml
+++ b/configs/systems/nrf52840-dk.yaml
@@ -1,3 +1,61 @@
+# LabWired - nRF52840-DK System Configuration
+#
+# Pin assignments from Zephyr board target nrf52840dk/nrf52840 (aliases in
+# core/configs/chips/onboarding/nrf52840dk_nrf52840.yaml). LEDs and buttons are
+# active-low. Product MCU profile nrf52840-dk onboard must match these pins
+# (board-config source-drift + playground product-board-io-alignment).
 name: "nrf52840-dk"
 chip: "../chips/nrf52840.yaml"
-peripherals: []
+external_devices: []
+board_io:
+  # LEDs — active-low (DT: GPIO_ACTIVE_LOW).
+  - id: "led0"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 13
+    signal: "output"
+    active_high: false
+  - id: "led1"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 14
+    signal: "output"
+    active_high: false
+  - id: "led2"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 15
+    signal: "output"
+    active_high: false
+  - id: "led3"
+    kind: "led"
+    peripheral: "gpio0"
+    pin: 16
+    signal: "output"
+    active_high: false
+
+  # Buttons — active-low with pull-ups.
+  - id: "button0"
+    kind: "button"
+    peripheral: "gpio0"
+    pin: 11
+    signal: "input"
+    active_high: false
+  - id: "button1"
+    kind: "button"
+    peripheral: "gpio0"
+    pin: 12
+    signal: "input"
+    active_high: false
+  - id: "button2"
+    kind: "button"
+    peripheral: "gpio0"
+    pin: 24
+    signal: "input"
+    active_high: false
+  - id: "button3"
+    kind: "button"
+    peripheral: "gpio0"
+    pin: 25
+    signal: "input"
+    active_high: false

--- a/configs/systems/rp2040-pico.yaml
+++ b/configs/systems/rp2040-pico.yaml
@@ -1,5 +1,15 @@
 # LabWired - Raspberry Pi Pico System Configuration
+#
+# On-board LED is GP25 (same pad as Pico 2 / core/examples/pico2). Product MCU
+# profile rpi-pico onboard must match these pins (board-config source-drift +
+# playground product-board-io-alignment).
 name: "rp2040-pico"
 chip: "../chips/rp2040.yaml"
 external_devices: []
-board_io: []
+board_io:
+  - id: "led_gp25"
+    kind: "led"
+    peripheral: "sio"
+    pin: 25
+    signal: "output"
+    active_high: true


### PR DESCRIPTION
## Summary
- `rp2040-pico.yaml`: add GP25 LED (`led_gp25` / sio:25) — was `board_io: []`
- `nrf52840-dk.yaml`: add Zephyr DK LEDs + buttons (active-low) — was empty

Product MCU profiles already emit this carrier I/O on canvas compile. Bare playground starters load these system YAMLs, so pins forked silently.

## Test plan
- [ ] Super PR gates: `mcu-profile-source-drift`, `product-board-io-alignment`
- [ ] No CLI bare-system regressions for pico / nRF52840-DK