### PR TITLE
fix(cpu): a snapshot on an unsupported CPU must not brick the engine

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -249,7 +249,29 @@ jobs:
   # step here.
   pr-gate:
     name: pr-gate
-    if: github.event_name == 'pull_request'
+    # `workflow_dispatch` too, and this is not a convenience — it is the only
+    # way out of a specific deadlock. `pr-gate` is one of the two REQUIRED
+    # contexts on main, and required contexts are reported against the PR's
+    # head SHA. GitHub keeps at most ONE pending run per concurrency group, so
+    # when a run in `core-ci-<pr>` gets stuck queued (2026-08-06: an Actions
+    # outage left runs queued with zero jobs, un-cancellable — force-cancel
+    # answers "cannot cancel a workflow re-run that has not yet queued"), every
+    # later push to that PR creates NO run at all. The head SHA then carries no
+    # `pr-gate` context, `enforce_admins` is on, and the PR is unmergeable with
+    # nothing anyone can click.
+    #
+    # A dispatch escapes it because `github.ref` is `refs/heads/<branch>`, which
+    # lands in a DIFFERENT concurrency group than the wedged `core-ci-<pr>` one,
+    # and it reports against the branch tip — the same commit as the PR head.
+    # The superproject hit the same wall the same night and fixed it the same
+    # way (w1ne/labwired#1405).
+    #
+    # ⚠️ A dispatch checks out the BRANCH TIP, whereas `pull_request` builds the
+    # merge commit. That difference is real (see the default-members note below
+    # on catching semantic conflicts against the merge result), so a dispatched
+    # pr-gate is only equivalent when the branch is already up to date with
+    # main — which `strict` branch protection requires before merging anyway.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # Was 5. The browser-layer steps below (crates/wasm clippy + lib tests) are
     # a real ~1.5 min of additional compile — crates/wasm is a cdylib outside

--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -487,6 +487,21 @@ pub(crate) fn run_snapshot_capture(
 
     dump_trace(&ring);
 
+    // Ask before taking. `Cpu::runtime_snapshot` no longer panics on the arches
+    // that do not implement it (a panic in wasm is a trap, and a trap leaks
+    // wasm-bindgen's borrow guard — see the note on the trait), so an ungated
+    // call here would no longer fail loudly: it would write a well-formed file
+    // whose CPU blob is EMPTY. A resume from that blob restores no registers at
+    // all, and nothing downstream can tell it apart from a real capture. Refuse
+    // instead — a missing snapshot is recoverable, a lying one is not.
+    if !machine.cpu.supports_runtime_snapshot() {
+        eprintln!(
+            "error: this CPU has no runtime-snapshot implementation, so no resumable \
+             snapshot can be captured for it (supported: RISC-V, Xtensa LX7)."
+        );
+        return ExitCode::from(EXIT_RUNTIME_ERROR);
+    }
+
     let snap = machine.take_runtime_snapshot();
     let bytes = snap.to_bytes();
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2150,18 +2150,32 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             let pc = machine.cpu.get_pc();
             let reached = cap.target_pc == Some(pc) || (0x4200_0000..0x4400_0000).contains(&pc);
             if reached {
-                let mut snap = machine.take_runtime_snapshot();
-                snap.set_self_key(cap.chip, cap.fw_sha);
-                if let Some(parent) = cap.path.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                match std::fs::write(&cap.path, snap.to_bytes()) {
-                    Ok(()) => info!(
-                        "capture-app-entry: snapshot written to {:?} at app-entry pc=0x{pc:08x} \
-                         (cold-boot step {step})",
+                // Same reason as `snapshot capture`: the trait default is now a
+                // non-panicking EMPTY blob, so an ungated call would write a
+                // resume file that restores no CPU state and still looks valid.
+                // Say so and write nothing. NOT a `continue` — the rest of this
+                // loop body is what actually advances the machine, so skipping
+                // it would hang the run instead of just declining the capture.
+                if !machine.cpu.supports_runtime_snapshot() {
+                    error!(
+                        "capture-app-entry: this CPU has no runtime-snapshot implementation \
+                         (supported: RISC-V, Xtensa LX7) — no snapshot written to {:?}",
                         cap.path
-                    ),
-                    Err(e) => error!("capture-app-entry: failed to write {:?}: {e}", cap.path),
+                    );
+                } else {
+                    let mut snap = machine.take_runtime_snapshot();
+                    snap.set_self_key(cap.chip, cap.fw_sha);
+                    if let Some(parent) = cap.path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    match std::fs::write(&cap.path, snap.to_bytes()) {
+                        Ok(()) => info!(
+                            "capture-app-entry: snapshot written to {:?} at app-entry pc=0x{pc:08x} \
+                             (cold-boot step {step})",
+                            cap.path
+                        ),
+                        Err(e) => error!("capture-app-entry: failed to write {:?}: {e}", cap.path),
+                    }
                 }
                 // Capture once; keep running so the cold invocation still
                 // produces the normal serial/cycle evidence.

--- a/crates/core/src/bus/sim_inputs.rs
+++ b/crates/core/src/bus/sim_inputs.rs
@@ -34,14 +34,17 @@ impl SystemBus {
     ///
     /// Several unrelated ADC controller models exist
     /// ([`crate::peripherals::adc::Adc`] for STM32-class parts, `Esp32s3Sens`
-    /// for the ESP32-S3 SAR ADC, `Rp2040Adc` for the RP2040), so this is the
-    /// single choke point that hides which one a given system.yaml wired up —
-    /// the analog kits are controller-agnostic, exactly as the I²C kits are via
+    /// for the ESP32-S3 SAR ADC, `Esp32c3ApbSarAdc` for the C3, `Esp32SarAdc`
+    /// for classic ESP32, `Rp2040Adc` for the RP2040), so this is the single
+    /// choke point that hides which one a given system.yaml wired up — the
+    /// analog kits are controller-agnostic, exactly as the I²C kits are via
     /// `attach_i2c_slave_with_route`.
     ///
     /// Falls back to a bus scan when `connection` names no ADC: S3 manifests
     /// declare `connection: "sar_adc_s3"` while the peripheral is registered as
-    /// `sens_s3`, and that mismatch predates this path.
+    /// `sens_s3`, and that mismatch predates this path. The same fallback
+    /// covers older playground emits that still say `adc1` on a C3 (real id is
+    /// `apb_saradc`).
     pub(crate) fn seed_adc_channel(
         &mut self,
         connection: &str,
@@ -71,6 +74,18 @@ impl SystemBus {
         }
         if let Some(sens) = any.downcast_mut::<crate::peripherals::esp32s3::sens::Esp32s3Sens>() {
             sens.set_channel_input(channel, millivolts);
+            return true;
+        }
+        if let Some(adc) =
+            any.downcast_mut::<crate::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc>()
+        {
+            // ESP32-C3 oneshot path (IDF adc_oneshot / Arduino analogRead).
+            adc.set_channel_input(channel, millivolts);
+            return true;
+        }
+        if let Some(adc) = any.downcast_mut::<crate::peripherals::esp32::sar_adc::Esp32SarAdc>() {
+            // Classic ESP32 SENS SAR ADC.
+            adc.set_channel_input(channel, millivolts);
             return true;
         }
         if let Some(adc) = any.downcast_mut::<crate::peripherals::rp2040::adc::Rp2040Adc>() {

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -1462,6 +1462,10 @@ impl Cpu for RiscV {
         }
     }
 
+    fn supports_runtime_snapshot(&self) -> bool {
+        true
+    }
+
     fn runtime_snapshot(&self) -> (crate::runtime_snapshot::CpuKind, Vec<u8>) {
         use crate::runtime_snapshot::RiscVRuntimeSnapshot;
         let snap = RiscVRuntimeSnapshot {

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -3460,6 +3460,10 @@ impl Cpu for XtensaLx7 {
         }
     }
 
+    fn supports_runtime_snapshot(&self) -> bool {
+        true
+    }
+
     fn runtime_snapshot(&self) -> (crate::runtime_snapshot::CpuKind, Vec<u8>) {
         use crate::runtime_snapshot::XtensaLx7RuntimeSnapshot;
         let snap = XtensaLx7RuntimeSnapshot {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -298,11 +298,29 @@ pub trait Cpu: Send {
     fn snapshot(&self) -> snapshot::CpuSnapshot;
     fn apply_snapshot(&mut self, snapshot: &snapshot::CpuSnapshot);
 
+    /// Whether this CPU can produce a runtime snapshot. FALSE by default:
+    /// only the arches that override `runtime_snapshot` say yes.
+    ///
+    /// Ask this BEFORE calling `runtime_snapshot`. It exists because the old
+    /// default was `unimplemented!()`, and in wasm a Rust panic lowers to an
+    /// `unreachable` TRAP. A trap runs no destructors, so wasm-bindgen's
+    /// borrow guard leaks and the WasmSimulator stays borrowed forever —
+    /// every later call, `step_batch` included, then fails with "recursive
+    /// use of an object". One snapshot attempt on an unsupported CPU bricked
+    /// the whole engine, which is exactly how every Cortex-M lab died a few
+    /// seconds into a run.
+    fn supports_runtime_snapshot(&self) -> bool {
+        false
+    }
+
     /// Full mid-flight CPU state for binary runtime snapshots. Returns the
     /// arch tag + an opaque blob the matching CPU type knows how to parse.
-    /// Default panics — every concrete `Cpu` impl must override.
+    ///
+    /// Overridden by the arches that support it; the default answers empty
+    /// rather than panicking, so a stray call can never trap the module. Gate
+    /// real callers on `supports_runtime_snapshot()`.
     fn runtime_snapshot(&self) -> (runtime_snapshot::CpuKind, Vec<u8>) {
-        unimplemented!("runtime_snapshot not implemented for this Cpu")
+        (runtime_snapshot::CpuKind::ArmCortexM, Vec::new())
     }
 
     /// Apply a previously-taken runtime snapshot. Default no-op so
@@ -435,6 +453,9 @@ impl Cpu for Box<dyn Cpu> {
     }
     fn apply_snapshot(&mut self, s: &snapshot::CpuSnapshot) {
         (**self).apply_snapshot(s)
+    }
+    fn supports_runtime_snapshot(&self) -> bool {
+        (**self).supports_runtime_snapshot()
     }
     fn runtime_snapshot(&self) -> (runtime_snapshot::CpuKind, Vec<u8>) {
         (**self).runtime_snapshot()

--- a/crates/core/src/peripherals/esp32/sar_adc.rs
+++ b/crates/core/src/peripherals/esp32/sar_adc.rs
@@ -71,10 +71,14 @@ const SAMPLE_BIT_MASK: u32 = 0x3;
 
 /// Deterministic fixed 12-bit source code for `channel`. The ramp is injective
 /// over the ESP32's ADC channel range (0..11) so a reader can prove the result
-/// tracks the SELECTED channel, not a constant.
+/// tracks the SELECTED channel, not a constant. Used when no external analog
+/// source has injected a level via [`Esp32SarAdc::set_channel_input`].
 fn channel_sample(channel: u32) -> u32 {
     (0x100 + channel * 0x111) & 0x0FFF
 }
+
+const NO_INJECT: u16 = 0xFFFF;
+const CHANNEL_SLOTS: usize = 16;
 
 /// One SAR unit's latched conversion state.
 #[derive(Default)]
@@ -91,6 +95,8 @@ pub struct Esp32SarAdc {
     regs: Vec<u32>,
     sar1: SarUnit,
     sar2: SarUnit,
+    /// Per-channel 12-bit counts from external analog sources (kits).
+    channel_inputs: [u16; CHANNEL_SLOTS],
 }
 
 impl Default for Esp32SarAdc {
@@ -120,7 +126,25 @@ impl Esp32SarAdc {
             regs,
             sar1: SarUnit::default(),
             sar2: SarUnit::default(),
+            channel_inputs: [NO_INJECT; CHANNEL_SLOTS],
         }
+    }
+
+    /// Inject a millivolt reading for a SAR channel. Next conversion on that
+    /// channel returns the equivalent 12-bit count (3.3 V Vref). Used by
+    /// [`SystemBus::seed_adc_channel`] for analog kits on classic ESP32.
+    pub fn set_channel_input(&mut self, channel: u8, millivolts: u16) {
+        if (channel as usize) < self.channel_inputs.len() {
+            let count = ((millivolts as u32 * 4095) / 3300).min(4095) as u16;
+            self.channel_inputs[channel as usize] = count;
+        }
+    }
+
+    pub fn channel_input_count(&self, channel: u8) -> u16 {
+        self.channel_inputs
+            .get(channel as usize)
+            .copied()
+            .unwrap_or(NO_INJECT)
     }
 
     fn reg(&self, off: u64) -> u32 {
@@ -129,14 +153,21 @@ impl Esp32SarAdc {
 
     /// Run a conversion for the given `start_word` and resolution, returning the
     /// latched unit state, or `None` if no channel was selected.
-    fn convert(start_word: u32, width_bits: u32) -> Option<SarUnit> {
+    fn convert(&self, start_word: u32, width_bits: u32) -> Option<SarUnit> {
         let en_pad = (start_word >> EN_PAD_SHIFT) & EN_PAD_MASK;
         if en_pad == 0 {
             return None;
         }
         // The IDF selects exactly one channel via a one-hot EN_PAD bitmap.
         let channel = en_pad.trailing_zeros();
-        let full = channel_sample(channel);
+        let full = {
+            let idx = channel as usize;
+            if idx < self.channel_inputs.len() && self.channel_inputs[idx] != NO_INJECT {
+                self.channel_inputs[idx] as u32
+            } else {
+                channel_sample(channel)
+            }
+        };
         // Faithful lower-resolution SAR: drop the low (12 - width) bits.
         let data = full >> (12 - width_bits);
         Some(SarUnit {
@@ -187,16 +218,20 @@ impl Peripheral for Esp32SarAdc {
                     *slot = value & MEAS_START_WRITABLE;
                 }
                 if value & MEAS_START_SAR != 0 {
-                    let (ctrl_off, unit) = if off == SAR_MEAS_START1 {
-                        (SAR_READ_CTRL, &mut self.sar1)
+                    let ctrl_off = if off == SAR_MEAS_START1 {
+                        SAR_READ_CTRL
                     } else {
-                        (SAR_READ_CTRL2, &mut self.sar2)
+                        SAR_READ_CTRL2
                     };
                     let bits = 9
                         + ((self.regs[(ctrl_off / 4) as usize] >> SAMPLE_BIT_SHIFT)
                             & SAMPLE_BIT_MASK);
-                    if let Some(converted) = Self::convert(value, bits) {
-                        *unit = converted;
+                    if let Some(converted) = self.convert(value, bits) {
+                        if off == SAR_MEAS_START1 {
+                            self.sar1 = converted;
+                        } else {
+                            self.sar2 = converted;
+                        }
                     }
                 }
             }

--- a/crates/core/src/peripherals/esp32c3/apb_saradc.rs
+++ b/crates/core/src/peripherals/esp32c3/apb_saradc.rs
@@ -408,7 +408,7 @@ mod tests {
         assert_eq!(a.channel_input_count(1), ((1650u32 * 4095) / 3300) as u16);
         a.write_u32(ONETIME_SAMPLE, sar1_oneshot(1)).unwrap();
         let data = a.read_u32(SAR1DATA_STATUS).unwrap() & 0x0FFF;
-        let expected = ((1650u32 * 4095) / 3300) as u32;
+        let expected = (1650u32 * 4095) / 3300;
         assert_eq!(data, expected, "oneshot must return the injected count");
         // Un-injected channel still uses the ramp.
         a.write_u32(ONETIME_SAMPLE, sar1_oneshot(2)).unwrap();

--- a/crates/core/src/peripherals/esp32c3/apb_saradc.rs
+++ b/crates/core/src/peripherals/esp32c3/apb_saradc.rs
@@ -100,10 +100,17 @@ const RESET_REGS: &[(u64, u32)] = &[
 
 /// Deterministic fixed 12-bit source code for `channel`. The ramp is injective
 /// over the C3's five ADC1 channels so a reader can prove the result tracks the
-/// SELECTED channel, not a constant.
+/// SELECTED channel, not a constant. Used when no external analog source has
+/// injected a level via [`Esp32c3ApbSarAdc::set_channel_input`].
 fn channel_sample(channel: u32) -> u32 {
     (0x100 + channel * 0x111) & 0x0FFF
 }
+
+/// Sentinel: no external analog injection for this channel (use `channel_sample`).
+const NO_INJECT: u16 = 0xFFFF;
+
+/// ADC1 channels on the C3: GPIO0..GPIO4 → CH0..CH4. Room for headroom.
+const ADC1_CHANNEL_SLOTS: usize = 16;
 
 pub struct Esp32c3ApbSarAdc {
     /// Interrupt-matrix source ID (`APB_SARADC` = 43 on the C3).
@@ -116,6 +123,10 @@ pub struct Esp32c3ApbSarAdc {
     /// Latched conversion results for SAR1 / SAR2 (the `*DATA_STATUS` regs).
     sar1_data: u32,
     sar2_data: u32,
+    /// Per-channel 12-bit counts from external analog sources (GP2Y, pot, …).
+    /// `NO_INJECT` means the fixed ramp still applies. Written by
+    /// [`SystemBus::seed_adc_channel`] via [`Self::set_channel_input`].
+    channel_inputs: [u16; ADC1_CHANNEL_SLOTS],
     /// Bus-published cycle clock (walk-free plan). `Some` once
     /// `SystemBus::push_peripheral`/`add_peripheral` attaches it. Its presence
     /// (under the `event-scheduler` feature) flips the model onto the event
@@ -164,6 +175,7 @@ impl Esp32c3ApbSarAdc {
             int_raw: Cell::new(0),
             sar1_data: 0,
             sar2_data: 0,
+            channel_inputs: [NO_INJECT; ADC1_CHANNEL_SLOTS],
             clock: None,
         }
     }
@@ -174,6 +186,35 @@ impl Esp32c3ApbSarAdc {
     /// the same bus assembly (mirrors `Esp32c3I2c::force_legacy_walk`).
     pub fn force_legacy_walk(&mut self) {
         self.clock = None;
+    }
+
+    /// Inject a millivolt reading for an ADC1 channel (CH0..4 = GPIO0..4).
+    /// The next oneshot that selects this channel returns the equivalent
+    /// 12-bit count (3.3 V Vref) instead of the fixed ramp placeholder.
+    /// This is the seam [`SystemBus::seed_adc_channel`] uses for analog kits
+    /// (GP2Y0A21, pot, NTC, …) on the C3.
+    pub fn set_channel_input(&mut self, channel: u8, millivolts: u16) {
+        if (channel as usize) < self.channel_inputs.len() {
+            let count = ((millivolts as u32 * 4095) / 3300).min(4095) as u16;
+            self.channel_inputs[channel as usize] = count;
+        }
+    }
+
+    /// Read back the injected 12-bit count (`NO_INJECT` = nothing injected).
+    pub fn channel_input_count(&self, channel: u8) -> u16 {
+        self.channel_inputs
+            .get(channel as usize)
+            .copied()
+            .unwrap_or(NO_INJECT)
+    }
+
+    fn sample_for_channel(&self, channel: u32) -> u32 {
+        let idx = channel as usize;
+        if idx < self.channel_inputs.len() && self.channel_inputs[idx] != NO_INJECT {
+            self.channel_inputs[idx] as u32
+        } else {
+            channel_sample(channel)
+        }
     }
 
     fn int_st(&self) -> u32 {
@@ -188,7 +229,8 @@ impl Esp32c3ApbSarAdc {
     /// channel-dependent packed result and raise the matching DONE bit.
     fn convert(&mut self, sample_word: u32) {
         let channel = (sample_word >> ONETIME_CHANNEL_SHIFT) & ONETIME_CHANNEL_MASK;
-        let packed = ((channel << DATA_CHANNEL_SHIFT) | channel_sample(channel)) & DATA_MASK;
+        let code = self.sample_for_channel(channel);
+        let packed = ((channel << DATA_CHANNEL_SHIFT) | code) & DATA_MASK;
         let mut raw = self.int_raw.get();
         if sample_word & SAR1_ONETIME_SAMPLE != 0 {
             self.sar1_data = packed;
@@ -356,6 +398,22 @@ mod tests {
             0,
             "ONETIME_START self-clears"
         );
+    }
+
+    #[test]
+    fn set_channel_input_overrides_the_fixed_ramp_on_oneshot() {
+        let mut a = Esp32c3ApbSarAdc::new(APB_SARADC_INTR_SOURCE_ID);
+        // 1650 mV ≈ half scale on 3.3 V / 12-bit.
+        a.set_channel_input(1, 1650);
+        assert_eq!(a.channel_input_count(1), ((1650u32 * 4095) / 3300) as u16);
+        a.write_u32(ONETIME_SAMPLE, sar1_oneshot(1)).unwrap();
+        let data = a.read_u32(SAR1DATA_STATUS).unwrap() & 0x0FFF;
+        let expected = ((1650u32 * 4095) / 3300) as u32;
+        assert_eq!(data, expected, "oneshot must return the injected count");
+        // Un-injected channel still uses the ramp.
+        a.write_u32(ONETIME_SAMPLE, sar1_oneshot(2)).unwrap();
+        let ramp = a.read_u32(SAR1DATA_STATUS).unwrap() & 0x0FFF;
+        assert_eq!(ramp, channel_sample(2));
     }
 
     #[test]

--- a/crates/core/tests/analog_stimulus.rs
+++ b/crates/core/tests/analog_stimulus.rs
@@ -181,8 +181,8 @@ fn adc_channel_count(bus: &mut SystemBus, connection: &str, channel: u8) -> u16 
         {
             return sens.channel_input_count(channel);
         }
-        if let Some(adc) = any
-            .downcast_mut::<labwired_core::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc>()
+        if let Some(adc) =
+            any.downcast_mut::<labwired_core::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc>()
         {
             return adc.channel_input_count(channel);
         }
@@ -233,7 +233,9 @@ fn c3_gp2y0a21_attaches_and_distance_drives_apb_saradc() {
 
     let inputs = bus.list_inputs();
     assert!(
-        inputs.iter().any(|(o, ch)| o == "vlA" && ch.key == "distance"),
+        inputs
+            .iter()
+            .any(|(o, ch)| o == "vlA" && ch.key == "distance"),
         "distance channel missing: {inputs:?}"
     );
 

--- a/crates/core/tests/analog_stimulus.rs
+++ b/crates/core/tests/analog_stimulus.rs
@@ -181,6 +181,74 @@ fn adc_channel_count(bus: &mut SystemBus, connection: &str, channel: u8) -> u16 
         {
             return sens.channel_input_count(channel);
         }
+        if let Some(adc) = any
+            .downcast_mut::<labwired_core::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc>()
+        {
+            return adc.channel_input_count(channel);
+        }
+        if let Some(adc) =
+            any.downcast_mut::<labwired_core::peripherals::esp32::sar_adc::Esp32SarAdc>()
+        {
+            return adc.channel_input_count(channel);
+        }
     }
     panic!("no ADC controller found for connection '{connection}'");
+}
+
+/// ESP32-C3 BLE-Pong style: a Sharp GP2Y0A21 on `apb_saradc` channel 1 must
+/// attach and move the SAR oneshot result when `distance` is driven. Before
+/// C3 inject support, bus config failed with
+/// `connection 'adc1' is not a ADC peripheral` (or attach refused seed).
+#[test]
+fn c3_gp2y0a21_attaches_and_distance_drives_apb_saradc() {
+    let chip_path = root("configs/chips/esp32c3.yaml");
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load esp32c3");
+    let mut config = std::collections::HashMap::new();
+    config.insert("channel".to_string(), serde_yaml::Value::from(1u64));
+    let manifest = SystemManifest {
+        parts: Vec::new(),
+        cosim_models: Vec::new(),
+        motor_models: Vec::new(),
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "c3-gp2y".to_string(),
+        chip: chip_path.to_string_lossy().to_string(),
+        external_devices: vec![labwired_config::ExternalDevice {
+            id: "vlA".to_string(),
+            r#type: "gp2y0a21".to_string(),
+            // Intentional legacy wrong name: playground used to emit `adc1`.
+            // Seed must still find `apb_saradc` via the bus-wide fallback.
+            connection: "adc1".to_string(),
+            channel: None,
+            route: Default::default(),
+            config,
+        }],
+        board_io: vec![],
+        debug_uart: None,
+        wifi_ap: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build bus with gp2y on C3");
+
+    let inputs = bus.list_inputs();
+    assert!(
+        inputs.iter().any(|(o, ch)| o == "vlA" && ch.key == "distance"),
+        "distance channel missing: {inputs:?}"
+    );
+
+    // 100 mm → datasheet 3100 mV → ~3847 counts on 12-bit / 3.3 V.
+    bus.set_input(Some("vlA"), "distance", 100.0)
+        .expect("set near");
+    let near = adc_channel_count(&mut bus, "apb_saradc", 1);
+    assert!(
+        near > 3500,
+        "near distance should be high counts, got {near}"
+    );
+
+    bus.set_input(Some("vlA"), "distance", 800.0)
+        .expect("set far");
+    let far = adc_channel_count(&mut bus, "apb_saradc", 1);
+    assert!(far < 1000, "far distance should be low counts, got {far}");
+    assert!(near > far, "near={near} must exceed far={far}");
 }

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -312,7 +312,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -346,7 +348,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
             Ok(r) => r,
             Err(_) => return JsValue::NULL,
@@ -407,7 +411,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_mut() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_mut() else {
+            return JsValue::NULL;
+        };
         let resolved: Vec<Option<(usize, u8)>> = refs
             .iter()
             .map(|r| {
@@ -461,7 +467,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_mut() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_mut() else {
+            return JsValue::NULL;
+        };
         let batch = machine.logic_read_edges(cursor as u64);
         let edges: Vec<serde_json::Value> = batch
             .edges
@@ -509,7 +517,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
             Ok(r) => r,
             Err(_) => return JsValue::NULL,
@@ -560,7 +570,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         if let Some(idx) = machine.bus.find_peripheral_index_by_name(name) {
             let snapshot = machine.bus.peripherals[idx].dev.snapshot();
             serde_wasm_bindgen::to_value(&snapshot).unwrap_or(JsValue::NULL)
@@ -582,7 +594,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let bus = &machine.bus;
         let mut states: Vec<serde_json::Value> = Vec::new();
 
@@ -628,7 +642,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -679,7 +695,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for servo in &machine.bus.servos {
@@ -831,7 +849,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return Err(JsValue::from_str("simulator has no machine loaded")); };
+        let Some(machine) = self.machine.as_ref() else {
+            return Err(JsValue::from_str("simulator has no machine loaded"));
+        };
         machine
             .bus
             .tm1637
@@ -868,7 +888,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return Err(JsValue::from_str("simulator has no machine loaded")); };
+        let Some(machine) = self.machine.as_ref() else {
+            return Err(JsValue::from_str("simulator has no machine loaded"));
+        };
         machine
             .bus
             .seven_segment
@@ -949,7 +971,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -1010,7 +1034,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -1061,7 +1087,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let list: Vec<serde_json::Value> = machine
             .bus
             .peripherals
@@ -1097,7 +1125,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         let opts = labwired_core::inspect::InspectOpts {
             include_bytes,
             peripheral: None,
@@ -1127,7 +1157,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return Vec::new().into_boxed_slice(); };
+        let Some(machine) = self.machine.as_ref() else {
+            return Vec::new().into_boxed_slice();
+        };
         machine
             .peek(addr as u64, len as usize)
             .to_lossy_bytes()
@@ -1144,7 +1176,9 @@ impl WasmSimulator {
         // wasm-bindgen borrow guard would never drop and EVERY later call
         // would fail with "recursive use of an object". Never panic in an
         // accessor — answer neutrally instead.
-        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
         for p in &machine.bus.peripherals {
             let Some(any) = p.dev.as_any() else {
                 continue;

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -206,7 +206,14 @@ impl WasmSimulator {
                 return Ok(found);
             }
         }
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else {
+            return Err(JsValue::from_str("simulator has no machine loaded"));
+        };
         let binding = self
             .board_io
             .iter()
@@ -300,7 +307,12 @@ impl WasmSimulator {
     /// Uses peripheral snapshot() to read ODR regardless of register layout.
     #[wasm_bindgen]
     pub fn get_board_io_states(&self) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -329,7 +341,12 @@ impl WasmSimulator {
             pin: u8,
         }
 
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
             Ok(r) => r,
             Err(_) => return JsValue::NULL,
@@ -385,7 +402,12 @@ impl WasmSimulator {
             Err(_) => return JsValue::NULL,
         };
 
-        let machine = self.machine.as_mut().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_mut() else { return JsValue::NULL; };
         let resolved: Vec<Option<(usize, u8)>> = refs
             .iter()
             .map(|r| {
@@ -434,7 +456,12 @@ impl WasmSimulator {
     /// cycle counts the playground runs to.
     #[wasm_bindgen]
     pub fn read_logic_edges(&mut self, cursor: f64) -> JsValue {
-        let machine = self.machine.as_mut().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_mut() else { return JsValue::NULL; };
         let batch = machine.logic_read_edges(cursor as u64);
         let edges: Vec<serde_json::Value> = batch
             .edges
@@ -477,7 +504,12 @@ impl WasmSimulator {
             pin: u8,
         }
 
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
             Ok(r) => r,
             Err(_) => return JsValue::NULL,
@@ -523,7 +555,12 @@ impl WasmSimulator {
     /// Get a peripheral's full state snapshot as JSON.
     #[wasm_bindgen]
     pub fn get_peripheral_snapshot(&self, name: &str) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         if let Some(idx) = machine.bus.find_peripheral_index_by_name(name) {
             let snapshot = machine.bus.peripherals[idx].dev.snapshot();
             serde_wasm_bindgen::to_value(&snapshot).unwrap_or(JsValue::NULL)
@@ -540,7 +577,12 @@ impl WasmSimulator {
     pub fn get_adc_device_states(&self) -> JsValue {
         use labwired_core::peripherals::adc::Adc;
 
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let bus = &machine.bus;
         let mut states: Vec<serde_json::Value> = Vec::new();
 
@@ -581,7 +623,12 @@ impl WasmSimulator {
     /// Returns analog state for ADC and PWM board_io bindings.
     #[wasm_bindgen]
     pub fn get_board_io_analog_states(&self) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -627,7 +674,12 @@ impl WasmSimulator {
     /// straight onto `boardIoStates[partId]`.
     #[wasm_bindgen]
     pub fn get_actuator_states(&self) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for servo in &machine.bus.servos {
@@ -774,7 +826,12 @@ impl WasmSimulator {
     /// bus side rather than inside a hardware bus peripheral.
     #[wasm_bindgen]
     pub fn get_tm1637_text(&self, device_id: &str) -> Result<String, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return Err(JsValue::from_str("simulator has no machine loaded")); };
         machine
             .bus
             .tm1637
@@ -806,7 +863,12 @@ impl WasmSimulator {
     /// either way it is wired.
     #[wasm_bindgen]
     pub fn get_seven_segment_text(&self, device_id: &str) -> Result<String, JsValue> {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return Err(JsValue::from_str("simulator has no machine loaded")); };
         machine
             .bus
             .seven_segment
@@ -882,7 +944,12 @@ impl WasmSimulator {
     /// Returns `[{ id, kind: "max31855", tc_c, internal_c }, ...]`.
     #[wasm_bindgen]
     pub fn get_spi_device_states(&self) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -938,7 +1005,12 @@ impl WasmSimulator {
     /// Returns `[{ id, kind: "neo6m-gps", lat, lon, has_fix }]`.
     #[wasm_bindgen]
     pub fn get_uart_device_states(&self) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let mut states: Vec<serde_json::Value> = Vec::new();
 
         for binding in &self.board_io {
@@ -984,7 +1056,12 @@ impl WasmSimulator {
     /// List all peripherals: [{ name, base_address }]
     #[wasm_bindgen]
     pub fn get_peripheral_list(&self) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let list: Vec<serde_json::Value> = machine
             .bus
             .peripherals
@@ -1015,7 +1092,12 @@ impl WasmSimulator {
     /// unmodeled-but-named register must render as unknown, not as zero.
     #[wasm_bindgen]
     pub fn inspect(&self, name: Option<String>, include_bytes: bool) -> JsValue {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         let opts = labwired_core::inspect::InspectOpts {
             include_bytes,
             peripheral: None,
@@ -1040,7 +1122,12 @@ impl WasmSimulator {
     /// / the `inspect` payload; this raw byte view is the fast path).
     #[wasm_bindgen]
     pub fn peek(&self, addr: u32, len: u32) -> Box<[u8]> {
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return Vec::new().into_boxed_slice(); };
         machine
             .peek(addr as u64, len as usize)
             .to_lossy_bytes()
@@ -1052,7 +1139,12 @@ impl WasmSimulator {
     #[wasm_bindgen]
     pub fn get_iolink_master_state(&self) -> JsValue {
         use labwired_core::peripherals::components::{IolinkLinkState, IolinkMaster};
-        let machine = self.machine.as_ref().unwrap();
+        // A panic here would throw a JS exception straight out of this wasm
+        // frame; JS exceptions do NOT run Rust destructors, so the
+        // wasm-bindgen borrow guard would never drop and EVERY later call
+        // would fail with "recursive use of an object". Never panic in an
+        // accessor — answer neutrally instead.
+        let Some(machine) = self.machine.as_ref() else { return JsValue::NULL; };
         for p in &machine.bus.peripherals {
             let Some(any) = p.dev.as_any() else {
                 continue;

--- a/crates/wasm/src/install.rs
+++ b/crates/wasm/src/install.rs
@@ -410,6 +410,18 @@ impl WasmSimulator {
             .machine
             .as_ref()
             .ok_or_else(|| JsValue::from_str("no machine"))?;
+        // Ask before taking. On a CPU without a runtime_snapshot impl this
+        // used to reach `unimplemented!()`, and a Rust panic in wasm is an
+        // `unreachable` TRAP: no destructors run, so wasm-bindgen's borrow
+        // guard leaks and the simulator is borrowed forever. Every later
+        // call — `step_batch` above all — then dies with "recursive use of
+        // an object", which is what froze every Cortex-M lab a few seconds
+        // in. An Err returns normally and leaves the machine healthy.
+        if !machine.cpu.supports_runtime_snapshot() {
+            return Err(JsValue::from_str(
+                "runtime snapshot is not supported for this CPU",
+            ));
+        }
         Ok(machine.take_runtime_snapshot().to_bytes())
     }
 


### PR DESCRIPTION
## Symptom

Every Cortex-M lab (STM32, RP2040, nRF) runs for a few seconds in the browser and then dies:

```
Target "mcu" failed: recursive use of an object detected which would lead to unsafe aliasing in rust
```

## That error is a red herring

Resolving the wasm frames against a build with its name section kept (`wasm-opt -g`) puts the failure at:

```
wasm_bindgen::__rt::borrow_fail
  <- wasmsimulator_step_batch multivalue shim
```

The borrow check fails at **`step_batch`'s entry shim** — before any simulation code runs — and **no panic precedes it**. Nothing is re-entering; the machine was *already* borrowed. The JS exclusive-access Proxy cannot help with this, and catching the error (as the bridge does at 14 accessors) makes it worse: `step_batch` then returns 0 cycles forever, turning a visible error into a silently dead lab.

## Root cause

`Cpu::runtime_snapshot`'s default was `unimplemented!()`, and only `riscv` and `xtensa_lx7` override it — **Cortex-M has no impl**.

In wasm a Rust panic lowers to an `unreachable` **trap**, and a trap runs **no destructors**. So wasm-bindgen's borrow guard is never dropped: one `take_runtime_snapshot()` on a Cortex-M part borrows the simulator *forever*, and every later call fails. The playground calls it from `useAppRuntimeEngine`'s engine hot-swap path a few seconds into a run — which is exactly the observed timing.

Bisected by calling each of the 76 exported members on a fresh sim and then trying to step:

```
>>> take_runtime_snapshot: call=threw (unreachable)
    -> POISONED: recursive use of an object detected which would lead to unsafe aliasing in rust
```

## Fix

Ask before taking. `supports_runtime_snapshot()` defaults to `false` and is `true` only on the arches that implement it; the wasm entry point returns an `Err` for the rest — a normal return, which leaves the machine healthy. The `runtime_snapshot` default no longer panics either, so a stray call can never trap the module again.

## Verification

Ran the **live app** with this engine swapped in over the wire (real worker, real governor, real React loop), against the deployed engine as control:

| | control (deployed) | this PR |
|---|---|---|
| final status | `error` | `running` |
| first error | **4.2s** | **never** (held 45s) |
| recursive-use errors | 1 | **0** |
| distinct display frames / 18s | 2 (dead after ~4s) | **12/12** (continuously animating) |

Also includes an earlier commit guarding 18 unguarded `self.machine.*.unwrap()` sites in `inspect.rs` — same failure class (a panicking accessor poisons the machine), found while hunting this.