### PR TITLE
SPI: serve a read that begins inside a multi-byte register

### DIFF
--- a/crates/core/src/peripherals/components/declarative_spi.rs
+++ b/crates/core/src/peripherals/components/declarative_spi.rs
@@ -104,6 +104,16 @@ impl GenericSpiDevice {
         self.registers.iter().find(|r| r.addr == addr)
     }
 
+    /// The register whose byte span covers `addr`, which is not always the one
+    /// whose base equals it — see `build_read_buf`.
+    fn find_register_containing(&self, addr: u8) -> Option<&RegisterSpec> {
+        self.registers.iter().find(|r| {
+            let base = u16::from(r.addr);
+            let a = u16::from(addr);
+            a >= base && a < base + u16::from(r.width)
+        })
+    }
+
     fn next_addr_above(&self, addr: u8) -> Option<u8> {
         self.registers
             .iter()
@@ -114,17 +124,43 @@ impl GenericSpiDevice {
 
     /// Concatenated read stream from `start`: every register at addr ≥ start in
     /// ascending order (auto-increment), or just the matched register.
+    /// Bytes a read beginning at `start` streams back.
+    ///
+    /// A read may begin *inside* a multi-byte register, because a datasheet
+    /// numbers every byte of one as its own address: the ADXL345 declares
+    /// DATAX0 at 0x32 and DATAX1 at 0x33 and says the low byte need not be read
+    /// when it is not wanted, so pointing at 0x33 must return the high byte.
+    ///
+    /// Selecting on `addr >= start` did not do that. It skipped the register
+    /// containing `start` and answered from the *next* one, so a firmware that
+    /// read one axis byte on its own got a different register's value —
+    /// 0x37 returned FIFO_CTL — with nothing to distinguish it from real data.
+    /// Matching on the span and dropping the bytes before `start` serves the
+    /// address the caller actually named.
     fn build_read_buf(&self, start: u8) -> Vec<u8> {
         let mut out = Vec::new();
         if self.framing.auto_increment {
-            let mut regs: Vec<&RegisterSpec> =
-                self.registers.iter().filter(|r| r.addr >= start).collect();
+            let mut regs: Vec<&RegisterSpec> = self
+                .registers
+                .iter()
+                .filter(|r| u16::from(r.addr) + u16::from(r.width) > u16::from(start))
+                .collect();
             regs.sort_by_key(|r| r.addr);
             for r in regs {
-                out.extend(register_read_bytes(r, &self.slots, &self.reg_values));
+                let skip = usize::from(start.saturating_sub(r.addr));
+                out.extend(
+                    register_read_bytes(r, &self.slots, &self.reg_values)
+                        .into_iter()
+                        .skip(skip),
+                );
             }
-        } else if let Some(r) = self.find_register(start) {
-            out.extend(register_read_bytes(r, &self.slots, &self.reg_values));
+        } else if let Some(r) = self.find_register_containing(start) {
+            let skip = usize::from(start - r.addr);
+            out.extend(
+                register_read_bytes(r, &self.slots, &self.reg_values)
+                    .into_iter()
+                    .skip(skip),
+            );
         }
         out
     }

--- a/crates/core/tests/adxl345_register_map.rs
+++ b/crates/core/tests/adxl345_register_map.rs
@@ -25,6 +25,7 @@
 
 use labwired_core::peripherals::components::declarative_spi::GenericSpiDevice;
 use labwired_core::peripherals::spi::SpiDevice;
+use labwired_core::sim_input::SimInput;
 
 fn adxl345() -> GenericSpiDevice {
     let yaml = labwired_config::embedded_device_yaml("adxl345_spi")
@@ -144,4 +145,48 @@ fn an_undocumented_address_still_reads_as_unmapped() {
     // registers were reaching it, not the default itself.
     let mut d = adxl345();
     assert_eq!(read_u8(&mut d, 0x3A), 0xFF);
+}
+
+#[test]
+fn each_data_byte_is_addressable_on_its_own() {
+    // Table 16 numbers all six data bytes separately (0x32-0x37), and page 18
+    // says "the least significant byte does not have to be read if that
+    // information is not needed" -- so pointing at the high byte alone is a
+    // supported access, not an edge case.
+    //
+    // The model declares them as three two-byte registers, which is right for a
+    // burst. What was wrong was a single-byte read: selecting registers by
+    // `addr >= start` skipped the register containing the address and answered
+    // from the next one, so 0x37 returned FIFO_CTL rather than DATAZ1 -- a
+    // different register's value, indistinguishable from real sensor data.
+    let mut d = adxl345();
+    d.set_input("accel_z", 1.0).unwrap();
+
+    // 1 g x 256 LSB/g = 0x0100, little-endian across 0x36 (lo) and 0x37 (hi).
+    d.cs_select();
+    d.transfer(0xC0 | 0x36);
+    let lo = d.transfer(0x00);
+    let hi = d.transfer(0x00);
+    d.cs_release();
+    assert_eq!((lo, hi), (0x00, 0x01), "burst read of DATAZ");
+
+    // The same two bytes, addressed one at a time.
+    assert_eq!(read_u8(&mut d, 0x36), lo, "DATAZ0 read on its own");
+    assert_eq!(read_u8(&mut d, 0x37), hi, "DATAZ1 read on its own");
+}
+
+#[test]
+fn a_read_inside_a_register_still_walks_on_to_the_next() {
+    // Starting mid-register must not break auto-increment: after the high byte
+    // of DATAZ the next byte is FIFO_CTL, exactly as a burst from 0x36 would
+    // reach it.
+    let mut d = adxl345();
+    d.set_input("accel_z", 1.0).unwrap();
+    d.cs_select();
+    d.transfer(0xC0 | 0x37);
+    let hi = d.transfer(0x00);
+    let next = d.transfer(0x00);
+    d.cs_release();
+    assert_eq!(hi, 0x01, "DATAZ1");
+    assert_eq!(next, 0x00, "FIFO_CTL follows");
 }


### PR DESCRIPTION
A datasheet numbers every byte of a multi-byte register as its own address. The ADXL345 declares `DATAX0` at `0x32` and `DATAX1` at `0x33`, and page 18 says the least significant byte need not be read when it isn't wanted — so pointing at the high byte alone is a supported access.

`build_read_buf` selected registers with `addr >= start`, which **skips the register containing `start`** and answers from the next one:

```
burst  0x36  ->  lo=0x00 hi=0x01     correct: 1 g × 256 = 0x0100
single 0x37  ->  0x00                FIFO_CTL's value, not DATAZ1
```

Nothing marked that wrong. Firmware reading one axis byte got another register's contents, indistinguishable from real sensor data. The failure scales with distance from the datasheet's numbering — before the ADXL345 map was completed, `0x37` fell past every declared register and read `0xFF`.

Matching on the byte span and dropping the bytes ahead of `start` serves the address the caller named. A read beginning mid-register still walks on normally: a burst from `0x37` yields `DATAZ1` then `FIFO_CTL`.

**Shared-engine fix, not an ADXL345 one** — every declarative SPI device with a register wider than one byte was affected identically.

## No existing chip moved

`declarative_device_byte_parity` unchanged for all 7 devices. A read starting at a register's base selects the same set under either rule: the new filter additionally admits a register spanning past `start`, which for a base address can only be that register itself.

labwired-core: **2775 tests pass**. `e2e_epaper_tricolor` hangs building its example firmware in a worktree with no embedded toolchain, as before this change; it touches neither the SPI engine nor adxl345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ji4gV2PPYC6f1zcvW5MmX