### PR TITLE
fix(esp32c3): a restarted BLE controller must not replay the old run's air

### DIFF
--- a/crates/core/src/peripherals/ble_air.rs
+++ b/crates/core/src/peripherals/ble_air.rs
@@ -169,6 +169,19 @@ impl BleAirBus {
 
     /// Drop every channel ring. Keeps the trace, exactly as
     /// `VirtualAirBus::clear` does.
+    /// The sequence number the NEXT transmission will carry.
+    ///
+    /// A controller binding to this air starts its cursor here, so it hears
+    /// only what is sent from that moment on. A radio has no history buffer:
+    /// frames that crossed the air before it powered on are simply gone. This
+    /// matters because a lab REUSES its air across a simulation restart (the
+    /// playground mints a new `AirBus` only when the source/diagram hash
+    /// changes), so without this a restarted node would replay the previous
+    /// run's backlog as live peer traffic.
+    pub fn current_seq(&self) -> u64 {
+        self.inner.lock().map(|a| a.next_seq).unwrap_or(0)
+    }
+
     pub fn clear(&self) {
         if let Ok(mut a) = self.inner.lock() {
             a.channels.clear();
@@ -253,6 +266,28 @@ mod tests {
         let b = BleAirBus::new();
         a.transmit(frame(37, 0x8E89_BED6, &[0x20, 0x00]));
         assert!(b.receive_from(37, 0x8E89_BED6, 0, 2).is_none());
+    }
+
+
+    /// `current_seq` is the join point a fresh controller uses to skip a
+    /// backlog it was not present for.
+    #[test]
+    fn current_seq_tracks_what_has_already_crossed_the_air() {
+        let bus = BleAirBus::new();
+        assert_eq!(bus.current_seq(), 0, "nothing sent yet");
+        for _ in 0..10 {
+            bus.transmit(frame(37, 0x8E89_BED6, &[0x20, 0x01]));
+        }
+        assert_eq!(bus.current_seq(), 10);
+        assert!(
+            bus.receive_from(37, 0x8E89_BED6, bus.current_seq(), 3).is_none(),
+            "a listener joining now hears none of the backlog",
+        );
+        assert!(
+            bus.receive_from(37, 0x8E89_BED6, 0, 3).is_some(),
+            "but the backlog is still there for cursor 0 — which is why the \
+             cursor, not the bus, is what has to be fixed",
+        );
     }
 
     /// The retention window is bounded and drops the oldest.

--- a/crates/core/src/peripherals/esp32c3/bt.rs
+++ b/crates/core/src/peripherals/esp32c3/bt.rs
@@ -1429,7 +1429,7 @@ impl Esp32c3Bt {
             prog_queue: VecDeque::new(),
             radio: None,
             radio_duration: 0,
-            rx_cursor: 0,
+            rx_cursor: default_ble_air_bus().current_seq(),
             node_id: next_node_id(),
             air: default_ble_air_bus().clone(),
         }
@@ -1439,12 +1439,24 @@ impl Esp32c3Bt {
     /// world share a medium and two worlds do not. Mirrors
     /// [`Nrf52Radio::with_air`](crate::peripherals::nrf52::radio::Nrf52Radio::with_air).
     /// Rebind the shared BLE air (browser multi-chip lab-group isolation).
+    ///
+    /// The cursor joins at the air's CURRENT sequence, never at 0: a radio has
+    /// no history buffer, so frames that crossed before this controller existed
+    /// are gone. A lab reuses its `AirBus` across a simulation restart (the
+    /// playground mints a new one only when the source/diagram hash changes),
+    /// and `next_node_id()` hands the restarted controller a fresh identity —
+    /// so without this join it would neither age out nor recognise the previous
+    /// run's frames, and would replay up to `AIR_DEPTH` of them per channel as
+    /// live peer traffic before ever seeing anything current.
     pub fn set_air(&mut self, air: BleAirBus) {
+        self.rx_cursor = air.current_seq();
         self.air = air;
     }
 
     pub fn with_air(air: BleAirBus) -> Self {
-        Self { air, ..Self::new() }
+        let mut bt = Self::new();
+        bt.set_air(air);
+        bt
     }
 
     /// The air this controller is on (tests, inspection, the air view).
@@ -3780,4 +3792,43 @@ mod tests {
         }
         assert!(last > 0, "CLKN never advanced");
     }
+    /// A simulation RESTART reuses the lab's `AirBus` and builds fresh
+    /// controllers. The previous run's frames are still on that air, and
+    /// `next_node_id()` gives the restarted controller a new identity — so the
+    /// old frames are not filtered out as its own. It must still not see them:
+    /// a radio hears what is transmitted while it is listening, not a backlog.
+    #[test]
+    fn a_controller_built_after_a_restart_skips_the_previous_runs_backlog() {
+        use crate::peripherals::ble_air::{BleAirBus, BleAirFrame};
+        let air = BleAirBus::new();
+
+        // Run 1: two nodes trade advertising frames on the primary channels.
+        for _ in 0..10 {
+            for ch in [37u8, 38, 39] {
+                air.transmit(BleAirFrame {
+                    seq: 0,
+                    source: 1,
+                    channel: ch,
+                    access_address: 0x8E89_BED6,
+                    crc_init: 0x0055_5555,
+                    pdu: vec![0x20, 0x02, 0xE5, 0x02],
+                });
+            }
+        }
+        let backlog = air.current_seq();
+        assert_eq!(backlog, 30, "the previous run left frames on the air");
+
+        // Restart: same air, brand-new controller.
+        let restarted = Esp32c3Bt::with_air(air.clone());
+        assert_eq!(
+            restarted.rx_cursor, backlog,
+            "a restarted controller joins the air where it is now, not at 0",
+        );
+        assert!(
+            air.receive_from(37, 0x8E89_BED6, restarted.rx_cursor, restarted.node_id)
+                .is_none(),
+            "and therefore sees none of the previous run's traffic",
+        );
+    }
+
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -10,7 +10,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-06 | ⚠ drift acked 2026-08-06 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
@@ -61,7 +61,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
-- Drift status: **⚠ drift acked 2026-08-06 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-07 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -953,7 +953,17 @@ boards:
     # 2603 core lib tests + xtensa 57 + esp32_ili9341_attach 2/2 green.
     # 2026-08-06: universal I2C kits + external_devices attach path; nRF UARTE RX test style only.
     # No register map / base / reset change on silicon-asserted set. Offline gates unchanged.
-    drift_ack: 2026-08-06
+    # 2026-08-07: BLE receive-cursor initialisation only. A controller binding
+    # to a BleAirBus now joins at the air's current sequence instead of 0, so a
+    # RESTART (which reuses the lab's air) stops replaying the previous run's
+    # frames as live peer traffic. `rx_cursor` is internal twin state — a cursor
+    # into the virtual air — not a hardware register: no register map, base,
+    # reset value, or silicon-asserted behaviour changes, and the reset oracle
+    # is untouched. Byte-identical for a normal run, where nothing has
+    # transmitted before the controllers attach and the join point is 0 anyway.
+    # Evidence: 2700 core lib tests green, 2816 with --features event-scheduler,
+    # workspace clippy --all-targets -D warnings clean.
+    drift_ack: 2026-08-07
 
   - id: nucleo-l476rg
     doc: docs/boards/nucleo-l476rg.md


### PR DESCRIPTION
## The bug

A simulation restart reuses the lab's `AirBus` — the playground keys it on `runtimeInputKey`, a hash of source + diagram, which does not change when you press Restart. Up to `AIR_DEPTH=64` frames per channel from the previous run are still sitting on that air.

Every controller on the restarted run is a fresh instance: `rx_cursor` 0, and a brand-new identity from the process-global `next_node_id()`. So the previous run's frames are **neither aged out nor recognised as its own transmissions**, and the restarted node drains all of them as if they were live peer traffic before it ever sees anything current.

Found while diagnosing the two-C3 BLE pong lab, where after a restart only the first node paints — the second spends the start of the run replaying a dead one.

## The fix

A controller joins the air at its **current** sequence, never at 0. A radio has no history buffer; frames that crossed before it powered on are gone.

Byte-identical for a normal run: at world setup nothing has transmitted yet, so the join point is 0 either way. Only the reused-bus restart path changes.

## Verification

Failing test written first — a fresh controller on a used bus saw frame `seq 0` from the dead run — then the fix.

- `cargo test -p labwired-core --lib` — 2700 passed, 0 failed
- `cargo test -p labwired-core --lib --features event-scheduler` — 2816 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — clean
- `generate_validation_status.py --check --drift` — exits 0 (esp32c3 drift re-acked; `rx_cursor` is internal twin state, not a register, so the reset oracle is untouched)

## Not covered

The nightly `e2e_esp32c3_ble_adv_republish` gate has not been run against this branch.

## Separate, still open

The **mid-run** node-B freeze is a different defect: the known `RWBLECNTL` bit-25 rapid-re-advertising stall. Not addressed here.