### PR TITLE
fix(ci): stop reporting green while formatting goes unchecked

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -236,6 +236,57 @@ jobs:
             echo "::notice title=fmt-autofix push skipped::${BRANCH} moved while this job was running, so the fixup was not pushed. The newer commit has its own fmt-autofix run."
           fi
 
+      # ── FALLBACK when the fixup CANNOT be pushed (fork PR / no PAT) ───────
+      #
+      # WHY THIS EXISTS. The green-skip above was meant to keep a job that has
+      # nothing to do from going red. What it actually did was report SUCCESS
+      # while formatting went unchecked, so unformatted code merged and
+      # `core-integrity` — which runs on push-to-main only — turned main red
+      # instead. On 2026-08-07 `CI_FMT_PAT` was unset and main was red on
+      # `Check Formatting` for seven consecutive pushes; every one of those PRs
+      # showed a green fmt-autofix.
+      #
+      # So the skip is now narrowed to what it always claimed to be: green when
+      # there is genuinely NOTHING TO DO. A PR whose tree is already formatted
+      # still passes with no PAT and no push. Only a PR that is actually
+      # unformatted, on a run that cannot fix it, goes red — and it says which
+      # files and what to type. That is a signal, not noise, so it cannot train
+      # anyone to ignore it.
+      #
+      # Configure `CI_FMT_PAT` (contents:write) and this path stops running at
+      # all: the push branch above handles it silently, as designed.
+      - name: Checkout for the read-only formatting check
+        if: steps.gate.outputs.ok != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust (pinned — must match pr-gate)
+        if: steps.gate.outputs.ok != 'true'
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          components: rustfmt
+
+      - name: Verify formatting (cannot push the fixup)
+        if: steps.gate.outputs.ok != 'true'
+        run: |
+          set -euo pipefail
+          cargo fmt --version
+
+          if cargo fmt --all -- --check; then
+            echo "Already formatted — nothing to push, and nothing to fix."
+            echo "### Formatting: clean (checked, not applied)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error title=Unformatted code, and this run cannot fix it::This PR is not rustfmt-clean and the autofix could not be pushed (fork PR, or CI_FMT_PAT is unset). Run 'cargo fmt --all' with the pinned 1.95.0 toolchain and push. Merging as-is turns main red on core-integrity."
+          {
+            echo "### Formatting: FAILED"
+            echo
+            echo 'Run `cargo +1.95.0 fmt --all` and push. The autofix job could not do it for you on this run.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
   # ── PR merge gate (REQUIRED) — target wall clock under ~1 minute ───────────
   # focused clippy/tests only. No firmware builds, no feature-variant
   # recompiles, no coverage/onboarding/arduino matrices (those are nightly).

--- a/crates/core/src/peripherals/ble_air.rs
+++ b/crates/core/src/peripherals/ble_air.rs
@@ -268,7 +268,6 @@ mod tests {
         assert!(b.receive_from(37, 0x8E89_BED6, 0, 2).is_none());
     }
 
-
     /// `current_seq` is the join point a fresh controller uses to skip a
     /// backlog it was not present for.
     #[test]
@@ -280,7 +279,8 @@ mod tests {
         }
         assert_eq!(bus.current_seq(), 10);
         assert!(
-            bus.receive_from(37, 0x8E89_BED6, bus.current_seq(), 3).is_none(),
+            bus.receive_from(37, 0x8E89_BED6, bus.current_seq(), 3)
+                .is_none(),
             "a listener joining now hears none of the backlog",
         );
         assert!(

--- a/crates/core/src/peripherals/esp32c3/bt.rs
+++ b/crates/core/src/peripherals/esp32c3/bt.rs
@@ -3830,5 +3830,4 @@ mod tests {
             "and therefore sees none of the previous run's traffic",
         );
     }
-
 }

--- a/crates/core/tests/adxl345_register_map.rs
+++ b/crates/core/tests/adxl345_register_map.rs
@@ -89,10 +89,16 @@ fn every_documented_register_reads_its_datasheet_reset_value() {
     for &(addr, name, _, reset) in TABLE_16 {
         let got = read_u8(&mut d, addr);
         if got != reset {
-            wrong.push(format!("{name} (0x{addr:02X}): got 0x{got:02X}, datasheet 0x{reset:02X}"));
+            wrong.push(format!(
+                "{name} (0x{addr:02X}): got 0x{got:02X}, datasheet 0x{reset:02X}"
+            ));
         }
     }
-    assert!(wrong.is_empty(), "registers disagree with Table 16:\n  {}", wrong.join("\n  "));
+    assert!(
+        wrong.is_empty(),
+        "registers disagree with Table 16:\n  {}",
+        wrong.join("\n  ")
+    );
 }
 
 #[test]
@@ -109,10 +115,16 @@ fn writable_registers_store_what_a_driver_writes() {
         write_u8(&mut d, addr, 0x5A);
         let got = read_u8(&mut d, addr);
         if got != 0x5A {
-            lost.push(format!("{name} (0x{addr:02X}): wrote 0x5A, read 0x{got:02X}"));
+            lost.push(format!(
+                "{name} (0x{addr:02X}): wrote 0x5A, read 0x{got:02X}"
+            ));
         }
     }
-    assert!(lost.is_empty(), "writes did not stick:\n  {}", lost.join("\n  "));
+    assert!(
+        lost.is_empty(),
+        "writes did not stick:\n  {}",
+        lost.join("\n  ")
+    );
 }
 
 #[test]
@@ -135,7 +147,11 @@ fn read_only_registers_ignore_writes() {
 fn the_table_covers_every_address_the_datasheet_documents() {
     // Guards the failure where this file quietly shrinks: Table 16 names thirty
     // registers, six of which are the DATAX0..DATAZ1 pair halves excluded above.
-    assert_eq!(TABLE_16.len(), 24, "Table 16 has 30 registers, 6 of them data-pair halves");
+    assert_eq!(
+        TABLE_16.len(),
+        24,
+        "Table 16 has 30 registers, 6 of them data-pair halves"
+    );
 }
 
 #[test]


### PR DESCRIPTION
main has been red on `core-integrity` → **Check Formatting** for **seven consecutive pushes** (since #836 landed at 09:23 UTC today). Every one of those PRs showed a **green** `fmt-autofix`.

## Root cause

`CI_FMT_PAT` is not set. `fmt-autofix` detects that, takes its `green-skip, never red` branch, and then **pushes nothing and checks nothing**:

```
##[notice]Secret CI_FMT_PAT is not set. GITHUB_TOKEN is not a fallback...
```

`cargo fmt --all -- --check` lives only in `core-integrity`, which is **push-to-main only**. So the one thing standing between unformatted code and a red main was a job that had quietly stopped doing its job. The failure did not disappear — it moved from the PR, where it is one command to fix, onto main, where it blocks the merge gate.

## Changes

**1. `cargo fmt --all` with the pinned 1.95.0 toolchain.** Whitespace only, three files — `ble_air.rs`, `esp32c3/bt.rs`, `adxl345_register_map.rs`. main goes green.

**2. The skip is narrowed to what it always claimed to be: green when there is genuinely _nothing to do_.** When the fixup cannot be pushed (fork PR, or no PAT), the job now still **checks**:

| Situation | Before | After |
|---|---|---|
| PAT set | autofix pushes | unchanged |
| No PAT, tree already formatted | green (unchecked) | **green** (checked) |
| No PAT, tree unformatted | **green — then main goes red** | **red on the PR, names the command** |
| Fork PR, unformatted | **green — then main goes red** | **red on the PR, names the command** |

This keeps the original intent — never a red X a contributor cannot act on — without the silent-degradation hole. A contributor who reads the red X gets `cargo +1.95.0 fmt --all` and a file list. Setting `CI_FMT_PAT` (contents:write) retires this path entirely.

## Verification

Both directions, against the pinned toolchain — not just the passing one:

```
--- clean tree (must pass) ---            STEP RESULT: pass   exit=0
--- deliberately misformatted (must fail) --- STEP RESULT: fail   exit=1
--- restored (must pass again) ---        STEP RESULT: pass   exit=0
```

This PR itself exercises the new path: `CI_FMT_PAT` is unset, so `fmt-autofix` takes the read-only branch and reports a real check rather than an assumption.

## Not done here

`fmt-autofix` is still **not a required context** (main requires only `pr-gate` and `release-runner-contract`), so a red X here does not physically block a merge. Promoting it is a branch-protection change and `enforce_admins` is on, so it is left as a deliberate follow-up.