### PR TITLE
perf(cli): let idle fast-forward actually skip an idle window

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -57,10 +57,29 @@ default = []
 # JIT-on vs JIT-off differential is byte-identical either way (both arms tick
 # peripherals identically), so the scheduler is not required for this path.
 jit-core = ["labwired-core/jit"]
-# Opt-in event scheduler + walk-delete / idle-FF infrastructure used by the
-# Arduino matrix speed path (`LABWIRED_MATRIX_SPEED=1`). Build:
+# Event scheduler + walk-delete / idle-FF infrastructure. Build:
 #   cargo build -p labwired-cli --release --features event-scheduler
-# Do NOT combine with `jit-core` for general CLI use (see note above).
+#
+# This feature is what makes CPU idle fast-forward EXIST: without it
+# `Machine::try_idle_fast_forward` is `#[cfg(not(feature = "event-scheduler"))]
+# { 0 }`, so `labwired test` interprets every instruction of every idle
+# FreeRTOS task and `idle_fast_forward_enabled` cannot do anything. On an
+# ESP32-C3 BLE bring-up that is 4x the interpreted instructions — measured, see
+# `apply_run_speed_opts` in `commands/test.rs`.
+#
+# ⚠️ It is nevertheless NOT enabled for the hosted builder image
+# (`services/labwired-builder/Dockerfile.builder`), and the reason is specific
+# and reproducible: with this feature on, ELEVEN ESP32-classic / ESP32-S3
+# tier-1 cells go from `pass` to `blocked` — the Xtensa fixtures HANG instead
+# of reporting. Reproduce on a pristine tree with
+#   cargo test --release -p labwired-cli --test tier1_matrix_ratchet \
+#     --features event-scheduler
+# (green without the flag). RISC-V/C3 is unaffected — no esp32c3 cell moves —
+# so the blocker is Xtensa scheduler coverage, not the accelerator. Turning
+# this on hosted requires fixing that first, or shipping a per-arch binary.
+#
+# Still NOT in `default`, and still not to be combined with `jit-core` for
+# general CLI use (see the note above).
 event-scheduler = ["labwired-core/event-scheduler"]
 # Swap the built-in fuzzing loop for the LibAFL engine (havoc/splice mutators,
 # map-feedback scheduler, crash objectives). Heavy dependency tree, so opt-in:

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -9,23 +9,74 @@
 use crate::*;
 use tracing::warn;
 
-/// Opt-in Arduino-matrix speed path (`LABWIRED_MATRIX_SPEED=1`).
+/// Turn on scheduler-safe CPU idle fast-forward for this `labwired test` run.
 ///
-/// Enables idle/delay fast-forward only (requires a CLI build with
-/// `--features event-scheduler`). Tick-interval widening is intentionally
-/// **not** applied here: under the event-scheduler feature, wide ticks have
-/// regressed ESP classic/S3/C3 FreeRTOS labs before, and the matrix already
-/// gets most of its wall-time win from shorter L2 delays + Waiti park.
-/// Default CLI / green labs are unchanged when the env var is unset.
-fn apply_matrix_speed_opts<C: labwired_core::Cpu>(machine: &mut labwired_core::Machine<C>) {
-    if std::env::var("LABWIRED_MATRIX_SPEED").as_deref() != Ok("1") {
-        return;
+/// `SimulationConfig::idle_fast_forward_enabled` stays **false** in core's
+/// `Default` (see `crates/core/src/config.rs`) so every embedder keeps
+/// instruction-for-instruction behaviour unless it explicitly opts in. That
+/// guarantee is preserved: this opts in at the *run path*, it does not flip
+/// the library default.
+///
+/// `labwired test` is the hosted simulation runner — the process
+/// `services/labwired-builder`'s `/run` endpoint execs for every hosted
+/// `labwired_run` — and a firmware that sleeps is the common case there. With
+/// the flag off, an ESP32-C3 `vTaskDelay(200)` retires ~32M instructions of an
+/// idle FreeRTOS task to produce nothing (~160k instructions per idle
+/// millisecond, exactly linear in the delay), which is the bulk of a BLE
+/// bring-up's step budget. Fast-forward skips that window to the next
+/// scheduler deadline instead. `Machine::try_idle_fast_forward` refuses
+/// whenever anything could observe the skipped cycles (cycle-accurate bus,
+/// polled logic capture, honored breakpoints, active legacy peripheral ticks)
+/// and clamps the skip to the next event/motor deadline, so the FIRMWARE sees
+/// the same thing: `interpreted + idle_ff == total_cycles`, and the serial of
+/// a C3 BLE bring-up is byte-identical with the flag on and off (measured).
+///
+/// ⚠️ What it DOES change is `cycles` in result.json. That field is not
+/// `Machine::total_cycles`; it is accumulated by a per-step observer
+/// (`PerformanceMetrics`), so cycles the CPU skipped while parked are not in
+/// it. On the C3 BLE image, reaching the same serial milestone reports
+/// 120,356,558 cycles with the flag off and 31,740,172 with it on, for an
+/// identical `total_cycles` of 44,646,954. `max_cycles` is checked against the
+/// same counter, so it now bounds interpreted work rather than device time — a
+/// run gets further into the firmware for the same limit. Runs that declare
+/// `after_cycles` stimuli are excluded from fast-forward entirely for this
+/// reason (see `execute_test_loop`).
+///
+/// Escape hatch (opt-out, not opt-in): `LABWIRED_IDLE_FAST_FORWARD=0` restores
+/// per-instruction idling for one run, so a fidelity investigation can diff
+/// the two arms without rebuilding the CLI.
+///
+/// ⚠️ Inert unless the CLI is built `--features event-scheduler` —
+/// `try_idle_fast_forward` compiles to `0` without it. The hosted builder image
+/// does NOT build with that feature today (11 Xtensa tier-1 cells hang when it
+/// is on — see the feature's note in `crates/cli/Cargo.toml`), so setting this
+/// flag currently buys the hosted runner nothing. It is set here so the run
+/// path is correct the moment that blocker clears, and so
+/// `--features event-scheduler` builds get the acceleration now.
+///
+/// `LABWIRED_MATRIX_SPEED=1` is still accepted by the Arduino-matrix scripts;
+/// it now only asks for the log line, because the setting it used to gate is
+/// the default.
+///
+/// Tick-interval widening is deliberately **not** applied here: under the
+/// event-scheduler feature, wide ticks have regressed ESP classic/S3/C3
+/// FreeRTOS labs before.
+fn apply_run_speed_opts<C: labwired_core::Cpu>(machine: &mut labwired_core::Machine<C>) {
+    let opted_out = std::env::var("LABWIRED_IDLE_FAST_FORWARD").as_deref() == Ok("0");
+    machine.config.idle_fast_forward_enabled = !opted_out;
+    // Only say so when the setting can actually do something, so the line is
+    // never a claim the build cannot honour.
+    if cfg!(feature = "event-scheduler") {
+        eprintln!(
+            "labwired-cli test: idle_ff={} (event_scheduler=on{})",
+            if opted_out { "off" } else { "on" },
+            if opted_out {
+                ", LABWIRED_IDLE_FAST_FORWARD=0"
+            } else {
+                ""
+            },
+        );
     }
-    machine.config.idle_fast_forward_enabled = true;
-    eprintln!(
-        "labwired-cli test: LABWIRED_MATRIX_SPEED=1 (idle_ff=on, event_scheduler={})",
-        cfg!(feature = "event-scheduler")
-    );
 }
 
 /// Apply the script's faults to the built bus before the run, logging any that
@@ -238,7 +289,7 @@ fn run_c3_rom_boot_no_elf(
     }
 
     let metrics = std::sync::Arc::new(labwired_core::metrics::PerformanceMetrics::new());
-    apply_matrix_speed_opts(&mut machine);
+    apply_run_speed_opts(&mut machine);
     machine.observers.push(metrics.clone());
     let fault_evidence = handle_faults(&mut machine.bus, faults);
 
@@ -1364,7 +1415,7 @@ pub(crate) fn run_test(
     macro_rules! run_machine {
         ($machine:expr) => {{
             let mut machine = $machine;
-            apply_matrix_speed_opts(&mut machine);
+            apply_run_speed_opts(&mut machine);
             // JIT-eligible RISC-V runs source cycles/instructions from the
             // machine's own counters (see `execute_test_loop`), so the metrics
             // step observer must NOT be installed — its presence would gate the

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1825,6 +1825,18 @@ fn map_sim_error_to_stop_reason(e: &labwired_core::SimulationError) -> StopReaso
 /// identical between the JIT-on and JIT-off arms.
 const JIT_RUN_CHUNK: u32 = 1_000_000;
 
+/// Fuel budget per `Machine::advance` call on an idle-fast-forward run whose
+/// stop conditions can all be checked at that granularity
+/// (`idle_ff_wide_observation` in `execute_test_loop`).
+///
+/// This is a FUEL budget, not a CPU batch width — the batch cap is passed
+/// separately and is unchanged. It bounds how far one idle skip may reach, so
+/// it has to comfortably exceed a FreeRTOS tick window: an ESP32-C3 at 160 MHz
+/// idles ~160k cycles per millisecond, so `vTaskDelay(200)` is ~32M cycles.
+/// Same value as [`JIT_RUN_CHUNK`], which already bounds this loop's
+/// observation granularity on the JIT-eligible path.
+const IDLE_FF_RUN_CHUNK: u32 = 1_000_000;
+
 #[allow(clippy::too_many_arguments)]
 fn execute_test_loop<C: labwired_core::Cpu>(
     args: &TestArgs,
@@ -2007,6 +2019,92 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         assertions,
         max_steps,
     );
+
+    // ── Fuel budget vs CPU batch width ──────────────────────────────────────
+    // These are two different knobs that this loop used to collapse into one
+    // number, and the collapse silently disarmed idle fast-forward.
+    //
+    // `batch_cap` is how many instructions the CPU may retire per window. It
+    // stays `batch_size`, which is 1 whenever batch mode is off (the ESP32-C3
+    // rom-boot path turns batching off because a fixed-width batch freezes
+    // interrupt delivery and FreeRTOS never runs). That is a FIDELITY setting
+    // and is not touched here or below.
+    //
+    // The advance call's `fuel` is a different thing: how much this call may
+    // consume before returning to the checks at the top of this loop. And
+    // `Machine::try_idle_fast_forward` clamps its skip to the fuel remaining —
+    // so with fuel pinned to 1, an idle FreeRTOS window was fast-forwarded ONE
+    // cycle at a time. Measured on a hosted-shaped ESP32-C3 BLE rom-boot run,
+    // turning the flag on that way bought 3% of the steps and ran ~2x SLOWER in
+    // wall clock than not skipping at all, because every skipped cycle paid a
+    // full plan/commit round trip. A `vTaskDelay(200)` window is ~32M cycles;
+    // it wants to go in a few thousand skips, not 32M of them.
+    //
+    // The widened fuel below is applied ONLY on an iteration where the CPU is
+    // already parked waiting for an interrupt (`idle_fast_forward_budget` is
+    // `Some`). That is the tight guard: while the CPU is parked the advance
+    // call retires no instructions at all, so nothing this loop observes
+    // between calls — PC, retired-step counts, assertion settling — can move
+    // inside the widened window. On every instruction-retiring iteration the
+    // fuel is exactly what it was before this change, so a busy run is
+    // unchanged instruction for instruction.
+    //
+    // `idle_ff_wide_observation` is the standing half of the condition. It
+    // excludes the features this loop — not `advance` — implements per
+    // iteration and which a parked CPU does not exempt:
+    //   * `--breakpoint` / `--detect-stuck` re-read the PC between calls, and
+    //     a WFI spin is exactly a stuck PC,
+    //   * `--capture-app-entry` watches for the app-entry PC between calls,
+    //   * poll-mode logic capture and ShutdownLatency assertions need
+    //     cycle-accurate attribution of events inside the window.
+    // Time-triggered stimuli, UART injections and `max_cycles` are NOT in that
+    // list: the per-iteration clamp below already shortens `limit` to land
+    // exactly on the next threshold.
+    //
+    // With idle fast-forward off — including via `LABWIRED_IDLE_FAST_FORWARD=0`
+    // — this is `false` and the loop is byte-identical to before.
+    //
+    // ⚠️ A run with `after_cycles` stimuli or UART injections turns idle
+    // fast-forward OFF outright, not just the widened fuel. Those thresholds
+    // are compared against `metrics.get_cycles()`, which is accumulated by a
+    // per-STEP observer: an idle skip retires no instructions, so it advances
+    // the machine's device clock without advancing that counter. Under
+    // fast-forward the two clocks separate, and a stimulus whose threshold is
+    // expressed in cycles would land late in device time — or, if the run ends
+    // first, never fire at all while still reporting a pass. A run that says
+    // when its input arrives gets instruction-for-instruction timing; the
+    // acceleration is not worth silently moving someone's stimulus.
+    let has_time_triggered_inputs = stimuli
+        .iter()
+        .any(|s| matches!(s.trigger, labwired_config::FaultTrigger::AfterCycles { .. }))
+        || uart_injections
+            .iter()
+            .any(|u| matches!(u.trigger, labwired_config::FaultTrigger::AfterCycles { .. }));
+    if has_time_triggered_inputs && machine.config.idle_fast_forward_enabled {
+        machine.config.idle_fast_forward_enabled = false;
+        eprintln!(
+            "labwired-cli test: idle_ff disabled for this run — it declares \
+             after_cycles stimuli/uart injections, whose thresholds idle skips \
+             do not advance"
+        );
+    }
+
+    // The `event-scheduler` clause is load-bearing, not belt-and-braces. Without
+    // that feature `Machine::try_idle_fast_forward` is compiled to `0`, so there
+    // is no skip for the wider fuel to fund — but `idle_fast_forward_budget`
+    // still reports the parked CPU, and widening on that would hand `advance` a
+    // million instructions of WFI spin to retire in one call. The outer loop's
+    // per-iteration checks (`stop_when_assertions_pass` settling,
+    // `max_uart_bytes`, `wall_time_ms`) would then run a million steps apart in
+    // a DEFAULT build. Gated here, a build without the feature takes the
+    // `else` arm exactly as it does today.
+    let idle_ff_wide_observation = cfg!(feature = "event-scheduler")
+        && machine.config.idle_fast_forward_enabled
+        && args.breakpoint.is_empty()
+        && detect_stuck.is_none()
+        && args.capture_app_entry.is_none()
+        && !machine.logic_poll_active()
+        && !requires_fine_grained_observation(assertions);
 
     // Declarative input stimuli (schema_version 1.2). Applied via the generic
     // `Machine::set_input` path (see `labwired_core::sim_input`), so no per-type
@@ -2329,6 +2427,17 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         let (mut limit, batch_cap) = if jit_eligible {
             let chunk = remaining.min(JIT_RUN_CHUNK);
             (u64::from(chunk), chunk)
+        } else if idle_ff_wide_observation
+            && machine
+                .cpu
+                .idle_fast_forward_budget(&machine.bus as &dyn labwired_core::Bus)
+                .is_some()
+        {
+            // CPU is parked on WFI right now: give the skip real fuel so the
+            // idle window goes in a few thousand skips instead of one cycle at
+            // a time. The CPU batch width is still `current_batch` — see the
+            // note beside `idle_ff_wide_observation`.
+            (u64::from(remaining.min(IDLE_FF_RUN_CHUNK)), current_batch)
         } else {
             (u64::from(to_execute), current_batch)
         };
@@ -2498,6 +2607,19 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             ),
             None => eprintln!("[jit-stats] JIT engine never created (interpreter-only run)"),
         }
+    }
+
+    // How much of this run's device time the CPU spent parked and skipped
+    // rather than interpreted. Printed whenever it is non-zero so a hosted run
+    // can be shown to have actually fast-forwarded — the failure mode this
+    // guards is a build or a run path where the flag is on and the skip is
+    // clamped to nothing, which is indistinguishable from working unless the
+    // number is visible. `steps_executed + skipped == machine.total_cycles`.
+    if machine.idle_fast_forward_cycles_skipped > 0 {
+        eprintln!(
+            "labwired-cli test: idle_ff skipped {} of {} device cycles ({} interpreted)",
+            machine.idle_fast_forward_cycles_skipped, machine.total_cycles, steps_executed
+        );
     }
 
     let uart_text = {


### PR DESCRIPTION
## The finding

`labwired test` is what the hosted runner executes (builder `POST /run` → `run.ts:1224` execFiles `$LABWIRED_BIN`). On an ESP32-C3 Arduino run it spends **82% of BLE bring-up** interpreting a FreeRTOS idle task one instruction at a time.

Measured with cumulative-prefix probes on the real pong image: `BLEDevice::init` costs **38,125,704 steps**, of which the BT controller + Bluedroid stack is only ~5.9M. The rest is one trailing `vTaskDelay(200 ms)`. Controls: `vTaskDelay(200)` with **no BLE at all** costs 31,995,821 steps; `vTaskDelay(400)` costs exactly 2× that. A flat **160,000 steps per idle millisecond**, producing nothing.

## The flag was not the bug

`execute_test_loop` conflated **fuel** with **CPU batch width**. C3 rom-boot sets `batch_mode_enabled = false` → `batch_size = 1` → `advance` received **fuel = 1**, and `try_idle_fast_forward` clamps its skip to remaining fuel.

**Simply enabling the flag gives 2.4M skips averaging 260 cycles — a 3% gain and 2× *worse* wall clock.** Fuel is now widened to 1M **only** on an iteration where the CPU is already parked on WFI, where it retires no instructions, so nothing observable can move between calls. The batch cap is untouched.

## Measured

5 interleaved rounds, two `cmp`-verified binaries, C3 rom-boot on the real BLE pong flash image:

| arm | steps executed |
|---|---|
| today's hosted build | 44,646,954 |
| patched, FF off | 44,646,954 — bit-identical |
| patched, FF on | **11,145,578** |

**4.01× fewer interpreted instructions.** 1,336 skips covering 33,501,376 cycles — the `vTaskDelay(200)` window.

## Correctness

- Invariant exact: 11,145,578 interpreted + 33,501,376 skipped = 44,646,954 = `total_cycles`
- Serial **byte-identical** — one sha256 across all 14 runs of all three arms
- Two-node BLE pong world test: identical roles and ball position both ways
- `cargo test --release -p labwired-cli` — 41 binaries, 205 passed, 0 failed, incl. `tier1_matrix_does_not_regress`
- clippy `-D warnings` and `cargo fmt --check` clean on the changed files

`SimulationConfig::default()` stays `false`, so the guarantee at `config.rs:19-23` for other embedders is preserved — the opt-in is at the run path.

## This does NOT speed up the hosted runner yet

The builder image builds the CLI with **no features** (`Dockerfile.builder:22`) and `try_idle_fast_forward` is `#[cfg(not(feature = "event-scheduler"))] { 0 }` — so this is **inert hosted** until the image can build with the feature.

Enabling it there regresses **11 Xtensa tier-1 cells** (`esp32`/`esp32s3` clock, timer, dma, gpio, i2c, irq, pwm, rmt, uart) from pass to **blocked** — the fixtures hang. Reproduced on a **pristine** tree, so it is the feature, not this change. No `esp32c3` cell moves. The `Dockerfile.builder` change is reverted rather than ship a known regression.

Two ways to finish it, needing a decision: fix the Xtensa hang, or build a second `--features event-scheduler` binary and have `run.ts` select it for RISC-V rom-boot chips only (`LABWIRED_BIN` is already the seam; C3 is proven safe under the feature by everything above).

## Known wart, pre-existing

Under FF, `cycles` in `result.json` drops 120,356,558 → 31,740,172 for identical `total_cycles`, because that field comes from a per-step observer. `max_cycles` then bounds interpreted work rather than device time. That is exactly why runs declaring `after_cycles` stimuli disable FF outright — those thresholds compare against the same per-step observer, so a stimulus would land late or never while still reporting a pass.

## Not run

The two nightly C3 BLE CLI gates (`e2e_esp32c3_ble_two_node`, `e2e_esp32c3_ble_adv_republish`) — their fixtures need a network fetch and `fixtures/esp32c3-ble/` is empty locally. They are the most relevant remaining gates for this change.