### PR TITLE
fix(cli): Xtensa `run` must drive Machine, not a hand-rolled loop

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -67,16 +67,23 @@ jit-core = ["labwired-core/jit"]
 # ESP32-C3 BLE bring-up that is 4x the interpreted instructions — measured, see
 # `apply_run_speed_opts` in `commands/test.rs`.
 #
-# ⚠️ It is nevertheless NOT enabled for the hosted builder image
-# (`services/labwired-builder/Dockerfile.builder`), and the reason is specific
-# and reproducible: with this feature on, ELEVEN ESP32-classic / ESP32-S3
-# tier-1 cells go from `pass` to `blocked` — the Xtensa fixtures HANG instead
-# of reporting. Reproduce on a pristine tree with
+# ⚠️ HISTORY — the Xtensa blocker that used to gate this, and what it was.
+# Turning this feature on used to move ELEVEN ESP32-classic / ESP32-S3 tier-1
+# cells from `pass` to `blocked`, while no esp32c3 cell moved. It was NOT
+# missing Xtensa scheduler coverage. The two Xtensa `labwired run` paths in
+# `commands/run.rs` were hand-rolled `cpu.step()` +
+# `bus.tick_peripherals_with_costs()` loops that never published the bus cycle
+# clock and had no event scheduler at all (the heap is a `Machine` field). With
+# the feature on, the per-cycle walk SKIPS every `uses_scheduler()` peripheral,
+# so those were the only two mechanisms left — `esp32::timg` stayed frozen at
+# cycle 0 and the shared `EspUart` TX FIFO never drained, spinning the S3 boot
+# ROM inside `uart_tx_one_char_uart`. ARM and RISC-V `run`, and `labwired test`
+# for every arch, already went through `Machine`, which is exactly why only
+# Xtensa `run` moved. Both loops now drive `Machine`; the ratchet
 #   cargo test --release -p labwired-cli --test tier1_matrix_ratchet \
 #     --features event-scheduler
-# (green without the flag). RISC-V/C3 is unaffected — no esp32c3 cell moves —
-# so the blocker is Xtensa scheduler coverage, not the accelerator. Turning
-# this on hosted requires fixing that first, or shipping a per-arch binary.
+# is green, and `tests/lifecycle_single_source.rs` fails if a CLI run path ever
+# forks the lifecycle again.
 #
 # Still NOT in `default`, and still not to be combined with `jit-core` for
 # general CLI use (see the note above).

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -502,12 +502,17 @@ pub(crate) fn run_firmware_esp32(args: &RunArgs) -> ExitCode {
     cpu.ps = labwired_core::cpu::xtensa_regs::Ps::from_raw(1 << 18);
 
     let limit = args.max_steps.unwrap_or(u64::MAX);
-    let observers: Vec<std::sync::Arc<dyn labwired_core::SimulationObserver>> = Vec::new();
-    let config = labwired_core::SimulationConfig::default();
     let mut steps = 0u64;
 
+    // Drive the authoritative `Machine` lifecycle, not a hand-rolled
+    // `cpu.step` + `bus.tick_peripherals_*` pair. See the note on
+    // `run_firmware`'s loop: the hand-rolled shape never published the bus
+    // cycle clock, which freezes every `uses_scheduler()` peripheral under
+    // `--features event-scheduler`.
+    let mut machine = labwired_core::Machine::new(cpu, bus);
+
     while steps < limit {
-        match cpu.step(&mut bus, &observers, &config) {
+        match machine.step() {
             Ok(()) => {}
             Err(SimulationError::BreakpointHit(_)) => break,
             Err(SimulationError::ExceptionRaised { cause, pc }) => {
@@ -517,19 +522,18 @@ pub(crate) fn run_firmware_esp32(args: &RunArgs) -> ExitCode {
             Err(e) => {
                 eprintln!(
                     "labwired-cli run (esp32): simulator error at pc=0x{:08x}: {e}",
-                    cpu.get_pc(),
+                    machine.cpu.get_pc(),
                 );
                 return ExitCode::from(EXIT_RUNTIME_ERROR);
             }
         }
-        bus.tick_peripherals_with_costs();
         steps += 1;
     }
     eprintln!(
         "labwired-cli run (esp32): reached --max-steps {limit}; pc=0x{:08x}",
-        cpu.get_pc(),
+        machine.cpu.get_pc(),
     );
-    export_bus_trace_if_requested(&args.bus_trace_out, &bus);
+    export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
     ExitCode::from(EXIT_PASS)
 }
 
@@ -719,10 +723,30 @@ pub(crate) fn run_firmware(
         }
     }
 
-    // Run the step loop.
+    // Run the step loop through the authoritative `Machine` lifecycle.
+    //
+    // This loop used to be a hand-rolled `cpu.step()` + `cpu1.step()` +
+    // `bus.tick_peripherals_with_costs()` triple. That reproduces only the
+    // legacy-walk half of the lifecycle and silently drops the other half:
+    // it never publishes the bus cycle clock (`SystemBus::set_current_cycle`)
+    // and it has no event scheduler at all, because the scheduler heap lives
+    // on `Machine`. Under `--features event-scheduler` the per-cycle walk
+    // SKIPS every `uses_scheduler()` peripheral (`bus/tick.rs`, the
+    // `p.dev.uses_scheduler()` early-return in the walk), so those two
+    // mechanisms are the ONLY things that advance them — leaving TIMG frozen
+    // at cycle 0 and the UART TX FIFO undrained, which spins the S3 boot ROM
+    // forever inside `uart_tx_one_char_uart`. `Machine::step`'s own doc says
+    // frontends "must not reproduce the lifecycle with direct `Cpu::step`
+    // calls"; this is why.
+    //
+    // `Machine::step` is `advance(AdvanceRequest::single())`: one primary
+    // quantum, then the secondary, then one peripheral boundary — the same
+    // order and the same cadence the hand-rolled loop had.
     let limit = args.max_steps.unwrap_or(u64::MAX);
-    let observers: Vec<std::sync::Arc<dyn labwired_core::SimulationObserver>> = Vec::new();
-    let config = labwired_core::SimulationConfig::default();
+    let mut machine = match cpu1 {
+        Some(c1) => labwired_core::Machine::new(cpu, bus).with_secondary_cpu(c1),
+        None => labwired_core::Machine::new(cpu, bus),
+    };
     let mut steps = 0u64;
     // Ring buffer of recent PCs for post-mortem on exceptions.
     const RING_LEN: usize = 1024;
@@ -784,7 +808,7 @@ pub(crate) fn run_firmware(
                         $c.regs.windowstart()
                     );
                     for &m in &watch_mem {
-                        match bus.read_u32(m as u64) {
+                        match machine.bus.read_u32(m as u64) {
                             Ok(v) => eprintln!("    mem[0x{m:08x}] = 0x{v:08x}"),
                             Err(e) => eprintln!("    mem[0x{m:08x}] = <unmapped: {e}>"),
                         }
@@ -808,12 +832,19 @@ pub(crate) fn run_firmware(
     }
 
     while steps < limit {
-        let pc_before = cpu.get_pc();
+        let pc_before = machine.cpu.get_pc();
         pc_ring[ring_head] = pc_before;
         ring_head = (ring_head + 1) % RING_LEN;
 
         // Debug breakpoint (PRO_CPU): dump on first hit.
-        check_break!(cpu, pc_before, break_hit);
+        check_break!(machine.cpu, pc_before, break_hit);
+
+        // Debug breakpoint (APP_CPU): dump on first hit, before the machine
+        // steps it. `Machine::step` drives both cores inside one call, so the
+        // APP_CPU's pre-step PC has to be sampled here.
+        if let Some(pc1) = machine.cpu_secondary.as_ref().map(|c| c.get_pc()) {
+            check_break!(machine.cpu_secondary.as_ref().unwrap(), pc1, break_hit1);
+        }
 
         // Capture the APP_CPU entry when PRO_CPU programs it. The ROM also
         // points the APP_CPU at early DRAM stubs during its own bring-up; only
@@ -828,7 +859,7 @@ pub(crate) fn run_firmware(
                 .with(|s| s.take())
         {
             appcpu_started = true;
-            if let Some(c1) = cpu1.as_mut() {
+            if let Some(c1) = machine.cpu_secondary.as_mut() {
                 c1.halted = false;
             }
             eprintln!(
@@ -836,22 +867,22 @@ pub(crate) fn run_firmware(
             );
         }
 
-        match cpu.step(&mut bus, &observers, &config) {
+        match machine.step() {
             Ok(()) => {}
             Err(SimulationError::BreakpointHit(pc)) => {
                 eprintln!("labwired-cli run: BREAK at 0x{pc:08x}");
-                export_bus_trace_if_requested(&args.bus_trace_out, &bus);
+                export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
                 return ExitCode::from(EXIT_PASS);
             }
             Err(SimulationError::ExceptionRaised { cause, pc }) => {
                 eprintln!("labwired-cli run: ExceptionRaised cause={cause} at 0x{pc:08x}");
                 eprintln!(
                     "labwired-cli run: PS=0x{:08x} (excm={} intlevel={}) WB={} WS=0x{:04x}",
-                    cpu.ps.as_raw(),
-                    cpu.ps.excm(),
-                    cpu.ps.intlevel(),
-                    cpu.regs.windowbase(),
-                    cpu.regs.windowstart(),
+                    machine.cpu.ps.as_raw(),
+                    machine.cpu.ps.excm(),
+                    machine.cpu.ps.intlevel(),
+                    machine.cpu.regs.windowbase(),
+                    machine.cpu.regs.windowstart(),
                 );
                 eprintln!("labwired-cli run: recent PCs (oldest first):");
                 for i in 0..RING_LEN {
@@ -865,16 +896,16 @@ pub(crate) fn run_firmware(
             Err(e) => {
                 eprintln!(
                     "labwired-cli run: simulator error at pc=0x{:08x}: {e}",
-                    cpu.get_pc(),
+                    machine.cpu.get_pc(),
                 );
                 eprintln!("labwired-cli run: a0..a15 at fault:");
                 for r in 0..16u8 {
-                    eprintln!("  a{:<2} = 0x{:08x}", r, cpu.regs.read_logical(r));
+                    eprintln!("  a{:<2} = 0x{:08x}", r, machine.cpu.regs.read_logical(r));
                 }
                 eprintln!(
                     "  WB=0x{:x} WS=0x{:04x}",
-                    cpu.regs.windowbase(),
-                    cpu.regs.windowstart(),
+                    machine.cpu.regs.windowbase(),
+                    machine.cpu.regs.windowstart(),
                 );
                 eprintln!("labwired-cli run: recent PCs (oldest first):");
                 for i in 0..RING_LEN {
@@ -890,38 +921,25 @@ pub(crate) fn run_firmware(
         // stores the assert/abort string ptr in a2 just before the trap. Helps
         // pinpoint firmware-level aborts during bring-up.
         if std::env::var("LABWIRED_CCDBG").is_ok() {
-            for c in [Some(&cpu), cpu1.as_ref()].into_iter().flatten() {
-                if c.get_pc() == 0x4037_e0a3 {
-                    let p = c.regs.read_logical(2);
-                    let mut s = String::new();
-                    for i in 0..160u32 {
-                        match bus.read_u8(p as u64 + i as u64) {
-                            Ok(0) | Err(_) => break,
-                            Ok(b) => s.push(b as char),
-                        }
+            // Collect the string pointers first: reading them back needs
+            // `&mut machine.bus`, so the core borrows have to be released.
+            let panic_args: Vec<u32> = [Some(&machine.cpu), machine.cpu_secondary.as_ref()]
+                .into_iter()
+                .flatten()
+                .filter(|c| c.get_pc() == 0x4037_e0a3)
+                .map(|c| c.regs.read_logical(2))
+                .collect();
+            for p in panic_args {
+                let mut s = String::new();
+                for i in 0..160u32 {
+                    match machine.bus.read_u8(p as u64 + i as u64) {
+                        Ok(0) | Err(_) => break,
+                        Ok(b) => s.push(b as char),
                     }
-                    eprintln!("CCDBG: panic \"{s}\" step={steps}");
                 }
+                eprintln!("CCDBG: panic \"{s}\" step={steps}");
             }
         }
-        // Step the APP_CPU round-robin (one instruction per PRO_CPU step).
-        // A halted APP_CPU returns immediately from step(). S32C1I is atomic
-        // within step(), so spinlocks between the cores behave correctly.
-        if let Some(c1) = cpu1.as_mut() {
-            // Debug breakpoint (APP_CPU): dump on first hit.
-            check_break!(c1, c1.get_pc(), break_hit1);
-            match c1.step(&mut bus, &observers, &config) {
-                Ok(()) | Err(SimulationError::BreakpointHit(_)) => {}
-                Err(e) => {
-                    eprintln!(
-                        "labwired-cli run: APP_CPU error at pc=0x{:08x}: {e}",
-                        c1.get_pc()
-                    );
-                    return ExitCode::from(EXIT_RUNTIME_ERROR);
-                }
-            }
-        }
-        bus.tick_peripherals_with_costs();
         steps += 1;
 
         // SMP bring-up tracer (gated). Prints both cores' PCs periodically and
@@ -929,10 +947,12 @@ pub(crate) fn run_firmware(
         // where setup()/loop()/Unity live) — the signal that the FreeRTOS SMP
         // scheduler finally dispatched the pinned loopTask.
         if smp_trace {
-            for (core, pc) in [
-                (0usize, cpu.get_pc()),
-                (1usize, cpu1.as_ref().map(|c| c.get_pc()).unwrap_or(0)),
-            ] {
+            let app_pc = machine
+                .cpu_secondary
+                .as_ref()
+                .map(|c| c.get_pc())
+                .unwrap_or(0);
+            for (core, pc) in [(0usize, machine.cpu.get_pc()), (1usize, app_pc)] {
                 for w in watch.iter_mut() {
                     if w.0 == pc && !w.2[core] {
                         w.2[core] = true;
@@ -942,23 +962,21 @@ pub(crate) fn run_firmware(
             }
             if steps.is_multiple_of(10_000_000) {
                 eprintln!(
-                    "SMP: step {steps:>11}  pro=0x{:08x}  app=0x{:08x}",
-                    cpu.get_pc(),
-                    cpu1.as_ref().map(|c| c.get_pc()).unwrap_or(0),
+                    "SMP: step {steps:>11}  pro=0x{:08x}  app=0x{app_pc:08x}",
+                    machine.cpu.get_pc(),
                 );
             }
             // Dense single-step trace window (env LABWIRED_DENSE_FROM / _LEN)
             // for following a context switch instruction-by-instruction.
             if steps >= dense_from && steps < dense_from + dense_len {
                 eprintln!(
-                    "D {steps} pro=0x{:08x} ps={:x} wb={} ws=0x{:04x} exc={} epc1=0x{:08x} | app=0x{:08x}",
-                    cpu.get_pc(),
-                    cpu.ps.as_raw(),
-                    cpu.regs.windowbase(),
-                    cpu.regs.windowstart(),
-                    cpu.sr.read(232),
-                    cpu.sr.read(177),
-                    cpu1.as_ref().map(|c| c.get_pc()).unwrap_or(0),
+                    "D {steps} pro=0x{:08x} ps={:x} wb={} ws=0x{:04x} exc={} epc1=0x{:08x} | app=0x{app_pc:08x}",
+                    machine.cpu.get_pc(),
+                    machine.cpu.ps.as_raw(),
+                    machine.cpu.regs.windowbase(),
+                    machine.cpu.regs.windowstart(),
+                    machine.cpu.sr.read(232),
+                    machine.cpu.sr.read(177),
                 );
             }
         }
@@ -972,7 +990,10 @@ pub(crate) fn run_firmware(
         if let Ok(base) = u32::from_str_radix(s.trim_start_matches("0x"), 16) {
             let mut words = [0u32; 10];
             for (i, w) in words.iter_mut().enumerate() {
-                *w = bus.read_u32(base as u64 + (i * 4) as u64).unwrap_or(0);
+                *w = machine
+                    .bus
+                    .read_u32(base as u64 + (i * 4) as u64)
+                    .unwrap_or(0);
             }
             eprint!("labwired-cli run: Unity@0x{base:08x}:");
             for w in &words {
@@ -985,15 +1006,16 @@ pub(crate) fn run_firmware(
             );
         }
     }
-    let cpu1_pc = cpu1
+    let cpu1_pc = machine
+        .cpu_secondary
         .as_ref()
         .map(|c| format!(" appcpu_pc=0x{:08x}", c.get_pc()))
         .unwrap_or_default();
     eprintln!(
         "labwired-cli run: reached --max-steps {limit}; pc=0x{:08x}{cpu1_pc}",
-        cpu.get_pc(),
+        machine.cpu.get_pc(),
     );
-    export_bus_trace_if_requested(&args.bus_trace_out, &bus);
+    export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
     ExitCode::from(EXIT_PASS)
 }
 

--- a/crates/cli/tests/lifecycle_single_source.rs
+++ b/crates/cli/tests/lifecycle_single_source.rs
@@ -1,0 +1,162 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! THE CONTRACT: `Machine` is the only place the simulation lifecycle lives.
+//! No `labwired` CLI run path may rebuild it out of `Cpu::step` +
+//! `SystemBus::tick_peripherals_*`.
+//!
+//! # The bug class this exists to prevent
+//!
+//! A "run loop" written as
+//!
+//! ```text
+//! while steps < limit {
+//!     cpu.step(&mut bus, &observers, &config)?;
+//!     bus.tick_peripherals_with_costs();
+//!     steps += 1;
+//! }
+//! ```
+//!
+//! looks complete and is not. It reproduces the *legacy-walk* half of
+//! [`labwired_core::Machine::advance`] and silently drops the other half:
+//!
+//! * it never publishes the bus cycle clock
+//!   (`SystemBus::set_current_cycle`), and
+//! * it has no event scheduler at all, because the scheduler heap is a
+//!   `Machine` field that a bare bus cannot reach.
+//!
+//! Both omissions are invisible in a default build, because with the
+//! `event-scheduler` feature OFF the per-cycle walk drives every peripheral
+//! and neither mechanism does anything. With the feature ON the walk SKIPS
+//! every `uses_scheduler()` peripheral, so those two mechanisms become the
+//! *only* thing that advances them — and a hand-rolled loop starves the lot.
+//!
+//! That is not hypothetical. It is exactly how eleven ESP32-classic / ESP32-S3
+//! Tier-1 cells went `pass -> blocked` under
+//! `--features event-scheduler` while every ARM and RISC-V cell stayed green:
+//! ARM and RISC-V `run` already went through `Machine`, and the two Xtensa
+//! `run` paths did not. `esp32::timg` never left cycle 0 (so `TIER1 clock` /
+//! `TIER1 timer` reported `timg0-not-advancing` / `timg0-not-counting`), and
+//! the shared `EspUart` TX FIFO — whose drain under the feature is owned by
+//! `on_event` — never emptied, so the ESP32-S3 boot ROM spun forever inside
+//! `uart_tx_one_char_uart` and no cell reported at all.
+//!
+//! `Machine::step`'s own doc comment already states the rule ("Frontends ...
+//! must not reproduce the lifecycle with direct `Cpu::step` calls"). A doc
+//! comment is not a gate. This is the gate.
+//!
+//! # Why this is a STATIC scan and not a behavioural test
+//!
+//! Every behavioural test in this crate builds a `Machine` — that is how the
+//! test harness gets a machine at all. So a behavioural test exercises the
+//! code path that was already correct and passes identically before and after
+//! the fix. The defect is the *existence of a second implementation*, which is
+//! a property of the source, not of any single run. Reading the source is what
+//! distinguishes them.
+//!
+//! # Scope
+//!
+//! `crates/cli/src` only: the shipped `labwired` binary's run paths. Core's own
+//! tests legitimately drive `tick()` and `Cpu::step` directly to pin
+//! peripheral behaviour, and `crates/core/src/tests/walk_starvation_contract.rs`
+//! already governs the peripheral side of this contract.
+
+use std::path::{Path, PathBuf};
+
+/// Workspace root = two parents up from the cli crate (crates/cli → core).
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read cli src dir").flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Strip `//`-style comments so the prose that DOCUMENTS the banned shape
+/// (including this file's own module docs and the explanatory comment in
+/// `commands/run.rs`) is not itself a violation. Block comments are not used
+/// for prose in this crate; string literals containing these tokens would be
+/// flagged, which is acceptable — none exist and one would be worth a look.
+fn strip_line_comments(line: &str) -> &str {
+    match line.find("//") {
+        Some(i) => &line[..i],
+        None => line,
+    }
+}
+
+/// Every banned token, with the reason it is banned.
+const BANNED: &[(&str, &str)] = &[
+    (
+        "tick_peripherals_",
+        "drives the peripheral walk directly; `Machine::commit_advance_boundary` \
+         owns the peripheral boundary, and it also publishes the cycle clock and \
+         drains the event scheduler, which this call does not",
+    ),
+    (
+        ".step(&mut",
+        "calls `Cpu::step` directly (its first argument is the bus); use \
+         `Machine::step` / `Machine::advance`, which run the whole lifecycle",
+    ),
+];
+
+#[test]
+fn cli_run_paths_do_not_fork_the_machine_lifecycle() {
+    let src = workspace_root().join("crates/cli/src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+
+    // A scan that found no files to scan is a green light for nothing.
+    assert!(
+        files.len() >= 10,
+        "expected to scan the cli crate's sources, found only {} file(s) under {} \
+         — the gate is not looking at anything",
+        files.len(),
+        src.display(),
+    );
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let text = std::fs::read_to_string(file).expect("read cli source");
+        for (lineno, line) in text.lines().enumerate() {
+            let code = strip_line_comments(line);
+            for (token, why) in BANNED {
+                if code.contains(token) {
+                    violations.push(format!(
+                        "{}:{}: `{}` — {}\n      {}",
+                        file.strip_prefix(workspace_root())
+                            .unwrap_or(file)
+                            .display(),
+                        lineno + 1,
+                        token,
+                        why,
+                        line.trim(),
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "a CLI run path is rebuilding the machine lifecycle by hand:\n\n  {}\n\n\
+         Route it through `labwired_core::Machine` (`Machine::step` for a \
+         one-instruction quantum, `Machine::advance`/`Machine::run` for a bounded \
+         run) instead. A hand-rolled `cpu.step` + `tick_peripherals_*` loop omits \
+         `SystemBus::set_current_cycle` and the event scheduler, which starves \
+         every `uses_scheduler()` peripheral under `--features event-scheduler` \
+         — silently, because a default build's per-cycle walk hides it.",
+        violations.join("\n\n  "),
+    );
+}


### PR DESCRIPTION
Unblocks enabling `event-scheduler` for the hosted builder image — which is what makes the measured **4.01× idle-fast-forward win (#850)** real for users instead of inert.

## The symptom

Turning the feature on moved **eleven** ESP32-classic / ESP32-S3 tier-1 cells from `pass` to `blocked` — the fixtures hung rather than reporting — while **no esp32c3 cell moved**.

## Root cause — not a peripheral bug

The two Xtensa `labwired run` paths (`run_firmware_esp32` classic, `run_firmware` S3) reimplemented the machine lifecycle by hand: `cpu.step(&mut bus, …)` + `bus.tick_peripherals_with_costs()` + `steps += 1`.

Neither ever called `SystemBus::set_current_cycle` — the single place that mirrors `total_cycles` into `bus.current_cycle` **and** publishes the shared `CycleClock`. Neither had an event scheduler at all; the heap is a `Machine` field, unreachable from a bare bus.

With the feature on, the per-cycle walk **skips** every `uses_scheduler()` peripheral, so `sync_to(current_cycle)` and the event drain are the only mechanisms left. Both were dead:

- **`esp32::timg`** got `sync_to(0)` forever. Instrumented: **32 calls, every one `now=0`** → `TIER1 clock FAIL code=timg0-not-advancing`, `timer FAIL code=timg0-not-counting`.
- **S3 `EspUart`** — `uses_scheduler()` is true once a clock is attached and the TX drain is owned by `on_event`, so the FIFO never emptied and the boot ROM spun forever. Stall PC `0x40048836..0x40048841` resolves against the real ROM ELF to `uart_tx_one_char_uart`. Nothing reported → all nine S3 cells `blocked`.

**That is exactly why no esp32c3 cell moved.** ARM and RISC-V `run`, and `labwired test` for every arch, already go through `Machine`. Only Xtensa `run` was forked — and `Machine::step`'s own doc already says frontends "must not reproduce the lifecycle with direct `Cpu::step` calls".

## The fix

Delete the second implementation rather than patch it. Both loops now build a `Machine` (`.with_secondary_cpu(c1)` for the S3) and call `machine.step()` — `advance(AdvanceRequest::single())`: one primary quantum, then the secondary, then one peripheral boundary. Same order and cadence as before, plus the cycle clock and the scheduler drain.

Patching `set_current_cycle` into the loops was **measured and rejected**: it fixes classic ESP32 and leaves the S3 stalled, because the scheduler hole remains.

## Evidence

```
cargo test --release -p labwired-cli --test tier1_matrix_ratchet
  → ok, 1 passed
cargo test --release -p labwired-cli --test tier1_matrix_ratchet --features event-scheduler
  → ok, 1 passed        (was: 11 cells pass -> blocked)
```

All 11 cells PASS under the feature. The ratchet's own runtime drops **360s → 120s** with the feature — the walk-free win finally reaching Xtensa. Full CLI suite (release, default): 206 passed, 0 failed. S3 end state under the feature (`pc=0x42015494 appcpu_pc=0x40000400`) is byte-identical to the no-feature baseline.

## Guard

`crates/cli/tests/lifecycle_single_source.rs` statically bans `tick_peripherals_*` and `.step(&mut` under `crates/cli/src`. **Proven non-vacuous** — restored against the pre-fix `run.rs` it FAILS, naming all five sites (`run.rs:496, :511, :825, :899, :910`). It also asserts it scanned ≥10 files, so an empty scan cannot pass. A behavioural test would have been vacuous here: every existing harness builds a `Machine`, which was already the correct path.

No peripheral model is touched (`crates/cli/` only), so the shared-model trap (`esp32::timg` is reused by the C3) does not apply and no drift re-ack is needed.

## Known regression, small

The S3's dedicated `"APP_CPU error at pc=…"` diagnostic is gone. A secondary-core error now surfaces through `Machine::step`'s generic handler, which prints the **primary** core's registers.

## Not done here

`Dockerfile.builder` still does not enable the feature — that is a deploy decision, now unblocked. The stale blocker note in `crates/cli/Cargo.toml` is rewritten to record what the blocker actually was.

**Coverage gap worth closing separately:** no CI lane runs the tier-1 matrix under `--features event-scheduler`, which is how this survived. `esp32_classic_walk_differential` does run with the feature, but drives a `Machine` — so it could never see this.