### PR TITLE
ci(esp32c3): a nightly BLE Pong soak that covers ~30 advertising republish periods

### DIFF
--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -5,6 +5,14 @@ on:
     # Nightly 02:00 UTC (was Sunday-only). Slow coverage / validation lives here.
     - cron: "0 2 * * *"
   workflow_dispatch:
+    inputs:
+      pong_soak_cycles:
+        description: >-
+          Cycles per node for the BLE Pong cadence soak. The default covers
+          ~30 advertising republish periods; raise it to characterise a
+          slower cadence, lower it to get a quick answer.
+        required: false
+        default: "480000000"
 
 permissions:
   contents: write
@@ -282,6 +290,86 @@ jobs:
         run: >
           cargo test --release -p labwired-cli --features event-scheduler
           --test e2e_esp32c3_ble_adv_republish -- --ignored --nocapture
+
+  # ── BLE Pong advertising-cadence soak ─────────────────────────────────────
+  #
+  # `crates/core/tests/world_esp32c3_ble_pong.rs` is release-gated and runs on
+  # push-to-main at `PONG_CYCLES` = 90M cycles per node. Roughly 45M of that is
+  # the C3 mask-ROM boot, so the sketch's `loop()` gets ~140 ms — about ONE
+  # advertising republish period at `PUBLISH_MS` 100. That window is why the
+  # 700 ms cadence regression was reported as "no host frame ever arrived"
+  # instead of being named: it did not fit in the window at all. A cadence that
+  # merely doubled or quadrupled would have fitted, and would have passed.
+  #
+  # This lane is the same test at `PONG_SOAK_CYCLES` = 480M, ~30 republish
+  # periods, which is the length the twin's RW-BLE controller has to survive
+  # for `stop() / setAdvertisementData() / start()` repetition to be under
+  # test at all. ~366 s of run on top of a release build, so it belongs here
+  # and NOT in the merge gate — the constant in the test file stays at 90M on
+  # purpose, because the gate's job is to be fast.
+  #
+  # Its own job rather than a step on `esp32c3-ble-e2e`: a soak that overruns
+  # must not take the three pinned-image BLE gates down with it.
+  esp32c3-ble-pong-soak:
+    name: ESP32-C3 BLE Pong Cadence Soak
+    runs-on: ubuntu-latest
+    # The run is ~6 min; the release build of labwired-core on a cold cache is
+    # the rest. Generous so a slow runner reports the SOAK's verdict rather
+    # than being measured by its own timeout.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-nightly-esp32c3-ble
+          workspaces: |
+            . -> target
+
+      # Everything this needs is committed: the flash image
+      # (crates/core/tests/fixtures/esp32c3-ble-pong-flash.bin), the C3 mask ROM
+      # blobs, and configs/systems/esp32c3-ble-pong.yaml. No fetch step, and no
+      # network — unlike the pinned-image BLE gates above.
+      #
+      # `--release` and `--features event-scheduler` are BOTH load-bearing. The
+      # test file is `#![cfg(all(feature = "event-scheduler",
+      # not(debug_assertions)))]`; drop either and this compiles to an empty
+      # binary that reports "ok. 0 passed" — green while proving nothing. The
+      # step after this one is what makes that impossible to miss.
+      - name: BLE Pong two-node soak (~30 advertising republish periods)
+        env:
+          PONG_SOAK_CYCLES: ${{ inputs.pong_soak_cycles || '480000000' }}
+        run: >
+          cargo test --release -p labwired-core --features event-scheduler
+          --test world_esp32c3_ble_pong -- --nocapture
+          | tee "$RUNNER_TEMP/pong-soak.log"
+
+      # An empty test binary and a passing one both exit 0. Assert the two
+      # properties actually ran, so a cfg/feature slip is a red lane rather
+      # than a soak that silently stops soaking.
+      - name: Assert the soak was not vacuous
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/pong-soak.log"
+          grep -q 'two_c3_nodes_in_one_lab_do_not_share_a_bluetooth_address' "$log" \
+            || { echo "::error::identity property did not run — release/feature gate slipped"; exit 1; }
+          grep -q 'two_c3_nodes_running_one_ble_pong_image_start_the_game' "$log" \
+            || { echo "::error::game-start property did not run — release/feature gate slipped"; exit 1; }
+
+      # The test eprintln!s both nodes' role, last status line and 8-line tail
+      # on PASS as well as on fail. At soak length that tail is the cadence
+      # evidence a human reads, so keep it even when the lane is green.
+      - name: Upload soak console
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: esp32c3-ble-pong-soak-log
+          path: ${{ runner.temp }}/pong-soak.log
+          if-no-files-found: warn
 
   tier1-fixture-drift:
     name: Tier-1 Fixture Drift Check

--- a/crates/core/tests/world_esp32c3_ble_pong.rs
+++ b/crates/core/tests/world_esp32c3_ble_pong.rs
@@ -288,9 +288,12 @@ fn ball(status: &str) -> (i32, i32) {
 /// distinguish "the cadence is too slow" from "delivery is broken".
 ///
 /// Raising it is expensive (the run is the whole cost of this test), so the
-/// budget stays where the gate needs it and characterisation work sets
-/// `PONG_SOAK_CYCLES` instead. CI never sets that variable; the constant below
-/// is what gates a merge.
+/// budget stays where the gate needs it and the long window lives in its own
+/// lane instead: `esp32c3-ble-pong-soak` in `.github/workflows/core-nightly.yml`
+/// runs this same file with `PONG_SOAK_CYCLES=480000000`, ~30 republish
+/// periods. No gate that has to be fast ever sets the variable, so the constant
+/// below is still what gates a merge — do not raise it to buy coverage the
+/// nightly already has.
 const PONG_CYCLES: usize = 90_000_000;
 
 /// ONE two-node run, shared by both tests. The run is the expensive part and
@@ -300,8 +303,9 @@ const PONG_CYCLES: usize = 90_000_000;
 fn consoles() -> &'static (String, String) {
     static RUN: std::sync::OnceLock<(String, String)> = std::sync::OnceLock::new();
     RUN.get_or_init(|| {
-        // Soak override for CHARACTERISATION ONLY — see the note on
-        // PONG_CYCLES. Unset in CI, so the merge gate is always the constant.
+        // Soak override — see the note on PONG_CYCLES. Set ONLY by the nightly
+        // `esp32c3-ble-pong-soak` job and by hand during characterisation; every
+        // gate that has to be fast leaves it unset and runs the constant.
         // It exists because answering "does this advertising cadence stall the
         // twin's RW-BLE controller?" needs tens of republish periods, and
         // hand-editing the constant to find out is how the edited value gets


### PR DESCRIPTION
> **Stacked on #855.** `PONG_SOAK_CYCLES` is introduced by that PR and does not exist on `main`, so this branches from `test/ble-pong-fixture-provenance` and targets it. Merge #855 first; GitHub will retarget this to `main` automatically. Nothing here conflicts with #855 — the workflow hunk is in `core-nightly.yml` (#855 touches `core-ci.yml`) and the test-file hunk is two comments #855 itself wrote.

## The hole

`crates/core/tests/world_esp32c3_ble_pong.rs` runs at `PONG_CYCLES` = 90M cycles per node. Roughly 45M of that is the C3 mask-ROM boot, so the sketch's `loop()` gets about **140 ms — one advertising republish period** at `PUBLISH_MS` 100.

That is why the 700 ms cadence regression surfaced as *"no host frame ever arrived"* instead of being named: it did not fit inside the window at all. A regression to 400 ms **does** fit, and would have passed.

## The lane

`PONG_SOAK_CYCLES` already existed and nothing set it. This wires the lane that does — `esp32c3-ble-pong-soak` in `core-nightly.yml`, **480M cycles per node (~366 s, ~30 republish periods)**, which is the length at which `stop() / setAdvertisementData() / start()` repetition is under test at all. That is the open hazard: a republish cadence that stalls the twin's RW-BLE controller while the silicon is fine.

`PONG_CYCLES` is deliberately **not** raised. The merge gate's job is to be fast; a bigger constant there is the wrong fix. The doc comment on the constant said "CI never sets that variable" — now it points at this lane instead, so the claim stays true.

- **Its own job**, not a step on `esp32c3-ble-e2e`: a soak that overruns must not take the three pinned-image BLE gates down with it.
- **No fetch, no network.** Unlike the pinned-image BLE gates above it, everything this needs is committed: the flash fixture, the C3 mask ROM blobs, `configs/systems/esp32c3-ble-pong.yaml`.
- **`workflow_dispatch` input** `pong_soak_cycles` (default `480000000`) so a characterisation run is one click rather than a hand-edited constant that gets committed by accident.
- **Anti-vacuity step.** The test file is `#![cfg(all(feature = "event-scheduler", not(debug_assertions)))]` — a lost `--release` or `--features` flag makes it an empty binary that exits 0 reporting "ok. 0 passed". A follow-up step greps the log for both property names, so that green goes red.
- `--nocapture` + an uploaded log artifact, because the test `eprintln!`s both nodes' role, last status line and 8-line tail on pass as well as on fail. At soak length that tail is the cadence evidence.

## Evidence

The workflow parses and the job wires up as intended (`yaml.safe_load`; job list, env, and the exact `cargo test` line inspected). The env var name matches the `std::env::var("PONG_SOAK_CYCLES")` read in `consoles()` verbatim.

## Not verified locally — read this before merging

**No `cargo` was run.** The shared Rust build cache is in use by another agent and the volume backing it is at 95%, so I did not compile or execute the soak. Two consequences:

1. The `~366 s` / `~30 republish periods` figures are carried over from the issue, not re-measured. The first nightly run is the measurement. If the job is much slower than that, the 90-minute timeout is the thing to adjust.
2. **This PR widens the window; it does not yet add a quantitative cadence assertion.** With dead reckoning in the sketch, a 400 ms cadence still starts the game, so the two existing properties would pass over the longer window too. What the soak *does* catch red is a controller stall or a delivery break across tens of republishes — and it prints the tail a human reads to name a cadence. A numeric bound (max host↔guest ball divergence, or packet-arrival lag in loop iterations) needs one calibration run to pick a threshold that is neither vacuous nor flaky, and inventing that constant without the run is exactly how a gate ends up measuring nothing. Left as a follow-up on purpose.