### PR TITLE
fix(core): advance the published cycle per instruction in CortexM batches

### DIFF
--- a/crates/cli/tests/arm_batched_path.rs
+++ b/crates/cli/tests/arm_batched_path.rs
@@ -149,23 +149,32 @@ fn default_run_is_untouched_by_the_flags_existence() {
     }
 }
 
-/// Boards whose TIER1 transcript is NOT the same on the batched path, with the
-/// symptom. This is recorded debt, not a tolerance: the browser runs the batched
-/// path, so on these three parts the browser is already showing a firmware
-/// result the single-step CLI does not.
+/// Boards whose TIER1 transcript is NOT the same on the batched path.
 ///
-/// Symptom on all three: `TIER1 timer FAIL code=timer-not-advancing`. The
-/// firmware polls a free-running counter (nRF52 TIMER, RP2040 TIMER) in a tight
-/// loop and sees it frozen, because inside a multi-instruction CPU batch the
-/// peripheral's read-side clock is only resynced at the batch boundary. The
-/// existing fidelity gate `crates/core/tests/nrf52_timer_walk_differential.rs`
-/// does not catch it: it holds `peripheral_tick_interval = 512` but observes
-/// "with single-cycle advance batches", so it varies the tick interval while
-/// keeping the CPU quantum at 1 — the opposite half of what #830 changed.
+/// EMPTY, and the emptiness is the point — every ARM board in `BOARDS` now
+/// produces byte-identical firmware output on both loops.
 ///
-/// This predates this file. It is surfaced here, not introduced here: the
-/// browser has run this path since #830 removed the clamps.
-const KNOWN_DIVERGENT: &[&str] = &["nrf52832", "nrf52840", "rp2040"];
+/// It held `nrf52832`, `nrf52840` and `rp2040`, all with the same symptom:
+/// `TIER1 timer FAIL code=timer-not-advancing`. Firmware polled a free-running
+/// counter (nRF52 TIMER, RP2040 TIMER) in a tight loop and saw it frozen,
+/// because `CortexM::step_batch` left `bus.current_cycle` — and the
+/// `CycleClock` published in lock-step with it — pinned to the BATCH-START
+/// cycle for the whole window, so every lazily-advanced peripheral read the
+/// same instant for `peripheral_tick_interval` instructions. Fixed in #842 by
+/// republishing the live cycle per retired instruction, which `RiscV::step_batch`
+/// had done all along; ARM simply never got that block, which is why no RISC-V
+/// board was ever on this list.
+///
+/// The unit-level twin now lives in
+/// `crates/core/tests/nrf52_timer_walk_differential.rs`
+/// (`timer0_capture_poll_advances_inside_batch_at_tick512`), which polls the
+/// counter from INSIDE a 512-instruction batch — the half that gate was
+/// missing when this list was written.
+///
+/// Keep the list and its two-directional check. This is the seam where a CPU
+/// batch loop and a lazily-advanced peripheral disagree about what time it is,
+/// and it has gone wrong once already.
+const KNOWN_DIVERGENT: &[&str] = &[];
 
 #[test]
 fn batching_does_not_change_what_the_firmware_does() {

--- a/crates/core/src/bus/mmio_activity.rs
+++ b/crates/core/src/bus/mmio_activity.rs
@@ -30,8 +30,33 @@ impl SystemBus {
 
     /// Bookkeep one peripheral MMIO via [`Peripheral::mmio_access_class`]
     /// only — no chip name or register map knowledge on the bus.
+    ///
+    /// Also the one place the shared [`crate::CycleClock`] is refreshed from
+    /// `current_cycle` (issue #842). Every CPU-facing peripheral access —
+    /// all six `dev.read*` dispatch sites and all three `dev.write*` ones —
+    /// passes through here first, which is exactly the property the read-side
+    /// freshness fix needs and exactly the property the bug lacked: a sync
+    /// hung off individual accessors is a sync that some accessor will be
+    /// added without.
+    ///
+    /// It lives HERE rather than in the CPU batch loop because the loop runs
+    /// per retired instruction and this runs per MMIO. The batch loop keeps
+    /// `current_cycle` live with a single in-place add; paying the ATOMIC store
+    /// only when a peripheral is actually touched is what keeps the fix inside
+    /// the throughput gate (the ALU spin fixture it measures does almost no
+    /// MMIO, and firmware that polls a counter pays it once per poll).
     #[inline]
     pub(crate) fn note_mmio_activity(&self, peri_idx: usize, offset: u64) {
+        // Before the bounds check: a model that lazily advances off the clock
+        // must see "now" even if the index lookup below bails.
+        //
+        // Feature-gated because lazy advance is only reachable under it —
+        // `legacy_tick_index_active` keeps every model on the per-cycle walk
+        // when the flag is off, and the batch loop's cycle accumulator is
+        // gated the same way. So a non-`event-scheduler` build has no reader
+        // for a mid-boundary clock value, and stays byte-identical.
+        #[cfg(feature = "event-scheduler")]
+        self.cycle_clock.publish(self.current_cycle);
         let Some(p) = self.peripherals.get(peri_idx) else {
             return;
         };

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -732,12 +732,60 @@ impl Cpu for CortexM {
         // clone + flag check per batch when disarmed.
         let tap = bus.logic_tap().filter(|t| t.push_armed());
 
+        // Exact-cycle clock (issue #842) — the ARM counterpart of the
+        // `exact_clock` block in `RiscV::step_batch`, which ARM never got.
+        // Same contract, cheaper shape (see the accumulator note below).
+        //
+        // `bus.current_cycle` (and the `CycleClock` published in lock-step with
+        // it) is refreshed at machine boundaries, so for the whole of a batch it
+        // holds the BATCH-START cycle. Every model that advances lazily off it —
+        // nRF52 TIMER/RTC, RP2040 TIMER, SysTick, DWT — therefore reads FROZEN
+        // mid-batch, on both the read side (`&self` clock sync) and the write
+        // side (`sync_scheduler_peripheral`, which reads `current_cycle`).
+        // Firmware polling a free-running counter in a tight loop sees it stop
+        // dead for a whole quantum: `TIER1 timer FAIL code=timer-not-advancing`
+        // on nrf52832 / nrf52840 / rp2040.
+        //
+        // Advancing the cycle once per retired instruction makes those accesses
+        // cycle-EXACT — instruction `i` of the batch runs at `batch_start + i`,
+        // which is what interval 1 already gives, where the batch is one
+        // instruction and the boundary refresh does it. That is why this is a
+        // fidelity fix and not a heuristic: the poll exits on the same
+        // instruction at any tick interval.
+        //
+        // Only ARM was affected because only ARM lacked this: RISC-V has carried
+        // it since its own walk-free migration, which is why no RISC-V board is
+        // on the batched-path divergence list.
+        //
+        // `current_cycle` is its OWN accumulator: it already holds the
+        // batch-start cycle on entry, so advancing it in place AFTER each
+        // retired instruction spells the whole fix as one read-modify-write
+        // (`add [bus+off], reg`) and costs no loop-carried register.
+        //
+        // That shape is not incidental. Keeping the live cycle in a local and
+        // storing it (`live = batch_start; …; bus.current_cycle = live; live +=
+        // step`) needs two extra u64s alive across the `step_internal` call, so
+        // both spill to the stack every iteration — measured at +3.2% Ir/step on
+        // all four boards, over the 3% gate. This form measures clean.
+        //
+        // `live_step` is 0 at interval 1, making the update a no-op write that
+        // leaves `current_cycle` pinned to batch-start for the whole batch —
+        // exactly the pre-#842 behaviour, with no test-and-branch per
+        // instruction.
+        #[cfg(feature = "event-scheduler")]
+        let live_step = u64::from(config.peripheral_tick_interval > 1);
+
         if !config.batch_mode_enabled {
             for i in 0..max_count {
                 if let Some(tap) = &tap {
                     tap.bump_clock();
                 }
                 self.step(bus, observers, config)?;
+                // Advance AFTER the step: the instruction just retired ran at
+                // the cycle already published, and this readies the next one.
+                // See the `live_step` block above.
+                #[cfg(feature = "event-scheduler")]
+                bus.publish_cycle(bus.current_cycle() + live_step);
                 // A latched SYSRESETREQ ends the batch on the instruction that
                 // wrote AIRCR, so the machine boundary applies the reset before
                 // anything else retires (see `CortexM::sysreset_signal`).
@@ -788,6 +836,15 @@ impl Cpu for CortexM {
                     tap.bump_clock();
                 }
                 self.step_internal(sysbus, observers, config)?;
+                // The hot arm. Concrete `SystemBus`, so this is one in-place
+                // add on a field, not a virtual call — and deliberately NOT
+                // `set_current_cycle`, whose extra job is republishing the
+                // `CycleClock`. That republish is an atomic store and belongs
+                // on the per-MMIO path (`note_mmio_activity`), not here.
+                #[cfg(feature = "event-scheduler")]
+                {
+                    sysbus.current_cycle += live_step;
+                }
                 executed += 1;
                 // See the `!batch_mode_enabled` arm: a latched SYSRESETREQ ends
                 // the batch here so the reset lands on this exact boundary.
@@ -827,6 +884,9 @@ impl Cpu for CortexM {
                     tap.bump_clock();
                 }
                 self.step_internal(bus, observers, config)?;
+                // See the `live_step` block above.
+                #[cfg(feature = "event-scheduler")]
+                bus.publish_cycle(bus.current_cycle() + live_step);
                 executed += 1;
                 if self.sysreset_latched() {
                     break;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -279,11 +279,20 @@ pub trait Cpu: Send {
         // One Arc clone + flag check per batch when idle; a relaxed atomic
         // increment per instruction while armed.
         let tap = bus.logic_tap().filter(|t| t.push_armed());
+        // Issue #842: republish the live cycle per retired instruction so a
+        // lazily-advanced peripheral is not pinned to the batch-start cycle for
+        // the whole window. Same gate and same rationale as the hand-written
+        // `CortexM::step_batch` / `RiscV::step_batch` twins — see either.
+        #[cfg(feature = "event-scheduler")]
+        let live_step = u64::from(config.peripheral_tick_interval > 1);
         for i in 0..max_count {
             if let Some(tap) = &tap {
                 tap.bump_clock();
             }
             self.step(bus, observers, config)?;
+            // Advance after the step — see `CortexM::step_batch`.
+            #[cfg(feature = "event-scheduler")]
+            bus.publish_cycle(bus.current_cycle() + live_step);
             if config.idle_fast_forward_enabled && self.idle_fast_forward_budget(bus).is_some() {
                 return Ok(i + 1);
             }

--- a/crates/core/tests/kw41z_walk_free_differential.rs
+++ b/crates/core/tests/kw41z_walk_free_differential.rs
@@ -21,13 +21,21 @@
 //!    exactly what the walk would have produced" proof (the CYCCNT reads land at
 //!    arbitrary unaligned cycles and every one is exact).
 //!
-//! 2. `dwt_cyccnt_reads_are_bounded_and_live_at_interval_64` — the same firmware
-//!    with the scheduler lane batched at tick interval 64 vs the walk-on
-//!    interval-1 golden reference. A bare Cortex-M + DWT fixture avoids the SCB
+//! 2. `dwt_cyccnt_reads_are_exact_at_interval_64` — the same firmware with the
+//!    scheduler lane batched at tick interval 64 vs the walk-on interval-1
+//!    golden reference. A bare Cortex-M + DWT fixture avoids the SCB
 //!    reset-fidelity clamp, and the step profile proves that wide batches really
-//!    formed. Mid-batch CYCCNT reads quantise to the batch-start grid, so every
-//!    read stays within one interval of the walk reference and the trace stays
-//!    live. `total_cycles` remains identical.
+//!    formed. Every mid-batch CYCCNT read equals the walk reference exactly, and
+//!    `total_cycles` remains identical.
+//!
+//!    This gate used to assert the opposite — that reads *quantise* to the
+//!    batch-start grid, staying merely within one interval of the reference. It
+//!    was describing issue #842 rather than catching it: `CortexM::step_batch`
+//!    left the published cycle pinned to batch start, so firmware polling any
+//!    lazily-advanced counter watched it stop for a whole quantum. Fixed by
+//!    advancing the cycle per retired instruction, which `RiscV::step_batch`
+//!    always did. The tolerance is gone because there is nothing left to
+//!    tolerate.
 //!
 //! 3. `mcg_tick_is_a_genuine_no_op` / `rsim_tick_is_a_genuine_no_op` — the two
 //!    combinational Kinetis models are driven through their real boot register
@@ -256,11 +264,16 @@ fn dwt_cyccnt_is_byte_identical_at_interval_1() {
 /// as a SINGLE batched call each. Both lanes use the bare Cortex-M + DWT fixture
 /// so SCB reset fidelity cannot clamp them to one instruction. The scheduler
 /// step profile proves wide batches formed (`cpu_batches` is nonzero and
-/// strictly less than `cpu_instructions`); its CYCCNT staircase independently
-/// shows batch-start quantisation. Every sample stays within one interval of the
-/// walk reference, the trace stays live, and `total_cycles` stays identical.
+/// strictly less than `cpu_instructions`), so the samples really are being taken
+/// from inside multi-instruction batches — which is the only place the #842
+/// defect existed. All 800 samples equal the walk reference exactly, and
+/// `total_cycles` stays identical.
+///
+/// This is the strongest of the #842 gates: real `CortexM`, real hand-assembled
+/// Thumb firmware, and the concrete-`SystemBus` batch arm — the hot path a
+/// synthetic `Cpu` test cannot reach.
 #[test]
-fn dwt_cyccnt_reads_are_bounded_and_live_at_interval_64() {
+fn dwt_cyccnt_reads_are_exact_at_interval_64() {
     const STEPS: u64 = 4_000;
     const INTERVAL: u64 = 64;
     // Well under the ~999 samples STEPS produces (loop is 4 instructions), so
@@ -305,7 +318,6 @@ fn dwt_cyccnt_reads_are_bounded_and_live_at_interval_64() {
     let w = read_buf(&walk);
     let s = read_buf(&sched);
 
-    let mut saw_plateau = false;
     for i in 0..N_SAMPLES as usize {
         // Both traces are monotone non-decreasing (CYCCNT never rewinds).
         if i > 0 {
@@ -315,25 +327,23 @@ fn dwt_cyccnt_reads_are_bounded_and_live_at_interval_64() {
                 w[i] > w[i - 1],
                 "walk CYCCNT must strictly advance at sample {i}"
             );
-            if s[i] == s[i - 1] {
-                saw_plateau = true;
-            }
+            // The scheduler lane must advance just as strictly. A plateau here
+            // IS the #842 defect: consecutive polls reading the same value is
+            // firmware watching the clock stop.
+            assert!(
+                s[i] > s[i - 1],
+                "scheduler CYCCNT plateaued at sample {i} (both {}) — mid-batch \
+                 reads are quantised to the batch-start grid again",
+                s[i]
+            );
         }
-        let diff = (w[i] as i64 - s[i] as i64).unsigned_abs();
-        assert!(
-            diff < INTERVAL,
-            "sample {i}: |walk {} - sched {}| = {} exceeds interval {}",
-            w[i],
-            s[i],
-            diff,
-            INTERVAL
+        assert_eq!(
+            w[i], s[i],
+            "sample {i}: walk {} != sched {} — a mid-batch CYCCNT read is not \
+             what the per-cycle walk would have produced",
+            w[i], s[i]
         );
     }
-
-    assert!(
-        saw_plateau,
-        "interval-64 CYCCNT must show batch-start quantisation"
-    );
     // Live, not frozen: the scheduler counter climbs well past zero.
     assert!(
         *s.last().unwrap() > 1_000,

--- a/crates/core/tests/nrf52_timer_walk_differential.rs
+++ b/crates/core/tests/nrf52_timer_walk_differential.rs
@@ -700,3 +700,201 @@ fn radio_disable_mid_transmission_aborts_the_packet() {
         "radio must settle in DISABLED after the abort"
     );
 }
+
+// ── DWT CYCCNT polled from inside a CPU batch (issue #842) ───────────────────
+//
+// The surface the defect actually lives on is a firmware READ of a lazily
+// advanced counter issued from *inside* a CPU batch. Reading from the harness
+// after `advance()` returns cannot see it: the boundary drain has already
+// republished the clock, so the staleness exists only between batch start and
+// batch end. The poll has to ride the CPU.
+//
+// DWT CYCCNT is the cleanest such counter on a Cortex-M bus: it advances 1:1
+// with CPU cycles (so every poll of a healthy build reads a fresh value), it is
+// derived lazily from the published `CycleClock`, and reading it is a PURE read
+// — no MMIO write, therefore no scheduler re-arm. That last property is not
+// cosmetic. The obvious surface, nRF52 TIMER via TASKS_CAPTURE/CC, needs a
+// WRITE per poll, and `Nrf52Timer::take_scheduled_events` bumps `arm_seq` on
+// every write; a fresh token defeats the scheduler's layer-1 identical-wake
+// dedup, so far-future compare wakes pile up until the run trips the
+// `MAX_LIVE_EVENTS_PER_PERIPHERAL` ceiling. That is a real defect, it is
+// pre-existing (it reproduces with this fix reverted, and at quantum 1 where
+// nothing here applies), and it is filed separately — but it makes CAPTURE
+// unusable as a *measuring instrument* for this one, so the measurement uses a
+// surface that does not perturb what it measures.
+
+const DWT_CTRL: u64 = 0xE000_1000;
+const DWT_CYCCNT: u64 = 0xE000_1004;
+const DWT_CTRL_CYCCNTENA: u32 = 1 << 0;
+
+/// A CPU whose every retired instruction is one iteration of a firmware
+/// counter-poll loop: read CYCCNT, remember what it saw. Stands in for the
+/// busy-wait loop in `tests/fixtures/tier1/*.elf` without needing the ELF, and
+/// — unlike a harness-side read — samples where real firmware does: mid-batch.
+#[derive(Debug, Default)]
+struct PollingCpu {
+    pc: u32,
+    observed: Vec<u32>,
+}
+
+impl PollingCpu {
+    /// Longest run of consecutive polls that read the SAME counter value.
+    /// This is the number the bug moves: a counter that only refreshes at
+    /// batch boundaries reads frozen for a whole quantum of polls.
+    fn longest_frozen_run(&self) -> usize {
+        let mut longest = 1usize;
+        let mut run = 1usize;
+        for w in self.observed.windows(2) {
+            if w[0] == w[1] {
+                run += 1;
+                longest = longest.max(run);
+            } else {
+                run = 1;
+            }
+        }
+        longest
+    }
+}
+
+impl Cpu for PollingCpu {
+    fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
+        self.pc = 0;
+        self.observed.clear();
+        Ok(())
+    }
+
+    fn step(
+        &mut self,
+        bus: &mut dyn Bus,
+        _observers: &[Arc<dyn SimulationObserver>],
+        _config: &SimulationConfig,
+    ) -> SimResult<()> {
+        self.observed.push(bus.read_u32(DWT_CYCCNT)?);
+        self.pc = self.pc.wrapping_add(2);
+        Ok(())
+    }
+
+    fn set_pc(&mut self, val: u32) {
+        self.pc = val;
+    }
+    fn get_pc(&self) -> u32 {
+        self.pc
+    }
+    fn set_sp(&mut self, _val: u32) {}
+    fn set_exception_pending(&mut self, _exception_num: u32) {}
+    fn get_register(&self, _id: u8) -> u32 {
+        0
+    }
+    fn set_register(&mut self, _id: u8, _val: u32) {}
+    fn snapshot(&self) -> CpuSnapshot {
+        CpuSnapshot::Arm(ArmCpuSnapshot {
+            registers: vec![0; 16],
+            pc: self.pc,
+            xpsr: 0,
+            primask: false,
+            pending_exceptions: 0,
+            pending_exceptions_hi: Vec::new(),
+            vtor: 0,
+        })
+    }
+    fn apply_snapshot(&mut self, _snapshot: &CpuSnapshot) {}
+    fn get_register_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+    fn index_of_register(&self, _name: &str) -> Option<u8> {
+        None
+    }
+}
+
+fn polling_machine_at_interval(interval: u32) -> Machine<PollingCpu> {
+    let bus = bus_nrf52840_walk_free();
+    let mut machine = Machine::new(PollingCpu::default(), bus);
+    machine.config.peripheral_tick_interval = interval;
+    machine.bus.config.peripheral_tick_interval = interval;
+    // The one write, before the run: arm CYCCNT. The poll loop itself is
+    // read-only (see the note above).
+    machine
+        .bus
+        .write_u32(DWT_CTRL, DWT_CTRL_CYCCNTENA)
+        .expect("arm DWT CYCCNT");
+    machine
+}
+
+fn run_poll(interval: u32, budget: u64) -> Machine<PollingCpu> {
+    let mut m = polling_machine_at_interval(interval);
+    m.advance(AdvanceRequest::run(Some(budget)).with_breakpoints(BreakpointPolicy::Ignore))
+        .expect("Machine::advance");
+    m
+}
+
+/// Issue #842: firmware polling a lazily-advanced counter must see it move
+/// even when the CPU retires a full 512-instruction batch between peripheral
+/// drains. CYCCNT advances once per CPU cycle, so a poll on every retired
+/// instruction reads a fresh value every time; a run the width of the quantum
+/// is the defect.
+#[test]
+fn cyccnt_poll_advances_inside_batch_at_tick512() {
+    const BUDGET: u64 = 4096;
+    let m = run_poll(RECOMMENDED_TICK_INTERVAL, BUDGET);
+
+    let polls = m.cpu.observed.len();
+    let frozen = m.cpu.longest_frozen_run();
+    let distinct = {
+        let mut v = m.cpu.observed.clone();
+        v.dedup();
+        v.len()
+    };
+    assert!(polls > 0, "CPU must have polled at least once");
+    assert!(
+        frozen <= 2,
+        "CYCCNT froze for {frozen} consecutive polls (of {polls}, {distinct} \
+         distinct values) — firmware sees a stopped counter for a whole CPU \
+         batch, because the CPU batch loop is not advancing the cycle the \
+         peripheral syncs against."
+    );
+}
+
+/// The strong form of the same claim: batching must not change what firmware
+/// observes AT ALL. Instruction `i` of a batch runs at `batch_start + i` on
+/// both lanes, so the two poll transcripts have to be equal element for
+/// element — not "close", not "within one tick". This is the gate that would
+/// catch a fix that merely un-freezes the counter while shifting it.
+#[test]
+fn cyccnt_poll_transcript_is_identical_walk1_vs_sched512() {
+    const BUDGET: u64 = 4096;
+
+    let lane_a = run_poll(1, BUDGET);
+    let lane_b = run_poll(RECOMMENDED_TICK_INTERVAL, BUDGET);
+
+    let (a, b) = (&lane_a.cpu.observed, &lane_b.cpu.observed);
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "both lanes must retire the same number of polls"
+    );
+    if let Some(i) = a.iter().zip(b).position(|(x, y)| x != y) {
+        panic!(
+            "poll {i} of {}: quantum 1 read {}, quantum {} read {} — batching \
+             changed what the firmware sees",
+            a.len(),
+            a[i],
+            RECOMMENDED_TICK_INTERVAL,
+            b[i]
+        );
+    }
+}
+
+/// Companion identity gate: the same poll loop at quantum 1 must be exactly
+/// what it always was — every poll a fresh value. Guards against a "fix" that
+/// makes the two lanes agree by degrading the reference lane.
+#[test]
+fn cyccnt_poll_is_exact_at_quantum_1() {
+    const BUDGET: u64 = 512;
+    let m = run_poll(1, BUDGET);
+    let frozen = m.cpu.longest_frozen_run();
+    assert!(
+        frozen <= 2,
+        "quantum 1 must observe a fresh counter on essentially every poll; \
+         longest frozen run was {frozen}"
+    );
+}


### PR DESCRIPTION
## Description

Firmware that polls a free-running counter saw it **frozen for a whole CPU quantum** on the batched execution path — the path the browser has driven exclusively since #830. On `nrf52832`, `nrf52840` and `rp2040` the TIER1 fixture reports `TIER1 timer FAIL code=timer-not-advancing` under `labwired run --batched` while passing on the single-step loop. Users were being shown a firmware result the CLI never reproduced.

### Root cause

`CortexM::step_batch` left `bus.current_cycle` — and the `CycleClock` published in lock-step with it — pinned to the **batch-start** cycle for the whole window. Every model that derives its counter lazily (nRF52 TIMER/RTC, RP2040 TIMER, SysTick, DWT) read the same instant for up to `peripheral_tick_interval` instructions, on the read path and the write path alike.

`RiscV::step_batch` has carried the fix since its own walk-free migration, with a comment describing this exact hazard (`crates/core/src/cpu/riscv.rs`). **ARM simply never got the equivalent block.** That is the entire reason every affected board is Cortex-M and no RISC-V board ever appeared on the divergence list.

The fix advances the cycle once per retired instruction, so instruction `i` of a batch runs at `batch_start + i` — exactly what interval 1 already produced. This is a fidelity fix, not a heuristic: a firmware poll now exits on the same instruction at any tick interval.

Note the read path was deliberately **not** made `&mut`. `crates/core/src/cycle_clock.rs` records that this was already evaluated and rejected as fatal — the CPU holds shared borrows of peripheral-backed buffers during instruction fetch.

### Why the code is shaped the way it is

`current_cycle` is used as its own accumulator so the update is a single read-modify-write with no loop-carried register. Keeping a live cycle in a local instead spills two `u64`s across every `step_internal` call and measured **+3.2% Ir/step — over the 3% perf gate**. The atomic `CycleClock` republish moves to `note_mmio_activity`, which all nine peripheral dispatch sites already funnel through, so the per-instruction path pays no atomic store. `live_step` is `0` at interval 1, leaving that hot path byte-unchanged.

## Related Issues

Fixes #842

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt` and `cargo clippy` — clean; the three remaining clippy warnings are in files this PR does not touch (`rc522.rs`, `esp32c3_shipped_lab_batch_gate.rs`, `esp32_classic_walk_differential.rs`).
- [x] I have added tests that prove my fix is effective — see below, each with a demonstrated negative control.
- [x] I have updated the documentation accordingly — the rationale lives next to the code, and the kw41z gate's module doc now records what it used to assert and why that was wrong.
- [x] My changes generate no new warnings.

### Every gate was verified by reverting the fix with the test in place

A passing test proves nothing unless it can fail, so each was run against reverted source:

| Gate | Without the fix |
| --- | --- |
| `arm_batched_path::batching_does_not_change_what_the_firmware_does` | `rp2040` batched: `TIER1 timer FAIL code=timer-not-advancing` vs stepped `TIER1 timer PASS` |
| `kw41z_walk_free_differential` gate 2 | scheduler lane plateaus; samples drift up to a full interval from the walk reference |
| `cyccnt_poll_advances_inside_batch_at_tick512` | *"CYCCNT froze for 512 consecutive polls (of 4096, 8 distinct values)"* — exactly the quantum width |
| `cyccnt_poll_transcript_is_identical_walk1_vs_sched512` | diverges at poll 1: quantum 1 reads `1`, quantum 512 reads `0` |
| `cyccnt_poll_is_exact_at_quantum_1` | passes either way — it is the reference lane, and it must not move |

With the fix, **all 10 ARM boards produce byte-identical firmware output on both loops**, so `KNOWN_DIVERGENT` in `crates/cli/tests/arm_batched_path.rs` is now empty. That emptiness is the proof the defect is gone.

### One existing gate was asserting the bug

`kw41z_walk_free_differential` gate 2 required CYCCNT reads to **quantise to the batch-start grid**, tolerating a full interval of error and asserting that a plateau was *observed*. It was describing #842 rather than catching it. All 800 samples now equal the walk reference exactly, so the tolerance is gone and the test is renamed `dwt_cyccnt_reads_are_exact_at_interval_64`.

This is the strongest of the three gates: real `CortexM`, real hand-assembled Thumb firmware, and the concrete-`SystemBus` batch arm — the hot path a synthetic `Cpu` test cannot reach.

### Throughput

Re-measured against the committed baselines after merging current `main` (`board_perf.py`, callgrind):

| board | mode | Ir/step | baseline | delta |
| --- | --- | --- | --- | --- |
| nrf52840 | batch | 208.2 | 205.4 | +1.4% |
| rp2040 | batch | 203.8 | 201.3 | +1.2% |
| nrf52832 | batch | 206.8 | 204.1 | +1.3% |
| stm32l476 | batch | 206.7 | 204.7 | +1.0% |
| *(all four)* | step | — | — | −1.6% … +0.0%, no systematic change |

`no throughput regression` — inside the 3% gate. The batched path costs ~1.3% more per step and is now correct; the naive port of the RISC-V loop cost 3.2% and failed.

### A separate defect found on the way, filed on its own

The natural surface for the new gates — nRF52 TIMER via `TASKS_CAPTURE`/`CC` — turned out to be unusable as a measuring instrument. It needs an MMIO **write** per poll, and `Nrf52Timer::take_scheduled_events` bumps `arm_seq` on every write. Since the scheduler's layer-1 dedup keys on `(peripheral_idx, event_token, deadline)`, a fresh token every time means dedup can never fire, and far-future compare wakes pile up until the run trips `MAX_LIVE_EVENTS_PER_PERIPHERAL` — the `#570` unbounded-heap class the scheduler docs name.

This is **pre-existing and unrelated**: it reproduces with this fix reverted, and at quantum 1 where none of this applies. Filed as #861 rather than folded in here. The new gates poll DWT CYCCNT instead — a pure read, so the instrument does not perturb what it measures.

### Test results

Branch (with `main` merged in) vs pristine `main`, same command, same machine:

- `labwired-core --features event-scheduler --no-fail-fast`: **159 test binaries pass on both.**
- The failing set is **byte-identical on both sides** — `diff` of the two sorted lists is empty, so this PR introduces no failure:
  - `firmware_drives_aht20_and_bmp280_through_simulator`
  - `firmware_drives_panel_to_three_band_pattern`
  - `l476_bldc_never_reports_target_without_rotor_motion`
  - `l476_bldc_stall_runs_real_firmware_and_disables_real_inverter`
  - `test_strict_board_onboarding`
- All five are the same environmental cause: this machine has only `thumbv6m-none-eabi`, `riscv32i`, `riscv32imc` and host targets installed, and each of these builds example firmware for `thumbv7m-none-eabi` / `thumbv7em-none-eabihf`. They fail at *firmware build*, before any simulation runs.
- `labwired-cli --features event-scheduler --release`: **45 test binaries pass**; the one failure (`test_demo_blinky_gpio_toggle`) is the same missing-cross-target class.

*(An earlier revision of this description said "3 failures". That was an undercount from a truncated grep window, not a change in behaviour — the corrected list above is from a full diff against pristine `main`.)*