### PR TITLE
fix(nrf52): keep the TIMER arming token steady across redundant re-arms

### DIFF
--- a/crates/core/src/peripherals/nrf52/timer.rs
+++ b/crates/core/src/peripherals/nrf52/timer.rs
@@ -90,10 +90,15 @@ pub struct Nrf52Timer {
     clock: Option<CycleClock>,
     /// CPU cycle of the last `sync_to` / advance.
     anchor: u64,
-    /// Bumped each arm so stale compare events die on arrival.
+    /// Bumped when the armed instant CHANGES, so stale compare events die on
+    /// arrival. Deliberately NOT bumped on a re-arm that targets the cycle
+    /// already in flight — see `take_scheduled_events`.
     arm_seq: u32,
     /// True while a compare event is live in the scheduler.
     scheduled: bool,
+    /// Absolute CPU cycle the live wake targets, or `None` when nothing is
+    /// armed. Paired with `arm_seq` to recognise a redundant re-arm.
+    armed_target: Option<u64>,
 }
 
 impl Default for Nrf52Timer {
@@ -114,6 +119,7 @@ impl Default for Nrf52Timer {
             anchor: 0,
             arm_seq: 0,
             scheduled: false,
+            armed_target: None,
         }
     }
 }
@@ -405,16 +411,37 @@ impl Peripheral for Nrf52Timer {
     fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
         if !self.scheduler_mode() || !self.running || self.mode != MODE_TIMER {
             self.scheduled = false;
+            self.armed_target = None;
             return Vec::new();
         }
         let Some(d) = self.cycles_until_next_compare() else {
             self.scheduled = false;
+            self.armed_target = None;
             return Vec::new();
         };
-        // Always re-arm with a fresh token so a CC rewrite invalidates the
-        // previous deadline. Dedup is not required for correctness.
-        self.arm_seq = self.arm_seq.wrapping_add(1);
+        // `d` counts from `anchor`, so this is the absolute cycle the compare
+        // lands on — the same instant the scheduler derives as its deadline.
+        let target = self.anchor.saturating_add(d);
+
+        // Re-arm with a FRESH token only when the instant actually moved (a CC
+        // rewrite, a prescaler change, a restart); a stale wake must then die on
+        // arrival, which is what the token check in `on_event` is for.
+        //
+        // Re-arming the instant already in flight must reuse the token instead.
+        // This drain runs after EVERY MMIO write to the peripheral, and reading
+        // the nRF52 counter is defined as a write (strobe `TASKS_CAPTURE[i]`,
+        // then read `CC[i]` — there is no COUNTER register). A fresh token every
+        // time makes the scheduler's dedup key `(peripheral_idx, event_token,
+        // deadline)` unique on every poll, so dedup can never fire and each poll
+        // leaves another live wake behind. With a far compare those never drain
+        // and the peripheral walks into `MAX_LIVE_EVENTS_PER_PERIPHERAL` — the
+        // unbounded-heap class the scheduler docs describe. Holding the token
+        // steady keeps the key identical, so layer-1 dedup collapses the repeat.
+        if !(self.scheduled && self.armed_target == Some(target)) {
+            self.arm_seq = self.arm_seq.wrapping_add(1);
+        }
         self.scheduled = true;
+        self.armed_target = Some(target);
         vec![(d.saturating_sub(1), self.arm_seq)]
     }
 
@@ -440,6 +467,15 @@ impl Peripheral for Nrf52Timer {
         };
         self.scheduled = self.running && self.mode == MODE_TIMER;
         let next = self.cycles_until_next_compare();
+        // `reschedule_delay` re-arms under the SAME token, so record the instant
+        // it targets. Without this, `armed_target` would still name the compare
+        // that just fired and the next drain would count as a change, bumping
+        // the token and killing the reschedule it had just handed back.
+        self.armed_target = if self.scheduled {
+            next.map(|d| now.saturating_add(d))
+        } else {
+            None
+        };
         crate::sched::EventResult {
             raise_own_irq: res.irq,
             fired_events: res.fired_events,

--- a/crates/core/src/sched/mod.rs
+++ b/crates/core/src/sched/mod.rs
@@ -15,6 +15,7 @@ pub mod result;
 
 pub use clock::{ClockDomain, ClockGraph};
 pub use event_scheduler::{
-    EventScheduler, ScheduledEvent, SchedulerStats, SimCycle, SUBSYSTEM_PERIPHERAL_IDX,
+    EventScheduler, ScheduledEvent, SchedulerStats, SimCycle, MAX_LIVE_EVENTS_PER_PERIPHERAL,
+    SUBSYSTEM_PERIPHERAL_IDX,
 };
 pub use result::EventResult;

--- a/crates/core/tests/nrf52_timer_walk_differential.rs
+++ b/crates/core/tests/nrf52_timer_walk_differential.rs
@@ -26,6 +26,12 @@
 //! 6. RADIO air time vs a spurious wake — an MMIO write to the RADIO while a
 //!    packet is transmitting must not shorten it, and TASKS_DISABLE mid-flight
 //!    must abort it rather than let it complete.
+//! 7. DWT CYCCNT polled from inside a CPU batch — the counter must advance per
+//!    retired instruction, not per batch (#842). Quantum 1 is the reference
+//!    lane and must stay byte-identical to quantum 512.
+//! 8. TIMER0 residency under a poll loop — repeatedly capturing a running timer
+//!    re-arms the same compare hundreds of times; those redundant wakes must
+//!    collapse via scheduler dedup instead of accumulating (#861).
 //!
 //! Requires `--features event-scheduler`.
 
@@ -253,6 +259,82 @@ fn timer0_compare_walk1_vs_sched512_cycle_identity() {
         "both lanes must latch EVENTS_COMPARE[0]"
     );
     assert_cycle_identity(at_a, at_b, "TIMER0 COMPARE[0]");
+}
+
+const TIMER_TASKS_CAPTURE1: u64 = TIMER0 + 0x044;
+const TIMER_CC1: u64 = TIMER0 + 0x544;
+
+/// Reading the nRF52 counter is *defined* as a write: there is no COUNTER
+/// register, so firmware strobes `TASKS_CAPTURE[i]` and then reads `CC[i]`.
+/// Every one of those writes drains `take_scheduled_events`, so a poll loop is
+/// the peripheral re-arming itself hundreds of times against a compare that has
+/// not moved.
+///
+/// The scheduler has no cancel API — an armed wake is always delivered — so the
+/// only way to stay inside `MAX_LIVE_EVENTS_PER_PERIPHERAL` is for a redundant
+/// re-arm to be recognised and collapsed by layer-1 dedup. Dedup keys on
+/// `(peripheral_idx, event_token, deadline)`, so that only works while the token
+/// holds steady across polls that do not move the compare.
+///
+/// Regression gate for #861: the timer used to bump `arm_seq` unconditionally,
+/// making the key unique on every poll. Dedup could never fire and each poll
+/// left another far-future wake resident. Reverting the fix trips the ceiling
+/// here (`peripheral N holds 9 live events (ceiling 8)`) within the first dozen
+/// polls, long before the 200 this gate performs.
+///
+/// The compare is deliberately far away (~16M cycles at PRESCALER=0) so nothing
+/// drains it: every wake armed during the loop is still resident at the end,
+/// which is exactly the condition the ceiling exists to catch.
+#[test]
+fn polling_a_running_timer_does_not_hoard_scheduler_wakes() {
+    const FAR_CC: u32 = 0x0100_0000;
+    const POLLS: usize = 200;
+
+    let mut m = machine_at_interval(1);
+    arm_timer0_compare(&mut m, FAR_CC);
+
+    let mut captures = Vec::with_capacity(POLLS);
+    for _ in 0..POLLS {
+        m.advance(AdvanceRequest::run(Some(4)).with_breakpoints(BreakpointPolicy::Ignore))
+            .expect("Machine::advance");
+        // The real firmware idiom: strobe CAPTURE, then read the channel back.
+        m.bus
+            .write_u32(TIMER_TASKS_CAPTURE1, 1)
+            .expect("TASKS_CAPTURE[1] is a legal MMIO write");
+        captures.push(m.bus.read_u32(TIMER_CC1).expect("CC[1] readback"));
+    }
+
+    let stats = m.sched.stats();
+    assert_eq!(
+        stats.live_event_ceiling_trips,
+        0,
+        "polling a running TIMER leaked wakes: {} ceiling trips, max live per \
+         peripheral {} (ceiling {})",
+        stats.live_event_ceiling_trips,
+        stats.max_live_events_per_peripheral,
+        labwired_core::sched::MAX_LIVE_EVENTS_PER_PERIPHERAL
+    );
+    assert!(
+        stats.max_live_events_per_peripheral
+            <= labwired_core::sched::MAX_LIVE_EVENTS_PER_PERIPHERAL,
+        "live-event high-water mark {} exceeded the ceiling {}",
+        stats.max_live_events_per_peripheral,
+        labwired_core::sched::MAX_LIVE_EVENTS_PER_PERIPHERAL
+    );
+
+    // Not hoarding must not mean not working: the captured counter has to keep
+    // moving, or this would pass just as well with the timer wedged.
+    assert!(
+        captures.last() > captures.first(),
+        "captured counter never advanced across {POLLS} polls ({:?} → {:?})",
+        captures.first(),
+        captures.last()
+    );
+    assert!(
+        !timer_compare_done(&m),
+        "the far compare must NOT have fired — otherwise the wakes drained and \
+         this gate proves nothing about residency"
+    );
 }
 
 // ── RTC0 COMPARE (EVTEN + INTEN path) ───────────────────────────────────────

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -7,8 +7,8 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 
 | Board | Tier | Last silicon capture | Newest model | Status |
 |-------|------|----------------------|--------------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-08-07 | ⚠ drift acked 2026-08-08 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-08-07 | ⚠ drift acked 2026-08-08 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | 2026-08-08 | ⚠ drift acked 2026-08-08 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | 2026-08-08 | ⚠ drift acked 2026-08-08 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | 2026-08-08 | ⚠ drift acked 2026-08-08 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | 2026-08-07 | ⚠ drift acked 2026-08-07 (re-capture pending) |
@@ -21,7 +21,7 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 | `nrf52832` | ⚪ structural | — | 2026-08-03 | no silicon capture |
 | `rp2040` | ⚪ structural | — | 2026-08-05 | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | 2026-08-05 | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-07 | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-08 | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-07 | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | 2026-08-07 | no silicon capture |
 | `esp32` | ⚪ structural | — | 2026-08-05 | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -180,8 +180,19 @@ boards:
     # 16/16 sweep changes address, reset value or access, and no base moves.
     # Owner-authorised ack WITHOUT a live re-capture; the RADIO packet-timing
     # live diff remains owed and is NOT evidenced by this entry.
+    # 2026-08-08: TIMER scheduler re-arm dedup (#861). `take_scheduled_events`
+    # kept minting a fresh arming token on every drain, which runs after every
+    # MMIO write; since scheduler dedup keys on (peripheral, token, deadline),
+    # a poll loop left one far-future compare wake resident per poll until the
+    # live-event ceiling tripped. The token now holds steady when a re-arm
+    # targets the instant already in flight. Scheduler bookkeeping, not silicon
+    # surface: no register in the asserted 16/16 sweep changes address, reset
+    # value or access; counter width/BITMODE masking, prescaler division,
+    # CC compare matching, SHORTS and EVENTS_COMPARE latching are all untouched,
+    # and TIMER0's 16/0 sweep re-runs green. Acked WITHOUT a live re-capture —
+    # no TIMER live diff is evidenced by this entry.
     drift_ack: 2026-08-08
-    drift_ack_digest: 8ea8122dea22fc64528fc41181d8e9b3d1e9b84a0d46cd499eec68a9d5f6213f
+    drift_ack_digest: 79e76b4dc42241fa06f7a45a78ea0f47e05dd1239521598e1a2d2ee0dce787fc
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -277,8 +288,12 @@ boards:
     # 16/16 sweep changes address, reset value or access, and no base moves.
     # Owner-authorised ack WITHOUT a live re-capture; the RADIO packet-timing
     # live diff remains owed and is NOT evidenced by this entry.
+    # 2026-08-08: rides the nrf52840 TIMER scheduler re-arm dedup (#861); same
+    # silicon. Scheduler bookkeeping only — no register address, reset value or
+    # access in the asserted sweep changes. See the nrf52840 drift_ack note; no
+    # TIMER live re-capture is evidenced by this entry.
     drift_ack: 2026-08-08
-    drift_ack_digest: 8ea8122dea22fc64528fc41181d8e9b3d1e9b84a0d46cd499eec68a9d5f6213f
+    drift_ack_digest: 79e76b4dc42241fa06f7a45a78ea0f47e05dd1239521598e1a2d2ee0dce787fc
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml


### PR DESCRIPTION
## Description

`Nrf52Timer::take_scheduled_events` bumped `arm_seq` on **every** call. That drain runs after every MMIO write to the peripheral, so every write to a running TIMER minted a new arming token.

The scheduler's layer-1 dedup keys on `(peripheral_idx, event_token, deadline)`, so a fresh token made the key unique on every poll and dedup could never fire. There is no scheduler-side cancel — an armed wake is always delivered — so each poll left another far-future compare wake resident until the peripheral walked into `MAX_LIVE_EVENTS_PER_PERIPHERAL`. This is the `#570` unbounded-heap class the scheduler's own docs name.

### Why a plain poll loop is the worst case

Reading the nRF52 counter is *defined* as a write. There is no COUNTER register — firmware strobes `TASKS_CAPTURE[i]` and then reads `CC[i]`. So "poll the timer", one of the most common things firmware does, is precisely the pattern that mints a token per iteration. It trips the ceiling within a dozen polls.

With a far compare (BITMODE=32 and a distant CC, up to 2^32 cycles out) those wakes never drain inside a realistic run.

### The two builds fail differently, and the release one is worse

- **Debug / tests:** hard panic on the `debug_assert`. A unit test that polls the TIMER the way real firmware does could not be written before this.
- **Release — what users and the browser actually run:** no panic. `live_event_ceiling_trips` increments and the heap grows for the lifetime of the run: a leak plus a rising O(log n) scheduling cost, on exactly the busy-wait pattern that is most common.

### The fix

Bump the token only when the armed instant actually moves. `armed_target` records the absolute cycle the live wake targets, so re-arming the instant already in flight reuses the token, the dedup key comes out identical, and the repeat collapses.

A genuine reconfiguration (CC rewrite, prescaler change, restart) still moves the target and still mints a fresh token — which is what the token exists for, since stale wakes must die on arrival in `on_event`.

`on_event` also records the target of the wake it hands back via `reschedule_delay`. That path deliberately reuses the current token, so without this the next drain would see a changed target, bump the token, and invalidate the reschedule it had just been given.

## Related Issues

Fixes #861

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist

- [x] I have run `cargo fmt` and `cargo clippy` — no new warnings; the three that remain are in files this PR does not touch (`rc522.rs`, `esp32c3_shipped_lab_batch_gate.rs`, `esp32_classic_walk_differential.rs`).
- [x] I have added a test that proves the fix is effective, with a demonstrated negative control.
- [x] I have updated the documentation accordingly — the rationale sits next to the code, and the test module's surface list now covers this gate and the #842 gates that landed in #860.
- [x] My changes generate no new warnings.

### The gate fails without the fix

`polling_a_running_timer_does_not_hoard_scheduler_wakes` arms a compare ~16M cycles out so nothing can drain it, then polls 200 times via `TASKS_CAPTURE`. Reverting just the token condition:

```
peripheral 14 holds 9 live events (ceiling 8): it re-arms without superseding
prior wakes — see the cancellation contract in this module's docs
```

— within the first dozen polls, far short of the 200 the gate performs.

The gate also asserts the captured counter keeps advancing and that the far compare never fired, so it cannot be satisfied by a wedged timer, nor by quietly draining the wakes it is supposed to be counting.

### Scope: two lookalikes deliberately left alone

`systick` and `esp32c3::ledc` share the same unconditional-bump shape. I did not change them. Both arm bounded, short deadlines that drain long before residency can build, and I could not construct a reproduction for either — so a change there would be speculative, and the token's invalidation semantics are load-bearing enough that I would not want to alter them without a failing test first. Noted in #861 for follow-up.

### Test results

- `labwired-core --features event-scheduler --no-fail-fast`: **159 test binaries pass.** Failing set is byte-identical to pristine `main` (`diff` empty) — the same five environmental failures, all example-firmware builds needing cross-targets not installed on this machine (`thumbv7m-none-eabi` / `thumbv7em-none-eabihf`).
- `labwired-cli --features event-scheduler --release`: **45 test binaries pass**; the single failure (`test_demo_blinky_gpio_toggle`) is the same missing-cross-target class.
- Perf (`board_perf.py`, callgrind) on the four boards this could plausibly touch — `no throughput regression`, and flat against the post-#860 measurements:

| board | mode | Ir/step | baseline | delta |
| --- | --- | --- | --- | --- |
| nrf52840 | batch | 208.1 | 205.4 | +1.3% |
| nrf52832 | batch | 206.8 | 204.1 | +1.3% |
| rp2040 | batch | 203.8 | 201.3 | +1.2% |
| stm32l476 | batch | 207.3 | 204.7 | +1.3% |

Those deltas are #860's, not this PR's — the committed baselines predate that merge and have not been re-recorded. Measured against post-#860 numbers this change is within noise (nrf52840 batch 208.1 vs 208.2).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRg2RBuVbEyw2N45yeest9)_