### PR TITLE
docs(readme): plain-English pass, and drop the printed-constant claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 # LabWired Core
 
-> Run your firmware on a virtual instance of a real chip, from your terminal, your CI, or
-> your AI coding agent. No board on your desk.
+Run your firmware on a virtual instance of a real chip, from your terminal, your CI, or your
+AI coding agent. No board on your desk.
 
 [![Rust Core CI](https://github.com/w1ne/labwired-core/actions/workflows/core-ci.yml/badge.svg?branch=main)](https://github.com/w1ne/labwired-core/actions/workflows/core-ci.yml)
 [![Board CI](https://github.com/w1ne/labwired-core/actions/workflows/core-board-ci.yml/badge.svg?branch=main)](https://github.com/w1ne/labwired-core/actions/workflows/core-board-ci.yml)
@@ -25,27 +25,54 @@
 
 <img alt="labwired test booting an nRF54L15 and gating on the result" src="https://raw.githubusercontent.com/w1ne/labwired-core/main/docs/assets/labwired-demo.gif" width="100%">
 
-<sub>Real terminal, real binary, nothing staged — recorded from
-[`docs/assets/demo.tape`](docs/assets/demo.tape), which you can re-run. The second half
-breaks one assertion on purpose: a gate that only ever goes green is not a gate.</sub>
+<sub>Recorded from [`docs/assets/demo.tape`](docs/assets/demo.tape) against a real binary. You
+can re-run it. The second half breaks an assertion on purpose, so you can see the gate
+fail.</sub>
 
-LabWired Core loads a real firmware ELF and executes it against modeled silicon: CPU,
-buses, peripherals, sensors, displays, and protocol devices. You get UART, GPIO, bus
-traces, and pass/fail, deterministically and without hardware.
+## What is LabWired Core?
 
-We publish what we model, what is smoke-tested, and what has been compared against real
-hardware, including [where we still cheat](FIDELITY.md).
+LabWired Core loads a firmware ELF and executes it against modeled silicon: CPU, buses,
+peripherals, sensors, displays, and protocol devices. You get UART output, GPIO and bus
+traces, register state, and a pass/fail exit code.
 
-This repository is the engine behind [labwired.com](https://labwired.com/). There is also
-a hosted browser [Playground](https://app.labwired.com/) and a hosted MCP connector, both
-running the same models. If you want to see it before installing anything, open a lab in
-the browser: [SSD1306 hello](https://app.labwired.com/?lab=ssd1306-hello-lab),
+Runs are deterministic. The same ELF and the same board manifest give the same trace on
+every machine. That is what makes a simulator run usable as a CI gate.
+
+Supported cores:
+
+* ARM Cortex-M0+, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M33
+* RISC-V
+* Xtensa LX6 and LX7 (selected ESP32 paths)
+
+This repository is the engine behind [labwired.com](https://labwired.com/). The hosted
+browser [Playground](https://app.labwired.com/) and the hosted MCP connector run the same
+models. To look before installing anything, open a lab:
+[SSD1306 hello](https://app.labwired.com/?lab=ssd1306-hello-lab),
 [BME280 weather](https://app.labwired.com/?lab=bme280-weather-lab), or
 [IO-Link DI/DO](https://app.labwired.com/?lab=iolink-dido).
 
+## Why use LabWired Core?
+
+Testing firmware on real boards is slow. You wait for hardware, you flash it, and when
+something breaks you get a dark LED and no trace. Do that for every board in a product line
+and a hardware CI bench stops being worth the upkeep.
+
+LabWired runs the same binary you would flash. You assert on what the firmware made the
+hardware do.
+
+Two things separate it from a CPU emulator.
+
+**The board is modeled, not only the chip.** Sensors, displays, and bus devices live in the
+system manifest. You can assert on I2C traffic, SPI framing, or what a panel was told to
+draw.
+
+**We publish where the model is thin.** Every capability sits in a named tier. Anywhere the
+simulator short-circuits real hardware, we write it down in the
+[Fidelity Ledger](FIDELITY.md). You cannot gate on a simulator you cannot audit.
+
 ## Quickstart
 
-Clone the repo, install the CLI, run a firmware. No cross-toolchain needed.
+Clone the repository, install the CLI, run a firmware. No cross-toolchain needed.
 
 ```sh
 git clone https://github.com/w1ne/labwired-core && cd labwired-core
@@ -62,63 +89,68 @@ PASS  4/4 checks · io-smoke · 200000 steps · 0.04s
 ```
 
 That is a committed bare-metal ELF booting on an nRF54L15-DK profile in under a second.
-The firmware read its own memory geometry and peripheral bases out of the modeled chip,
-and the script asserts all three lines plus the stop reason — the four checks in that
-verdict. The register map comes from the MDK/SVD data for this part, so the output is a
-check on the chip model, not a printed constant. Nothing is compiled on your machine.
+Nothing is compiled on your machine.
 
-The verdict goes to stderr and the exit code is the gate: `0` for pass, non-zero for a
-failed assertion. Firmware UART output and `--json` both stay on stdout, so piping is
-unaffected.
+The four checks are the three UART lines plus the stop reason.
 
-Linux, macOS, and Windows via WSL2. `LABWIRED_VERSION=` pins a release,
-`LABWIRED_INSTALL_DIR=` sets the install directory, `LABWIRED_FROM_SOURCE=1` builds from
-source. To read the installer first:
-`curl -fsSL https://labwired.com/install.sh -o install.sh`, review it, then `sh install.sh`.
+The firmware prints those lines from string literals. The text proves nothing by itself.
+What it proves is that the bytes arrived. To send them, the firmware had to boot from RRAM
+at `0x0`, set up RAM at `0x20000000`, and drive UARTE20 over EasyDMA. Get the UARTE base
+wrong in the chip model and you get no output at all.
 
-## Three ways to drive it
+GPIO is checked at the pin, not in the banner, by
+`firmware_survival::test_nrf54l15_lights_dk_led0`. The
+[example README](examples/nrf54l15-dk/README.md) says why both tests are needed.
 
-<details>
-<summary><b>From your terminal</b></summary>
+The verdict goes to stderr. The exit code is the gate: `0` passes, anything else fails.
+UART output and `--json` stay on stdout, so pipes keep working.
+
+## Installation
+
+The install script covers Linux, macOS, and Windows via WSL2.
+
+```sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh
+```
+
+| Variable | Effect |
+| --- | --- |
+| `LABWIRED_VERSION=` | pin a release |
+| `LABWIRED_INSTALL_DIR=` | choose the install directory |
+| `LABWIRED_FROM_SOURCE=1` | build from source instead of downloading |
+
+To read the installer before running it:
+
+```sh
+curl -fsSL https://labwired.com/install.sh -o install.sh   # review it, then:
+sh install.sh
+```
+
+Or build it yourself:
+
+```sh
+cargo build --release -p labwired-cli
+```
+
+## Running LabWired
+
+### From your terminal
 
 ```sh
 labwired run  --firmware path/to/firmware.elf --system configs/systems/<board>.yaml
 labwired test --script  path/to/test.yaml --junit report.xml
 ```
 
-`run` is interactive: UART, GPIO, traces, snapshots. `test` is the deterministic gate. It
-emits `result.json`, `uart.log`, and JUnit, and returns an exit code. See the
-[CLI reference](docs/cli_reference.md) and [test runner](docs/ci_test_runner.md).
-</details>
+`run` is interactive: UART, GPIO, traces, snapshots.
 
-<details>
-<summary><b>From your AI coding agent (MCP)</b></summary>
+`test` is the gate. It writes `result.json`, `uart.log`, and JUnit, and returns an exit code.
+Assertions cover UART content, memory and register values, stop reasons, and step and
+wall-time limits.
 
-LabWired speaks MCP, so an agent can assemble a board, run firmware, and read back the
-result without you driving the toolchain.
+See the [CLI reference](docs/cli_reference.md) and the
+[test runner reference](docs/ci_test_runner.md).
 
-```sh
-claude mcp add labwired --transport http https://api.labwired.com/mcp
-codex   mcp add labwired --url https://api.labwired.com/mcp
-```
-
-On first use your client opens a browser to sign in. Other MCP clients take the standard
-block:
-
-```json
-{ "mcpServers": { "labwired": { "type": "http", "url": "https://api.labwired.com/mcp" } } }
-```
-
-Then tell your agent:
-
-> *"Connect LabWired over MCP. Load a virtual STM32 LED + UART board, run the firmware,
-> check the UART output, and give me the Playground URL."*
-
-Agents working inside this repository should read [docs/agents.md](docs/agents.md).
-</details>
-
-<details>
-<summary><b>In CI</b></summary>
+### In CI
 
 The same YAML scripts are the merge gate, with no HIL bench to maintain:
 
@@ -126,50 +158,74 @@ The same YAML scripts are the merge gate, with no HIL bench to maintain:
 - run: labwired test --script examples/ci/uart-ok.yaml --junit report.xml
 ```
 
-Assertions cover UART content, memory and register values, stop reasons, and step and
-wall-time limits. See [CI integration](docs/ci_integration.md) and
+See [CI integration](docs/ci_integration.md) and
 [labwired.com/ci](https://labwired.com/ci.html).
-</details>
 
-## How it works
+### From an AI coding agent (MCP)
 
-Your firmware ELF runs against a modeled chip and board, produces real peripheral traffic,
-and gives you output you can assert on. Runs are deterministic: the same inputs give the
-same trace on every machine.
+LabWired speaks MCP. An agent can assemble a board, run firmware, and read the result back.
+You never touch the toolchain.
 
-A board is described in data rather than code. A chip descriptor in
-[`configs/chips`](configs/chips/) and a system manifest in
-[`configs/systems`](configs/systems/) wire up memory, pins, buses, and attached devices.
-Firmware writes to modeled registers and the modeled hardware drives the firmware back.
-The quickstart above passes because the firmware really read the nRF54L15 memory geometry
-and UARTE/GPIO bases out of that data, not because the result was stubbed.
+```sh
+claude mcp add labwired --transport http https://api.labwired.com/mcp
+codex   mcp add labwired --url https://api.labwired.com/mcp
+```
+
+Your client opens a browser to sign in on first use. Other MCP clients take the standard
+block:
+
+```json
+{ "mcpServers": { "labwired": { "type": "http", "url": "https://api.labwired.com/mcp" } } }
+```
+
+Then ask for what you want:
+
+> *"Connect LabWired over MCP. Load a virtual STM32 LED + UART board, run the firmware,
+> check the UART output, and give me the Playground URL."*
+
+Agents working inside this repository should read [docs/agents.md](docs/agents.md).
+
+## How a board is described
+
+A board is data, not code.
+
+A chip descriptor in [`configs/chips`](configs/chips/) declares memory geometry, cores, and
+peripheral bases. A system manifest in [`configs/systems`](configs/systems/) wires up pins,
+buses, and the devices on them. Firmware writes to modeled registers. The modeled hardware
+drives the firmware back.
+
+To add a board you write those two files and an example. You do not patch the engine. See
+the [board onboarding playbook](docs/board_onboarding_playbook.md) and the
+[configuration reference](docs/configuration_reference.md).
 
 ## What we validate
 
-Every capability here sits in one of three tiers, and we say which:
+Every capability sits in one of three tiers, and we say which:
 
-- **Modeled**: simulator logic exists and firmware can execute against it.
-- **Smoke-tested**: a committed test or example exercises the model and checks output.
-- **Hardware-compared**: captured silicon behavior is diffed against simulator behavior
-  for a documented scope.
+* **Modeled** — simulator logic exists and firmware can execute against it.
+* **Smoke-tested** — a committed test or example exercises the model and checks output.
+* **Hardware-compared** — captured silicon behavior is diffed against simulator behavior for
+  a documented scope.
 
-The NUCLEO-H563ZI example is the reference case, with the same firmware on a physical
-board and on the simulator and the artifacts committed:
+The NUCLEO-H563ZI example is the reference case. The same firmware runs on a physical board
+and on the simulator, and the artifacts are committed. See
 [`VALIDATION.md`](examples/nucleo-h563zi/VALIDATION.md),
 [`determinism_report_h563.json`](examples/nucleo-h563zi/golden-reference/determinism_report_h563.json),
 and the [golden reference method](docs/golden_reference.md).
 
-Those reports are evidence for the scope they describe, not a claim that every instruction
-and timing path matches silicon. Where we short-circuit hardware, it is recorded in the
-[Fidelity Ledger](FIDELITY.md), along with the cases that hold up, such as an e-paper
-panel matching silicon on 19033 of 19033 SPI transfers.
+Each report covers the scope it describes. None of them claim that every instruction and
+timing path matches silicon. The [Fidelity Ledger](FIDELITY.md) has both sides: where we
+short-circuit hardware, and where we hold up. One e-paper panel matches silicon on 19033 of
+19033 SPI transfers.
 
 ## Boards and examples
 
-ARM Cortex-M and RISC-V have the deepest coverage. Selected ESP32/Xtensa paths exist for
-specific examples. Per-board status is in [docs/boards](docs/boards/) and the
-[validation status matrix](docs/boards/VALIDATION_STATUS.md). Check it before assuming a
-peripheral is modeled. The browsable catalog of chips, boards, and peripherals is at
+ARM Cortex-M and RISC-V have the deepest coverage. Some ESP32/Xtensa paths exist for
+specific examples.
+
+Check the per-board status before you assume a peripheral is modeled. It is in
+[docs/boards](docs/boards/), the
+[validation status matrix](docs/boards/VALIDATION_STATUS.md), and the browsable catalog at
 [app.labwired.com/validation](https://app.labwired.com/validation).
 
 | To see | Run |
@@ -181,8 +237,8 @@ peripheral is modeled. The browsable catalog of chips, boards, and peripherals i
 | An IO-Link device | [IO-Link DIDO](examples/iolink-dido/README.md) |
 | GDB or VS Code debugging without a probe | [Debugging](docs/debugging.md), [GDB](docs/gdb_integration.md) |
 
-The full list is in [docs/demos.md](docs/demos.md). Each example's README and validation
-file is the source of truth for what that example actually models.
+The full list is in [docs/demos.md](docs/demos.md). Each example's README and validation file
+is the source of truth for what that example actually models.
 
 ## The LabWired ecosystem
 
@@ -224,18 +280,18 @@ This repository is the engine. Everything below runs on it, and all of it is pub
 
 Using LabWired for something public? [Open an issue][new-issue] and it goes on this list.
 
-## Missing a chip? Peripheral behaving wrong? Tell us here.
+## Missing a chip? Peripheral behaving wrong?
 
 [Open an issue][new-issue] for a wrong register, an unsupported instruction, a board you
-need, or a peripheral you would model differently. Wrong-behavior reports are most useful
-with a firmware ELF and a system manifest attached, since those usually become regression
-tests.
+need, or a peripheral you would model differently. Attach a firmware ELF and a system
+manifest if you can — those usually become regression tests.
 
 Adding a board is the easiest way to contribute: follow the
-[board onboarding playbook](docs/board_onboarding_playbook.md), mirror an existing
-example, and check the result against the
-[target support rubric](docs/target_support_rubric.md). See [ROADMAP.md](ROADMAP.md) for
-what is planned.
+[board onboarding playbook](docs/board_onboarding_playbook.md), mirror an existing example,
+and check the result against the [target support rubric](docs/target_support_rubric.md).
+
+See [ROADMAP.md](ROADMAP.md) for what is planned, [CONTRIBUTING.md](CONTRIBUTING.md) for
+repository workflow, and [SECURITY.md](SECURITY.md) for security issues.
 
 [new-issue]: https://github.com/w1ne/labwired-core/issues/new
 
@@ -244,29 +300,18 @@ what is planned.
 This repository owns the core simulator and its validation assets: CPU, bus, memory,
 peripheral, and external device execution; chip and system descriptors; CLI, test runner,
 debug adapters, and snapshot/trace tooling; and hardware-target validation metadata.
-Application UI, hosted Playground behavior, and product surfaces live outside this
-package.
+Application UI, hosted Playground behavior, and product surfaces live outside this package.
 
-The merge gate is [`core-ci.yml`](.github/workflows/core-ci.yml). Narrower signals come
-from board smoke coverage ([`core-board-ci.yml`](.github/workflows/core-board-ci.yml)),
-coverage ([matrix smoke](.github/workflows/core-coverage-matrix-smoke.yml),
+The merge gate is [`core-ci.yml`](.github/workflows/core-ci.yml). Narrower signals come from
+board smoke coverage ([`core-board-ci.yml`](.github/workflows/core-board-ci.yml)), coverage
+([matrix smoke](.github/workflows/core-coverage-matrix-smoke.yml),
 [weekly](.github/workflows/core-coverage-weekly.yml)),
 [unsupported instruction audits](.github/workflows/core-unsupported-audit.yml),
 [nightly validation](.github/workflows/core-nightly.yml),
 [hardware target sweeps](.github/workflows/core-validate-hw-targets.yml), and per-board
-throughput ([`core-perf.yml`](.github/workflows/core-perf.yml)). For release mechanics see
+throughput ([`core-perf.yml`](.github/workflows/core-perf.yml)). Release mechanics are in
 [RELEASE_PROCESS.md](RELEASE_PROCESS.md) and
 [RELEASE_READINESS_CHECKLIST.md](RELEASE_READINESS_CHECKLIST.md).
-
-## Project links
-
-[labwired.com](https://labwired.com/) ·
-[Playground](https://app.labwired.com/) ·
-[Docs](https://docs.labwired.com/) ·
-[Validation](https://app.labwired.com/validation) ·
-[For CI](https://labwired.com/ci.html) ·
-[Blog](https://labwired.com/blog/) ·
-[Pricing](https://labwired.com/pricing.html)
 
 ## Documentation
 
@@ -281,6 +326,16 @@ throughput ([`core-perf.yml`](.github/workflows/core-perf.yml)). For release mec
 [Debugging](docs/debugging.md) ·
 [PlatformIO integration](docs/platformio_integration.md) ·
 [Agents manual](docs/agents.md)
+
+## Project links
+
+[labwired.com](https://labwired.com/) ·
+[Playground](https://app.labwired.com/) ·
+[Docs](https://docs.labwired.com/) ·
+[Validation](https://app.labwired.com/validation) ·
+[For CI](https://labwired.com/ci.html) ·
+[Blog](https://labwired.com/blog/) ·
+[Pricing](https://labwired.com/pricing.html)
 
 ## Contributing
 


### PR DESCRIPTION
## The correctness fix

The quickstart claimed the nRF54L15 banner "is a check on the chip model, **not a printed constant**". It is a printed constant — `examples/nrf54l15-dk/src/main.c:77-80` prints four string literals. The same claim appeared again under "How it works".

Replaced with what the smoke test actually establishes: the strings prove nothing by themselves, the arrival of the bytes does, and that requires the RRAM/RAM setup plus a correct UARTE20 base. Added a pointer to `firmware_survival::test_nrf54l15_lights_dk_led0`, since GPIO is asserted at the pin and the banner cannot catch a base-address error.

Verified while writing: `io-smoke.yaml` has 3 `uart_contains` + 1 `expected_stop_reason`, which is the `4/4` in the verdict.

## Readability

- Flat sections — `What is` / `Why use` / `Quickstart` / `Installation` / `Running LabWired`. The three `<details>` collapsibles are now plain subsections.
- One idea per sentence. Dropped the trailing "why that matters" clauses and the repeated `X, not Y` construction.
- Added the supported-cores list, which was missing.
- Installation variables moved into a table.

## Unchanged

Logo, all badges, the demo GIF and its caption target, every link, and the ecosystem tables. Relative-link check passes with 0 broken.