### PR TITLE
test: gate the esp32c3::bt residency fix, and stop asserting two free-running counters as constants

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -597,9 +597,21 @@ jobs:
       # reasoned in `scheduler_lane_coverage`'s NIGHTLY_ONLY table — that
       # ratchet is what keeps this list from silently rotting again: a new
       # scheduler-gated test file must be added here or given a written reason.
+      # `esp32c3_bt_event_residency_gate` is here and not in `core-integrity`
+      # BECAUSE OF THE FEATURE MATRIX, not because it is cheap (it is: 4.5s).
+      # The property it defends — `esp32c3::bt` stays inside
+      # MAX_LIVE_EVENTS_PER_PERIPHERAL — has an in-engine backstop, the
+      # `debug_assert!` behind `live_event_ceiling_trips`, and NEITHER standing
+      # lane can reach it: `cargo test -p labwired-core` runs debug but without
+      # `event-scheduler`, so no scheduler runs at all, and `core-integrity`'s
+      # scheduler lane is `--release`, which compiles `debug_assert!` out. Debug
+      # + `--features event-scheduler` is this job, and only this job. The fix
+      # that took `live_event_ceiling_trips` from 3310 to 0 merged with nothing
+      # asserting that number anywhere.
       - name: Scheduler-only fidelity lanes (walk≡scheduler timing gates)
         run: >
           cargo test -p labwired-core --features event-scheduler
+          --test esp32c3_bt_event_residency_gate
           --test nrf52_timer_walk_differential
           --test nrf52_easydma_tick512_fidelity
           --test nrf52840_timer_machine_gate

--- a/crates/core/tests/esp32c3_bt_event_residency_gate.rs
+++ b/crates/core/tests/esp32c3_bt_event_residency_gate.rs
@@ -1,0 +1,295 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! THE GATE FOR THE `esp32c3::bt` EVENT-RESIDENCY FIX.
+//!
+//! # What was broken, and what nothing was checking
+//!
+//! `Esp32c3Bt::take_scheduled_events` runs after **every MMIO write** to the BT
+//! window. It used to bump [`Esp32c3Bt::arm_seq`] unconditionally, so every poll
+//! produced a fresh `(peripheral, token, deadline)` key that the scheduler's
+//! dedup index could not collapse. There is no scheduler-side cancel by design,
+//! so each duplicate stayed **live** until it fired and was rejected as stale.
+//! Measured on the two-node BLE Pong lab (96 M cycles/node, release):
+//!
+//! ```text
+//! LIVE_HWM [bt=789 systimer=4]   max_queued=792  live_event_ceiling_trips=3310
+//! ```
+//!
+//! 789 simultaneously-live events against a ceiling of
+//! [`MAX_LIVE_EVENTS_PER_PERIPHERAL`] = 8. The fix (`arm_seq` gated on
+//! [`Esp32c3Bt::armed_wake`], plus `CHAIN_REEVALUATE_HORIZON`) drives that to
+//! `bt <= 8` and `live_event_ceiling_trips == 0`.
+//!
+//! **Nothing asserted the headline number.** `live_event_ceiling_trips`'s only
+//! reader was `tests/esp32c3_ble_pong_perf_probe.rs`, whose own module docs say
+//! "Every test here is `#[ignore]`d and asserts nothing". And the
+//! `debug_assert!` behind the counter — the in-engine backstop — was unreachable
+//! in BOTH CI configurations:
+//!
+//! | lane | why the assert cannot fire |
+//! |------|----------------------------|
+//! | `cargo test -p labwired-core` (debug, default features) | `event-scheduler` is not a default feature, so no scheduler runs at all |
+//! | `cargo test --release -p labwired-core --features event-scheduler` | `--release` compiles `debug_assert!` out |
+//!
+//! The only armed corner is **debug + `--features event-scheduler`**, which is
+//! exactly what the `pr-scheduler-observable` job runs. This file lives there.
+//!
+//! # Why the assertions are explicit and not left to the `debug_assert!`
+//!
+//! In a debug build the scheduler panics on the ninth live event, so a
+//! regression fails here before the assertions at the bottom are reached — that
+//! is fine, and it is the loudest possible failure. The explicit checks exist so
+//! that the property is stated where someone looks for it, and so that the same
+//! file is still a gate if it is ever run in a configuration where
+//! `debug_assert!` is compiled out (`core-integrity`'s release scheduler lane).
+//!
+//! # Why the run has to be a real one
+//!
+//! The leak is driven by MMIO-write cadence during link-layer activity, so a
+//! synthetic bus poke would not reproduce it. This boots the shipped
+//! `esp32c3-ble-pong` flash through the mask-ROM fast start and runs until the
+//! controller has actually transmitted advertising PDUs onto a private
+//! [`BleAirBus`]. The preconditions below refuse to let the test pass without
+//! that: no advertising, or too few arms, is a vacuous run and is reported as a
+//! failure rather than a pass.
+
+#![cfg(feature = "event-scheduler")]
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::boot::esp32c3_rom::{
+    build_rom_boot_machine, c3_rom_data_init_writes, inject_rom_regions, RomBootOpts,
+};
+use labwired_core::boot::esp32s3_rom::RomImages;
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::RiscV;
+use labwired_core::memory::ProgramImage;
+use labwired_core::peripherals::ble_air::BleAirBus;
+use labwired_core::peripherals::esp32c3::bt::Esp32c3Bt;
+use labwired_core::sched::MAX_LIVE_EVENTS_PER_PERIPHERAL;
+use labwired_core::{Arch, Bus, Cpu, DebugControl, Machine};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+const ESP_IMAGE_HEADER_LEN: usize = 24;
+const ESP_IMAGE_MAGIC: u8 = 0xE9;
+
+/// Cycles per `machine.run` slice. Small enough that the stop condition is
+/// checked often, large enough not to dominate.
+const SLICE: u32 = 500_000;
+
+/// Hard ceiling on the run. Sized from measurement, not guessed: this image
+/// puts its first advertising PDU on the air at 44.5 M cycles (measured, debug,
+/// `idle_fast_forward_enabled`), so this is ~1.8x headroom. A run that needs the
+/// whole budget fails its precondition rather than passing quietly.
+const BUDGET: u64 = 80_000_000;
+
+/// The block has to have transmitted, not merely initialised.
+const MIN_ADVERTISEMENTS: u64 = 1;
+
+/// The block has to have armed enough wakes for the ceiling to be a meaningful
+/// question. Pre-fix the ceiling (8) was crossed within the first handful of
+/// arms, so this is comfortably above the threshold at which the old defect is
+/// observable — it is a floor on "did this exercise the arm path at all", not a
+/// tuned number.
+const MIN_BT_ARMS: u64 = 32;
+
+fn bootloader_image(flash: &[u8]) -> ProgramImage {
+    assert!(flash.len() > ESP_IMAGE_HEADER_LEN, "flash image truncated");
+    assert_eq!(flash[0], ESP_IMAGE_MAGIC, "bad bootloader image magic");
+    let segment_count = flash[1] as usize;
+    let entry = u32::from_le_bytes(flash[4..8].try_into().unwrap()) as u64;
+    let mut program = ProgramImage::new(entry, Arch::RiscV);
+    let mut cursor = ESP_IMAGE_HEADER_LEN;
+    for _ in 0..segment_count {
+        let load_addr = u32::from_le_bytes(flash[cursor..cursor + 4].try_into().unwrap()) as u64;
+        let len = u32::from_le_bytes(flash[cursor + 4..cursor + 8].try_into().unwrap()) as usize;
+        cursor += 8;
+        program.add_segment(load_addr, flash[cursor..cursor + len].to_vec());
+        cursor += len;
+    }
+    program
+}
+
+/// One `esp32c3-ble-pong` node, mask-ROM fast start, shipped flash, private air.
+/// Returns the machine, the serial sink and the air so the caller can prove the
+/// node really advertised.
+fn build_advertising_node() -> (Machine<RiscV>, Arc<Mutex<Vec<u8>>>, BleAirBus) {
+    let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
+        .expect("load esp32c3 chip yaml");
+    let manifest =
+        SystemManifest::from_file(root().join("../../configs/systems/esp32c3-ble-pong.yaml"))
+            .expect("load esp32c3-ble-pong system yaml");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build ble-pong bus");
+
+    let irom = std::fs::read(root().join("roms/esp32c3/esp32c3_rom.bin")).expect("read C3 IROM");
+    let drom = std::fs::read(root().join("roms/esp32c3/esp32c3_drom.bin")).expect("read C3 DROM");
+    let flash = std::fs::read(root().join("tests/fixtures/esp32c3-ble-pong-flash.bin"))
+        .expect("read BLE Pong flash image");
+    assert!(
+        inject_rom_regions(
+            &mut bus,
+            &RomImages {
+                irom: irom.clone(),
+                drom,
+            },
+        ),
+        "chip yaml must declare the C3 IROM region"
+    );
+    for (dst, bytes) in c3_rom_data_init_writes(&irom) {
+        for (i, b) in bytes.iter().enumerate() {
+            let _ = bus.write_u8(dst as u64 + i as u64, *b);
+        }
+    }
+
+    let serial = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(serial.clone(), false);
+
+    // A PRIVATE air: "did THIS node transmit?" must not be answerable by some
+    // other controller sharing a process-global bus.
+    let air = BleAirBus::new();
+    {
+        let idx = bus
+            .find_peripheral_index_by_name("bt")
+            .expect("esp32c3 chip yaml registers the `bt` block");
+        bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32c3Bt>())
+            .expect("`bt` is the C3 BT controller model")
+            .set_air(air.clone());
+    }
+    assert_eq!(air.current_seq(), 0, "private air starts silent");
+
+    let boot = bootloader_image(&flash);
+    let mut machine: Machine<RiscV> = build_rom_boot_machine(
+        bus,
+        flash.clone(),
+        RomBootOpts {
+            pinned_efuse_mac: None,
+            usb_serial_sink: None,
+        },
+        |c| c,
+    );
+    for segment in &boot.segments {
+        if machine.bus.flash.load_from_segment(segment)
+            || machine.bus.ram.load_from_segment(segment)
+            || machine
+                .bus
+                .extra_mem
+                .iter_mut()
+                .any(|m| m.load_from_segment(segment))
+        {
+            continue;
+        }
+        for (i, byte) in segment.data.iter().enumerate() {
+            machine
+                .bus
+                .write_u8(segment.start_addr + i as u64, *byte)
+                .expect("load bootloader segment");
+        }
+    }
+    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    machine.cpu.set_sp(sp_top & !0xF);
+    machine.cpu.set_pc(boot.entry_point as u32);
+
+    // Exactly the browser's own policy, read the way `build_node` does.
+    let tick = machine.bus.max_safe_tick_interval();
+    machine.config.peripheral_tick_interval = tick;
+    machine.bus.config.peripheral_tick_interval = tick;
+    machine.config.idle_fast_forward_enabled = true;
+
+    (machine, serial, air)
+}
+
+/// THE GATE. An advertising `esp32c3-ble-pong` node must keep `bt` inside
+/// [`MAX_LIVE_EVENTS_PER_PERIPHERAL`], and the scheduler must record ZERO
+/// ceiling trips.
+///
+/// This is the assertion the `arm_seq` residency fix was measured by
+/// (`live_event_ceiling_trips` 3310 -> 0) and which nothing in the tree
+/// previously made. Deliberately NOT `#[ignore]`d: the whole defect it covers is
+/// a metric that no lane checked.
+#[test]
+fn advertising_ble_pong_node_keeps_bt_inside_the_live_event_ceiling() {
+    let (mut machine, serial, air) = build_advertising_node();
+    let bt_idx = machine
+        .bus
+        .find_peripheral_index_by_name("bt")
+        .expect("`bt` peripheral index");
+
+    let started = std::time::Instant::now();
+    let mut steps = 0u64;
+    while steps < BUDGET && air.current_seq() < MIN_ADVERTISEMENTS {
+        let _ = machine.run(Some(SLICE));
+        steps += u64::from(SLICE);
+    }
+
+    let stats = machine.sched.stats();
+    let bt_arms = stats.arms_per_peripheral.get(bt_idx).copied().unwrap_or(0);
+    let bt_live_hwm = stats
+        .max_live_per_peripheral
+        .get(bt_idx)
+        .copied()
+        .unwrap_or(0);
+    let console = String::from_utf8_lossy(&serial.lock().unwrap()).to_string();
+
+    eprintln!(
+        "RESIDENCY steps={steps} wall={:.2}s total_cycles={} air_frames={} \
+         bt_arms={bt_arms} bt_live_hwm={bt_live_hwm} ceiling={MAX_LIVE_EVENTS_PER_PERIPHERAL} \
+         ceiling_trips={} max_queued={} serial_bytes={}",
+        started.elapsed().as_secs_f64(),
+        machine.total_cycles,
+        air.current_seq(),
+        stats.live_event_ceiling_trips,
+        stats.max_queued_events,
+        console.len(),
+    );
+
+    // ── PRECONDITIONS: refuse to be a vacuous gate ────────────────────────────
+    // A run that never advertises, or never arms, would satisfy every assertion
+    // below trivially. Both are failures, not passes.
+    assert!(
+        air.current_seq() >= MIN_ADVERTISEMENTS,
+        "precondition: the node must actually transmit advertising PDUs \
+         (got {} frames in {steps} steps). Without a live link layer the \
+         residency assertions below prove nothing. Console tail:\n{}",
+        air.current_seq(),
+        console
+            .lines()
+            .rev()
+            .take(20)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        bt_arms >= MIN_BT_ARMS,
+        "precondition: `bt` must have armed at least {MIN_BT_ARMS} scheduler \
+         events (got {bt_arms}). Too few arms means the arm path was barely \
+         exercised and the ceiling below is not a meaningful question."
+    );
+
+    // ── THE PROPERTY ──────────────────────────────────────────────────────────
+    assert!(
+        bt_live_hwm <= MAX_LIVE_EVENTS_PER_PERIPHERAL,
+        "`bt` held {bt_live_hwm} simultaneously-live scheduler events (ceiling \
+         {MAX_LIVE_EVENTS_PER_PERIPHERAL}) over {bt_arms} arms: it is re-arming \
+         without superseding its prior wake. This is the pre-fix leak — 789 live \
+         events from ~3.3k arms — which inflated the scheduler's linearly-scanned \
+         dedup index until `EventScheduler::{{drain_due_into,schedule}}` cost 4.7x \
+         the RISC-V interpreter. See `arm_seq` / `armed_wake` in \
+         `peripherals/esp32c3/bt.rs`."
+    );
+    assert_eq!(
+        stats.live_event_ceiling_trips, 0,
+        "the scheduler recorded {} live-event ceiling trips (max live on any \
+         peripheral: {}). This is the number the `esp32c3::bt` residency fix was \
+         measured by: 3310 -> 0. Non-zero means it regressed.",
+        stats.live_event_ceiling_trips, stats.max_live_events_per_peripheral
+    );
+}

--- a/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
+++ b/crates/hw-oracle/tests/esp32c3_reset_conformance.rs
@@ -35,6 +35,16 @@
 //! values. This oracle therefore asserts only the **ROM-untouched, static**
 //! reset values where descriptor and silicon agree.
 //!
+//! ## 2026-08-08: two entries were NOT reset values at all
+//!
+//! Repeat-reads on live silicon retired the equality claim on `WIFI_MAC`
+//! `0x60035000` and `0x6003507C`: both change on every read. They moved to
+//! [`FREE_RUNNING_COUNTERS`], which asserts only that the window maps. Two
+//! further entries (`RADIO_FE 0x60006000`, `WIFI_MAC 0x6003502C`) mismatched
+//! live but were stable, which is the signature of a powered PHY rather than a
+//! wrong descriptor; they stay asserted and are annotated in the table with what
+//! a capture would have to do to confirm them.
+//!
 //! ## Running
 //!
 //! Sim-only (normal CI):
@@ -160,12 +170,26 @@ const RESET_VALUES: &[(&str, u64, u32)] = &[
     // --- Radio (WiFi/BT) register-backed model, REVERSE-ENGINEERED from live
     // --- silicon (docs/esp32c3_radio_reverse_engineering.md), not SVD. These
     // --- windows reset cold (pre-phy_enable); assert they map + return cold
-    // --- state. The WiFi MAC carries 12 non-zero hardware reset defaults.
+    // --- state. The WiFi MAC carries 10 non-zero hardware reset defaults here;
+    // --- two more used to be listed and are now in FREE_RUNNING_COUNTERS below.
+    //
+    // ⚠️ TWO OF THESE NEED A COLD POWER-CYCLE CAPTURE TO VALIDATE, and a live
+    // read on 2026-08-08 could not supply one. Both boards were running a BLE
+    // sketch, and openocd `reset halt` on the C3 is a SOFTWARE core reset that
+    // leaves the PHY powered, so the radio estate is read post-`phy_enable`:
+    //
+    //   RADIO_FE 0x60006000  asserted 0x00000000, live 0x06828040
+    //   WIFI_MAC 0x6003502C  asserted 0x00000002, live 0x00000000
+    //
+    // Unlike FREE_RUNNING_COUNTERS these were STABLE across repeat reads, which
+    // is what says "powered-up state", not "counter". The cold values are still
+    // the right thing for the descriptor to model, so the assertions stay. To
+    // confirm them against silicon, capture with the board freshly power-cycled
+    // into a firmware that never calls `phy_enable` — not via `reset halt`.
     ("RADIO_FE (cold)", 0x6000_6000, 0x0000_0000),
     ("RADIO_NRX (cold)", 0x6001_CC00, 0x0000_0000),
     ("WIFI_MAC base (cold)", 0x6003_3000, 0x0000_0000),
     // WiFi MAC non-zero cold-reset defaults (silicon-corroborated)
-    ("WIFI_MAC 0x60035000", 0x6003_5000, 0x000C_9858),
     ("WIFI_MAC 0x60035024", 0x6003_5024, 0x024E_01FF),
     ("WIFI_MAC 0x60035028", 0x6003_5028, 0xB000_0000),
     ("WIFI_MAC 0x6003502C", 0x6003_502C, 0x0000_0002),
@@ -173,10 +197,46 @@ const RESET_VALUES: &[(&str, u64, u32)] = &[
     ("WIFI_MAC 0x6003503C", 0x6003_503C, 0x0000_0064),
     ("WIFI_MAC 0x60035048", 0x6003_5048, 0x0000_0064),
     ("WIFI_MAC 0x60035054", 0x6003_5054, 0x0000_0064),
-    ("WIFI_MAC 0x6003507C", 0x6003_507C, 0x7D9A_D8A3),
     ("WIFI_MAC 0x60035080", 0x6003_5080, 0x0000_07FF),
     ("WIFI_MAC 0x60035084", 0x6003_5084, 0x0000_3202),
     ("WIFI_MAC 0x60035094", 0x6003_5094, 0x0000_0004),
+];
+
+/// FREE-RUNNING COUNTERS — mapped, but deliberately NOT equality-asserted.
+///
+/// These two addresses were in [`RESET_VALUES`] with fixed expected words. They
+/// cannot be. Triple repeat-reads inside ONE halted openocd session on a live
+/// ESP32-C3 (2026-08-08, reproduced on both attached boards):
+///
+/// ```text
+/// 0x60035000  asserted 0x000C9858   live: 0x00006E8E -> 0x0000A438 -> 0x0000D62B
+/// 0x6003507C  asserted 0x7D9AD8A3   live: 0x53327C00 -> 0x1E028FBF -> 0x6F48DDB5
+/// ```
+///
+/// The value changes on EVERY read while the core is halted, so no capture from
+/// any silicon can ever equal a constant, and the committed "silicon-corroborated
+/// reset default" was a single sample of a counter mistaken for a reset value.
+/// 0x60035000 advances monotonically at a fixed rate (a free-running timer);
+/// 0x6003507C is unordered between reads (a counter fed by the PHY/PRNG side of
+/// the MAC). Neither is documented in the SVD — this window is
+/// reverse-engineered, see `docs/esp32c3_radio_reverse_engineering.md`.
+///
+/// The offline test passed only because the simulator returns a frozen word: an
+/// oracle that could never fail against the sim and could never pass against
+/// hardware. That is a vacuous gate, so the equality claim is withdrawn.
+///
+/// They are kept HERE, not deleted, for two reasons: the next person must be
+/// able to see that they were considered and excluded on evidence rather than
+/// quietly dropped; and the property that DOES hold — the window is mapped and
+/// reads without a bus fault, which is what proves the radio estate is wired —
+/// is still worth asserting. [`esp32c3_free_running_counters_are_mapped`] does
+/// exactly that and nothing more.
+///
+/// To turn either back into an equality assertion you need a model of what the
+/// counter counts, and then the assertion is about its RATE, not its value.
+const FREE_RUNNING_COUNTERS: &[(&str, u64)] = &[
+    ("WIFI_MAC 0x60035000 (free-running counter)", 0x6003_5000),
+    ("WIFI_MAC 0x6003507C (free-running counter)", 0x6003_507C),
 ];
 
 fn build_sim_bus() -> SystemBus {
@@ -224,6 +284,30 @@ fn esp32c3_reset_values_match_silicon() {
         "ESP32-C3 reset-state model diverged from silicon in {} of {} register(s):\n{}",
         failures.len(),
         RESET_VALUES.len(),
+        failures.join("\n")
+    );
+}
+
+/// The two [`FREE_RUNNING_COUNTERS`] windows must still MAP — a read must not
+/// bus-fault — which is the part of the old claim that survives contact with
+/// silicon. Their VALUE is not asserted, and must not be: see the table's docs
+/// for the live read sequences that retired the equality claim.
+#[test]
+fn esp32c3_free_running_counters_are_mapped() {
+    let sim = build_sim_bus();
+    let mut failures = Vec::new();
+
+    for &(label, addr) in FREE_RUNNING_COUNTERS {
+        if let Err(e) = sim.read_u32(addr) {
+            failures.push(format!("  [FAULT] {label} 0x{addr:08X}: {e:?}"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} free-running WiFi MAC window(s) failed to map:\n{}",
+        failures.len(),
+        FREE_RUNNING_COUNTERS.len(),
         failures.join("\n")
     );
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -60,7 +60,8 @@ Machine-generated from `validation/manifest.yaml`. CI regenerates this on every 
 - Doc: [`docs/boards/esp32c3.md`](esp32c3.md)  ·  Chip: `configs/chips/esp32c3.yaml`
 - Note: Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says).
 - Silicon: **2026-06-17** on USB-JTAG (built-in, openocd-esp32) — re-verified live — reset oracle re-captured live 2026-06-17: 1123/1123 static registers match committed baseline (13 deltas all in per-chip efuse + live USB-device state, none in the asserted set); esp32c3_reset_values_match_silicon passes
-  - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)
+  - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (87 regs; 366/423 overlap matched silicon)
+  - offline (CI): esp32c3_reset_conformance::esp32c3_free_running_counters_are_mapped (2 WiFi MAC counter windows; mapping only, no equality claim)
 - Drift status: **⚠ drift acked 2026-08-08 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -506,7 +506,13 @@ boards:
     tier: silicon-verified
     note: "Reset-state oracle, not behavioural. ~40 peripherals declared (NOT 6 as the prose doc says)."
     offline_tests:
-      - "esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (79 regs; 366/423 overlap matched silicon)"
+      # 89 until 2026-08-08. The "79" that stood here was stale by ten entries.
+      # Two of the 89 (WIFI_MAC 0x60035000, 0x6003507C) turned out to be
+      # free-running counters — they change on every read on live silicon, so a
+      # constant could never match — and moved to esp32c3_free_running_counters
+      # _are_mapped, which asserts the window maps and nothing about its value.
+      - "esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (87 regs; 366/423 overlap matched silicon)"
+      - "esp32c3_reset_conformance::esp32c3_free_running_counters_are_mapped (2 WiFi MAC counter windows; mapping only, no equality claim)"
     silicon:
       last_capture: 2026-06-17
       probe: "USB-JTAG (built-in, openocd-esp32) — re-verified live"


### PR DESCRIPTION
Two oracles that could not fail. Both are now real gates.

## 1. The residency fix had no gate

`ca454225` stopped `esp32c3::bt` leaking scheduler events — its success metric is
`live_event_ceiling_trips` going 3310 -> 0. Nothing asserted that. The counter's only
reader was `esp32c3_ble_pong_perf_probe.rs:209`, and every test in that file is
`#[ignore]`d by design ("Every test here is `#[ignore]`d and asserts nothing").

Neither CI lane could catch a regression via the engine's own `debug_assert!` either:
the debug run has no `event-scheduler` feature so the scheduler never runs, and
`--release` compiles the assert out. The only corner that arms it is debug +
`--features event-scheduler`, which is exactly what `pr-scheduler-observable` runs — so
the new gate goes there, and the YAML now says why.

`esp32c3_bt_event_residency_gate.rs` boots the shipped `esp32c3-ble-pong` flash, runs
until the controller puts real advertising PDUs on a private `BleAirBus`, then asserts
`bt` stayed inside `MAX_LIVE_EVENTS_PER_PERIPHERAL` with `ceiling_trips == 0`. It fails
if the node never advertised and fails if `bt` armed fewer than 32 events, so it cannot
pass vacuously.

Watched red against pre-fix `bt.rs` both ways — in debug via the engine's assert
(`peripheral 24 holds 9 live events (ceiling 8)`) and in release via its own
(`bt held 71 simultaneously-live events over 101 arms`, `ceiling_trips=93`). Green after:
`air_frames=1 bt_arms=51 bt_live_hwm=4 ceiling_trips=0 max_queued=8`. ~4.5s.

## 2. Two free-running counters were asserted as constants

`WIFI_MAC 0x60035000` and `0x6003507C` are hardware counters. Triple repeat-reads in one
halted openocd session on live silicon:

    0x60035000: 0x00006e8e -> 0x0000a438 -> 0x0000d62b
    0x6003507C: 0x53327c00 -> 0x1e028fbf -> 0x6f48ddb5

They change on every read, so no live C3 can ever match the asserted constants. The
offline test passed only because the simulator returns frozen words — an entry that could
never fail against the sim and never pass against hardware. Reproduced on both boards.

`RESET_VALUES` 89 -> 87; the two move to `FREE_RUNNING_COUNTERS`, asserted only to MAP
(no bus fault) — the part of the claim that survives silicon. The live sequences are
recorded in the doc comment as the evidence, so the exclusion is visibly deliberate.

`RADIO_FE 0x60006000` and `WIFI_MAC 0x6003502C` also mismatched live but were STABLE
across reads — a powered PHY under a software-only `reset halt` — so they stay asserted,
with a note that confirming them needs a cold power-cycle capture.

`validation/manifest.yaml` said 79 regs; it was ten stale. Corrected to 87, doc
regenerated, `--check --drift` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
