### PR TITLE
perf(dev): build the debug profile at opt-level 1

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -844,7 +844,16 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'push' && contains(github.event.head_commit.message, '[full-ci]'))
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 45 was the budget for a job that never finished: `Run Workspace Tests`
+    # was cancelled at exactly 45:00 on every run, including the nightly, so
+    # the two steps after it never ran at all. With `opt-level = 1` the job
+    # completes in 44m32s — which cleared the old limit by 28 SECONDS while
+    # now doing strictly more work, since those two steps execute. That is a
+    # coin flip, not a margin. 75 leaves room for runner variance and a cold
+    # cache without hiding a real regression: if this job starts approaching
+    # 75 minutes, something has genuinely got slower and should be measured,
+    # not accommodated again.
+    timeout-minutes: 75
     steps:
       # fetch-depth: 0 — the Tier-1 baseline ratchet resolves its baseline from
       # `git merge-base HEAD origin/main`. On a shallow checkout that cannot be

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,14 @@ ureq = { version = "2.12", features = ["json"] }
 
 [profile.dev]
 panic = "abort"
+# The simulator is an interpreter: its hot loop is thousands of tiny generic
+# calls (HashMap<u64,u32> register lookups, `Option`/iterator adapters, `Any`
+# downcasts) that cost nothing once inlined and cost a call each when not.
+# At opt-level 0 that makes debug ~13x slower than release, which is what
+# pushes `cargo test --workspace` past the CI timeout. opt-level = 1 turns on
+# inlining + mem2reg WITHOUT touching `debug-assertions` or `overflow-checks`,
+# so every `debug_assert!` and every std UB precondition check still runs.
+opt-level = 1
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
`core-full` is the only job that runs `cargo test --workspace`, and it is cancelled at exactly its `timeout-minutes: 45` on every run — the nightly on main included. **So the full core regression currently completes nowhere.** It reports as `cancelled` rather than `failure`, and the job is skipped on PRs and on push-to-main, which is why this has been invisible.

## It is not a hang

`no_elf_c3_rom_boot` finishes in **4m56s** in debug (201.35s CPU) versus **52s** in release (15.09s CPU) — **13.3x**, an ordinary unoptimised-Rust ratio, not a pathology. The timeout is the whole debug workspace at 13x on a slower 2-core runner, aggregated. Nothing needs quarantining or relocating to a release lane.

## Where the time goes

The simulator is an interpreter, so its hot loop is thousands of tiny generic calls that vanish when inlined and cost a call each when not. Profiling the debug run (macOS `sample`, 1ms, 15238 samples; a second independent sample agreed within ~1pt):

- `commit_advance_boundary` → `tick_peripherals_*` — **71.3%** of the run
- `RiscV::step`, the actual instruction interpreter — **5.8%**

Self-time: SipHash 15.5% · hashbrown probe + UB precondition checks 11.1% · Vec/iterator churn 13.5% · nRF52 NVMC scan 6.7% · a long tail of `Option::copied` / `unwrap_or` / `slice::get` / `Iterator::next`, all free in release and one call each in debug.

## The change

`opt-level = 1` enables inlining and mem2reg **without** touching `debug-assertions` or `overflow-checks`.

| build | wall | user CPU |
|---|---|---|
| release | 52.40s | 15.09s |
| debug (opt-level 0) | 295.83s | 201.35s |
| **debug + opt-level 1** | **73.52s** | **20.02s** |

**201.35s → 20.02s CPU — 10.1x.** Debug is now 1.33x release instead of 13.3x.

Verified it does not weaken the debug lane:
- rustc still receives `debug-assertions=on` (33 occurrences under `cargo build -v`)
- the binary still carries 135 `ub_checks`/`precondition_check` symbols — the std UB checks that exist only in debug
- semantically identical: `uart.log` is byte-for-byte the same 3525 bytes across opt0, opt1 **and** release; `result.json`/`snapshot.json` differ only in embedded paths

Compile cost: cold build 1m46s → 2m07s wall; incremental trivial edit 6.2s → 12.3s. Trading ~20% of build wall-clock for 10x on every test run.

## Not addressed here

Two genuinely wasteful paths the profile named. Both cost release time too, and both want their own guard tests, so they are deliberately left for a follow-up:

1. **`EspUart` stores its register file in a `HashMap<u64, u32>`** (`esp_uart.rs:252`) and `reg()` SipHashes a `u64` to read a constant config register every tick. The `int_raw()` → `txfifo_empty_thrhd()` → `reg(OFF_CONF1)` chain alone is **7.6%**.
2. **`machine/boundary.rs:284` scans every peripheral with an `Any` downcast** hunting for an `Nrf52Nvmc` — on chips that cannot have one. ~40 vtable calls + 40 `TypeId` compares at every advance boundary, **6.5%**. `rtc_cntl_index`, `flash_index`, `simctl_index` and `scb_index` are all resolved once in `Machine::new`; NVMC is the one left as a scan.

## Caveat

Measured on an M-series Mac under heavy load from other sessions (wall-clock is contaminated, hence CPU time as the honest metric). **Not** measured on `ubuntu-latest`, so this proves the 10x, not that `core-full` now fits in 45 minutes. A `workflow_dispatch` run on this branch is in flight to establish exactly that.