### PR TITLE
fix(ssd1306,sh1107): re-read the control byte on every I²C START

### DIFF
--- a/crates/core/src/peripherals/components/sh1107.rs
+++ b/crates/core/src/peripherals/components/sh1107.rs
@@ -214,6 +214,16 @@ impl I2cDevice for Sh1107 {
         0 // SH1107 is write-only over I²C
     }
 
+    /// A START (or repeated START) begins a new transaction, so the next byte
+    /// is a control byte again. See the SSD1306 model for the failure this
+    /// prevents: a driver issuing several transfers under one STOP loses the
+    /// control byte on every transfer after the first, and a `0x40` data
+    /// prefix turns the framebuffer behind it into a command stream.
+    fn start(&mut self) {
+        self.register_address_written = false;
+        self.control_byte = None;
+    }
+
     fn write(&mut self, data: u8) {
         if !self.register_address_written {
             // First byte of a transaction is the control byte.

--- a/crates/core/src/peripherals/components/ssd1306.rs
+++ b/crates/core/src/peripherals/components/ssd1306.rs
@@ -269,6 +269,22 @@ impl I2cDevice for Ssd1306 {
         0 // SSD1306 is write-only over I²C
     }
 
+    /// A START (or repeated START) begins a new transaction, so the next byte
+    /// is a control byte again.
+    ///
+    /// Resetting only in `stop()` was wrong: a driver that issues several
+    /// transfers and one trailing STOP — which is what the nRF52 TWIM does,
+    /// one STARTTX per transfer — kept `register_address_written` set across
+    /// the whole burst. Every transfer after the first then lost its leading
+    /// control byte into `handle_command`, and a `0x40` data-stream prefix
+    /// silently became "set display start line". The 1 KiB framebuffer behind
+    /// it was parsed as commands, which is a garbled panel and not a NACK.
+    /// Real silicon re-reads the control byte after every START.
+    fn start(&mut self) {
+        self.register_address_written = false;
+        self.control_byte = None;
+    }
+
     fn write(&mut self, data: u8) {
         if !self.register_address_written {
             // First byte of a transaction is the control byte.
@@ -417,6 +433,60 @@ mod tests {
             dev.framebuffer()[39],
             0,
             "init command parameters must not be misread as column-nibble commands"
+        );
+    }
+
+    /// Every transfer is its own START, and the driver sends ONE STOP at the
+    /// end of the frame. That is what the nRF52 TWIM does: one STARTTX per
+    /// transfer, `TASKS_STOP` only after the framebuffer burst.
+    ///
+    /// The model used to reset its control-byte state in `stop()` alone, so
+    /// each transfer after the first fed its leading control byte to
+    /// `handle_command`. The `0x40` in front of the framebuffer became "set
+    /// display start line" and all 1024 pixel bytes were parsed as commands:
+    /// on the secure-boot lab the panel came out shifted 49 columns with rows
+    /// wrapped into the wrong pages. Painting nothing would have been easier
+    /// to spot than painting the wrong thing convincingly.
+    #[test]
+    fn transfers_under_one_stop_keep_their_control_bytes() {
+        let mut dev = Ssd1306::new(0x3c);
+
+        // Init burst: START + [control, cmd, ...params] per transfer, no STOP.
+        for transfer in [
+            [0x00u8, 0xAE, 0x00].as_slice(),
+            &[0x00, 0xD5, 0x80],
+            &[0x00, 0x20, 0x00],
+            &[0x00, 0xA1],
+            &[0x00, 0xAF],
+        ] {
+            dev.start();
+            for &b in transfer {
+                dev.write(b);
+            }
+        }
+
+        // Window, then the data burst — still no STOP until the very end.
+        dev.start();
+        for &b in &[0x00u8, 0x21, 0x00, 0x7F] {
+            dev.write(b);
+        }
+        dev.start();
+        for &b in &[0x00u8, 0x22, 0x00, 0x07] {
+            dev.write(b);
+        }
+        dev.start();
+        dev.write(0x40); // data stream
+        for i in 0..8u32 {
+            dev.write(0x80 | i as u8);
+        }
+        dev.stop();
+
+        let fb = dev.framebuffer();
+        assert_eq!(
+            &fb[..8],
+            &[0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87],
+            "data must land at column 0 of page 0, not wherever a mis-parsed \
+             control byte moved the cursor"
         );
     }
 


### PR DESCRIPTION
## Description

Both OLED models reset their control-byte state in `stop()` only. The nRF52 TWIM issues one STARTTX per transfer and sends `TASKS_STOP` once, at the end of the frame, so `register_address_written` stayed set across the whole burst.

Every transfer after the first fed its leading control byte to `handle_command`. The `0x40` in front of the framebuffer became "set display start line", and the 1024 pixel bytes behind it were then parsed as commands — bytes like `0x21`, `0x7F` and `0x00`-`0x0F` moved the cursor around.

On `examples/nrf52840-secure-boot-lab` that painted a panel shifted 49 columns, with rows wrapped into the wrong pages and stale text from an earlier boot still on screen. Measured from the panel's own framebuffer artifact, before and after:

```
before                          after
page 0: cols 49..127            page 0: cols 0..82   "SECURE BOOT OK"
page 1: cols 0..76              page 1: cols 0..70   "FW V2 ACTIVE"
page 2: blank                   page 2: cols 0..94   "ANTI-ROLLBACK ON"
page 3: cols 49..125            page 3: blank
page 4: cols 49..101            page 4: cols 0..100  "ROLLBACK REJECTED"
page 5: cols 0..7               page 5: cols 0..88   "FORGED REJECTED"
```

Every row now starts at column 0 and the inked column ranges match the strings the firmware paints, six pixels per character cell.

The run stayed green through all of it: the lab has 45 assertions and none of them look at the display. A model that paints the wrong thing convincingly is worse than one that paints nothing, so this is the class of bug the project cannot ship.

Real silicon re-reads the control byte after every START, so `start()` now clears the state. `sh1107.rs` had the identical defect and gets the identical fix.

## Related Issues

None filed — found while checking the panel in the CRA secure-boot lab embedded on the blog.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist
- [x] I have run `cargo fmt` and `cargo clippy`. (`fmt --check` clean; clippy's one warning is pre-existing in `rc522.rs`, untouched here)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation accordingly. (the `why` is in the doc comments on both `start()` impls and on the test)
- [x] My changes generate no new warnings.

`transfers_under_one_stop_keep_their_control_bytes` drives the transfers the way a real driver does — START per transfer, one trailing STOP. The existing coverage called `stop()` after every transaction, which is exactly why it never saw this.

Full lib suite: 2792 passed, 0 failed. Lab still passes 45/45.

## Screenshots (if applicable)

Panel content after the fix, read back from the framebuffer artifact:

```
.####.#####..###..#...#.####..#####.......####...###...###..#####........###..#...#
#.....#.....#...#.#...#.#...#.#...........#...#.#...#.#...#...#.........#...#.#..#.
#.....#.....#.....#...#.#...#.#...........#...#.#...#.#...#...#.........#...#.#.#..
.###..####..#.....#...#.####..####........####..#...#.#...#...#.........#...#.##...
....#.#.....#.....#...#.#.#...#...........#...#.#...#.#...#...#.........#...#.#.#..
####..#####..###...###..#...#.#####.......####...###...###....#..........###..#...#
```

---
_Generated by [Claude Code](https://claude.ai/code/session_017TSTywgvCmjfo9C4Gm6Tcn)_