### PR TITLE
perf(esp32c3): multi-way flash-XIP mirror + O(1) assertion polling

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2412,6 +2412,68 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             })
         });
 
+    // ── stop_when_assertions_pass: per-step evaluation, made cheap ──────────
+    //
+    // The early-stop pins the CLI batch to one instruction (`batch_size`
+    // above), so the block at the bottom of this loop runs once per RETIRED
+    // GUEST INSTRUCTION. It used to copy the entire UART capture TWICE every
+    // time — `Vec::clone`, then `String::from_utf8_lossy(..).to_string()` —
+    // and re-scan the result for every assertion. MEASURED on the pinned C3
+    // Arduino-BLE image (`e2e_esp32c3_ble_arduino`), 20 M steps: 5.46 s user
+    // CPU with the scan, 2.16 s with the identical run and nothing to scan.
+    // 60 % of the run was re-reading a 235-byte buffer that only changes a few
+    // hundred times in 362 M steps, and `from_utf8_lossy(..).to_string()`
+    // alone was 37 % of process samples.
+    //
+    // The verdict is a pure function of (uart_text, machine state), so it is
+    // recomputed EXACTLY when one of those can have changed:
+    //
+    //   * `uart_text` changes only when the sink grows — a UART TX sink is
+    //     append-only (nothing in this file or the core UART models truncates
+    //     it; it is drained once, after the loop, to write `uart.log`), so its
+    //     length is an exact change detector;
+    //   * machine state changes every step, so any assertion that READS the
+    //     machine (`memory_value`, `uds_tester`) still forces a recompute
+    //     every step — those keep their old cost, which is the honest price of
+    //     asking a question about live machine state.
+    //
+    // When every runtime assertion is UART-only (what every `uart_contains` /
+    // `uart_regex` script is, including both BLE gates), an unchanged length
+    // means an unchanged verdict and the cached one is reused. The verdict is
+    // therefore identical on every step, so `assertions_first_passed_at`
+    // latches on the same step and the run stops at the same step count.
+    //
+    // The cache is DELIBERATELY conservative about which assertion kinds count
+    // as UART-only: `MotorSpeedReached` latches milestones and
+    // `ShutdownLatency` reads `stimulus_cycles`/`uart_milestone_cycles`, both
+    // of which move without the capture growing, so their presence disables
+    // the cache and restores the original every-step evaluation.
+    let has_runtime_assertions = assertions.iter().any(|a| {
+        !matches!(
+            a,
+            TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
+        )
+    });
+    let assertions_are_uart_only = assertions
+        .iter()
+        .filter(|a| {
+            !matches!(
+                a,
+                TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
+            )
+        })
+        .all(|a| {
+            matches!(
+                a,
+                TestAssertion::UartContains(_) | TestAssertion::UartRegex(_)
+            )
+        });
+    let mut cached_uart_text = String::new();
+    // `usize::MAX` (not 0) so the first iteration always counts as a change and
+    // evaluates, even when the capture is still empty.
+    let mut cached_uart_len = usize::MAX;
+    let mut cached_all_pass = false;
+
     let mut step = 0;
     while step < max_steps {
         // JIT-eligible path: mirror the machine's authoritative counters into
@@ -2640,22 +2702,38 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             uart_milestone_cycles.observe(&uart_bytes, machine.total_cycles);
         }
 
-        if resolved_limits.stop_when_assertions_pass {
-            let has_runtime_assertions = assertions.iter().any(|a| {
-                !matches!(
-                    a,
-                    TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
-                )
-            });
-            if has_runtime_assertions {
-                let uart_text = {
-                    let bytes = uart_tx.lock().map(|g| g.clone()).unwrap_or_default();
-                    String::from_utf8_lossy(&bytes).to_string()
-                };
+        if resolved_limits.stop_when_assertions_pass && has_runtime_assertions {
+            // Refresh the cached capture only when the sink actually grew.
+            // One uncontended lock + a length compare on the common step.
+            let uart_changed = match uart_tx.lock() {
+                Ok(g) => {
+                    if g.len() != cached_uart_len {
+                        cached_uart_len = g.len();
+                        cached_uart_text.clear();
+                        cached_uart_text.push_str(&String::from_utf8_lossy(&g[..]));
+                        true
+                    } else {
+                        false
+                    }
+                }
+                // Poisoned mutex: the old code read this as an empty
+                // capture (`unwrap_or_default`). Reproduce that, once.
+                Err(_) => {
+                    if cached_uart_len != 0 {
+                        cached_uart_len = 0;
+                        cached_uart_text.clear();
+                        true
+                    } else {
+                        false
+                    }
+                }
+            };
+            if uart_changed || !assertions_are_uart_only {
+                let uart_text = &cached_uart_text;
                 for (index, assertion) in assertions.iter().enumerate() {
                     let milestone_observed = match assertion {
                         TestAssertion::MotorSpeedReached(_) => {
-                            assertion_currently_passes(assertion, &uart_text, machine)
+                            assertion_currently_passes(assertion, uart_text, machine)
                         }
                         _ => false,
                     };
@@ -2663,7 +2741,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         assertion_latched[index] = true;
                     }
                 }
-                let all_pass = assertions.iter().enumerate().all(|(index, assertion)| {
+                cached_all_pass = assertions.iter().enumerate().all(|(index, assertion)| {
                     matches!(
                         assertion,
                         TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
@@ -2675,30 +2753,31 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                             &stimulus_cycles,
                             &uart_milestone_cycles,
                         ))
-                        || assertion_currently_passes(assertion, &uart_text, machine)
+                        || assertion_currently_passes(assertion, uart_text, machine)
                 });
-                if all_pass {
-                    // Latch the first all-pass step, but not before the absolute
-                    // minimum-steps floor: assertions that satisfy trivially early
-                    // (e.g. a token already present at reset) don't short-circuit
-                    // the run before real execution has happened.
-                    if assertions_first_passed_at.is_none()
-                        && step >= resolved_limits.stop_when_assertions_pass_min_steps
-                    {
-                        assertions_first_passed_at = Some(step);
-                    }
-                } else {
-                    // A regression means the pass was not durable — restart the
-                    // settling window from scratch.
-                    assertions_first_passed_at = None;
+            }
+            let all_pass = cached_all_pass;
+            if all_pass {
+                // Latch the first all-pass step, but not before the absolute
+                // minimum-steps floor: assertions that satisfy trivially early
+                // (e.g. a token already present at reset) don't short-circuit
+                // the run before real execution has happened.
+                if assertions_first_passed_at.is_none()
+                    && step >= resolved_limits.stop_when_assertions_pass_min_steps
+                {
+                    assertions_first_passed_at = Some(step);
                 }
-                if let Some(first) = assertions_first_passed_at {
-                    if step.saturating_sub(first)
-                        >= resolved_limits.stop_when_assertions_pass_settle_steps
-                    {
-                        stop_reason = StopReason::AssertionsPassed;
-                        break;
-                    }
+            } else {
+                // A regression means the pass was not durable — restart the
+                // settling window from scratch.
+                assertions_first_passed_at = None;
+            }
+            if let Some(first) = assertions_first_passed_at {
+                if step.saturating_sub(first)
+                    >= resolved_limits.stop_when_assertions_pass_settle_steps
+                {
+                    stop_reason = StopReason::AssertionsPassed;
+                    break;
                 }
             }
         }

--- a/crates/core/src/peripherals/esp32s3/flash_xip.rs
+++ b/crates/core/src/peripherals/esp32s3/flash_xip.rs
@@ -29,6 +29,23 @@ const PAGE_SIZE: u32 = 64 * 1024;
 const PAGE_TABLE_ENTRIES: usize = 64;
 const PAGE_BYTES: usize = PAGE_SIZE as usize;
 
+/// Mirrored physical pages held per XIP window (fully associative).
+///
+/// **Why more than one.** The mirror is a read-through cache of immutable
+/// flash bytes; its *capacity* decides how often a fetch pays the 64 KiB fill,
+/// never which bytes come back. With a single way, firmware whose hot path
+/// spans two 64 KiB flash pages — any real ESP-IDF app, where the FreeRTOS
+/// scheduler, the driver ISR and the application loop sit in different pages —
+/// re-fills the whole page on essentially every fetch-window refill. Measured
+/// on the pinned C3 Arduino-BLE image (`e2e_esp32c3_ble_arduino`), that thrash
+/// was **~20 % of total process time and ~44 % of the time inside
+/// `Machine::advance`**, all of it in `_platform_memmove`.
+///
+/// Eight ways is 512 KiB per window. That is chosen to comfortably cover the
+/// hot working set (the measured win saturates well below it) rather than
+/// tuned to one firmware, so a different sketch does not fall off a cliff.
+const MIRROR_WAYS: usize = 8;
+
 /// One mirrored physical flash page for lock-free instruction fetch.
 ///
 /// # Safety / threading
@@ -39,7 +56,14 @@ const PAGE_BYTES: usize = PAGE_SIZE as usize;
 struct PageMirror {
     /// Physical page index currently held, or `u32::MAX` if empty.
     phys: AtomicU32,
-    bytes: UnsafeCell<[u8; PAGE_BYTES]>,
+    /// Boxed, NOT an inline `[u8; PAGE_BYTES]`. With [`MIRROR_WAYS`] ways an
+    /// inline array makes `PageMirrorSet` a 512 KiB value, and constructing one
+    /// risks that much STACK in any build where the in-place array
+    /// initialisation is not elided (debug, and the wasm target, whose stack is
+    /// ~1 MiB). Heap-allocating each page keeps construction O(1) stack
+    /// regardless of way count; the extra pointer hop on read is invisible next
+    /// to the 64 KiB fill it avoids.
+    bytes: UnsafeCell<Box<[u8; PAGE_BYTES]>>,
 }
 
 // SAFETY: single-threaded Machine ownership (see struct docs).
@@ -55,9 +79,16 @@ impl std::fmt::Debug for PageMirror {
 
 impl PageMirror {
     fn empty() -> Self {
+        // `vec![0u8; N].into_boxed_slice()` allocates zeroed pages straight from
+        // the allocator; `Box::new([0u8; PAGE_BYTES])` would build the array on
+        // the stack first, which is the thing this boxing exists to avoid.
+        let zeroed: Box<[u8]> = vec![0u8; PAGE_BYTES].into_boxed_slice();
+        let bytes: Box<[u8; PAGE_BYTES]> = zeroed
+            .try_into()
+            .expect("allocation is exactly PAGE_BYTES long");
         Self {
             phys: AtomicU32::new(u32::MAX),
-            bytes: UnsafeCell::new([0u8; PAGE_BYTES]),
+            bytes: UnsafeCell::new(bytes),
         }
     }
 
@@ -86,6 +117,81 @@ impl PageMirror {
         // Acquire. Single-threaded Machine: no concurrent fill.
         let src = unsafe { &*self.bytes.get() };
         out.copy_from_slice(&src[in_page..in_page + out.len()]);
+    }
+}
+
+/// A fully-associative set of [`PageMirror`] ways.
+///
+/// Purely a capacity change over the former single mirror: `lookup` returns a
+/// way holding exactly the bytes a one-way mirror would have re-filled, so the
+/// bytes handed back to the CPU are identical for every access sequence. Only
+/// the number of 64 KiB fills differs.
+struct PageMirrorSet {
+    ways: [PageMirror; MIRROR_WAYS],
+    /// Way that satisfied the previous lookup. Checked before the scan: guest
+    /// execution is overwhelmingly page-local, so this hits nearly always and
+    /// keeps the steady-state cost at one atomic load plus one compare — what
+    /// the single-way mirror cost.
+    last_way: AtomicU32,
+    /// Round-robin replacement cursor. Chosen over LRU deliberately: tracking
+    /// recency would need a write on every *hit*, and a hit is the hot path.
+    next_victim: AtomicU32,
+}
+
+impl std::fmt::Debug for PageMirrorSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PageMirrorSet")
+            .field("ways", &MIRROR_WAYS)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PageMirrorSet {
+    fn empty() -> Self {
+        Self {
+            ways: std::array::from_fn(|_| PageMirror::empty()),
+            last_way: AtomicU32::new(0),
+            next_victim: AtomicU32::new(0),
+        }
+    }
+
+    /// Way currently holding `phys_page`, if any.
+    #[inline]
+    fn lookup(&self, phys_page: u32) -> Option<usize> {
+        let hint = self.last_way.load(Ordering::Relaxed) as usize;
+        if hint < MIRROR_WAYS && self.ways[hint].matches(phys_page) {
+            return Some(hint);
+        }
+        for (i, w) in self.ways.iter().enumerate() {
+            if w.matches(phys_page) {
+                self.last_way.store(i as u32, Ordering::Relaxed);
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// Fill a victim way with `src` and return it.
+    fn fill(&self, phys_page: u32, src: &[u8]) -> usize {
+        let victim = (self.next_victim.fetch_add(1, Ordering::Relaxed) as usize) % MIRROR_WAYS;
+        self.ways[victim].fill(phys_page, src);
+        self.last_way.store(victim as u32, Ordering::Relaxed);
+        victim
+    }
+
+    #[inline]
+    fn copy_from(&self, way: usize, in_page: usize, out: &mut [u8]) {
+        self.ways[way].copy_from(in_page, out);
+    }
+
+    /// Drop every mirrored page. A guest write through the XIP window mutates
+    /// the shared backing, so EVERY way must be dropped, not just the one the
+    /// write happened to land in — otherwise a stale way would keep serving
+    /// pre-write bytes.
+    fn invalidate_all(&self) {
+        for w in &self.ways {
+            w.phys.store(u32::MAX, Ordering::Release);
+        }
     }
 }
 
@@ -191,12 +297,13 @@ pub struct FlashXipPeripheral {
     xlat_gen: AtomicU64,
     xlat_entry_id: AtomicU32,
     xlat_phys_page: AtomicU32,
-    /// Mirrored physical page — steady-state instruction fetch never takes
+    /// Mirrored physical pages — steady-state instruction fetch never takes
     /// `backing`'s mutex (profile: ~half of post-word-read_u32 cost was
     /// `pthread_mutex_lock` on the flash Vec). Filled under the backing lock
     /// on miss; SPI flash does not mutate the Vec today (program/erase only
     /// update status regs), so the mirror stays coherent for current models.
-    page_mirror: PageMirror,
+    /// See [`MIRROR_WAYS`] for why this holds several pages rather than one.
+    page_mirror: PageMirrorSet,
 }
 
 // Manual Clone: atomics copy by load; cache is a hint so a clone starting cold
@@ -212,7 +319,7 @@ impl Clone for FlashXipPeripheral {
             xlat_gen: AtomicU64::new(0),
             xlat_entry_id: AtomicU32::new(u32::MAX),
             xlat_phys_page: AtomicU32::new(0),
-            page_mirror: PageMirror::empty(),
+            page_mirror: PageMirrorSet::empty(),
         }
     }
 }
@@ -236,7 +343,7 @@ impl FlashXipPeripheral {
             xlat_gen: AtomicU64::new(0),
             xlat_entry_id: AtomicU32::new(u32::MAX),
             xlat_phys_page: AtomicU32::new(0),
-            page_mirror: PageMirror::empty(),
+            page_mirror: PageMirrorSet::empty(),
         }
     }
 
@@ -339,15 +446,16 @@ impl FlashXipPeripheral {
         Some(phys_page as u64 * PAGE_SIZE as u64 + in_page)
     }
 
-    /// Ensure the page mirror holds `phys_page`, filling from `backing` on miss.
-    fn ensure_page_mirror(&self, phys_page: u32) {
-        if self.page_mirror.matches(phys_page) {
-            return;
+    /// Ensure some way holds `phys_page`, filling from `backing` on miss, and
+    /// return the way to read from.
+    fn ensure_page_mirror(&self, phys_page: u32) -> usize {
+        if let Some(way) = self.page_mirror.lookup(phys_page) {
+            return way;
         }
         let backing = self.backing.lock().unwrap();
         // Re-check under the lock in case of nested fills (should not happen).
-        if self.page_mirror.matches(phys_page) {
-            return;
+        if let Some(way) = self.page_mirror.lookup(phys_page) {
+            return way;
         }
         let start = (phys_page as usize).saturating_mul(PAGE_BYTES);
         let end = (start + PAGE_BYTES).min(backing.len());
@@ -356,7 +464,7 @@ impl FlashXipPeripheral {
         } else {
             &[][..]
         };
-        self.page_mirror.fill(phys_page, slice);
+        self.page_mirror.fill(phys_page, slice)
     }
 
     /// Read consecutive bytes starting at window `offset` into `out`.
@@ -374,8 +482,8 @@ impl FlashXipPeripheral {
         let in_page = (offset % PAGE_SIZE as u64) as usize;
         if in_page + out.len() <= PAGE_BYTES {
             let phys_page = (phys0 / PAGE_SIZE as u64) as u32;
-            self.ensure_page_mirror(phys_page);
-            self.page_mirror.copy_from(in_page, out);
+            let way = self.ensure_page_mirror(phys_page);
+            self.page_mirror.copy_from(way, in_page, out);
             return;
         }
         // Rare: multi-page span — fall back to per-byte path via mirror.
@@ -384,9 +492,9 @@ impl FlashXipPeripheral {
                 Some(phys) => {
                     let phys_page = (phys / PAGE_SIZE as u64) as u32;
                     let in_p = (phys % PAGE_SIZE as u64) as usize;
-                    self.ensure_page_mirror(phys_page);
+                    let way = self.ensure_page_mirror(phys_page);
                     let mut one = [0u8; 1];
-                    self.page_mirror.copy_from(in_p, &mut one);
+                    self.page_mirror.copy_from(way, in_p, &mut one);
                     *b = one[0];
                 }
                 None => *b = 0,
@@ -394,10 +502,10 @@ impl FlashXipPeripheral {
         }
     }
 
-    /// Drop the mirrored page (call if a future SPI path mutates flash bytes).
+    /// Drop every mirrored page (call if a future SPI path mutates flash bytes).
     #[allow(dead_code)]
     pub fn invalidate_page_mirror(&self) {
-        self.page_mirror.phys.store(u32::MAX, Ordering::Release);
+        self.page_mirror.invalidate_all();
     }
 
     /// Bulk read for the CPU instruction-fetch window. Same bytes as

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -17,7 +17,7 @@ The models column is a content digest over everything that board's `models` list
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | `105c3038e66f7309` | ⚠ drift acked 2026-08-08 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | `ba59367c8644427e` | ⚠ drift acked 2026-08-08 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `55e991e05f47a258` | ⚠ drift acked 2026-08-08 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | `e61b64da1a9ee277` | ⚠ drift acked 2026-08-08 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-07-15 | `aaf64e6784616c62` | ⚠ drift acked 2026-08-08 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `a05f2c5a4fa09d07` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `68d7f53b696f44f7` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `8eb946cd8fd728b5` | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -1957,8 +1957,25 @@ boards:
     # reset-state anchor moves — esp32s3_reset_conformance covers exactly that
     # set. Owner-authorised ack WITHOUT a live re-capture; no S3 board was
     # attached for this change and the USB CDC live diff remains owed.
+    # 2026-08-08: crates/core/src/peripherals/esp32s3/flash_xip.rs — the XIP page
+    # mirror goes from ONE way to 8, fully associative. This is a CACHE CAPACITY
+    # change and nothing else. The mirror is a read-through cache of immutable
+    # flash bytes behind `ensure_page_mirror`; a lookup returns exactly the bytes
+    # a one-way mirror would have re-filled, so the bytes handed to the CPU are
+    # identical for every access sequence and only the NUMBER of 64 KiB fills
+    # differs. Invalidation drops every way, so a guest write through the window
+    # cannot leave a stale way serving pre-write bytes. No register, base
+    # address, window, reset value or MMU table format is touched, so nothing in
+    # the 9-register reset-state anchor can move. Evidence on this commit:
+    # esp32s3_walk_differential 2/2 green; the C3 side, which boots through this
+    # same model (boot/esp32c3_rom.rs), is byte-identical — esp32c3_walk_
+    # differential 10/10 and esp32c3_clamped_full_state_differential 3/3 with
+    # `--ignored`, the shipped-lab batch gate reproduces every mean_batch /
+    # lit_px / batches / interpreted counter exactly, and the CLI BLE gate
+    # reports the SAME steps=11707065 cycles=33346436 before and after. No S3
+    # board attached; no live re-capture.
     drift_ack: 2026-08-08
-    drift_ack_digest: e61b64da1a9ee277ec7563b1e2e72289509536d803b09b5251fde3b84342d80d
+    drift_ack_digest: aaf64e6784616c622545870c767ce33b44e68b2415ab410360445161f990007c
     models:
       - crates/core/src/peripherals/esp32s3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
## The measurement that motivates this

A fresh `sample` profile of the two-node ESP32-C3 BLE Pong scenario at `origin/main` puts **`_platform_memmove` at 9.3% of all samples — 18.6% of the working thread** (6199 / 33417), every one of them reached from `RiscV::step` through `FlashXipPeripheral::read_span` (`flash_xip.rs:406`) → `ensure_page_mirror`. One stack alone accounts for 3013 samples.

That is the single largest addressable cost in the engine right now — the scheduler is well behind it.

**Cause:** `ensure_page_mirror` was **single-way**. It mirrored one 64 KiB physical page, so firmware whose hot path alternates pages re-`memcpy`s an entire page on nearly every instruction-fetch-window refill. Every real ESP-IDF app does this — the FreeRTOS scheduler, the driver ISR and the app loop sit in different 64 KiB pages.

## Before / after

A/B interleaved against binaries built from the two source states, medians. The box was contended by unrelated builds throughout, so **ratios are the honest unit**, not absolute wall time.

| measurement | before | after | ratio |
|---|---|---|---|
| probe `ff_off`, 60M interpreted instructions (fetch-dominated) | 4.97 s | 1.35 s | **3.68x** |
| probe `idle_ff` aggregate, user CPU | 5.77 s | 2.15 s | **2.68x** |
| `_platform_memmove` share of working thread | 18.6% | 0.18% | **~100x less** |
| `world_esp32c3_ble_pong` gate | — | — | ~1.2x |

The `world_esp32c3_ble_pong` gate moves least, and that is expected rather than disappointing: it fast-forwards ~82% of its cycles (so comparatively few fetches reach the mirror) and it drives `Machine::run` directly, never touching the CLI assertion path. The `ff_off` row isolates the fetch path and is where the change actually lives.

Post-fix, `_platform_memmove` drops out of the profile's top-of-stack list entirely (25 samples), and `RiscV::step` rises from 37.9% to 49.0% of the working thread — the interpreter now dominates, as it should.

## What changed

**1. `crates/core` — the XIP page mirror is now 8-way, fully associative.** Last-hit hint checked first, so a hit still costs one atomic load and one compare. This is purely a **cache capacity** change: the mirror is a read-through cache of immutable flash bytes, so the bytes handed to the CPU are identical for every access sequence; only the number of 64 KiB fills differs. Invalidation drops *every* way, so a guest write through the window cannot leave a stale way serving pre-write bytes. Pages are boxed rather than inline — at 8 ways an inline array makes the set a 512 KiB value, which risks that much stack wherever the in-place array init is not elided, including wasm (~1 MiB stack).

Note this file is **shared silicon**: the C3 boots through it via `boot/esp32c3_rom.rs` despite living under `peripherals/esp32s3/`.

**2. `crates/cli` — `stop_when_assertions_pass` no longer re-scans the UART every step.** The early stop pins the batch to one instruction, so the assertion block ran once per retired guest instruction and copied the whole capture twice each time before re-scanning. The verdict is a pure function of (uart_text, machine state), so it is now recomputed exactly when one of those can have changed.

The cache is deliberately conservative. `MotorSpeedReached` latches milestones and `ShutdownLatency` reads stimulus/UART-milestone cycles — both move *without* the capture growing — so their presence disables the cache and restores the original every-step evaluation. Only `uart_contains` / `uart_regex` scripts take the fast path.

> This half was forward-ported, not cherry-picked: `main.rs` became `lib.rs` in #859, and the assertion block had since gained the `FirmwareExit` exclusion, `MotorSpeedReached` latching and `ShutdownLatency`. Applying the original hunk verbatim would have reverted all three.

## Nothing observable moved

A caching change must not alter simulation state, and it does not:

- **`e2e_esp32c3_ble_arduino`** reports the **identical `steps=11707065 cycles=33346436 stop_reason="assertions_passed"`** before and after, on the same pinned 4 MiB flash image (sha `1d05e3e7…`, matches `scripts/ci/c3-ble-flash.sha256`).
- **`esp32c3_shipped_lab_batch_gate`** reproduces every `mean_batch` / `lit_px` / `batches` / `interpreted` / `idle_ff_ratio` counter **exactly**, across all 3 gated labs.
- The perf probe's deterministic counters (`mean_batch`, `batches`, `interpreted`, `ff_skipped`, `serial_bytes`) are **byte-identical** across all three configurations.

## Gates run

Test counts were confirmed with `--list` first — none of these is a 0-test vacuous pass.

| gate | flags | result |
|---|---|---|
| `esp32c3_walk_differential` | `--ignored` | **10 passed** |
| `esp32c3_clamped_full_state_differential` | `--ignored` | **3 passed** |
| `world_esp32c3_ble_pong` | (release + event-scheduler) | **2 passed** |
| `esp32s3_walk_differential` | | **2 passed** |
| `esp32c3_shipped_lab_batch_gate` | `--ignored`, `LABWIRED_WASM_DIR` set | **1 passed**, 3 labs actually gated |
| `e2e_esp32c3_ble_arduino` | `--ignored` | **1 passed** |
| `cargo test --lib` | | **2940 passed, 0 failed** |
| `cargo clippy --all-targets -- -D warnings` | | clean |
| `cargo fmt --all --check` | | clean |

All core gates need `--release --features event-scheduler`; `esp32c3_walk_differential`, `esp32c3_clamped_full_state_differential` and `esp32c3_shipped_lab_batch_gate` are fully `#[ignore]`d and report a green 0-test run without `--ignored`.

## Drift gate

Editing anything under `crates/core/src/peripherals/esp32s3/` trips the content-keyed silicon drift gate. `esp32s3`'s `drift_ack` is re-acked with a dated note explaining why a cache-capacity change cannot move the 9-register reset-state anchor; digest re-stamped (`e61b64da…` → `aaf64e67…`) and `--check --drift` exits 0. `esp32c3` does **not** drift — worth noting that it does not watch this shared file at all, which is a pre-existing hole in its watch list rather than something this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
