### PR TITLE
fix(secure-boot-lab): blank the row before redrawing it, and assert the panel

### DIFF
--- a/crates/firmware-nrf52840-secure-boot/src/display.rs
+++ b/crates/firmware-nrf52840-secure-boot/src/display.rs
@@ -97,6 +97,19 @@ pub unsafe fn display_init() {
 pub unsafe fn display_text(page: u8, x: usize, s: &str) {
     let fb = &mut *core::ptr::addr_of_mut!(FB);
     let base = page as usize * 128;
+
+    // Blank the rest of the row first.
+    //
+    // The glyph loop below writes the 5 columns a character occupies and
+    // nothing else, so a shorter string used to leave the tail of whatever was
+    // on that row before. Boot 2 painted "ECDSA VERIFY..." on page 4 and then
+    // "SE: SIG OK" over it, and the panel showed "SE: SIG OK" followed by a
+    // leftover "FY...". Clearing only this row keeps the dashboard's other
+    // lines, which the caller expects to survive.
+    for c in x..128 {
+        fb[base + c] = 0;
+    }
+
     for (i, ch) in s.bytes().enumerate() {
         let col = x + i * 6;
         if col + 5 > 128 {

--- a/examples/nrf52840-secure-boot-lab/secure-boot-smoke.yaml
+++ b/examples/nrf52840-secure-boot-lab/secure-boot-smoke.yaml
@@ -251,4 +251,114 @@ assertions:
       expected_value: 0x242FD799
       size: 4
 
+  # ── The panel ────────────────────────────────────────────────────────────
+  # Until now nothing in this script read the OLED, and the run went green
+  # while the panel painted scrambled output: the SSD1306 model dropped the
+  # control byte on every transfer after the first, so the framebuffer was
+  # parsed as commands and the image landed 49 columns to the right with rows
+  # wrapped into the wrong pages. 45 passing assertions said nothing about it.
+  #
+  # These measure the final frame, which is boot 3's screen:
+  #
+  #   page 0  SECURE BOOT OK     page 4  ROLLBACK REJECTED
+  #   page 1  FW V2 ACTIVE       page 5  FORGED REJECTED
+  #   page 2  ANTI-ROLLBACK ON   page 6  ATTEST + FLASH OK
+  #   page 3  (never painted)    page 7  CRA READY
+  #
+  # Each text row sits near 0.28 ink, so 0.15..0.45 passes the real glyphs and
+  # fails both a blank row and a row of noise. The tail regions are the ones
+  # that matter most: they must be EXACTLY empty, which is what a shifted,
+  # wrapped or overrun image cannot be.
+  #
+  # Coverage limit, stated because a check only covers what it reads: this is
+  # the final frame only. A row that is wrong mid-run and repainted correctly
+  # after a reboot passes here. Catching that needs either a time-scoped
+  # display assertion or a second capped run, and a second run would mean a
+  # third copy of the injected package bytes.
+
+  # Text is present, and starts at the left edge. Under the shifted-image bug
+  # this first character cell was blank.
+  - display_region:
+      id: "oled"
+      x: 0
+      y: 0
+      w: 6
+      h: 8
+      min_ink: 0.10
+      max_ink: 0.60
+  - display_region:
+      id: "oled"
+      x: 0
+      y: 0
+      w: 84
+      h: 8
+      min_ink: 0.15
+      max_ink: 0.45
+  - display_region:
+      id: "oled"
+      x: 0
+      y: 16
+      w: 96
+      h: 8
+      min_ink: 0.15
+      max_ink: 0.45
+  - display_region:
+      id: "oled"
+      x: 0
+      y: 32
+      w: 102
+      h: 8
+      min_ink: 0.15
+      max_ink: 0.45
+  - display_region:
+      id: "oled"
+      x: 0
+      y: 56
+      w: 54
+      h: 8
+      min_ink: 0.15
+      max_ink: 0.45
+
+  # Nothing past the end of a line, and nothing on the row boot 3 never paints.
+  - display_region:
+      id: "oled"
+      x: 90
+      y: 0
+      w: 38
+      h: 8
+      min_ink: 0.0
+      max_ink: 0.0
+  - display_region:
+      id: "oled"
+      x: 102
+      y: 16
+      w: 26
+      h: 8
+      min_ink: 0.0
+      max_ink: 0.0
+  - display_region:
+      id: "oled"
+      x: 0
+      y: 24
+      w: 128
+      h: 8
+      min_ink: 0.0
+      max_ink: 0.0
+  - display_region:
+      id: "oled"
+      x: 108
+      y: 32
+      w: 20
+      h: 8
+      min_ink: 0.0
+      max_ink: 0.0
+  - display_region:
+      id: "oled"
+      x: 60
+      y: 56
+      w: 68
+      h: 8
+      min_ink: 0.0
+      max_ink: 0.0
+
   - expected_stop_reason: max_steps


### PR DESCRIPTION
## Description

Second display bug in this lab, this one in the firmware. #870 fixed the simulator side.

`display_text` writes the 5 columns each glyph occupies and nothing else, and nothing ever cleared the framebuffer. Boot 2 paints page 4 twice:

```
"ECDSA VERIFY..."   15 chars -> columns 0..88
"SE: SIG OK"        10 chars -> columns 0..58
```

Columns 60..88 kept characters 10 to 14 of the first string, so the panel read `SE: SIG OKFY...`. Captured at 5,500,000 steps, page 4:

```
before   .####.#####..............####..###...###.........###..#...#.#####.#...#
after    .####.#####..............####..###...###.........###..#...#
         S     E      :          S      I     G           O     K   | leftover FY...
```

This is a single boot, so it is not the reset-clears-bss case. It also explains why the run looked fine when the final frame was checked: boot 3 paints onto a freshly zeroed buffer after the reboot, so only the mid-run frame is wrong. Watching the lab run is where it shows.

The fix blanks the row being written rather than the whole buffer. Boot 2's second paint deliberately leaves the header lines on pages 0, 1 and 3 standing, and clearing everything would wipe them. Pages 0, 1, 3, 5 and 6 come out byte-identical before and after; only page 4 changes.

## Assert the panel

Nothing in `secure-boot-smoke.yaml` read the display, which is why both bugs shipped green. Ten `display_region` clauses now measure the final frame.

Text rows sit near 0.28 ink, so `0.15..0.45` passes real glyphs and fails a blank row or a row of noise. The tail regions have to be exactly empty, which a shifted, wrapped or overrun image cannot be.

Replayed against the framebuffer captured before #870, 6 of the 10 fail:

```
left cell    0.000  need 0.10..0.60  FAIL
row0         0.144  need 0.15..0.45  FAIL
row2         0.000  need 0.15..0.45  FAIL
row7         0.000  need 0.15..0.45  FAIL
row0 tail    0.283  need 0.00..0.00  FAIL
row3 blank   0.146  need 0.00..0.00  FAIL
```

That run reported `PASS 45/45`.

**Coverage limit**, written into the script next to the clauses rather than left to be discovered: this reads the final frame only. A row that is wrong mid-run and repainted after a reboot still passes, which is exactly the bug fixed here. Closing that needs a time-scoped display assertion or a second capped run, and a second run would mean a third copy of the injected package bytes. Worth doing, but as its own change.

Separately: nothing in this repo's CI runs this lab at all, so these assertions gate manual runs and the evidence repo, not `pr-gate`.

## Related Issues

Follow-up to #870.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist
- [x] I have run `cargo fmt` and `cargo clippy`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

## Screenshots (if applicable)

Lab goes from `PASS 45/45` to `PASS 55/55`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017TSTywgvCmjfo9C4Gm6Tcn)_