### PR TITLE
fix(cortex-m): propagate bus memory violations from every load and store

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -922,7 +922,62 @@ impl Cpu for CortexM {
     }
 }
 
+/// Width of a Cortex-M data-side memory access.
+///
+/// The third argument to [`CortexM::load`] / [`CortexM::store`], which are the
+/// only two doors through which this core touches the data bus.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum AccessWidth {
+    Byte,
+    Half,
+    Word,
+}
+
 impl CortexM {
+    /// The ONE data-side load on this core.
+    ///
+    /// `bus/accessors.rs` returns `Err(SimulationError::MemoryViolation(addr))`
+    /// for any address no memory region or peripheral window covers. This helper
+    /// propagates that `Err` to the caller, which propagates it out of
+    /// `step_internal` with `?` — the same contract `RiscV::step_internal` has
+    /// always had, and the reason the same firmware bug is fatal there.
+    ///
+    /// It exists so there is exactly one place where a Cortex-M load can decide
+    /// what a failed access means. Before it, 41 call sites decided
+    /// independently, and every one of them decided "pretend it worked": a
+    /// failed load left the destination register holding its previous value and
+    /// the run continued green.
+    ///
+    /// This deliberately does NOT raise a pending BusFault/HardFault
+    /// (ARMv7-M B1.5.14). Modelling ARM fault escalation is a separate change;
+    /// this one only makes the access contract explicit and consistent.
+    #[inline(always)]
+    fn load<B: Bus + ?Sized>(&self, bus: &B, addr: u32, width: AccessWidth) -> SimResult<u32> {
+        Ok(match width {
+            AccessWidth::Byte => bus.read_u8(addr as u64)? as u32,
+            AccessWidth::Half => bus.read_u16(addr as u64)? as u32,
+            AccessWidth::Word => bus.read_u32(addr as u64)?,
+        })
+    }
+
+    /// The ONE data-side store on this core. Counterpart to [`CortexM::load`];
+    /// see that doc for why. A failed store used to vanish at 25 `let _ =
+    /// bus.write_*` sites.
+    #[inline(always)]
+    fn store<B: Bus + ?Sized>(
+        &self,
+        bus: &mut B,
+        addr: u32,
+        width: AccessWidth,
+        value: u32,
+    ) -> SimResult<()> {
+        match width {
+            AccessWidth::Byte => bus.write_u8(addr as u64, value as u8),
+            AccessWidth::Half => bus.write_u16(addr as u64, value as u16),
+            AccessWidth::Word => bus.write_u32(addr as u64, value),
+        }
+    }
+
     #[inline(always)]
     fn step_internal<B: Bus + ?Sized>(
         &mut self,
@@ -986,14 +1041,18 @@ impl CortexM {
                     // Stack: R0, R1, R2, R3, R12, LR, PC, xPSR (with previous IPSR)
                     let stacked_lr = self.lr;
                     let stacked_pc = self.pc;
-                    let _ = bus.write_u32(frame_ptr as u64, self.r0);
-                    let _ = bus.write_u32((frame_ptr + 4) as u64, self.r1);
-                    let _ = bus.write_u32((frame_ptr + 8) as u64, self.r2);
-                    let _ = bus.write_u32((frame_ptr + 12) as u64, self.r3);
-                    let _ = bus.write_u32((frame_ptr + 16) as u64, self.r12);
-                    let _ = bus.write_u32((frame_ptr + 20) as u64, self.lr);
-                    let _ = bus.write_u32((frame_ptr + 24) as u64, self.pc);
-                    let _ = bus.write_u32((frame_ptr + 28) as u64, save_xpsr);
+                    // Stacking is a data-side store like any other: if the frame
+                    // does not fit in mapped memory the write must surface, not
+                    // vanish. `exception_return`'s matching unstacking loads have
+                    // always propagated with `?`; this makes entry symmetric.
+                    self.store(bus, frame_ptr, AccessWidth::Word, self.r0)?;
+                    self.store(bus, frame_ptr + 4, AccessWidth::Word, self.r1)?;
+                    self.store(bus, frame_ptr + 8, AccessWidth::Word, self.r2)?;
+                    self.store(bus, frame_ptr + 12, AccessWidth::Word, self.r3)?;
+                    self.store(bus, frame_ptr + 16, AccessWidth::Word, self.r12)?;
+                    self.store(bus, frame_ptr + 20, AccessWidth::Word, self.lr)?;
+                    self.store(bus, frame_ptr + 24, AccessWidth::Word, self.pc)?;
+                    self.store(bus, frame_ptr + 28, AccessWidth::Word, save_xpsr)?;
 
                     // Bank the preempted stack pointer into its bank (PSP or MSP)
                     // BEFORE entering Handler mode, then switch the live `sp` to MSP.
@@ -1033,13 +1092,12 @@ impl CortexM {
                             bus.read_u32(vector_addr as u64)
                         );
                     }
-                    if let Ok(handler) = bus.read_u32(vector_addr as u64) {
-                        self.pc = handler & !1;
-                        tracing::debug!(
+                    let handler = self.load(bus, vector_addr, AccessWidth::Word)?;
+                    self.pc = handler & !1;
+                    tracing::debug!(
                         "EXC_ENTRY: exc={} handler={:#010x} frame={:#010x} stacked_lr={:#010x} stacked_pc={:#010x}",
                         exception_num, self.pc, frame_ptr, stacked_lr, stacked_pc
                     );
-                    }
 
                     return Ok(());
                 } // end else (NVIC ISPR still set — take the exception)
@@ -1540,14 +1598,13 @@ impl CortexM {
                         self.read_reg(rn)
                     };
                     let addr = base.wrapping_add(imm12 as u32);
-                    if let Ok(val) = bus.read_u32(addr as u64) {
-                        if rt == 15 {
-                            // LDR PC, [...] is an interworking branch — must go through branch_to
-                            self.branch_to(val, bus)?;
-                            pc_increment = 0;
-                        } else {
-                            self.write_reg(rt, val);
-                        }
+                    let val = self.load(bus, addr, AccessWidth::Word)?;
+                    if rt == 15 {
+                        // LDR PC, [...] is an interworking branch — must go through branch_to
+                        self.branch_to(val, bus)?;
+                        pc_increment = 0;
+                    } else {
+                        self.write_reg(rt, val);
                     }
                     // pc_increment stays at 4 (set by decode) unless we took a branch above
                 }
@@ -1555,7 +1612,7 @@ impl CortexM {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm12 as u32);
                     let val = self.read_reg(rt);
-                    let _ = bus.write_u32(addr as u64, val);
+                    self.store(bus, addr, AccessWidth::Word, val)?;
                     pc_increment = 4;
                 }
                 Instruction::LdrImm32Idx {
@@ -1577,21 +1634,18 @@ impl CortexM {
                         base.wrapping_sub(offset)
                     };
                     let access_addr = if pre_index { offset_addr } else { base };
-                    if let Ok(val) = bus.read_u32(access_addr as u64) {
-                        // Commit writeback before branching so a load-to-PC
-                        // (function return) leaves Rn=SP correct.
-                        if writeback {
-                            self.write_reg(rn, offset_addr);
-                        }
-                        if rt == 15 {
-                            // LDR PC, [...] — interworking branch (function return).
-                            self.branch_to(val, bus)?;
-                            pc_increment = 0;
-                        } else {
-                            self.write_reg(rt, val);
-                            pc_increment = 4;
-                        }
+                    let val = self.load(bus, access_addr, AccessWidth::Word)?;
+                    // Commit writeback before branching so a load-to-PC
+                    // (function return) leaves Rn=SP correct.
+                    if writeback {
+                        self.write_reg(rn, offset_addr);
+                    }
+                    if rt == 15 {
+                        // LDR PC, [...] — interworking branch (function return).
+                        self.branch_to(val, bus)?;
+                        pc_increment = 0;
                     } else {
+                        self.write_reg(rt, val);
                         pc_increment = 4;
                     }
                 }
@@ -1612,7 +1666,7 @@ impl CortexM {
                     };
                     let access_addr = if pre_index { offset_addr } else { base };
                     let val = self.read_reg(rt);
-                    let _ = bus.write_u32(access_addr as u64, val);
+                    self.store(bus, access_addr, AccessWidth::Word, val)?;
                     if writeback {
                         self.write_reg(rn, offset_addr);
                     }
@@ -1637,12 +1691,10 @@ impl CortexM {
                         base.wrapping_sub(imm8 << 2)
                     };
                     let addr = if index { offset_addr } else { base };
-                    if let Ok(v1) = bus.read_u32(addr as u64) {
-                        self.write_reg(rt, v1);
-                    }
-                    if let Ok(v2) = bus.read_u32(addr.wrapping_add(4) as u64) {
-                        self.write_reg(rt2, v2);
-                    }
+                    let v1 = self.load(bus, addr, AccessWidth::Word)?;
+                    self.write_reg(rt, v1);
+                    let v2 = self.load(bus, addr.wrapping_add(4), AccessWidth::Word)?;
+                    self.write_reg(rt2, v2);
                     if writeback {
                         self.write_reg(rn, offset_addr);
                     }
@@ -1666,8 +1718,8 @@ impl CortexM {
                     let addr = if index { offset_addr } else { base };
                     let v1 = self.read_reg(rt);
                     let v2 = self.read_reg(rt2);
-                    let _ = bus.write_u32(addr as u64, v1);
-                    let _ = bus.write_u32(addr.wrapping_add(4) as u64, v2);
+                    self.store(bus, addr, AccessWidth::Word, v1)?;
+                    self.store(bus, addr.wrapping_add(4), AccessWidth::Word, v2)?;
                     if writeback {
                         self.write_reg(rn, offset_addr);
                     }
@@ -1686,11 +1738,10 @@ impl CortexM {
                     }
                     let index = self.read_reg(rm);
                     let addr = base.wrapping_add(index);
-                    if let Ok(byte) = bus.read_u8(addr as u64) {
-                        let offset = (byte as u32) << 1;
-                        self.pc = self.pc.wrapping_add(4).wrapping_add(offset);
-                        pc_increment = 0;
-                    }
+                    let byte = self.load(bus, addr, AccessWidth::Byte)?;
+                    let offset = byte << 1;
+                    self.pc = self.pc.wrapping_add(4).wrapping_add(offset);
+                    pc_increment = 0;
                 }
                 Instruction::Tbh { rn, rm } => {
                     let mut base = self.read_reg(rn);
@@ -1700,11 +1751,10 @@ impl CortexM {
                     }
                     let index = self.read_reg(rm);
                     let addr = base.wrapping_add(index << 1);
-                    if let Ok(halfword) = bus.read_u16(addr as u64) {
-                        let offset = (halfword as u32) << 1;
-                        self.pc = self.pc.wrapping_add(4).wrapping_add(offset);
-                        pc_increment = 0;
-                    }
+                    let halfword = self.load(bus, addr, AccessWidth::Half)?;
+                    let offset = halfword << 1;
+                    self.pc = self.pc.wrapping_add(4).wrapping_add(offset);
+                    pc_increment = 0;
                 }
                 Instruction::Unknown32(h1, h2) => {
                     // Manual fallback for complex bit patterns not yet in Instruction enum.
@@ -1724,9 +1774,8 @@ impl CortexM {
                         let rt = ((h2 >> 12) & 0xF) as u8;
                         let imm8 = (h2 & 0xFF) as u32;
                         let addr = self.get_register(rn).wrapping_add(imm8 * 4);
-                        if let Ok(val) = bus.read_u32(addr as u64) {
-                            self.set_register(rt, val);
-                        }
+                        let val = self.load(bus, addr, AccessWidth::Word)?;
+                        self.set_register(rt, val);
                         pc_increment = 4;
                     } else if (h1 & 0xFFF0) == 0xE840 {
                         // STREX
@@ -1736,7 +1785,7 @@ impl CortexM {
                         let imm8 = (h2 & 0xFF) as u32;
                         let addr = self.get_register(rn).wrapping_add(imm8 * 4);
                         let val = self.get_register(rt);
-                        let _ = bus.write_u32(addr as u64, val);
+                        self.store(bus, addr, AccessWidth::Word, val)?;
                         // Rd = 0 → success.
                         self.set_register(rd, 0);
                         pc_increment = 4;
@@ -1753,14 +1802,15 @@ impl CortexM {
                         // LDAEX/STLEX.
                         let rn = (h1 & 0xF) as u8;
                         let rt = ((h2 >> 12) & 0xF) as u8;
-                        let addr = self.get_register(rn) as u64;
-                        let loaded = match (h2 >> 4) & 0xF {
-                            0x8 | 0xC => bus.read_u8(addr).ok().map(|v| v as u32),
-                            0x9 | 0xD => bus.read_u16(addr).ok().map(|v| v as u32),
-                            0xA | 0xE => bus.read_u32(addr).ok(),
+                        let addr = self.get_register(rn);
+                        let width = match (h2 >> 4) & 0xF {
+                            0x8 | 0xC => Some(AccessWidth::Byte),
+                            0x9 | 0xD => Some(AccessWidth::Half),
+                            0xA | 0xE => Some(AccessWidth::Word),
                             _ => None,
                         };
-                        if let Some(val) = loaded {
+                        if let Some(width) = width {
+                            let val = self.load(bus, addr, width)?;
                             self.set_register(rt, val);
                         }
                         pc_increment = 4;
@@ -1771,20 +1821,17 @@ impl CortexM {
                         //   h1 = 0xE8C0 | Rn, h2 = Rt<<12 | 0xF<<8 | sz<<4 | Rd/0xF
                         let rn = (h1 & 0xF) as u8;
                         let rt = ((h2 >> 12) & 0xF) as u8;
-                        let addr = self.get_register(rn) as u64;
+                        let addr = self.get_register(rn);
                         let val = self.get_register(rt);
                         let sz = (h2 >> 4) & 0xF;
-                        match sz {
-                            0x8 | 0xC => {
-                                let _ = bus.write_u8(addr, val as u8);
-                            }
-                            0x9 | 0xD => {
-                                let _ = bus.write_u16(addr, val as u16);
-                            }
-                            0xA | 0xE => {
-                                let _ = bus.write_u32(addr, val);
-                            }
-                            _ => {}
+                        let width = match sz {
+                            0x8 | 0xC => Some(AccessWidth::Byte),
+                            0x9 | 0xD => Some(AccessWidth::Half),
+                            0xA | 0xE => Some(AccessWidth::Word),
+                            _ => None,
+                        };
+                        if let Some(width) = width {
+                            self.store(bus, addr, width, val)?;
                         }
                         if matches!(sz, 0xC..=0xE) {
                             let rd = (h2 & 0xF) as u8;
@@ -1859,51 +1906,48 @@ impl CortexM {
                             let mut branch_taken = false;
                             match op1 & 0x7 {
                                 0 => {
-                                    let val = (self.read_reg(rt) & 0xFF) as u8;
-                                    let _ = bus.write_u8(addr as u64, val);
+                                    let val = self.read_reg(rt) & 0xFF;
+                                    self.store(bus, addr, AccessWidth::Byte, val)?;
                                 }
                                 // Rt==15 = PLD/PLI preload hint — NOP (handled by `_`).
                                 1 if rt != 15 => {
-                                    if let Ok(v) = bus.read_u8(addr as u64) {
-                                        let out = if is_signed {
-                                            (v as i8) as i32 as u32
-                                        } else {
-                                            v as u32
-                                        };
-                                        self.write_reg(rt, out);
-                                    }
+                                    let v = self.load(bus, addr, AccessWidth::Byte)?;
+                                    let out = if is_signed {
+                                        (v as u8 as i8) as i32 as u32
+                                    } else {
+                                        v
+                                    };
+                                    self.write_reg(rt, out);
                                 }
                                 2 => {
-                                    let val = (self.read_reg(rt) & 0xFFFF) as u16;
-                                    let _ = bus.write_u16(addr as u64, val);
+                                    let val = self.read_reg(rt) & 0xFFFF;
+                                    self.store(bus, addr, AccessWidth::Half, val)?;
                                 }
                                 // Rt==15 = PLDW preload hint — NOP (handled by `_`).
                                 3 if rt != 15 => {
-                                    if let Ok(v) = bus.read_u16(addr as u64) {
-                                        let out = if is_signed {
-                                            (v as i16) as i32 as u32
-                                        } else {
-                                            v as u32
-                                        };
-                                        self.write_reg(rt, out);
-                                    }
+                                    let v = self.load(bus, addr, AccessWidth::Half)?;
+                                    let out = if is_signed {
+                                        (v as u16 as i16) as i32 as u32
+                                    } else {
+                                        v
+                                    };
+                                    self.write_reg(rt, out);
                                 }
                                 4 => {
                                     let val = self.read_reg(rt);
-                                    let _ = bus.write_u32(addr as u64, val);
+                                    self.store(bus, addr, AccessWidth::Word, val)?;
                                 }
                                 5 => {
-                                    if let Ok(v) = bus.read_u32(addr as u64) {
-                                        if rt == 15 {
-                                            if wb {
-                                                self.write_reg(rn, wb_val);
-                                                wb = false;
-                                            }
-                                            self.branch_to(v, bus)?;
-                                            branch_taken = true;
-                                        } else {
-                                            self.write_reg(rt, v);
+                                    let v = self.load(bus, addr, AccessWidth::Word)?;
+                                    if rt == 15 {
+                                        if wb {
+                                            self.write_reg(rn, wb_val);
+                                            wb = false;
                                         }
+                                        self.branch_to(v, bus)?;
+                                        branch_taken = true;
+                                    } else {
+                                        self.write_reg(rt, v);
                                     }
                                 }
                                 _ => {
@@ -1934,47 +1978,44 @@ impl CortexM {
                             let mut branch_taken = false;
                             match op1 & 0x7 {
                                 0 => {
-                                    let val = (self.read_reg(rt) & 0xFF) as u8;
-                                    let _ = bus.write_u8(addr as u64, val);
+                                    let val = self.read_reg(rt) & 0xFF;
+                                    self.store(bus, addr, AccessWidth::Byte, val)?;
                                 }
                                 // Rt==15 = PLD/PLI preload hint — NOP (handled by `_`).
                                 1 if rt != 15 => {
-                                    if let Ok(v) = bus.read_u8(addr as u64) {
-                                        let out = if is_signed {
-                                            (v as i8) as i32 as u32
-                                        } else {
-                                            v as u32
-                                        };
-                                        self.write_reg(rt, out);
-                                    }
+                                    let v = self.load(bus, addr, AccessWidth::Byte)?;
+                                    let out = if is_signed {
+                                        (v as u8 as i8) as i32 as u32
+                                    } else {
+                                        v
+                                    };
+                                    self.write_reg(rt, out);
                                 }
                                 2 => {
-                                    let val = (self.read_reg(rt) & 0xFFFF) as u16;
-                                    let _ = bus.write_u16(addr as u64, val);
+                                    let val = self.read_reg(rt) & 0xFFFF;
+                                    self.store(bus, addr, AccessWidth::Half, val)?;
                                 }
                                 // Rt==15 = PLDW preload hint — NOP (handled by `_`).
                                 3 if rt != 15 => {
-                                    if let Ok(v) = bus.read_u16(addr as u64) {
-                                        let out = if is_signed {
-                                            (v as i16) as i32 as u32
-                                        } else {
-                                            v as u32
-                                        };
-                                        self.write_reg(rt, out);
-                                    }
+                                    let v = self.load(bus, addr, AccessWidth::Half)?;
+                                    let out = if is_signed {
+                                        (v as u16 as i16) as i32 as u32
+                                    } else {
+                                        v
+                                    };
+                                    self.write_reg(rt, out);
                                 }
                                 4 => {
                                     let val = self.read_reg(rt);
-                                    let _ = bus.write_u32(addr as u64, val);
+                                    self.store(bus, addr, AccessWidth::Word, val)?;
                                 }
                                 5 => {
-                                    if let Ok(v) = bus.read_u32(addr as u64) {
-                                        if rt == 15 {
-                                            self.branch_to(v, bus)?;
-                                            branch_taken = true;
-                                        } else {
-                                            self.write_reg(rt, v);
-                                        }
+                                    let v = self.load(bus, addr, AccessWidth::Word)?;
+                                    if rt == 15 {
+                                        self.branch_to(v, bus)?;
+                                        branch_taken = true;
+                                    } else {
+                                        self.write_reg(rt, v);
                                     }
                                 }
                                 _ => {}
@@ -2452,71 +2493,45 @@ impl CortexM {
                 Instruction::LdrImm { rt, rn, imm } => {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm as u32);
-                    if let Ok(val) = bus.read_u32(addr as u64) {
-                        self.write_reg(rt, val);
-                        if val == 0x021d0000 {
-                            tracing::info!("LDR Literal/Imm SUSPICIOUS: R{} loaded with {:#x} from {:#x} (PC={:#x})", rt, val, addr, self.pc);
-                        }
-                    } else {
-                        tracing::error!(
-                            "Bus Read Fault at {:#x} (PC={:#x}, Opcode={:#04x})",
-                            addr,
-                            self.pc,
-                            opcode
-                        );
+                    let val = self.load(bus, addr, AccessWidth::Word)?;
+                    self.write_reg(rt, val);
+                    if val == 0x021d0000 {
+                        tracing::info!("LDR Literal/Imm SUSPICIOUS: R{} loaded with {:#x} from {:#x} (PC={:#x})", rt, val, addr, self.pc);
                     }
                 }
                 Instruction::StrImm { rt, rn, imm } => {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm as u32);
                     let val = self.read_reg(rt);
-                    if bus.write_u32(addr as u64, val).is_err() {
-                        tracing::error!(
-                            "Bus Write Fault at {:#x} (PC={:#x}, Opcode={:#04x})",
-                            addr,
-                            self.pc,
-                            opcode
-                        );
-                    }
+                    self.store(bus, addr, AccessWidth::Word, val)?;
                 }
                 Instruction::LdrReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    if let Ok(val) = bus.read_u32(addr as u64) {
-                        self.write_reg(rt, val);
-                    } else {
-                        tracing::error!("Bus Read Fault (LDR reg) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Word)?;
+                    self.write_reg(rt, val);
                 }
                 Instruction::StrReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
                     let val = self.read_reg(rt);
-                    let _ = bus.write_u32(addr as u64, val);
+                    self.store(bus, addr, AccessWidth::Word, val)?;
                 }
 
                 Instruction::LdrLit { rt, imm } => {
                     let pc_val = (self.pc & !3) + 4;
                     let addr = pc_val.wrapping_add(imm as u32);
-                    if let Ok(val) = bus.read_u32(addr as u64) {
-                        self.write_reg(rt, val);
-                    } else {
-                        tracing::error!("Bus Read Fault (LdrLit) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Word)?;
+                    self.write_reg(rt, val);
                 }
 
                 Instruction::LdrSp { rt, imm } => {
                     let addr = self.sp.wrapping_add(imm as u32);
-                    if let Ok(val) = bus.read_u32(addr as u64) {
-                        self.write_reg(rt, val);
-                    } else {
-                        tracing::error!("Bus Read Fault (LdrSp) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Word)?;
+                    self.write_reg(rt, val);
                 }
                 Instruction::StrSp { rt, imm } => {
                     let addr = self.sp.wrapping_add(imm as u32);
                     let val = self.read_reg(rt);
-                    if bus.write_u32(addr as u64, val).is_err() {
-                        tracing::error!("Bus Write Fault (StrSp) at {:#x}", addr);
-                    }
+                    self.store(bus, addr, AccessWidth::Word, val)?;
                 }
                 Instruction::AddSpReg { rd, imm } => {
                     let res = self.sp.wrapping_add(imm as u32);
@@ -2545,90 +2560,58 @@ impl CortexM {
                 Instruction::LdrbImm { rt, rn, imm } => {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm as u32);
-                    if let Ok(val) = bus.read_u8(addr as u64) {
-                        self.write_reg(rt, val as u32);
-                    } else {
-                        tracing::error!(
-                            "Bus Read Fault (LDRB) at {:#x} (PC={:#x}, Opcode={:#04x})",
-                            addr,
-                            self.pc,
-                            opcode
-                        );
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Byte)?;
+                    self.write_reg(rt, val);
                 }
                 Instruction::LdrbReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    if let Ok(val) = bus.read_u8(addr as u64) {
-                        self.write_reg(rt, val as u32);
-                    } else {
-                        tracing::error!("Bus Read Fault (LDRB reg) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Byte)?;
+                    self.write_reg(rt, val);
                 }
                 Instruction::StrbReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    let val = (self.read_reg(rt) & 0xFF) as u8;
-                    let _ = bus.write_u8(addr as u64, val);
+                    let val = self.read_reg(rt) & 0xFF;
+                    self.store(bus, addr, AccessWidth::Byte, val)?;
                 }
                 Instruction::LdrsbReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    if let Ok(val) = bus.read_u8(addr as u64) {
-                        let res = (val as i8) as i32 as u32;
-                        self.write_reg(rt, res);
-                    } else {
-                        tracing::error!("Bus Read Fault (LDRSB reg) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Byte)?;
+                    let res = (val as u8 as i8) as i32 as u32;
+                    self.write_reg(rt, res);
                 }
                 Instruction::LdrhReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    if let Ok(val) = bus.read_u16(addr as u64) {
-                        self.write_reg(rt, val as u32);
-                    } else {
-                        tracing::error!("Bus Read Fault (LDRH reg) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Half)?;
+                    self.write_reg(rt, val);
                 }
                 Instruction::StrhReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    let val = (self.read_reg(rt) & 0xFFFF) as u16;
-                    let _ = bus.write_u16(addr as u64, val);
+                    let val = self.read_reg(rt) & 0xFFFF;
+                    self.store(bus, addr, AccessWidth::Half, val)?;
                 }
                 Instruction::LdrshReg { rt, rn, rm } => {
                     let addr = self.read_reg(rn).wrapping_add(self.read_reg(rm));
-                    if let Ok(val) = bus.read_u16(addr as u64) {
-                        let res = (val as i16) as i32 as u32;
-                        self.write_reg(rt, res);
-                    } else {
-                        tracing::error!("Bus Read Fault (LDRSH reg) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Half)?;
+                    let res = (val as u16 as i16) as i32 as u32;
+                    self.write_reg(rt, res);
                 }
                 Instruction::StrbImm { rt, rn, imm } => {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm as u32);
-                    let val = (self.read_reg(rt) & 0xFF) as u8;
-                    if bus.write_u8(addr as u64, val).is_err() {
-                        tracing::error!(
-                            "Bus Write Fault (STRB) at {:#x} (PC={:#x}, Opcode={:#04x})",
-                            addr,
-                            self.pc,
-                            opcode
-                        );
-                    }
+                    let val = self.read_reg(rt) & 0xFF;
+                    self.store(bus, addr, AccessWidth::Byte, val)?;
                 }
                 Instruction::LdrhImm { rt, rn, imm } => {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm as u32);
-                    if let Ok(val) = bus.read_u16(addr as u64) {
-                        self.write_reg(rt, val as u32);
-                    } else {
-                        tracing::error!("Bus Read Fault (LDRH) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Half)?;
+                    self.write_reg(rt, val);
                 }
                 Instruction::StrhImm { rt, rn, imm } => {
                     let base = self.read_reg(rn);
                     let addr = base.wrapping_add(imm as u32);
-                    let val = (self.read_reg(rt) & 0xFFFF) as u16;
-                    if bus.write_u16(addr as u64, val).is_err() {
-                        tracing::error!("Bus Write Fault (STRH) at {:#x}", addr);
-                    }
+                    let val = self.read_reg(rt) & 0xFFFF;
+                    self.store(bus, addr, AccessWidth::Half, val)?;
                 }
                 Instruction::Bkpt { imm8 } => {
                     // ARM semihosting uses `bkpt #0xAB` as the trap into
@@ -2671,9 +2654,7 @@ impl CortexM {
                     if m {
                         sp = sp.wrapping_sub(4);
                         let val = self.read_reg(14);
-                        if bus.write_u32(sp as u64, val).is_err() {
-                            tracing::error!("Stack Overflow (PUSH LR)");
-                        }
+                        self.store(bus, sp, AccessWidth::Word, val)?;
                     }
 
                     // Registers R7 down to R0
@@ -2681,9 +2662,7 @@ impl CortexM {
                         if (registers & (1 << i)) != 0 {
                             sp = sp.wrapping_sub(4);
                             let val = self.read_reg(i);
-                            if bus.write_u32(sp as u64, val).is_err() {
-                                tracing::error!("Stack Overflow (PUSH R{})", i);
-                            }
+                            self.store(bus, sp, AccessWidth::Word, val)?;
                         }
                     }
 
@@ -2695,9 +2674,8 @@ impl CortexM {
                     // Registers R0 up to R7
                     for i in 0..=7 {
                         if (registers & (1 << i)) != 0 {
-                            if let Ok(val) = bus.read_u32(sp as u64) {
-                                self.write_reg(i, val);
-                            }
+                            let val = self.load(bus, sp, AccessWidth::Word)?;
+                            self.write_reg(i, val);
                             sp = sp.wrapping_add(4);
                         }
                     }
@@ -2720,17 +2698,13 @@ impl CortexM {
                     // 2. If PC, read, add 4.
 
                     if p {
-                        if let Ok(val) = bus.read_u32(sp as u64) {
-                            // Commit SP before branching so EXC_RETURN unstacking reads the
-                            // hardware exception frame, not this function's software save area.
-                            sp = sp.wrapping_add(4);
-                            self.write_reg(13, sp);
-                            self.branch_to(val, bus)?;
-                            pc_increment = 0; // Branch taken
-                        } else {
-                            sp = sp.wrapping_add(4);
-                            self.write_reg(13, sp);
-                        }
+                        let val = self.load(bus, sp, AccessWidth::Word)?;
+                        // Commit SP before branching so EXC_RETURN unstacking reads the
+                        // hardware exception frame, not this function's software save area.
+                        sp = sp.wrapping_add(4);
+                        self.write_reg(13, sp);
+                        self.branch_to(val, bus)?;
+                        pc_increment = 0; // Branch taken
                     } else {
                         self.write_reg(13, sp);
                     }
@@ -2739,9 +2713,8 @@ impl CortexM {
                     let mut base = self.read_reg(rn);
                     for i in 0..=7 {
                         if (registers & (1 << i)) != 0 {
-                            if let Ok(val) = bus.read_u32(base as u64) {
-                                self.write_reg(i, val);
-                            }
+                            let val = self.load(bus, base, AccessWidth::Word)?;
+                            self.write_reg(i, val);
                             base = base.wrapping_add(4);
                         }
                     }
@@ -2762,9 +2735,7 @@ impl CortexM {
                     for i in 0..=7 {
                         if (registers & (1 << i)) != 0 {
                             let val = self.read_reg(i);
-                            if bus.write_u32(base as u64, val).is_err() {
-                                tracing::error!("Bus Write Fault (STM) at {:#x}", base);
-                            }
+                            self.store(bus, base, AccessWidth::Word, val)?;
                             base = base.wrapping_add(4);
                         }
                     }
@@ -2783,9 +2754,7 @@ impl CortexM {
                     for i in 0u8..=15 {
                         if (reg_list & (1 << i)) != 0 {
                             let val = self.read_reg(i);
-                            if bus.write_u32(addr as u64, val).is_err() {
-                                tracing::error!("Bus Write Fault (STMDB) at {:#x}", addr);
-                            }
+                            self.store(bus, addr, AccessWidth::Word, val)?;
                             addr = addr.wrapping_add(4);
                         }
                     }
@@ -2805,9 +2774,7 @@ impl CortexM {
                     for i in 0u8..=14 {
                         if (reg_list & (1 << i)) != 0 {
                             let val = self.read_reg(i);
-                            if bus.write_u32(addr as u64, val).is_err() {
-                                tracing::error!("Bus Write Fault (STMIA.W) at {:#x}", addr);
-                            }
+                            self.store(bus, addr, AccessWidth::Word, val)?;
                             addr = addr.wrapping_add(4);
                         }
                     }
@@ -2828,9 +2795,8 @@ impl CortexM {
                     let mut addr = start;
                     for i in 0u8..=14 {
                         if (reg_list & (1 << i)) != 0 {
-                            if let Ok(val) = bus.read_u32(addr as u64) {
-                                self.write_reg(i, val);
-                            }
+                            let val = self.load(bus, addr, AccessWidth::Word)?;
+                            self.write_reg(i, val);
                             addr = addr.wrapping_add(4);
                         }
                     }
@@ -2838,12 +2804,9 @@ impl CortexM {
                         self.write_reg(rn, start);
                     }
                     if (reg_list & (1 << 15)) != 0 {
-                        if let Ok(pc_val) = bus.read_u32(addr as u64) {
-                            self.branch_to(pc_val, bus)?;
-                            pc_increment = 0;
-                        } else {
-                            pc_increment = 4;
-                        }
+                        let pc_val = self.load(bus, addr, AccessWidth::Word)?;
+                        self.branch_to(pc_val, bus)?;
+                        pc_increment = 0;
                     } else {
                         pc_increment = 4;
                     }
@@ -2859,28 +2822,20 @@ impl CortexM {
                     // Load R0-R14 (skip PC; handle separately to commit SP first)
                     for i in 0u8..=14 {
                         if (reg_list & (1 << i)) != 0 {
-                            if let Ok(val) = bus.read_u32(addr as u64) {
-                                self.write_reg(i, val);
-                            }
+                            let val = self.load(bus, addr, AccessWidth::Word)?;
+                            self.write_reg(i, val);
                             addr = addr.wrapping_add(4);
                         }
                     }
                     // Handle PC (bit 15) — commit writeback before branching
                     if (reg_list & (1 << 15)) != 0 {
-                        if let Ok(pc_val) = bus.read_u32(addr as u64) {
-                            addr = addr.wrapping_add(4);
-                            if writeback {
-                                self.write_reg(rn, addr);
-                            }
-                            self.branch_to(pc_val, bus)?;
-                            pc_increment = 0;
-                        } else {
-                            addr = addr.wrapping_add(4);
-                            if writeback {
-                                self.write_reg(rn, addr);
-                            }
-                            pc_increment = 4;
+                        let pc_val = self.load(bus, addr, AccessWidth::Word)?;
+                        addr = addr.wrapping_add(4);
+                        if writeback {
+                            self.write_reg(rn, addr);
                         }
+                        self.branch_to(pc_val, bus)?;
+                        pc_increment = 0;
                     } else {
                         if writeback {
                             self.write_reg(rn, addr);
@@ -3106,11 +3061,8 @@ impl CortexM {
                     } else {
                         base.wrapping_sub(imm as u32)
                     };
-                    if let Ok(val) = bus.read_u32(addr as u64) {
-                        self.fpu_s[sd as usize] = val;
-                    } else {
-                        tracing::error!("Bus Read Fault (VLDR) at {:#x}", addr);
-                    }
+                    let val = self.load(bus, addr, AccessWidth::Word)?;
+                    self.fpu_s[sd as usize] = val;
                     pc_increment = 4;
                 }
                 Instruction::Vstr { sd, rn, imm, add } => {
@@ -3121,9 +3073,7 @@ impl CortexM {
                         base.wrapping_sub(imm as u32)
                     };
                     let val = self.fpu_s[sd as usize];
-                    if bus.write_u32(addr as u64, val).is_err() {
-                        tracing::error!("Bus Write Fault (VSTR) at {:#x}", addr);
-                    }
+                    self.store(bus, addr, AccessWidth::Word, val)?;
                     pc_increment = 4;
                 }
                 Instruction::VmulF32 { sd, sn, sm } => {
@@ -3252,9 +3202,7 @@ impl CortexM {
                         let idx = s_first as usize + i as usize;
                         let val = if idx < 32 { self.fpu_s[idx] } else { 0 };
                         let addr = start.wrapping_add(4 * i as u32);
-                        if bus.write_u32(addr as u64, val).is_err() {
-                            tracing::error!("Bus Write Fault (VSTM) at {:#x}", addr);
-                        }
+                        self.store(bus, addr, AccessWidth::Word, val)?;
                     }
                     if wback {
                         let nb = if add {
@@ -3279,13 +3227,9 @@ impl CortexM {
                     for i in 0..count {
                         let idx = s_first as usize + i as usize;
                         let addr = start.wrapping_add(4 * i as u32);
-                        match bus.read_u32(addr as u64) {
-                            Ok(v) => {
-                                if idx < 32 {
-                                    self.fpu_s[idx] = v;
-                                }
-                            }
-                            Err(_) => tracing::error!("Bus Read Fault (VLDM) at {:#x}", addr),
+                        let v = self.load(bus, addr, AccessWidth::Word)?;
+                        if idx < 32 {
+                            self.fpu_s[idx] = v;
                         }
                     }
                     if wback {
@@ -3307,16 +3251,9 @@ impl CortexM {
                         base.wrapping_sub(imm as u32)
                     };
                     for (w, off) in [(0usize, 0u32), (1, 4)] {
-                        match bus.read_u32(addr.wrapping_add(off) as u64) {
-                            Ok(v) => {
-                                if (dd as usize + w) < 32 {
-                                    self.fpu_s[dd as usize + w] = v;
-                                }
-                            }
-                            Err(_) => tracing::error!(
-                                "Bus Read Fault (VLDR.64) at {:#x}",
-                                addr.wrapping_add(off)
-                            ),
+                        let v = self.load(bus, addr.wrapping_add(off), AccessWidth::Word)?;
+                        if (dd as usize + w) < 32 {
+                            self.fpu_s[dd as usize + w] = v;
                         }
                     }
                     pc_increment = 4;
@@ -3334,12 +3271,7 @@ impl CortexM {
                         } else {
                             0
                         };
-                        if bus.write_u32(addr.wrapping_add(off) as u64, val).is_err() {
-                            tracing::error!(
-                                "Bus Write Fault (VSTR.64) at {:#x}",
-                                addr.wrapping_add(off)
-                            );
-                        }
+                        self.store(bus, addr.wrapping_add(off), AccessWidth::Word, val)?;
                     }
                     pc_increment = 4;
                 }

--- a/crates/core/src/cpu/mod.rs
+++ b/crates/core/src/cpu/mod.rs
@@ -4,7 +4,21 @@
 // This software is released under the MIT License.
 // See the LICENSE file in the project root for full license information.
 
+// A discarded bus access is a fabricated fact: `bus/accessors.rs` returns
+// `Err(SimulationError::MemoryViolation(addr))` for unmapped space, and a core
+// that throws that away runs firmware that would fault on silicon and reports a
+// green verdict. `let _ = bus.write_*` is how that happened 25 times in
+// `cortex_m.rs`. `Result` is `#[must_use]`, so denying
+// `clippy::let_underscore_must_use` here makes reintroducing the shape a
+// compile error under CI's `cargo clippy --all-targets -- -D warnings`.
+//
+// Scoped to the modules that hold the line rather than to `cpu/**`: `xtensa_lx7`
+// still carries four discarded stores (see the shrink-only allowlist in
+// `crate::tests::cortex_m_memory_contract`, which covers the whole `cpu/` tree
+// and catches the `is_err()` / `.ok()` discard shapes clippy cannot see).
+#[deny(clippy::let_underscore_must_use)]
 pub mod cortex_m;
+#[deny(clippy::let_underscore_must_use)]
 pub mod riscv;
 pub mod xtensa_lockstep;
 pub mod xtensa_lx7;

--- a/crates/core/src/tests/cortex_m_memory_contract.rs
+++ b/crates/core/src/tests/cortex_m_memory_contract.rs
@@ -1,0 +1,480 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Guard: the Cortex-M **load/store** path must honour the bus memory contract.
+//!
+//! `bus/accessors.rs` returns `Err(SimulationError::MemoryViolation(addr))` for
+//! any address no memory region or peripheral window covers. The RISC-V core
+//! propagates that with `?` at every access site. The Cortex-M core historically
+//! did not: data loads used `if let Ok(val) = bus.read_*` (leaving the
+//! destination register at its previous value) and data stores used
+//! `let _ = bus.write_*` (vanishing entirely). Firmware that would fault on
+//! silicon ran on with fabricated state and a green verdict.
+//!
+//! **How this differs from `examples/ci/dummy-memory-violation.yaml`.** That
+//! fixture asserts `expected_stop_reason: memory_violation` and passes today —
+//! but it gets there through the *instruction-fetch* path (`bus.read_u16(fetch_pc)?`
+//! in `step_internal`), which has always propagated. It proves the stop-reason
+//! plumbing works; it proves nothing about load/store. Every test below keeps
+//! the PC inside mapped flash for the whole run and faults only on the *data*
+//! address held in `Rn` — the half that was broken.
+//!
+//! Both directions are covered: an unmapped access must stop the run, and a
+//! **valid** access must still succeed and leave the run alive. A change that
+//! aborted on every access would pass a one-directional test.
+
+#[cfg(test)]
+mod no_discarded_bus_access {
+    //! The enforceable half: a discarded bus access anywhere under
+    //! `crates/core/src/cpu/**` fails this test.
+    //!
+    //! `#[deny(clippy::let_underscore_must_use)]` on the `cortex_m` and `riscv`
+    //! modules (see `cpu/mod.rs`) already makes `let _ = bus.write_*` a compile
+    //! error there under CI's `cargo clippy --all-targets -- -D warnings`. This
+    //! scan covers the whole `cpu/` tree and also catches the two discard shapes
+    //! clippy cannot see — `if bus.write_*(..).is_err() { log }` and
+    //! `bus.read_*(..).ok()` — and it runs in the cheap `cargo test -p
+    //! labwired-core --lib` lane, so both a clippy-less lane and a
+    //! clippy-carrying lane catch a reintroduction.
+
+    use std::path::{Path, PathBuf};
+
+    /// The complete set of discarded bus accesses allowed to remain under
+    /// `src/cpu/**`, keyed by file and matched on **exact line content** so a new
+    /// discard can never hide behind a line-number shift or a budget count.
+    ///
+    /// SHRINK-ONLY. Every entry is named and reasoned:
+    ///
+    /// **`cortex_m.rs` — the 2 reset-vector reads in `Cpu::reset`.** Deliberately
+    /// left tolerant, and the tolerance is load-bearing: making these propagate
+    /// was tried and measured, and it flips `examples/ci/dummy-memory-violation.yaml`
+    /// from `PASS / stop=memory_violation` to `FAIL / stop=halt`. That fixture's
+    /// 1-byte flash means the vector table is unreadable, and a reset that returns
+    /// `Err` is reported through a different path than a run-time violation. Boot
+    /// is a separate contract from the load/store contract this module pins; it
+    /// needs its own change and its own blast-radius work. Everything in
+    /// `step_internal` — every data load and store, and exception stacking — now
+    /// propagates.
+    ///
+    /// **`xtensa_lx7.rs` — 7 sites**, of which
+    ///   * **4 are the same defect this change fixed in Cortex-M**: the windowed
+    ///     register-overflow spill (~L778-781) writes a0..a3 with
+    ///     `let _ = bus.write_u32`, so the spill silently vanishes if the spill
+    ///     area is unmapped. Real debt, on a different core with its own blast
+    ///     radius — counted here rather than left silent.
+    ///   * **1 is legitimate**: `px_current_tcb` (~L1042) *probes* candidate BSS
+    ///     addresses for a live FreeRTOS TCB pointer. An `Err` there means "not
+    ///     this address", which is a real answer, not a fabricated one.
+    ///   * **2 are legitimate**: the hot-BB JIT pre-reads (~L555/L559) *decline
+    ///     the fast path* on `Err` (`return Ok(None)`) so the interpreter re-runs
+    ///     the access and raises the genuine fault with full context. The error is
+    ///     honoured by deferring, not dropped.
+    const ALLOWED_DISCARDS: &[(&str, &[&str])] = &[
+        (
+            "cortex_m.rs",
+            &[
+                "if let Ok(sp) = bus.read_u32(vtor) {",
+                "if let Ok(pc) = bus.read_u32(vtor + 4) {",
+            ],
+        ),
+        (
+            "xtensa_lx7.rs",
+            &[
+                "let b0 = match bus.read_u8(a3 as u64) {",
+                "let b1 = match bus.read_u8((a3.wrapping_add(1)) as u64) {",
+                "let _ = bus.write_u32(b as u64, r0);",
+                "let _ = bus.write_u32(b as u64 + 4, r1);",
+                "let _ = bus.write_u32(b as u64 + 8, r2);",
+                "let _ = bus.write_u32(b as u64 + 12, r3);",
+                "|base: u32| -> Option<u32> { bus.read_u32((base.wrapping_add(core * 4)) as u64).ok() };",
+            ],
+        ),
+    ];
+
+    fn cpu_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/cpu")
+    }
+
+    fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        let mut paths: Vec<PathBuf> = entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+        paths.sort();
+        for p in paths {
+            if p.is_dir() {
+                rust_files(&p, out);
+            } else if p.extension().is_some_and(|e| e == "rs") {
+                out.push(p);
+            }
+        }
+    }
+
+    /// True if `line` discards the result of a bus access.
+    ///
+    /// Deliberately syntactic: it is a guard against a shape being reintroduced
+    /// by a copy/paste, not a borrow checker.
+    fn is_discarded_bus_access(line: &str) -> bool {
+        let l = line.trim();
+        if l.starts_with("//") || l.starts_with("///") || l.starts_with("*") {
+            return false;
+        }
+        let touches_bus = l.contains("bus.read_u")
+            || l.contains("bus.write_u")
+            || l.contains("bus.read_")
+            || l.contains("bus.write_");
+        if !touches_bus {
+            return false;
+        }
+        // `let _ = bus.write_u32(..)` / `let _ = bus.read_u8(..)`
+        if l.starts_with("let _ =") || l.starts_with("let _:") {
+            return true;
+        }
+        // `if bus.write_u32(..).is_err() { .. }` — the error is observed and
+        // then dropped on the floor, which is the same fabricated fact.
+        if l.contains(".is_err()") || l.contains(".is_ok()") {
+            return true;
+        }
+        // `bus.read_u32(..).ok()` — Err collapsed to None and defaulted away.
+        if l.contains(".ok()") {
+            return true;
+        }
+        // `if let Ok(val) = bus.read_u32(..) { .. }` — the shape 41 of the
+        // original 66 sites used. The Err arm either logs or does nothing, and
+        // the destination register keeps whatever it held before. This is the
+        // single most important shape to catch: it is invisible to clippy,
+        // because nothing is being discarded as far as the type system can see.
+        if l.contains("if let Ok(") || l.contains("match bus.read_") {
+            return true;
+        }
+        false
+    }
+
+    /// Everything a scan finds, as (file name, hit count, rendered hits).
+    /// Hits are rendered as `path:line: <trimmed content>`.
+    fn scan() -> Vec<(String, u32, Vec<String>)> {
+        let mut files = Vec::new();
+        rust_files(&cpu_root(), &mut files);
+        assert!(
+            !files.is_empty(),
+            "found no .rs files under {} — the scanner is looking in the wrong \
+             place and would pass vacuously",
+            cpu_root().display()
+        );
+        let mut out = Vec::new();
+        for f in files {
+            let Ok(text) = std::fs::read_to_string(&f) else {
+                continue;
+            };
+            let mut hits = Vec::new();
+            let mut in_tests = false;
+            for (i, line) in text.lines().enumerate() {
+                // Test modules legitimately use `.unwrap()`/`let _`; the contract
+                // is about the production execute paths.
+                if line.trim_start().starts_with("#[cfg(test)]") {
+                    in_tests = true;
+                }
+                if in_tests {
+                    continue;
+                }
+                if is_discarded_bus_access(line) {
+                    hits.push(format!("{}:{}: {}", f.display(), i + 1, line.trim()));
+                }
+            }
+            if !hits.is_empty() {
+                let name = f.file_name().unwrap().to_string_lossy().to_string();
+                out.push((name, hits.len() as u32, hits));
+            }
+        }
+        out
+    }
+
+    /// The trimmed source line out of a rendered `path:line: content` hit.
+    fn content_of(hit: &str) -> &str {
+        hit.splitn(3, ':').nth(2).unwrap_or(hit).trim()
+    }
+
+    fn allowed_for(file: &str) -> &'static [&'static str] {
+        ALLOWED_DISCARDS
+            .iter()
+            .find(|(f, _)| *f == file)
+            .map(|(_, lines)| *lines)
+            .unwrap_or(&[])
+    }
+
+    /// The headline contract: nothing in the Cortex-M **execute path** discards a
+    /// bus access. The only permitted hits in `cortex_m.rs` are the two
+    /// reset-vector reads named in [`ALLOWED_DISCARDS`].
+    #[test]
+    fn cortex_m_execute_path_has_no_discarded_bus_accesses() {
+        let found = scan();
+        let hits: Vec<String> = found
+            .iter()
+            .filter(|(n, _, _)| n == "cortex_m.rs")
+            .flat_map(|(_, _, h)| h.iter().cloned())
+            .collect();
+        let allowed = allowed_for("cortex_m.rs");
+        let unexpected: Vec<&String> = hits
+            .iter()
+            .filter(|h| !allowed.contains(&content_of(h)))
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "cortex_m.rs discards a bus access outside the two documented \
+             reset-vector reads. `bus/accessors.rs` returns \
+             Err(MemoryViolation) and a discard fabricates state — a failed load \
+             leaves the destination register stale, a failed store vanishes, and \
+             the run stays green. Use CortexM::load / CortexM::store, which \
+             propagate with `?`. Found:\n{}",
+            unexpected
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    /// The same contract for every other core under `src/cpu/**`, so the debt on
+    /// `xtensa_lx7.rs` stays exactly where it is instead of growing quietly.
+    #[test]
+    fn cpu_module_discards_only_the_named_shrink_only_sites() {
+        let found = scan();
+        for (name, _, hits) in &found {
+            let allowed = allowed_for(name);
+            let unexpected: Vec<&String> = hits
+                .iter()
+                .filter(|h| !allowed.contains(&content_of(h)))
+                .collect();
+            assert!(
+                unexpected.is_empty(),
+                "{name} discards a bus access that is not in ALLOWED_DISCARDS. \
+                 Either propagate the Err, or add the line with a written reason \
+                 (the list is shrink-only). Found:\n{}",
+                unexpected
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+        // Shrink-only, enforced in the other direction: an allowlisted line that
+        // no longer exists must be deleted from the list, so the list can never
+        // quietly become a licence for a future discard.
+        for (name, lines) in ALLOWED_DISCARDS {
+            let hits: Vec<String> = found
+                .iter()
+                .filter(|(n, _, _)| n == name)
+                .flat_map(|(_, _, h)| h.iter().cloned())
+                .collect();
+            for want in *lines {
+                assert!(
+                    hits.iter().any(|h| content_of(h) == *want),
+                    "ALLOWED_DISCARDS still permits `{want}` in {name}, but the \
+                     scan no longer finds it. Remove the entry — the list is \
+                     shrink-only."
+                );
+            }
+        }
+    }
+
+    /// ANTI-VACUITY. The scanner must actually recognise the shapes it bans —
+    /// otherwise both tests above pass forever no matter what is committed.
+    #[test]
+    fn the_scanner_recognises_every_banned_shape() {
+        for bad in [
+            "let _ = bus.write_u32(addr as u64, val);",
+            "                    let _ = bus.write_u8(addr, v);",
+            "let _ = bus.read_u32(addr as u64);",
+            "if bus.write_u32(addr as u64, val).is_err() { log(); }",
+            "let v = bus.read_u32(addr).ok();",
+            "if let Ok(val) = bus.read_u32(addr as u64) {",
+            "match bus.read_u32(addr as u64) {",
+        ] {
+            assert!(
+                is_discarded_bus_access(bad),
+                "scanner failed to flag a banned shape: {bad}"
+            );
+        }
+        for good in [
+            "let val = self.load(bus, addr, AccessWidth::Word)?;",
+            "self.store(bus, addr, AccessWidth::Word, val)?;",
+            "let h1 = bus.read_u16(fetch_pc as u64)?;",
+            "bus.write_u32(addr as u64, value)",
+            "// let _ = bus.write_u32(addr, val); -- historical note",
+        ] {
+            assert!(
+                !is_discarded_bus_access(good),
+                "scanner wrongly flagged a propagating access: {good}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cpu::CortexM;
+    use crate::{Bus, Cpu, Machine, SimulationError};
+
+    /// Address covered by no memory region and no peripheral window on a default
+    /// `SystemBus` (flash 0x0000_0000..0x0010_0000, RAM 0x2000_0000..0x2010_0000,
+    /// peripherals at 0x4000_C000 / 0x4001_0800 / 0x4002_1000 / 0xE000_E010).
+    /// Also outside both bit-band alias windows.
+    const UNMAPPED: u32 = 0x9000_0000;
+    /// Mapped, writable RAM.
+    const MAPPED: u32 = 0x2000_0100;
+    /// Where the test instruction lives — always mapped, so instruction fetch
+    /// never faults and only the data access can.
+    const CODE: u32 = 0x1000;
+
+    const SENTINEL: u32 = 0xDEAD_BEEF;
+
+    fn machine_with_instr(instr: u16) -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        bus.write_u16(CODE as u64, instr)
+            .expect("code address must be mapped — otherwise this test would be a fetch test");
+        let mut machine = Machine::new(cpu, bus);
+        machine.cpu.set_pc(CODE);
+        machine
+    }
+
+    /// `LDR r0, [r1, #0]` — T1 encoding, rn = r1, rt = r0.
+    const LDR_R0_R1: u16 = 0x6808;
+    /// `STR r0, [r1, #0]` — T1 encoding, rn = r1, rt = r0.
+    const STR_R0_R1: u16 = 0x6008;
+
+    #[test]
+    fn cortex_m_load_from_unmapped_address_stops_the_run() {
+        let mut machine = machine_with_instr(LDR_R0_R1);
+        machine.cpu.set_register(1, UNMAPPED); // base address: unmapped
+        machine.cpu.set_register(0, SENTINEL); // destination: pre-loaded sentinel
+
+        let step = machine.step();
+
+        assert!(
+            matches!(step, Err(SimulationError::MemoryViolation(a)) if a == UNMAPPED as u64),
+            "a load from unmapped 0x{UNMAPPED:08X} must surface the bus \
+             MemoryViolation, not be discarded. got {step:?}; \
+             r0 = 0x{:08X} (stale sentinel means the load was silently dropped), \
+             pc = 0x{:08X}",
+            machine.cpu.get_register(0),
+            machine.cpu.get_pc(),
+        );
+    }
+
+    #[test]
+    fn cortex_m_store_to_unmapped_address_stops_the_run() {
+        let mut machine = machine_with_instr(STR_R0_R1);
+        machine.cpu.set_register(1, UNMAPPED); // base address: unmapped
+        machine.cpu.set_register(0, SENTINEL);
+
+        let step = machine.step();
+
+        assert!(
+            matches!(step, Err(SimulationError::MemoryViolation(a)) if a == UNMAPPED as u64),
+            "a store to unmapped 0x{UNMAPPED:08X} must surface the bus \
+             MemoryViolation, not vanish. got {step:?}; pc = 0x{:08X}",
+            machine.cpu.get_pc(),
+        );
+    }
+
+    #[test]
+    fn cortex_m_load_from_mapped_address_still_succeeds() {
+        let mut machine = machine_with_instr(LDR_R0_R1);
+        machine
+            .bus
+            .write_u32(MAPPED as u64, 0xA5A5_1234)
+            .expect("RAM write must succeed");
+        machine.cpu.set_register(1, MAPPED);
+        machine.cpu.set_register(0, SENTINEL);
+
+        let step = machine.step();
+
+        assert!(
+            step.is_ok(),
+            "a valid load must not abort the run: {step:?}"
+        );
+        assert_eq!(
+            machine.cpu.get_register(0),
+            0xA5A5_1234,
+            "a valid load must actually deliver the value"
+        );
+        assert_eq!(
+            machine.cpu.get_pc(),
+            CODE + 2,
+            "pc must advance past the LDR"
+        );
+    }
+
+    #[test]
+    fn cortex_m_store_to_mapped_address_still_succeeds() {
+        let mut machine = machine_with_instr(STR_R0_R1);
+        machine.cpu.set_register(1, MAPPED);
+        machine.cpu.set_register(0, SENTINEL);
+
+        let step = machine.step();
+
+        assert!(
+            step.is_ok(),
+            "a valid store must not abort the run: {step:?}"
+        );
+        assert_eq!(
+            machine.bus.read_u32(MAPPED as u64).unwrap(),
+            SENTINEL,
+            "a valid store must actually land in RAM"
+        );
+        assert_eq!(
+            machine.cpu.get_pc(),
+            CODE + 2,
+            "pc must advance past the STR"
+        );
+    }
+
+    /// The other direction, at run length: a loop of valid loads and stores must
+    /// keep running for many steps. Catches an over-eager fix that aborts on
+    /// every access, or one that faults on a legitimate peripheral access.
+    #[test]
+    fn cortex_m_repeated_valid_accesses_keep_the_run_alive() {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        // STR r0,[r1] ; LDR r2,[r1] ; B .-4   (branch back to CODE)
+        bus.write_u16(CODE as u64, STR_R0_R1).unwrap();
+        bus.write_u16((CODE + 2) as u64, 0x680A).unwrap(); // LDR r2,[r1,#0]
+        bus.write_u16((CODE + 4) as u64, 0xE7FC).unwrap(); // B  -> CODE
+        let mut machine = Machine::new(cpu, bus);
+        machine.cpu.set_pc(CODE);
+        machine.cpu.set_register(0, SENTINEL);
+        machine.cpu.set_register(1, MAPPED);
+
+        for i in 0..300 {
+            machine
+                .step()
+                .unwrap_or_else(|e| panic!("valid access loop died at step {i}: {e:?}"));
+        }
+        assert_eq!(
+            machine.cpu.get_register(2),
+            SENTINEL,
+            "the loop must have loaded back what it stored"
+        );
+    }
+
+    /// A store into a real peripheral window (UART1 data register on the default
+    /// bus) must remain `Ok`. Guards the "peripheral legitimately returns Err on
+    /// a benign access" hazard.
+    #[test]
+    fn cortex_m_store_to_peripheral_window_still_succeeds() {
+        let mut machine = machine_with_instr(STR_R0_R1);
+        machine.cpu.set_register(1, 0x4000_C000); // uart1 base
+        machine.cpu.set_register(0, 0x41); // 'A'
+
+        let step = machine.step();
+
+        assert!(
+            step.is_ok(),
+            "a store into a mapped peripheral window must not abort the run: {step:?}"
+        );
+    }
+}

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1588,6 +1588,15 @@ pub mod integration_tests {
     fn test_nvic_external_interrupt() {
         let mut machine: Machine<CortexM> = create_machine();
 
+        // Give the core a real stack. `create_machine` builds the CPU straight from
+        // `CortexM::default()` without a `reset()`, so SP is 0 — and exception entry
+        // stacks an 8-word frame at SP-32 = 0xFFFF_FFE0, which no region covers. On
+        // silicon that is a stacking bus fault at exception entry; the sim now
+        // surfaces it instead of discarding all eight stacking writes. Any machine
+        // that has actually booted has SP loaded from the vector table.
+        machine.cpu.sp = 0x2000_1000;
+        machine.cpu.msp = 0x2000_1000;
+
         // IRQ 0 (Exception 16)
         let irq_num = 16;
         let isr_addr = 0x2000;

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -5,6 +5,8 @@ pub mod bus_proof_matrix;
 #[cfg(test)]
 pub mod bus_trace_one_home;
 #[cfg(test)]
+pub mod cortex_m_memory_contract;
+#[cfg(test)]
 pub mod device_identity_one_home;
 #[cfg(test)]
 pub mod esp32;

--- a/crates/core/src/tests/simctl_machine.rs
+++ b/crates/core/src/tests/simctl_machine.rs
@@ -91,20 +91,36 @@ fn a_nonzero_exit_code_reaches_the_harness_intact() {
 
 #[test]
 fn a_bus_without_simctl_never_stops_early() {
-    // ANTI-VACUITY CONTROL. Same program, same addresses, no device: the store
-    // lands in unmapped space and the firmware spins until it runs out of fuel.
-    // If this test ever starts reporting a firmware verdict, the ones above are
-    // proving nothing about the device.
+    // ANTI-VACUITY CONTROL. Same program, same addresses, no device: nothing may
+    // report a firmware verdict. If this test ever starts reporting one, the
+    // tests above are proving nothing about the device.
+    //
+    // With no simctl installed, SIMCTL_BASE is covered by no memory region and no
+    // peripheral window, so the `STR` is a store to unmapped space. The Cortex-M
+    // core propagates the bus's `MemoryViolation` (as RISC-V always has), so the
+    // run ends there. This used to assert `AdvanceStop::FuelLimit` — the spin
+    // loop burning its fuel — which only happened because the failing store was
+    // silently discarded. Faulting on the store is the stronger control: it
+    // proves the address really is unmapped without the device, rather than
+    // proving the fuel counter works.
     let mut m = machine(false);
     load_store_to_simctl_program(&mut m, SIMCTL_BASE + EXIT_OFFSET, 0);
 
-    let report = m.advance(AdvanceRequest::run(Some(64))).unwrap();
+    let outcome = m.advance(AdvanceRequest::run(Some(64)));
 
-    assert_eq!(
-        report.stop,
-        AdvanceStop::FuelLimit,
-        "with no simctl on the bus nothing may end the run early"
-    );
+    match outcome {
+        Err(crate::SimulationError::MemoryViolation(addr)) => {
+            assert_eq!(
+                addr,
+                SIMCTL_BASE + EXIT_OFFSET,
+                "the violation must be the simctl store itself"
+            );
+        }
+        other => panic!(
+            "with no simctl on the bus the store must fault, and nothing may end \
+             the run with a firmware verdict; got {other:?}"
+        ),
+    }
 }
 
 #[test]


### PR DESCRIPTION
`bus/accessors.rs` returns `Err(SimulationError::MemoryViolation(addr))`. `cpu/cortex_m.rs` threw it away at **66 sites** — 25 `let _ = bus.write_*`, 41 discarded or `unwrap_or(0)` reads. A failed load left the destination register stale; a failed store vanished; the run stayed green. `cpu/riscv.rs` has always propagated all 32 of its accesses with `?`, so the same firmware bug was fatal on RISC-V and invisible on Cortex-M.

Now: one `CortexM::load` / `CortexM::store` pair over `AccessWidth::{Byte,Half,Word}`, propagating with `?`, at all 70 call sites. `step_internal` already returned `SimResult<()>`, so no restructuring was needed and no site resisted.

**Scope is the contract, not ARM fault semantics.** No `BusFault`/`HardFault` escalation here — no `set_exception_pending(3|4|5|6)` anywhere. That is the next task and needs its own blast-radius work.

## Zero labs changed

A census over 68 labs found this path taken twice corpus-wide. That was a prediction, so it was checked: every `examples/**/*.yaml` with an assertion block and a committed ELF — **21 runnable** — run before and after, recording verdict *and* `stop_reason`. **The two lists are byte-identical.** `scripts/example_smokes.sh`: 10 pass / 0 fail, unchanged. `cargo test -p labwired-core --lib`: 2,808 passed.

## The guard fails first, and not on the easy path

`examples/ci/dummy-memory-violation.yaml` already asserted `expected_stop_reason: memory_violation` and passed before this change — a guard could easily re-test it and prove nothing. Probing it shows why: its `result.json` reports **`"instructions": 0`**. Its chip has a 1-byte flash, so the first instruction *fetch* fails and the run stops before anything retires. It can only ever exercise `bus.read_u16(fetch_pc)?`, the path that already worked.

The new tests keep the PC inside mapped flash for the whole run and fault only on the data address in `Rn`, over a real `SystemBus`. On unmodified main:

```
a load from unmapped 0x90000000 must surface the bus MemoryViolation, not be discarded.
got Ok(()); r0 = 0xDEADBEEF (stale sentinel means the load was silently dropped), pc = 0x00001002

a store to unmapped 0x90000000 must surface the bus MemoryViolation, not vanish.
got Ok(()); pc = 0x00001002
```

Four counterweights passed before and after — valid RAM load, valid RAM store, a 300-step loop of valid accesses, and a store into a real peripheral window — so a change that aborted on every access could not have passed.

## The lint, in two halves

`#[deny(clippy::let_underscore_must_use)]` on the `cortex_m` and `riscv` modules catches `let _ = bus.write_*`. But **41 of the original 66 sites were `if let Ok(..) = bus.read_*`**, which the type system cannot see — so a source scan over `src/cpu/**` covers `.ok()`, `.is_err()` and `if let Ok` too. Its allowlist is **content-keyed and shrink-only**: entries are exact line text, so a line-number shift cannot hide a new discard, and a stale entry fails just as loudly. An anti-vacuity test proves the scanner recognises every banned shape and none of the propagating ones.

Both fire independently on a reintroduced discard — verified.

## Three findings

**Propagating in `Cpu::reset` aborts a run that should survive, so it was not done.** Measured, not assumed: making the two reset-vector reads propagate flips `dummy-memory-violation.yaml` from `PASS / stop=memory_violation` to `FAIL / stop=halt`. That fixture's 1-byte flash makes the vector table unreadable, and a failed *reset* surfaces through a different path than a run-time violation. Boot is a separate contract. Those two sites are the only discards left in the file, named in the allowlist with the measurement written beside them.

**Two in-tree tests were passing only because of the bug.** Both verified green on pristine `origin/main` first, so this is not the known-red pair.
- `simctl_machine::a_bus_without_simctl_never_stops_early` — the anti-vacuity *control* asserted the run reached `FuelLimit`, which only happened because its store to unmapped `0x5000_0000` was dropped and the spin loop burned fuel. It now asserts the store faults at that exact address: a stronger control, because it proves the address really is unmapped without the device.
- `integration::test_nvic_external_interrupt` — `create_machine()` never calls `reset()`, so SP=0 and exception entry stacks at `SP-32 = 0xFFFF_FFE0`. On silicon that is a genuine stacking bus fault; it passed only because all eight stacking writes were discarded. Given a real stack.

**Xtensa LX7 has the same defect, 4 sites** — the windowed register-overflow spill writes `a0..a3` with `let _ = bus.write_u32`, so a spill into unmapped memory silently vanishes. Different core, own blast radius, left alone — but now *counted* in the allowlist rather than silent. Three other Xtensa hits were checked and judged legitimate (a TCB address probe where `Err` means "not this address"; two JIT pre-reads that decline the fast path so the interpreter raises the real fault) and are documented as such.

## Not run

`cargo build --workspace` (unbuildable on macOS — `pyo3-ffi` vs Python 3.14, `riscv-rt` ELF sections invalid in Mach-O) and the full 167-target integration suite. Ran core `--lib`, `labwired-cli --test outputs` (11 passed — it covers the `MemoryViolation` → `StopReason` surface), clippy `-D warnings` on core and cli, and `cargo fmt --check`.