### PR TITLE
fix(perf): give the xtensa perf fixture a backtrace backend so the lane can run

### DIFF
--- a/crates/firmware-perf-spin-xtensa/Cargo.toml
+++ b/crates/firmware-perf-spin-xtensa/Cargo.toml
@@ -20,7 +20,12 @@ esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3"]
 
 [dependencies]
 esp-hal = { version = "1.1", features = ["unstable"] }
-esp-backtrace = { version = "0.19", features = ["panic-handler"] }
+# `println` is not optional decoration: esp-backtrace's build script requires
+# exactly one of `defmt` or `println` and fails the build with neither. This
+# fixture was the only consumer in the repo omitting it — the eight examples all
+# pass it — so the perf lane died compiling the fixture instead of measuring
+# anything, on every main commit since at least 41cff595.
+esp-backtrace = { version = "0.19", features = ["panic-handler", "println"] }
 
 [[bin]]
 name = "perf-spin-xtensa"


### PR DESCRIPTION
## Why

`Core Perf (simulator throughput)` has been failing on main since at least `41cff595` — **the pin the product currently ships** — through `d503501d`, `6a46eb75`, `5974f3db` and `bc2ce2d1`. It is not a throughput regression. The lane dies compiling its own fixture and never reaches a measurement:

```
error: failed to run custom build command for `esp-backtrace v0.19.0`
  Exactly one of the following features must be enabled: defmt, println.
  Currently enabled: none. This might be caused by enabled default features.
```

## Cause

Read out of the crate source rather than inferred — `esp-backtrace-0.19.0/build.rs`:

```rust
// Ensure that exactly a backend is selected:
assert_unique_used_features!("defmt", "println");
```

and its manifest:

```toml
panic-handler = []              # line 137 — orthogonal, selects no backend
println = ["dep:esp-println"]   # line 139
```

`crates/firmware-perf-spin-xtensa` asked for `panic-handler` alone, so it satisfied neither arm of that assertion. **Every other consumer in the repo — all eight examples — already passes `println`.** This fixture was the lone omission.

## Fix

One line, matching the eight existing call sites:

```diff
-esp-backtrace = { version = "0.19", features = ["panic-handler"] }
+esp-backtrace = { version = "0.19", features = ["panic-handler", "println"] }
```

## Verification — read this part

**I could not build this locally.** There is no Xtensa/esp toolchain on this machine (`rustup toolchain list` has no esp entry), so the fixture cannot be compiled here and I am not going to claim otherwise.

What I did verify, against the actual vendored crate in `~/.cargo/registry`, not from memory or docs:

- `build.rs` really does require exactly one of `defmt` / `println`
- `println` is a real feature of `esp-backtrace 0.19.0` (manifest line 139)
- `panic-handler` is a separate feature that selects no backend (line 137)
- the eight other consumers in this repo all pass `println` alongside `panic-handler`

The proof this works is the lane itself going green — which is this PR's own gate, since `Core Perf` runs on main. If it stays red after merge, the cause is something past the fixture build and this change is still necessary but not sufficient.

## Note

This is worth someone's attention beyond the one line: a perf gate that has been red for the whole day, on the shipping pin, is a gate nobody is reading. It went unnoticed because a red lane that is *always* red stops carrying information.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)