### PR TITLE
ci(perf): make the perf lane watch all three fixture crates it builds

### DIFF
--- a/.github/workflows/core-perf.yml
+++ b/.github/workflows/core-perf.yml
@@ -27,7 +27,15 @@ on:
       - "crates/cli/**"
       - "crates/config/**"
       - "configs/chips/**"
+      # All THREE fixture crates, not just the unsuffixed one. This lane builds
+      # firmware-perf-spin-xtensa and -riscv as well, and `firmware-perf-spin/**`
+      # matches neither — so a change to a fixture never re-ran the lane that
+      # consumes it. That is not hypothetical: the xtensa fixture was missing a
+      # required esp-backtrace feature, the lane died compiling it on every main
+      # commit for a day, and the one-line fix could not trigger its own gate.
       - "crates/firmware-perf-spin/**"
+      - "crates/firmware-perf-spin-riscv/**"
+      - "crates/firmware-perf-spin-xtensa/**"
       - "scripts/perf/**"
       - ".github/workflows/core-perf.yml"
   schedule:


### PR DESCRIPTION
## Why

`core-perf.yml` triggers on:

```yaml
- "crates/firmware-perf-spin/**"
```

but three fixture crates exist and the lane builds all of them:

```
crates/firmware-perf-spin
crates/firmware-perf-spin-riscv
crates/firmware-perf-spin-xtensa
```

`crates/firmware-perf-spin/**` matches only the first. **A change to a fixture never re-ran the lane that consumes it.**

## How this surfaced

`Core Perf` was red on main all day — including on `41cff595`, the pin the product ships — because the xtensa fixture asked `esp-backtrace` for `panic-handler` alone and satisfied neither arm of its `assert_unique_used_features!("defmt", "println")` build gate. The lane died compiling the fixture and never measured throughput.

#882 fixes that in one line. But it touches only `crates/firmware-perf-spin-xtensa/Cargo.toml`, which matches **no path in this filter** — so the fix cannot trigger its own gate, and the repair stays unverified until some unrelated commit happens to touch `crates/core/**` or the nightly cron fires at 03:45.

That is the same failure shape as the fixture bug itself: a gate that cannot see the inputs it depends on is only accidentally a gate.

## Change

Two paths added, nothing removed:

```diff
   - "crates/firmware-perf-spin/**"
+  - "crates/firmware-perf-spin-riscv/**"
+  - "crates/firmware-perf-spin-xtensa/**"
   - "scripts/perf/**"
```

## Verification

YAML parses and both new globs are present in the resolved `on.push.paths` — asserted, not eyeballed.

This PR does not prove the lane passes; #882 does that, and only once something triggers it. What this guarantees is that the *next* fixture change re-runs the lane instead of silently skipping it.

Worth noting: merging this will itself trigger `Core Perf` (the workflow file is in its own filter), which makes it the first run to carry #882's fixture fix.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)