### PR TITLE
ci: run firmware_survival on pull requests, where it would have caught #880

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -341,7 +341,22 @@ jobs:
     # 10 buys headroom on a shared runner without hiding a real slowdown: if
     # this job starts approaching 10 it has genuinely grown and the browser
     # steps should move to their own job, the way pr-scheduler-observable did.
-    timeout-minutes: 10
+    #
+    # ⚠️ IT HAS GROWN, AND THAT IS ALREADY TRUE WITHOUT THE FIRMWARE-SURVIVAL
+    # STEP ADDED BELOW. Three consecutive green runs on 2026-08-08 measured
+    # 8m20s, 9m09s and 9m11s against this 10-minute wall — 49-100s of headroom,
+    # i.e. the condition the paragraph above says to act on. The growth is in
+    # steps that predate this change: `Unit tests (default-members lib)` alone
+    # is 173-192s and `Generated artifacts — regenerate and assert no drift` is
+    # 107-117s. So 12, not because the new step is expensive (it is ~10s of
+    # local wall-clock; see its own note) but because shipping a gate into a
+    # job that is already at 92% of its timeout is how you get a red lane that
+    # means nothing — the same mis-read this comment's first paragraph is about.
+    #
+    # 12 is a stay of execution, not a fix. The lasting answer is still the one
+    # named above: move the browser layer (~100s) to its own job. Do that before
+    # bumping this number a third time.
+    timeout-minutes: 12
     steps:
       # Full history required: generate_validation_status.py uses
       # `git log -1 --format=%cI -- <model>` for drift. Shallow checkout
@@ -487,6 +502,71 @@ jobs:
       # class walks back through.
       - name: Walk-deletion derivation (PR-fast structural arm)
         run: cargo test -p labwired-core --test esp32_classic_walk_differential
+
+      # THE SHARED-MODEL NET THAT NEVER GATED A MERGE.
+      #
+      # `firmware_survival` boots ~50 committed ELFs — every Cortex-M and
+      # RISC-V chip this engine claims, across Zephyr, Arduino, CubeMX HAL and
+      # bare-metal toolchains — and asserts each one survives its boot and
+      # emits the UART trace real silicon does. It is the broadest regression
+      # net in the repo for a change to the shared CPU or bus models, and until
+      # now NOTHING ran it before a merge: it lives in `core-integrity`, which
+      # is `push`/`schedule`/`dispatch`-only and skipped on every pull request.
+      #
+      # #880 is what that cost. "propagate bus memory violations from every
+      # load and store" was green on all four checks its PR ran, merged, and
+      # faulted five chips at boot on main:
+      #
+      #   nrf52832  step 1     0x2003fffc   RAM top
+      #   nrf54l15  step 6460  0xe000e500   upper NVIC window
+      #   stm32g474 step 4302  0xe0042004   DBGMCU
+      #   stm32wb55 step 4214  0xe0042004   DBGMCU
+      #   stm32wba52 step 4003 0x20020000   RAM top
+      #
+      # The change was right in intent — those accesses had been silently
+      # swallowed — but the models do not decode those regions, so real
+      # firmware faulted. Reverted in #881. Every one of those five is a test
+      # in this file, and every one of them would have gone red on the PR if
+      # this step had existed. (Verified, not assumed: applying #880 to a clean
+      # tree reproduces exactly those five failures and nothing else.)
+      #
+      # The note on the equivalent step in `core-integrity` already made this
+      # argument once — the suite was pulled out of the nightly `core-full` job
+      # because "a shared-model rework could land on main silently". It was
+      # never carried the last step, to PRs. This is that step.
+      #
+      # ── WHY A STEP IN `pr-gate`, NOT A NEW JOB, AND NOT `paths:`-FILTERED ──
+      #
+      # A new required job filtered to `crates/core/src/cpu/**` would be worse
+      # than no gate at all. `main` requires exactly two contexts (`pr-gate`,
+      # `release-runner-contract`) with `enforce_admins` ON, and required
+      # contexts are resolved against the PR's HEAD SHA. A path-filtered job
+      # emits NO context on a PR that does not match the filter, so that PR's
+      # head would carry an unreported required check and could never be merged
+      # by anyone, the owner included — the identical deadlock the PAT note at
+      # the top of this file describes and that stranded #1207/#1208/#1195 in
+      # the superproject. `pr-gate` is already required and already reports on
+      # every PR, so a step inside it adds a GATE without adding a CONTEXT.
+      # That is the whole reason this is eleven lines of YAML and not a job.
+      #
+      # ── COST, MEASURED ──
+      #
+      # No toolchain, no target, no cross-build: the ~50 ELFs are committed
+      # under `tests/fixtures/` and read straight off disk, and every
+      # dev-dependency (labwired-loader, svd-ingestor, svd-parser) is already
+      # built by the `--test esp32_classic_walk_differential` step above, which
+      # costs 0-1s here for exactly that reason. Locally: 1.3s to compile and
+      # link the test binary, 6.5s to run it (9.7s pinned to 4 threads, which
+      # is the hosted runner's core count).
+      #
+      # It deliberately does NOT bring `--test e2e_stm32f407_i2c` along, which
+      # `core-integrity` runs beside it. That one cross-builds the AHT20/BMP280
+      # firmware from source and needs `rustup target add thumbv7em-none-eabi`
+      # — a toolchain install and a firmware build this lane needs for nothing
+      # else. #880 is the regression that escaped; this is the suite that
+      # catches it.
+      - name: Firmware survival (committed ELF fixtures, ~50 chips)
+        run: cargo test -p labwired-core --test firmware_survival
 
       # The BLE Pong fixture is a COMMITTED copy of a published community lab,
       # and `world_esp32c3_ble_pong` (release-only, push-to-main) is the only


### PR DESCRIPTION
#880 passed all four required checks and broke `main`: five `firmware_survival` tests faulted at boot. **Those checks could not have caught it.** `firmware_survival` runs in the `integrity` job, which triggers on push-to-main and schedule — not on pull requests.

The reasoning was already applied once and stopped one step short: the comment at ~line 683 records pulling this suite out of the nightly `core-full` job into the push gate because "a shared-model rework could land on main silently". It was never carried to PRs, which is where it needed to be.

One step added to `pr-gate`: `cargo test -p labwired-core --test firmware_survival`.

## Proof it would have caught the regression

#880's propagation applied locally, then the suite:

```
test result: FAILED. 46 passed; 5 failed; 5 ignored

test_nrf52832_demo_survival:     step 1    (PC=0x00000490)  violation at 0x2003fffc
test_nrf54l15_zephyr_survival:   step 6460 (PC=0x00004428)  violation at 0xe000e500
test_stm32g474_zephyr_survival:  step 4302 (PC=0x0800055e)  violation at 0xe0042004
test_stm32wb55_zephyr_survival:  step 4214 (PC=0x0800048e)  violation at 0xe0042004
test_stm32wba52_zephyr_survival: step 4003 (PC=0x080030ca)  violation at 0x20020000
```

Same five names, same addresses, same step numbers as #881's revert — nrf54l15 matches to the step. Experiment reverted; the tree was verified clean and it is **not** in this diff.

Green on unmodified main at the base, and re-verified at `eb59c4b0` after main advanced mid-run (#872 touches nrf52 and ESP UART, so that mattered): `51 passed, 0 failed, 5 ignored` both times.

Note a detail #881's revert message got slightly wrong: **wba52 faults on RAM top `0x20020000`, not DBGMCU.** Only g474 and wb55 hit `0xe0042004`. #885 identified the real cause — an ARMv8-M `TT` instruction executing as `STREX`.

## Why a step, not a new job

`main` requires exactly `pr-gate` and `release-runner-contract`, with `enforce_admins` ON. Required contexts resolve against the PR head SHA, and GitHub has no notion of "legitimately skipped" — a job skipped by `paths:` reports *nothing*, so the head SHA never acquires that context and the PR waits forever with no way to click past it.

A path filter on `crates/core/src/cpu/**` would therefore be correct on the PRs it ran on and would **permanently brick every other PR** — a docs typo, a YAML fix, this one. That failure shape is documented twice in this file already: the `GITHUB_TOKEN` note (a push fires no workflow, so the new head carries zero contexts) and the `workflow_dispatch` escape hatch on `pr-gate` (a wedged concurrency group produces the same "no run, no context, unmergeable" state).

A step inside an already-required job changes what that context *means* without changing which contexts exist. Nothing to register in branch protection, nothing that can skip.

## Cost

**Marginal, and not on the constrained pool** — every job in this workflow is `ubuntu-latest`, and this repo is public, so hosted minutes are free. The two-slot `ci` pool is only used by `core-hil.yml` and `core-release.yml`.

Measured with `CARGO_INCREMENTAL=0` (rust-cache sets it in CI, so incremental numbers would flatter it): **1.29s** to compile and link the test binary — verified genuinely relinked by mtime, not a fingerprint no-op — and **6.5s** to run, **9.66s** at the 4-thread hosted core count. Estimate **25-45s** on `ubuntu-latest`. For calibration, `core-integrity`'s combined `firmware_survival + e2e_stm32f407_i2c` step measures 96-119s, and the e2e half is a cross-build.

**No new toolchain.** All ~50 fixtures are committed, tracked ELFs read straight off disk — no `rustup target add`, no cross-build. The fixture crates are not built by this suite; `riscv-ci-fixture.elf` is a committed artifact. Its dev-deps are already built by the `esp32_classic_walk_differential` step directly above.

## One thing beyond scope, flagged loudly

**`timeout-minutes: 10` → `12`.** `pr-gate` is already at **83-92% of its own timeout before this change** — three consecutive green runs on 2026-08-08 took 500s, 549s and 551s against a 600s limit. The growth is entirely pre-existing: unit tests 173-192s, generated-artifact regeneration 107-117s, browser layer 95-104s.

Shipping a gate into a job that intermittently hits the wall would produce exactly the failure this PR exists to eliminate — and the file itself notes that a timeout kill "reads as a test failure and is not one."

This is a stay of execution, not a fix. The comment at line 341 already says that if `pr-gate` approaches 10 minutes the browser steps should move to their own job. **That condition is now met**, and it wants its own PR.

The step is placed before the two BLE Pong steps deliberately, so a model regression reports even when the network-dependent drift check flakes.

`actionlint` output is byte-identical to pristine main (one pre-existing SC2016 info in `fmt-autofix`, untouched). Job set unchanged, asserted programmatically.