### PR TITLE
fix(bus): a batch-unsafe peripheral pins the tick interval to 1

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -482,6 +482,12 @@ jobs:
       - name: Clippy + build the browser layer (crates/wasm)
         run: cargo clippy -p labwired-wasm --all-targets -- -D warnings
 
+      # playground_repro drives the secure-boot lab through the same entry
+      # points simulator-bridge.ts uses, so it needs that lab's firmware. It
+      # builds the ELF itself (ensure_firmware_built) and needs the target to
+      # do it. ~10s once, cached with the rest of the toolchain.
+      - name: Add ARM target (secure-boot lab firmware for the browser repro)
+        run: rustup target add thumbv7em-none-eabi
       - name: Unit tests (browser layer)
         run: cargo test -p labwired-wasm --lib
 

--- a/crates/core/src/peripherals/nrf52/rng.rs
+++ b/crates/core/src/peripherals/nrf52/rng.rs
@@ -204,6 +204,27 @@ impl Nrf52Rng {
         let mut left = cycles;
         let mut irq = false;
         while left > 0 && self.running {
+            // A byte is already sitting in VALUE that firmware has not taken
+            // yet. Stop here rather than grinding out bytes nobody can observe.
+            //
+            // This loop used to keep producing for as many BYTE_PERIODs as the
+            // batch covered, overwriting `value` each time and raising VALRDY
+            // once. At `peripheral_tick_interval` 1 a batch spans one period
+            // and one byte survives, which is why the CLI never saw it. At the
+            // interval the browser auto-applies from `recommended_tick_interval`
+            // a batch spans several and only the last byte of each reached
+            // firmware, so the stream depended on how the host chose to batch:
+            // the secure-boot lab's provisioned root key came out shifted four
+            // bytes and the lab never got past boot 2 in the playground.
+            //
+            // Real silicon free-runs and a slow reader does miss bytes, but
+            // there the pacing is the chip's. Here it would be the host's
+            // batching choice, and no firmware-visible sequence may depend on
+            // that. Gating on VALRDY makes it a function of reads alone: one
+            // byte per byte taken, whatever the batching.
+            if self.events_valrdy != 0 {
+                break;
+            }
             let need = (BYTE_PERIOD - self.accum) as u64;
             if left < need {
                 self.accum += left as u32;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -11,6 +11,8 @@ mod inputs;
 mod inspect;
 mod install;
 mod jit_browser;
+#[cfg(test)]
+mod playground_repro;
 mod traces;
 // CortexM and XtensaLx7 are used via Box<dyn Cpu>; the concrete types are
 // only constructed inside the configure_* fns and immediately boxed.

--- a/crates/wasm/src/playground_repro.rs
+++ b/crates/wasm/src/playground_repro.rs
@@ -1,0 +1,182 @@
+#[cfg(test)]
+mod playground_secure_boot_repro {
+    //! Does the secure-boot lab reach boot 3 the way the PLAYGROUND drives it?
+    //!
+    //! The CLI runs it through a test script and sees all three boots. The
+    //! browser reportedly sits on boot 1 forever. This drives the same entry
+    //! points the playground bridge uses -- `new_from_config_arm`, then
+    //! `feed_uart_input`, then `step_batch` in a loop -- so a divergence shows
+    //! up here rather than only in a browser nobody can attach a debugger to.
+    use crate::{ChipDescriptor, SystemManifest, WasmSimulator};
+
+    const OTA_PACKAGES: &[u8] = &[
+        // package 1 (140 bytes)
+        0x4C, 0x57, 0x4F, 0x54, 0x02, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x4C, 0x61, 0x62,
+        0x57, 0x69, 0x72, 0x65, 0x64, 0x20, 0x4F, 0x54, 0x41, 0x20, 0x69, 0x6D, 0x61, 0x67, 0x65,
+        0x20, 0x76, 0x32, 0x20, 0x28, 0x64, 0x65, 0x6D, 0x6F, 0x20, 0x70, 0x61, 0x79, 0x6C, 0x6F,
+        0x61, 0x64, 0x2C, 0x20, 0x6E, 0x6F, 0x74, 0x20, 0x65, 0x78, 0x65, 0x63, 0x75, 0x74, 0x61,
+        0x62, 0x6C, 0x65, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x0D, 0xA7, 0x58, 0xA8, 0x3B, 0x83, 0xA9, 0x84, 0x98, 0x17, 0x55, 0x00, 0xFA, 0xD3,
+        0x79, 0xC0, 0x86, 0x95, 0xBB, 0xD1, 0xEB, 0xE2, 0xE6, 0x30, 0xB2, 0x0C, 0xAE, 0xB0, 0x86,
+        0x4D, 0xCB, 0x3A, 0x8E, 0xBB, 0x8F, 0x50, 0xB8, 0x47, 0x25, 0xBA, 0x5B, 0x54, 0x64, 0x19,
+        0x1E, 0x2B, 0xBB, 0x02, 0xFD, 0xDB, 0xFD, 0x1B, 0x57, 0x81, 0x5C, 0x06, 0xB9, 0x44, 0xA7,
+        0x3A, 0xA9, 0x04, 0xA1, 0x6E, // package 2 (140 bytes)
+        0x4C, 0x57, 0x4F, 0x54, 0x01, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x4C, 0x61, 0x62,
+        0x57, 0x69, 0x72, 0x65, 0x64, 0x20, 0x4F, 0x54, 0x41, 0x20, 0x69, 0x6D, 0x61, 0x67, 0x65,
+        0x20, 0x76, 0x31, 0x20, 0x2D, 0x20, 0x61, 0x75, 0x74, 0x68, 0x65, 0x6E, 0x74, 0x69, 0x63,
+        0x20, 0x62, 0x75, 0x74, 0x20, 0x4F, 0x4C, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x31, 0xEF, 0xD2, 0xC3, 0x12, 0x19, 0xE7, 0x99, 0x09, 0x23, 0x1B, 0x46, 0x76, 0x8E,
+        0x08, 0xF5, 0xAB, 0x29, 0xA2, 0x8D, 0x7E, 0xC8, 0x91, 0xA6, 0x8C, 0x82, 0x66, 0xBD, 0xC6,
+        0xC4, 0x8E, 0x0B, 0x8D, 0x77, 0xD3, 0xF1, 0x28, 0x21, 0x94, 0x7E, 0xF4, 0xF5, 0xC1, 0xD0,
+        0x09, 0x45, 0x8F, 0x25, 0xBF, 0xB5, 0x05, 0x79, 0x9A, 0xF0, 0x45, 0x41, 0x22, 0xA5, 0xC3,
+        0x7F, 0xB9, 0xF2, 0xF5, 0x71, // package 3 (140 bytes)
+        0x4C, 0x57, 0x4F, 0x54, 0x03, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x4C, 0x61, 0x62,
+        0x57, 0x69, 0x72, 0x65, 0x64, 0x20, 0x4F, 0x54, 0x41, 0x20, 0x69, 0x6D, 0x61, 0x67, 0x65,
+        0x20, 0x76, 0x33, 0x20, 0x2D, 0x20, 0x46, 0x4F, 0x52, 0x47, 0x45, 0x44, 0x20, 0x73, 0x69,
+        0x67, 0x6E, 0x61, 0x74, 0x75, 0x72, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x89, 0xE4, 0x9C, 0x72, 0x50, 0xF9, 0x41, 0x48, 0x09, 0x42, 0xC6, 0x2C, 0x45, 0xF3,
+        0x0E, 0xC0, 0xF4, 0x35, 0xB0, 0x1A, 0x61, 0x95, 0xDB, 0x6A, 0x0E, 0x7E, 0x08, 0xE7, 0xC1,
+        0x86, 0x3B, 0xDB, 0x38, 0x7E, 0x48, 0xC5, 0x84, 0x71, 0x42, 0xF5, 0x27, 0x27, 0xCA, 0x97,
+        0x3B, 0xBF, 0x73, 0x3F, 0x87, 0x80, 0x07, 0x57, 0x9F, 0xE6, 0x2A, 0x05, 0x59, 0x5D, 0xAE,
+        0x3F, 0x34, 0x38, 0x23, 0xDE,
+    ];
+
+    /// Drive the lab exactly as `simulator-bridge.ts` does and return the UART.
+    /// Build the lab firmware if the source is newer than the ELF.
+    ///
+    /// Same shape as `e2e_nrf52840_proximity`. CI runs `cargo test -p
+    /// labwired-wasm --lib` without building any firmware first, so a test that
+    /// only READS the ELF fails on a clean checkout — which is exactly how the
+    /// first version of this file took pr-gate red.
+    ///
+    /// `CARGO_ENCODED_RUSTFLAGS`/`RUSTFLAGS` are cleared for the reason the core
+    /// e2e tests clear them: coverage instrumentation flags leak into the no_std
+    /// cross-build and fail it with E0463 (can't find crate `core`).
+    fn ensure_firmware_built() -> std::path::PathBuf {
+        let elf = labwired_core::test_support::target_dir()
+            .join("thumbv7em-none-eabi/release/firmware-nrf52840-secure-boot");
+        let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../crates/firmware-nrf52840-secure-boot/src/main.rs");
+        if let (Ok(e), Ok(s)) = (std::fs::metadata(&elf), std::fs::metadata(&src)) {
+            if e.modified().unwrap() >= s.modified().unwrap() {
+                return elf;
+            }
+        }
+        let status = std::process::Command::new("cargo")
+            .args([
+                "build",
+                "-p",
+                "firmware-nrf52840-secure-boot",
+                "--target",
+                "thumbv7em-none-eabi",
+                "--release",
+            ])
+            .env_remove("CARGO_ENCODED_RUSTFLAGS")
+            .env_remove("RUSTFLAGS")
+            .current_dir(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../.."))
+            .status()
+            .expect("cargo build firmware-nrf52840-secure-boot");
+        assert!(status.success(), "secure-boot firmware build failed");
+        assert!(elf.exists(), "ELF not found at {elf:?}");
+        elf
+    }
+
+    fn run_playground_path(idle_fast_forward: bool, auto_tick: bool) -> (String, Vec<u8>) {
+        let chip_yaml = include_str!("../../../configs/chips/nrf52840.yaml");
+        let system_yaml = include_str!("../../../examples/nrf52840-secure-boot-lab/system.yaml");
+        let firmware = std::fs::read(ensure_firmware_built()).expect("read firmware ELF");
+
+        let chip: ChipDescriptor = serde_yaml::from_str(chip_yaml).unwrap();
+        let manifest: SystemManifest = serde_yaml::from_str(system_yaml).unwrap();
+        let mut sim = WasmSimulator::new_from_config_arm(&chip, &manifest, &firmware)
+            .expect("simulator builds");
+
+        // The bridge injects right after construction (simulator-bridge.ts:583).
+        sim.feed_uart_input(OTA_PACKAGES);
+        if idle_fast_forward {
+            sim.set_idle_fast_forward_enabled(true);
+        }
+        if auto_tick {
+            let interval = sim.recommended_tick_interval();
+            if interval > 1 {
+                sim.set_peripheral_tick_interval(interval);
+            }
+        }
+
+        let mut uart = String::new();
+        for _ in 0..400 {
+            sim.step_batch(200_000).expect("batch advances");
+            uart.push_str(&String::from_utf8_lossy(&sim.drain_uart_output()));
+            if uart.contains("ATTESTATION OK") {
+                break;
+            }
+        }
+
+        // RESULTS.key_words lives at 0x20000058 (see the smoke script header).
+        let key = sim.read_memory(0x2000_0058, 16);
+        (uart, key)
+    }
+
+    fn assert_all_three_boots(uart: &str, label: &str) {
+        for marker in [
+            "ROT: PROVISIONED",
+            "SECURE BOOT OK (v1)",
+            "OTA v2 COMMITTED",
+            "SECURE BOOT OK (v2)",
+            "ROLLBACK REJECTED",
+            "ATTESTATION OK",
+        ] {
+            assert!(
+                uart.contains(marker),
+                "{label}: never reached {marker:?}. UART so far:\n{uart}"
+            );
+        }
+    }
+
+    #[test]
+    fn matrix() {
+        for (idle, tick) in [(false, false), (false, true), (true, false), (true, true)] {
+            let (uart, key) = run_playground_path(idle, tick);
+            let last = uart.lines().last().unwrap_or("(no uart)").to_string();
+            let reached = uart.contains("ATTESTATION OK");
+            let hex: String = key.iter().map(|b| format!("{b:02X} ")).collect();
+            println!(
+                "idle_ff={idle:<5} auto_tick={tick:<5} boot3={reached:<5} key={hex}last={last:?}"
+            );
+        }
+    }
+
+    /// At interval 1 the lab walks all three boots, which is what the CLI does.
+    #[test]
+    fn playground_path_reaches_boot_three() {
+        let (uart, _) = run_playground_path(false, false);
+        assert_all_three_boots(&uart, "tick interval 1");
+    }
+
+    /// KNOWN BUG, ignored so it documents rather than blocks.
+    ///
+    /// The browser applies `recommended_tick_interval()` at init
+    /// (simulator-bridge.ts), and `max_safe_tick_interval` reports > 1 for this
+    /// bus because it only rules out HC-SR04 and the legacy walk. The nRF52 RNG
+    /// is not safe at that interval: `advance_cycles` produces one byte per
+    /// BYTE_PERIOD in a loop, overwriting `value` and raising VALRDY once, so a
+    /// batch spanning N periods hands firmware only the last byte and drops the
+    /// other N-1.
+    ///
+    /// The provisioned root key comes out shifted four bytes:
+    ///
+    ///   interval 1   22 CA B3 3F 02 30 A2 F2 0B EE F7 8A 31 63 B7 56
+    ///   interval >1  02 30 A2 F2 0B EE F7 8A 31 63 B7 56 B6 16 91 9C
+    ///
+    /// so the AES boot challenge misses GOLDEN_CIPHERTEXT, boot 2 prints
+    /// SECURE BOOT FAILED, and the lab never reaches boots 2 or 3 in the
+    /// Un-ignore when the RNG stops losing bytes under batching.
+    #[test]
+    #[ignore = "nRF52 RNG drops bytes at peripheral_tick_interval > 1"]
+    fn browser_tick_interval_reaches_boot_three() {
+        let (uart, _) = run_playground_path(false, true);
+        assert_all_three_boots(&uart, "auto-raised tick interval");
+    }
+}

--- a/crates/wasm/src/playground_repro.rs
+++ b/crates/wasm/src/playground_repro.rs
@@ -172,9 +172,7 @@ mod playground_secure_boot_repro {
     ///
     /// so the AES boot challenge misses GOLDEN_CIPHERTEXT, boot 2 prints
     /// SECURE BOOT FAILED, and the lab never reaches boots 2 or 3 in the
-    /// Un-ignore when the RNG stops losing bytes under batching.
     #[test]
-    #[ignore = "nRF52 RNG drops bytes at peripheral_tick_interval > 1"]
     fn browser_tick_interval_reaches_boot_three() {
         let (uart, _) = run_playground_path(false, true);
         assert_all_three_boots(&uart, "auto-raised tick interval");

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,8 +9,8 @@ The models column is a content digest over everything that board's `models` list
 
 | Board | Tier | Last silicon capture | Models | Status |
 |-------|------|----------------------|--------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | `6142ba057c56f787` | ⚠ drift acked 2026-08-08 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | `6142ba057c56f787` | ⚠ drift acked 2026-08-08 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-06-17 | `1069454e8c736b0e` | ⚠ drift acked 2026-08-09 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | `1069454e8c736b0e` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | `bec6988944d80986` | ⚠ drift acked 2026-08-08 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-06-17 | `7a687f785b9f9f85` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | `266bc466735dd241` | ⚠ drift acked 2026-08-08 (re-capture pending) |
@@ -23,7 +23,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf52832` | ⚪ structural | — | `8eb946cd8fd728b5` | no silicon capture |
 | `rp2040` | ⚪ structural | — | `c103296ae72395af` | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | `fa3b47246c7b0401` | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `5b2437d601e703b8` | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `af066a5b3d56a73b` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `53fd2ce53e11a335` | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `9c285292b9bd9476` | no silicon capture |
 | `esp32` | ⚪ structural | — | `072e70147b3b21a3` | no silicon capture |
@@ -39,7 +39,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — conformance 16/16; mmio 16/16; GPIO P0 22/0, P1 23/0; onboarding 22/22; POWER 10/0, SPIS 19/0, TWIS 20/0, RTC0 12/0, TIMER0 16/0; SPIM0/CCM/full-register clean
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-08-08 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-09 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -47,7 +47,7 @@ The models column is a content digest over everything that board's `models` list
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-06-17** on ST-LINK V2 (J37S7) — rides the nrf52840 full register sweep (16/16) re-confirmed 2026-06-17
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-08-08 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-09 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -217,8 +217,24 @@ boards:
     # CC compare matching, SHORTS and EVENTS_COMPARE latching are all untouched,
     # and TIMER0's 16/0 sweep re-runs green. Acked WITHOUT a live re-capture —
     # no TIMER live diff is evidenced by this entry.
-    drift_ack: 2026-08-08
-    drift_ack_digest: 6142ba057c56f787631dde73492b725ac7f4490d77933b37aeea5fb3b8ba6612
+    # 2026-08-09: RNG byte production now stops while a byte sits unread in
+    # VALUE. BEHAVIOURAL, not additive — the diff is +21/-0 in nrf52/rng.rs and
+    # removes no line, but it changes WHEN bytes are produced: the model used to
+    # keep generating for every BYTE_PERIOD a batch covered, overwriting VALUE
+    # and handing firmware only the last one. Real silicon free-runs and a slow
+    # reader does miss bytes, so this is a deliberate divergence: on silicon the
+    # pacing is the chip's, in the sim it was the host's batching choice, and no
+    # firmware-visible sequence may depend on that. The byte SEQUENCE is
+    # unchanged (same xorshift32 chain from the same seed, one byte per byte
+    # read); only production timing moves.
+    #
+    # No register address, reset value, access or layout changes, and the
+    # asserted 2026-06-17 sweep does not cover RNG at all — it is
+    # conformance/mmio/GPIO/POWER/SPIS/TWIS/RTC0/TIMER0 plus SPIM0/CCM. Acked
+    # WITHOUT a live re-capture (no bench board); an RNG live diff is owed and is
+    # NOT evidenced by this entry.
+    drift_ack: 2026-08-09
+    drift_ack_digest: 1069454e8c736b0eec67e6865e16dfca371f905fab39d1a9aadf8ea2c0e4bbb5
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml
@@ -326,8 +342,11 @@ boards:
     # silicon. Scheduler bookkeeping only — no register address, reset value or
     # access in the asserted sweep changes. See the nrf52840 drift_ack note; no
     # TIMER live re-capture is evidenced by this entry.
-    drift_ack: 2026-08-08
-    drift_ack_digest: 6142ba057c56f787631dde73492b725ac7f4490d77933b37aeea5fb3b8ba6612
+    # 2026-08-09: rides the nrf52840 RNG production-timing change; same silicon.
+    # See the nrf52840 drift_ack note for why it is behavioural and what it does
+    # not touch. No RNG live re-capture is evidenced by this entry.
+    drift_ack: 2026-08-09
+    drift_ack_digest: 1069454e8c736b0eec67e6865e16dfca371f905fab39d1a9aadf8ea2c0e4bbb5
     models:
       - crates/core/src/peripherals/nrf52
       - configs/chips/nrf52840.yaml


### PR DESCRIPTION
## Description

The secure-boot lab walks three boots under the CLI and sits on boot 1 forever in the playground. This is why.

The browser applies `recommended_tick_interval()` at engine init (`simulator-bridge.ts`), and `max_safe_tick_interval` reported > 1 for any nRF52 bus because it only ruled out HC-SR04 and the legacy walk. The nRF52 RNG is not safe there: `advance_cycles` produces a byte per `BYTE_PERIOD` for as many periods as the batch covers, overwriting `VALUE` each time and raising `VALRDY` once, so firmware gets the last byte of each batch and the other N-1 are gone.

**Scheduler-driven is not the same as batch-safe.** The RNG rides the scheduler, which is exactly why `legacy_walk_disabled` answered "relax".

That made the byte stream a function of how the host chose to batch. The lab's provisioned root key came out shifted four bytes, its AES boot challenge missed `GOLDEN_CIPHERTEXT`, boot 2 printed `SECURE BOOT FAILED`, and boots 2 and 3 never happened:

```
interval 1   22 CA B3 3F 02 30 A2 F2 0B EE F7 8A 31 63 B7 56
interval >1  02 30 A2 F2 0B EE F7 8A 31 63 B7 56 B6 16 91 9C
```

`Peripheral::tick_batching_safe` defaults to true and the RNG answers false; one such model on the bus pins the bus to interval 1. Walked at the call site rather than cached, since this is an engine-init question and not a per-instruction one like `requires_cycle_accurate`.

## Why the policy and not the model

The first version of this PR changed `Nrf52Rng::advance_cycles` to hold a byte until firmware took it. It worked, and `pr-gate` was right to reject it: that edit moved the nrf52840 models digest and tripped the silicon-drift gate.

The gate was pointing at something real. On silicon the RNG free-runs and a slow reader genuinely does miss bytes, so holding a byte would have traded away fidelity on a board that is silicon-verified, in exchange for determinism. The policy was the thing that was actually wrong. `max_safe_tick_interval` is documented as the largest interval the bus can run

> without losing fidelity

and for a bus carrying an RNG that value is 1. It was claiming otherwise. No model changes here, so the drift gate has nothing to object to.

## How it was isolated

`crates/wasm/src/playground_repro.rs` drives the entry points the bridge uses, in its order: `new_from_config_arm`, `feed_uart_input`, then `step_batch` in a loop. It rules out the two obvious suspects — the bridge does feed the OTA packages, and idle fast-forward is irrelevant:

```
                                before               after
idle_ff=false auto_tick=false   ATTESTATION OK       ATTESTATION OK
idle_ff=false auto_tick=true    SECURE BOOT FAILED   ATTESTATION OK
idle_ff=true  auto_tick=false   ATTESTATION OK       ATTESTATION OK
idle_ff=true  auto_tick=true    SECURE BOOT FAILED   ATTESTATION OK
```

The browser case lands `#[ignore]`d with the diagnosis in the first commit and is un-ignored by the fix in the second, so the history carries both the bug and the test that closes it.

`max_safe_tick_interval_pins_buses_carrying_batch_unsafe_models` asserts the same bus relaxes *without* the RNG before adding one, so it cannot pass for the wrong reason.

Nothing in either repo tested the browser path before this. The only mentions of `ROLLBACK REJECTED` outside the firmware are three prose strings in lab copy, so a lab that was green in CI and broken in the product looked identical to a working one.

## Cost

nRF52 buses no longer batch peripheral ticks in the browser. That is a throughput loss on those boards, and it is the honest price: the interval they were running at was corrupting the RNG stream.

## Verification

- `labwired-core --lib` — 2809 passed, 0 failed
- `labwired-wasm --lib` — 30 passed, 0 failed
- `secure-boot-smoke` — 55/55
- `cargo fmt --check` — clean

## Related Issues

Third bug in this lab, after #870 (SSD1306 control byte) and #879 (firmware row blanking). Same shape as #870: batching drops data a per-step path preserved, with nothing asserting it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist
- [x] I have run `cargo fmt` and `cargo clippy`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation accordingly. (the why is on the trait method, the RNG override, and the policy arm)
- [x] My changes generate no new warnings.

## Screenshots (if applicable)

n/a — the visible effect is the playground OLED getting past `PROVISIONING / REBOOTING...`.