### PR TITLE
ci(coverage): give the weekly coverage gate the history its ratchet needs

### DIFF
--- a/.github/workflows/core-coverage-weekly.yml
+++ b/.github/workflows/core-coverage-weekly.yml
@@ -14,7 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # Full history, because the tier1 ratchet resolves its baseline from
+      # `origin/main` and refuses to run without one:
+      #
+      #   tier1 ratchet: this is a SHALLOW clone, so the baseline cannot be
+      #   established. Refusing to run: a gate that cannot find its baseline
+      #   must not pass.
+      #
+      # That refusal is correct, and it took the whole job down with it. This
+      # lane has failed on every run it has ever had -- 2026-07-26, 08-02 and
+      # 08-09 -- so the coverage gate has never once produced a coverage number.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.95.0


### PR DESCRIPTION
## The lane has never passed

`Core Coverage Gate` runs weekly (`cron: 20 2 * * 0`). Every run it has ever had has failed:

| run | sha | result |
| --- | --- | --- |
| 2026-08-09 | `a174cadf` | failure |
| 2026-08-02 | `2bd7c1dc` | failure |
| 2026-07-26 | `87bcbc44` | failure |

So there is no coverage number, and has not been one for at least three weeks.

## Cause

Not a coverage regression. The job checks out shallow, and the tier1 ratchet resolves its baseline from `origin/main`:

```
tier1 ratchet: this is a SHALLOW clone, so the baseline cannot be established.
Deepen it first (`git fetch --unshallow origin` or `actions/checkout` with `fetch-depth: 0`)
Refusing to run: a gate that cannot find its baseline must not pass.
```

```
failures:
    tier1::tests::baseline_fails_loudly_on_an_unresolvable_ref
    tier1::tests::baseline_resolves_in_this_repo_and_parses
test result: FAILED. 111 passed; 2 failed
```

**The refusal is correct** — a ratchet with no baseline ratchets nothing, and failing closed is the right call. It just takes `cargo llvm-cov` down with it, because those two tests run inside the covered test set. The gate that exists to prevent a vacuous pass is what makes the lane produce nothing at all.

## Fix

```diff
   - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
```

Nothing else. The comment records why, so nobody trims it back to a shallow clone for speed.

## Verification

YAML parses and `fetch-depth: 0` is asserted present on the checkout step.

I have not run `cargo llvm-cov` locally — the real proof is the next weekly run, or a `workflow_dispatch` if you want it sooner. What this PR establishes is that the two tier1 tests can resolve a baseline; whether coverage then meets its threshold is a separate question this lane has never been able to ask.

Worth expecting: the first successful run may well fail on an actual coverage threshold, since nothing has enforced one in three weeks. That would be the gate finally working, not a new problem.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)