### PR TITLE
ci(core-integrity): add the ARM target before the --lib run, not after it

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -763,6 +763,15 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      # Before the --lib run, not just before the fixture suites below. The
+      # playground secure-boot repro in crates/wasm builds
+      # firmware-nrf52840-secure-boot on demand for thumbv7em, and it is a
+      # #[cfg(test)] module in src/, so `--workspace --lib` runs it. With the
+      # target added ten lines further down, those three tests died on
+      # "secure-boot firmware build failed" and took main red.
+      - name: Install ARM target for firmware builds under test
+        run: rustup target add thumbv7em-none-eabi
+
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
 


### PR DESCRIPTION
## Why

Main is red at `344e0683` (#891). Three tests fail in `core-integrity` → **Unit tests (no fixtures)**:

```
playground_repro::playground_secure_boot_repro::matrix
playground_repro::playground_secure_boot_repro::browser_tick_interval_reaches_boot_three
playground_repro::playground_secure_boot_repro::playground_path_reaches_boot_three

panicked at crates/wasm/src/playground_repro.rs:81:9:
secure-boot firmware build failed
```

Not a regression in #891's logic — a step-ordering bug in this workflow.

#891's repro calls `ensure_firmware_built()`, which shells out to `cargo build -p firmware-nrf52840-secure-boot --target thumbv7em-none-eabi`. It lives in a `#[cfg(test)]` module under `crates/wasm/src`, so **`cargo test --workspace --lib` runs it** — and that step sits ten lines *above* the `rustup target add thumbv7em-none-eabi` the fixture suites below depend on.

The job already knew the rule. Its own comment reads:

> The e2e firmware targets thumbv7em, so the target must be installed first (as `core-full` does).

It installed it first for the *fixture* step, and `--lib` grew a cross-build afterwards.

## Fix

Move the target install above the `--lib` run. The later install stays where it is, so the fixture suites keep their explicit dependency rather than inheriting it silently.

```diff
+      - name: Install ARM target for firmware builds under test
+        run: rustup target add thumbv7em-none-eabi
+
       - name: Unit tests (no fixtures)
         run: cargo test --workspace --lib
```

## Why the PR was green

`pr-gate` runs the browser layer as its own step and never executes `cargo test --workspace --lib`. `core-integrity` is push-to-main only. So this failure was unreachable from the pull request — the same shape as #880 (`firmware_survival`, since fixed by #888) and #886 (`Core Arduino Matrix Smoke`, still PR-invisible).

That is three distinct main-only lanes in one day. Worth its own pass: a change to `crates/core` or `crates/wasm` currently cannot see what `--workspace --lib`, the Arduino matrix, or the S3 e2e will say until after it merges.

## Verification

YAML parses; asserted that the target-install step index precedes the `--lib` step index in the resolved `integrity` job, and that the F407 install is still present.

The proof is main going green on merge — this step only runs on push to main, so like the lane it fixes, it cannot be exercised from a PR.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)