### PR TITLE
ci: stop gating pull requests on the live published lab

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -576,19 +576,26 @@ jobs:
 
       # The BLE Pong fixture is a COMMITTED copy of a published community lab,
       # and `world_esp32c3_ble_pong` (release-only, push-to-main) is the only
-      # thing that boots it. Both checks are cheap enough to run here so a PR
-      # that touches the sketch is told BEFORE the merge, not after.
-      #
-      #   * the cargo test hashes the committed .ino/.bin pair, so neither can
-      #     move without the other;
-      #   * the drift script asks api.labwired.com whether the OWNER has since
-      #     edited the live project. Nothing in-tree can know that, and not
-      #     knowing it is how the fixture sat at the #828 build while the
-      #     published lab moved on and three gates stayed green.
+      # thing that boots it. This hashes the committed .ino/.bin pair, so
+      # neither can move without the other. It is pure in-tree consistency:
+      # no network, and a PR that touches the sketch is told before the merge.
       - name: BLE Pong fixture provenance (committed .ino ↔ .bin)
         run: cargo test -p labwired-core --test fixture_ble_pong_provenance
-      - name: BLE Pong fixture drift (committed .ino ↔ LIVE published lab)
-        run: scripts/ci/check-published-lab-drift.sh
+
+      # The LIVE-published-lab drift check deliberately does NOT run here.
+      #
+      # It asks api.labwired.com whether the owner has since edited the live
+      # project. That is a useful thing to know, but it is not a property of
+      # the pull request: a published lab is a living product artifact and is
+      # SUPPOSED to change. Asserting it as a required merge gate meant one
+      # ordinary lab edit blocked every PR in the repo — which is exactly what
+      # happened, blocking four unrelated PRs at once — and it also put a
+      # third-party network call on the critical path of every merge.
+      #
+      # It still runs on push-to-main and on the nightly cron (see
+      # `core-integrity`), where a lab edit reports a finding instead of
+      # halting the repo. That lane is what catches the case no PR causes:
+      # the owner editing the live project between merges.
 
   # ── Browser-configuration observable gate (PR; parallel with pr-gate) ──────
   #
@@ -830,10 +837,13 @@ jobs:
       # same address" hid.
       # Run the drift check BEFORE the release-gated world test below, so a red
       # lane says "the published lab moved" rather than leaving someone to infer
-      # it from a two-node BLE failure. `pr-gate` runs this too; keeping it here
-      # is what covers the case nobody's PR causes — the owner editing the live
-      # project between merges. On push-to-main and on the nightly cron this is
-      # the only lane that looks at production at all.
+      # it from a two-node BLE failure. This is now the ONLY lane that runs it —
+      # `pr-gate` deliberately does not, because a published lab is supposed to
+      # change and one edit there blocked every PR in the repo. Here it is a
+      # monitor rather than a merge gate, and it covers the case nobody's PR
+      # causes: the owner editing the live project between merges. On
+      # push-to-main and on the nightly cron this is the only lane that looks
+      # at production at all.
       - name: BLE Pong fixture drift (committed .ino ↔ LIVE published lab)
         run: scripts/ci/check-published-lab-drift.sh
 


### PR DESCRIPTION
A published lab is a living product artifact. It is **supposed** to change. Gating merges on it being byte-identical to a committed copy means the owner editing his own lab breaks the build — which is what just happened.

## What broke

`scripts/ci/check-published-lab-drift.sh` asks `api.labwired.com` whether the owner has since edited the live BLE Pong project, and `pr-gate` treated any difference as a merge failure:

```
PUBLISHED LAB HAS DRIFTED FROM THE COMMITTED FIXTURE.
  live      sha256 3b4d793e…  (12654 bytes)
  committed sha256 8dcfc480…  (12654 bytes)
```

One ordinary lab edit blocked **every open PR in the repo** — four unrelated ones, none of which touch the sketch. It also puts a third-party network call on the critical path of every merge, so an API blip or an expired token stops all work.

## What changes

`pr-gate` no longer runs the live drift check. Nothing else moves.

The check keeps its value where it belongs: `core-integrity` still runs it on push-to-main and on the nightly cron, where a lab edit **reports a finding instead of halting the repo**. That lane also still covers the case no PR can cause — the owner editing the live project between merges, which is the scenario that let the fixture sit at the #828 build while the published lab moved on.

`pr-gate` keeps the offline half: `fixture_ble_pong_provenance` hashes the committed `.ino`/`.bin` pair so neither can move without the other. That *is* a property of the pull request, and it needs no network.

## The distinction

The drift check is not wrong. Asserting it as a **required merge gate** is. "Has production changed?" is a monitoring question with a monitoring answer; it is not a statement about whether a patch is correct.

This is ledger item **2.12**, filed as Queued and now actively blocking.

## Verification

Workflow parses, and the step landed in exactly one job:

```
integrity: ['BLE Pong fixture drift (committed .ino ↔ LIVE published lab)']
pr-gate:   ['BLE Pong fixture provenance (committed .ino ↔ .bin)']
```

YAML-only change; no test, script or fixture is touched. `check-published-lab-drift.sh` itself is unmodified.
