### PR TITLE
test(contract): teach the discard scanner to see .unwrap_or

### DIFF
--- a/crates/core/src/tests/cortex_m_memory_contract.rs
+++ b/crates/core/src/tests/cortex_m_memory_contract.rs
@@ -90,6 +90,15 @@ mod no_discarded_bus_access {
                 "let _ = bus.write_u32(b as u64 + 8, r2);",
                 "let _ = bus.write_u32(b as u64 + 12, r3);",
                 "|base: u32| -> Option<u32> { bus.read_u32((base.wrapping_add(core * 4)) as u64).ok() };",
+                // `raw_word_for_trace` is an OBSERVER: it re-reads the word at
+                // the PC purely so a trace line can show it. It is on no
+                // execution path and its value reaches no register. Turning a
+                // lost trace word into a fault would mean switching tracing on
+                // could change whether a run passes, which is the one thing an
+                // observer must never do — so here the default IS the honest
+                // answer, and it is why these two are allowed rather than fixed.
+                "bus.read_u16(addr).map(u32::from).unwrap_or(0)",
+                "bus.read_u32(addr).unwrap_or(0)",
             ],
         ),
     ];
@@ -148,6 +157,17 @@ mod no_discarded_bus_access {
         // single most important shape to catch: it is invisible to clippy,
         // because nothing is being discarded as far as the type system can see.
         if l.contains("if let Ok(") || l.contains("match bus.read_") {
+            return true;
+        }
+        // `bus.read_u32(..).unwrap_or(0)` — the Err is collapsed to a default
+        // and the caller cannot tell a real 0 from a refused access, which is
+        // precisely the fabricated fact every other arm here exists to catch.
+        //
+        // This arm was missing while the six above were present, so the one
+        // spelling that reads most like ordinary Rust was the one spelling the
+        // guard could not see. A regression reintroduced as `.unwrap_or(0)`
+        // would have passed a green gate.
+        if l.contains(".unwrap_or") {
             return true;
         }
         false


### PR DESCRIPTION
The memory-contract scanner catches six ways to throw away a bus error — `let _ =`, `.is_err()`, `.is_ok()`, `.ok()`, `if let Ok(..)`, `match bus.read_`. It did not catch the seventh:

```rust
let value = bus.read_u32(addr).unwrap_or(0);
```

The `Err` collapses into a default and the caller cannot tell a real `0` from a refused access. That is the same fabricated fact every other arm exists to catch — and it is the spelling that reads most like ordinary Rust, so the one shape the guard could not see is the one most likely to be written by accident.

**A regression reintroduced as `.unwrap_or(0)` would have passed a green gate**, in the exact module this contract guards. That matters this week in particular: the propagation work this scanner protects was reverted from main twice, and #902 is currently re-landing the Xtensa half.

## Scope is two lines

Widening the scanner flags exactly two existing sites in `src/cpu/**`, both in `raw_word_for_trace`:

```
xtensa_lx7.rs:349: bus.read_u16(addr).map(u32::from).unwrap_or(0)
xtensa_lx7.rs:351: bus.read_u32(addr).unwrap_or(0)
```

Both are **allowed rather than fixed**, with the reason recorded next to the entries. `raw_word_for_trace` is an observer: it re-reads the word at the PC purely so a trace line can display it, its value reaches no register, and it is on no execution path. Faulting there would mean switching tracing on could change whether a run passes — the one thing an observer must never do. Here the default *is* the honest answer.

(61 further sites exist elsewhere in the crate, outside `src/cpu/**`, which is the only scope this contract enforces. Not touched — a separate question about whether the contract should widen its scope.)

## Watched in both directions

- **Before** adding the allowlist entries, the widened scanner fails (exit **101**) naming exactly those two lines and nothing else.
- **After**, green.
- A newly planted `bus.read_u32(addr).unwrap_or(0xDEAD_BEEF)` in `src/cpu/` still fails (exit **101**).

So the allowlist pins that specific content; it does not disable the shape. The list stays shrink-only.

## Verification

| check | exit |
|---|---|
| `labwired-core --lib` (2953 passed) | 0 |
| `cargo fmt --all -- --check` | 0 |

Test-only change; no production code touched.

**Conflicts with #902** in `ALLOWED_DISCARDS` — that PR removes the four Xtensa spill-write entries as it propagates them. Resolve by keeping both edits: #902's removals and this PR's two additions.
