### PR TITLE
feat(logic-analyzer): put ESP32-C3 and S3 SPI and UART on the wire

### DIFF
--- a/crates/core/src/bus/attach.rs
+++ b/crates/core/src/bus/attach.rs
@@ -502,6 +502,222 @@ impl SystemBus {
         }
     }
 
+    /// Bind the ESP32-C3 GP-SPI2 (FSPI) controller's SCK/MOSI/CS wire to the
+    /// pads its output matrix can route them to, so a probe on GPIO6 shows the
+    /// shifted bytes rather than the GPIO output latch. No-op unless both C3
+    /// models are on the bus.
+    ///
+    /// Unlike the RP2040 there is no pad table to transcribe: the ESP32 GPIO
+    /// matrix can route ANY peripheral signal to ANY pad, so every pad is bound
+    /// to all three signals and `FUNCn_OUT_SEL_CFG` decides which one is live.
+    /// The signal indices are C3-specific — see `SIG_FSPICLK` and friends in
+    /// `peripherals::esp32c3::gpio`, cited to esp-idf `gpio_sig_map.h`.
+    ///
+    /// MISO is deliberately unbound; see [`crate::peripherals::esp_gpspi_wire`].
+    pub(crate) fn wire_esp32c3_spi_pads(&mut self) {
+        use crate::peripherals::esp32c3::gpio::Esp32c3Gpio;
+        use crate::peripherals::esp32c3::spi::Esp32c3Spi;
+
+        let spi_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|a| a.is::<Esp32c3Spi>())
+                .unwrap_or(false)
+        });
+        let gpio_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|a| a.is::<Esp32c3Gpio>())
+                .unwrap_or(false)
+        });
+        // ⚠️ Resolve BOTH before touching either: `pad_lines_arc` CREATES the
+        // wire cell, and a controller that owns a cell no route reaches still
+        // buffers every launched transaction, arms a wakeup per burst, and
+        // narrates into a wire nothing reads.
+        let (Some(spi_idx), Some(gpio_idx)) = (spi_idx, gpio_idx) else {
+            return;
+        };
+        let Some(lines) = self.peripherals[spi_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32c3Spi>())
+            .map(Esp32c3Spi::pad_lines_arc)
+        else {
+            return;
+        };
+        if let Some(gpio) = self.peripherals[gpio_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32c3Gpio>())
+        {
+            gpio.bind_spi_lines(&lines);
+        }
+    }
+
+    /// Bind each ESP32-C3 UART's TX wire to the pads its output matrix can route
+    /// it to, so serial output is a waveform on a remapped pad rather than the
+    /// idle GPIO latch. No-op unless C3 GPIO and at least one C3 UART are on the
+    /// bus.
+    ///
+    /// ⚠️ The stock `Serial` console is NOT visible through this, and that is
+    /// correct: `U0TXD`'s default pad (GPIO21) is driven through IO_MUX
+    /// function 0, bypassing the matrix entirely, so `FUNCn_OUT_SEL` never
+    /// names it and the pad genuinely is showing its GPIO state. The binding
+    /// goes live the moment firmware remaps TX to a non-IO_MUX pin — which is
+    /// what `uart_set_pin` does through `gpio_matrix_out` — and UART1 has no
+    /// IO_MUX route on this part at all, so it is matrix-only.
+    ///
+    /// TX ONLY; see `Esp32c3Gpio::bind_uart_tx_lines`.
+    pub(crate) fn wire_esp32c3_uart_pads(&mut self) {
+        use crate::peripherals::esp32c3::gpio::Esp32c3Gpio;
+        use crate::peripherals::esp_uart::EspUart;
+
+        let Some(gpio_idx) = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|a| a.is::<Esp32c3Gpio>())
+                .unwrap_or(false)
+        }) else {
+            return;
+        };
+        for (instance, name) in ["uart0", "uart1"].iter().enumerate() {
+            let Some(idx) = self.find_peripheral_index_by_name(name) else {
+                continue;
+            };
+            let Some(lines) = self.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<EspUart>())
+                .map(EspUart::pad_lines_arc)
+            else {
+                continue;
+            };
+            if let Some(gpio) = self.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Esp32c3Gpio>())
+            {
+                gpio.bind_uart_tx_lines(instance, &lines);
+            }
+        }
+    }
+
+    /// The ESP32-S3 counterpart of [`Self::wire_esp32c3_spi_pads`]: bind SPI2
+    /// (and SPI3, when the bus carries it) to the S3 output matrix.
+    ///
+    /// ⚠️ The signal indices are NOT the C3's. `FSPICLK`/`FSPID`/`FSPICS0` are
+    /// 101/103/110 here against the C3's 63/65/68, and 63 on the S3 is not a SPI
+    /// signal at all — a borrowed constant would decode routed pads as plain and
+    /// plain pads as routed, silently, in both directions.
+    ///
+    /// Only SPI2 is bound. Both S3 GP-SPI instances are the same model type, so
+    /// the first one found is taken and SPI3 keeps the latch fallback; binding
+    /// both would need a per-instance signal set (`SPI3_CLK_OUT_IDX` and
+    /// friends) that no lab drives today.
+    pub(crate) fn wire_esp32s3_spi_pads(&mut self) {
+        use crate::peripherals::esp32s3::gpio::Esp32s3Gpio;
+        use crate::peripherals::esp32s3::gpspi::Esp32s3Spi;
+
+        let gpio_idx = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|a| a.is::<Esp32s3Gpio>())
+                .unwrap_or(false)
+        });
+        // Prefer the instance the chip calls SPI2 (`spi2_s3` on the programmatic
+        // builder, `spi2` from a yaml); fall back to the first GP-SPI on the bus
+        // so a hand-built test bus with one controller still wires.
+        let spi_idx = ["spi2_s3", "spi2"]
+            .iter()
+            .find_map(|n| self.find_peripheral_index_by_name(n))
+            .filter(|&i| {
+                self.peripherals[i]
+                    .dev
+                    .as_any()
+                    .map(|a| a.is::<Esp32s3Spi>())
+                    .unwrap_or(false)
+            })
+            .or_else(|| {
+                self.peripherals.iter().position(|p| {
+                    p.dev
+                        .as_any()
+                        .map(|a| a.is::<Esp32s3Spi>())
+                        .unwrap_or(false)
+                })
+            });
+        // ⚠️ Resolve BOTH first — `pad_lines_arc` CREATES the wire cell.
+        let (Some(spi_idx), Some(gpio_idx)) = (spi_idx, gpio_idx) else {
+            return;
+        };
+        let Some(lines) = self.peripherals[spi_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32s3Spi>())
+            .map(Esp32s3Spi::pad_lines_arc)
+        else {
+            return;
+        };
+        if let Some(gpio) = self.peripherals[gpio_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32s3Gpio>())
+        {
+            gpio.bind_spi_lines(&lines);
+        }
+    }
+
+    /// The ESP32-S3 counterpart of [`Self::wire_esp32c3_uart_pads`]. Same
+    /// IO_MUX caveat: `U0TXD`'s default pad is GPIO43 at IO_MUX function 0, so
+    /// the stock console route is not matrix-visible; UART2 has no IO_MUX pad at
+    /// all and is matrix-only.
+    ///
+    /// The instance names differ from the C3's because the programmatic builder
+    /// registers them as `uart0_s3`/`uart1_s3`/`uart2_s3`; a yaml-built bus
+    /// spells them without the suffix, and both are accepted.
+    pub(crate) fn wire_esp32s3_uart_pads(&mut self) {
+        use crate::peripherals::esp32s3::gpio::Esp32s3Gpio;
+        use crate::peripherals::esp_uart::EspUart;
+
+        let Some(gpio_idx) = self.peripherals.iter().position(|p| {
+            p.dev
+                .as_any()
+                .map(|a| a.is::<Esp32s3Gpio>())
+                .unwrap_or(false)
+        }) else {
+            return;
+        };
+        for (instance, names) in [
+            ["uart0_s3", "uart0"],
+            ["uart1_s3", "uart1"],
+            ["uart2_s3", "uart2"],
+        ]
+        .iter()
+        .enumerate()
+        {
+            let Some(idx) = names
+                .iter()
+                .find_map(|n| self.find_peripheral_index_by_name(n))
+            else {
+                continue;
+            };
+            let Some(lines) = self.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<EspUart>())
+                .map(EspUart::pad_lines_arc)
+            else {
+                continue;
+            };
+            if let Some(gpio) = self.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Esp32s3Gpio>())
+            {
+                gpio.bind_uart_tx_lines(instance, &lines);
+            }
+        }
+    }
+
     /// Wire C3 IO_MUX per-pad controls into C3 GPIO after both models have
     /// been constructed. The IO_MUX owns the shared register bank; GPIO reads
     /// `FUN_WPU` from it to model Arduino `INPUT_PULLUP`. No-op on any bus

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -872,9 +872,18 @@ impl SystemBus {
         // the C3 GPIO model so matrix-routed pads carry the real waveform.
         // No-op for every other chip.
         bus.wire_esp32c3_i2c_pads();
+        // And GP-SPI2's SCK/MOSI/CS plus each UART's TX, so those buses are
+        // measurable on the C3 too rather than reading as a flat line. MISO/RX
+        // are deliberately unbound — nothing drives them.
+        bus.wire_esp32c3_spi_pads();
+        bus.wire_esp32c3_uart_pads();
         // Same for the S3's I²C0, whose pads reach GPIO through the S3 output
         // matrix rather than an AF nibble.
         bus.wire_esp32s3_i2c_pads();
+        // …and the S3's GP-SPI2 / UART TX, whose matrix indices are 101/103/110
+        // and 12/15/18 — neither the C3's nor the classic part's.
+        bus.wire_esp32s3_spi_pads();
+        bus.wire_esp32s3_uart_pads();
         // Same for classic ESP32 (LX6), whose matrix indices are 29/30 —
         // neither the C3's 53/54 nor the S3's 89/90.
         bus.wire_esp32_i2c_pads();

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -30,6 +30,29 @@ const SIG_GPIO_OUT: u32 = 128;
 /// `soc/esp32c3/include/soc/gpio_sig_map.h`).
 const SIG_I2CEXT0_SCL: u32 = 53;
 const SIG_I2CEXT0_SDA: u32 = 54;
+/// GPIO-matrix OUTPUT signal indices of GP-SPI2 (FSPI) — the controller
+/// arduino-esp32's `SPIClass SPI(FSPI)` drives. esp-idf
+/// `soc/esp32c3/include/soc/gpio_sig_map.h`: `FSPICLK_OUT_IDX` :104,
+/// `FSPID_OUT_IDX` :108, `FSPICS0_OUT_IDX` :114.
+///
+/// ⚠️ These are C3 numbers. The S3 spells the same three signals 101/103/110
+/// and the classic ESP32's VSPI is 63/65/68 — the index space is PER CHIP, and
+/// borrowing a sibling's constant fails silently in BOTH directions: a plain
+/// pad decodes as routed and a routed pad as plain.
+const SIG_FSPICLK: u32 = 63;
+const SIG_FSPID: u32 = 65;
+const SIG_FSPICS0: u32 = 68;
+/// GPIO-matrix OUTPUT signal indices of the UART transmitters (esp-idf
+/// `gpio_sig_map.h` :29 `U0TXD_OUT_IDX`, :35 `U1TXD_OUT_IDX`).
+///
+/// ⚠️ The DEFAULT `U0TXD` pad (GPIO21) reaches the pin through IO_MUX
+/// function 0 (`io_mux_reg.h` :267), NOT through this matrix, so a stock
+/// `Serial.begin()` leaves these routes dark and the pad rightly keeps reading
+/// the GPIO latch. The route lights up when firmware remaps TX to any other pin
+/// — `uart_set_pin` falls back to `gpio_matrix_out` for a non-IO_MUX pad, and
+/// UART1 has no IO_MUX route on the C3 at all, so it is matrix-only.
+const SIG_U0TXD: u32 = 6;
+const SIG_U1TXD: u32 = 9;
 
 /// ESP32-C3 GPIO-matrix OUTPUT signal index → signal name, for the I²C / SPI /
 /// UART signals the logic analyzer cares about (from esp-idf
@@ -167,6 +190,57 @@ impl Esp32c3Gpio {
                 .bind(&wire, pin, Some(SIG_I2CEXT0_SDA), 1, "I2CEXT0_SDA");
         }
         self.i2c_lines = Some(lines);
+    }
+
+    /// Bind GP-SPI2's SCK/MOSI/CS wire to every pad the output matrix can route
+    /// it to. Which pad is live at any moment is then decided by
+    /// `FUNCn_OUT_SEL_CFG`, through the shared routing seam — exactly as for
+    /// I²C above. MISO is deliberately not bound; see
+    /// [`crate::peripherals::esp_gpspi_wire`].
+    pub(crate) fn bind_spi_lines(
+        &mut self,
+        lines: &std::sync::Arc<crate::peripherals::pad_lines::PadLines>,
+    ) {
+        use crate::peripherals::esp_gpspi_wire::{LINE_CS, LINE_MOSI, LINE_SCK};
+        for pin in 0..PIN_COUNT {
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_FSPICLK), LINE_SCK, "SPI2_SCK");
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_FSPID), LINE_MOSI, "SPI2_MOSI");
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_FSPICS0), LINE_CS, "SPI2_CS");
+        }
+    }
+
+    /// Bind one UART's TX wire to every pad the output matrix can route it to.
+    ///
+    /// TX ONLY. Nothing in the engine drives the RX line, so a bound RX pad
+    /// would report a confident constant idle-high — including while an attached
+    /// GPS or modem was actually sending. That is worse than the GPIO-latch
+    /// fallback it would replace, because it looks authoritative. Same call as
+    /// `wire_rp2040_uart_pads` documents. RX joins the table when something
+    /// drives it, not before.
+    pub(crate) fn bind_uart_tx_lines(
+        &mut self,
+        instance: usize,
+        lines: &std::sync::Arc<crate::peripherals::pad_lines::PadLines>,
+    ) {
+        let (signal, func) = match instance {
+            0 => (SIG_U0TXD, "UART0_TX"),
+            1 => (SIG_U1TXD, "UART1_TX"),
+            // The C3 has two UARTs (`SOC_UART_NUM` = 2) and no U2 signal exists
+            // in its matrix at all, so there is nothing to bind.
+            _ => return,
+        };
+        for pin in 0..PIN_COUNT {
+            self.pad_routes.bind(
+                lines,
+                pin,
+                Some(signal),
+                crate::peripherals::uart::LINE_TX,
+                func,
+            );
+        }
     }
 
     /// Every signal name bound to this port's pads, live or not — the

--- a/crates/core/src/peripherals/esp32c3/spi.rs
+++ b/crates/core/src/peripherals/esp32c3/spi.rs
@@ -44,8 +44,15 @@
 //! mirroring the I²C / UART pattern; the bus routes it through the per-core
 //! interrupt matrix.
 
+use crate::peripherals::esp_gpspi_wire::EspSpiWire;
 use crate::peripherals::spi::SpiDevice;
 use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
+
+/// ESP32-C3 core clock. The GP-SPI divisors count APB ticks, and the engine's
+/// cycle axis is CPU cycles, so the narration scales by `CPU_CLOCK_HZ /
+/// APB_CLK_HZ` — the same conversion `esp_uart` applies to its baud divisor.
+/// The C3 runs its core at 160 MHz; the S3's copy of this model says 240.
+const CPU_CLOCK_HZ: u64 = 160_000_000;
 
 pub const SPI2_BASE: u32 = 0x6002_4000;
 pub const SPI2_SIZE: u64 = 0x1000;
@@ -154,6 +161,11 @@ pub struct Esp32c3Spi {
     /// (feature off, a hand-built bus, or the differential's `force_legacy_walk`)
     /// keeps the legacy per-cycle walk. Not serialized — re-attached by the bus.
     clock: Option<CycleClock>,
+    /// Narration state for the SCK/MOSI/CS pads the output matrix can route this
+    /// controller to. Inert until `SystemBus::wire_esp32c3_spi_pads` binds it;
+    /// see [`crate::peripherals::esp_gpspi_wire`], shared with the S3's copy of
+    /// this same IP.
+    wire: EspSpiWire,
 }
 
 impl std::fmt::Debug for Esp32c3Spi {
@@ -187,7 +199,37 @@ impl Esp32c3Spi {
             int_raw: 0,
             attached_devices: Vec::new(),
             clock: None,
+            wire: EspSpiWire::default(),
         }
+    }
+
+    /// The shared pad-line cell for this controller's SCK/MOSI/CS, created on
+    /// first use at bus wiring time.
+    ///
+    /// ⚠️ Creating the cell turns narration ON. `SystemBus::wire_esp32c3_spi_pads`
+    /// resolves the GPIO port FIRST for that reason: a controller owning a cell
+    /// no route reaches still buffers every launched transaction, arms a wakeup
+    /// per burst, and narrates into a wire nothing reads.
+    pub(crate) fn pad_lines_arc(
+        &mut self,
+    ) -> std::sync::Arc<crate::peripherals::pad_lines::PadLines> {
+        let cpol = crate::peripherals::esp_gpspi_wire::framing(self.reg(MISC), self.reg(USER)).cpol;
+        self.wire.pad_lines_arc(cpol)
+    }
+
+    /// Engine cycles per SCK period, from this controller's own `SPI_CLOCK`.
+    fn bit_time_cycles(&self) -> Option<u64> {
+        crate::peripherals::esp_gpspi_wire::bit_time_cycles(self.reg(CLOCK), CPU_CLOCK_HZ)
+    }
+
+    /// Publish a held burst once the wire has carried it. The cycle axis comes
+    /// from the bus clock; with none attached (a hand-built test bus) there is no
+    /// axis to place a waveform on and nothing is published.
+    fn wire_flush(&mut self, force: bool) {
+        let Some(now) = self.clock.as_ref().map(|c| c.now()) else {
+            return;
+        };
+        self.wire.flush(now, force);
     }
 
     /// Test/differential knob: detach the cycle clock, pinning the model to the
@@ -278,10 +320,19 @@ impl Esp32c3Spi {
     /// clear `USR` and latch `SPI_TRANS_DONE`.
     fn launch_transaction(&mut self) {
         let bytes = self.transfer_bytes();
+        // Read the framing and rate ONCE per transaction, before the exchange
+        // loop: they are the registers this launch was configured with, and a
+        // device callback cannot change them mid-transfer on real silicon.
+        let framing = crate::peripherals::esp_gpspi_wire::framing(self.reg(MISC), self.reg(USER));
+        let bit_time = self.bit_time_cycles();
+        let now = self.clock.as_ref().map_or(0, |c| c.now());
         for i in 0..bytes {
             let off = W0 + (i as u64 / 4) * 4;
             let shift = (i % 4) * 8;
             let mosi = ((self.reg(off) >> shift) & 0xFF) as u8;
+            // Narrate the byte the CPU put on the bus, at the point it goes out
+            // — before the MISO response overwrites the W slot it came from.
+            self.wire.push(mosi, framing, bit_time, now);
             let miso = self.exchange_byte(mosi);
             let word = (self.reg(off) & !(0xFFu32 << shift)) | ((miso as u32) << shift);
             self.set_reg_raw(off, word);
@@ -374,6 +425,11 @@ impl Peripheral for Esp32c3Spi {
     /// level from [`Self::matrix_irq_sources`] instead; this reporter is a pure
     /// no-op on state, so a stray call is harmless.
     fn tick(&mut self) -> PeripheralTickResult {
+        // Legacy-walk publication point. Under `event-scheduler` the walk skips
+        // this model and the chain in `take_scheduled_events` owns it; without
+        // the feature this is where a held burst reaches the pads. Inert — one
+        // `is_empty` — on every bus that never routed an SPI pad.
+        self.wire_flush(false);
         PeripheralTickResult {
             explicit_irqs: if self.int_st() != 0 {
                 Some(vec![self.source_id])
@@ -384,8 +440,13 @@ impl Peripheral for Esp32c3Spi {
         }
     }
 
+    /// ⚠️ A held narration counts as ACTIVE. This gate decides whether the walk
+    /// calls `tick()` at all, and `int_st()` alone goes false the moment
+    /// firmware clears TRANS_DONE — which is long before the wire has finished
+    /// carrying the burst that transaction launched. Without the second term the
+    /// featureless build drops the flush entirely and the pads stay flat.
     fn legacy_tick_active(&self) -> bool {
-        self.int_st() != 0
+        self.int_st() != 0 || self.wire.is_pending()
     }
 
     fn legacy_tick_dynamic(&self) -> bool {
@@ -403,6 +464,51 @@ impl Peripheral for Esp32c3Spi {
     /// semantics.
     fn uses_scheduler(&self) -> bool {
         cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Publish a held burst under the scheduler, where the walk skips this model.
+    ///
+    /// # Why an event chain and not `needs_legacy_walk() -> true`
+    ///
+    /// `SystemBus::derive_walk_deletable` is all-or-nothing: one model forcing
+    /// the walk back on drops walk-deletion for the WHOLE bus, including every
+    /// C3 lab that never routes an SPI pad. This chain costs wakeups only while
+    /// a burst is genuinely held — which needs BOTH routed pads and a launched
+    /// transaction — and it arms at the exact cycle the wire finishes
+    /// (`ready_in`), so a 64-byte burst costs ONE wakeup rather than 100 000.
+    /// `uses_scheduler`/`needs_legacy_walk` are deliberately UNCHANGED above.
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if !self.uses_scheduler() || !self.wire.is_pending() || self.wire.scheduled {
+            return Vec::new();
+        }
+        let Some(now) = self.clock.as_ref().map(|c| c.now()) else {
+            return Vec::new();
+        };
+        self.wire.arm_seq = self.wire.arm_seq.wrapping_add(1);
+        self.wire.scheduled = true;
+        vec![(self.wire.ready_in(now), self.wire.arm_seq)]
+    }
+
+    fn on_event(
+        &mut self,
+        event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if event_token != self.wire.arm_seq {
+            // Stale token from a superseded arm; the live chain owns publication.
+            return crate::sched::EventResult::default();
+        }
+        self.wire_flush(false);
+        // A flush that reported LevelsOnly keeps its bytes; `ready_in` is then 0,
+        // so `max(1)` retries next cycle and converges as the run grows.
+        let now = self.clock.as_ref().map_or(0, |c| c.now());
+        let pending = self.wire.is_pending();
+        self.wire.scheduled = pending;
+        crate::sched::EventResult {
+            reschedule_delay: pending.then(|| self.wire.ready_in(now).max(1)),
+            ..Default::default()
+        }
     }
 
     fn attach_cycle_clock(&mut self, clock: CycleClock) {

--- a/crates/core/src/peripherals/esp32s3/gpio.rs
+++ b/crates/core/src/peripherals/esp32s3/gpio.rs
@@ -141,6 +141,31 @@ const SIG_GPIO_OUT: u32 = 256;
 const SIG_I2CEXT0_SCL: u32 = 89;
 const SIG_I2CEXT0_SDA: u32 = 90;
 
+/// GPIO-matrix OUTPUT signal indices of GP-SPI2 (FSPI) — the controller
+/// arduino-esp32's `SPIClass SPI(FSPI)` drives. esp-idf
+/// `soc/esp32s3/include/soc/gpio_sig_map.h`: `FSPICLK_OUT_IDX` :194,
+/// `FSPID_OUT_IDX` :198, `FSPICS0_OUT_IDX` :212.
+///
+/// ⚠️ S3 numbers. The C3 spells the same three signals 63/65/68 and the classic
+/// ESP32's VSPI is 63/65/68 as well — identical VALUES with a different
+/// meaning, which is precisely why a sibling's constant must never be borrowed:
+/// on the S3, 63 is not a SPI signal at all.
+const SIG_FSPICLK: u32 = 101;
+const SIG_FSPID: u32 = 103;
+const SIG_FSPICS0: u32 = 110;
+/// GPIO-matrix OUTPUT signal indices of the UART transmitters (esp-idf
+/// `gpio_sig_map.h` :39 `U0TXD_OUT_IDX`, :45 `U1TXD_OUT_IDX`,
+/// :51 `U2TXD_OUT_IDX`).
+///
+/// ⚠️ The DEFAULT `U0TXD` pad (GPIO43) reaches the pin through IO_MUX
+/// function 0 (`io_mux_reg.h` :407), NOT through this matrix, so a stock
+/// `Serial.begin()` leaves that route dark and the pad rightly keeps reading the
+/// GPIO latch. The route lights up when firmware remaps TX — and UART2 has no
+/// IO_MUX route on the S3 at all, so it is matrix-only.
+const SIG_U0TXD: u32 = 12;
+const SIG_U1TXD: u32 = 15;
+const SIG_U2TXD: u32 = 18;
+
 /// Line indices within the I²C controller's published pad lines.
 const I2C_LINE_SCL: usize = super::i2c::LINE_SCL;
 const I2C_LINE_SDA: usize = super::i2c::LINE_SDA;
@@ -416,6 +441,54 @@ impl Esp32s3Gpio {
                 Some(SIG_I2CEXT0_SDA),
                 I2C_LINE_SDA,
                 "I2CEXT0_SDA",
+            );
+        }
+    }
+
+    /// Bind GP-SPI2's SCK/MOSI/CS wire to every pad the output matrix can route
+    /// it to. Which pad is live at any moment is then decided by
+    /// `FUNCn_OUT_SEL_CFG`, through the shared routing seam — exactly as for
+    /// I²C above. MISO is deliberately not bound; see
+    /// [`crate::peripherals::esp_gpspi_wire`].
+    pub(crate) fn bind_spi_lines(
+        &mut self,
+        lines: &std::sync::Arc<crate::peripherals::pad_lines::PadLines>,
+    ) {
+        use crate::peripherals::esp_gpspi_wire::{LINE_CS, LINE_MOSI, LINE_SCK};
+        for pin in 0..PAD_COUNT {
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_FSPICLK), LINE_SCK, "SPI2_SCK");
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_FSPID), LINE_MOSI, "SPI2_MOSI");
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_FSPICS0), LINE_CS, "SPI2_CS");
+        }
+    }
+
+    /// Bind one UART's TX wire to every pad the output matrix can route it to.
+    ///
+    /// TX ONLY, for the reason `wire_rp2040_uart_pads` documents: nothing in the
+    /// engine drives RX, so a bound RX pad would report a confident constant
+    /// idle-high — worse than the GPIO-latch fallback, because it looks
+    /// authoritative.
+    pub(crate) fn bind_uart_tx_lines(
+        &mut self,
+        instance: usize,
+        lines: &std::sync::Arc<crate::peripherals::pad_lines::PadLines>,
+    ) {
+        let (signal, func) = match instance {
+            0 => (SIG_U0TXD, "UART0_TX"),
+            1 => (SIG_U1TXD, "UART1_TX"),
+            2 => (SIG_U2TXD, "UART2_TX"),
+            _ => return,
+        };
+        for pin in 0..PAD_COUNT {
+            self.pad_routes.bind(
+                lines,
+                pin,
+                Some(signal),
+                crate::peripherals::uart::LINE_TX,
+                func,
             );
         }
     }

--- a/crates/core/src/peripherals/esp32s3/gpspi.rs
+++ b/crates/core/src/peripherals/esp32s3/gpspi.rs
@@ -80,8 +80,15 @@
 //! mirroring the UART/systimer pattern; the bus routes it through the per-core
 //! interrupt matrix.
 
+use crate::peripherals::esp_gpspi_wire::EspSpiWire;
 use crate::peripherals::spi::SpiDevice;
 use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
+
+/// ESP32-S3 core clock. The GP-SPI divisors count APB ticks and the engine's
+/// cycle axis is CPU cycles, so the narration scales by `CPU_CLOCK_HZ /
+/// APB_CLK_HZ` — the same conversion `esp_uart` applies to its baud divisor.
+/// The S3 runs its core at 240 MHz; the C3's copy of this model says 160.
+const CPU_CLOCK_HZ: u64 = 240_000_000;
 
 const CMD: u64 = 0x00;
 const ADDR: u64 = 0x04;
@@ -208,6 +215,11 @@ pub struct Esp32s3Spi {
 
     /// Bus-published cycle clock (walk-free level export).
     clock: Option<CycleClock>,
+    /// Narration state for the SCK/MOSI/CS pads the output matrix can route this
+    /// controller to. Inert until `SystemBus::wire_esp32s3_spi_pads` binds it;
+    /// see [`crate::peripherals::esp_gpspi_wire`], shared with the C3's copy of
+    /// this same IP.
+    wire: EspSpiWire,
 }
 
 impl std::fmt::Debug for Esp32s3Spi {
@@ -245,7 +257,51 @@ impl Esp32s3Spi {
             attached_devices: Vec::new(),
 
             clock: None,
+            wire: EspSpiWire::default(),
         }
+    }
+
+    /// The shared pad-line cell for this controller's SCK/MOSI/CS, created on
+    /// first use at bus wiring time.
+    ///
+    /// ⚠️ Creating the cell turns narration ON. `SystemBus::wire_esp32s3_spi_pads`
+    /// resolves the GPIO port FIRST for that reason: a controller owning a cell
+    /// no route reaches still buffers every launched transaction, arms a wakeup
+    /// per burst, and narrates into a wire nothing reads.
+    pub(crate) fn pad_lines_arc(
+        &mut self,
+    ) -> std::sync::Arc<crate::peripherals::pad_lines::PadLines> {
+        let cpol = crate::peripherals::esp_gpspi_wire::framing(self.reg(MISC), self.reg(USER)).cpol;
+        self.wire.pad_lines_arc(cpol)
+    }
+
+    /// Engine cycles per SCK period, from this controller's own `SPI_CLOCK`.
+    fn bit_time_cycles(&self) -> Option<u64> {
+        crate::peripherals::esp_gpspi_wire::bit_time_cycles(self.reg(CLOCK), CPU_CLOCK_HZ)
+    }
+
+    /// Queue the bytes a transaction put on the wire, with the framing and rate
+    /// its registers were configured with.
+    fn wire_push_bytes(&mut self, bytes: &[u8]) {
+        if !self.wire.is_bound() {
+            return;
+        }
+        let framing = crate::peripherals::esp_gpspi_wire::framing(self.reg(MISC), self.reg(USER));
+        let bit_time = self.bit_time_cycles();
+        let now = self.clock.as_ref().map_or(0, |c| c.now());
+        for &b in bytes {
+            self.wire.push(b, framing, bit_time, now);
+        }
+    }
+
+    /// Publish a held burst once the wire has carried it. The cycle axis comes
+    /// from the bus clock; with none attached (a hand-built test bus) there is
+    /// no axis to place a waveform on and nothing is published.
+    fn wire_flush(&mut self, force: bool) {
+        let Some(now) = self.clock.as_ref().map(|c| c.now()) else {
+            return;
+        };
+        self.wire.flush(now, force);
     }
 
     /// Raw device push — does NOT wrap for tracing. The only production caller
@@ -335,6 +391,18 @@ impl Esp32s3Spi {
         }
         // Non-DMA (W-buffer) mode: existing logic unchanged.
         let bytes = self.miso_bytes();
+        // Narrate the MOSI payload FIRST. It is still sitting in W0..W15 at this
+        // point and the fill below overwrites it with the idle-MISO 0xFF, so
+        // reading it after would report a bus that only ever carried ones.
+        if self.wire.is_bound() {
+            let mosi: Vec<u8> = (0..bytes)
+                .map(|i| {
+                    let off = W0 + (i as u64 / 4) * 4;
+                    ((self.reg(off) >> ((i % 4) * 8)) & 0xFF) as u8
+                })
+                .collect();
+            self.wire_push_bytes(&mosi);
+        }
         for w in 0..bytes.div_ceil(4) {
             let off = W0 + (w as u64) * 4;
             // Bytes covered by this word: full 0xFF, partial keep only valid bytes.
@@ -369,6 +437,9 @@ impl Esp32s3Spi {
     /// With no device attached the MISO line floats high, so every byte
     /// reads 0xFF. Advances `pending_dma.transferred` by the burst length.
     pub(crate) fn dma_transfer(&mut self, mosi: &[u8]) -> Vec<u8> {
+        // GDMA-coupled transfers are the path esp_lcd drives a display over, so
+        // this is where most real S3 SPI traffic reaches the wire.
+        self.wire_push_bytes(mosi);
         let mut miso = Vec::with_capacity(mosi.len());
         for &m in mosi {
             let byte = if self.attached_devices.is_empty() {
@@ -489,6 +560,11 @@ impl Peripheral for Esp32s3Spi {
     }
 
     fn tick(&mut self) -> PeripheralTickResult {
+        // Legacy-walk publication point. Under `event-scheduler` the walk skips
+        // this model and the chain in `take_scheduled_events` owns it; without
+        // the feature this is where a held burst reaches the pads. Inert — one
+        // `is_empty` — on every bus that never routed an SPI pad.
+        self.wire_flush(false);
         PeripheralTickResult {
             explicit_irqs: if self.int_st() != 0 {
                 Some(vec![self.source_id])
@@ -508,6 +584,51 @@ impl Peripheral for Esp32s3Spi {
 
     fn needs_legacy_walk(&self) -> bool {
         !self.uses_scheduler()
+    }
+
+    /// Publish a held burst under the scheduler, where the walk skips this model.
+    ///
+    /// # Why an event chain and not `needs_legacy_walk() -> true`
+    ///
+    /// `SystemBus::derive_walk_deletable` is all-or-nothing: one model forcing
+    /// the walk back on drops walk-deletion for the WHOLE bus, including every
+    /// S3 lab that never routes an SPI pad. This chain costs wakeups only while
+    /// a burst is genuinely held — which needs BOTH routed pads and a launched
+    /// transaction — and it arms at the exact cycle the wire finishes
+    /// (`ready_in`), so a 64-byte burst costs ONE wakeup rather than 150 000.
+    /// `uses_scheduler`/`needs_legacy_walk` are deliberately UNCHANGED above.
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if !self.uses_scheduler() || !self.wire.is_pending() || self.wire.scheduled {
+            return Vec::new();
+        }
+        let Some(now) = self.clock.as_ref().map(|c| c.now()) else {
+            return Vec::new();
+        };
+        self.wire.arm_seq = self.wire.arm_seq.wrapping_add(1);
+        self.wire.scheduled = true;
+        vec![(self.wire.ready_in(now), self.wire.arm_seq)]
+    }
+
+    fn on_event(
+        &mut self,
+        event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if event_token != self.wire.arm_seq {
+            // Stale token from a superseded arm; the live chain owns publication.
+            return crate::sched::EventResult::default();
+        }
+        self.wire_flush(false);
+        // A flush that reported LevelsOnly keeps its bytes; `ready_in` is then 0,
+        // so `max(1)` retries next cycle and converges as the run grows.
+        let now = self.clock.as_ref().map_or(0, |c| c.now());
+        let pending = self.wire.is_pending();
+        self.wire.scheduled = pending;
+        crate::sched::EventResult {
+            reschedule_delay: pending.then(|| self.wire.ready_in(now).max(1)),
+            ..Default::default()
+        }
     }
 
     fn attach_cycle_clock(&mut self, clock: CycleClock) {

--- a/crates/core/src/peripherals/esp_gpspi_wire.rs
+++ b/crates/core/src/peripherals/esp_gpspi_wire.rs
@@ -1,0 +1,358 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! The ONE way an Espressif GP-SPI master puts a real waveform on its pads.
+//!
+//! # Why this is shared
+//!
+//! The ESP32-C3 `SPI2` (FSPI) and the ESP32-S3 `SPI2`/`SPI3` are the same
+//! Espressif GP-SPI IP. Every register this module reads sits at the same
+//! offset with the same bit positions on both parts, verified field by field
+//! against the local esp-idf headers:
+//!
+//! | field | reg | bits | C3 `spi_reg.h` | S3 `spi_reg.h` |
+//! |---|---|---|---|---|
+//! | `SPI_CLK_EQU_SYSCLK` | CLOCK 0x0C | 31 | :140 | :169 |
+//! | `SPI_CLKDIV_PRE` | CLOCK 0x0C | 21:18 | :147 | :176 |
+//! | `SPI_CLKCNT_N` | CLOCK 0x0C | 17:12 | :154 | :183 |
+//! | `SPI_CK_OUT_EDGE` (CPHA) | USER 0x10 | 9 | :262 | :298 |
+//! | `SPI_CK_IDLE_EDGE` (CPOL) | MISC 0x20 | 29 | :398 | :441 |
+//!
+//! (paths under
+//! `framework-arduinoespressif32/tools/sdk/<chip>/include/soc/<chip>/include/soc/`.)
+//!
+//! The two controllers keep their own register files, their own transaction
+//! engines and their own interrupt-matrix ids — everything that genuinely
+//! differs. What they share is this: how a completed transaction becomes edges.
+//! Two copies of it would be two places to get MSB-order or the CS framing
+//! wrong, and only one of them would be under test.
+//!
+//! # What the caller owes this type
+//!
+//! * Call [`EspSpiWire::pad_lines_arc`] once at bus wiring time, AFTER the GPIO
+//!   port has been resolved — creating the cell is what turns narration on, and
+//!   a controller narrating into a wire no pad reaches is pure cost.
+//! * Call [`EspSpiWire::push`] with each MOSI byte at the moment the
+//!   transaction engine puts it on the bus.
+//! * Call [`EspSpiWire::flush`] from a wakeup — `tick()` on the legacy walk, an
+//!   event chain under the scheduler — so a burst is published once the wire has
+//!   had time to carry it.
+//!
+//! # What is NOT bound
+//!
+//! MISO. The S3's W-buffer path fills the MISO region with a constant `0xFF`
+//! without consulting an attached device at all, so a bound MISO pad would
+//! report a confident idle level while a display or flash was supposedly
+//! answering — worse than the GPIO-latch fallback it would replace, because it
+//! looks authoritative. Same rule that keeps `wire_rp2040_uart_pads` TX-only.
+//! MISO joins the table when the W-buffer path genuinely exchanges, not before.
+
+use std::sync::Arc;
+
+use super::pad_lines::PadLines;
+use super::spi_waveform::{NarrationFit, SpiFraming, SpiNarrator};
+
+/// APB clock the GP-SPI divisors count. 80 MHz on both parts — the same source
+/// clock `esp_uart` scales its baud divisor against.
+pub const APB_CLK_HZ: u64 = 80_000_000;
+
+/// The pad lines a GP-SPI master DRIVES, in the order a lab probes them.
+/// See the module header for why MISO is absent.
+pub const SPI_LINES: &[&str] = &["SCK", "MOSI", "CS"];
+pub const LINE_SCK: usize = 0;
+pub const LINE_MOSI: usize = 1;
+pub const LINE_CS: usize = 2;
+
+/// Bytes a narration may hold waiting for the wire before it is published
+/// anyway, compressed. Deeper than the 64-byte W buffer, so a burst reaches
+/// this only when firmware is launching transactions faster than the rate it
+/// programmed can carry them.
+const WIRE_BURST_CAP: usize = 256;
+
+/// `SPI_CLK_EQU_SYSCLK` — SPI clock equals the APB clock, divisors bypassed.
+const CLK_EQU_SYSCLK: u32 = 1 << 31;
+/// `SPI_CLKDIV_PRE` [21:18].
+const CLKDIV_PRE_SHIFT: u32 = 18;
+const CLKDIV_PRE_MASK: u32 = 0xF;
+/// `SPI_CLKCNT_N` [17:12].
+const CLKCNT_N_SHIFT: u32 = 12;
+const CLKCNT_N_MASK: u32 = 0x3F;
+/// `SPI_CK_OUT_EDGE` in `SPI_USER` — CPHA.
+const CK_OUT_EDGE: u32 = 1 << 9;
+/// `SPI_CK_IDLE_EDGE` in `SPI_MISC` — CPOL.
+const CK_IDLE_EDGE: u32 = 1 << 29;
+
+/// Engine cycles in one SCK period, from the controller's own `SPI_CLOCK`.
+///
+/// `f_spi = f_apb / ((CLKDIV_PRE + 1) * (CLKCNT_N + 1))`, or `f_apb` outright
+/// when `CLK_EQU_SYSCLK` is set (the reset state, and what
+/// `spi_ll_master_set_clock` programs for an 80 MHz request). Scaled from APB
+/// ticks into CPU cycles by `cpu_clock_hz / APB_CLK_HZ`, because the engine's
+/// cycle axis is CPU cycles — the same conversion `EspUart::cycles_per_byte`
+/// applies to `CLKDIV`, and exact on both parts (160 and 240 MHz are whole
+/// multiples of 80).
+///
+/// `None` below two cycles per bit, where [`super::wave_plan::WavePlan`] cannot
+/// keep a period's halves distinct and nothing honest can be drawn.
+pub fn bit_time_cycles(clock_reg: u32, cpu_clock_hz: u64) -> Option<u64> {
+    let apb_ticks = if clock_reg & CLK_EQU_SYSCLK != 0 {
+        1
+    } else {
+        let pre = u64::from((clock_reg >> CLKDIV_PRE_SHIFT) & CLKDIV_PRE_MASK) + 1;
+        let n = u64::from((clock_reg >> CLKCNT_N_SHIFT) & CLKCNT_N_MASK) + 1;
+        pre * n
+    };
+    let ticks = apb_ticks * cpu_clock_hz / APB_CLK_HZ;
+    (ticks >= 2).then_some(ticks)
+}
+
+/// How `SPI_MISC` and `SPI_USER` currently frame a byte on the wire.
+///
+/// Width is fixed at 8: the GP-SPI's `SPI_MS_DLEN` counts the transaction in
+/// BITS and the transaction engines above walk the W buffer a byte at a time,
+/// so a byte is the unit that reaches this wire. `SPI_WR_BIT_ORDER` (CTRL bit
+/// 26 on the C3, [26:25] on the S3) selects LSB-first and is NOT read here —
+/// the narrator only draws MSB-first, which is what every ESP-IDF path
+/// programs; a firmware that flipped it would get a trace at the right rate
+/// with the bits reversed, so it is called out rather than silently assumed.
+pub fn framing(misc_reg: u32, user_reg: u32) -> SpiFraming {
+    SpiFraming {
+        cpol: misc_reg & CK_IDLE_EDGE != 0,
+        cpha: user_reg & CK_OUT_EDGE != 0,
+        bits: 8,
+    }
+}
+
+/// The narration state one GP-SPI controller carries.
+#[derive(Debug, Default)]
+pub struct EspSpiWire {
+    /// Levels published to matrix-routed pads. `None` — the common case, no lab
+    /// routed an SPI pad — costs one branch per transaction and publishes
+    /// nothing.
+    lines: Option<Arc<PadLines>>,
+    /// Bytes shifted since the last flush, each with the framing the registers
+    /// held AT THE MOMENT it went out. Carried per byte rather than re-read at
+    /// flush time so firmware that reprograms CPOL/CPHA between transactions
+    /// still narrates each byte the way it actually went.
+    words: Vec<(u8, SpiFraming)>,
+    /// Bit period the held burst is narrated at, captured on its first byte. A
+    /// rate change mid-burst force-flushes what is held rather than repainting
+    /// it at a rate no transaction used.
+    bit_time: u64,
+    /// Cycle the last narration ran to — the floor the next may not reach back
+    /// past, or two bursts splice into bytes neither transaction sent.
+    wave_cursor: u64,
+    /// True while a flush wakeup is in flight, so a run of transactions arms one
+    /// chain rather than one per transaction.
+    pub scheduled: bool,
+    /// Monotonic token so a stale wakeup from a superseded arm is ignored.
+    pub arm_seq: u32,
+}
+
+impl EspSpiWire {
+    /// The shared pad-line cell for SCK/MOSI/CS, created on first use.
+    ///
+    /// SCK idles at the programmed polarity, MOSI low, chip select RELEASED —
+    /// an idle SPI bus reads CS high, and a model that idled it low would frame
+    /// a transaction that never happened.
+    pub fn pad_lines_arc(&mut self, cpol: bool) -> Arc<PadLines> {
+        self.lines
+            .get_or_insert_with(|| Arc::new(PadLines::new(SPI_LINES, &[cpol, false, true])))
+            .clone()
+    }
+
+    /// `true` once a lab has routed pads to this controller.
+    pub fn is_bound(&self) -> bool {
+        self.lines.is_some()
+    }
+
+    /// `true` while a burst is held and unpublished.
+    pub fn is_pending(&self) -> bool {
+        !self.words.is_empty()
+    }
+
+    /// Queue one MOSI byte. Buffered, not published — see [`Self::flush`]. No
+    /// routed pads or no usable bit period ⇒ nothing to narrate, and the call
+    /// costs one branch.
+    pub fn push(&mut self, byte: u8, framing: SpiFraming, bit_time: Option<u64>, now: u64) {
+        if self.lines.is_none() {
+            return;
+        }
+        let Some(bit_time) = bit_time else {
+            return;
+        };
+        if !self.words.is_empty() && bit_time != self.bit_time {
+            self.flush(now, true);
+        }
+        if self.words.is_empty() {
+            self.bit_time = bit_time;
+        }
+        self.words.push((byte, framing));
+    }
+
+    /// Cycles until the held burst has had its wire time — 0 when it is due now,
+    /// when nothing is held, or when it has hit the cap and must be published
+    /// compressed rather than held longer.
+    ///
+    /// Both the pacing test and the scheduler deadline, computed the ONE way, so
+    /// a wakeup can never land before the burst is publishable (a wasted wakeup)
+    /// or after it (a late trace).
+    pub fn ready_in(&self, now: u64) -> u64 {
+        if self.words.is_empty() || self.words.len() >= WIRE_BURST_CAP {
+            return 0;
+        }
+        let duration: u64 = self
+            .words
+            .iter()
+            .map(|(_, framing)| framing.frame_bits() * self.bit_time)
+            .sum();
+        self.wave_cursor
+            .saturating_add(duration)
+            .saturating_sub(now)
+    }
+
+    /// Publish the held bytes onto the routed pads, once the wire has had time
+    /// to carry them.
+    ///
+    /// The transaction engines above run a whole `SPI_CMD.USR` launch inside one
+    /// MMIO write and clear `USR` immediately, so firmware hands this model a
+    /// 64-byte buffer within a few cycles. The WIRE cannot do that — 64 bytes at
+    /// the arduino-esp32 default of 1 MHz take ~102 000 CPU cycles on a 160 MHz
+    /// C3 — and the capture layer (`LogicTap::push_at` →
+    /// `LogicCapture::ingest_push`) accepts stamps in the PAST only, keeping one
+    /// level per channel per cycle. There is nowhere to put a byte that has not
+    /// yet had time to cross.
+    ///
+    /// So the burst accumulates and is narrated as one waveform ending at the
+    /// present cycle. Holding until `now` has passed its wire time is what makes
+    /// the common case EXACT: the trace then carries every byte at the rate
+    /// `SPI_CLOCK` programs.
+    ///
+    /// `force` publishes regardless — the cap path and the rate-change path. The
+    /// burst is then compressed: the bytes stay readable, the timebase does not.
+    pub fn flush(&mut self, now: u64, force: bool) {
+        if self.words.is_empty() {
+            return;
+        }
+        let Some(lines) = self.lines.clone() else {
+            self.words.clear();
+            return;
+        };
+        if !force && self.ready_in(now) > 0 {
+            return;
+        }
+        let mut narrator = SpiNarrator::with_lines(
+            LINE_SCK,
+            LINE_MOSI,
+            Some(LINE_CS),
+            &[
+                lines.level(LINE_SCK),
+                lines.level(LINE_MOSI),
+                lines.level(LINE_CS),
+            ],
+            self.bit_time,
+        );
+        for &(byte, framing) in &self.words {
+            narrator.frame(u16::from(byte), framing);
+        }
+        if let NarrationFit::LevelsOnly { .. } =
+            narrator.emit_between(&lines, self.wave_cursor, now)
+        {
+            // Fewer cycles exist than the waveform has transitions, so nothing
+            // was drawn. Keep the bytes and the cursor: `now` only grows, so a
+            // later wakeup will have the room. Clearing here would delete bytes
+            // that really crossed the bus and advance the cursor past cycles
+            // nothing painted — silent, unrecoverable loss, and the reason
+            // `emit_between` is `#[must_use]`.
+            return;
+        }
+        self.wave_cursor = now;
+        self.words.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reset `SPI_CLOCK` (0x8000_3043 on both parts) has
+    /// `CLK_EQU_SYSCLK` set, which really is "SPI runs at the APB rate" — one
+    /// APB tick per bit, i.e. 2 CPU cycles on a 160 MHz C3 and 3 on a 240 MHz
+    /// S3. Not a refusal: it is what the register says, and what silicon would
+    /// do if firmware launched without touching CLOCK.
+    #[test]
+    fn the_reset_clock_register_means_the_apb_rate() {
+        assert_eq!(bit_time_cycles(0x8000_3043, 160_000_000), Some(2));
+        assert_eq!(bit_time_cycles(0x8000_3043, 240_000_000), Some(3));
+    }
+
+    /// 1 MHz from an 80 MHz APB is a divide by 80, and `CLKCNT_N` is only SIX
+    /// bits — 79 does not fit, which is exactly why `spi_ll_master_cal_clock_reg`
+    /// searches for a `(pre, n)` PAIR. `pre_reg = 1` (÷2) with `n_reg = 39` (÷40)
+    /// is one such pair. On the C3 that is 160 CPU cycles per bit; on the S3,
+    /// 240.
+    #[test]
+    fn the_divisors_give_the_programmed_rate() {
+        let clock = (1 << CLKDIV_PRE_SHIFT) | (39 << CLKCNT_N_SHIFT);
+        assert_eq!(bit_time_cycles(clock, 160_000_000), Some(160));
+        assert_eq!(bit_time_cycles(clock, 240_000_000), Some(240));
+    }
+
+    /// ⚠️ Both divisor fields are narrow and a value that overflows one spills
+    /// into the next. Writing 79 into `CLKCNT_N` keeps only its low six bits
+    /// (15 ⇒ ÷16) AND sets `CLKDIV_PRE` to 1 (⇒ ÷2), giving ÷32 — not the ÷80
+    /// the caller meant. Decoding those fields as if they were wide enough is a
+    /// trace at a frequency the firmware never asked for.
+    #[test]
+    fn an_overflowing_divisor_is_masked_not_widened() {
+        let clock = 79 << CLKCNT_N_SHIFT;
+        assert_eq!(bit_time_cycles(clock, 160_000_000), Some(2 * 16 * 160 / 80));
+    }
+
+    /// CPOL/CPHA come from the two registers the datasheet puts them in, and
+    /// nowhere else. Reading `CK_IDLE_EDGE` out of `USER` (or `CK_OUT_EDGE` out
+    /// of `MISC`) would give a trace at the right rate sampled on the wrong
+    /// edge, which decodes to garbage that looks plausible.
+    #[test]
+    fn mode_bits_come_from_misc_and_user() {
+        assert_eq!(
+            framing(0, 0),
+            SpiFraming {
+                cpol: false,
+                cpha: false,
+                bits: 8
+            }
+        );
+        assert!(framing(CK_IDLE_EDGE, 0).cpol);
+        assert!(!framing(CK_IDLE_EDGE, 0).cpha);
+        assert!(framing(0, CK_OUT_EDGE).cpha);
+        assert!(!framing(0, CK_OUT_EDGE).cpol);
+        // The bit positions must not be confused for one another.
+        assert!(!framing(CK_OUT_EDGE, 0).cpol, "USER's bit is not MISC's");
+        assert!(!framing(0, CK_IDLE_EDGE).cpha, "MISC's bit is not USER's");
+    }
+
+    /// An unbound wire — every lab that never routed an SPI pad — buffers
+    /// nothing at all, so the whole path costs one branch per byte.
+    #[test]
+    fn an_unrouted_controller_holds_nothing() {
+        let mut wire = EspSpiWire::default();
+        wire.push(0xA5, SpiFraming::default(), Some(160), 0);
+        assert!(!wire.is_pending());
+        assert_eq!(wire.ready_in(0), 0);
+    }
+
+    /// A held burst is due exactly when its wire time has elapsed, never before.
+    #[test]
+    fn a_held_burst_is_due_when_the_wire_has_carried_it() {
+        let mut wire = EspSpiWire::default();
+        let _ = wire.pad_lines_arc(false);
+        wire.push(0xA5, SpiFraming::default(), Some(160), 0);
+        // One 8-bit frame occupies 10 bit periods (8 clocked + CS + idle).
+        let duration = SpiFraming::default().frame_bits() * 160;
+        assert_eq!(wire.ready_in(0), duration);
+        assert_eq!(wire.ready_in(duration - 1), 1);
+        assert_eq!(wire.ready_in(duration), 0);
+    }
+}

--- a/crates/core/src/peripherals/esp_uart.rs
+++ b/crates/core/src/peripherals/esp_uart.rs
@@ -66,6 +66,10 @@
 //! read back byte-identical to real ESP32-S3 silicon. The C3 shares the IP but
 //! its config-register reset values are not separately silicon-pinned.
 
+use crate::peripherals::pad_lines::PadLines;
+use crate::peripherals::uart::{LINE_RX, LINE_TX, UART_LINES};
+use crate::peripherals::uart_waveform::{UartFraming, UartNarrator};
+use crate::peripherals::wave_plan::NarrationFit;
 use crate::{CycleClock, Peripheral, PeripheralTickResult, SimResult};
 
 const UART_WAKE_TOKEN: u32 = 1;
@@ -136,6 +140,23 @@ const UART_SCLK_HZ: u64 = 80_000_000;
 /// that family passes its own rate via [`EspUart::new_with_cpu_clock`];
 /// otherwise every byte would take 1.5× too long to shift out.
 const CPU_CLOCK_HZ: u64 = 240_000_000;
+
+/// Bit periods one 10-bit 8N1 character occupies — the divisor between
+/// [`EspUart::cycles_per_byte`] (which paces the shift register) and the bit
+/// period the narration is drawn at. Named rather than inlined so the two can
+/// never disagree about what "one character" means; it is `frame_bits()` of
+/// [`UartFraming::default`], asserted against it in the tests below.
+const FRAME_BITS: u64 = 10;
+
+/// Characters a narration may hold before it is published anyway, compressed.
+///
+/// Unreachable in the common case — this model shifts bytes out at the real
+/// baud rate, so a flush follows each drain and holds at most the handful of
+/// characters one elapsed window completed. It exists for the pathological
+/// caller that drives `tick()` with no cycle axis at all (the GDMA UART-TX
+/// descriptor tests), where `now` never moves and a held burst could otherwise
+/// grow without bound. Mirrors `peripherals::uart::WIRE_BURST_CAP`.
+const WIRE_BURST_CAP: usize = 256;
 
 // SVD reset values for config registers.
 const RESET_CLKDIV: u32 = 0x0000_02B6; // 694 decimal
@@ -336,6 +357,18 @@ pub struct EspUart {
     /// touches it is guarded on non-empty, so an unlinked UART behaves exactly
     /// as it did before this existed.
     attached_streams: Vec<Box<dyn crate::peripherals::uart::UartStreamDevice>>,
+    /// Wire levels published to matrix-routed TX pads, so a logic analyzer
+    /// clipped to `U0TXD` measures a serial waveform instead of the GPIO output
+    /// latch. `None` — the common case, no lab routed the pad — costs one
+    /// branch per shifted byte and publishes nothing.
+    lines: Option<Arc<PadLines>>,
+    /// Characters that have LEFT the shift register but are not yet painted.
+    /// Non-empty only between a drain and the flush that follows it in the same
+    /// call, or while the flush had no cycles to draw in.
+    wire_chars: Vec<u8>,
+    /// Cycle the last narration ran to — the floor the next one may not reach
+    /// back past, or two bursts splice into characters neither one sent.
+    wave_cursor: u64,
 }
 
 impl std::fmt::Debug for EspUart {
@@ -386,7 +419,109 @@ impl EspUart {
             scheduled: false,
             cpu_clock_hz,
             rx_source: Arc::new(Mutex::new(VecDeque::new())),
+            lines: None,
+            wire_chars: Vec::new(),
+            wave_cursor: 0,
         }
+    }
+
+    /// The shared pad-line cell for this UART's TX/RX pair, created on first use
+    /// at bus wiring time. A serial line idles HIGH (mark) in both directions,
+    /// so a start bit is always a falling edge.
+    ///
+    /// ⚠️ Creating the cell is what turns narration ON. Resolve the GPIO port
+    /// FIRST, as `SystemBus::wire_esp32c3_uart_pads` does: a controller that
+    /// owns a cell no route reaches still buffers and narrates on every
+    /// transmitted byte, into a wire nothing reads.
+    pub(crate) fn pad_lines_arc(&mut self) -> Arc<PadLines> {
+        self.lines
+            .get_or_insert_with(|| Arc::new(PadLines::new(UART_LINES, &[true, true])))
+            .clone()
+    }
+
+    /// Engine cycles in one bit period.
+    ///
+    /// Derived FROM [`Self::cycles_per_byte`] rather than recomputed from
+    /// `CLKDIV`, so the rate the trace measures can never disagree with the rate
+    /// the shift register actually drained at — the two would otherwise differ
+    /// by integer rounding, and a waveform that is a cycle per bit off from the
+    /// model that produced it is exactly the kind of wrong that looks right.
+    ///
+    /// `None` below two cycles per bit: [`crate::peripherals::wave_plan::WavePlan`]
+    /// cannot keep a period's halves distinct there, so nothing honest can be
+    /// drawn. Unreachable at any real baud rate — `CLKDIV` resets to 694
+    /// (115200 baud at the 80 MHz APB source), which is 2082 CPU cycles per bit
+    /// on the C3.
+    fn wire_bit_time(&self) -> Option<u64> {
+        let bit = self.cycles_per_byte() / FRAME_BITS;
+        (bit >= 2).then_some(bit)
+    }
+
+    /// Queue a character that has just left the shift register. Buffered, not
+    /// published — see [`Self::wire_flush`].
+    fn wire_push(&mut self, byte: u8) {
+        if self.lines.is_some() && self.wire_bit_time().is_some() {
+            self.wire_chars.push(byte);
+        }
+    }
+
+    /// Paint the characters this drain shifted out onto the routed TX pads.
+    ///
+    /// Unlike the STM32/PL011 `Uart`, this model does NOT need to hold a burst
+    /// waiting for the wire: it already shifts at the programmed baud rate, and
+    /// [`Self::drain_cycles`] only pops a character once a full frame time has
+    /// elapsed for it. So by the moment this runs, every buffered character has
+    /// genuinely had its wire time — which is why it narrates unconditionally
+    /// instead of pacing against a deadline.
+    ///
+    /// What it still must respect is the capture layer: `LogicTap::push_at` →
+    /// `LogicCapture::ingest_push` accepts stamps in the PAST only and keeps one
+    /// level per channel per cycle. So the burst is drawn as one waveform ENDING
+    /// at `now` and reaching no further back than the previous flush, exactly as
+    /// the I²C and SPI narrators publish.
+    fn wire_flush(&mut self) {
+        if self.wire_chars.is_empty() {
+            return;
+        }
+        let (Some(lines), Some(clock)) = (self.lines.clone(), self.clock.clone()) else {
+            // No cycle axis (a hand-built bus, a caller ticking us directly):
+            // there is nowhere to place a waveform, so drop rather than grow.
+            self.wire_chars.clear();
+            return;
+        };
+        let Some(bit_time) = self.wire_bit_time() else {
+            self.wire_chars.clear();
+            return;
+        };
+        let now = clock.now();
+        let mut narrator = UartNarrator::with_lines(
+            LINE_TX,
+            &[lines.level(LINE_TX), lines.level(LINE_RX)],
+            bit_time,
+        );
+        for &byte in &self.wire_chars {
+            narrator.frame(byte, UartFraming::default());
+        }
+        if let NarrationFit::LevelsOnly { .. } =
+            narrator.emit_between(&lines, self.wave_cursor, now)
+        {
+            // Fewer cycles exist than the waveform has transitions, so nothing
+            // was drawn. KEEP the characters and the cursor: `now` only grows,
+            // so a later drain will have the room. Clearing here would delete
+            // bytes that really crossed the wire and advance the cursor past
+            // cycles nothing painted — silent, unrecoverable loss, and the
+            // reason `emit_between` is `#[must_use]`.
+            if self.wire_chars.len() > WIRE_BURST_CAP {
+                // …except when the caller advances no cycles at all, where
+                // "later" never comes. Give up on the timeline rather than the
+                // memory; the levels above were already applied.
+                self.wire_chars.clear();
+                self.wave_cursor = now;
+            }
+            return;
+        }
+        self.wave_cursor = now;
+        self.wire_chars.clear();
     }
 
     /// Shared handle to the external RX queue. Bytes pushed into it are
@@ -625,6 +760,10 @@ impl EspUart {
     fn drain_cycles(&mut self, cycles: u64) {
         if self.tx_fifo.is_empty() {
             self.drain_accum = 0;
+            // Still retry a narration the last drain could not place: `now` has
+            // moved on, so cycles that did not exist then may exist now. An
+            // empty buffer makes this one `is_empty` check.
+            self.wire_flush();
             return;
         }
         self.drain_accum += cycles;
@@ -632,8 +771,10 @@ impl EspUart {
         while self.drain_accum >= per_byte && !self.tx_fifo.is_empty() {
             self.drain_accum -= per_byte;
             if let Some(byte) = self.tx_fifo.pop_front() {
-                // Same choke point as the sink, for the same reason: a byte
-                // leaves the shift register exactly once.
+                // The wire sees the byte at the SAME choke point the sink does,
+                // for the same reason: a byte leaves the shift register exactly
+                // once, and this is that once.
+                self.wire_push(byte);
                 self.trace.push(
                     &self.trace_name,
                     crate::bus::bus_trace::BusPayload::Uart {
@@ -662,6 +803,10 @@ impl EspUart {
                 self.tx_active = false;
             }
         }
+        // Paint whatever this window shifted out. Inert (one `is_empty`) on
+        // every bus that has not routed a TX pad, which is every ESP lab that
+        // existed before this.
+        self.wire_flush();
     }
 
     /// Apply a CONF0 write: the RXFIFO_RST/TXFIFO_RST pulse bits flush a FIFO.

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -21,6 +21,7 @@ pub mod dwt;
 pub mod esp32;
 pub mod esp32c3;
 pub mod esp32s3;
+pub mod esp_gpspi_wire;
 pub mod esp_uart;
 pub mod esp_xtensa_common;
 pub mod exti;

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -696,6 +696,17 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
     // CREATES the wire cell, and a controller owning a cell no route reaches
     // narrates into nothing.
     bus.wire_esp32s3_i2c_pads();
+    // Same for GP-SPI2 (SCK/MOSI/CS, matrix signals 101/103/110) and each
+    // UART's TX (12/15/18).
+    //
+    // ⚠️ These calls live HERE, not only in `from_config`, for the reason the
+    // I²C comment above records: `esp32s3.yaml` is an address-map stub — `uart0`
+    // is the vendor-neutral `uart` type, `gpio` is `declarative`, and there is no
+    // `spi2` entry at all — so `from_config` finds no S3 model to route and this
+    // programmatic builder is what every real S3 lab is built from. Gating on
+    // `from_config` alone would be green in test and dark in production.
+    bus.wire_esp32s3_spi_pads();
+    bus.wire_esp32s3_uart_pads();
 }
 
 /// Register the default thunk set for esp-hal hello-world boot.

--- a/crates/core/src/tests/esp_spi_uart_waveform.rs
+++ b/crates/core/src/tests/esp_spi_uart_waveform.rs
@@ -1,0 +1,745 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! End-to-end waveform gates for the ESP32-C3 and ESP32-S3 SPI and UART pads.
+//!
+//! Before this, both buses ran and neither could be measured on either part: the
+//! GP-SPI transaction engine moves a whole `SPI_CMD.USR` launch inside one MMIO
+//! write and the UART hands a byte to its sink with no bit engine at all, so a
+//! probe clipped to `FSPICLK` or a remapped `U0TXD` read the GPIO output latch
+//! while the firmware was clocking bytes out.
+//!
+//! # What makes these gates rather than mirrors
+//!
+//! The decoders below share NO code with the models. They replay the captured
+//! edges, sample MOSI on the edge CPOL/CPHA select, cut SPI frames on chip
+//! select, and recover UART characters by sampling the middle of each bit period
+//! after a falling start edge — which is what a real receiver does. That is what
+//! makes them sensitive to bit ORDER and to the mode bits: narrating LSB-first,
+//! or reading `CK_IDLE_EDGE` out of the wrong register, produces a trace that
+//! looks entirely plausible and decodes to garbage.
+//!
+//! # The per-chip index trap, gated explicitly
+//!
+//! GPIO-matrix signal indices are PER CHIP. `FSPICLK` is 63 on the C3 and 101 on
+//! the S3; 63 on the S3 is not a SPI signal at all. Borrowing a sibling's
+//! constant fails silently in BOTH directions — a plain pad decodes as routed
+//! and a routed pad as plain — so
+//! [`the_matrix_indices_are_per_chip_and_do_not_cross`] routes each part's pads
+//! with the OTHER part's numbers and asserts nothing lights up.
+//!
+//! # Production, not just possible
+//!
+//! Two tests assert on the builders real labs are made from — `from_config` for
+//! the C3 and `configure_xtensa_esp32s3` for the S3 — because a waveform gate
+//! that constructs its own wiring proves the narration works, not that anything
+//! ships it. That is exactly how the S3's I²C binding stayed green in test while
+//! being dark in every real lab.
+
+#[cfg(test)]
+mod esp_spi_uart_waveform_tests {
+    use crate::cpu::CortexM;
+    use crate::logic_capture::LogicEdge;
+    use crate::peripherals::esp32c3::gpio::Esp32c3Gpio;
+    use crate::peripherals::esp32c3::spi::Esp32c3Spi;
+    use crate::peripherals::esp32s3::gpio::Esp32s3Gpio;
+    use crate::peripherals::esp32s3::gpspi::Esp32s3Spi;
+    use crate::{Bus, Machine};
+
+    const RAM_BASE: u64 = 0x2000_0000;
+    const GPIO_BASE: u64 = 0x6000_4000;
+    const SPI2_BASE: u64 = 0x6002_4000;
+    const UART0_BASE: u64 = 0x6000_0000;
+
+    // --- GPIO matrix registers, identical offsets on both parts -------------
+    const ENABLE_W1TS: u64 = 0x24;
+    const FUNC_OUT_SEL: u64 = 0x554;
+
+    // --- GP-SPI registers (same offsets on C3 and S3, `spi_reg.h`) ----------
+    const SPI_CMD: u64 = 0x00;
+    const SPI_CLOCK: u64 = 0x0C;
+    const SPI_USER: u64 = 0x10;
+    const SPI_MS_DLEN: u64 = 0x1C;
+    const SPI_MISC: u64 = 0x20;
+    const SPI_W0: u64 = 0x98;
+    const SPI_USR: u32 = 1 << 24;
+    /// `SPI_CK_OUT_EDGE` (USER bit 9) — CPHA.
+    const CK_OUT_EDGE: u32 = 1 << 9;
+    /// `SPI_CK_IDLE_EDGE` (MISC bit 29) — CPOL.
+    const CK_IDLE_EDGE: u32 = 1 << 29;
+
+    // --- Espressif UART registers ------------------------------------------
+    const UART_FIFO: u64 = 0x00;
+    const UART_CLKDIV: u64 = 0x14;
+
+    // --- Matrix signal indices, from esp-idf `gpio_sig_map.h` ---------------
+    //
+    // Hand-entered here rather than imported from the models, so a change to a
+    // model's constant is a DISAGREEMENT between two lists instead of a shared
+    // mistake — the mirror-test failure mode.
+    /// C3 `FSPICLK_OUT_IDX` :104 / `FSPID_OUT_IDX` :108 / `FSPICS0_OUT_IDX` :114.
+    const C3_SIG_SCK: u32 = 63;
+    const C3_SIG_MOSI: u32 = 65;
+    const C3_SIG_CS: u32 = 68;
+    /// C3 `U0TXD_OUT_IDX` :29.
+    const C3_SIG_U0TXD: u32 = 6;
+    /// S3 `FSPICLK_OUT_IDX` :194 / `FSPID_OUT_IDX` :198 / `FSPICS0_OUT_IDX` :212.
+    const S3_SIG_SCK: u32 = 101;
+    const S3_SIG_MOSI: u32 = 103;
+    const S3_SIG_CS: u32 = 110;
+    /// S3 `U0TXD_OUT_IDX` :39.
+    const S3_SIG_U0TXD: u32 = 12;
+
+    // Pads the "firmware" picks. Any pad works — the matrix routes anything
+    // anywhere — which is itself part of what is being asserted.
+    const SCK_PIN: u8 = 6;
+    const MOSI_PIN: u8 = 7;
+    const CS_PIN: u8 = 10;
+    const TX_PIN: u8 = 5;
+
+    /// Channel order matters: MOSI is watched FIRST so that when a data setup
+    /// and a clock edge land on the same cycle (CPHA=1's leading edge) the
+    /// cycle-then-channel sort settles MOSI before SCK, which is what a setup
+    /// window means physically.
+    const CH_MOSI: u32 = 0;
+    const CH_SCK: u32 = 1;
+    const CH_CS: u32 = 2;
+    const CH_TX: u32 = 0;
+
+    /// 1 MHz from the 80 MHz APB — a divide by 80. `CLKCNT_N` [17:12] is only
+    /// six bits, so 79 does not fit and the divisor is a PAIR:
+    /// `CLKDIV_PRE` [21:18] = 1 (÷2) and `CLKCNT_N` = 39 (÷40).
+    /// `CLK_EQU_SYSCLK` (bit 31) must stay CLEAR or the divisors are bypassed.
+    const SPI_CLOCK_1MHZ: u32 = (1 << 18) | (39 << 12);
+    /// One bit period at that setting: 80 APB ticks × (cpu/apb).
+    const C3_SPI_BIT: u64 = 160; // 160 MHz core
+    const S3_SPI_BIT: u64 = 240; // 240 MHz core
+    /// 8 clocked bits + one period of CS setup/hold + one idle period. Mirrors
+    /// `SpiFraming::frame_bits`, hand-entered so a change to the pacing rule is
+    /// a disagreement between two lists.
+    const SPI_FRAME_BITS: u64 = 10;
+
+    /// `CLKDIV` for 115200 baud from the 80 MHz UART source clock — and the
+    /// register's reset value, so this is also what a UART that was never
+    /// configured shifts at.
+    const UART_CLKDIV_115200: u32 = 694;
+    const C3_UART_BIT: u64 = 694 * 160 / 80; // 1388 CPU cycles per bit
+    const S3_UART_BIT: u64 = 694 * 240 / 80; // 2082
+    /// start + 8 data + stop.
+    const UART_FRAME_BITS: u64 = 10;
+
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    struct Mode {
+        cpol: bool,
+        cpha: bool,
+    }
+    const MODE0: Mode = Mode {
+        cpol: false,
+        cpha: false,
+    };
+    const MODE3: Mode = Mode {
+        cpol: true,
+        cpha: true,
+    };
+
+    /// A NOP slab so `step()` advances the cycle axis deterministically. The
+    /// waveform is placed on absolute cycles, so a bus that never advances has
+    /// nowhere to put one — running the CPU is part of the measurement, not
+    /// scaffolding.
+    fn finish(bus: crate::bus::SystemBus) -> Machine<CortexM> {
+        let mut bus = bus;
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+        let mut machine = Machine::new(cpu, bus);
+        for i in 0..1022u64 {
+            let byte = if i % 2 == 0 { 0x00 } else { 0x20 };
+            machine.bus.write_u8(RAM_BASE + i, byte).unwrap();
+        }
+        machine.bus.write_u8(RAM_BASE + 1022, 0xFF).unwrap();
+        machine.bus.write_u8(RAM_BASE + 1023, 0xE5).unwrap();
+        machine.cpu.pc = RAM_BASE as u32;
+        machine
+    }
+
+    fn c3_spi_machine() -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        bus.add_peripheral(
+            "gpio",
+            GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32c3Gpio::new()),
+        );
+        bus.add_peripheral(
+            "spi2",
+            SPI2_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32c3Spi::new(19)),
+        );
+        bus.wire_esp32c3_spi_pads();
+        finish(bus)
+    }
+
+    fn s3_spi_machine() -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        bus.add_peripheral(
+            "gpio",
+            GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32s3Gpio::new()),
+        );
+        bus.add_peripheral(
+            "spi2_s3",
+            SPI2_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32s3Spi::new(21)),
+        );
+        bus.wire_esp32s3_spi_pads();
+        finish(bus)
+    }
+
+    fn c3_uart_machine() -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        bus.add_peripheral(
+            "gpio",
+            GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32c3Gpio::new()),
+        );
+        bus.add_peripheral(
+            "uart0",
+            UART0_BASE,
+            0x100,
+            None,
+            Box::new(crate::peripherals::esp32c3::uart::new(false, 21)),
+        );
+        bus.wire_esp32c3_uart_pads();
+        finish(bus)
+    }
+
+    fn s3_uart_machine() -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        bus.add_peripheral(
+            "gpio",
+            GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32s3Gpio::new()),
+        );
+        bus.add_peripheral(
+            "uart0_s3",
+            UART0_BASE,
+            0x100,
+            None,
+            Box::new(crate::peripherals::esp_uart::EspUart::new(false, 27)),
+        );
+        bus.wire_esp32s3_uart_pads();
+        finish(bus)
+    }
+
+    /// `gpio_matrix_out(pin, signal, false, false)` plus the output-driver
+    /// enable, which is what `esp_rom_gpio_connect_out_signal` +
+    /// `gpio_set_direction` do.
+    fn route(machine: &mut Machine<CortexM>, pin: u8, signal: u32) {
+        machine
+            .bus
+            .write_u32(GPIO_BASE + ENABLE_W1TS, 1u32 << pin)
+            .unwrap();
+        machine
+            .bus
+            .write_u32(GPIO_BASE + FUNC_OUT_SEL + u64::from(pin) * 4, signal)
+            .unwrap();
+    }
+
+    /// Program the transfer rate and mode, then launch a `SPI_CMD.USR`
+    /// transaction carrying `payload`, then run the engine long enough for the
+    /// wire to have carried it.
+    fn spi_transfer(machine: &mut Machine<CortexM>, payload: &[u8], mode: Mode, bit_time: u64) {
+        {
+            let bus = &mut machine.bus;
+            bus.write_u32(SPI2_BASE + SPI_CLOCK, SPI_CLOCK_1MHZ)
+                .unwrap();
+            bus.write_u32(
+                SPI2_BASE + SPI_MISC,
+                if mode.cpol { CK_IDLE_EDGE } else { 0 },
+            )
+            .unwrap();
+            bus.write_u32(
+                SPI2_BASE + SPI_USER,
+                if mode.cpha { CK_OUT_EDGE } else { 0 },
+            )
+            .unwrap();
+            bus.write_u32(SPI2_BASE + SPI_MS_DLEN, (payload.len() as u32 * 8) - 1)
+                .unwrap();
+            for (w, chunk) in payload.chunks(4).enumerate() {
+                let mut word = 0u32;
+                for (b, &byte) in chunk.iter().enumerate() {
+                    word |= u32::from(byte) << (8 * b);
+                }
+                bus.write_u32(SPI2_BASE + SPI_W0 + (w as u64) * 4, word)
+                    .unwrap();
+            }
+            bus.write_u32(SPI2_BASE + SPI_CMD, SPI_USR).unwrap();
+        }
+        // The model completes the transaction inside that last write; the WIRE
+        // needs ten bit periods per byte. Running that time out is the point.
+        let wire = payload.len() as u64 * SPI_FRAME_BITS * bit_time;
+        for _ in 0..wire + 256 {
+            machine.step().unwrap();
+        }
+    }
+
+    /// Push characters into the TX FIFO and let the shift register drain them
+    /// at the programmed baud rate.
+    fn uart_send(machine: &mut Machine<CortexM>, base: u64, bytes: &[u8], bit_time: u64) {
+        {
+            let bus = &mut machine.bus;
+            bus.write_u32(base + UART_CLKDIV, UART_CLKDIV_115200)
+                .unwrap();
+            for &b in bytes {
+                bus.write_u32(base + UART_FIFO, u32::from(b)).unwrap();
+            }
+        }
+        let wire = bytes.len() as u64 * UART_FRAME_BITS * bit_time;
+        for _ in 0..wire + 256 {
+            machine.step().unwrap();
+        }
+    }
+
+    /// An INDEPENDENT SPI decoder. Knows the protocol, nothing about the model.
+    fn decode_spi(edges: &[LogicEdge], mode: Mode) -> Vec<u8> {
+        let mut events: Vec<(u64, u32, bool)> =
+            edges.iter().map(|e| (e.cycle, e.ch, e.value)).collect();
+        events.sort_by_key(|&(cycle, ch, _)| (cycle, ch));
+
+        let (mut sck, mut mosi, mut cs) = (mode.cpol, false, true);
+        let (mut acc, mut count) = (0u32, 0u8);
+        let mut out = Vec::new();
+        for (_, ch, value) in events {
+            let previous_sck = sck;
+            match ch {
+                CH_SCK => sck = value,
+                CH_MOSI => mosi = value,
+                CH_CS => cs = value,
+                _ => {}
+            }
+            if ch == CH_CS && value {
+                // Chip select released: a partial word is not a frame.
+                acc = 0;
+                count = 0;
+                continue;
+            }
+            if ch == CH_SCK && !cs && previous_sck != sck {
+                let sampling = if mode.cpha {
+                    sck == mode.cpol // CPHA=1 samples on the trailing edge
+                } else {
+                    sck != mode.cpol // CPHA=0 samples on the leading edge
+                };
+                if sampling {
+                    acc = (acc << 1) | u32::from(mosi); // MSB first
+                    count += 1;
+                    if count == 8 {
+                        out.push(acc as u8);
+                        acc = 0;
+                        count = 0;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// An INDEPENDENT asynchronous-serial decoder: find a falling start edge,
+    /// then sample the MIDDLE of each of the next nine bit periods — eight data
+    /// bits LSB-first and a stop bit that MUST read high, exactly as a UART
+    /// receiver synchronises.
+    ///
+    /// Sampling mid-bit rather than on transitions is what makes this sensitive
+    /// to the programmed baud rate: a waveform drawn at the wrong bit period
+    /// walks off the character and the stop-bit check rejects it.
+    fn decode_uart(edges: &[LogicEdge], bit_time: u64) -> Vec<u8> {
+        let mut ev: Vec<(u64, bool)> = edges
+            .iter()
+            .filter(|e| e.ch == CH_TX)
+            .map(|e| (e.cycle, e.value))
+            .collect();
+        ev.sort_by_key(|&(cycle, _)| cycle);
+        if ev.is_empty() {
+            return Vec::new();
+        }
+        // Level of the line at an arbitrary cycle, replayed from the edges.
+        let level_at = |t: u64| -> bool {
+            let mut level = true; // idle mark
+            for &(cycle, value) in &ev {
+                if cycle <= t {
+                    level = value;
+                } else {
+                    break;
+                }
+            }
+            level
+        };
+
+        let mut out = Vec::new();
+        let mut cursor = 0u64;
+        for &(start, value) in &ev {
+            if value || start < cursor {
+                continue; // not a falling edge, or inside a character
+            }
+            let mut byte = 0u8;
+            for bit in 0..8u64 {
+                let t = start + bit_time + bit * bit_time + bit_time / 2;
+                if level_at(t) {
+                    byte |= 1 << bit; // LSB first
+                }
+            }
+            let stop = start + 9 * bit_time + bit_time / 2;
+            if !level_at(stop) {
+                continue; // framing error — not a character
+            }
+            out.push(byte);
+            // Re-arm just after the stop-bit sample, which is what a receiver
+            // does — NOT at a full ten bit periods from this start edge. The two
+            // differ by half a bit, and that slack is load-bearing: the event
+            // scheduler arms its first wakeup one cycle later than the per-cycle
+            // walk does, so the character train sits one cycle earlier relative
+            // to the first start edge under `--features event-scheduler`. A
+            // cursor pinned to an exact multiple rejects the next start edge by
+            // that one cycle and then decodes the REST of the message from a
+            // mid-character transition, which reads as a model bug and is not
+            // one. Data transitions all fall before 9.5 bit periods, so nothing
+            // inside a character is admitted either.
+            cursor = start + 9 * bit_time + bit_time / 2;
+        }
+        out
+    }
+
+    fn watch_spi(machine: &mut Machine<CortexM>) {
+        let gpio = machine.bus.find_peripheral_index_by_name("gpio").unwrap();
+        machine.logic_watch(&[
+            Some((gpio, MOSI_PIN)),
+            Some((gpio, SCK_PIN)),
+            Some((gpio, CS_PIN)),
+        ]);
+    }
+
+    fn watch_tx(machine: &mut Machine<CortexM>) {
+        let gpio = machine.bus.find_peripheral_index_by_name("gpio").unwrap();
+        machine.logic_watch(&[Some((gpio, TX_PIN))]);
+    }
+
+    // ================= C3 =================
+
+    #[test]
+    fn c3_spi_bytes_reach_the_matrix_routed_pads() {
+        let mut m = c3_spi_machine();
+        route(&mut m, SCK_PIN, C3_SIG_SCK);
+        route(&mut m, MOSI_PIN, C3_SIG_MOSI);
+        route(&mut m, CS_PIN, C3_SIG_CS);
+        watch_spi(&mut m);
+
+        // ⚠️ Every byte here is bit-ASYMMETRIC on purpose. 0xA5, 0x5A, 0x3C,
+        // 0xFF and 0x00 are all bit-palindromes, so a payload of those decodes
+        // identically MSB- and LSB-first and a gate built on them cannot see a
+        // reversed narration at all. 0x01/0xB2/0x0F reverse to 0x80/0x4D/0xF0.
+        let payload = [0xA5u8, 0x01, 0xB2, 0x0F];
+        spi_transfer(&mut m, &payload, MODE0, C3_SPI_BIT);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            !edges.is_empty(),
+            "GP-SPI2 clocked {} bytes and the routed pads recorded NOTHING — the \
+             wire is not reaching the C3 output matrix",
+            payload.len()
+        );
+        assert_eq!(
+            decode_spi(&edges, MODE0),
+            payload.to_vec(),
+            "the captured waveform must decode back to exactly what the W buffer \
+             carried, MSB-first"
+        );
+    }
+
+    /// Mode 3 is what an SSD1306/ILI9341 panel is usually driven at, and it is
+    /// the case a model that hardcoded mode 0 would still pass the test above.
+    ///
+    /// Asserted on the two things the mode bits physically CHANGE, not on
+    /// "decodes differently": modes 0 and 3 genuinely sample on the same
+    /// physical edge, so a decode comparison would pass on a model that ignored
+    /// both bits. What actually differs is the clock's resting level (CPOL) and
+    /// whether the data setup shares a cycle with the leading edge (CPHA).
+    #[test]
+    fn c3_spi_honours_the_mode_bits_in_misc_and_user() {
+        let payload = [0x12u8, 0x34]; // bit-asymmetric, see above
+
+        let mut m = c3_spi_machine();
+        route(&mut m, SCK_PIN, C3_SIG_SCK);
+        route(&mut m, MOSI_PIN, C3_SIG_MOSI);
+        route(&mut m, CS_PIN, C3_SIG_CS);
+        watch_spi(&mut m);
+        spi_transfer(&mut m, &payload, MODE3, C3_SPI_BIT);
+        let mode3 = m.logic_read_edges(0).edges;
+        assert_eq!(
+            decode_spi(&mode3, MODE3),
+            payload.to_vec(),
+            "a mode-3 transfer must decode as mode 3"
+        );
+
+        let mut m = c3_spi_machine();
+        route(&mut m, SCK_PIN, C3_SIG_SCK);
+        route(&mut m, MOSI_PIN, C3_SIG_MOSI);
+        route(&mut m, CS_PIN, C3_SIG_CS);
+        watch_spi(&mut m);
+        spi_transfer(&mut m, &payload, MODE0, C3_SPI_BIT);
+        let mode0 = m.logic_read_edges(0).edges;
+
+        // CPOL (`SPI_MISC.CK_IDLE_EDGE`): the level SCK rests at once the burst
+        // is over. A narration that never read MISC parks it at 0 either way.
+        let rest = |edges: &[LogicEdge]| edges.iter().rfind(|e| e.ch == CH_SCK).map(|e| e.value);
+        assert_eq!(rest(&mode3), Some(true), "CPOL=1 must idle SCK HIGH");
+        assert_eq!(rest(&mode0), Some(false), "CPOL=0 must idle SCK LOW");
+
+        // CPHA (`SPI_USER.CK_OUT_EDGE`): the phase decides chip-select framing.
+        // Under CPHA=0 every word gets its own CS pulse, so a two-byte burst
+        // asserts and releases twice; under CPHA=1 CS is held LOW across the
+        // whole burst and asserts once. A slave that latches on the CS edge
+        // (every shift register, every display) sees a completely different bus
+        // between the two, so this is behaviour, not cosmetics.
+        let cs_edges = |edges: &[LogicEdge]| edges.iter().filter(|e| e.ch == CH_CS).count();
+        assert_eq!(
+            cs_edges(&mode0),
+            2 * payload.len(),
+            "CPHA=0 must pulse chip select once per word"
+        );
+        assert_eq!(
+            cs_edges(&mode3),
+            2,
+            "CPHA=1 must HOLD chip select low ACROSS the burst — one assert at \
+             the start and one release when the burst closes, whatever its \
+             length. More than that means the narration ignored CK_OUT_EDGE and \
+             re-framed every word."
+        );
+    }
+
+    #[test]
+    fn c3_uart_characters_reach_a_matrix_routed_tx_pad() {
+        let mut m = c3_uart_machine();
+        route(&mut m, TX_PIN, C3_SIG_U0TXD);
+        watch_tx(&mut m);
+
+        let msg = b"Hi!";
+        uart_send(&mut m, UART0_BASE, msg, C3_UART_BIT);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            !edges.is_empty(),
+            "UART0 shifted {} characters and the routed TX pad recorded NOTHING",
+            msg.len()
+        );
+        assert_eq!(
+            decode_uart(&edges, C3_UART_BIT),
+            msg.to_vec(),
+            "the captured waveform must decode as 8N1 at the programmed baud rate"
+        );
+    }
+
+    // ================= S3 =================
+
+    #[test]
+    fn s3_spi_bytes_reach_the_matrix_routed_pads() {
+        let mut m = s3_spi_machine();
+        route(&mut m, SCK_PIN, S3_SIG_SCK);
+        route(&mut m, MOSI_PIN, S3_SIG_MOSI);
+        route(&mut m, CS_PIN, S3_SIG_CS);
+        watch_spi(&mut m);
+
+        // ⚠️ Every byte here is bit-ASYMMETRIC on purpose. 0xA5, 0x5A, 0x3C,
+        // 0xFF and 0x00 are all bit-palindromes, so a payload of those decodes
+        // identically MSB- and LSB-first and a gate built on them cannot see a
+        // reversed narration at all. 0x01/0xB2/0x0F reverse to 0x80/0x4D/0xF0.
+        let payload = [0xA5u8, 0x01, 0xB2, 0x0F];
+        spi_transfer(&mut m, &payload, MODE0, S3_SPI_BIT);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            !edges.is_empty(),
+            "GP-SPI2 clocked {} bytes and the routed pads recorded NOTHING — the \
+             wire is not reaching the S3 output matrix",
+            payload.len()
+        );
+        assert_eq!(
+            decode_spi(&edges, MODE0),
+            payload.to_vec(),
+            "the captured waveform must decode back to the W-buffer payload. \
+             ⚠️ The S3's non-DMA path OVERWRITES W0..W15 with the idle-MISO \
+             0xFF; a narration taken after that fill decodes to all-ones"
+        );
+    }
+
+    #[test]
+    fn s3_uart_characters_reach_a_matrix_routed_tx_pad() {
+        let mut m = s3_uart_machine();
+        route(&mut m, TX_PIN, S3_SIG_U0TXD);
+        watch_tx(&mut m);
+
+        let msg = b"S3";
+        uart_send(&mut m, UART0_BASE, msg, S3_UART_BIT);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(!edges.is_empty(), "the routed S3 TX pad recorded NOTHING");
+        assert_eq!(
+            decode_uart(&edges, S3_UART_BIT),
+            msg.to_vec(),
+            "the S3 UART runs at 240 MHz, so the same CLKDIV is a different \
+             number of engine cycles per bit than on the C3"
+        );
+    }
+
+    // ================= the traps =================
+
+    /// ⚠️ The single most dangerous failure mode on this family: matrix signal
+    /// indices are PER CHIP, and a borrowed constant is silent in BOTH
+    /// directions.
+    ///
+    /// Route each part's pads with the OTHER part's numbers and assert nothing
+    /// is captured. If either half of this ever passes traffic, some model is
+    /// decoding a sibling's index space.
+    #[test]
+    fn the_matrix_indices_are_per_chip_and_do_not_cross() {
+        let mut m = c3_spi_machine();
+        route(&mut m, SCK_PIN, S3_SIG_SCK); // 101 — meaningless on the C3
+        route(&mut m, MOSI_PIN, S3_SIG_MOSI);
+        route(&mut m, CS_PIN, S3_SIG_CS);
+        watch_spi(&mut m);
+        spi_transfer(&mut m, &[0xA5, 0x01], MODE0, C3_SPI_BIT);
+        assert!(
+            m.logic_read_edges(0).edges.is_empty(),
+            "the C3 routed the S3's FSPI indices (101/103/110) and still showed \
+             traffic — the C3 GPIO is decoding an index space that is not its own"
+        );
+
+        let mut m = s3_spi_machine();
+        route(&mut m, SCK_PIN, C3_SIG_SCK); // 63 — not a SPI signal on the S3
+        route(&mut m, MOSI_PIN, C3_SIG_MOSI);
+        route(&mut m, CS_PIN, C3_SIG_CS);
+        watch_spi(&mut m);
+        spi_transfer(&mut m, &[0xA5, 0x01], MODE0, S3_SPI_BIT);
+        assert!(
+            m.logic_read_edges(0).edges.is_empty(),
+            "the S3 routed the C3's FSPI indices (63/65/68) and still showed \
+             traffic — 63 is not a SPI signal on this part"
+        );
+    }
+
+    /// A pad the firmware kept for plain GPIO must keep reading the output
+    /// latch, not the bus. The control case for every binding above: a wire
+    /// bound to every pad is only correct if the selector gates it.
+    #[test]
+    fn an_unrouted_pad_still_reads_the_gpio_latch() {
+        let mut m = c3_spi_machine();
+        // SCK and MOSI routed; CS deliberately left as a plain GPIO output.
+        route(&mut m, SCK_PIN, C3_SIG_SCK);
+        route(&mut m, MOSI_PIN, C3_SIG_MOSI);
+        m.bus
+            .write_u32(GPIO_BASE + ENABLE_W1TS, 1u32 << CS_PIN)
+            .unwrap();
+        watch_spi(&mut m);
+        spi_transfer(&mut m, &[0xA5, 0x01], MODE0, C3_SPI_BIT);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            edges.iter().any(|e| e.ch == CH_SCK),
+            "the routed clock pad must still carry the bus"
+        );
+        assert!(
+            !edges.iter().any(|e| e.ch == CH_CS),
+            "a pad left at SIG_GPIO_OUT must show its latch, never the \
+             controller's chip select — a route that ignores the selector makes \
+             every plain GPIO on the chip report bus traffic"
+        );
+    }
+
+    // ================= production paths =================
+
+    /// The bus a REAL C3 lab is built from must have its SPI and UART pads
+    /// bound.
+    ///
+    /// Every test above hand-builds a bus and calls the wiring itself, which is
+    /// exactly how the S3's I²C binding stayed green while being dark in
+    /// production. This one asserts on `from_config` — the path
+    /// `configs/chips/esp32c3.yaml` really takes — and reads the routes through
+    /// the same `bound_pad_functions` hook the bus-visibility scoreboard uses,
+    /// so the two can never disagree about whether a chip can show its bus.
+    #[test]
+    fn the_production_c3_builder_routes_the_spi_and_uart_pads() {
+        use labwired_config::{ChipDescriptor, SystemManifest};
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("configs/chips/esp32c3.yaml");
+        let chip = ChipDescriptor::from_file(&path).expect("load esp32c3.yaml");
+        // The same minimal manifest `crates/core/tests/bus_visibility.rs` uses,
+        // so this test and the scoreboard measure the same construction path.
+        let manifest = SystemManifest {
+            parts: Vec::new(),
+            walk_deleted: Some(false),
+            schema_version: "1.0".to_string(),
+            name: "esp-spi-uart-waveform".to_string(),
+            chip: path.to_string_lossy().to_string(),
+            external_devices: vec![],
+            cosim_models: Vec::new(),
+            motor_models: Vec::new(),
+            board_io: vec![],
+            debug_uart: None,
+            wifi_ap: None,
+            peripherals: vec![],
+            memory_overrides: Default::default(),
+        };
+        let bus = crate::bus::SystemBus::from_config(&chip, &manifest)
+            .expect("assemble the production C3 bus");
+        let bound = bus.bound_pad_functions();
+        for want in ["SPI2_SCK", "SPI2_MOSI", "SPI2_CS", "UART0_TX", "UART1_TX"] {
+            assert!(
+                bound.contains(&want),
+                "SystemBus::from_config must bind {want} on the C3, or every C3 \
+                 lab reads a flat line while the bus is busy; bound functions \
+                 were {bound:?}"
+            );
+        }
+    }
+
+    /// The same question for the S3, asked of `configure_xtensa_esp32s3`.
+    ///
+    /// ⚠️ NOT `from_config`, and that is deliberate: `configs/chips/esp32s3.yaml`
+    /// is an address-map stub — `gpio` is `type: "declarative"`, `uart0` is the
+    /// vendor-neutral `uart` type, and there is no `spi2` entry at all — so a
+    /// `from_config` build has no S3 model to route and this programmatic
+    /// builder is what every real S3 lab is made from. Gating on `from_config`
+    /// here would assert on a bus nobody runs.
+    #[test]
+    fn the_production_s3_builder_routes_the_spi_and_uart_pads() {
+        let mut bus = crate::bus::SystemBus::new();
+        let _wiring = crate::system::xtensa::configure_xtensa_esp32s3(
+            &mut bus,
+            &crate::system::xtensa::Esp32s3Opts::default(),
+        );
+        let bound = bus.bound_pad_functions();
+        for want in [
+            "SPI2_SCK",
+            "SPI2_MOSI",
+            "SPI2_CS",
+            "UART0_TX",
+            "UART1_TX",
+            "UART2_TX",
+        ] {
+            assert!(
+                bound.contains(&want),
+                "configure_xtensa_esp32s3 must bind {want}, or every S3 lab reads \
+                 a flat line while the bus is busy; bound functions were {bound:?}"
+            );
+        }
+    }
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -31,6 +31,7 @@ pub mod logic_capture_differential;
 pub mod esp32_i2c_waveform;
 #[cfg(test)]
 pub mod esp32s3_i2c_waveform;
+pub mod esp_spi_uart_waveform;
 #[cfg(test)]
 pub mod machine_advance;
 #[cfg(test)]

--- a/crates/core/tests/bus_visibility.rs
+++ b/crates/core/tests/bus_visibility.rs
@@ -250,11 +250,16 @@ fn bus_visibility_ratchet() {
          also built programmatically by `configure_xtensa_esp32*`, which registers \
          its peripheral bank in Rust and bypasses the chip yaml, so a — here can \
          still mean \"routed on the builder a real lab uses\". esp32s3 is exactly \
-         that today: `configure_xtensa_esp32s3` binds its I²C pads, while this row \
-         reads — because `esp32s3.yaml` declares `gpio` as `type: \"declarative\"` \
-         rather than the `esp32s3_gpio` factory type, so `from_config` finds no \
-         model to route. Closing that gap is a yaml change with its own register \
-         risk, tracked separately — do not close it by editing this board.\n\n\
+         that today: `configure_xtensa_esp32s3` binds its I²C, GP-SPI2 and UART \
+         pads, while every cell in this row reads —. The reason is that \
+         `esp32s3.yaml` is an ADDRESS-MAP STUB, not a peripheral list: `gpio` is \
+         `type: \"declarative\"`, `uart0` is the vendor-neutral `uart` type (the \
+         STM32 register map), `i2c0` is the generic `i2c`, and there is no `spi2` \
+         entry at all. So a `from_config` build of the S3 contains no S3 model \
+         for any of the three buses to route — closing it means porting the whole \
+         yaml onto the real factory types, with the register risk that carries, \
+         not flipping one `type:` field. Tracked separately; do not close it by \
+         editing this board.\n\n\
          | Chip | I2C | SPI | UART |\n\
          |------|-----|-----|------|\n",
     );

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -12,12 +12,12 @@ The models column is a content digest over everything that board's `models` list
 | `nrf52840` | 🟢 silicon-verified | 2026-06-17 | `8875af363a791247` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-06-17 | `8875af363a791247` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-06-22 | `3ed061a1ebb627c1` | ⚠ drift acked 2026-08-09 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `22561803f119f07f` | ✅ fresh |
+| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `9b6261ec0b6fa40d` | ✅ fresh |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-06-20 | `74c3295f7fc6a6e1` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-06-20 | `f3f0162478718854` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-06-20 | `82da6c9c79251753` | ⚠ drift acked 2026-08-09 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `c673f4e53a525ea1` | ⚠ drift acked 2026-08-09 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `e105831f55c058fe` | ✅ fresh |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `b66236aad88336c3` | ✅ fresh |
 | `stm32f401` | 🟡 smoke-manual | — | `a05f2c5a4fa09d07` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `d74a307a4a4e6116` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `8eb946cd8fd728b5` | no silicon capture |

--- a/docs/coverage/bus-visibility.json
+++ b/docs/coverage/bus-visibility.json
@@ -7,7 +7,9 @@
   },
   {
     "buses": [
-      "I2C"
+      "I2C",
+      "SPI",
+      "UART"
     ],
     "name": "esp32c3"
   },

--- a/docs/coverage/bus-visibility.md
+++ b/docs/coverage/bus-visibility.md
@@ -6,12 +6,12 @@ A ✓ means the engine BINDS that bus's controller wire to at least one pad on t
 
 Derived from live `SystemBus::from_config` builds — never hand-edited. Bind a bus by adding a `wire_*_pads` function in `crates/core/src/bus/attach.rs` (reference: `wire_rp2040_uart_pads`) and calling it from `from_config`.
 
-⚠️ SCOPE: this measures the `from_config` path ONLY. The Xtensa chips are also built programmatically by `configure_xtensa_esp32*`, which registers its peripheral bank in Rust and bypasses the chip yaml, so a — here can still mean "routed on the builder a real lab uses". esp32s3 is exactly that today: `configure_xtensa_esp32s3` binds its I²C pads, while this row reads — because `esp32s3.yaml` declares `gpio` as `type: "declarative"` rather than the `esp32s3_gpio` factory type, so `from_config` finds no model to route. Closing that gap is a yaml change with its own register risk, tracked separately — do not close it by editing this board.
+⚠️ SCOPE: this measures the `from_config` path ONLY. The Xtensa chips are also built programmatically by `configure_xtensa_esp32*`, which registers its peripheral bank in Rust and bypasses the chip yaml, so a — here can still mean "routed on the builder a real lab uses". esp32s3 is exactly that today: `configure_xtensa_esp32s3` binds its I²C, GP-SPI2 and UART pads, while every cell in this row reads —. The reason is that `esp32s3.yaml` is an ADDRESS-MAP STUB, not a peripheral list: `gpio` is `type: "declarative"`, `uart0` is the vendor-neutral `uart` type (the STM32 register map), `i2c0` is the generic `i2c`, and there is no `spi2` entry at all. So a `from_config` build of the S3 contains no S3 model for any of the three buses to route — closing it means porting the whole yaml onto the real factory types, with the register risk that carries, not flipping one `type:` field. Tracked separately; do not close it by editing this board.
 
 | Chip | I2C | SPI | UART |
 |------|-----|-----|------|
 | esp32 | ✓ | — | — |
-| esp32c3 | ✓ | — | — |
+| esp32c3 | ✓ | ✓ | ✓ |
 | esp32s3 | — | — | — |
 | esp32s3-zero | — | — | — |
 | mkw41z4 | — | — | — |


### PR DESCRIPTION
`esp32c3` goes `✓ — —` → **`✓ ✓ ✓`**. The S3's SPI and UART are wired on the builder every real S3 lab uses; its board row stays `—` for a reason worth reading.

C3 SPI2 and S3 SPI2 are the same IP with byte-identical `CLOCK`/`USER`/`MISC` bit positions, so the wire lives **once** in `esp_gpspi_wire.rs`. Both are transaction-level (`launch_transaction` completes inside the `SPI_CMD.USR` write). UART is byte-paced rather than a bit engine, so it narrates too.

Every signal index comes from that chip's **own** esp-idf header, cited by file and line. The trap here is real: **C3 FSPI is 63/65/68 and classic VSPI is also 63/65/68**, while on the S3 those numbers mean something else entirely. Borrowing a sibling's constant fails silently in both directions.

## UART reaches the matrix — but only after firmware remaps it

`U0TXD_OUT_IDX` exists on all three chips, so a matrix-keyed route *can* go live. The default TX pad is IO_MUX function 0 and bypasses the matrix (GPIO1 / GPIO21 / GPIO43), so a stock `Serial.begin()` correctly stays dark and the pad keeps reading the latch; the route lights up on `uart_set_pin`. C3 UART1 and S3 UART2 have no IO_MUX pad at all and are matrix-only.

## The esp32s3 yaml: left alone, and the old note was wrong

The scoreboard claimed the only thing holding the S3 row at `—` was its `gpio` `type: "declarative"`. **That was wrong**, and this corrects it. `esp32s3.yaml` is an *address-map stub*: `uart0` is the vendor-neutral `uart` type, `i2c0` is generic `i2c`, and there is **no `spi2` entry at all**. Flipping `gpio` would put a real port on a bus with nothing to bind — two of three columns would still read `—`, for register risk that buys nothing. The S3 is gated on `configure_xtensa_esp32s3` instead.

## Verification

2986 lib tests, 172 integration binaries, both feature sets; clippy and fmt clean.

**Running both feature sets caught a real defect**: the scheduler arms its first wakeup one cycle later than the walk, so an exact-multiple re-arm in the decoder rejected character 2 and decoded the rest mid-character — `left: [72, 90, 200] right: [72, 105, 33]`. Fixed by re-arming after the stop-bit sample, as a real receiver does.

`derive_walk_deletable` untouched. `Esp32c3Spi::legacy_tick_active` widened to include a pending wire — `int_st()` goes false the moment firmware clears TRANS_DONE, long before the wire finishes.

**9/9 mutations killed**, each with a green control after restore. M5 (LSB-first) initially **survived**, and that was the gate's fault: the payload `[0xA5, 0x00, 0xFF, 0x5A]` is entirely bit-palindromic, so both orders decode identically. Payloads are now bit-asymmetric.

## Stated limits

MISO/RX unbound on both — the S3's non-DMA path fills W0..W15 with `0xFF` without consulting any device, so a bound pad would look authoritative while carrying nothing. Only SPI2 on the S3. `SPI_WR_BIT_ORDER` unread, so LSB-first firmware gets the right rate with reversed bits. Classic ESP32 and esp32s3-zero do **not** fall out of this seam — each needs its own wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)