### PR TITLE
Fix C3 ROM-boot analog stimuli

### DIFF
--- a/crates/core/src/boot/esp32c3_rom.rs
+++ b/crates/core/src/boot/esp32c3_rom.rs
@@ -423,19 +423,20 @@ pub fn build_rom_boot_machine<C: crate::Cpu, F: FnOnce(crate::cpu::RiscV) -> C>(
             MMU_FMT_C3,
         )),
     );
-    // SAR ADC (APB_SARADC, 0x6004_0000): the IDF's adc_hal_self_calibration
-    // triggers single conversions and polls a data-valid flag (0x44 bit31/
-    // bit30) before reading the result; the declarative stub never asserts
-    // it, so read_cal_channel spins forever after spi_flash init. Model
-    // conversions as instant (valid flags set, mid-scale sample) so the
-    // bounded cal search converges and boot continues.
-    bus.add_peripheral(
-        "apb_saradc",
-        0x6004_0000,
-        0x100,
-        None,
-        Box::new(crate::peripherals::esp32c3::sar_adc::Esp32c3SarAdc::new()),
-    );
+    // SAR ADC (APB_SARADC, 0x6004_0000): use the ONE behavioral controller
+    // for both ROM/IDF calibration and application one-shot reads. The old
+    // calibration-only replacement always returned mid-scale and silently
+    // discarded levels attached by GP2Y/pot/NTC models, so real firmware's
+    // analogRead() could never observe a live stimulus after ROM boot.
+    if bus.find_peripheral_index_by_name("apb_saradc").is_none() {
+        bus.add_peripheral(
+            "apb_saradc",
+            0x6004_0000,
+            0x100,
+            None,
+            Box::new(crate::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc::default()),
+        );
+    }
     // SYSTIMER (0x6002_3000): the 16 MHz free-running counter behind
     // esp_timer and the FreeRTOS tick. systimer_hal_get_counter_value sets
     // UNITx_OP bit30 (UPDATE) then polls bit29 (VALUE_VALID) before reading

--- a/crates/core/tests/world_esp32c3_ble_pong.rs
+++ b/crates/core/tests/world_esp32c3_ble_pong.rs
@@ -273,6 +273,16 @@ fn ball(status: &str) -> (i32, i32) {
     (x.parse().expect("ball x"), y.parse().expect("ball y"))
 }
 
+fn paddle(status: &str) -> i32 {
+    status
+        .split(" me=")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .unwrap_or_else(|| panic!("no me= in {status:?}"))
+        .parse()
+        .unwrap_or_else(|e| panic!("bad me= in {status:?}: {e}"))
+}
+
 /// Cycles per node. The C3 rom-boot path reaches `setup()`'s ROLE banner in
 /// roughly 45M and needs a few advertising rounds after that for the election
 /// to settle and the ball to move.
@@ -371,5 +381,34 @@ fn two_c3_nodes_running_one_ble_pong_image_start_the_game() {
     assert!(
         ball(&sa).0.abs_diff(ball(&sb).0) <= 8,
         "the two nodes are painting different worlds\n  nodeA: {sa}\n  nodeB: {sb}"
+    );
+}
+
+#[test]
+fn shipped_pong_firmware_observes_gp2y_distance_through_gpio1_adc() {
+    let flash = std::fs::read(root().join("tests/fixtures/esp32c3-ble-pong-flash.bin"))
+        .expect("read BLE Pong flash image");
+    let mut near = build_node(&flash);
+    let mut far = build_node(&flash);
+    near.machine
+        .set_input_on("vl", "distance", 100.0)
+        .expect("drive near GP2Y distance");
+    far.machine
+        .set_input_on("vl", "distance", 800.0)
+        .expect("drive far GP2Y distance");
+
+    for _ in 0..PONG_CYCLES {
+        near.machine.step().expect("near node steps");
+        far.machine.step().expect("far node steps");
+    }
+
+    let near_status = last_status(&near.console());
+    let far_status = last_status(&far.console());
+    eprintln!("near: {near_status}");
+    eprintln!("far:  {far_status}");
+    assert!(
+        paddle(&near_status) < paddle(&far_status),
+        "near and far stimuli must move the firmware paddle through GPIO1 ADC\n\
+         near: {near_status}\nfar:  {far_status}",
     );
 }


### PR DESCRIPTION
## What changed

- Keep the manifest-installed, stimulus-capable ESP32-C3 APB SAR ADC during ROM boot instead of overlaying it with a second calibration-only peripheral.
- Fall back to installing the unified behavioral ADC only when a bus genuinely lacks `apb_saradc`.
- Add a release-gated real-firmware regression test that drives the Pong GP2Y0A21 at 100 mm and 800 mm and verifies the firmware observes different paddle positions through `analogRead(GPIO1)`.

## Root cause

ROM boot unconditionally added a second peripheral at `0x6004_0000`. Sensor stimuli updated the manifest ADC, while firmware reads resolved against the boot-added calibration stub, which always returned mid-scale. Slider events therefore reached the correct model and worker but produced no firmware-visible change.

## Validation

- `cargo test -p labwired-core --test analog_stimulus c3_gp2y0a21_attaches_and_distance_drives_apb_saradc -- --nocapture`
- `cargo test -p labwired-core --release --features event-scheduler --test world_esp32c3_ble_pong shipped_pong_firmware_observes_gp2y_distance_through_gpio1_adc -- --nocapture`
  - near: `me=0`
  - far: `me=48`
