### PR TITLE
test(tier1): kill the write-then-exec ETXTBSY flake

### DIFF
--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -1602,35 +1602,56 @@ peripherals:
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Resolve a committed, already-executable fake `labwired` binary.
+    ///
+    /// THE ETXTBSY TRAP. These tests used to write the script themselves,
+    /// `chmod 0755` it, and then exec it. In a multithreaded test binary that
+    /// is a race: `exec` fails with `ETXTBSY` ("Text file busy") if *any*
+    /// process still holds the file open for writing. While this thread's
+    /// write fd is open, a concurrent `Command::spawn` on another test thread
+    /// forks, the child inherits the descriptor, and until that child reaches
+    /// its own `exec` (which is where `O_CLOEXEC` finally closes the
+    /// inherited fd) our exec is refused. The `git`-backed baseline tests
+    /// below fork repeatedly, so the window gets hit under CI parallelism.
+    ///
+    /// Exec'ing a fixture this process never opens for writing removes the
+    /// window by construction — no lock and no retry needed, and no
+    /// production code has to change to accommodate a test.
+    fn fake_labwired_bin(name: &str) -> PathBuf {
+        let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures")
+            .join(name);
+        assert!(p.is_file(), "missing committed fixture: {}", p.display());
+        // The exec bit is carried by git (mode 100755). If a checkout ever
+        // drops it, fail here with the reason rather than as a baffling
+        // "Permission denied" inside the assertions below.
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+        assert!(
+            mode & 0o111 != 0,
+            "fixture must stay executable (mode {mode:o}): {}",
+            p.display()
+        );
+        p
+    }
+
     #[test]
     fn run_target_surfaces_child_crash_instead_of_blocked_row() {
-        let dir = std::env::temp_dir().join(format!("tier1-crash-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let fake = dir.join("labwired-fake");
-        std::fs::write(&fake, "#!/bin/sh\necho boom-stderr >&2\nexit 3\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let fake = fake_labwired_bin("tier1-fake-crash.sh");
         let target = &TIER1_TARGETS[0];
         // chip yaml exists in-repo, ELF path doesn't need to exist for the spawn itself
         let err = run_target(target, &fake).unwrap_err();
         assert!(err.contains("boom-stderr"), "{err}");
         assert!(err.contains("esp32s3"), "{err}");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn stderr_tail_truncation_is_char_boundary_safe() {
-        let dir = std::env::temp_dir().join(format!("tier1-crash-utf8-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let fake = dir.join("labwired-fake");
-        // >500 bytes of multibyte stderr (U+2744 = 3 bytes each × 200 = 600 bytes)
-        // so the naive len-500 cut lands mid-char.
-        std::fs::write(&fake, "#!/bin/sh\npython3 << 'PYEOF'\nimport sys\nfor i in range(200):\n    sys.stderr.buffer.write(b'\\xe2\\x9d\\x84')\nsys.exit(3)\nPYEOF\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // The fixture writes >500 bytes of multibyte stderr (U+2744 = 3 bytes
+        // each × 200 = 600 bytes) so the naive len-500 cut lands mid-char.
+        let fake = fake_labwired_bin("tier1-fake-crash-utf8.sh");
         let target = &TIER1_TARGETS[0];
         let err = run_target(target, &fake).unwrap_err();
         assert!(err.contains("exited"), "{err}");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/cli/tests/fixtures/tier1-fake-crash-utf8.sh
+++ b/crates/cli/tests/fixtures/tier1-fake-crash-utf8.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+python3 << 'PYEOF'
+import sys
+for i in range(200):
+    sys.stderr.buffer.write(b'\xe2\x9d\x84')
+sys.exit(3)
+PYEOF

--- a/crates/cli/tests/fixtures/tier1-fake-crash.sh
+++ b/crates/cli/tests/fixtures/tier1-fake-crash.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo boom-stderr >&2
+exit 3


### PR DESCRIPTION
`tier1::run_target_surfaces_child_crash_instead_of_blocked_row` fails intermittently in CI and has already blocked unrelated PRs:

```
panicked at crates/cli/src/tier1.rs:1616:9:
spawn /tmp/tier1-crash-11177/labwired-fake: Text file busy (os error 26)
```

The test writes a shell script, `chmod 0755`s it, then execs it. `ETXTBSY` means some process still holds that inode open for **writing** — the classic fork/exec race: another test thread forks while the write fd is live, the child inherits it, and the exec fails. The lib's two spawn sites are `git()` and `run_target`, and four baseline tests drive `git()` hard (`baseline_refuses_to_run_on_a_shallow_clone` alone forks five git processes), so there are plenty of forks landing inside the write window.

## This bug is invisible on macOS — which is why it kept coming back

**macOS does not implement the ETXTBSY check at all.** Verified directly: exec a file while holding an open write fd to it, and on Darwin it runs cleanly; on Linux it is `exit 126, Text file busy`. The pre-fix code passes 150/150 locally at `--test-threads=16`. **No amount of local looping can ever surface this**, so a local green run is not evidence either way.

Reproduced on Linux (`alpine:3.20`) instead:

| case | result |
|---|---|
| A: nobody holds a write fd | exit 3 — script runs |
| B: this process holds a write fd | **exit 126, Text file busy** |
| C: parent closed its fd, forked child inherited it | **exit 126** ← the CI stack trace |
| D: exec a file never opened for writing | exit 3 — clean |

Case C is the failure. Case D is the fix.

## Fix: exec a committed fixture

Both write-then-exec tests now exec `crates/cli/tests/fixtures/tier1-fake-crash.sh` / `-utf8.sh`, committed at mode `100755`. **A file the test process never opens for writing cannot be ETXTBSY** — the window is gone by construction, for every thread, not just these two. That is case D.

The fixture bytes are `diff`-identical to the strings the tests used to write, and behaviour is unchanged (exit 3; 12 stderr bytes / 600 bytes of U+2744). The helper also asserts the exec bit survived checkout, so a lost mode fails with a named reason instead of "Permission denied".

Why not the alternatives:
- **Spawn the interpreter with the script as an argument** — `run_target` hardcodes `Command::new(labwired_bin)` with fixed args; this would change a production signature purely for a test.
- **Close/sync before exec** — already the case (`fs::write` drops the `File` before the `chmod`, and `std::fs::File` is `O_CLOEXEC`). The leaked fd belongs to *another thread's* forked child; the writer cannot control that.
- **Serialize the two tests** — insufficient. They write to different directories, so different inodes; they cannot busy each other. The trigger is the git-forking tests, so a sufficient lock would have to wrap the *production* spawn sites.
- **Retry on ETXTBSY** — hides the race rather than removing it, and is unnecessary once the write is gone.

## Assertions unchanged

`boom-stderr` + `esp32s3` in test 1, `exited` in test 2 — verbatim. Proven still real by temporarily regressing `run_target`'s crash-surfacing branch: both tests then failed on `unwrap_err()` against an `Ok` holding exactly the row of `Blocked` cells they exist to catch.

**No production behaviour changed** — the single diff hunk starts at line 1602; `mod tests` starts at 961.

## Verification

| check | exit |
|---|---|
| `cargo test -p labwired-cli --lib` | 0 |
| `cargo test -p labwired-core --lib` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p labwired-cli --all-targets -- -D warnings` | 0 |
| 60× loop at `--test-threads=16` | 60/60 |

Stated plainly: that loop cannot distinguish fixed from broken on macOS, for the reason above. The load-bearing evidence is the Linux table.
