### PR TITLE
feat(logic-analyzer): put classic ESP32 SPI and UART on the wire

### DIFF
--- a/crates/core/src/bus/attach.rs
+++ b/crates/core/src/bus/attach.rs
@@ -170,6 +170,129 @@ impl SystemBus {
         }
     }
 
+    /// Bind the classic-ESP32 **VSPI** master's SCK/MOSI/CS wire to the pads its
+    /// output matrix can route them to, so a probe on GPIO18 shows the shifted
+    /// bytes rather than the GPIO output latch.
+    ///
+    /// # Why VSPI, and only VSPI
+    ///
+    /// Classic ESP32 has FOUR SPI controllers and three matrix signal groups
+    /// (ESP32 datasheet v5.3 §4.8.2 p36 and Appendix A p61): SPI0/SPI1 drive the
+    /// `SPI*` group and are the flash path, SPI2 drives `HSPI*`, SPI3 drives
+    /// `VSPI*`. Arduino's `SPI` object is VSPI on this part
+    /// (`libraries/SPI/src/SPI.cpp` :348 `SPIClass SPI(VSPI);`), which is what
+    /// every classic lab in this repo actually drives, and `spi3`
+    /// (`0x3FF6_5000`) is the instance this engine registers for it.
+    ///
+    /// The other instances are left on the latch fallback deliberately. SPI0/1
+    /// carry flash traffic on the bonded flash pins, which no board routes to a
+    /// probe, and binding them here would need the `SPI*` group's indices
+    /// (`SPICLK_OUT_IDX` = 0, …), not VSPI's — the same wire on three different
+    /// index sets. SPI2/HSPI is not registered on this bus at all. Both join
+    /// when something drives them, not before.
+    ///
+    /// Resolution is by NAME, and only by name. Three `Esp32Spi` instances sit
+    /// on a classic bus and they are indistinguishable by type, so "the first
+    /// one found" would bind VSPI's signals onto whichever flash controller
+    /// happened to be registered first — a wire published under a signal that
+    /// controller never drives. Both production builders spell the VSPI
+    /// instance `spi3` (`ESP32_PERIPHERALS` and `configs/chips/esp32.yaml`);
+    /// anything else is a no-op, deliberately.
+    ///
+    /// MISO (`VSPIQ`) is unbound; see [`crate::peripherals::esp_gpspi_wire`].
+    pub(crate) fn wire_esp32_spi_pads(&mut self) {
+        use crate::peripherals::esp32::gpio::Esp32Gpio;
+        use crate::peripherals::esp32::spi::Esp32Spi;
+
+        let gpio_idx = self
+            .peripherals
+            .iter()
+            .position(|p| p.dev.as_any().map(|a| a.is::<Esp32Gpio>()).unwrap_or(false));
+        let spi_idx = self.find_peripheral_index_by_name("spi3").filter(|&i| {
+            self.peripherals[i]
+                .dev
+                .as_any()
+                .map(|a| a.is::<Esp32Spi>())
+                .unwrap_or(false)
+        });
+        // ⚠️ Resolve BOTH before touching either: `pad_lines_arc` CREATES the
+        // wire cell, and a controller that owns a cell no route reaches still
+        // buffers every launched transaction, arms a wakeup per burst, and
+        // narrates into a wire nothing reads.
+        let (Some(spi_idx), Some(gpio_idx)) = (spi_idx, gpio_idx) else {
+            return;
+        };
+        let Some(lines) = self.peripherals[spi_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32Spi>())
+            .map(Esp32Spi::pad_lines_arc)
+        else {
+            return;
+        };
+        if let Some(gpio) = self.peripherals[gpio_idx]
+            .dev
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<Esp32Gpio>())
+        {
+            gpio.bind_spi_lines(&lines);
+        }
+    }
+
+    /// Bind each classic-ESP32 UART's TX wire to the pads its output matrix can
+    /// route it to, so serial output is a waveform on a remapped pad rather than
+    /// the idle GPIO latch. No-op unless classic GPIO and at least one
+    /// `Esp32Uart` are on the bus.
+    ///
+    /// ⚠️ The IO_MUX verdict is NOT the C3's or the S3's. On classic, ALL THREE
+    /// UARTs have an IO_MUX default pad — U0TXD on GPIO1 at function 0, U1TXD on
+    /// GPIO10 and U2TXD on GPIO17 at function 4 — so none of them is
+    /// matrix-visible on a stock default-pin `Serial.begin()`, and that is
+    /// correct: the pad genuinely is showing its GPIO state. Every route lights
+    /// the moment firmware remaps TX, which `uart_set_pin` does through
+    /// `gpio_matrix_out` for any non-default pin. See
+    /// `peripherals::esp32::gpio`'s `SIG_U0TXD` for the header citations.
+    ///
+    /// ⚠️ `configs/chips/esp32.yaml` declares `uart0` as the vendor-neutral
+    /// `uart` type (the STM32 register map) rather than `esp32_uart`, so a
+    /// `from_config` build of this chip binds UART1/UART2 only. The programmatic
+    /// `configure_xtensa_esp32` — the builder every real classic lab uses —
+    /// registers all three as `Esp32Uart` and binds all three.
+    ///
+    /// TX ONLY; see `Esp32Gpio::bind_uart_tx_lines`.
+    pub(crate) fn wire_esp32_uart_pads(&mut self) {
+        use crate::peripherals::esp32::gpio::Esp32Gpio;
+        use crate::peripherals::esp32::uart::Esp32Uart;
+
+        let Some(gpio_idx) = self
+            .peripherals
+            .iter()
+            .position(|p| p.dev.as_any().map(|a| a.is::<Esp32Gpio>()).unwrap_or(false))
+        else {
+            return;
+        };
+        for (instance, name) in ["uart0", "uart1", "uart2"].iter().enumerate() {
+            let Some(idx) = self.find_peripheral_index_by_name(name) else {
+                continue;
+            };
+            let Some(lines) = self.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Esp32Uart>())
+                .map(Esp32Uart::pad_lines_arc)
+            else {
+                continue;
+            };
+            if let Some(gpio) = self.peripherals[gpio_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Esp32Gpio>())
+            {
+                gpio.bind_uart_tx_lines(instance, &lines);
+            }
+        }
+    }
+
     /// Bind the RP2040 UARTs' TX/RX wires to the pads IO_BANK0 can route them
     /// to, so a probe on GP0 shows the serial waveform rather than the SIO
     /// output latch. No-op unless IO_BANK0, SIO and a UART are all on the bus.

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -887,6 +887,11 @@ impl SystemBus {
         // Same for classic ESP32 (LX6), whose matrix indices are 29/30 —
         // neither the C3's 53/54 nor the S3's 89/90.
         bus.wire_esp32_i2c_pads();
+        // …and the classic part's VSPI (SPI3) and UART TX. VSPI's 63/65/68
+        // happen to be the C3's FSPI numbers and are NOT SPI signals on the S3;
+        // the UART indices 14/17/198 are the classic part's alone.
+        bus.wire_esp32_spi_pads();
+        bus.wire_esp32_uart_pads();
         // RP2040: bind I²C wires to the pads IO_BANK0's FUNCSEL can route them to.
         bus.wire_rp2040_i2c_pads();
         // Same for the RP2040 UARTs' TX/RX, so serial output is a waveform on

--- a/crates/core/src/peripherals/esp32/gpio.rs
+++ b/crates/core/src/peripherals/esp32/gpio.rs
@@ -83,6 +83,55 @@ const FUNC_OUT_SEL_RESET: u32 = 0x0000_0100;
 const SIG_I2CEXT0_SCL: u32 = 29;
 const SIG_I2CEXT0_SDA: u32 = 30;
 
+/// GPIO-matrix OUTPUT signal indices of the **VSPI** master — the controller the
+/// ESP32 datasheet (v5.3 p61) calls `SPI3` and whose matrix signals are prefixed
+/// `VSPI`, and the one arduino-esp32's `SPIClass SPI(VSPI)` drives
+/// (`libraries/SPI/src/SPI.cpp` :348). esp-idf
+/// `soc/esp32/include/soc/gpio_sig_map.h` :138 / :142 / :148.
+///
+/// ⚠️ Classic carries THREE GP-SPI signal groups and they share NO numbers:
+/// `SPICLK_OUT_IDX` = 0 (:18 — the flash controller SPI0/1), `HSPICLK_OUT_IDX`
+/// = 8 (:34 — SPI2), `VSPICLK_OUT_IDX` = 63 (:138 — SPI3). Index 0 being a live
+/// SPI signal is exactly why [`FUNC_OUT_SEL_RESET`] must be 0x100 and not 0.
+///
+/// ⚠️ 63/65/68 are ALSO the ESP32-C3's `FSPI*` indices. That is a collision of
+/// two per-chip index spaces, not a shared space: on the ESP32-S3 the same three
+/// numbers are not SPI signals at all (`FSPICLK` is 101 there). Borrowing a
+/// sibling's constant fails SILENTLY in both directions — a plain pad decodes as
+/// routed and a routed pad as plain — so every index here is cited to the
+/// CLASSIC header and to nothing else.
+const SIG_VSPICLK: u32 = 63;
+/// `VSPIQ_OUT_IDX` = 64 is VSPI's MISO and is deliberately NOT bound; see
+/// [`crate::peripherals::esp_gpspi_wire`] for why an undriven line stays on the
+/// latch fallback.
+const SIG_VSPID: u32 = 65;
+const SIG_VSPICS0: u32 = 68;
+
+/// GPIO-matrix OUTPUT signal indices of the three UART transmitters — esp-idf
+/// `soc/esp32/include/soc/gpio_sig_map.h` :46 `U0TXD_OUT_IDX`, :52
+/// `U1TXD_OUT_IDX`, :360 `U2TXD_OUT_IDX`.
+///
+/// ⚠️ The IO_MUX verdict differs from BOTH siblings. On the C3 UART1 is
+/// matrix-only and on the S3 UART2 is; on classic **all three** UARTs have an
+/// IO_MUX pad, so none of them is matrix-visible on a stock default-pin
+/// `Serial.begin()`:
+///
+/// | UART | default TX pad | IO_MUX function |
+/// |---|---|---|
+/// | U0TXD | GPIO1 (`uart_pins.h` :23) | 0 (`io_mux_reg.h` :128 `FUNC_U0TXD_U0TXD`) |
+/// | U1TXD | GPIO10 (`uart_pins.h` :28) | 4 (`io_mux_reg.h` :195 `FUNC_SD_DATA3_U1TXD`) |
+/// | U2TXD | GPIO17 (`uart_pins.h` :33) | 4 (`io_mux_reg.h` :256 `FUNC_GPIO17_U2TXD`) |
+///
+/// `uart_set_pin` takes the IO_MUX path for exactly those pads and falls back to
+/// `gpio_matrix_out` for every other pin, and this model does not model IO_MUX
+/// at all — so a default-pin console correctly leaves `FUNCn_OUT_SEL` at the
+/// bypass sentinel and the pad keeps reading its latch. The routes light the
+/// moment firmware remaps TX, which every real WROOM-32 board does for UART1
+/// (GPIO9/GPIO10 are the flash pins) and most do for UART2.
+const SIG_U0TXD: u32 = 14;
+const SIG_U1TXD: u32 = 17;
+const SIG_U2TXD: u32 = 198;
+
 /// Pads that can drive an output at all: `SOC_GPIO_VALID_OUTPUT_GPIO_MASK`
 /// (esp-idf `soc_caps.h`) — the 40 pads minus GPIO24 and GPIO28..31 (absent
 /// from the package) and minus GPIO34..39 (input-only). Binding a peripheral
@@ -106,17 +155,19 @@ fn esp32_out_signal_name(idx: u32) -> Option<&'static str> {
         9 => "HSPIQ",
         10 => "HSPID",
         11 => "HSPICS0",
-        14 => "U0TXD",
-        17 => "U1TXD",
-        29 => "I2CEXT0_SCL",
-        30 => "I2CEXT0_SDA",
-        63 => "VSPICLK",
-        64 => "VSPIQ",
-        65 => "VSPID",
-        68 => "VSPICS0",
+        // The routed signals resolve through their named constants, so this
+        // table and the bindings below cannot drift apart on an index.
+        SIG_U0TXD => "U0TXD",
+        SIG_U1TXD => "U1TXD",
+        SIG_I2CEXT0_SCL => "I2CEXT0_SCL",
+        SIG_I2CEXT0_SDA => "I2CEXT0_SDA",
+        SIG_VSPICLK => "VSPICLK",
+        64 => "VSPIQ", // VSPI MISO — named, never bound (nothing drives it)
+        SIG_VSPID => "VSPID",
+        SIG_VSPICS0 => "VSPICS0",
         95 => "I2CEXT1_SCL",
         96 => "I2CEXT1_SDA",
-        198 => "U2TXD",
+        SIG_U2TXD => "U2TXD",
         _ => return None,
     })
 }
@@ -327,6 +378,69 @@ impl Esp32Gpio {
                 Some(SIG_I2CEXT0_SDA),
                 crate::peripherals::esp32::i2c::LINE_SDA,
                 "I2CEXT0_SDA",
+            );
+        }
+    }
+
+    /// Bind the VSPI (SPI3) master's SCK/MOSI/CS wire to every output-capable
+    /// pad the matrix can route it to. Which pad is live at any moment is then
+    /// decided by `FUNCn_OUT_SEL`, through the shared seam.
+    ///
+    /// Unlike the RP2040 there is no pad table to transcribe: the ESP32 GPIO
+    /// matrix routes ANY peripheral signal to ANY output-capable pad, so every
+    /// pad is bound to all three signals and the selector picks the live one.
+    ///
+    /// MISO (`VSPIQ`, index 64) is deliberately unbound — see
+    /// [`crate::peripherals::esp_gpspi_wire`]. A bound-but-undriven pad reports
+    /// a confident idle level that looks authoritative, which is worse than the
+    /// latch fallback it would replace.
+    pub(crate) fn bind_spi_lines(&mut self, lines: &Arc<crate::peripherals::pad_lines::PadLines>) {
+        use crate::peripherals::esp_gpspi_wire::{LINE_CS, LINE_MOSI, LINE_SCK};
+        for pin in 0..PAD_COUNT {
+            if VALID_OUTPUT_PADS & (1u64 << pin) == 0 {
+                continue;
+            }
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_VSPICLK), LINE_SCK, "SPI3_SCK");
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_VSPID), LINE_MOSI, "SPI3_MOSI");
+            self.pad_routes
+                .bind(lines, pin, Some(SIG_VSPICS0), LINE_CS, "SPI3_CS");
+        }
+    }
+
+    /// Bind one UART's TX wire to every output-capable pad the matrix can route
+    /// it to.
+    ///
+    /// TX ONLY. Nothing in the engine drives the RX line, so a bound RX pad
+    /// would report a confident constant idle-high — including while an attached
+    /// GPS or modem was actually sending. Same call `wire_rp2040_uart_pads`
+    /// documents. RX joins the table when something drives it, not before.
+    ///
+    /// See [`SIG_U0TXD`] for why a stock default-pin `Serial.begin()` correctly
+    /// leaves every one of these routes dark on this part.
+    pub(crate) fn bind_uart_tx_lines(
+        &mut self,
+        instance: usize,
+        lines: &Arc<crate::peripherals::pad_lines::PadLines>,
+    ) {
+        let (signal, func) = match instance {
+            0 => (SIG_U0TXD, "UART0_TX"),
+            1 => (SIG_U1TXD, "UART1_TX"),
+            // Classic ESP32 has exactly three UARTs (`SOC_UART_NUM` = 3).
+            2 => (SIG_U2TXD, "UART2_TX"),
+            _ => return,
+        };
+        for pin in 0..PAD_COUNT {
+            if VALID_OUTPUT_PADS & (1u64 << pin) == 0 {
+                continue;
+            }
+            self.pad_routes.bind(
+                lines,
+                pin,
+                Some(signal),
+                crate::peripherals::uart::LINE_TX,
+                func,
             );
         }
     }

--- a/crates/core/src/peripherals/esp32/spi.rs
+++ b/crates/core/src/peripherals/esp32/spi.rs
@@ -39,7 +39,11 @@
 //! simplification as `peripherals::spi::Spi`. For the e-paper lab one
 //! SSD1680 panel is attached on SPI3.
 
+use crate::cycle_clock::CycleClock;
+use crate::peripherals::esp_gpspi_wire::EspSpiWire;
+use crate::peripherals::pad_lines::PadLines;
 use crate::peripherals::spi::SpiDevice;
+use crate::peripherals::spi_waveform::SpiFraming;
 use crate::{Peripheral, PeripheralTickResult, SimResult};
 use std::sync::{Arc, Mutex};
 
@@ -48,6 +52,11 @@ fn spi_debug_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var("LABWIRED_SPI_DEBUG").is_ok())
 }
+
+/// Classic-ESP32 core clock. The GP-SPI divisors count APB (80 MHz) ticks and
+/// the engine's cycle axis is CPU cycles, so a bit period is scaled by
+/// `CPU_CLOCK_HZ / APB_CLK_HZ` — exact here, 240 being a whole multiple of 80.
+const CPU_CLOCK_HZ: u64 = 240_000_000;
 
 const REG_CMD: u64 = 0x00;
 const REG_ADDR: u64 = 0x04;
@@ -59,6 +68,71 @@ const REG_MOSI_DLEN: u64 = 0x28;
 const REG_MISO_DLEN: u64 = 0x2C;
 const FIFO_START: u64 = 0x80;
 const FIFO_END: u64 = 0xC0; // exclusive — W0..W15 = 64 bytes
+
+/// `SPI_CLOCK_REG` — classic `spi_reg.h` :328. **0x18**, not the C3/S3's 0x0C.
+const REG_CLOCK: u64 = 0x18;
+/// `SPI_PIN_REG` — classic `spi_reg.h` :587. Classic has NO `SPI_MISC`; the
+/// clock-idle polarity that the C3/S3 keep in `MISC` (0x20) lives here.
+const REG_PIN: u64 = 0x34;
+
+/// `SPI_CLK_EQU_SYSCLK` (CLOCK bit 31) — `spi_reg.h` :332.
+const CLK_EQU_SYSCLK: u32 = 1 << 31;
+/// `SPI_CLKDIV_PRE` (CLOCK [30:18], **13 bits**) — `spi_reg.h` :341, `_V 0x1FFF`.
+/// ⚠️ The C3/S3 field is only four bits wide; masking with the sibling's 0xF
+/// would silently clamp every divider above 15 and report a rate the firmware
+/// never asked for.
+const CLKDIV_PRE_SHIFT: u32 = 18;
+const CLKDIV_PRE_MASK: u32 = 0x1FFF;
+/// `SPI_CLKCNT_N` (CLOCK [17:12], 6 bits) — `spi_reg.h` :348.
+const CLKCNT_N_SHIFT: u32 = 12;
+const CLKCNT_N_MASK: u32 = 0x3F;
+/// `SPI_CK_OUT_EDGE` (CPHA) — `SPI_USER` bit **7** on classic (`spi_reg.h`
+/// :506). ⚠️ The C3 and the S3 put it at bit 9; reading the sibling's bit gives
+/// a trace at the right rate framed on the wrong phase, which decodes to
+/// something plausible and wrong.
+const CK_OUT_EDGE: u32 = 1 << 7;
+/// `SPI_CK_IDLE_EDGE` (CPOL) — `SPI_PIN` bit 29 (`spi_reg.h` :599).
+const CK_IDLE_EDGE: u32 = 1 << 29;
+
+/// Engine cycles in one SCK period, from this controller's own `SPI_CLOCK`.
+///
+/// `f_spi = f_apb / ((CLKDIV_PRE + 1) * (CLKCNT_N + 1))`, or `f_apb` outright
+/// when `CLK_EQU_SYSCLK` is set — which is the register's RESET state
+/// (`spi_reg.h` :329 records `default: 1'b1`). `None` below two cycles per bit,
+/// where [`crate::peripherals::wave_plan::WavePlan`] cannot keep a period's
+/// halves distinct and nothing honest can be drawn.
+///
+/// Deliberately NOT `esp_gpspi_wire::bit_time_cycles`: that reads the same three
+/// field POSITIONS out of a register at a different offset with a different
+/// `CLKDIV_PRE` width. Only the narration machinery is shared, never the decode.
+fn bit_time_cycles(clock_reg: u32) -> Option<u64> {
+    let apb_ticks = if clock_reg & CLK_EQU_SYSCLK != 0 {
+        1
+    } else {
+        let pre = u64::from((clock_reg >> CLKDIV_PRE_SHIFT) & CLKDIV_PRE_MASK) + 1;
+        let n = u64::from((clock_reg >> CLKCNT_N_SHIFT) & CLKCNT_N_MASK) + 1;
+        pre * n
+    };
+    let ticks = apb_ticks * CPU_CLOCK_HZ / crate::peripherals::esp_gpspi_wire::APB_CLK_HZ;
+    (ticks >= 2).then_some(ticks)
+}
+
+/// How `SPI_PIN` and `SPI_USER` currently frame a byte on the wire.
+///
+/// Width is fixed at 8: `SPI_MOSI_DLEN` counts the transaction in BITS and the
+/// transaction engine walks the W buffer a byte at a time, so a byte is the unit
+/// that reaches the wire. `SPI_WR_BIT_ORDER` (`SPI_CTRL` bit 26, `spi_reg.h`
+/// :142) selects LSB-first and is NOT read here — the narrator only draws
+/// MSB-first, which is what every ESP-IDF/Arduino path programs; a firmware that
+/// flipped it would get a trace at the right rate with the bits reversed, so it
+/// is called out rather than silently assumed.
+fn framing(pin_reg: u32, user_reg: u32) -> SpiFraming {
+    SpiFraming {
+        cpol: pin_reg & CK_IDLE_EDGE != 0,
+        cpha: user_reg & CK_OUT_EDGE != 0,
+        bits: 8,
+    }
+}
 
 const CMD_USR_BIT: u32 = 1 << 18;
 /// All CMD bits that launch an operation and auto-clear (bits [31:16]:
@@ -151,6 +225,18 @@ pub struct Esp32Spi {
     record_enabled: bool,
     captured_bytes: Vec<u8>,
     transactions: u64,
+
+    /// Levels published to matrix-routed pads, so a probe on `VSPICLK` /
+    /// `VSPID` / `VSPICS0` measures the shifted bytes rather than the GPIO
+    /// output latch. Inert until `SystemBus::wire_esp32_spi_pads` binds it;
+    /// the narration machinery is shared with the C3/S3 (see
+    /// [`crate::peripherals::esp_gpspi_wire`]) — only the register decode above
+    /// is classic-specific.
+    wire: EspSpiWire,
+    /// Bus-published cycle clock. `Some` once the bus has attached it, which
+    /// every production `add_peripheral`/`push_peripheral` does; `None` on a
+    /// hand-built bus, where there is no axis to place a waveform on.
+    clock: Option<CycleClock>,
 }
 
 impl std::fmt::Debug for Esp32Spi {
@@ -176,6 +262,28 @@ impl Esp32Spi {
     /// the same backing the XIP windows use.
     pub fn set_flash_backing(&mut self, flash: Arc<Mutex<Vec<u8>>>) {
         self.flash = Some(flash);
+    }
+
+    /// The shared pad-line cell for SCK/MOSI/CS, created on first use.
+    ///
+    /// ⚠️ Creating the cell is what turns narration ON.
+    /// `SystemBus::wire_esp32_spi_pads` resolves the GPIO port FIRST for that
+    /// reason: a controller that owns a cell no route reaches still buffers
+    /// every launched transaction, arms a wakeup per burst, and narrates into a
+    /// wire nothing reads.
+    pub(crate) fn pad_lines_arc(&mut self) -> Arc<PadLines> {
+        let cpol = framing(self.read_word(REG_PIN), self.user).cpol;
+        self.wire.pad_lines_arc(cpol)
+    }
+
+    /// Publish a held burst once the wire has carried it. Without a cycle clock
+    /// (a hand-built test bus) there is nowhere to place a waveform, so nothing
+    /// is drawn.
+    fn wire_flush(&mut self, force: bool) {
+        let Some(now) = self.clock.as_ref().map(|c| c.now()) else {
+            return;
+        };
+        self.wire.flush(now, force);
     }
 
     /// Raw device push — does NOT wrap for tracing. The only production caller
@@ -316,12 +424,23 @@ impl Esp32Spi {
         if self.user & USER_USR_MOSI_BIT != 0 {
             let bits = (self.mosi_dlen & 0x7FF) + 1;
             let byte_count = bits.div_ceil(8) as usize;
+            // Read the framing ONCE, before the loop, from the registers as they
+            // stand at the launch — that is the state the whole transaction goes
+            // out under, and `read_word` needs `&self` while the loop below
+            // holds `&mut self.attached_devices`.
+            let framing = framing(self.read_word(REG_PIN), self.user);
+            let bit_time = bit_time_cycles(self.read_word(REG_CLOCK));
+            let now = self.clock.as_ref().map_or(0, |c| c.now());
             for i in 0..byte_count {
                 let word = self.fifo[i / 4];
                 let byte = ((word >> ((i % 4) * 8)) & 0xFF) as u8;
                 if self.record_enabled {
                     self.captured_bytes.push(byte);
                 }
+                // The wire sees the byte at the SAME choke point the attached
+                // devices do: it leaves the W buffer exactly once, and this is
+                // that once. One branch when no pad routes this controller.
+                self.wire.push(byte, framing, bit_time, now);
                 for dev in &mut self.attached_devices {
                     dev.transfer(byte);
                 }
@@ -456,9 +575,27 @@ impl Esp32Spi {
 }
 
 impl Peripheral for Esp32Spi {
-    // Inert walk: SPI transactions run atomically at the launching CMD write (USR auto-clears there); tick() is an explicit no-op.
+    /// This model needs the walk EXACTLY when it is not on the scheduler.
+    ///
+    /// ⚠️ It used to be a flat `false` under the note "inert walk: SPI
+    /// transactions run atomically at the launching CMD write". That was true
+    /// while `tick()` was literally `default()`. It stopped being true the
+    /// moment `tick()` gained the burst flush: on a build without
+    /// `event-scheduler` the walk is the ONLY thing that publishes a narration,
+    /// so a flat `false` is the walk-starvation claim that
+    /// `crates/core/src/tests/walk_starvation_contract.rs` exists to catch —
+    /// and it caught this.
+    ///
+    /// The negation shape is what keeps `SystemBus::derive_walk_deletable`
+    /// (which is ALL-OR-NOTHING across the bus) unchanged where it matters:
+    /// under the feature a cycle clock is always attached, so
+    /// [`Self::uses_scheduler`] is true, this is false, and the bus stays as
+    /// deletable as it was — the [`Self::take_scheduled_events`] chain owns
+    /// publication and arms one wakeup per burst. Without the feature the walk
+    /// always runs regardless (`legacy_walk_disabled` is only read there) and
+    /// [`Self::tick`] publishes.
     fn needs_legacy_walk(&self) -> bool {
-        false
+        !self.uses_scheduler()
     }
 
     fn read(&self, offset: u64) -> SimResult<u8> {
@@ -577,8 +714,67 @@ impl Peripheral for Esp32Spi {
         Ok(())
     }
 
+    /// Legacy-walk publication point. Under `event-scheduler` the walk skips
+    /// this model (see [`Self::uses_scheduler`]) and the event chain owns it;
+    /// without the feature this is where a held burst reaches the pads. Inert —
+    /// one `is_empty` — on every bus that never routed an SPI pad, which is what
+    /// this method did in full before the wire existed.
     fn tick(&mut self) -> PeripheralTickResult {
+        self.wire_flush(false);
         PeripheralTickResult::default()
+    }
+
+    /// Driven by the event scheduler once the bus has attached its cycle clock
+    /// (production `add_peripheral`/`push_peripheral` always do, under the
+    /// `event-scheduler` feature). The per-cycle walk then skips this
+    /// peripheral; nothing here advances on its own, so there is no counter to
+    /// sync and no interrupt level to re-export — only the burst flush, which
+    /// [`Self::take_scheduled_events`] arms. Without a clock (feature off, or a
+    /// hand-built bus) it stays on the legacy walk and `tick()` publishes.
+    fn uses_scheduler(&self) -> bool {
+        cfg!(feature = "event-scheduler") && self.clock.is_some()
+    }
+
+    /// Arm ONE wakeup for a held burst, at the cycle the wire finishes carrying
+    /// it. Costs nothing unless a lab has BOTH routed a pad and launched a
+    /// transaction, so a 64-byte burst is one wakeup rather than 100 000 walk
+    /// ticks. Mirrors `Esp32c3Spi`.
+    fn take_scheduled_events(&mut self) -> Vec<(u64, u32)> {
+        if !self.uses_scheduler() || !self.wire.is_pending() || self.wire.scheduled {
+            return Vec::new();
+        }
+        let Some(now) = self.clock.as_ref().map(|c| c.now()) else {
+            return Vec::new();
+        };
+        self.wire.arm_seq = self.wire.arm_seq.wrapping_add(1);
+        self.wire.scheduled = true;
+        vec![(self.wire.ready_in(now), self.wire.arm_seq)]
+    }
+
+    fn on_event(
+        &mut self,
+        event_token: u32,
+        _sched: &mut crate::sched::EventScheduler,
+        _bus: &mut dyn crate::Bus,
+    ) -> crate::sched::EventResult {
+        if event_token != self.wire.arm_seq {
+            // Stale token from a superseded arm; the live chain owns publication.
+            return crate::sched::EventResult::default();
+        }
+        self.wire_flush(false);
+        // A flush that reported LevelsOnly keeps its bytes; `ready_in` is then 0,
+        // so `max(1)` retries next cycle and converges as the run grows.
+        let now = self.clock.as_ref().map_or(0, |c| c.now());
+        let pending = self.wire.is_pending();
+        self.wire.scheduled = pending;
+        crate::sched::EventResult {
+            reschedule_delay: pending.then(|| self.wire.ready_in(now).max(1)),
+            ..Default::default()
+        }
+    }
+
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        self.clock = Some(clock);
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/crates/core/src/peripherals/esp32/uart.rs
+++ b/crates/core/src/peripherals/esp32/uart.rs
@@ -34,6 +34,11 @@
 //! `tick()` emits the UART interrupt-matrix source while `INT_ST != 0`; the bus
 //! routes it through the per-core interrupt matrix.
 
+use crate::cycle_clock::CycleClock;
+use crate::peripherals::pad_lines::PadLines;
+use crate::peripherals::uart::{LINE_RX, LINE_TX, UART_LINES};
+use crate::peripherals::uart_waveform::{UartFraming, UartNarrator};
+use crate::peripherals::wave_plan::NarrationFit;
 use crate::{Peripheral, PeripheralTickResult, SimResult};
 use std::collections::VecDeque;
 use std::io::{self, Write};
@@ -70,6 +75,23 @@ const CPU_CLOCK_HZ: u64 = 240_000_000;
 /// CLKDIV reset (≈80 MHz / 115200). Used when CLKDIV reads 0.
 const RESET_CLKDIV: u32 = 0x0000_02B6;
 
+/// Bit periods one 10-bit 8N1 character occupies — the divisor between
+/// [`UartCore::cycles_per_byte`] (which paces the shift register) and the bit
+/// period the narration is drawn at. Named rather than inlined so the two can
+/// never disagree about what "one character" means; it is `frame_bits()` of
+/// [`UartFraming::default`], asserted against it in the tests below.
+const FRAME_BITS: u64 = 10;
+
+/// Characters a narration may hold before it is published anyway, compressed.
+///
+/// Unreachable in the common case — this model shifts bytes out at the real
+/// baud rate, so a flush follows each drain and holds at most the handful of
+/// characters one elapsed window completed. It exists for the caller that ticks
+/// this model directly with no cycle axis at all (the unit tests below), where
+/// `now` never moves and a held burst could otherwise grow without bound.
+/// Mirrors [`crate::peripherals::esp_uart`]'s constant of the same name.
+const WIRE_BURST_CAP: usize = 256;
+
 /// Config registers that are simple masked storage: (offset, reset, mask).
 /// The firmware writes CLKDIV/CONF0/CONF1/INT_ENA during `uart_hal` setup and
 /// reads them back; other offsets fall through to round-trip storage.
@@ -101,6 +123,22 @@ struct UartCore {
     int_raw_sticky: u32,
     drain_accum: u64,
     tx_active: bool,
+    /// Wire levels published to matrix-routed TX pads, so a logic analyzer
+    /// clipped to a remapped `U0TXD`/`U1TXD`/`U2TXD` measures a serial waveform
+    /// instead of the GPIO output latch. `None` — the common case, no lab routed
+    /// the pad — costs one branch per shifted byte and publishes nothing.
+    ///
+    /// On the CORE rather than on either window, for the same reason the FIFO
+    /// and the trace are: the APB and AHB aliases are two doors onto one UART,
+    /// and a character crosses the wire once whichever door pushed it.
+    lines: Option<Arc<PadLines>>,
+    /// Characters that have LEFT the shift register but are not yet painted.
+    /// Non-empty only between a drain and the flush that follows it in the same
+    /// call, or while the flush had no cycles to draw in.
+    wire_chars: Vec<u8>,
+    /// Cycle the last narration ran to — the floor the next one may not reach
+    /// back past, or two bursts splice into characters neither one sent.
+    wave_cursor: u64,
 }
 
 pub struct Esp32Uart {
@@ -108,6 +146,17 @@ pub struct Esp32Uart {
     echo_stdout: bool,
     /// Interrupt-matrix source ID (UART0=34, UART1=35, UART2=36).
     source_id: u32,
+    /// Bus-published cycle clock — the axis a narration is placed on. `Some`
+    /// once the bus has attached it (every `add_peripheral` does, feature or
+    /// not); `None` when a test ticks this model directly, where there is
+    /// nowhere to put a waveform.
+    ///
+    /// This does NOT migrate the model to the event scheduler:
+    /// `uses_scheduler()` stays false and `needs_legacy_walk()` stays at its
+    /// `true` default, because `tick_elapsed` still drains the TX FIFO and
+    /// nothing else does. Changing either is what wedged classic ESP32 in the
+    /// browser once already — see the note in `configure_xtensa_esp32`.
+    clock: Option<CycleClock>,
 }
 
 /// AHB-bus FIFO alias (`UART_FIFO_AHB_REG(i)`). Write-only TX push into the
@@ -156,10 +205,29 @@ impl Esp32Uart {
                 int_raw_sticky: 0,
                 drain_accum: 0,
                 tx_active: false,
+                lines: None,
+                wire_chars: Vec::new(),
+                wave_cursor: 0,
             })),
             echo_stdout,
             source_id,
+            clock: None,
         }
+    }
+
+    /// The shared pad-line cell for this UART's TX/RX pair, created on first use
+    /// at bus wiring time. A serial line idles HIGH (mark) in both directions,
+    /// so a start bit is always a falling edge.
+    ///
+    /// ⚠️ Creating the cell is what turns narration ON. Resolve the GPIO port
+    /// FIRST, as `SystemBus::wire_esp32_uart_pads` does: a controller that owns
+    /// a cell no route reaches still buffers and narrates on every transmitted
+    /// byte, into a wire nothing reads.
+    pub(crate) fn pad_lines_arc(&mut self) -> Arc<PadLines> {
+        let mut core = self.core.lock().unwrap();
+        core.lines
+            .get_or_insert_with(|| Arc::new(PadLines::new(UART_LINES, &[true, true])))
+            .clone()
     }
 
     /// AHB FIFO window paired with this APB UART (same FIFO/sink/state).
@@ -224,6 +292,88 @@ impl UartCore {
             clkdiv
         };
         (10 * clkdiv * CPU_CLOCK_HZ / UART_SCLK_HZ).max(1)
+    }
+
+    /// Engine cycles in one bit period.
+    ///
+    /// Derived FROM [`Self::cycles_per_byte`] rather than recomputed from
+    /// `CLKDIV`, so the rate the trace measures can never disagree with the rate
+    /// the shift register actually drained at — the two would otherwise differ
+    /// by integer rounding, and a waveform a cycle per bit off from the model
+    /// that produced it is exactly the kind of wrong that looks right.
+    ///
+    /// `None` below two cycles per bit, where
+    /// [`crate::peripherals::wave_plan::WavePlan`] cannot keep a period's halves
+    /// distinct. Unreachable at any real baud rate: `CLKDIV` resets to 694
+    /// (115200 from the 80 MHz APB source), which is 2082 CPU cycles per bit on
+    /// this 240 MHz part.
+    fn wire_bit_time(&self) -> Option<u64> {
+        let bit = self.cycles_per_byte() / FRAME_BITS;
+        (bit >= 2).then_some(bit)
+    }
+
+    /// Queue a character that has just left the shift register. Buffered, not
+    /// published — see [`Self::wire_flush`].
+    fn wire_push(&mut self, byte: u8) {
+        if self.lines.is_some() && self.wire_bit_time().is_some() {
+            self.wire_chars.push(byte);
+        }
+    }
+
+    /// Paint the characters this drain shifted out onto the routed TX pads.
+    ///
+    /// This model is a byte-paced ENGINE, not a transaction-level one: a
+    /// character only leaves [`Self::drain_accum`] once a full frame time has
+    /// elapsed for it. So by the moment this runs every buffered character has
+    /// genuinely had its wire time, and there is nothing to pace against — it
+    /// narrates unconditionally rather than holding for a deadline the way the
+    /// SPI wire must.
+    ///
+    /// What it still must respect is the capture layer: `LogicTap::push_at` →
+    /// `LogicCapture::ingest_push` accepts stamps in the PAST only and keeps one
+    /// level per channel per cycle. So the burst is drawn as one waveform ENDING
+    /// at `now` and reaching no further back than the previous flush, exactly as
+    /// the classic I²C narrator publishes.
+    fn wire_flush(&mut self, now: u64) {
+        if self.wire_chars.is_empty() {
+            return;
+        }
+        let Some(lines) = self.lines.clone() else {
+            self.wire_chars.clear();
+            return;
+        };
+        let Some(bit_time) = self.wire_bit_time() else {
+            self.wire_chars.clear();
+            return;
+        };
+        let mut narrator = UartNarrator::with_lines(
+            LINE_TX,
+            &[lines.level(LINE_TX), lines.level(LINE_RX)],
+            bit_time,
+        );
+        for &byte in &self.wire_chars {
+            narrator.frame(byte, UartFraming::default());
+        }
+        if let NarrationFit::LevelsOnly { .. } =
+            narrator.emit_between(&lines, self.wave_cursor, now)
+        {
+            // Fewer cycles exist than the waveform has transitions, so nothing
+            // was drawn. KEEP the characters and the cursor: `now` only grows,
+            // so a later drain will have the room. Clearing here would delete
+            // bytes that really crossed the wire and advance the cursor past
+            // cycles nothing painted — silent, unrecoverable loss, and the
+            // reason `emit_between` is `#[must_use]`.
+            if self.wire_chars.len() > WIRE_BURST_CAP {
+                // …except when the caller advances no cycles at all, where
+                // "later" never comes. Give up on the timeline rather than the
+                // memory; the levels above were already applied.
+                self.wire_chars.clear();
+                self.wave_cursor = now;
+            }
+            return;
+        }
+        self.wave_cursor = now;
+        self.wire_chars.clear();
     }
 
     fn int_raw(&self) -> u32 {
@@ -388,6 +538,9 @@ impl Peripheral for Esp32Uart {
     /// shared C3/S3 twin already documents — see
     /// [`crate::peripherals::esp_uart::EspUart::tick_elapsed`].
     fn tick_elapsed(&mut self, cycles: u64) -> PeripheralTickResult {
+        // Read the axis before taking the core lock; a narration is placed on
+        // absolute cycles, and there is nowhere to put one without a clock.
+        let now = self.clock.as_ref().map(|c| c.now());
         let mut core = self.core.lock().unwrap();
         if !core.tx_fifo.is_empty() {
             core.drain_accum += cycles;
@@ -395,6 +548,10 @@ impl Peripheral for Esp32Uart {
             while core.drain_accum >= per_byte && !core.tx_fifo.is_empty() {
                 core.drain_accum -= per_byte;
                 if let Some(byte) = core.tx_fifo.pop_front() {
+                    // The wire sees the byte at the SAME choke point the sink
+                    // and the trace do, for the same reason: a byte leaves the
+                    // shift register exactly once, and this is that once.
+                    core.wire_push(byte);
                     core.trace.push(
                         &core.trace_name,
                         crate::bus::bus_trace::BusPayload::Uart {
@@ -420,6 +577,14 @@ impl Peripheral for Esp32Uart {
         } else {
             core.drain_accum = 0;
         }
+        // Paint whatever this window shifted out, and retry a narration an
+        // earlier window had no cycles to place: `now` has moved on, so cycles
+        // that did not exist then may exist now. One `is_empty` check on every
+        // bus that never routed a TX pad, which is every classic lab that
+        // existed before this.
+        if let Some(now) = now {
+            core.wire_flush(now);
+        }
 
         let asserting = core.int_raw() & core.reg(OFF_INT_ENA);
         PeripheralTickResult {
@@ -430,6 +595,15 @@ impl Peripheral for Esp32Uart {
             },
             ..PeripheralTickResult::default()
         }
+    }
+
+    /// Take the bus's cycle axis so a shifted character can be narrated onto its
+    /// routed pad. ⚠️ Storing a clock does NOT migrate this model to the event
+    /// scheduler — `uses_scheduler()` is deliberately left at its `false`
+    /// default, because `tick_elapsed` is still the only thing that drains the
+    /// TX FIFO.
+    fn attach_cycle_clock(&mut self, clock: CycleClock) {
+        self.clock = Some(clock);
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -505,6 +679,13 @@ mod tests {
 
     fn int_raw(u: &Esp32Uart) -> u32 {
         u.core.lock().unwrap().int_raw()
+    }
+
+    /// The pacing divisor and the narration's frame width must be the same
+    /// number, or the waveform is drawn at a rate the shift register never used.
+    #[test]
+    fn one_character_is_ten_bit_periods_to_both_the_shifter_and_the_narrator() {
+        assert_eq!(UartFraming::default().frame_bits(), FRAME_BITS);
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp_gpspi_wire.rs
+++ b/crates/core/src/peripherals/esp_gpspi_wire.rs
@@ -28,6 +28,20 @@
 //! Two copies of it would be two places to get MSB-order or the CS framing
 //! wrong, and only one of them would be under test.
 //!
+//! # The classic ESP32 shares the machinery and NOT the decode
+//!
+//! `peripherals::esp32::spi::Esp32Spi` (the LX6 part's SPI0/1/HSPI/VSPI) is also
+//! transaction-level and also holds an [`EspSpiWire`], because the buffering,
+//! the burst pacing and the CS framing are the same problem. Its REGISTERS are
+//! not: `SPI_CLOCK` is at 0x18 rather than 0x0C, `CLKDIV_PRE` is thirteen bits
+//! rather than four, `SPI_CK_OUT_EDGE` (CPHA) is `USER` bit **7** rather than
+//! bit 9, and there is no `SPI_MISC` at all — `SPI_CK_IDLE_EDGE` (CPOL) lives in
+//! `SPI_PIN` at 0x34. So the classic model keeps its own `bit_time_cycles` and
+//! `framing` and calls only [`EspSpiWire::push`] / [`EspSpiWire::flush`] /
+//! [`EspSpiWire::ready_in`] here. The free functions below are C3/S3 ONLY;
+//! calling them with a classic register would read three fields out of the wrong
+//! bits of the wrong words.
+//!
 //! # What the caller owes this type
 //!
 //! * Call [`EspSpiWire::pad_lines_arc`] once at bus wiring time, AFTER the GPIO

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -564,6 +564,17 @@ pub fn configure_xtensa_esp32(bus: &mut SystemBus) -> XtensaLx7 {
     // `pad_lines_arc` CREATES the wire cell, and a controller owning a cell no
     // route reaches narrates into nothing.
     bus.wire_esp32_i2c_pads();
+    // Same for VSPI (the `spi3` instance at 0x3FF6_5000 — the controller
+    // arduino-esp32's `SPI` object drives) and each UART's TX, so those buses
+    // are measurable on this part rather than reading as a flat line. Must come
+    // AFTER `register_esp32_peripherals` above, which is what puts spi3 and
+    // uart0/1/2 on the bus; `pad_lines_arc` CREATES the wire cell, and a
+    // controller owning a cell no route reaches narrates into nothing.
+    //
+    // ⚠️ Unlike I²C these are the ONLY call sites that matter for a real lab:
+    // `configs/chips/esp32.yaml` is not what a classic lab is built from.
+    bus.wire_esp32_spi_pads();
+    bus.wire_esp32_uart_pads();
     // AHB TX FIFO alias registered after wifi_mac_phy (see below).
 
     // SYSCON (TRM §13.2) — system controller. Owns SYSCLK_CONF, TICK_CONF,

--- a/crates/core/src/tests/esp_spi_uart_waveform.rs
+++ b/crates/core/src/tests/esp_spi_uart_waveform.rs
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! End-to-end waveform gates for the ESP32-C3 and ESP32-S3 SPI and UART pads.
+//! End-to-end waveform gates for the Espressif SPI and UART pads — ESP32-C3,
+//! ESP32-S3 and classic ESP32 (LX6).
 //!
 //! Before this, both buses ran and neither could be measured on either part: the
 //! GP-SPI transaction engine moves a whole `SPI_CMD.USR` launch inside one MMIO
@@ -29,13 +30,36 @@
 //! [`the_matrix_indices_are_per_chip_and_do_not_cross`] routes each part's pads
 //! with the OTHER part's numbers and asserts nothing lights up.
 //!
+//! ⚠️ Classic ESP32 makes the trap worse, not better: its VSPI indices are 63 /
+//! 65 / 68, byte for byte the C3's FSPI numbers. That is a COLLISION of two
+//! index spaces, not evidence of a shared one — the classic UART indices in the
+//! same header are 14 / 17 / 198 against the C3's 6 / 9 / (none), and on the S3
+//! 63 is not a SPI signal. So the classic part is crossed against the S3 (where
+//! the numbers differ and must not light) and against the C3 on the UART indices
+//! (where the SPI numbers coincide and the UART ones cannot).
+//!
+//! # The register geometry is not shared either
+//!
+//! The classic SPI's `SPI_CLOCK` is at 0x18, its CPHA bit is `SPI_USER` bit 7
+//! (not 9), and its CPOL bit is in `SPI_PIN` at 0x34 because the part has no
+//! `SPI_MISC`. The classic constants below are hand-entered from
+//! `soc/esp32/include/soc/spi_reg.h` for the same reason the signal indices are:
+//! a change to a model constant should be a DISAGREEMENT between two lists, not
+//! a shared mistake.
+//!
 //! # Production, not just possible
 //!
-//! Two tests assert on the builders real labs are made from — `from_config` for
-//! the C3 and `configure_xtensa_esp32s3` for the S3 — because a waveform gate
-//! that constructs its own wiring proves the narration works, not that anything
-//! ships it. That is exactly how the S3's I²C binding stayed green in test while
-//! being dark in every real lab.
+//! Four tests assert on the builders real labs are made from — `from_config`
+//! for the C3, `configure_xtensa_esp32s3` for the S3, and BOTH
+//! `configure_xtensa_esp32` and `from_config` for the classic part — because a
+//! waveform gate that constructs its own wiring proves the narration works, not
+//! that anything ships it. That is exactly how the S3's I²C binding stayed green
+//! in test while being dark in every real lab.
+//!
+//! Classic ESP32 needs both because its two builders disagree:
+//! `configure_xtensa_esp32` registers the peripheral bank in Rust and is what
+//! every real lab runs, while `configs/chips/esp32.yaml` is what
+//! `crates/core/tests/bus_visibility.rs` scores the fleet on.
 
 #[cfg(test)]
 mod esp_spi_uart_waveform_tests {
@@ -599,6 +623,410 @@ mod esp_spi_uart_waveform_tests {
         );
     }
 
+    // ================= classic ESP32 (LX6) =================
+    //
+    // Its own bases, its own register offsets, its own signal indices. Nothing
+    // in this block may be expressed in terms of the C3/S3 constants above —
+    // that reuse IS the bug class being gated.
+
+    /// `DR_REG_GPIO_BASE` / `DR_REG_SPI3_BASE` (VSPI) / `DR_REG_UART_BASE`.
+    const CL_GPIO_BASE: u64 = 0x3FF4_4000;
+    const CL_SPI3_BASE: u64 = 0x3FF6_5000;
+    const CL_UART0_BASE: u64 = 0x3FF4_0000;
+
+    /// `GPIO_FUNC0_OUT_SEL_CFG_REG` — classic `gpio_reg.h`; 0x530, NOT the
+    /// C3/S3's 0x554.
+    const CL_FUNC_OUT_SEL: u64 = 0x530;
+
+    // --- classic SPI registers (`soc/esp32/include/soc/spi_reg.h`) ----------
+    const CL_SPI_CMD: u64 = 0x00;
+    /// `SPI_CLOCK_REG` :328 — 0x18, not 0x0C.
+    const CL_SPI_CLOCK: u64 = 0x18;
+    /// `SPI_USER_REG` :364.
+    const CL_SPI_USER: u64 = 0x1C;
+    /// `SPI_MOSI_DLEN_REG` — sizes the MOSI stream in bits minus one.
+    const CL_SPI_MOSI_DLEN: u64 = 0x28;
+    /// `SPI_PIN_REG` :587. Classic has no `SPI_MISC`.
+    const CL_SPI_PIN: u64 = 0x34;
+    /// `SPI_W0` — the 64-byte FIFO starts at 0x80 here, not 0x98.
+    const CL_SPI_W0: u64 = 0x80;
+    /// `SPI_USR` :116 — CMD bit 18, not the C3/S3's bit 24.
+    const CL_SPI_USR: u32 = 1 << 18;
+    /// `SPI_USR_MOSI` — USER bit 27.
+    const CL_USER_USR_MOSI: u32 = 1 << 27;
+    /// `SPI_CK_OUT_EDGE` :506 — USER bit **7** (CPHA). The C3/S3 use bit 9.
+    const CL_CK_OUT_EDGE: u32 = 1 << 7;
+    /// `SPI_CK_IDLE_EDGE` :599 — `SPI_PIN` bit 29 (CPOL).
+    const CL_CK_IDLE_EDGE: u32 = 1 << 29;
+
+    // --- classic matrix signal indices (`gpio_sig_map.h`) -------------------
+    /// `VSPICLK_OUT_IDX` :138 / `VSPID_OUT_IDX` :142 / `VSPICS0_OUT_IDX` :148.
+    /// ⚠️ Numerically identical to the C3's FSPI trio, and meaningless on the
+    /// S3 — see the module header.
+    const CL_SIG_SCK: u32 = 63;
+    const CL_SIG_MOSI: u32 = 65;
+    const CL_SIG_CS: u32 = 68;
+    /// `U0TXD_OUT_IDX` :46. The C3's is 6 and the S3's is 12.
+    const CL_SIG_U0TXD: u32 = 14;
+    /// `SIG_GPIO_OUT_IDX` :399 — the matrix-bypass sentinel, 256 on classic.
+    const CL_SIG_GPIO_OUT: u32 = 256;
+
+    /// The WROOM-32 VSPI pin-out (`variants/esp32/pins_arduino.h`: SCK 18,
+    /// MOSI 23, SS 5) and GPIO4 for TX. Real pads rather than the C3 block's
+    /// 6/7/10, which are the classic part's flash pins.
+    const CL_SCK_PIN: u8 = 18;
+    const CL_MOSI_PIN: u8 = 23;
+    const CL_CS_PIN: u8 = 5;
+    const CL_TX_PIN: u8 = 4;
+
+    /// 1 MHz from the 80 MHz APB, spelled with a divisor pair that DOES NOT FIT
+    /// the C3/S3's four-bit `CLKDIV_PRE`: `pre_reg` = 19 (÷20) with `CLKCNT_N` =
+    /// 3 (÷4) gives ÷80. Classic's field is [30:18], THIRTEEN bits (`spi_reg.h`
+    /// :341), so a model masking it with the sibling's 0xF reads `pre_reg` = 3
+    /// and narrates at five times the programmed rate — carrying the SAME bytes,
+    /// because an edge-driven decoder is rate-blind. Hence the separate rate
+    /// assertion in the test below.
+    const CL_SPI_CLOCK_1MHZ: u32 = (19 << 18) | (3 << 12);
+    /// One bit period at that setting: 80 APB ticks × (240/80).
+    const CL_SPI_BIT: u64 = 240;
+    /// 694 × 240 / 80 — `Esp32Uart::cycles_per_byte` / 10.
+    const CL_UART_BIT: u64 = 694 * 240 / 80;
+
+    fn classic_spi_machine() -> Machine<CortexM> {
+        use crate::peripherals::esp32::gpio::Esp32Gpio;
+        use crate::peripherals::esp32::spi::Esp32Spi;
+        let mut bus = crate::bus::SystemBus::new();
+        bus.add_peripheral(
+            "gpio",
+            CL_GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32Gpio::new()),
+        );
+        bus.add_peripheral(
+            "spi3",
+            CL_SPI3_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32Spi::new()),
+        );
+        bus.wire_esp32_spi_pads();
+        finish(bus)
+    }
+
+    fn classic_uart_machine() -> Machine<CortexM> {
+        use crate::peripherals::esp32::gpio::Esp32Gpio;
+        use crate::peripherals::esp32::uart::Esp32Uart;
+        let mut bus = crate::bus::SystemBus::new();
+        bus.add_peripheral(
+            "gpio",
+            CL_GPIO_BASE,
+            0x1000,
+            None,
+            Box::new(Esp32Gpio::new()),
+        );
+        bus.add_peripheral(
+            "uart0",
+            CL_UART0_BASE,
+            0x100,
+            None,
+            Box::new(Esp32Uart::new(false, 34)),
+        );
+        bus.wire_esp32_uart_pads();
+        finish(bus)
+    }
+
+    /// `gpio_matrix_out(pin, signal, false, false)` plus the output-driver
+    /// enable — the classic `pinMatrixOutAttach` after a `pinMode(_, OUTPUT)`.
+    /// The ENABLE write is load-bearing: `Esp32Gpio::matrix_signal` refuses a
+    /// pad whose driver is off, exactly as `i2cInit` sets direction first.
+    fn classic_route(machine: &mut Machine<CortexM>, pin: u8, signal: u32) {
+        machine
+            .bus
+            .write_u32(CL_GPIO_BASE + ENABLE_W1TS, 1u32 << pin)
+            .unwrap();
+        machine
+            .bus
+            .write_u32(CL_GPIO_BASE + CL_FUNC_OUT_SEL + u64::from(pin) * 4, signal)
+            .unwrap();
+    }
+
+    fn classic_spi_transfer(machine: &mut Machine<CortexM>, payload: &[u8], mode: Mode) {
+        {
+            let bus = &mut machine.bus;
+            bus.write_u32(CL_SPI3_BASE + CL_SPI_CLOCK, CL_SPI_CLOCK_1MHZ)
+                .unwrap();
+            bus.write_u32(
+                CL_SPI3_BASE + CL_SPI_PIN,
+                if mode.cpol { CL_CK_IDLE_EDGE } else { 0 },
+            )
+            .unwrap();
+            bus.write_u32(
+                CL_SPI3_BASE + CL_SPI_USER,
+                CL_USER_USR_MOSI | if mode.cpha { CL_CK_OUT_EDGE } else { 0 },
+            )
+            .unwrap();
+            bus.write_u32(
+                CL_SPI3_BASE + CL_SPI_MOSI_DLEN,
+                (payload.len() as u32 * 8) - 1,
+            )
+            .unwrap();
+            for (w, chunk) in payload.chunks(4).enumerate() {
+                let mut word = 0u32;
+                for (b, &byte) in chunk.iter().enumerate() {
+                    word |= u32::from(byte) << (8 * b);
+                }
+                bus.write_u32(CL_SPI3_BASE + CL_SPI_W0 + (w as u64) * 4, word)
+                    .unwrap();
+            }
+            bus.write_u32(CL_SPI3_BASE + CL_SPI_CMD, CL_SPI_USR)
+                .unwrap();
+        }
+        // The model completes the whole transaction inside that last write; the
+        // WIRE needs ten bit periods per byte. Running that time out is the
+        // point — it is what makes this a measurement and not a mirror.
+        let wire = payload.len() as u64 * SPI_FRAME_BITS * CL_SPI_BIT;
+        for _ in 0..wire + 256 {
+            machine.step().unwrap();
+        }
+    }
+
+    fn classic_uart_send(machine: &mut Machine<CortexM>, bytes: &[u8]) {
+        {
+            let bus = &mut machine.bus;
+            bus.write_u32(CL_UART0_BASE + UART_CLKDIV, UART_CLKDIV_115200)
+                .unwrap();
+            for &b in bytes {
+                bus.write_u32(CL_UART0_BASE + UART_FIFO, u32::from(b))
+                    .unwrap();
+            }
+        }
+        let wire = bytes.len() as u64 * UART_FRAME_BITS * CL_UART_BIT;
+        for _ in 0..wire + 256 {
+            machine.step().unwrap();
+        }
+    }
+
+    fn watch_classic_spi(machine: &mut Machine<CortexM>) {
+        let gpio = machine.bus.find_peripheral_index_by_name("gpio").unwrap();
+        machine.logic_watch(&[
+            Some((gpio, CL_MOSI_PIN)),
+            Some((gpio, CL_SCK_PIN)),
+            Some((gpio, CL_CS_PIN)),
+        ]);
+    }
+
+    fn watch_classic_tx(machine: &mut Machine<CortexM>) {
+        let gpio = machine.bus.find_peripheral_index_by_name("gpio").unwrap();
+        machine.logic_watch(&[Some((gpio, CL_TX_PIN))]);
+    }
+
+    #[test]
+    fn classic_spi_bytes_reach_the_matrix_routed_pads() {
+        let mut m = classic_spi_machine();
+        classic_route(&mut m, CL_SCK_PIN, CL_SIG_SCK);
+        classic_route(&mut m, CL_MOSI_PIN, CL_SIG_MOSI);
+        classic_route(&mut m, CL_CS_PIN, CL_SIG_CS);
+        watch_classic_spi(&mut m);
+
+        // ⚠️ Bit-ASYMMETRIC on purpose. 0xA5, 0x5A, 0x3C, 0xFF and 0x00 are all
+        // bit-palindromes: a payload of those decodes identically MSB- and
+        // LSB-first, so a gate built on them cannot see a reversed narration at
+        // all. 0x01/0xB2/0x0F reverse to 0x80/0x4D/0xF0.
+        let payload = [0x01u8, 0xB2, 0x0F, 0x80];
+        classic_spi_transfer(&mut m, &payload, MODE0);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            !edges.is_empty(),
+            "VSPI clocked {} bytes and the routed pads recorded NOTHING — the \
+             wire is not reaching the classic-ESP32 output matrix",
+            payload.len()
+        );
+        assert_eq!(
+            decode_spi(&edges, MODE0),
+            payload.to_vec(),
+            "the captured waveform must decode back to exactly what the W buffer \
+             carried, MSB-first"
+        );
+
+        // ⚠️ And at the RATE the firmware programmed. `decode_spi` replays edges
+        // and is deliberately rate-BLIND, so a divisor read out of the wrong
+        // register (classic `SPI_CLOCK` is 0x18, the C3/S3's is 0x0C) or masked
+        // to the wrong width (thirteen bits here, four there) decodes to exactly
+        // the right bytes at a frequency nothing on the bus ever ran at.
+        // Measured back off the capture the way a user reading the analyzer
+        // would: the tightest spacing between two clock edges IS one half
+        // period.
+        let mut sck: Vec<u64> = edges
+            .iter()
+            .filter(|e| e.ch == CH_SCK)
+            .map(|e| e.cycle)
+            .collect();
+        sck.sort_unstable();
+        let tightest = sck.windows(2).map(|w| w[1] - w[0]).min();
+        assert_eq!(
+            tightest,
+            Some(CL_SPI_BIT / 2),
+            "the trace measures {tightest:?} cycles between the closest pair of \
+             SCK edges; one half of the programmed {CL_SPI_BIT}-cycle period is \
+             {}. A trace at the wrong frequency carrying the right bytes is what \
+             a divisor decoded from a sibling part's register geometry looks \
+             like.",
+            CL_SPI_BIT / 2
+        );
+    }
+
+    /// The classic mode bits sit at register positions the C3/S3 do not share:
+    /// CPHA is `SPI_USER` bit 7 (theirs is bit 9) and CPOL is `SPI_PIN` bit 29
+    /// (they have no `SPI_PIN` and keep it in `SPI_MISC`). Reading either from a
+    /// sibling's position yields a trace at the right rate framed on the wrong
+    /// phase — plausible, and garbage.
+    #[test]
+    fn classic_spi_honours_the_mode_bits_in_pin_and_user() {
+        let payload = [0x12u8, 0x34]; // bit-asymmetric: reverses to 0x48/0x2C
+
+        let mut m = classic_spi_machine();
+        classic_route(&mut m, CL_SCK_PIN, CL_SIG_SCK);
+        classic_route(&mut m, CL_MOSI_PIN, CL_SIG_MOSI);
+        classic_route(&mut m, CL_CS_PIN, CL_SIG_CS);
+        watch_classic_spi(&mut m);
+        classic_spi_transfer(&mut m, &payload, MODE3);
+        let mode3 = m.logic_read_edges(0).edges;
+        assert_eq!(
+            decode_spi(&mode3, MODE3),
+            payload.to_vec(),
+            "a mode-3 transfer must decode as mode 3"
+        );
+
+        let mut m = classic_spi_machine();
+        classic_route(&mut m, CL_SCK_PIN, CL_SIG_SCK);
+        classic_route(&mut m, CL_MOSI_PIN, CL_SIG_MOSI);
+        classic_route(&mut m, CL_CS_PIN, CL_SIG_CS);
+        watch_classic_spi(&mut m);
+        classic_spi_transfer(&mut m, &payload, MODE0);
+        let mode0 = m.logic_read_edges(0).edges;
+
+        // CPOL (`SPI_PIN.CK_IDLE_EDGE`): the level SCK rests at once the burst
+        // is over. A narration that read USER instead parks it at 0 either way.
+        let rest = |edges: &[LogicEdge]| edges.iter().rfind(|e| e.ch == CH_SCK).map(|e| e.value);
+        assert_eq!(rest(&mode3), Some(true), "CPOL=1 must idle SCK HIGH");
+        assert_eq!(rest(&mode0), Some(false), "CPOL=0 must idle SCK LOW");
+
+        // CPHA (`SPI_USER.CK_OUT_EDGE`, bit 7 here): the phase decides
+        // chip-select framing. A model reading bit 9 sees CPHA=0 for both modes
+        // and pulses CS per word in each.
+        let cs_edges = |edges: &[LogicEdge]| edges.iter().filter(|e| e.ch == CH_CS).count();
+        assert_eq!(
+            cs_edges(&mode0),
+            2 * payload.len(),
+            "CPHA=0 must pulse chip select once per word"
+        );
+        assert_eq!(
+            cs_edges(&mode3),
+            2,
+            "CPHA=1 must HOLD chip select low ACROSS the burst — one assert and \
+             one release, whatever its length. More than that means the \
+             narration read CK_OUT_EDGE from the wrong bit and re-framed every \
+             word."
+        );
+    }
+
+    #[test]
+    fn classic_uart_characters_reach_a_matrix_routed_tx_pad() {
+        let mut m = classic_uart_machine();
+        classic_route(&mut m, CL_TX_PIN, CL_SIG_U0TXD);
+        watch_classic_tx(&mut m);
+
+        // ⚠️ Bit-asymmetric characters: 'L' (0x4C) reverses to 0x32, 'W' (0x57)
+        // to 0xEA. A palindromic message would decode the same LSB- and
+        // MSB-first and could not see a reversed frame.
+        let msg = b"LW";
+        classic_uart_send(&mut m, msg);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            !edges.is_empty(),
+            "UART0 shifted {} characters and the routed TX pad recorded NOTHING",
+            msg.len()
+        );
+        assert_eq!(
+            decode_uart(&edges, CL_UART_BIT),
+            msg.to_vec(),
+            "the captured waveform must decode as 8N1 at the programmed baud \
+             rate — 694 CLKDIV against an 80 MHz APB on a 240 MHz core"
+        );
+    }
+
+    /// A pad the firmware kept for plain GPIO must keep reading the output
+    /// latch. The control case for a wire bound to every output-capable pad:
+    /// binding is only correct if the selector gates it.
+    #[test]
+    fn a_classic_pad_left_at_the_bypass_sentinel_still_reads_the_gpio_latch() {
+        let mut m = classic_spi_machine();
+        classic_route(&mut m, CL_SCK_PIN, CL_SIG_SCK);
+        classic_route(&mut m, CL_MOSI_PIN, CL_SIG_MOSI);
+        // CS enabled as an output but left at SIG_GPIO_OUT — a plain GPIO.
+        classic_route(&mut m, CL_CS_PIN, CL_SIG_GPIO_OUT);
+        watch_classic_spi(&mut m);
+        classic_spi_transfer(&mut m, &[0x01, 0xB2], MODE0);
+
+        let edges = m.logic_read_edges(0).edges;
+        assert!(
+            edges.iter().any(|e| e.ch == CH_SCK),
+            "the routed clock pad must still carry the bus"
+        );
+        assert!(
+            !edges.iter().any(|e| e.ch == CH_CS),
+            "a pad left at SIG_GPIO_OUT (256 on classic) must show its latch, \
+             never the controller's chip select"
+        );
+    }
+
+    /// ⚠️ The classic half of the per-chip index trap.
+    ///
+    /// VSPI's 63/65/68 collide numerically with the C3's FSPI trio, so the SPI
+    /// half is crossed against the **S3** — where 101/103/110 mean FSPI and 63
+    /// is not a SPI signal at all. The UART half is crossed against the C3,
+    /// where the numbers genuinely differ (classic `U0TXD` = 14, C3 = 6) and a
+    /// borrowed constant would be silent in both directions.
+    #[test]
+    fn the_classic_matrix_indices_are_its_own() {
+        let mut m = classic_spi_machine();
+        classic_route(&mut m, CL_SCK_PIN, S3_SIG_SCK); // 101 — nothing on classic
+        classic_route(&mut m, CL_MOSI_PIN, S3_SIG_MOSI);
+        classic_route(&mut m, CL_CS_PIN, S3_SIG_CS);
+        watch_classic_spi(&mut m);
+        classic_spi_transfer(&mut m, &[0x01, 0xB2], MODE0);
+        assert!(
+            m.logic_read_edges(0).edges.is_empty(),
+            "classic ESP32 routed the S3's FSPI indices (101/103/110) and still \
+             showed traffic — the classic GPIO is decoding an index space that \
+             is not its own"
+        );
+
+        let mut m = classic_uart_machine();
+        classic_route(&mut m, CL_TX_PIN, C3_SIG_U0TXD); // 6 — the C3's U0TXD
+        watch_classic_tx(&mut m);
+        classic_uart_send(&mut m, b"LW");
+        assert!(
+            m.logic_read_edges(0).edges.is_empty(),
+            "classic ESP32 routed the C3's U0TXD index (6) and still showed \
+             traffic; classic U0TXD is 14"
+        );
+
+        // …and the mirror image: the C3, routed with the classic index.
+        let mut m = c3_uart_machine();
+        route(&mut m, TX_PIN, CL_SIG_U0TXD); // 14 — classic's U0TXD
+        watch_tx(&mut m);
+        uart_send(&mut m, UART0_BASE, b"LW", C3_UART_BIT);
+        assert!(
+            m.logic_read_edges(0).edges.is_empty(),
+            "the C3 routed the classic part's U0TXD index (14) and still showed \
+             traffic; 14 is not U0TXD on the C3"
+        );
+    }
+
     // ================= the traps =================
 
     /// ⚠️ The single most dangerous failure mode on this family: matrix signal
@@ -707,6 +1135,81 @@ mod esp_spi_uart_waveform_tests {
                 "SystemBus::from_config must bind {want} on the C3, or every C3 \
                  lab reads a flat line while the bus is busy; bound functions \
                  were {bound:?}"
+            );
+        }
+    }
+
+    /// The same question for classic ESP32, asked of `configure_xtensa_esp32` —
+    /// the programmatic builder every real classic lab is made from, which
+    /// registers its peripheral bank in Rust and bypasses the chip yaml.
+    ///
+    /// ⚠️ This is the gate that matters. Every waveform test above hand-builds a
+    /// bus and calls the wiring itself, which proves the narration works and NOT
+    /// that anything ships it — exactly how the S3's I²C binding stayed green in
+    /// test while being dark in every production lab.
+    #[test]
+    fn the_production_classic_esp32_builder_routes_the_spi_and_uart_pads() {
+        let mut bus = crate::bus::SystemBus::new();
+        let _cpu = crate::system::xtensa::configure_xtensa_esp32(&mut bus);
+        let bound = bus.bound_pad_functions();
+        for want in [
+            "SPI3_SCK",
+            "SPI3_MOSI",
+            "SPI3_CS",
+            "UART0_TX",
+            "UART1_TX",
+            "UART2_TX",
+        ] {
+            assert!(
+                bound.contains(&want),
+                "configure_xtensa_esp32 must bind {want}, or every classic-ESP32 \
+                 lab reads a flat line while the bus is busy; bound functions \
+                 were {bound:?}"
+            );
+        }
+    }
+
+    /// And of `from_config`, which is the path
+    /// `crates/core/tests/bus_visibility.rs` scores the fleet on — so the board
+    /// and this file can never disagree about whether the classic part can show
+    /// its buses.
+    ///
+    /// ⚠️ `UART0_TX` is deliberately absent from the list.
+    /// `configs/chips/esp32.yaml` declares `uart0` as the vendor-neutral `uart`
+    /// type (the STM32 register map at a classic base), not `esp32_uart`, so a
+    /// `from_config` build has no classic UART0 model to route. UART1/UART2 are
+    /// `esp32_uart` and do bind, which is what turns the board's UART cell. The
+    /// programmatic builder gated above covers all three.
+    #[test]
+    fn the_production_classic_from_config_build_routes_the_spi_and_uart_pads() {
+        use labwired_config::{ChipDescriptor, SystemManifest};
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("configs/chips/esp32.yaml");
+        let chip = ChipDescriptor::from_file(&path).expect("load esp32.yaml");
+        let manifest = SystemManifest {
+            parts: Vec::new(),
+            walk_deleted: Some(false),
+            schema_version: "1.0".to_string(),
+            name: "esp-spi-uart-waveform".to_string(),
+            chip: path.to_string_lossy().to_string(),
+            external_devices: vec![],
+            cosim_models: Vec::new(),
+            motor_models: Vec::new(),
+            board_io: vec![],
+            debug_uart: None,
+            wifi_ap: None,
+            peripherals: vec![],
+            memory_overrides: Default::default(),
+        };
+        let bus = crate::bus::SystemBus::from_config(&chip, &manifest)
+            .expect("assemble the production classic-ESP32 bus");
+        let bound = bus.bound_pad_functions();
+        for want in ["SPI3_SCK", "SPI3_MOSI", "SPI3_CS", "UART1_TX", "UART2_TX"] {
+            assert!(
+                bound.contains(&want),
+                "SystemBus::from_config must bind {want} on classic ESP32; bound \
+                 functions were {bound:?}"
             );
         }
     }

--- a/docs/coverage/bus-visibility.json
+++ b/docs/coverage/bus-visibility.json
@@ -1,7 +1,9 @@
 [
   {
     "buses": [
-      "I2C"
+      "I2C",
+      "SPI",
+      "UART"
     ],
     "name": "esp32"
   },

--- a/docs/coverage/bus-visibility.md
+++ b/docs/coverage/bus-visibility.md
@@ -10,7 +10,7 @@ Derived from live `SystemBus::from_config` builds — never hand-edited. Bind a 
 
 | Chip | I2C | SPI | UART |
 |------|-----|-----|------|
-| esp32 | ✓ | — | — |
+| esp32 | ✓ | ✓ | ✓ |
 | esp32c3 | ✓ | ✓ | ✓ |
 | esp32s3 | — | — | — |
 | esp32s3-zero | — | — | — |


### PR DESCRIPTION
`esp32` goes `✓ — —` → **`✓ ✓ ✓`**. Last Espressif family to get a wire, and it shares no decode with the C3/S3 work.

**Classic SPI is transaction-level** — `kick_user_transaction` drains the whole W buffer inside the write that sets `SPI_USR`. **Classic UART is a byte-paced engine** — `tick_elapsed` pops one byte per `cycles_per_byte` of *elapsed* cycles, so characters really leave at the programmed baud.

The register geometry is classic-specific, which is why `esp_gpspi_wire`'s decode is not reused: `SPI_CLOCK` at 0x18 not 0x0C, `CLKDIV_PRE` 13 bits not 4, CPHA at `SPI_USER` bit 7 not 9, and CPOL in `SPI_PIN` bit 29 because this part has **no `SPI_MISC` at all**.

## VSPI is selected by name, deliberately

Classic has three SPI blocks and SPI0/1 drive the flash. All three are the same Rust type, so a "first found" downcast would publish VSPI's signals **onto a flash controller**. The wiring resolves by peripheral name.

## IO_MUX: classic differs from both siblings

| UART | default TX | IO_MUX func |
|---|---|---|
| U0TXD | GPIO1 | 0 |
| U1TXD | GPIO10 | 4 |
| U2TXD | GPIO17 | 4 |

None is matrix-only, unlike C3 UART1 and S3 UART2 — so none shows on a stock default-pin `Serial.begin()`. All three are still bound: every real WROOM-32 remaps UART1, because GPIO9/10 are the flash pins.

## The walk hazard fired

A first cut kept `needs_legacy_walk() -> false` while `tick()` gained the flush. `walk_starvation_contract` failed in **both** feature sets, exactly as designed. Fixed to `!self.uses_scheduler()`. The per-cycle walk is not forced back on, and `esp32_classic_walk_differential` stayed green in both sets.

## Verification

2994 lib tests, 3114 with `event-scheduler`, 172 integration binaries with 0 failures in both sets. clippy and fmt clean. Drift gate did not fire.

**12/12 mutations killed**, each with a green control after restore. Two worth naming: swapping CPHA to the C3/S3 bit position, and swapping `SIG_VSPICLK` to the S3's index — both decode to plausible garbage rather than failing loudly, which is exactly how a borrowed constant hides.

M3/M4 also earned their keep: the decoder is edge-driven and rate-blind, so a wrong `REG_CLOCK` offset and a truncated `CLKDIV_PRE` mask both still decoded the **right bytes**. Only the separate period assertion caught them.

## Stated limits

UART0 is unbound on the `from_config` path — `esp32.yaml` declares `uart0` as the vendor-neutral `uart` type, not `esp32_uart`, so only UART1/UART2 bind there. The programmatic builder binds all three. `SPI_WR_BIT_ORDER` is unread. MISO and RX stay unbound because nothing drives them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)