### PR TITLE
fix(examples): mux STM32 serial pads and program BRR so probes see the wire

### DIFF
--- a/crates/core/tests/logic_analyzer_lab_pad_visibility.rs
+++ b/crates/core/tests/logic_analyzer_lab_pad_visibility.rs
@@ -1,0 +1,335 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Does a probe on a lab's serial pad actually show the serial waveform?
+//!
+//! `crates/core/src/tests/stm32_uart_waveform.rs` already proves the pad-route
+//! MACHINERY works: it hand-builds a bus, writes MODER + AFRH + BRR itself, and
+//! decodes the edges back to characters. It passes. This file asks the
+//! different question the browser asks — "does the lab a user actually opens
+//! show anything?" — and it is built the way the PLAYGROUND builds a lab:
+//! `SystemManifest::from_file` on the lab's own `system.yaml`, its `chip:`
+//! resolved relatively, `SystemBus::from_config`. No wiring call by hand.
+//!
+//! The register writes below are not invented. They are exactly, and only, what
+//! `examples/iolink-station/master-fw-4port/{main.c,phy_labwired.c}` does to
+//! bring its USARTs up and transmit — that is the firmware `env4.yaml` runs on
+//! this very `master/system.yaml`. If that firmware changes, this replay is
+//! wrong and must be changed with it; it is a mirror of the source, never a
+//! hand-tuned sequence chosen to make the assertion pass.
+//!
+//! PA2 is USART2_TX on the STM32L476 (DS10198 Rev 11, Table 17, p88), and it IS
+//! in the `wire_stm32_uart_pads` V2 table, so this is not an unbound pad.
+//!
+//! # History
+//!
+//! This file was written as a REPRODUCTION and its main test failed. The
+//! firmware programmed neither `BRR` nor any GPIO register: `bit_time_cycles`
+//! returned `None` so `wire_push` dropped every character, and `PadRoutes`
+//! found no live route so the probe read the GPIO output latch. Both omissions
+//! were in the firmware; the engine was right to show a dark pad for an
+//! unmuxed one. The two `diagnostic_*` tests below preserve each half of that
+//! old behaviour, so the reason the pad was dark stays documented and pinned.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::cortex_m::CortexM;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::{Bus, Machine};
+use std::path::PathBuf;
+
+type Cm = Machine<CortexM>;
+
+const SRAM_BASE: u64 = 0x2000_0000;
+
+// STM32L476 (configs/chips/stm32l476.yaml + configs/peripherals/stm32l476/).
+const RCC_BASE: u64 = 0x4002_1000;
+const RCC_AHB2ENR: u64 = 0x4C;
+const RCC_APB1ENR1: u64 = 0x58;
+const RCC_APB2ENR: u64 = 0x60;
+
+const GPIOA_BASE: u64 = 0x4800_0000;
+const GPIOB_BASE: u64 = 0x4800_0400;
+const GPIOC_BASE: u64 = 0x4800_0800;
+const GPIOD_BASE: u64 = 0x4800_0C00;
+const MODER: u64 = 0x00;
+const OTYPER: u64 = 0x04;
+const OSPEEDR: u64 = 0x08;
+const PUPDR: u64 = 0x0C;
+/// `AFR[0]` (pins 0-7) and `AFR[1]` (pins 8-15).
+const AFR: u64 = 0x20;
+
+const USART2_BASE: u64 = 0x4000_4400;
+const USART3_BASE: u64 = 0x4000_4800;
+const UART4_BASE: u64 = 0x4000_4C00;
+const UART5_BASE: u64 = 0x4000_5000;
+const CR1: u64 = 0x00;
+const CR2: u64 = 0x04;
+const CR3: u64 = 0x08;
+const BRR: u64 = 0x0C;
+const TDR: u64 = 0x28;
+
+/// PA2 = USART2_TX, AF7 (DS10198 Rev 11, Table 17, p88).
+const TX_PIN: u8 = 2;
+const TX_AF: u32 = 7;
+
+/// `USART_CR1_UE | USART_CR1_TE | USART_CR1_RE` — the literal value
+/// `phy_labwired.c`'s `init_N` writes last.
+const CR1_UE_TE_RE: u32 = (1 << 0) | (1 << 3) | (1 << 2);
+
+/// `IOLINK_COM2_BRR` from `phy_labwired.c`. 4 MHz MSI (the lab's `cpu_hz`) at
+/// 38.4 kbaud (IO-Link COM2, which `fill_one` configures the master for):
+/// USARTDIV = 4e6 / 38400 = 104.17 → 104.
+const USARTDIV_COM2: u32 = 104;
+
+/// `DBG_BRR` from `debug_uart.c`: 4 MHz at 115200 → 34.72 → 35. Unused by the
+/// C/Q path, kept so the console's divisor is mirrored here too.
+#[allow(dead_code)]
+const USARTDIV_DEBUG: u32 = 35;
+
+/// Build the IO-Link master lab exactly as the playground does.
+fn lab_machine() -> Cm {
+    let system_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/iolink-station/master/system.yaml");
+    let manifest = SystemManifest::from_file(&system_path).expect("load lab system.yaml");
+    let chip_path = system_path.parent().unwrap().join(&manifest.chip);
+    let chip = ChipDescriptor::from_file(&chip_path).expect("load chip descriptor");
+    let mut bus = SystemBus::from_config(&chip, &manifest).expect("build lab bus");
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+
+    // A NOP slab in SRAM with a Thumb branch back to its start, so `step()`
+    // advances cycles deterministically without needing the release ELF (which
+    // is a sha-pinned GitHub Release asset, not a committed file).
+    for i in 0..1022u64 {
+        let byte = if i % 2 == 0 { 0x00 } else { 0x20 };
+        machine.bus.write_u8(SRAM_BASE + i, byte).unwrap();
+    }
+    machine.bus.write_u8(SRAM_BASE + 1022, 0xFF).unwrap();
+    machine.bus.write_u8(SRAM_BASE + 1023, 0xE5).unwrap();
+    machine.cpu.pc = SRAM_BASE as u32;
+    machine
+}
+
+/// `pad_af()` from `phy_labwired.c`, register for register: MODER = 10
+/// (alternate function), push-pull, very-high speed, no pull, AF nibble into
+/// `AFR[pin / 8]`.
+fn pad_af(machine: &mut Cm, gpio_base: u64, pin: u8, af: u32) {
+    let shift = u32::from(pin) * 2;
+    let moder = machine.bus.read_u32(gpio_base + MODER).unwrap();
+    machine
+        .bus
+        .write_u32(
+            gpio_base + MODER,
+            (moder & !(0b11 << shift)) | (0b10 << shift),
+        )
+        .unwrap();
+    let otyper = machine.bus.read_u32(gpio_base + OTYPER).unwrap();
+    machine
+        .bus
+        .write_u32(gpio_base + OTYPER, otyper & !(1 << pin))
+        .unwrap();
+    let ospeedr = machine.bus.read_u32(gpio_base + OSPEEDR).unwrap();
+    machine
+        .bus
+        .write_u32(gpio_base + OSPEEDR, ospeedr | (0b11 << shift))
+        .unwrap();
+    let pupdr = machine.bus.read_u32(gpio_base + PUPDR).unwrap();
+    machine
+        .bus
+        .write_u32(gpio_base + PUPDR, pupdr & !(0b11 << shift))
+        .unwrap();
+    let afr_off = AFR + u64::from(pin >> 3) * 4;
+    let nib = u32::from(pin & 7) * 4;
+    let afr = machine.bus.read_u32(gpio_base + afr_off).unwrap();
+    machine
+        .bus
+        .write_u32(gpio_base + afr_off, (afr & !(0xF << nib)) | (af << nib))
+        .unwrap();
+}
+
+/// `rcc_init()` from `master-fw-4port/main.c`, verbatim in effect.
+fn firmware_rcc_init(machine: &mut Cm) {
+    machine
+        .bus
+        .write_u32(RCC_BASE + RCC_APB2ENR, 1 << 14)
+        .unwrap(); // USART1EN
+    machine
+        .bus
+        .write_u32(
+            RCC_BASE + RCC_APB1ENR1,
+            (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20),
+        )
+        .unwrap(); // USART2/3EN, UART4/5EN
+    machine
+        .bus
+        .write_u32(RCC_BASE + RCC_AHB2ENR, 0b1111)
+        .unwrap(); // GPIOA/B/C/DEN
+}
+
+/// One expansion of the `PORT` macro's `init_##IDX` from `phy_labwired.c`: mux
+/// the TX and RX pads, clear CR1/CR2/CR3, program BRR, then enable.
+fn firmware_port_init(
+    machine: &mut Cm,
+    uart_base: u64,
+    tx_gpio: u64,
+    tx_pin: u8,
+    rx_gpio: u64,
+    rx_pin: u8,
+    af: u32,
+) {
+    pad_af(machine, tx_gpio, tx_pin, af);
+    pad_af(machine, rx_gpio, rx_pin, af);
+    machine.bus.write_u32(uart_base + CR1, 0).unwrap();
+    machine.bus.write_u32(uart_base + CR2, 0).unwrap();
+    machine.bus.write_u32(uart_base + CR3, 0).unwrap();
+    machine
+        .bus
+        .write_u32(uart_base + BRR, USARTDIV_COM2)
+        .unwrap();
+    machine
+        .bus
+        .write_u32(uart_base + CR1, CR1_UE_TE_RE)
+        .unwrap();
+}
+
+/// The four `PORT(...)` rows of `phy_labwired.c`, in the order
+/// `iolink_master_controller_init` calls them. Pads and AF numbers are the
+/// table in that file, read off DS10198 Rev 11 Table 17 (AF0-AF7, p88/p89) and
+/// Table 18 (AF8-AF15, p95/p97/p98).
+fn firmware_all_ports_init(machine: &mut Cm) {
+    firmware_port_init(machine, USART2_BASE, GPIOA_BASE, 2, GPIOA_BASE, 3, 7);
+    firmware_port_init(machine, USART3_BASE, GPIOB_BASE, 10, GPIOB_BASE, 11, 7);
+    firmware_port_init(machine, UART4_BASE, GPIOA_BASE, 0, GPIOA_BASE, 1, 8);
+    firmware_port_init(machine, UART5_BASE, GPIOC_BASE, 12, GPIOD_BASE, 2, 8);
+}
+
+/// What `init_0` used to be before the pad and baud repair: CR1 and nothing
+/// else. Kept ONLY to drive the two `diagnostic_*` tests below.
+fn legacy_usart2_init_cr1_only(machine: &mut Cm) {
+    machine
+        .bus
+        .write_u32(USART2_BASE + CR1, CR1_UE_TE_RE)
+        .unwrap();
+}
+
+/// Arm the analyzer on PA2 the way `watch_logic_signals` does, run the wake-up
+/// byte plus one M-sequence's worth of traffic through `TDR`, and count edges.
+fn tx_edges_on_pa2(machine: &mut Cm, bytes: &[u8]) -> usize {
+    let gpioa = machine
+        .bus
+        .find_peripheral_index_by_name("gpioa")
+        .expect("gpioa on the lab bus");
+    machine.logic_watch(&[Some((gpioa, TX_PIN))]);
+
+    for &byte in bytes {
+        machine.bus.write_u8(USART2_BASE + TDR, byte).unwrap();
+        // Ten bit periods per character at COM2, plus slack, so the narrator's
+        // buffered burst has had wire time to publish.
+        for _ in 0..(USARTDIV_COM2 as u64 * 12) {
+            machine.step().expect("step");
+        }
+    }
+    for _ in 0..(USARTDIV_COM2 as u64 * 40) {
+        machine.step().expect("step");
+    }
+
+    machine.logic_read_edges(0).edges.len()
+}
+
+/// THE GATE. Everything the firmware really does, and nothing it does not. A
+/// probe on PA2 must show the IO-Link wake-up preamble.
+#[test]
+fn iolink_master_lab_shows_uart_edges_on_pa2() {
+    let mut machine = lab_machine();
+    firmware_rcc_init(&mut machine);
+    firmware_all_ports_init(&mut machine);
+
+    // 0x55 is the IO-Link wake-up the master's PHY sends first (`wake_0`),
+    // followed by a type-1_1 M-sequence request.
+    let edges = tx_edges_on_pa2(&mut machine, &[0x55, 0xA2, 0x00, 0x1A]);
+
+    assert!(
+        edges > 0,
+        "a probe on PA2 (USART2_TX) captured {edges} edges while USART2 \
+         transmitted — the lab's logic analyzer shows a flat line for traffic \
+         the bus monitor decodes fine"
+    );
+}
+
+/// Which of the two old omissions was load-bearing, arm 1: the pad IS routed to
+/// AF7 and GPIOA IS clocked, but BRR is still 0 — the state the firmware left
+/// PA2 in for everything except the AF nibble. `Uart::bit_time_cycles` returns
+/// `None`, so `wire_push` drops every character before it reaches the wire.
+///
+/// This is HISTORY, pinned: it is why adding the pad mux alone would not have
+/// fixed the lab. The repaired `init_N` programs BRR, so nothing in the shipping
+/// firmware reaches this state any more.
+#[test]
+fn diagnostic_af7_alone_is_not_enough_without_brr() {
+    let mut machine = lab_machine();
+    firmware_rcc_init(&mut machine);
+    pad_af(&mut machine, GPIOA_BASE, TX_PIN, TX_AF);
+    legacy_usart2_init_cr1_only(&mut machine);
+
+    let edges = tx_edges_on_pa2(&mut machine, &[0x55, 0xA2, 0x00, 0x1A]);
+    assert_eq!(
+        edges, 0,
+        "documenting the old behaviour: no BRR ⇒ no narration at all"
+    );
+}
+
+/// Arm 2: BRR IS programmed, but the pad is left in its reset state — the state
+/// the firmware left PA2 in for everything except the divisor. The wire carries
+/// the waveform; no route reaches the pad, so no tap is registered and
+/// `read_gpio_pad` answers with the GPIO latch.
+///
+/// Also HISTORY: it is why programming the baud rate alone would not have fixed
+/// the lab either. Both halves were missing, and both are now written.
+#[test]
+fn diagnostic_brr_alone_is_not_enough_without_af7() {
+    let mut machine = lab_machine();
+    firmware_rcc_init(&mut machine);
+    machine
+        .bus
+        .write_u32(USART2_BASE + BRR, USARTDIV_COM2)
+        .unwrap();
+    legacy_usart2_init_cr1_only(&mut machine);
+
+    let edges = tx_edges_on_pa2(&mut machine, &[0x55, 0xA2, 0x00, 0x1A]);
+    assert_eq!(
+        edges, 0,
+        "documenting the old behaviour: unrouted pad ⇒ the latch, not the wire"
+    );
+}
+
+/// The control, kept from the reproduction: the same two writes done BY HAND,
+/// independent of the firmware replay above. If this ever fails while the gate
+/// passes, the replay has drifted away from the mechanism it claims to exercise.
+#[test]
+fn iolink_master_lab_shows_uart_edges_once_pad_and_baud_are_configured() {
+    let mut machine = lab_machine();
+    firmware_rcc_init(&mut machine);
+    machine
+        .bus
+        .write_u32(GPIOA_BASE + MODER, 0b10 << (TX_PIN * 2))
+        .unwrap();
+    machine
+        .bus
+        .write_u32(GPIOA_BASE + AFR, TX_AF << (u32::from(TX_PIN) * 4))
+        .unwrap();
+    machine
+        .bus
+        .write_u32(USART2_BASE + BRR, USARTDIV_COM2)
+        .unwrap();
+    legacy_usart2_init_cr1_only(&mut machine);
+
+    let edges = tx_edges_on_pa2(&mut machine, &[0x55, 0xA2, 0x00, 0x1A]);
+
+    assert!(
+        edges > 0,
+        "with AF7 + BRR configured the pad route is live and the narrator has a \
+         timebase, so the engine's own machinery should publish edges; got {edges}"
+    );
+}

--- a/examples/h563-uds-ecu/firmware/main.c
+++ b/examples/h563-uds-ecu/firmware/main.c
@@ -80,17 +80,48 @@ static volatile uint32_t g_now_ms;
 
 #define USART3_BASE 0x40004800u
 #define USART3_CR1 REG32(USART3_BASE + 0x00u)
+#define USART3_BRR REG32(USART3_BASE + 0x0Cu)
 #define USART3_ISR REG32(USART3_BASE + 0x1Cu)
 #define USART3_TDR REG32(USART3_BASE + 0x28u)
 #define USART_ISR_TXE (1u << 7)
 #define USART_CR1_UE (1u << 0)
 #define USART_CR1_TE (1u << 3)
 
+/* 115200 8N1. Nothing in this firmware configures the PLL, so the core and APB1
+ * stay on the reset clock: "after reset, the microcontroller restarts by
+ * default with an internal 32 MHz clock (HSI/2)" — STM32H563 datasheet DS14258
+ * Rev 6, section 3.12 "Reset and clock controller", p35. Under the default 16x
+ * oversampling BRR IS USARTDIV (RM0481 40.8.4):
+ *
+ *   USARTDIV = 32 000 000 / 115 200 = 277.8 -> 278 (rounded, as the ST HAL does)
+ *   actual baud = 32 000 000 / 278 = 115 107.9 (-0.08%)
+ *
+ * BRR left at its 0 reset is an invalid divisor rather than a slow one: there
+ * is no bit period at all, so nothing reaches the wire for a probe to show. */
+#define USART3_BRR_115200 278u
+
+/* PD8 = USART3_TX, PD9 = USART3_RX, both AF7 — STM32H563 datasheet DS14258
+ * Rev 6, Table 15 "Alternate functions AF0 to AF7", port D, p109. */
+#define GPIOD_BASE 0x42020C00u
+#define GPIOD_MODER REG32(GPIOD_BASE + 0x00u)
+#define GPIOD_OTYPER REG32(GPIOD_BASE + 0x04u)
+#define GPIOD_OSPEEDR REG32(GPIOD_BASE + 0x08u)
+#define GPIOD_PUPDR REG32(GPIOD_BASE + 0x0Cu)
+#define GPIOD_AFRH REG32(GPIOD_BASE + 0x24u)
+/* PD8/PD9 occupy MODER/OSPEEDR/PUPDR bits [19:16] and AFRH bits [7:0]. */
+#define PD89_PAIR_MASK (0xFu << 16)
+#define PD89_MODE_AF (0xAu << 16)
+#define PD89_AFRH_AF7 0x77u
+
 /* RCC: FDCAN1 hangs off APB1H and is clock-gated out of reset (RM0481 §11.8.38).
  * Its register surface reads 0 / ignores writes until RCC_APB1HENR.FDCAN1EN is
  * set, so the clock MUST be enabled before any FDCAN access — the simulator
  * models this gate (chip YAML `clock: { reg: apb1henr, bit: 9 }`). */
 #define RCC_BASE 0x44020C00u
+#define RCC_AHB2ENR REG32(RCC_BASE + 0x08Cu)
+#define RCC_AHB2ENR_GPIODEN (1u << 3)
+#define RCC_APB1LENR REG32(RCC_BASE + 0x09Cu)
+#define RCC_APB1LENR_USART3EN (1u << 18)
 #define RCC_APB1HENR REG32(RCC_BASE + 0x0A0u)
 #define RCC_APB1HENR_FDCAN1EN (1u << 9)
 
@@ -124,6 +155,21 @@ typedef struct {
 
 static void uart_init(void)
 {
+    /* MODER and AFR are dead until the port is clocked (RM0481 11.8.34), and a
+     * pad left in its reset state is not connected to the USART at all — so
+     * without this the console text arrives perfectly while a logic probe on
+     * PD8 shows the idle GPIO latch. Clock, mux, baud, then enable. */
+    RCC_AHB2ENR |= RCC_AHB2ENR_GPIODEN;
+    RCC_APB1LENR |= RCC_APB1LENR_USART3EN;
+
+    GPIOD_MODER = (GPIOD_MODER & ~PD89_PAIR_MASK) | PD89_MODE_AF;
+    GPIOD_OTYPER &= ~((1u << 8) | (1u << 9));
+    GPIOD_OSPEEDR |= PD89_PAIR_MASK;
+    GPIOD_PUPDR &= ~PD89_PAIR_MASK;
+    GPIOD_AFRH = (GPIOD_AFRH & ~0xFFu) | PD89_AFRH_AF7;
+
+    USART3_CR1 = 0u;
+    USART3_BRR = USART3_BRR_115200;
     USART3_CR1 = USART_CR1_UE | USART_CR1_TE;
 }
 

--- a/examples/h735-telematics-lab/src/main.rs
+++ b/examples/h735-telematics-lab/src/main.rs
@@ -21,18 +21,51 @@ use panic_halt as _;
 
 // ── Bases (configs/chips/stm32h735.yaml) ───────────────────────────────────
 const RCC_BASE: u32 = 0x5802_4400;
+const RCC_AHB4ENR: u32 = RCC_BASE + 0xE0;
 const RCC_APB1LENR: u32 = RCC_BASE + 0xE8;
 const RCC_APB2ENR: u32 = RCC_BASE + 0xF0;
 
 const GPIOA_BASE: u32 = 0x5802_0000;
+const GPIOB_BASE: u32 = 0x5802_0400;
+
+// stm32v2 GPIO: MODER @ 0x00, OTYPER @ 0x04, OSPEEDR @ 0x08, PUPDR @ 0x0C,
+// AFR[0] @ 0x20 (pins 0-7), AFR[1] @ 0x24 (pins 8-15).
+const GPIO_MODER: u32 = 0x00;
+const GPIO_OTYPER: u32 = 0x04;
+const GPIO_OSPEEDR: u32 = 0x08;
+const GPIO_PUPDR: u32 = 0x0C;
+const GPIO_AFR: u32 = 0x20;
 
 const USART3_BASE: u32 = 0x4000_4800; // console
 const USART1_BASE: u32 = 0x4001_1000; // modem
 const SPI1_BASE: u32 = 0x4001_3000; // TFT
 
-// stm32v2 UART: ISR @ 0x1C, RDR @ 0x24, TDR @ 0x28
+// stm32v2 UART: CR1 @ 0x00, BRR @ 0x0C, ISR @ 0x1C, RDR @ 0x24, TDR @ 0x28
+const USART_CR1: u32 = 0x00;
+const USART_BRR: u32 = 0x0C;
+const CR1_UE: u32 = 1 << 0;
+const CR1_RE: u32 = 1 << 2;
+const CR1_TE: u32 = 1 << 3;
 const ISR_TXE: u32 = 1 << 7;
 const ISR_RXNE: u32 = 1 << 5;
+
+/// 115200 8N1. This firmware never touches the PLL, so the core and the APB
+/// buses stay on the HSI reset clock: the H735 "system starts on the HSI clock"
+/// (DS13312 Rev 4, §3.10.1, p30), HSI is 64 MHz (same page, Table 40 p151), and
+/// RCC_CR resets with HSIDIV = 00 (÷1) per configs/peripherals/stm32h735/rcc.yaml.
+/// Under the default 16× oversampling BRR IS USARTDIV (RM0468 §51.8.4):
+///
+///   USARTDIV = 64_000_000 / 115_200 = 555.6 → 556
+///   actual baud = 64_000_000 / 556 = 115_107.9 (−0.08%)
+///
+/// Left at its 0 reset the divisor is invalid, not slow: there is no bit period,
+/// so nothing can be placed on the wire for a probe to see.
+const BRR_115200: u32 = 556;
+
+/// PA9 = USART1_TX, PA10 = USART1_RX, both AF7 — STM32H735xG datasheet DS13312
+/// Rev 4, Table 9 "pin alternate functions", port A, p97.
+/// PB10 = USART3_TX, PB11 = USART3_RX, both AF7 — same table, port B, p99.
+const AF7: u32 = 7;
 
 // SPI v2 (stm32h5): CR1, CR2, CFG1, CFG2, SR, IFCR, TXDR
 const H5_SPE: u32 = 1;
@@ -54,6 +87,61 @@ fn wr32(addr: u32, value: u32) {
 fn spin(n: u32) {
     for i in 0..n {
         core::hint::black_box(i);
+    }
+}
+
+// ── Serial pads ────────────────────────────────────────────────────────────
+
+/// Hand one pad to a USART: MODER = 10 (alternate function), push-pull, very
+/// high speed, no pull, and the AF nibble into AFR[pin / 8].
+///
+/// The AF nibble is the field that actually connects the pad to the peripheral.
+/// Without it the pin stays a plain GPIO, so a logic probe reads the output
+/// latch — a flat line — while the byte-level bus monitor decodes the same
+/// traffic perfectly. Both views are then "working" and they disagree.
+fn pad_af(gpio_base: u32, pin: u32, af: u32) {
+    let shift = pin * 2;
+    let moder = rd32(gpio_base + GPIO_MODER);
+    wr32(
+        gpio_base + GPIO_MODER,
+        (moder & !(0b11 << shift)) | (0b10 << shift),
+    );
+    wr32(
+        gpio_base + GPIO_OTYPER,
+        rd32(gpio_base + GPIO_OTYPER) & !(1 << pin),
+    );
+    wr32(
+        gpio_base + GPIO_OSPEEDR,
+        rd32(gpio_base + GPIO_OSPEEDR) | (0b11 << shift),
+    );
+    wr32(
+        gpio_base + GPIO_PUPDR,
+        rd32(gpio_base + GPIO_PUPDR) & !(0b11 << shift),
+    );
+    let afr = gpio_base + GPIO_AFR + (pin >> 3) * 4;
+    let nib = (pin & 7) * 4;
+    wr32(afr, (rd32(afr) & !(0xF << nib)) | (af << nib));
+}
+
+/// Mux both UARTs onto their pads and give each one a real bit period.
+///
+/// The H7 USART kernel clock needs no selection here: RCC_D2CCIP2R resets to 0,
+/// which is rcc_pclk2 for USART1 and rcc_pclk1 for USART3 (RM0468 §9.7.21) —
+/// the buses this firmware already leaves at their reset rate.
+fn uart_pads_init() {
+    // GPIOA (bit 0) + GPIOB (bit 1) on AHB4 — MODER/AFR are dead until the port
+    // is clocked (RM0468 §9.7.43).
+    wr32(RCC_AHB4ENR, rd32(RCC_AHB4ENR) | (1 << 0) | (1 << 1));
+
+    pad_af(GPIOA_BASE, 9, AF7); // USART1_TX → modem
+    pad_af(GPIOA_BASE, 10, AF7); // USART1_RX → modem
+    pad_af(GPIOB_BASE, 10, AF7); // USART3_TX → console
+    pad_af(GPIOB_BASE, 11, AF7); // USART3_RX → console
+
+    for base in [USART1_BASE, USART3_BASE] {
+        wr32(base + USART_CR1, 0);
+        wr32(base + USART_BRR, BRR_115200);
+        wr32(base + USART_CR1, CR1_UE | CR1_TE | CR1_RE);
     }
 }
 
@@ -449,6 +537,7 @@ fn main() -> ! {
     // Enable USART3 (APB1 bit 18) + USART1 (APB2 bit 4) + SPI1 (APB2 bit 12).
     wr32(RCC_APB1LENR, rd32(RCC_APB1LENR) | (1 << 18));
     wr32(RCC_APB2ENR, rd32(RCC_APB2ENR) | (1 << 4) | (1 << 12));
+    uart_pads_init();
 
     console_str("LabWired telematics / H735 + modem + TFT\r\n");
     console_str("Stand-in: BG770A AT model (not production modem)\r\n\r\n");

--- a/examples/h735-telematics-lab/src/subscriber.rs
+++ b/examples/h735-telematics-lab/src/subscriber.rs
@@ -12,14 +12,37 @@ use cortex_m_rt::entry;
 use panic_halt as _;
 
 const RCC_BASE: u32 = 0x5802_4400;
+const RCC_AHB4ENR: u32 = RCC_BASE + 0xE0;
 const RCC_APB1LENR: u32 = RCC_BASE + 0xE8;
 const RCC_APB2ENR: u32 = RCC_BASE + 0xF0;
+
+const GPIOA_BASE: u32 = 0x5802_0000;
+const GPIOB_BASE: u32 = 0x5802_0400;
+
+const GPIO_MODER: u32 = 0x00;
+const GPIO_OTYPER: u32 = 0x04;
+const GPIO_OSPEEDR: u32 = 0x08;
+const GPIO_PUPDR: u32 = 0x0C;
+const GPIO_AFR: u32 = 0x20;
 
 const USART3_BASE: u32 = 0x4000_4800; // console
 const USART1_BASE: u32 = 0x4001_1000; // modem
 
+const USART_CR1: u32 = 0x00;
+const USART_BRR: u32 = 0x0C;
+const CR1_UE: u32 = 1 << 0;
+const CR1_RE: u32 = 1 << 2;
+const CR1_TE: u32 = 1 << 3;
 const ISR_TXE: u32 = 1 << 7;
 const ISR_RXNE: u32 = 1 << 5;
+
+/// 115200 8N1 off the 64 MHz HSI reset clock, exactly as in `main.rs` — see the
+/// arithmetic there. USARTDIV = 64_000_000 / 115_200 = 555.6 → 556.
+const BRR_115200: u32 = 556;
+
+/// PA9/PA10 = USART1_TX/RX and PB10/PB11 = USART3_TX/RX, all AF7 — STM32H735xG
+/// datasheet DS13312 Rev 4, Table 9, port A p97 and port B p99.
+const AF7: u32 = 7;
 
 #[inline(always)]
 fn rd32(addr: u32) -> u32 {
@@ -28,6 +51,52 @@ fn rd32(addr: u32) -> u32 {
 #[inline(always)]
 fn wr32(addr: u32, value: u32) {
     unsafe { write_volatile(addr as *mut u32, value) }
+}
+
+/// Hand one pad to a USART: MODER = 10 (alternate function), push-pull, very
+/// high speed, no pull, and the AF nibble into AFR[pin / 8]. Without the AF
+/// nibble the pin stays a plain GPIO and a logic probe reads the output latch
+/// instead of the serial waveform.
+fn pad_af(gpio_base: u32, pin: u32, af: u32) {
+    let shift = pin * 2;
+    let moder = rd32(gpio_base + GPIO_MODER);
+    wr32(
+        gpio_base + GPIO_MODER,
+        (moder & !(0b11 << shift)) | (0b10 << shift),
+    );
+    wr32(
+        gpio_base + GPIO_OTYPER,
+        rd32(gpio_base + GPIO_OTYPER) & !(1 << pin),
+    );
+    wr32(
+        gpio_base + GPIO_OSPEEDR,
+        rd32(gpio_base + GPIO_OSPEEDR) | (0b11 << shift),
+    );
+    wr32(
+        gpio_base + GPIO_PUPDR,
+        rd32(gpio_base + GPIO_PUPDR) & !(0b11 << shift),
+    );
+    let afr = gpio_base + GPIO_AFR + (pin >> 3) * 4;
+    let nib = (pin & 7) * 4;
+    wr32(afr, (rd32(afr) & !(0xF << nib)) | (af << nib));
+}
+
+/// Mux both UARTs onto their pads and give each one a real bit period. The H7
+/// USART kernel clock needs no selection: RCC_D2CCIP2R resets to rcc_pclk1/2
+/// (RM0468 §9.7.21), the buses this firmware leaves at their reset rate.
+fn uart_pads_init() {
+    wr32(RCC_AHB4ENR, rd32(RCC_AHB4ENR) | (1 << 0) | (1 << 1));
+
+    pad_af(GPIOA_BASE, 9, AF7); // USART1_TX → modem
+    pad_af(GPIOA_BASE, 10, AF7); // USART1_RX → modem
+    pad_af(GPIOB_BASE, 10, AF7); // USART3_TX → console
+    pad_af(GPIOB_BASE, 11, AF7); // USART3_RX → console
+
+    for base in [USART1_BASE, USART3_BASE] {
+        wr32(base + USART_CR1, 0);
+        wr32(base + USART_BRR, BRR_115200);
+        wr32(base + USART_CR1, CR1_UE | CR1_TE | CR1_RE);
+    }
 }
 
 fn console_byte(b: u8) {
@@ -123,6 +192,7 @@ fn send_at(line: &str, buf: &mut [u8], len: &mut usize) {
 fn main() -> ! {
     wr32(RCC_APB1LENR, rd32(RCC_APB1LENR) | (1 << 18));
     wr32(RCC_APB2ENR, rd32(RCC_APB2ENR) | (1 << 4));
+    uart_pads_init();
 
     console_str("LabWired telematics subscriber / H735 + modem\r\n");
     console_str("Collect: QMTSUB telematics/# → wait +QMTRECV from fabric\r\n\r\n");

--- a/examples/iolink-station/device-fw-svc/debug_uart.c
+++ b/examples/iolink-station/device-fw-svc/debug_uart.c
@@ -1,12 +1,47 @@
 /* USART1 polled TX (debug console captured by the simulator). Driven through the
- * CMSIS register definitions. The simulator's UART model transmits on any TDR
- * write and reports TXE ready unconditionally, so only a token CR1 (UE|TE) is
- * needed. */
+ * CMSIS register definitions.
+ *
+ * The simulator's byte-level UART model transmits on any TDR write and reports
+ * TXE ready unconditionally, so a token CR1 (UE|TE) is all it takes to make the
+ * console TEXT appear. It is not what it takes to make a WAVEFORM appear: a pad
+ * left in its reset state is not connected to the USART at all, and BRR = 0 is
+ * an invalid divisor rather than a slow one, so a logic probe on the TX pad
+ * shows the idle GPIO latch while the console reads perfectly. Bring the pad
+ * and the baud rate up the way silicon needs them and it is visible both ways. */
 #include "stm32l476xx.h"
 #include "debug_uart.h"
 #include <stdint.h>
 
+/* PA9 = USART1_TX at AF7 — STM32L476xx datasheet DS10198 Rev 11, Table 17
+ * "Alternate function AF0 to AF7", p88, port A. Only TX is muxed: this console
+ * never reads RDR, and routing a pad to a receiver nothing drives would claim
+ * an idle-high line that is not ours to claim. */
+#define DBG_TX_PIN 9u
+#define DBG_TX_AF 7u
+
+/* 115200 8N1, the rate the NUCLEO-L476RG's ST-LINK virtual COM port runs at.
+ * This firmware never configures the PLL, so the core and APB2 stay on the MSI
+ * reset clock — 4 MHz, the value master/system.yaml records as `cpu_hz`. Under
+ * the default 16x oversampling BRR IS USARTDIV (RM0351 §38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 115 200 = 34.72 -> 35
+ *   actual baud = 4 000 000 / 35 = 114 285.7 (-0.79%, inside 8N1 tolerance)
+ */
+#define DBG_BRR 35u
+
 void dbg_uart_init(void) {
+    const uint32_t shift = DBG_TX_PIN * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift); /* AF mode */
+    GPIOA->OTYPER &= ~(1u << DBG_TX_PIN);                           /* push-pull */
+    GPIOA->OSPEEDR |= 3u << shift;                                  /* very high */
+    GPIOA->PUPDR &= ~(3u << shift);                                 /* no pull */
+    GPIOA->AFR[1] = (GPIOA->AFR[1] & ~(0xFu << ((DBG_TX_PIN - 8u) * 4u))) |
+                    (DBG_TX_AF << ((DBG_TX_PIN - 8u) * 4u));
+
+    USART1->CR1 = 0u;
+    USART1->CR2 = 0u;
+    USART1->CR3 = 0u;
+    USART1->BRR = DBG_BRR;
     USART1->CR1 = USART_CR1_UE | USART_CR1_TE;
 }
 

--- a/examples/iolink-station/device-fw-svc/main.c
+++ b/examples/iolink-station/device-fw-svc/main.c
@@ -86,6 +86,11 @@ static const iolink_ds_storage_api_t DS_STORAGE = {
 static void rcc_init(void) {
     RCC->APB2ENR |= RCC_APB2ENR_USART1EN;   /* debug UART */
     RCC->APB1ENR1 |= RCC_APB1ENR1_USART2EN; /* IO-Link C/Q PHY */
+    /* GPIOA carries both of them: PA2/PA3 are the USART2 C/Q pair and PA9 is
+     * the debug console TX. MODER and AFR are dead until the port is clocked
+     * (RM0351 6.4.17), so without this the pads never leave the GPIO block and
+     * a probe on the C/Q line shows the idle latch, not the serial waveform. */
+    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN;
 }
 
 int main(void) {

--- a/examples/iolink-station/device-fw-svc/phy_labwired.c
+++ b/examples/iolink-station/device-fw-svc/phy_labwired.c
@@ -10,8 +10,46 @@
 #include "phy_labwired.h"
 #include <stdint.h>
 
+/* COM2 (38.4 kbaud) is the IO-Link line speed this port runs at, so it is what
+ * the wire must actually carry. The L476 stays on its MSI reset clock - 4 MHz,
+ * the value this lab's system.yaml records as `cpu_hz`, since no PLL is ever
+ * configured - and that clock reaches APB1 unprescaled. Under the default 16x
+ * oversampling BRR IS USARTDIV (RM0351 38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 38 400 = 104.17 -> 104
+ *   actual baud = 4 000 000 / 104 = 38 461.5 (+0.16%, inside 8N1 tolerance)
+ *
+ * BRR left at its 0 reset is not a slow link, it is no link: the divisor is
+ * invalid, so there is no bit period at all and nothing reaches the wire. */
+#define IOLINK_COM2_BRR 104u
+
+/* PA2 = USART2_TX, PA3 = USART2_RX, both AF7 - STM32L476xx datasheet DS10198
+ * Rev 11, Table 17 "Alternate function AF0 to AF7", p88, port A. */
+#define CQ_TX_PIN 2u
+#define CQ_RX_PIN 3u
+#define CQ_AF 7u
+
+/* Hand one pad to USART2: MODER = 10 (alternate function), push-pull, high
+ * speed, no pull, and the AF nibble in AFR[0]. The AF number is what actually
+ * selects which peripheral owns the pad, so it is the one field that has to
+ * come from the datasheet rather than from habit. */
+static void cq_pad_af(uint32_t pin) {
+    const uint32_t shift = pin * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift);
+    GPIOA->OTYPER &= ~(1u << pin);
+    GPIOA->OSPEEDR |= 3u << shift;
+    GPIOA->PUPDR &= ~(3u << shift);
+    GPIOA->AFR[0] = (GPIOA->AFR[0] & ~(0xFu << (pin * 4u))) | (CQ_AF << (pin * 4u));
+}
+
 static int phy_init(void *user) {
     (void)user;
+    cq_pad_af(CQ_TX_PIN);
+    cq_pad_af(CQ_RX_PIN);
+    USART2->CR1 = 0u;
+    USART2->CR2 = 0u;
+    USART2->CR3 = 0u;
+    USART2->BRR = IOLINK_COM2_BRR;
     USART2->CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
     return 0;
 }

--- a/examples/iolink-station/master-fw-4port/debug_uart.c
+++ b/examples/iolink-station/master-fw-4port/debug_uart.c
@@ -1,12 +1,47 @@
 /* USART1 polled TX (debug console captured by the simulator). Driven through the
- * CMSIS register definitions. The simulator's UART model transmits on any TDR
- * write and reports TXE ready unconditionally, so only a token CR1 (UE|TE) is
- * needed. */
+ * CMSIS register definitions.
+ *
+ * The simulator's byte-level UART model transmits on any TDR write and reports
+ * TXE ready unconditionally, so a token CR1 (UE|TE) is all it takes to make the
+ * console TEXT appear. It is not what it takes to make a WAVEFORM appear: a pad
+ * left in its reset state is not connected to the USART at all, and BRR = 0 is
+ * an invalid divisor rather than a slow one, so a logic probe on the TX pad
+ * shows the idle GPIO latch while the console reads perfectly. Bring the pad
+ * and the baud rate up the way silicon needs them and it is visible both ways. */
 #include "stm32l476xx.h"
 #include "debug_uart.h"
 #include <stdint.h>
 
+/* PA9 = USART1_TX at AF7 — STM32L476xx datasheet DS10198 Rev 11, Table 17
+ * "Alternate function AF0 to AF7", p88, port A. Only TX is muxed: this console
+ * never reads RDR, and routing a pad to a receiver nothing drives would claim
+ * an idle-high line that is not ours to claim. */
+#define DBG_TX_PIN 9u
+#define DBG_TX_AF 7u
+
+/* 115200 8N1, the rate the NUCLEO-L476RG's ST-LINK virtual COM port runs at.
+ * This firmware never configures the PLL, so the core and APB2 stay on the MSI
+ * reset clock — 4 MHz, the value master/system.yaml records as `cpu_hz`. Under
+ * the default 16x oversampling BRR IS USARTDIV (RM0351 §38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 115 200 = 34.72 -> 35
+ *   actual baud = 4 000 000 / 35 = 114 285.7 (-0.79%, inside 8N1 tolerance)
+ */
+#define DBG_BRR 35u
+
 void dbg_uart_init(void) {
+    const uint32_t shift = DBG_TX_PIN * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift); /* AF mode */
+    GPIOA->OTYPER &= ~(1u << DBG_TX_PIN);                           /* push-pull */
+    GPIOA->OSPEEDR |= 3u << shift;                                  /* very high */
+    GPIOA->PUPDR &= ~(3u << shift);                                 /* no pull */
+    GPIOA->AFR[1] = (GPIOA->AFR[1] & ~(0xFu << ((DBG_TX_PIN - 8u) * 4u))) |
+                    (DBG_TX_AF << ((DBG_TX_PIN - 8u) * 4u));
+
+    USART1->CR1 = 0u;
+    USART1->CR2 = 0u;
+    USART1->CR3 = 0u;
+    USART1->BRR = DBG_BRR;
     USART1->CR1 = USART_CR1_UE | USART_CR1_TE;
 }
 

--- a/examples/iolink-station/master-fw-4port/main.c
+++ b/examples/iolink-station/master-fw-4port/main.c
@@ -35,6 +35,16 @@ static void rcc_init(void) {
     RCC->APB2ENR |= RCC_APB2ENR_USART1EN; /* debug UART */
     RCC->APB1ENR1 |= RCC_APB1ENR1_USART2EN | RCC_APB1ENR1_USART3EN |
                      RCC_APB1ENR1_UART4EN | RCC_APB1ENR1_UART5EN; /* IO-Link ports */
+    /* The GPIO ports carrying those USART pads (RM0351 §6.4.17). A pad only
+     * leaves the GPIO block and reaches the USART once MODER selects alternate
+     * function AND the AFR nibble names the peripheral — and both of those
+     * registers are dead until the port is clocked. Without this a scope on the
+     * C/Q pad shows the idle GPIO latch while the bus decodes traffic fine.
+     *   A: PA0/PA1 UART4, PA2/PA3 USART2, PA9/PA10 USART1 (debug)
+     *   B: PB10/PB11 USART3
+     *   C: PC12 UART5_TX      D: PD2 UART5_RX */
+    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN | RCC_AHB2ENR_GPIOBEN |
+                    RCC_AHB2ENR_GPIOCEN | RCC_AHB2ENR_GPIODEN;
 }
 
 int main(void) {

--- a/examples/iolink-station/master-fw-4port/phy_labwired.c
+++ b/examples/iolink-station/master-fw-4port/phy_labwired.c
@@ -28,7 +28,34 @@ static int p_set_baud_chk(iolink_baudrate_t b) {
 }
 static int p_prepare(void) { return 0; }
 
-#define PORT(IDX, U)                                                            \
+/* COM2 (38.4 kbaud) is what fill_one() asks the master stack for, so it is what
+ * the wire must actually carry. The L476 runs this lab on the MSI reset clock,
+ * 4 MHz (master/system.yaml `cpu_hz: 4_000_000` — no PLL is ever configured),
+ * and that clock feeds APB1/APB2 unprescaled. Under the default 16x
+ * oversampling BRR IS USARTDIV (RM0351 §38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 38 400 = 104.17 -> 104
+ *   actual baud = 4 000 000 / 104 = 38 461.5 (+0.16%, well inside 8N1 tolerance)
+ *
+ * Leaving BRR at its 0 reset is not a slow link, it is no link: the divisor is
+ * invalid, so there is no bit period at all. */
+#define IOLINK_COM2_BRR 104u
+
+/* Hand one pad to a USART: MODER = 10 (alternate function), push-pull, high
+ * speed, no pull, and the AF nibble in AFR[pin/8]. The AF number is what
+ * actually selects WHICH peripheral gets the pad, so it is the one field that
+ * must come from the datasheet rather than from habit. */
+static void pad_af(GPIO_TypeDef *g, uint32_t pin, uint32_t af) {
+    const uint32_t shift = pin * 2u;
+    g->MODER = (g->MODER & ~(3u << shift)) | (2u << shift);
+    g->OTYPER &= ~(1u << pin);
+    g->OSPEEDR |= 3u << shift;
+    g->PUPDR &= ~(3u << shift);
+    g->AFR[pin >> 3u] = (g->AFR[pin >> 3u] & ~(0xFu << ((pin & 7u) * 4u))) |
+                        (af << ((pin & 7u) * 4u));
+}
+
+#define PORT(IDX, U, GTX, TXP, GRX, RXP, AF)                                    \
     static int send_##IDX(void *user, const uint8_t *d, size_t n) {             \
         (void)user;                                                             \
         for (size_t i = 0; i < n; i++) {                                        \
@@ -48,6 +75,12 @@ static int p_prepare(void) { return 0; }
     }                                                                           \
     static int init_##IDX(void *user) {                                         \
         (void)user;                                                             \
+        pad_af((GTX), (TXP), (AF));                                             \
+        pad_af((GRX), (RXP), (AF));                                             \
+        (U)->CR1 = 0u;                                                          \
+        (U)->CR2 = 0u;                                                          \
+        (U)->CR3 = 0u;                                                          \
+        (U)->BRR = IOLINK_COM2_BRR;                                             \
         (U)->CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;                  \
         return 0;                                                              \
     }                                                                           \
@@ -62,10 +95,20 @@ static int p_prepare(void) { return 0; }
         return 0;                                                              \
     }
 
-PORT(0, USART2)
-PORT(1, USART3)
-PORT(2, UART4)
-PORT(3, UART5)
+/* Pad + AF per port, every row read off STM32L476xx datasheet DS10198 Rev 11:
+ * Table 17 "Alternate function AF0 to AF7" for the USART1/2/3 rows and Table 18
+ * "AF8 to AF15" for the UART4/5 rows.
+ *   PA2/PA3   AF7  USART2_TX / USART2_RX   (Table 17, p88, port A)
+ *   PB10/PB11 AF7  USART3_TX / USART3_RX   (Table 17, p89, port B)
+ *   PA0/PA1   AF8  UART4_TX  / UART4_RX    (Table 18, p95, port A)
+ *   PC12      AF8  UART5_TX                (Table 18, p97, port C)
+ *   PD2       AF8  UART5_RX                (Table 18, p98, port D)
+ * UART5 is the one port whose TX and RX sit on different GPIO ports, which is
+ * why the macro takes a port per direction rather than one for both. */
+PORT(0, USART2, GPIOA, 2u, GPIOA, 3u, 7u)
+PORT(1, USART3, GPIOB, 10u, GPIOB, 11u, 7u)
+PORT(2, UART4, GPIOA, 0u, GPIOA, 1u, 8u)
+PORT(3, UART5, GPIOC, 12u, GPIOD, 2u, 8u)
 
 static void fill_one(iolink_phy_api_t *phy, iolink_master_config_t *cfg,
                      int (*init)(void *), int (*send)(void *, const uint8_t *, size_t),

--- a/examples/iolink-station/master-fw-svc/debug_uart.c
+++ b/examples/iolink-station/master-fw-svc/debug_uart.c
@@ -1,12 +1,47 @@
 /* USART1 polled TX (debug console captured by the simulator). Driven through the
- * CMSIS register definitions. The simulator's UART model transmits on any TDR
- * write and reports TXE ready unconditionally, so only a token CR1 (UE|TE) is
- * needed. */
+ * CMSIS register definitions.
+ *
+ * The simulator's byte-level UART model transmits on any TDR write and reports
+ * TXE ready unconditionally, so a token CR1 (UE|TE) is all it takes to make the
+ * console TEXT appear. It is not what it takes to make a WAVEFORM appear: a pad
+ * left in its reset state is not connected to the USART at all, and BRR = 0 is
+ * an invalid divisor rather than a slow one, so a logic probe on the TX pad
+ * shows the idle GPIO latch while the console reads perfectly. Bring the pad
+ * and the baud rate up the way silicon needs them and it is visible both ways. */
 #include "stm32l476xx.h"
 #include "debug_uart.h"
 #include <stdint.h>
 
+/* PA9 = USART1_TX at AF7 — STM32L476xx datasheet DS10198 Rev 11, Table 17
+ * "Alternate function AF0 to AF7", p88, port A. Only TX is muxed: this console
+ * never reads RDR, and routing a pad to a receiver nothing drives would claim
+ * an idle-high line that is not ours to claim. */
+#define DBG_TX_PIN 9u
+#define DBG_TX_AF 7u
+
+/* 115200 8N1, the rate the NUCLEO-L476RG's ST-LINK virtual COM port runs at.
+ * This firmware never configures the PLL, so the core and APB2 stay on the MSI
+ * reset clock — 4 MHz, the value master/system.yaml records as `cpu_hz`. Under
+ * the default 16x oversampling BRR IS USARTDIV (RM0351 §38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 115 200 = 34.72 -> 35
+ *   actual baud = 4 000 000 / 35 = 114 285.7 (-0.79%, inside 8N1 tolerance)
+ */
+#define DBG_BRR 35u
+
 void dbg_uart_init(void) {
+    const uint32_t shift = DBG_TX_PIN * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift); /* AF mode */
+    GPIOA->OTYPER &= ~(1u << DBG_TX_PIN);                           /* push-pull */
+    GPIOA->OSPEEDR |= 3u << shift;                                  /* very high */
+    GPIOA->PUPDR &= ~(3u << shift);                                 /* no pull */
+    GPIOA->AFR[1] = (GPIOA->AFR[1] & ~(0xFu << ((DBG_TX_PIN - 8u) * 4u))) |
+                    (DBG_TX_AF << ((DBG_TX_PIN - 8u) * 4u));
+
+    USART1->CR1 = 0u;
+    USART1->CR2 = 0u;
+    USART1->CR3 = 0u;
+    USART1->BRR = DBG_BRR;
     USART1->CR1 = USART_CR1_UE | USART_CR1_TE;
 }
 

--- a/examples/iolink-station/master-fw-svc/main.c
+++ b/examples/iolink-station/master-fw-svc/main.c
@@ -84,6 +84,11 @@ volatile uint8_t g_diag_event_pending = 0u;
 static void rcc_init(void) {
     RCC->APB2ENR |= RCC_APB2ENR_USART1EN;   /* debug UART */
     RCC->APB1ENR1 |= RCC_APB1ENR1_USART2EN; /* IO-Link C/Q PHY */
+    /* GPIOA carries both of them: PA2/PA3 are the USART2 C/Q pair and PA9 is
+     * the debug console TX. MODER and AFR are dead until the port is clocked
+     * (RM0351 6.4.17), so without this the pads never leave the GPIO block and
+     * a probe on the C/Q line shows the idle latch, not the serial waveform. */
+    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN;
 }
 
 int main(void) {

--- a/examples/iolink-station/master-fw-svc/phy_labwired.c
+++ b/examples/iolink-station/master-fw-svc/phy_labwired.c
@@ -15,8 +15,46 @@
 #include "phy_labwired.h"
 #include <stdint.h>
 
+/* COM2 (38.4 kbaud) is the IO-Link line speed this port runs at, so it is what
+ * the wire must actually carry. The L476 stays on its MSI reset clock - 4 MHz,
+ * the value this lab's system.yaml records as `cpu_hz`, since no PLL is ever
+ * configured - and that clock reaches APB1 unprescaled. Under the default 16x
+ * oversampling BRR IS USARTDIV (RM0351 38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 38 400 = 104.17 -> 104
+ *   actual baud = 4 000 000 / 104 = 38 461.5 (+0.16%, inside 8N1 tolerance)
+ *
+ * BRR left at its 0 reset is not a slow link, it is no link: the divisor is
+ * invalid, so there is no bit period at all and nothing reaches the wire. */
+#define IOLINK_COM2_BRR 104u
+
+/* PA2 = USART2_TX, PA3 = USART2_RX, both AF7 - STM32L476xx datasheet DS10198
+ * Rev 11, Table 17 "Alternate function AF0 to AF7", p88, port A. */
+#define CQ_TX_PIN 2u
+#define CQ_RX_PIN 3u
+#define CQ_AF 7u
+
+/* Hand one pad to USART2: MODER = 10 (alternate function), push-pull, high
+ * speed, no pull, and the AF nibble in AFR[0]. The AF number is what actually
+ * selects which peripheral owns the pad, so it is the one field that has to
+ * come from the datasheet rather than from habit. */
+static void cq_pad_af(uint32_t pin) {
+    const uint32_t shift = pin * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift);
+    GPIOA->OTYPER &= ~(1u << pin);
+    GPIOA->OSPEEDR |= 3u << shift;
+    GPIOA->PUPDR &= ~(3u << shift);
+    GPIOA->AFR[0] = (GPIOA->AFR[0] & ~(0xFu << (pin * 4u))) | (CQ_AF << (pin * 4u));
+}
+
 static int phy_init(void *user) {
     (void)user;
+    cq_pad_af(CQ_TX_PIN);
+    cq_pad_af(CQ_RX_PIN);
+    USART2->CR1 = 0u;
+    USART2->CR2 = 0u;
+    USART2->CR3 = 0u;
+    USART2->BRR = IOLINK_COM2_BRR;
     USART2->CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
     return 0;
 }

--- a/examples/iolink-station/master-fw/debug_uart.c
+++ b/examples/iolink-station/master-fw/debug_uart.c
@@ -1,12 +1,47 @@
 /* USART1 polled TX (debug console captured by the simulator). Driven through the
- * CMSIS register definitions. The simulator's UART model transmits on any TDR
- * write and reports TXE ready unconditionally, so only a token CR1 (UE|TE) is
- * needed. */
+ * CMSIS register definitions.
+ *
+ * The simulator's byte-level UART model transmits on any TDR write and reports
+ * TXE ready unconditionally, so a token CR1 (UE|TE) is all it takes to make the
+ * console TEXT appear. It is not what it takes to make a WAVEFORM appear: a pad
+ * left in its reset state is not connected to the USART at all, and BRR = 0 is
+ * an invalid divisor rather than a slow one, so a logic probe on the TX pad
+ * shows the idle GPIO latch while the console reads perfectly. Bring the pad
+ * and the baud rate up the way silicon needs them and it is visible both ways. */
 #include "stm32l476xx.h"
 #include "debug_uart.h"
 #include <stdint.h>
 
+/* PA9 = USART1_TX at AF7 — STM32L476xx datasheet DS10198 Rev 11, Table 17
+ * "Alternate function AF0 to AF7", p88, port A. Only TX is muxed: this console
+ * never reads RDR, and routing a pad to a receiver nothing drives would claim
+ * an idle-high line that is not ours to claim. */
+#define DBG_TX_PIN 9u
+#define DBG_TX_AF 7u
+
+/* 115200 8N1, the rate the NUCLEO-L476RG's ST-LINK virtual COM port runs at.
+ * This firmware never configures the PLL, so the core and APB2 stay on the MSI
+ * reset clock — 4 MHz, the value master/system.yaml records as `cpu_hz`. Under
+ * the default 16x oversampling BRR IS USARTDIV (RM0351 §38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 115 200 = 34.72 -> 35
+ *   actual baud = 4 000 000 / 35 = 114 285.7 (-0.79%, inside 8N1 tolerance)
+ */
+#define DBG_BRR 35u
+
 void dbg_uart_init(void) {
+    const uint32_t shift = DBG_TX_PIN * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift); /* AF mode */
+    GPIOA->OTYPER &= ~(1u << DBG_TX_PIN);                           /* push-pull */
+    GPIOA->OSPEEDR |= 3u << shift;                                  /* very high */
+    GPIOA->PUPDR &= ~(3u << shift);                                 /* no pull */
+    GPIOA->AFR[1] = (GPIOA->AFR[1] & ~(0xFu << ((DBG_TX_PIN - 8u) * 4u))) |
+                    (DBG_TX_AF << ((DBG_TX_PIN - 8u) * 4u));
+
+    USART1->CR1 = 0u;
+    USART1->CR2 = 0u;
+    USART1->CR3 = 0u;
+    USART1->BRR = DBG_BRR;
     USART1->CR1 = USART_CR1_UE | USART_CR1_TE;
 }
 

--- a/examples/iolink-station/master-fw/main.c
+++ b/examples/iolink-station/master-fw/main.c
@@ -35,6 +35,11 @@ volatile uint8_t g_master_pd0 = 0xFFu;
 static void rcc_init(void) {
     RCC->APB2ENR |= RCC_APB2ENR_USART1EN;   /* debug UART */
     RCC->APB1ENR1 |= RCC_APB1ENR1_USART2EN; /* IO-Link C/Q PHY */
+    /* GPIOA carries both of them: PA2/PA3 are the USART2 C/Q pair and PA9 is
+     * the debug console TX. MODER and AFR are dead until the port is clocked
+     * (RM0351 6.4.17), so without this the pads never leave the GPIO block and
+     * a probe on the C/Q line shows the idle latch, not the serial waveform. */
+    RCC->AHB2ENR |= RCC_AHB2ENR_GPIOAEN;
 }
 
 int main(void) {

--- a/examples/iolink-station/master-fw/phy_labwired.c
+++ b/examples/iolink-station/master-fw/phy_labwired.c
@@ -15,8 +15,46 @@
 #include "phy_labwired.h"
 #include <stdint.h>
 
+/* COM2 (38.4 kbaud) is the IO-Link line speed this port runs at, so it is what
+ * the wire must actually carry. The L476 stays on its MSI reset clock - 4 MHz,
+ * the value this lab's system.yaml records as `cpu_hz`, since no PLL is ever
+ * configured - and that clock reaches APB1 unprescaled. Under the default 16x
+ * oversampling BRR IS USARTDIV (RM0351 38.5.4):
+ *
+ *   USARTDIV = f_ck / baud = 4 000 000 / 38 400 = 104.17 -> 104
+ *   actual baud = 4 000 000 / 104 = 38 461.5 (+0.16%, inside 8N1 tolerance)
+ *
+ * BRR left at its 0 reset is not a slow link, it is no link: the divisor is
+ * invalid, so there is no bit period at all and nothing reaches the wire. */
+#define IOLINK_COM2_BRR 104u
+
+/* PA2 = USART2_TX, PA3 = USART2_RX, both AF7 - STM32L476xx datasheet DS10198
+ * Rev 11, Table 17 "Alternate function AF0 to AF7", p88, port A. */
+#define CQ_TX_PIN 2u
+#define CQ_RX_PIN 3u
+#define CQ_AF 7u
+
+/* Hand one pad to USART2: MODER = 10 (alternate function), push-pull, high
+ * speed, no pull, and the AF nibble in AFR[0]. The AF number is what actually
+ * selects which peripheral owns the pad, so it is the one field that has to
+ * come from the datasheet rather than from habit. */
+static void cq_pad_af(uint32_t pin) {
+    const uint32_t shift = pin * 2u;
+    GPIOA->MODER = (GPIOA->MODER & ~(3u << shift)) | (2u << shift);
+    GPIOA->OTYPER &= ~(1u << pin);
+    GPIOA->OSPEEDR |= 3u << shift;
+    GPIOA->PUPDR &= ~(3u << shift);
+    GPIOA->AFR[0] = (GPIOA->AFR[0] & ~(0xFu << (pin * 4u))) | (CQ_AF << (pin * 4u));
+}
+
 static int phy_init(void *user) {
     (void)user;
+    cq_pad_af(CQ_TX_PIN);
+    cq_pad_af(CQ_RX_PIN);
+    USART2->CR1 = 0u;
+    USART2->CR2 = 0u;
+    USART2->CR3 = 0u;
+    USART2->BRR = IOLINK_COM2_BRR;
     USART2->CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
     return 0;
 }


### PR DESCRIPTION
## Why

A probe on `PA2` (USART2_TX) in the live `iolink-station-4port` lab reads **0 edges** while the transaction-level bus monitor decodes 512 UART bytes. Two firmware omissions, not an engine bug:

1. **`BRR` was never programmed.** `Uart::bit_time_cycles` returns `None` for a zero divisor, so `wire_push` dropped every character before it reached the wire. Nothing to narrate.
2. **The pad was never muxed.** The GPIO port was never clocked, `MODER` never selected alternate function, and the `AFR` nibble was never written. `PadRoutes::active` found no live route, so the probe read the GPIO output latch.

An unmuxed pad SHOULD be dark — the engine is behaving correctly. Correctly configured firmware works on the **current** engine with no model change, which is why this is firmware-only. **No engine/model file is touched.**

## What changed

| Firmware | Before | After |
|---|---|---|
| `iolink-station/master-fw-4port` | `CR1 = UE\|TE\|RE` only | GPIO A/B/C/D clocked; TX+RX muxed per port; `CR1/2/3` cleared; `BRR = 104` |
| `iolink-station/master-fw`, `master-fw-svc`, `device-fw-svc` | `CR1 = UE\|TE\|RE` only | GPIOA clocked; PA2/PA3 → AF7; `BRR = 104` |
| `debug_uart.c` (all four) | `CR1 = UE\|TE` only | PA9 → AF7; `BRR = 35` |
| `h735-telematics-lab` `main.rs`, `subscriber.rs` | clock enables only, no `CR1`/`BRR`/GPIO | GPIOA/B on `AHB4ENR`; PA9/PA10 + PB10/PB11 → AF7; `BRR = 556`; `CR1 = UE\|TE\|RE` |
| `h563-uds-ecu/firmware/main.c` | `CR1 = UE\|TE` only | GPIOD + USART3 clocked; PD8/PD9 → AF7; `BRR = 278` |

### Divisor arithmetic

Each is computed from that lab's own configured clock, stated in a comment at the definition. Under 16× oversampling `BRR` **is** `USARTDIV`.

- **L476 IO-Link ports** — 4 MHz MSI reset clock (`master/system.yaml` `cpu_hz: 4_000_000`, no PLL configured), COM2 38.4 kbaud: `4_000_000 / 38_400 = 104.17 → 104` (+0.16%).
- **L476 debug console** — 4 MHz at 115200 (NUCLEO-L476RG ST-LINK VCP rate): `4_000_000 / 115_200 = 34.72 → 35` (−0.79%).
- **H735** — 64 MHz HSI reset clock: `64_000_000 / 115_200 = 555.6 → 556` (−0.08%).
- **H563** — 32 MHz reset clock (HSI/2, DS14258 Rev 6 p35): `32_000_000 / 115_200 = 277.8 → 278` (−0.08%).

### AF numbers, every one from the datasheet

Verified via `labwired_datasheet`; no PDF was downloaded. Citations are in the source.

- **DS10198 Rev 11 (L476)** — Table 17 p88: PA2/PA3 AF7 USART2_TX/RX, PA9 AF7 USART1_TX; p89: PB10/PB11 AF7 USART3_TX/RX. Table 18 p95: PA0/PA1 AF8 UART4_TX/RX; p97: PC12 AF8 UART5_TX; p98: PD2 AF8 UART5_RX.
- **DS13312 Rev 4 (H735)** — Table 9 p97: PA9/PA10 AF7 USART1_TX/RX; p99: PB10/PB11 AF7 USART3_TX/RX.
- **DS14258 Rev 6 (H563)** — Table 15 p109: PD8/PD9 AF7 USART3_TX/RX.

## The gate

`crates/core/tests/logic_analyzer_lab_pad_visibility.rs` builds the lab through the playground's own config path (`SystemManifest::from_file` → relative `chip:` → `SystemBus::from_config`), calls no `wire_*_pads` by hand, and replays **only** the register writes the firmware actually performs.

It was **watched failing first**, against pristine `origin/main` firmware:

```
test iolink_master_lab_shows_uart_edges_on_pa2 ... FAILED
a probe on PA2 (USART2_TX) captured 0 edges while USART2 transmitted
test result: FAILED. 3 passed; 1 failed
EXIT=101
```

After the repair, both feature sets exit 0:

```
running 4 tests
test diagnostic_af7_alone_is_not_enough_without_brr ... ok
test diagnostic_brr_alone_is_not_enough_without_af7 ... ok
test iolink_master_lab_shows_uart_edges_once_pad_and_baud_are_configured ... ok
test iolink_master_lab_shows_uart_edges_on_pa2 ... ok
test result: ok. 4 passed; 0 failed
```

The gate is live under **both** feature sets: reverting only the replay to the pre-fix sequence fails at exit 101 bare *and* with `--features event-scheduler`. The two `diagnostic_*` tests keep each half of the old behaviour pinned, so the reason the pad was dark stays documented.

## Verification

- `cargo test -p labwired-core --test logic_analyzer_lab_pad_visibility` — exit 0
- same with `--features event-scheduler` — exit 0
- `cargo check --target thumbv7em-none-eabihf` (h735, both bins) — exit 0
- All 12 C files syntax-clean under `-Wall -Wextra` (CMSIS/`stm32l476xx.h` is an external pack, so a stub header was used; H563 `uart_init` checked in isolation as udslib is fetched at build time)
- `cargo fmt --all -- --check` — exit 0
- Regression, all exit 0: `e2e_iolink_dido`, `iolink_native_master` (incl. the CI's `--features iolink-native` gate, 6 passed), `world_multichip`, `world_station_services`, `world_can_bus`, `labwired-cli e2e_h563_uds`

## ⚠️ This does not fix the live labs yet

Production runs prebuilt ELFs published as GitHub Release assets and pinned by sha256 in `packages/playground/demo-assets.json`; they are not built from source at deploy. These ELFs must be rebuilt and republished before a user sees any change:

- `examples/iolink-station/master-fw-4port/master.elf` (the `iolink-station-4port` lab)
- `examples/iolink-station/master-fw/master.elf`, `master-fw-svc/`, `device-fw-svc/`
- `examples/h735-telematics-lab` — both `h735-telematics-lab` and `h735-telematics-subscriber` bins
- `examples/h563-uds-ecu/firmware/h563_uds_ecu.elf` (committed in-tree, still the old build)

## Known engine-side limit (not addressed here, out of scope)

`wire_stm32_uart_pads` iterates instances 1–3 only, so **UART4/UART5 pads can never route** regardless of firmware. Ports 2 and 3 of the 4-port master are configured correctly for silicon but will still read flat in the analyzer. Closing that needs an engine change.