### PR TITLE
test: 57 test targets could report success while running nothing

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -508,8 +508,16 @@ jobs:
       # the CLI and livelocked in the browser for as long as nobody ran a
       # browser-configuration lane. A gate nobody runs on PRs is a gate this
       # class walks back through.
+      #
+      # Run through `cargo-test-nonvacuous.sh`: under DEFAULT features this file
+      # is down to ONE test, and "one" and "zero" print the same colour. The
+      # wrapper asks the built binary how many tests it holds and fails on zero,
+      # so if a `#[cfg]` ever empties the structural arm this step says so
+      # instead of reporting `0 passed` as a pass.
       - name: Walk-deletion derivation (PR-fast structural arm)
-        run: cargo test -p labwired-core --test esp32_classic_walk_differential
+        run: >
+          scripts/ci/cargo-test-nonvacuous.sh
+          -p labwired-core --test esp32_classic_walk_differential
 
       # THE SHARED-MODEL NET THAT NEVER GATED A MERGE.
       #
@@ -668,7 +676,8 @@ jobs:
       # "was skipped" is the failure mode this job was added to remove.
       - name: Observable arm — classic-ESP32 serial reaches the sink (browser policy)
         run: >
-          cargo test -p labwired-core --features event-scheduler
+          scripts/ci/cargo-test-nonvacuous.sh
+          -p labwired-core --features event-scheduler
           --test esp32_classic_walk_differential -- --nocapture
 
       # SCHEDULER-ONLY FIDELITY LANES — the tests that no PR job could run.
@@ -703,9 +712,18 @@ jobs:
       # + `--features event-scheduler` is this job, and only this job. The fix
       # that took `live_event_ceiling_trips` from 3310 to 0 merged with nothing
       # asserting that number anywhere.
+      #
+      # `cargo-test-nonvacuous.sh`, not bare `cargo test`: every file below is
+      # `#![cfg(feature = "event-scheduler")]`, which is the exact shape that
+      # prints `test result: ok. 0 passed` and exits 0 when the feature is
+      # missing. The manifests now carry `required-features`, so cargo would
+      # refuse rather than fake it — the wrapper is the second lock, and it also
+      # catches the emptying this step could still suffer silently: a per-item
+      # `#[cfg]` or a deleted test leaving a binary with nothing in it.
       - name: Scheduler-only fidelity lanes (walk≡scheduler timing gates)
         run: >
-          cargo test -p labwired-core --features event-scheduler
+          scripts/ci/cargo-test-nonvacuous.sh
+          -p labwired-core --features event-scheduler
           --test esp32c3_bt_event_residency_gate
           --test nrf52_timer_walk_differential
           --test nrf52_easydma_tick512_fidelity
@@ -933,6 +951,32 @@ jobs:
         run: >
           cargo test -p labwired-hw-oracle
           --features labwired-core/event-scheduler
+
+      # HARDWARE-ONLY HARNESSES — COMPILED HERE, DELIBERATELY NOT RUN.
+      #
+      # `hw-oracle-nrf52` and `hw-oracle-stm32` gate ten integration files that
+      # drive a PHYSICAL nRF52840 / STM32F103 over ST-Link SWD (`OpenOcd`,
+      # `LABWIRED_STLINK_SERIAL`). No hosted runner has a board on it, so
+      # running them is not a throughput decision, it is impossible — that is
+      # the written reason this step is `--no-run`.
+      #
+      # Compiling them is NOT optional, and this is what it cost to learn:
+      # because no lane anywhere enabled either feature, rustc had never seen
+      # these files, and FIVE of them had rotted into a hard compile error —
+      # `no method named write_u32 found for &mut SystemBus`, a lost
+      # `use labwired_core::Bus`, in nrf52_mmio_diff, nrf52_gpio_conformance,
+      # nrf52_onboarding_diff, nrf52_power_conformance,
+      # nrf52_full_register_conformance and nrf52_timer_rtc_conformance. The
+      # bring-up harness for a whole chip family was unbuildable and nothing
+      # said so, exactly as `crates/core/tests/event_scheduler.rs` rotted behind
+      # `cfg(not(debug_assertions))` until the release lane above existed.
+      #
+      # The crate is small and its dependency graph is already warm from the
+      # step above, so this is seconds.
+      - name: Compile-only — hardware-oracle harnesses (nRF52 / STM32 over SWD)
+        run: >
+          cargo test -p labwired-hw-oracle
+          --features hw-oracle-nrf52,hw-oracle-stm32 --no-run
 
   # ── CI runner OCI smoke (NOT a PR required check) ──────────────────────────
   ci-runner-image:

--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -195,6 +195,19 @@ jobs:
         # None by design, breaking the ROM-provisioning tests).
         run: cargo test --release -p labwired-core --features esp32s3-fixtures --test e2e_blinky --test e2e_hello_world --test e2e_i2c_tmp102
 
+      # WHY `openai_deck_s3_boot` IS NOT IN EITHER LINE ABOVE.
+      #
+      # It is the fifth `#![cfg(feature = "esp32s3-fixtures")]` file, and it is
+      # the only one no lane names — so before `required-features` landed on
+      # these targets it was one `--test openai_deck_s3_boot` away from
+      # reporting `test result: ok. 0 passed` at anyone who went looking for it.
+      # It is left OFF on purpose, not by oversight: `examples/openai-deck-s3`
+      # is quarantined over a REAL ESP32-S3 hang in the deck firmware, and a
+      # lane here would be measuring the quarantine. Reproduce it by hand with
+      #   cargo test -p labwired-core --features esp32s3-fixtures --release \
+      #     --test openai_deck_s3_boot -- --nocapture
+      # Turn this into a step when the S3 hang is fixed, not before.
+
   # ── ESP32-C3 BLE baseband: the only gate that runs a real BLE stack ────────
   #
   # `crates/core/src/peripherals/esp32c3/bt.rs` models the BLE baseband window
@@ -472,3 +485,110 @@ jobs:
 
           print(f"All {len(committed)} fixture blobs match committed manifest hashes.")
           EOF
+
+  # ── THE FEATURES NO WORKFLOW EVER TURNED ON ────────────────────────────────
+  #
+  # A `#![cfg(feature = "x")]` integration test built without `x` compiles to an
+  # EMPTY libtest binary: `test result: ok. 0 passed`, exit 0, green tick. Until
+  # this job existed, SEVEN of this repo's features were named by no workflow at
+  # all — `silent-census`, `net-tests`, `wifi-thunks`, `jit-framework`,
+  # `mlx90640-decode-test`, `hw-oracle-nrf52`, `hw-oracle-stm32` — so twenty-two
+  # test targets were not "skipped", they were reported as PASSING, forever.
+  #
+  # `required-features` in the manifests now stops those targets from faking a
+  # pass. It does not make them RUN. This job does, for the ones a hosted runner
+  # can run; the two `hw-oracle-*` features need a physical board over SWD and
+  # are compile-checked in `core-integrity` instead, with the reason written
+  # there.
+  #
+  # Nightly rather than pre-merge on cost: each step below is a distinct feature
+  # variant of `labwired-core`, i.e. a full recompile of the crate, for a few
+  # seconds of test runtime. Put a step here first; promote it into `core-ci` if
+  # it ever catches something a PR should have caught.
+  never-run-features:
+    name: never-run-feature-lanes
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: core-nightly-never-run-features
+          workspaces: |
+            . -> target
+
+      # `silent-census` counts the three paths on which the simulator can be
+      # wrong and still report success; `net-tests` opens real localhost
+      # sockets for the egress bridge. Both measured green locally on this
+      # tree (census_probe 3/3, egress_e2e 1/1) — the only thing that was ever
+      # wrong with them is that nothing ran them.
+      #
+      # Through the wrapper, because that is the whole point: if a future
+      # feature rename empties one of these binaries, the step must go RED
+      # rather than back to the `0 passed` it spent its whole life reporting.
+      - name: Census probe + egress bridge (silent-census, net-tests)
+        run: >
+          scripts/ci/cargo-test-nonvacuous.sh
+          -p labwired-core --features silent-census,net-tests,wifi-thunks
+          --test census_probe --test egress_e2e
+
+      # `wifi-thunks` gates ONE test and it is `#[ignore]`d, so a plain lane
+      # would run zero of it and report green — a vacuous gate is worse than
+      # none. `-- --ignored` is what actually executes it. Same feature set as
+      # the step above so it is a cache hit, not a second compile.
+      - name: WiFi thunk bring-up harness (wifi-thunks, #[ignore]d)
+        run: >
+          cargo test -p labwired-core
+          --features silent-census,net-tests,wifi-thunks
+          --test e2e_labwired_wifi -- --ignored
+
+      # Compiles the REAL vendored Melexis MLX90640 driver (third_party/) and
+      # asserts it decodes per-pixel °C out of the LabWired device model. Needs
+      # a C compiler, which ubuntu-latest has. 3/3 locally.
+      - name: MLX90640 round-trip through the real vendor driver
+        run: >
+          scripts/ci/cargo-test-nonvacuous.sh
+          -p labwired-core --features mlx90640-decode-test
+          --test mlx90640_decode
+
+      # ⚠️ THIS STEP IS RED TODAY, AND THAT IS THE FINDING.
+      #
+      # These files assert the universal-dispatch JIT is BYTE-IDENTICAL to the
+      # interpreter — the property that makes a JIT admissible in a simulator
+      # sold as an oracle. `jit-framework` was named by no workflow, so they had
+      # never executed. Run on this tree (debug, macOS aarch64, and identically
+      # with and without `event-scheduler`, so it is not a feature interaction):
+      #
+      #   riscv_jit_lockstep            1/1  ok
+      #   riscv_jit_alu_lockstep        2/2  ok (1 ignored)
+      #   riscv_jit_branch_lockstep     1 FAILED  "no block ever crossed the hot
+      #                                            threshold / compiled"
+      #   riscv_jit_mem_lockstep        2 FAILED  "no block compiled",
+      #                                           "no memory block compiled"
+      #   riscv_jit_combined_lockstep   2 FAILED  "no block compiled",
+      #                                           "no combined block compiled"
+      #
+      # Every failure is the same shape: the frontend never compiles a block, so
+      # the lockstep never happens. The tests are not wrong — they REFUSE to
+      # pass on a JIT that never engaged, which is the anti-vacuity this repo
+      # runs on. Leaving the step out to keep the tick green would re-create
+      # exactly the silence that hid it.
+      #
+      # `--no-fail-fast` so one red target does not hide the other four.
+      # `riscv_jit_combined_bench` and `riscv_jit_c3_oled_differential` are
+      # excluded: every test in them is `#[ignore]`d (a micro-benchmark and a
+      # ~30M-step release-only differential), so a step naming them would report
+      # a green tick for zero executed tests.
+      - name: RISC-V JIT lockstep (jit-framework) — KNOWN RED, see comment
+        run: >
+          cargo test --no-fail-fast -p labwired-core --features jit,jit-framework
+          --test riscv_jit_lockstep
+          --test riscv_jit_alu_lockstep
+          --test riscv_jit_branch_lockstep
+          --test riscv_jit_mem_lockstep
+          --test riscv_jit_combined_lockstep

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -97,3 +97,23 @@ event-scheduler = ["labwired-core/event-scheduler"]
 # map-feedback scheduler, crash objectives). Heavy dependency tree, so opt-in:
 # `cargo build --release -p labwired-cli --features fuzz-libafl`.
 fuzz-libafl = ["labwired-fuzz/libafl"]
+
+# ── ZERO-TEST TARGETS CANNOT REPORT GREEN ────────────────────────────────────
+# Every target below is an integration test whose ENTIRE body sits behind an
+# inner `#![cfg(feature = "...")]`. Built without the feature the file compiles
+# to an EMPTY libtest binary, which prints `test result: ok. 0 passed` and exits
+# 0 — indistinguishable, to CI and to a human, from a suite that ran and passed.
+# `required-features` makes cargo SKIP the target instead of reporting it green,
+# and makes an explicit `--test <name>` without the feature a hard error.
+# Adding a new `#![cfg(feature = ...)]` test file without a block here fails
+# `crates/core/src/tests/no_vacuous_test_targets.rs`.
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "e2e_esp32c3_ble_adv_republish"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "e2e_esp32c3_ble_two_node"
+required-features = ["event-scheduler"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -130,3 +130,233 @@ required-features = ["mlx90640-decode-test"]
 labwired-loader = { path = "../loader" }
 svd-ingestor = { path = "../svd-ingestor" }
 svd-parser = "0.14"
+
+# ── ZERO-TEST TARGETS CANNOT REPORT GREEN ────────────────────────────────────
+# Every target below is an integration test whose ENTIRE body sits behind an
+# inner `#![cfg(feature = "...")]`. Built without the feature the file compiles
+# to an EMPTY libtest binary, which prints `test result: ok. 0 passed` and exits
+# 0 — indistinguishable, to CI and to a human, from a suite that ran and passed.
+# `required-features` makes cargo SKIP the target instead of reporting it green,
+# and makes an explicit `--test <name>` without the feature a hard error.
+# Adding a new `#![cfg(feature = ...)]` test file without a block here fails
+# `crates/core/src/tests/no_vacuous_test_targets.rs`.
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "bench_walk_free_kw41z"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "board_batch_width"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "silent-census")]
+[[test]]
+name = "census_probe"
+required-features = ["silent-census"]
+
+# #![cfg(feature = "esp32s3-fixtures")]
+[[test]]
+name = "e2e_blinky"
+required-features = ["esp32s3-fixtures"]
+
+# #![cfg(feature = "esp32s3-fixtures")]
+[[test]]
+name = "e2e_esp32s3_faithful_boot"
+required-features = ["esp32s3-fixtures"]
+
+# #![cfg(feature = "esp32s3-fixtures")]
+[[test]]
+name = "e2e_hello_world"
+required-features = ["esp32s3-fixtures"]
+
+# #![cfg(feature = "esp32s3-fixtures")]
+[[test]]
+name = "e2e_i2c_tmp102"
+required-features = ["esp32s3-fixtures"]
+
+# #![cfg(feature = "wifi-thunks")]
+[[test]]
+name = "e2e_labwired_wifi"
+required-features = ["wifi-thunks"]
+
+# #![cfg(feature = "net-tests")]
+[[test]]
+name = "egress_e2e"
+required-features = ["net-tests"]
+
+# #![cfg(all(feature = "event-scheduler", not(debug_assertions)))]
+[[test]]
+name = "esp32c3_ble_pong_perf_probe"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32c3_bt_event_residency_gate"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32c3_clamped_full_state_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32c3_oled_profile"
+required-features = ["event-scheduler"]
+
+# #![cfg(all(feature = "event-scheduler", not(debug_assertions)))]
+[[test]]
+name = "esp32c3_pms_shipped_firmware"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32c3_shipped_lab_batch_gate"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32c3_usb_cdc_console"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32c3_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "esp32s3_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "iolink-native")]
+[[test]]
+name = "iolink_native_master"
+required-features = ["iolink-native"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "kw41z_walk_free_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "nrf52840_timer_machine_gate"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "nrf52_easydma_tick512_fidelity"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "nrf52_timer_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "nrf54l15_grtc_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "nrf54l15_idle_ff_speedup"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "esp32s3-fixtures")]
+[[test]]
+name = "openai_deck_s3_boot"
+required-features = ["esp32s3-fixtures"]
+
+# #![cfg(all(feature = "jit-framework", feature = "jit"))]
+[[test]]
+name = "riscv_jit_alu_lockstep"
+required-features = ["jit", "jit-framework"]
+
+# #![cfg(all(feature = "jit-framework", feature = "jit"))]
+[[test]]
+name = "riscv_jit_branch_lockstep"
+required-features = ["jit", "jit-framework"]
+
+# #![cfg(all(feature = "jit", feature = "event-scheduler"))]
+[[test]]
+name = "riscv_jit_c3_oled_differential"
+required-features = ["event-scheduler", "jit"]
+
+# #![cfg(all(feature = "jit-framework", feature = "jit"))]
+[[test]]
+name = "riscv_jit_combined_bench"
+required-features = ["jit", "jit-framework"]
+
+# #![cfg(all(feature = "jit-framework", feature = "jit"))]
+[[test]]
+name = "riscv_jit_combined_lockstep"
+required-features = ["jit", "jit-framework"]
+
+# #![cfg(feature = "jit-framework")]
+[[test]]
+name = "riscv_jit_lockstep"
+required-features = ["jit-framework"]
+
+# #![cfg(all(feature = "jit-framework", feature = "jit"))]
+[[test]]
+name = "riscv_jit_mem_lockstep"
+required-features = ["jit", "jit-framework"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "rp2040_i2c_irq_delivery"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "rp2040_timer_machine_gate"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32_dma_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32_timer_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32f103_dma_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32f401_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32h563_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32l073_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "stm32l476_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(feature = "event-scheduler")]
+[[test]]
+name = "systick_walk_differential"
+required-features = ["event-scheduler"]
+
+# #![cfg(all(feature = "event-scheduler", not(debug_assertions)))]
+[[test]]
+name = "world_esp32c3_ble_pong"
+required-features = ["event-scheduler"]

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -35,6 +35,8 @@ pub mod esp_spi_uart_waveform;
 #[cfg(test)]
 pub mod machine_advance;
 #[cfg(test)]
+pub mod no_vacuous_test_targets;
+#[cfg(test)]
 pub mod nrf52;
 pub mod nrf52_nvmc;
 #[cfg(test)]

--- a/crates/core/src/tests/no_vacuous_test_targets.rs
+++ b/crates/core/src/tests/no_vacuous_test_targets.rs
@@ -1,0 +1,600 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! THE CONTRACT: no test target in this workspace may report success while
+//! executing zero tests.
+//!
+//! # The failure
+//!
+//! A libtest binary that contains no tests prints
+//!
+//! ```text
+//! running 0 tests
+//! test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+//! ```
+//!
+//! and **exits 0**. To CI, and to a human reading a green tick, that is
+//! indistinguishable from a suite that ran and passed. This repo sells a
+//! simulator as a hardware oracle — "it said PASS" has to mean something ran.
+//!
+//! The way a target gets into that state here is an inner attribute:
+//! `crates/core/tests/board_batch_width.rs` opens with
+//! `#![cfg(feature = "event-scheduler")]`, so without the feature the whole
+//! file compiles to nothing. `cargo test -p labwired-core --test
+//! board_batch_width` printed `0 passed` and exited 0 while three real tests
+//! sat in the file. `census_probe` (`silent-census`, 3 tests) did the same.
+//! Both were noticed by accident, not by a gate. The workspace had **56** test
+//! targets in that state across `labwired-core`, `labwired-cli` and
+//! `labwired-hw-oracle`.
+//!
+//! # The fix this gate enforces
+//!
+//! Cargo already has the right mechanism: a `[[test]]` block with
+//! `required-features`. With it, cargo **skips** the target when the feature is
+//! off — no binary, no `0 passed` line, nothing to misread — and turns an
+//! explicit `--test <name>` without the feature into a hard error:
+//!
+//! ```text
+//! error: target `board_batch_width` in package `labwired-core` requires the
+//! features: `event-scheduler`
+//! ```
+//!
+//! So the rule is: **an integration test file gated by an inner
+//! `#![cfg(feature = ...)]` must carry a matching `required-features`
+//! declaration in its crate's manifest.** This test reads both sides and fails
+//! when they disagree. It is static — no firmware, no fixtures, milliseconds —
+//! and it runs in `cargo test -p labwired-core --lib`, which every PR lane
+//! already runs.
+//!
+//! # How this differs from `scheduler_lane_coverage`
+//!
+//! That file asks a different question: "does a merge-gating lane RUN this
+//! scheduler test at all?" It is about `core-ci.yml`. This one asks "can this
+//! target ever report green without running?" and is about the manifests. A
+//! target can satisfy one and fail the other, and both failures have shipped.
+//!
+//! # What this gate does NOT cover
+//!
+//! * A target whose every test is `#[ignore]`d executes nothing in a normal
+//!   lane. `required-features` cannot express that, and this repo has lanes
+//!   that legitimately run such files with `-- --ignored`. Those are reasoned
+//!   about by name in `NIGHTLY_ONLY` in `scheduler_lane_coverage.rs`.
+//! * A test that runs but returns early on a missing env var. It executes and
+//!   reports honestly; that is a coverage question, not a false green.
+//! * The trailing `test result: ok. 0 passed` that `cargo test -p <crate>`
+//!   prints for a crate with **no doc examples**. That line is the *doctest*
+//!   target and is legitimate — `cargo test -p labwired-config` really runs
+//!   107 tests and then prints that zero. Reading it as the whole verdict is
+//!   how this class gets misdiagnosed in the other direction.
+//!
+//! The runtime half lives in `scripts/ci/cargo-test-nonvacuous.sh`, which asks
+//! each test binary a CI step builds how many tests it holds and fails on zero.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+/// Feature-gated integration tests allowed to keep reporting green with
+/// zero tests. **Empty, and meant to stay that way** — `required-features`
+/// works for every gate cargo can express, so an entry here is a claim that
+/// cargo cannot express this one.
+///
+/// SHRINK-ONLY, content-keyed on `(package, target)`. Each entry needs a
+/// reason someone can argue with; `allowlist_entries_are_real_and_still_needed`
+/// deletes the excuse the moment the target stops needing it.
+const ALLOWED_VACUOUS: &[(&str, &str, &str)] = &[];
+
+/// Gated files whose `#![cfg(...)]` ALSO carries `not(debug_assertions)`.
+/// `required-features` covers the feature half and cannot cover the other:
+/// in a debug build with the feature ON these still compile to nothing.
+/// That residue is deliberate — they are release-only by construction — so
+/// each one is named here with where it actually runs.
+const RELEASE_ONLY: &[(&str, &str)] = &[
+    (
+        "world_esp32c3_ble_pong",
+        "Release-only by construction (it plays a two-node BLE election out \
+         over ~180M cycles; debug is minutes per assertion). It RUNS in \
+         core-ci.yml's `--release ... --features event-scheduler` step and \
+         in core-nightly.yml. A debug lane could not run it at any price.",
+    ),
+    (
+        "esp32c3_pms_shipped_firmware",
+        "Release-only by construction: it boots the shipped PMS firmware on \
+         the C3 mask ROM, which is minutes in debug. It RUNS in core-ci.yml's \
+         `--release ... --features event-scheduler` step.",
+    ),
+    (
+        "esp32c3_ble_pong_perf_probe",
+        "Release-only AND every test in it is #[ignore]d — it is a perf probe \
+         whose wall clock is the measurement, so a lane that ran it \
+         automatically would be measuring the runner, not the engine. It is \
+         invoked by hand with `-- --ignored`; no lane claims to cover it.",
+    ),
+];
+
+// ── Anti-vacuity floors ─────────────────────────────────────────────────
+// A gate against suites that check nothing must not be a suite that checks
+// nothing. These are the numbers the scan sees on the tree that introduced
+// it (12 crates, 267 files, 57 gated). They are floors, not equalities, so
+// normal growth does not trip them — but a mis-rooted path, a bad
+// extension filter or a `tests/` layout change collapses the scanned set to
+// ~0 and fails LOUDLY instead of passing over an empty set.
+const MIN_CRATES_WITH_TESTS: usize = 8;
+const MIN_TEST_FILES: usize = 200;
+const MIN_GATED_FILES: usize = 40;
+
+#[derive(Debug)]
+struct GatedTest {
+    package: String,
+    manifest: PathBuf,
+    /// Cargo target name = the file stem.
+    target: String,
+    /// Features named inside the inner `#![cfg(...)]`, sorted and deduped.
+    features: Vec<String>,
+    /// The attribute line itself, for the failure message.
+    attr: String,
+    /// The `#![cfg(...)]` also carries `not(debug_assertions)`.
+    release_only: bool,
+}
+
+struct Scan {
+    gated: Vec<GatedTest>,
+    crates_with_tests: usize,
+    test_files: usize,
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+/// Every directory under the repo that holds both a `Cargo.toml` and a
+/// `tests/` directory. Walked rather than hard-coded so a crate added
+/// later is covered without anyone remembering to list it.
+fn crates_with_test_dirs(root: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+        if depth > 4 {
+            return;
+        }
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            // Build output, vendored source and VCS internals are not ours
+            // and would make the walk enormous.
+            if matches!(
+                name,
+                "target" | ".git" | "node_modules" | "third_party" | ".github"
+            ) {
+                continue;
+            }
+            if is_package_with_tests(&path) {
+                out.push(path.clone());
+            }
+            walk(&path, depth + 1, out);
+        }
+    }
+    /// A directory counts only if it is a real package (the workspace root
+    /// manifest is virtual — `[workspace]`, no `[package]` — and the repo's
+    /// top-level `tests/` directory holds fixtures, not cargo targets).
+    fn is_package_with_tests(dir: &Path) -> bool {
+        let manifest = dir.join("Cargo.toml");
+        if !manifest.is_file() || !dir.join("tests").is_dir() {
+            return false;
+        }
+        std::fs::read_to_string(&manifest)
+            .map(|src| src.lines().any(|l| l.trim() == "[package]"))
+            .unwrap_or(false)
+    }
+    let mut out = Vec::new();
+    walk(root, 0, &mut out);
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn package_name(manifest_src: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in manifest_src.lines() {
+        let t = line.trim();
+        if t.starts_with('[') && t.ends_with(']') && !t.contains('=') {
+            in_package = t == "[package]";
+            continue;
+        }
+        if in_package {
+            if let Some(rest) = t.strip_prefix("name") {
+                if let Some(v) = first_quoted(rest) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn first_quoted(s: &str) -> Option<String> {
+    let start = s.find('"')? + 1;
+    let end = s[start..].find('"')? + start;
+    Some(s[start..end].to_string())
+}
+
+fn quoted_items(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = s;
+    while let Some(start) = rest.find('"') {
+        let after = &rest[start + 1..];
+        match after.find('"') {
+            Some(end) => {
+                out.push(after[..end].to_string());
+                rest = &after[end + 1..];
+            }
+            None => break,
+        }
+    }
+    out
+}
+
+/// `[[test]]` blocks in a manifest, as `target name -> required-features`.
+/// A target declared without `required-features` maps to an empty vector.
+fn declared_test_targets(manifest_src: &str) -> BTreeMap<String, Vec<String>> {
+    let mut out = BTreeMap::new();
+    let mut in_block = false;
+    let mut name: Option<String> = None;
+    let mut required: Vec<String> = Vec::new();
+    let mut array_open = false;
+
+    let mut flush = |name: &mut Option<String>, required: &mut Vec<String>| {
+        if let Some(n) = name.take() {
+            out.insert(n, std::mem::take(required));
+        } else {
+            required.clear();
+        }
+    };
+
+    for line in manifest_src.lines() {
+        let t = line.trim();
+
+        if array_open {
+            required.extend(quoted_items(t));
+            if t.contains(']') {
+                array_open = false;
+            }
+            continue;
+        }
+
+        // A table header — `[[test]]`, `[dev-dependencies]`, `[features]`.
+        // `required-features = [..]` also starts with a bracket further in,
+        // but not at the start, and it contains `=`.
+        if t.starts_with('[') && t.ends_with(']') && !t.contains('=') {
+            if in_block {
+                flush(&mut name, &mut required);
+            }
+            in_block = t == "[[test]]";
+            continue;
+        }
+        if !in_block || t.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = t.strip_prefix("name") {
+            if rest.trim_start().starts_with('=') {
+                name = first_quoted(rest);
+            }
+        } else if let Some(rest) = t.strip_prefix("required-features") {
+            if rest.trim_start().starts_with('=') {
+                required.extend(quoted_items(rest));
+                if !rest.contains(']') {
+                    array_open = true;
+                }
+            }
+        }
+    }
+    if in_block {
+        flush(&mut name, &mut required);
+    }
+    out
+}
+
+fn scan() -> Scan {
+    let root = repo_root();
+    let mut gated = Vec::new();
+    let mut test_files = 0usize;
+    let crates = crates_with_test_dirs(&root);
+
+    for crate_dir in &crates {
+        let manifest = crate_dir.join("Cargo.toml");
+        let manifest_src = std::fs::read_to_string(&manifest)
+            .unwrap_or_else(|e| panic!("read {}: {e}", manifest.display()));
+        let package = package_name(&manifest_src).unwrap_or_else(|| {
+            panic!("no [package] name in {}", manifest.display());
+        });
+
+        let tests_dir = crate_dir.join("tests");
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&tests_dir)
+            .unwrap_or_else(|e| panic!("read {}: {e}", tests_dir.display()))
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("rs"))
+            .collect();
+        files.sort();
+
+        for path in files {
+            test_files += 1;
+            let src = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let target = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .expect("test file stem")
+                .to_string();
+
+            for line in src.lines() {
+                let t = line.trim();
+                if !t.starts_with("#![cfg(") {
+                    continue;
+                }
+                // A multi-line inner attribute would make the rest of this
+                // scan read half a condition. Nothing in the tree does it;
+                // say so rather than guess.
+                assert!(
+                    t.ends_with(")]"),
+                    "{}: inner `#![cfg(...)]` spans multiple lines, which this \
+                     scan cannot read. Put it on one line.",
+                    path.display()
+                );
+                let features = features_named(t);
+                if features.is_empty() {
+                    continue;
+                }
+                assert!(
+                    !t.contains("any("),
+                    "{}: `#![cfg(any(feature = ...))]` cannot be expressed by \
+                     cargo's `required-features`, which is an AND. Split the \
+                     file, or add it to ALLOWED_VACUOUS with a reason.",
+                    path.display()
+                );
+                gated.push(GatedTest {
+                    package: package.clone(),
+                    manifest: manifest.clone(),
+                    target: target.clone(),
+                    features,
+                    attr: t.to_string(),
+                    release_only: t.contains("not(debug_assertions)"),
+                });
+                break;
+            }
+        }
+    }
+
+    Scan {
+        gated,
+        crates_with_tests: crates.len(),
+        test_files,
+    }
+}
+
+/// Cargo features named inside an attribute line, sorted and deduped.
+fn features_named(attr: &str) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    let mut rest = attr;
+    while let Some(pos) = rest.find("feature") {
+        rest = &rest[pos + "feature".len()..];
+        let trimmed = rest.trim_start();
+        if !trimmed.starts_with('=') {
+            continue;
+        }
+        if let Some(v) = first_quoted(trimmed) {
+            out.insert(v);
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// The scan must be looking at the repository it claims to be looking at.
+/// A wrong root, a renamed `tests/` layout or a broken extension filter all
+/// present as "nothing to report", which is exactly the shape of bug this
+/// file exists to make impossible.
+#[test]
+fn the_scan_is_not_vacuous() {
+    let scan = scan();
+    // Printed, not just asserted: run this with `-- --nocapture` and the log
+    // says what the scan actually saw. A gate whose log cannot distinguish
+    // "swept 267 files" from "swept nothing" is the bug it is guarding.
+    println!(
+        "no_vacuous_test_targets: {} crates with tests/, {} integration test \
+         files, {} feature-gated",
+        scan.crates_with_tests,
+        scan.test_files,
+        scan.gated.len()
+    );
+    assert!(
+        scan.crates_with_tests >= MIN_CRATES_WITH_TESTS,
+        "found only {} crates with a tests/ directory (expected >= {}). The \
+         walk is looking in the wrong place, not at a repo that lost its \
+         integration tests.",
+        scan.crates_with_tests,
+        MIN_CRATES_WITH_TESTS
+    );
+    assert!(
+        scan.test_files >= MIN_TEST_FILES,
+        "found only {} integration test files (expected >= {}). See above — \
+         an empty scan must fail, never pass.",
+        scan.test_files,
+        MIN_TEST_FILES
+    );
+    assert!(
+        scan.gated.len() >= MIN_GATED_FILES,
+        "found only {} feature-gated integration test files (expected >= {}). \
+         Either the inner-attribute detection broke, or the files moved.",
+        scan.gated.len(),
+        MIN_GATED_FILES
+    );
+
+    // Named sentinels, so a scan that "finds things" but not the RIGHT
+    // things still fails. board_batch_width is the target that was found
+    // reporting green with 3 tests unrun; the other two prove the walk
+    // reaches past labwired-core into the other two affected crates.
+    for (pkg, target) in [
+        ("labwired-core", "board_batch_width"),
+        ("labwired-cli", "e2e_esp32c3_ble_two_node"),
+        ("labwired-hw-oracle", "nrf52_mmio_diff"),
+    ] {
+        assert!(
+            scan.gated
+                .iter()
+                .any(|g| g.package == pkg && g.target == target),
+            "the scan did not find the known feature-gated target {pkg}/{target}. \
+             It is not measuring what it claims to measure."
+        );
+    }
+}
+
+/// The gate itself.
+#[test]
+fn every_feature_gated_test_target_declares_required_features() {
+    let scan = scan();
+    let excused: BTreeSet<(&str, &str)> =
+        ALLOWED_VACUOUS.iter().map(|(p, t, _)| (*p, *t)).collect();
+
+    let mut manifests: BTreeMap<PathBuf, BTreeMap<String, Vec<String>>> = BTreeMap::new();
+    let mut failures = Vec::new();
+
+    for g in &scan.gated {
+        if excused.contains(&(g.package.as_str(), g.target.as_str())) {
+            continue;
+        }
+        let declared = manifests.entry(g.manifest.clone()).or_insert_with(|| {
+            let src = std::fs::read_to_string(&g.manifest).expect("read manifest");
+            declared_test_targets(&src)
+        });
+
+        match declared.get(&g.target) {
+            None => failures.push(format!(
+                "{}/{}: {}\n      no `[[test]] name = \"{}\"` block in {}",
+                g.package,
+                g.target,
+                g.attr,
+                g.target,
+                g.manifest.display()
+            )),
+            Some(req) => {
+                let req_set: BTreeSet<&str> = req.iter().map(String::as_str).collect();
+                let cfg_set: BTreeSet<&str> = g.features.iter().map(String::as_str).collect();
+                if req_set != cfg_set {
+                    failures.push(format!(
+                        "{}/{}: {}\n      required-features = {:?} but the cfg names {:?}",
+                        g.package, g.target, g.attr, req, g.features
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} integration test target(s) can report `test result: ok. 0 passed` \
+         and exit 0:\n\n    {}\n\n\
+         Built without the feature the file compiles to an EMPTY libtest \
+         binary, which is indistinguishable from a suite that ran and passed \
+         — that is how `board_batch_width` (3 tests) and `census_probe` \
+         (3 tests) sat green in CI.\n\n\
+         Fix it in the crate's Cargo.toml:\n\n    \
+         [[test]]\n    name = \"<target>\"\n    required-features = [\"<feature>\"]\n\n\
+         Cargo then SKIPS the target when the feature is off — no binary and \
+         no `0 passed` line — and turns an explicit `--test <target>` without \
+         the feature into a hard error instead of a green tick. Do not fix \
+         this by deleting the tests, and do not fix it by removing the \
+         `#![cfg]`: the feature exists for a reason.",
+        failures.len(),
+        failures.join("\n    ")
+    );
+}
+
+/// `required-features` cannot express `not(debug_assertions)`, so a file
+/// gated on both is still empty in a debug build with the feature on. Each
+/// one must say, in writing, where it really runs.
+#[test]
+fn release_only_gated_tests_are_named_with_a_reason() {
+    let scan = scan();
+    let listed: BTreeMap<&str, &str> = RELEASE_ONLY.iter().copied().collect();
+
+    let missing: Vec<&str> = scan
+        .gated
+        .iter()
+        .filter(|g| g.release_only && !listed.contains_key(g.target.as_str()))
+        .map(|g| g.target.as_str())
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these tests are gated on a feature AND `not(debug_assertions)`, so \
+         they still compile to an empty binary in a debug build with the \
+         feature ON — `required-features` cannot reach that half:\n  {}\n\n\
+         Add each to RELEASE_ONLY in this file with the lane that actually \
+         runs it.",
+        missing.join("\n  ")
+    );
+
+    let actual: BTreeSet<&str> = scan
+        .gated
+        .iter()
+        .filter(|g| g.release_only)
+        .map(|g| g.target.as_str())
+        .collect();
+    for (name, reason) in RELEASE_ONLY {
+        assert!(
+            actual.contains(name),
+            "RELEASE_ONLY names `{name}`, which is no longer a test gated on a \
+             feature AND `not(debug_assertions)` (renamed? deleted? un-gated?). \
+             Remove the entry."
+        );
+        assert!(
+            reason.len() > 40,
+            "RELEASE_ONLY entry `{name}` needs a reason someone can argue \
+             with, not a label"
+        );
+    }
+}
+
+/// An allowlist entry must correspond to a target that really is gated and
+/// really is missing its declaration — otherwise the table rots into a list
+/// of excuses for problems that no longer exist.
+#[test]
+fn allowlist_entries_are_real_and_still_needed() {
+    let scan = scan();
+    for (pkg, target, reason) in ALLOWED_VACUOUS {
+        let g = scan
+            .gated
+            .iter()
+            .find(|g| g.package == *pkg && g.target == *target)
+            .unwrap_or_else(|| {
+                panic!(
+                    "ALLOWED_VACUOUS names {pkg}/{target}, which is not a \
+                     feature-gated integration test. Remove the entry."
+                )
+            });
+        let src = std::fs::read_to_string(&g.manifest).expect("read manifest");
+        let declared = declared_test_targets(&src);
+        assert!(
+            !declared.contains_key(&g.target),
+            "ALLOWED_VACUOUS excuses {pkg}/{target}, but its manifest already \
+             declares `[[test]] required-features` for it. Drop the excuse."
+        );
+        assert!(
+            reason.len() > 40,
+            "ALLOWED_VACUOUS entry {pkg}/{target} needs a reason someone can \
+             argue with, not a label"
+        );
+    }
+}

--- a/crates/core/src/tests/scheduler_lane_coverage.rs
+++ b/crates/core/src/tests/scheduler_lane_coverage.rs
@@ -16,6 +16,14 @@
 //! lane that does not pass the feature therefore does not merely skip the file:
 //! it reports it GREEN.
 //!
+//! **That last sentence is now false, deliberately.** Every file in this set
+//! carries a `[[test]] required-features` block, so cargo SKIPS the target
+//! instead of faking a pass, and a bare `--test <name>` is a hard error. That
+//! contract is enforced across the whole workspace by
+//! `no_vacuous_test_targets.rs`. It closes the "reports GREEN" half. This file
+//! still owns the other half — **which lane actually runs it** — and that half
+//! has no mechanical fix.
+//!
 //! The only lane that ran all of them was `core-full`, which is
 //! schedule/dispatch/`[full-ci]` only — not push, not PR. So a fidelity
 //! regression could land on `main` with every required check green and stay

--- a/crates/hw-oracle/Cargo.toml
+++ b/crates/hw-oracle/Cargo.toml
@@ -48,3 +48,63 @@ hw-oracle-nrf52 = []
 
 [dev-dependencies]
 labwired-fuzz = { path = "../labwired-fuzz" }
+
+# ── ZERO-TEST TARGETS CANNOT REPORT GREEN ────────────────────────────────────
+# Every target below is an integration test whose ENTIRE body sits behind an
+# inner `#![cfg(feature = "...")]`. Built without the feature the file compiles
+# to an EMPTY libtest binary, which prints `test result: ok. 0 passed` and exits
+# 0 — indistinguishable, to CI and to a human, from a suite that ran and passed.
+# `required-features` makes cargo SKIP the target instead of reporting it green,
+# and makes an explicit `--test <name>` without the feature a hard error.
+# Adding a new `#![cfg(feature = ...)]` test file without a block here fails
+# `crates/core/src/tests/no_vacuous_test_targets.rs`.
+
+# #![cfg(feature = "hw-oracle-stm32")]
+[[test]]
+name = "f103_fuzz_hil_confirm"
+required-features = ["hw-oracle-stm32"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_ccm_conformance"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_full_register_conformance"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_gpio_conformance"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_mmio_diff"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_onboarding_diff"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_power_conformance"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_spim_easydma_conformance"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_spis_twis_conformance"
+required-features = ["hw-oracle-nrf52"]
+
+# #![cfg(feature = "hw-oracle-nrf52")]
+[[test]]
+name = "nrf52_timer_rtc_conformance"
+required-features = ["hw-oracle-nrf52"]

--- a/crates/hw-oracle/tests/nrf52_full_register_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_full_register_conformance.rs
@@ -34,7 +34,11 @@
 #![cfg(feature = "hw-oracle-nrf52")]
 
 use labwired_config::{ChipDescriptor, SystemManifest};
+// `Bus` carries read_u32/write_u32; `SystemBus` alone does not. This import
+// went missing while the file was behind `hw-oracle-nrf52`, a feature NO CI
+// lane enables, so nothing compiled it for as long as it was broken.
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use labwired_hw_oracle::openocd::OpenOcd;
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/crates/hw-oracle/tests/nrf52_gpio_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_gpio_conformance.rs
@@ -50,7 +50,11 @@
 #![cfg(feature = "hw-oracle-nrf52")]
 
 use labwired_config::{ChipDescriptor, SystemManifest};
+// `Bus` carries read_u32/write_u32; `SystemBus` alone does not. This import
+// went missing while the file was behind `hw-oracle-nrf52`, a feature NO CI
+// lane enables, so nothing compiled it for as long as it was broken.
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use labwired_hw_oracle::openocd::OpenOcd;
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/crates/hw-oracle/tests/nrf52_mmio_diff.rs
+++ b/crates/hw-oracle/tests/nrf52_mmio_diff.rs
@@ -22,7 +22,11 @@
 #![cfg(feature = "hw-oracle-nrf52")]
 
 use labwired_config::{ChipDescriptor, SystemManifest};
+// `Bus` carries read_u32/write_u32; `SystemBus` alone does not. This import
+// went missing while the file was behind `hw-oracle-nrf52`, a feature NO CI
+// lane enables, so nothing compiled it for as long as it was broken.
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use labwired_hw_oracle::openocd::OpenOcd;
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/crates/hw-oracle/tests/nrf52_onboarding_diff.rs
+++ b/crates/hw-oracle/tests/nrf52_onboarding_diff.rs
@@ -23,7 +23,11 @@
 #![cfg(feature = "hw-oracle-nrf52")]
 
 use labwired_config::{ChipDescriptor, SystemManifest};
+// `Bus` carries read_u32/write_u32; `SystemBus` alone does not. This import
+// went missing while the file was behind `hw-oracle-nrf52`, a feature NO CI
+// lane enables, so nothing compiled it for as long as it was broken.
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use labwired_hw_oracle::openocd::OpenOcd;
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/crates/hw-oracle/tests/nrf52_power_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_power_conformance.rs
@@ -25,7 +25,11 @@
 #![cfg(feature = "hw-oracle-nrf52")]
 
 use labwired_config::{ChipDescriptor, SystemManifest};
+// `Bus` carries read_u32/write_u32; `SystemBus` alone does not. This import
+// went missing while the file was behind `hw-oracle-nrf52`, a feature NO CI
+// lane enables, so nothing compiled it for as long as it was broken.
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use labwired_hw_oracle::openocd::OpenOcd;
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/crates/hw-oracle/tests/nrf52_timer_rtc_conformance.rs
+++ b/crates/hw-oracle/tests/nrf52_timer_rtc_conformance.rs
@@ -21,7 +21,11 @@
 #![cfg(feature = "hw-oracle-nrf52")]
 
 use labwired_config::{ChipDescriptor, SystemManifest};
+// `Bus` carries read_u32/write_u32; `SystemBus` alone does not. This import
+// went missing while the file was behind `hw-oracle-nrf52`, a feature NO CI
+// lane enables, so nothing compiled it for as long as it was broken.
 use labwired_core::bus::SystemBus;
+use labwired_core::Bus;
 use labwired_hw_oracle::openocd::OpenOcd;
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/scripts/ci/cargo-test-nonvacuous.sh
+++ b/scripts/ci/cargo-test-nonvacuous.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# LabWired - Firmware Simulation Platform
+# Copyright (C) 2026 Andrii Shylenko
+#
+# This software is released under the MIT License.
+# See the LICENSE file in the project root for full license information.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# A `cargo test` wrapper that refuses to report green for a test target which
+# contains ZERO tests.
+#
+# THE FAILURE THIS EXISTS FOR. A libtest binary with no tests prints
+#
+#     running 0 tests
+#     test result: ok. 0 passed; 0 failed; 0 ignored; ...
+#
+# and exits 0. To CI, and to a human reading a green tick, that is
+# indistinguishable from a suite that ran and passed. `crates/core/tests/` is
+# full of files whose whole body sits behind `#![cfg(feature = "...")]`; built
+# without the feature each one compiles to an empty binary and reports success.
+# `board_batch_width` (3 tests) and `census_probe` (3 tests) were both caught
+# doing this by accident rather than by a gate.
+#
+# HOW IT CHECKS. It does not parse `cargo test` stdout — the `Running <path>`
+# banner goes to stderr and the `0 passed` line to stdout, so pairing them is
+# an ordering guess. Instead it asks cargo, in JSON, which test executables the
+# invocation builds, then asks each executable how many tests it holds
+# (`--list`). A binary that lists nothing is the bug, named by path, before a
+# single test runs.
+#
+# Doctests are deliberately out of scope: `cargo test --no-run` does not build
+# them, and a crate with no doc examples legitimately reports `0 passed`. That
+# trailing zero is also exactly what makes this class easy to MISREAD by eye —
+# `cargo test -p labwired-config` really runs 107 tests and then prints a
+# fourth `test result: ok. 0 passed` for its (empty) doctest target.
+#
+# USAGE — drop it in front of an existing CI step, arguments unchanged:
+#
+#     scripts/ci/cargo-test-nonvacuous.sh -p labwired-core \
+#       --features event-scheduler --test board_batch_width -- --nocapture
+#
+# It compiles once (`--no-run`), verifies, then runs the real `cargo test` with
+# the identical arguments and exits with ITS status. The second cargo call is a
+# cache hit, so the wrapper costs the `--list` calls and nothing else.
+#
+# WHAT IT DOES NOT COVER. A target whose every test is `#[ignore]`d also
+# executes nothing in a normal lane, but libtest's `--list` cannot distinguish
+# those (it lists ignored tests too), and this repo has lanes that legitimately
+# run such files with `-- --ignored`. That class is reasoned about by name in
+# `NIGHTLY_ONLY` in crates/core/src/tests/scheduler_lane_coverage.rs.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+    echo "usage: $0 <cargo test arguments...>" >&2
+    exit 2
+fi
+
+# `--no-run` has to go BEFORE the harness separator, or cargo hands it to
+# libtest and the suite runs anyway. Split argv at the first bare `--`.
+cargo_args=()
+harness_args=()
+seen_sep=0
+for arg in "$@"; do
+    if [ "$seen_sep" -eq 0 ] && [ "$arg" = "--" ]; then
+        seen_sep=1
+        continue
+    fi
+    if [ "$seen_sep" -eq 0 ]; then
+        cargo_args+=("$arg")
+    else
+        harness_args+=("$arg")
+    fi
+done
+
+artifacts="$(mktemp)"
+trap 'rm -f "$artifacts"' EXIT
+
+echo "==> cargo test ${cargo_args[*]} --no-run (enumerating test targets)"
+cargo test "${cargo_args[@]}" --no-run --message-format=json >"$artifacts"
+
+# Pull the test executables out of cargo's JSON. `"test": true` in the profile
+# is what marks a compiler-artifact as a libtest binary; it excludes build
+# scripts, dependency rlibs and any plain bin target rebuilt along the way.
+# `mapfile` is bash 4+, and macOS ships bash 3.2 — read the list the portable
+# way so this script behaves the same locally and on the runner.
+executables=()
+while IFS= read -r line; do
+    [ -n "$line" ] && executables+=("$line")
+done < <(
+    python3 - "$artifacts" <<'PY'
+import json, sys
+
+seen = []
+with open(sys.argv[1], encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("reason") != "compiler-artifact":
+            continue
+        if not msg.get("profile", {}).get("test"):
+            continue
+        exe = msg.get("executable")
+        if exe and exe not in seen:
+            seen.append(exe)
+for exe in seen:
+    print(exe)
+PY
+)
+
+# ── ANTI-VACUITY ────────────────────────────────────────────────────────────
+# This script's whole job is to catch a suite that checked nothing; a wrapper
+# that itself checked nothing would be the same bug one level up. Every
+# `cargo test` invocation in this repo builds at least one test binary, so an
+# empty list means the JSON shape changed, the arguments selected no target, or
+# the compile produced nothing — never "all clear".
+if [ ${#executables[@]} -eq 0 ]; then
+    {
+        echo "FAIL: cargo built NO test executables for: cargo test ${cargo_args[*]}"
+        echo "      This wrapper cannot have verified anything. Either the argument"
+        echo "      selection matches no target, or the --message-format=json shape"
+        echo "      changed. Do not read this as a pass."
+    } >&2
+    exit 1
+fi
+
+vacuous=()
+total_tests=0
+for exe in "${executables[@]}"; do
+    n="$("$exe" --list --format terse 2>/dev/null | grep -c ': test$' || true)"
+    total_tests=$((total_tests + n))
+    if [ "$n" -eq 0 ]; then
+        vacuous+=("$exe")
+    fi
+done
+
+echo "==> ${#executables[@]} test target(s), $total_tests test(s) total"
+
+if [ ${#vacuous[@]} -gt 0 ]; then
+    {
+        echo
+        echo "FAIL: ${#vacuous[@]} test target(s) contain ZERO tests:"
+        printf '        %s\n' "${vacuous[@]}"
+        echo
+        echo "  A libtest binary with no tests prints \`test result: ok. 0 passed\`"
+        echo "  and exits 0, so this step would have reported GREEN while checking"
+        echo "  nothing. Almost always the file is behind \`#![cfg(feature = ...)]\`"
+        echo "  and this invocation did not pass the feature."
+        echo
+        echo "  Fix it in the manifest, not here: give the target a"
+        echo "    [[test]]"
+        echo "    name = \"<target>\""
+        echo "    required-features = [\"<feature>\"]"
+        echo "  block, and cargo will REFUSE to build it without the feature"
+        echo "  instead of reporting it green. That contract is enforced by"
+        echo "  crates/core/src/tests/no_vacuous_test_targets.rs."
+    } >&2
+    exit 1
+fi
+
+echo "==> cargo test ${cargo_args[*]}${harness_args[*]:+ -- ${harness_args[*]}}"
+if [ ${#harness_args[@]} -gt 0 ]; then
+    exec cargo test "${cargo_args[@]}" -- "${harness_args[@]}"
+else
+    exec cargo test "${cargo_args[@]}"
+fi


### PR DESCRIPTION
A test target that runs **zero tests** prints `test result: ok` and exits **0**. To CI, and to anyone reading a green tick, that is indistinguishable from a suite that ran and passed. Three instances were found by accident yesterday. This is the sweep.

## 57 targets, and what was behind them

**57 integration test targets** report `ok. 0 passed` and exit 0 under a default `cargo test` — every one an inner `#![cfg(feature = ...)]`. Scan: 13 crates with `tests/`, 267 integration files.

| feature | targets | 0 → real |
|---|---|---|
| `event-scheduler` (core) | 25 | 0 → **88** |
| `event-scheduler` + `not(debug_assertions)` | 3 | 0 → 11 (release only) |
| `jit` / `jit-framework` | 7 | 0 → **15** |
| `esp32s3-fixtures` | 5 | 0 → 5 (static count) |
| `silent-census`, `net-tests`, `wifi-thunks`, `mlx90640-decode-test`, `iolink-native` | 5 | 0 → 14 |
| `hw-oracle-nrf52` / `-stm32` | 10 | 0 → 10 |
| `event-scheduler` (cli) | 2 | 0 → 2 |

**Seven features were named by no workflow at all** — `silent-census`, `net-tests`, `wifi-thunks`, `jit-framework`, `mlx90640-decode-test`, `hw-oracle-nrf52`, `hw-oracle-stm32`. **22 targets have been reporting green forever without ever executing.**

Fairness to the CI authors: no workflow runs a *bare* `--test <name>` on a gated target — `--features event-scheduler` was already threaded through the lanes that name them. The genuinely bare invocations are `cargo test -p labwired-hw-oracle` in `core-integrity` (10 fake greens per run) and `cargo test --workspace` in `core-full`.

## Running them found two broken things

**The RISC-V JIT lockstep suites are RED.** Five failures across three targets, all variants of *"no block ever crossed the hot threshold / compiled"*, *"no block compiled"*. These are the tests that assert the JIT is **byte-identical to the interpreter** — the property that makes a JIT admissible in an oracle at all. They refuse to pass on a JIT that never engages. Identical with and without `event-scheduler`, so not a feature interaction.

**Independently reproduced:** `--features jit,jit-framework` → exit **101**, `no block ever crossed the hot threshold / compiled`.

They are **not** silenced. They run in a new nightly job, documented as red. Fixing the JIT is out of scope here — the finding is that this was invisible.

**Six nRF52 hardware-oracle harnesses did not COMPILE.** `error[E0599]: no method named write_u32` — a lost `use labwired_core::Bus;`. rustc had never seen those files, because no lane enabled the feature. **Independently reproduced on unmodified main:** `cargo test -p labwired-hw-oracle --features hw-oracle-nrf52 --no-run` → exit **101**. Import restored; all 32 hw-oracle targets now compile. They still need a board to execute.

## A correction to yesterday's report

`labwired-config` was **not** a vacuous suite — I misread it. `cargo test -p labwired-config` runs all **107** tests. The trailing `test result: ok. 0 passed` is the **Doc-tests** target, which has no doc examples; `--all-targets` omits doctests, which is why the zero disappears. Nothing was being missed. That failure mode is now noted in the gate's module docs so nobody "fixes" it in the wrong direction.

## The fix, in three parts

**Structural — makes the class impossible.** 56 `[[test]] required-features` blocks. Cargo now *skips* the target when the feature is off, so a bare invocation is a hard error instead of a green tick:

```
$ cargo test -p labwired-core --test board_batch_width
error: target `board_batch_width` requires the features: `event-scheduler`     # exit 101
$ cargo test -p labwired-core --features event-scheduler --test board_batch_width
test result: ok. 3 passed                                                       # exit 0
```

**Arm A — static**, in `--lib`, which every PR already runs: walks every crate with `tests/`, reads inner attributes, fails when a feature-gated file lacks a matching `required-features` (set-equality; rejects `any(...)`, which cargo's AND cannot express). `ALLOWED_VACUOUS` is **empty**.

**Arm B — runtime**, `scripts/ci/cargo-test-nonvacuous.sh`: asks cargo which test binaries an invocation builds, asks each `--list` how many tests it holds, fails on zero, then `exec`s the real `cargo test`. It deliberately does **not** parse cargo stdout — the `Running` banner is stderr and the `0 passed` is stdout, so pairing them is an ordering guess.

## Watched failing — re-derived independently

I injected my own vacuous target (`#![cfg(feature = "silent-census")]`, one test, no manifest block):

| | exit | result |
|---|---|---|
| the disease, bare | **0** | `test result: ok. 0 passed` |
| the static gate | **101** | names `zz_my_probe`, points at the missing `[[test]]` block |
| after revert | **0** | clean |

## The gate is not itself vacuous

The load-bearing proof: with a deliberately mis-rooted scan, the main assertion **passed vacuously** while `the_scan_is_not_vacuous` went red. Floors: ≥8 crates, ≥200 files, ≥40 gated (today **13 / 267 / 57**), plus three *named* sentinels, so a scan that finds things but not the right things still fails. It prints its counts so a CI log distinguishes "swept 267" from "swept nothing".

## Verification

| | before | after |
|---|---|---|
| `cargo test -p labwired-core --lib` | 0 — 3044 | **0 — 3048** (+4 gate tests) |
| `--test firmware_survival` | 0 — 61 | **0 — 61** |

Also green: `fmt --check`, `clippy --all-targets -D warnings`, `shellcheck`, `actionlint`, all six regen generators.

## Not done

- **The 3 `not(debug_assertions)` targets stay vacuous in a debug+feature build** — `required-features` cannot express it. Documented in `RELEASE_ONLY`, not mechanically closed.
- `esp32s3-fixtures` (5) and `iolink_native_master` (6) counts are static, not measured — no espup/Xtensa, no native IO-Link stack.
- hw-oracle harnesses compile but were never executed — no board.
- `cargo test --workspace` not run; the claim that `required-features` only *removes* fake greens there is reasoned, not measured.
- **The JIT is not fixed.** The new nightly job will be RED on its first run. That is deliberate and is the finding — say if you'd rather it were parked.