### PR TITLE
fix(wasm): sample wire channels, and publish the wire vocabulary

### DIFF
--- a/crates/core/src/bus/attach.rs
+++ b/crates/core/src/bus/attach.rs
@@ -1506,12 +1506,6 @@ impl SystemBus {
             (2, 'a', 2, LINE_TX, "USART2_TX"),
         ];
 
-        // L0 IOPORT base (RM0367 / stm32l073.yaml). F4/L4 GPIO lives at
-        // 0x4800_0000; matching the V2 register layout alone cannot pick AF4.
-        let is_stm32l0 = self
-            .find_peripheral_index_by_name("gpioa")
-            .is_some_and(|idx| self.peripherals[idx].base == 0x5000_0000);
-
         for instance in 1u8..=3 {
             // Chip configs name these both ways — `uart2` on the L4/F1 configs,
             // `usart2` on the G4. Looking up both is what stops a rename in one
@@ -1529,9 +1523,13 @@ impl SystemBus {
             // must not reach `pad_lines_arc` at all.
             let mut plan: Vec<(char, u8, Option<u8>, usize, &'static str)> = Vec::new();
             for port in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] {
-                let Some(gpio_layout) = self
-                    .find_peripheral_index_by_name(&format!("gpio{port}"))
-                    .and_then(|idx| self.peripherals[idx].dev.as_any())
+                let Some(gpio_idx) = self.find_peripheral_index_by_name(&format!("gpio{port}"))
+                else {
+                    continue;
+                };
+                let Some(gpio_layout) = self.peripherals[gpio_idx]
+                    .dev
+                    .as_any()
                     .and_then(|a| a.downcast_ref::<GpioPort>())
                     .map(GpioPort::register_layout)
                 else {
@@ -1539,7 +1537,17 @@ impl SystemBus {
                 };
                 match gpio_layout {
                     GpioRegisterLayout::Stm32V2 => {
-                        let table = if is_stm32l0 { L0 } else { V2 };
+                        // AF map is per GPIO *window*, not a chip-wide flag.
+                        // L0 IOPORT bank is 0x5000_xxxx (stm32l073.yaml);
+                        // F4/L4/H5 AHB2 GPIO is 0x4800_xxxx. Matching the V2
+                        // register layout alone would install AF7 on an L0 pad
+                        // and the AF4 firmware nibble would never resolve.
+                        let base = self.peripherals[gpio_idx].base;
+                        let table = if (0x5000_0000..0x5001_0000).contains(&base) {
+                            L0
+                        } else {
+                            V2
+                        };
                         for &(inst, p, pin, af, line, func) in table {
                             if inst == instance && p == port {
                                 plan.push((port, pin, Some(af), line, func));

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1990,6 +1990,34 @@ impl<C: Cpu> Machine<C> {
             .find_peripheral_index_by_name(peripheral)
             .map_or(&[], |idx| self.bus.peripherals[idx].dev.line_names())
     }
+
+    /// Every peripheral on this bus that publishes wire lines, with the lines
+    /// it publishes — the whole probeable wire surface, in one answer.
+    ///
+    /// A frontend that builds a probe menu MUST read it from here. The line
+    /// vocabulary is not uniform and cannot be guessed from the protocol: the
+    /// generic STM32 SPI publishes `SCK/MOSI/MISO` with no chip-select line at
+    /// all, RP2040 SPI spells its select `CSn`, and the ESP GPSPI spells it
+    /// `CS`. A UI that hardcodes one spelling offers lanes that cannot resolve
+    /// on two families out of three.
+    pub fn wire_surface(&self) -> Vec<(&str, &'static [&'static str])> {
+        self.bus
+            .peripherals
+            .iter()
+            .filter_map(|p| {
+                let names = p.dev.line_names();
+                (!names.is_empty()).then_some((p.name.as_str(), names))
+            })
+            .collect()
+    }
+
+    /// The level a already-resolved channel source reads right now, without
+    /// arming capture. Same [`read_logic_source`](Self::read_logic_source)
+    /// body the watch path uses, so a live readout and a captured waveform can
+    /// never disagree about what a channel means.
+    pub fn read_logic_level(&self, source: logic_capture::LogicSource) -> Option<bool> {
+        Self::read_logic_source(&self.bus, source)
+    }
 }
 
 impl<C: Cpu> Machine<C> {

--- a/crates/core/src/tests/stm32_uart_waveform.rs
+++ b/crates/core/src/tests/stm32_uart_waveform.rs
@@ -268,32 +268,50 @@ mod stm32_uart_waveform_tests {
         );
     }
 
-    /// STM32L0 puts USART2_TX on PA2 at **AF4**, not AF7. Detect L0 by the
-    /// IOPORT GPIO base `0x5000_0000` (stm32l073.yaml) and bind AF4; the
-    /// generic V2 table's AF7 rows leave the pad on the idle latch.
+    /// STM32L0 puts USART2_TX on PA2 at **AF4**, not AF7. `wire_stm32_uart_pads`
+    /// selects the AF table from each GPIO port's MMIO base: the L0 IOPORT bank
+    /// is `0x5000_xxxx` (stm32l073.yaml); F4/L4/H5 AHB2 GPIO is `0x4800_xxxx`.
+    /// An AF7-only V2 table leaves an L0 pad on the GPIO latch while USART TX
+    /// narrates on its wire.
     ///
-    /// `SystemBus::new` ships an F1-layout `gpioa` at `0x4001_0800`. A second
-    /// peripheral named `gpioa` is shadowed by name lookup — swap the default
-    /// device and rebase the window, same pattern as `stm32_spi_waveform`.
+    /// Built on [`SystemBus::empty`] so the default F1 `gpioa` at `0x4001_0800`
+    /// cannot shadow the L0 window by name (a second `gpioa` is invisible to
+    /// `find_peripheral_index_by_name` and to the wire planner).
     #[test]
     fn stm32l0_usart2_tx_on_pa2_af4_carries_a_decodable_waveform() {
+        use crate::memory::LinearMemory;
+
         const GPIOA_L0: u64 = 0x5000_0000;
         const USART2: u64 = 0x4000_4400;
         const PA2: u8 = 2;
         // Bit-asymmetric payload (not LSB-first palindromes like 0xA5/0x00).
         const PAYLOAD: &[u8] = b"Lw\x12\x34";
 
-        let mut bus = crate::bus::SystemBus::new();
+        let mut bus = crate::bus::SystemBus::empty();
+        bus.ram = LinearMemory::new(1024 * 1024, RAM_BASE);
         let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
-        let gpioa_idx = bus.find_peripheral_index_by_name("gpioa").unwrap();
-        bus.peripherals[gpioa_idx].base = GPIOA_L0;
-        bus.peripherals[gpioa_idx].size = 0x400;
-        bus.peripherals[gpioa_idx].dev =
-            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2));
+        bus.add_peripheral(
+            "gpioa",
+            GPIOA_L0,
+            0x400,
+            None,
+            Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Stm32V2)),
+        );
         let mut uart = Uart::new_with_layout(UartRegisterLayout::Stm32V2);
         uart.set_sink(None, false);
         bus.add_peripheral("uart2", USART2, 0x400, None, Box::new(uart));
         bus.wire_stm32_uart_pads();
+
+        assert_eq!(
+            bus.bound_pad_functions(),
+            vec!["USART2_TX"],
+            "L0 IOPORT base must install the AF4 USART2_TX route, not the AF7 V2 table",
+        );
+        assert_eq!(
+            bus.peripherals[bus.find_peripheral_index_by_name("gpioa").unwrap()].base,
+            GPIOA_L0,
+            "the only gpioa on this bus is the L0 window",
+        );
 
         let mut machine = Machine::new(cpu, bus);
         for i in 0..1022u64 {
@@ -316,6 +334,25 @@ mod stm32_uart_waveform_tests {
         machine.bus.write_u32(USART2 + BRR, USARTDIV).unwrap();
 
         let gpio_idx = machine.bus.find_peripheral_index_by_name("gpioa").unwrap();
+        // Pin down WHERE a failure is before arming: a wrong AF table shows up
+        // as a pad that never leaves the latch, which is indistinguishable from
+        // a MODER/AFRL write that landed on the wrong window.
+        assert_eq!(
+            machine.bus.read_u32(GPIOA_L0 + MODER).unwrap(),
+            0b10 << (PA2 * 2),
+            "MODER write must land on the L0 gpioa window",
+        );
+        assert_eq!(
+            machine.bus.read_u32(GPIOA_L0 + AFRL).unwrap(),
+            4 << (PA2 * 4),
+            "AFRL write must land on the L0 gpioa window",
+        );
+        assert_eq!(
+            machine.bus.peripherals[gpio_idx].dev.read_gpio_pad(PA2),
+            Some(true),
+            "AF4 route must already resolve the USART TX mark before arming",
+        );
+
         let initial = machine.logic_watch(&[Some(LogicSource::pad(gpio_idx, PA2))]);
         assert_eq!(
             initial,

--- a/crates/core/tests/logic_wire_channels_cross_family.rs
+++ b/crates/core/tests/logic_wire_channels_cross_family.rs
@@ -457,3 +457,65 @@ fn the_same_named_wire_call_resolves_on_every_wired_family() {
         );
     }
 }
+
+/// The reason a frontend must ASK for the line vocabulary instead of encoding
+/// it: the vocabulary is not uniform and is not derivable from the protocol.
+///
+/// Chip select is the case that bites. Generic STM32 SPI publishes no select
+/// line at all, RP2040 spells it `CSn`, ESP GPSPI spells it `CS`. A probe menu
+/// that hardcodes `"CS"` therefore offers a lane that cannot resolve on two of
+/// those three, and the user sees an empty trace with no cause.
+///
+/// So `wire_surface()` is the single source of the vocabulary, and this test
+/// fails the moment a family's spelling moves out from under a caller.
+#[test]
+fn the_wire_surface_reports_each_familys_own_spelling_of_its_lines() {
+    for (chip, peripheral, expected) in [
+        ("esp32c3", "i2c0", &["SCL", "SDA"][..]),
+        ("rp2040", "i2c0", &["SCL", "SDA"][..]),
+        ("stm32l476", "uart5", &["TX", "RX"][..]),
+    ] {
+        let machine = machine_for(chip);
+        let surface = machine.wire_surface();
+        let found = surface
+            .iter()
+            .find(|(name, _)| *name == peripheral)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{chip}: {peripheral} must appear in the wire surface; it holds {:?}",
+                    surface.iter().map(|(n, _)| *n).collect::<Vec<_>>(),
+                )
+            });
+        assert_eq!(
+            found.1, expected,
+            "{chip}: {peripheral} must publish its own spelling, not a guessed one",
+        );
+    }
+}
+
+/// Every peripheral the surface advertises must actually resolve by name.
+/// A menu built from this answer can then never offer a dead lane — which is
+/// the whole point of publishing it.
+#[test]
+fn every_line_the_wire_surface_advertises_resolves_by_name() {
+    for chip in ["esp32c3", "nrf52840", "rp2040", "stm32l476"] {
+        let machine = machine_for(chip);
+        let surface = machine.wire_surface();
+        assert!(
+            !surface.is_empty(),
+            "{chip}: a chip with wired buses must advertise at least one",
+        );
+        for (peripheral, lines) in surface {
+            assert!(
+                !lines.is_empty(),
+                "{chip}: {peripheral} is listed with no lines — it should not be listed",
+            );
+            for line in lines {
+                assert!(
+                    machine.resolve_wire_source(peripheral, line).is_ok(),
+                    "{chip}: {peripheral}.{line} is advertised but does not resolve",
+                );
+            }
+        }
+    }
+}

--- a/crates/wasm/src/inspect.rs
+++ b/crates/wasm/src/inspect.rs
@@ -11,6 +11,28 @@ use labwired_core::inspect::artifact_format as F;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+/// One logic-analyzer channel reference as JS sends it — the FLAT surface
+/// shared by [`WasmSimulator::watch_logic_signals`] and
+/// [`WasmSimulator::sample_logic_signals`]. One definition, so the two calls
+/// cannot drift into accepting different shapes.
+///
+/// ⚠️ `pin` and `line` are BOTH `#[serde(default)]`, and that is load-bearing.
+/// A wire ref carries no `pin` and a pad ref carries no `line`; serde fails the
+/// deserialize of the WHOLE `Vec` on one missing required field, so making
+/// either mandatory turns a single wire lane into a null answer for every
+/// channel beside it. `logic_ref_deserialize_tests` pins this down.
+#[derive(serde::Deserialize)]
+pub(crate) struct LogicRef {
+    pub(crate) kind: String,
+    pub(crate) peripheral: String,
+    /// Pad refs only; a wire ref omits it.
+    #[serde(default)]
+    pub(crate) pin: u8,
+    /// Wire refs only, by datasheet role name.
+    #[serde(default)]
+    pub(crate) line: Option<String>,
+}
+
 pub(crate) fn motor_states_json(
     snapshots: Vec<labwired_core::bus::MotorSnapshot>,
 ) -> Vec<serde_json::Value> {
@@ -328,21 +350,25 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&states).unwrap_or(JsValue::NULL)
     }
 
-    /// Sample the pad level of GPIO pins for the logic analyzer.
-    /// Input: `[{ kind: "gpio", peripheral, pin }]`.
-    /// Output: the same refs each extended with `value: bool | null` —
-    /// `null` when the pin's wire state is unknown (missing peripheral,
-    /// out-of-range pin, or a pad handed to a bus controller the GPIO
-    /// model doesn't track). Cheap enough to call every UI frame.
+    /// Sample the live level of logic-analyzer channels — the per-frame
+    /// readout beside [`watch_logic_signals`]'s captured waveform. It takes
+    /// the SAME flat ref surface, both kinds:
+    ///
+    /// * `{ kind: "gpio", peripheral, pin }` — the chip pad.
+    /// * `{ kind: "wire", peripheral, line }` — the peripheral's own line.
+    ///
+    /// ⚠️ `pin` is `#[serde(default)]` for a reason a test pins down: a wire
+    /// ref legitimately carries no `pin`, and a required field made
+    /// `from_value` fail for the WHOLE array, so one wire lane silently
+    /// blanked the live readout of every pad lane beside it.
+    ///
+    /// Output mirrors each ref, extended with `value: bool | null` — `null`
+    /// when the level is unknown (missing peripheral, out-of-range pin,
+    /// unknown line, or a pad handed to a bus controller the GPIO model does
+    /// not track) — plus an `error` string on a wire ref that could not
+    /// resolve, so a blank lane says why. Cheap enough to call every frame.
     #[wasm_bindgen]
     pub fn sample_logic_signals(&self, refs: JsValue) -> JsValue {
-        #[derive(serde::Deserialize)]
-        struct Ref {
-            kind: String,
-            peripheral: String,
-            pin: u8,
-        }
-
         // A panic here would throw a JS exception straight out of this wasm
         // frame; JS exceptions do NOT run Rust destructors, so the
         // wasm-bindgen borrow guard would never drop and EVERY later call
@@ -351,7 +377,7 @@ impl WasmSimulator {
         let Some(machine) = self.machine.as_ref() else {
             return JsValue::NULL;
         };
-        let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
+        let refs: Vec<LogicRef> = match serde_wasm_bindgen::from_value(refs) {
             Ok(r) => r,
             Err(_) => return JsValue::NULL,
         };
@@ -359,6 +385,26 @@ impl WasmSimulator {
         let samples: Vec<serde_json::Value> = refs
             .iter()
             .map(|r| {
+                if r.kind == "wire" {
+                    let line = r.line.as_deref().unwrap_or("");
+                    // Resolve through the same door the watch path uses, so a
+                    // live readout and a captured lane cannot disagree.
+                    return match machine.resolve_wire_source(&r.peripheral, line) {
+                        Ok(source) => serde_json::json!({
+                            "kind": "wire",
+                            "peripheral": r.peripheral,
+                            "line": line,
+                            "value": machine.read_logic_level(source),
+                        }),
+                        Err(err) => serde_json::json!({
+                            "kind": "wire",
+                            "peripheral": r.peripheral,
+                            "line": line,
+                            "value": serde_json::Value::Null,
+                            "error": err.to_string(),
+                        }),
+                    };
+                }
                 let value = if r.kind == "gpio" {
                     machine
                         .bus
@@ -377,6 +423,33 @@ impl WasmSimulator {
             .collect();
 
         serde_wasm_bindgen::to_value(&samples).unwrap_or(JsValue::NULL)
+    }
+
+    /// The whole probeable WIRE surface of this chip: every peripheral that
+    /// publishes wire lines, with the exact line names it publishes.
+    ///
+    /// Returns `[{ peripheral, lines: ["TX", "RX"] }]`, bus order.
+    ///
+    /// This exists so a probe menu is built from engine truth instead of a
+    /// second, hand-maintained copy of the vocabulary. The spellings are not
+    /// uniform and are not derivable from the protocol — generic STM32 SPI
+    /// publishes `SCK/MOSI/MISO` and NO chip select, RP2040 SPI spells it
+    /// `CSn`, ESP GPSPI spells it `CS`. Anything that guesses `"CS"` offers a
+    /// lane that cannot resolve on two of those three.
+    #[wasm_bindgen]
+    pub fn logic_wire_surface(&self) -> JsValue {
+        // Never panic in an accessor — see `sample_logic_signals`.
+        let Some(machine) = self.machine.as_ref() else {
+            return JsValue::NULL;
+        };
+        let surface: Vec<serde_json::Value> = machine
+            .wire_surface()
+            .into_iter()
+            .map(|(peripheral, lines)| {
+                serde_json::json!({ "peripheral": peripheral, "lines": lines })
+            })
+            .collect();
+        serde_wasm_bindgen::to_value(&surface).unwrap_or(JsValue::NULL)
     }
 
     /// Arm deterministic, in-engine logic-analyzer capture. TWO channel kinds,
@@ -410,20 +483,7 @@ impl WasmSimulator {
     /// empty array to disarm capture.
     #[wasm_bindgen]
     pub fn watch_logic_signals(&mut self, refs: JsValue) -> JsValue {
-        #[derive(serde::Deserialize)]
-        struct Ref {
-            kind: String,
-            peripheral: String,
-            /// Pad refs only. Defaulted so a `wire` ref may simply omit it —
-            /// the surface stays flat, with no nested variant object.
-            #[serde(default)]
-            pin: u8,
-            /// Wire refs only, by datasheet role name.
-            #[serde(default)]
-            line: Option<String>,
-        }
-
-        let refs: Vec<Ref> = match serde_wasm_bindgen::from_value(refs) {
+        let refs: Vec<LogicRef> = match serde_wasm_bindgen::from_value(refs) {
             Ok(r) => r,
             Err(_) => return JsValue::NULL,
         };
@@ -1315,5 +1375,46 @@ mod motor_state_tests {
         );
         assert_eq!(states[1]["commutation_sector"], 4);
         assert_eq!(states[1]["faults"], serde_json::json!(["open-phase-a"]));
+    }
+}
+
+/// The regression that made this module's shared [`LogicRef`] necessary.
+///
+/// The analyzer sends ONE array holding every armed channel. Before this,
+/// `sample_logic_signals` declared its own copy of the ref struct with `pin`
+/// REQUIRED, so the moment a user switched one lane to a wire probe the array
+/// failed to deserialize, `sample_logic_signals` returned `null`, and the live
+/// level column went blank on every pad lane too. Nothing threw; the readout
+/// just stopped. These deserialize the real type, not a mirror of it.
+#[cfg(test)]
+mod logic_ref_deserialize_tests {
+    use super::LogicRef;
+
+    #[test]
+    fn a_wire_ref_beside_a_pad_ref_does_not_null_the_whole_array() {
+        let refs: Vec<LogicRef> = serde_json::from_str(
+            r#"[{"kind":"gpio","peripheral":"gpioa","pin":5},
+                {"kind":"wire","peripheral":"usart2","line":"TX"}]"#,
+        )
+        .expect("a mixed pad/wire watch set must deserialize as one array");
+
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].pin, 5);
+        assert_eq!(refs[0].line, None);
+        assert_eq!(refs[1].line.as_deref(), Some("TX"));
+        // A wire ref has no pad. `0` here is serde's default filling an absent
+        // field, never a claim that the wire sits on pin 0 — the `kind` is what
+        // the read path branches on.
+        assert_eq!(refs[1].pin, 0);
+    }
+
+    #[test]
+    fn a_pad_ref_needs_no_line_field() {
+        let refs: Vec<LogicRef> =
+            serde_json::from_str(r#"[{"kind":"gpio","peripheral":"gpiob","pin":3}]"#)
+                .expect("the pad shape that predates wire channels must still parse");
+        assert_eq!(refs[0].kind, "gpio");
+        assert_eq!(refs[0].peripheral, "gpiob");
+        assert_eq!(refs[0].line, None);
     }
 }


### PR DESCRIPTION
Three fixes in one seam, all surfaced by wiring the wire-probe contract into the analyzer UI.

## 1. A wire ref blanked the live readout of every lane

`sample_logic_signals` declared its own copy of the ref struct with `pin` **required**. A wire ref carries no `pin`, so `serde_wasm_bindgen::from_value` failed on the whole `Vec` and the call returned `null` — the panel's `raw ?? []` then produced an empty map and every lane's live level column went blank, pads included. Nothing threw.

The two entry points now share one `LogicRef`. `logic_ref_deserialize_tests` exercises the real type; removing either `#[serde(default)]` reproduces the exact failure (`missing field 'pin'`), which I confirmed by mutation.

Wire refs are now genuinely sampled, through `resolve_wire_source` — the same door `watch_logic_signals` uses — so a live readout and a captured lane cannot disagree about what a channel means. An unresolvable wire ref answers with `error` instead of a silent null.

## 2. `logic_wire_surface()` — the vocabulary, from the engine

A frontend had no way to ask which lines a peripheral publishes, so it had to encode them. That encoding cannot be right, because the spellings are neither uniform nor derivable from the protocol:

| family | SPI lines |
|---|---|
| generic STM32 | `SCK`, `MOSI`, `MISO` — **no chip select at all** |
| RP2040 | `SCK`, `MOSI`, **`CSn`** |
| ESP GPSPI | `SCK`, `MOSI`, **`CS`** |

A menu assuming `"CS"` offers a lane that cannot resolve on two of those three. `Machine::wire_line_names` already existed for exactly this purpose and was simply unreachable from wasm; `wire_surface()` returns the whole set and `logic_wire_surface()` exposes it.

Two tests: one pins each family's own spelling, one asserts every advertised line actually resolves — so a menu built from this answer can never offer a dead lane. Mutation-checked (dropping the empty-lines filter fails it).

## 3. L0 AF table, per GPIO window

`wire_stm32_uart_pads` picked the AF table from a chip-wide `is_stm32l0` flag derived from `gpioa`'s base. The AF map is a property of the GPIO **window** (L0 IOPORT at `0x5000_xxxx`, F4/L4/H5 AHB2 at `0x4800_xxxx`), not of the chip. Now read per port.

Its test is rebuilt on `SystemBus::empty` so the default F1 `gpioa` at `0x4001_0800` cannot shadow the L0 window by name, and asserts the route resolves *before* arming — so a wrong AF table is distinguishable from a MODER/AFRL write that landed on the wrong window. Supersedes the cruder version merged in #924.

## Verification

- `cargo fmt --all -- --check` → 0
- `cargo clippy -p labwired-core -p labwired-wasm --all-targets` → 0, no warnings in changed files
- `cargo test -p labwired-wasm` → 0
- `cargo test -p labwired-core --features jit,event-scheduler` → green except `test_strict_board_onboarding`

⚠️ `test_strict_board_onboarding` fails **identically at `origin/main` dcf65286** on this machine: the stm32l073 firmware link passes `-Tlink.x` twice and rust-lld rejects `region 'FLASH' already defined`. I baselined it by stashing this branch's changes and re-running at main. Pre-existing and unrelated; building `firmware-l073-demo` directly succeeds, so it looks like the test's extra thumbv6m link-arg colliding with `cortex-m-rt`'s own.