### PR TITLE
fix(cli): one verdict per run — status and exit code stop disagreeing

### DIFF
--- a/crates/cli/src/commands/environment_test.rs
+++ b/crates/cli/src/commands/environment_test.rs
@@ -9,7 +9,7 @@ use crate::artifacts::{
     AssertionResult, EnvironmentConfig, EnvironmentNodeProvenance, EnvironmentNodeSnapshot,
     EnvironmentTestResult, Snapshot,
 };
-use crate::{build_stop_reason_details, TestArgs, EXIT_CONFIG_ERROR, EXIT_RUNTIME_ERROR};
+use crate::{build_stop_reason_details, TestArgs, EXIT_CONFIG_ERROR};
 use labwired_config::{EnvTestScript, EnvironmentManifest, StopReason, TestAssertion, TestLimits};
 use labwired_core::world::{MachineTrait, World};
 use sha2::{Digest, Sha256};
@@ -519,16 +519,20 @@ fn run_world(
         stop_reason,
         StopReason::WallTime | StopReason::MaxUartBytes | StopReason::NoProgress
     );
-    // Mirror the single-machine runner's precedence: a failed assertion is a
-    // test failure even if a runtime fault also occurred; wall/UART/no-progress
-    // limits are safety stops and cannot certify a world as passed.
-    let status = if !all_assertions_passed || safety_stop_requires_failure {
-        "fail"
-    } else if runtime_error {
-        "error"
-    } else {
-        "pass"
-    };
+    // The single-machine runner's precedence, by USING it rather than
+    // restating it: a failed assertion is a test failure even if a runtime
+    // fault also occurred; wall/UART/no-progress limits are safety stops and
+    // cannot certify a world as passed. The fields this runner leaves false are
+    // the ones its execution model cannot observe — a world node has no
+    // `simctl` verdict, no stimulus rejection and no fault gate.
+    let verdict = crate::verdict::RunFacts {
+        assertions_failed: !all_assertions_passed,
+        unexpected_safety_stop: safety_stop_requires_failure,
+        unrescued_runtime_error: runtime_error,
+        ..crate::verdict::RunFacts::default()
+    }
+    .verdict();
+    let status = verdict.status();
     let stop_reason_details = build_stop_reason_details(
         &stop_reason,
         &limits,
@@ -579,15 +583,9 @@ fn run_world(
         duration,
     );
 
-    let exit_code = if !all_assertions_passed || safety_stop_requires_failure {
-        ExitCode::from(crate::EXIT_ASSERT_FAIL)
-    } else if runtime_error {
-        ExitCode::from(EXIT_RUNTIME_ERROR)
-    } else {
-        ExitCode::SUCCESS
-    };
     EnvironmentRunOutcome {
-        exit_code,
+        // The same `verdict` the result above was written from.
+        exit_code: verdict.exit_code(),
         world_firmware_hash: result.config.world_firmware_hash.clone(),
         cycles,
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pc_coverage_report;
 pub mod regex;
 pub mod test_support;
 pub mod tier1;
+pub mod verdict;
 
 mod api_client;
 mod artifacts;
@@ -1528,9 +1529,12 @@ fn handle_load_error<C: labwired_core::Cpu>(
         std::time::Duration::from_secs(0),
         0, // vcd_bytes
     );
+    // The pre-run bail-out. Even here the two views come from one verdict, so
+    // this path cannot drift the way the run path did.
+    let verdict = crate::verdict::Verdict::RuntimeError;
     write_outputs(
         args,
-        "error",
+        verdict,
         0,
         metrics,
         StopReason::Halt,
@@ -1553,7 +1557,7 @@ fn handle_load_error<C: labwired_core::Cpu>(
         // Load/reset failed before the run loop, so no stimulus was attempted.
         Vec::new(),
     );
-    ExitCode::from(EXIT_RUNTIME_ERROR)
+    verdict.exit_code()
 }
 
 fn assertion_currently_passes(
@@ -2981,18 +2985,34 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         );
     }
 
-    let status = if stimuli_rejected > 0 {
-        "error"
-    } else if firmware_declared_failure
-        || !all_passed
-        || (stop_requires_assertion && !expected_stop_reason_matched)
-    {
-        "fail"
-    } else if sim_error_happened && !expected_stop_reason_matched {
-        "error"
-    } else {
-        "pass"
-    };
+    // Finalise runtime-observed fault outcomes (e.g. missing_clock fires only
+    // when the firmware actually accessed the unclocked peripheral) and enforce
+    // the require_fault_fired gate: a fault that never took effect makes the run
+    // invalid, not a firmware pass.
+    //
+    // This must happen BEFORE the verdict, not after it. It used to sit thirty
+    // lines below, which is precisely why `fault_gate_failed` could only reach
+    // the exit code and never the `status` — the artifact certified a pass for
+    // a run the exit code called invalid. See `crate::verdict`.
+    labwired_cli::faults::finalize_fault_evidence(&machine.bus, faults, &mut fault_evidence);
+    let fault_gate_failed = require_fault_fired && fault_evidence.iter().any(|e| !e.fired);
+    if fault_gate_failed {
+        let n = fault_evidence.iter().filter(|e| !e.fired).count();
+        error!("require_fault_fired: {n} fault(s) did not fire; run is invalid");
+    }
+
+    // THE verdict. One decision, from which both `status` and the exit code are
+    // read below — they cannot disagree because there is nothing left to
+    // disagree with. Do not reintroduce a second chain here.
+    let verdict = crate::verdict::RunFacts {
+        stimuli_rejected: stimuli_rejected > 0,
+        firmware_declared_failure,
+        assertions_failed: !all_passed,
+        fault_gate_failed,
+        unexpected_safety_stop: stop_requires_assertion && !expected_stop_reason_matched,
+        unrescued_runtime_error: sim_error_happened && !expected_stop_reason_matched,
+    }
+    .verdict();
 
     let duration = start.elapsed();
     let uart_bytes = uart_tx.lock().map(|g| g.len() as u64).unwrap_or(0);
@@ -3006,17 +3026,6 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         duration,
         0, // vcd_bytes - will be updated below
     );
-    // Finalise runtime-observed fault outcomes (e.g. missing_clock fires only
-    // when the firmware actually accessed the unclocked peripheral) and enforce
-    // the require_fault_fired gate: a fault that never took effect makes the run
-    // invalid, not a firmware pass.
-    labwired_cli::faults::finalize_fault_evidence(&machine.bus, faults, &mut fault_evidence);
-    let fault_gate_failed = require_fault_fired && fault_evidence.iter().any(|e| !e.fired);
-    if fault_gate_failed {
-        let n = fault_evidence.iter().filter(|e| !e.fired).count();
-        error!("require_fault_fired: {n} fault(s) did not fire; run is invalid");
-    }
-
     // Final-state universal inspect block (summary mode: decoded registers +
     // artifact metadata, framebuffer bytes omitted/hashed). This is the
     // agent-facing oracle payload — after a run the caller sees the decoded
@@ -3063,11 +3072,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     {
         let checked = assertion_results.len();
         let passed = assertion_results.iter().filter(|a| a.passed).count();
-        let label = match status {
-            "pass" => "PASS",
-            "fail" => "FAIL",
-            _ => "ERROR",
-        };
+        let label = verdict.banner_label();
         // The SCRIPT, not the system manifest: nearly every board ships its
         // manifest as `system.yaml`, so naming that would print the same
         // uninformative "system" for every board in the repo. The script stem
@@ -3087,7 +3092,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
 
     write_outputs(
         args,
-        status,
+        verdict,
         steps_executed,
         metrics,
         stop_reason.clone(),
@@ -3109,24 +3114,19 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         stimulus_outcomes,
     );
 
-    if stimuli_rejected > 0 {
-        ExitCode::from(EXIT_CONFIG_ERROR)
-    } else if !all_passed
-        || fault_gate_failed
-        || (stop_requires_assertion && !expected_stop_reason_matched)
-    {
-        ExitCode::from(EXIT_ASSERT_FAIL)
-    } else if sim_error_happened && !expected_stop_reason_matched {
-        ExitCode::from(EXIT_RUNTIME_ERROR)
-    } else {
-        ExitCode::from(EXIT_PASS)
-    }
+    // The same `verdict` the artifact above was written from. Not a second
+    // chain — that is the whole point of `crate::verdict`.
+    verdict.exit_code()
 }
 
 #[allow(clippy::too_many_arguments, clippy::if_same_then_else)]
 fn write_outputs<C: labwired_core::Cpu>(
     args: &TestArgs,
-    status: &str,
+    // The run's ONE verdict, not a status string. Taking `&str` here meant a
+    // caller could invent a status that disagreed with the exit code it went on
+    // to return; that is the drift `crate::verdict` exists to make
+    // unrepresentable, so the artifact writer is handed the verdict itself.
+    verdict: crate::verdict::Verdict,
     steps_executed: u64,
     metrics: &labwired_core::metrics::PerformanceMetrics,
     stop_reason: StopReason,
@@ -3148,6 +3148,8 @@ fn write_outputs<C: labwired_core::Cpu>(
     logic_edges: Option<labwired_core::logic_capture::LogicEdgesResult>,
     stimuli: Vec<StimulusOutcome>,
 ) {
+    let status = verdict.status();
+
     let mut hasher = Sha256::new();
     hasher.update(firmware_bytes);
     let firmware_hash = format!("{:x}", hasher.finalize());

--- a/crates/cli/src/verdict.rs
+++ b/crates/cli/src/verdict.rs
@@ -1,0 +1,248 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! The ONE verdict of a run.
+//!
+//! A run produces a single judgment. `result.json`'s `status`, the JUnit
+//! summary, the stderr banner and the process exit code are four *views* of
+//! that one judgment, not four judgments.
+//!
+//! They used to be computed separately. `execute_test_loop` had a `status`
+//! chain and, 128 lines later, an exit-code chain built from a different set of
+//! predicates, and the multi-node `run_world` had a second pair of its own. The
+//! two single-machine chains had drifted apart in both directions:
+//!
+//! * `firmware_declared_failure` was only in the `status` chain, so firmware
+//!   that ended its own run with `EXIT 5` produced `status: "fail"`, a `FAIL`
+//!   banner — and exit code `0`, which
+//!   `docs/simulation_protocol.md` §5 tells a CI runner to "Treat as CI
+//!   Success".
+//! * `fault_gate_failed` was only in the exit-code chain — it could not be in
+//!   the other, because it was not computed until thirty lines after `status`
+//!   had already been decided — so a `require_fault_fired` run whose fault never
+//!   fired shipped `status: "pass"`, a `PASS` banner and a JUnit file with zero
+//!   failures, while the process exited `1`.
+//!
+//! Either way round, a harness reading the artifact and a harness reading `$?`
+//! reported opposite outcomes for the same silicon. For a tool sold as a
+//! hardware oracle that is the worst available failure: not a wrong answer, but
+//! two answers.
+//!
+//! So the decision is made exactly once, here, from [`RunFacts`]. The two views
+//! are [`Verdict::status`] and [`Verdict::exit_code`], both derived from that
+//! one value — divergence is no longer something you can express. Adding a new
+//! way for a run to fail means adding a field to [`RunFacts`], which every
+//! consumer of every view then inherits at once.
+
+use std::process::ExitCode;
+
+use crate::{EXIT_ASSERT_FAIL, EXIT_CONFIG_ERROR, EXIT_PASS, EXIT_RUNTIME_ERROR};
+
+/// The judgment. One value per run.
+///
+/// The variants are the protocol's exit codes, named for their cause;
+/// `docs/simulation_protocol.md` §5 is the source of both the codes and the
+/// `status` spellings, and [`Verdict::status`] / [`Verdict::exit_code`] are the
+/// only implementations of that table in the tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Every assertion held and nothing invalidated the run.
+    Pass,
+    /// The firmware, or the script's assertions, said no.
+    AssertionFail,
+    /// The run never happened as configured, so it proved nothing.
+    ConfigError,
+    /// The simulation itself failed in a way the script did not expect.
+    RuntimeError,
+}
+
+impl Verdict {
+    /// The `status` field of `result.json`, the snapshot and the JUnit report.
+    pub fn status(self) -> &'static str {
+        match self {
+            Verdict::Pass => "pass",
+            Verdict::AssertionFail => "fail",
+            Verdict::ConfigError | Verdict::RuntimeError => "error",
+        }
+    }
+
+    /// The human-facing one-line banner label on stderr.
+    pub fn banner_label(self) -> &'static str {
+        match self {
+            Verdict::Pass => "PASS",
+            Verdict::AssertionFail => "FAIL",
+            Verdict::ConfigError | Verdict::RuntimeError => "ERROR",
+        }
+    }
+
+    /// The process exit code. `docs/simulation_protocol.md` §5.
+    pub fn exit_code(self) -> ExitCode {
+        ExitCode::from(self.exit_status())
+    }
+
+    /// The exit code as a number, so tests can compare it. `ExitCode` is
+    /// deliberately opaque and cannot be inspected.
+    pub fn exit_status(self) -> u8 {
+        match self {
+            Verdict::Pass => EXIT_PASS,
+            Verdict::AssertionFail => EXIT_ASSERT_FAIL,
+            Verdict::ConfigError => EXIT_CONFIG_ERROR,
+            Verdict::RuntimeError => EXIT_RUNTIME_ERROR,
+        }
+    }
+}
+
+/// Everything about a finished run that bears on its verdict.
+///
+/// Every field is a *reason the run is not a pass*; `Default` is therefore the
+/// clean run. A runner fills in the ones its execution model can observe and
+/// leaves the rest false — the multi-node runner has no `simctl` verdict and no
+/// fault gate, and says so by omission rather than by keeping its own chain.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RunFacts {
+    /// A declared stimulus was refused by the engine, so nothing the run
+    /// observed can be attributed to it. Dominates every other reason: a
+    /// "fail" from a run whose inputs never arrived is not a trustworthy fail
+    /// either.
+    pub stimuli_rejected: bool,
+    /// The firmware ended its own run with a non-zero code through `simctl`.
+    pub firmware_declared_failure: bool,
+    /// At least one script assertion did not hold.
+    pub assertions_failed: bool,
+    /// `require_fault_fired` was set and some injected fault never took
+    /// effect, so the run did not test what it claimed to test.
+    pub fault_gate_failed: bool,
+    /// The run hit a safety limit (wall time, UART cap, no progress) that no
+    /// `expected_stop_reason` assertion accounted for.
+    pub unexpected_safety_stop: bool,
+    /// The simulation raised an error that no `expected_stop_reason` assertion
+    /// accounted for.
+    pub unrescued_runtime_error: bool,
+}
+
+impl RunFacts {
+    /// The single decision. Order is precedence, highest first.
+    pub fn verdict(&self) -> Verdict {
+        if self.stimuli_rejected {
+            Verdict::ConfigError
+        } else if self.firmware_declared_failure
+            || self.assertions_failed
+            || self.fault_gate_failed
+            || self.unexpected_safety_stop
+        {
+            Verdict::AssertionFail
+        } else if self.unrescued_runtime_error {
+            Verdict::RuntimeError
+        } else {
+            Verdict::Pass
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The protocol table, transcribed from `docs/simulation_protocol.md` §5
+    /// and §4.1 rather than from the code above.
+    ///
+    /// | Exit | Constant             | status    |
+    /// |------|----------------------|-----------|
+    /// | 0    | `EXIT_PASS`          | `"pass"`  |
+    /// | 1    | `EXIT_ASSERT_FAIL`   | `"fail"`  |
+    /// | 2    | `EXIT_CONFIG_ERROR`  | `"error"` |
+    /// | 3    | `EXIT_RUNTIME_ERROR` | `"error"` |
+    #[test]
+    fn the_two_views_agree_for_every_reachable_run() {
+        // Exhaustive over the fact space: 2^6 = 64 runs, every combination of
+        // reasons a run might not be a pass. No sampling, no representative
+        // cases — if any combination could produce a status and an exit code
+        // that tell different stories, it is in here.
+        for bits in 0u8..64 {
+            let facts = RunFacts {
+                stimuli_rejected: bits & 1 != 0,
+                firmware_declared_failure: bits & 2 != 0,
+                assertions_failed: bits & 4 != 0,
+                fault_gate_failed: bits & 8 != 0,
+                unexpected_safety_stop: bits & 16 != 0,
+                unrescued_runtime_error: bits & 32 != 0,
+            };
+            let verdict = facts.verdict();
+            let expected_status = match verdict.exit_status() {
+                0 => "pass",
+                1 => "fail",
+                2 | 3 => "error",
+                other => panic!("{facts:?} produced exit code {other}, outside the protocol"),
+            };
+            assert_eq!(
+                verdict.status(),
+                expected_status,
+                "{facts:?}: status {:?} and exit code {} disagree",
+                verdict.status(),
+                verdict.exit_status()
+            );
+            assert_eq!(verdict.banner_label(), verdict.status().to_uppercase());
+        }
+    }
+
+    #[test]
+    fn a_clean_run_passes() {
+        assert_eq!(RunFacts::default().verdict(), Verdict::Pass);
+        assert_eq!(RunFacts::default().verdict().exit_status(), 0);
+    }
+
+    /// The first half of the drift this module removed: the firmware's own
+    /// verdict must reach the exit code, not only the artifact.
+    #[test]
+    fn a_firmware_declared_failure_is_a_failing_exit_code() {
+        let facts = RunFacts {
+            firmware_declared_failure: true,
+            ..RunFacts::default()
+        };
+        assert_eq!(facts.verdict(), Verdict::AssertionFail);
+        assert_eq!(facts.verdict().exit_status(), EXIT_ASSERT_FAIL);
+        assert_eq!(facts.verdict().status(), "fail");
+    }
+
+    /// The second half: the fault gate must reach the artifact, not only the
+    /// exit code.
+    #[test]
+    fn a_fault_gate_trip_is_a_failing_status() {
+        let facts = RunFacts {
+            fault_gate_failed: true,
+            ..RunFacts::default()
+        };
+        assert_eq!(facts.verdict(), Verdict::AssertionFail);
+        assert_eq!(facts.verdict().status(), "fail");
+        assert_eq!(facts.verdict().exit_status(), EXIT_ASSERT_FAIL);
+    }
+
+    /// A rejected stimulus outranks everything, including a firmware pass.
+    #[test]
+    fn a_rejected_stimulus_dominates() {
+        let facts = RunFacts {
+            stimuli_rejected: true,
+            assertions_failed: true,
+            unrescued_runtime_error: true,
+            ..RunFacts::default()
+        };
+        assert_eq!(facts.verdict(), Verdict::ConfigError);
+        assert_eq!(facts.verdict().status(), "error");
+        assert_eq!(facts.verdict().exit_status(), EXIT_CONFIG_ERROR);
+    }
+
+    /// An assertion failure outranks a runtime error: the firmware got a
+    /// verdict, and a fault that also occurred does not rescue it.
+    #[test]
+    fn an_assertion_failure_outranks_a_runtime_error() {
+        let facts = RunFacts {
+            assertions_failed: true,
+            unrescued_runtime_error: true,
+            ..RunFacts::default()
+        };
+        assert_eq!(facts.verdict(), Verdict::AssertionFail);
+    }
+}

--- a/crates/cli/tests/run_verdict_single_source.rs
+++ b/crates/cli/tests/run_verdict_single_source.rs
@@ -1,0 +1,339 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! A run has ONE verdict, and `result.json` and the process exit code are two
+//! views of it.
+//!
+//! `docs/simulation_protocol.md` §5 is the contract these tests are derived
+//! from — not the runner's own source. It defines the exit codes a LabWired CI
+//! runner may produce and what a consumer must do with each:
+//!
+//! | Exit | Constant            | Protocol Action                    |
+//! |------|---------------------|------------------------------------|
+//! | `0`  | `EXIT_PASS`         | Treat as CI Success.               |
+//! | `1`  | `EXIT_ASSERT_FAIL`  | Treat as CI Failure (Logic Error). |
+//! | `2`  | `EXIT_CONFIG_ERROR` | Fix configuration inputs.          |
+//! | `3`  | `EXIT_RUNTIME_ERROR`| Report issue.                      |
+//!
+//! `result.json`'s `status` is the same judgment spelled `"pass"` / `"fail"` /
+//! `"error"` (§4.1). The two therefore cannot disagree: a run whose artifact
+//! says `"fail"` and whose process says "CI Success" has told two different
+//! stories about one piece of silicon, and whichever the harness reads is a
+//! coin toss. `docs/simulation_protocol.md` gives no licence for the exit code
+//! and the status to be computed from different evidence.
+//!
+//! `simctl_firmware_verdict_e2e.rs` already covers the `status` side of these
+//! same runs. It never inspects the process exit code, so it stayed green
+//! while the two views disagreed — which is the whole reason this file exists.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Repository root, from this crate's manifest directory.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn temp_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join("labwired-tests");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Assemble a minimal Cortex-M ELF whose only job is to store `value` to
+/// `target`, then spin.
+///
+/// ```text
+///   0x0000  .word 0x20001000      ; initial SP
+///   0x0004  .word 0x00000101      ; reset vector (Thumb bit set)
+///   0x0100  LDR  r0, [pc, #8]     ; r0 = target   (literal @ 0x10c)
+///   0x0102  LDR  r1, [pc, #12]    ; r1 = value    (literal @ 0x110)
+///   0x0104  STR  r1, [r0, #0]     ; the write the whole feature rests on
+///   0x0106  B    .                ; spin
+///   0x010c  .word target
+///   0x0110  .word value
+/// ```
+fn build_firmware(target: u32, value: u32) -> Vec<u8> {
+    let mut image = vec![0u8; 0x114];
+
+    image[0x00..0x04].copy_from_slice(&0x2000_1000u32.to_le_bytes()); // initial SP
+    image[0x04..0x08].copy_from_slice(&0x0000_0101u32.to_le_bytes()); // reset, Thumb
+
+    image[0x100..0x102].copy_from_slice(&0x4802u16.to_le_bytes()); // LDR r0,[pc,#8]
+    image[0x102..0x104].copy_from_slice(&0x4903u16.to_le_bytes()); // LDR r1,[pc,#12]
+    image[0x104..0x106].copy_from_slice(&0x6001u16.to_le_bytes()); // STR r1,[r0]
+    image[0x106..0x108].copy_from_slice(&0xE7FEu16.to_le_bytes()); // B .
+
+    image[0x10c..0x110].copy_from_slice(&target.to_le_bytes());
+    image[0x110..0x114].copy_from_slice(&value.to_le_bytes());
+
+    wrap_in_elf(&image)
+}
+
+/// Wrap a flat image in the smallest ELF32/ARM the loader accepts.
+fn wrap_in_elf(image: &[u8]) -> Vec<u8> {
+    const EHDR: u32 = 52;
+    const PHDR: u32 = 32;
+    let offset = EHDR + PHDR;
+
+    let mut elf = Vec::new();
+    elf.extend_from_slice(&[0x7f, b'E', b'L', b'F', 1, 1, 1, 0]);
+    elf.extend_from_slice(&[0; 8]);
+    elf.extend_from_slice(&2u16.to_le_bytes()); // e_type = ET_EXEC
+    elf.extend_from_slice(&40u16.to_le_bytes()); // e_machine = EM_ARM
+    elf.extend_from_slice(&1u32.to_le_bytes());
+    elf.extend_from_slice(&0x101u32.to_le_bytes()); // e_entry (Thumb)
+    elf.extend_from_slice(&EHDR.to_le_bytes()); // e_phoff
+    elf.extend_from_slice(&0u32.to_le_bytes());
+    elf.extend_from_slice(&0u32.to_le_bytes());
+    elf.extend_from_slice(&(EHDR as u16).to_le_bytes());
+    elf.extend_from_slice(&(PHDR as u16).to_le_bytes());
+    elf.extend_from_slice(&1u16.to_le_bytes()); // e_phnum
+    elf.extend_from_slice(&40u16.to_le_bytes());
+    elf.extend_from_slice(&0u16.to_le_bytes());
+    elf.extend_from_slice(&0u16.to_le_bytes());
+
+    elf.extend_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+    elf.extend_from_slice(&offset.to_le_bytes());
+    elf.extend_from_slice(&0u32.to_le_bytes());
+    elf.extend_from_slice(&0u32.to_le_bytes());
+    elf.extend_from_slice(&(image.len() as u32).to_le_bytes());
+    elf.extend_from_slice(&(image.len() as u32).to_le_bytes());
+    elf.extend_from_slice(&5u32.to_le_bytes()); // R|X
+    elf.extend_from_slice(&4u32.to_le_bytes());
+
+    elf.extend_from_slice(image);
+    elf
+}
+
+const SIMCTL_BASE: u32 = 0x6000_0000;
+const EXIT_OFFSET: u32 = 0x00;
+
+/// What the protocol table permits. Exactly one exit code per status, and
+/// exactly one status per exit code — this mapping IS the single-verdict claim.
+///
+/// `"error"` covers both `EXIT_CONFIG_ERROR` (2) and `EXIT_RUNTIME_ERROR` (3);
+/// the protocol distinguishes their causes but calls both an `"error"` status,
+/// so this direction of the mapping is one-to-many and checked as such.
+fn assert_one_verdict(
+    case: &str,
+    status: &str,
+    exit_code: Option<i32>,
+    result: &serde_json::Value,
+) {
+    let code = exit_code.unwrap_or_else(|| panic!("[{case}] runner was killed by a signal"));
+    let permitted: &[i32] = match status {
+        "pass" => &[0],
+        "fail" => &[1],
+        "error" => &[2, 3],
+        other => panic!("[{case}] result.json status {other:?} is not in the protocol vocabulary"),
+    };
+    assert!(
+        permitted.contains(&code),
+        "[{case}] ONE run, TWO verdicts: result.json says status={status:?} but the process \
+         exited {code}. docs/simulation_protocol.md §5 permits {permitted:?} for that status. \
+         A CI harness reading the exit code and a dashboard reading result.json would report \
+         opposite outcomes for the same silicon.\nresult.json:\n{result:#}"
+    );
+}
+
+struct RunOutput {
+    result: serde_json::Value,
+    exit_code: Option<i32>,
+}
+
+/// Everything one case needs on disk: firmware, a board declaring `simctl`, and
+/// a script. `extra` is appended to the script verbatim (faults, verdict, ...);
+/// `faults`/`verdict` are a schema 1.1 feature, so cases that use them say so.
+fn stage_case(
+    name: &str,
+    exit_code: u32,
+    assertions: &str,
+    schema_version: &str,
+    extra: &str,
+) -> (PathBuf, PathBuf) {
+    let unique = labwired_cli::test_support::unique_name(name);
+    let dir = temp_dir();
+
+    let fw_path = dir.join(format!("{unique}.elf"));
+    std::fs::write(
+        &fw_path,
+        build_firmware(SIMCTL_BASE + EXIT_OFFSET, exit_code),
+    )
+    .expect("write firmware");
+
+    let chip = workspace_root().join("configs/chips/ci-fixture-cortex-m3-uart1.yaml");
+    let system_path = dir.join(format!("{unique}-system.yaml"));
+    std::fs::write(
+        &system_path,
+        format!(
+            r#"name: "{unique}-system"
+chip: "{}"
+peripherals:
+  - id: "simctl"
+    type: "simctl"
+    base_address: 0x60000000
+    size: "32"
+"#,
+            chip.display()
+        ),
+    )
+    .expect("write system manifest");
+
+    let script_path = dir.join(format!("{unique}.yaml"));
+    std::fs::write(
+        &script_path,
+        format!(
+            r#"schema_version: "{schema_version}"
+inputs:
+  firmware: "{}"
+  system: "{}"
+limits:
+  max_steps: 100000
+assertions:
+{assertions}
+{extra}"#,
+            fw_path.display(),
+            system_path.display()
+        ),
+    )
+    .expect("write script");
+
+    let output_dir = labwired_cli::test_support::unique_temp_dir(&format!("labwired-{name}"));
+    let _ = std::fs::remove_dir_all(&output_dir);
+    (script_path, output_dir)
+}
+
+fn run_case(script: &Path, output_dir: &Path) -> RunOutput {
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .args([
+            "test",
+            "--script",
+            script.to_str().unwrap(),
+            "--no-uart-stdout",
+            "--output-dir",
+            output_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run the labwired binary");
+
+    let result_path = output_dir.join("result.json");
+    let body = std::fs::read_to_string(&result_path).unwrap_or_else(|e| {
+        panic!(
+            "no result.json at {}: {e}\nstdout:\n{}\nstderr:\n{}",
+            result_path.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    RunOutput {
+        result: serde_json::from_str(&body).expect("result.json is valid JSON"),
+        exit_code: output.status.code(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The two directions the fork ran in.
+// ---------------------------------------------------------------------------
+
+/// Firmware declares failure through `simctl` and the script asserts nothing.
+///
+/// `simctl_firmware_verdict_e2e::a_nonzero_exit_fails_the_run_even_with_no_assertions`
+/// already pins `status == "fail"` here. The exit code was computed from a
+/// different chain that had no `firmware_declared_failure` term at all, so the
+/// process reported CI Success for firmware that said it had failed.
+#[test]
+fn a_firmware_declared_failure_fails_the_process_too() {
+    let (script, out) = stage_case("verdict-fw-exit", 5, "  []", "1.0", "");
+    let run = run_case(&script, &out);
+
+    assert_eq!(
+        run.result["firmware_exit_code"], 5,
+        "precondition: the firmware verdict must reach the result"
+    );
+    assert_eq!(
+        run.result["status"], "fail",
+        "precondition: a non-zero firmware exit fails the run"
+    );
+    assert_one_verdict(
+        "firmware exited 5, no assertions",
+        run.result["status"].as_str().unwrap(),
+        run.exit_code,
+        &run.result,
+    );
+}
+
+/// The opposite direction: a `require_fault_fired` gate that trips.
+///
+/// The fault targets `uart1`, which this firmware never touches, so it can
+/// never fire and the run is invalid. The exit-code chain knew that; the
+/// `status` chain was computed thirty lines earlier, before `fault_gate_failed`
+/// existed, so the artifact certified a pass while the process failed.
+#[test]
+fn a_fault_that_never_fired_fails_the_artifact_too() {
+    let (script, out) = stage_case(
+        "verdict-fault-gate",
+        0,
+        "  - firmware_exit: 0",
+        "1.1",
+        r#"faults:
+  - id: "uart1-unclocked"
+    kind: "missing_clock"
+    target:
+      peripheral: "uart1"
+verdict:
+  require_fault_fired: true
+"#,
+    );
+    let run = run_case(&script, &out);
+
+    assert_eq!(
+        run.result["firmware_exit_code"], 0,
+        "precondition: the firmware itself ran to a clean exit"
+    );
+    assert_one_verdict(
+        "require_fault_fired gate tripped",
+        run.result["status"].as_str().unwrap(),
+        run.exit_code,
+        &run.result,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ANTI-VACUITY CONTROLS. These pass on unmodified main. If a change to the
+// verdict makes THESE fail, the collapse broke the ordinary paths.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_clean_run_agrees_on_success() {
+    let (script, out) = stage_case("verdict-clean", 0, "  - firmware_exit: 0", "1.0", "");
+    let run = run_case(&script, &out);
+
+    assert_eq!(run.result["status"], "pass", "result: {}", run.result);
+    assert_one_verdict(
+        "firmware exited 0, assertion matched",
+        run.result["status"].as_str().unwrap(),
+        run.exit_code,
+        &run.result,
+    );
+}
+
+#[test]
+fn a_failed_assertion_agrees_on_failure() {
+    let (script, out) = stage_case("verdict-assert-fail", 7, "  - firmware_exit: 0", "1.0", "");
+    let run = run_case(&script, &out);
+
+    assert_eq!(run.result["status"], "fail", "result: {}", run.result);
+    assert_one_verdict(
+        "firmware exited 7, assertion demanded 0",
+        run.result["status"].as_str().unwrap(),
+        run.exit_code,
+        &run.result,
+    );
+}


### PR DESCRIPTION
Ledger section 5, row **5.8 — "One `verdict()`"**.

## What was forked

A run's verdict was computed in **four** places, none of which was a function:

| # | Site | Produces |
|---|---|---|
| 1 | `crates/cli/src/lib.rs` `execute_test_loop`, ~L2984 | `result.json` `status`, stderr banner, JUnit |
| 2 | same function, ~L3112 (128 lines later) | process exit code |
| 3 | `crates/cli/src/commands/environment_test.rs` `run_world`, ~L525 | environment `status` |
| 4 | same function, ~L582 | environment exit code |

`docs/simulation_protocol.md` §5 defines one exit code per outcome and §4.1 the
matching `status` spelling. They are two views of one judgment, so they cannot
disagree — but sites 1 and 2 were built from **different predicate sets**.

## How the copies had drifted

**Direction A — `firmware_declared_failure` was only in the `status` chain.**
It is `let firmware_declared_failure = firmware_exit_code.is_some_and(|code| code != 0);`,
used at site 1 and absent from site 2. Firmware that ends its own run with
`EXIT 5` therefore produced `status: "fail"`, a `FAIL` banner — and exit code
`0`, which the protocol table tells a CI runner to "Treat as CI Success".

**Direction B — `fault_gate_failed` was only in the exit-code chain.**
It *could not* be in the other one: it was computed at ~L3014, thirty lines
**after** `status` had already been decided. So a `require_fault_fired` run
whose fault never fired shipped `status: "pass"`, a `PASS` banner and a JUnit
file with `failures="0"`, while the process exited `1`.

Sites 3 and 4 carried a comment claiming to "mirror the single-machine runner's
precedence" while using predicates that runner does not use (a safety stop is
unconditionally fatal there, but rescuable by `expected_stop_reason` at site 1).

For a hardware oracle this is worse than a wrong answer: it is two answers about
one piece of silicon, and which one you get depends on whether your harness
reads `$?` or the artifact. It also defeats the house rule of judging runs by
exit code — the exit code was the lying view.

## The gate, failing first

`crates/cli/tests/run_verdict_single_source.rs` drives the **real `labwired`
binary** and asserts `result.json`'s `status` and the process exit code agree,
with the permitted mapping transcribed from `docs/simulation_protocol.md` §5 —
not from the code under test.

Against **unmodified `main`** (`origin/main` @ `1a6819ca`), source untouched:

```
$ cargo test -p labwired-cli --test run_verdict_single_source
[require_fault_fired gate tripped] ONE run, TWO verdicts: result.json says
  status="pass" but the process exited 1. docs/simulation_protocol.md §5
  permits [0] for that status.
[firmware exited 5, no assertions] ONE run, TWO verdicts: result.json says
  status="fail" but the process exited 0. docs/simulation_protocol.md §5
  permits [1] for that status.

failures:
    a_fault_that_never_fired_fails_the_artifact_too
    a_firmware_declared_failure_fails_the_process_too

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out.
exit code 101
```

Both directions reproduce. The 2 that pass are anti-vacuity controls (a clean
run and an ordinary assertion failure), so the file is not simply broken.

Worth noting: `simctl_firmware_verdict_e2e.rs` already pinned `status == "fail"`
for the first scenario and stayed green throughout, because it never inspected
`output.status`. It tested one of the two homes.

## What now makes the fork impossible

`crates/cli/src/verdict.rs` is the single home:

- `RunFacts` holds every reason a run is not a pass; `Default` is the clean run.
- `RunFacts::verdict()` is the **only** decision chain.
- `Verdict::status()`, `banner_label()` and `exit_code()` are views of that one
  value — divergence is not expressible.
- `write_outputs` now takes a `Verdict` instead of a `&str` status, so a call
  site cannot invent a status that disagrees with the exit code it returns.
- `finalize_fault_evidence` moved **before** the verdict, removing the ordering
  hazard that made direction B structurally unfixable in place.
- Adding a new way for a run to fail means adding a `RunFacts` field, which
  every view inherits at once.

Guards: a 64-combination **exhaustive** unit test over the entire `RunFacts`
space asserts the two views agree for every reachable run, plus the four e2e
scenarios above against the real binary.

## Verification

| Check | Exit | Result |
|---|---|---|
| `cargo test -p labwired-core --lib` | 0 | 3051 passed |
| `cargo test -p labwired-core --test firmware_survival` | 0 | 61 passed, 5 ignored |
| `cargo fmt --all -- --check` | 0 | clean |
| `python3 scripts/generate_validation_status.py --check --drift` | 0 | no drift (run at the committed tree) |
| `cargo clippy -p labwired-cli --all-targets -- -D warnings` | 0 | clean |
| `cargo test -p labwired-cli --lib` | 0 | 119 passed (6 new) |
| `cargo test -p labwired-cli --test run_verdict_single_source` | 0 | 4 passed |

Full CLI suite (`cargo test -p labwired-cli --no-fail-fast`): 40 test targets,
**one** failure — `environment_runner_prioritizes_failed_assertions_over_runtime_errors`,
which asserts `stop_reason == "halt"` and gets `"memory_violation"`. I reverted
this branch's changes in place and reran it against pristine `main`: it fails
there identically (`left: "memory_violation"`, `right: "halt"`, exit 101). It is
**pre-existing and unrelated** — it fails on `stop_reason`, not on status or
exit code — and is not addressed here.

No crate in the workspace depends on `labwired-cli`, so the blast radius is
contained to this crate.
