### PR TITLE
fix(arch): the browser stops guessing an undeclared architecture

### DIFF
--- a/crates/core/src/system/arch_policy.rs
+++ b/crates/core/src/system/arch_policy.rs
@@ -1,0 +1,69 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! The one place that decides what silicon a run models.
+//!
+//! Two decisions live here, and nowhere else:
+//!
+//! * [`machine_family`] — what a *chip* becomes, read from its declared `arch:`.
+//! * [`elf_arch`] — what an *ELF* is, read from its `e_machine` field.
+//!
+//! Both were previously duplicated, and both duplicates had drifted. The CLI
+//! refused a chip that declared no architecture; the browser ran it as a
+//! Cortex-M. The in-core ELF decoder bailed on an unrecognised machine; the
+//! `loader` crate warned and returned [`crate::Arch::Unknown`], spelling
+//! EM_XTENSA as the literal `94`. A simulator sold as an oracle cannot hold two
+//! opinions about what processor the firmware is, so these are functions rather
+//! than a convention, and `crate::tests::one_arch_policy` fails if a second
+//! copy grows back.
+
+use labwired_config::{Arch, ChipDescriptor};
+
+/// The machine family a chip is built as.
+///
+/// This is deliberately coarser than [`Arch`]: it answers "which builder", not
+/// "which core". Callers still choose among variants *within* a family (an
+/// ESP32-S3 boots differently from an ESP32), because that is a build detail
+/// and not an architecture decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MachineFamily {
+    CortexM,
+    RiscV,
+    Xtensa,
+}
+
+/// What machine family this chip is built as, or an error naming why not.
+///
+/// A chip that declares no architecture is **refused**. It is never guessed:
+/// guessing is what let an `arch: unknown` chip execute as a Cortex-M in the
+/// browser, producing confident output about silicon nobody had modelled.
+pub fn machine_family(chip: &ChipDescriptor) -> anyhow::Result<MachineFamily> {
+    match chip.arch {
+        Arch::Arm => Ok(MachineFamily::CortexM),
+        Arch::RiscV => Ok(MachineFamily::RiscV),
+        Arch::Xtensa => Ok(MachineFamily::Xtensa),
+        Arch::Unknown => anyhow::bail!(
+            "chip '{}' does not declare a known architecture (`arch:` must be arm, riscv, or xtensa)",
+            chip.name
+        ),
+    }
+}
+
+/// The architecture an ELF's `e_machine` field names, or `None` if this engine
+/// models no machine for it.
+///
+/// `None` is the single meaning of "unrecognised". What to *do* about it is the
+/// caller's business — the in-core node builder treats it as fatal, the loader
+/// records it as [`crate::Arch::Unknown`] for a caller that will check later —
+/// but neither decides any longer what the bytes mean.
+pub fn elf_arch(e_machine: u16) -> Option<crate::Arch> {
+    match e_machine {
+        goblin::elf::header::EM_ARM => Some(crate::Arch::Arm),
+        goblin::elf::header::EM_RISCV => Some(crate::Arch::RiscV),
+        goblin::elf::header::EM_XTENSA => Some(crate::Arch::XtensaLx7),
+        _ => None,
+    }
+}

--- a/crates/core/src/system/mod.rs
+++ b/crates/core/src/system/mod.rs
@@ -1,3 +1,4 @@
+pub mod arch_policy;
 pub mod builder;
 pub mod cortex_m;
 pub mod efuse;

--- a/crates/core/src/system/node.rs
+++ b/crates/core/src/system/node.rs
@@ -16,10 +16,11 @@
 //! That keeps it callable from the CLI, the hosted runner, and the browser
 //! without dragging any of their orchestration along.
 
+use crate::system::arch_policy::{elf_arch, machine_family, MachineFamily};
 use crate::world::MachineTrait;
 use crate::Machine;
 use anyhow::Context;
-use labwired_config::{Arch, ChipDescriptor, SystemManifest};
+use labwired_config::{ChipDescriptor, SystemManifest};
 
 /// The image a node executes.
 ///
@@ -84,14 +85,10 @@ pub fn build_node_with_plugins(
     firmware: NodeFirmware,
     plugins: &[&dyn crate::plugin::ChipPlugin],
 ) -> anyhow::Result<Box<dyn MachineTrait>> {
-    match chip.arch {
-        Arch::Arm => build_cortex_m_node(id, chip, system, firmware, plugins),
-        Arch::RiscV => build_riscv_node(id, chip, system, firmware, plugins),
-        Arch::Xtensa => build_xtensa_node(id, chip, system, firmware),
-        Arch::Unknown => anyhow::bail!(
-            "node '{id}': chip '{}' does not declare a known architecture (`arch:` must be arm, riscv, or xtensa)",
-            chip.name
-        ),
+    match machine_family(chip).with_context(|| format!("node '{id}'"))? {
+        MachineFamily::CortexM => build_cortex_m_node(id, chip, system, firmware, plugins),
+        MachineFamily::RiscV => build_riscv_node(id, chip, system, firmware, plugins),
+        MachineFamily::Xtensa => build_xtensa_node(id, chip, system, firmware),
     }
 }
 
@@ -343,12 +340,9 @@ pub fn parse_elf_image(bytes: &[u8]) -> anyhow::Result<crate::memory::ProgramIma
     use goblin::elf::Elf;
 
     let elf = Elf::parse(bytes).context("parse ELF")?;
-    let arch = match elf.header.e_machine {
-        goblin::elf::header::EM_ARM => crate::Arch::Arm,
-        goblin::elf::header::EM_RISCV => crate::Arch::RiscV,
-        goblin::elf::header::EM_XTENSA => crate::Arch::XtensaLx7,
-        machine => anyhow::bail!("unsupported ELF machine type {machine}"),
-    };
+    let machine = elf.header.e_machine;
+    let arch = elf_arch(machine)
+        .ok_or_else(|| anyhow::anyhow!("unsupported ELF machine type {machine}"))?;
     let mut image = crate::memory::ProgramImage::new(elf.entry, arch);
     for ph in &elf.program_headers {
         if ph.p_type != PT_LOAD || ph.p_filesz == 0 {

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -40,6 +40,8 @@ pub mod no_vacuous_test_targets;
 pub mod nrf52;
 pub mod nrf52_nvmc;
 #[cfg(test)]
+pub mod one_arch_policy;
+#[cfg(test)]
 pub mod one_arduino_boot_path;
 #[cfg(test)]
 pub mod peripheral_reachability;

--- a/crates/core/src/tests/one_arch_policy.rs
+++ b/crates/core/src/tests/one_arch_policy.rs
@@ -1,0 +1,230 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! ONE architecture policy — a guard, not a convention.
+//!
+//! Two questions decide what silicon a run models, and both had more than one
+//! answer:
+//!
+//! 1. **"What can this chip be?"** — a match on `chip.arch`. The CLI
+//!    (`system::node`) rejected `Arch::Unknown`; the browser
+//!    (`crates/wasm/src/lib.rs`) ran it as a Cortex-M. Same chip, two answers,
+//!    and nothing went red.
+//! 2. **"What is this ELF?"** — a match on `e_machine`. `system::node`
+//!    bailed on an unrecognised machine; `crates/loader` warned and returned
+//!    `Arch::Unknown`, and one of the two spelled EM_XTENSA as the literal 94.
+//!
+//! For a product sold as an oracle, "the browser and the CLI disagree about
+//! what processor your firmware is" is a correctness defect, not untidiness.
+//!
+//! Both questions now have exactly one implementation, in
+//! [`crate::system::arch_policy`]. These tests assert the answer *and* that no
+//! second copy grows back.
+
+use crate::system::arch_policy::{elf_arch, machine_family, MachineFamily};
+use labwired_config::{Arch, ChipDescriptor};
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+fn read(root: &Path, rel: &str) -> String {
+    std::fs::read_to_string(root.join(rel))
+        .unwrap_or_else(|e| panic!("{rel} must be readable for this guard to mean anything: {e}"))
+}
+
+/// Strip `//` line comments so prose that names a symbol is not mistaken for
+/// code that uses it. The same extractor idiom as `one_arduino_boot_path`.
+fn code_only(src: &str) -> String {
+    src.lines()
+        .map(|l| match l.find("//") {
+            Some(i) => &l[..i],
+            None => l,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+const POLICY: &str = "crates/core/src/system/arch_policy.rs";
+
+/// Every file that is allowed to decide an architecture is listed here, and
+/// only [`POLICY`] may actually contain the decision. Adding a file to this
+/// list is not how you fix a failure — routing it through `arch_policy` is.
+const SCANNED: &[&str] = &[
+    "crates/core/src/system/node.rs",
+    "crates/loader/src/lib.rs",
+    "crates/wasm/src/lib.rs",
+    // Added because the compiler, not the author, found an architecture
+    // literal here. Any file that names one belongs in this list.
+    "crates/wasm/src/inputs.rs",
+];
+
+#[test]
+fn only_one_file_maps_an_elf_machine_to_an_arch() {
+    let root = repo_root();
+    let mut offenders = Vec::new();
+    for rel in SCANNED {
+        let src = code_only(&read(&root, rel));
+        // Reading `e_machine` to hand it to the policy is correct use, so the
+        // marker is naming a machine *constant* — that can only be part of a
+        // second table. `94` is EM_XTENSA, which is how the loader's copy was
+        // written and how it escaped a search for the constant.
+        let maps = src.contains("EM_ARM")
+            || src.contains("EM_RISCV")
+            || src.contains("EM_XTENSA")
+            || src.contains("94 =>");
+        if maps {
+            offenders.push(*rel);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "{} file(s) decode an ELF machine type outside {}. Two decoders drift: one of them \
+         spelled EM_XTENSA as the literal 94, and they disagreed about what an unrecognised \
+         machine means (bail vs Arch::Unknown). Call `arch_policy::elf_arch` instead:\n  {}",
+        offenders.len(),
+        POLICY,
+        offenders.join("\n  ")
+    );
+}
+
+#[test]
+fn only_one_file_dispatches_on_a_chip_arch() {
+    let root = repo_root();
+    let mut offenders = Vec::new();
+    for rel in SCANNED {
+        let src = code_only(&read(&root, rel));
+        // A dispatch is a match arm naming a config Arch variant. Storing an
+        // arch (`arch: Arch::Arm` in a struct literal) is not a dispatch, so
+        // the marker is the arm form `Arch::X =>` / `Arch::X |`.
+        let dispatches = ["Arm", "RiscV", "Xtensa", "Unknown"].iter().any(|v| {
+            src.contains(&format!("Arch::{v} =>")) || src.contains(&format!("Arch::{v} |"))
+        });
+        if dispatches {
+            offenders.push(*rel);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "{} file(s) decide what machine a chip becomes outside {}. That fork is how the \
+         browser came to run an `arch: unknown` chip as a Cortex-M while the CLI refused it. \
+         Call `arch_policy::machine_family` instead:\n  {}",
+        offenders.len(),
+        POLICY,
+        offenders.join("\n  ")
+    );
+}
+
+fn chip_with_arch(arch: Arch) -> ChipDescriptor {
+    let yaml = format!(
+        "name: \"guard-fixture\"\narch: \"{}\"\nregisters_count: 16\n\
+         flash:\n  base: 0x8000000\n  size: \"128KB\"\nram:\n  base: 0x20000000\n  size: \"64KB\"\n\
+         peripherals: []\n",
+        match arch {
+            Arch::Arm => "arm",
+            Arch::RiscV => "riscv",
+            Arch::Xtensa => "xtensa",
+            Arch::Unknown => "unknown",
+        }
+    );
+    serde_yaml::from_str(&yaml).expect("fixture chip must parse")
+}
+
+#[test]
+fn an_undeclared_architecture_is_refused_not_guessed() {
+    let err = machine_family(&chip_with_arch(Arch::Unknown))
+        .expect_err("a chip that names no architecture must not silently become a Cortex-M");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("architecture"),
+        "the refusal must say what is wrong; got {msg:?}"
+    );
+}
+
+#[test]
+fn each_declared_architecture_reaches_its_own_family() {
+    for (arch, want) in [
+        (Arch::Arm, MachineFamily::CortexM),
+        (Arch::RiscV, MachineFamily::RiscV),
+        (Arch::Xtensa, MachineFamily::Xtensa),
+    ] {
+        let got = machine_family(&chip_with_arch(arch)).expect("declared arch must be accepted");
+        assert_eq!(got, want, "chip arch {arch:?} reached the wrong family");
+    }
+}
+
+#[test]
+fn the_elf_machine_table_is_the_only_one() {
+    assert_eq!(
+        elf_arch(goblin::elf::header::EM_ARM),
+        Some(crate::Arch::Arm)
+    );
+    assert_eq!(
+        elf_arch(goblin::elf::header::EM_RISCV),
+        Some(crate::Arch::RiscV)
+    );
+    assert_eq!(
+        elf_arch(goblin::elf::header::EM_XTENSA),
+        Some(crate::Arch::XtensaLx7)
+    );
+    // 94 is EM_XTENSA. The loader used to hard-code it; if goblin's constant
+    // ever stopped being 94 the two copies would have silently disagreed.
+    assert_eq!(goblin::elf::header::EM_XTENSA, 94);
+    // An unrecognised machine has exactly one answer: None. Callers decide
+    // whether that is fatal, but they no longer decide what it *means*.
+    assert_eq!(elf_arch(0), None);
+    assert_eq!(elf_arch(3), None); // EM_386 — real, but not modelled here
+}
+
+/// The repository ships exactly one chip that declares no architecture, and it
+/// exists to prove this refusal. Asserting against the real file — not a
+/// hand-built fixture — is what ties the guard to the thing that shipped.
+#[test]
+fn the_shipped_unknown_arch_fixture_is_refused() {
+    let root = repo_root();
+    let yaml = read(&root, "configs/chips/ci-fixture-unknown-arch.yaml");
+    let chip: ChipDescriptor = serde_yaml::from_str(&yaml).expect("fixture chip must parse");
+    assert_eq!(
+        chip.arch,
+        Arch::Unknown,
+        "the fixture stopped declaring `arch: unknown`, so this test no longer proves anything"
+    );
+    assert!(
+        machine_family(&chip).is_err(),
+        "the browser used to build this chip as a Cortex-M while the CLI refused it"
+    );
+}
+
+#[test]
+fn the_scan_is_not_vacuous() {
+    let root = repo_root();
+    // The policy module must exist and carry both decisions, or every scan
+    // above passes by finding nothing anywhere.
+    let policy = read(&root, POLICY);
+    assert!(
+        policy.contains("EM_XTENSA") && policy.contains("Arch::Unknown"),
+        "{POLICY} must hold both decisions; it is the only file exempt from the scans"
+    );
+    for rel in SCANNED {
+        let src = read(&root, rel);
+        assert!(
+            src.len() > 1_000,
+            "{rel} is {} bytes — too small to be the real file; the scan is reading the wrong path",
+            src.len()
+        );
+    }
+    // The comment stripper must actually strip, or a scan can be defeated by
+    // a comment and — worse — pass while the code below it still forks.
+    let stripped = code_only("let a = EM_ARM; // EM_XTENSA\n");
+    assert!(
+        stripped.contains("EM_ARM") && !stripped.contains("EM_XTENSA"),
+        "the scan must read code and ignore comments; got {stripped:?}"
+    );
+}

--- a/crates/core/src/tests/one_arduino_boot_path.rs
+++ b/crates/core/src/tests/one_arduino_boot_path.rs
@@ -43,9 +43,16 @@
 //! ## Why an allowlist and not a deletion
 //!
 //! The 29 entries below are not hypothetical debt — they are thunks the
-//! browser installs today. Deleting them changes what a lab renders, and this
-//! repo has exactly **zero** test files under `crates/wasm/tests/`, so nothing
-//! here can tell you whether a lab still paints afterwards. The earlier attempt
+//! browser installs today. Deleting them changes what a lab renders, and
+//! nothing in this repo runs in a browser to tell you whether a lab still
+//! paints afterwards.
+//!
+//! (An earlier version of this comment said `crates/wasm/tests/` held **zero**
+//! test files. That was wrong: it holds `motor_states.rs`, and the crate has
+//! 32 more host-side tests behind `cfg(all(test, not(target_arch = "wasm32")))`.
+//! They compile the browser crate natively, which is real coverage — it is just
+//! not a browser, so the conclusion stands on the corrected fact rather than
+//! the overstated one.) The earlier attempt
 //! at this fix deleted all of them at once with no lab run and no gate; that is
 //! the mistake this file exists to avoid repeating. Closing an entry means
 //! running the lab that exercises it, not arguing that it looks safe.

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -413,15 +413,15 @@ pub fn load_elf_bytes(buffer: &[u8]) -> Result<ProgramImage> {
 
     info!("ELF Entry Point: {:#x}", elf.entry);
 
-    let arch = match elf.header.e_machine {
-        goblin::elf::header::EM_ARM => labwired_core::Arch::Arm,
-        goblin::elf::header::EM_RISCV => labwired_core::Arch::RiscV,
-        94 => labwired_core::Arch::XtensaLx7, // EM_XTENSA = 94
-        _ => {
+    // The mapping itself lives in `labwired_core::system::arch_policy`; this
+    // crate only chooses what to do when it says "not modelled". It records
+    // Unknown rather than failing, because a caller that never runs the image
+    // (a symboliser, a disassembler) is still served by a parsed one.
+    let arch =
+        labwired_core::system::arch_policy::elf_arch(elf.header.e_machine).unwrap_or_else(|| {
             warn!("Unknown ELF machine type: {}", elf.header.e_machine);
             labwired_core::Arch::Unknown
-        }
-    };
+        });
 
     let mut program_image = ProgramImage::new(elf.entry, arch);
 

--- a/crates/wasm/src/inputs.rs
+++ b/crates/wasm/src/inputs.rs
@@ -789,7 +789,7 @@ board_io:
                 labwired_core::console::HostConsole::UsbSerialJtag,
             ),
             uart_rx_bufs: Vec::new(),
-            arch: Arch::RiscV,
+            arch: labwired_core::system::arch_policy::MachineFamily::RiscV,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,6 +1,4 @@
-use labwired_config::{
-    Arch, BoardIoBinding, BoardIoKind, BoardIoSignal, ChipDescriptor, SystemManifest,
-};
+use labwired_config::{BoardIoBinding, BoardIoKind, BoardIoSignal, ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::console::{ConsoleCapture, HostConsole};
 
@@ -24,6 +22,7 @@ use labwired_core::decoder::xtensa_length;
 use labwired_core::decoder::xtensa_narrow;
 use labwired_core::memory::{LinearMemory, ProgramImage};
 use labwired_core::peripherals::adc::Adc;
+use labwired_core::system::arch_policy::{machine_family, MachineFamily};
 use labwired_core::system::cortex_m::configure_cortex_m;
 use labwired_core::system::xtensa::configure_xtensa_esp32;
 use labwired_core::Arch as CoreArch;
@@ -76,7 +75,12 @@ pub struct WasmSimulator {
     console: ConsoleCapture,
     uart_rx_bufs: Vec<Arc<Mutex<VecDeque<u8>>>>,
     #[allow(dead_code)]
-    arch: Arch,
+    /// Which decoder the Trace panel uses. Typed as `MachineFamily`, not
+    /// `Arch`, so `Unknown` is unrepresentable: the disassembler used to
+    /// fold it in with Arm and print Thumb for an architecture nobody had
+    /// established — the same guess that let an unknown chip boot as a
+    /// Cortex-M.
+    arch: MachineFamily,
     /// Set by `install_esp32_arduino_quirks` / `enable_esp32_dual_core_emulation`.
     /// When `Some`, `step_with_esp32_aids` runs the IPI bridge + dual-core
     /// handshake keep-alives each cycle.
@@ -341,7 +345,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::Arm,
+            arch: MachineFamily::CortexM,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -370,9 +374,14 @@ impl WasmSimulator {
         let chip: ChipDescriptor = serde_yaml::from_str(chip_yaml)
             .map_err(|e| JsValue::from_str(&format!("Chip YAML error: {}", e)))?;
 
-        match chip.arch {
-            Arch::Arm | Arch::Unknown => Self::new_from_config_arm(&chip, &manifest, firmware),
-            Arch::RiscV => {
+        // The dispatch is `arch_policy`'s, not this crate's. It used to be a
+        // local match that folded `Unknown` in with `Arm`, so a chip declaring
+        // no architecture ran here as a Cortex-M while the CLI refused it.
+        let family = machine_family(&chip)
+            .map_err(|e| JsValue::from_str(&format!("Chip architecture error: {e:#}")))?;
+        match family {
+            MachineFamily::CortexM => Self::new_from_config_arm(&chip, &manifest, firmware),
+            MachineFamily::RiscV => {
                 let blob_map = parse_named_blobs(&blobs);
                 // A board opts into faithful ROM boot by supplying the merged
                 // flash image (`bootloader@0x0 + partition-table@0x8000 +
@@ -392,11 +401,11 @@ impl WasmSimulator {
                     Self::new_from_config_riscv(&chip, &manifest, firmware, &blob_map)
                 }
             }
-            Arch::Xtensa if chip.name.starts_with("esp32s3") => {
+            MachineFamily::Xtensa if chip.name.starts_with("esp32s3") => {
                 let blob_map = parse_named_blobs(&blobs);
                 Self::new_from_config_xtensa_esp32s3(&manifest, firmware, &blob_map)
             }
-            Arch::Xtensa => Self::new_from_config_xtensa_esp32(&manifest, firmware),
+            MachineFamily::Xtensa => Self::new_from_config_xtensa_esp32(&manifest, firmware),
         }
     }
 
@@ -432,7 +441,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::Arm,
+            arch: MachineFamily::CortexM,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -591,7 +600,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::RiscV,
+            arch: MachineFamily::RiscV,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -747,7 +756,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::RiscV,
+            arch: MachineFamily::RiscV,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -835,7 +844,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::RiscV,
+            arch: MachineFamily::RiscV,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -907,7 +916,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::Xtensa,
+            arch: MachineFamily::Xtensa,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -1010,7 +1019,7 @@ impl WasmSimulator {
             uart_sink,
             console,
             uart_rx_bufs,
-            arch: Arch::Xtensa,
+            arch: MachineFamily::Xtensa,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -1165,7 +1174,7 @@ impl WasmSimulator {
             // ESP32-C3 / generic RV32: use the RISC-V decoder. The previous path
             // always ran Thumb decode, so C3 Trace showed ARM-looking ops and
             // frequent `Unknown32` against real RISC-V encodings.
-            Arch::RiscV => {
+            MachineFamily::RiscV => {
                 let pc = pc & !1;
                 match machine.bus.read_u16(pc as u64) {
                     Ok(lo) => {
@@ -1185,7 +1194,7 @@ impl WasmSimulator {
                     Err(_) => "?? (Error reading RV instruction)".to_string(),
                 }
             }
-            Arch::Xtensa => {
+            MachineFamily::Xtensa => {
                 // Match the LX7 fetch path: length from byte0, then narrow/wide.
                 match machine.bus.read_u8(pc as u64) {
                     Ok(b0) => {
@@ -1205,7 +1214,7 @@ impl WasmSimulator {
                     Err(_) => "?? (Error reading Xtensa instruction)".to_string(),
                 }
             }
-            Arch::Arm | Arch::Unknown => {
+            MachineFamily::CortexM => {
                 let pc = pc & !1;
                 match machine.bus.read_u16(pc as u64) {
                     Ok(h1) => {
@@ -1802,7 +1811,7 @@ mod machine_advance_tests {
     fn wrap_test_machine<C: Cpu + 'static>(
         cpu: C,
         mut bus: SystemBus,
-        arch: Arch,
+        arch: MachineFamily,
     ) -> WasmSimulator {
         let uart_sink = Arc::new(Mutex::new(Vec::new()));
         bus.attach_uart_tx_sink(uart_sink.clone(), false);
@@ -1832,7 +1841,7 @@ mod machine_advance_tests {
             bus.write_u16(index * 2, 0xBF00).unwrap();
         }
         cpu.set_pc(0);
-        wrap_test_machine(cpu, bus, Arch::Arm)
+        wrap_test_machine(cpu, bus, MachineFamily::CortexM)
     }
 
     fn configured_arm_simulator() -> WasmSimulator {
@@ -1842,7 +1851,7 @@ mod machine_advance_tests {
             bus.write_u16(index * 2, 0xBF00).unwrap();
         }
         cpu.set_pc(0);
-        wrap_test_machine(cpu, bus, Arch::Arm)
+        wrap_test_machine(cpu, bus, MachineFamily::CortexM)
     }
 
     fn riscv_simulator() -> WasmSimulator {
@@ -1852,7 +1861,7 @@ mod machine_advance_tests {
             bus.write_u32(index * 4, 0x0000_0013).unwrap();
         }
         cpu.set_pc(0);
-        wrap_test_machine(cpu, bus, Arch::RiscV)
+        wrap_test_machine(cpu, bus, MachineFamily::RiscV)
     }
 
     fn xtensa_simulator() -> WasmSimulator {
@@ -1863,7 +1872,7 @@ mod machine_advance_tests {
             bus.write_u8(index * 2 + 1, 0xf0).unwrap();
         }
         cpu.set_pc(0);
-        wrap_test_machine(cpu, bus, Arch::Xtensa)
+        wrap_test_machine(cpu, bus, MachineFamily::Xtensa)
     }
 
     fn assert_batch_matches_32_singles(


### PR DESCRIPTION
Ledger **5.13**, "One `Arch` enum, one `arch_from_elf()`" — the highest-harm row left in the queue.

Two corrections to the row before the fix: there is **no `arch_from_elf()`** anywhere; nothing derives architecture from the ELF for dispatch, it comes from the chip YAML. And the fork is not one enum — it is **two decisions, each with two implementations that had already drifted**.

## The defect

```rust
// crates/wasm/src/lib.rs, before
Arch::Arm | Arch::Unknown => Self::new_from_config_arm(&chip, &manifest, firmware),
```

```rust
// crates/core/src/system/node.rs, before
Arch::Unknown => anyhow::bail!("chip '{}' does not declare a known architecture", chip.name),
```

Same chip. The CLI refuses it; the browser runs it as a Cortex-M and reports confidently on silicon nobody modelled. Nothing goes red.

The ELF side had the same shape: `parse_elf_image` bailed on an unrecognised `e_machine`; `crates/loader` warned and recorded `Arch::Unknown` — and spelled EM_XTENSA as the literal `94`, so a search for the constant would never have found the second copy.

## The fix

`core::system::arch_policy` owns both decisions and nothing else may:

| | |
|---|---|
| `machine_family(chip)` | what a chip is built as. `Unknown` is an **error**, never a guess |
| `elf_arch(e_machine)` | what an ELF is. One table; `None` is the single meaning of "not modelled" |

`WasmSimulator::arch` is retyped `Arch` → `MachineFamily`, so `Unknown` is **unrepresentable** in the Trace decoder. That dispatch had the same `Arm | Unknown` fallback, printing Thumb for an architecture nobody had established — the code's own comment records that bug biting once already on the C3.

## Why no lab can move

Measured, not asserted:

| Check | Result |
|---|---|
| Chip YAMLs on main | 229 |
| Missing `arch:` | 0 |
| `arch: unknown` | **1** — `configs/chips/ci-fixture-unknown-arch.yaml` |
| `arch` serde default / `#[serde(other)]` | neither — a typo is a parse error, not a silent Unknown |

The only chip that trips the changed line is a fixture that exists to prove the CLI rejects it. `the_shipped_unknown_arch_fixture_is_refused` asserts against that real file, so the guard is tied to the thing that shipped rather than to a hand-built stand-in.

## Watched failing first, both directions

| | |
|---|---|
| scans vs unmodified main | **101** — named all four forked sites |
| re-fold `Unknown` into the Arm arm | **101** |
| add a second `EM_ARM` table to the loader | **101** |
| both injections reverted | tree clean |

The dispatch scan found a **fourth** site I had not: the Trace decoder. The compiler then found a **fifth**, in `crates/wasm/src/inputs.rs` — now in `SCANNED`, with a comment saying why.

## Green

`core --lib` 3063 · `loader` 13 · `wasm` 32 + 1 · `firmware_survival` 61 · `world_manifest_validation` 7 · `world_node_factory` 3 · `world_multichip` 3 · `multi_node_iot` 1 · `e2e_labwired_ereader` 1 · `esp32_classic_aids_stability` 5 · fmt 0 · clippy (`wasm --all-targets`, `core --lib`, `loader`) 0 · drift gate at the committed tree 0.

The two clippy errors that appear under a multi-package `--all-targets` invocation (feature unification pulls in `event-scheduler` targets) **reproduce identically on pristine main** — same `StepProfile` lint, exit 101. Baselined in a throwaway worktree at `origin/main`, not assumed.

## Deliberately not done

The browser still does not check that the firmware's ELF architecture matches the chip's, which `validate_cortex_m_firmware` does on the CLI. **That check can reject a lab**, and nothing in this repo runs in a browser, so it needs a lab run rather than an argument. It is the larger half of 5.13's harm and it stays open on purpose.

## One correction

The doc comment landed with #934 said `crates/wasm/tests/` held **zero** test files. It holds one (`motor_states.rs`), and the crate has 32 more host-side tests. The conclusion it supported is unchanged — none of them run in a browser — but the stated fact was wrong, so the comment is corrected here.
