### PR TITLE
fix(cpu): MOV PC, Rm is a branch, not a register write

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -2638,7 +2638,30 @@ impl CortexM {
                 }
                 Instruction::MovReg { rd, rm } => {
                     let val = self.read_reg(rm);
-                    self.write_reg(rd, val);
+                    if rd == 15 {
+                        // ARMv7-M: writing PC through MOV is BXWritePC, i.e. a
+                        // BRANCH — bit 0 selects the instruction set and is not
+                        // part of the address, and no sequential PC advance
+                        // follows. Falling through to `write_reg` alone left the
+                        // Thumb bit in PC and then added `pc_increment` on top,
+                        // landing 2 bytes past the target.
+                        //
+                        // rustc emits exactly this for a dense `match` over
+                        // bytes: `ADR Rn, table` / `ADD Rd, Rn, idx LSL #2` /
+                        // `MOV PC, Rd` into a table of 4-byte `B.W` entries.
+                        // Two bytes late is the middle of an entry, so the
+                        // second halfword of that branch executed as a stray
+                        // 16-bit instruction and control fell through to the
+                        // NEXT entry — every arm ran its successor's code. The
+                        // nRF52840 OBD-II scanner painted its OLED that way:
+                        // "RPM 3000" came out "S N 3000" (R->S, P->Q which is
+                        // absent so blank, M->N), while digits, dispatched by
+                        // arithmetic rather than by this table, stayed exact.
+                        self.pc = val & !1;
+                        pc_increment = 0;
+                    } else {
+                        self.write_reg(rd, val);
+                    }
                 }
                 // Logic
                 Instruction::And { rd, rm } => {
@@ -3879,6 +3902,41 @@ mod tests {
             bus.write_u16(pc as u64, instr_bin as u16).unwrap();
         }
         cpu.step_internal(bus, &[], &bus.config.clone()).unwrap();
+    }
+
+    /// `MOV PC, Rm` is a branch (BXWritePC), not a register write.
+    ///
+    /// rustc lowers a dense byte `match` to `ADR`/`ADD Rd, Rn, idx LSL #2`/
+    /// `MOV PC, Rd` over a table of 4-byte `B.W` entries. Advancing PC after
+    /// the write lands 2 bytes into the selected entry, so its second halfword
+    /// runs as a stray instruction and control falls through to the NEXT
+    /// entry — every match arm silently executes its successor's.
+    #[test]
+    fn armv7m_mov_to_pc_branches_instead_of_advancing() {
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x451A;
+        cpu.r5 = 0x45B0; // a 4-aligned jump-table entry, as ADD LSL #2 produces
+        run_test_instr(&mut cpu, &mut bus, 0x46AF, false); // MOV pc, r5
+        assert_eq!(cpu.pc, 0x45B0, "MOV PC, Rm must branch to Rm exactly");
+
+        // Thumb bit is the instruction-set selector, never part of the address.
+        cpu.pc = 0x451A;
+        cpu.r5 = 0x45B1;
+        run_test_instr(&mut cpu, &mut bus, 0x46AF, false);
+        assert_eq!(cpu.pc, 0x45B0, "MOV PC, Rm must clear the Thumb bit");
+    }
+
+    /// A non-PC destination keeps plain register-move semantics.
+    #[test]
+    fn armv7m_mov_reg_still_moves_and_advances_for_normal_registers() {
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+        cpu.pc = 0x451A;
+        cpu.r5 = 0x45B1;
+        run_test_instr(&mut cpu, &mut bus, 0x462F, false); // MOV r7, r5
+        assert_eq!(cpu.r7, 0x45B1);
+        assert_eq!(cpu.pc, 0x451C, "a normal MOV advances one halfword");
     }
 
     #[test]


### PR DESCRIPTION
## Description

`Instruction::MovReg` treated a PC destination like any other register: `write_reg(15, val)`, then the step epilogue added `pc_increment` on top. Two things are wrong with that. ARMv7-M defines a PC write through MOV as `BXWritePC` — bit 0 is the instruction-set selector and is **not** part of the address, and a branch takes no sequential advance. So the emulator kept the Thumb bit in PC and then landed 2 bytes past the target.

Two bytes is not a crash; it is worse. rustc lowers a dense byte `match` to

```
ADR  Rn, table          ; addw rn, pc, #imm
ADD  Rd, Rn, idx LSL #2
MOV  PC, Rd             ; -> table of 4-byte B.W entries
```

Landing 2 bytes late puts execution *inside* the selected 4-byte `B.W`. Its second halfword decodes as a stray 16-bit instruction, and control then falls through into the **next** table entry — so every match arm silently ran its successor's code.

### How it surfaced

The shipped `nrf52840-obd2-scanner` lab painted its OLED with every letter shifted one position along the alphabet:

| firmware writes | emulator painted |
|---|---|
| `RPM 3000` | `S N 3000` |
| `SPD 88 km/h` | `T E 88` |
| `TEMP 90 C` | `U N  90 D` |
| `DTC 2` | `EUD 2` |
| `STALE` / `OK` | `TU M` / `PL` |

R→S, M→N, D→E, T→U, C→D, O→P; letters whose successor is absent from the firmware's 5×7 font (P→Q, E→F, A→B) fell to the default arm and rendered blank. Digits were exact throughout because `glyph()` dispatches them by arithmetic into a table load, never through the jump table.

The firmware is not at fault: its font table is correct in every commit, and the ELF's own dispatch tables resolve `'R'` to R's arm. `configs`/decode were fine too — the TBB path and `ADDW Rd, PC, #imm` both compute correctly; I probed them individually before finding this.

### Verification

Before/after on the identical native harness, running the **shipped** scanner ELF (single machine, so live values read `--`):

| | before | after |
|---|---|---|
| page0 | `S N` | `RPM --` |
| page1 | `T E` | `SPD -- km/h` |
| page2 | `U N     D` | `TEMP -- C` |
| page3 | `EUD 0` | `DTC 0` |
| page5 | `TU M  U N P U` | `STALE TIMEOUT` |

Regression tests added at the exact shape the firmware uses: a 4-aligned jump-table entry must be branched to exactly, the Thumb bit must be cleared, and a non-PC destination must keep plain move-and-advance semantics.

## Related Issues

None filed. Downstream symptom was the blank/garbled OLED in the OBD-II lab embedded at `labwired.com/blog/building-an-obd2-scanner-without-hardware` (the lab not *running* at all was a separate playground bug, fixed in w1ne/labwired#1572).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New peripheral/architecture support
- [ ] Documentation update

## Checklist
- [x] I have run `cargo fmt` and `cargo clippy`. (`cargo fmt --check` clean; clippy clean on `-p labwired-core`)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation accordingly. (no doc surface changes)
- [x] My changes generate no new warnings.

### Test runs

```text
cargo test --release -p labwired-core --lib     3065 passed, 0 failed
cargo test --release -p labwired-core --tests     63 passed, 1 failed
```

The single integration failure is `e2e_epaper_tricolor::firmware_drives_panel_to_three_band_pattern`, which panics in `ensure_firmware_built` before any instruction executes — it shells out to `cargo build --target thumbv7m-none-eabi` and this environment has only `x86_64-unknown-linux-gnu` installed. Not related to this change, but it does mean **the firmware e2e gates were not exercised here**.

## Reviewer note

Please run the firmware e2e gates on a machine with the bare-metal targets before landing. `MOV PC, Rm` is load-bearing well beyond the lab that exposed it: `MOV PC, LR` is a return idiom, and every rustc dense-`match` dispatch goes through this instruction. Anything that previously used it was executing the wrong arm or returning two bytes off, so the blast radius of *correcting* it is equally broad — this is exactly the change that wants the full cross-compiled suite behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf4dK7pTJ1UjSX19cT7bHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cf4dK7pTJ1UjSX19cT7bHQ)_