### PR TITLE
ci(integrity): a live monitor can no longer hide the engine's own gates

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -867,6 +867,16 @@ jobs:
       - name: BLE Pong fixture drift (committed .ino ↔ LIVE published lab)
         run: scripts/ci/check-published-lab-drift.sh
 
+      # ⚠ EVERY ENGINE GATE BELOW CARRIES `if: !cancelled()`, AND THE STEP ABOVE
+      # IS WHY. The drift check reads production over the network, so it fails
+      # for reasons that have nothing to do with the commit — and a failed step
+      # skips the rest of the job by default. On 2026-08-09 it went red at 15:53
+      # because the owner edited the published sketch. #908 merged 46 minutes
+      # later and broke `world_esp32c3_ble_pong` (two C3 nodes stopped electing
+      # a host); that test sits in the step below and DID NOT RUN for the next
+      # 29 hours, on that merge or any after it. A third-party monitor must
+      # never be able to stand in front of this repo's own gates.
+
       # `esp32c3_usb_cdc_console` is here for COST, not because it is
       # release-only: same reason as `world_esp32c3_ble_pong` above. It boots
       # the C3 mask ROM, which is 335s in debug (measured) and seconds in
@@ -881,6 +891,7 @@ jobs:
       # its own headline behaviour — CDC-on-boot builds actually printing — with
       # no lane running the test that proves it.
       - name: Release-gated tests — cfg(not(debug_assertions))
+        if: ${{ !cancelled() }}
         run: >
           cargo test --release -p labwired-core --features event-scheduler
           --lib --test event_scheduler --test release_only_cfg_ratchet
@@ -910,6 +921,7 @@ jobs:
       # ratchet; see the comment on that PR step for what shipped through the
       # hole they close.
       - name: Feature gate — scheduler IRQ delivery (jit + event-scheduler)
+        if: ${{ !cancelled() }}
         run: >
           cargo test -p labwired-core --features jit,event-scheduler
           --test intmatrix_alarm
@@ -948,6 +960,7 @@ jobs:
       # `tick_elapsed_forced` has it. This step runs the oracle in the
       # configuration that exposes it, on every push to main.
       - name: Feature gate — hardware oracle under event-scheduler
+        if: ${{ !cancelled() }}
         run: >
           cargo test -p labwired-hw-oracle
           --features labwired-core/event-scheduler
@@ -974,6 +987,7 @@ jobs:
       # The crate is small and its dependency graph is already warm from the
       # step above, so this is seconds.
       - name: Compile-only — hardware-oracle harnesses (nRF52 / STM32 over SWD)
+        if: ${{ !cancelled() }}
         run: >
           cargo test -p labwired-hw-oracle
           --features hw-oracle-nrf52,hw-oracle-stm32 --no-run


### PR DESCRIPTION
## The hole

`core-integrity` runs the BLE Pong **published-lab drift check** — a network read against production — immediately before four steps that gate the engine itself. In GitHub Actions a failed step skips the rest of the job. So a third-party monitor sat in front of this repo's own gates.

It fired:

| When | What |
|---|---|
| 2026-08-09 15:53Z | drift check goes red — the owner edited the published sketch (three lines of OLED text size) |
| 2026-08-09 16:39Z | **#908 merges and breaks `world_esp32c3_ble_pong`** |
| …for the next 29 hours | that test never ran again — not on #908, not on any merge after it |

Two ESP32-C3 nodes stopped electing a host, so **the published two-node lab does not start a game**, and every merge since has been green on `pr-gate` while main carried it.

## Evidence for #908

Same fixture, same command, bisected:

| Commit | Result |
|---|---|
| `11207ae1` last green | pass |
| `a67876bd` parent of the suspect | pass |
| `bd32b101` — #908, "Fix C3 ROM-boot analog stimuli" | **FAIL** — `left: 0, right: 1`, "exactly one node must elect HOST" |

```
nodeA tag=5 G ball=72,36 v=2,1 me=0 peer=0 score=0:0
nodeB tag=6 G ball=72,36 v=2,1 me=0 peer=0 score=0:0
```

Not a cycle budget: at 3× `PONG_SOAK_CYCLES` the ball reaches 123,61 and neither node ever sees a peer. #908's only engine change is swapping the ROM-boot SAR ADC stub for the shared behavioural controller.

## What this PR changes

The masking, and only the masking. The four engine gates after the monitor carry `if: !cancelled()`, so they run and report regardless of what the network-facing step did. Both still fail the job; neither can stand in front of the other.

## What it deliberately does not change

**#908 itself.** A straight revert restores the two-node lab — proven, its parent passes — but turns #908's own `shipped_pong_firmware_observes_gp2y_distance_through_gpio1_adc` red, because that test exists to prove the new ADC path observes a live stimulus. That is a choice about which user-facing behaviour matters more, not a mechanical revert, and the mechanism linking an ADC swap to a dead BLE election is not yet established.

**The fixture refresh.** I rebuilt it (live sketch, hosted recompile, four blobs verified by digest, merged at `0 / 0x8000 / 0xe000 / 0x10000`) and the drift check goes green with it. It is not here because **the recompiled image never reaches its serial banner in the twin** — dead at the green parent commit too, so it is a separate defect from #908. Same IDF `v4.4.7`, byte-identical bootloader, same five segments at the same load addresses, all the sketch's own strings present, app 14,400 bytes smaller. Landing that fixture would pin an image that does not boot.
