### PR TITLE
feat: resource metrics P0 (footprint, stack paint, budget asserts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
+ "goblin",
  "human-size",
  "labwired-codegen",
  "labwired-config",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 vcd = "0.7"
 ureq = { workspace = true }
+goblin = { workspace = true }
 
 [features]
 default = []

--- a/crates/cli/src/artifacts.rs
+++ b/crates/cli/src/artifacts.rs
@@ -143,6 +143,68 @@ pub(crate) struct TestResult {
     /// the ones that never fired.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) stimuli: Vec<StimulusOutcome>,
+    /// ELF Berkeley-style flash/RAM footprint (text/data/bss). Absent when
+    /// footprint was not computed for this run (e.g. config error, or not yet
+    /// wired). Optional totals/pct fields omitted when device limits unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) footprint: Option<FootprintReport>,
+    /// Main-stack paint / high-water report. Absent when not collected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) memory: Option<labwired_core::stack_paint::MainStackReport>,
+}
+
+/// Berkeley-style firmware footprint for `result.json` (`footprint`).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct FootprintReport {
+    pub method: String,
+    pub text_bytes: u64,
+    pub data_bytes: u64,
+    pub bss_bytes: u64,
+    pub flash_used_bytes: u64,
+    pub ram_static_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flash_total_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ram_total_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flash_used_pct: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ram_static_pct: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+}
+
+/// Percent used of total, half-up to 2 decimal places. Returns 0.0 if total is 0.
+pub(crate) fn pct2(used: u64, total: u64) -> f64 {
+    if total == 0 {
+        return 0.0;
+    }
+    let v = (used as f64) * 100.0 / (total as f64);
+    (v * 100.0).round() / 100.0
+}
+
+/// Build a [`FootprintReport`] from loader ELF section totals and optional
+/// device flash/RAM capacities.
+pub(crate) fn footprint_from_elf_totals(
+    totals: &labwired_loader::ElfSectionTotals,
+    flash_total: Option<u64>,
+    ram_total: Option<u64>,
+) -> FootprintReport {
+    let flash_used = totals.flash_used();
+    let ram_static = totals.ram_static();
+    FootprintReport {
+        method: labwired_loader::FOOTPRINT_METHOD.to_string(),
+        text_bytes: totals.text,
+        data_bytes: totals.data,
+        bss_bytes: totals.bss,
+        flash_used_bytes: flash_used,
+        ram_static_bytes: ram_static,
+        flash_total_bytes: flash_total,
+        ram_total_bytes: ram_total,
+        flash_used_pct: flash_total.map(|t| pct2(flash_used, t)),
+        ram_static_pct: ram_total.map(|t| pct2(ram_static, t)),
+        notes: Vec::new(),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -174,6 +236,12 @@ pub(crate) enum AssertionEvidence {
         token_cycle: u64,
         latency_cycles: u64,
         configured_max_cycles: u64,
+    },
+    ResourceBudget {
+        name: String,
+        measured: Option<u64>,
+        limit: u64,
+        method: String,
     },
 }
 

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -403,9 +403,7 @@ pub(crate) fn run_test(
     // legacy scripts and environment runs default to enabled. Env kill switch
     // applied via `stack_paint_enabled_flag`.
     let stack_paint = match &loaded {
-        LoadedTestScript::V1_0(script) => {
-            crate::resource_report::stack_paint_enabled(script)
-        }
+        LoadedTestScript::V1_0(script) => crate::resource_report::stack_paint_enabled(script),
         _ => crate::resource_report::stack_paint_enabled_flag(true),
     };
 

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -156,6 +156,8 @@ fn run_c3_rom_boot_no_elf(
     stimuli: &[labwired_config::StimulusSpec],
     uart_injections: &[labwired_config::UartInjectionSpec],
     plugins: &[&dyn labwired_core::plugin::ChipPlugin],
+    stack_paint: bool,
+    chip_mem: Option<crate::resource_report::ChipMemoryMap>,
 ) -> ExitCode {
     // Build the from_config bus (peripherals + external devices) exactly as the
     // ELF rom-boot path does before build_c3_rom_boot_machine.
@@ -313,6 +315,9 @@ fn run_c3_rom_boot_no_elf(
         uart_injections,
         // rom-boot is never JIT-eligible (it forces cycle-accurate stepping).
         false,
+        labwired_core::Arch::RiscV,
+        stack_paint,
+        chip_mem,
     )
 }
 
@@ -392,6 +397,16 @@ pub(crate) fn run_test(
     let script_profile = match &loaded {
         LoadedTestScript::V1_0(script) => script.inputs.profile.clone(),
         _ => None,
+    };
+
+    // Main-stack paint: schema_version 1.0 carries `stack_paint` (default true);
+    // legacy scripts and environment runs default to enabled. Env kill switch
+    // applied via `stack_paint_enabled_flag`.
+    let stack_paint = match &loaded {
+        LoadedTestScript::V1_0(script) => {
+            crate::resource_report::stack_paint_enabled(script)
+        }
+        _ => crate::resource_report::stack_paint_enabled_flag(true),
     };
 
     let (
@@ -601,6 +616,13 @@ pub(crate) fn run_test(
         (None, None) => None,
     };
 
+    // Chip flash/RAM totals + primary RAM region for footprint % and stack paint.
+    let chip_mem = resolved_system.as_ref().and_then(|s| {
+        s.chip_with_plugins(&crate::plugin_chip_yaml(plugins))
+            .ok()
+            .map(|c| crate::resource_report::ChipMemoryMap::from_chip(&c))
+    });
+
     // Resolve the firmware source. Normally an ELF is required (via --firmware or
     // inputs.firmware). The ONE exception is the faithful ESP32-C3 (RISC-V)
     // rom-boot path: the flash image (LABWIRED_ESP32C3_FLASH) is the program the
@@ -643,6 +665,8 @@ pub(crate) fn run_test(
             &stimuli,
             &uart_injections,
             plugins,
+            stack_paint,
+            chip_mem,
         );
         // Best-effort Pro-tier metering (no ELF → hash the empty program; the
         // no-key MCP path never meters). Mirrors the ELF paths' tail metering.
@@ -1231,6 +1255,9 @@ pub(crate) fn run_test(
                 // Xtensa (ESP32) path: never JIT-eligible (the RV32IMC JIT is
                 // RISC-V only), so keep the exact current observer-based metrics.
                 false,
+                labwired_core::Arch::XtensaLx7,
+                stack_paint,
+                chip_mem,
             );
             // Device-block render readout. Surfaces the attached panel block's
             // REAL render state — refresh_gen AND black-plane ink — so a generic
@@ -1458,6 +1485,9 @@ pub(crate) fn run_test(
                 &stimuli,
                 &uart_injections,
                 jit_eligible,
+                program.arch,
+                stack_paint,
+                chip_mem,
             )
         }};
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2889,12 +2889,8 @@ fn execute_test_loop<C: labwired_core::Cpu>(
 
     for (assertion_index, assertion) in assertions.iter().enumerate() {
         let (passed, evidence) = match assertion {
-            TestAssertion::UartContains(a) => {
-                (uart_text.contains(&a.uart_contains), None)
-            }
-            TestAssertion::UartRegex(a) => {
-                (simple_regex_is_match(&a.uart_regex, &uart_text), None)
-            }
+            TestAssertion::UartContains(a) => (uart_text.contains(&a.uart_contains), None),
+            TestAssertion::UartRegex(a) => (simple_regex_is_match(&a.uart_regex, &uart_text), None),
             TestAssertion::UartOrdered(_)
             | TestAssertion::MotorState(_)
             | TestAssertion::MqttFabric(_) => (
@@ -2927,16 +2923,12 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                 });
                 (passed, evidence)
             }
-            TestAssertion::ExpectedStopReason(a) => {
-                (a.expected_stop_reason == stop_reason, None)
-            }
+            TestAssertion::ExpectedStopReason(a) => (a.expected_stop_reason == stop_reason, None),
             // Passes only if the FIRMWARE ended the run with exactly this code.
             // A timeout, halt or fault leaves `firmware_exit_code` None, so a
             // run that never reached its own success path fails rather than
             // passing by silence.
-            TestAssertion::FirmwareExit(a) => {
-                (firmware_exit_code == Some(a.firmware_exit), None)
-            }
+            TestAssertion::FirmwareExit(a) => (firmware_exit_code == Some(a.firmware_exit), None),
             TestAssertion::MemoryValue(a) => {
                 // `size` is the value width. Accept either bytes (1/2/4) or
                 // bits (8/16/32) — both name the same u8/u16/u32 reads — so a
@@ -2986,14 +2978,14 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                 (passed, None)
             }
             TestAssertion::UdsTester(a) => {
-                let passed =
-                    match evaluate_uds_tester(&machine.bus.can_uds_testers, &a.uds_tester) {
-                        Ok(()) => true,
-                        Err(msg) => {
-                            error!("Assertion failed: {}", msg);
-                            false
-                        }
-                    };
+                let passed = match evaluate_uds_tester(&machine.bus.can_uds_testers, &a.uds_tester)
+                {
+                    Ok(()) => true,
+                    Err(msg) => {
+                        error!("Assertion failed: {}", msg);
+                        false
+                    }
+                };
                 (passed, None)
             }
             // The measurement itself carries the diagnosis (which region, how
@@ -3009,11 +3001,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                 };
                 (passed, None)
             }
-            TestAssertion::ResourceBudget(a) => evaluate_resource_budget(
-                &a.resource_budget,
-                footprint.as_ref(),
-                Some(&memory),
-            ),
+            TestAssertion::ResourceBudget(a) => {
+                evaluate_resource_budget(&a.resource_budget, footprint.as_ref(), Some(&memory))
+            }
         };
 
         if matches!(assertion, TestAssertion::ExpectedStopReason(_)) && passed {
@@ -4461,8 +4451,7 @@ mod resource_budget_tests {
     #[test]
     fn flash_budget_passes_when_measured_within_limit() {
         let fp = sample_footprint(1000, 200);
-        let (passed, evidence) =
-            evaluate_resource_budget(&flash_details(1000), Some(&fp), None);
+        let (passed, evidence) = evaluate_resource_budget(&flash_details(1000), Some(&fp), None);
         assert!(passed);
         assert!(evidence.is_none());
     }
@@ -4470,8 +4459,7 @@ mod resource_budget_tests {
     #[test]
     fn flash_budget_fails_with_evidence_when_over_limit() {
         let fp = sample_footprint(1001, 200);
-        let (passed, evidence) =
-            evaluate_resource_budget(&flash_details(1000), Some(&fp), None);
+        let (passed, evidence) = evaluate_resource_budget(&flash_details(1000), Some(&fp), None);
         assert!(!passed);
         let Some(AssertionEvidence::ResourceBudget {
             name,
@@ -4493,9 +4481,7 @@ mod resource_budget_tests {
         let (passed, evidence) = evaluate_resource_budget(&flash_details(1000), None, None);
         assert!(!passed);
         let Some(AssertionEvidence::ResourceBudget {
-            measured,
-            method,
-            ..
+            measured, method, ..
         }) = evidence
         else {
             panic!("expected ResourceBudget evidence");
@@ -4516,13 +4502,11 @@ mod resource_budget_tests {
             main_stack_overflow_suspected: Some(false),
             main_stack_unsupported_reason: None,
         };
-        let (passed, evidence) =
-            evaluate_resource_budget(&stack_details(512), None, Some(&mem));
+        let (passed, evidence) = evaluate_resource_budget(&stack_details(512), None, Some(&mem));
         assert!(passed);
         assert!(evidence.is_none());
 
-        let (passed, evidence) =
-            evaluate_resource_budget(&stack_details(511), None, Some(&mem));
+        let (passed, evidence) = evaluate_resource_budget(&stack_details(511), None, Some(&mem));
         assert!(!passed);
         match evidence {
             Some(AssertionEvidence::ResourceBudget {
@@ -4543,14 +4527,11 @@ mod resource_budget_tests {
     #[test]
     fn main_stack_budget_fails_when_high_water_missing() {
         let mem = MainStackReport::disabled();
-        let (passed, evidence) =
-            evaluate_resource_budget(&stack_details(512), None, Some(&mem));
+        let (passed, evidence) = evaluate_resource_budget(&stack_details(512), None, Some(&mem));
         assert!(!passed);
         match evidence {
             Some(AssertionEvidence::ResourceBudget {
-                measured,
-                method,
-                ..
+                measured, method, ..
             }) => {
                 assert_eq!(measured, None);
                 assert_eq!(method, "disabled");
@@ -4562,11 +4543,9 @@ mod resource_budget_tests {
     #[test]
     fn resource_budget_fail_evidence_serializes() {
         let result = AssertionResult {
-            assertion: TestAssertion::ResourceBudget(
-                labwired_config::ResourceBudgetAssertion {
-                    resource_budget: flash_details(100),
-                },
-            ),
+            assertion: TestAssertion::ResourceBudget(labwired_config::ResourceBudgetAssertion {
+                resource_budget: flash_details(100),
+            }),
             passed: false,
             evidence: Some(AssertionEvidence::ResourceBudget {
                 name: "max_flash_bytes".to_string(),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1633,9 +1633,73 @@ fn assertion_currently_passes(
         TestAssertion::DisplayRegion(a) => {
             evaluate_display_region(&machine.bus, &a.display_region).is_ok()
         }
-        // Evaluated post-run from footprint/memory (Tasks 5–6); not a live latch.
-        TestAssertion::ResourceBudget(_) => false,
+        // Post-run only (footprint / stack paint). Terminal like FirmwareExit:
+        // does not block `stop_when_assertions_pass` early-stop of live checks.
+        TestAssertion::ResourceBudget(_) => true,
     }
+}
+
+/// Evaluate a `resource_budget` assertion against post-run footprint / memory.
+///
+/// Exactly one of the three limits is set (validated at script load).
+/// Evidence is attached **only on failure**.
+fn evaluate_resource_budget(
+    details: &labwired_config::ResourceBudgetDetails,
+    footprint: Option<&artifacts::FootprintReport>,
+    memory: Option<&labwired_core::stack_paint::MainStackReport>,
+) -> (bool, Option<AssertionEvidence>) {
+    use labwired_core::stack_paint::MainStackMethod;
+
+    let (name, measured, limit, method) = if let Some(limit) = details.max_flash_bytes {
+        let (measured, method) = match footprint {
+            Some(f) => (Some(f.flash_used_bytes), f.method.clone()),
+            None => (None, "footprint_unavailable".to_string()),
+        };
+        ("max_flash_bytes", measured, limit, method)
+    } else if let Some(limit) = details.max_ram_static_bytes {
+        let (measured, method) = match footprint {
+            Some(f) => (Some(f.ram_static_bytes), f.method.clone()),
+            None => (None, "footprint_unavailable".to_string()),
+        };
+        ("max_ram_static_bytes", measured, limit, method)
+    } else if let Some(limit) = details.max_main_stack_bytes {
+        let (measured, method) = match memory {
+            Some(m) => {
+                let method = match m.main_stack_method {
+                    MainStackMethod::Paint => "paint",
+                    MainStackMethod::Disabled => "disabled",
+                    MainStackMethod::Unsupported => "unsupported",
+                };
+                (m.main_stack_high_water_bytes, method.to_string())
+            }
+            None => (None, "unsupported".to_string()),
+        };
+        ("max_main_stack_bytes", measured, limit, method)
+    } else {
+        // validate() should reject this; fail closed if it ever reaches here.
+        return (
+            false,
+            Some(AssertionEvidence::ResourceBudget {
+                name: "resource_budget".to_string(),
+                measured: None,
+                limit: 0,
+                method: "invalid".to_string(),
+            }),
+        );
+    };
+
+    let passed = measured.is_some_and(|m| m <= limit);
+    let evidence = if !passed {
+        Some(AssertionEvidence::ResourceBudget {
+            name: name.to_string(),
+            measured,
+            limit,
+            method,
+        })
+    } else {
+        None
+    };
+    (passed, evidence)
 }
 
 /// Measure one `display_region` assertion against the live panel.
@@ -2431,7 +2495,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     let has_runtime_assertions = assertions.iter().any(|a| {
         !matches!(
             a,
-            TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
+            TestAssertion::ExpectedStopReason(_)
+                | TestAssertion::FirmwareExit(_)
+                | TestAssertion::ResourceBudget(_)
         )
     });
     let assertions_are_uart_only = assertions
@@ -2439,7 +2505,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         .filter(|a| {
             !matches!(
                 a,
-                TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
+                TestAssertion::ExpectedStopReason(_)
+                    | TestAssertion::FirmwareExit(_)
+                    | TestAssertion::ResourceBudget(_)
             )
         })
         .all(|a| {
@@ -2724,7 +2792,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                 cached_all_pass = assertions.iter().enumerate().all(|(index, assertion)| {
                     matches!(
                         assertion,
-                        TestAssertion::ExpectedStopReason(_) | TestAssertion::FirmwareExit(_)
+                        TestAssertion::ExpectedStopReason(_)
+                            | TestAssertion::FirmwareExit(_)
+                            | TestAssertion::ResourceBudget(_)
                     ) || (matches!(assertion, TestAssertion::MotorSpeedReached(_))
                         && assertion_latched[index])
                         || matches!(assertion, TestAssertion::ShutdownLatency(a)
@@ -2804,34 +2874,69 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         String::from_utf8_lossy(&bytes).to_string()
     };
 
+    // Finalize main-stack report before assertion evaluation so
+    // `resource_budget` can compare against high-water / footprint.
+    let memory = if let Some(session) = paint_session {
+        let final_sp = resource_report::arm_sp(&machine.cpu);
+        resource_report::finalize_paint_report(&machine.bus, final_sp, session)
+    } else {
+        memory_pre
+    };
+
     let mut assertion_results = Vec::new();
     let mut all_passed = true;
     let mut expected_stop_reason_matched = false;
 
     for (assertion_index, assertion) in assertions.iter().enumerate() {
-        let passed = match assertion {
-            TestAssertion::UartContains(a) => uart_text.contains(&a.uart_contains),
-            TestAssertion::UartRegex(a) => simple_regex_is_match(&a.uart_regex, &uart_text),
+        let (passed, evidence) = match assertion {
+            TestAssertion::UartContains(a) => {
+                (uart_text.contains(&a.uart_contains), None)
+            }
+            TestAssertion::UartRegex(a) => {
+                (simple_regex_is_match(&a.uart_regex, &uart_text), None)
+            }
             TestAssertion::UartOrdered(_)
             | TestAssertion::MotorState(_)
-            | TestAssertion::MqttFabric(_) => {
-                assertion_currently_passes(assertion, &uart_text, machine)
-            }
-            TestAssertion::MotorSpeedReached(_) => {
-                assertion_latched[assertion_index]
-                    || assertion_currently_passes(assertion, &uart_text, machine)
-            }
-            TestAssertion::ShutdownLatency(a) => shutdown_latency_passes(
-                &a.shutdown_latency,
-                &stimulus_cycles,
-                &uart_milestone_cycles,
+            | TestAssertion::MqttFabric(_) => (
+                assertion_currently_passes(assertion, &uart_text, machine),
+                None,
             ),
-            TestAssertion::ExpectedStopReason(a) => a.expected_stop_reason == stop_reason,
+            TestAssertion::MotorSpeedReached(_) => (
+                assertion_latched[assertion_index]
+                    || assertion_currently_passes(assertion, &uart_text, machine),
+                None,
+            ),
+            TestAssertion::ShutdownLatency(a) => {
+                let passed = shutdown_latency_passes(
+                    &a.shutdown_latency,
+                    &stimulus_cycles,
+                    &uart_milestone_cycles,
+                );
+                let evidence = shutdown_latency_cycles(
+                    &a.shutdown_latency,
+                    &stimulus_cycles,
+                    &uart_milestone_cycles,
+                )
+                .map(|(stimulus_cycle, token_cycle, latency_cycles)| {
+                    AssertionEvidence::ShutdownLatency {
+                        stimulus_cycle,
+                        token_cycle,
+                        latency_cycles,
+                        configured_max_cycles: a.shutdown_latency.max_cycles,
+                    }
+                });
+                (passed, evidence)
+            }
+            TestAssertion::ExpectedStopReason(a) => {
+                (a.expected_stop_reason == stop_reason, None)
+            }
             // Passes only if the FIRMWARE ended the run with exactly this code.
             // A timeout, halt or fault leaves `firmware_exit_code` None, so a
             // run that never reached its own success path fails rather than
             // passing by silence.
-            TestAssertion::FirmwareExit(a) => firmware_exit_code == Some(a.firmware_exit),
+            TestAssertion::FirmwareExit(a) => {
+                (firmware_exit_code == Some(a.firmware_exit), None)
+            }
             TestAssertion::MemoryValue(a) => {
                 // `size` is the value width. Accept either bytes (1/2/4) or
                 // bits (8/16/32) — both name the same u8/u16/u32 reads — so a
@@ -2857,7 +2962,7 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                     }
                 };
 
-                match result {
+                let passed = match result {
                     Ok(val) => {
                         let mask = a.memory_value.mask.unwrap_or(0xFFFFFFFF) as u32;
                         let expected = a.memory_value.expected_value as u32;
@@ -2877,31 +2982,38 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         );
                         false
                     }
-                }
+                };
+                (passed, None)
             }
             TestAssertion::UdsTester(a) => {
-                match evaluate_uds_tester(&machine.bus.can_uds_testers, &a.uds_tester) {
-                    Ok(()) => true,
-                    Err(msg) => {
-                        error!("Assertion failed: {}", msg);
-                        false
-                    }
-                }
+                let passed =
+                    match evaluate_uds_tester(&machine.bus.can_uds_testers, &a.uds_tester) {
+                        Ok(()) => true,
+                        Err(msg) => {
+                            error!("Assertion failed: {}", msg);
+                            false
+                        }
+                    };
+                (passed, None)
             }
             // The measurement itself carries the diagnosis (which region, how
             // much ink, what was required), so it is logged rather than
             // reduced to a bare `false`.
             TestAssertion::DisplayRegion(a) => {
-                match evaluate_display_region(&machine.bus, &a.display_region) {
+                let passed = match evaluate_display_region(&machine.bus, &a.display_region) {
                     Ok(()) => true,
                     Err(msg) => {
                         error!("Assertion failed: {}", msg);
                         false
                     }
-                }
+                };
+                (passed, None)
             }
-            // Footprint / stack paint evaluation lands in Tasks 5–6.
-            TestAssertion::ResourceBudget(_) => false, // MqttFabric is handled above via assertion_currently_passes.
+            TestAssertion::ResourceBudget(a) => evaluate_resource_budget(
+                &a.resource_budget,
+                footprint.as_ref(),
+                Some(&memory),
+            ),
         };
 
         if matches!(assertion, TestAssertion::ExpectedStopReason(_)) && passed {
@@ -2917,22 +3029,6 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             );
         }
 
-        let evidence = match &assertion {
-            TestAssertion::ShutdownLatency(a) => shutdown_latency_cycles(
-                &a.shutdown_latency,
-                &stimulus_cycles,
-                &uart_milestone_cycles,
-            )
-            .map(|(stimulus_cycle, token_cycle, latency_cycles)| {
-                AssertionEvidence::ShutdownLatency {
-                    stimulus_cycle,
-                    token_cycle,
-                    latency_cycles,
-                    configured_max_cycles: a.shutdown_latency.max_cycles,
-                }
-            }),
-            _ => None,
-        };
         assertion_results.push(AssertionResult {
             assertion: assertion.clone(),
             passed,
@@ -3117,14 +3213,6 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             duration.as_secs_f64()
         );
     }
-
-    // Finalize main-stack report: scan paint window if we filled one.
-    let memory = if let Some(session) = paint_session {
-        let final_sp = resource_report::arm_sp(&machine.cpu);
-        resource_report::finalize_paint_report(&machine.bus, final_sp, session)
-    } else {
-        memory_pre
-    };
 
     write_outputs(
         args,
@@ -4330,6 +4418,170 @@ mod tests {
 
         let json = serde_json::to_value(snapshot).expect("snapshot should serialize");
         assert_eq!(json["type"], "config_error");
+    }
+}
+
+#[cfg(test)]
+mod resource_budget_tests {
+    use super::*;
+    use labwired_core::stack_paint::{MainStackMethod, MainStackReport};
+
+    fn flash_details(limit: u64) -> labwired_config::ResourceBudgetDetails {
+        labwired_config::ResourceBudgetDetails {
+            max_flash_bytes: Some(limit),
+            max_ram_static_bytes: None,
+            max_main_stack_bytes: None,
+        }
+    }
+
+    fn stack_details(limit: u64) -> labwired_config::ResourceBudgetDetails {
+        labwired_config::ResourceBudgetDetails {
+            max_flash_bytes: None,
+            max_ram_static_bytes: None,
+            max_main_stack_bytes: Some(limit),
+        }
+    }
+
+    fn sample_footprint(flash: u64, ram: u64) -> artifacts::FootprintReport {
+        artifacts::FootprintReport {
+            method: "elf_section_totals_v1".to_string(),
+            text_bytes: flash,
+            data_bytes: 0,
+            bss_bytes: ram,
+            flash_used_bytes: flash,
+            ram_static_bytes: ram,
+            flash_total_bytes: None,
+            ram_total_bytes: None,
+            flash_used_pct: None,
+            ram_static_pct: None,
+            notes: vec![],
+        }
+    }
+
+    #[test]
+    fn flash_budget_passes_when_measured_within_limit() {
+        let fp = sample_footprint(1000, 200);
+        let (passed, evidence) =
+            evaluate_resource_budget(&flash_details(1000), Some(&fp), None);
+        assert!(passed);
+        assert!(evidence.is_none());
+    }
+
+    #[test]
+    fn flash_budget_fails_with_evidence_when_over_limit() {
+        let fp = sample_footprint(1001, 200);
+        let (passed, evidence) =
+            evaluate_resource_budget(&flash_details(1000), Some(&fp), None);
+        assert!(!passed);
+        let Some(AssertionEvidence::ResourceBudget {
+            name,
+            measured,
+            limit,
+            method,
+        }) = evidence
+        else {
+            panic!("expected ResourceBudget evidence");
+        };
+        assert_eq!(name, "max_flash_bytes");
+        assert_eq!(measured, Some(1001));
+        assert_eq!(limit, 1000);
+        assert_eq!(method, "elf_section_totals_v1");
+    }
+
+    #[test]
+    fn flash_budget_fails_when_footprint_unavailable() {
+        let (passed, evidence) = evaluate_resource_budget(&flash_details(1000), None, None);
+        assert!(!passed);
+        let Some(AssertionEvidence::ResourceBudget {
+            measured,
+            method,
+            ..
+        }) = evidence
+        else {
+            panic!("expected ResourceBudget evidence");
+        };
+        assert_eq!(measured, None);
+        assert_eq!(method, "footprint_unavailable");
+    }
+
+    #[test]
+    fn main_stack_budget_uses_high_water_and_paint_method() {
+        let mem = MainStackReport {
+            main_stack_method: MainStackMethod::Paint,
+            main_stack_limit_bytes: Some(2048),
+            main_stack_high_water_bytes: Some(512),
+            main_stack_free_min_bytes: Some(1536),
+            main_stack_base: Some(0x2000_0000),
+            main_stack_top: Some(0x2000_0800),
+            main_stack_overflow_suspected: Some(false),
+            main_stack_unsupported_reason: None,
+        };
+        let (passed, evidence) =
+            evaluate_resource_budget(&stack_details(512), None, Some(&mem));
+        assert!(passed);
+        assert!(evidence.is_none());
+
+        let (passed, evidence) =
+            evaluate_resource_budget(&stack_details(511), None, Some(&mem));
+        assert!(!passed);
+        match evidence {
+            Some(AssertionEvidence::ResourceBudget {
+                name,
+                measured,
+                limit,
+                method,
+            }) => {
+                assert_eq!(name, "max_main_stack_bytes");
+                assert_eq!(measured, Some(512));
+                assert_eq!(limit, 511);
+                assert_eq!(method, "paint");
+            }
+            other => panic!("unexpected evidence: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn main_stack_budget_fails_when_high_water_missing() {
+        let mem = MainStackReport::disabled();
+        let (passed, evidence) =
+            evaluate_resource_budget(&stack_details(512), None, Some(&mem));
+        assert!(!passed);
+        match evidence {
+            Some(AssertionEvidence::ResourceBudget {
+                measured,
+                method,
+                ..
+            }) => {
+                assert_eq!(measured, None);
+                assert_eq!(method, "disabled");
+            }
+            other => panic!("unexpected evidence: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resource_budget_fail_evidence_serializes() {
+        let result = AssertionResult {
+            assertion: TestAssertion::ResourceBudget(
+                labwired_config::ResourceBudgetAssertion {
+                    resource_budget: flash_details(100),
+                },
+            ),
+            passed: false,
+            evidence: Some(AssertionEvidence::ResourceBudget {
+                name: "max_flash_bytes".to_string(),
+                measured: Some(150),
+                limit: 100,
+                method: "elf_section_totals_v1".to_string(),
+            }),
+        };
+        let json = serde_json::to_value(result).unwrap();
+        assert_eq!(json["evidence"]["type"], "resource_budget");
+        assert_eq!(json["evidence"]["name"], "max_flash_bytes");
+        assert_eq!(json["evidence"]["measured"], 150);
+        assert_eq!(json["evidence"]["limit"], 100);
+        assert_eq!(json["evidence"]["method"], "elf_section_totals_v1");
+        assert_eq!(json["passed"], false);
     }
 }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1629,6 +1629,8 @@ fn assertion_currently_passes(
         TestAssertion::DisplayRegion(a) => {
             evaluate_display_region(&machine.bus, &a.display_region).is_ok()
         }
+        // Evaluated post-run from footprint/memory (Tasks 5–6); not a live latch.
+        TestAssertion::ResourceBudget(_) => false,
     }
 }
 
@@ -2873,7 +2875,9 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         false
                     }
                 }
-            } // MqttFabric is handled above via assertion_currently_passes.
+            }
+            // Footprint / stack paint evaluation lands in Tasks 5–6.
+            TestAssertion::ResourceBudget(_) => false, // MqttFabric is handled above via assertion_currently_passes.
         };
 
         if matches!(assertion, TestAssertion::ExpectedStopReason(_)) && passed {
@@ -3210,6 +3214,9 @@ fn write_outputs<C: labwired_core::Cpu>(
         fidelity,
         logic_edges,
         stimuli,
+        // Resource metrics (footprint / stack paint) wired in later tasks.
+        footprint: None,
+        memory: None,
     };
 
     if let Some(output_dir) = &args.output_dir {
@@ -3547,6 +3554,9 @@ pub(crate) fn write_config_error_outputs(
         // Nor any stimulus outcomes: the run was rejected before a machine
         // existed, so no stimulus was ever attempted.
         stimuli: Vec::new(),
+        // Config error: no firmware footprint or stack paint collected.
+        footprint: None,
+        memory: None,
     };
 
     if let Some(output_dir) = &args.output_dir {
@@ -3880,6 +3890,18 @@ fn assertion_short_name(assertion: &TestAssertion) -> String {
                 d.min_ink,
                 d.max_ink.unwrap_or(1.0)
             )
+        }
+        TestAssertion::ResourceBudget(a) => {
+            let b = &a.resource_budget;
+            if let Some(n) = b.max_flash_bytes {
+                format!("resource_budget: max_flash_bytes={n}")
+            } else if let Some(n) = b.max_ram_static_bytes {
+                format!("resource_budget: max_ram_static_bytes={n}")
+            } else if let Some(n) = b.max_main_stack_bytes {
+                format!("resource_budget: max_main_stack_bytes={n}")
+            } else {
+                "resource_budget".to_string()
+            }
         }
     };
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,6 +25,7 @@ mod asset_validation;
 mod commands;
 mod component_validation;
 mod gpio_observer;
+mod resource_report;
 mod size_limited_writer;
 mod vcd_trace;
 mod wifi_frames;
@@ -1556,6 +1557,9 @@ fn handle_load_error<C: labwired_core::Cpu>(
         None,
         // Load/reset failed before the run loop, so no stimulus was attempted.
         Vec::new(),
+        // Load failed: no successful machine run for footprint/paint.
+        None,
+        None,
     );
     verdict.exit_code()
 }
@@ -1934,7 +1938,27 @@ fn execute_test_loop<C: labwired_core::Cpu>(
     // forces the JIT's correctness gate shut), so the loop mirrors the machine's
     // own counters into `metrics` before each cycle-sensitive check.
     jit_eligible: bool,
+    // Architecture of the loaded image (paint is ARM-only in P0).
+    arch: labwired_core::Arch,
+    // Script + env kill switch for main-stack paint.
+    stack_paint: bool,
+    // Chip flash/RAM map for footprint totals and paint RAM bounds.
+    chip_mem: Option<resource_report::ChipMemoryMap>,
 ) -> ExitCode {
+    // ── Resource metrics: footprint + main-stack paint (load/reset-time) ────
+    // Paint is not a SimulationObserver: fill unused stack RAM now, scan after
+    // the run. Footprint is pure ELF section math and does not touch the bus.
+    let footprint = resource_report::compute_footprint(firmware_bytes, chip_mem.as_ref());
+    let sp_top = resource_report::arm_sp(&machine.cpu);
+    let (memory_pre, paint_session) = resource_report::apply_stack_paint(
+        &mut machine.bus,
+        sp_top,
+        arch,
+        stack_paint,
+        firmware_bytes,
+        chip_mem.as_ref(),
+    );
+
     let max_steps = resolved_limits.max_steps;
     let max_cycles = resolved_limits.max_cycles;
     let max_uart_bytes = resolved_limits.max_uart_bytes;
@@ -3094,6 +3118,14 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         );
     }
 
+    // Finalize main-stack report: scan paint window if we filled one.
+    let memory = if let Some(session) = paint_session {
+        let final_sp = resource_report::arm_sp(&machine.cpu);
+        resource_report::finalize_paint_report(&machine.bus, final_sp, session)
+    } else {
+        memory_pre
+    };
+
     write_outputs(
         args,
         verdict,
@@ -3116,6 +3148,8 @@ fn execute_test_loop<C: labwired_core::Cpu>(
         Some(inspect_block),
         logic_edges,
         stimulus_outcomes,
+        footprint,
+        Some(memory),
     );
 
     // The same `verdict` the artifact above was written from. Not a second
@@ -3151,6 +3185,8 @@ fn write_outputs<C: labwired_core::Cpu>(
     inspect: Option<labwired_core::inspect::MachineInspect>,
     logic_edges: Option<labwired_core::logic_capture::LogicEdgesResult>,
     stimuli: Vec<StimulusOutcome>,
+    footprint: Option<artifacts::FootprintReport>,
+    memory: Option<labwired_core::stack_paint::MainStackReport>,
 ) {
     let status = verdict.status();
 
@@ -3214,9 +3250,8 @@ fn write_outputs<C: labwired_core::Cpu>(
         fidelity,
         logic_edges,
         stimuli,
-        // Resource metrics (footprint / stack paint) wired in later tasks.
-        footprint: None,
-        memory: None,
+        footprint,
+        memory,
     };
 
     if let Some(output_dir) = &args.output_dir {

--- a/crates/cli/src/resource_report.rs
+++ b/crates/cli/src/resource_report.rs
@@ -96,7 +96,9 @@ pub(crate) fn compute_footprint(
     Some(report)
 }
 
-/// PT_LOAD extents using `p_vaddr` + `p_memsz` (includes BSS; not filesz).
+/// PT_LOAD extents with `p_vaddr` / `p_memsz` / `p_filesz`.
+///
+/// `memsz` includes BSS; `filesz` is 0 for pure NOBITS reserves (heap/stack).
 pub(crate) fn load_extents_from_elf(firmware_bytes: &[u8]) -> Vec<LoadExtent> {
     let Ok(elf) = Elf::parse(firmware_bytes) else {
         return Vec::new();
@@ -112,6 +114,7 @@ pub(crate) fn load_extents_from_elf(firmware_bytes: &[u8]) -> Vec<LoadExtent> {
         extents.push(LoadExtent {
             vaddr: ph.p_vaddr,
             memsz: ph.p_memsz,
+            filesz: ph.p_filesz,
         });
     }
     extents

--- a/crates/cli/src/resource_report.rs
+++ b/crates/cli/src/resource_report.rs
@@ -146,10 +146,7 @@ pub(crate) fn apply_stack_paint(
         return (MainStackReport::disabled(), None);
     }
     if !matches!(arch, labwired_core::Arch::Arm) {
-        return (
-            MainStackReport::unsupported("arch_not_implemented"),
-            None,
-        );
+        return (MainStackReport::unsupported("arch_not_implemented"), None);
     }
     let Some(mem) = chip_mem else {
         return (

--- a/crates/cli/src/resource_report.rs
+++ b/crates/cli/src/resource_report.rs
@@ -1,0 +1,220 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Firmware footprint and main-stack paint helpers for `labwired test`.
+//!
+//! Paint is a load/reset-time RAM fill (not a `SimulationObserver`). Footprint
+//! uses Berkeley-style section totals from the loader.
+
+use crate::artifacts::{footprint_from_elf_totals, FootprintReport};
+use goblin::elf::program_header::PT_LOAD;
+use goblin::elf::Elf;
+use labwired_core::stack_paint::{
+    compute_paint_range, scan_paint, LoadExtent, MainStackMethod, MainStackReport, RamRegion,
+    PAINT_WORD,
+};
+use labwired_core::Bus; // write_u32 / read_u32 on SystemBus
+
+/// Half-open paint window `[lo, hi)` filled with [`PAINT_WORD`] before the run.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PaintSession {
+    pub lo: u64,
+    pub hi: u64,
+}
+
+/// Chip flash/RAM capacities and primary RAM region for paint bounds.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ChipMemoryMap {
+    pub ram: RamRegion,
+    pub flash_total: Option<u64>,
+    pub ram_total: Option<u64>,
+}
+
+impl ChipMemoryMap {
+    /// Build from a chip descriptor; size strings use [`labwired_config::parse_size`].
+    pub(crate) fn from_chip(chip: &labwired_config::ChipDescriptor) -> Self {
+        let flash_total = labwired_config::parse_size(&chip.flash.size).ok();
+        let ram_total = labwired_config::parse_size(&chip.ram.size).ok();
+        let ram_size = ram_total.unwrap_or(0);
+        Self {
+            ram: RamRegion {
+                base: chip.ram.base,
+                size: ram_size,
+            },
+            flash_total,
+            ram_total,
+        }
+    }
+}
+
+/// YAML `stack_paint` plus `LABWIRED_STACK_PAINT` env kill switch.
+///
+/// Env values `0` / `false` / `off` (case-insensitive) force paint off even when
+/// the script requests it. Missing env leaves the script flag as-is.
+pub(crate) fn stack_paint_enabled(script: &labwired_config::TestScript) -> bool {
+    stack_paint_enabled_flag(script.stack_paint)
+}
+
+/// Same kill switch when only the boolean flag is available (legacy scripts).
+pub(crate) fn stack_paint_enabled_flag(script_wants: bool) -> bool {
+    if !script_wants {
+        return false;
+    }
+    match std::env::var("LABWIRED_STACK_PAINT") {
+        Ok(v) => {
+            let v = v.to_ascii_lowercase();
+            !(v == "0" || v == "false" || v == "off")
+        }
+        Err(_) => true,
+    }
+}
+
+/// Berkeley footprint from ELF bytes and optional chip catalog totals.
+///
+/// Notes always include `section_sum_not_bin_image`. When either total is known,
+/// also notes `totals_from_chip_catalog`.
+pub(crate) fn compute_footprint(
+    firmware_bytes: &[u8],
+    chip_mem: Option<&ChipMemoryMap>,
+) -> Option<FootprintReport> {
+    if firmware_bytes.is_empty() {
+        return None;
+    }
+    let totals = labwired_loader::elf_section_totals_v1(firmware_bytes).ok()?;
+    let (flash_total, ram_total) = match chip_mem {
+        Some(m) => (m.flash_total, m.ram_total),
+        None => (None, None),
+    };
+    let mut report = footprint_from_elf_totals(&totals, flash_total, ram_total);
+    report.notes.push("section_sum_not_bin_image".to_string());
+    if flash_total.is_some() || ram_total.is_some() {
+        report.notes.push("totals_from_chip_catalog".to_string());
+    }
+    Some(report)
+}
+
+/// PT_LOAD extents using `p_vaddr` + `p_memsz` (includes BSS; not filesz).
+pub(crate) fn load_extents_from_elf(firmware_bytes: &[u8]) -> Vec<LoadExtent> {
+    let Ok(elf) = Elf::parse(firmware_bytes) else {
+        return Vec::new();
+    };
+    let mut extents = Vec::new();
+    for ph in &elf.program_headers {
+        if ph.p_type != PT_LOAD {
+            continue;
+        }
+        if ph.p_memsz == 0 {
+            continue;
+        }
+        extents.push(LoadExtent {
+            vaddr: ph.p_vaddr,
+            memsz: ph.p_memsz,
+        });
+    }
+    extents
+}
+
+/// First of `_end`, `__bss_end__`, `__heap_start` present in the ELF.
+pub(crate) fn heap_floor_symbol(firmware_bytes: &[u8]) -> Option<u64> {
+    for name in ["_end", "__bss_end__", "__heap_start"] {
+        if let Some(addr) = labwired_loader::resolve_symbol_in_elf(firmware_bytes, name) {
+            return Some(addr as u64);
+        }
+    }
+    None
+}
+
+/// Apply main-stack paint after load/reset, or return a disabled/unsupported report.
+///
+/// On `Ok`, fills `[lo, hi)` with [`PAINT_WORD`] and returns a [`PaintSession`]
+/// for post-run scanning. Paint is ARM-only in P0.
+pub(crate) fn apply_stack_paint(
+    bus: &mut labwired_core::bus::SystemBus,
+    sp_top: u64,
+    arch: labwired_core::Arch,
+    stack_paint: bool,
+    firmware_bytes: &[u8],
+    chip_mem: Option<&ChipMemoryMap>,
+) -> (MainStackReport, Option<PaintSession>) {
+    if !stack_paint {
+        return (MainStackReport::disabled(), None);
+    }
+    if !matches!(arch, labwired_core::Arch::Arm) {
+        return (
+            MainStackReport::unsupported("arch_not_implemented"),
+            None,
+        );
+    }
+    let Some(mem) = chip_mem else {
+        return (
+            MainStackReport::unsupported("stack_ram_region_unknown"),
+            None,
+        );
+    };
+    if mem.ram.size == 0 {
+        return (
+            MainStackReport::unsupported("stack_ram_region_unknown"),
+            None,
+        );
+    }
+
+    let extents = load_extents_from_elf(firmware_bytes);
+    let heap_floor = heap_floor_symbol(firmware_bytes);
+    let (lo, hi) = match compute_paint_range(sp_top, mem.ram, &extents, heap_floor) {
+        Ok(r) => r,
+        Err(reason) => return (MainStackReport::unsupported(reason), None),
+    };
+
+    let mut addr = lo;
+    while addr + 4 <= hi {
+        if bus.write_u32(addr, PAINT_WORD).is_err() {
+            return (
+                MainStackReport::unsupported("stack_paint_write_failed"),
+                None,
+            );
+        }
+        addr += 4;
+    }
+
+    (
+        // Placeholder until post-run scan; not written to result.json.
+        MainStackReport::unsupported("paint_pending"),
+        Some(PaintSession { lo, hi }),
+    )
+}
+
+/// Read the paint window and build a full [`MainStackReport`] with method Paint.
+pub(crate) fn finalize_paint_report(
+    bus: &labwired_core::bus::SystemBus,
+    final_sp: u64,
+    session: PaintSession,
+) -> MainStackReport {
+    let PaintSession { lo, hi } = session;
+    let word_count = ((hi - lo) / 4) as usize;
+    let mut words = Vec::with_capacity(word_count);
+    let mut addr = lo;
+    while addr + 4 <= hi {
+        words.push(bus.read_u32(addr).unwrap_or(0));
+        addr += 4;
+    }
+    let (high_water, free_min, overflow) = scan_paint(&words, final_sp, lo, hi);
+    MainStackReport {
+        main_stack_method: MainStackMethod::Paint,
+        main_stack_limit_bytes: Some(hi - lo),
+        main_stack_high_water_bytes: Some(high_water),
+        main_stack_free_min_bytes: Some(free_min),
+        main_stack_base: Some(lo),
+        main_stack_top: Some(hi),
+        main_stack_overflow_suspected: Some(overflow),
+        main_stack_unsupported_reason: None,
+    }
+}
+
+/// Active SP via register index 13 (ARM r13 / AAPCS). Used for paint SP top
+/// and post-run high-water scan on Cortex-M.
+pub(crate) fn arm_sp(cpu: &impl labwired_core::Cpu) -> u64 {
+    cpu.get_register(13) as u64
+}

--- a/crates/cli/tests/resource_metrics.rs
+++ b/crates/cli/tests/resource_metrics.rs
@@ -1,0 +1,170 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+//
+// End-to-end coverage for P0 resource metrics via examples/metrics/stm32f103-blinky.
+//
+// Exercises the path an author (or CI gate) runs:
+//
+//   labwired test --script examples/metrics/stm32f103-blinky/test-pass.yaml
+//   labwired test --script examples/metrics/stm32f103-blinky/test-fail-stack.yaml
+//
+// Pass asserts ELF footprint totals + stack paint method; fail asserts a
+// resource_budget failure with limit evidence for max_main_stack_bytes: 1.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+struct MetricsRun {
+    exit_code: Option<i32>,
+    stderr: String,
+    result: serde_json::Value,
+}
+
+/// Run a metrics scenario script (relative to the repo root) through
+/// `labwired test` and return exit code + parsed result.json.
+fn run_metrics(script_rel: &str) -> MetricsRun {
+    let root = repo_root();
+    let out_dir = labwired_cli::test_support::unique_temp_dir("labwired-resource-metrics");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(&root)
+        .args([
+            "test",
+            "--script",
+            script_rel,
+            "--no-uart-stdout",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("execute labwired");
+
+    let result_path = out_dir.join("result.json");
+    if !result_path.exists() {
+        let _ = std::fs::remove_dir_all(&out_dir);
+        panic!(
+            "result.json missing after running {script_rel}\nexit: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let result_json = std::fs::read_to_string(&result_path).expect("read result.json");
+    let result: serde_json::Value =
+        serde_json::from_str(&result_json).expect("parse result.json");
+
+    let run = MetricsRun {
+        exit_code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        result,
+    };
+
+    let _ = std::fs::remove_dir_all(&out_dir);
+    run
+}
+
+#[test]
+fn resource_metrics_pass_footprint_and_stack_paint() {
+    let run = run_metrics("examples/metrics/stm32f103-blinky/test-pass.yaml");
+
+    assert_eq!(
+        run.exit_code,
+        Some(0),
+        "expected exit 0 (assertions pass); stderr: {}",
+        run.stderr
+    );
+    assert_eq!(
+        run.result["status"].as_str().unwrap_or(""),
+        "pass",
+        "expected result.json status=pass; result: {}",
+        run.result
+    );
+
+    // Berkeley-style ELF section totals for tests/fixtures/stm32f103-blinky.elf
+    // (locked by crates/loader footprint unit tests).
+    let footprint = &run.result["footprint"];
+    assert_eq!(
+        footprint["text_bytes"].as_u64(),
+        Some(12760),
+        "footprint.text_bytes; footprint: {footprint}"
+    );
+    assert_eq!(
+        footprint["data_bytes"].as_u64(),
+        Some(124),
+        "footprint.data_bytes; footprint: {footprint}"
+    );
+    assert_eq!(
+        footprint["bss_bytes"].as_u64(),
+        Some(2548),
+        "footprint.bss_bytes; footprint: {footprint}"
+    );
+
+    let method = run.result["memory"]["main_stack_method"]
+        .as_str()
+        .unwrap_or("");
+    assert_eq!(
+        method, "paint",
+        "expected memory.main_stack_method == paint; memory: {}",
+        run.result["memory"]
+    );
+}
+
+#[test]
+fn resource_metrics_fail_stack_budget_evidence() {
+    let run = run_metrics("examples/metrics/stm32f103-blinky/test-fail-stack.yaml");
+
+    assert_ne!(
+        run.exit_code,
+        Some(0),
+        "expected non-zero exit (stack budget fail); stderr: {}",
+        run.stderr
+    );
+    assert_eq!(
+        run.result["status"].as_str().unwrap_or(""),
+        "fail",
+        "expected result.json status=fail; result: {}",
+        run.result
+    );
+
+    let assertions = run.result["assertions"]
+        .as_array()
+        .expect("result.assertions array");
+
+    let failed_stack = assertions.iter().find(|a| {
+        a["passed"] == false
+            && a["evidence"]["type"] == "resource_budget"
+            && a["evidence"]["name"] == "max_main_stack_bytes"
+    });
+
+    let failed = failed_stack.unwrap_or_else(|| {
+        panic!(
+            "expected a failed resource_budget max_main_stack_bytes assertion; assertions: {assertions:?}"
+        )
+    });
+
+    assert_eq!(
+        failed["evidence"]["limit"].as_u64(),
+        Some(1),
+        "expected evidence.limit == 1; evidence: {}",
+        failed["evidence"]
+    );
+    // Script sets max_main_stack_bytes: 1 under resource_budget.
+    assert_eq!(
+        failed["assertion"]["resource_budget"]["max_main_stack_bytes"].as_u64(),
+        Some(1),
+        "expected assertion resource_budget max_main_stack_bytes == 1; assertion: {}",
+        failed["assertion"]
+    );
+}

--- a/crates/cli/tests/resource_metrics.rs
+++ b/crates/cli/tests/resource_metrics.rs
@@ -62,8 +62,7 @@ fn run_metrics(script_rel: &str) -> MetricsRun {
     }
 
     let result_json = std::fs::read_to_string(&result_path).expect("read result.json");
-    let result: serde_json::Value =
-        serde_json::from_str(&result_json).expect("parse result.json");
+    let result: serde_json::Value = serde_json::from_str(&result_json).expect("parse result.json");
 
     let run = MetricsRun {
         exit_code: output.status.code(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3402,9 +3402,43 @@ pub struct DisplayRegionAssertion {
     pub display_region: DisplayRegionDetails,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceBudgetAssertion {
+    pub resource_budget: ResourceBudgetDetails,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceBudgetDetails {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_flash_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_ram_static_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_main_stack_bytes: Option<u64>,
+}
+
+impl ResourceBudgetDetails {
+    pub fn validate(&self, index: usize) -> anyhow::Result<()> {
+        let n = self.max_flash_bytes.is_some() as u8
+            + self.max_ram_static_bytes.is_some() as u8
+            + self.max_main_stack_bytes.is_some() as u8;
+        if n != 1 {
+            anyhow::bail!(
+                "assertions[{index}]: resource_budget must set exactly one of \
+                 max_flash_bytes, max_ram_static_bytes, max_main_stack_bytes"
+            );
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum TestAssertion {
+    /// Early for untagged serde: unique `resource_budget` key disambiguates.
+    ResourceBudget(ResourceBudgetAssertion),
     UartContains(UartContainsAssertion),
     UartRegex(UartRegexAssertion),
     UartOrdered(UartOrderedAssertion),
@@ -3621,6 +3655,10 @@ pub struct UartInjectionSpec {
     pub trigger: FaultTrigger,
 }
 
+fn default_stack_paint() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TestScript {
@@ -3629,6 +3667,9 @@ pub struct TestScript {
     pub limits: TestLimits,
     #[serde(default)]
     pub assertions: Vec<TestAssertion>,
+    /// When true (default), paint the main stack before run for high-water tracking.
+    #[serde(default = "default_stack_paint")]
+    pub stack_paint: bool,
     /// Faults to inject into the simulated silicon (schema_version 1.1+).
     #[serde(default)]
     pub faults: Vec<FaultSpec>,
@@ -3808,6 +3849,9 @@ impl TestScript {
             }
             if let TestAssertion::DisplayRegion(assertion) = assertion {
                 validate_display_region(index, &assertion.display_region)?;
+            }
+            if let TestAssertion::ResourceBudget(assertion) = assertion {
+                assertion.resource_budget.validate(index)?;
             }
         }
 
@@ -4887,6 +4931,37 @@ assertions:
         assert_eq!(script.inputs.firmware, "path/to/fw.elf");
         assert_eq!(script.limits.max_steps, 1000);
         assert_eq!(script.assertions.len(), 2);
+        // stack_paint defaults to true when omitted
+        assert!(script.stack_paint);
+    }
+
+    #[test]
+    fn parses_resource_budget_and_stack_paint() {
+        let yaml = r#"
+schema_version: "1.0"
+inputs:
+  firmware: "path/to/fw.elf"
+  system: "path/to/sys.yaml"
+limits:
+  max_steps: 1000
+stack_paint: false
+assertions:
+  - resource_budget:
+      max_main_stack_bytes: 512
+"#;
+        let script: TestScript = serde_yaml::from_str(yaml).unwrap();
+        script.validate().unwrap();
+        assert!(!script.stack_paint);
+        assert_eq!(script.assertions.len(), 1);
+        let TestAssertion::ResourceBudget(a) = &script.assertions[0] else {
+            panic!(
+                "expected resource_budget assertion, got {:?}",
+                script.assertions[0]
+            );
+        };
+        assert_eq!(a.resource_budget.max_main_stack_bytes, Some(512));
+        assert!(a.resource_budget.max_flash_bytes.is_none());
+        assert!(a.resource_budget.max_ram_static_bytes.is_none());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod sched;
 pub mod signals;
 pub mod sim_input;
 pub mod snapshot;
+pub mod stack_paint;
 pub mod system;
 #[doc(hidden)]
 pub mod test_support;

--- a/crates/core/src/stack_paint.rs
+++ b/crates/core/src/stack_paint.rs
@@ -91,11 +91,18 @@ impl RamRegion {
     }
 }
 
-/// Load segment extent for paint safety (use `p_vaddr` + `p_memsz`, not filesz).
+/// Load segment extent for paint floor / safety.
+///
+/// - `memsz` (`p_memsz`): full runtime image including BSS — used for the default
+///   heap floor so paint starts after zeroed globals.
+/// - `filesz` (`p_filesz`): bytes actually present in the ELF file. Pure NOBITS
+///   reservations (`filesz == 0`), such as GNU `._user_heap_stack`, are free
+///   space (heap/stack) and may be painted when a heap-floor symbol is known.
 #[derive(Debug, Clone, Copy)]
 pub struct LoadExtent {
     pub vaddr: u64,
     pub memsz: u64,
+    pub filesz: u64,
 }
 
 /// Word pattern written into the unused stack window before the run.
@@ -152,8 +159,15 @@ pub fn compute_paint_range(
         return Err("stack_region_too_small_or_unknown");
     }
 
-    // Refuse if any load extent overlaps the paint window.
+    // Refuse if file-backed image (data + BSS via memsz) overlaps the paint
+    // window. Pure NOBITS segments (`filesz == 0`) are skipped: they are either
+    // a dedicated BSS PT_LOAD (already covered by image_ram_end / heap-floor
+    // symbols) or a heap/stack reserve (GNU `._user_heap_stack`) that paint
+    // is *meant* to cover when `_end` / `__bss_end__` is known.
     for ext in load_extents {
+        if ext.filesz == 0 {
+            continue;
+        }
         let lo = ext.vaddr.max(paint_lo);
         let hi = ext.vaddr.saturating_add(ext.memsz).min(paint_hi);
         if hi > lo {
@@ -200,11 +214,38 @@ mod tests {
         let extents = [LoadExtent {
             vaddr: 0x2000_0000,
             memsz: 0x1000, // 4K image in RAM
+            filesz: 0x80,
         }];
         let sp = 0x2000_5000;
         let (lo, hi) = compute_paint_range(sp, ram, &extents, None).unwrap();
         assert_eq!(lo, 0x2000_1000);
         assert_eq!(hi, 0x2000_5000);
+    }
+
+    #[test]
+    fn user_heap_stack_nobits_is_paintable_with_end_symbol() {
+        // Matches stm32f103-blinky.elf: .data+.bss LOAD + pure NOBITS heap/stack.
+        let ram = RamRegion {
+            base: 0x2000_0000,
+            size: 0x5000,
+        };
+        let extents = [
+            LoadExtent {
+                vaddr: 0x2000_0000,
+                memsz: 0x46c,
+                filesz: 0x7c,
+            },
+            LoadExtent {
+                vaddr: 0x2000_046c,
+                memsz: 0x604,
+                filesz: 0,
+            },
+        ];
+        let sp = 0x2000_5000;
+        let end = 0x2000_0470;
+        let (lo, hi) = compute_paint_range(sp, ram, &extents, Some(end)).unwrap();
+        assert_eq!(lo, end);
+        assert_eq!(hi, sp);
     }
 
     #[test]

--- a/crates/core/src/stack_paint.rs
+++ b/crates/core/src/stack_paint.rs
@@ -130,10 +130,9 @@ pub fn compute_paint_range(
 
     // SP at top of RAM (one past last byte) is OK when sp_top == ram.end().
     // Otherwise SP (or the last stack byte) must lie in the RAM region.
-    if !ram.contains(sp_top.saturating_sub(1)) && sp_top != ram.end() {
-        if sp_top != ram.end() && !ram.contains(sp_top) {
-            return Err("stack_ram_region_unknown");
-        }
+    let sp_in_ram = ram.contains(sp_top) || ram.contains(sp_top.saturating_sub(1));
+    if sp_top != ram.end() && !sp_in_ram {
+        return Err("stack_ram_region_unknown");
     }
 
     let mut image_ram_end = ram.base;

--- a/crates/core/src/stack_paint.rs
+++ b/crates/core/src/stack_paint.rs
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn scan_half_used() {
         let mut words = vec![PAINT_WORD; 64]; // 256 bytes
-        // "use" top 128 bytes → last 32 words clobbered
+                                              // "use" top 128 bytes → last 32 words clobbered
         for w in words.iter_mut().skip(32) {
             *w = 0;
         }

--- a/crates/core/src/stack_paint.rs
+++ b/crates/core/src/stack_paint.rs
@@ -1,0 +1,235 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Main-stack paint range and high-water scan helpers.
+//!
+//! Pure bounds/fill/scan math for resource-metrics P0. Bus fill and CLI wiring
+//! live elsewhere; this module only computes paint windows and scans words.
+
+use serde::{Deserialize, Serialize};
+
+/// How main-stack depth was obtained for a test run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MainStackMethod {
+    Paint,
+    Unsupported,
+    Disabled,
+}
+
+/// Main-stack report block for `result.json` (`memory`).
+///
+/// Optional fields are omitted when unset (no `null` placeholders).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MainStackReport {
+    pub main_stack_method: MainStackMethod,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_limit_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_high_water_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_free_min_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_base: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_top: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_overflow_suspected: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub main_stack_unsupported_reason: Option<String>,
+}
+
+impl MainStackReport {
+    /// Paint was skipped by YAML/env kill switch.
+    pub fn disabled() -> Self {
+        Self {
+            main_stack_method: MainStackMethod::Disabled,
+            main_stack_limit_bytes: None,
+            main_stack_high_water_bytes: None,
+            main_stack_free_min_bytes: None,
+            main_stack_base: None,
+            main_stack_top: None,
+            main_stack_overflow_suspected: None,
+            main_stack_unsupported_reason: None,
+        }
+    }
+
+    /// Paint could not be performed safely; `reason` is a stable code string.
+    pub fn unsupported(reason: &str) -> Self {
+        Self {
+            main_stack_method: MainStackMethod::Unsupported,
+            main_stack_limit_bytes: None,
+            main_stack_high_water_bytes: None,
+            main_stack_free_min_bytes: None,
+            main_stack_base: None,
+            main_stack_top: None,
+            main_stack_overflow_suspected: None,
+            main_stack_unsupported_reason: Some(reason.to_string()),
+        }
+    }
+}
+
+/// Chip RAM region used for stack placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RamRegion {
+    pub base: u64,
+    pub size: u64,
+}
+
+impl RamRegion {
+    /// Exclusive end address (`base + size`, saturating).
+    pub fn end(&self) -> u64 {
+        self.base.saturating_add(self.size)
+    }
+
+    /// True if `addr` is in `[base, end)`.
+    pub fn contains(&self, addr: u64) -> bool {
+        addr >= self.base && addr < self.end()
+    }
+}
+
+/// Load segment extent for paint safety (use `p_vaddr` + `p_memsz`, not filesz).
+#[derive(Debug, Clone, Copy)]
+pub struct LoadExtent {
+    pub vaddr: u64,
+    pub memsz: u64,
+}
+
+/// Word pattern written into the unused stack window before the run.
+pub const PAINT_WORD: u32 = 0xA5A5_A5A5;
+
+/// Minimum paint window size; smaller ranges are rejected as unsupported.
+pub const MIN_PAINT_BYTES: u64 = 64;
+
+/// Compute half-open paint range `[paint_lo, paint_hi)` or an unsupported reason.
+///
+/// - `sp_top`: reset SP, word-aligned down (exclusive top of paint).
+/// - `ram`: chip RAM region containing the stack.
+/// - `load_extents`: PT_LOAD-style extents using **memsz** so BSS is excluded.
+/// - `heap_floor_symbol`: optional `_end` / `__bss_end__` / `__heap_start` if in RAM.
+///
+/// Error codes: `stack_ram_region_unknown`, `stack_region_too_small_or_unknown`,
+/// `stack_range_unsafe`.
+pub fn compute_paint_range(
+    sp_top: u64,
+    ram: RamRegion,
+    load_extents: &[LoadExtent],
+    heap_floor_symbol: Option<u64>,
+) -> Result<(u64, u64), &'static str> {
+    let sp_top = sp_top & !0x3; // word align down
+
+    // SP at top of RAM (one past last byte) is OK when sp_top == ram.end().
+    // Otherwise SP (or the last stack byte) must lie in the RAM region.
+    if !ram.contains(sp_top.saturating_sub(1)) && sp_top != ram.end() {
+        if sp_top != ram.end() && !ram.contains(sp_top) {
+            return Err("stack_ram_region_unknown");
+        }
+    }
+
+    let mut image_ram_end = ram.base;
+    for ext in load_extents {
+        let start = ext.vaddr;
+        let end = ext.vaddr.saturating_add(ext.memsz);
+        // Intersect load extent with RAM.
+        let lo = start.max(ram.base);
+        let hi = end.min(ram.end());
+        if hi > lo {
+            image_ram_end = image_ram_end.max(hi);
+        }
+    }
+
+    let heap_floor = match heap_floor_symbol {
+        Some(s) if ram.contains(s) || s == ram.end() => s,
+        _ => image_ram_end,
+    };
+
+    let paint_lo = ram.base.max(heap_floor);
+    let paint_hi = sp_top;
+    if paint_hi <= paint_lo || paint_hi - paint_lo < MIN_PAINT_BYTES {
+        return Err("stack_region_too_small_or_unknown");
+    }
+
+    // Refuse if any load extent overlaps the paint window.
+    for ext in load_extents {
+        let lo = ext.vaddr.max(paint_lo);
+        let hi = ext.vaddr.saturating_add(ext.memsz).min(paint_hi);
+        if hi > lo {
+            return Err("stack_range_unsafe");
+        }
+    }
+
+    Ok((paint_lo, paint_hi))
+}
+
+/// Scan painted region from low addresses upward while words equal [`PAINT_WORD`].
+///
+/// Returns `(high_water_bytes, free_min_bytes, overflow_suspected)`.
+///
+/// - `words` must cover `[paint_lo, paint_hi)` as little-endian words in address order.
+/// - Overflow is suspected if no paint remains, or `final_sp` is outside the window.
+pub fn scan_paint(words: &[u32], final_sp: u64, paint_lo: u64, paint_hi: u64) -> (u64, u64, bool) {
+    let limit = paint_hi - paint_lo;
+    let mut unused_words = 0u64;
+    for &w in words {
+        if w == PAINT_WORD {
+            unused_words += 1;
+        } else {
+            break;
+        }
+    }
+    let unused = unused_words * 4;
+    let high_water = limit.saturating_sub(unused);
+    let overflow = unused == 0 || final_sp < paint_lo || final_sp > paint_hi;
+    (high_water, unused, overflow)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paint_range_uses_memsz_not_filesz() {
+        let ram = RamRegion {
+            base: 0x2000_0000,
+            size: 0x5000,
+        };
+        // .data filesz small but memsz includes bss — paint must start after memsz.
+        let extents = [LoadExtent {
+            vaddr: 0x2000_0000,
+            memsz: 0x1000, // 4K image in RAM
+        }];
+        let sp = 0x2000_5000;
+        let (lo, hi) = compute_paint_range(sp, ram, &extents, None).unwrap();
+        assert_eq!(lo, 0x2000_1000);
+        assert_eq!(hi, 0x2000_5000);
+    }
+
+    #[test]
+    fn scan_half_used() {
+        let mut words = vec![PAINT_WORD; 64]; // 256 bytes
+        // "use" top 128 bytes → last 32 words clobbered
+        for w in words.iter_mut().skip(32) {
+            *w = 0;
+        }
+        let paint_lo = 0x2000_0000;
+        let paint_hi = paint_lo + 256;
+        let (hw, free, ov) = scan_paint(&words, paint_hi - 4, paint_lo, paint_hi);
+        assert_eq!(free, 128);
+        assert_eq!(hw, 128);
+        assert!(!ov);
+    }
+
+    #[test]
+    fn too_small_is_unsupported() {
+        let ram = RamRegion {
+            base: 0x2000_0000,
+            size: 0x100,
+        };
+        let sp = 0x2000_0030;
+        let err = compute_paint_range(sp, ram, &[], None).unwrap_err();
+        assert_eq!(err, "stack_region_too_small_or_unknown");
+    }
+}

--- a/crates/loader/src/footprint.rs
+++ b/crates/loader/src/footprint.rs
@@ -1,0 +1,106 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Berkeley-style ELF footprint totals matching GNU `arm-none-eabi-size`.
+//!
+//! Classifies `SHF_ALLOC` sections into text / data / bss using the
+//! `elf_section_totals_v1` rules. Pure function over ELF bytes — no I/O
+//! beyond what the caller provides.
+
+use anyhow::{Context, Result};
+use goblin::elf::section_header::{SHF_ALLOC, SHF_EXECINSTR, SHF_WRITE, SHT_NOBITS, SHT_PROGBITS};
+use goblin::elf::Elf;
+
+/// Method string identifying this classifier version.
+pub const FOOTPRINT_METHOD: &str = "elf_section_totals_v1";
+
+/// Berkeley-style section totals (bytes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElfSectionTotals {
+    pub text: u64,
+    pub data: u64,
+    pub bss: u64,
+}
+
+impl ElfSectionTotals {
+    /// Flash occupancy: text + data (initialized image in flash).
+    pub fn flash_used(&self) -> u64 {
+        self.text + self.data
+    }
+
+    /// Static RAM occupancy: data + bss (runtime RAM for globals / zeroed / heap-stack reserve).
+    pub fn ram_static(&self) -> u64 {
+        self.data + self.bss
+    }
+}
+
+/// Classify `SHF_ALLOC` sections into Berkeley text/data/bss.
+///
+/// Rules (`elf_section_totals_v1`):
+/// - Only sections with `SHF_ALLOC` are counted.
+/// - `SHT_NOBITS` alloc → **bss** (includes GNU `._user_heap_stack`).
+/// - Writable non-exec `SHT_PROGBITS` → **data**.
+/// - Everything else alloc (code, rodata, vectors, init arrays, …) → **text**.
+pub fn elf_section_totals_v1(buffer: &[u8]) -> Result<ElfSectionTotals> {
+    let elf = Elf::parse(buffer).context("failed to parse ELF for section totals")?;
+
+    let mut text: u64 = 0;
+    let mut data: u64 = 0;
+    let mut bss: u64 = 0;
+
+    for sh in &elf.section_headers {
+        let flags = sh.sh_flags as u32;
+        if flags & SHF_ALLOC == 0 {
+            continue;
+        }
+
+        let size = sh.sh_size;
+        if size == 0 {
+            continue;
+        }
+
+        if sh.sh_type == SHT_NOBITS {
+            bss += size;
+            continue;
+        }
+
+        let writable = flags & SHF_WRITE != 0;
+        let executable = flags & SHF_EXECINSTR != 0;
+        if sh.sh_type == SHT_PROGBITS && writable && !executable {
+            data += size;
+        } else {
+            text += size;
+        }
+    }
+
+    Ok(ElfSectionTotals { text, data, bss })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn stm32f103_blinky_matches_gnu_berkeley_size() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/stm32f103-blinky.elf");
+        let buffer = std::fs::read(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
+
+        let totals = elf_section_totals_v1(&buffer).expect("classify fixture");
+
+        // Verified with `arm-none-eabi-size` on tests/fixtures/stm32f103-blinky.elf:
+        //   text=12760 data=124 bss=2548
+        // bss includes .bss (1008) + ._user_heap_stack (1540).
+        assert_eq!(totals.text, 12760, "text");
+        assert_eq!(totals.data, 124, "data");
+        assert_eq!(totals.bss, 2548, "bss");
+        assert_eq!(totals.flash_used(), 12760 + 124);
+        assert_eq!(totals.ram_static(), 124 + 2548);
+        assert_eq!(FOOTPRINT_METHOD, "elf_section_totals_v1");
+    }
+}

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-pub mod multi_image;
 pub mod footprint;
+pub mod multi_image;
 
 pub use footprint::{elf_section_totals_v1, ElfSectionTotals, FOOTPRINT_METHOD};
 

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 pub mod multi_image;
+pub mod footprint;
+
+pub use footprint::{elf_section_totals_v1, ElfSectionTotals, FOOTPRINT_METHOD};
 
 pub fn load_elf(path: &Path) -> Result<ProgramImage> {
     let buffer = fs::read(path).with_context(|| format!("Failed to read ELF file: {:?}", path))?;

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Popular boards: [ESP32-C3](boards/esp32c3.md) · [nRF52840](boards/nrf52840.md) 
 - [Architecture overview](architecture.md) — CPU, bus, peripherals
 - [Hardware–sim parity](golden_reference.md)
 - [Configuration (YAML)](configuration_reference.md)
+- [Resource metrics](resource_metrics.md) — flash / RAM footprint and main-stack budgets in `labwired test`
 - [Target support rubric](target_support_rubric.md)
 
 ---
@@ -40,6 +41,7 @@ Popular boards: [ESP32-C3](boards/esp32c3.md) · [nRF52840](boards/nrf52840.md) 
 - [Simulating sensors (I²C)](examples/i2c_sensor_example.md)
 - [DMA & interrupts](examples/dma_exti_example.md)
 - [Integrated test walkthrough](examples/integrated_test_walkthrough.md)
+- [Resource metrics examples](../examples/metrics/README.md) — STM32F103 blinky flash / stack budgets
 
 ---
 

--- a/docs/resource_metrics.md
+++ b/docs/resource_metrics.md
@@ -1,0 +1,175 @@
+# Resource metrics (P0)
+
+Scenario budgets for firmware **footprint** and **main-stack high-water** during
+`labwired test`. These are CI gates for “does this build still fit?”, not
+silicon performance counters (no MHz, no CPI, no peripheral latency).
+
+Worked examples: [examples/metrics/](../examples/metrics/README.md).
+
+---
+
+## What is measured
+
+| Signal | Source | `result.json` path |
+|--------|--------|--------------------|
+| Flash used | ELF section sum (text + data) | `footprint.flash_used_bytes` |
+| Static RAM | ELF section sum (data + bss) | `footprint.ram_static_bytes` |
+| Main stack high-water | Stack paint after load/reset | `memory.main_stack_high_water_bytes` |
+
+Also present when available:
+
+- `footprint.text_bytes` / `data_bytes` / `bss_bytes` — Berkeley-style split
+- `footprint.flash_total_bytes` / `ram_total_bytes` — from the **chip catalog**
+  (YAML `flash.size` / `ram.size`), not from the linker script
+- `footprint.flash_used_pct` / `ram_static_pct` — percent of catalog totals
+- `memory.main_stack_method` — `paint` | `disabled` | `unsupported`
+- `memory.main_stack_free_min_bytes`, `main_stack_overflow_suspected`, …
+
+Method string for footprint is always `elf_section_totals_v1`. Notes typically
+include:
+
+- `section_sum_not_bin_image` — totals are section sums, not `objcopy -O binary` size
+- `totals_from_chip_catalog` — device totals came from the chip descriptor
+
+---
+
+## Scope and limits (P0)
+
+- **Scenario budgets, not silicon perf.** Limits you write in the test script
+  are product/CI ceilings for that scenario, not datasheet capacity tests.
+- **Main stack only.** Paint tracks the primary ARM stack (reset SP → heap
+  floor). No FreeRTOS task stacks, no MSP/PSP split, no ISR depth in P0.
+- **Section-sum flash.** Flash used = sum of alloc `text` + `data` sections.
+  Compare to `arm-none-eabi-size`, not to the flashed `.bin` length.
+- **Catalog totals.** Percent-full uses chip YAML sizes when the system
+  references a known chip; unknown totals omit the pct fields.
+- **`labwired test` only.** Footprint and paint are wired into the headless
+  test runner. Interactive `run` / playground do not emit these blocks today.
+
+---
+
+## Script surface
+
+```yaml
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "./firmware.elf"
+limits:
+  max_steps: 200000
+  max_cycles: 200000
+stack_paint: true          # default true; set false to skip paint
+assertions:
+  # Exactly one limit key per resource_budget assertion.
+  - resource_budget:
+      max_flash_bytes: 20000
+  - resource_budget:
+      max_ram_static_bytes: 8000
+  - resource_budget:
+      max_main_stack_bytes: 4096
+  - expected_stop_reason: max_cycles
+```
+
+### `stack_paint`
+
+| Value | Effect |
+|-------|--------|
+| `true` (default) | Fill free main-stack RAM with a paint pattern before the run; scan high-water after |
+| `false` | Skip paint; `memory.main_stack_method` is `disabled`; do not assert `max_main_stack_bytes` |
+
+### Kill switch
+
+Environment variable **`LABWIRED_STACK_PAINT`**:
+
+- `0`, `false`, or `off` (case-insensitive) → force paint **off** even if the
+  script sets `stack_paint: true`
+- unset or any other value → honor the script flag
+
+### `resource_budget`
+
+Each assertion must set **exactly one** of:
+
+| Key | Compared to |
+|-----|-------------|
+| `max_flash_bytes` | `footprint.flash_used_bytes` |
+| `max_ram_static_bytes` | `footprint.ram_static_bytes` |
+| `max_main_stack_bytes` | `memory.main_stack_high_water_bytes` (paint) |
+
+Pass when `measured <= limit`. If the metric is unavailable (`measured` null —
+e.g. paint `unsupported` / `disabled`), the assertion **fails**.
+
+### Fail-only evidence
+
+On failure, `assertions[].evidence` is:
+
+```json
+{
+  "type": "resource_budget",
+  "name": "max_main_stack_bytes",
+  "measured": 172,
+  "limit": 1,
+  "method": "paint"
+}
+```
+
+On pass, `evidence` is omitted. Methods you may see: `elf_section_totals_v1`,
+`paint`, `disabled`, `unsupported`, `footprint_unavailable`.
+
+---
+
+## jq examples
+
+```bash
+# Footprint + memory block from a green run
+jq '{footprint, memory}' /tmp/m-pass/result.json
+
+# text_bytes path (section-sum text)
+jq '.footprint.text_bytes' /tmp/m-pass/result.json
+
+# Only failed budget asserts (evidence present)
+jq '.assertions[] | select(.passed == false)' /tmp/m-fail/result.json
+
+# High-water vs limit when evidence is attached
+jq '.assertions[]
+    | select(.evidence.type == "resource_budget")
+    | {name: .evidence.name, measured: .evidence.measured, limit: .evidence.limit}' \
+  /tmp/m-fail/result.json
+```
+
+---
+
+## Paint behaviour (ARM)
+
+1. After load/reset, resolve SP (vector table / CPU) and a heap floor
+   (`_end`, `__bss_end__`, or `__heap_start` when present; otherwise the end of
+   RAM-resident PT_LOAD image including BSS).
+2. Fill `[heap_floor, SP)` with paint word `0xA5A5A5A5` (skipping pure
+   file-backed image; GNU `._user_heap_stack` NOBITS reserves are paintable).
+3. After the run, scan from low addresses upward while words still equal paint;
+   high-water = window size − remaining paint.
+
+If the range is too small, outside RAM, or otherwise unsafe, paint is
+`unsupported` with a stable `main_stack_unsupported_reason` string — and any
+`max_main_stack_bytes` assert fails closed.
+
+Non-ARM arches report `unsupported` / `arch_not_implemented` in P0.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All assertions passed |
+| 1 | One or more assertions failed (including resource budgets) |
+| 2 | Config / script error |
+| 3 | Runtime error |
+
+---
+
+## See also
+
+- [Run limits](limits.md) — `max_steps`, `max_cycles`, wall time, …
+- [CLI reference](cli_reference.md) — `labwired test` flags
+- [Configuration reference](configuration_reference.md) — system / chip YAML
+- [examples/metrics](../examples/metrics/README.md) — STM32F103 blinky budgets

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -1,0 +1,112 @@
+# Resource metrics examples (P0)
+
+Scenario budgets for flash, static RAM, and **main stack** high-water — not
+silicon performance counters. Metrics and assertions are collected by
+`labwired test` only (not `labwired run` / playground).
+
+## Layout
+
+```
+examples/metrics/
+  README.md                          # this file
+  stm32f103-blinky/
+    system.yaml                      # chip + optional LED on PA5
+    test-pass.yaml                   # green path: flash + RAM + stack budgets
+    test-fail-stack.yaml             # max_main_stack_bytes: 1 → assert fail
+    test-paint-off.yaml              # stack_paint: false, no stack budget
+```
+
+Firmware: `tests/fixtures/stm32f103-blinky.elf` (Arduino-style forever blink).
+
+Full reference: [docs/resource_metrics.md](../../docs/resource_metrics.md).
+
+## Run
+
+From the repo root (use `--script`; the binary is `labwired`):
+
+```bash
+cargo run -p labwired-cli -- test \
+  --script examples/metrics/stm32f103-blinky/test-pass.yaml \
+  --output-dir /tmp/m-pass
+
+cargo run -p labwired-cli -- test \
+  --script examples/metrics/stm32f103-blinky/test-fail-stack.yaml \
+  --output-dir /tmp/m-fail
+# exit code 1, resource_budget evidence on the stack assert
+
+cargo run -p labwired-cli -- test \
+  --script examples/metrics/stm32f103-blinky/test-paint-off.yaml \
+  --output-dir /tmp/m-paint-off
+```
+
+## What each script shows
+
+| Script | `stack_paint` | Stack budget | Expected |
+|--------|---------------|--------------|----------|
+| `test-pass.yaml` | `true` (default) | `max_main_stack_bytes: 4096` | pass (exit 0) |
+| `test-fail-stack.yaml` | `true` | `max_main_stack_bytes: 1` | fail (exit 1) + evidence |
+| `test-paint-off.yaml` | `false` | none | pass; `memory.main_stack_method: disabled` |
+
+Flash / RAM budgets are scenario ceilings (generous for this blinky), not
+datasheet fill targets. Each `resource_budget` assertion sets **exactly one**
+of `max_flash_bytes`, `max_ram_static_bytes`, `max_main_stack_bytes`.
+
+## jq samples
+
+Pass result — footprint and main-stack high-water:
+
+```bash
+jq '{footprint, memory}' /tmp/m-pass/result.json
+# {
+#   "footprint": {
+#     "method": "elf_section_totals_v1",
+#     "text_bytes": 12760,
+#     "data_bytes": 124,
+#     "bss_bytes": 2548,
+#     "flash_used_bytes": 12884,
+#     "ram_static_bytes": 2672,
+#     "flash_total_bytes": 1000000,
+#     "ram_total_bytes": 20480,
+#     "flash_used_pct": 1.29,
+#     "ram_static_pct": 13.05,
+#     "notes": ["section_sum_not_bin_image", "totals_from_chip_catalog"]
+#   },
+#   "memory": {
+#     "main_stack_method": "paint",
+#     "main_stack_high_water_bytes": 172,
+#     ...
+#   }
+# }
+```
+
+Fail-only evidence (stack budget breach):
+
+```bash
+jq '.assertions[] | select(.passed == false)' /tmp/m-fail/result.json
+# {
+#   "assertion": { "resource_budget": { "max_main_stack_bytes": 1 } },
+#   "passed": false,
+#   "evidence": {
+#     "type": "resource_budget",
+#     "name": "max_main_stack_bytes",
+#     "measured": 172,
+#     "limit": 1,
+#     "method": "paint"
+#   }
+# }
+```
+
+## Kill switch
+
+`LABWIRED_STACK_PAINT=0` (or `false` / `off`) forces paint off even when the
+script has `stack_paint: true`. Useful when debugging paint interaction.
+
+## Notes
+
+- **Main stack only** — no RTOS task stacks, no ISR nesting water-marks in P0.
+- **Section-sum flash** — Berkeley text/data/bss from ELF sections, not the
+  raw `.bin` image size (`notes` include `section_sum_not_bin_image`).
+- **Catalog totals** — chip YAML flash/RAM sizes fill `*_total_bytes` /
+  `*_pct` when known (`totals_from_chip_catalog`).
+- Behavioral stop for this fixture with `max_steps` = `max_cycles` = 200000 is
+  `max_cycles` (cycles advance faster than steps on multi-cycle ops).

--- a/examples/metrics/stm32f103-blinky/system.yaml
+++ b/examples/metrics/stm32f103-blinky/system.yaml
@@ -1,0 +1,11 @@
+# Minimal STM32F103 system for resource-metrics examples.
+# Paths are relative to this directory (examples/metrics/stm32f103-blinky/).
+name: "metrics-stm32f103-blinky"
+chip: "../../../configs/chips/stm32f103.yaml"
+board_io:
+  - id: "led_pa5"
+    kind: "led"
+    peripheral: "gpioa"
+    pin: 5
+    signal: "output"
+    active_high: true

--- a/examples/metrics/stm32f103-blinky/test-fail-stack.yaml
+++ b/examples/metrics/stm32f103-blinky/test-fail-stack.yaml
@@ -1,0 +1,18 @@
+# Intentionally fails: main-stack high-water cannot fit in 1 byte.
+# Expect exit code 1 (assert fail) with resource_budget evidence on the stack assert.
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "../../../tests/fixtures/stm32f103-blinky.elf"
+limits:
+  max_steps: 200000
+  max_cycles: 200000
+stack_paint: true
+assertions:
+  - resource_budget:
+      max_flash_bytes: 20000
+  - resource_budget:
+      max_ram_static_bytes: 8000
+  - resource_budget:
+      max_main_stack_bytes: 1
+  - expected_stop_reason: max_cycles

--- a/examples/metrics/stm32f103-blinky/test-paint-off.yaml
+++ b/examples/metrics/stm32f103-blinky/test-paint-off.yaml
@@ -1,0 +1,16 @@
+# Same behavioral stop as test-pass, but stack paint disabled.
+# No max_main_stack_bytes assert (paint/high-water is unavailable).
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "../../../tests/fixtures/stm32f103-blinky.elf"
+limits:
+  max_steps: 200000
+  max_cycles: 200000
+stack_paint: false
+assertions:
+  - resource_budget:
+      max_flash_bytes: 20000
+  - resource_budget:
+      max_ram_static_bytes: 8000
+  - expected_stop_reason: max_cycles

--- a/examples/metrics/stm32f103-blinky/test-pass.yaml
+++ b/examples/metrics/stm32f103-blinky/test-pass.yaml
@@ -1,0 +1,21 @@
+# Green path: footprint + main-stack budgets within generous scenario limits.
+# Stop reason is calibrated against the blinky fixture (see README).
+schema_version: "1.0"
+inputs:
+  system: "./system.yaml"
+  firmware: "../../../tests/fixtures/stm32f103-blinky.elf"
+limits:
+  max_steps: 200000
+  max_cycles: 200000
+stack_paint: true
+assertions:
+  # Exactly one limit per resource_budget assertion.
+  - resource_budget:
+      max_flash_bytes: 20000
+  - resource_budget:
+      max_ram_static_bytes: 8000
+  - resource_budget:
+      max_main_stack_bytes: 4096
+  # Blinky is a forever loop; with max_steps == max_cycles the cycle budget
+  # trips first (wait states / multi-cycle ops make cycles > steps).
+  - expected_stop_reason: max_cycles


### PR DESCRIPTION
## Summary

Adds a **resource budget report** on `labwired test` (P0):

- **ELF footprint** (`elf_section_totals_v1`) matching GNU Berkeley `size` (golden: stm32f103-blinky 12760/124/2548)
- **Main-stack paint** high-water in the twin (kill switch: `stack_paint: false` / `LABWIRED_STACK_PAINT=0`)
- **`resource_budget` assertions** with fail-only evidence (`max_flash_bytes`, `max_ram_static_bytes`, `max_main_stack_bytes`)
- Example suite under `examples/metrics/stm32f103-blinky/` + `docs/resource_metrics.md`

Does **not** claim silicon wall-clock or multi-task stack safety. No nested `metrics{}` object; no MCP/`labwired run` surface yet.

Design/plan (parent monorepo): `docs/superpowers/specs/2026-08-11-resource-metrics-p0-design.md`, `docs/superpowers/plans/2026-08-11-resource-metrics-p0.md`.

## Test plan

- [x] `cargo test -p labwired-loader stm32f103_blinky`
- [x] `cargo test -p labwired-core --lib stack_paint`
- [x] `cargo test -p labwired-config parses_resource_budget`
- [x] `cargo test -p labwired-cli --lib resource_budget`
- [x] `cargo test -p labwired-cli --test resource_metrics`
- [ ] Manual: `cargo run -p labwired-cli -- test --script examples/metrics/stm32f103-blinky/test-pass.yaml --output-dir /tmp/m-pass && jq '.footprint, .memory' /tmp/m-pass/result.json`
- [ ] Manual: fail-stack script exits non-zero with `resource_budget` evidence