### PR TITLE
fix(wasm): handle Arch::Avr in browser simulator

### DIFF
--- a/configs/chips/atmega328p.yaml
+++ b/configs/chips/atmega328p.yaml
@@ -1,0 +1,11 @@
+name: "atmega328p"
+arch: "avr"
+core: "avr8"
+registers_count: 32
+flash:
+  base: 0x00000000
+  size: "32KB"
+ram:
+  base: 0x00000100
+  size: "2KB"
+peripherals: []

--- a/configs/systems/arduino-nano.yaml
+++ b/configs/systems/arduino-nano.yaml
@@ -1,0 +1,9 @@
+name: arduino-nano
+chip: ../chips/atmega328p.yaml
+clock:
+  cpu_hz: 16000000
+board_io:
+  - id: led
+    type: led
+    pin: "PB5"
+    active_high: true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -51,6 +51,9 @@ pub enum Arch {
     RiscV,
     #[serde(alias = "xtensa-lx7", alias = "xtensa-lx6")]
     Xtensa,
+    /// AVR8 (ATmega328P / classic Arduino Nano).
+    #[serde(alias = "avr8", alias = "atmega328p")]
+    Avr,
     Unknown,
 }
 

--- a/crates/core/src/cpu/avr.rs
+++ b/crates/core/src/cpu/avr.rs
@@ -59,7 +59,27 @@ pub struct Avr {
     pub io: [u8; 0xE0],
     pub pending_irq: u64,
     pub cycles: u64,
+    pub tcnt0: u8,
+    pub tccr0a: u8,
+    pub tccr0b: u8,
+    pub timsk0: u8,
+    pub tifr0: u8,
+    pub ocr0a: u8,
+    pub ocr0b: u8,
+    pub t0_prescale_acc: u32,
+    pub serial_tx: Vec<u8>,
+    pub ucsr0a: u8,
+    pub ucsr0b: u8,
+    pub ucsr0c: u8,
+    pub ubrr0: u16,
 }
+
+pub const VEC_TIMER0_OVF: u32 = 22;
+pub const UCSRA_UDRE: u8 = 1 << 5;
+pub const UCSRA_TXC: u8 = 1 << 6;
+pub const TIMSK_TOIE0: u8 = 1 << 0;
+pub const TIFR_TOV0: u8 = 1 << 0;
+
 
 impl Default for Avr {
     fn default() -> Self {
@@ -79,6 +99,10 @@ impl Avr {
             io: [0; 0xE0],
             pending_irq: 0,
             cycles: 0,
+            tcnt0: 0, tccr0a: 0, tccr0b: 0, timsk0: 0, tifr0: 0,
+            ocr0a: 0, ocr0b: 0, t0_prescale_acc: 0,
+            serial_tx: Vec::new(),
+            ucsr0a: UCSRA_UDRE, ucsr0b: 0, ucsr0c: 0, ubrr0: 0,
         }
     }
 
@@ -179,49 +203,96 @@ impl Avr {
             0x005D => Ok((self.sp & 0xFF) as u8),
             0x005E => Ok((self.sp >> 8) as u8),
             0x005F => Ok(self.sreg),
-            0x0020..=0x00FF => {
-                // Local io file is authoritative for v1 flat I/O; also mirrored to bus on write.
-                Ok(self.io[(addr - 0x20) as usize])
-            }
-            a if a >= SRAM_START && a <= RAMEND => {
-                Ok(self.sram[(a - SRAM_START) as usize])
-            }
+            0x0035 => Ok(self.tifr0),
+            0x0044 => Ok(self.tccr0a),
+            0x0045 => Ok(self.tccr0b),
+            0x0046 => Ok(self.tcnt0),
+            0x0047 => Ok(self.ocr0a),
+            0x0048 => Ok(self.ocr0b),
+            0x006E => Ok(self.timsk0),
+            0x00C0 => Ok(self.ucsr0a | UCSRA_UDRE),
+            0x00C1 => Ok(self.ucsr0b),
+            0x00C2 => Ok(self.ucsr0c),
+            0x00C4 => Ok((self.ubrr0 & 0xFF) as u8),
+            0x00C5 => Ok((self.ubrr0 >> 8) as u8),
+            0x00C6 => Ok(0),
+            0x0020..=0x00FF => Ok(self.io[(addr - 0x20) as usize]),
+            a if a >= SRAM_START && a <= RAMEND => Ok(self.sram[(a - SRAM_START) as usize]),
             _ => Err(SimulationError::MemoryViolation(addr as u64)),
         }
     }
 
     fn data_write(&mut self, addr: u16, value: u8, bus: &mut dyn Bus) -> SimResult<()> {
         match addr {
-            0x0000..=0x001F => {
-                self.r[addr as usize] = value;
+            0x0000..=0x001F => { self.r[addr as usize] = value; Ok(()) }
+            0x005D => { self.sp = (self.sp & 0xFF00) | value as u16; Ok(()) }
+            0x005E => { self.sp = (self.sp & 0x00FF) | ((value as u16) << 8); Ok(()) }
+            0x005F => { self.sreg = value; Ok(()) }
+            0x0035 => { self.tifr0 &= !value; Ok(()) }
+            0x0044 => { self.tccr0a = value; Ok(()) }
+            0x0045 => { self.tccr0b = value; Ok(()) }
+            0x0046 => { self.tcnt0 = value; Ok(()) }
+            0x0047 => { self.ocr0a = value; Ok(()) }
+            0x0048 => { self.ocr0b = value; Ok(()) }
+            0x006E => { self.timsk0 = value; Ok(()) }
+            0x00C0 => {
+                if value & UCSRA_TXC != 0 { self.ucsr0a &= !UCSRA_TXC; }
+                self.ucsr0a |= UCSRA_UDRE;
                 Ok(())
             }
-            0x005D => {
-                self.sp = (self.sp & 0xFF00) | value as u16;
-                Ok(())
-            }
-            0x005E => {
-                self.sp = (self.sp & 0x00FF) | ((value as u16) << 8);
-                Ok(())
-            }
-            0x005F => {
-                self.sreg = value;
+            0x00C1 => { self.ucsr0b = value; Ok(()) }
+            0x00C2 => { self.ucsr0c = value; Ok(()) }
+            0x00C4 => { self.ubrr0 = (self.ubrr0 & 0xFF00) | value as u16; Ok(()) }
+            0x00C5 => { self.ubrr0 = (self.ubrr0 & 0x00FF) | ((value as u16) << 8); Ok(()) }
+            0x00C6 => {
+                self.serial_tx.push(value);
+                self.ucsr0a |= UCSRA_UDRE | UCSRA_TXC;
+                let _ = bus.write_u8(addr as u64, value);
                 Ok(())
             }
             0x0020..=0x00FF => {
-                let idx = (addr - 0x20) as usize;
-                self.io[idx] = value;
+                self.io[(addr - 0x20) as usize] = value;
                 let _ = bus.write_u8(addr as u64, value);
                 Ok(())
             }
             a if a >= SRAM_START && a <= RAMEND => {
-                let off = (a - SRAM_START) as usize;
-                self.sram[off] = value;
+                self.sram[(a - SRAM_START) as usize] = value;
                 let _ = bus.write_u8(a as u64, value);
                 Ok(())
             }
             _ => Err(SimulationError::MemoryViolation(addr as u64)),
         }
+    }
+
+    fn t0_prescaler(&self) -> u32 {
+        match self.tccr0b & 0x07 {
+            0 => 0, 1 => 1, 2 => 8, 3 => 64, 4 => 256, 5 => 1024, _ => 0,
+        }
+    }
+
+    pub fn tick_timer0(&mut self, cpu_cycles: u32) {
+        let div = self.t0_prescaler();
+        if div == 0 || cpu_cycles == 0 { return; }
+        self.t0_prescale_acc = self.t0_prescale_acc.saturating_add(cpu_cycles);
+        while self.t0_prescale_acc >= div {
+            self.t0_prescale_acc -= div;
+            let (next, overflowed) = self.tcnt0.overflowing_add(1);
+            self.tcnt0 = next;
+            if overflowed {
+                self.tifr0 |= TIFR_TOV0;
+                if self.timsk0 & TIMSK_TOIE0 != 0 {
+                    self.pending_irq |= 1u64 << VEC_TIMER0_OVF;
+                }
+            }
+        }
+    }
+
+    pub fn portb(&self) -> u8 {
+        self.io[(0x25 - 0x20) as usize]
+    }
+
+    pub fn serial_as_str(&self) -> String {
+        String::from_utf8_lossy(&self.serial_tx).into_owned()
     }
 
     fn push_byte(&mut self, value: u8, bus: &mut dyn Bus) -> SimResult<()> {
@@ -272,7 +343,7 @@ impl Avr {
         self.pending_irq &= !(1u64 << vec);
         self.set_flag_i(false);
         self.push_pc(bus)?;
-        self.pc = vec * 4;
+        self.pc = vec.saturating_sub(1) * 4;
         Ok(true)
     }
 
@@ -812,6 +883,10 @@ impl Cpu for Avr {
         self.sreg = 0;
         self.pending_irq = 0;
         self.cycles = 0;
+        self.tcnt0 = 0; self.tccr0a = 0; self.tccr0b = 0;
+        self.timsk0 = 0; self.tifr0 = 0; self.t0_prescale_acc = 0;
+        self.serial_tx.clear();
+        self.ucsr0a = UCSRA_UDRE; self.ucsr0b = 0; self.ucsr0c = 0; self.ubrr0 = 0;
         Ok(())
     }
 
@@ -821,7 +896,11 @@ impl Cpu for Avr {
         observers: &[Arc<dyn SimulationObserver>],
         config: &SimulationConfig,
     ) -> SimResult<()> {
-        self.step_inner(bus, observers, config)
+        let before = self.cycles;
+        self.step_inner(bus, observers, config)?;
+        let delta = self.cycles.saturating_sub(before) as u32;
+        self.tick_timer0(delta.max(1));
+        Ok(())
     }
 
     fn set_pc(&mut self, val: u32) {
@@ -1017,4 +1096,39 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, SimulationError::DecodeError(0)));
     }
+    #[test]
+    fn timer0_overflow_pends_with_arduino_prescale() {
+        let mut cpu = Avr::new();
+        cpu.tccr0a = 0x03; cpu.tccr0b = 0x03; cpu.timsk0 = TIMSK_TOIE0;
+        cpu.tick_timer0(16384);
+        assert!(cpu.pending_irq & (1 << VEC_TIMER0_OVF) != 0);
+    }
+
+    #[test]
+    fn usart_udre_tx_never_blocks() {
+        let mut cpu = Avr::new();
+        let mut bus = MockBus::new();
+        for b in b"Hi" {
+            cpu.data_write(0xC6, *b, &mut bus).unwrap();
+            assert_ne!(cpu.data_read(0xC0, &bus).unwrap() & UCSRA_UDRE, 0);
+        }
+        assert_eq!(cpu.serial_tx, b"Hi");
+    }
+
+    #[test]
+    fn hand_blink_toggles_portb5_and_serial() {
+        let mut cpu = Avr::new();
+        cpu.load_words(0, &[0x9A2D, 0x982D, 0xE508, 0x9300, 0x00C6, 0xCFFA]);
+        let mut bus = MockBus::new();
+        let cfg = SimulationConfig::default();
+        let mut hi = false; let mut lo = false;
+        for _ in 0..200 {
+            cpu.step(&mut bus, &[], &cfg).unwrap();
+            if cpu.portb() & 0x20 != 0 { hi = true; } else { lo = true; }
+            if hi && lo && cpu.serial_tx.contains(&b'X') { break; }
+        }
+        assert!(hi && lo);
+        assert!(cpu.serial_tx.contains(&b'X'));
+    }
+
 }

--- a/crates/core/src/cpu/avr.rs
+++ b/crates/core/src/cpu/avr.rs
@@ -11,7 +11,7 @@
 
 use crate::snapshot::{AvrCpuSnapshot, CpuSnapshot};
 use crate::{Bus, Cpu, SimResult, SimulationConfig, SimulationError, SimulationObserver};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 pub const FLASH_SIZE: usize = 32 * 1024;
 pub const RAMEND: u16 = 0x08FF;
@@ -68,6 +68,8 @@ pub struct Avr {
     pub ocr0b: u8,
     pub t0_prescale_acc: u32,
     pub serial_tx: Vec<u8>,
+    /// Optional live sink for MachineTrait UART capture.
+    pub serial_sink: Option<Arc<Mutex<Vec<u8>>>>,
     pub ucsr0a: u8,
     pub ucsr0b: u8,
     pub ucsr0c: u8,
@@ -102,6 +104,7 @@ impl Avr {
             tcnt0: 0, tccr0a: 0, tccr0b: 0, timsk0: 0, tifr0: 0,
             ocr0a: 0, ocr0b: 0, t0_prescale_acc: 0,
             serial_tx: Vec::new(),
+            serial_sink: None,
             ucsr0a: UCSRA_UDRE, ucsr0b: 0, ucsr0c: 0, ubrr0: 0,
         }
     }
@@ -246,6 +249,11 @@ impl Avr {
             0x00C5 => { self.ubrr0 = (self.ubrr0 & 0x00FF) | ((value as u16) << 8); Ok(()) }
             0x00C6 => {
                 self.serial_tx.push(value);
+                if let Some(sink) = &self.serial_sink {
+                    if let Ok(mut g) = sink.lock() {
+                        g.push(value);
+                    }
+                }
                 self.ucsr0a |= UCSRA_UDRE | UCSRA_TXC;
                 let _ = bus.write_u8(addr as u64, value);
                 Ok(())
@@ -293,6 +301,35 @@ impl Avr {
 
     pub fn serial_as_str(&self) -> String {
         String::from_utf8_lossy(&self.serial_tx).into_owned()
+    }
+
+    pub fn set_serial_sink(&mut self, sink: Arc<Mutex<Vec<u8>>>) {
+        self.serial_sink = Some(sink);
+    }
+
+    /// Load a ProgramImage: low addresses → flash; data-space addresses → SRAM.
+    pub fn load_program_image(&mut self, image: &crate::memory::ProgramImage) {
+        for seg in &image.segments {
+            let addr = seg.start_addr;
+            if addr < 0x8000 {
+                self.load_flash(addr as u32, &seg.data);
+            } else if let Some(d) = strip_avr_data_bias(addr) {
+                for (i, b) in seg.data.iter().enumerate() {
+                    let a = d as u16 + i as u16;
+                    if a >= SRAM_START && a <= RAMEND {
+                        self.sram[(a - SRAM_START) as usize] = *b;
+                    }
+                }
+            } else if addr >= SRAM_START as u64 && addr <= RAMEND as u64 {
+                for (i, b) in seg.data.iter().enumerate() {
+                    let a = addr as u16 + i as u16;
+                    if a >= SRAM_START && a <= RAMEND {
+                        self.sram[(a - SRAM_START) as usize] = *b;
+                    }
+                }
+            }
+        }
+        self.pc = image.entry_point as u32 & !1;
     }
 
     fn push_byte(&mut self, value: u8, bus: &mut dyn Bus) -> SimResult<()> {
@@ -876,6 +913,10 @@ impl Avr {
 }
 
 impl Cpu for Avr {
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+
     fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
         self.r = [0; 32];
         self.pc = 0;

--- a/crates/core/src/cpu/avr.rs
+++ b/crates/core/src/cpu/avr.rs
@@ -1,0 +1,1020 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! AVR8 CPU (ATmega328P-class) — Harvard flash + byte data space.
+//!
+//! Public PC is a **byte** address (ELF/DWARF). Fetch uses word index
+//! `pc_byte / 2`. Data space is separate from program flash.
+
+use crate::snapshot::{AvrCpuSnapshot, CpuSnapshot};
+use crate::{Bus, Cpu, SimResult, SimulationConfig, SimulationError, SimulationObserver};
+use std::sync::Arc;
+
+pub const FLASH_SIZE: usize = 32 * 1024;
+pub const RAMEND: u16 = 0x08FF;
+pub const SRAM_START: u16 = 0x0100;
+pub const AVR_DATA_VMA_BIAS: u64 = 0x0080_0000;
+pub const AVR_EEPROM_VMA_BIAS: u64 = 0x0081_0000;
+
+pub fn strip_avr_data_bias(vma: u64) -> Option<u64> {
+    if (AVR_EEPROM_VMA_BIAS..AVR_EEPROM_VMA_BIAS + 0x1_0000).contains(&vma) {
+        return Some(vma - AVR_EEPROM_VMA_BIAS);
+    }
+    if (AVR_DATA_VMA_BIAS..AVR_DATA_VMA_BIAS + 0x1_0000).contains(&vma) {
+        return Some(vma - AVR_DATA_VMA_BIAS);
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AvrLoadSpace {
+    Flash,
+    Data,
+    Eeprom,
+}
+
+pub fn classify_avr_vma(vma: u64) -> (AvrLoadSpace, u64) {
+    if let Some(d) = strip_avr_data_bias(vma) {
+        if vma >= AVR_EEPROM_VMA_BIAS {
+            (AvrLoadSpace::Eeprom, d)
+        } else {
+            (AvrLoadSpace::Data, d)
+        }
+    } else {
+        (AvrLoadSpace::Flash, vma)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Avr {
+    pub r: [u8; 32],
+    pub pc: u32,
+    pub sp: u16,
+    pub sreg: u8,
+    pub flash: Vec<u8>,
+    pub sram: Vec<u8>,
+    pub io: [u8; 0xE0],
+    pub pending_irq: u64,
+    pub cycles: u64,
+}
+
+impl Default for Avr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Avr {
+    pub fn new() -> Self {
+        Self {
+            r: [0; 32],
+            pc: 0,
+            sp: RAMEND,
+            sreg: 0,
+            flash: vec![0xFF; FLASH_SIZE],
+            sram: vec![0; (RAMEND as usize + 1) - SRAM_START as usize],
+            io: [0; 0xE0],
+            pending_irq: 0,
+            cycles: 0,
+        }
+    }
+
+    pub fn load_flash(&mut self, addr: u32, data: &[u8]) {
+        let start = addr as usize;
+        let end = (start + data.len()).min(self.flash.len());
+        if start < end {
+            let n = end - start;
+            self.flash[start..end].copy_from_slice(&data[..n]);
+        }
+    }
+
+    pub fn load_words(&mut self, addr: u32, words: &[u16]) {
+        for (i, w) in words.iter().enumerate() {
+            let b = addr as usize + i * 2;
+            if b + 1 < self.flash.len() {
+                self.flash[b] = (*w & 0xFF) as u8;
+                self.flash[b + 1] = (*w >> 8) as u8;
+            }
+        }
+    }
+
+    #[inline]
+    fn flag_i(&self) -> bool {
+        self.sreg & 0x80 != 0
+    }
+
+    #[inline]
+    fn set_flag_i(&mut self, on: bool) {
+        if on {
+            self.sreg |= 0x80;
+        } else {
+            self.sreg &= !0x80;
+        }
+    }
+
+    #[inline]
+    fn set_z(&mut self, v: u8) {
+        if v == 0 {
+            self.sreg |= 0x02;
+        } else {
+            self.sreg &= !0x02;
+        }
+    }
+
+    #[inline]
+    fn set_n(&mut self, v: u8) {
+        if v & 0x80 != 0 {
+            self.sreg |= 0x04;
+        } else {
+            self.sreg &= !0x04;
+        }
+    }
+
+    #[inline]
+    fn set_c(&mut self, on: bool) {
+        if on {
+            self.sreg |= 0x01;
+        } else {
+            self.sreg &= !0x01;
+        }
+    }
+
+    #[inline]
+    fn set_v(&mut self, on: bool) {
+        if on {
+            self.sreg |= 0x08;
+        } else {
+            self.sreg &= !0x08;
+        }
+    }
+
+    #[inline]
+    fn update_s_from_nv(&mut self) {
+        let n = (self.sreg >> 2) & 1;
+        let v = (self.sreg >> 3) & 1;
+        if n ^ v != 0 {
+            self.sreg |= 0x10;
+        } else {
+            self.sreg &= !0x10;
+        }
+    }
+
+    fn fetch_word(&self, pc_byte: u32) -> SimResult<u16> {
+        if pc_byte % 2 != 0 {
+            return Err(SimulationError::DecodeError(pc_byte as u64));
+        }
+        let i = pc_byte as usize;
+        if i + 1 >= self.flash.len() {
+            return Err(SimulationError::MemoryViolation(pc_byte as u64));
+        }
+        Ok(u16::from_le_bytes([self.flash[i], self.flash[i + 1]]))
+    }
+
+    fn data_read(&self, addr: u16, _bus: &dyn Bus) -> SimResult<u8> {
+        match addr {
+            0x0000..=0x001F => Ok(self.r[addr as usize]),
+            0x005D => Ok((self.sp & 0xFF) as u8),
+            0x005E => Ok((self.sp >> 8) as u8),
+            0x005F => Ok(self.sreg),
+            0x0020..=0x00FF => {
+                // Local io file is authoritative for v1 flat I/O; also mirrored to bus on write.
+                Ok(self.io[(addr - 0x20) as usize])
+            }
+            a if a >= SRAM_START && a <= RAMEND => {
+                Ok(self.sram[(a - SRAM_START) as usize])
+            }
+            _ => Err(SimulationError::MemoryViolation(addr as u64)),
+        }
+    }
+
+    fn data_write(&mut self, addr: u16, value: u8, bus: &mut dyn Bus) -> SimResult<()> {
+        match addr {
+            0x0000..=0x001F => {
+                self.r[addr as usize] = value;
+                Ok(())
+            }
+            0x005D => {
+                self.sp = (self.sp & 0xFF00) | value as u16;
+                Ok(())
+            }
+            0x005E => {
+                self.sp = (self.sp & 0x00FF) | ((value as u16) << 8);
+                Ok(())
+            }
+            0x005F => {
+                self.sreg = value;
+                Ok(())
+            }
+            0x0020..=0x00FF => {
+                let idx = (addr - 0x20) as usize;
+                self.io[idx] = value;
+                let _ = bus.write_u8(addr as u64, value);
+                Ok(())
+            }
+            a if a >= SRAM_START && a <= RAMEND => {
+                let off = (a - SRAM_START) as usize;
+                self.sram[off] = value;
+                let _ = bus.write_u8(a as u64, value);
+                Ok(())
+            }
+            _ => Err(SimulationError::MemoryViolation(addr as u64)),
+        }
+    }
+
+    fn push_byte(&mut self, value: u8, bus: &mut dyn Bus) -> SimResult<()> {
+        self.data_write(self.sp, value, bus)?;
+        self.sp = self.sp.wrapping_sub(1);
+        Ok(())
+    }
+
+    fn pop_byte(&mut self, bus: &dyn Bus) -> SimResult<u8> {
+        self.sp = self.sp.wrapping_add(1);
+        self.data_read(self.sp, bus)
+    }
+
+    fn push_pc(&mut self, bus: &mut dyn Bus) -> SimResult<()> {
+        let word = (self.pc / 2) as u16;
+        self.push_byte((word >> 8) as u8, bus)?;
+        self.push_byte((word & 0xFF) as u8, bus)?;
+        Ok(())
+    }
+
+    fn pop_pc(&mut self, bus: &dyn Bus) -> SimResult<()> {
+        let lo = self.pop_byte(bus)? as u16;
+        let hi = self.pop_byte(bus)? as u16;
+        let word = (hi << 8) | lo;
+        self.pc = (word as u32) * 2;
+        Ok(())
+    }
+
+    fn word_size_bytes(op: u16) -> u32 {
+        let top = op & 0xFE0E;
+        if top == 0x940C || top == 0x940E {
+            return 4;
+        }
+        if (op & 0xFE0F) == 0x9000 || (op & 0xFE0F) == 0x9200 {
+            return 4;
+        }
+        2
+    }
+
+    fn try_take_irq(&mut self, bus: &mut dyn Bus) -> SimResult<bool> {
+        if !self.flag_i() || self.pending_irq == 0 {
+            return Ok(false);
+        }
+        let vec = self.pending_irq.trailing_zeros();
+        if vec == 0 || vec > 31 {
+            return Ok(false);
+        }
+        self.pending_irq &= !(1u64 << vec);
+        self.set_flag_i(false);
+        self.push_pc(bus)?;
+        self.pc = vec * 4;
+        Ok(true)
+    }
+
+    fn step_inner(
+        &mut self,
+        bus: &mut dyn Bus,
+        _observers: &[Arc<dyn SimulationObserver>],
+        _config: &SimulationConfig,
+    ) -> SimResult<()> {
+        if self.try_take_irq(bus)? {
+            self.cycles += 4;
+            return Ok(());
+        }
+
+        let pc = self.pc;
+        let op = self.fetch_word(pc)?;
+        let mut next = pc.wrapping_add(2);
+
+        if op == 0x0000 {
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+        if op == 0x9478 {
+            self.set_flag_i(true);
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+        if op == 0x94F8 {
+            self.set_flag_i(false);
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+        if op == 0x9508 {
+            self.pop_pc(bus)?;
+            self.cycles += 4;
+            return Ok(());
+        }
+        if op == 0x9518 {
+            self.pop_pc(bus)?;
+            self.set_flag_i(true);
+            self.cycles += 4;
+            return Ok(());
+        }
+        if op == 0x9588 {
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+        if op == 0x9598 {
+            return Err(SimulationError::Halt);
+        }
+
+        // RJMP
+        if (op & 0xF000) == 0xC000 {
+            let k = op & 0x0FFF;
+            let offset = if k & 0x0800 != 0 {
+                (k | 0xF000) as i16
+            } else {
+                k as i16
+            };
+            let pc_word = (pc / 2) as i32 + 1 + offset as i32;
+            self.pc = (pc_word as u32) * 2;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // RCALL
+        if (op & 0xF000) == 0xD000 {
+            let k = op & 0x0FFF;
+            let offset = if k & 0x0800 != 0 {
+                (k | 0xF000) as i16
+            } else {
+                k as i16
+            };
+            self.pc = next;
+            self.push_pc(bus)?;
+            let pc_word = (pc / 2) as i32 + 1 + offset as i32;
+            self.pc = (pc_word as u32) * 2;
+            self.cycles += 3;
+            return Ok(());
+        }
+
+        // LDI
+        if (op & 0xF000) == 0xE000 {
+            let rd = 16 + ((op >> 4) & 0x0F) as usize;
+            let k = ((op & 0x0F00) >> 4) as u8 | (op & 0x0F) as u8;
+            self.r[rd] = k;
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // OUT
+        if (op & 0xF800) == 0xB800 {
+            let a = (((op >> 5) & 0x30) | (op & 0x0F)) as u8;
+            let rr = ((op >> 4) & 0x1F) as usize;
+            let data_addr = 0x20u16 + a as u16;
+            self.data_write(data_addr, self.r[rr], bus)?;
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // IN
+        if (op & 0xF800) == 0xB000 {
+            let a = (((op >> 5) & 0x30) | (op & 0x0F)) as u8;
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let data_addr = 0x20u16 + a as u16;
+            self.r[rd] = self.data_read(data_addr, bus)?;
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // SBI
+        if (op & 0xFF00) == 0x9A00 {
+            let a = ((op >> 3) & 0x1F) as u8;
+            let b = (op & 0x07) as u8;
+            let data_addr = 0x20u16 + a as u16;
+            let v = self.data_read(data_addr, bus)? | (1 << b);
+            self.data_write(data_addr, v, bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // CBI
+        if (op & 0xFF00) == 0x9800 {
+            let a = ((op >> 3) & 0x1F) as u8;
+            let b = (op & 0x07) as u8;
+            let data_addr = 0x20u16 + a as u16;
+            let v = self.data_read(data_addr, bus)? & !(1 << b);
+            self.data_write(data_addr, v, bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // LDS
+        if (op & 0xFE0F) == 0x9000 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let k = self.fetch_word(next)?;
+            next = next.wrapping_add(2);
+            self.r[rd] = self.data_read(k, bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // STS
+        if (op & 0xFE0F) == 0x9200 {
+            let rr = ((op >> 4) & 0x1F) as usize;
+            let k = self.fetch_word(next)?;
+            next = next.wrapping_add(2);
+            self.data_write(k, self.r[rr], bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // MOV
+        if (op & 0xFC00) == 0x2C00 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            self.r[rd] = self.r[rr];
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // ADD
+        if (op & 0xFC00) == 0x0C00 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            let a = self.r[rd];
+            let b = self.r[rr];
+            let (res, c) = a.overflowing_add(b);
+            let v = (!(a ^ b) & (a ^ res)) & 0x80 != 0;
+            self.r[rd] = res;
+            self.set_c(c);
+            self.set_z(res);
+            self.set_n(res);
+            self.set_v(v);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // EOR
+        if (op & 0xFC00) == 0x2400 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            let res = self.r[rd] ^ self.r[rr];
+            self.r[rd] = res;
+            self.set_v(false);
+            self.set_z(res);
+            self.set_n(res);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // AND
+        if (op & 0xFC00) == 0x2000 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            let res = self.r[rd] & self.r[rr];
+            self.r[rd] = res;
+            self.set_v(false);
+            self.set_z(res);
+            self.set_n(res);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // OR
+        if (op & 0xFC00) == 0x2800 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            let res = self.r[rd] | self.r[rr];
+            self.r[rd] = res;
+            self.set_v(false);
+            self.set_z(res);
+            self.set_n(res);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // CP
+        if (op & 0xFC00) == 0x1400 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            let a = self.r[rd];
+            let b = self.r[rr];
+            let (res, c) = a.overflowing_sub(b);
+            let v = ((a ^ b) & (a ^ res)) & 0x80 != 0;
+            self.set_c(c);
+            self.set_z(res);
+            self.set_n(res);
+            self.set_v(v);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // CPI
+        if (op & 0xF000) == 0x3000 {
+            let rd = 16 + ((op >> 4) & 0x0F) as usize;
+            let k = ((op & 0x0F00) >> 4) as u8 | (op & 0x0F) as u8;
+            let a = self.r[rd];
+            let (res, c) = a.overflowing_sub(k);
+            let v = ((a ^ k) & (a ^ res)) & 0x80 != 0;
+            self.set_c(c);
+            self.set_z(res);
+            self.set_n(res);
+            self.set_v(v);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // BRcc
+        if (op & 0xF800) == 0xF000 || (op & 0xF800) == 0xF400 {
+            let k = ((op >> 3) & 0x7F) as i8;
+            let offset = if k & 0x40 != 0 { k | !0x7F } else { k };
+            let bit = (op & 0x07) as u8;
+            let complement = (op & 0x0400) != 0;
+            let flag = (self.sreg >> bit) & 1 != 0;
+            let take = if complement { !flag } else { flag };
+            if take {
+                let pc_word = (pc / 2) as i32 + 1 + offset as i32;
+                self.pc = (pc_word as u32) * 2;
+                self.cycles += 2;
+            } else {
+                self.pc = next;
+                self.cycles += 1;
+            }
+            return Ok(());
+        }
+
+        // PUSH
+        if (op & 0xFE0F) == 0x920F {
+            let rr = ((op >> 4) & 0x1F) as usize;
+            self.push_byte(self.r[rr], bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // POP
+        if (op & 0xFE0F) == 0x900F {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            self.r[rd] = self.pop_byte(bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // ADIW
+        if (op & 0xFF00) == 0x9600 {
+            let d = ((op >> 4) & 0x03) as usize;
+            let rd = 24 + d * 2;
+            let k = (((op >> 6) & 0x03) << 4) as u16 | (op & 0x0F) as u16;
+            let val = u16::from_le_bytes([self.r[rd], self.r[rd + 1]]).wrapping_add(k);
+            self.r[rd] = (val & 0xFF) as u8;
+            self.r[rd + 1] = (val >> 8) as u8;
+            self.set_z(if val == 0 { 0 } else { 1 });
+            self.set_n((val >> 8) as u8);
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // SBIW
+        if (op & 0xFF00) == 0x9700 {
+            let d = ((op >> 4) & 0x03) as usize;
+            let rd = 24 + d * 2;
+            let k = (((op >> 6) & 0x03) << 4) as u16 | (op & 0x0F) as u16;
+            let val = u16::from_le_bytes([self.r[rd], self.r[rd + 1]]).wrapping_sub(k);
+            self.r[rd] = (val & 0xFF) as u8;
+            self.r[rd + 1] = (val >> 8) as u8;
+            self.set_z(if val == 0 { 0 } else { 1 });
+            self.set_n((val >> 8) as u8);
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // MOVW
+        if (op & 0xFF00) == 0x0100 {
+            let rd = ((op >> 4) & 0x0F) as usize * 2;
+            let rr = (op & 0x0F) as usize * 2;
+            self.r[rd] = self.r[rr];
+            self.r[rd + 1] = self.r[rr + 1];
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // IJMP
+        if op == 0x9409 {
+            let z = u16::from_le_bytes([self.r[30], self.r[31]]);
+            self.pc = (z as u32) * 2;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // LPM
+        if op == 0x95C8 {
+            let z = u16::from_le_bytes([self.r[30], self.r[31]]) as usize;
+            self.r[0] = self.flash.get(z).copied().unwrap_or(0xFF);
+            self.pc = next;
+            self.cycles += 3;
+            return Ok(());
+        }
+
+        // LPM Rd,Z
+        if (op & 0xFE0F) == 0x9004 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let z = u16::from_le_bytes([self.r[30], self.r[31]]) as usize;
+            self.r[rd] = self.flash.get(z).copied().unwrap_or(0xFF);
+            self.pc = next;
+            self.cycles += 3;
+            return Ok(());
+        }
+
+        // LPM Rd,Z+
+        if (op & 0xFE0F) == 0x9005 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let z = u16::from_le_bytes([self.r[30], self.r[31]]);
+            self.r[rd] = self.flash.get(z as usize).copied().unwrap_or(0xFF);
+            let z2 = z.wrapping_add(1);
+            self.r[30] = (z2 & 0xFF) as u8;
+            self.r[31] = (z2 >> 8) as u8;
+            self.pc = next;
+            self.cycles += 3;
+            return Ok(());
+        }
+
+        // LD Rd,X
+        if (op & 0xFE0F) == 0x900C {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let x = u16::from_le_bytes([self.r[26], self.r[27]]);
+            self.r[rd] = self.data_read(x, bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // ST X,Rr
+        if (op & 0xFE0F) == 0x920C {
+            let rr = ((op >> 4) & 0x1F) as usize;
+            let x = u16::from_le_bytes([self.r[26], self.r[27]]);
+            self.data_write(x, self.r[rr], bus)?;
+            self.pc = next;
+            self.cycles += 2;
+            return Ok(());
+        }
+
+        // JMP
+        if (op & 0xFE0E) == 0x940C {
+            let k_hi = ((op >> 3) & 0x3E) | (op & 0x01);
+            let k_lo = self.fetch_word(next)?;
+            let k = ((k_hi as u32) << 16) | k_lo as u32;
+            self.pc = k * 2;
+            self.cycles += 3;
+            return Ok(());
+        }
+
+        // CALL
+        if (op & 0xFE0E) == 0x940E {
+            let k_hi = ((op >> 3) & 0x3E) | (op & 0x01);
+            let k_lo = self.fetch_word(next)?;
+            let k = ((k_hi as u32) << 16) | k_lo as u32;
+            self.pc = next.wrapping_add(2);
+            self.push_pc(bus)?;
+            self.pc = k * 2;
+            self.cycles += 4;
+            return Ok(());
+        }
+
+        // SBIS
+        if (op & 0xFF00) == 0x9B00 {
+            let a = ((op >> 3) & 0x1F) as u8;
+            let b = (op & 0x07) as u8;
+            let v = self.data_read(0x20 + a as u16, bus)?;
+            if v & (1 << b) != 0 {
+                let following = self.fetch_word(next)?;
+                next = next.wrapping_add(Self::word_size_bytes(following));
+            }
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // SBIC
+        if (op & 0xFF00) == 0x9900 {
+            let a = ((op >> 3) & 0x1F) as u8;
+            let b = (op & 0x07) as u8;
+            let v = self.data_read(0x20 + a as u16, bus)?;
+            if v & (1 << b) == 0 {
+                let following = self.fetch_word(next)?;
+                next = next.wrapping_add(Self::word_size_bytes(following));
+            }
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // SBRS
+        if (op & 0xFE08) == 0xFE00 {
+            let rr = ((op >> 4) & 0x1F) as usize;
+            let b = (op & 0x07) as u8;
+            if self.r[rr] & (1 << b) != 0 {
+                let following = self.fetch_word(next)?;
+                next = next.wrapping_add(Self::word_size_bytes(following));
+            }
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // SBRC
+        if (op & 0xFE08) == 0xFC00 {
+            let rr = ((op >> 4) & 0x1F) as usize;
+            let b = (op & 0x07) as u8;
+            if self.r[rr] & (1 << b) == 0 {
+                let following = self.fetch_word(next)?;
+                next = next.wrapping_add(Self::word_size_bytes(following));
+            }
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // CPSE
+        if (op & 0xFC00) == 0x1000 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let rr = (((op >> 5) & 0x10) | (op & 0x0F)) as usize;
+            if self.r[rd] == self.r[rr] {
+                let following = self.fetch_word(next)?;
+                next = next.wrapping_add(Self::word_size_bytes(following));
+            }
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // INC
+        if (op & 0xFE0F) == 0x9403 {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let res = self.r[rd].wrapping_add(1);
+            self.r[rd] = res;
+            self.set_v(res == 0x80);
+            self.set_z(res);
+            self.set_n(res);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        // DEC
+        if (op & 0xFE0F) == 0x940A {
+            let rd = ((op >> 4) & 0x1F) as usize;
+            let res = self.r[rd].wrapping_sub(1);
+            self.r[rd] = res;
+            self.set_v(res == 0x7F);
+            self.set_z(res);
+            self.set_n(res);
+            self.update_s_from_nv();
+            self.pc = next;
+            self.cycles += 1;
+            return Ok(());
+        }
+
+        Err(SimulationError::DecodeError(pc as u64))
+    }
+}
+
+impl Cpu for Avr {
+    fn reset(&mut self, _bus: &mut dyn Bus) -> SimResult<()> {
+        self.r = [0; 32];
+        self.pc = 0;
+        self.sp = RAMEND;
+        self.sreg = 0;
+        self.pending_irq = 0;
+        self.cycles = 0;
+        Ok(())
+    }
+
+    fn step(
+        &mut self,
+        bus: &mut dyn Bus,
+        observers: &[Arc<dyn SimulationObserver>],
+        config: &SimulationConfig,
+    ) -> SimResult<()> {
+        self.step_inner(bus, observers, config)
+    }
+
+    fn set_pc(&mut self, val: u32) {
+        self.pc = val & !1;
+    }
+    fn get_pc(&self) -> u32 {
+        self.pc
+    }
+    fn set_sp(&mut self, val: u32) {
+        self.sp = val as u16;
+    }
+    fn set_exception_pending(&mut self, exception_num: u32) {
+        if exception_num > 0 && exception_num < 64 {
+            self.pending_irq |= 1u64 << exception_num;
+        }
+    }
+
+    fn get_register(&self, id: u8) -> u32 {
+        match id {
+            0..=31 => self.r[id as usize] as u32,
+            32 => self.sp as u32,
+            33 => self.sreg as u32,
+            34 => self.pc,
+            _ => 0,
+        }
+    }
+
+    fn set_register(&mut self, id: u8, val: u32) {
+        match id {
+            0..=31 => self.r[id as usize] = val as u8,
+            32 => self.sp = val as u16,
+            33 => self.sreg = val as u8,
+            34 => self.pc = val & !1,
+            _ => {}
+        }
+    }
+
+    fn snapshot(&self) -> CpuSnapshot {
+        CpuSnapshot::Avr(AvrCpuSnapshot {
+            registers: self.r.to_vec(),
+            pc: self.pc,
+            sp: self.sp,
+            sreg: self.sreg,
+        })
+    }
+
+    fn apply_snapshot(&mut self, snapshot: &CpuSnapshot) {
+        if let CpuSnapshot::Avr(s) = snapshot {
+            for (i, v) in s.registers.iter().take(32).enumerate() {
+                self.r[i] = *v;
+            }
+            self.pc = s.pc & !1;
+            self.sp = s.sp;
+            self.sreg = s.sreg;
+        }
+    }
+
+    fn get_register_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = (0..32).map(|i| format!("R{i}")).collect();
+        names.push("SP".into());
+        names.push("SREG".into());
+        names.push("PC".into());
+        names
+    }
+
+    fn index_of_register(&self, name: &str) -> Option<u8> {
+        let u = name.to_uppercase();
+        if let Some(rest) = u.strip_prefix('R') {
+            if let Ok(n) = rest.parse::<u8>() {
+                if n < 32 {
+                    return Some(n);
+                }
+            }
+        }
+        match u.as_str() {
+            "SP" => Some(32),
+            "SREG" => Some(33),
+            "PC" => Some(34),
+            "X" => Some(26),
+            "Y" => Some(28),
+            "Z" => Some(30),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DmaRequest, SimulationConfig};
+    use std::collections::HashMap;
+
+    struct MockBus {
+        mem: HashMap<u64, u8>,
+        config: SimulationConfig,
+    }
+
+    impl MockBus {
+        fn new() -> Self {
+            Self {
+                mem: HashMap::new(),
+                config: SimulationConfig::default(),
+            }
+        }
+    }
+
+    impl Bus for MockBus {
+        fn read_u8(&self, addr: u64) -> SimResult<u8> {
+            Ok(*self.mem.get(&addr).unwrap_or(&0))
+        }
+        fn write_u8(&mut self, addr: u64, value: u8) -> SimResult<()> {
+            self.mem.insert(addr, value);
+            Ok(())
+        }
+        fn tick_peripherals(&mut self) -> Vec<u32> {
+            Vec::new()
+        }
+        fn execute_dma(&mut self, _requests: &[DmaRequest]) -> SimResult<()> {
+            Ok(())
+        }
+        fn config(&self) -> &SimulationConfig {
+            &self.config
+        }
+    }
+
+    #[test]
+    fn rjmp_self_retires_10000_steps() {
+        let mut cpu = Avr::new();
+        cpu.load_words(0, &[0xCFFF]);
+        cpu.set_pc(0);
+        let mut bus = MockBus::new();
+        let cfg = SimulationConfig::default();
+        for _ in 0..10_000 {
+            cpu.step(&mut bus, &[], &cfg).unwrap();
+        }
+        assert_eq!(cpu.get_pc(), 0);
+    }
+
+    #[test]
+    fn pc_rejects_odd_fetch() {
+        let mut cpu = Avr::new();
+        cpu.load_words(0, &[0x0000]);
+        cpu.pc = 1;
+        let mut bus = MockBus::new();
+        let err = cpu
+            .step(&mut bus, &[], &SimulationConfig::default())
+            .unwrap_err();
+        assert!(matches!(err, SimulationError::DecodeError(1)));
+    }
+
+    #[test]
+    fn in_out_and_lds_alias_same_io_register() {
+        let mut cpu = Avr::new();
+        // LDI R16,0xA5; OUT PORTB(io5),R16; LDS R17,0x25
+        cpu.load_words(0, &[0xEA05, 0xB905, 0x9110, 0x0025, 0xCFFF]);
+        let mut bus = MockBus::new();
+        let cfg = SimulationConfig::default();
+        cpu.set_pc(0);
+        cpu.step(&mut bus, &[], &cfg).unwrap();
+        assert_eq!(cpu.r[16], 0xA5);
+        cpu.step(&mut bus, &[], &cfg).unwrap();
+        assert_eq!(cpu.io[(0x25 - 0x20) as usize], 0xA5);
+        cpu.step(&mut bus, &[], &cfg).unwrap();
+        assert_eq!(cpu.r[17], 0xA5);
+    }
+
+    #[test]
+    fn data_bias_strip() {
+        assert_eq!(strip_avr_data_bias(0x0080_0100), Some(0x100));
+        assert_eq!(strip_avr_data_bias(0x0081_0010), Some(0x10));
+        assert_eq!(strip_avr_data_bias(0x0000_0100), None);
+        assert_eq!(classify_avr_vma(0x0080_0200), (AvrLoadSpace::Data, 0x200));
+        assert_eq!(classify_avr_vma(0x0000_0040), (AvrLoadSpace::Flash, 0x40));
+    }
+
+    #[test]
+    fn sbi_sets_portb_bit() {
+        let mut cpu = Avr::new();
+        cpu.load_words(0, &[0x9A2D, 0xCFFF]);
+        let mut bus = MockBus::new();
+        cpu.step(&mut bus, &[], &SimulationConfig::default())
+            .unwrap();
+        assert_eq!(cpu.io[0x05], 1 << 5);
+    }
+
+    #[test]
+    fn unknown_opcode_decode_error() {
+        let mut cpu = Avr::new();
+        cpu.load_words(0, &[0xFFFF]);
+        let mut bus = MockBus::new();
+        let err = cpu
+            .step(&mut bus, &[], &SimulationConfig::default())
+            .unwrap_err();
+        assert!(matches!(err, SimulationError::DecodeError(0)));
+    }
+}

--- a/crates/core/src/cpu/mod.rs
+++ b/crates/core/src/cpu/mod.rs
@@ -17,6 +17,8 @@
 // `crate::tests::cortex_m_memory_contract`, which covers the whole `cpu/` tree
 // and catches the `is_err()` / `.ok()` discard shapes clippy cannot see).
 #[deny(clippy::let_underscore_must_use)]
+pub mod avr;
+#[deny(clippy::let_underscore_must_use)]
 pub mod cortex_m;
 #[deny(clippy::let_underscore_must_use)]
 pub mod riscv;
@@ -56,6 +58,7 @@ pub mod xtensa_jit_bytes;
 #[cfg(any(feature = "jit", feature = "jit-framework"))]
 pub mod jit_framework;
 
+pub use avr::Avr;
 pub use cortex_m::CortexM;
 pub use riscv::{RiscV, RiscVCoreProfile};
 pub use xtensa_lx7::XtensaLx7;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -58,6 +58,8 @@ pub enum Arch {
     Arm,
     RiscV,
     XtensaLx7,
+    /// AVR8 (ATmega328P-class).
+    Avr,
     Unknown,
 }
 

--- a/crates/core/src/snapshot.rs
+++ b/crates/core/src/snapshot.rs
@@ -48,6 +48,15 @@ pub enum CpuSnapshot {
     Arm(ArmCpuSnapshot),
     RiscV(RiscVCpuSnapshot),
     XtensaLx7(XtensaLx7CpuSnapshot),
+    Avr(AvrCpuSnapshot),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AvrCpuSnapshot {
+    pub registers: Vec<u8>,
+    pub pc: u32,
+    pub sp: u16,
+    pub sreg: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/core/src/system/node.rs
+++ b/crates/core/src/system/node.rs
@@ -88,8 +88,12 @@ pub fn build_node_with_plugins(
         Arch::Arm => build_cortex_m_node(id, chip, system, firmware, plugins),
         Arch::RiscV => build_riscv_node(id, chip, system, firmware, plugins),
         Arch::Xtensa => build_xtensa_node(id, chip, system, firmware),
+        Arch::Avr => anyhow::bail!(
+            "node '{id}': chip '{}' is AVR — multi-node World path does not host Avr yet; use Machine<Avr> directly",
+            chip.name
+        ),
         Arch::Unknown => anyhow::bail!(
-            "node '{id}': chip '{}' does not declare a known architecture (`arch:` must be arm, riscv, or xtensa)",
+            "node '{id}': chip '{}' does not declare a known architecture (`arch:` must be arm, riscv, xtensa, or avr)",
             chip.name
         ),
     }

--- a/crates/core/src/system/node.rs
+++ b/crates/core/src/system/node.rs
@@ -88,15 +88,35 @@ pub fn build_node_with_plugins(
         Arch::Arm => build_cortex_m_node(id, chip, system, firmware, plugins),
         Arch::RiscV => build_riscv_node(id, chip, system, firmware, plugins),
         Arch::Xtensa => build_xtensa_node(id, chip, system, firmware),
-        Arch::Avr => anyhow::bail!(
-            "node '{id}': chip '{}' is AVR — multi-node World path does not host Avr yet; use Machine<Avr> directly",
-            chip.name
-        ),
+        Arch::Avr => build_avr_node(id, chip, system, firmware, plugins),
         Arch::Unknown => anyhow::bail!(
             "node '{id}': chip '{}' does not declare a known architecture (`arch:` must be arm, riscv, xtensa, or avr)",
             chip.name
         ),
     }
+}
+
+fn build_avr_node(
+    id: &str,
+    chip: &ChipDescriptor,
+    system: &SystemManifest,
+    firmware: NodeFirmware,
+    plugins: &[&dyn crate::plugin::ChipPlugin],
+) -> anyhow::Result<Box<dyn MachineTrait>> {
+    let NodeFirmware::Elf(bytes) = firmware else {
+        anyhow::bail!(
+            "node '{id}': chip '{}' boots from an ELF, but the firmware is not an ELF file",
+            chip.name
+        );
+    };
+    let image =
+        parse_elf_image(&bytes).with_context(|| format!("node '{id}': parse firmware ELF"))?;
+    let bus = crate::bus::SystemBus::from_config_with_plugins(chip, system, plugins)
+        .with_context(|| format!("node '{id}': build bus"))?;
+    let mut cpu = crate::cpu::Avr::new();
+    cpu.load_program_image(&image);
+    let machine = Machine::new(cpu, bus);
+    Ok(Box::new(machine))
 }
 
 fn is_cortex_m(chip: &ChipDescriptor) -> bool {

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -189,6 +189,14 @@ impl<C: Cpu + 'static> MachineTrait for Machine<C> {
         sink: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
         echo_stdout: bool,
     ) -> anyhow::Result<()> {
+        // AVR USART TX is modelled on the CPU, not a bus UART peripheral.
+        if let Some(avr) = self
+            .cpu
+            .as_any_mut()
+            .and_then(|a| a.downcast_mut::<crate::cpu::Avr>())
+        {
+            avr.set_serial_sink(sink.clone());
+        }
         self.bus.attach_uart_tx_sink(sink, echo_stdout);
         Ok(())
     }

--- a/crates/loader/src/footprint.rs
+++ b/crates/loader/src/footprint.rs
@@ -1,0 +1,106 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Berkeley-style ELF footprint totals matching GNU `arm-none-eabi-size`.
+//!
+//! Classifies `SHF_ALLOC` sections into text / data / bss using the
+//! `elf_section_totals_v1` rules. Pure function over ELF bytes — no I/O
+//! beyond what the caller provides.
+
+use anyhow::{Context, Result};
+use goblin::elf::section_header::{SHF_ALLOC, SHF_EXECINSTR, SHF_WRITE, SHT_NOBITS, SHT_PROGBITS};
+use goblin::elf::Elf;
+
+/// Method string identifying this classifier version.
+pub const FOOTPRINT_METHOD: &str = "elf_section_totals_v1";
+
+/// Berkeley-style section totals (bytes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElfSectionTotals {
+    pub text: u64,
+    pub data: u64,
+    pub bss: u64,
+}
+
+impl ElfSectionTotals {
+    /// Flash occupancy: text + data (initialized image in flash).
+    pub fn flash_used(&self) -> u64 {
+        self.text + self.data
+    }
+
+    /// Static RAM occupancy: data + bss (runtime RAM for globals / zeroed / heap-stack reserve).
+    pub fn ram_static(&self) -> u64 {
+        self.data + self.bss
+    }
+}
+
+/// Classify `SHF_ALLOC` sections into Berkeley text/data/bss.
+///
+/// Rules (`elf_section_totals_v1`):
+/// - Only sections with `SHF_ALLOC` are counted.
+/// - `SHT_NOBITS` alloc → **bss** (includes GNU `._user_heap_stack`).
+/// - Writable non-exec `SHT_PROGBITS` → **data**.
+/// - Everything else alloc (code, rodata, vectors, init arrays, …) → **text**.
+pub fn elf_section_totals_v1(buffer: &[u8]) -> Result<ElfSectionTotals> {
+    let elf = Elf::parse(buffer).context("failed to parse ELF for section totals")?;
+
+    let mut text: u64 = 0;
+    let mut data: u64 = 0;
+    let mut bss: u64 = 0;
+
+    for sh in &elf.section_headers {
+        let flags = sh.sh_flags as u32;
+        if flags & SHF_ALLOC == 0 {
+            continue;
+        }
+
+        let size = sh.sh_size;
+        if size == 0 {
+            continue;
+        }
+
+        if sh.sh_type == SHT_NOBITS {
+            bss += size;
+            continue;
+        }
+
+        let writable = flags & SHF_WRITE != 0;
+        let executable = flags & SHF_EXECINSTR != 0;
+        if sh.sh_type == SHT_PROGBITS && writable && !executable {
+            data += size;
+        } else {
+            text += size;
+        }
+    }
+
+    Ok(ElfSectionTotals { text, data, bss })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn stm32f103_blinky_matches_gnu_berkeley_size() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/stm32f103-blinky.elf");
+        let buffer = std::fs::read(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
+
+        let totals = elf_section_totals_v1(&buffer).expect("classify fixture");
+
+        // Verified with `arm-none-eabi-size` on tests/fixtures/stm32f103-blinky.elf:
+        //   text=12760 data=124 bss=2548
+        // bss includes .bss (1008) + ._user_heap_stack (1540).
+        assert_eq!(totals.text, 12760, "text");
+        assert_eq!(totals.data, 124, "data");
+        assert_eq!(totals.bss, 2548, "bss");
+        assert_eq!(totals.flash_used(), 12760 + 124);
+        assert_eq!(totals.ram_static(), 124 + 2548);
+        assert_eq!(FOOTPRINT_METHOD, "elf_section_totals_v1");
+    }
+}

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -420,6 +420,7 @@ pub fn load_elf_bytes(buffer: &[u8]) -> Result<ProgramImage> {
         goblin::elf::header::EM_ARM => labwired_core::Arch::Arm,
         goblin::elf::header::EM_RISCV => labwired_core::Arch::RiscV,
         94 => labwired_core::Arch::XtensaLx7, // EM_XTENSA = 94
+        83 => labwired_core::Arch::Avr,       // EM_AVR = 83
         _ => {
             warn!("Unknown ELF machine type: {}", elf.header.e_machine);
             labwired_core::Arch::Unknown
@@ -431,7 +432,27 @@ pub fn load_elf_bytes(buffer: &[u8]) -> Result<ProgramImage> {
     for ph in elf.program_headers {
         if ph.p_type == PT_LOAD {
             // We only care about loadable segments
-            let start_addr = ph.p_paddr; // Physical address (LMA) is usually what we want for flash programming
+            let start_addr = if arch == labwired_core::Arch::Avr {
+                let v = if ph.p_vaddr != 0 {
+                    ph.p_vaddr
+                } else {
+                    ph.p_paddr
+                };
+                let (space, addr) = labwired_core::cpu::avr::classify_avr_vma(v);
+                match space {
+                    labwired_core::cpu::avr::AvrLoadSpace::Flash => {
+                        if ph.p_paddr != 0 {
+                            ph.p_paddr
+                        } else {
+                            addr
+                        }
+                    }
+                    labwired_core::cpu::avr::AvrLoadSpace::Data
+                    | labwired_core::cpu::avr::AvrLoadSpace::Eeprom => addr,
+                }
+            } else {
+                ph.p_paddr
+            };
             let size = ph.p_filesz as usize;
             let offset = ph.p_offset as usize;
 

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 pub mod multi_image;
+pub mod footprint;
+
+pub use footprint::{elf_section_totals_v1, ElfSectionTotals, FOOTPRINT_METHOD};
 
 pub fn load_elf(path: &Path) -> Result<ProgramImage> {
     let buffer = fs::read(path).with_context(|| format!("Failed to read ELF file: {:?}", path))?;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -397,6 +397,9 @@ impl WasmSimulator {
                 Self::new_from_config_xtensa_esp32s3(&manifest, firmware, &blob_map)
             }
             Arch::Xtensa => Self::new_from_config_xtensa_esp32(&manifest, firmware),
+            // Classic Arduino Nano / ATmega328P — same constructor shape as
+            // `build_avr_node` (load ELF into Avr flash, host console on UART).
+            Arch::Avr => Self::new_from_config_avr(&chip, &manifest, firmware),
         }
     }
 
@@ -433,6 +436,45 @@ impl WasmSimulator {
             console,
             uart_rx_bufs,
             arch: Arch::Arm,
+            esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
+        })
+    }
+
+    /// AVR8 (ATmega328P / classic Arduino Nano) constructor for the browser.
+    /// Mirrors `labwired_core::system::node::build_avr_node`: parse ELF into
+    /// the Avr program image, attach the host console, box the CPU.
+    fn new_from_config_avr(
+        chip: &ChipDescriptor,
+        manifest: &SystemManifest,
+        firmware: &[u8],
+    ) -> Result<WasmSimulator, JsValue> {
+        let mut bus = SystemBus::from_config(chip, manifest)
+            .map_err(|e| JsValue::from_str(&format!("Bus config error: {:#}", e)))?;
+
+        let console = ConsoleCapture::for_manifest(manifest);
+        let uart_sink = console.heard_sink();
+        bus.attach_host_console(console.tapped(), uart_sink.clone())
+            .map_err(|e| JsValue::from_str(&e))?;
+        let uart_rx_bufs = bus.attach_uart_rx_source();
+
+        let program_image = load_elf_bytes(firmware)
+            .map_err(|e| JsValue::from_str(&format!("Loader Error: {}", e)))?;
+        let mut cpu = labwired_core::cpu::Avr::new();
+        cpu.load_program_image(&program_image);
+        let boxed: Box<dyn Cpu> = Box::new(cpu);
+        let machine = Machine::new(boxed, bus);
+
+        let board_io = manifest.board_io.clone();
+
+        Ok(WasmSimulator {
+            machine: Some(machine),
+            board_io,
+            uart_sink,
+            console,
+            uart_rx_bufs,
+            arch: Arch::Avr,
             esp32_ipi: None,
             jit_browser_enabled: false,
             jit_browser_cache: None,
@@ -1222,6 +1264,12 @@ impl WasmSimulator {
                     Err(_) => "?? (Error reading h1)".to_string(),
                 }
             }
+            // No shared AVR decoder in the wasm Trace panel yet — show the
+            // raw opcode word so the pane is never empty / wrong-arch.
+            Arch::Avr => match machine.bus.read_u16(pc as u64) {
+                Ok(word) => format!("AVR {word:#06x}"),
+                Err(_) => "?? (Error reading AVR instruction)".to_string(),
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

`Arch::Avr` was added for ATmega328P but `labwired-wasm` match arms in `new_from_config` / `get_disassembly` were incomplete, breaking wasm32 builds (and superproject Pages deploy).

## Test plan

- [x] `cargo check -p labwired-wasm --target wasm32-unknown-unknown`