### PR TITLE
docs: Start here (drop four doors wording)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Run **real firmware** on a **digital twin** of the board — in the browser, fro
 
 ---
 
-## Start here (four doors)
+## Start here
 
 | Door | You want to… | Start |
 |------|----------------|--------|


### PR DESCRIPTION
## Summary
- Home heading: **Start here** instead of "Start here (four doors)".

## Test plan
- [ ] https://docs.labwired.com/ shows plain Start here after deploy