### PR TITLE
docs: drop llms.txt from site navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,6 @@ plugins:
 nav:
   - Home: index.md
   - Fidelity: fidelity.md
-  - llms.txt (agents): llms.md
   - Architecture Overview: architecture.md
   - Hardware-Sim Parity: golden_reference.md
 


### PR DESCRIPTION
## Summary
- Remove **llms.txt (agents)** from `mkdocs.yml` nav. Page file stays available if linked directly.

## Test plan
- [ ] Nav no longer shows llms.txt after deploy