### PR TITLE
docs: sidebar nav only (no top tabs)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,9 +6,9 @@ repo_name: w1ne/labwired-core
 theme:
   name: material
   features:
+    # No navigation.tabs — all sections live in the left sidebar, not top tabs.
     - navigation.instant
     - navigation.tracking
-    - navigation.tabs
     - navigation.sections
     - navigation.expand
     - navigation.top
@@ -56,7 +56,6 @@ plugins:
 nav:
   - Home: index.md
   - Fidelity: fidelity.md
-  - llms.txt (agents): llms.md
   - Architecture Overview: architecture.md
   - Hardware-Sim Parity: golden_reference.md
 


### PR DESCRIPTION
## Summary
- Remove Material **`navigation.tabs`** so the full site tree lives in the **left sidebar**, not a top tab bar.
- Remove **llms.txt (agents)** from nav (page file still exists).

## Test plan
- [ ] After deploy: no top section tabs for Home / Agent / Boards / …
- [ ] Left drawer shows the full hierarchy
- [ ] llms not listed in nav