### PR TITLE
docs: site name LabWired docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: LabWired Core
+site_name: LabWired docs
 site_url: https://docs.labwired.com/
 repo_url: https://github.com/w1ne/labwired-core
 repo_name: w1ne/labwired-core


### PR DESCRIPTION
## Summary
- `site_name`: **LabWired Core** → **LabWired docs** (header / browser title).

## Test plan
- [ ] After deploy, docs.labwired.com header says LabWired docs