### PR TITLE
test(esp32c3): give each BLE Pong lab its own air — the #928 flake was cross-lab, not a race

### DIFF
--- a/crates/core/tests/world_esp32c3_ble_pong.rs
+++ b/crates/core/tests/world_esp32c3_ble_pong.rs
@@ -89,6 +89,10 @@ use labwired_core::boot::esp32s3_rom::RomImages;
 use labwired_core::bus::SystemBus;
 use labwired_core::cpu::RiscV;
 use labwired_core::memory::ProgramImage;
+use labwired_core::network::SimMqttFabric;
+use labwired_core::peripherals::ble_air::BleAirBus;
+use labwired_core::peripherals::nrf52::radio::VirtualAirBus;
+use labwired_core::peripherals::rf_medium::{PathLossParams, RfMedium};
 use labwired_core::{Arch, Bus, Cpu, Machine};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -133,10 +137,41 @@ impl Node {
     }
 }
 
+/// One lab's radio fabric — the same trio `World` mints per lab
+/// (`world.rs`), bound to both nodes of a pair via `attach_lab_air`.
+///
+/// Why this exists (issue #928): an `Esp32c3Bt` that nobody binds falls back
+/// to the PROCESS-GLOBAL `default_ble_air_bus()`. This binary holds TWO
+/// independent two-node labs — the election pair (`run_pong`) and the ADC
+/// pair (`shipped_pong_firmware_observes_gp2y_…`) — and the test harness runs
+/// them on parallel threads, so all four controllers advertised into one
+/// shared air and the election lab heard the ADC lab's frames. Which frames
+/// landed depended on thread interleaving, which is why the election flaked
+/// ~2 runs in 3 while every solo run passed. The browser never hits this: a
+/// lab gets its own worker there, and `World` mints one `BleAirBus` per lab —
+/// binding the same way here restores that isolation.
+struct LabAir {
+    nrf: VirtualAirBus,
+    ble: BleAirBus,
+    fabric: SimMqttFabric,
+}
+
+impl LabAir {
+    fn new() -> Self {
+        let nrf = VirtualAirBus::new();
+        nrf.attach_medium(RfMedium::new(1).with_params(PathLossParams::default()));
+        Self {
+            nrf,
+            ble: BleAirBus::new(),
+            fabric: SimMqttFabric::new(),
+        }
+    }
+}
+
 /// The browser fast-start assembly for one C3 node, identical to the shipped
 /// lab batch gate's `build_lab` — same ROM injection, same rom-boot options,
 /// same browser tick policy — so what runs here is what runs in the tab.
-fn build_node(flash: &[u8]) -> Node {
+fn build_node(flash: &[u8], lab: &LabAir, node_id: &str) -> Node {
     let chip = ChipDescriptor::from_file(root().join("../../configs/chips/esp32c3.yaml"))
         .expect("load esp32c3 chip yaml");
     let manifest =
@@ -177,6 +212,15 @@ fn build_node(flash: &[u8]) -> Node {
         },
         |c| c,
     );
+    // Bind this node's radios to the lab-private air (see LabAir). Both nodes
+    // of a pair get clones of the same trio, so they hear each other and no
+    // other lab in the process.
+    machine.bus.attach_lab_air(
+        node_id,
+        lab.nrf.clone(),
+        lab.ble.clone(),
+        lab.fabric.clone(),
+    );
     for segment in &bootloader.segments {
         if machine.bus.flash.load_from_segment(segment)
             || machine.bus.ram.load_from_segment(segment)
@@ -215,8 +259,9 @@ const SLICE_CYCLES: usize = 100_000;
 fn run_pong(cycles_per_node: usize) -> (Node, Node) {
     let flash = std::fs::read(root().join("tests/fixtures/esp32c3-ble-pong-flash.bin"))
         .expect("read BLE Pong flash image");
-    let mut a = build_node(&flash);
-    let mut b = build_node(&flash);
+    let lab = LabAir::new();
+    let mut a = build_node(&flash, &lab, "nodeA");
+    let mut b = build_node(&flash, &lab, "nodeB");
     let mut done = 0usize;
     while done < cycles_per_node {
         let slice = SLICE_CYCLES.min(cycles_per_node - done);
@@ -388,8 +433,11 @@ fn two_c3_nodes_running_one_ble_pong_image_start_the_game() {
 fn shipped_pong_firmware_observes_gp2y_distance_through_gpio1_adc() {
     let flash = std::fs::read(root().join("tests/fixtures/esp32c3-ble-pong-flash.bin"))
         .expect("read BLE Pong flash image");
-    let mut near = build_node(&flash);
-    let mut far = build_node(&flash);
+    // A second, independent lab — its own air, so its advertisements never
+    // reach the election pair above even when both run concurrently (#928).
+    let lab = LabAir::new();
+    let mut near = build_node(&flash, &lab, "near");
+    let mut far = build_node(&flash, &lab, "far");
     near.machine
         .set_input_on("vl", "distance", 100.0)
         .expect("drive near GP2Y distance");


### PR DESCRIPTION
## The flake

`two_c3_nodes_running_one_ble_pong_image_start_the_game` failed ~2 runs in 3 on main (#928). Every prior theory died in experiment:

- **"Race inside one lab" (#928's slice-boundary theory)** — solo runs of just the election test pass deterministically (4/4). The mechanism had to come from *outside* the lab.
- **"#908's ADC model"** — reverting it changed nothing (established 08-10). Correct, but incomplete: #908's actual contribution to the flake was the **third test it added** (`shipped_pong_firmware_observes_gp2y_distance_through_gpio1_adc`) — two more nodes booting the same advertising firmware.
- **The green parent** passes because that third test doesn't exist there.

## Root cause

All three tests share one process, run on parallel threads. An `Esp32c3Bt` nobody explicitly binds falls back to the **process-global** `default_ble_air_bus()` — so the election pair and the ADC pair, four controllers total, advertised into one shared medium. Whether an election advertisement landed in a scan window depended on how the harness interleaved the two labs. The process-global fab MAC allocator interleaved too, which is why tags wandered (4–7) between runs.

The browser never hits this: a lab gets its own worker there, and `World` mints one `BleAirBus` per lab. The native harness just never did the same.

## Fix

A `LabAir` trio per lab (nrf / ble / fabric — mirroring `attach_private_lab_air`), bound to both nodes of the pair with `attach_lab_air`, the one bind API. Election lab and ADC lab now advertise on separate media, exactly the isolation `World` and the browser already have.

## Evidence

Full binary, all three tests in parallel — the configuration that flaked:

| | result |
|---|---|
| before (unmodified main) | 4 FAIL / 6 runs |
| after | **8 / 8 ok** |

Solo and `--test-threads=1` runs were already deterministic-pass and remain so. `cargo clippy --release --features event-scheduler -D warnings` clean; `cargo fmt --check` clean.

Not in scope: #927 (refreshed fixture image boots to an empty console) is a separate, still-open defect — see its issue.

Closes #928
