### PR TITLE
feat(core): Cortex-M fault escalation defaults on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   steps_per_batch=..` line so a caller can prove which loop executed. The default
   `labwired run` for ARM is unchanged.
 
+### Changed
+- **ARMv7-M fault escalation now defaults ON** (#903 shipped it flagged and
+  off). A precise data-access fault on Cortex-M raises BusFault — escalating to
+  HardFault per B1.5.14 when the handler is not enabled — instead of aborting
+  the run with `memory_violation`, and the SCB serves the SHCSR/CFSR/HFSR/
+  MMFAR/BFAR register surface. `LABWIRED_CORTEXM_FAULTS=0` (or `false`) is the
+  process-wide opt-out that keeps the legacy #880 abort contract;
+  `CortexM::set_faults_enabled` remains the per-core override. Instruction
+  fetch, vector-table reads and stacking faults stay on the abort path by
+  design, so `examples/ci/dummy-memory-violation.yaml` is unaffected.
+
 ### Fixed
 - **Two I²C parts powered up in a state silicon never powers up in.** Firmware
   that relies on the documented power-on state worked in simulation and would

--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -251,7 +251,9 @@ impl CortexM {
     }
 
     /// Turn ARMv7-M fault escalation (and the SCB fault register surface) on or
-    /// off. **Default off.** This is the single switch for the whole feature:
+    /// off. The process default is **on** (`LABWIRED_CORTEXM_FAULTS` is the
+    /// opt-out); this is the explicit per-core override, and the single switch
+    /// for the whole feature:
     /// the CPU and the SCB read the same `AtomicBool`, so they cannot disagree
     /// about whether firmware can enable a handler the core will never pend.
     ///
@@ -1189,7 +1191,8 @@ impl CortexM {
     /// address is the faulting instruction — which is what B1.5.6 requires for a
     /// synchronous fault.
     ///
-    /// With fault modelling off (the default) this is `step_execute` verbatim:
+    /// With fault modelling off (the `LABWIRED_CORTEXM_FAULTS` opt-out) this is
+    /// `step_execute` verbatim:
     /// `pending_data_fault` is only ever written on the error path, and the
     /// `Err` is returned unchanged.
     #[inline(always)]

--- a/crates/core/src/system/cortex_m.rs
+++ b/crates/core/src/system/cortex_m.rs
@@ -16,31 +16,31 @@ use std::sync::Arc;
 /// Process-wide default for ARMv7-M fault escalation, read once from
 /// `LABWIRED_CORTEXM_FAULTS`.
 ///
-/// **False unless the variable is set.** This is the opt-in that lets the lab
-/// corpus be measured both ways without a per-call-site plumbing change to
-/// `configure_cortex_m`, which has ~150 callers. `CortexM::set_faults_enabled`
-/// remains the explicit per-core override, and is what the in-tree guards use.
-///
-/// Flipping the default is deliberately NOT part of this change: it is a second
-/// PR, taken once the measured lab diff has been triaged. When that happens this
-/// function is where it happens.
+/// **True unless the variable is explicitly set to `0` or `false`.** Fault
+/// escalation is the default; the variable is the opt-*out* that keeps the
+/// legacy #880 abort behaviour for a corpus that needs it, without a
+/// per-call-site plumbing change to `configure_cortex_m`, which has ~150
+/// callers. `CortexM::set_faults_enabled` remains the explicit per-core
+/// override, and is what the in-tree guards use.
 ///
 /// Hoisted into a `OnceLock` for the same reason `trace_insn_enabled` is: an
 /// `std::env::var` call walks the environment, and `configure_cortex_m` runs on
 /// every machine build.
 ///
-/// The notice is not decoration: a blast-radius measurement that compares "flag
-/// off" against "flag on" is vacuous unless the flag demonstrably reached the
-/// engine, and an identical corpus is exactly what a silently-ignored
-/// environment variable also produces.
+/// The notice fires only on the opt-out: escalation-on is the default, so the
+/// noteworthy event is a run that deliberately disabled it. Keeping the default
+/// path silent also keeps lab `stderr` free of a per-run banner.
 fn faults_enabled_default() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| {
-        let on = std::env::var("LABWIRED_CORTEXM_FAULTS").is_ok_and(|v| v != "0");
-        if on {
-            eprintln!("[cortex-m] ARMv7-M fault escalation ENABLED (B1.5.14)");
+        let off = matches!(
+            std::env::var("LABWIRED_CORTEXM_FAULTS").as_deref(),
+            Ok("0") | Ok("false")
+        );
+        if off {
+            eprintln!("[cortex-m] ARMv7-M fault escalation DISABLED (LABWIRED_CORTEXM_FAULTS)");
         }
-        on
+        !off
     })
 }
 
@@ -57,10 +57,10 @@ pub fn configure_cortex_m(bus: &mut SystemBus) -> (CortexM, Arc<NvicState>) {
     // Cortex-M bus just to keep the reset boundary exact.
     let sysreset_signal = Arc::new(AtomicBool::new(false));
     // Shared ARMv7-M fault register file (SHCSR/CFSR/HFSR/BFAR) + the master
-    // switch for fault escalation. Created DISABLED: with it off the SCB does
-    // not serve those offsets at all and the core keeps #880's abort contract,
-    // so every existing board is byte-identical. `CortexM::set_faults_enabled`
-    // is the one door that flips it.
+    // switch for fault escalation. Seeded from the process default: escalation
+    // is ON unless `LABWIRED_CORTEXM_FAULTS` opts out; with it off the SCB does
+    // not serve those offsets at all and the core keeps #880's abort contract.
+    // `CortexM::set_faults_enabled` is the per-core override.
     let faults = Arc::new(ScbFaultState::new(faults_enabled_default()));
 
     let mut cpu = CortexM::default();

--- a/crates/core/src/tests/cortex_m_fault_escalation.rs
+++ b/crates/core/src/tests/cortex_m_fault_escalation.rs
@@ -33,9 +33,10 @@
 //!
 //! * with escalation **on**, a run of valid accesses must pend nothing and leave
 //!   every fault status register at zero;
-//! * with escalation **off** (the default), the #880 abort contract must be
-//!   byte-for-byte what it is today — `Err(MemoryViolation)`, no exception, and
-//!   the fault status registers not even served by the SCB.
+//! * with escalation **off** (the `LABWIRED_CORTEXM_FAULTS=0` opt-out), the
+//!   #880 abort contract must be byte-for-byte what it is today —
+//!   `Err(MemoryViolation)`, no exception, and the fault status registers not
+//!   even served by the SCB.
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/tests/cortex_m_memory_contract.rs
+++ b/crates/core/src/tests/cortex_m_memory_contract.rs
@@ -368,6 +368,10 @@ mod tests {
     #[test]
     fn cortex_m_load_from_unmapped_address_stops_the_run() {
         let mut machine = machine_with_instr(LDR_R0_R1);
+        // The #880 abort contract is the opt-out behaviour now that fault
+        // escalation defaults on (`LABWIRED_CORTEXM_FAULTS=0`); pin it
+        // explicitly rather than depending on the process default.
+        machine.cpu.set_faults_enabled(false);
         machine.cpu.set_register(1, UNMAPPED); // base address: unmapped
         machine.cpu.set_register(0, SENTINEL); // destination: pre-loaded sentinel
 
@@ -387,6 +391,9 @@ mod tests {
     #[test]
     fn cortex_m_store_to_unmapped_address_stops_the_run() {
         let mut machine = machine_with_instr(STR_R0_R1);
+        // See the load twin above: the abort contract is pinned with fault
+        // escalation explicitly off.
+        machine.cpu.set_faults_enabled(false);
         machine.cpu.set_register(1, UNMAPPED); // base address: unmapped
         machine.cpu.set_register(0, SENTINEL);
 

--- a/crates/core/src/tests/simctl_machine.rs
+++ b/crates/core/src/tests/simctl_machine.rs
@@ -103,7 +103,13 @@ fn a_bus_without_simctl_never_stops_early() {
     // silently discarded. Faulting on the store is the stronger control: it
     // proves the address really is unmapped without the device, rather than
     // proving the fuel counter works.
+    //
+    // The abort contract is the `LABWIRED_CORTEXM_FAULTS=0` opt-out behaviour
+    // now that ARMv7-M fault escalation defaults on — with escalation on, this
+    // store would pend a BusFault/HardFault instead. The control is about the
+    // missing device, not about fault semantics, so pin the opt-out explicitly.
     let mut m = machine(false);
+    m.cpu.set_faults_enabled(false);
     load_store_to_simctl_program(&mut m, SIMCTL_BASE + EXIT_OFFSET, 0);
 
     let outcome = m.advance(AdvanceRequest::run(Some(64)));


### PR DESCRIPTION
Ledger 4.2, second half of #903. The flag landed there OFF by default with the flip explicitly deferred until the silent-path census (#876) landed and the flag-on lab diff was triaged. This is that flip, as its own PR.

## What the flag gates

`ScbFaultState::enabled`, one `AtomicBool` shared by the Cortex-M CPU and the SCB. When on, a precise data-access fault raises BusFault — escalating to HardFault with `HFSR.FORCED` per ARMv7-M ARM B1.5.14 when `SHCSR.BUSFAULTENA` is clear or priority does not permit — and the SCB serves the SHCSR/CFSR/HFSR/MMFAR/BFAR register surface. When off, the core keeps #880's abort contract (`Err(MemoryViolation)` ends the run) and the SCB does not serve those offsets at all. Two doors: `CortexM::set_faults_enabled(bool)` (per-core; what the in-tree guards use) and `LABWIRED_CORTEXM_FAULTS` (process default, read once).

## The flip

`faults_enabled_default()` (`crates/core/src/system/cortex_m.rs`) now returns **true unless `LABWIRED_CORTEXM_FAULTS` is explicitly set to `0` or `false`**. The variable changes from opt-in to opt-out. The one-shot stderr notice moves with it — it fires on the opt-out (`[cortex-m] ARMv7-M fault escalation DISABLED …`), so the default path adds no per-run banner to lab stderr. Instruction fetch, vector-table reads and stacking faults stay on the abort path by design (HFSR.VECTTBL is unmodelled), unchanged from #903.

Three in-tree guards pinned the old default without setting the variable; each now opts out explicitly via `set_faults_enabled(false)`, with a comment saying why:

- `cortex_m_memory_contract::cortex_m_load_from_unmapped_address_stops_the_run`
- `cortex_m_memory_contract::cortex_m_store_to_unmapped_address_stops_the_run`
- `simctl_machine::a_bus_without_simctl_never_stops_early` (the anti-vacuity control; it is about the missing device, not fault semantics)

## Watched the gate fail first

With the flip applied and the pins **not** yet in place, all three guards fail exactly as the new semantics predict — the unmapped access escalates instead of aborting:

```
---- cortex_m_load_from_unmapped_address_stops_the_run stdout ----
a load from unmapped 0x90000000 must surface the bus MemoryViolation, not be discarded. got Ok(()); r0 = 0xDEADBEEF …, pc = 0x00001000
---- cortex_m_store_to_unmapped_address_stops_the_run stdout ----
a store to unmapped 0x90000000 must surface the bus MemoryViolation, not vanish. got Ok(()); pc = 0x00001000
```

This doubles as the anti-vacuity proof for the triage below: an identical corpus is also what a silently-ignored default produces, and here the default demonstrably reaches the engine.

## The gate: lab catalog triage, flag ON vs flag OFF

Every runnable committed-example smoke (the `scripts/example_smokes.sh` floor), run twice with the same binary — `LABWIRED_CORTEXM_FAULTS=0` vs unset (default-on) — comparing `result.json`, `uart.log` and `snapshot.json` byte-for-byte plus process exit codes:

| lab | exit OFF | exit ON | artifacts |
|---|---|---|---|
| h563-uds-ecu/uds-session-smoke | 0 | 0 | identical |
| h563-uds-ecu/uds-smoke | 0 | 0 | identical |
| nrf54l15-dk/io-smoke | 0 | 0 | identical |
| nrf54l15-smart-ring/io-smoke | 0 | 0 | identical |
| stm32f411ceu6-blackpill/io-smoke | 0 | 0 | identical |
| stm32h735-smoke/io-smoke | 0 | 0 | identical |
| esp32c3-blinky/test-blink | 0 | 0 | identical |
| esp32c3-leo-airquality/test-fresh | 0 | 0 | identical |
| esp32c3-leo-airquality/test-stuffy | 0 | 0 | identical |
| esp32c3-leo-airquality/test | 0 | 0 | identical |

**10/10 labs, 30/30 artifact files byte-identical, no lab newly fails or changes verdict.** This is the expected shape, not a missing measurement: the corpus contains no firmware that makes a bad data access (#903 established the same for its 62-lab corpus), so nothing reaches the escalation path. The diff-relevant change is in what happens *when* firmware faults — and that is pinned at register level by the 17 escalation guards.

Separately, `examples/ci/dummy-memory-violation.yaml` — the one fixture whose *purpose* is `memory_violation` — passes both ways with `stop_reason: memory_violation` and byte-identical `result.json`: it faults on the instruction-fetch path, which stays on the abort contract by design.

## Test evidence

| check | flag | result | exit |
|---|---|---|---|
| `cargo test -p labwired-core --lib` | unset (default-on) | 3085 passed, 0 failed | 0 |
| `cargo test -p labwired-core --lib` | `=0` (opt-out) | 3085 passed, 0 failed | 0 |
| `cargo test -p labwired-core --test firmware_survival` | unset | 61 passed, 0 failed | 0 |
| `cargo test -p labwired-core --test firmware_survival` | `=0` | 61 passed, 0 failed | 0 |
| opt-out probe on a Cortex-M lab | `=0` / `=false` | DISABLED notice fires once | 0 |
| same probe | `=1` / unset | silent | 0 |
| `cargo fmt --all -- --check` | — | clean | 0 |
| `cargo clippy -p labwired-core --all-targets -- -D warnings` | — | clean | 0 |
| `scripts/generate_validation_status.py --check` | — | clean | 0 |

The 17 fault-escalation guards (#903) all pass under the new default unchanged — they set the switch explicitly per machine and never depended on the process default.

## How to opt out

- Process-wide: `LABWIRED_CORTEXM_FAULTS=0 labwired test …` (or `=false`) — legacy #880 abort behaviour, with a one-shot stderr notice.
- Per core, in code: `cpu.set_faults_enabled(false)` — the explicit override, unchanged.

## Known limits (unchanged from #903)

- No MemManage/UsageFault, no LOCKUP, no STKERR/UNSTKERR bits; a fault inside HardFault aborts the run rather than locking up.
- `Cpu::reset` vector reads and the instruction-fetch path stay on the abort path (HFSR.VECTTBL unmodelled).
- Pre-existing: byte writes to the W1C CFSR/HFSR clear more than the targeted byte (read-modify-write byte path); word writes — what CMSIS emits — are correct.
