### PR TITLE
fix(adc): NTC lab converts again — F1 clock enable + SQR3 channel select

### DIFF
--- a/crates/core/src/peripherals/adc.rs
+++ b/crates/core/src/peripherals/adc.rs
@@ -113,6 +113,11 @@ impl FromStr for AdcRegisterLayout {
 pub struct F1AdcRegs {
     cr1: u32, // 0x04
     cr2: u32, // 0x08
+    /// ADC_SQR3 @ 0x34 (RM0008 §11.12.14). Only SQ1[4:0] — the first (and, on
+    /// this single-shot model, only) regular-sequence channel — is consumed,
+    /// by `advance_conversion`. Reset value 0 selects channel 0, which is what
+    /// firmware that never programs the sequence converts on silicon.
+    sqr3: u32,
 }
 
 /// STM32L4 ADC register file (data `dr` is shared on `Adc`).
@@ -284,8 +289,13 @@ impl Adc {
                 let (cr1, cr2) = self.f1_ctrl();
 
                 // Injected channel value if available; else increment DR for
-                // visual feedback. SQR3 ch fallback uses CR2 low bits (legacy).
-                let ch = (cr2 & 0x1F) as usize;
+                // visual feedback. The converted channel is SQR3 SQ1[4:0]
+                // (RM0008 §11.12.14) — NOT a CR2 bit field: the earlier CR2
+                // low-bits fallback always read ≥ 1 for any firmware that
+                // holds ADON set, so a seeded channel 0 was never returned.
+                // SQR3 resets to 0, so firmware that never programs the
+                // sequence converts channel 0, exactly like silicon.
+                let ch = self.f1_regular_channel();
                 if ch < self.channel_inputs.len() && self.channel_inputs[ch] != 0xFFFF {
                     self.dr = self.channel_inputs[ch] as u32;
                 } else {
@@ -339,6 +349,15 @@ impl Adc {
             AdcRegs::Stm32F1(r) => (r.cr1, r.cr2),
             // Neither the L4 nor the H7 runs the F1 countdown engine.
             AdcRegs::Stm32L4(_) | AdcRegs::Stm32H7(_) => (0, 0),
+        }
+    }
+
+    /// Regular channel being converted: SQR3 SQ1[4:0] on the F1 layout; 0 on
+    /// the other families (their engines select from their own SQR1/PCSEL).
+    fn f1_regular_channel(&self) -> usize {
+        match &self.regs {
+            AdcRegs::Stm32F1(r) => (r.sqr3 & 0x1F) as usize,
+            AdcRegs::Stm32L4(_) | AdcRegs::Stm32H7(_) => 0,
         }
     }
 
@@ -600,6 +619,7 @@ impl Peripheral for Adc {
                 0x00..=0x03 => self.sr,
                 0x04..=0x07 => r.cr1,
                 0x08..=0x0B => r.cr2,
+                0x34..=0x37 => r.sqr3,
                 0x4C..=0x4F => self.dr,
                 _ => {
                     crate::census_reg!("adc:Adc", offset, "read");
@@ -644,6 +664,11 @@ impl Peripheral for Adc {
                     }
                     if trigger {
                         self.start_conversion();
+                    }
+                }
+                0x34..=0x37 => {
+                    if let AdcRegs::Stm32F1(r) = &mut self.regs {
+                        r.sqr3 = (r.sqr3 & !mask) | val_shifted;
                     }
                 }
                 _ => {
@@ -791,6 +816,71 @@ mod tests {
         assert!(!adc.converting);
         assert_eq!(adc.dr, 1);
         assert!((adc.sr & (1 << 1)) != 0); // EOC
+    }
+
+    /// RM0008 §11.12.14: the regular channel comes from SQR3 SQ1[4:0], not from
+    /// any CR2 bit field. A seeded channel 5 must land in DR only when SQR3
+    /// selects it; selecting channel 0 must return that channel's seed instead.
+    #[test]
+    fn f1_conversion_channel_comes_from_sqr3_sq1() {
+        let mut adc = Adc::new();
+        adc.set_channel_input(0, 1650); // ch0 ≈ half scale
+        adc.set_channel_input(5, 3300); // ch5 full scale
+
+        // SQR3 read/write round-trips at 0x34.
+        adc.write_u32(0x34, 5).unwrap();
+        assert_eq!(adc.read_u32(0x34).unwrap(), 5);
+
+        let convert = |adc: &mut Adc| {
+            adc.write(0x08, 1).unwrap(); // ADON
+            adc.write(0x0B, 1 << 6).unwrap(); // SWSTART
+            for _ in 0..15 {
+                adc.tick();
+            }
+            assert!((adc.sr & (1 << 1)) != 0, "EOC");
+            adc.dr
+        };
+
+        let ch5 = adc.channel_input_count(5) as u32;
+        assert_eq!(convert(&mut adc), ch5, "SQR3 SQ1 = 5 converts channel 5");
+
+        // Re-select channel 0: the next conversion returns the ch0 seed, not a
+        // stale ch5 result. (ADON stays set; SWSTART rising edge retriggers.)
+        adc.write_u32(0x34, 0).unwrap();
+        let ch0 = adc.channel_input_count(0) as u32;
+        assert_eq!(convert(&mut adc), ch0, "SQR3 SQ1 = 0 converts channel 0");
+    }
+
+    /// Firmware that never programs the sequence converts channel 0 — SQR3
+    /// resets to 0 on silicon. This is the ntc-thermistor-lab shape: the demo
+    /// firmware triggers conversions with SQR3 untouched, and the NTC seed on
+    /// channel 0 must reach DR. (The legacy CR2 low-bits fallback read 1 here
+    /// because ADON is CR2 bit 0, so the ch0 seed was never returned.)
+    #[test]
+    fn f1_unwritten_sqr3_converts_channel_zero() {
+        let mut adc = Adc::new();
+        adc.set_channel_input(0, 1650);
+        adc.write(0x08, 1).unwrap(); // ADON, CR2 low bits = 1
+        adc.write(0x0B, 1 << 6).unwrap(); // SWSTART
+        for _ in 0..15 {
+            adc.tick();
+        }
+        assert_eq!(adc.dr, adc.channel_input_count(0) as u32);
+    }
+
+    /// CR2 low bits must NOT influence the converted channel: with SQR3 = 0,
+    /// garbage in CR2[4:0] (here CONT|ADON) still converts channel 0.
+    #[test]
+    fn f1_cr2_low_bits_do_not_select_the_channel() {
+        let mut adc = Adc::new();
+        adc.set_channel_input(0, 1650);
+        adc.set_channel_input(3, 3300);
+        adc.write(0x08, 1 | (1 << 1)).unwrap(); // ADON | CONT
+        adc.write(0x0B, 1 << 6).unwrap(); // SWSTART
+        for _ in 0..15 {
+            adc.tick();
+        }
+        assert_eq!(adc.dr, adc.channel_input_count(0) as u32);
     }
 
     #[test]
@@ -981,10 +1071,13 @@ mod scheduler_diff {
 
     #[test]
     fn f1_single_conversion_walk_identity() {
-        // EOCIE + ADON + SWSTART on channel 3 → 14-cycle countdown → EOC + DR.
+        // EOCIE + ADON + SWSTART on channel 3 (SQR3 SQ1) → 14-cycle countdown →
+        // EOC + DR. The channel is programmed through SQR3 @ 0x34, the register
+        // the model consults since the CR2 low-bits fallback was removed.
         let script = [
             (1u64, Op::Write(0x04, 1 << 5)), // CR1.EOCIE
-            (1, Op::Write(0x08, 1 | 3)),     // CR2.ADON, SQR-fallback channel 3
+            (1, Op::Write(0x34, 3)),         // SQR3.SQ1 = channel 3
+            (1, Op::Write(0x08, 1)),         // CR2.ADON
             (2, Op::Write(0x0B, 1 << 6)),    // CR2.SWSTART (bit 30) → convert
             (20, Op::Write(0x00, 0)),        // read-back settle (no-op SR write)
         ];
@@ -996,9 +1089,10 @@ mod scheduler_diff {
         // CONT + ADON: after the first EOC the engine re-arms and converts again,
         // so the chain must perpetuate across multiple completions.
         let script = [
-            (1u64, Op::Write(0x04, 1 << 5)),        // CR1.EOCIE
-            (1, Op::Write(0x08, 1 | (1 << 1) | 3)), // CR2.ADON | CONT | channel 3
-            (2, Op::Write(0x0B, 1 << 6)),           // SWSTART → first conversion
+            (1u64, Op::Write(0x04, 1 << 5)),    // CR1.EOCIE
+            (1, Op::Write(0x34, 3)),            // SQR3.SQ1 = channel 3
+            (1, Op::Write(0x08, 1 | (1 << 1))), // CR2.ADON | CONT
+            (2, Op::Write(0x0B, 1 << 6)),       // SWSTART → first conversion
         ];
         // 2 + 15 + 15 + 15 ≈ 47 cycles covers three back-to-back conversions.
         assert_walk_identical(&script, 50);

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -11,11 +11,11 @@ The models column is a content digest over everything that board's `models` list
 |-------|------|----------------------|--------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `c6872bbd0b1353e3` | ⚠ drift acked 2026-08-10 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `c6872bbd0b1353e3` | ⚠ drift acked 2026-08-10 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `1a723b165e42c49b` | ✅ fresh |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `ac762f3fb959172a` | ⚠ drift acked 2026-08-12 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `078c92aa3ef810a7` | ⚠ drift acked 2026-08-10 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `fe9aeec8dda6854c` | ⚠ drift acked 2026-08-10 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `de6d9ab4938346d0` | ⚠ drift acked 2026-08-12 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `5c0c39f903efb563` | ⚠ drift acked 2026-08-10 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `bf4bc6823001078d` | ⚠ drift acked 2026-08-10 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `d0d040b86d23f017` | ⚠ drift acked 2026-08-12 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `11ff9229d7ed39dc` | ⚠ drift acked 2026-08-10 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `2db52b8c59a9b1ce` | ⚠ drift acked 2026-08-10 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `a05f2c5a4fa09d07` | no silicon capture |
@@ -25,7 +25,7 @@ The models column is a content digest over everything that board's `models` list
 | `rp2350` | 🟡 smoke-manual | — | `503c1a26a6a58e50` | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `472d098118c98e2f` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `304051ade8b9ff6f` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `0d7b1c221e916ceb` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `1b88daa372c19064` | no silicon capture |
 | `esp32` | ⚪ structural | — | `d1ab42bd6cb0bed6` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `2b15565f0ffebc59` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `0245323b5b7b1f9e` | no silicon capture |
@@ -55,7 +55,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-10** on STLINK-V3 (V3J13, serial 002100174741500220383733, USB 0483:374e, NUCLEO-H563ZI on-board CN1/STLK, dapdirect AP1 recipe) — Re-captured live 2026-08-10 with H563_STRICT=1 on merge commit e1851d80 (a clean tree — see the caveat below): h563_mmio_diff 8/8, h563_parity_diff 48/48, h563_class_diff 65/65, 121 cases total, 0 divergence / 0 both_disagree / 0 sim_err. Clean on arrival; nothing to fix. Target answered SWD DPIDR 0x6ba02477, Cortex-M33 r0p4, target voltage 3.289 V. Probe serial is recorded from this run on — the 2026-06-22 entry named the USB PID but no serial, so whether this is the same physical NUCLEO as that capture cannot be established either way. SCOPE CAVEAT, read before treating this as a full re-validation: this run re-executed the MMIO/parity/class register diff ONLY. The FLASH program-behaviour live-diff described below (real program/erase driven over SWD) was NOT re-run on 2026-08-10; its findings are carried forward from 2026-06-22 and are older than this date stamp implies. TREE CAVEAT: an initial run of the same 121 cases also passed, but was executed while another session had an uncommitted merge of origin/main staged in this worktree, so it was not attributable to any commit; it was discarded and the run recorded here was repeated against a 0-dirty checkout of e1851d80. FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (6 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **✅ fresh**
+- Drift status: **⚠ drift acked 2026-08-12 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -73,7 +73,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — re-captured live 2026-08-09 with L476_STRICT=1: l476_mmio_diff 15/15 and l476_parity_diff 104/104, 0 divergence — identical to the 2026-06-20 figures. Clean on arrival; nothing to fix. SAME physical board as that baseline, established by probe serial 0670FF535155878281121747 being recorded in both (the L073 entry could not make that claim, having no serial on file before today). Scope unchanged and still partial: the mmio+parity set, not a full-chip sweep.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-08-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-12 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -91,7 +91,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on ST-LINK V2.1 (V2J43S28, serial 066CFF534951775087071123, USB 0483:374b), genuine STM32F103 — chipid 0x410 STM32F1xx_MD, 128K flash / 20K SRAM — re-captured live 2026-08-09 with F103_STRICT=1: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance reports no sim-vs-silicon gaps — identical to the 2026-06-20 figures. Clean on arrival; nothing to fix. f103_conformance needed firmware-f103-conformance built for thumbv7m-none-eabi first; without it the test panics in 0.00s, which reads like a failure but is a missing prerequisite. Probe serial recorded from this run on, so a future capture can tell whether it is the same physical board (the earlier entry named none). (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-08-10 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-12 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 

--- a/examples/ntc-thermistor-lab/io-smoke.yaml
+++ b/examples/ntc-thermistor-lab/io-smoke.yaml
@@ -1,11 +1,33 @@
 # LabWired - NTC Thermistor Lab smoke test
-schema_version: "1.0"
+#
+# The assertions below exist because this smoke once passed while the lab was
+# broken twice over: the firmware never enabled the ADC1 clock (so the gated
+# peripheral dropped every write and the EOC poll timed out to adc=0), and the
+# F1 ADC model picked the converted channel from CR2 low bits instead of SQR3
+# SQ1 (so even clocked, the seeded NTC level on channel 0 never reached DR).
+# Banner-only assertions cannot see either failure — the firmware prints
+# "[NTC] iter=" no matter what the ADC does. Assert the CONVERSION: the boot
+# reading must be the 25 °C divider midpoint, and a temperature stimulus must
+# move a later reading in the physically correct direction (NTC resistance
+# falls as it heats, so the pull-down divider output rises).
+schema_version: "1.2"
 inputs:
   firmware: "../../target/thumbv7m-none-eabi/release/ntc-thermistor-lab"
   system: "./system.yaml"
 limits:
-  max_steps: 200000
+  max_steps: 4000000
 assertions:
   - uart_contains: "NTC Thermistor Lab"
   - uart_contains: "[NTC] iter="
+  # Boot conversion: 25 °C = Vref/2 = 1650 mV = 2047 counts. A dead ADC
+  # (unclocked, or converting a channel with no seed) can never print this.
+  - uart_contains: "[NTC] iter=0 adc=2047/4095"
+  # After the 80 °C stimulus below, some later reading must land in the
+  # 3000..4095 range (80 °C computes to ~3633 counts on this divider; the
+  # range pins the DIRECTION, not the float rounding).
+  - uart_regex: '\[NTC\] iter=[1-9][0-9]* adc=[3-9][0-9]{3}/4095'
   - expected_stop_reason: max_steps
+stimuli:
+  - target: { component: "thermistor", channel: "temperature" }
+    trigger: !after_cycles { cycles: 1000000 }
+    value: 80.0

--- a/examples/ntc-thermistor-lab/src/main.rs
+++ b/examples/ntc-thermistor-lab/src/main.rs
@@ -131,8 +131,13 @@ fn uart2_init() {
 /// Configure ADC1 channel 0.
 fn adc1_init() {
     unsafe {
-        // Enable ADC clock via RCC_APB2ENR (bit 9 = ADC1EN).
-        // Skipped in sim — peripheral is always available.
+        // Enable the ADC1 clock via RCC_APB2ENR (bit 9 = ADC1EN, RM0008 §7.3.7).
+        // ADC1 is unclocked out of reset, and LabWired's chip YAML gates the
+        // peripheral the same way silicon does: with the clock off every ADC1
+        // register read returns 0 and every write is dropped, so SR never
+        // raises EOC and conversions never complete.
+        let apb2 = core::ptr::read_volatile(RCC_APB2ENR);
+        core::ptr::write_volatile(RCC_APB2ENR, apb2 | (1 << 9));
         // Set ADC CR1: no interrupts, single channel mode.
         core::ptr::write_volatile(ADC1_CR1, 0);
         // CR2: ADON = 0 initially; software trigger (EXTSEL = 0b111, EXTTRIG = 1).

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -647,8 +647,18 @@ boards:
     # longer stands in for a missing capture; see silicon.last_capture. Note the
     # scope caveat recorded there: the register diff was re-run, the FLASH
     # program-behaviour live-diff was not.
-    drift_ack: 2026-08-10
-    drift_ack_digest: 1a723b165e42c49b19f54091b7254eadd3c16ac53d1ed2f28b3565f40432ae06
+    # 2026-08-12 (#959): peripherals/adc.rs — the F1 regular-channel select moved
+    # off the legacy CR2[4:0] fallback onto SQR3 SQ1[4:0] (RM0008 §11.12.14),
+    # with ADC_SQR3 newly stored/readable @ 0x34; the same PR's NTC example
+    # firmware now enables ADC1EN. THIS BOARD'S ADC PATH IS UNTOUCHED: the H563
+    # maps to the L4/modern layout, and every non-test edit is inside F1AdcRegs
+    # or the F1-only advance_conversion channel pick — the L4/H7 arms and the
+    # synchronous L4 conversion path are byte-unchanged. The remaining diff is
+    # unit/differential test scripts. No register layout, reset value or byte
+    # path this board's capture pins moved; drift is the shared-file hash only.
+    # Re-capture pending (no H563 probe attached this session).
+    drift_ack: 2026-08-12
+    drift_ack_digest: ac762f3fb959172a6e267b6c9ef22580ace1d6a488e32ee8e083001cba2fc64c
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -1531,8 +1541,15 @@ boards:
     # Merged 2026-08-10: the discharge recorded above applies to the tree as it
     # stood at that live capture. The acks below cover model changes that
     # postdate it and are NOT evidenced by that capture.
-    drift_ack: 2026-08-10
-    drift_ack_digest: fe9aeec8dda6854ca6ba421e77bebbc1a10b5239429a8b3abc47303cac5e1f67
+    # 2026-08-12 (#959): peripherals/adc.rs — the F1 regular-channel select moved
+    # to SQR3 SQ1[4:0] (RM0008 §11.12.14) and ADC_SQR3 is newly stored @ 0x34;
+    # the same PR's NTC example firmware enables ADC1EN. The L4 ADC engine this
+    # board runs is byte-unchanged: every non-test edit is inside F1AdcRegs or
+    # the F1-only channel pick, and l476_mmio_diff/parity (RCC/GPIO/SPI1/TIM2)
+    # cannot observe the F1 arm at all. Drift is the shared-file hash only.
+    # Re-capture pending (no L476 probe attached this session).
+    drift_ack: 2026-08-12
+    drift_ack_digest: de6d9ab4938346d0ecaf976534becadb42ddb76ae58356cb9523c7ffa0402a02
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -1944,8 +1961,22 @@ boards:
     # Merged 2026-08-10: the discharge recorded above applies to the tree as it
     # stood at that live capture. The acks below cover model changes that
     # postdate it and are NOT evidenced by that capture.
-    drift_ack: 2026-08-10
-    drift_ack_digest: bf4bc6823001078d05c619850a228c985c16420a53de4df0afbc44317fba2529
+    # 2026-08-12 (#959): BEHAVIOURAL, deliberate — peripherals/adc.rs F1
+    # regular-channel select moved from the legacy CR2[4:0] fallback to SQR3
+    # SQ1[4:0] per RM0008 §11.12.14, and ADC_SQR3 @ 0x34 is now stored and
+    # readable (previously unmapped, read 0). The fallback always read >= 1 for
+    # any firmware holding ADON (CR2 bit 0), so a stimulus-seeded channel 0
+    # never reached DR: the ntc-thermistor-lab printed adc=0/4095 (unclocked
+    # ADC1EN — fixed by the same PR's firmware change) and would have printed a
+    # bare DR increment even clocked. The change moves the model TOWARD silicon:
+    # real F1 firmware selects the regular channel in SQR3, and SQR3 resetting
+    # to 0 keeps unwritten-sequence firmware on channel 0. The frozen capture is
+    # unaffected — the tier-1 ADC cell (gated-dead, then ADON/SWSTART -> EOC ->
+    # DR != 0) still converts channel 0 with nothing injected (DR = 1 as
+    # before), and the cell passes unchanged on this branch. ADC channel-select
+    # re-capture pending (no F103 probe attached this session).
+    drift_ack: 2026-08-12
+    drift_ack_digest: d0d040b86d23f01760e689262ee2498dd17cf3cd25e4696103be87cca885dd61
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/peripherals/rcc.rs
@@ -2616,8 +2647,18 @@ boards:
     # use. Recorded explicitly because `--write-ack-digests` re-stamps EVERY
     # ack, which would otherwise have widened this one to cover a change
     # nobody had written down.
+    # 2026-08-12 (#959): peripherals/adc.rs — the F1 regular-channel select moved
+    # to SQR3 SQ1[4:0] (RM0008 §11.12.14) and ADC_SQR3 is newly stored/readable
+    # @ 0x34. This board's ADC1 runs the F1 layout (no profile override in its
+    # chip yaml), so the arm IS reachable here — but the tier-1 fixture's adc
+    # cell (ADON/SWSTART -> EOC -> DR != 0, nothing injected) converts channel 0
+    # under the SQR3 reset value exactly as before, and DR = 1 either way.
+    # Recorded explicitly for the same reason as the 2026-08-09 note:
+    # `--write-ack-digests` re-stamps every ack, and this digest now covers the
+    # #959 adc.rs content. No silicon capture exists to re-run (sim-derived
+    # board); the tier-1 fixture lane is the evidence and passes unchanged.
     drift_ack: 2026-07-28
-    drift_ack_digest: 0d7b1c221e916cebed6f697e7f40e05ae3e0ec340e2c7df93e19625e4a61da55
+    drift_ack_digest: 1b88daa372c190647c0e4f4e9f80119760415b103e488884152566895d7edacf
     models:
       - configs/chips/stm32f411ceu6.yaml
       - crates/core/src/peripherals/rcc.rs


### PR DESCRIPTION
## Root cause

The `ntc-thermistor-lab` printed `adc=0/4095` from boot on every platform (production app.labwired.com and local dev), and the temperature slider never moved it. Root-cause investigation (monorepo side fully cleared first: `compile()` emits the correct `external_devices` entry — id `ntc`, type `ntc-thermistor`, `adc1` ch0 — and the worker stimulus path delivers `set_input` correctly) proved the failure reproduces with zero playground code, at the core CLI with the stock example YAML. Two stacked bugs, each individually sufficient:

1. **The demo firmware never enabled the ADC1 clock.** `adc1_init` carried a stale comment — *"Skipped in sim — peripheral is always available."* — which stopped being true when RCC clock-gating was retrofitted onto the f103 cells (`347a0e7b`). With `ADC1EN` (RCC_APB2ENR bit 9) clear, the gated peripheral drops every write and reads back 0, so SR never raises EOC and the firmware's 100 000-iteration timeout returns 0 → `adc=0/4095` forever.
2. **The F1 ADC model selected the converted channel from CR2[4:0]** ("SQR3 ch fallback", legacy). ADON is CR2 bit 0, so any firmware holding the ADC on converts channel ≥ 1 — the NTC seed on channel 0 could never reach DR. With the gate experimentally removed this surfaced as `adc=1,2,3,…` (the no-injection DR increment), never the seeded value.

## Fix

- `examples/ntc-thermistor-lab/src/main.rs`: `adc1_init` now sets RCC_APB2ENR bit 9 (ADC1EN) before touching ADC1, per RM0008 §7.3.7; stale comment replaced with an accurate one.
- `crates/core/src/peripherals/adc.rs`: `F1AdcRegs` now stores `ADC_SQR3` @ 0x34 (RM0008 §11.12.14) with byte-merged read/write, and `advance_conversion` selects the regular channel from `SQR3 SQ1[4:0]`. SQR3 resets to 0, so firmware that never programs the sequence converts channel 0 — exactly like silicon.
- `examples/ntc-thermistor-lab/io-smoke.yaml`: banner-only assertions are why both bugs shipped green. The smoke now asserts the boot conversion (`adc=2047`, the 25 °C divider midpoint) and — via a schema-1.2 `stimuli:` entry driving `thermistor/temperature` to 80 °C — a later reading in the 3000..4095 range (80 °C computes to ~3633; the range pins the direction, not float rounding).

## Evidence (CLI, stock `examples/ntc-thermistor-lab/system.yaml` + rebuilt firmware)

| scenario | result |
|---|---|
| before (old ELF + old model) | `[NTC] iter=N adc=0/4095` forever |
| new firmware + old model | `adc=1,2,3,4…` (seed never returned) |
| old firmware + new model | `adc=0/4095` forever |
| **both fixes** | `iter=0 adc=2047/4095`; 80 °C stimulus → `adc=3633/4095` |

The strengthened io-smoke **fails 3/5** against the previous demo ELF and **passes 5/5** with this fix — non-vacuous.

## Tests

- 3 new unit tests pin SQR3-based channel select, unwritten-SQR3 → channel 0 (the lab's shape), and CR2-low-bits independence.
- The walk/scheduler differential scripts (`f1_single/f1_continuous_conversion_walk_identity`) programmed the channel via the removed CR2 fallback; they now write SQR3 @ 0x34 like real firmware. (Only in-tree dependents of the fallback — triaged per grep.)
- Lanes: `cargo fmt --check` clean; `clippy -p labwired-core --lib --tests -D warnings` clean; labwired-core lib **3088/3088**; `scheduler_diff` **14/14** under `event-scheduler`; `analog_stimulus` **5/5**; io-smoke **5/5**.
- `cpu_trace_conformance::every_cpu_core_is_covered_by_this_file` fails identically on pristine `origin/main` (AVR trace coverage) — pre-existing, unrelated; verified by stash-and-rerun.

## Follow-up (not in this PR)

The playground serves a pre-built `demo-ntc-thermistor-lab.elf` from the `firmware-demos-v3` release. After this merges, the demo firmware bundle needs a new release tag + a `demo-assets.json` bump in the monorepo for the browser lab to pick up the fixed ELF.