### PR TITLE
fix(core): re-vendor the peripherals manifest after the WS2812 doc change

### DIFF
--- a/crates/core/tests/fixtures/peripherals/manifest.json
+++ b/crates/core/tests/fixtures/peripherals/manifest.json
@@ -2408,7 +2408,7 @@
         {
           "name": "cpu_hz",
           "ty": "int",
-          "doc": "Simulated CPU Hz for edge timing. Defaults to 160_000_000."
+          "doc": "Simulated CPU Hz for edge timing. Defaults to the system's clock (the manifest's `cpu_hz:`, else the chip descriptor's)."
         }
       ],
       "labs": [],


### PR DESCRIPTION
Main is red. #962 changed the WS2812 kit's `cpu_hz` ConfigKey doc string, and
`crates/core/tests/fixtures/peripherals/manifest.json` mirrors the kit registry
byte for byte, so `peripheral_kit_gate::manifest_json_matches_registry` fails.

Regenerated with the tool the gate's own panic message names:

    cargo run -p labwired-cli --bin gen-peripherals-manifest -- \
      --out crates/core/tests/fixtures/peripherals/manifest.json

One line changes. `peripheral_kit_gate` 8 passed / 0 failed locally against
`origin/main @ be6e2d25c` plus this commit.

**Why the PR that caused it was green.** `pr-workspace-tests` does not run on
pull requests today. #958 is the PR that changes that, and this was found by
updating #958's branch with main — the gate caught it on its first run against
the merged tree, which is the argument for #958 in one line.

The parent repo carries the same string in
`packages/ui/src/peripherals/manifest.json`; it is updated in labwired#1628,
which bumps the submodule to #962.