### PR TITLE
fix(install): repair the documented install, and gate what it claims

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -45,6 +45,18 @@ jobs:
       - name: Verify installer contract
         run: bash scripts/ci/test-install-script.sh
 
+      # Docs are checked against the RELEASED CLI, not the workspace build:
+      # what a reader can run is whatever they were able to install. The README
+      # told people to pass `--system` to `labwired run` for months; that flag
+      # has never existed on that subcommand.
+      - name: Install the released CLI
+        run: |
+          curl -fsSL https://labwired.com/install.sh | LABWIRED_NO_MODIFY_PATH=1 sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Every documented command is one the CLI accepts
+        run: python3 scripts/ci/docs-commands-gate.py "$HOME/.local/bin/labwired"
+
   # ── Formatting is APPLIED, not demanded (PR only) ─────────────────────────
   #
   # `cargo fmt --all -- --check` used to sit in `pr-gate`, i.e. a REQUIRED

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Verify release runner contract
         run: bash scripts/ci/verify-release-runner-contract.sh
 
+      # scripts/install.sh is a shipped artifact — it is what
+      # https://labwired.com/install.sh serves — so it gets tested like one.
+      - name: Verify installer contract
+        run: bash scripts/ci/test-install-script.sh
+
   # ── Formatting is APPLIED, not demanded (PR only) ─────────────────────────
   #
   # `cargo fmt --all -- --check` used to sit in `pr-gate`, i.e. a REQUIRED

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  # Dry-run the build legs on a branch. A release build that first executes at
+  # tag time is a release build nobody has ever seen fail safely: publishing is
+  # gated on the tag below, so a dispatch run builds, asserts and smokes the
+  # artifacts without creating anything.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,6 +18,16 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
+    # Linux legs build inside a Debian 11 image on purpose. A glibc binary runs
+    # on the glibc it was built against OR NEWER, never older, so the build
+    # host's C library is the floor every user must clear. Building on
+    # `ubuntu-latest` made that floor whatever GitHub last upgraded to: the
+    # v0.21.0 Linux archives came out needing GLIBC_2.39, which excluded
+    # Ubuntu 22.04 LTS, Debian 12 (so every Raspberry Pi OS), RHEL 9 and
+    # Amazon Linux 2023 — and no CI job could see it, because CI is 24.04 too.
+    # bullseye's 2.31 covers Debian 11+, Ubuntu 20.04+, RHEL 9, AL2023.
+    # The floor is asserted below, not assumed.
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,21 +35,33 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             platform: linux-x86_64
+            container: rust:1.95-bullseye
+            glibc_max: GLIBC_2.31
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             platform: linux-aarch64
-            cross: true
+            container: rust:1.95-bullseye
+            glibc_max: GLIBC_2.31
           - target: x86_64-apple-darwin
             runner: macos-latest
             platform: darwin-x86_64
           - target: aarch64-apple-darwin
             runner: macos-latest
             platform: darwin-aarch64
+          # Windows was never built — not because anything blocked it, but
+          # because no leg ever asked for it, and "Windows via WSL2" in the
+          # README made that read like a decision. The CLI and the DAP have no
+          # unix-only code outside test modules, so the target is just a target.
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            platform: windows-x86_64
+            exe: .exe
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust
+        if: matrix.container == ''
         uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
@@ -45,23 +72,20 @@ jobs:
           shared-key: release-${{ matrix.target }}
           workspaces: . -> target
 
-      - name: Install cross (for aarch64 Linux)
-        if: matrix.cross == true
-        run: cargo install cross --git https://github.com/cross-rs/cross
-
-      - name: Build (cross)
-        if: matrix.cross == true
-        run: cross build -p labwired-cli -p labwired-dap --release --target ${{ matrix.target }}
-
-      - name: Build (native)
-        if: matrix.cross != true
+      # Both Linux targets are now built natively — x86_64 on the standard
+      # runner, aarch64 on an arm64 runner — so there is no `cross` and no
+      # unpinned toolchain image deciding our glibc floor for us.
+      - name: Build
         run: cargo build -p labwired-cli -p labwired-dap --release --target ${{ matrix.target }}
 
       - name: Package binary
         shell: bash
         run: |
-          VERSION="${{ github.ref_name }}"
+          set -euo pipefail
+          # On a dispatch dry-run there is no tag to name the archive after.
+          VERSION="${{ github.ref_type == 'tag' && github.ref_name || 'v0.0.0-dryrun' }}"
           PLATFORM="${{ matrix.platform }}"
+          EXE="${{ matrix.exe }}"
           ARCHIVE="labwired-${VERSION}-${PLATFORM}.tar.gz"
 
           mkdir -p dist
@@ -70,13 +94,36 @@ jobs:
           # and labwired-dap is the Debug Adapter the VS Code extension spawns for
           # F5. Shipping only the CLI is what made editor debugging source-build-only.
           # These lines are pinned by scripts/ci/verify-release-runner-contract.sh.
-          cp "target/${{ matrix.target }}/release/labwired" dist/labwired
-          chmod +x dist/labwired
-          cp "target/${{ matrix.target }}/release/labwired-dap" dist/labwired-dap
-          chmod +x dist/labwired-dap
+          cp "target/${{ matrix.target }}/release/labwired${EXE}" "dist/labwired${EXE}"
+          chmod +x "dist/labwired${EXE}"
+          cp "target/${{ matrix.target }}/release/labwired-dap${EXE}" "dist/labwired-dap${EXE}"
+          chmod +x "dist/labwired-dap${EXE}"
 
-          tar -czf "${ARCHIVE}" -C dist labwired labwired-dap
+          # Debug symbols made the Linux archives 174 MB unpacked against 9 MB
+          # on macOS. Strip the shipped copies; the build tree keeps its own.
+          if [ -z "$EXE" ]; then strip dist/labwired dist/labwired-dap || true; fi
+
+          tar -czf "${ARCHIVE}" -C dist "labwired${EXE}" "labwired-dap${EXE}"
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      # The floor is a claim, so it gets checked. Without this the next runner
+      # image bump silently raises it again.
+      - name: Assert glibc floor
+        if: matrix.glibc_max != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+          for b in dist/labwired dist/labwired-dap; do
+            max="$(readelf -V "$b" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -V -u | tail -1)"
+            echo "$b requires $max (floor ${{ matrix.glibc_max }})"
+            newest="$(printf '%s\n%s\n' "$max" "${{ matrix.glibc_max }}" | sort -V | tail -1)"
+            if [ "$newest" != "${{ matrix.glibc_max }}" ]; then
+              echo "::error::$b requires $max, above the ${{ matrix.glibc_max }} floor — it will not start on Debian 12 or Ubuntu 22.04."
+              fail=1
+            fi
+          done
+          exit "$fail"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -84,9 +131,43 @@ jobs:
           name: labwired-${{ matrix.platform }}
           path: ${{ env.ARCHIVE }}
 
+  # Run the artifact somewhere old before anyone can download it. The symbol
+  # assert above proves what the binary asks for; this proves the binary starts.
+  linux-smoke:
+    name: Start on ${{ matrix.image }} (${{ matrix.platform }})
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { platform: linux-x86_64,  runner: ubuntu-latest,    image: 'debian:12-slim' }
+          - { platform: linux-x86_64,  runner: ubuntu-latest,    image: 'ubuntu:22.04' }
+          - { platform: linux-x86_64,  runner: ubuntu-latest,    image: 'almalinux:9' }
+          - { platform: linux-aarch64, runner: ubuntu-24.04-arm, image: 'debian:12-slim' }
+          - { platform: linux-aarch64, runner: ubuntu-24.04-arm, image: 'ubuntu:22.04' }
+    steps:
+      - name: Download the release archive
+        uses: actions/download-artifact@v4
+        with:
+          name: labwired-${{ matrix.platform }}
+          path: archive
+
+      - name: Extract and run it
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          tar -xzf archive/*.tar.gz -C dist
+          docker run --rm -v "$PWD/dist:/d" "${{ matrix.image }}" /d/labwired --version
+          docker run --rm -v "$PWD/dist:/d" "${{ matrix.image }}" /d/labwired-dap --version
+
   release:
     name: Create GitHub Release
-    needs: build
+    # A tarball nobody could start must never become a published release.
+    needs: [build, linux-smoke]
+    # Publishing only ever happens for a tag; a dispatch run stops after
+    # the artifacts have been built, asserted and smoked.
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -121,6 +202,7 @@ jobs:
   publish:
     name: Publish CI runner image
     needs: release
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -152,6 +234,7 @@ jobs:
   release-smoke:
     name: Smoke released archives and runner image
     needs: [release, publish]
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -114,6 +114,41 @@ jobs:
           curl -fsSL https://labwired.com/install.sh | LABWIRED_NO_MODIFY_PATH=1 sh
           "$HOME/.local/bin/labwired" --version
 
+  # ── Every chip we document, run with the CLI a user can install ─────────────
+  chips:
+    name: Documented chips on ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest, label: Ubuntu 24.04 x86_64 }
+          - { runner: macos-14,      label: macOS 14 arm64 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install with the documented one-liner
+        run: |
+          set -euo pipefail
+          curl -fsSL https://labwired.com/install.sh | LABWIRED_NO_MODIFY_PATH=1 sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Firmware comes from the pinned demo release, so this is the experience
+      # of someone who installed the CLI and cloned the repo: no Rust, no
+      # cross toolchain, no build. Judged on what the firmware printed.
+      - name: Run every documented chip
+        run: bash scripts/ci/docs-runnable-chips.sh "$HOME/.local/bin/labwired"
+
+      - name: Every documented command is one the CLI accepts
+        run: python3 scripts/ci/docs-commands-gate.py "$HOME/.local/bin/labwired"
+
+      - name: Heartbeat
+        if: success()
+        continue-on-error: true
+        run: |
+          curl -fsS -m 5 -X POST "$LABWIRED_TELEMETRY_URL" -H 'content-type: application/json' \
+            -d "{\"surface\":\"canary\",\"event\":\"canary_ok\",\"stage\":\"run\",\"platform\":\"${{ matrix.runner }}\",\"channel\":\"install.sh\"}" || true
+
   # ── The agent one-liner, in every shell the docs' `| sh` can land in ─────────
   mcp-oneliner:
     name: mcp.sh under ${{ matrix.shell }}
@@ -240,7 +275,7 @@ jobs:
   # ── One issue, kept current, when any of the above goes red ─────────────────
   report:
     name: Raise the alarm
-    needs: [cli, cli-old-distros, mcp-oneliner, mcp-windows, packages]
+    needs: [cli, cli-old-distros, chips, mcp-oneliner, mcp-windows, packages]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -1,0 +1,253 @@
+# Install canary — runs the instructions we publish, on the platforms we claim.
+#
+# This exists because for two weeks in August 2026 the documented one-liner
+# installed nothing on any platform, and the Linux archives could not start on
+# Debian 12 or Ubuntu 22.04 LTS, while every workflow in this repo stayed green.
+# Nothing was wrong with the code under test — the tests simply never ran what a
+# user runs, on a machine like a user's.
+#
+# Two rules keep it honest:
+#   1. Fetch the scripts LIVE from labwired.com. The copy in this repo is not
+#      what users execute; the landing site serves the file, and the two have
+#      drifted before.
+#   2. Assert on output, not exit codes alone. An installer that prints
+#      "Installation complete!" and exits 0 is exactly how the last outage hid.
+name: Install canary
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: install-canary
+  cancel-in-progress: false
+
+env:
+  # Where a failing leg reports itself, so a broken install is data and not a
+  # support message. Best effort: a canary leg never fails because of telemetry.
+  LABWIRED_TELEMETRY_URL: https://api.labwired.com/v1/telemetry/failure
+
+jobs:
+  # ── The CLI, installed the way the README says ───────────────────────────────
+  cli:
+    name: CLI on ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-14,         label: macOS 14 arm64 }
+          - { runner: macos-13,         label: macOS 13 x86_64 }
+          - { runner: ubuntu-latest,    label: Ubuntu 24.04 x86_64 }
+          - { runner: ubuntu-22.04,     label: Ubuntu 22.04 x86_64 }
+          - { runner: ubuntu-24.04-arm, label: Ubuntu 24.04 arm64 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install with the documented one-liner
+        run: |
+          set -euo pipefail
+          curl -fsSL https://labwired.com/install.sh | LABWIRED_NO_MODIFY_PATH=1 sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: The binary starts, and says which version it is
+        run: |
+          set -euo pipefail
+          out="$(labwired --version)"
+          echo "$out"
+          echo "$out" | grep -qE '^labwired-cli [0-9]+\.[0-9]+\.[0-9]+$'
+          labwired-dap --version
+
+      - name: The README quickstart prints what the README says it prints
+        run: |
+          set -euo pipefail
+          labwired test --script examples/nrf54l15-dk/io-smoke.yaml 2>&1 | tee out.txt
+          for line in \
+            'nRF54L15 boot OK' \
+            'core=cortex-m33 rram=1524K ram=256K' \
+            'uarte20@0x500C6000 gpio2@0x50050400' \
+            'regs from MDK/SVD, not nRF52'
+          do
+            grep -qF "$line" out.txt || { echo "::error::quickstart no longer prints: $line"; exit 1; }
+          done
+
+      - name: Heartbeat
+        if: success()
+        continue-on-error: true
+        run: |
+          curl -fsS -m 5 -X POST "$LABWIRED_TELEMETRY_URL" -H 'content-type: application/json' \
+            -d "{\"surface\":\"canary\",\"event\":\"canary_ok\",\"stage\":\"cli\",\"platform\":\"${{ matrix.runner }}\",\"channel\":\"install.sh\"}" || true
+
+  # ── The distributions people actually run, not the one CI runs ───────────────
+  cli-old-distros:
+    name: CLI on ${{ matrix.image }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: 'debian:12-slim', arch: x86_64,  runner: ubuntu-latest }
+          - { image: 'ubuntu:22.04',   arch: x86_64,  runner: ubuntu-latest }
+          - { image: 'almalinux:9',    arch: x86_64,  runner: ubuntu-latest }
+          - { image: 'debian:12-slim', arch: aarch64, runner: ubuntu-24.04-arm }
+          - { image: 'ubuntu:22.04',   arch: aarch64, runner: ubuntu-24.04-arm }
+    steps:
+      - name: Bare-image prerequisites
+        run: |
+          if command -v apt-get >/dev/null; then
+            apt-get -qq update && apt-get -qq install -y curl ca-certificates >/dev/null
+          else
+            (yum install -y -q curl ca-certificates || dnf install -y -q curl ca-certificates) >/dev/null
+          fi
+
+      - name: Install and start
+        run: |
+          set -eu
+          curl -fsSL https://labwired.com/install.sh | LABWIRED_NO_MODIFY_PATH=1 sh
+          "$HOME/.local/bin/labwired" --version
+
+  # ── The agent one-liner, in every shell the docs' `| sh` can land in ─────────
+  mcp-oneliner:
+    name: mcp.sh under ${{ matrix.shell }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [sh, bash, zsh, busybox]
+    steps:
+      - name: Install the shell under test
+        run: sudo apt-get -qq update && sudo apt-get -qq install -y zsh busybox dash >/dev/null
+
+      - name: Pretend every supported editor is installed
+        run: mkdir -p ~/.cursor ~/.config/Code/User ~/.config/opencode
+
+      # `/bin/sh` is dash on Debian and Ubuntu. The published command pipes into
+      # `sh`, so a bash-only test in the script does not fail loudly — it
+      # evaluates false, and the editor is skipped without a word. That is how
+      # Cursor, VS Code and OpenCode silently went unregistered on every
+      # Debian-family machine.
+      - name: Run the published command, then check what it actually registered
+        run: |
+          set -euo pipefail
+          curl -fsSL https://labwired.com/mcp.sh -o mcp.sh
+          case "${{ matrix.shell }}" in
+            busybox) timeout 120 busybox sh mcp.sh ;;
+            *)       timeout 120 ${{ matrix.shell }} mcp.sh ;;
+          esac
+          for f in ~/.cursor/mcp.json ~/.config/Code/User/mcp.json ~/.config/opencode/opencode.json; do
+            test -s "$f" || { echo "::error::${{ matrix.shell }}: $f was never written"; exit 1; }
+            grep -q 'api.labwired.com/mcp' "$f" || { echo "::error::$f has no LabWired entry"; exit 1; }
+          done
+
+      # A one-liner that waits on a browser OAuth flow inside a pipe never
+      # returns, and every agent after it in the script goes unregistered.
+      - name: It returns on its own
+        run: |
+          start=$(date +%s)
+          timeout 120 sh mcp.sh >/dev/null 2>&1 || true
+          echo "took $(( $(date +%s) - start ))s"
+          test $(( $(date +%s) - start )) -lt 90
+
+  # ── Windows: both PowerShells, and the user's other MCP servers survive ──────
+  mcp-windows:
+    name: mcp.ps1 on ${{ matrix.ps }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ps: [powershell, pwsh]
+    steps:
+      # `ConvertFrom-Json -AsHashtable` needs PowerShell 6+. On the Windows
+      # PowerShell 5.1 that ships with Windows, the merge throws, the catch
+      # swallows it, and the file is rewritten with only our entry — taking the
+      # user's other MCP servers with it. So the canary plants one first.
+      - name: Plant an existing MCP server in the Cursor config
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.cursor" | Out-Null
+          '{"mcpServers":{"someone-elses":{"url":"https://example.invalid/mcp"}}}' |
+            Set-Content "$env:USERPROFILE\.cursor\mcp.json" -Encoding utf8
+
+      - name: Run the published Windows one-liner
+        shell: ${{ matrix.ps }} {0}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          irm https://labwired.com/mcp.ps1 | iex
+
+      - name: LabWired is registered and the other server is still there
+        shell: pwsh
+        run: |
+          $raw = Get-Content "$env:USERPROFILE\.cursor\mcp.json" -Raw
+          Write-Host $raw
+          if ($raw -notmatch 'api\.labwired\.com/mcp') { throw 'LabWired was not registered' }
+          if ($raw -notmatch 'someone-elses')          { throw 'the pre-existing MCP server was destroyed' }
+
+  # ── The npm and container channels ──────────────────────────────────────────
+  packages:
+    name: npm and container channels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with: { node-version: '22' }
+
+      - name: npx serves a real MCP handshake
+        run: |
+          set -euo pipefail
+          printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"canary","version":"1"}}}' \
+            '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' > rpc.jsonl
+          timeout 180 npx -y @labwired/mcp < rpc.jsonl > out.jsonl
+          grep -q '"serverInfo"' out.jsonl
+          # An empty tools list must not read as success.
+          grep -q 'labwired_search' out.jsonl
+
+      - name: A global install puts a working binary on PATH
+        run: |
+          set -euo pipefail
+          npm install -g @labwired/mcp
+          command -v labwired-mcp
+
+      - name: The runner image is pullable on both architectures
+        run: |
+          set -euo pipefail
+          for p in linux/amd64 linux/arm64; do
+            docker manifest inspect ghcr.io/w1ne/labwired:latest \
+              | grep -q "$(echo "$p" | cut -d/ -f2)" \
+              || { echo "::error::no $p manifest — docker pull fails outright on that architecture"; exit 1; }
+          done
+          docker run --rm --platform linux/amd64 ghcr.io/w1ne/labwired:latest --version
+
+  # ── One issue, kept current, when any of the above goes red ─────────────────
+  report:
+    name: Raise the alarm
+    needs: [cli, cli-old-distros, mcp-oneliner, mcp-windows, packages]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update the canary issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title='install-canary: a published install path is broken'
+          body="A leg of the install canary failed. What a user runs right now does not work.
+
+          Run: $RUN
+
+          Check the failing leg before anything else — this workflow only runs commands we publish."
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number' || true)"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body" --label bug
+          fi

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         include:
           - { runner: macos-14,         label: macOS 14 arm64 }
-          - { runner: macos-13,         label: macOS 13 x86_64 }
+          - { runner: macos-15-intel,   label: macOS 15 x86_64 }
           - { runner: ubuntu-latest,    label: Ubuntu 24.04 x86_64 }
           - { runner: ubuntu-22.04,     label: Ubuntu 22.04 x86_64 }
           - { runner: ubuntu-24.04-arm, label: Ubuntu 24.04 arm64 }
@@ -176,8 +176,19 @@ jobs:
           '{"mcpServers":{"someone-elses":{"url":"https://example.invalid/mcp"}}}' |
             Set-Content "$env:USERPROFILE\.cursor\mcp.json" -Encoding utf8
 
-      - name: Run the published Windows one-liner
-        shell: ${{ matrix.ps }} {0}
+      # `shell:` cannot take an expression, so the two shells are two steps.
+      # Windows PowerShell 5.1 is the one that ships with Windows and the one
+      # the -AsHashtable merge used to destroy configs on.
+      - name: Run the published Windows one-liner (Windows PowerShell 5.1)
+        if: matrix.ps == 'powershell'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          irm https://labwired.com/mcp.ps1 | iex
+
+      - name: Run the published Windows one-liner (PowerShell 7)
+        if: matrix.ps == 'pwsh'
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           irm https://labwired.com/mcp.ps1 | iex

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ cargo build --release -p labwired-cli
 ### From your terminal
 
 ```sh
-labwired run  --firmware path/to/firmware.elf --system configs/systems/<board>.yaml
+labwired run  --chip configs/chips/<chip>.yaml --firmware path/to/firmware.elf
 labwired test --script  path/to/test.yaml --junit report.xml
 ```
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -20,7 +20,7 @@ These options apply to the interactive runner and most subcommands.
 Executes a firmware simulation interactively. If no subcommand is provided, this mode is used.
 
 ```bash
-labwired [OPTIONS] --firmware <ELF> --system <YAML>
+labwired --firmware <ELF> --system <YAML> [OPTIONS]
 ```
 
 **Options:**

--- a/docs/gdb_integration.md
+++ b/docs/gdb_integration.md
@@ -8,7 +8,7 @@ The GDB server is embedded within the `labwired-cli`. It listens on TCP port `33
 
 ### Starting the Server manually
 ```bash
-labwired --gdb --port 3333 --firmware firmware.elf --system system.yaml
+labwired --gdb 3333 --firmware firmware.elf --system system.yaml
 ```
 
 ## 2. Connecting with GDB

--- a/docs/vscode_debugging.md
+++ b/docs/vscode_debugging.md
@@ -52,5 +52,5 @@ Uses the standard `cortex-debug` extension connected to LabWired's GDB server. B
 
 **Note**: You must start the LabWired GDB server manually before launching this configuration:
 ```bash
-labwired --gdb --port 3333 --firmware ...
+labwired --gdb 3333 --firmware firmware.elf --system system.yaml
 ```

--- a/scripts/ci/docs-commands-gate.py
+++ b/scripts/ci/docs-commands-gate.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Every `labwired ...` command we print in user-facing docs must be a command.
+
+The README told people to run
+
+    labwired run --firmware path/to/firmware.elf --system configs/systems/<board>.yaml
+
+for months. `labwired run` has never had a `--system` flag — it takes `--chip` —
+so anyone who followed the "from your terminal" section got
+
+    error: unexpected argument '--system' found
+
+Nothing could have caught that: the docs were prose, and the CLI's flags live in
+clap. This asks the binary itself what it accepts, which makes the CLI the one
+source of truth and the docs the thing that has to keep up.
+
+Usage: scripts/ci/docs-commands-gate.py [path-to-labwired]
+"""
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# User-facing docs only. Plans and strategy notes under docs/superpowers and
+# docs/strategy record what we were thinking at a point in time; they are not
+# instructions anybody is invited to run.
+INCLUDE = [
+    REPO / "README.md",
+    *(REPO / "docs").glob("*.md"),
+    *(REPO / "docs" / "agent").rglob("*.md"),
+    *(REPO / "docs" / "guides").rglob("*.md"),
+    *(REPO / "docs" / "boards").rglob("*.md"),
+]
+
+COMMAND_RE = re.compile(r"^\s*(?:\$\s*)?(labwired(?:-dap)?\s+[^\n]*)$")
+# `--flag`, `--flag=value`, but not a bare `--` or a markdown rule.
+FLAG_RE = re.compile(r"^--[a-z0-9][a-z0-9-]*")
+
+
+def cli_flags(cli: str, subcommand: str | None) -> set[str] | None:
+    """Long flags clap advertises for a subcommand, or None if it has none."""
+    argv = [cli] + ([subcommand] if subcommand else []) + ["--help"]
+    try:
+        out = subprocess.run(argv, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return set(re.findall(r"(--[a-z0-9][a-z0-9-]*)", out.stdout))
+
+
+def subcommands(cli: str) -> set[str]:
+    out = subprocess.run([cli, "--help"], capture_output=True, text=True, timeout=60)
+    found: set[str] = set()
+    in_commands = False
+    for line in out.stdout.splitlines():
+        if re.match(r"^\s*Commands:", line):
+            in_commands = True
+            continue
+        if in_commands:
+            if re.match(r"^\s*(Options|Arguments):", line):
+                break
+            m = re.match(r"^\s{2,}([a-z][a-z0-9-]*)\s", line)
+            if m:
+                found.add(m.group(1))
+    return found
+
+
+def main() -> int:
+    cli = sys.argv[1] if len(sys.argv) > 1 else "labwired"
+    subs = subcommands(cli)
+    if not subs:
+        print(f"could not read subcommands from '{cli} --help'", file=sys.stderr)
+        return 1
+
+    flag_cache: dict[str | None, set[str] | None] = {}
+    failures = 0
+    checked = 0
+
+    for path in sorted(set(INCLUDE)):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(REPO)
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            m = COMMAND_RE.match(line)
+            if not m:
+                continue
+            raw = m.group(1).rstrip("\\").strip()
+            # Placeholders like <board> are fine; the shell would choke on the
+            # angle brackets, so strip them before splitting.
+            cleaned = raw.replace("<", "").replace(">", "")
+            try:
+                argv = shlex.split(cleaned)
+            except ValueError:
+                continue
+            if not argv:
+                continue
+            checked += 1
+
+            # A subcommand, when there is one, is the FIRST word after the
+            # program name. Anything else that is not a flag is a flag's value
+            # — `--port 3333` does not mean there is a `3333` subcommand — and
+            # the CLI also still accepts the legacy top-level form
+            # (`labwired --firmware X --system Y`), where there is no
+            # subcommand at all. Both had to be understood before this gate
+            # could tell a broken instruction from an old-style one.
+            sub = None
+            if argv[0] == "labwired" and len(argv) > 1 and not argv[1].startswith("-"):
+                if argv[1] not in subs:
+                    print(f"{rel}:{lineno}: `{argv[1]}` is not a labwired subcommand")
+                    print(f"    {raw}")
+                    failures += 1
+                    continue
+                sub = argv[1]
+
+            key = sub
+            if key not in flag_cache:
+                flag_cache[key] = cli_flags(cli, sub)
+            allowed = flag_cache[key]
+            if allowed is None:
+                continue
+
+            for token in argv[1:]:
+                if not FLAG_RE.match(token):
+                    continue
+                flag = token.split("=", 1)[0]
+                if flag not in allowed:
+                    near = sorted(f for f in allowed if f[2:4] == flag[2:4])
+                    hint = f" (did you mean {', '.join(near)}?)" if near else ""
+                    print(f"{rel}:{lineno}: `labwired {sub or ''}` has no {flag}{hint}")
+                    print(f"    {raw}")
+                    failures += 1
+
+    print()
+    print(f"checked {checked} documented command(s) against {cli}")
+    if failures:
+        print(f"{failures} documented command(s) cannot run as written.")
+        return 1
+    print("every documented command is one the CLI accepts.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/docs-runnable-chips.json
+++ b/scripts/ci/docs-runnable-chips.json
@@ -95,19 +95,72 @@
       "sha256": "7bb826e01c4118a475eda32279304279ef664b1a9d9cfde74a7f8dcdd517cd70",
       "expect": "KW41Z_LCD_OK"
     },
-
-    "nrf52832": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "nrf5340": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "rp2350": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "esp32s3-zero": { "how": "needs-build", "why": "board variant of esp32s3; no prebuilt firmware of its own" },
-    "stm32f401cdu6": { "how": "needs-build", "why": "board variant of stm32f401; no prebuilt firmware of its own" },
-    "stm32f405": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "stm32f407": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "stm32f767": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "stm32g474re": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "stm32l073": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "stm32wb55": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "stm32wba52": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
-    "atmega328p": { "how": "needs-build", "why": "AVR firmware is built from examples/arduino-nano-blinky; no prebuilt asset" }
+    "nrf52832": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "nrf5340": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "rp2350": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "esp32s3-zero": {
+      "how": "asset",
+      "firmware": "demo-esp32s3-hello-world.elf",
+      "sha256": "31d8facfc6fc0faeb32a82166d13827a99e6eee77d438ee5a5da2fa9d12ca0ec",
+      "expect": "faithful ROM loaded",
+      "note": "Board variant of esp32s3, and it boots the same image."
+    },
+    "stm32f401cdu6": {
+      "how": "asset",
+      "firmware": "demo-nucleo-f401.elf",
+      "sha256": "eee67caf8ded9f9385981ce43220b4d6677d1cd34c49f528f964b7462b558674",
+      "expect": "LabWired Playground",
+      "note": "Cortex-M4 STM32F4 built for F401. Family-compatible, not part-specific: it proves this chip model boots an image and talks over its USART, not that every F4 peripheral is exercised."
+    },
+    "stm32f405": {
+      "how": "asset",
+      "firmware": "demo-nucleo-f401.elf",
+      "sha256": "eee67caf8ded9f9385981ce43220b4d6677d1cd34c49f528f964b7462b558674",
+      "expect": "LabWired Playground",
+      "note": "Cortex-M4 STM32F4 built for F401. Family-compatible, not part-specific: it proves this chip model boots an image and talks over its USART, not that every F4 peripheral is exercised."
+    },
+    "stm32f407": {
+      "how": "asset",
+      "firmware": "demo-nucleo-f401.elf",
+      "sha256": "eee67caf8ded9f9385981ce43220b4d6677d1cd34c49f528f964b7462b558674",
+      "expect": "LabWired Playground",
+      "note": "Cortex-M4 STM32F4 built for F401. Family-compatible, not part-specific: it proves this chip model boots an image and talks over its USART, not that every F4 peripheral is exercised."
+    },
+    "stm32f767": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "stm32g474re": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "stm32l073": {
+      "how": "blocked",
+      "why": "the released CLI cannot read the shipped descriptor: `cannot parse chip YAML: peripherals[34].clock: invalid type: sequence`. configs/chips/stm32l073.yaml uses a schema newer than v0.21.0 \u2014 another face of the release lag. Re-check on the next release.",
+      "firmware": "demo-nucleo-f401.elf",
+      "sha256": "eee67caf8ded9f9385981ce43220b4d6677d1cd34c49f528f964b7462b558674",
+      "expect": null
+    },
+    "stm32wb55": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "stm32wba52": {
+      "how": "needs-build",
+      "why": "no prebuilt demo firmware for this part yet"
+    },
+    "atmega328p": {
+      "how": "needs-build",
+      "why": "AVR firmware is built from examples/arduino-nano-blinky; no prebuilt asset"
+    }
   }
 }

--- a/scripts/ci/docs-runnable-chips.json
+++ b/scripts/ci/docs-runnable-chips.json
@@ -1,0 +1,113 @@
+{
+  "_comment": [
+    "Every chip this repo documents, and how a person with nothing but the",
+    "installed CLI can run it. Read scripts/ci/docs-runnable-chips.sh for the",
+    "rules; the short version is that each chip must be in exactly one bucket,",
+    "and 'blocked' entries are re-run too so that a fix cannot sit unnoticed.",
+    "",
+    "Firmware comes from the firmware-demos release: prebuilt ELFs, pinned by",
+    "tag AND sha256, so nothing here needs a cross toolchain and a re-uploaded",
+    "asset cannot silently change what the gate proves.",
+    "",
+    "`expect` is a line the firmware itself prints. It is deliberately not an",
+    "exit code: `labwired run` treats a simulation error as a non-fatal end of",
+    "run and still exits 0, so exit status alone proves nothing here."
+  ],
+  "firmware_release": "firmware-demos-v3",
+  "chips": {
+    "esp32": {
+      "how": "asset",
+      "firmware": "demo-esp32-epaper-lab.elf",
+      "sha256": "b0db06a8f8bdb2c358a37101a3962c4de461a6f6fd97f944a557ffff867ac5c5",
+      "expect": null,
+      "note": "Runs to the step limit without a fault; this firmware drives a panel, not serial."
+    },
+    "esp32s3": {
+      "how": "asset",
+      "firmware": "demo-esp32s3-hello-world.elf",
+      "sha256": "31d8facfc6fc0faeb32a82166d13827a99e6eee77d438ee5a5da2fa9d12ca0ec",
+      "expect": "faithful ROM loaded"
+    },
+    "esp32c3": {
+      "how": "blocked",
+      "firmware": "demo-esp32c3-blink.elf",
+      "sha256": "aea04c8527eff25e8969b851dc9cc2436cf13e40c6019788741b7eecd5004789",
+      "expect": null,
+      "note": "v0.21.0 refuses the board: `UART type 'esp32c3_uart' has no register layout modelled yet`. Fixed on main; this entry flips to `asset` in the first release that carries the fix, and the gate fails if it starts passing while still marked blocked."
+    },
+    "nrf52840": {
+      "how": "asset",
+      "firmware": "demo-nrf52840-secure-boot.elf",
+      "sha256": "11b2826640bde079880378c13faeae5ffbae1e8bca9c7e20bf23ad920a369a1b",
+      "expect": "ROT: PROVISIONED"
+    },
+    "nrf54l15": {
+      "how": "example",
+      "script": "examples/nrf54l15-dk/io-smoke.yaml",
+      "expect": "nRF54L15 boot OK",
+      "note": "The README quickstart. Firmware is committed, so a clone is enough."
+    },
+    "rp2040": {
+      "how": "asset",
+      "firmware": "demo-rp2040-pico.elf",
+      "sha256": "09f70c83a434d5fa2fdd69807e543ace86cccd12be7f213e3291cf5c8edd1522",
+      "expect": "RP2040_SMOKE_OK"
+    },
+    "stm32f103": {
+      "how": "asset",
+      "firmware": "demo-f103-uds-ecu.elf",
+      "sha256": "ba9be0d0f82d301df56b0d5c927d7c8a94d04955a3136e961b5ad4d001dc95e1",
+      "expect": "F103-UDS-ECU"
+    },
+    "stm32f401": {
+      "how": "asset",
+      "firmware": "demo-nucleo-f401.elf",
+      "sha256": "eee67caf8ded9f9385981ce43220b4d6677d1cd34c49f528f964b7462b558674",
+      "expect": "LabWired Playground"
+    },
+    "stm32f411ceu6": {
+      "how": "example",
+      "script": "examples/stm32f411ceu6-blackpill/io-smoke.yaml",
+      "expect": null
+    },
+    "stm32h563": {
+      "how": "asset",
+      "firmware": "demo-stm32h5-uds-ecu.elf",
+      "sha256": "d85a1b23d33f5347e774ffc38c98e25cfe92fda6c0f3df17734f91eb0275b1fe",
+      "expect": "H563-UDS-ECU"
+    },
+    "stm32h735": {
+      "how": "asset",
+      "firmware": "demo-h735-telematics-lab.elf",
+      "sha256": "9e8bef1a5c45d012e70977f1843dbf9c9b90192450a7f9c51310d50f0a1fd573",
+      "expect": "LabWired telematics"
+    },
+    "stm32l476": {
+      "how": "asset",
+      "firmware": "demo-stm32l476-blink.elf",
+      "sha256": "c426653a45e6a091ad9d39f50060804ca3e6bf01af06414901ef499aa736dba9",
+      "expect": null,
+      "note": "Blink: GPIO only, no serial output to assert on."
+    },
+    "mkw41z4": {
+      "how": "asset",
+      "firmware": "demo-kw41z-lcd-activity.elf",
+      "sha256": "7bb826e01c4118a475eda32279304279ef664b1a9d9cfde74a7f8dcdd517cd70",
+      "expect": "KW41Z_LCD_OK"
+    },
+
+    "nrf52832": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "nrf5340": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "rp2350": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "esp32s3-zero": { "how": "needs-build", "why": "board variant of esp32s3; no prebuilt firmware of its own" },
+    "stm32f401cdu6": { "how": "needs-build", "why": "board variant of stm32f401; no prebuilt firmware of its own" },
+    "stm32f405": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "stm32f407": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "stm32f767": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "stm32g474re": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "stm32l073": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "stm32wb55": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "stm32wba52": { "how": "needs-build", "why": "no prebuilt demo firmware for this part yet" },
+    "atmega328p": { "how": "needs-build", "why": "AVR firmware is built from examples/arduino-nano-blinky; no prebuilt asset" }
+  }
+}

--- a/scripts/ci/docs-runnable-chips.sh
+++ b/scripts/ci/docs-runnable-chips.sh
@@ -101,7 +101,11 @@ run_and_judge() { # $1 chip, $2 how, $3 firmware, $4 sha, $5 script, $6 expect â
   fi
   printf '%s' "$out" > "$work/log-$chip"
   grep -q "simulation error" "$work/log-$chip" && { echo "FAULT"; return; }
-  grep -qE "^error:|failed to build system bus" "$work/log-$chip" && { echo "REFUSED"; return; }
+  grep -qE "^error:|failed to build system bus|cannot parse chip YAML" "$work/log-$chip" && { echo "REFUSED"; return; }
+  # A bus fault or a CPU error is a failure even when the CLI keeps going and
+  # prints nothing else; without this, pairing a chip with firmware built for a
+  # different part reads as a silent pass.
+  grep -qE "ERROR .*labwired_core" "$work/log-$chip" && { echo "CHIP_ERROR"; return; }
   if [ -n "$expect" ] && ! grep -qF -- "$expect" "$work/log-$chip"; then echo "SILENT"; return; fi
   echo "OK"
 }

--- a/scripts/ci/docs-runnable-chips.sh
+++ b/scripts/ci/docs-runnable-chips.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Every chip we document, run with the CLI a user can actually install.
+#
+# The claim this defends is the one on the front page: pick a supported chip,
+# run firmware on it, no cross toolchain. On 2026-08-14 that claim held for six
+# chips out of twenty-four from a fresh clone — not because the models were
+# broken, but because the firmware the examples point at is built in CI and
+# never shipped, and because the last release was 984 commits behind the
+# examples in the same tree.
+#
+# Rules, all enforced below:
+#   * every chip descriptor in configs/chips (minus CI fixtures) must appear in
+#     docs-runnable-chips.json — a new chip cannot arrive untested and silent;
+#   * `asset` and `example` entries are RUN, and judged on what the firmware
+#     printed. Not on exit status: `labwired run` deliberately treats a
+#     simulation error as a non-fatal end of run and still exits 0;
+#   * prebuilt firmware is pinned by release tag AND sha256, so a re-uploaded
+#     asset cannot quietly change what this proves;
+#   * `blocked` entries are run too, and a blocked chip that now WORKS fails the
+#     gate. A ratchet that only catches regressions leaves fixed things marked
+#     broken forever.
+#
+# Usage: scripts/ci/docs-runnable-chips.sh [path-to-labwired]
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root" || exit 1
+CLI="${1:-labwired}"
+MAP=scripts/ci/docs-runnable-chips.json
+REPO=w1ne/labwired-core
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+command -v "$CLI" >/dev/null 2>&1 || [ -x "$CLI" ] || {
+  echo "no labwired binary at '$CLI' — install one first:" >&2
+  echo "  curl -fsSL https://labwired.com/install.sh | sh" >&2
+  exit 1
+}
+
+# Fields are unit-separated, not tab-separated: a TAB is whitespace to `read`,
+# which collapses runs of it, so two empty fields in a row silently become one.
+read_map() { python3 -c "
+import json,sys
+m = json.load(open('$MAP'))
+print(m['firmware_release'])
+for chip, e in m['chips'].items():
+    print('\x1f'.join([
+        chip, e.get('how',''), e.get('firmware',''), e.get('sha256',''),
+        e.get('script',''), e.get('expect') or '', e.get('why','')]))
+"; }
+
+# bash 3.2 on macOS has no `mapfile`, and the canary runs this on macOS.
+read_map > "$work/map.tsv" || { echo "cannot read $MAP" >&2; exit 1; }
+release="$(head -1 "$work/map.tsv")"
+tail -n +2 "$work/map.tsv" > "$work/entries.tsv"
+
+# ── The map has to cover the chips we ship ──────────────────────────────────
+missing=""
+for path in configs/chips/*.yaml; do
+  chip="$(basename "$path" .yaml)"
+  case "$chip" in ci-fixture-*) continue ;; esac
+  cut -d$'\x1f' -f1 "$work/entries.tsv" | grep -qx "$chip" || missing="$missing $chip"
+done
+if [ -n "$missing" ]; then
+  echo "::error::these chips ship but are absent from $MAP:$missing"
+  echo "Add each one: how it runs from a clean install, or 'needs-build' with a reason."
+  exit 1
+fi
+
+fetch_asset() {
+  local name="$1"
+  local want="$2"
+  local dest="$work/$name"
+  [ -f "$dest" ] && { printf '%s' "$dest"; return 0; }
+  curl -fsSL --retry 3 -o "$dest" \
+    "https://github.com/${REPO}/releases/download/${release}/${name}" || return 1
+  local got
+  got="$(shasum -a 256 "$dest" | cut -d' ' -f1)"
+  if [ "$got" != "$want" ]; then
+    echo "::error::$name in $release has sha256 $got, the map pins $want — the asset was replaced" >&2
+    return 1
+  fi
+  printf '%s' "$dest"
+}
+
+# Judged on output, never on exit status alone.
+run_and_judge() { # $1 chip, $2 how, $3 firmware, $4 sha, $5 script, $6 expect → prints verdict
+  local chip="$1"
+  local how="$2"
+  local fw="$3"
+  local sha="$4"
+  local script="$5"
+  local expect="$6"
+  local out=""
+  local path=""
+  if [ "$how" = example ]; then
+    out="$("$CLI" test --script "$script" --output-dir "$work/out-$chip" 2>&1)"
+  else
+    path="$(fetch_asset "$fw" "$sha")" || { echo "ASSET"; return; }
+    out="$("$CLI" run --chip "configs/chips/${chip}.yaml" --firmware "$path" --max-steps 4000000 2>&1)"
+  fi
+  printf '%s' "$out" > "$work/log-$chip"
+  grep -q "simulation error" "$work/log-$chip" && { echo "FAULT"; return; }
+  grep -qE "^error:|failed to build system bus" "$work/log-$chip" && { echo "REFUSED"; return; }
+  if [ -n "$expect" ] && ! grep -qF -- "$expect" "$work/log-$chip"; then echo "SILENT"; return; fi
+  echo "OK"
+}
+
+runnable=0; blocked=0; needs_build=0; failures=0
+printf '%-16s %-12s %s\n' CHIP HOW RESULT
+while IFS=$'\x1f' read -r chip how fw sha script expect why; do
+  case "$how" in
+    asset|example)
+      verdict="$(run_and_judge "$chip" "$how" "$fw" "$sha" "$script" "$expect")"
+      if [ "$verdict" = OK ]; then
+        runnable=$((runnable + 1))
+        printf '%-16s %-12s ok\n' "$chip" "$how"
+      else
+        failures=$((failures + 1))
+        printf '%-16s %-12s FAILED (%s)\n' "$chip" "$how" "$verdict"
+        sed -n '1,6p' "$work/log-$chip" 2>/dev/null | sed 's/^/      /'
+        echo "::error::$chip is documented as runnable and is not: $verdict"
+      fi
+      ;;
+    blocked)
+      blocked=$((blocked + 1))
+      verdict="$(run_and_judge "$chip" asset "$fw" "$sha" "" "$expect")"
+      if [ "$verdict" = OK ]; then
+        failures=$((failures + 1))
+        printf '%-16s %-12s FIXED — promote it\n' "$chip" "$how"
+        echo "::error::$chip is marked blocked but now runs. Move it to \"how\": \"asset\" in $MAP."
+      else
+        printf '%-16s %-12s still blocked (%s)\n' "$chip" "$how" "$verdict"
+      fi
+      ;;
+    needs-build)
+      needs_build=$((needs_build + 1))
+      printf '%-16s %-12s no prebuilt firmware — %s\n' "$chip" "$how" "$why"
+      ;;
+    *)
+      failures=$((failures + 1))
+      echo "::error::$chip has an unknown \"how\": $how"
+      ;;
+  esac
+done < "$work/entries.tsv"
+
+total=$((runnable + blocked + needs_build))
+echo
+echo "$runnable of $total documented chips run from an install with no toolchain."
+echo "$blocked blocked by the released CLI, $needs_build still need firmware built from source."
+[ "$failures" -eq 0 ] || { echo; echo "$failures chip(s) do not match what this repo claims."; exit 1; }

--- a/scripts/ci/test-install-script.sh
+++ b/scripts/ci/test-install-script.sh
@@ -15,6 +15,10 @@ failures=0
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# `grep -q` inverted, as a named helper: `check` takes a command, and a bare
+# `! grep …` cannot be passed as one.
+lacks() { ! grep -qi -- "$1" "$2"; }
+
 check() {
   local description=$1
   shift
@@ -82,8 +86,9 @@ set -e
 check "a missing archive exits non-zero" test "$code" -ne 0
 check "a missing archive asks before building from source" \
   grep -q "LABWIRED_FROM_SOURCE=1" <<<"$out"
+printf '%s' "$out" > "$tmp/missing-archive.out"
 check "a missing archive does not install rustup behind the user's back" \
-  bash -c '! grep -qi "installing via rustup" <<<"$0"' "$out"
+  lacks "installing via rustup" "$tmp/missing-archive.out"
 
 # ── 5. Verification runs the binary, and reports what it saw ────────────────
 check "the installer runs the binary it installed" grep -q 'verify_install' "$script"

--- a/scripts/ci/test-install-script.sh
+++ b/scripts/ci/test-install-script.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Tests for scripts/install.sh — the file every `curl … | sh` executes.
+#
+# They are fast and touch the network only to prove a missing archive 404s, so
+# they can run on every PR. They cover
+# the three ways the installer failed a user in August 2026:
+#   1. it resolved "latest" to a release that carries no CLI archive,
+#   2. it treated a missing archive as consent to install a Rust toolchain,
+#   3. it reported success for a binary that could not start.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/install.sh"
+failures=0
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+check() {
+  local description=$1
+  shift
+  if "$@"; then
+    printf 'ok   %s\n' "$description"
+  else
+    printf 'FAIL %s\n' "$description" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# ── 1. Syntax, in the shells the published command can land in ────────────────
+check "parses as POSIX sh" sh -n "$script"
+if command -v dash >/dev/null 2>&1; then
+  check "parses as dash" dash -n "$script"
+fi
+if command -v bash >/dev/null 2>&1; then
+  check "parses as bash" bash -n "$script"
+fi
+
+# ── 2. "latest" means the newest CLI release, not the newest release ──────────
+# This fixture is the shape that broke it: an asset-only demo-firmware release
+# published after the last CLI release, so it sorts first in the API response.
+cat > "$tmp/releases.json" <<'JSON'
+[
+  { "tag_name": "firmware-demos-v3", "prerelease": false },
+  { "tag_name": "firmware-demos-v2", "prerelease": false },
+  { "tag_name": "v0.21.0", "prerelease": false },
+  { "tag_name": "v0.20.0", "prerelease": false }
+]
+JSON
+
+selector() {
+  # Kept character-identical to resolve_version() in install.sh.
+  sed -n 's/.*"tag_name": *"\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' | head -1
+}
+
+selected="$(selector < "$tmp/releases.json")"
+check "picks v0.21.0 over a newer firmware-demos release (got '$selected')" \
+  test "$selected" = "v0.21.0"
+
+check "the selector in install.sh is the one under test here" \
+  grep -Fq 's/.*"tag_name": *"\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' "$script"
+
+no_release="$(printf '[{"tag_name":"firmware-demos-v3"}]' | selector || true)"
+check "an API response with no CLI release selects nothing (got '$no_release')" \
+  test -z "$no_release"
+
+# ── 3. A non-release tag is refused before any network call ──────────────────
+set +e
+out="$(LABWIRED_VERSION=firmware-demos-v3 LABWIRED_TELEMETRY=0 LABWIRED_NO_MODIFY_PATH=1 \
+        LABWIRED_INSTALL_DIR="$tmp/bin" sh "$script" 2>&1)"
+code=$?
+set -e
+check "a non-release version pin exits non-zero" test "$code" -ne 0
+check "a non-release version pin says what a valid pin looks like" \
+  grep -q "must be a release tag" <<<"$out"
+
+# ── 4. A missing archive never installs a toolchain on its own ───────────────
+set +e
+out="$(LABWIRED_VERSION=v0.0.0 LABWIRED_TELEMETRY=0 LABWIRED_NO_MODIFY_PATH=1 \
+        LABWIRED_INSTALL_DIR="$tmp/bin" sh "$script" 2>&1)"
+code=$?
+set -e
+check "a missing archive exits non-zero" test "$code" -ne 0
+check "a missing archive asks before building from source" \
+  grep -q "LABWIRED_FROM_SOURCE=1" <<<"$out"
+check "a missing archive does not install rustup behind the user's back" \
+  bash -c '! grep -qi "installing via rustup" <<<"$0"' "$out"
+
+# ── 5. Verification runs the binary, and reports what it saw ────────────────
+check "the installer runs the binary it installed" grep -q 'verify_install' "$script"
+check "a binary that cannot start is a failed install" \
+  grep -q 'die glibc_missing' "$script"
+
+if [ "$failures" -ne 0 ]; then
+  printf '\ninstall.sh contract failed with %d issue(s).\n' "$failures" >&2
+  exit 1
+fi
+printf '\ninstall.sh contract passed.\n'

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -145,17 +145,30 @@ for platform in linux-x86_64 linux-aarch64 darwin-x86_64 darwin-aarch64; do
   require_literal "$workflow" "platform: $platform" "archive matrix includes $platform"
 done
 require_literal "$workflow" 'ARCHIVE="labwired-${VERSION}-${PLATFORM}.tar.gz"' 'archive names include the release version and platform'
-require_literal "$workflow" 'cp "target/${{ matrix.target }}/release/labwired" dist/labwired' 'archive package copies the labwired binary'
+require_literal "$workflow" 'cp "target/${{ matrix.target }}/release/labwired${EXE}" "dist/labwired${EXE}"' 'archive package copies the labwired binary'
 # The DAP is the binary VS Code spawns for F5. It was absent from every release
 # through v0.19.2, which made editor debugging work only on machines that had
 # built core from source. Pin it so it cannot be dropped again unnoticed.
 require_literal "$workflow" 'cargo build -p labwired-cli -p labwired-dap --release --target ${{ matrix.target }}' 'release builds both the CLI and the debug adapter'
-require_literal "$workflow" 'cp "target/${{ matrix.target }}/release/labwired-dap" dist/labwired-dap' 'archive package copies the labwired-dap binary'
-require_literal "$workflow" 'tar -czf "${ARCHIVE}" -C dist labwired labwired-dap' 'archive package contains both the CLI and the debug adapter'
+require_literal "$workflow" 'cp "target/${{ matrix.target }}/release/labwired-dap${EXE}" "dist/labwired-dap${EXE}"' 'archive package copies the labwired-dap binary'
+require_literal "$workflow" 'tar -czf "${ARCHIVE}" -C dist "labwired${EXE}" "labwired-dap${EXE}"' 'archive package contains both the CLI and the debug adapter'
 require_literal "$workflow" 'name: labwired-${{ matrix.platform }}' 'archive artifact names follow the platform matrix'
 
+# The two guards that would have caught the v0.21.0 Linux archives, which
+# installed fine and then died with `GLIBC_2.39 not found` on Debian 12 and
+# Ubuntu 22.04. Both are pinned here because a build-host bump is exactly the
+# kind of change that quietly removes them.
+require_literal "$workflow" 'container: rust:1.95-bullseye' 'Linux archives are built against an old glibc, not the runner default'
+require_literal "$workflow" 'glibc_max: GLIBC_2.31' 'the Linux glibc floor is declared'
+require_literal "$workflow" 'name: Assert glibc floor' 'the declared glibc floor is asserted on the built binary'
+smoke_block=$(job_block linux-smoke)
+require_block_literal "$smoke_block" "image: 'debian:12-slim'" 'archives are started on Debian 12 before release'
+require_block_literal "$smoke_block" "image: 'ubuntu:22.04'" 'archives are started on Ubuntu 22.04 LTS before release'
+
 release_block=$(job_block release)
-require_block_literal "$release_block" 'needs: build' 'release waits for all archive builds'
+# The release job must wait for the archives AND for the smoke run that proves
+# they start on an older distribution than the build host.
+require_block_literal "$release_block" 'needs: [build, linux-smoke]' 'release waits for all archive builds and the old-distro smoke'
 require_block_literal "$release_block" 'softprops/action-gh-release@v2' 'release creates the GitHub release with action-gh-release'
 require_block_literal "$release_block" 'files: dist/*.tar.gz' 'release uploads every generated archive asset'
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@
 #   LABWIRED_INSTALL_DIR=~/.local/bin - install directory
 #   LABWIRED_NO_MODIFY_PATH=1        - skip adding to PATH in shell rc
 #   LABWIRED_FROM_SOURCE=1           - skip prebuilt, always build from source
+#   LABWIRED_TELEMETRY=0             - do not report install failures (DO_NOT_TRACK also honoured)
 #
 # MIT License - Copyright (C) 2026 LabWired
 
@@ -18,6 +19,10 @@ DAP_BINARY_NAME="labwired-dap"
 INSTALL_DIR="${LABWIRED_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${LABWIRED_VERSION:-latest}"
 FROM_SOURCE="${LABWIRED_FROM_SOURCE:-0}"
+TELEMETRY_URL="${LABWIRED_TELEMETRY_URL:-https://api.labwired.com/v1/telemetry/failure}"
+PLATFORM=""
+HOST_CLASS=""
+STAGE="start"
 
 # ── Colours ────────────────────────────────────────────────────────────────────
 red=""
@@ -38,7 +43,39 @@ fi
 info()  { printf '%s  %s%s\n' "${cyn}→${rst}" "$*" "${rst}"; }
 ok()    { printf '%s  %s%s\n' "${grn}✓${rst}" "$*" "${rst}"; }
 warn()  { printf '%s  %s%s\n' "${ylw}!${rst}" "$*" "${rst}"; }
-die()   { printf '%s  %s%s\n' "${red}✗${rst}" "$*" "${rst}" >&2; exit 1; }
+
+# ── Failure reporting ──────────────────────────────────────────────────────────
+# Every exit path reports one enumerated field set — no paths, no user data, no
+# free text. This is the only signal we have that an install broke on a machine
+# we do not own: the 2026-08 outage (a `latest` tag with no CLI archive, and a
+# Linux binary that needed a newer glibc than the distro shipped) was invisible
+# for two weeks because a failing install told nobody. `$1` is the event, `$2`
+# the enumerated class. Never blocks the install: 2 s budget, failures ignored.
+beacon() {
+  if [ "${LABWIRED_TELEMETRY:-1}" = "0" ] || [ -n "${DO_NOT_TRACK:-}" ]; then
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    return 0
+  fi
+  curl -fsS -m 2 -X POST "$TELEMETRY_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"surface\":\"installer\",\"event\":\"$1\",\"stage\":\"${STAGE}\",\
+\"error_class\":\"$2\",\"platform\":\"${PLATFORM:-unknown}\",\
+\"release\":\"${VERSION:-unknown}\",\"host_class\":\"${HOST_CLASS:-unknown}\",\
+\"channel\":\"install.sh\"}" >/dev/null 2>&1 || true
+  return 0
+}
+
+# `die <error_class> <message>` — the class is enumerated and reported, the
+# message is for the human in front of the terminal only.
+die() {
+  _class="$1"
+  shift
+  beacon install_fail "$_class"
+  printf '%s  %s%s\n' "${red}✗${rst}" "$*" "${rst}" >&2
+  exit 1
+}
 # ── Banner ─────────────────────────────────────────────────────────────────────
 print_banner() {
   _c="${cyn}"
@@ -83,10 +120,20 @@ detect_platform() {
   else
     PLATFORM=""
   fi
+
+  # The host's C library / OS version. This is the field that names a
+  # "binary installed but will not start" failure without a bug report.
+  if [ "$_os_tag" = "linux" ]; then
+    HOST_CLASS="glibc-$(ldd --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+$' || echo unknown)"
+  elif [ "$_os_tag" = "darwin" ]; then
+    HOST_CLASS="macos-$(sw_vers -productVersion 2>/dev/null | cut -d. -f1 || echo unknown)"
+  else
+    HOST_CLASS="unknown"
+  fi
 }
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
-need_cmd() { command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1 — please install it and retry."; }
+need_cmd() { command -v "$1" >/dev/null 2>&1 || die missing_command "Required command not found: $1 — please install it and retry."; }
 
 check_downloader() {
   if command -v curl >/dev/null 2>&1; then
@@ -94,7 +141,7 @@ check_downloader() {
   elif command -v wget >/dev/null 2>&1; then
     DOWNLOADER="wget"
   else
-    die "Neither curl nor wget found. Please install one and retry."
+    die no_downloader "Neither curl nor wget found. Please install one and retry."
   fi
 }
 
@@ -117,16 +164,34 @@ download_stdout() {
   fi
 }
 
+# Resolve "latest" to the newest CLI release — and ONLY to a CLI release.
+#
+# `/releases/latest` returns the newest non-prerelease of ANY kind. This repo
+# also publishes asset-only releases (`firmware-demos-vN`, playground demo
+# ELFs), and on 2026-08-01 one of those became "latest": every unpinned
+# `curl … | sh` then asked for labwired-firmware-demos-v3-<platform>.tar.gz,
+# got a 404, and silently escalated to a from-source build. So filter the
+# release list to vMAJOR.MINOR.PATCH here rather than trusting the endpoint —
+# the same guard `.github/actions/labwired-test/action.yml` already applies to
+# its `version` input.
 resolve_version() {
   if [ "$VERSION" = "latest" ]; then
+    STAGE="resolve"
     info "Resolving latest version..."
-    _api="https://api.github.com/repos/${REPO}/releases/latest"
+    _api="https://api.github.com/repos/${REPO}/releases?per_page=50"
     _json="$(download_stdout "$_api" 2>/dev/null)" || true
-    VERSION="$(printf '%s' "$_json" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+    VERSION="$(printf '%s' "$_json" \
+      | sed -n 's/.*"tag_name": *"\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' \
+      | head -1)"
     if [ -z "$VERSION" ]; then
-      warn "Could not resolve latest version from GitHub API — will build from source."
-      VERSION=""
+      die no_cli_release "Could not resolve a CLI release (vMAJOR.MINOR.PATCH) from the GitHub API.
+     Pin one instead:  curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh"
     fi
+  else
+    case "$VERSION" in
+      v[0-9]*.[0-9]*.[0-9]*) : ;;
+      *) die bad_version_pin "LABWIRED_VERSION must be a release tag like v0.21.0, got: ${VERSION}" ;;
+    esac
   fi
 }
 
@@ -137,6 +202,7 @@ install_prebuilt() {
   _archive="${BINARY_NAME}-${_version}-${_platform}.tar.gz"
   _url="https://github.com/${REPO}/releases/download/${_version}/${_archive}"
 
+  STAGE="download"
   info "Downloading prebuilt binary: ${_archive}"
 
   _tmpdir="$(mktemp -d)"
@@ -147,6 +213,7 @@ install_prebuilt() {
     return 1
   fi
 
+  STAGE="extract"
   tar -xzf "$_archive_path" -C "$_tmpdir"
   rm "$_archive_path"
 
@@ -210,6 +277,7 @@ install_from_source() {
     _version_arg="--tag ${VERSION}"
   fi
 
+  STAGE="build"
   ensure_rust
   info "Building labwired from source (this takes a few minutes)..."
 
@@ -224,6 +292,34 @@ install_from_source() {
   INSTALL_DIR="${INSTALL_DIR%/bin}/.cargo/bin"
   [ -d "$INSTALL_DIR" ] || INSTALL_DIR="${HOME}/.cargo/bin"
   ok "Built and installed ${BINARY_NAME} → ${INSTALL_DIR}/${BINARY_NAME}"
+}
+
+# ── Post-install verification ──────────────────────────────────────────────────
+# An installed file is not an installed program. The v0.21.0 Linux archives were
+# built on a runner whose glibc was newer than the distros we tell people to use,
+# so the copy succeeded, the installer printed "Installation complete!", exited
+# 0, and the binary then died with `GLIBC_2.39 not found` the first time anyone
+# ran it. Run it here, while we still hold the context to explain what happened.
+verify_install() {
+  STAGE="verify"
+  _bin="${INSTALL_DIR}/${BINARY_NAME}"
+  [ -x "$_bin" ] || die missing_binary "Install finished but ${_bin} is not there."
+
+  if _out="$("$_bin" --version 2>&1)"; then
+    ok "Verified: ${_out}"
+    return 0
+  fi
+
+  case "$_out" in
+    *GLIBC*|*"libc.so"*|*"not found"*)
+      die glibc_missing "The installed binary cannot start on this system:
+       ${_out}
+     This build needs a newer C library than this distribution provides.
+     Please report it with your distro version: https://github.com/${REPO}/issues" ;;
+    *)
+      die binary_wont_run "The installed binary cannot start on this system:
+       ${_out}" ;;
+  esac
 }
 
 # ── PATH setup ─────────────────────────────────────────────────────────────────
@@ -263,20 +359,27 @@ main() {
 
     # Try prebuilt first
     _prebuilt_ok=0
-    if [ -n "$PLATFORM" ] && [ -n "$VERSION" ]; then
+    if [ -n "$PLATFORM" ]; then
       install_prebuilt "$PLATFORM" "$VERSION" && _prebuilt_ok=1 || true
     fi
 
+    # A missing archive used to fall through to `install_from_source`, which
+    # downloads a whole Rust toolchain and compiles the engine — minutes of
+    # work, gigabytes of disk, and none of it asked for. Building from source
+    # is a fine answer, but it is the user's answer to give.
     if [ "$_prebuilt_ok" = "0" ]; then
       if [ -z "$PLATFORM" ]; then
-        warn "Unsupported platform ($(uname -s)/$(uname -m)) — falling back to source build."
-      else
-        warn "No prebuilt binary available for ${PLATFORM} ${VERSION} — falling back to source build."
+        die unsupported_platform "No prebuilt binary for $(uname -s)/$(uname -m).
+     Build it yourself (installs Rust, takes a few minutes):
+       curl -fsSL https://labwired.com/install.sh | LABWIRED_FROM_SOURCE=1 sh"
       fi
-      install_from_source
+      die asset_404 "No prebuilt binary for ${PLATFORM} at ${VERSION}.
+     Pick another release:  https://github.com/${REPO}/releases
+     Or build from source:  curl -fsSL https://labwired.com/install.sh | LABWIRED_FROM_SOURCE=1 sh"
     fi
   fi
 
+  verify_install
   add_to_path
 
   printf '\n'


### PR DESCRIPTION
Every line below was reproduced by running the published instructions in clean rooms on macOS arm64, Debian 12 (arm64 and amd64), Ubuntu 24.04 amd64, and the amd64 runner image.

## What was broken

| | Defect | Reproduced |
|---|---|---|
| 1 | `curl -fsSL https://labwired.com/install.sh \| sh` resolved `latest` to **`firmware-demos-v3`** — an asset-only demo release with no CLI archive — 404'd, and silently escalated to downloading a Rust toolchain and building from source | macOS arm64, Linux arm64, Linux x86_64 |
| 2 | Both Linux archives require **`GLIBC_2.39`** (CLI and DAP). They cannot start on Ubuntu 22.04 LTS, Debian 12 (so Raspberry Pi OS), RHEL 9 or Amazon Linux 2023 | Debian 12, both arches |
| 3 | An install that produced an unusable binary printed `Installation complete!` and exited 0 | Debian 12 |

Neither 1 nor 2 could go red in CI: `release-smoke` and the composite action both run on `ubuntu-latest`, which is 24.04, and no job ever ran the unpinned install line.

Defect 1 is already mitigated in production — `firmware-demos-v2/v3` are now marked prerelease, so `/releases/latest` returns `v0.21.0` again and the documented one-liner installs. This PR is the durable fix: the installer no longer trusts that endpoint.

## What changed

**`scripts/install.sh`** — filter the release list to `vMAJOR.MINOR.PATCH`; refuse a non-release pin before any network call; never install a toolchain to work around a missing archive (`LABWIRED_FROM_SOURCE=1` is the user's to give); run the binary before claiming success and name the reason when it cannot start; report failures as enumerated fields (`surface`, `stage`, `platform`, `host_class`, `release`, `error_class`) with no paths and no free text, off with `LABWIRED_TELEMETRY=0` or `DO_NOT_TRACK`.

**`core-release.yml`** — build the Linux targets in `rust:1.95-bullseye`, natively on x86_64 and arm64 runners, so the glibc floor is a decision (2.31) rather than whatever the runner image last became; assert it with `readelf`; start the archive in `debian:12`, `ubuntu:22.04` and `almalinux:9` before the release job may publish; build `x86_64-pc-windows-msvc`; strip the shipped binaries; `workflow_dispatch` to dry-run the build legs without tagging.

**Gates** — `scripts/ci/test-install-script.sh` (13 checks, wired into core-ci), new pins in the release contract for the container, the floor, the assert and the smoke images, and `install-canary.yml`, which every 6 hours runs the **live** published instructions on macOS 13/14, Ubuntu 22.04/24.04 on both architectures, Debian 12, AlmaLinux 9, four shells, both PowerShells, npx, `npm -g` and both container architectures — asserting the README quickstart still prints the four lines it promises.

## Windows

Nothing blocked it. The CLI and the DAP have no unix-only code outside test modules, so this adds the target to the matrix. The claim in the README stays as it is until an archive actually exists — the first tagged release after this merge produces one.

## Expected canary state on merge

The canary is red until its siblings land, and that is the point:
- old-distro legs stay red until the first release built by this workflow;
- `mcp.sh` shell legs and the Windows legs stay red until the landing-repo fix (bash-only `[[` under `sh`, and the Codex OAuth hang);
- the arm64 container leg stays red until the runner image is published for `linux/arm64`.

## Verification

- `bash scripts/ci/test-install-script.sh` — 13/13
- `bash scripts/ci/verify-release-runner-contract.sh` — passes
- Patched installer, macOS arm64 clean room: unpinned install → `✓ Verified: labwired-cli 0.21.0`
- Patched installer, Debian 12 arm64: exits 1 with `The installed binary cannot start on this system: … GLIBC_2.39 not found` instead of reporting success
- `LABWIRED_VERSION=firmware-demos-v3` → exits 1, tells the user what a valid pin looks like
- `shellcheck -s sh scripts/install.sh` — clean (one pre-existing SC1091 info)

Please run the workflow once on this branch (`Release` → Run workflow) before merging, so the new Linux containers, the arm64 runner and the Windows target are proven to build.