### PR TITLE
fix(cli): a run that ends on a fault exits 3, not 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`labwired run` exits 3 when the run ends on a simulation fault.** It used to
+  print `simulation error: Memory access violation at 0x…` and exit **0**, so
+  `labwired run … && echo ok` printed `ok` for firmware that died on its second
+  instruction, and any harness judging by exit status read a fault as a pass.
+  Xtensa already exited non-zero on the same class of failure; ARM is now
+  consistent with it, in both the default and `--batched` loops. `--allow-sim-error`
+  restores the old behaviour for callers that own the verdict and read it from
+  the output — the TIER1 matrix takes the protocol lines on stdout as the result
+  and ignores the exit code either way.
+
 ### Added
 - **`labwired run --batched`** drives ARM through
   `Machine::advance(AdvanceRequest::run(..))` — the call the browser makes from

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1380,15 +1380,26 @@ pub(crate) fn run_firmware_arm(
     // Splitting them puts each loop back in a frame whose codegen does not
     // depend on the other's existence, which is what "the default path is
     // unaffected" has to mean for a gate that measures instructions.
-    if args.batched {
-        run_arm_batched_loop(&mut machine, limit);
+    let faulted = if args.batched {
+        run_arm_batched_loop(&mut machine, limit)
     } else {
-        run_arm_step_loop(&mut machine, limit);
-    }
+        run_arm_step_loop(&mut machine, limit)
+    };
 
     // Flush stdout.
     let _ = std::io::stdout().flush();
     export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
+
+    // A run that ended on a fault reports a fault. It used to print the error
+    // and exit 0, so `labwired run … && echo ok` printed ok for firmware that
+    // died on its second instruction, and any CI judging by exit status read a
+    // memory access violation as a pass. Xtensa already exited non-zero here;
+    // ARM is now consistent with it. `--allow-sim-error` restores the old
+    // behaviour for callers that own the verdict themselves — the TIER1 matrix
+    // reads protocol lines from stdout and ignores the exit code either way.
+    if faulted && !args.allow_sim_error {
+        return ExitCode::from(EXIT_RUNTIME_ERROR);
+    }
     ExitCode::from(EXIT_PASS)
 }
 
@@ -1397,7 +1408,7 @@ pub(crate) fn run_firmware_arm(
 fn run_arm_step_loop(
     machine: &mut labwired_core::Machine<labwired_core::cpu::CortexM>,
     limit: u64,
-) {
+) -> bool {
     let dbg_trace: u64 = std::env::var("LABWIRED_ARM_TRACE")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -1420,11 +1431,15 @@ fn run_arm_step_loop(
             }
             Err(e) => {
                 eprintln!("labwired run (arm): simulation error: {e}");
-                // Non-fatal for TIER1: the protocol may already be complete.
-                break;
+                // The caller decides what this means. It ends the run either
+                // way; whether it ends the PROCESS with a failure is up to
+                // `--allow-sim-error`, because a TIER1 protocol may already
+                // have printed its verdict before the fault.
+                return true;
             }
         }
     }
+    false
 }
 
 /// One line of proof that the batched path ran, and how wide its batches were.
@@ -1476,8 +1491,10 @@ fn print_batched_summary(profile: labwired_core::StepProfile, tick_interval: u32
 fn run_arm_batched_loop(
     machine: &mut labwired_core::Machine<labwired_core::cpu::CortexM>,
     limit: u64,
-) {
+) -> bool {
     use labwired_core::{AdvanceRequest, AdvanceStop};
+
+    let mut faulted = false;
 
     let interval = machine.bus.max_safe_tick_interval();
     machine.config.peripheral_tick_interval = interval;
@@ -1495,10 +1512,9 @@ fn run_arm_batched_loop(
         let stop = match machine.advance(AdvanceRequest::run(Some(fuel))) {
             Ok(report) => Some(report.stop),
             Err(e) => {
-                // Same contract as the single-step loop above: a simulation
-                // error ends the run without failing it, because the TIER1
-                // protocol may already be complete.
+                // Same contract as the single-step loop above.
                 eprintln!("labwired run (arm, batched): simulation error: {e}");
+                faulted = true;
                 None
             }
         };
@@ -1514,6 +1530,7 @@ fn run_arm_batched_loop(
     }
 
     print_batched_summary(machine.step_profile(), interval);
+    faulted
 }
 
 pub(crate) fn run_interactive_arm(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -353,6 +353,15 @@ pub struct RunArgs {
     #[arg(long)]
     pub max_steps: Option<u64>,
 
+    /// Exit 0 even when the run ends on a simulation fault.
+    ///
+    /// A fault normally exits 3, the same as every other runtime error. Use
+    /// this when the caller owns the verdict and reads it from the output —
+    /// the TIER1 matrix, for instance, treats the protocol lines on stdout as
+    /// the result and a late fault as noise.
+    #[arg(long)]
+    pub allow_sim_error: bool,
+
     /// Optional path to write a JSON-line GPIO transition trace.
     /// Each line is `{"sim_cycle":N, "pin":P, "from":B, "to":B}`.
     #[arg(long)]

--- a/crates/cli/tests/run_exit_code.rs
+++ b/crates/cli/tests/run_exit_code.rs
@@ -1,0 +1,115 @@
+//! `labwired run` reports a fault in its exit status.
+//!
+//! It used to print
+//!
+//! ```text
+//! labwired run (arm): simulation error: Memory access violation at 0x8000400
+//! ```
+//!
+//! and exit 0, so `labwired run … && echo ok` printed `ok` for firmware that
+//! died on its second instruction, and any harness judging by exit status read
+//! a memory access violation as a pass. Xtensa already exited non-zero on the
+//! same class of failure; ARM did not.
+//!
+//! The escape hatch stays, because one caller genuinely owns the verdict: the
+//! TIER1 matrix reads protocol lines from stdout and a late fault is noise to
+//! it. That is what `--allow-sim-error` is for — an explicit opt-in, rather
+//! than the default that hid every other caller's failures.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Exit 3 — `EXIT_RUNTIME_ERROR`, shared with every other runtime failure.
+const EXIT_RUNTIME_ERROR: i32 = 3;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn labwired_bin() -> PathBuf {
+    // The integration-test binary sits next to the CLI it tests.
+    let mut path = std::env::current_exe().expect("test binary path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.join("labwired")
+}
+
+/// An ARM chip and an ELF built for something else: it loads, then faults.
+fn faulting_run(extra: &[&str]) -> std::process::Output {
+    let root = workspace_root();
+    let mut cmd = Command::new(labwired_bin());
+    cmd.arg("run")
+        .arg("--chip")
+        .arg(root.join("configs/chips/nrf52832.yaml"))
+        .arg("--firmware")
+        .arg(root.join("crates/core/tests/fixtures/esp32_brom.elf"))
+        .arg("--max-steps")
+        .arg("100000");
+    for arg in extra {
+        cmd.arg(arg);
+    }
+    cmd.output().expect("spawn labwired")
+}
+
+#[test]
+fn a_run_that_ends_on_a_fault_exits_non_zero() {
+    let out = faulting_run(&[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("simulation error"),
+        "expected the fault to be reported on stderr, got: {stderr}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_RUNTIME_ERROR),
+        "a fault must not report success; stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn the_batched_loop_reports_a_fault_the_same_way() {
+    let out = faulting_run(&["--batched"]);
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_RUNTIME_ERROR),
+        "--batched must not have a different verdict from the default loop"
+    );
+}
+
+#[test]
+fn allow_sim_error_restores_exit_zero_for_callers_that_own_the_verdict() {
+    let out = faulting_run(&["--allow-sim-error"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("simulation error"),
+        "the fault is still reported, only the exit status changes: {stderr}"
+    );
+    assert_eq!(out.status.code(), Some(0), "explicit opt-in must exit 0");
+}
+
+#[test]
+fn a_clean_run_still_exits_zero() {
+    let root = workspace_root();
+    let out = Command::new(labwired_bin())
+        .arg("run")
+        .arg("--chip")
+        .arg(root.join("configs/chips/nrf54l15.yaml"))
+        .arg("--firmware")
+        .arg(root.join("tests/fixtures/nrf54l15-smoke.elf"))
+        .arg("--max-steps")
+        .arg("2000000")
+        .output()
+        .expect("spawn labwired");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a run with no fault must stay a pass; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
```
$ labwired run --chip configs/chips/nrf52832.yaml --firmware blinky.elf
…
labwired run (arm): simulation error: Memory access violation at 0x8000400
$ echo $?
0
```

So `labwired run … && echo ok` printed `ok` for firmware that died on its second instruction, and any harness judging by exit status read a memory access violation as a pass. Found while building the documented-chips gate: pairing a chip with firmware built for a different part produced no output, a core `ERROR` line, and a clean exit — indistinguishable from success.

It is the same shape as the installer that printed `Installation complete!` and exited 0 with a binary that could not start: the failure is on the screen and absent from the one signal automation reads.

**Xtensa already did the right thing** — `run_firmware_esp32` returns `EXIT_RUNTIME_ERROR` for exactly this class. ARM is now consistent with it, in the default loop and under `--batched`.

## The escape hatch is now explicit

`--allow-sim-error` keeps exit 0 for a caller that owns the verdict itself. That is the TIER1 matrix: it reads protocol lines from stdout and treats a late fault as noise. It already tolerates a non-zero exit — its guard errors only when there is no TIER1 output **and** no `done` **and** a failed exit, which is the crash its own comment says must not become a row of Blocked cells. So nothing in this repo needs the flag today; making the opt-in explicit stops every other caller from being opted in silently.

`scripts/arduino-conformance-sweep.sh` pipes the run into `grep`, so it reads grep's status, not the sim's — unaffected.

## Verification

`crates/cli/tests/run_exit_code.rs`, 4/4:

| case | exit |
|---|---|
| fault, default loop | 3 |
| fault, `--batched` | 3 |
| fault, `--allow-sim-error` | 0, fault still printed |
| clean run | 0 |

Existing `arm_batched_path` tests 3/3 green, `cargo fmt` and `clippy -p labwired-cli` clean.

Follows w1ne/labwired-core#964, which documents the old behaviour as the reason its chips gate judges output rather than exit status. Once this lands, that gate can also trust the exit code.