### PR TITLE
fix(release): publish the runner image for arm64 too, from the released binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,14 @@
 .git
 target
 out
-dist
 coverage
+
+# `dist/<arch>/labwired` IS the build context now: Dockerfile.ci copies the
+# binary out of the release archive instead of compiling one. Everything else
+# a local build drops in dist/ stays out.
+dist
+!dist/amd64/labwired
+!dist/arm64/labwired
 
 # Locally produced archives, logs, and OS metadata only enlarge the build context.
 *.tar.gz

--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -207,6 +207,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The two Linux archives this tag just published, unpacked into the
+      # per-architecture layout Dockerfile.ci copies from.
+      - name: Download the released Linux archives
+        uses: actions/download-artifact@v4
+        with:
+          pattern: labwired-linux-*
+          path: archives
+          merge-multiple: true
+
+      - name: Lay the binaries out by architecture
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/amd64 dist/arm64
+          tar -xzf archives/labwired-${{ github.ref_name }}-linux-x86_64.tar.gz -C dist/amd64
+          tar -xzf archives/labwired-${{ github.ref_name }}-linux-aarch64.tar.gz -C dist/arm64
+          test -x dist/amd64/labwired && test -x dist/arm64/labwired
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -223,7 +244,7 @@ jobs:
           context: .
           file: ./Dockerfile.ci
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/w1ne/labwired:${{ github.ref_name }}
             ghcr.io/w1ne/labwired:latest

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,24 +8,25 @@
 # only the labwired CLI, so `docker run ... image test --script ...` uses the
 # same command line as a native release archive.
 
-# Stage 1: Builder
-FROM rust:1.95-slim-bookworm AS builder
+# The image ships the RELEASED binary rather than a rebuild of it. It used to
+# compile the CLI from source in a builder stage, which meant the image and the
+# release archive of the same tag were two different builds of that commit —
+# and, because a Rust compile under emulation is unaffordable, it also meant the
+# image could only ever be published for one architecture. `docker pull` then
+# failed outright on Apple Silicon and on arm64 Linux:
+#
+#   no matching manifest for linux/arm64/v8 in the manifest list entries
+#
+# Copying the archive's own binary makes both architectures cheap (the only
+# emulated work is one `apt-get install ca-certificates`) and makes the image
+# and the archive the same bytes.
 
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-COPY . .
-
-RUN cargo build --release -p labwired-cli --locked
-
-# Stage 2: Runtime
 FROM debian:bookworm-slim
 
 ARG VERSION
 ARG REVISION
+# Set by buildx per platform: amd64 | arm64.
+ARG TARGETARCH
 
 LABEL org.opencontainers.image.source="https://github.com/w1ne/labwired-core" \
       org.opencontainers.image.version="${VERSION}" \
@@ -35,7 +36,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/target/release/labwired /usr/local/bin/labwired
+COPY dist/${TARGETARCH}/labwired /usr/local/bin/labwired
 
 WORKDIR /workspace
 RUN labwired --version

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -176,6 +176,10 @@ require_literal "$workflow" 'packages: write' 'release workflow grants GHCR pack
 require_literal "$workflow" 'docker/setup-buildx-action@v3' 'publish job configures Docker Buildx'
 require_literal "$workflow" 'docker/login-action@v3' 'publish job logs into GHCR'
 require_literal "$workflow" 'docker/build-push-action@v6' 'publish job pushes the runner image'
+# The image is published for both Linux architectures. Publishing amd64 only
+# made `docker pull` fail outright on Apple Silicon and arm64 Linux, which is
+# not a degraded experience — it is no experience.
+require_literal "$workflow" 'platforms: linux/amd64,linux/arm64' 'runner image is published for both Linux architectures'
 
 release_line=$(job_line release || true)
 publish_line=$(job_line publish || true)
@@ -246,9 +250,14 @@ require_block_literal "$smoke_block" 'output-dir: out/release-action-smoke-secon
 require_block_literal "$smoke_block" 'test -s out/release-action-smoke-second/result.json' 'release smoke asserts the second action result JSON exists and is nonempty'
 require_block_literal "$smoke_block" 'test -s out/release-action-smoke-second/junit.xml' 'release smoke asserts the second action writes JUnit in its output directory'
 
-require_literal "$dockerfile" 'FROM rust:1.95-slim-bookworm AS builder' 'runner image builds with Rust 1.95 on bookworm'
-require_literal "$dockerfile" 'FROM debian:bookworm-slim' 'runner image runtime matches the builder libc baseline'
-require_literal "$dockerfile" 'RUN cargo build --release -p labwired-cli --locked' 'runner image builds only the CLI'
+# The image no longer compiles the CLI: it copies the binary out of the release
+# archive this tag published, so the image and the archive are the same bytes
+# and both Linux architectures cost one emulated `apt-get` rather than one
+# emulated Rust build. These three lines are what makes that true.
+require_literal "$dockerfile" 'FROM debian:bookworm-slim' 'runner image runtime is the same base the archives target'
+require_literal "$dockerfile" 'ARG TARGETARCH' 'runner image picks its binary by build platform'
+require_literal "$dockerfile" 'COPY dist/${TARGETARCH}/labwired /usr/local/bin/labwired' 'runner image ships the released binary, not a rebuild of it'
+require_absent_literal "$dockerfile" 'cargo build' 'runner image must not rebuild the CLI — the archive is the artifact'
 require_literal "$dockerfile" 'ARG VERSION' 'runner image accepts a release version build argument'
 require_literal "$dockerfile" 'ARG REVISION' 'runner image accepts a source revision build argument'
 require_literal "$dockerfile" 'org.opencontainers.image.source="https://github.com/w1ne/labwired-core"' 'runner image declares its OCI source label'


### PR DESCRIPTION
```
$ docker pull ghcr.io/w1ne/labwired:latest
Error response from daemon: no matching manifest for linux/arm64/v8 in the
manifest list entries: no match for platform in manifest: not found
```

On Apple Silicon and on arm64 Linux the runner image does not fail gracefully — it does not exist. The publish job built `platforms: linux/amd64` only, and it could not reasonably do more: the image compiled the CLI from source in a builder stage, and a Rust build under QEMU is unaffordable in a release.

## The image stops rebuilding what the tag already published

`Dockerfile.ci` now copies `dist/${TARGETARCH}/labwired` out of the release archive, and the publish job unpacks the two Linux archives it just built into that layout. Consequences, both of them good:

- **Both architectures are cheap.** The only emulated work is one `apt-get install ca-certificates`, not a compile.
- **The image and the archive become the same bytes.** Until now `ghcr.io/w1ne/labwired:v0.21.0` and `labwired-v0.21.0-linux-x86_64.tar.gz` were two separate builds of one commit, and nothing compared them.

## Kept honest by

The release contract now requires the Dockerfile to declare `ARG TARGETARCH`, to copy the released binary, to contain **no** `cargo build`, and the workflow to publish `linux/amd64,linux/arm64`. `.dockerignore` keeps excluding `dist` except the two binaries the image needs.

## Verification

Built locally for arm64 from the `v0.0.0-dryrun` archive produced by the release dry-run:

```
$ docker run --rm lw-image-test --version
labwired-cli 0.21.0
$ docker run --rm -v "$PWD:/workspace" -w /workspace lw-image-test \
    test --script examples/nrf54l15-dk/io-smoke.yaml --output-dir out/smoke --no-uart-stdout
PASS  4/4 checks · io-smoke · 200000 steps · 0.06s
$ ls out/smoke
junit.xml  result.json  snapshot.json  uart.log
```

`verify-release-runner-contract.sh` and `actionlint` both pass.

Should land **before v0.22.0** is tagged, so the first release with a glibc floor and a Windows archive also gets an image that arm64 machines can pull. The `packages` leg of the install canary asserts both manifests exist and stays red until then.