### PR TITLE
feat(ci): build and publish the demo firmware a documented chip needs

### DIFF
--- a/.github/workflows/firmware-demos.yml
+++ b/.github/workflows/firmware-demos.yml
@@ -1,0 +1,94 @@
+# Build the demo firmware the documented chips are proven with, and publish it.
+#
+# scripts/ci/docs-runnable-chips.json pairs every chip we document with a
+# prebuilt ELF, so that running a supported chip needs an install and nothing
+# else — no Rust, no cross toolchain, no vendor SDK. Chips with no prebuilt
+# firmware are stuck in the `needs-build` bucket, which is a polite way of
+# saying the front page's claim does not hold for them.
+#
+# This is how an ELF gets into that release. It is dispatch-only and additive:
+# a new tag never replaces assets on an existing one, because demo-assets.json
+# in the playground pins tag AND sha256, and an asset that changes underneath a
+# pin is a silent lie rather than an update.
+name: Publish demo firmware
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create (must not already exist)"
+        required: true
+        default: "firmware-demos-v4"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust with the bare-metal targets
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: thumbv7em-none-eabihf,thumbv8m.main-none-eabi
+
+      # One line per chip that gains a runnable claim. Keep the ELF name in the
+      # `demo-` shape the other assets use, so the map reads the same either way.
+      - name: Build
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          cargo build -p firmware-nrf52832-demo --release --target thumbv7em-none-eabihf
+          cp target/thumbv7em-none-eabihf/release/firmware-nrf52832-demo out/demo-nrf52832-smoke.elf
+          cargo build -p firmware-rp2350-demo --release --target thumbv8m.main-none-eabi
+          cp target/thumbv8m.main-none-eabi/release/firmware-rp2350-demo out/demo-rp2350-smoke.elf
+
+      # An ELF that does not run on its own chip is not a demo. Prove it here,
+      # with the same released CLI a reader would install, before it is
+      # published — not after somebody reports it.
+      - name: Run each ELF on its chip with the released CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://labwired.com/install.sh | LABWIRED_NO_MODIFY_PATH=1 sh
+          CLI="$HOME/.local/bin/labwired"
+          fail=0
+          check() { # $1 chip, $2 elf, $3 expected marker ('' = must merely not fault)
+            "$CLI" run --chip "configs/chips/$1.yaml" --firmware "out/$2" --max-steps 3000000 > "out/$1.log" 2>&1 || true
+            if grep -qE "simulation error|ERROR .*labwired_core|^error:" "out/$1.log"; then
+              echo "::error::$2 faults on $1"; sed -n '1,5p' "out/$1.log"; fail=1; return
+            fi
+            if [ -n "$3" ] && ! grep -qF -- "$3" "out/$1.log"; then
+              echo "::error::$2 never printed '$3' on $1"; fail=1; return
+            fi
+            echo "ok  $1 <- $2"
+          }
+          check nrf52832 demo-nrf52832-smoke.elf NRF52832_SMOKE_OK
+          check rp2350   demo-rp2350-smoke.elf   ''
+          exit "$fail"
+
+      - name: Digests for the chip map
+        run: |
+          cd out && sha256sum ./*.elf | tee digests.txt
+          echo "Paste these into scripts/ci/docs-runnable-chips.json." >> "$GITHUB_STEP_SUMMARY"
+          sed 's/^/    /' digests.txt >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Refuse to overwrite an existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ inputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::${{ inputs.tag }} already exists. Demo assets are pinned by tag AND sha256; publish a new tag instead of replacing one."
+            exit 1
+          fi
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ inputs.tag }}" out/*.elf \
+            --title "Playground demo firmware — ${{ inputs.tag }}" \
+            --notes "Prebuilt demo firmware for the documented chips. Pinned by tag and sha256 from scripts/ci/docs-runnable-chips.json and packages/playground/demo-assets.json." \
+            --prerelease

--- a/scripts/ci/docs-runnable-chips.sh
+++ b/scripts/ci/docs-runnable-chips.sh
@@ -46,12 +46,13 @@ print(m['firmware_release'])
 for chip, e in m['chips'].items():
     print('\x1f'.join([
         chip, e.get('how',''), e.get('firmware',''), e.get('sha256',''),
-        e.get('script',''), e.get('expect') or '', e.get('why','')]))
+        e.get('script',''), e.get('expect') or '', e.get('why',''),
+        e.get('release', m['firmware_release'])]))
 "; }
 
 # bash 3.2 on macOS has no `mapfile`, and the canary runs this on macOS.
 read_map > "$work/map.tsv" || { echo "cannot read $MAP" >&2; exit 1; }
-release="$(head -1 "$work/map.tsv")"
+release_default="$(head -1 "$work/map.tsv")"
 tail -n +2 "$work/map.tsv" > "$work/entries.tsv"
 
 # ── The map has to cover the chips we ship ──────────────────────────────────
@@ -70,6 +71,10 @@ fi
 fetch_asset() {
   local name="$1"
   local want="$2"
+  # Per-chip release override: firmware for a chip that was added later lives
+  # on a later tag, and an existing tag is never re-uploaded — the playground
+  # pins these same assets by tag and digest.
+  local release="${3:-$release_default}"
   local dest="$work/$name"
   [ -f "$dest" ] && { printf '%s' "$dest"; return 0; }
   curl -fsSL --retry 3 -o "$dest" \
@@ -84,19 +89,20 @@ fetch_asset() {
 }
 
 # Judged on output, never on exit status alone.
-run_and_judge() { # $1 chip, $2 how, $3 firmware, $4 sha, $5 script, $6 expect → prints verdict
+run_and_judge() { # $1 chip, $2 how, $3 firmware, $4 sha, $5 script, $6 expect, $7 release → verdict
   local chip="$1"
   local how="$2"
   local fw="$3"
   local sha="$4"
   local script="$5"
   local expect="$6"
+  local release="${7:-$release_default}"
   local out=""
   local path=""
   if [ "$how" = example ]; then
     out="$("$CLI" test --script "$script" --output-dir "$work/out-$chip" 2>&1)"
   else
-    path="$(fetch_asset "$fw" "$sha")" || { echo "ASSET"; return; }
+    path="$(fetch_asset "$fw" "$sha" "$release")" || { echo "ASSET"; return; }
     out="$("$CLI" run --chip "configs/chips/${chip}.yaml" --firmware "$path" --max-steps 4000000 2>&1)"
   fi
   printf '%s' "$out" > "$work/log-$chip"
@@ -112,10 +118,10 @@ run_and_judge() { # $1 chip, $2 how, $3 firmware, $4 sha, $5 script, $6 expect �
 
 runnable=0; blocked=0; needs_build=0; failures=0
 printf '%-16s %-12s %s\n' CHIP HOW RESULT
-while IFS=$'\x1f' read -r chip how fw sha script expect why; do
+while IFS=$'\x1f' read -r chip how fw sha script expect why release; do
   case "$how" in
     asset|example)
-      verdict="$(run_and_judge "$chip" "$how" "$fw" "$sha" "$script" "$expect")"
+      verdict="$(run_and_judge "$chip" "$how" "$fw" "$sha" "$script" "$expect" "$release")"
       if [ "$verdict" = OK ]; then
         runnable=$((runnable + 1))
         printf '%-16s %-12s ok\n' "$chip" "$how"
@@ -128,7 +134,7 @@ while IFS=$'\x1f' read -r chip how fw sha script expect why; do
       ;;
     blocked)
       blocked=$((blocked + 1))
-      verdict="$(run_and_judge "$chip" asset "$fw" "$sha" "" "$expect")"
+      verdict="$(run_and_judge "$chip" asset "$fw" "$sha" "" "$expect" "$release")"
       if [ "$verdict" = OK ]; then
         failures=$((failures + 1))
         printf '%-16s %-12s FIXED — promote it\n' "$chip" "$how"


### PR DESCRIPTION
Eight documented chips are in the `needs-build` bucket of `scripts/ci/docs-runnable-chips.json`. Their firmware exists in this repo as a crate and is compiled in CI — it just never ships, so running those chips needs the cross toolchain the front page says you do not need.

This is the workflow that gets an ELF out of that state.

**It proves the artifact before publishing it.** Each ELF is run on its own chip descriptor with the **released** CLI, and the job fails if the run faults or never prints its marker. Publishing an unrun demo binary is how you end up with a documented chip that does not work.

**It refuses to publish over an existing tag.** `packages/playground/demo-assets.json` and the chips map both pin these assets by tag *and* sha256; an asset replaced under a live pin is a silent lie, not an update. The release is also marked prerelease, so a demo-firmware tag can never become `/releases/latest` again.

Starting with the two chips whose crates build clean and whose output I verified locally against v0.21.0:

| chip | crate | target | verdict |
|---|---|---|---|
| `nrf52832` | `firmware-nrf52832-demo` | `thumbv7em-none-eabihf` | prints `NRF52832_SMOKE_OK` |
| `rp2350` | `firmware-rp2350-demo` | `thumbv8m.main-none-eabi` | runs 3M steps, no fault |

The gate also learns a per-chip `release` override, so firmware added later lives on a later tag and no existing release has to be re-uploaded to keep one field in the map consistent.

## After this merges

Dispatch it to create `firmware-demos-v4`, then a follow-up moves `nrf52832` and `rp2350` from `needs-build` to `asset` with their digests: **16 → 18 of 26** chips runnable from a plain install. The remaining six need firmware that does not exist yet (`nrf5340` is a Zephyr build; `stm32f767`, `g474re`, `wb55`, `wba52` and `atmega328p` have no crate at all) — that is firmware to write, not a workflow to run, and the map says so per chip rather than in a footnote.