### PR TITLE
fix(install): resolve "latest" through the web redirect, not the API

### DIFF
--- a/scripts/ci/test-install-script.sh
+++ b/scripts/ci/test-install-script.sh
@@ -63,6 +63,16 @@ check "picks v0.21.0 over a newer firmware-demos release (got '$selected')" \
 check "the selector in install.sh is the one under test here" \
   grep -Fq 's/.*"tag_name": *"\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' "$script"
 
+# The API allows 60 unauthenticated requests an hour per address, so resolving
+# through it makes an install fail on a shared address for reasons that have
+# nothing to do with the machine. The install canary hit exactly that on its
+# first run: macOS and Ubuntu 22.04 legs died with "could not resolve a CLI
+# release" while the identical Ubuntu 24.04 leg installed fine.
+check "latest resolves through the un-rate-limited web redirect first" \
+  grep -Fq 'releases/latest' "$script"
+check "the redirect is read from the effective URL, not a parsed body" \
+  grep -Fq 'url_effective' "$script"
+
 no_release="$(printf '[{"tag_name":"firmware-demos-v3"}]' | selector || true)"
 check "an API response with no CLI release selects nothing (got '$no_release')" \
   test -z "$no_release"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,14 +178,39 @@ resolve_version() {
   if [ "$VERSION" = "latest" ]; then
     STAGE="resolve"
     info "Resolving latest version..."
-    _api="https://api.github.com/repos/${REPO}/releases?per_page=50"
-    _json="$(download_stdout "$_api" 2>/dev/null)" || true
-    VERSION="$(printf '%s' "$_json" \
-      | sed -n 's/.*"tag_name": *"\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' \
-      | head -1)"
-    if [ -z "$VERSION" ]; then
-      die no_cli_release "Could not resolve a CLI release (vMAJOR.MINOR.PATCH) from the GitHub API.
-     Pin one instead:  curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh"
+
+    # First choice is the web redirect, NOT the API. `github.com/<repo>/releases/latest`
+    # redirects to `/releases/tag/<tag>`, needs no token, and — unlike a bare
+    # API call — is not rate limited per IP. That matters more than it sounds:
+    # the API allows 60 unauthenticated requests an hour per address, so on a
+    # shared address (CI, an office, a container host) an install can fail for
+    # reasons that have nothing to do with this machine. The redirect also
+    # excludes prereleases, which is how demo-firmware tags stay out of it.
+    _tag=""
+    if [ "$DOWNLOADER" = "curl" ]; then
+      _tag="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+        "https://github.com/${REPO}/releases/latest" 2>/dev/null | sed 's#.*/tag/##')"
+    fi
+    case "$_tag" in
+      v[0-9]*.[0-9]*.[0-9]*) VERSION="$_tag" ;;
+      *) _tag="" ;;
+    esac
+
+    # Fall back to the release list, filtered to CLI releases. Reached when the
+    # redirect is unavailable (wget, a proxy that eats redirects) or points at
+    # something that is not a CLI release.
+    if [ -z "$_tag" ]; then
+      _api="https://api.github.com/repos/${REPO}/releases?per_page=50"
+      _json="$(download_stdout "$_api" 2>/dev/null)" || true
+      VERSION="$(printf '%s' "$_json" \
+        | sed -n 's/.*"tag_name": *"\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' \
+        | head -1)"
+    fi
+
+    if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
+      die no_cli_release "Could not resolve a CLI release (vMAJOR.MINOR.PATCH).
+     GitHub may be rate limiting this address. Pin a version instead:
+       curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh"
     fi
   else
     case "$VERSION" in


### PR DESCRIPTION
The install canary caught this on its first real run against main, which is the point of having it.

```
✗  Could not resolve a CLI release (vMAJOR.MINOR.PATCH) from the GitHub API.
```

macOS 14, macOS 15 and Ubuntu 22.04 legs all failed there. The identical Ubuntu 24.04 legs installed fine. Nothing was wrong with those machines: the unauthenticated GitHub API allows **60 requests an hour per address**, and several legs installing at once from shared runner addresses exhausts it. Any office, CI system or container host behind one NAT hits the same wall.

#964 is what made it visible — it turned "could not resolve" from a silent fallback into a hard failure. That was right; the resolution path just should not have depended on a rate-limited API in the first place.

## The fix

`github.com/<repo>/releases/latest` redirects to `/releases/tag/<tag>`. No token, no rate limit, and it **excludes prereleases** — exactly the filter we want now that demo-firmware tags are marked prerelease. The API list stays as the fallback, still filtered to `vMAJOR.MINOR.PATCH`, for `wget` and for proxies that eat redirects.

## Verification

```
$ curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/w1ne/labwired-core/releases/latest | sed 's#.*/tag/##'
v0.21.0
$ curl -fsSL … install.sh | sh
→  Resolving latest version...
✓  Verified: labwired-cli 0.21.0
```

The installer contract now pins both the redirect and that the tag is read from the effective URL rather than a parsed body.

Canary state from that same run, for the record: **all four `mcp.sh` shells green, both Windows PowerShells green** (the 5.1 merge no longer destroys a pre-existing MCP entry), Ubuntu 24.04 x86_64 and arm64 green. The Debian 12 / Ubuntu 22.04 / AlmaLinux 9 legs stay red until v0.22.0 ships the glibc floor, and the container leg until #967 publishes an arm64 image.