### PR TITLE
chore: bump version to 0.22.0

### DIFF
--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -10,13 +10,13 @@ intentionally documents the action beside its implementation rather than
 choosing its own source SHA: every immutable revision therefore carries its own
 matching input and report contract.
 
-The `version` input defaults to `v0.21.0` and independently selects the
+The `version` input defaults to `v0.22.0` and independently selects the
 immutable Core CLI release archive named
-`labwired-v0.21.0-<platform>.tar.gz`. The action downloads that public archive
+`labwired-v0.22.0-<platform>.tar.gz`. The action downloads that public archive
 from the `w1ne/labwired-core` GitHub release with `curl`; it does not build Core
 on the consumer runner.
 
-Its inputs are exactly `script` (required), `version` (default `v0.21.0`),
+Its inputs are exactly `script` (required), `version` (default `v0.22.0`),
 `output-dir`, and `args`. `args` is whitespace-separated extra CLI flags; shell
 quoting inside this input is not interpreted.
 

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: "Immutable LabWired Core release tag to install."
     required: false
-    default: "v0.21.0"
+    default: "v0.22.0"
   output-dir:
     description: "Directory for run artifacts (result.json, uart.log, junit.xml, and reports)."
     required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-14
+
+The install release. Everything below was found by running the instructions we
+publish, on the platforms we claim, rather than by reading them.
+
+### Fixed
+- **The documented one-liner installs a CLI again.** `curl … install.sh | sh`
+  resolved "latest" to `firmware-demos-v3` — an asset-only demo release with no
+  CLI archive — 404'd, and silently escalated to downloading a Rust toolchain
+  and building from source. Dead from 2026-08-01 to 2026-08-14 on every
+  platform.
+- **The Linux archives start on the distributions people run.** They were built
+  on `ubuntu-latest` and required `GLIBC_2.39`, so they could not start on
+  Ubuntu 22.04 LTS, Debian 12 (every Raspberry Pi OS), RHEL 9 or Amazon Linux
+  2023. They are now built against a 2.31 floor, asserted with `readelf`, and
+  started in `debian:12`, `ubuntu:22.04` and `almalinux:9` before the release
+  job may publish.
+- **An install that produced an unusable binary reported success.** The
+  installer now runs what it installed and names the reason when it cannot
+  start.
+- Four documented commands could not run as written, including
+  `labwired run --system …` — that flag has never existed on that subcommand.
+
+### Added
+- **Windows.** `x86_64-pc-windows-msvc` archives ship from this release.
+  Nothing had blocked it; no leg of the release had ever asked for it.
+- **The runner image is published for arm64 as well**, and now carries the
+  released binary instead of a separate rebuild of the same commit. `docker
+  pull` failed outright on Apple Silicon before this.
+- Install failures are reported (enumerated fields only, `LABWIRED_TELEMETRY=0`
+  or `DO_NOT_TRACK` to opt out), and an install canary runs the published
+  instructions every six hours across nine platform legs.
+
+### Changed
+- Shipped binaries are stripped: the Linux archives went from 65 MB to 12 MB.
+
 ### Added
 - **`labwired run --batched`** drives ARM through
   `Machine::advance(AdvanceRequest::run(..))` — the call the browser makes from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1116,56 +1116,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
 ]
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-nrf52840-obd2-scanner"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-perf-spin"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cortex-m-rt",
  "panic-halt",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-perf-spin-riscv"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
  "riscv-rt",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-uart-echo-fixture"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1910,7 +1910,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "human-size",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-egress-relay"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "labwired-core",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -2079,11 +2079,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.21.0"
+version = "0.22.0"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3643,7 +3643,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Clone the repository, install the CLI, run a firmware. No cross-toolchain needed
 
 ```sh
 git clone https://github.com/w1ne/labwired-core && cd labwired-core
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.0 sh
 labwired test --script examples/nrf54l15-dk/io-smoke.yaml
 ```
 
@@ -110,7 +110,7 @@ UART output and `--json` stay on stdout, so pipes keep working.
 The install script covers Linux, macOS, and Windows via WSL2.
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.0 sh
 ```
 
 | Variable | Effect |

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -64,7 +64,7 @@ Example JSON shape:
 2. **`labwired` CLI on `PATH`** for local runs:
 
 ```bash
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.21.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.0 sh
 labwired --help
 ```
 

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -276,7 +276,7 @@ if [[ -f "$dockerignore" ]]; then
   done
 fi
 
-require_literal "$action" 'default: "v0.21.0"' 'core action defaults to the supported public release'
+require_literal "$action" 'default: "v0.22.0"' 'core action defaults to the supported public release'
 action_inputs=$(awk '
   /^inputs:$/ { inside = 1; next }
   inside && /^[^[:space:]]/ { exit }
@@ -525,9 +525,9 @@ require_literal docs/configuration_reference.md 'including `{}` and `null`' 'con
 require_literal docs/configuration_reference.md 'stop_when_assertions_pass' 'configuration reference documents world assertion completion'
 require_literal examples/egress-demo/README.md 'config` is a closed mapping' 'egress example documents its closed config mapping'
 require_literal examples/egress-demo/README.md 'positive integer' 'egress example documents buffer_max type validation'
-require_literal Cargo.toml 'version = "0.21.0"' 'workspace metadata uses the current release version'
+require_literal Cargo.toml 'version = "0.22.0"' 'workspace metadata uses the current release version'
 require_literal CHANGELOG.md '## [0.21.0] - 2026-07-27' 'changelog records the current release version'
-require_literal README.md 'LABWIRED_VERSION=v0.21.0' 'public README pins the current release version'
+require_literal README.md 'LABWIRED_VERSION=v0.22.0' 'public README pins the current release version'
 require_absent_literal README.md 'LABWIRED_VERSION=v0.20.0' 'public README does not retain the superseded release version'
 
 if (( failures > 0 )); then


### PR DESCRIPTION
The install release.

`labwired --version` → `labwired-cli 0.22.0`, built and checked locally.

## What this release carries

- The documented one-liner installs a CLI again (it resolved to a demo-firmware release with no CLI archive, and had been dead since 2026-08-01).
- Linux archives start on the distributions people run — built against a **glibc 2.31** floor, asserted with `readelf`, and started in `debian:12`, `ubuntu:22.04` and `almalinux:9` before the release job may publish.
- An install that produces an unusable binary now fails instead of printing "Installation complete!".
- **Windows archives** (`x86_64-pc-windows-msvc`) for the first time.
- The runner image publishes for **arm64** too, carrying the released binary rather than a separate rebuild.
- Stripped binaries: Linux archives 65 MB → 12 MB.
- Four documented commands that could not run as written are corrected, and a gate asks the CLI itself whether the docs are accurate.

## Ritual

Two commits, the same as 0.21.0: this one bumps the workspace, the action default, the README/docs pins and the CHANGELOG. The **documented runner pins** (`safe_action_sha`, `safe_action_version`, the `version: v0.22.0` in the integration docs and templates) move in a follow-up, because they pin the bump commit by sha and that sha does not exist until this merges.

## Verification

- `verify-release-runner-contract.sh` — passes
- `test-install-script.sh` — 15/15
- `docs-commands-gate.py` — 24 documented commands, all valid
- `cargo build -p labwired-cli --release` → `labwired-cli 0.22.0`