### PR TITLE
chore(chips): promote esp32c3, and say what stm32l073 actually needs

### DIFF
--- a/scripts/ci/docs-runnable-chips.json
+++ b/scripts/ci/docs-runnable-chips.json
@@ -29,11 +29,11 @@
       "expect": "faithful ROM loaded"
     },
     "esp32c3": {
-      "how": "blocked",
+      "how": "asset",
       "firmware": "demo-esp32c3-blink.elf",
       "sha256": "aea04c8527eff25e8969b851dc9cc2436cf13e40c6019788741b7eecd5004789",
-      "expect": null,
-      "note": "v0.21.0 refuses the board: `UART type 'esp32c3_uart' has no register layout modelled yet`. Fixed on main; this entry flips to `asset` in the first release that carries the fix, and the gate fails if it starts passing while still marked blocked."
+      "expect": "C3 BLINKY BOOT",
+      "note": "Blocked until v0.22.0, which fixed `UART type esp32c3_uart has no register layout modelled yet`."
     },
     "nrf52840": {
       "how": "asset",
@@ -144,11 +144,8 @@
       "why": "no prebuilt demo firmware for this part yet"
     },
     "stm32l073": {
-      "how": "blocked",
-      "why": "the released CLI cannot read the shipped descriptor: `cannot parse chip YAML: peripherals[34].clock: invalid type: sequence`. configs/chips/stm32l073.yaml uses a schema newer than v0.21.0 \u2014 another face of the release lag. Re-check on the next release.",
-      "firmware": "demo-nucleo-f401.elf",
-      "sha256": "eee67caf8ded9f9385981ce43220b4d6677d1cd34c49f528f964b7462b558674",
-      "expect": null
+      "how": "needs-build",
+      "why": "v0.22.0 reads the descriptor (v0.21.0 could not parse it), but there is no published firmware for this part. firmware-l073-demo builds in this repo \u2014 publish it through the demo-firmware workflow and this becomes an `asset`."
     },
     "stm32wb55": {
       "how": "needs-build",


### PR DESCRIPTION
The chips gate did the thing it was built for. Run against the freshly released v0.22.0 it did not quietly stay green on a stale note — it **failed**:

```
esp32c3  blocked  FIXED — promote it
::error::esp32c3 is marked blocked but now runs. Move it to "how": "asset".
```

v0.22.0 carries the fix for `UART type 'esp32c3_uart' has no register layout modelled yet`, so the C3 boots its demo:

```
C3 BLINKY BOOT
LED ON
LED OFF
```

It is an `asset` entry now, asserted on that first line.

**stm32l073 changed reason, not state.** On v0.21.0 the CLI could not parse the descriptor we ship for it (`peripherals[34].clock: invalid type: sequence`). v0.22.0 reads it fine and the run faults instead — the firmware it was paired with is built for Cortex-M4 and this part is M0+. So it is not blocked by the CLI, it needs firmware: `firmware-l073-demo` builds in this repo and only needs publishing through the demo-firmware workflow (#968).

**17 of 26** documented chips now run from a plain install with no toolchain, and **nothing is blocked by the released CLI**.