### PR TITLE
chore(release): move documented runner pins to v0.22.1

### DIFF
--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -2,14 +2,14 @@
 
 Run the **same** `labwired test` command on your laptop and in GitHub Actions or GitLab. Pin a CLI release so firmware changes are judged by a fixed simulator version.
 
-Default pin used in examples: **v0.22.0**.
+Default pin used in examples: **v0.22.1**.
 
 ---
 
 ## Local first
 
 ```bash
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.0 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.1 sh
 
 labwired test \
   --script tests/firmware-test.yaml \
@@ -43,10 +43,10 @@ jobs:
 
       - id: labwired
         name: Run LabWired
-        uses: w1ne/labwired-core/.github/actions/labwired-test@163737266ff562814bd8c7e5b6271994f1e7c00e
+        uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
         with:
           script: tests/firmware-test.yaml
-          version: v0.22.0
+          version: v0.22.1
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -56,8 +56,8 @@ jobs:
 ```
 
 The public action reference is an **immutable action-source pin** to
-`163737266ff562814bd8c7e5b6271994f1e7c00e`. Inputs: `script` (required), `version`
-(default `v0.22.0`), `output-dir`, and `args`. The action downloads that CLI
+`cfc26b5df0218cceedcd832bc689c89d00a13e2d`. Inputs: `script` (required), `version`
+(default `v0.22.1`), `output-dir`, and `args`. The action downloads that CLI
 release, writes JUnit to `output-dir/junit.xml`, appends `summary.md` to the job
 summary, and always uploads the output directory (including on failure).
 
@@ -76,7 +76,7 @@ docker run --rm \
   --user "$(id -u):$(id -g)" \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
-  ghcr.io/w1ne/labwired:v0.22.0 \
+  ghcr.io/w1ne/labwired:v0.22.1 \
   test --script tests/firmware-test.yaml \
        --output-dir out/labwired \
        --no-uart-stdout
@@ -95,7 +95,7 @@ Clear the image entrypoint so GitLab can start its job shell. See
 ```yaml
 test:firmware:
   image:
-    name: ghcr.io/w1ne/labwired:v0.22.0
+    name: ghcr.io/w1ne/labwired:v0.22.1
     entrypoint: [""]
   script:
     - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -415,21 +415,21 @@ configuration; these produce `status: "error"` with `stop_reason:
 
 ## CI release runners
 
-Use the pinned v0.22.0 release runner in CI. It runs the same `labwired test`
+Use the pinned v0.22.1 release runner in CI. It runs the same `labwired test`
 command described above and writes the same artifact contract.
 
 ### GitHub Actions
 
 Use the public Core action and pin the Core CLI with its version input. Its
 only inputs are required `script`, optional `version` (default
-`v0.22.0`), `output-dir`, and `args`:
+`v0.22.1`), `output-dir`, and `args`:
 
 ~~~yaml
 - id: labwired
   name: Run LabWired tests
-  uses: w1ne/labwired-core/.github/actions/labwired-test@163737266ff562814bd8c7e5b6271994f1e7c00e
+  uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
   with:
-    version: v0.22.0
+    version: v0.22.1
     script: examples/ci/dummy-max-steps.yaml
     output-dir: out/artifacts
     args: --no-uart-stdout
@@ -440,7 +440,7 @@ only inputs are required `script`, optional `version` (default
 ~~~
 
 The Core action is an immutable action-source pin to
-`163737266ff562814bd8c7e5b6271994f1e7c00e`; `version: v0.22.0` independently
+`cfc26b5df0218cceedcd832bc689c89d00a13e2d`; `version: v0.22.1` independently
 pins the immutable Core CLI release. It downloads that public release archive
 with `curl`, creates `output-dir/junit.xml` plus Markdown and HTML reports,
 appends the Markdown report to the job summary, and always uploads the entire
@@ -456,7 +456,7 @@ use either a single-machine script or an `inputs.env` world script.
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.22.0 \
+  ghcr.io/w1ne/labwired:v0.22.1 \
   test --script examples/ci/dummy-max-steps.yaml \
        --output-dir out/artifacts \
        --no-uart-stdout
@@ -466,7 +466,7 @@ GitLab should clear that entrypoint and invoke labwired from its job shell:
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.22.0
+  name: ghcr.io/w1ne/labwired:v0.22.1
   entrypoint: [""]
 script:
   - labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -1,14 +1,14 @@
 # CI workflow templates
 
-These templates run a pinned LabWired Core v0.22.0 release and preserve the
+These templates run a pinned LabWired Core v0.22.1 release and preserve the
 result.json, uart.log, snapshot.json, and junit.xml artifacts.
 
 ## GitHub Actions
 
 [github-actions.yml](github-actions.yml) is the primary GitHub template. It
 uses the public Core action at
-w1ne/labwired-core/.github/actions/labwired-test@163737266ff562814bd8c7e5b6271994f1e7c00e
-as an immutable action-source pin, while `version: v0.22.0` independently pins
+w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
+as an immutable action-source pin, while `version: v0.22.1` independently pins
 the Core CLI. Its only inputs are `script` (required), `version`, `output-dir`,
 and whitespace-separated `args`. The action downloads the public release archive
 with `curl`, writes JUnit at `output-dir/junit.xml`, renders the GitHub report,
@@ -27,7 +27,7 @@ cp docs/integration-templates/github-actions.yml .github/workflows/firmware-test
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.22.0
+  name: ghcr.io/w1ne/labwired:v0.22.1
   entrypoint: [""]
 ~~~
 
@@ -42,7 +42,7 @@ entrypoint:
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.22.0 \
+  ghcr.io/w1ne/labwired:v0.22.1 \
   test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
 ~~~
 

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -23,10 +23,10 @@ jobs:
       - id: labwired
         name: Run LabWired test
         # This immutable action-source pin is separate from the CLI version below.
-        uses: w1ne/labwired-core/.github/actions/labwired-test@163737266ff562814bd8c7e5b6271994f1e7c00e
+        uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
         with:
           script: tests/firmware-test.yaml
-          version: v0.22.0
+          version: v0.22.1
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -36,4 +36,4 @@ jobs:
 
 # Advanced alternative: build LabWired from a source checkout only when testing
 # an unreleased LabWired change. For normal firmware CI, keep the pinned release
-# selected by version: v0.22.0 above.
+# selected by version: v0.22.1 above.

--- a/docs/integration-templates/gitlab-ci.yml
+++ b/docs/integration-templates/gitlab-ci.yml
@@ -17,7 +17,7 @@ build:firmware:
 test:labwired:
   stage: test
   image:
-    name: ghcr.io/w1ne/labwired:v0.22.0
+    name: ghcr.io/w1ne/labwired:v0.22.1
     entrypoint: [""]
   dependencies:
     - build:firmware

--- a/docs/reference_client_flows.md
+++ b/docs/reference_client_flows.md
@@ -37,16 +37,16 @@ jobs:
       # Step 2: Run the public immutable Core action
       - id: labwired
         name: Run LabWired CLI
-        uses: w1ne/labwired-core/.github/actions/labwired-test@163737266ff562814bd8c7e5b6271994f1e7c00e
+        uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
         with:
           script: tests/hardware_validation.yaml
-          version: v0.22.0
+          version: v0.22.1
           output-dir: out/labwired
           args: --no-uart-stdout
 ```
 
 The action source is an immutable action-source pin. It has exactly four inputs:
-`script` (required), `version` (default `v0.22.0`), `output-dir`, and
+`script` (required), `version` (default `v0.22.1`), `output-dir`, and
 `args`. It downloads the selected public release
 with `curl`; callers do not need to add a token, repository, JUnit, or artifact
 upload setting. It automatically uploads `out/labwired/`, including

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -405,8 +405,8 @@ require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner 
 require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
 require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
 
-safe_action_sha=163737266ff562814bd8c7e5b6271994f1e7c00e
-safe_action_version=v0.22.0
+safe_action_sha=cfc26b5df0218cceedcd832bc689c89d00a13e2d
+safe_action_version=v0.22.1
 safe_action_ref="w1ne/labwired-core/.github/actions/labwired-test@${safe_action_sha}"
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md docs/reference_client_flows.md .github/actions/labwired-test/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
@@ -416,7 +416,7 @@ for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templa
   require_absent_literal "$doc" 'fda6a7bfb0328d9909ee07ba53ed05c84901f627' "$doc does not retain the superseded action pin"
   require_absent_literal "$doc" 'version: v0.18.0' "$doc does not retain the superseded Core release version"
   require_absent_literal "$doc" 'version: v0.19.0' "$doc does not retain the superseded Core release version"
-  require_absent_literal "$doc" 'v0.21.0' "$doc does not retain the superseded Core release version"
+  require_absent_literal "$doc" 'v0.22.0' "$doc does not retain the superseded Core release version"
 done
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/README.md; do
   require_literal "$doc" '--user "$(id -u):$(id -g)"' "$doc keeps bind-mounted container artifacts writable by the caller"
@@ -458,7 +458,7 @@ else
     fail "immutable action-source commit $safe_action_sha contains its action README"
   fi
   if [[ -n "$pinned_action" ]]; then
-    require_block_literal "$pinned_action" 'default: "v0.22.0"' 'pinned action defaults to the supported public release'
+    require_block_literal "$pinned_action" 'default: "v0.22.1"' 'pinned action defaults to the supported public release'
     require_block_literal "$pinned_action" 'https://github.com/w1ne/labwired-core/releases/download/${version}/${asset}' 'pinned action downloads the public release archive'
     pinned_action_inputs=$(awk '
       /^inputs:$/ { inside = 1; next }
@@ -479,7 +479,7 @@ else
     require_block_literal "$pinned_action" 'name: labwired-${{ github.job }}-${{ github.run_id }}-${{ github.action }}' 'pinned action gives each invocation a unique artifact name'
   fi
   if [[ -n "$pinned_action_readme" ]]; then
-    require_block_literal "$pinned_action_readme" 'defaults to `v0.22.0`' 'pinned action README states the supported public release'
+    require_block_literal "$pinned_action_readme" 'defaults to `v0.22.1`' 'pinned action README states the supported public release'
     require_block_literal "$pinned_action_readme" '[CI integration guide](../../../docs/ci_integration.md)' 'pinned action README links the canonical consumer guide'
     require_block_literal "$pinned_action_readme" 'intentionally documents the action beside its implementation' 'pinned action README explains its source-local contract'
     require_block_absent_literal "$pinned_action_readme" 'uses: w1ne/labwired-core/.github/actions/labwired-test@' 'pinned action README does not recursively choose its own SHA'


### PR DESCRIPTION
Step two of the release ritual: the integration docs and templates pin the composite action **by sha**, and `cfc26b5d` only existed once the bump was on main.

Everything a consumer copies now points at **v0.22.1** — the first release whose `labwired run` reports a fault in its exit status:

```
$ curl -fsSL https://labwired.com/install.sh | sh
✓  Verified: labwired-cli 0.22.1
$ labwired run --chip configs/chips/nrf52832.yaml --firmware tests/fixtures/tier1/stm32f407.elf ; echo $?
3
$ labwired run --chip configs/chips/nrf52832.yaml --firmware tests/fixtures/tier1/nrf52832.elf ; echo $?
0
```

The superseded-version check moves with it, so `v0.22.0` cannot linger in a doc somebody copies from. `verify-release-runner-contract.sh` passes.