### PR TITLE
fix(gdbstub): stop the e2e test fighting for port 9001

### DIFF
--- a/crates/gdbstub/src/lib.rs
+++ b/crates/gdbstub/src/lib.rs
@@ -238,10 +238,65 @@ pub struct GdbServer {
     port: u16,
 }
 
+/// A GDB server whose socket is already open, and whose address is therefore
+/// knowable before a client tries to connect.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct BoundGdbServer {
+    listener: TcpListener,
+    addr: std::net::SocketAddr,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl BoundGdbServer {
+    /// The address the OS gave us. With port 0 this is the only way to learn it.
+    pub fn local_addr(&self) -> std::net::SocketAddr {
+        self.addr
+    }
+
+    /// Serve one session on the already-bound socket.
+    pub fn run<C: Cpu + 'static>(self, machine: Machine<C>) -> anyhow::Result<()>
+    where
+        LabwiredTarget<C>: Target<Error = Infallible, Arch: gdbstub::arch::Arch<Usize = u32>>,
+        GdbEventLoop<C>: gdbstub::stub::run_blocking::BlockingEventLoop<
+            Target = LabwiredTarget<C>,
+            Connection = TcpStream,
+            StopReason = BaseStopReason<(), u32>,
+        >,
+    {
+        tracing::info!("GDB server listening on {}", self.addr);
+        let (stream, peer) = self.listener.accept()?;
+        tracing::info!("GDB client connected from {}", peer);
+
+        let mut target = LabwiredTarget::new(machine);
+        let gdb = GdbStub::new(stream);
+        match gdb.run_blocking::<GdbEventLoop<C>>(&mut target) {
+            Ok(reason) => tracing::info!("GDB session ended: {:?}", reason),
+            Err(e) => tracing::error!("GDB session error: {:?}", e),
+        }
+        Ok(())
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl GdbServer {
     pub fn new(port: u16) -> Self {
         Self { port }
+    }
+
+    /// Bind now and report the port that was actually taken.
+    ///
+    /// `run` binds when it is called, which is fine for `labwired --gdb 3333`
+    /// where the user chose the number. It is not fine for a test: a fixed
+    /// port is a shared resource, and two jobs on one machine — two CI shards,
+    /// or a developer with a stale process — collide. The failure then reads as
+    /// a broken debugger rather than a busy socket.
+    ///
+    /// Binding to port 0 through this constructor lets the OS pick a free one
+    /// and hands it back, so nothing has to guess.
+    pub fn bind(port: u16) -> std::io::Result<BoundGdbServer> {
+        let listener = TcpListener::bind(format!("127.0.0.1:{port}"))?;
+        let addr = listener.local_addr()?;
+        Ok(BoundGdbServer { listener, addr })
     }
 
     pub fn run<C: Cpu + 'static>(&self, machine: Machine<C>) -> anyhow::Result<()>

--- a/crates/gdbstub/tests/gdb_e2e.rs
+++ b/crates/gdbstub/tests/gdb_e2e.rs
@@ -76,8 +76,15 @@ fn test_gdb_rsp_basic_commands() {
         firmware_path
     );
 
-    // 1. Setup a machine and GDB server in a background thread
-    let port = 9001;
+    // 1. Setup a machine and GDB server in a background thread.
+    //
+    // Port 0, not 9001. A fixed port is a shared resource: two CI shards on one
+    // runner, or a developer with a stale process, collide — and the collision
+    // reads as a broken debugger rather than a busy socket. This test has gone
+    // red that way three times in a day. Bind first, learn the port the OS
+    // gave us, and connect to that.
+    let bound = GdbServer::bind(0).expect("bind an ephemeral port");
+    let port = bound.local_addr().port();
     thread::spawn(move || {
         let mut bus = SystemBus::new();
         let (cpu, _nvic) = labwired_core::system::cortex_m::configure_cortex_m(&mut bus);
@@ -87,16 +94,26 @@ fn test_gdb_rsp_basic_commands() {
         let image = labwired_loader::load_elf(&firmware_path).unwrap();
         machine.load_firmware(&image).unwrap();
 
-        let server = GdbServer::new(port);
-        server.run(machine).unwrap();
+        bound.run(machine).unwrap();
     });
 
-    // Wait for server to start
-    thread::sleep(Duration::from_millis(100));
-
-    // 2. Connect client
+    // 2. Connect client. The socket is already listening — it was bound before
+    // the thread started — so this needs no sleep to be correct. The retries
+    // cover the moment between `accept` being reached and the OS scheduling us.
     println!("Connecting to GDB server on port {}...", port);
-    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port)).unwrap();
+    let mut stream = {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            match TcpStream::connect(format!("127.0.0.1:{}", port)) {
+                Ok(s) => break s,
+                Err(e) if std::time::Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(20));
+                    let _ = e;
+                }
+                Err(e) => panic!("could not reach the GDB server on port {port}: {e}"),
+            }
+        }
+    };
     stream
         .set_read_timeout(Some(Duration::from_secs(1)))
         .unwrap();


### PR DESCRIPTION
This test has gone red three times today on unrelated pull requests, and each time the message read like a broken debugger:

```
shard 2: labwired-gdbstub/gdb_e2e — error (build failure or vacuous target; always new red)
```

It was a busy socket. The test hardcoded port **9001**, so two CI shards on one runner — or a developer with a stale process — collide, the server thread panics on bind, and the client's connect fails. Nothing about the debugger is wrong; the test owns a shared resource it cannot reserve, and the aggregate classifies that as "always new red", which blocks merges on other people's work.

## The fix

`GdbServer::bind(0)` opens the socket **first** and reports the address the OS gave it, so the test asks for an ephemeral port and connects to whatever it got.

`GdbServer::new(port).run(..)` is untouched: `labwired --gdb 3333` is a case where the user chose the number, and failing to bind it is a real error worth surfacing.

The fixed `sleep(100ms)` is gone too. The socket is listening before the thread is spawned, so the connect needs no timing guess; a bounded retry covers the gap between spawning the thread and the OS scheduling it.

## Proven both ways

With port 9001 deliberately held by another process:

```
old test → exit 101, panic at gdb_e2e.rs:91  (TcpListener::bind)
new test → exit 0
```

Unblocks #979 and #981, both of which are currently red on exactly this.