### PR TITLE
feat(wasm): tell the browser what the model could not model

### DIFF
--- a/crates/wasm/src/fidelity_surface.rs
+++ b/crates/wasm/src/fidelity_surface.rs
@@ -1,0 +1,141 @@
+//! The browser must be told what the model could not model.
+//!
+//! Phases 3.1-3.3 built the census: `record_undecoded` / `record_unmapped` on
+//! the silent paths, and `FidelityReport::to_gaps()` to flatten it for a
+//! consumer. Then only the CLI read it — `to_gaps` had three callers, all under
+//! `crates/cli`, and "fidelity" appeared in this crate only inside comments. The
+//! engine knew exactly which instructions it had skipped, and the surface where
+//! nearly every user actually runs a lab never said so.
+//!
+//! That matters because the failure is silent by construction: an undecoded
+//! instruction is skipped with the registers left stale, which is
+//! indistinguishable from firmware running correctly. The UADD8/SEL incident in
+//! `fidelity.rs`'s own header is the canonical case — every C-string length came
+//! out garbage and it took a deep debugging session to notice.
+//!
+//! These tests pin the two properties the browser surface depends on:
+//!   1. a recorded gap is visible through the accessor, with its shape intact;
+//!   2. the accessor is scoped to the current machine — the log is
+//!      THREAD-LOCAL and outlives any one `WasmSimulator`, so without the reset
+//!      in the constructors a second lab inherits the first one's gaps.
+//!
+//! Property 2 is the one that cannot be caught by reading the accessor alone,
+//! and is why the reset lives in `new`/`new_from_config` rather than here.
+
+#[cfg(test)]
+mod tests {
+    use crate::WasmSimulator;
+    use labwired_core::fidelity;
+
+    #[test]
+    fn a_recorded_gap_is_visible_and_keeps_its_shape() {
+        fidelity::reset();
+        fidelity::record_undecoded(0x0800_0abc, 0xfa80_f040, "UADD8 (unmodelled)");
+        fidelity::record_unmapped(0x4002_0000, "read");
+
+        let gaps = fidelity::report().to_gaps();
+        assert_eq!(gaps.len(), 2, "both gap kinds must survive to_gaps()");
+
+        // unmapped_mmio comes first and carries an address but no opcode.
+        let mmio = gaps
+            .iter()
+            .find(|g| g.kind == "unmapped_mmio")
+            .expect("unmapped_mmio gap missing");
+        assert_eq!(mmio.address.as_deref(), Some("0x40020000"));
+        assert!(mmio.opcode.is_none(), "MMIO gap must not carry an opcode");
+        assert_eq!(mmio.detail, "read");
+
+        // undecoded_instruction carries an opcode and the PC of first sighting.
+        let insn = gaps
+            .iter()
+            .find(|g| g.kind == "undecoded_instruction")
+            .expect("undecoded_instruction gap missing");
+        assert_eq!(insn.opcode.as_deref(), Some("0xfa80f040"));
+        assert!(
+            insn.address.is_none(),
+            "instruction gap must not carry an address"
+        );
+        assert_eq!(insn.first_pc, "0x8000abc");
+        assert_eq!(insn.count, 1);
+
+        fidelity::reset();
+    }
+
+    /// `count` must be HITS, not distinct gaps — one unmodelled instruction in a
+    /// hot loop is a far louder signal than a single sighting, and collapsing
+    /// the two would hide exactly the case worth surfacing. The browser renders
+    /// its total by summing this field, so the arithmetic has to hold here.
+    #[test]
+    fn repeated_hits_accumulate_rather_than_dedup_to_one() {
+        fidelity::reset();
+        for _ in 0..5 {
+            fidelity::record_undecoded(0x0800_0abc, 0xfa80_f040, "UADD8 (unmodelled)");
+        }
+        let report = fidelity::report();
+        assert_eq!(report.to_gaps().len(), 1, "same opcode is one gap entry");
+        assert_eq!(report.to_gaps()[0].count, 5, "but five hits");
+        assert_eq!(report.total_hits(), 5);
+        fidelity::reset();
+    }
+
+    /// `report()` must NOT drain. A polling UI calls this repeatedly, and
+    /// `take()` semantics would hand the gaps to whichever poll landed first and
+    /// show nothing to the next — a warning that blinks out once is worse than
+    /// no warning, because it teaches the reader that the panel is noise.
+    #[test]
+    fn reading_twice_returns_the_same_gaps() {
+        fidelity::reset();
+        fidelity::record_unmapped(0x4002_0000, "write");
+
+        let first = fidelity::report().to_gaps();
+        let second = fidelity::report().to_gaps();
+        assert_eq!(first, second, "report() must not drain the log");
+        assert_eq!(second.len(), 1);
+
+        // ...whereas take() does, which is why the accessor does not use it.
+        let drained = fidelity::take().to_gaps();
+        assert_eq!(drained.len(), 1);
+        assert!(
+            fidelity::report().to_gaps().is_empty(),
+            "take() is the draining one — kept here so the difference stays pinned"
+        );
+    }
+
+    /// The scoping property. The log is thread-local and outlives any single
+    /// machine, so a second lab opened in the same browser tab would otherwise
+    /// show the first lab's gaps as its own.
+    #[test]
+    fn a_new_machine_does_not_inherit_the_previous_machines_gaps() {
+        fidelity::reset();
+        fidelity::record_undecoded(0x0800_0abc, 0xfa80_f040, "lab one's gap");
+        assert_eq!(
+            fidelity::report().total_hits(),
+            1,
+            "precondition: log is dirty"
+        );
+
+        // Drive the REAL constructor, not a stand-in that calls reset() itself —
+        // the property under test is that `WasmSimulator::new` clears the log,
+        // and a helper asserting `reset()` resets would pass with the production
+        // line deleted.
+        //
+        // It must SUCCEED, so a committed Cortex-M ELF from this crate's own
+        // fixtures is used rather than junk bytes. The error arms build a
+        // `JsValue`, which aborts the process outside wasm (non-unwinding panic,
+        // SIGABRT) — so a deliberately-invalid image cannot be used to reach
+        // this assertion natively.
+        let firmware = include_bytes!("../tests/fixtures/firmware-l476-bldc-six-step.elf");
+        let sim = WasmSimulator::new(firmware).expect("committed l476 fixture must load");
+
+        assert!(
+            fidelity::report().to_gaps().is_empty(),
+            "a freshly constructed machine must start with a clean fidelity log — \
+             the thread-local outlives the machine, so without the reset in \
+             WasmSimulator::new the next lab shows the previous lab's gaps"
+        );
+
+        // And the machine really was built — otherwise this test would pass on a
+        // constructor that never ran.
+        assert!(sim.get_pc().is_ok(), "constructed machine must be usable");
+    }
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -8,6 +8,7 @@ use labwired_core::console::{ConsoleCapture, HostConsole};
 /// Ratchet: the wasm boundary must return errors, not `null`.
 #[cfg(test)]
 mod error_boundary_ratchet;
+mod fidelity_surface;
 mod inputs;
 mod inspect;
 mod install;
@@ -339,6 +340,11 @@ impl WasmSimulator {
     /// Kept for backward compatibility with the existing landing page sandbox.
     #[wasm_bindgen(constructor)]
     pub fn new(firmware: &[u8]) -> Result<WasmSimulator, JsValue> {
+        // The fidelity log is THREAD-LOCAL, and the browser builds one machine
+        // after another on the same thread — open a second lab and it would
+        // inherit the first one's undecoded instructions. Scope it here so
+        // `fidelity_gaps()` always describes the machine you are looking at.
+        labwired_core::fidelity::reset();
         let mut bus = SystemBus::new();
         bus.flash = LinearMemory::new(128 * 1024, 0x0800_0000);
         bus.ram = LinearMemory::new(20 * 1024, 0x2000_0000);
@@ -389,6 +395,9 @@ impl WasmSimulator {
         firmware: &[u8],
         blobs: JsValue,
     ) -> Result<WasmSimulator, JsValue> {
+        // Same reason as `new()`: the fidelity log is thread-local and outlives
+        // the machine, so scope it to this one.
+        labwired_core::fidelity::reset();
         let manifest: SystemManifest = serde_yaml::from_str(system_yaml)
             .map_err(|e| JsValue::from_str(&format!("System YAML error: {}", e)))?;
         let chip: ChipDescriptor = serde_yaml::from_str(chip_yaml)
@@ -1231,6 +1240,39 @@ impl WasmSimulator {
         serde_wasm_bindgen::to_value(&names)
             .map_err(|error| JsValue::from_str(&format!("register names: {error}")))
     }
+
+    /// Everything this machine failed to model so far, as a flat list of
+    /// [`labwired_core::fidelity::FidelityGap`].
+    ///
+    /// Phases 3.1-3.3 built the census — `record_undecoded` / `record_unmapped`
+    /// on the silent paths, `to_gaps()` to flatten it — and then only the CLI
+    /// ever read it. `to_gaps` had exactly three callers, all under `crates/cli`,
+    /// and the word "fidelity" appeared in this crate only inside comments. So
+    /// the engine knew precisely which instructions it had skipped and which
+    /// addresses nothing claimed, and the browser — where nearly every user
+    /// actually runs a lab — was never told. An undecoded instruction is a
+    /// silent no-op that leaves registers stale; it looks exactly like firmware
+    /// running correctly.
+    ///
+    /// Non-draining ON PURPOSE: this reads `report()`, not `take()`. A UI polls,
+    /// and `take()` would hand the gaps to whichever poll happened to land first
+    /// and show nothing to the next — a warning that blinks out is worse than no
+    /// warning. Scoping is done by resetting at construction instead, so the
+    /// list always means "gaps for the machine you are looking at".
+    #[wasm_bindgen]
+    pub fn fidelity_gaps(&self) -> Result<JsValue, JsValue> {
+        let gaps = labwired_core::fidelity::report().to_gaps();
+        serde_wasm_bindgen::to_value(&gaps)
+            .map_err(|error| JsValue::from_str(&format!("fidelity gaps: {error}")))
+    }
+
+    // A `fidelity_total_hits() -> u64` companion was written and then removed:
+    // it is a bare return type, so `error_boundary_ratchet` counted it as a new
+    // failure-blind boundary and went red (77 against a ceiling of 76). That
+    // ratchet is correct to complain and the ceiling only shrinks, so raising it
+    // for a convenience accessor would be the exact move its doc comment warns
+    // against. The count is `gaps.length` / a `reduce` over `count` on the JS
+    // side, from data `fidelity_gaps()` already returns.
 
     /// Read `len` bytes at `addr` through the real bus read path.
     ///


### PR DESCRIPTION
Core half of ledger row **3.4**.

## The gap

Phases 3.1–3.3 built the fidelity census: `record_undecoded` / `record_unmapped` on the silent paths, and `FidelityReport::to_gaps()` to flatten it for a consumer. **Then only the CLI ever read it.**

Derived on `main`:

- `to_gaps()` has exactly **three** callers — `cli/src/commands/environment_test.rs` ×2 and `cli/src/lib.rs:3337`.
- Inside `crates/wasm/`, "fidelity" appears **only in comments** (`install.rs:241`, `lib.rs:1509/2049/2062`). Zero calls.

So the engine knew precisely which instructions it had skipped and which addresses nothing claimed, and the surface where nearly every user actually runs a lab was never told.

That matters because the failure is silent *by construction*: an undecoded instruction is skipped with the registers left stale, which looks exactly like firmware running correctly. `fidelity.rs`'s own header records the canonical case — two unmodelled SIMD instructions in newlib's `strlen` made every C-string length come out garbage, and it took a deep debugging session to notice.

## What this adds

`WasmSimulator::fidelity_gaps() -> Result<JsValue, JsValue>`.

**Non-draining on purpose** — it reads `report()`, not `take()`. A UI polls, and `take()` would hand the gaps to whichever poll landed first and show nothing to the next. A warning that blinks out once is worse than no warning: it teaches the reader that the panel is noise.

**Scoping is done by resetting instead.** The log is thread-local and outlives any one `WasmSimulator`, so opening a second lab in the same tab would otherwise show the first lab's gaps as its own. Both browser constructors now reset first; `new_from_config`'s reset also covers the RISC-V romboot and flash-fastboot paths, which are reached from *inside* it (`lib.rs:425,427`) rather than being separate entry points.

## A companion accessor written, then deleted

`fidelity_total_hits() -> u64` was a bare return type, so `error_boundary_ratchet` — merged this morning in #970 — counted it as a **new failure-blind boundary** and went red at **77 against a ceiling of 76**.

The ratchet is right to complain, and its ceiling only shrinks. Raising it for a convenience accessor is the exact move its doc comment warns against, so the accessor is gone; JS sums `count` over the gaps it already receives.

## Tests — properties, not implementation

| test | pins |
| --- | --- |
| `a_recorded_gap_is_visible_and_keeps_its_shape` | address xor opcode, hex `first_pc`, `count` |
| `repeated_hits_accumulate_rather_than_dedup_to_one` | 5 hits of one opcode = 1 entry, `count: 5` |
| `reading_twice_returns_the_same_gaps` | `report()` does not drain — with `take()` shown draining beside it so the difference stays pinned |
| `a_new_machine_does_not_inherit_the_previous_machines_gaps` | the scoping property |

The last one drives the **real** constructor with a committed Cortex-M ELF from this crate's fixtures, not a helper that calls `reset()` itself — such a helper would pass with the production line deleted.

**Negative control:** removing the reset from `WasmSimulator::new` fails that test *alone* (1 failed / 3 passed). Restored: **43 passed / 0 failed**.

Worth recording: the error arms build a `JsValue`, which aborts natively with a non-unwinding SIGABRT, so an intentionally-invalid image cannot be used to reach the assertion off-wasm. Hence the real fixture.

`cargo fmt` clean, `clippy` clean.

## Not done here

The browser cannot see this until the monorepo bumps the core pointer **and rebuilds the wasm** — a new export changes the generated glue. That bump also carries #970's `read_memory` → `Result<…>` ABI change, so the glue must be regenerated with `npm -w packages/wasm-runtime run sync` in the same commit. `tsc` will not catch a mismatch.

Row 3.4 therefore stays **half** until the playground renders the gaps.