### PR TITLE
fix(canary): Windows has no heartbeat, so its silence is invisible

### DIFF
--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -145,6 +145,22 @@ jobs:
           labwired run --chip configs/chips/nrf52832.yaml --firmware tests/fixtures/tier1/nrf52832.elf --max-steps 3000000 | Out-Null
           if ($LASTEXITCODE -ne 0) { throw "a clean run exited $LASTEXITCODE on Windows" }
 
+      # Without this, Windows is watched only while the workflow runs. The
+      # daily watchdog alerts on a platform going SILENT, and a platform that
+      # never spoke cannot go silent — so a Windows leg that stopped being
+      # scheduled would look exactly like a Windows leg that is fine.
+      - name: Heartbeat
+        if: success()
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $body = '{"surface":"canary","event":"canary_ok","stage":"cli","platform":"windows-latest","channel":"install.sh"}'
+          try {
+            Invoke-RestMethod -Method Post -Uri $env:LABWIRED_TELEMETRY_URL -ContentType 'application/json' -Body $body -TimeoutSec 5 | Out-Null
+          } catch {
+            Write-Host "heartbeat not delivered: $_"
+          }
+
   # ── The distributions people actually run, not the one CI runs ───────────────
   cli-old-distros:
     name: CLI on ${{ matrix.image }} (${{ matrix.arch }})


### PR DESCRIPTION
The daily watchdog alerts when a platform stops reporting. **A platform that never reported cannot stop reporting** — so the Windows leg, added hours ago and green on its first run, is watched only while the workflow happens to run. A Windows job that quietly stopped being scheduled would look exactly like a Windows job that is fine.

That is the fail-open shape the heartbeat exists to close, and I left it open on the newest platform.

Verified the payload against the **deployed** endpoint before wiring it in:

```
{"surface":"canary","event":"canary_ok","stage":"cli","platform":"macos-14","channel":"install.sh"}   → 204
{"surface":"canary","event":"canary_ok","stage":"run","platform":"ubuntu-24.04-arm","channel":"install.sh"} → 204
```

Needs the matching one-line change in `labwired` — `INSTALL_CANARY_PLATFORMS` must list `windows-latest`, or the heartbeat arrives and nothing expects it.

**Known limitation, stated rather than hidden:** the watchdog is keyed by platform, so the `mcp.sh` shell legs, the package-channel leg and the promises job still have no absence detection. They are keyed by shell and by claim, not by machine, and giving them one means the watchdog needs a second dimension. Worth doing; not smuggled into this change.