### PR TITLE
feat(ci): give nrf5340 a CLI cell — an in-process boot is not a gate

### DIFF
--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -144,6 +144,14 @@ jobs:
           - id: esp32s3-zero
             script: examples/esp32s3-zero/tier1-smoke.yaml
             system: examples/esp32s3-zero/system.yaml
+          # nRF5340: real upstream Zephyr v3.7 hello_world on the application
+          # core. The ELF already booted in firmware_survival.rs, but IN
+          # PROCESS — no CLI ran it, which is why the chip sat in the coverage
+          # ledger. Non-vacuity checked: pointed at the nrf52840-dk system the
+          # same script drops to 1/3, with both banner assertions failing.
+          - id: nrf5340dk-zephyr
+            script: examples/nrf5340dk/zephyr-smoke.yaml
+            system: examples/nrf5340dk/system.yaml
 
     steps:
       - uses: actions/checkout@v4

--- a/configs/ci/chip-coverage.yaml
+++ b/configs/ci/chip-coverage.yaml
@@ -20,17 +20,9 @@
 # and SMOKE_LESS_ALLOWLIST in crates/core/tests/strict_onboarding.rs. Do NOT add
 # a row to turn a red gate green — that re-opens the hole the gate exists to close.
 
-max_uncovered: 2
+max_uncovered: 1
 
 uncovered:
-  nrf5340:
-    kind: pending
-    reason: >-
-      Boots a real Zephyr ELF (tests/fixtures/nrf5340-zephyr-hello.elf) in
-      firmware_survival.rs, but in-process — nothing drives it through the CLI.
-      configs/systems/nrf5340dk.yaml and the ELF are both committed, so this
-      needs only an io-smoke.yaml plus a coverage-matrix cell.
-
   rp2350:
     kind: pending
     reason: >-

--- a/examples/nrf5340dk/system.yaml
+++ b/examples/nrf5340dk/system.yaml
@@ -1,0 +1,8 @@
+# LabWired — nRF5340-DK, application core.
+#
+# Same board profile as configs/systems/nrf5340dk.yaml, kept beside the smoke
+# script so the script's `system:` is relative to itself, the way every other
+# committed-ELF cell in the coverage matrix is written.
+name: "nrf5340dk"
+chip: "../../configs/chips/nrf5340.yaml"
+peripherals: []

--- a/examples/nrf5340dk/zephyr-smoke.yaml
+++ b/examples/nrf5340dk/zephyr-smoke.yaml
@@ -1,0 +1,25 @@
+# LabWired — nRF5340-DK Zephyr boot smoke test
+#
+# Runs REAL, unmodified upstream Zephyr v3.7 `hello_world`, built for board
+# `nrf5340dk/nrf5340/cpuapp`, through the whole nRF5340 boot: clock_control
+# starts and polls HFCLK/LFCLK, nrf_rtc_timer initialises, and the banner
+# leaves over the UARTE0 EasyDMA console at the 0x50000000 non-secure alias.
+#
+# The ELF already booted in `firmware_survival.rs` — IN PROCESS. Nothing drove
+# it through the CLI, so nrf5340 was carried in configs/ci/chip-coverage.yaml as
+# a chip no gate executed. An in-process test proves the models; it does not
+# prove the command every user and every other gate runs. This closes that.
+#
+# Committed fixture, no toolchain, well under a second.
+schema_version: "1.0"
+inputs:
+  firmware: "../../tests/fixtures/nrf5340-zephyr-hello.elf"
+  system: "./system.yaml"
+limits:
+  max_steps: 3000000
+assertions:
+  # The Zephyr banner names the board it was built for: a fixture swapped for
+  # some other Nordic image would still print "Booting Zephyr OS" and fail here.
+  - uart_contains: "*** Booting Zephyr OS build"
+  - uart_contains: "Hello World! nrf5340dk/nrf5340/cpuapp"
+  - expected_stop_reason: max_steps


### PR DESCRIPTION
nrf5340 boots real upstream Zephyr v3.7 `hello_world` in `firmware_survival.rs` — in process. Nothing drove it through `labwired test`, so the chip-coverage ledger carried it as uncovered, correctly: an in-process test proves the models, not the command.

Nothing was broken. The fixture and the board profile were already committed; the script and the matrix cell were missing, which is what the ledger entry said. **3/3 assertions, 1.8s, no toolchain.**

**Non-vacuity checked, not assumed.** The banner assertion names the board the image was built for (`nrf5340dk/nrf5340/cpuapp`), so another Nordic image fails it. Pointed at the `nrf52840-dk` system, the same script drops to **1/3** — both banner assertions fail, only `expected_stop_reason` survives.

**Ledger:** nrf5340 closed, ceiling 2 → 1. 25 of 26 chips proven by a CLI gate. `rp2350` remains and is the one entry that genuinely needs an artifact written (no system manifest exists for it).

`strict_onboarding` is red on this tree for `stm32l073` (local toolchain) and `atmega328p` (no example dir) — verified identical with these changes stashed, so pre-existing on main.