### PR TITLE
fix(core): the Cpu trait stops fabricating runtime snapshots

### DIFF
--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -498,22 +498,18 @@ pub(crate) fn run_snapshot_capture(
 
     dump_trace(&ring);
 
-    // Ask before taking. `Cpu::runtime_snapshot` no longer panics on the arches
-    // that do not implement it (a panic in wasm is a trap, and a trap leaks
-    // wasm-bindgen's borrow guard — see the note on the trait), so an ungated
-    // call here would no longer fail loudly: it would write a well-formed file
-    // whose CPU blob is EMPTY. A resume from that blob restores no registers at
-    // all, and nothing downstream can tell it apart from a real capture. Refuse
-    // instead — a missing snapshot is recoverable, a lying one is not.
-    if !machine.cpu.supports_runtime_snapshot() {
+    // `None` means this CPU models no runtime snapshot. There is no longer a
+    // separate capability query to ask first: the take itself is the answer,
+    // so the check cannot disagree with what a capture would contain. Refuse —
+    // a missing snapshot is recoverable, a file whose CPU blob is empty but
+    // which looks like a real capture is not.
+    let Some(snap) = machine.take_runtime_snapshot() else {
         eprintln!(
             "error: this CPU has no runtime-snapshot implementation, so no resumable \
              snapshot can be captured for it (supported: RISC-V, Xtensa LX7)."
         );
         return ExitCode::from(EXIT_RUNTIME_ERROR);
-    }
-
-    let snap = machine.take_runtime_snapshot();
+    };
     let bytes = snap.to_bytes();
 
     if let Some(parent) = args.output.parent() {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2564,20 +2564,14 @@ fn execute_test_loop<C: labwired_core::Cpu>(
             let pc = machine.cpu.get_pc();
             let reached = cap.target_pc == Some(pc) || (0x4200_0000..0x4400_0000).contains(&pc);
             if reached {
-                // Same reason as `snapshot capture`: the trait default is now a
-                // non-panicking EMPTY blob, so an ungated call would write a
-                // resume file that restores no CPU state and still looks valid.
-                // Say so and write nothing. NOT a `continue` — the rest of this
-                // loop body is what actually advances the machine, so skipping
-                // it would hang the run instead of just declining the capture.
-                if !machine.cpu.supports_runtime_snapshot() {
-                    error!(
-                        "capture-app-entry: this CPU has no runtime-snapshot implementation \
-                         (supported: RISC-V, Xtensa LX7) — no snapshot written to {:?}",
-                        cap.path
-                    );
-                } else {
-                    let mut snap = machine.take_runtime_snapshot();
+                // Same reason as `snapshot capture`: a CPU that models no
+                // runtime snapshot answers `None`, and writing a resume file
+                // without a CPU half would produce something that still looks
+                // valid. Say so and write nothing. NOT a `continue` — the rest
+                // of this loop body is what actually advances the machine, so
+                // skipping it would hang the run instead of just declining the
+                // capture.
+                if let Some(mut snap) = machine.take_runtime_snapshot() {
                     snap.set_self_key(cap.chip, cap.fw_sha);
                     if let Some(parent) = cap.path.parent() {
                         let _ = std::fs::create_dir_all(parent);
@@ -2590,6 +2584,12 @@ fn execute_test_loop<C: labwired_core::Cpu>(
                         ),
                         Err(e) => error!("capture-app-entry: failed to write {:?}: {e}", cap.path),
                     }
+                } else {
+                    error!(
+                        "capture-app-entry: this CPU has no runtime-snapshot implementation \
+                         (supported: RISC-V, Xtensa LX7) — no snapshot written to {:?}",
+                        cap.path
+                    );
                 }
                 // Capture once; keep running so the cold invocation still
                 // produces the normal serial/cycle evidence.

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -1490,11 +1490,7 @@ impl Cpu for RiscV {
         }
     }
 
-    fn supports_runtime_snapshot(&self) -> bool {
-        true
-    }
-
-    fn runtime_snapshot(&self) -> (crate::runtime_snapshot::CpuKind, Vec<u8>) {
+    fn runtime_snapshot(&self) -> Option<(crate::runtime_snapshot::CpuKind, Vec<u8>)> {
         use crate::runtime_snapshot::RiscVRuntimeSnapshot;
         let snap = RiscVRuntimeSnapshot {
             x: self.x,
@@ -1512,7 +1508,7 @@ impl Cpu for RiscV {
             reservation: self.reservation,
         };
         let bytes = bincode::serialize(&snap).expect("bincode serialize RiscVRuntimeSnapshot");
-        (crate::runtime_snapshot::CpuKind::RiscV, bytes)
+        Some((crate::runtime_snapshot::CpuKind::RiscV, bytes))
     }
 
     fn apply_runtime_snapshot(

--- a/crates/core/src/cpu/xtensa_lx7.rs
+++ b/crates/core/src/cpu/xtensa_lx7.rs
@@ -3481,11 +3481,7 @@ impl Cpu for XtensaLx7 {
         }
     }
 
-    fn supports_runtime_snapshot(&self) -> bool {
-        true
-    }
-
-    fn runtime_snapshot(&self) -> (crate::runtime_snapshot::CpuKind, Vec<u8>) {
+    fn runtime_snapshot(&self) -> Option<(crate::runtime_snapshot::CpuKind, Vec<u8>)> {
         use crate::runtime_snapshot::XtensaLx7RuntimeSnapshot;
         let snap = XtensaLx7RuntimeSnapshot {
             pc: self.pc,
@@ -3497,7 +3493,7 @@ impl Cpu for XtensaLx7 {
             sr: self.sr.raw_storage().to_vec(),
         };
         let bytes = bincode::serialize(&snap).expect("bincode serialize XtensaLx7RuntimeSnapshot");
-        (crate::runtime_snapshot::CpuKind::XtensaLx7, bytes)
+        Some((crate::runtime_snapshot::CpuKind::XtensaLx7, bytes))
     }
 
     fn apply_runtime_snapshot(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -315,39 +315,54 @@ pub trait Cpu: Send {
     fn snapshot(&self) -> snapshot::CpuSnapshot;
     fn apply_snapshot(&mut self, snapshot: &snapshot::CpuSnapshot);
 
-    /// Whether this CPU can produce a runtime snapshot. FALSE by default:
-    /// only the arches that override `runtime_snapshot` say yes.
+    /// Full mid-flight CPU state for binary runtime snapshots: the arch tag
+    /// plus an opaque blob the matching CPU type knows how to parse, or
+    /// `None` when this core models no runtime snapshot at all.
     ///
-    /// Ask this BEFORE calling `runtime_snapshot`. It exists because the old
-    /// default was `unimplemented!()`, and in wasm a Rust panic lowers to an
-    /// `unreachable` TRAP. A trap runs no destructors, so wasm-bindgen's
-    /// borrow guard leaks and the WasmSimulator stays borrowed forever —
-    /// every later call, `step_batch` included, then fails with "recursive
-    /// use of an object". One snapshot attempt on an unsupported CPU bricked
-    /// the whole engine, which is exactly how every Cortex-M lab died a few
-    /// seconds into a run.
-    fn supports_runtime_snapshot(&self) -> bool {
-        false
+    /// `None` is the ONLY way to say "I cannot" — the return type carries no
+    /// arch tag to fabricate. That is the point. This method used to return
+    /// `(CpuKind::ArmCortexM, Vec::new())` for every core without an
+    /// implementation, so an AVR reported itself as a Cortex-M and a Cortex-M
+    /// reported a well-formed snapshot with an EMPTY body. Nothing downstream
+    /// could tell that apart from a real capture: `snapshot capture` wrote the
+    /// file, the browser handed the bytes to JS, and the resume restored no
+    /// registers while every layer reported success. A simulator sold as a
+    /// hardware oracle may decline to answer; it may not invent one.
+    ///
+    /// The default is deliberately a value and not a panic: in wasm a Rust
+    /// panic lowers to an `unreachable` TRAP, which runs no destructors, so
+    /// wasm-bindgen's borrow guard leaks and the `WasmSimulator` stays
+    /// borrowed forever — every later call, `step_batch` included, then fails
+    /// with "recursive use of an object". One snapshot attempt on an
+    /// unsupported CPU bricked the whole engine, which is how Cortex-M labs
+    /// died seconds into a run. `None` returns normally and leaves the module
+    /// healthy.
+    ///
+    /// A core that overrides this MUST also override
+    /// [`Self::apply_runtime_snapshot`] — a capture nothing can restore is
+    /// the same lie in the other direction. `cpu_runtime_snapshot_honesty`
+    /// fails the build if the two halves ever come apart.
+    fn runtime_snapshot(&self) -> Option<(runtime_snapshot::CpuKind, Vec<u8>)> {
+        None
     }
 
-    /// Full mid-flight CPU state for binary runtime snapshots. Returns the
-    /// arch tag + an opaque blob the matching CPU type knows how to parse.
+    /// Apply a previously-taken runtime snapshot.
     ///
-    /// Overridden by the arches that support it; the default answers empty
-    /// rather than panicking, so a stray call can never trap the module. Gate
-    /// real callers on `supports_runtime_snapshot()`.
-    fn runtime_snapshot(&self) -> (runtime_snapshot::CpuKind, Vec<u8>) {
-        (runtime_snapshot::CpuKind::ArmCortexM, Vec::new())
-    }
-
-    /// Apply a previously-taken runtime snapshot. Default no-op so
-    /// stub/test CPUs don't need to override.
+    /// The default REFUSES. It used to be `Ok(())` with the bytes dropped on
+    /// the floor, which made "restored" and "silently ignored" the same
+    /// observable outcome: `WasmSimulator::apply_runtime_snapshot` returned
+    /// success to JS after leaving the CPU cold and the peripherals warm — a
+    /// machine that never existed on silicon, reported as a good resume. A
+    /// core that models no restore says so, and the caller decides.
     fn apply_runtime_snapshot(
         &mut self,
-        _kind: runtime_snapshot::CpuKind,
+        kind: runtime_snapshot::CpuKind,
         _bytes: &[u8],
     ) -> SimResult<()> {
-        Ok(())
+        Err(SimulationError::NotImplemented(format!(
+            "apply_runtime_snapshot: this CPU models no runtime snapshot, so a \
+             {kind:?} blob cannot be restored onto it"
+        )))
     }
     fn get_register_names(&self) -> Vec<String>;
     fn index_of_register(&self, name: &str) -> Option<u8>;
@@ -471,10 +486,7 @@ impl Cpu for Box<dyn Cpu> {
     fn apply_snapshot(&mut self, s: &snapshot::CpuSnapshot) {
         (**self).apply_snapshot(s)
     }
-    fn supports_runtime_snapshot(&self) -> bool {
-        (**self).supports_runtime_snapshot()
-    }
-    fn runtime_snapshot(&self) -> (runtime_snapshot::CpuKind, Vec<u8>) {
+    fn runtime_snapshot(&self) -> Option<(runtime_snapshot::CpuKind, Vec<u8>)> {
         (**self).runtime_snapshot()
     }
     fn apply_runtime_snapshot(
@@ -2329,13 +2341,21 @@ impl<C: Cpu> Machine<C> {
     /// on a freshly-constructed `Machine` with the same firmware loaded
     /// and the same bus topology.
     ///
+    /// `None` when this machine's CPU models no runtime snapshot
+    /// ([`Cpu::runtime_snapshot`]). A machine-level snapshot whose CPU half
+    /// is missing is not a cheaper snapshot, it is a resume that silently
+    /// starts from a cold core with warm RAM — so there is no such value to
+    /// return. Callers that used to gate on a separate capability query now
+    /// simply handle the `None`, which cannot disagree with what a capture
+    /// would actually contain.
+    ///
     /// Distinct from [`Self::snapshot`] (which produces a JSON value for
     /// the determinism gates) — this one is binary, captures everything
     /// needed for resume (full SR file, shadow stacks, RAM regions, etc.)
     /// and is what the playground uses to ship pre-warmed boot snapshots
     /// alongside firmware ELFs.
-    pub fn take_runtime_snapshot(&self) -> runtime_snapshot::MachineRuntimeSnapshot {
-        let (cpu_kind, cpu_data) = self.cpu.runtime_snapshot();
+    pub fn take_runtime_snapshot(&self) -> Option<runtime_snapshot::MachineRuntimeSnapshot> {
+        let (cpu_kind, cpu_data) = self.cpu.runtime_snapshot()?;
         let peripherals: Vec<(String, Vec<u8>)> = self
             .bus
             .peripherals
@@ -2366,7 +2386,7 @@ impl<C: Cpu> Machine<C> {
             }
             snap.memories = memories;
         }
-        snap
+        Some(snap)
     }
 
     /// Restore from a previously-taken runtime snapshot. Bus topology
@@ -2375,6 +2395,12 @@ impl<C: Cpu> Machine<C> {
     /// peripherals named in the snapshot but missing on the bus return
     /// `MissingPeripheral` so the caller can fail loudly instead of
     /// silently dropping state.
+    ///
+    /// The CPU half is restored FIRST and its error is propagated, so a core
+    /// that models no restore ([`Cpu::apply_runtime_snapshot`]'s default)
+    /// fails the whole call before a single peripheral is touched. That
+    /// ordering is deliberate: a partial restore that reported `Ok(())` gave
+    /// back a machine with warm peripherals and a cold CPU.
     pub fn apply_runtime_snapshot(
         &mut self,
         snap: &runtime_snapshot::MachineRuntimeSnapshot,

--- a/crates/core/src/peripherals/esp32c3/gpio.rs
+++ b/crates/core/src/peripherals/esp32c3/gpio.rs
@@ -1127,7 +1127,9 @@ chip: "../chips/esp32c3.yaml"
             .write_u32(IO_MUX_DATE, 0x0bad_c0de)
             .expect("write source IO_MUX DATE");
         assert_eq!(source.bus.read_u32(GPIO_IN).unwrap() & (1 << 4), 0);
-        let snapshot = source.take_runtime_snapshot();
+        let snapshot = source
+            .take_runtime_snapshot()
+            .expect("the C3's RISC-V core models a runtime snapshot");
 
         let mut resumed_bus =
             SystemBus::from_config(&chip, &manifest).expect("construct fresh C3 bus");

--- a/crates/core/src/tests/machine_advance.rs
+++ b/crates/core/src/tests/machine_advance.rs
@@ -158,7 +158,7 @@ impl Cpu for CountingCpu {
         }
     }
 
-    fn runtime_snapshot(&self) -> (CpuKind, Vec<u8>) {
+    fn runtime_snapshot(&self) -> Option<(CpuKind, Vec<u8>)> {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&self.pc.to_le_bytes());
         bytes.extend_from_slice(&self.sp.to_le_bytes());
@@ -168,7 +168,7 @@ impl Cpu for CountingCpu {
         for word in &self.pending {
             bytes.extend_from_slice(&word.to_le_bytes());
         }
-        (CpuKind::ArmCortexM, bytes)
+        Some((CpuKind::ArmCortexM, bytes))
     }
 
     fn apply_runtime_snapshot(&mut self, kind: CpuKind, bytes: &[u8]) -> SimResult<()> {
@@ -331,7 +331,9 @@ fn counting_cpu_runtime_snapshot_round_trips() {
         push_level: None,
         ..Default::default()
     };
-    let (kind, bytes) = source.runtime_snapshot();
+    let (kind, bytes) = source
+        .runtime_snapshot()
+        .expect("CountingCpu models a runtime snapshot");
     let mut restored = CountingCpu::default();
 
     restored

--- a/crates/core/tests/cpu_runtime_snapshot_honesty.rs
+++ b/crates/core/tests/cpu_runtime_snapshot_honesty.rs
@@ -1,0 +1,319 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! `Cpu::runtime_snapshot` / `Cpu::apply_runtime_snapshot` must not fabricate.
+//!
+//! What these tests are about, in one sentence: a core that models no runtime
+//! snapshot has to SAY SO, and a restore that does nothing must not report
+//! success.
+//!
+//! Before this file existed, the trait defaults were
+//! `(CpuKind::ArmCortexM, Vec::new())` and `Ok(())`. That produced two
+//! confidently-wrong answers with no way for any caller to detect either:
+//!
+//!   * an AVR core reported its arch as `ArmCortexM`, and a Cortex-M reported
+//!     a well-formed snapshot whose body was EMPTY — `snapshot capture` wrote
+//!     that to a file, `WasmSimulator::take_runtime_snapshot` handed it to JS,
+//!     and neither could tell it from a real capture;
+//!   * `apply_runtime_snapshot` dropped the bytes and returned `Ok(())`, so
+//!     `WasmSimulator::apply_runtime_snapshot` reported a good resume after
+//!     leaving the CPU cold and the peripherals warm — a machine that has
+//!     never existed on silicon.
+//!
+//! The fix is in the types, not in a runtime check: the capture returns
+//! `Option`, which carries no arch tag to invent, and the restore's default is
+//! an `Err`. These tests hold both ends, plus the pairing between them.
+
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::avr::Avr;
+use labwired_core::runtime_snapshot::CpuKind;
+use labwired_core::system::cortex_m::configure_cortex_m;
+use labwired_core::system::riscv::configure_riscv;
+use labwired_core::system::xtensa::configure_xtensa_esp32;
+use labwired_core::{Cpu, Machine};
+
+// ── 1. The ISAs that DO model a runtime snapshot still round-trip ──────────
+
+#[test]
+fn xtensa_lx7_runtime_snapshot_round_trips() {
+    let mut bus = SystemBus::new();
+    let mut cpu = configure_xtensa_esp32(&mut bus);
+    cpu.set_pc(0x400D_BEEF);
+    for i in 0..16u8 {
+        cpu.set_register(i, 0xDEAD_0000 | u32::from(i));
+    }
+
+    let (kind, blob) = cpu
+        .runtime_snapshot()
+        .expect("Xtensa LX7 models a runtime snapshot");
+    assert_eq!(kind, CpuKind::XtensaLx7);
+    assert!(!blob.is_empty(), "a modelled snapshot has a body");
+
+    // Clobber, so a restore that did nothing would be visible.
+    cpu.set_pc(0);
+    for i in 0..16u8 {
+        cpu.set_register(i, 0);
+    }
+    cpu.apply_runtime_snapshot(kind, &blob)
+        .expect("Xtensa LX7 restores its own snapshot");
+
+    assert_eq!(cpu.get_pc(), 0x400D_BEEF);
+    for i in 0..16u8 {
+        assert_eq!(cpu.get_register(i), 0xDEAD_0000 | u32::from(i));
+    }
+}
+
+#[test]
+fn riscv_runtime_snapshot_round_trips() {
+    let mut bus = SystemBus::new();
+    let mut cpu = configure_riscv(&mut bus);
+    cpu.set_pc(0x4200_1234);
+    for i in 1..16u8 {
+        cpu.set_register(i, 0xC0DE_0000 | u32::from(i));
+    }
+
+    let (kind, blob) = cpu
+        .runtime_snapshot()
+        .expect("RISC-V models a runtime snapshot");
+    assert_eq!(kind, CpuKind::RiscV);
+    assert!(!blob.is_empty(), "a modelled snapshot has a body");
+
+    cpu.set_pc(0);
+    for i in 1..16u8 {
+        cpu.set_register(i, 0);
+    }
+    cpu.apply_runtime_snapshot(kind, &blob)
+        .expect("RISC-V restores its own snapshot");
+
+    assert_eq!(cpu.get_pc(), 0x4200_1234);
+    for i in 1..16u8 {
+        assert_eq!(cpu.get_register(i), 0xC0DE_0000 | u32::from(i));
+    }
+}
+
+// ── 2. The ISAs that do NOT report honestly, instead of claiming Cortex-M ──
+
+#[test]
+fn cortex_m_reports_no_snapshot_rather_than_an_empty_one() {
+    let mut bus = SystemBus::new();
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    assert!(
+        cpu.runtime_snapshot().is_none(),
+        "CortexM models no runtime snapshot; it must not answer a \
+         well-formed ArmCortexM tag with an empty body"
+    );
+}
+
+#[test]
+fn avr_never_reports_itself_as_cortex_m() {
+    let cpu = Avr::new();
+    // The strong form: not merely "not ArmCortexM", but no tag at all. There
+    // is no `CpuKind::Avr`, so any `Some(..)` here would name silicon this
+    // core is not.
+    assert!(
+        cpu.runtime_snapshot().is_none(),
+        "an AVR core produced a CpuKind for a snapshot it does not model"
+    );
+}
+
+/// The forwarding impl for `Box<dyn Cpu>` is what the browser runtime holds.
+/// It must forward the honest answer rather than fall back to a default.
+#[test]
+fn boxed_dyn_cpu_forwards_the_honest_answer_both_ways() {
+    let mut bus = SystemBus::new();
+    let (cortex, _nvic) = configure_cortex_m(&mut bus);
+    let boxed: Box<dyn Cpu> = Box::new(cortex);
+    assert!(boxed.runtime_snapshot().is_none());
+
+    let mut xtensa_bus = SystemBus::new();
+    let xtensa = configure_xtensa_esp32(&mut xtensa_bus);
+    let boxed: Box<dyn Cpu> = Box::new(xtensa);
+    let (kind, blob) = boxed
+        .runtime_snapshot()
+        .expect("a boxed Xtensa still models a runtime snapshot");
+    assert_eq!(kind, CpuKind::XtensaLx7);
+    assert!(!blob.is_empty());
+}
+
+// ── 3. A discarded restore is distinguishable from a successful one ────────
+
+#[test]
+fn a_cpu_that_cannot_restore_returns_err_not_ok() {
+    let mut bus = SystemBus::new();
+    let (mut cortex, _nvic) = configure_cortex_m(&mut bus);
+    // Every kind, including its "own": the old default swallowed all of them.
+    for kind in [CpuKind::ArmCortexM, CpuKind::RiscV, CpuKind::XtensaLx7] {
+        assert!(
+            cortex.apply_runtime_snapshot(kind, &[1, 2, 3, 4]).is_err(),
+            "CortexM returned Ok(()) after discarding a {kind:?} blob"
+        );
+    }
+
+    let mut avr = Avr::new();
+    assert!(
+        avr.apply_runtime_snapshot(CpuKind::XtensaLx7, &[9; 64])
+            .is_err(),
+        "AVR returned Ok(()) after discarding an Xtensa blob"
+    );
+}
+
+/// The two outcomes must not merely differ in some internal flag — they differ
+/// in the `Result` a caller sees, which is the only thing `WasmSimulator` and
+/// the CLI can act on.
+#[test]
+fn success_and_refusal_are_different_results_on_the_same_call() {
+    let mut xtensa_bus = SystemBus::new();
+    let mut xtensa = configure_xtensa_esp32(&mut xtensa_bus);
+    xtensa.set_pc(0x400D_0042);
+    let (kind, blob) = xtensa.runtime_snapshot().expect("modelled");
+
+    let restored = xtensa.apply_runtime_snapshot(kind, &blob);
+    assert!(restored.is_ok(), "the modelling core accepts its own blob");
+
+    let mut cortex_bus = SystemBus::new();
+    let (mut cortex, _nvic) = configure_cortex_m(&mut cortex_bus);
+    let refused = cortex.apply_runtime_snapshot(kind, &blob);
+    assert!(
+        refused.is_err(),
+        "the non-modelling core reported the SAME outcome as a real restore"
+    );
+}
+
+// ── 4. Same contract one level up, at the Machine ──────────────────────────
+
+#[test]
+fn machine_without_a_cpu_snapshot_produces_none() {
+    let mut bus = SystemBus::new();
+    let (cpu, _nvic) = configure_cortex_m(&mut bus);
+    let machine = Machine::new(cpu, bus);
+    assert!(
+        machine.take_runtime_snapshot().is_none(),
+        "a machine whose CPU models no snapshot must not hand back a \
+         resumable-looking blob with no CPU state in it"
+    );
+}
+
+#[test]
+fn machine_restore_fails_before_touching_a_single_peripheral() {
+    // Capture a real Xtensa machine snapshot, then try to stamp it onto a
+    // Cortex-M machine. The peripheral half would happily apply; the CPU half
+    // is checked first and fails the whole call.
+    let mut xtensa_bus = SystemBus::new();
+    let xtensa = configure_xtensa_esp32(&mut xtensa_bus);
+    let mut source = Machine::new(xtensa, xtensa_bus);
+    source.cpu.set_pc(0x400D_0042);
+    let snap = source
+        .take_runtime_snapshot()
+        .expect("Xtensa machine models a runtime snapshot");
+
+    let mut cortex_bus = SystemBus::new();
+    let (cortex, _nvic) = configure_cortex_m(&mut cortex_bus);
+    let mut target = Machine::new(cortex, cortex_bus);
+    let pc_before = target.cpu.get_pc();
+
+    assert!(
+        target.apply_runtime_snapshot(&snap).is_err(),
+        "Machine<CortexM> reported a successful resume having restored no CPU"
+    );
+    assert_eq!(
+        target.cpu.get_pc(),
+        pc_before,
+        "a refused resume must not have moved the CPU"
+    );
+}
+
+#[test]
+fn machine_round_trip_still_works_where_it_is_modelled() {
+    let mut bus = SystemBus::new();
+    let cpu = configure_xtensa_esp32(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+    machine.cpu.set_pc(0x400D_0042);
+    machine.cpu.set_register(5, 0x1234_5678);
+
+    let snap = machine.take_runtime_snapshot().expect("modelled");
+    machine.cpu.set_pc(0);
+    machine.cpu.set_register(5, 0);
+    machine.apply_runtime_snapshot(&snap).expect("apply");
+
+    assert_eq!(machine.cpu.get_pc(), 0x400D_0042);
+    assert_eq!(machine.cpu.get_register(5), 0x1234_5678);
+}
+
+// ── 5. The two halves may not come apart ──────────────────────────────────
+
+/// A core that captures but cannot restore is the same lie pointed the other
+/// way: `take_runtime_snapshot` hands back a blob, and the resume that reads
+/// it hits the refusing default. A core that restores but cannot capture is a
+/// restore path nothing in the tree can produce input for.
+///
+/// Enforced by reading the sources rather than by instantiating every core:
+/// a new arch added tomorrow is covered without anyone remembering to list it
+/// here. The scan carries its own positive control — it asserts it FOUND the
+/// two cores that are known to implement both halves, so a scan that silently
+/// matches nothing fails instead of passing.
+#[test]
+fn every_core_implements_both_snapshot_halves_or_neither() {
+    let cpu_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cpu");
+    let mut captures: Vec<String> = Vec::new();
+    let mut restores: Vec<String> = Vec::new();
+    let mut files_read = 0usize;
+
+    let mut stack = vec![cpu_dir.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read crates/core/src/cpu") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("read cpu source");
+            files_read += 1;
+            let name = path
+                .strip_prefix(&cpu_dir)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            // The `Cpu`-trait overrides, distinguished from the `Peripheral`
+            // trait's same-named methods by their return types.
+            if src
+                .contains("fn runtime_snapshot(&self) -> Option<(crate::runtime_snapshot::CpuKind")
+            {
+                captures.push(name.clone());
+            }
+            if src.contains("fn apply_runtime_snapshot(") {
+                restores.push(name);
+            }
+        }
+    }
+
+    // Positive control: the scan must see the cores that are known to be
+    // there. Without this, a typo'd pattern would match nothing and the
+    // pairing assertion below would pass vacuously.
+    assert!(files_read >= 4, "scanned only {files_read} cpu sources");
+    captures.sort();
+    restores.sort();
+    for known in ["riscv.rs", "xtensa_lx7.rs"] {
+        assert!(
+            captures.iter().any(|f| f == known),
+            "the capture scan stopped finding {known}, which does implement \
+             `Cpu::runtime_snapshot` — fix the pattern, do not relax the \
+             assertion below (it would pass on an empty scan)"
+        );
+        assert!(
+            restores.iter().any(|f| f == known),
+            "the restore scan stopped finding {known}, which does implement \
+             `Cpu::apply_runtime_snapshot`"
+        );
+    }
+
+    assert_eq!(
+        captures, restores,
+        "a CPU core implements `runtime_snapshot` and `apply_runtime_snapshot` \
+         together or not at all: capture-only means a blob nothing can restore, \
+         restore-only means a path nothing can feed"
+    );
+}

--- a/crates/core/tests/e2e_esp32c3_snapshot_resume.rs
+++ b/crates/core/tests/e2e_esp32c3_snapshot_resume.rs
@@ -99,7 +99,9 @@ fn resume_is_byte_equivalent_to_cold_boot_and_far_cheaper() {
     for step in 0..MAX_BOOT_STEPS {
         if APP_WINDOW.contains(&cold.cpu.get_pc()) {
             // Snapshot the LIVE machine mid-flight — a real boot state.
-            let mut snap = cold.take_runtime_snapshot();
+            let mut snap = cold
+                .take_runtime_snapshot()
+                .expect("the C3's RISC-V core models a runtime snapshot");
             // Self-key it exactly as `--capture-app-entry` does.
             let fw_sha = sha256(&flash_image());
             snap.set_self_key("esp32c3", fw_sha);

--- a/crates/core/tests/runtime_snapshot.rs
+++ b/crates/core/tests/runtime_snapshot.rs
@@ -26,7 +26,9 @@ fn cpu_runtime_snapshot_roundtrips_full_state() {
         cpu.set_register(i, 0xDEAD_0000 | (i as u32));
     }
 
-    let (kind, blob) = cpu.runtime_snapshot();
+    let (kind, blob) = cpu
+        .runtime_snapshot()
+        .expect("Xtensa LX7 models a runtime snapshot");
     assert_eq!(kind, CpuKind::XtensaLx7);
     assert!(blob.len() > 64, "snapshot blob should be substantial");
 
@@ -145,7 +147,9 @@ fn machine_runtime_snapshot_roundtrips_through_serialization() {
         .write_u32(0x3FFB_0200, 0xDEAD_BEEF)
         .expect("dram write");
 
-    let snap = machine.take_runtime_snapshot();
+    let snap = machine
+        .take_runtime_snapshot()
+        .expect("Xtensa machine models a runtime snapshot");
     let bytes = snap.to_bytes();
     assert!(
         bytes.len() > 1000,

--- a/crates/wasm/src/install.rs
+++ b/crates/wasm/src/install.rs
@@ -410,19 +410,17 @@ impl WasmSimulator {
             .machine
             .as_ref()
             .ok_or_else(|| JsValue::from_str("no machine"))?;
-        // Ask before taking. On a CPU without a runtime_snapshot impl this
-        // used to reach `unimplemented!()`, and a Rust panic in wasm is an
+        // A CPU without a runtime_snapshot impl answers `None`. This used to
+        // reach `unimplemented!()`, and a Rust panic in wasm is an
         // `unreachable` TRAP: no destructors run, so wasm-bindgen's borrow
         // guard leaks and the simulator is borrowed forever. Every later
         // call — `step_batch` above all — then dies with "recursive use of
         // an object", which is what froze every Cortex-M lab a few seconds
         // in. An Err returns normally and leaves the machine healthy.
-        if !machine.cpu.supports_runtime_snapshot() {
-            return Err(JsValue::from_str(
-                "runtime snapshot is not supported for this CPU",
-            ));
-        }
-        Ok(machine.take_runtime_snapshot().to_bytes())
+        machine
+            .take_runtime_snapshot()
+            .map(|snap| snap.to_bytes())
+            .ok_or_else(|| JsValue::from_str("runtime snapshot is not supported for this CPU"))
     }
 
     /// Re-write the dual-core handshake bytes. Call every ~10k steps from JS

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -12,7 +12,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `7ff611a215be6e82` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `7ff611a215be6e82` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `37b51e405aa21480` | ⚠ drift acked 2026-08-13 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `f364ebc696e57dae` | ⚠ drift acked 2026-08-13 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `a79a88552908426a` | ⚠ drift acked 2026-08-15 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `d426d9ffbafaa978` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `911aa0ddc97db339` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `7f49451fc56984bf` | ⚠ drift acked 2026-08-13 (re-capture pending) |
@@ -64,7 +64,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on USB-JTAG (built-in) + openocd-esp32 v0.12.0-esp32-20260703, board MAC 9c:cc:01:d0:98:e0 (QFN32 rev v0.4) — re-captured live 2026-08-09 on a SECOND physical C3 (MAC 9c:cc:01:d0:98:e0; the 2026-06-11 baseline came from 38:44:be:42:f5:58, same QFN32 rev v0.4) — cross-board corroboration, not a re-read of the same part. 1207 registers read in ONE state (21 estate windows + 43 control registers + the radio windows): 84/84 RESET_VALUES matched, 0 mismatched, and both FREE_RUNNING_COUNTERS windows mapped. Radio note: a JTAG `reset halt` on the C3 is a software CORE reset that does not cold-reset peripherals, so RADIO_FE/WIFI_MAC only read their cold baseline when no resident firmware has brought the PHY up — the board was temporarily flashed with crates/wasm/tests/fixtures/esp32c3-hello-world-flash.bin for the capture, then its original 4 MB image was restored and verified byte-identical (sha256 844abc88…8a910). Do NOT try to reach cold radio via RTC_CNTL SW_SYS_RST: it resets the USB-Serial-JTAG bridge too and drops the debug link mid-write (verified, LIBUSB_ERROR_IO). Artifacts: scripts/hw-oracle/captures/esp32c3/recapture-20260809T121824Z/.
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (87 regs; 366/423 overlap matched silicon)
   - offline (CI): esp32c3_reset_conformance::esp32c3_free_running_counters_are_mapped (2 WiFi MAC counter windows; mapping only, no equality claim)
-- Drift status: **⚠ drift acked 2026-08-13 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-15 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -743,8 +743,23 @@ boards:
     # attach path (DHT22, HC-SR04, rotary encoder, WS2812), and no silicon
     # capture covers any of those. No live re-capture owed for this change;
     # any re-capture already owed above still is.
-    drift_ack: 2026-08-13
-    drift_ack_digest: f364ebc696e57daef3e0092e5697399c3c018db313aa4f44e830df1029836760
+    # 2026-08-15 (#991): `Cpu::runtime_snapshot` returns `Option<(CpuKind,
+    # Vec<u8>)>` instead of fabricating `(ArmCortexM, vec![])` for cores that
+    # model no snapshot, and the `supports_runtime_snapshot()` predicate — a
+    # second source of truth that could disagree with what a capture contained —
+    # is deleted. NOTHING THIS CAPTURE PINS MOVED. Read the whole diff for the
+    # two watched files rather than taking the summary: in
+    # crates/core/src/cpu/riscv.rs the override that returned `true` is removed
+    # and the return becomes `Some((CpuKind::RiscV, bytes))` — the SAME
+    # `CpuKind` over the SAME bincode bytes, so a C3 resume restores exactly
+    # what it restored before. In crates/core/src/peripherals/esp32c3/gpio.rs
+    # the only change is inside `#[cfg(test)]`: `.expect(...)` to unwrap the new
+    # Option. No register, reset value, or peripheral code path is touched, and
+    # the 84/84 RESET_VALUES this capture pins cannot observe a Rust return
+    # type. The source digest moved; the model did not. No live re-capture owed
+    # for this change; any re-capture already owed above still is.
+    drift_ack: 2026-08-15
+    drift_ack_digest: a79a88552908426ae843082500d5ecaafc06497f76c133d5b76596309e36585c
     models:
       - crates/core/src/peripherals/esp32c3
       - crates/core/src/peripherals/esp_xtensa_common


### PR DESCRIPTION
Ledger row 4.5.

## What was wrong

`crates/core/src/lib.rs`, the `Cpu` trait:

```rust
fn runtime_snapshot(&self) -> (runtime_snapshot::CpuKind, Vec<u8>) {
    (runtime_snapshot::CpuKind::ArmCortexM, Vec::new())
}

fn apply_runtime_snapshot(&mut self, _kind: CpuKind, _bytes: &[u8]) -> SimResult<()> {
    Ok(())
}
```

Two cores hit these defaults today: **AVR**, which reported its arch as
`ArmCortexM` — a `CpuKind` that does not even have an `Avr` variant — and
**Cortex-M**, which reported a well-formed `ArmCortexM` snapshot with an
**empty body**. `snapshot capture` wrote that to a file;
`WasmSimulator::take_runtime_snapshot` handed it to JS. Nothing downstream
could tell either apart from a real capture.

The restore half was worse: it discarded the bytes and returned `Ok(())`, so
"restored" and "silently ignored" were the same observable outcome. In the
browser that is a reported-good resume onto a machine with warm peripherals
and a cold CPU — a machine that has never existed on silicon.

A prior PR added `supports_runtime_snapshot()` and a doc comment explaining
why the fabrication was there. That mitigated the three call sites that
remembered to ask, and left the fabrication itself in place.

## What changed

The wrong answer is now unrepresentable rather than checked for — the same
approach `system::arch_policy` takes to refusing to guess an architecture.

* `Cpu::runtime_snapshot` returns `Option<(CpuKind, Vec<u8>)>`. `None` is the
  only way to say "I cannot"; the type carries no arch tag to invent.
* `Machine::take_runtime_snapshot` returns `Option<MachineRuntimeSnapshot>`
  for the same reason — a machine snapshot missing its CPU half is not a
  cheaper snapshot, it is a resume that starts from a cold core.
* `Cpu::apply_runtime_snapshot`'s default is
  `Err(SimulationError::NotImplemented)`. The CPU half is applied **first** in
  `Machine::apply_runtime_snapshot`, so a refusal fails the call before a
  single peripheral is touched.
* `supports_runtime_snapshot` is removed. It was a second source of truth for
  the same fact and could disagree with what a capture actually contained. All
  three callers (`snapshot capture`, `--capture-app-entry`,
  `WasmSimulator::take_runtime_snapshot`) gated on it and then immediately
  took the snapshot, so they now just handle the `None`.

## Existing chips are untouched

RISC-V and Xtensa LX7 are the only cores that model runtime snapshots. Their
blob bytes, `CpuKind` and restore paths are unchanged — only the wrapper moved
from `(k, v)` to `Some((k, v))`. `RUNTIME_SNAPSHOT_VERSION` is untouched and no
committed artifact moves. Both CLI resume paths are RISC-V-only and keep
working; the ESP32-C3 resume tests are unchanged apart from the `Option`.

## Tests

New `crates/core/tests/cpu_runtime_snapshot_honesty.rs` (11 tests):

* an ISA with a real snapshot round-trips — Xtensa LX7, RISC-V, and through
  the `Box<dyn Cpu>` forwarding impl the browser runtime holds;
* an ISA without one reports `None` instead of claiming Cortex-M — Cortex-M
  itself and AVR;
* a refused restore is a different `Result` than a successful one, at both the
  CPU and the `Machine` level, and a refused `Machine` restore leaves the PC
  where it was;
* a source scan holding the two halves together: a core implements capture and
  restore, or neither, never one. The scan asserts it *found* the cores that do
  implement them, so a pattern that matches nothing fails rather than passing
  vacuously.

### Negative control

The behavioural assertions were first written against the **old** signatures
and watched failing on pristine `origin/main` (commit 22574f888):

```
test result: FAILED. 1 passed; 6 failed
  negctl_avr_never_reports_itself_as_cortex_m
  negctl_avr_restore_of_a_foreign_blob_is_not_ok
  negctl_cortex_m_does_not_claim_an_empty_snapshot_is_a_snapshot
  negctl_discarded_restore_is_distinguishable_from_a_successful_one
  negctl_machine_restore_onto_a_cpu_that_cannot_restore_is_not_ok
  negctl_machine_without_a_cpu_snapshot_refuses_to_produce_one
```

The one that passed was the Xtensa round-trip — the control proving this PR
does not change the ISAs that already work.

The pairing ratchet was driven red in both directions by temporarily giving
`Avr` one half: restore-only (`left: [riscv, xtensa]` vs
`right: [avr, riscv, xtensa]`) and capture-only (the mirror image, plus
`avr_never_reports_itself_as_cortex_m` going red).

## Local runs

| command | pristine `origin/main` | this branch |
| --- | --- | --- |
| `cargo check --workspace --all-targets` | 0 | 0 |
| `cargo clippy --all-targets -- -D warnings` (CI's default-members lane) | — | 0 |
| `cargo clippy -p labwired-wasm --all-targets -- -D warnings` | — | 0 |
| `cargo test -p labwired-core --lib` | 3092 passed, 0 failed | 3092 passed, 0 failed |
| `cargo test -p labwired-core --test runtime_snapshot` | 5 passed, 1 ignored | 5 passed, 1 ignored |
| `cargo test -p labwired-core --test e2e_esp32c3_snapshot_resume` | 1 ignored | 1 ignored |
| `cargo test -p labwired-core --test cpu_runtime_snapshot_honesty` | n/a | 11 passed |
| `cargo test -p labwired-cli --lib` | — | 0 |
| `cargo test -p labwired-wasm --lib` | — | 43 passed, 7 ignored |

**Pre-existing red, not caused here:** `cpu_trace_conformance ::
every_cpu_core_is_covered_by_this_file` fails identically before and after
(2 passed, 1 failed) — the `known_red` entry for #961.

`cpu_runtime_snapshot_honesty` lands in PR shard 2 automatically
(`workspace_test_shard.py plan` confirms), so no shard-config change is needed.