### PR TITLE
cli: accept an ELF-less --rom-boot on esp32s3, not only esp32c3

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -117,10 +117,10 @@ fn metering_exit_status(exit_code: &ExitCode) -> i32 {
 
 use super::esp32_boot_state::resolve_esp_partitions_bin;
 
-/// True when the system manifest at `sys_path` targets the ESP32-C3 (the only
-/// chip family with an ELF-less faithful rom-boot machine). Reads the manifest
-/// and its referenced chip descriptor; any load failure → false (fall back to
-/// requiring firmware). Mirrors the C3 detection used on the fast-boot path.
+/// True when the system manifest at `sys_path` targets the ESP32-C3. Reads the
+/// manifest and its referenced chip descriptor; any load failure → false (fall
+/// back to requiring firmware). Mirrors the C3 detection used on the fast-boot
+/// path.
 fn system_is_esp32c3(
     system: &labwired_config::ResolvedSystem,
     plugins: &[&dyn labwired_core::plugin::ChipPlugin],
@@ -129,6 +129,220 @@ fn system_is_esp32c3(
         .chip_with_plugins(&crate::plugin_chip_yaml(plugins))
         .map(|c| c.name == "esp32c3")
         .unwrap_or(false)
+}
+
+/// True when the system targets an ESP32-S3 die. `is_esp32s3` (not `== "esp32s3"`)
+/// so shipped board variants — `esp32s3-zero` &c. — resolve to the same silicon,
+/// exactly as the ELF-bearing rom-boot arm selects its machine.
+fn system_is_esp32s3(
+    system: &labwired_config::ResolvedSystem,
+    plugins: &[&dyn labwired_core::plugin::ChipPlugin],
+) -> bool {
+    system
+        .chip_with_plugins(&crate::plugin_chip_yaml(plugins))
+        .map(|c| c.is_esp32s3())
+        .unwrap_or(false)
+}
+
+/// Which chip family's ELF-less faithful rom-boot machine a firmware-less
+/// request selects. Every other missing-firmware case is still a config error:
+/// only these two families have a mask-ROM machine that can boot with the flash
+/// image alone.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum NoElfRomBootChip {
+    Esp32c3,
+    Esp32s3,
+}
+
+/// Select the ELF-less rom-boot family for this request, or `None` to fall
+/// through to the normal "firmware required" contract.
+///
+/// Both arms need the SAME two things: the chip's flash-image env pin set (the
+/// flash image is the program the mask ROM loads) and a manifest that resolves
+/// to that silicon. They differ in what a bare `--resume-snapshot` means:
+/// the C3 has a snapshot resume path, the S3 does not (see the Xtensa guard in
+/// `run_test`), so an S3 request must actually carry `--rom-boot`.
+fn no_elf_rom_boot_chip(
+    args: &TestArgs,
+    system: Option<&labwired_config::ResolvedSystem>,
+    plugins: &[&dyn labwired_core::plugin::ChipPlugin],
+) -> Option<NoElfRomBootChip> {
+    let system = system?;
+    if (args.rom_boot || args.resume_snapshot.is_some())
+        && std::env::var("LABWIRED_ESP32C3_FLASH").is_ok()
+        && system_is_esp32c3(system, plugins)
+    {
+        return Some(NoElfRomBootChip::Esp32c3);
+    }
+    if args.rom_boot
+        && std::env::var("LABWIRED_ESP32S3_FLASH").is_ok()
+        && system_is_esp32s3(system, plugins)
+    {
+        return Some(NoElfRomBootChip::Esp32s3);
+    }
+    None
+}
+
+/// Faithful ESP32-S3 (Xtensa LX7) rom-boot with NO debug ELF — the S3 twin of
+/// [`run_c3_rom_boot_no_elf`], and for the same production reason: the hosted
+/// compile ships flash images but no `firmware_ref` for rom-boot chips (a
+/// multi-MB debug ELF overflows the D1 blob row → SQLITE_TOOBIG), so the builder
+/// sends `labwired test --rom-boot` with `LABWIRED_ESP32S3_FLASH` and no ELF.
+///
+/// Nothing in the S3 machine needs the app ELF. This mirrors the `is_esp32s3 &&
+/// args.rom_boot` arm of `run_test` line for line: `configure_xtensa_esp32s3`
+/// with `real_reset_boot`, the manifest's external devices, the Faithful
+/// boot-mode check, faithful windowed registers. The mask ROM comes from
+/// `esp32s3_rom::provision_rom_images()` (explicit `LABWIRED_ESP32S3_ROM`/`_DROM`
+/// bins, else the toolchain's ROM ELF — the vendor's mask-ROM dump, not the
+/// firmware — else the vendored images embedded at build time), and the
+/// application comes out of the flash image through the SPI-flash controller.
+/// The ELF arm only ever used `firmware_bytes` for symbol/diagnostic context;
+/// here `execute_test_loop` gets an empty slice and those diagnostics degrade
+/// gracefully, exactly as on the C3 ELF-less path.
+#[allow(clippy::too_many_arguments)]
+fn run_s3_rom_boot_no_elf(
+    args: &TestArgs,
+    resolved_limits: &TestLimits,
+    system_path: Option<&std::path::PathBuf>,
+    system: Option<&labwired_config::ResolvedSystem>,
+    assertions: &[TestAssertion],
+    faults: &[labwired_config::FaultSpec],
+    require_fault_fired: bool,
+    stimuli: &[labwired_config::StimulusSpec],
+    uart_injections: &[labwired_config::UartInjectionSpec],
+    stack_paint: bool,
+    chip_mem: Option<crate::resource_report::ChipMemoryMap>,
+) -> ExitCode {
+    use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3BootMode, Esp32s3Opts};
+
+    let fail = |msg: String| -> ExitCode {
+        error!("{}", msg);
+        write_config_error_outputs(args, None, system_path, None, Some(resolved_limits), msg);
+        ExitCode::from(EXIT_CONFIG_ERROR)
+    };
+
+    // Same guard the ELF Xtensa path carries: the S3 faithful machine populates
+    // app regions via bootloader copies during the cold boot, so resuming it
+    // needs cache re-derivation work that is deferred. Fail loudly rather than
+    // silently restore a partial state.
+    if args.resume_snapshot.is_some() {
+        return fail(
+            "--resume-snapshot is not yet supported for ESP32-S3 (Xtensa); \
+             cold-boot with --rom-boot instead"
+                .to_string(),
+        );
+    }
+
+    let Some(manifest) = system.map(|s| s.manifest.clone()) else {
+        return fail(
+            "ELF-less ESP32-S3 rom-boot needs a resolved system (set inputs.system or \
+             inputs.chip)"
+                .to_string(),
+        );
+    };
+
+    let uart_tx = Arc::new(Mutex::new(Vec::new()));
+    let metrics = std::sync::Arc::new(labwired_core::metrics::PerformanceMetrics::new());
+
+    let mut bus = labwired_core::bus::SystemBus::new();
+    let opts = Esp32s3Opts {
+        real_reset_boot: true,
+        ..Esp32s3Opts::default()
+    };
+    let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
+    // Wire matrix kits (INA219, OLED, …) the same way the ELF arm does.
+    if let Err(e) =
+        labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, &manifest)
+    {
+        return fail(format!("ESP32-S3 external_devices attach: {e:#}"));
+    }
+    bus.refresh_peripheral_index();
+    if wiring.boot_mode != Esp32s3BootMode::Faithful {
+        return fail(
+            "--rom-boot needs the real ESP32-S3 boot ROM, but none was found. \
+             Install the ESP toolchain or set LABWIRED_ESP32S3_ROM_ELF \
+             (or pin LABWIRED_ESP32S3_ROM/_DROM)."
+                .to_string(),
+        );
+    }
+    let mut cpu = wiring.cpu;
+    cpu.faithful_windows = true;
+    bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+    let mut machine = labwired_core::Machine::new(cpu, bus);
+    machine.observers.push(metrics.clone());
+
+    let fault_evidence = handle_faults(&mut machine.bus, faults);
+
+    // No ELF: empty firmware bytes degrade symbol/hash diagnostics gracefully; a
+    // placeholder path is recorded as config.firmware in result.json.
+    let placeholder = std::path::PathBuf::from("<flash-image>");
+    let exit_code = execute_test_loop(
+        args,
+        &mut machine,
+        resolved_limits,
+        assertions,
+        &[],
+        &uart_tx,
+        &metrics,
+        &placeholder,
+        system_path,
+        faults,
+        require_fault_fired,
+        fault_evidence,
+        stimuli,
+        uart_injections,
+        // Xtensa is never JIT-eligible (the JIT is RISC-V only).
+        false,
+        labwired_core::Arch::XtensaLx7,
+        stack_paint,
+        chip_mem,
+    );
+    // Same readout the ELF-bearing S3 arm emits — a panel wired to this machine
+    // must report identically whether or not an ELF came with the request.
+    emit_device_block_readout(&machine.bus);
+    exit_code
+}
+
+/// Device-block render readout. Surfaces the attached panel block's REAL render
+/// state — refresh_gen AND black-plane ink — so a generic verify (e.g.
+/// proto.cat's device loop) can judge whether the device-block actually PAINTED,
+/// not merely refreshed. A refresh with a blank plane is a false positive (the
+/// DC-latch class of bug; see FIDELITY.md §E2). Emitted to stderr alongside the
+/// boot logs.
+///
+/// ONE home: both S3 rom-boot arms (ELF-bearing and ELF-less) call this, so the
+/// two cannot drift into reporting different things about the same panel.
+fn emit_device_block_readout(bus: &labwired_core::bus::SystemBus) {
+    use labwired_core::peripherals::components::{Ssd1680Tricolor290, Uc8151dTricolor290};
+    use labwired_core::peripherals::esp32::spi::Esp32Spi;
+    let Some(idx) = bus.find_peripheral_index_by_name("spi3") else {
+        return;
+    };
+    let Some(any) = bus.peripherals[idx].dev.as_any() else {
+        return;
+    };
+    let Some(spi3) = any.downcast_ref::<Esp32Spi>() else {
+        return;
+    };
+    for dev in &spi3.attached_devices {
+        let Some(a) = dev.as_any() else { continue };
+        if let Some(p) = a.downcast_ref::<Ssd1680Tricolor290>() {
+            let ink = p.black_plane().iter().filter(|&&b| b != 0xFF).count();
+            eprintln!(
+                "[device-block] ssd1680_tricolor_290 refresh_gen={} black_ink={}",
+                p.refresh_generation(),
+                ink
+            );
+        } else if let Some(p) = a.downcast_ref::<Uc8151dTricolor290>() {
+            let ink = p.black_plane().iter().filter(|&&b| b != 0xFF).count();
+            eprintln!(
+                "[device-block] uc8151d_tricolor_290 refresh_gen={} black_ink={}",
+                p.refresh_generation(),
+                ink
+            );
+        }
+    }
 }
 
 /// Faithful ESP32-C3 (RISC-V) rom-boot with NO debug ELF. The flash image
@@ -659,11 +873,11 @@ pub(crate) fn run_test(
     });
 
     // Resolve the firmware source. Normally an ELF is required (via --firmware or
-    // inputs.firmware). The ONE exception is the faithful ESP32-C3 (RISC-V)
-    // rom-boot path: the flash image (LABWIRED_ESP32C3_FLASH) is the program the
+    // inputs.firmware). The exception is a faithful rom-boot chip: the flash
+    // image (LABWIRED_ESP32C3_FLASH / LABWIRED_ESP32S3_FLASH) is the program the
     // real mask ROM loads, so no debug ELF is needed — the hosted compile
     // deliberately withholds it (a multi-MB ELF overflows the D1 blob row →
-    // SQLITE_TOOBIG). See run_c3_rom_boot_no_elf.
+    // SQLITE_TOOBIG). See run_c3_rom_boot_no_elf / run_s3_rom_boot_no_elf.
     let firmware_path_opt: Option<std::path::PathBuf> = match args.firmware.clone() {
         Some(p) => Some(p),
         None => script_firmware
@@ -672,37 +886,58 @@ pub(crate) fn run_test(
             .map(|s| resolve_script_path(&args.script, s)),
     };
 
-    // ELF-less C3 rom-boot: no firmware given, --rom-boot (or a --resume-snapshot
-    // cache-hit) requested, the flash image env pin is set, and the manifest's
-    // chip is esp32c3. Every other missing-firmware case is still a config error,
-    // and no other chip family has an ELF-less rom-boot machine.
-    let no_elf_rom_boot = firmware_path_opt.is_none()
-        && (args.rom_boot || args.resume_snapshot.is_some())
-        && std::env::var("LABWIRED_ESP32C3_FLASH").is_ok()
-        && resolved_system
-            .as_ref()
-            .map(|s| system_is_esp32c3(s, plugins))
-            .unwrap_or(false);
+    // ELF-less rom-boot: no firmware given, a rom-boot requested, the chip's
+    // flash image env pin set, and the manifest resolving to a chip that HAS a
+    // mask-ROM machine. Every other missing-firmware case is still a config
+    // error.
+    let no_elf_rom_boot = if firmware_path_opt.is_none() {
+        no_elf_rom_boot_chip(&args, resolved_system.as_ref(), plugins)
+    } else {
+        None
+    };
 
-    if no_elf_rom_boot {
-        eprintln!(
-            "labwired-cli test: no --firmware provided; faithful ESP32-C3 rom-boot from \
-             LABWIRED_ESP32C3_FLASH (the flash image is the program; ELF-less)"
-        );
-        let exit_code = run_c3_rom_boot_no_elf(
-            &args,
-            &resolved_limits,
-            system_path.as_ref(),
-            resolved_system.as_ref(),
-            &assertions,
-            &faults,
-            require_fault_fired,
-            &stimuli,
-            &uart_injections,
-            plugins,
-            stack_paint,
-            chip_mem,
-        );
+    if let Some(chip) = no_elf_rom_boot {
+        let exit_code = match chip {
+            NoElfRomBootChip::Esp32c3 => {
+                eprintln!(
+                    "labwired-cli test: no --firmware provided; faithful ESP32-C3 rom-boot from \
+                     LABWIRED_ESP32C3_FLASH (the flash image is the program; ELF-less)"
+                );
+                run_c3_rom_boot_no_elf(
+                    &args,
+                    &resolved_limits,
+                    system_path.as_ref(),
+                    resolved_system.as_ref(),
+                    &assertions,
+                    &faults,
+                    require_fault_fired,
+                    &stimuli,
+                    &uart_injections,
+                    plugins,
+                    stack_paint,
+                    chip_mem,
+                )
+            }
+            NoElfRomBootChip::Esp32s3 => {
+                eprintln!(
+                    "labwired-cli test: no --firmware provided; faithful ESP32-S3 rom-boot from \
+                     LABWIRED_ESP32S3_FLASH (the flash image is the program; ELF-less)"
+                );
+                run_s3_rom_boot_no_elf(
+                    &args,
+                    &resolved_limits,
+                    system_path.as_ref(),
+                    resolved_system.as_ref(),
+                    &assertions,
+                    &faults,
+                    require_fault_fired,
+                    &stimuli,
+                    &uart_injections,
+                    stack_paint,
+                    chip_mem,
+                )
+            }
+        };
         // Best-effort Pro-tier metering (no ELF → hash the empty program; the
         // no-key MCP path never meters). Mirrors the ELF paths' tail metering.
         if let Some(ref key) = api_key_opt {
@@ -1332,44 +1567,9 @@ pub(crate) fn run_test(
                 stack_paint,
                 chip_mem,
             );
-            // Device-block render readout. Surfaces the attached panel block's
-            // REAL render state — refresh_gen AND black-plane ink — so a generic
-            // verify (e.g. proto.cat's device loop) can judge whether the
-            // device-block actually PAINTED, not merely refreshed. A refresh with
-            // a blank plane is a false positive (the DC-latch class of bug; see
-            // FIDELITY.md §E2). Emitted to stderr alongside the boot logs.
-            {
-                use labwired_core::peripherals::components::{
-                    Ssd1680Tricolor290, Uc8151dTricolor290,
-                };
-                use labwired_core::peripherals::esp32::spi::Esp32Spi;
-                if let Some(idx) = machine.bus.find_peripheral_index_by_name("spi3") {
-                    if let Some(any) = machine.bus.peripherals[idx].dev.as_any() {
-                        if let Some(spi3) = any.downcast_ref::<Esp32Spi>() {
-                            for dev in &spi3.attached_devices {
-                                let Some(a) = dev.as_any() else { continue };
-                                if let Some(p) = a.downcast_ref::<Ssd1680Tricolor290>() {
-                                    let ink =
-                                        p.black_plane().iter().filter(|&&b| b != 0xFF).count();
-                                    eprintln!(
-                                        "[device-block] ssd1680_tricolor_290 refresh_gen={} black_ink={}",
-                                        p.refresh_generation(),
-                                        ink
-                                    );
-                                } else if let Some(p) = a.downcast_ref::<Uc8151dTricolor290>() {
-                                    let ink =
-                                        p.black_plane().iter().filter(|&&b| b != 0xFF).count();
-                                    eprintln!(
-                                        "[device-block] uc8151d_tricolor_290 refresh_gen={} black_ink={}",
-                                        p.refresh_generation(),
-                                        ink
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            // Device-block render readout (see `emit_device_block_readout` —
+            // shared with the ELF-less S3 rom-boot arm).
+            emit_device_block_readout(&machine.bus);
             if let Some(ref key) = api_key_opt {
                 use sha2::{Digest, Sha256};
                 let mut hasher = Sha256::new();

--- a/crates/cli/tests/no_elf_s3_rom_boot.rs
+++ b/crates/cli/tests/no_elf_s3_rom_boot.rs
@@ -1,0 +1,171 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! HARD GATE for the ELF-less ESP32-S3 rom-boot path — the S3 twin of
+//! `no_elf_c3_rom_boot.rs`.
+//!
+//! For rom-boot chips the hosted compile deliberately ships the flash image but
+//! NO firmware ELF (a multi-MB debug ELF overflows the D1 blob row →
+//! SQLITE_TOOBIG). The builder therefore invokes `labwired test --rom-boot` with
+//! `LABWIRED_ESP32S3_FLASH` set and NO `--firmware`/`inputs.firmware`.
+//!
+//! The C3 accepted that request; the S3 refused it with
+//! `Missing firmware path (provide --firmware or set inputs.firmware in script)`
+//! and `status: config_error` at 0 steps, because the ELF-less dispatch was
+//! gated on `LABWIRED_ESP32C3_FLASH` + an `esp32c3` chip name. An ELF-less
+//! hosted S3 rom-boot was therefore dead in production.
+//!
+//! Nothing about the S3 machine needed the ELF: the ELF-bearing `--rom-boot`
+//! arm in `commands/test.rs` builds it from `configure_xtensa_esp32s3` +
+//! `esp32s3_rom::provision_rom_images()` (mask ROM from env pins / the
+//! toolchain's ROM ELF / the vendored images) and the flash image, and uses the
+//! app ELF only for symbol diagnostics.
+//!
+//! ── Why this test stops where it stops ──────────────────────────────────
+//!
+//! It asserts the EARLIEST line that proves the ELF-less request was accepted
+//! AND that code fetched from the flash image is executing: the 2nd-stage
+//! bootloader's own `ESP-IDF ... 2nd stage bootloader` banner. Everything
+//! before it (`ESP-ROM:esp32s3-20210327`, `load:0x...`, `entry 0x403c8924`) is
+//! printed by the mask ROM; the banner is the first byte emitted by code the
+//! mask ROM read out of `LABWIRED_ESP32S3_FLASH` and jumped to. That is the
+//! whole claim — "the flash image is the program", with no ELF present.
+//!
+//! It deliberately does NOT run the app to completion. Like the C3, this boot
+//! is CONSOLE-BOUND, not compute-bound: `EspUart` models the real shift-out
+//! rate, so the transcript costs cycles by the byte. The sibling
+//! `no_elf_c3_rom_boot` runs 32M steps for its app-level marker and takes ~423 s
+//! of `pr-workspace-tests` wall-clock — the single largest item in that lane. A
+//! second test of that size is not acceptable, and is not needed: the app-level
+//! S3 boot is already covered by the TIER1 matrix (`tier1.rs`, 30M steps,
+//! ELF-bearing). What is uncovered, and what this gates, is the ELF-LESS
+//! request shape.
+//!
+//! MEASURED against the committed tier1 flash fixture on this tree: the banner
+//! lands between 3M and 4M steps; 5M is that plus ~38 % headroom and the run
+//! still stops on `max_steps` (476 UART bytes, ~3 s wall-clock).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Step budget that reaches the 2nd-stage bootloader banner. See the module
+/// comment for the measurement.
+const BOOTLOADER_BANNER_MAX_STEPS: u64 = 5_000_000;
+
+/// The first console bytes emitted by code loaded from the flash image.
+const FLASH_BOOT_MARKER: &str = "2nd stage bootloader";
+
+/// Repo root = crates/cli/../.. (matches the other CLI integration tests).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+fn require(path: PathBuf) -> PathBuf {
+    assert!(path.exists(), "missing fixture: {}", path.display());
+    path
+}
+
+/// Write a `labwired test` script that names a chip + limits + assertions but
+/// deliberately sets an EMPTY firmware input (the schema requires the key; the
+/// CLI filters empty and takes the ELF-less rom-boot path). Returns its path.
+///
+/// `inputs.chip` rather than `inputs.system` on purpose: it is the shape with
+/// no manifest file behind it, so it also covers the `sys_anchor` fallback the
+/// S3 machine build needs.
+fn write_no_firmware_script(dir: &Path) -> PathBuf {
+    let script = format!(
+        "schema_version: \"1.0\"\n\
+         inputs:\n  \
+           firmware: \"\"\n  \
+           chip: \"esp32s3\"\n\
+         limits:\n  \
+           max_steps: {BOOTLOADER_BANNER_MAX_STEPS}\n\
+         assertions:\n  \
+           - expected_stop_reason: max_steps\n  \
+           - uart_contains: \"{FLASH_BOOT_MARKER}\"\n",
+    );
+    let path = dir.join("no_firmware_romboot_s3.yaml");
+    std::fs::write(&path, script).expect("write test script");
+    path
+}
+
+#[test]
+fn s3_rom_boot_runs_with_flash_and_no_elf() {
+    let root = repo_root();
+    // The committed TIER1 rom-boot fixture (bootloader + partition table + app),
+    // the same flash image `tier1::run_target` boots the S3 row from.
+    let flash = require(root.join("tests/fixtures/tier1/esp32s3-flash.bin"));
+
+    let tmp = std::env::temp_dir().join(format!("lw-no-elf-s3-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("create tmp dir");
+    let script = write_no_firmware_script(&tmp);
+    let out_dir = tmp.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    // Invoke exactly as the builder does on the rom-boot path: `--rom-boot`, the
+    // flash image via the env pin, and NO `--firmware`. The boot ROM
+    // auto-provisions from the vendored images (crates/core/roms/esp32s3/).
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(&root)
+        .env("LABWIRED_ESP32S3_FLASH", &flash)
+        .env_remove("LABWIRED_ESP32C3_FLASH")
+        .env_remove("LABWIRED_ESP32S3_FASTBOOT")
+        .args([
+            "test",
+            "--script",
+            script.to_str().unwrap(),
+            "--rom-boot",
+            "--no-uart-stdout",
+            "--no-key",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn labwired");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    // The ELF-less branch must have been taken (not a silent firmware fallback).
+    assert!(
+        stderr.contains("ELF-less"),
+        "expected the ELF-less S3 rom-boot branch to run; stderr:\n{stderr}"
+    );
+
+    // result.json must exist — proving the sim actually ran (a config error before
+    // the sim starts writes it via write_config_error_outputs, so we ALSO assert
+    // the run succeeded + the flash-loaded bootloader spoke below).
+    let result_path = out_dir.join("result.json");
+    let result_json = std::fs::read_to_string(&result_path).unwrap_or_else(|e| {
+        panic!(
+            "no result.json at {} (exit {:?}): {e}\nstderr:\n{stderr}",
+            result_path.display(),
+            output.status.code(),
+        )
+    });
+
+    assert!(
+        !result_json.contains("\"config_error\""),
+        "run ended in a config_error (firmware still required?):\n{result_json}\nstderr:\n{stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "ELF-less S3 rom-boot run failed (exit {:?}); the flash-boot assertion did not pass.\n\
+         result.json:\n{result_json}\nstderr:\n{stderr}",
+        output.status.code(),
+    );
+
+    // Belt and braces: the marker must be in the captured UART, not merely in a
+    // passing-assertion summary.
+    let uart = std::fs::read_to_string(out_dir.join("uart.log")).expect("read uart.log");
+    assert!(
+        uart.contains(FLASH_BOOT_MARKER),
+        "no `{FLASH_BOOT_MARKER}` in the console — the mask ROM did not hand off to \
+         code loaded from the flash image.\nuart.log:\n{uart}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## The gap

The hosted compile **deliberately withholds the debug ELF for rom-boot chips** — a multi-MB debug ELF overflows the D1 blob row (`SQLITE_TOOBIG`). So the builder sends `labwired test --rom-boot` with a flash image and **no firmware**. On `esp32c3` that boots to real output. On `esp32s3` it came back:

```
Missing firmware path (provide --firmware or set inputs.firmware in script)
```

`status: config_error`, exit 2, 0 steps. **An ELF-less hosted S3 rom-boot was dead in production.**

The ELF-less dispatch in `commands/test.rs` was gated on three esp32c3-specific things — `LABWIRED_ESP32C3_FLASH`, an `esp32c3` chip name, and dispatch into `run_c3_rom_boot_no_elf`. Every other missing-firmware case fell through to the config error.

## Why the S3 shape was already buildable

Nothing about the S3 machine needed the app ELF:

* the ELF-bearing `--rom-boot` arm builds it from `configure_xtensa_esp32s3` with `real_reset_boot`, the manifest's `external_devices`, and the `Esp32s3BootMode::Faithful` check — it never touches `firmware_bytes` except as symbol/diagnostic context;
* `esp32s3_rom::provision_rom_images()` obtains the mask ROM **with no app ELF at all**: explicit `LABWIRED_ESP32S3_ROM`/`_DROM` bins, else a discovered toolchain ROM ELF (the vendor's mask-ROM dump), else the images vendored under `crates/core/roms/esp32s3/` and embedded at build time;
* the application comes out of the flash image through the SPI-flash controller.

## The change

* `no_elf_rom_boot_chip` — a two-arm selector replacing the C3-only boolean. The C3 condition is carried over unchanged, including its `--resume-snapshot` trigger. The S3 arm requires an actual `--rom-boot`, because the Xtensa snapshot-resume path does not exist; asking for one now says so explicitly instead of reporting a missing firmware.
* `system_is_esp32s3` uses `ChipDescriptor::is_esp32s3`, not `== "esp32s3"` — board variants (`esp32s3-zero`) resolve to the same silicon, exactly as the ELF arm selects its machine.
* `run_s3_rom_boot_no_elf` mirrors the ELF-bearing S3 rom-boot arm without the ELF; `execute_test_loop` gets an empty firmware slice, so symbol diagnostics degrade gracefully as they already do on the C3 ELF-less path.
* The device-block render readout moves into `emit_device_block_readout`, called by **both** S3 arms — a panel wired to this machine must report identically whether or not an ELF came with the request.

## Evidence

Same request, before and after, on the committed TIER1 flash fixture with no ELF:

| | exit | `result.json` |
|---|---|---|
| before | 2 | `stop_reason: config_error`, `Missing firmware path (provide --firmware or set inputs.firmware in script)`, 0 steps |
| after | 0 | `status: pass`, `stop_reason: max_steps`, `PASS 2/2 checks` |

The console after the fix, ELF-less:

```
ESP-ROM:esp32s3-20210327
...
load:0x3fce2820,len:0x158c
entry 0x403c8924
I (124) boot: ESP-IDF v5.5.1-838-gd66ebb86d2e 2nd stage bootloader
```

## The gate, and what it costs

`crates/cli/tests/no_elf_s3_rom_boot.rs` drives the real binary exactly as the builder does and asserts the 2nd-stage bootloader's own banner — the **earliest** console byte emitted by code the mask ROM read out of `LABWIRED_ESP32S3_FLASH` and jumped to. Everything before it is printed by the mask ROM, so that line is where "the flash image is the program" is first proven. It deliberately does not run the app to completion; the app-level S3 boot is already covered by the TIER1 matrix at 30M steps.

That restraint is the point. `no_elf_c3_rom_boot` runs **232s** on this machine under the same feature unification `pr-workspace-tests` uses (`labwired-core/event-scheduler`) — 423s on CI, the single largest item in that lane. This test, measured the same way: **1.08s**. It lands in shard 3, the fastest shard.

Both negative controls were run and both went red, on code that executes:

* forcing the S3 arm off → the original `Missing firmware path` failure;
* `real_reset_boot: false` → memory violation at step 20000, `FAIL 0/2`, so the flash-boot assertion is load-bearing and not merely the branch marker.

The test also passes with `HOME` pointed at an empty directory, i.e. resolving the mask ROM from the **vendored** images rather than the local toolchain — the shape CI runs.

## Not regressed

`no_elf_c3_rom_boot` passes, under both feature configurations. `cargo test -p labwired-cli`: 266 passed, 0 failed, 6 ignored (`demo_blinky` is `cross_build_excluded` and only failed until its thumbv7m fixture was built locally). `cargo clippy -p labwired-cli --all-targets` clean.

## Known, deliberate gaps

* `labwired run --rom-boot` still requires `--firmware` on every chip — pre-existing, and true of the C3 too.
* The S3 rom-boot arms tap the UARTs and do not honour `debug_uart: usb_serial_jtag`. The ELF-bearing arm has never done so either; this change keeps the two identical rather than fixing one of them. If hosted S3 Arduino builds compile with `-DARDUINO_USB_CDC_ON_BOOT=1`, that is the next thing to close, exactly as #992 closed it for the C3.
