### PR TITLE
fix(esp32s3): model the S3's interrupt matrix, not the C3's

### DIFF
--- a/configs/peripherals/esp32s3/interrupt_core0.yaml
+++ b/configs/peripherals/esp32s3/interrupt_core0.yaml
@@ -1,219 +1,244 @@
-# ESP32-S3 Interrupt Matrix - CPU Core 0
-# Based on ESP32-S3 Technical Reference Manual
+# ESP32-S3 Interrupt Matrix - CPU Core 0 (INTERRUPT_CORE0, base 0x600C_2000)
+#
+# Offsets, register names and reset values are taken from the vendored Espressif
+# SVD, tests/fixtures/svd/esp32s3.svd, peripheral INTERRUPT_CORE0. That map is a
+# uniform array: INTERRUPT_CORE0_<source>_MAP_REG sits at 4 * source_id, so an
+# offset here IS the source ID times four, and PRO_INTR_STATUS_0..3 / CLOCK_GATE
+# follow the last map register.
+#
+# ⚠️ This file previously carried the ESP32-C3's map, not the S3's. The C3 lacks
+# GPIO_INTERRUPT_APP_MAP (0x48), GPIO_INTERRUPT_APP_NMI_MAP (0x4C) and
+# SPI_INTR_1_MAP (0x50); with those three rows missing every later register was
+# modelled 8, then 20, then 40 bytes low (SPI_INTR_2_MAP 0x4C vs 0x54,
+# UART_INTR_MAP 0x58 vs 0x6C, TG_T0_INT_MAP 0xA0 vs 0xC8). The first register
+# was also named MAC_INTR_MAP — the C3's name; the S3 calls it PRO_MAC_INTR_MAP,
+# and because the names differed nothing ever compared the two maps. The block
+# at 0x104..0x194 held CPU_INT_ENABLE / CPU_INT_TYPE / CPU_INT_CLEAR /
+# CPU_INT_EIP_STATUS / CPU_INT_PRI_n / CPU_INT_THRESH: those are the C3's RISC-V
+# INTC control registers. The S3 is Xtensa LX7 and has none of them — those
+# offsets are ordinary source-map registers on this silicon.
+#
+# Coverage: this descriptor models the source rows the S3 models actually drive,
+# not all 99. Unlisted source offsets stay undecoded (read-as-zero, writes
+# dropped) exactly as before — that gap is pre-existing and unchanged here. The
+# behavioural S3 model is crates/core/src/peripherals/esp32s3/intmatrix.rs,
+# which decodes all 99 sources plus the CORE1 window at +0x800; this descriptor
+# must not disagree with it. Deliberately unmodelled: DATE (0x7FC, an
+# informational silicon-revision stamp) and the INTERRUPT_CORE1 mirror
+# (+0x800), which the SVD carries as its own peripheral.
+#
+# Every *_MAP register resets to 0x10 on this part (SVD resetValue), not 0x0.
 
 peripheral: "INTERRUPT_CORE0"
-version: "0.1.0"
+version: "0.2.0"
 
 registers:
-  - id: "MAC_INTR_MAP"
+  - id: "PRO_MAC_INTR_MAP"
     address_offset: 0x000
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "MAC_NMI_MAP"
     address_offset: 0x004
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "PWR_INTR_MAP"
     address_offset: 0x008
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "BB_INT_MAP"
     address_offset: 0x00C
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "BT_MAC_INT_MAP"
     address_offset: 0x010
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "BT_BB_INT_MAP"
     address_offset: 0x014
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "BT_BB_NMI_MAP"
     address_offset: 0x018
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "GPIO_INTERRUPT_PRO_MAP"
     address_offset: 0x040
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "GPIO_INTERRUPT_PRO_NMI_MAP"
     address_offset: 0x044
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
-  - id: "SPI_INTR_2_MAP"
+  # 0x048/0x04C/0x050 exist on the S3 and not on the C3. Their absence is what
+  # pushed every register below them onto a C3 offset.
+  - id: "GPIO_INTERRUPT_APP_MAP"
+    address_offset: 0x048
+    size: 32
+    access: "R/W"
+    reset_value: 0x00000010
+
+  - id: "GPIO_INTERRUPT_APP_NMI_MAP"
     address_offset: 0x04C
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
-  - id: "SPI_INTR_3_MAP"
+  - id: "SPI_INTR_1_MAP"
     address_offset: 0x050
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
-  - id: "UART_INTR_MAP"
+  - id: "SPI_INTR_2_MAP"
+    address_offset: 0x054
+    size: 32
+    access: "R/W"
+    reset_value: 0x00000010
+
+  - id: "SPI_INTR_3_MAP"
     address_offset: 0x058
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
+
+  - id: "UART_INTR_MAP"
+    address_offset: 0x06C
+    size: 32
+    access: "R/W"
+    reset_value: 0x00000010
 
   - id: "UART1_INTR_MAP"
-    address_offset: 0x05C
+    address_offset: 0x070
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "UART2_INTR_MAP"
-    address_offset: 0x060
+    address_offset: 0x074
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "LEDC_INT_MAP"
-    address_offset: 0x068
+    address_offset: 0x08C
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "USB_INTR_MAP"
-    address_offset: 0x088
+    address_offset: 0x098
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
-  - id: "TG_T0_INT_MAP"
-    address_offset: 0x0A0
-    size: 32
-    access: "R/W"
-    reset_value: 0x00000000
-
-  - id: "TG_T1_INT_MAP"
-    address_offset: 0x0A4
-    size: 32
-    access: "R/W"
-    reset_value: 0x00000000
-
-  - id: "TG_WDT_INT_MAP"
+  # Source 42. The Tier-1 S3 fixture binds this row through the matrix
+  # (examples/tier1-fixture/esp32s3/src/main.rs, check_irq), so it is a proven
+  # consumer of a decoded offset, not a row added to raise a count.
+  - id: "I2C_EXT0_INTR_MAP"
     address_offset: 0x0A8
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
+
+  - id: "TG_T0_INT_MAP"
+    address_offset: 0x0C8
+    size: 32
+    access: "R/W"
+    reset_value: 0x00000010
+
+  - id: "TG_T1_INT_MAP"
+    address_offset: 0x0CC
+    size: 32
+    access: "R/W"
+    reset_value: 0x00000010
+
+  - id: "TG_WDT_INT_MAP"
+    address_offset: 0x0D0
+    size: 32
+    access: "R/W"
+    reset_value: 0x00000010
 
   - id: "TG1_T0_INT_MAP"
-    address_offset: 0x0AC
+    address_offset: 0x0D4
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "TG1_T1_INT_MAP"
-    address_offset: 0x0B0
+    address_offset: 0x0D8
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
   - id: "TG1_WDT_INT_MAP"
-    address_offset: 0x0B4
+    address_offset: 0x0DC
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    reset_value: 0x00000010
 
-  - id: "CPU_INT_ENABLE"
-    address_offset: 0x104
-    size: 32
-    access: "R/W"
-    reset_value: 0x00000000
-    fields:
-      - name: "ENABLE"
-        bit_range: [31, 0]
-        description: "Enable each of 32 CPU interrupts"
-
-  - id: "CPU_INT_TYPE"
-    address_offset: 0x108
-    size: 32
-    access: "R/W"
-    reset_value: 0x00000000
-    fields:
-      - name: "TYPE"
-        bit_range: [31, 0]
-        description: "Interrupt type (0=level, 1=edge)"
-
-  - id: "CPU_INT_CLEAR"
-    address_offset: 0x10C
-    size: 32
-    access: "WO"
-    reset_value: 0x00000000
-    side_effects:
-      write_action: oneToClear
-
-  - id: "CPU_INT_EIP_STATUS"
-    address_offset: 0x110
+  # Source-assertion bitmap, read-only. Four words at 0x18C..0x198 cover source
+  # bits 0..127 (99 sources). The native model uses exactly these offsets — see
+  # INTR_STATUS_BASE in crates/core/src/peripherals/esp32s3/intmatrix.rs. The
+  # names INTR_STATUS_REG_0/1 at 0x198/0x19C that used to sit here are the C3's.
+  - id: "PRO_INTR_STATUS_0"
+    address_offset: 0x18C
     size: 32
     access: "RO"
     reset_value: 0x00000000
 
-  # CPU interrupt priority registers (0-31)
-  - id: "CPU_INT_PRI_0"
-    address_offset: 0x114
+  - id: "PRO_INTR_STATUS_1"
+    address_offset: 0x190
     size: 32
-    access: "R/W"
+    access: "RO"
     reset_value: 0x00000000
 
-  - id: "CPU_INT_PRI_1"
-    address_offset: 0x118
-    size: 32
-    access: "R/W"
-    reset_value: 0x00000000
-
-  - id: "CPU_INT_THRESH"
+  - id: "PRO_INTR_STATUS_2"
     address_offset: 0x194
     size: 32
-    access: "R/W"
+    access: "RO"
     reset_value: 0x00000000
 
-  - id: "INTR_STATUS_REG_0"
+  - id: "PRO_INTR_STATUS_3"
     address_offset: 0x198
     size: 32
     access: "RO"
     reset_value: 0x00000000
 
-  - id: "INTR_STATUS_REG_1"
-    address_offset: 0x19C
-    size: 32
-    access: "RO"
-    reset_value: 0x00000000
-
   - id: "CLOCK_GATE"
-    address_offset: 0x1A0
+    address_offset: 0x19C
     size: 32
     access: "R/W"
     reset_value: 0x00000001
 
+# Source IDs, i.e. the map register's offset / 4 on this part. FROM_CPU_INTR0..3
+# were 50..53 here — the C3's numbers. On the S3 CPU_INTR_FROM_CPU_0_MAP is at
+# 0x13C, so the sources are 79..82, which is also what the S3 cross-core IPI
+# model uses (crates/core/src/peripherals/esp32s3/crosscore_ipi.rs: 79 for core
+# 0, 80 for core 1).
 interrupts:
   WIFI_MAC: 0
   WIFI_MAC_NMI: 1
   GPIO: 16
   GPIO_NMI: 17
-  FROM_CPU_INTR0: 50
-  FROM_CPU_INTR1: 51
-  FROM_CPU_INTR2: 52
-  FROM_CPU_INTR3: 53
+  FROM_CPU_INTR0: 79
+  FROM_CPU_INTR1: 80
+  FROM_CPU_INTR2: 81
+  FROM_CPU_INTR3: 82

--- a/crates/core/tests/esp32s3_interrupt_map_vendor_offsets.rs
+++ b/crates/core/tests/esp32s3_interrupt_map_vendor_offsets.rs
@@ -1,0 +1,335 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! The ESP32-S3 interrupt matrix descriptor must carry the **S3's** register
+//! map, and the ESP32-C3's must stay on the **C3's**.
+//!
+//! `configs/peripherals/esp32s3/interrupt_core0.yaml` shipped a hybrid of the
+//! two parts. The C3 has no `GPIO_INTERRUPT_APP_MAP` (0x48), no
+//! `GPIO_INTERRUPT_APP_NMI_MAP` (0x4C) and no `SPI_INTR_1_MAP` (0x50); those
+//! three rows were missing from the S3 file, so every register after them sat
+//! 8, then 20, then 40 bytes low — `SPI_INTR_2_MAP` at 0x4C instead of 0x54,
+//! `UART_INTR_MAP` at 0x58 instead of 0x6C, `TG_T0_INT_MAP` at 0xA0 instead of
+//! 0xC8. The first register was named `MAC_INTR_MAP`, which is what the C3
+//! calls it; on the S3 it is `PRO_MAC_INTR_MAP`, and *because the names
+//! differed nothing ever compared the two files*. The 0x104..0x194 block held
+//! the C3's RISC-V INTC control registers (`CPU_INT_ENABLE`, `CPU_INT_PRI_n`,
+//! `CPU_INT_THRESH`), which the Xtensa LX7 S3 does not have at all.
+//!
+//! Why this needs a gate at all: an undecoded offset in a declarative
+//! peripheral is a **silent no-op** — the write is dropped and the read
+//! fabricates a zero (see `GenericPeripheral::read`/`write`). "Nothing happens"
+//! is exactly what an untested fix looks like too, so the map is asserted here
+//! against the vendored SVD rather than against a hand-copied table.
+//!
+//! Two chips, deliberately. A test that only proves the S3 now decodes at
+//! 0x6C cannot tell a fixed S3 from a C3 that was dragged onto the S3's
+//! offsets — and the C3 map is correct today (103/103 against its own SVD).
+//! `bus/routing.rs` finds the C3 INTC by NAME AND BASE
+//! (`p.name == "interrupt_core0" && p.base == 0x600C_2000`), which is exactly
+//! what the S3 chip YAML also declares, so the two files are one edit away
+//! from each other at all times.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use labwired_config::PeripheralDescriptor;
+use labwired_core::peripherals::declarative::GenericPeripheral;
+use labwired_core::Peripheral;
+
+const S3_DESCRIPTOR: &str = "configs/peripherals/esp32s3/interrupt_core0.yaml";
+const C3_DESCRIPTOR: &str = "configs/peripherals/esp32c3/interrupt_core0.yaml";
+const S3_SVD: &str = "tests/fixtures/svd/esp32s3.svd";
+const C3_SVD: &str = "tests/fixtures/real_world/esp32c3.svd";
+
+fn root(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+fn descriptor(rel: &str) -> PeripheralDescriptor {
+    PeripheralDescriptor::from_file(root(rel)).unwrap_or_else(|e| panic!("load {rel}: {e}"))
+}
+
+/// The vendor's `INTERRUPT_CORE0` register map: name → (offset, reset value).
+/// Parsed with the same `svd_ingestor` the CLI importer and the coverage scan
+/// use, so this gate reads the SVD the way the rest of the repo does.
+fn vendor_map(svd_rel: &str) -> HashMap<String, (u64, u32)> {
+    let xml =
+        std::fs::read_to_string(root(svd_rel)).unwrap_or_else(|e| panic!("read {svd_rel}: {e}"));
+    let device = svd_ingestor::parse_svd(&xml).unwrap_or_else(|e| panic!("parse {svd_rel}: {e}"));
+    let peripheral = device
+        .peripherals
+        .iter()
+        .find(|p| p.name == "INTERRUPT_CORE0")
+        .unwrap_or_else(|| panic!("{svd_rel} has no INTERRUPT_CORE0 peripheral"));
+    let desc = svd_ingestor::process_peripheral(&device, peripheral)
+        .unwrap_or_else(|e| panic!("process INTERRUPT_CORE0 from {svd_rel}: {e}"));
+    let map: HashMap<String, (u64, u32)> = desc
+        .registers
+        .iter()
+        .map(|r| (r.id.clone(), (r.address_offset, r.reset_value)))
+        .collect();
+    assert!(
+        map.len() > 90,
+        "{svd_rel} yielded only {} INTERRUPT_CORE0 registers — the SVD parse has \
+         broken and every comparison below would pass vacuously",
+        map.len()
+    );
+    map
+}
+
+/// Every register a descriptor declares, checked against the vendor's own map
+/// for that silicon: same name, same offset, same reset value.
+fn assert_conforms(descriptor_rel: &str, svd_rel: &str, min_registers: usize) {
+    let desc = descriptor(descriptor_rel);
+    let vendor = vendor_map(svd_rel);
+
+    assert!(
+        desc.registers.len() >= min_registers,
+        "{descriptor_rel} declares only {} registers (expected at least \
+         {min_registers}) — the descriptor was gutted, not fixed",
+        desc.registers.len()
+    );
+
+    let mut findings = Vec::new();
+    for reg in &desc.registers {
+        match vendor.get(&reg.id) {
+            None => findings.push(format!(
+                "{}: not a register of this silicon's INTERRUPT_CORE0 \
+                 (offset {:#05X} in our model)",
+                reg.id, reg.address_offset
+            )),
+            Some(&(offset, reset)) => {
+                if reg.address_offset != offset {
+                    findings.push(format!(
+                        "{}: modelled at {:#05X}, silicon puts it at {:#05X}",
+                        reg.id, reg.address_offset, offset
+                    ));
+                }
+                if reg.reset_value != reset {
+                    findings.push(format!(
+                        "{}: reset {:#010X}, silicon resets to {:#010X}",
+                        reg.id, reg.reset_value, reset
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        findings.is_empty(),
+        "{descriptor_rel} disagrees with {svd_rel} ({} findings of {} registers \
+         checked):\n  {}",
+        findings.len(),
+        desc.registers.len(),
+        findings.join("\n  ")
+    );
+}
+
+/// Read a 32-bit register out of a declarative peripheral the way the bus does.
+fn read32(p: &GenericPeripheral, offset: u64) -> u32 {
+    p.read_u32(offset).expect("read_u32")
+}
+
+fn write32(p: &mut GenericPeripheral, offset: u64, value: u32) {
+    p.write_u32(offset, value).expect("write_u32");
+}
+
+fn build(rel: &str) -> GenericPeripheral {
+    GenericPeripheral::new(descriptor(rel))
+}
+
+/// Offset → register id, for saying *which* register answers an address.
+fn register_at(rel: &str, offset: u64) -> Option<String> {
+    descriptor(rel)
+        .registers
+        .iter()
+        .find(|r| r.address_offset == offset)
+        .map(|r| r.id.clone())
+}
+
+// ── ESP32-S3: the fix ────────────────────────────────────────────────────────
+
+#[test]
+fn esp32s3_interrupt_map_matches_the_vendor_svd() {
+    assert_conforms(S3_DESCRIPTOR, S3_SVD, 30);
+
+    // The four offsets the defect was found on, stated outright so a future
+    // reader does not have to re-derive them from the SVD. Left column is what
+    // the file used to say.
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x000).as_deref(),
+        Some("PRO_MAC_INTR_MAP"),
+        "source 0 is PRO_MAC_INTR_MAP on the S3; MAC_INTR_MAP is the C3's name \
+         for it, and a name mismatch is what kept this out of every comparison"
+    );
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x054).as_deref(),
+        Some("SPI_INTR_2_MAP"),
+        "SPI_INTR_2_MAP is at 0x54 on the S3 (it was modelled at the C3's 0x4C)"
+    );
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x06C).as_deref(),
+        Some("UART_INTR_MAP"),
+        "UART_INTR_MAP is at 0x6C on the S3 (it was modelled at 0x58)"
+    );
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x0C8).as_deref(),
+        Some("TG_T0_INT_MAP"),
+        "TG_T0_INT_MAP is at 0xC8 on the S3 (it was modelled at 0xA0)"
+    );
+
+    // The three S3-only rows whose absence produced the 8 → 20 → 40 byte drift.
+    for (offset, id) in [
+        (0x048u64, "GPIO_INTERRUPT_APP_MAP"),
+        (0x04C, "GPIO_INTERRUPT_APP_NMI_MAP"),
+        (0x050, "SPI_INTR_1_MAP"),
+    ] {
+        assert_eq!(
+            register_at(S3_DESCRIPTOR, offset).as_deref(),
+            Some(id),
+            "{id} at {offset:#05X} is what the C3 lacks and the S3 has; without \
+             it every register below is back on a C3 offset"
+        );
+    }
+
+    // The C3's RISC-V INTC block has no counterpart on Xtensa. Its former
+    // offsets here are ordinary source-map registers on this silicon.
+    let s3 = descriptor(S3_DESCRIPTOR);
+    for c3_only in [
+        "CPU_INT_ENABLE",
+        "CPU_INT_TYPE",
+        "CPU_INT_CLEAR",
+        "CPU_INT_EIP_STATUS",
+        "CPU_INT_PRI_0",
+        "CPU_INT_THRESH",
+        "INTR_STATUS_REG_0",
+        "MAC_INTR_MAP",
+    ] {
+        assert!(
+            !s3.registers.iter().any(|r| r.id == c3_only),
+            "{c3_only} is an ESP32-C3 register; the S3 model must not declare it"
+        );
+    }
+}
+
+#[test]
+fn esp32s3_interrupt_matrix_decodes_at_the_vendor_offset() {
+    let mut s3 = build(S3_DESCRIPTOR);
+
+    // Reset state first: every *_MAP register on this part resets to 0x10, not
+    // 0. A read of 0 here would mean either the wrong reset value or — worse —
+    // that 0x6C decodes to nothing and the peripheral is fabricating a zero.
+    assert_eq!(
+        read32(&s3, 0x06C),
+        0x10,
+        "UART_INTR_MAP (0x6C) must reset to 0x10; 0 means the offset is \
+         undecoded (silent no-op) or the reset value is still the old 0"
+    );
+
+    // Write-then-read at the vendor's offset. On the shipped model 0x6C fell in
+    // the hole between UART2_INTR_MAP (0x60) and LEDC_INT_MAP (0x68 + 4), so
+    // this write was dropped and the read returned 0.
+    write32(&mut s3, 0x06C, 0x17);
+    assert_eq!(
+        read32(&s3, 0x06C),
+        0x17,
+        "a write to UART_INTR_MAP at the vendor's 0x6C must round-trip"
+    );
+
+    // …and it must be that register alone. 0x58 is where UART_INTR_MAP used to
+    // sit; it is SPI_INTR_3_MAP on real S3 silicon and must not have moved.
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x058).as_deref(),
+        Some("SPI_INTR_3_MAP")
+    );
+    assert_eq!(
+        read32(&s3, 0x058),
+        0x10,
+        "the old (C3) UART offset must be untouched by a write to the real one"
+    );
+
+    // The Tier-1 S3 fixture binds a source through `INTMATRIX_BASE + 4*source`
+    // (examples/tier1-fixture/esp32s3/src/main.rs, check_irq, source 42), so
+    // that row must decode — it did before this change too, as the wrong
+    // register.
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 4 * 42).as_deref(),
+        Some("I2C_EXT0_INTR_MAP"),
+        "source 42 is I2C_EXT0 on the S3"
+    );
+    write32(&mut s3, 4 * 42, 17);
+    assert_eq!(read32(&s3, 4 * 42), 17);
+
+    // The source-assertion words sit where the behavioural model puts them
+    // (INTR_STATUS_BASE = 0x18C in peripherals/esp32s3/intmatrix.rs). Two
+    // models of one block that disagree on an address is the defect this file
+    // exists to prevent.
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x18C).as_deref(),
+        Some("PRO_INTR_STATUS_0")
+    );
+    assert_eq!(
+        register_at(S3_DESCRIPTOR, 0x19C).as_deref(),
+        Some("CLOCK_GATE"),
+        "CLOCK_GATE is at 0x19C on the S3 (it was modelled at the C3-shifted 0x1A0)"
+    );
+    assert_eq!(read32(&s3, 0x19C), 1, "CLOCK_GATE resets to 1");
+}
+
+// ── ESP32-C3: the chip that must not move ────────────────────────────────────
+
+#[test]
+fn esp32c3_interrupt_map_is_unchanged_at_its_own_offsets() {
+    // The C3 descriptor is SVD-generated and fully conformant; assert all of it,
+    // so "fixing" the S3 by dragging the C3 along cannot pass.
+    assert_conforms(C3_DESCRIPTOR, C3_SVD, 100);
+
+    let mut c3 = build(C3_DESCRIPTOR);
+
+    // The C3's own UART_INTR_MAP is at 0x54 — NOT at the S3's 0x6C, which on
+    // this part is RTC_CORE_INTR_MAP.
+    assert_eq!(
+        register_at(C3_DESCRIPTOR, 0x054).as_deref(),
+        Some("UART_INTR_MAP")
+    );
+    assert_eq!(
+        register_at(C3_DESCRIPTOR, 0x06C).as_deref(),
+        Some("RTC_CORE_INTR_MAP"),
+        "0x6C is UART_INTR_MAP on the S3 and RTC_CORE_INTR_MAP on the C3; if \
+         these two ever agree, one of them is wrong"
+    );
+    write32(&mut c3, 0x054, 0x0C);
+    assert_eq!(
+        read32(&c3, 0x054),
+        0x0C,
+        "the C3's UART_INTR_MAP must still round-trip at its own offset"
+    );
+
+    // `SystemBus::rebuild_esp32c3_irq_cache` reads these exact offsets out of
+    // this descriptor (bus/routing.rs): CPU_INT_ENABLE 0x104, per-line priority
+    // 0x114 + line*4, CPU_INT_THRESH 0x194. They are C3-only registers and the
+    // C3 INTC stops working without them.
+    assert_eq!(
+        register_at(C3_DESCRIPTOR, 0x104).as_deref(),
+        Some("CPU_INT_ENABLE")
+    );
+    assert_eq!(
+        register_at(C3_DESCRIPTOR, 0x114).as_deref(),
+        Some("CPU_INT_PRI_0")
+    );
+    assert_eq!(
+        register_at(C3_DESCRIPTOR, 0x194).as_deref(),
+        Some("CPU_INT_THRESH")
+    );
+    write32(&mut c3, 0x104, 0xDEAD_BEEF);
+    assert_eq!(read32(&c3, 0x104), 0xDEAD_BEEF);
+
+    // Source 0 is MAC_INTR_MAP on the C3 and PRO_MAC_INTR_MAP on the S3.
+    assert_eq!(
+        register_at(C3_DESCRIPTOR, 0x000).as_deref(),
+        Some("MAC_INTR_MAP")
+    );
+}

--- a/crates/gdbstub/tests/gdb_e2e.rs
+++ b/crates/gdbstub/tests/gdb_e2e.rs
@@ -85,7 +85,7 @@ fn test_gdb_rsp_basic_commands() {
     // gave us, and connect to that.
     let bound = GdbServer::bind(0).expect("bind an ephemeral port");
     let port = bound.local_addr().port();
-    thread::spawn(move || {
+    let server = thread::spawn(move || {
         let mut bus = SystemBus::new();
         let (cpu, _nvic) = labwired_core::system::cortex_m::configure_cortex_m(&mut bus);
         let mut machine = Machine::new(cpu, bus);
@@ -258,4 +258,11 @@ fn test_gdb_rsp_basic_commands() {
     send_packet(&mut stream, "m0,4");
     let resp = read_packet(&mut stream);
     assert!(!resp.contains("E01"), "GDB memory read failed");
+
+    // End the session before this test returns. An unsynchronized
+    // UnexpectedEof log from `run` can splice into libtest's
+    // `test result:` line; CI then treats a passed run as a hard error.
+    send_packet(&mut stream, "k");
+    drop(stream);
+    server.join().expect("GDB server thread panicked");
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -17,7 +17,7 @@ The models column is a content digest over everything that board's `models` list
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `c6edd440f7d52912` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `d17e310c125d5612` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `cba8077c91077c75` | ⚠ drift acked 2026-08-13 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `ce851b8dd4e6a6e0` | ⚠ drift acked 2026-08-17 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `6d1b78a03ba2a9c7` | ⚠ drift acked 2026-08-17 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `1944e48e1e75ed3b` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a8c9baa90cb2a903` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `9637527458c15225` | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -2593,6 +2593,26 @@ boards:
     # attach path (DHT22, HC-SR04, rotary encoder, WS2812), and no silicon
     # capture covers any of those. No live re-capture owed for this change;
     # any re-capture already owed above still is.
+    # 2026-08-15: configs/peripherals/esp32s3/interrupt_core0.yaml carried the
+    # ESP32-C3's register map, not the S3's — SPI_INTR_2_MAP at 0x4C (0x54 on
+    # this part), UART_INTR_MAP at 0x58 (0x6C), TG_T0_INT_MAP at 0xA0 (0xC8),
+    # source 0 named MAC_INTR_MAP (the C3's name for PRO_MAC_INTR_MAP), every
+    # *_MAP resetting to 0 where silicon resets it to 0x10, plus the C3's
+    # RISC-V INTC block (CPU_INT_ENABLE / CPU_INT_PRI_n / CPU_INT_THRESH),
+    # which an Xtensa LX7 part does not have. Corrected against the vendored
+    # SVD (tests/fixtures/svd/esp32s3.svd, INTERRUPT_CORE0) and gated by a new
+    # test that compares every register in the descriptor to it.
+    #
+    # THE NINE ANCHORED RESET REGISTERS DO NOT MOVE. The 2026-08-09 capture
+    # read UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM and
+    # RTC_CNTL; INTERRUPT_CORE0 is not among them, so no captured value is
+    # affected and a re-capture could not evidence this change either way.
+    # No S3 firmware run changes either: configure_xtensa_esp32s3 clears the
+    # from_config peripheral bank and installs the behavioural Rust model
+    # (crates/core/src/peripherals/esp32s3/intmatrix.rs), which already decodes
+    # at 4*source_id, so this descriptor is live only on from_config-built
+    # buses (chip_conformance, bus_visibility). Nothing is owed by this ack;
+    # the re-captures already owed above still are.
     # 2026-08-16: nine RESET VALUES corrected in configs/peripherals/esp32s3/
     # {timg0,gpio}.yaml — T0CONFIG/T1CONFIG, WDTCONFIG0, WDTCONFIG2..5,
     # RTCCALICFG and GPIO REG_DATE. Like the nRF52840 UARTE BAUDRATE ack above
@@ -2677,7 +2697,10 @@ boards:
     # 2026-08-12: chip yaml documents sar_adc_s3 + twai already registered by
     # configure_xtensa_esp32s3 (ESP32S3_PERIPHERALS). Address-map honesty only —
     # 9-reg reset-state silicon anchor unchanged. Arduino matrix L5/L8 green.
-    drift_ack_digest: ce851b8dd4e6a6e03c46521c4a0729321de66d29805e73b719b821da53edaf1d
+    # 2026-08-20: interrupt_core0.yaml now names the S3's own source-map
+    # offsets (SVD INTERRUPT_CORE0), not the C3's. Descriptor-only; the
+    # behavioural matrix and the 9-reg reset-state anchor are untouched.
+    drift_ack_digest: 6d1b78a03ba2a9c73fccb758fc80d80361d505d9562e7a7f96bc871bb8d3b62a
     models:
       - crates/core/src/cpu/xtensa_lx7.rs
       - crates/core/src/decoder/xtensa.rs


### PR DESCRIPTION
## The defect

`configs/peripherals/esp32s3/interrupt_core0.yaml` did not describe the ESP32-S3's
interrupt matrix. Verified against the vendored SVD in this repo —
`tests/fixtures/svd/esp32s3.svd`, peripheral `INTERRUPT_CORE0`, base `0x600C_2000`
(byte-identical to `cmsis-svd-data/data/Espressif/esp32s3.svd` for this block):

| register | was | silicon |
|---|---|---|
| `PRO_MAC_INTR_MAP` | `0x000`, **named `MAC_INTR_MAP`** | `0x000` |
| `GPIO_INTERRUPT_PRO_MAP` | `0x040` | `0x040` |
| `SPI_INTR_2_MAP` | `0x04C` | `0x054` |
| `SPI_INTR_3_MAP` | `0x050` | `0x058` |
| `UART_INTR_MAP` | `0x058` | `0x06C` |
| `UART1_INTR_MAP` | `0x05C` | `0x070` |
| `UART2_INTR_MAP` | `0x060` | `0x074` |
| `LEDC_INT_MAP` | `0x068` | `0x08C` |
| `USB_INTR_MAP` | `0x088` | `0x098` |
| `TG_T0_INT_MAP` | `0x0A0` | `0x0C8` |
| `TG_T1_INT_MAP` | `0x0A4` | `0x0CC` |
| `TG_WDT_INT_MAP` | `0x0A8` | `0x0D0` |
| `TG1_T0_INT_MAP` | `0x0AC` | `0x0D4` |
| `TG1_T1_INT_MAP` | `0x0B0` | `0x0D8` |
| `TG1_WDT_INT_MAP` | `0x0B4` | `0x0DC` |
| `CLOCK_GATE` | `0x1A0` | `0x19C` |

One cause: the S3 has `GPIO_INTERRUPT_APP_MAP` (0x48), `GPIO_INTERRUPT_APP_NMI_MAP`
(0x4C) and `SPI_INTR_1_MAP` (0x50); the C3 has none of them. Those three rows were
missing, so every register below them sat 8, then 20, then 40 bytes low. They are
added here.

Three more, in the same file:

* **Name.** Source 0 was `MAC_INTR_MAP` — the C3's name. The S3 calls it
  `PRO_MAC_INTR_MAP`. Because the names differed, no tool ever compared the two
  maps: the mismatch hid itself.
* **Reset values.** Every `*_MAP` register resets to `0x10` on this part (SVD
  `resetValue`). The model said `0x0` for all of them.
* **Registers that do not exist on this silicon.** `0x104..0x19C` held
  `CPU_INT_ENABLE` / `CPU_INT_TYPE` / `CPU_INT_CLEAR` / `CPU_INT_EIP_STATUS` /
  `CPU_INT_PRI_0/1` / `CPU_INT_THRESH` and `INTR_STATUS_REG_0/1` — the C3's RISC-V
  INTC control block, at the C3's offsets. An Xtensa LX7 part has none of them, and
  on the S3 those addresses are ordinary source-map registers. Replaced with what
  the silicon puts there: `PRO_INTR_STATUS_0..3` at `0x18C..0x198` — which is also
  exactly where the behavioural model reads them (`INTR_STATUS_BASE` in
  `crates/core/src/peripherals/esp32s3/intmatrix.rs`).

The `interrupts:` block also carried the C3's source IDs for `FROM_CPU_INTR0..3`
(50..53). On the S3 `CPU_INTR_FROM_CPU_0_MAP` is at `0x13C`, so the sources are
79..82 — which is already what `peripherals/esp32s3/crosscore_ipi.rs` uses.

## Corrections to the report this started from

Re-derived from the SVD before changing anything. Three details in the original
write-up are wrong; none of them changes the fix, but they should not be repeated:

1. **`INTERRUPT_CORE0` is 105 registers, not 101, and is not fully contiguous.**
   `0x000..0x19C` is contiguous (104 registers), then `DATE` sits alone at `0x7FC`.
2. **`UART_INTR_MAP` on the C3 is at `0x54`, not `0x58`.** `0x58` is the C3's
   `UART1_INTR_MAP`.
3. **`TG_T0_INT_MAP` on the C3 is at `0x80`, not `0xA0`.** `0xA0` is the C3's
   `SPI_MEM_REJECT_INTR_MAP`.

So "every wrong offset is exactly the C3's offset" holds for `SPI_INTR_2_MAP`
(0x4C) and for the whole `CPU_INT_*` block, but not for the rest: the file was a
hand-compressed hybrid, not a copy of the C3 map. The defect itself — wrong
offsets, wrong first-register name, wrong reset values, C3-only registers — is
confirmed exactly as described.

## Blast radius: none at runtime

`configure_xtensa_esp32s3` calls `bus.peripherals.clear()`
(`crates/core/src/system/xtensa/esp32s3.rs:379`) before registering
`Esp32s3IntMatrix` at `0x600C_2000`. Every S3 firmware path — CLI `run`/`test`,
wasm, world nodes, DAP, Python — goes through that builder, so the declarative
descriptor is *deleted*, not out-voted, and the behavioural model (which already
decoded at `4 * source_id`) is what firmware talks to. This descriptor is live only
on `from_config`-built buses: `chip_conformance`, `bus_visibility`,
`unknown_peripheral_type`.

That makes this a correction to a committed model artifact, not a change in what
any simulation does today. It is still worth fixing: the file is the S3 interrupt
matrix's declarative model of record, it is `include_str!`d into every native and
wasm binary, it is watched by the board drift gate, and it is one `type:` change
away from being the live model.

**The ESP32-C3 is untouched** and stays 103/103 against its own SVD. Every
construction site was checked: the only cross-chip coupling is
`bus/routing.rs:331-334`, which binds the C3 INTC cache by name+base
(`p.name == "interrupt_core0" && p.base == 0x600C_2000`) — which the S3 chip YAML
also declares. That cache is only consumed when `esp32c3_irq_routing` is set, and
that happens in `boot/esp32c3_rom.rs` alone.

## Prove it was broken: RED before, GREEN after

New gate: `crates/core/tests/esp32s3_interrupt_map_vendor_offsets.rs`. Nothing
compared a peripheral descriptor's register offsets to an SVD before —
`svd_conformance` checks base addresses and IRQ numbers only, and
`register_coverage` counts *responses*, which a register at the wrong offset still
produces. An undecoded write in a declarative peripheral is a **silent no-op**, so
"nothing happens" is also what an untested fix looks like.

RED — the descriptor reverted to its committed content (`git diff` empty for that
file, i.e. provably back at HEAD; `grep` confirmed `UART_INTR_MAP: address_offset:
0x058`), everything else unchanged:

```
running 3 tests
test esp32s3_interrupt_matrix_decodes_at_the_vendor_offset ... FAILED
test esp32c3_interrupt_map_is_unchanged_at_its_own_offsets ... ok
test esp32s3_interrupt_map_matches_the_vendor_svd ... FAILED

---- esp32s3_interrupt_matrix_decodes_at_the_vendor_offset stdout ----
assertion `left == right` failed: UART_INTR_MAP (0x6C) must reset to 0x10; 0 means
the offset is undecoded (silent no-op) or the reset value is still the old 0
  left: 0
 right: 16

---- esp32s3_interrupt_map_matches_the_vendor_svd stdout ----
configs/peripherals/esp32s3/interrupt_core0.yaml disagrees with
tests/fixtures/svd/esp32s3.svd (45 findings of 32 registers checked):
  MAC_INTR_MAP: not a register of this silicon's INTERRUPT_CORE0 (offset 0x000 in our model)
  MAC_NMI_MAP: reset 0x00000000, silicon resets to 0x00000010
  SPI_INTR_2_MAP: modelled at 0x04C, silicon puts it at 0x054
  UART_INTR_MAP: modelled at 0x058, silicon puts it at 0x06C
  TG_T0_INT_MAP: modelled at 0x0A0, silicon puts it at 0x0C8
  CPU_INT_ENABLE: not a register of this silicon's INTERRUPT_CORE0 (offset 0x104 in our model)
  CPU_INT_THRESH: not a register of this silicon's INTERRUPT_CORE0 (offset 0x194 in our model)
  CLOCK_GATE: modelled at 0x1A0, silicon puts it at 0x19C
  … 37 more

test result: FAILED. 1 passed; 2 failed
```

GREEN — with the fix restored (`git diff --stat` non-empty: `1 file changed, 118
insertions(+), 93 deletions(-)`):

```
running 3 tests
test esp32s3_interrupt_matrix_decodes_at_the_vendor_offset ... ok
test esp32c3_interrupt_map_is_unchanged_at_its_own_offsets ... ok
test esp32s3_interrupt_map_matches_the_vendor_svd ... ok

test result: ok. 3 passed; 0 failed
```

And the C3 guard can say no. Sabotage: `esp32c3/interrupt_core0.yaml`
`UART_INTR_MAP` moved 84 → 108 (i.e. onto the S3's `0x6C`). `git diff` non-empty
before the run (`1 file changed, 1 insertion(+), 1 deletion(-)`, diff hunk shown):

```
test esp32s3_interrupt_matrix_decodes_at_the_vendor_offset ... ok
test esp32c3_interrupt_map_is_unchanged_at_its_own_offsets ... FAILED
test esp32s3_interrupt_map_matches_the_vendor_svd ... ok

configs/peripherals/esp32c3/interrupt_core0.yaml disagrees with
tests/fixtures/real_world/esp32c3.svd (1 findings of 103 registers checked):
  UART_INTR_MAP: modelled at 0x06C, silicon puts it at 0x054
```

Sabotage reverted; `git diff` for that file empty again.

## Regeneration

`scripts/regen-all.sh` run: exit 0, and the only artifact it moved is
`docs/boards/VALIDATION_STATUS.md`. A second run left the tree clean, so nothing
else is stale. `embedded_descriptors.rs` did **not** change — it `include_str!`s
this file by path, so a content edit needs no regeneration there.

`generate_validation_status.py` digests every path in the board's `models` list,
which includes `configs/peripherals/esp32s3`, so the esp32s3 row flipped to
`✖ DRIFT — model 2026-08-13 > capture; RE-CAPTURE` and the required PR-gate step
`generate_validation_status.py --check --drift` exited **1** (measured). The ack is
therefore re-stamped in `validation/manifest.yaml` with a dated reason: the
2026-08-09 capture read UART0/GPIO/I2C0/RMT/MCPWM0/TIMG0/SYSTIMER/GDMA/SYSTEM/
RTC_CNTL — `INTERRUPT_CORE0` is not among them, so no captured value moves and a
re-capture could not evidence this change either way. `--write-ack-digests` stamped
exactly 1 board. Gate now exits 0.

## Scope — what is deliberately NOT modelled

This models the source rows the S3's own models drive, 31 registers, not all 99.
Offsets not listed stay undecoded — read-as-zero, writes dropped — exactly as
before; that gap is pre-existing and unchanged by this PR. `I2C_EXT0_INTR_MAP`
(0xA8, source 42) is added because the Tier-1 S3 fixture binds that row through the
matrix (`examples/tier1-fixture/esp32s3/src/main.rs`, `check_irq`) — a row with a
proven consumer, not a row added to raise a count.

Left out on purpose:

* `DATE` (0x7FC) — an informational silicon-revision stamp outside the contiguous
  block; the behavioural model reads-as-zero above 0x19C.
* The `INTERRUPT_CORE1` mirror at +0x800 — the SVD carries it as its own
  peripheral, and `Esp32s3IntMatrix` already serves that window.
* The 68 source rows between the modelled ones. Modelling all 99 is the obvious
  follow-up; it is a bigger claim than this fix and belongs in its own change.

## Verification (measured, by exit code)

| suite | pristine `main` | this branch |
|---|---|---|
| `cargo test -p labwired-core --lib` | 3093 passed, 0 failed, exit 0 | 3093 passed, 0 failed, exit 0 |
| `chip_conformance`, `bus_visibility`, `unknown_peripheral_type`, `register_coverage`, `svd_conformance` | 13 passed, 0 failed, exit 0 | 13 passed, 0 failed, exit 0 |
| new `esp32s3_interrupt_map_vendor_offsets` | — | 3 passed, 0 failed, exit 0 |
| `intmatrix_alarm`, `debug_schema_is_not_fidelity` | — | 2 passed, 0 failed, exit 0 |
| `esp32s3_walk_differential` + `intmatrix_alarm` (`--features event-scheduler`) — the S3 interrupt path on the behavioural model | — | 3 passed, 0 failed, exit 0 |

`cargo fmt --all -- --check` exit 0. `cargo clippy -p labwired-core --test
esp32s3_interrupt_map_vendor_offsets -- -D warnings` clean.

Not run here, for an environment reason rather than a result:
`e2e_hello_world` (`--features esp32s3-fixtures`) cross-compiles the S3 example
and dies at `error: linker xtensa-esp32s3-elf-gcc not found` — the Xtensa ESP
toolchain is not installed on this machine. That is not a verdict on the change;
CI has the toolchain.
