### PR TITLE
fix(cli): a ratchet's baseline must be a different commit, and a matrix needs a floor

### DIFF
--- a/crates/cli/src/baseline.rs
+++ b/crates/cli/src/baseline.rs
@@ -1,0 +1,221 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Where a ratchet's baseline comes from.
+//!
+//! A ratchet compares "now" against "the last agreed state". The whole guarantee
+//! rests on those being two DIFFERENT commits. Read the baseline out of the
+//! working tree — `include_str!`, or just opening the file — and the gate
+//! compares the tree to itself: a change that lowers the number and regenerates
+//! the snapshot in the same commit passes, which is precisely the change the
+//! ratchet exists to stop.
+//!
+//! `tier1` got this right and the SVD coverage ratchet did not, so the git dance
+//! lives here once instead of twice: resolve a commit that is genuinely earlier
+//! than HEAD, then read the file's blob AT that commit.
+//!
+//! Refusing is a legitimate answer. A shallow clone cannot resolve a merge base,
+//! and a wrong baseline is indistinguishable from a green gate — so this returns
+//! an error naming the fix rather than guessing.
+
+use std::path::Path;
+
+/// The ref baselines are taken against.
+pub const DEFAULT_BASELINE_REF: &str = "origin/main";
+
+/// Override for [`DEFAULT_BASELINE_REF`] — forks, release branches, and the
+/// tests that must not mutate the process environment to pick one.
+pub const BASELINE_REF_ENV: &str = "LABWIRED_BASELINE_REF";
+
+/// The ref the baseline is taken against, honouring [`BASELINE_REF_ENV`].
+pub fn baseline_ref() -> String {
+    std::env::var(BASELINE_REF_ENV).unwrap_or_else(|_| DEFAULT_BASELINE_REF.to_string())
+}
+
+pub(crate) fn git(root: &Path, args: &[&str]) -> Result<String, String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .map_err(|e| format!("git {}: {e}", args.join(" ")))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git {} failed ({}): {}",
+            args.join(" "),
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// What a baseline lookup found.
+#[derive(Debug)]
+pub struct Baseline {
+    /// Short commit + how it was chosen, for the failure message.
+    pub label: String,
+    /// The file's contents at that commit. `None` means there is no earlier
+    /// recorded state — the file is new — so there is nothing yet to protect.
+    pub blob: Option<String>,
+}
+
+/// Resolve `path`'s contents at the baseline commit.
+///
+/// `what` names the gate in error messages, so a failure says which ratchet
+/// could not establish its baseline.
+pub fn resolve(root: &Path, base_ref: &str, path: &str, what: &str) -> Result<Baseline, String> {
+    // A shallow clone cannot be trusted to resolve a merge base or to walk the
+    // file's history, and a wrong baseline is indistinguishable from a green
+    // gate. Fail loudly with the fix instead of guessing.
+    if git(root, &["rev-parse", "--is-shallow-repository"])? == "true" {
+        return Err(format!(
+            "{what}: this is a SHALLOW clone, so the baseline cannot be established. \
+             Deepen it first (`git fetch --unshallow origin` or `actions/checkout` with \
+             `fetch-depth: 0`) and make sure `{base_ref}` exists. \
+             Refusing to run: a gate that cannot find its baseline must not pass."
+        ));
+    }
+
+    let head = git(root, &["rev-parse", "HEAD"])?;
+    let merge_base = git(root, &["merge-base", "HEAD", base_ref]).map_err(|e| {
+        format!(
+            "{what}: cannot compute merge-base(HEAD, {base_ref}): {e}. \
+             Fetch the baseline ref (`git fetch --no-tags origin \
+             +refs/heads/main:refs/remotes/origin/main`) or point {BASELINE_REF_ENV} \
+             at a ref that exists. Refusing to run without a baseline."
+        )
+    })?;
+
+    let (commit, how) = if merge_base != head {
+        (merge_base.clone(), format!("merge-base with {base_ref}"))
+    } else {
+        // On the trunk: the newest commit that touched the file, and the one
+        // before it.
+        let log = git(
+            root,
+            &["log", "--format=%H", "--first-parent", "HEAD", "--", path],
+        )?;
+        let revs: Vec<&str> = log.lines().collect();
+        match revs.first() {
+            // HEAD itself changed the file — measure against what it replaced.
+            Some(&newest) if newest == head => match revs.get(1) {
+                Some(&prev) => (
+                    prev.to_string(),
+                    "previous recorded state (HEAD is on the baseline branch)".to_string(),
+                ),
+                None => {
+                    return Ok(Baseline {
+                        label: "no prior revision (file introduced by HEAD)".to_string(),
+                        blob: None,
+                    })
+                }
+            },
+            // Unchanged at HEAD: nothing new to ratchet.
+            Some(&newest) => (
+                newest.to_string(),
+                "newest recorded state (unchanged at HEAD)".to_string(),
+            ),
+            None => {
+                return Ok(Baseline {
+                    label: "no recorded revision".to_string(),
+                    blob: None,
+                })
+            }
+        }
+    };
+
+    // The path may not exist at the baseline at all — a file introduced on this
+    // branch. That is "nothing promised yet", NOT a broken gate, so it must be
+    // distinguished from a git failure rather than reported as one. Ask first:
+    // `git show` on a missing path and `git show` on a broken repo both exit
+    // non-zero, and collapsing the two would turn a new file into a hard error.
+    if git(root, &["cat-file", "-e", &format!("{commit}:{path}")]).is_err() {
+        return Ok(Baseline {
+            label: format!("{} (path absent at baseline)", &commit[..commit.len().min(12)]),
+            blob: None,
+        });
+    }
+    let blob = git(root, &["show", &format!("{commit}:{path}")])
+        .map_err(|e| format!("{what}: cannot read {path} at baseline {commit}: {e}"))?;
+    Ok(Baseline {
+        label: format!("{} ({how})", &commit[..commit.len().min(12)]),
+        blob: Some(blob),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seed(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("baseline-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        for args in [
+            vec!["init", "-q"],
+            vec!["config", "user.email", "t@example.com"],
+            vec!["config", "user.name", "t"],
+        ] {
+            git(&dir, &args).unwrap();
+        }
+        dir
+    }
+
+    fn commit(dir: &std::path::Path, path: &str, body: &str, msg: &str) -> String {
+        std::fs::write(dir.join(path), body).unwrap();
+        git(dir, &["add", "-A"]).unwrap();
+        git(dir, &["commit", "-qm", msg, "--no-verify"]).unwrap();
+        git(dir, &["rev-parse", "HEAD"]).unwrap()
+    }
+
+    /// THE DEFECT THIS MODULE EXISTS TO PREVENT. A ratchet that reads its
+    /// baseline from the working tree grades a commit against itself, so a
+    /// change that lowers the number AND rewrites the snapshot in one commit
+    /// passes. The baseline must be the blob at an EARLIER commit.
+    #[test]
+    fn reads_the_earlier_commit_not_the_working_tree() {
+        let dir = seed("earlier");
+        let base = commit(&dir, "snap.json", "{\"v\":1}", "baseline");
+        git(&dir, &["branch", "trunk"]).unwrap();
+        git(&dir, &["checkout", "-q", "-b", "work"]).unwrap();
+        // The shape that used to slip through: change the artifact on the branch.
+        commit(&dir, "snap.json", "{\"v\":0}", "lower it and rewrite the snapshot");
+
+        let found = resolve(&dir, "trunk", "snap.json", "test gate").unwrap();
+        assert_eq!(
+            found.blob.as_deref(),
+            Some("{\"v\":1}"),
+            "baseline must be the blob at {base}, not what the working tree says"
+        );
+        assert!(found.label.contains("merge-base"), "{}", found.label);
+    }
+
+    /// A file introduced by HEAD has no earlier state, so there is nothing to
+    /// protect — and that must be said, not reported as an empty baseline the
+    /// caller mistakes for "no regressions".
+    #[test]
+    fn says_so_when_the_file_is_new() {
+        let dir = seed("new");
+        commit(&dir, "other", "x", "seed");
+        git(&dir, &["branch", "trunk"]).unwrap();
+        commit(&dir, "snap.json", "{\"v\":1}", "introduce the snapshot");
+
+        let found = resolve(&dir, "trunk", "snap.json", "test gate").unwrap();
+        assert!(found.blob.is_none(), "expected no baseline blob");
+    }
+
+    /// A shallow clone cannot resolve a merge base, and a wrong baseline is
+    /// indistinguishable from a green gate.
+    #[test]
+    fn refuses_a_shallow_clone() {
+        let dir = seed("shallow");
+        commit(&dir, "snap.json", "{}", "seed");
+        std::fs::write(dir.join(".git/shallow"), "").unwrap();
+
+        let err = resolve(&dir, DEFAULT_BASELINE_REF, "snap.json", "test gate")
+            .expect_err("a shallow clone must be an error, never a silent pass");
+        assert!(err.contains("SHALLOW"), "{err}");
+    }
+}

--- a/crates/cli/src/baseline.rs
+++ b/crates/cli/src/baseline.rs
@@ -133,7 +133,10 @@ pub fn resolve(root: &Path, base_ref: &str, path: &str, what: &str) -> Result<Ba
     // non-zero, and collapsing the two would turn a new file into a hard error.
     if git(root, &["cat-file", "-e", &format!("{commit}:{path}")]).is_err() {
         return Ok(Baseline {
-            label: format!("{} (path absent at baseline)", &commit[..commit.len().min(12)]),
+            label: format!(
+                "{} (path absent at baseline)",
+                &commit[..commit.len().min(12)]
+            ),
             blob: None,
         });
     }
@@ -181,7 +184,12 @@ mod tests {
         git(&dir, &["branch", "trunk"]).unwrap();
         git(&dir, &["checkout", "-q", "-b", "work"]).unwrap();
         // The shape that used to slip through: change the artifact on the branch.
-        commit(&dir, "snap.json", "{\"v\":0}", "lower it and rewrite the snapshot");
+        commit(
+            &dir,
+            "snap.json",
+            "{\"v\":0}",
+            "lower it and rewrite the snapshot",
+        );
 
         let found = resolve(&dir, "trunk", "snap.json", "test gate").unwrap();
         assert_eq!(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -9,6 +9,7 @@
 // `labwired_cli::...` paths the binary used valid inside the library.
 extern crate self as labwired_cli;
 
+pub mod baseline;
 pub mod bus_vcd;
 pub mod coverage;
 pub mod crash_report;

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -415,26 +415,6 @@ pub fn load_ratchet_acks(root: &Path) -> Result<Vec<RatchetAck>, String> {
     Ok(doc.acks)
 }
 
-/// Resolve the baseline commit for the ratchet, as a `(description, commit)`
-/// pair. See [`resolve_baseline_matrix`] for the rule.
-fn git(root: &Path, args: &[&str]) -> Result<String, String> {
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(args)
-        .output()
-        .map_err(|e| format!("git {}: {e}", args.join(" ")))?;
-    if !out.status.success() {
-        return Err(format!(
-            "git {} failed ({}): {}",
-            args.join(" "),
-            out.status,
-            String::from_utf8_lossy(&out.stderr).trim()
-        ));
-    }
-    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
-}
-
 /// The ref the baseline is taken against.
 pub fn baseline_ref() -> String {
     std::env::var(BASELINE_REF_ENV).unwrap_or_else(|_| DEFAULT_BASELINE_REF.to_string())
@@ -469,86 +449,20 @@ pub fn resolve_baseline_matrix_against(
     root: &Path,
     base_ref: &str,
 ) -> Result<(String, Tier1Matrix), String> {
-    // A shallow clone cannot be trusted to resolve a merge base or to walk the
-    // file's history, and a wrong baseline is indistinguishable from a green
-    // gate. Fail loudly with the fix instead of guessing.
-    if git(root, &["rev-parse", "--is-shallow-repository"])? == "true" {
-        return Err(format!(
-            "tier1 ratchet: this is a SHALLOW clone, so the baseline cannot be established. \
-             Deepen it first (`git fetch --unshallow origin` or \
-             `actions/checkout` with `fetch-depth: 0`) and make sure `{base_ref}` exists. \
-             Refusing to run: a gate that cannot find its baseline must not pass."
-        ));
-    }
-
-    let head = git(root, &["rev-parse", "HEAD"])?;
-    let merge_base = git(root, &["merge-base", "HEAD", base_ref]).map_err(|e| {
-        format!(
-            "tier1 ratchet: cannot compute merge-base(HEAD, {base_ref}): {e}. \
-             Fetch the baseline ref (`git fetch --no-tags origin \
-             +refs/heads/main:refs/remotes/origin/main`) or point {BASELINE_REF_ENV} \
-             at a ref that exists. Refusing to run without a baseline."
-        )
-    })?;
-
-    let (commit, how) = if merge_base != head {
-        (merge_base.clone(), format!("merge-base with {base_ref}"))
-    } else {
-        // On the trunk: the newest commit that touched the matrix, and the one
-        // before it.
-        let log = git(
-            root,
-            &[
-                "log",
-                "--format=%H",
-                "--first-parent",
-                "HEAD",
-                "--",
-                MATRIX_PATH,
-            ],
-        )?;
-        let revs: Vec<&str> = log.lines().collect();
-        match revs.first() {
-            // HEAD itself changed the matrix — measure against what it replaced.
-            Some(&newest) if newest == head => match revs.get(1) {
-                Some(&prev) => (
-                    prev.to_string(),
-                    "previous recorded matrix (HEAD is on the baseline branch)".to_string(),
-                ),
-                // The commit that introduced the file. There is no earlier
-                // recorded state, so there are no `pass` cells to protect.
-                None => {
-                    return Ok((
-                        "no prior matrix revision (file introduced by HEAD)".to_string(),
-                        Tier1Matrix::default(),
-                    ))
-                }
-            },
-            // The matrix is unchanged at HEAD: nothing new to ratchet. The
-            // committed-vs-live ratchet still guards engine drift.
-            Some(&newest) => (
-                newest.to_string(),
-                "newest recorded matrix (unchanged at HEAD)".to_string(),
-            ),
-            None => {
-                return Ok((
-                    "no recorded matrix revision".to_string(),
-                    Tier1Matrix::default(),
-                ))
-            }
-        }
+    // The git dance — shallow-clone refusal, merge-base, walking back on trunk —
+    // lives in `crate::baseline` because the SVD coverage ratchet needs exactly
+    // the same thing. Two copies of "where is my baseline" is how one of them
+    // ends up reading the working tree and grading a commit against itself.
+    let found = crate::baseline::resolve(root, base_ref, MATRIX_PATH, "tier1 ratchet")?;
+    let Some(blob) = found.blob else {
+        // No earlier recorded state: nothing has been promised yet, so there are
+        // no `pass` cells to protect.
+        return Ok((found.label, Tier1Matrix::default()));
     };
-
-    let blob = git(root, &["show", &format!("{commit}:{MATRIX_PATH}")]).map_err(|e| {
-        format!("tier1 ratchet: cannot read {MATRIX_PATH} at baseline {commit}: {e}")
-    })?;
     let matrix: Tier1Matrix = serde_json::from_str(&blob).map_err(|e| {
-        format!("tier1 ratchet: baseline {MATRIX_PATH} at {commit} does not parse: {e}")
+        format!("tier1 ratchet: baseline {MATRIX_PATH} at {} does not parse: {e}", found.label)
     })?;
-    Ok((
-        format!("{} ({how})", &commit[..commit.len().min(12)]),
-        matrix,
-    ))
+    Ok((found.label, matrix))
 }
 
 /// Run the baseline gate: every `pass` the baseline records must still pass
@@ -1396,11 +1310,11 @@ peripherals:
             vec!["config", "user.email", "t@example.com"],
             vec!["config", "user.name", "t"],
         ] {
-            git(&dir, &args).unwrap();
+            crate::baseline::git(&dir, &args).unwrap();
         }
         std::fs::write(dir.join("f"), "x").unwrap();
-        git(&dir, &["add", "-A"]).unwrap();
-        git(&dir, &["commit", "-qm", "seed", "--no-verify"]).unwrap();
+        crate::baseline::git(&dir, &["add", "-A"]).unwrap();
+        crate::baseline::git(&dir, &["commit", "-qm", "seed", "--no-verify"]).unwrap();
         // What `git clone --depth` leaves behind; `rev-parse
         // --is-shallow-repository` keys on exactly this file.
         std::fs::write(dir.join(".git/shallow"), "").unwrap();

--- a/crates/cli/src/tier1.rs
+++ b/crates/cli/src/tier1.rs
@@ -460,7 +460,10 @@ pub fn resolve_baseline_matrix_against(
         return Ok((found.label, Tier1Matrix::default()));
     };
     let matrix: Tier1Matrix = serde_json::from_str(&blob).map_err(|e| {
-        format!("tier1 ratchet: baseline {MATRIX_PATH} at {} does not parse: {e}", found.label)
+        format!(
+            "tier1 ratchet: baseline {MATRIX_PATH} at {} does not parse: {e}",
+            found.label
+        )
     })?;
     Ok((found.label, matrix))
 }

--- a/crates/cli/tests/svd_coverage_ratchet.rs
+++ b/crates/cli/tests/svd_coverage_ratchet.rs
@@ -36,13 +36,9 @@ fn esp32s3_coverage_does_not_regress() {
 
     let root = repo_root();
     let base_ref = labwired_cli::baseline::baseline_ref();
-    let found = labwired_cli::baseline::resolve(
-        &root,
-        &base_ref,
-        COVERAGE_PATH,
-        "svd coverage ratchet",
-    )
-    .expect("resolve the coverage baseline");
+    let found =
+        labwired_cli::baseline::resolve(&root, &base_ref, COVERAGE_PATH, "svd coverage ratchet")
+            .expect("resolve the coverage baseline");
 
     let Some(blob) = found.blob else {
         // The snapshot is new in this commit: nothing has been promised yet, so
@@ -52,7 +48,12 @@ fn esp32s3_coverage_does_not_regress() {
     };
 
     let snapshot: labwired_cli::coverage::CoverageMatrix = serde_json::from_str(&blob)
-        .unwrap_or_else(|e| panic!("baseline {COVERAGE_PATH} at {} does not parse: {e}", found.label));
+        .unwrap_or_else(|e| {
+            panic!(
+                "baseline {COVERAGE_PATH} at {} does not parse: {e}",
+                found.label
+            )
+        });
 
     let mut regressions: BTreeMap<String, (usize, usize)> = BTreeMap::new();
     for (name, snap) in &snapshot.0 {

--- a/crates/cli/tests/svd_coverage_ratchet.rs
+++ b/crates/cli/tests/svd_coverage_ratchet.rs
@@ -1,8 +1,30 @@
 // Regression ratchet: per-peripheral `modelled` coverage must never DROP below
-// the committed snapshot. Gated on the ESP32-S3 SVD being discoverable — skips
-// cleanly where the toolchain isn't installed (like the firmware e2e tests).
+// the baseline. Gated on the ESP32-S3 SVD being discoverable — skips cleanly
+// where the toolchain isn't installed (like the firmware e2e tests).
+//
+// THE BASELINE IS A DIFFERENT COMMIT, AND THAT IS THE WHOLE GUARANTEE.
+// This used to read the snapshot with
+// `include_str!("../../../docs/coverage/esp32s3-coverage.json")` — the file as
+// it exists in the tree being graded. So a change that lowered coverage and
+// regenerated the snapshot in the same commit compared the tree to itself and
+// passed. That is exactly the change this gate exists to stop, and it was the
+// one shape it could not see.
+//
+// It now resolves the blob at the merge-base with the baseline ref, through the
+// same `crate::baseline` resolver the tier1 ratchet uses.
 
 use std::collections::BTreeMap;
+use std::path::Path;
+
+const COVERAGE_PATH: &str = "docs/coverage/esp32s3-coverage.json";
+
+/// Repo root = crates/cli/../.. (same convention as the other CLI tests).
+fn repo_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
 
 #[test]
 fn esp32s3_coverage_does_not_regress() {
@@ -12,9 +34,25 @@ fn esp32s3_coverage_does_not_regress() {
     }
     let (live, _text) = labwired_cli::coverage::run().expect("coverage run");
 
-    let snapshot_json = include_str!("../../../docs/coverage/esp32s3-coverage.json");
-    let snapshot: labwired_cli::coverage::CoverageMatrix =
-        serde_json::from_str(snapshot_json).expect("parse snapshot");
+    let root = repo_root();
+    let base_ref = labwired_cli::baseline::baseline_ref();
+    let found = labwired_cli::baseline::resolve(
+        &root,
+        &base_ref,
+        COVERAGE_PATH,
+        "svd coverage ratchet",
+    )
+    .expect("resolve the coverage baseline");
+
+    let Some(blob) = found.blob else {
+        // The snapshot is new in this commit: nothing has been promised yet, so
+        // there is no earlier number to protect.
+        eprintln!("SKIP: no baseline coverage snapshot yet ({})", found.label);
+        return;
+    };
+
+    let snapshot: labwired_cli::coverage::CoverageMatrix = serde_json::from_str(&blob)
+        .unwrap_or_else(|e| panic!("baseline {COVERAGE_PATH} at {} does not parse: {e}", found.label));
 
     let mut regressions: BTreeMap<String, (usize, usize)> = BTreeMap::new();
     for (name, snap) in &snapshot.0 {
@@ -25,7 +63,8 @@ fn esp32s3_coverage_does_not_regress() {
     }
     assert!(
         regressions.is_empty(),
-        "register coverage regressed (snapshot modelled -> current): {regressions:?}. \
-         If intentional, regenerate: cargo run -p labwired-cli -- coverage --json-out docs/coverage/esp32s3-coverage.json"
+        "register coverage regressed against baseline {} (baseline modelled -> current): {regressions:?}. \
+         If intentional, regenerate: cargo run -p labwired-cli -- coverage --json-out {COVERAGE_PATH}",
+        found.label
     );
 }

--- a/crates/cli/tests/tier1_matrix.rs
+++ b/crates/cli/tests/tier1_matrix.rs
@@ -5,6 +5,19 @@
 // Per-PR Tier-1 matrix harness. Runs every target whose committed fixture
 // exists; skips cleanly (like svd_coverage_ratchet) on fresh clones or before
 // the fixture blobs land.
+//
+// TIER1_TARGETS holds 17 entries: one written as a literal Tier1Target and
+// sixteen built by the fast_boot() helper. Grepping for `chip: "…"` finds only
+// the literal — worth knowing before anyone counts them that way.
+//
+// THE FLOOR. This used to assert row completeness by iterating the matrix it
+// got back — so when `run_all` returned NOTHING, the loop body never executed
+// and the test passed having checked nothing. "Skips cleanly" was doing more
+// work than intended: an absent fixture and a harness that silently produced no
+// rows were the same green. The skip is still legitimate, but it now has to be
+// EXPLAINED: every target is either exercised or named as skipped for a reason
+// that is visible from disk, and the two sets must together account for every
+// declared target.
 use labwired_cli::tier1;
 
 #[test]
@@ -16,10 +29,59 @@ use labwired_cli::tier1;
 )]
 fn tier1_matrix_runs_all_available_fixtures() {
     let bin = std::path::Path::new(env!("CARGO_BIN_EXE_labwired"));
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let (matrix, skipped) = tier1::run_all(bin).unwrap_or_else(|e| panic!("tier1 run_all: {e}"));
     for chip in &skipped {
         eprintln!("SKIP: {chip} (fixture not present)");
     }
+
+    // Every declared target is accounted for exactly once, as either exercised
+    // or skipped. A target that appears in neither is a target the harness
+    // quietly dropped.
+    let exercised: std::collections::BTreeSet<&str> =
+        matrix.0.keys().map(|s| s.as_str()).collect();
+    let skipped_set: std::collections::BTreeSet<&str> =
+        skipped.iter().map(|s| s.as_str()).collect();
+    let unaccounted: Vec<&str> = tier1::TIER1_TARGETS
+        .iter()
+        .map(|t| t.chip)
+        .filter(|c| !exercised.contains(c) && !skipped_set.contains(c))
+        .collect();
+    assert!(
+        unaccounted.is_empty(),
+        "targets neither exercised nor skipped: {unaccounted:?} — the harness dropped them"
+    );
+
+    // A target may only be skipped because its fixture is genuinely absent from
+    // disk. Without this, "skipped" is an unfalsifiable excuse and an empty
+    // matrix is indistinguishable from a working one.
+    for chip in &skipped {
+        let target = tier1::TIER1_TARGETS
+            .iter()
+            .find(|t| t.chip == chip.as_str())
+            .unwrap_or_else(|| panic!("skipped chip {chip} is not a declared target"));
+        let elf = root.join(target.elf);
+        assert!(
+            !elf.exists(),
+            "{chip} was skipped but its fixture IS present at {} — that is a silent drop, not a skip",
+            elf.display()
+        );
+    }
+
+    // THE FLOOR: if any fixture is on disk, the matrix must not be empty. This
+    // is the assertion whose absence let a no-op run report success.
+    let present: Vec<&str> = tier1::TIER1_TARGETS
+        .iter()
+        .filter(|t| root.join(t.elf).exists())
+        .map(|t| t.chip)
+        .collect();
+    assert_eq!(
+        exercised.len(),
+        present.len(),
+        "fixtures on disk: {present:?}, but the matrix exercised {exercised:?} — \
+         a matrix that runs fewer chips than it has fixtures for is not a matrix"
+    );
+
     // Every exercised chip must produce a full row (rubric + extra classes).
     for (chip, row) in &matrix.0 {
         let target = tier1::TIER1_TARGETS

--- a/crates/cli/tests/tier1_matrix.rs
+++ b/crates/cli/tests/tier1_matrix.rs
@@ -38,8 +38,7 @@ fn tier1_matrix_runs_all_available_fixtures() {
     // Every declared target is accounted for exactly once, as either exercised
     // or skipped. A target that appears in neither is a target the harness
     // quietly dropped.
-    let exercised: std::collections::BTreeSet<&str> =
-        matrix.0.keys().map(|s| s.as_str()).collect();
+    let exercised: std::collections::BTreeSet<&str> = matrix.0.keys().map(|s| s.as_str()).collect();
     let skipped_set: std::collections::BTreeSet<&str> =
         skipped.iter().map(|s| s.as_str()).collect();
     let unaccounted: Vec<&str> = tier1::TIER1_TARGETS


### PR DESCRIPTION
Rows **2.4** and **2.11**. Both are the same defect in different clothes: a gate that cannot fail on the change it exists to stop.

## 2.4 — the baseline was the tree being graded

`svd_coverage_ratchet` read its baseline with `include_str!("../../../docs/coverage/esp32s3-coverage.json")` — the file as it exists **in the commit under test**. A change that lowered coverage *and* regenerated the snapshot compared the tree to itself and passed. That is the one shape the ratchet exists to catch.

`tier1` already solved this properly, so the git dance (shallow-clone refusal, merge-base, walking back on trunk) moves into **`crate::baseline`** and both callers share it rather than growing a second copy. `resolve_baseline_matrix_against` becomes a thin wrapper — env var and error prefixes unchanged, its 42 tests still pass — and tier1's now-duplicate private `git()` is deleted.

**Writing the shared module's tests found a real gap in it.** A path that doesn't exist at the baseline commit — a file introduced on this branch — *errored* instead of reporting "no baseline". `git show` fails identically for a missing path and a broken repo, so the two are now distinguished with `cat-file -e`. Collapsing them turns a new file into a hard error.

## 2.11 — the matrix had no floor

`tier1_matrix` asserted row completeness **by iterating the matrix it got back**, so when `run_all` returned nothing the loop body never executed and the test passed having checked nothing. It now:

- accounts for every declared target as either exercised or skipped;
- allows a skip **only** when the fixture is genuinely absent from disk;
- asserts the exercised count equals the number of fixtures present.

An absent fixture and a harness producing no rows are no longer the same green.

## Verified by running it

- Real run: **71.7s, passes** (it is `#[ignore]`d in debug, so this was run with `-- --ignored`).
- **Sabotage:** clearing the matrix after `run_all` — the exact no-op the old test called success — fails with `targets neither exercised nor skipped`, naming fifteen chips.
- 3 new tests on the shared resolver, including the decisive one: the baseline must be the blob at an **earlier** commit, not what the working tree says.
- `labwired-cli` lib: **134 passed**. `clippy --all-targets -D warnings`: clean.

⚠️ That sabotage also **corrected me**. I had recorded that `TIER1_TARGETS` holds *one* entry. It holds **17** — one literal plus sixteen from a `fast_boot()` helper, so grepping `chip: "…"` finds only the literal. The count is now stated in the test file so nobody repeats the grep.
