### PR TITLE
fix(codegen): decide every IrAccess variant, and delete the dead converter

### DIFF
--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -136,13 +136,34 @@ impl PeripheralGenerator {
             }
         };
 
-        // Generate setter only if access allows write
-        let setter = if matches!(
-            field.access,
-            None | Some(labwired_ir::IrAccess::ReadWrite)
-                | Some(labwired_ir::IrAccess::WriteOnly)
-                | Some(labwired_ir::IrAccess::Write1ToClear)
-        ) {
+        // Generate setter only if access allows write.
+        //
+        // EXHAUSTIVE ON PURPOSE — no `_` arm. This was a `matches!` whitelist,
+        // which is a wildcard wearing a list: every variant it did not name was
+        // silently denied a setter, so ADDING a variant to IrAccess produced a
+        // register type quietly missing a write path instead of a build error.
+        // For generated code that is the worst shape of failure — nothing to
+        // read, nothing to grep, and the omission only shows up as firmware
+        // that cannot drive a peripheral.
+        //
+        // The arms below preserve exactly what the whitelist did. WriteOnce and
+        // ReadWriteOnce are deliberately still `false`: they are OTP and lock
+        // bits, a plain `set_*` would invite the second write that silicon
+        // refuses, and giving them one is a modelling decision rather than a
+        // mechanical fix. Recorded here so the next reader sees a choice and not
+        // an oversight.
+        let writable = match field.access {
+            None
+            | Some(labwired_ir::IrAccess::ReadWrite)
+            | Some(labwired_ir::IrAccess::WriteOnly)
+            | Some(labwired_ir::IrAccess::Write1ToClear) => true,
+            Some(labwired_ir::IrAccess::ReadOnly)
+            | Some(labwired_ir::IrAccess::ReadToClear)
+            | Some(labwired_ir::IrAccess::WriteOnce)
+            | Some(labwired_ir::IrAccess::ReadWriteOnce)
+            | Some(labwired_ir::IrAccess::Unknown) => false,
+        };
+        let setter = if writable {
             quote! {
                 #[doc = #description]
                 pub fn #set_name(&mut self, value: u32) {

--- a/crates/ir/src/lib.rs
+++ b/crates/ir/src/lib.rs
@@ -170,23 +170,6 @@ pub enum IrAccess {
     Unknown,
 }
 
-#[cfg(feature = "config-interop")]
-impl IrAccess {
-    /// Converts IrAccess to labwired-config::Access
-    pub fn to_config_access(&self) -> Option<serde_yaml::Value> {
-        // This is a bit of a hack because labwired-config::Access is an enum.
-        // But since we are likely going to use this in a From implementation,
-        // it's better to just return the string or a real type.
-        // Let's assume we want the literal string that serde would expect.
-        match self {
-            IrAccess::ReadOnly => Some(serde_yaml::Value::String("RO".to_string())),
-            IrAccess::WriteOnly => Some(serde_yaml::Value::String("WO".to_string())),
-            IrAccess::ReadWrite => Some(serde_yaml::Value::String("R/W".to_string())),
-            _ => None,
-        }
-    }
-}
-
 /// Represents an interrupt definition associated with a peripheral.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IrInterrupt {


### PR DESCRIPTION
Row 4.7, **first of three sub-fixes**.

Whether a generated register field gets a setter was decided by a `matches!` whitelist — **a wildcard wearing a list**. Every variant it did not name was silently denied a setter, so *adding* a variant to `IrAccess` produced a register type quietly missing its write path instead of a build error.

For generated code that is the worst shape of failure: nothing to read, nothing to grep, and the omission only surfaces as firmware that cannot drive a peripheral.

## Now exhaustive, with no `_` arm

Behaviour is unchanged — the same four cases are writable — but the compiler refuses a variant nobody has classified.

**Verified:** adding one fails with
`error[E0004]: non-exhaustive patterns: Some(IrAccess::ReadWriteHalfWord) not covered`.
Before this, that variant compiled and lost its setter in silence.

`WriteOnce` and `ReadWriteOnce` stay non-writable, and the reason is now written down rather than implied by omission: they are OTP and lock bits, a plain `set_*` invites the second write silicon refuses, and giving them one is a modelling decision rather than a mechanical fix.

`IrAccess::to_config_access` is **deleted** — one reference in the whole repo, its own definition, and its own comment called it *"a bit of a hack"*.

## Not done — the row stays half

`MemoryRange.size` is still `String` with `// e.g. "128KB"` beside it, parsed by `parse_size` at each call site. Typing it means a custom `Deserialize` plus every chip YAML and construction site in the test corpus — its own change, not a rider on this one.

## Verified

- `labwired-codegen` + `labwired-ir`: build, test, `clippy --all-targets -D warnings` clean.
- `labwired-core`, `labwired-cli`, `labwired-config` build.
- ⚠️ `cargo build --workspace` fails on `riscv-rt` and `pyo3-ffi` — **byte-identical on pristine main**, toolchain gaps on this host, not this change.
