### PR TITLE
test(core): ratchet the undecoded-register allow-list

### DIFF
--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -531,11 +531,18 @@ jobs:
       # Through the wrapper, because that is the whole point: if a future
       # feature rename empties one of these binaries, the step must go RED
       # rather than back to the `0 passed` it spent its whole life reporting.
+      # `undecoded_register_ratchet` rides along here: same feature set, so it
+      # is a cache hit rather than a second compile, and the wrapper stops it
+      # from ever reporting `0 passed`. It replays every entry in
+      # docs/coverage/undecoded-registers.json against the real model and goes
+      # RED when one stops falling through — i.e. when the register got
+      # implemented and the entry should have been deleted.
       - name: Census probe + egress bridge (silent-census, net-tests)
         run: >
           scripts/ci/cargo-test-nonvacuous.sh
           -p labwired-core --features silent-census,net-tests,wifi-thunks
           --test census_probe --test egress_e2e
+          --test undecoded_register_ratchet
 
       # `wifi-thunks` gates ONE test and it is `#[ignore]`d, so a plain lane
       # would run zero of it and report green — a vacuous gate is worse than

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -156,6 +156,11 @@ required-features = ["event-scheduler"]
 name = "census_probe"
 required-features = ["silent-census"]
 
+# #![cfg(feature = "silent-census")]
+[[test]]
+name = "undecoded_register_ratchet"
+required-features = ["silent-census"]
+
 # #![cfg(feature = "esp32s3-fixtures")]
 [[test]]
 name = "e2e_blinky"

--- a/crates/core/tests/undecoded_register_ratchet.rs
+++ b/crates/core/tests/undecoded_register_ratchet.rs
@@ -1,0 +1,242 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Ratchet over the undecoded MMIO register accesses the shipped corpus performs.
+//!
+//! # What this enforces
+//!
+//! `docs/coverage/undecoded-registers.json` is the committed allow-list: the 5
+//! distinct `(peripheral, offset, kind)` triples the silent-path census found
+//! across 68 runs. This file holds that list to three rules:
+//!
+//! 1. **Every entry still reproduces.** Each one is replayed against the real
+//!    model, and the census must record it. The day someone implements the
+//!    register — or removes the guard that was rejecting the write — the replay
+//!    stops being recorded and this test goes RED, forcing the entry out of the
+//!    list. That is the shrink direction, and it is the whole point: a fixed
+//!    register that stays on the list turns the list into an excuse.
+//! 2. **The list cannot grow silently.** `max_entries` is committed alongside
+//!    it and must be lowered whenever an entry is removed.
+//! 3. **Every entry is classified and justified.** An entry with no reason is
+//!    an entry nobody has looked at.
+//!
+//! # What this does NOT do
+//!
+//! It does not *discover* new undecoded accesses. Discovery needs the full
+//! census campaign — build the CLI with `--features silent-census`, run the
+//! corpus with `LABWIRED_CENSUS_OUT` set, aggregate. That is documented in
+//! `docs/coverage/silent-path-census.md` and costs far more than a test lane.
+//! What this catches is the *other* direction: the list going stale while the
+//! models move underneath it.
+//!
+//! Stating that plainly matters. A gate whose limits are not written down gets
+//! read as covering more than it does — which is how a green tick starts
+//! meaning "nobody checked".
+//!
+//! # Why a replay and not a corpus run
+//!
+//! Reproducing an entry needs the peripheral, the offset and the direction —
+//! all three are in the allow-list, and every one of these models is
+//! constructible in isolation. Replaying costs microseconds; running the five
+//! labs that hit these offsets costs ~9.5M simulated steps and needs their
+//! firmware ELFs. The replay tests the same claim: *is this offset still
+//! undecoded on this model?*
+//!
+//! Runs in the nightly `silent-census` lane, through
+//! `scripts/ci/cargo-test-nonvacuous.sh`, so an empty binary fails instead of
+//! reporting `0 passed`.
+
+#![cfg(feature = "silent-census")]
+
+use labwired_core::Peripheral;
+
+/// The census is process-global, and every test here asserts absolute totals
+/// after a `reset()`. `cargo test` runs a binary's tests concurrently, so
+/// without this they read each other's tallies.
+static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn serialized() -> std::sync::MutexGuard<'static, ()> {
+    let g = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    labwired_core::census::reset();
+    g
+}
+
+const ALLOW_LIST: &str = include_str!("../../../docs/coverage/undecoded-registers.json");
+
+const CLASSIFICATIONS: &[&str] = &["guard_reject", "not_a_register", "unmodelled_register"];
+
+fn allow_list() -> serde_json::Value {
+    serde_json::from_str(ALLOW_LIST)
+        .expect("docs/coverage/undecoded-registers.json is not valid JSON")
+}
+
+fn entries(v: &serde_json::Value) -> &Vec<serde_json::Value> {
+    v["entries"].as_array().expect("`entries` must be an array")
+}
+
+/// Replay one allow-list entry against the real model it names.
+///
+/// Every peripheral is built fresh and left in its reset state, which is what
+/// makes the `guard_reject` entries reproduce: `Iwdg` boots with the write
+/// unlock clear and `Fdcan` with `CCCR.TEST` clear, so those writes fall to the
+/// catch-all exactly as they do on the labs that recorded them.
+fn replay(peripheral: &str, offset: u64, kind: &str) {
+    assert_eq!(
+        kind, "write",
+        "only write replays are implemented; {peripheral}@{offset:#06x} is a {kind}"
+    );
+    let mut model: Box<dyn Peripheral> = match peripheral {
+        "iwdg:Iwdg" => Box::new(labwired_core::peripherals::iwdg::Iwdg::new()),
+        "fdcan:Fdcan" => Box::new(labwired_core::peripherals::fdcan::Fdcan::new()),
+        "nrf52.twim:Nrf52Twim" => {
+            Box::new(labwired_core::peripherals::nrf52::twim::Nrf52Twim::new())
+        }
+        "nrf54l.twim:Nrf54lTwim" => {
+            Box::new(labwired_core::peripherals::nrf54l::twim::Nrf54lTwim::new())
+        }
+        other => panic!(
+            "the allow-list names peripheral `{other}`, which this test cannot construct. \
+             Add it to `replay` — an entry nothing can replay is an entry nothing enforces."
+        ),
+    };
+    model
+        .write_u32(offset, 0xDEAD_BEEF)
+        .unwrap_or_else(|e| panic!("{peripheral}@{offset:#06x} write failed: {e:?}"));
+}
+
+fn parse_offset(s: &str) -> u64 {
+    u64::from_str_radix(s.trim_start_matches("0x"), 16)
+        .unwrap_or_else(|_| panic!("offset `{s}` is not hex"))
+}
+
+/// The load-bearing test: each committed entry must STILL be undecoded.
+#[test]
+fn every_allow_listed_entry_is_still_undecoded() {
+    let _guard = serialized();
+    let list = allow_list();
+
+    for e in entries(&list) {
+        labwired_core::census::reset();
+        let periph = e["peripheral"].as_str().expect("peripheral");
+        let offset_str = e["offset"].as_str().expect("offset");
+        let kind = e["kind"].as_str().expect("kind");
+
+        replay(periph, parse_offset(offset_str), kind);
+
+        let j = labwired_core::census::to_json();
+        let hit = j["undecoded_register_access"]["entries"]
+            .as_array()
+            .expect("entries")
+            .iter()
+            .any(|r| {
+                r["peripheral"] == *periph && r["offset"] == *offset_str && r["kind"] == *kind
+            });
+
+        assert!(
+            hit,
+            "{periph}@{offset_str} ({kind}) is on the allow-list in \
+             docs/coverage/undecoded-registers.json but the model no longer falls through on it. \
+             If the register was implemented, or the guard that was rejecting the write is gone, \
+             DELETE this entry and lower `max_entries`. The list only shrinks."
+        );
+    }
+}
+
+/// The probe must be able to tell decoded from undecoded, or the test above
+/// passes for the wrong reason.
+#[test]
+fn a_decoded_offset_is_not_recorded() {
+    let _guard = serialized();
+
+    // IWDG KR at 0x00 is decoded unconditionally (it is the unlock register
+    // itself, so it carries no guard) — the one offset on this model that
+    // cannot fall through.
+    let mut iwdg = labwired_core::peripherals::iwdg::Iwdg::new();
+    iwdg.write_u32(0x00, 0x5555).unwrap();
+    assert_eq!(
+        labwired_core::census::to_json()["undecoded_register_access"]["total"],
+        0,
+        "a decoded offset was recorded as undecoded — the counter is firing on everything, \
+         which would make the allow-list test vacuously green"
+    );
+
+    // And the same model DOES record a genuinely unmapped offset, so the zero
+    // above is a real negative and not a dead counter.
+    //
+    // Asserted per-key, not on `total`: a 32-bit access is serviced as four
+    // byte accesses, and on this model `write_u32` is a read-modify-write, so
+    // one call lands 4 reads AND 4 writes on the same key. That multiplier is
+    // why `silent-path-census.md` reads raw counts with a 4x divide — it is a
+    // property of the bus width, not of how undecoded the offset is, so
+    // pinning an exact total here would encode an unrelated implementation
+    // detail and break the day a model stops round-tripping.
+    iwdg.write_u32(0xF0, 0x1).unwrap();
+    let j = labwired_core::census::to_json();
+    let hit = j["undecoded_register_access"]["entries"]
+        .as_array()
+        .expect("entries")
+        .iter()
+        .find(|r| r["offset"] == "0x00f0" && r["kind"] == "write")
+        .and_then(|r| r["count"].as_u64())
+        .unwrap_or(0);
+    assert!(
+        hit > 0,
+        "the counter never fired on a known-unmapped offset; census entries were {}",
+        j["undecoded_register_access"]["entries"]
+    );
+}
+
+/// Structural rules: the list cannot grow by editing, and cannot rot into a
+/// bare list of offsets nobody has reasoned about.
+#[test]
+fn the_allow_list_only_shrinks_and_every_entry_is_justified() {
+    let list = allow_list();
+    let es = entries(&list);
+    let max = list["max_entries"].as_u64().expect("max_entries") as usize;
+
+    assert!(
+        !es.is_empty(),
+        "the allow-list is empty. If the corpus really performs zero undecoded accesses that is \
+         excellent news — but delete this test with it, because an empty list makes \
+         `every_allow_listed_entry_is_still_undecoded` iterate nothing and report green."
+    );
+    assert!(
+        es.len() <= max,
+        "{} entries against max_entries {}. The list grew. A new undecoded access is a finding, \
+         not a line to add: fix the model, or raise max_entries in the same commit that explains why.",
+        es.len(),
+        max
+    );
+    assert_eq!(
+        es.len(),
+        max,
+        "max_entries is {} but the list holds {}. When an entry is removed, lower max_entries in \
+         the same commit — otherwise the slack silently re-admits it later.",
+        max,
+        es.len()
+    );
+
+    for e in es {
+        let periph = e["peripheral"].as_str().expect("peripheral");
+        let off = e["offset"].as_str().expect("offset");
+        let class = e["classification"].as_str().unwrap_or("");
+        assert!(
+            CLASSIFICATIONS.contains(&class),
+            "{periph}@{off} has classification `{class}`, which is not one of {CLASSIFICATIONS:?}"
+        );
+        let reason = e["reason"].as_str().unwrap_or("");
+        assert!(
+            reason.len() > 80,
+            "{periph}@{off} has no real reason ({} chars). Say which register the offset is, on \
+             whose authority, and what would have to change to remove the entry.",
+            reason.len()
+        );
+        assert!(
+            e["seen_in"].as_str().is_some_and(|s| s.contains(".yaml")),
+            "{periph}@{off} must name the lab that recorded it, so the claim can be re-measured"
+        );
+    }
+}

--- a/docs/coverage/undecoded-registers.json
+++ b/docs/coverage/undecoded-registers.json
@@ -1,0 +1,57 @@
+{
+  "_about": "Committed allow-list of undecoded MMIO register accesses that the shipped corpus actually performs. Enforced by crates/core/tests/undecoded_register_ratchet.rs. This list may only SHRINK: remove an entry when the model grows the register or the firmware stops writing it, and lower max_entries to match. Adding an entry is a deliberate act that must carry a reason and a classification.",
+  "_source": "Measured by the silent-path census, counter (c). See docs/coverage/silent-path-census.md: 11 raw hits, 5 distinct (peripheral, offset, kind), in 5 of 68 runs. Every entry below is one of those 5.",
+  "_classification": {
+    "guard_reject": "NOT a modelling gap. The offset IS decoded, but its match arm carries a guard (an unlock bit, a mode bit) that was false, so control fell to the catch-all. Dropping the write is the silicon-correct behaviour. The census cannot distinguish this from an unmapped offset, because a guarded arm and a missing arm reach the same `_`. Present here so the count is honest, not because anything is wrong.",
+    "not_a_register": "The offset does not exist on this peripheral in the vendor spec. Firmware wrote to it anyway; the model is right to ignore it. What deserves attention is the firmware, not the model.",
+    "unmodelled_register": "A real register in the vendor spec that the model does not implement. This is the actionable class — the WB55 shape, where a configuration write is silently swallowed and the sim stays green while silicon would not."
+  },
+  "max_entries": 5,
+  "entries": [
+    {
+      "peripheral": "iwdg:Iwdg",
+      "offset": "0x0008",
+      "kind": "write",
+      "classification": "guard_reject",
+      "register": "RLR (Reload)",
+      "seen_in": "examples/stm32f411ceu6-blackpill/io-smoke.yaml",
+      "reason": "iwdg.rs decodes 0x08 as `0x08 if self.write_access => self.rlr = value & 0xFFF`. RLR is write-protected: without the 0x5555 unlock key in KR the write is dropped, which is what the F103 bench silicon does. The guard being false routes the access to the catch-all, so the census records it as undecoded. The register is modelled; nothing to fix."
+    },
+    {
+      "peripheral": "fdcan:Fdcan",
+      "offset": "0x0010",
+      "kind": "write",
+      "classification": "guard_reject",
+      "register": "TEST",
+      "seen_in": "examples/h563-uds-ecu/uds-smoke.yaml, examples/h563-uds-ecu/uds-session-smoke.yaml",
+      "reason": "fdcan.rs decodes REG_TEST (0x010) as `REG_TEST if self.cccr & CCCR_TEST != 0`. TEST is writable only while CCCR.TEST is set; the UDS firmware writes it without entering test mode, so the guard is false and the access falls through. The register is modelled; nothing to fix."
+    },
+    {
+      "peripheral": "nrf52.twim:Nrf52Twim",
+      "offset": "0x0510",
+      "kind": "write",
+      "classification": "not_a_register",
+      "register": "none — 0x510 is unassigned on TWIM",
+      "seen_in": "examples/seeed-xiao-nrf52840-sense/uart-gpio-spi-smoke.yaml",
+      "reason": "The nRF52840 Product Specification v1.11 TWIM register overview (p.791) runs ENABLE 0x500, PSEL.SCL 0x508, PSEL.SDA 0x50C, FREQUENCY 0x524 — there is no 0x510. 0x510 is PSEL.MOSI on SPIM (p.728) and PSEL.MISO on SPI (p.718); nRF52840 shares one address block between SPIM/SPIS/TWIM/TWIS per instance, so this is a driver writing the SPI pin-select layout at a TWIM-modelled instance. Ignoring it matches silicon. Do NOT add a 0x510 arm to the TWIM model to silence this."
+    },
+    {
+      "peripheral": "nrf54l.twim:Nrf54lTwim",
+      "offset": "0x0508",
+      "kind": "write",
+      "classification": "unmodelled_register",
+      "register": "legacy PSEL.SCL offset; on nRF54L the register lives at 0x600",
+      "seen_in": "examples/nrf54l15-smart-ring/io-smoke.yaml",
+      "reason": "Two defects meet here. (1) The nRF54L15 datasheet v1.0 TWIM register overview (p.660, detail p.679 §8.23.10.29) puts PSEL.SCL at 0x600 — the 0x508 of the nRF52 generation was moved. Firmware writing 0x508 is using the old map, and on real nRF54L silicon that write lands on reserved space and the pin is never selected. (2) nrf54l/twim.rs models neither offset: it has no OFF_PSEL_* constant at all, so even a correct write to 0x600 would be swallowed. The model must grow PSEL.SCL/PSEL.SDA at 0x600/0x604 before this entry can be judged; removing it requires fixing the firmware too."
+    },
+    {
+      "peripheral": "nrf54l.twim:Nrf54lTwim",
+      "offset": "0x050c",
+      "kind": "write",
+      "classification": "unmodelled_register",
+      "register": "legacy PSEL.SDA offset; on nRF54L the register lives at 0x604",
+      "seen_in": "examples/nrf54l15-smart-ring/io-smoke.yaml",
+      "reason": "The SDA half of the 0x508 entry above, and the same two defects. nRF54L15 datasheet v1.0 p.660 puts PSEL.SDA at 0x604."
+    }
+  ]
+}


### PR DESCRIPTION
Remediation row 4.4 — *register-enforcement gate with a shrinking allow-list*. The ledger check found no committed allow-list existed: outside Rust source the only file mentioning "undecoded" was `crates/core/Cargo.toml`, the census feature's own doc comment.

The silent-path census measured counter (c) once — 11 raw hits, **5 distinct** `(peripheral, offset, kind)` across 68 runs — and wrote it into a document. Nothing held the models to it, so the number could rot in either direction unnoticed.

## What this adds

`docs/coverage/undecoded-registers.json` commits those 5. `undecoded_register_ratchet.rs` enforces three rules:

1. **Every entry still reproduces** — each is replayed against the real model and the census must record it. Implement the register, or drop the guard that was rejecting the write, and the replay stops being recorded → RED → the entry must go. That is the shrink direction.
2. **The list cannot grow silently** — `max_entries` is committed beside it and must be lowered whenever an entry is removed.
3. **Every entry carries a classification and a real reason.**

## Watched failing in both directions first

```
# adding a decoded 0x508 arm to nrf54l/twim.rs
nrf54l.twim:Nrf54lTwim@0x0508 (write) is on the allow-list in
docs/coverage/undecoded-registers.json but the model no longer falls through on it.
... DELETE this entry and lower `max_entries`. The list only shrinks.

# appending a 6th entry without touching max_entries
6 entries against max_entries 5. The list grew. A new undecoded access is a finding,
not a line to add.
```

Both sabotages reverted; `no_vacuous_test_targets` and `census_probe` still 4/4 and 3/3.

## Classifying the 5 found two false positives and one real defect

| entry | class | finding |
| --- | --- | --- |
| `iwdg` `0x0008` | `guard_reject` | **Not a gap.** Decoded as `0x08 if self.write_access`. RLR is write-protected; without the `0x5555` unlock the write is dropped — silicon-correct. A false guard reaches the same `_` an unmapped offset would. |
| `fdcan` `0x0010` | `guard_reject` | **Not a gap.** `REG_TEST if self.cccr & CCCR_TEST != 0`. The UDS firmware writes TEST without entering test mode. |
| `nrf52.twim` `0x0510` | `not_a_register` | **Not a TWIM register.** nRF52840 PS v1.11 TWIM map (p.791): ENABLE 0x500, PSEL.SCL 0x508, PSEL.SDA 0x50C, FREQUENCY 0x524 — no 0x510. That offset is PSEL.MOSI on SPIM (p.728), and the part shares one address block across SPIM/SPIS/TWIM/TWIS. A driver writing the SPI layout at a TWIM instance. The entry says *do not* add an arm to silence it. |
| `nrf54l.twim` `0x0508`/`0x050c` | `unmodelled_register` | **Real, and worse than a missing arm.** nRF54L15 datasheet v1.0 (p.660, detail p.679 §8.23.10.29) puts PSEL.SCL/PSEL.SDA at **0x600/0x604** — the nRF52-era offsets were moved. Firmware writes the old ones, which on real silicon land in reserved space and never select the pins; and `nrf54l/twim.rs` models neither address, so the sim stays green either way. |

MCU facts are from `labwired_datasheet`, page-cited, not inferred.

## Scope, stated in the file

This does **not** discover new undecoded accesses — that needs the full census campaign (`--features silent-census` + `LABWIRED_CENSUS_OUT` over the corpus). It catches the other direction: the list going stale while the models move underneath it. Writing that limit down is deliberate; a gate whose limits are unstated gets read as covering more than it does.

## CI cost

Effectively zero. It rides the existing nightly `silent-census` step with the same feature set (cache hit, not a second compile), wrapped in `cargo-test-nonvacuous.sh` so an empty binary fails instead of reporting `0 passed`.