### PR TITLE
refactor(config): memory sizes are u64, parsed once at the boundary

### DIFF
--- a/crates/cli/src/asset_validation.rs
+++ b/crates/cli/src/asset_validation.rs
@@ -332,8 +332,8 @@ fn validate_chip(path: &PathBuf) -> ExitCode {
     }
 
     // 2. Memory Region Validation
-    let flash_size = labwired_config::parse_size(&chip.flash.size).unwrap_or(0);
-    let ram_size = labwired_config::parse_size(&chip.ram.size).unwrap_or(0);
+    let flash_size = chip.flash.size;
+    let ram_size = chip.ram.size;
 
     if flash_size == 0 {
         result.add_error(

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -139,8 +139,7 @@ pub(crate) fn run_firmware_riscv(
         // stack pointer before jumping to the app, so SP=0 and the app's first
         // prologue store faults near 0xffffffff. Seed SP at the top of DRAM
         // (16-byte aligned, RISC-V ABI) so real IDF apps can boot.
-        let sp_top =
-            (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+        let sp_top = (chip.ram.base + chip.ram.size) as u32;
         machine.cpu.set_sp(sp_top & !0xF);
         machine
     };

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -1825,8 +1825,8 @@ pub(crate) fn run_test(
                             .unwrap_or_else(|| std::path::Path::new("."))
                             ;
                         if let Ok(chip) = labwired_config::ChipDescriptor::resolve_with(&manifest.chip, chip_dir, &crate::plugin_chip_yaml(plugins)) {
-                            if let Ok(ram_sz) = labwired_config::parse_size(&chip.ram.size) {
-                                let mut sp_top = (chip.ram.base + ram_sz) as u32;
+                            {
+                                let mut sp_top = (chip.ram.base + chip.ram.size) as u32;
                                 // ESP32-C3 boot stack placement:
                                 // - IDF `SOC_DRAM_HIGH` = 0x3FCE_0000; SP must
                                 //   be < that for `s_task_stack_is_sane_when_cache_frozen`.

--- a/crates/cli/src/resource_report.rs
+++ b/crates/cli/src/resource_report.rs
@@ -34,11 +34,12 @@ pub(crate) struct ChipMemoryMap {
 }
 
 impl ChipMemoryMap {
-    /// Build from a chip descriptor; size strings use [`labwired_config::parse_size`].
+    /// Build from a chip descriptor. Sizes arrive already in bytes — the parse
+    /// moved to deserialisation, so there is no longer a failure to swallow.
     pub(crate) fn from_chip(chip: &labwired_config::ChipDescriptor) -> Self {
-        let flash_total = labwired_config::parse_size(&chip.flash.size).ok();
-        let ram_total = labwired_config::parse_size(&chip.ram.size).ok();
-        let ram_size = ram_total.unwrap_or(0);
+        let flash_total = Some(chip.flash.size);
+        let ram_total = Some(chip.ram.size);
+        let ram_size = chip.ram.size;
         Self {
             ram: RamRegion {
                 base: chip.ram.base,

--- a/crates/cli/tests/config_validation.rs
+++ b/crates/cli/tests/config_validation.rs
@@ -103,8 +103,14 @@ fn test_stm32f401cdu6_chip_loads_with_i2c1() {
     let chip = ChipDescriptor::from_file(&chip_path).expect("F401CDU6 chip yaml failed to parse");
 
     assert_eq!(chip.name, "stm32f401cdu6");
-    assert_eq!(chip.flash.size, "384KB");
-    assert_eq!(chip.ram.size, "96KB");
+    // The yaml says "384KB" / "96KB"; the field now holds the parsed byte
+    // count. Asserting the number rather than the spelling makes this a test of
+    // the DATA instead of the string, and it pins an interpretation that is not
+    // obvious: `parse_size` reads KB as 1024, so these are 384 KiB and 96 KiB —
+    // which is exactly the F401CDU6's real geometry. (MB, in the same parser,
+    // is 1000^2. That asymmetry is why the byte count is worth writing down.)
+    assert_eq!(chip.flash.size, 393_216);
+    assert_eq!(chip.ram.size, 98_304);
     assert!(
         chip.peripherals
             .iter()

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -75,11 +75,74 @@ pub enum Arch {
     Unknown,
 }
 
+/// Deserialize a memory size, in bytes, from the human form the chip YAMLs use.
+///
+/// The wire format is unchanged — `128KB`, `1.5 MiB`, `0x20000` and a bare
+/// `131072` all still load. What changed is that the parse happens HERE, once,
+/// at the boundary, instead of at each of the 39 places that used to call
+/// `parse_size(&chip.ram.size)` on a `String` field.
+///
+/// That mattered: 18 of those call sites ended `.unwrap_or(0)`. A size that
+/// failed to parse did not fail the run — it silently became **zero bytes of
+/// RAM**, and the eleven ESP32-C3 suites computing `sp_top = ram.base + size`
+/// got a stack pointer at the very bottom of RAM. Wrong, and green. Making the
+/// field a `u64` deletes the fallible read, so that state cannot be
+/// constructed: a bad size is now a load error naming the field.
+fn deserialize_size<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IntOrString {
+        Int(u64),
+        String(String),
+    }
+
+    match IntOrString::deserialize(deserializer)? {
+        IntOrString::Int(v) => Ok(v),
+        IntOrString::String(s) => parse_size(&s).map_err(serde::de::Error::custom),
+    }
+}
+
+/// Serialize a size back as a bare byte count.
+///
+/// Deliberately NOT re-rendered in a unit, because the units here do not mean
+/// what they look like. Measured against the real parser:
+///
+/// ```text
+///   1KB  -> 1024          1KiB -> 1024
+///   1MB  -> 1_000_000     1MiB -> 1_048_576
+/// ```
+///
+/// `KB` is BINARY and `MB` is DECIMAL — inconsistent with each other, inside
+/// one parser. So re-rendering `1048576` as `1MB` would read back as
+/// `1_000_000` and quietly shrink a chip's flash by 4.9% on every round trip.
+/// A bare byte count says exactly one thing and `parse_size` reads it back
+/// unchanged.
+///
+/// (The same asymmetry is a live fidelity bug in the committed chips: nine of
+/// them spell flash in `MB`, so e.g. esp32s3 models 16_000_000 bytes where the
+/// part has 16 MiB = 16_777_216. Not changed here — this commit is a refactor,
+/// and moving a flash boundary belongs with its own tests.)
+fn serialize_size<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_u64(*value)
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MemoryRange {
     #[serde(deserialize_with = "deserialize_u64_lax")]
     pub base: u64,
-    pub size: String, // e.g. "128KB"
+    /// Size in BYTES. Parsed from the YAML's human form at load time.
+    #[serde(
+        deserialize_with = "deserialize_size",
+        serialize_with = "serialize_size"
+    )]
+    pub size: u64,
 }
 
 /// An additional named RAM/ROM-backed memory window beyond the primary
@@ -91,7 +154,12 @@ pub struct NamedMemoryRange {
     pub name: String,
     #[serde(deserialize_with = "deserialize_u64_lax")]
     pub base: u64,
-    pub size: String,
+    /// Size in BYTES — same boundary parse as [`MemoryRange::size`].
+    #[serde(
+        deserialize_with = "deserialize_size",
+        serialize_with = "serialize_size"
+    )]
+    pub size: u64,
     /// Optional env var naming a path to a raw binary loaded into this region at
     /// `base` (e.g. a chip's mask ROM dump). Used for copyrighted vendor blobs
     /// that can't be committed — the region stays zero-filled if unset/missing.
@@ -2886,24 +2954,24 @@ impl From<labwired_ir::IrDevice> for ChipDescriptor {
             .get("FLASH")
             .map(|r| MemoryRange {
                 base: r.base,
-                size: format!("{}B", r.size),
+                // r.size is already a byte count; it used to be formatted to
+                // "<n>B" purely so this field could hold a String, then parsed
+                // straight back at every read. That round-trip is gone.
+                size: r.size,
             })
-            .unwrap_or(MemoryRange {
-                base: 0,
-                size: "0".to_string(),
-            });
+            .unwrap_or(MemoryRange { base: 0, size: 0 });
 
         let ram = ir
             .memory_regions
             .get("RAM")
             .map(|r| MemoryRange {
                 base: r.base,
-                size: format!("{}B", r.size),
+                // r.size is already a byte count; it used to be formatted to
+                // "<n>B" purely so this field could hold a String, then parsed
+                // straight back at every read. That round-trip is gone.
+                size: r.size,
             })
-            .unwrap_or(MemoryRange {
-                base: 0,
-                size: "0".to_string(),
-            });
+            .unwrap_or(MemoryRange { base: 0, size: 0 });
 
         Self {
             schema_version: default_schema_version(),
@@ -6103,6 +6171,68 @@ registers:
 }
 
 #[cfg(test)]
+mod memory_size_tests {
+    use super::*;
+
+    fn chip(flash: &str, ram: &str) -> Result<ChipDescriptor, serde_yaml::Error> {
+        serde_yaml::from_str(&format!(
+            "name: t\narch: arm\nflash: {{ base: 0, size: \"{flash}\" }}\n\
+             ram: {{ base: 0x20000000, size: \"{ram}\" }}\nperipherals: []\n"
+        ))
+    }
+
+    /// The wire format is unchanged: every spelling the chip yamls use still loads.
+    #[test]
+    fn the_human_forms_still_load() {
+        assert_eq!(chip("64KB", "16KiB").unwrap().flash.size, 64 * 1024);
+        assert_eq!(chip("64KB", "16KiB").unwrap().ram.size, 16 * 1024);
+        assert_eq!(chip("1MiB", "131072").unwrap().flash.size, 1024 * 1024);
+        assert_eq!(chip("1MiB", "131072").unwrap().ram.size, 131_072);
+    }
+
+    /// KB is BINARY and MB is DECIMAL, in the same parser. Pinned here because
+    /// it is the opposite of what the spelling suggests, it is load-bearing for
+    /// nine committed chips, and nothing else states it.
+    #[test]
+    fn kb_is_1024_and_mb_is_1000000() {
+        assert_eq!(chip("1KB", "1KB").unwrap().flash.size, 1024);
+        assert_eq!(chip("1MB", "1KB").unwrap().flash.size, 1_000_000);
+        assert_eq!(chip("1MiB", "1KB").unwrap().flash.size, 1_048_576);
+    }
+
+    /// The point of moving the parse to the boundary: a size that does not
+    /// parse is now a load error. It used to be stored verbatim and then hit
+    /// `parse_size(..).unwrap_or(0)` at the point of use — so a typo'd unit
+    /// gave the machine ZERO bytes of RAM and ran anyway.
+    #[test]
+    fn an_unparseable_size_fails_the_load_instead_of_becoming_zero() {
+        let err = chip("64K", "16KB").expect_err("a bare `K` is not a unit human_size accepts");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("flash"),
+            "the error must name the field: {msg}"
+        );
+        assert!(
+            msg.contains("Invalid size format"),
+            "the error must say what was wrong: {msg}"
+        );
+    }
+
+    /// Sizes round-trip through serde without changing value. They serialise as
+    /// a bare byte count precisely so this holds — re-rendering `1048576` as
+    /// `1MB` would read back as 1_000_000.
+    #[test]
+    fn a_size_round_trips_without_shrinking() {
+        let c = chip("1MiB", "192KB").unwrap();
+        let back: ChipDescriptor =
+            serde_yaml::from_str(&serde_yaml::to_string(&c).unwrap()).unwrap();
+        assert_eq!(back.flash.size, c.flash.size);
+        assert_eq!(back.ram.size, c.ram.size);
+        assert_eq!(back.flash.size, 1_048_576);
+    }
+}
+
+#[cfg(test)]
 mod pin_map_tests {
     use super::*;
 
@@ -6111,8 +6241,8 @@ mod pin_map_tests {
         let yaml = r#"
 name: "test-chip"
 arch: "arm"
-flash: { base: 0, size: "64K" }
-ram: { base: 0x20000000, size: "16K" }
+flash: { base: 0, size: "64KB" }
+ram: { base: 0x20000000, size: "16KB" }
 peripherals: []
 pins:
   PC0: { gpio: gpioc, bit: 0, functions: [{ type: gpio, peripheral: gpioc }] }
@@ -6132,8 +6262,8 @@ pins:
         let yaml = r#"
 name: "no-pins"
 arch: "arm"
-flash: { base: 0, size: "64K" }
-ram: { base: 0x20000000, size: "16K" }
+flash: { base: 0, size: "64KB" }
+ram: { base: 0x20000000, size: "16KB" }
 peripherals: []
 "#;
         let chip: ChipDescriptor = serde_yaml::from_str(yaml).expect("parse");

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -10,7 +10,7 @@ use crate::memory::LinearMemory;
 use crate::peripherals::gpio::GpioRegisterLayout;
 use crate::Peripheral;
 use anyhow::Context;
-use labwired_config::{parse_size, ChipDescriptor, SystemManifest};
+use labwired_config::{ChipDescriptor, SystemManifest};
 use std::cell::Cell;
 use std::path::{Path, PathBuf};
 
@@ -137,12 +137,12 @@ impl SystemBus {
         // parse with `from_yaml`. Validating at load time only would mean two
         // of our three runtimes silently accept documents the third rejects.
         manifest.validate_parts()?;
-        let flash_size = parse_size(&chip.flash.size)?;
-        let ram_size = parse_size(&chip.ram.size)?;
+        let flash_size = chip.flash.size;
+        let ram_size = chip.ram.size;
 
         let mut extra_mem = Vec::with_capacity(chip.memory_regions.len());
         for region in &chip.memory_regions {
-            let size = parse_size(&region.size)?;
+            let size = region.size;
             let mut mem = LinearMemory::new(size as usize, region.base);
             // Optionally preload a raw binary image (e.g. a dumped mask ROM)
             // from a path given by an env var. Copyrighted vendor blobs are not

--- a/crates/core/src/bus/tests_main.rs
+++ b/crates/core/src/bus/tests_main.rs
@@ -647,11 +647,11 @@ fn test_from_config_attaches_adxl345_external_device_to_i2c() {
         core: None,
         flash: MemoryRange {
             base: 0x0800_0000,
-            size: "64KB".to_string(),
+            size: 64000,
         },
         ram: MemoryRange {
             base: 0x2000_0000,
-            size: "20KB".to_string(),
+            size: 20000,
         },
         peripherals: vec![PeripheralConfig {
             id: "i2c1".to_string(),
@@ -1377,11 +1377,11 @@ fn test_from_config_attaches_bmp280_to_esp32c3_i2c0() {
         core: None,
         flash: MemoryRange {
             base: 0x4200_0000,
-            size: "4MB".to_string(),
+            size: 4000000,
         },
         ram: MemoryRange {
             base: 0x3FC8_0000,
-            size: "400KB".to_string(),
+            size: 400000,
         },
         peripherals: vec![
             PeripheralConfig {
@@ -1528,11 +1528,11 @@ fn test_from_config_attaches_mlx90640_to_esp32c3_i2c0_and_reads_eeprom() {
         core: None,
         flash: MemoryRange {
             base: 0x4200_0000,
-            size: "4MB".to_string(),
+            size: 4000000,
         },
         ram: MemoryRange {
             base: 0x3FC8_0000,
-            size: "400KB".to_string(),
+            size: 400000,
         },
         peripherals: vec![
             PeripheralConfig {
@@ -2899,11 +2899,11 @@ fn chip_with_i2c_and_uart() -> labwired_config::ChipDescriptor {
         core: None,
         flash: MemoryRange {
             base: 0x0800_0000,
-            size: "64KB".to_string(),
+            size: 64000,
         },
         ram: MemoryRange {
             base: 0x2000_0000,
-            size: "20KB".to_string(),
+            size: 20000,
         },
         peripherals: vec![
             PeripheralConfig {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2613,7 +2613,7 @@ impl<C: Cpu> Machine<C> {
                 FlashOp::SwapAndReset => {
                     // Swap the two architectural 1 MiB (0x100000) banks. The
                     // H563 flash buffer is sized to exactly 2 * BANK_SIZE by the
-                    // chip yaml (`size: "2MiB"`), so the same BANK_SIZE used by
+                    // chip yaml (`size: 2MiB`), so the same BANK_SIZE used by
                     // EraseSector above also bounds the swap — keeping erase and
                     // swap on one consistent bank-size notion (real silicon:
                     // bank 2 @ 0x08100000). swap_banks returns false if the

--- a/crates/core/src/system/node.rs
+++ b/crates/core/src/system/node.rs
@@ -233,7 +233,7 @@ fn build_riscv_node(
             // Fast boot skips the ROM/2nd-stage bootloader that would normally
             // set the stack pointer, so seed it at the top of RAM (16-byte
             // aligned, RISC-V ABI) or the first prologue store faults.
-            let ram_size = labwired_config::parse_size(&chip.ram.size).unwrap_or(0);
+            let ram_size = chip.ram.size;
             let sp_top = (chip.ram.base + ram_size) as u32;
             machine.cpu.set_sp(sp_top & !0xF);
             Ok(Box::new(machine))
@@ -408,18 +408,10 @@ fn validate_cortex_m_firmware(
         );
     }
 
-    let flash_size = labwired_config::parse_size(&chip.flash.size).with_context(|| {
-        format!(
-            "node '{node_id}': invalid flash size for chip '{}'",
-            chip.name
-        )
-    })?;
-    let ram_size = labwired_config::parse_size(&chip.ram.size).with_context(|| {
-        format!(
-            "node '{node_id}': invalid RAM size for chip '{}'",
-            chip.name
-        )
-    })?;
+    // No parse and no error path: the sizes were validated when the chip
+    // deserialised, so "invalid flash size" is no longer reachable here.
+    let flash_size = chip.flash.size;
+    let ram_size = chip.ram.size;
     let vector_base = chip
         .flash
         .base

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -406,11 +406,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -595,11 +595,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -682,11 +682,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -746,11 +746,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -816,11 +816,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -963,11 +963,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             memory_regions: Vec::new(),
             peripherals: vec![
@@ -1039,11 +1039,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -1106,11 +1106,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -1173,11 +1173,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -2402,11 +2402,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x4200_0000,
-                size: "4MB".to_string(),
+                size: 4000000,
             },
             ram: MemoryRange {
                 base: 0x3FC8_0000,
-                size: "400KB".to_string(),
+                size: 400000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -2496,11 +2496,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x4200_0000,
-                size: "4MB".to_string(),
+                size: 4000000,
             },
             ram: MemoryRange {
                 base: 0x3FC8_0000,
-                size: "400KB".to_string(),
+                size: 400000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -2563,11 +2563,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x4200_0000,
-                size: "4MB".to_string(),
+                size: 4000000,
             },
             ram: MemoryRange {
                 base: 0x3FC8_0000,
-                size: "400KB".to_string(),
+                size: 400000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -2775,11 +2775,11 @@ pub mod integration_tests {
             core: None,
             flash: MemoryRange {
                 base: 0x4200_0000,
-                size: "4MB".to_string(),
+                size: 4000000,
             },
             ram: MemoryRange {
                 base: 0x3FC8_0000,
-                size: "400KB".to_string(),
+                size: 400000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,
@@ -2939,11 +2939,11 @@ pub mod integration_tests {
                 core: None,
                 flash: MemoryRange {
                     base: 0x4200_0000,
-                    size: "4MB".to_string(),
+                    size: 4000000,
                 },
                 ram: MemoryRange {
                     base: 0x3FC8_0000,
-                    size: "400KB".to_string(),
+                    size: 400000,
                 },
                 reset_vector_offset: 0,
                 atomic_register_aliases: false,

--- a/crates/core/src/tests/simctl_machine.rs
+++ b/crates/core/src/tests/simctl_machine.rs
@@ -205,11 +205,11 @@ mod from_declaration {
             core: None,
             flash: MemoryRange {
                 base: 0x0,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: MemoryRange {
                 base: 0x2000_0000,
-                size: "20KB".to_string(),
+                size: 20000,
             },
             reset_vector_offset: 0,
             atomic_register_aliases: false,

--- a/crates/core/tests/esp32c3_ble_pong_perf_probe.rs
+++ b/crates/core/tests/esp32c3_ble_pong_perf_probe.rs
@@ -246,7 +246,7 @@ fn build_node_air(flash: &[u8], idle_ff: bool, private_air: Option<&str>) -> Nod
                 .unwrap();
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_bt_active_walk_pinners.rs
+++ b/crates/core/tests/esp32c3_bt_active_walk_pinners.rs
@@ -297,7 +297,7 @@ fn ble_pong_advertising_node_walk_pinners() {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(boot.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_bt_event_residency_gate.rs
+++ b/crates/core/tests/esp32c3_bt_event_residency_gate.rs
@@ -194,7 +194,7 @@ fn build_advertising_node() -> (Machine<RiscV>, Arc<Mutex<Vec<u8>>>, BleAirBus) 
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(boot.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_clamped_full_state_differential.rs
+++ b/crates/core/tests/esp32c3_clamped_full_state_differential.rs
@@ -143,7 +143,7 @@ fn build_oled_lab(tick_interval: u32) -> OledLab {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_oled_profile.rs
+++ b/crates/core/tests/esp32c3_oled_profile.rs
@@ -123,7 +123,7 @@ fn build_oled_lab() -> OledLab {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_pms_shipped_firmware.rs
+++ b/crates/core/tests/esp32c3_pms_shipped_firmware.rs
@@ -148,7 +148,7 @@ fn boot_ble_pong() -> Machine<RiscV> {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
     let rec = machine.bus.max_safe_tick_interval();

--- a/crates/core/tests/esp32c3_shipped_lab_batch_gate.rs
+++ b/crates/core/tests/esp32c3_shipped_lab_batch_gate.rs
@@ -206,7 +206,7 @@ fn build_lab(chip_yaml: &str, system_yaml: &str, flash_path: &PathBuf) -> Lab {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_usb_cdc_console.rs
+++ b/crates/core/tests/esp32c3_usb_cdc_console.rs
@@ -183,7 +183,7 @@ fn build_lab(fixture: &str) -> CdcLab {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/esp32c3_walk_differential.rs
+++ b/crates/core/tests/esp32c3_walk_differential.rs
@@ -174,7 +174,7 @@ fn build_oled_lab(
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/nrf54l15_boot.rs
+++ b/crates/core/tests/nrf54l15_boot.rs
@@ -95,12 +95,13 @@ fn memory_map_is_rram_at_zero_with_256k_sram() {
     // RRAM, not flash: based at 0x0, and 1524 KB is the real (odd) size.
     assert_eq!(chip.flash.base, 0x0000_0000, "RRAM must be based at 0x0");
     assert_eq!(
-        chip.flash.size, "1524KB",
+        chip.flash.size,
+        1_524 * 1024,
         "nRF54L15 RRAM is 1524 KB (DT: cpuapp_rram), not 1.5 MB rounded"
     );
 
     assert_eq!(chip.ram.base, 0x2000_0000);
-    assert_eq!(chip.ram.size, "256KB");
+    assert_eq!(chip.ram.size, 256 * 1024);
 
     // Consequence that actually bites: the reset stack pointer. 256 KB at
     // 0x2000_0000 puts the initial SP at 0x2004_0000, which is exactly what

--- a/crates/core/tests/register_compliance.rs
+++ b/crates/core/tests/register_compliance.rs
@@ -42,8 +42,8 @@ fn validate_chip(path: &PathBuf) -> anyhow::Result<()> {
     // Note: SystemBus::new() creates default memories. We resize them.
     // Actually, SystemBus::from_config uses chip.flash/ram directly, so we don't need to manually resize here.
     // We just need to ensure the values are valid.
-    let _flash_size = labwired_config::parse_size(&chip.flash.size)? as usize;
-    let _ram_size = labwired_config::parse_size(&chip.ram.size)? as usize;
+    let _flash_size = chip.flash.size as usize;
+    let _ram_size = chip.ram.size as usize;
 
     // Create Manual System Manifest
     let dummy_manifest = labwired_config::SystemManifest {

--- a/crates/core/tests/riscv_jit_c3_oled_differential.rs
+++ b/crates/core/tests/riscv_jit_c3_oled_differential.rs
@@ -145,7 +145,7 @@ fn build_oled_lab(jit_enabled: bool) -> OledLab {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/core/tests/world_esp32c3_ble_pong.rs
+++ b/crates/core/tests/world_esp32c3_ble_pong.rs
@@ -245,7 +245,7 @@ fn build_node(flash: &[u8], lab: &LabAir, node_id: &str) -> Node {
                 .expect("load bootloader segment");
         }
     }
-    let sp_top = (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+    let sp_top = (chip.ram.base + chip.ram.size) as u32;
     machine.cpu.set_sp(sp_top & !0xF);
     machine.cpu.set_pc(bootloader.entry_point as u32);
 

--- a/crates/dap/src/adapter.rs
+++ b/crates/dap/src/adapter.rs
@@ -1165,11 +1165,11 @@ mod tests {
             core: None,
             flash: labwired_config::MemoryRange {
                 base: 0x0800_0000,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: labwired_config::MemoryRange {
                 base: 0x2000_0000,
-                size: "32KB".to_string(),
+                size: 32000,
             },
             peripherals: vec![labwired_config::PeripheralConfig {
                 id: "gpioa".to_string(),
@@ -1230,11 +1230,11 @@ mod tests {
             core: None,
             flash: labwired_config::MemoryRange {
                 base: 0x0800_0000,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: labwired_config::MemoryRange {
                 base: 0x2000_0000,
-                size: "32KB".to_string(),
+                size: 32000,
             },
             peripherals: vec![labwired_config::PeripheralConfig {
                 id: "gpiob".to_string(),
@@ -1309,11 +1309,11 @@ mod tests {
             core: None,
             flash: labwired_config::MemoryRange {
                 base: 0x0800_0000,
-                size: "128KB".to_string(),
+                size: 125 * 1024,
             },
             ram: labwired_config::MemoryRange {
                 base: 0x2000_0000,
-                size: "32KB".to_string(),
+                size: 32000,
             },
             peripherals: vec![labwired_config::PeripheralConfig {
                 id: "gpiob".to_string(),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -664,8 +664,7 @@ impl WasmSimulator {
         load_program_segments_without_reset(&mut machine, &bootloader_image)
             .map_err(|e| JsValue::from_str(&format!("C3 flash fast-start load: {e}")))?;
 
-        let sp_top =
-            (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+        let sp_top = (chip.ram.base + chip.ram.size) as u32;
         machine.cpu.set_sp(sp_top & !0xF);
         machine.cpu.set_pc(bootloader_image.entry_point as u32);
 
@@ -825,8 +824,7 @@ impl WasmSimulator {
             .load_firmware(program_image)
             .map_err(|e| JsValue::from_str(&format!("Simulation Error: {}", e)))?;
 
-        let sp_top =
-            (chip.ram.base + labwired_config::parse_size(&chip.ram.size).unwrap_or(0)) as u32;
+        let sp_top = (chip.ram.base + chip.ram.size) as u32;
         machine.cpu.set_sp(sp_top & !0xF);
         machine.cpu.set_pc(program_image.entry_point as u32);
 


### PR DESCRIPTION
Remediation row 4.7's last sub-fix. The other two — `to_config_access` deleted, and codegen's `matches!` whitelist made an exhaustive `match` — already landed.

`MemoryRange.size` was a `String` with `// e.g. "128KB"` beside it, so every reader had to parse it. **39 call sites did, and 18 of them ended `.unwrap_or(0)`.**

That fallback is the defect. A size that failed to parse did not fail the run — it silently became **zero bytes of RAM**, and the eleven ESP32-C3 suites computing `sp_top = ram.base + size` got a stack pointer at the very bottom of RAM. Wrong, and green.

The field is now `u64`, parsed by the same `parse_size` at deserialisation. The wire format is untouched — `"128KB"`, `"1.5 MiB"`, `0x20000` and a bare `131072` all still load — but the fallible read is gone, so that state cannot be constructed. A bad size is now a load error naming the field.

**Nothing shipped breaks:** all 468 flash/ram/named-memory sizes across `configs/` and `examples/` parse, so no chip changes value or fails to load.

## Two things this surfaced — neither fixed here

**1. `parse_size` is internally inconsistent, and the opposite of what the spelling suggests.** Measured, not assumed:

```
1KB  -> 1024          1KiB -> 1024
1MB  -> 1_000_000     1MiB -> 1_048_576
```

KB is binary; MB is decimal. I had this backwards in an earlier draft of the commit and the nRF54L15 boot test caught it — which is why it is now pinned by a test rather than a comment. It is also why sizes serialise as a bare byte count: re-rendering `1048576` as `"1MB"` would read back as `1_000_000` and shrink a chip's flash by 4.9% on every round trip.

**2. Nine committed chips spell flash in `MB`, so they are modelled short:**

| chip | yaml | modelled | if MiB | short by |
| --- | --- | ---: | ---: | ---: |
| esp32s3 | `16MB` | 16,000,000 | 16,777,216 | 777,216 |
| esp32c3 | `4MB` | 4,000,000 | 4,194,304 | 194,304 |
| rp2040 / rp2350 / stm32f767 | `2MB` | 2,000,000 | 2,097,152 | 97,152 |
| stm32f103 / f405 / f407 / l476 | `1MB` | 1,000,000 | 1,048,576 | 48,576 |

Pre-existing and unchanged by this PR. Moving a flash boundary can shift partition tables, XIP windows and memory-violation limits, so it needs its own change with its own tests — not a rider on a refactor. **Worth its own ledger row.**

## New tests

`memory_size_tests` in `crates/config`: the human forms still load; KB=1024 / MB=1e6 pinned; an unparseable size fails the load *instead of becoming zero*; and a size round-trips through serde without shrinking.

## Also removed

Two `format!("{}B", r.size)` calls that existed only to turn an IR byte count into a string this field could hold — so it could be parsed straight back.

## Verification

config 84 + 3 + 19 + 9, core lib 3093, cli lib 134, dap 23, codegen 4, wasm 43, nrf54l15_boot 11, config_validation 6 — all green. `cargo clippy -D warnings` clean on every crate touched (the one workspace clippy error is in `firmware-nrf52840-proximity`, which has no labwired dependency and is untouched by this PR).