### PR TITLE
fix(esp32s3): nine reset values the S3's own TRM contradicts

### DIFF
--- a/configs/peripherals/esp32s3/gpio.yaml
+++ b/configs/peripherals/esp32s3/gpio.yaml
@@ -335,7 +335,11 @@ registers:
     address_offset: 0x6FC
     size: 32
     access: "R/W"
-    reset_value: 0x02108190
+    # GPIO_DATE_REG, the S3's silicon version stamp. TRM v1.8 Register 6.34
+    # (p.512): GPIO_DATE (b27:0) = 0x1907040, b31:28 reserved. The previous
+    # 0x02108190 is not this part's stamp and is not any Espressif part's —
+    # the S2 reads 0x01905061, the C3 0x02006130, the C2 0x02106190.
+    reset_value: 0x01907040
 
 interrupts:
   GPIO: 16

--- a/configs/peripherals/esp32s3/timg0.yaml
+++ b/configs/peripherals/esp32s3/timg0.yaml
@@ -9,7 +9,9 @@ registers:
     address_offset: 0x000
     size: 32
     access: "R/W"
-    reset_value: 0x60013000
+    # TRM v1.8 Register 12.1 (p.662): INCREASE=1 (b30), AUTORELOAD=1 (b29),
+    # DIVIDER=0x01 (b28:13). Everything else resets to 0.
+    reset_value: 0x60002000
     fields:
       - name: "USE_XTAL"
         bit_range: [9, 9]
@@ -78,7 +80,9 @@ registers:
     address_offset: 0x024
     size: 32
     access: "R/W"
-    reset_value: 0x60013000
+    # Same layout and same reset as T0CONFIG — TRM v1.8 documents both as
+    # TIMG_TxCONFIG_REG (x: 0-1), Register 12.1 (p.662).
+    reset_value: 0x60002000
 
   - id: "T1LO"
     address_offset: 0x028
@@ -102,7 +106,11 @@ registers:
     address_offset: 0x048
     size: 32
     access: "R/W"
-    reset_value: 0x00048D00
+    # TRM v1.8 Register 12.10 (p.665): CPU_RESET_LENGTH=0x1 (b20:18),
+    # SYS_RESET_LENGTH=0x1 (b17:15), FLASHBOOT_MOD_EN=1 (b14). Flash-boot
+    # protection is ARMED out of reset — a model that says 0 here claims the
+    # opposite.
+    reset_value: 0x0004C000
 
   - id: "WDTCONFIG1"
     address_offset: 0x04C
@@ -114,25 +122,29 @@ registers:
     address_offset: 0x050
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    # WDT_STG0_HOLD. TRM v1.8 Register 12.12 (p.666) states 26000000.
+    reset_value: 0x018CBA80
 
   - id: "WDTCONFIG3"
     address_offset: 0x054
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    # WDT_STG1_HOLD. TRM v1.8 Register 12.13 (p.666): 0x7ffffff.
+    reset_value: 0x07FFFFFF
 
   - id: "WDTCONFIG4"
     address_offset: 0x058
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    # WDT_STG2_HOLD. TRM v1.8 Register 12.14 (p.666): 0x0fffff.
+    reset_value: 0x000FFFFF
 
   - id: "WDTCONFIG5"
     address_offset: 0x05C
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    # WDT_STG3_HOLD. TRM v1.8 Register 12.15 (p.667): 0x0fffff.
+    reset_value: 0x000FFFFF
 
   - id: "WDTFEED"
     address_offset: 0x060
@@ -176,7 +188,9 @@ registers:
     address_offset: 0x068
     size: 32
     access: "R/W"
-    reset_value: 0x00000000
+    # TRM v1.8 Register 12.18 (p.668): RTC_CALI_MAX=0x01 (b30:16),
+    # RTC_CALI_CLK_SEL=0x1 (b14:13), RTC_CALI_START_CYCLING=1 (b12).
+    reset_value: 0x00013000
 
   - id: "RTCCALICFG1"
     address_offset: 0x06C

--- a/crates/core/tests/esp32s3_timg_gpio_reset_values.rs
+++ b/crates/core/tests/esp32s3_timg_gpio_reset_values.rs
@@ -1,0 +1,279 @@
+// LabWired - Firmware Simulation Platform
+// SPDX-License-Identifier: MIT
+
+//! The ESP32-S3 `TIMG0` and `GPIO` descriptors must carry the reset values the
+//! **S3's own reference manual** states, and the sibling Espressif parts must
+//! keep theirs.
+//!
+//! `configs/peripherals/esp32s3/timg0.yaml` and `.../gpio.yaml` say at the top
+//! that they are "Based on ESP32-S3 Technical Reference Manual". Nine of their
+//! reset values are not in that manual, and not in any Espressif part:
+//!
+//! | register | modelled | ESP32-S3 TRM v1.8 |
+//! |---|---|---|
+//! | `TIMG0.T0CONFIG`   | `0x60013000` | `0x60002000` (Reg 12.1, p.662) |
+//! | `TIMG0.T1CONFIG`   | `0x60013000` | `0x60002000` (Reg 12.1, p.662) |
+//! | `TIMG0.WDTCONFIG0` | `0x00048D00` | `0x0004C000` (Reg 12.10, p.665) |
+//! | `TIMG0.WDTCONFIG2` | `0x00000000` | `0x018CBA80` (Reg 12.12, p.666) |
+//! | `TIMG0.WDTCONFIG3` | `0x00000000` | `0x07FFFFFF` (Reg 12.13, p.666) |
+//! | `TIMG0.WDTCONFIG4` | `0x00000000` | `0x000FFFFF` (Reg 12.14, p.666) |
+//! | `TIMG0.WDTCONFIG5` | `0x00000000` | `0x000FFFFF` (Reg 12.15, p.667) |
+//! | `TIMG0.RTCCALICFG` | `0x00000000` | `0x00013000` (Reg 12.18, p.668) |
+//! | `GPIO.REG_DATE`    | `0x02108190` | `0x01907040` (Reg 6.34, p.512) |
+//!
+//! The TRM prints these per field, so they are reconstructed rather than
+//! quoted: `T0CONFIG` is `INCREASE=1`(b30) `AUTORELOAD=1`(b29) `DIVIDER=0x01`
+//! (b28:13) = `0x6000_2000`; `WDTCONFIG0` is `CPU_RESET_LENGTH=0x1`(b20:18)
+//! `SYS_RESET_LENGTH=0x1`(b17:15) `FLASHBOOT_MOD_EN=1`(b14) = `0x0004_C000`;
+//! `RTCCALICFG` is `CALI_MAX=0x01`(b30:16) `CALI_CLK_SEL=0x1`(b14:13)
+//! `START_CYCLING=1`(b12) = `0x0001_3000`. The vendor SVD states the same
+//! numbers independently, and this gate asserts against the SVD so the check is
+//! machine-checkable and re-runnable.
+//!
+//! These nine are the `esp32s3` half of the 34 model/silicon conflicts that
+//! `0036_part_knowledge_svd_promotion.sql` published: the corpus recorded that
+//! our model and the vendor disagree, without deciding which was wrong. The TRM
+//! decides it — the model was.
+//!
+//! Why a gate rather than a bare edit: a declarative descriptor's reset value
+//! is what firmware reads before it writes anything, and nothing compared these
+//! files to a vendor artifact before. `register_coverage` counts *responses*,
+//! which a register holding the wrong reset value still produces, and
+//! `svd_conformance` checks base addresses and IRQ numbers only.
+//!
+//! Three chips, deliberately. The ESP32-C3 and the classic ESP32 model the same
+//! two peripherals, at register names that are character-for-character
+//! identical, and both are correct today. `GPIO.REG_DATE` is the sharpest
+//! control available: it is a silicon version stamp, so every part has a
+//! *different* right answer — S3 `0x01907040`, C3 `0x02006130`. A test that only
+//! proved the S3 now reads `0x01907040` could not tell a fixed S3 from a C3 that
+//! had been dragged onto the S3's value.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use labwired_config::PeripheralDescriptor;
+use labwired_core::peripherals::declarative::GenericPeripheral;
+use labwired_core::Peripheral;
+
+const S3_TIMG0: &str = "configs/peripherals/esp32s3/timg0.yaml";
+const S3_GPIO: &str = "configs/peripherals/esp32s3/gpio.yaml";
+const C3_TIMG0: &str = "configs/peripherals/esp32c3/timg0.yaml";
+const C3_GPIO: &str = "configs/peripherals/esp32c3/gpio.yaml";
+const ESP32_TIMG0: &str = "configs/peripherals/esp32/timg0.yaml";
+
+const S3_SVD: &str = "tests/fixtures/svd/esp32s3.svd";
+const C3_SVD: &str = "tests/fixtures/real_world/esp32c3.svd";
+const ESP32_SVD: &str = "tests/fixtures/real_world/esp32.svd";
+
+fn root(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+fn descriptor(rel: &str) -> PeripheralDescriptor {
+    PeripheralDescriptor::from_file(root(rel)).unwrap_or_else(|e| panic!("load {rel}: {e}"))
+}
+
+/// One peripheral's register map as the vendor's SVD states it: name →
+/// (offset, reset value). Parsed with the same `svd_ingestor` the CLI importer
+/// and the coverage scan use, so this gate reads the SVD the way the rest of
+/// the repo does — including `<dim>` array expansion, which is how the S3's
+/// `T%sCONFIG` becomes `T0CONFIG` and `T1CONFIG`.
+fn vendor_map(svd_rel: &str, peripheral: &str) -> HashMap<String, (u64, u32)> {
+    let xml =
+        std::fs::read_to_string(root(svd_rel)).unwrap_or_else(|e| panic!("read {svd_rel}: {e}"));
+    let device = svd_ingestor::parse_svd(&xml).unwrap_or_else(|e| panic!("parse {svd_rel}: {e}"));
+    let found = device
+        .peripherals
+        .iter()
+        .find(|p| p.name == peripheral)
+        .unwrap_or_else(|| panic!("{svd_rel} has no {peripheral} peripheral"));
+    let desc = svd_ingestor::process_peripheral(&device, found)
+        .unwrap_or_else(|e| panic!("process {peripheral} from {svd_rel}: {e}"));
+    let map: HashMap<String, (u64, u32)> = desc
+        .registers
+        .iter()
+        .map(|r| (r.id.clone(), (r.address_offset, r.reset_value)))
+        .collect();
+    assert!(
+        map.len() >= 20,
+        "{svd_rel} yielded only {} {peripheral} registers — the SVD parse has \
+         broken and every comparison below would pass vacuously",
+        map.len()
+    );
+    map
+}
+
+/// Every register the descriptor declares *that the vendor also names*, checked
+/// against the vendor's own map: same offset, same reset value.
+///
+/// Registers the vendor does not name are skipped rather than failed: the S3
+/// `GPIO` model is a 50-register subset chosen by whoever implemented the
+/// behaviour, and naming a register the SVD omits is not by itself an error.
+fn assert_reset_values_conform(
+    descriptor_rel: &str,
+    svd_rel: &str,
+    peripheral: &str,
+    min_shared: usize,
+) {
+    let desc = descriptor(descriptor_rel);
+    let vendor = vendor_map(svd_rel, peripheral);
+
+    let mut findings = Vec::new();
+    let mut shared = 0usize;
+    for reg in &desc.registers {
+        let Some(&(offset, reset)) = vendor.get(&reg.id) else {
+            continue;
+        };
+        shared += 1;
+        if reg.address_offset != offset {
+            findings.push(format!(
+                "{}: modelled at {:#05X}, silicon puts it at {:#05X}",
+                reg.id, reg.address_offset, offset
+            ));
+        }
+        if reg.reset_value != reset {
+            findings.push(format!(
+                "{}: reset {:#010X}, silicon resets to {:#010X}",
+                reg.id, reg.reset_value, reset
+            ));
+        }
+    }
+
+    assert!(
+        shared >= min_shared,
+        "{descriptor_rel} shares only {shared} register names with {svd_rel} \
+         (expected at least {min_shared}) — the comparison has gone vacuous"
+    );
+    assert!(
+        findings.is_empty(),
+        "{descriptor_rel} disagrees with {svd_rel} ({} findings over {shared} \
+         shared registers):\n  {}",
+        findings.len(),
+        findings.join("\n  ")
+    );
+}
+
+fn reset_of(rel: &str, register: &str) -> u32 {
+    descriptor(rel)
+        .registers
+        .iter()
+        .find(|r| r.id == register)
+        .unwrap_or_else(|| panic!("{rel} declares no {register}"))
+        .reset_value
+}
+
+fn read32(rel: &str, offset: u64) -> u32 {
+    GenericPeripheral::new(descriptor(rel))
+        .read_u32(offset)
+        .expect("read_u32")
+}
+
+// ── ESP32-S3: the fix ────────────────────────────────────────────────────────
+
+#[test]
+fn esp32s3_timg0_reset_values_match_the_vendor_svd() {
+    assert_reset_values_conform(S3_TIMG0, S3_SVD, "TIMG0", 24);
+
+    // The eight the corpus flagged, stated outright so a future reader does not
+    // have to re-derive them from the SVD. Right column is the TRM v1.8 value.
+    for (register, trm) in [
+        ("T0CONFIG", 0x6000_2000u32),
+        ("T1CONFIG", 0x6000_2000),
+        ("WDTCONFIG0", 0x0004_C000),
+        ("WDTCONFIG2", 0x018C_BA80),
+        ("WDTCONFIG3", 0x07FF_FFFF),
+        ("WDTCONFIG4", 0x000F_FFFF),
+        ("WDTCONFIG5", 0x000F_FFFF),
+        ("RTCCALICFG", 0x0001_3000),
+    ] {
+        assert_eq!(
+            reset_of(S3_TIMG0, register),
+            trm,
+            "TIMG0.{register} resets to {trm:#010X} on this silicon \
+             (ESP32-S3 TRM v1.8, chapter 12)"
+        );
+    }
+}
+
+#[test]
+fn esp32s3_gpio_version_stamp_matches_the_vendor_svd() {
+    // 0x01907040 is what GPIO_DATE_REG reads on an S3 (TRM v1.8 Register 6.34,
+    // p.512). The modelled 0x02108190 is not this part's stamp and is not any
+    // other Espressif part's either — the S2 reads 0x01905061, the C3
+    // 0x02006130, the C2 0x02106190. It was invented.
+    assert_eq!(
+        reset_of(S3_GPIO, "REG_DATE"),
+        0x0190_7040,
+        "GPIO.REG_DATE is the S3's silicon version stamp"
+    );
+    // CLOCK_GATE already agreed, and 0036 promoted it to `proven`. Pinned so a
+    // sweep over this file cannot quietly take it with the others.
+    assert_eq!(reset_of(S3_GPIO, "CLOCK_GATE"), 0x0000_0001);
+}
+
+#[test]
+fn esp32s3_timg0_answers_reads_with_the_trm_reset_values() {
+    // A descriptor edit that never reaches the bus is indistinguishable from no
+    // edit: `GenericPeripheral` fabricates a zero for any offset it does not
+    // decode, so four of these eight registers would read 0 either way. Drive
+    // the peripheral the way the bus does and demand the number.
+    for (offset, register, trm) in [
+        (0x000u64, "T0CONFIG", 0x6000_2000u32),
+        (0x024, "T1CONFIG", 0x6000_2000),
+        (0x048, "WDTCONFIG0", 0x0004_C000),
+        (0x050, "WDTCONFIG2", 0x018C_BA80),
+        (0x054, "WDTCONFIG3", 0x07FF_FFFF),
+        (0x058, "WDTCONFIG4", 0x000F_FFFF),
+        (0x05C, "WDTCONFIG5", 0x000F_FFFF),
+        (0x068, "RTCCALICFG", 0x0001_3000),
+    ] {
+        assert_eq!(
+            read32(S3_TIMG0, offset),
+            trm,
+            "reading TIMG0+{offset:#05X} ({register}) must yield {trm:#010X}; \
+             a zero here means the offset is undecoded or the reset value is \
+             still the old one"
+        );
+    }
+    assert_eq!(
+        read32(S3_GPIO, 0x6FC),
+        0x0190_7040,
+        "reading GPIO+0x6FC (REG_DATE) must yield the S3's version stamp"
+    );
+}
+
+// ── The sibling parts, which must not move ───────────────────────────────────
+
+#[test]
+fn esp32c3_and_esp32_timg_gpio_stay_on_their_own_silicon() {
+    assert_reset_values_conform(C3_TIMG0, C3_SVD, "TIMG0", 24);
+    assert_reset_values_conform(ESP32_TIMG0, ESP32_SVD, "TIMG0", 24);
+    assert_reset_values_conform(C3_GPIO, C3_SVD, "GPIO", 2);
+
+    // The version stamps, spelled out. These are the values an edit that
+    // "harmonised" the three files would destroy, and they are all different.
+    assert_eq!(
+        reset_of(C3_GPIO, "REG_DATE"),
+        0x0200_6130,
+        "the C3's GPIO version stamp is its own, not the S3's 0x01907040"
+    );
+    assert_ne!(
+        reset_of(C3_GPIO, "REG_DATE"),
+        reset_of(S3_GPIO, "REG_DATE"),
+        "two different Espressif parts cannot carry the same silicon version \
+         stamp; if these ever match, one file was copied onto the other"
+    );
+
+    // The C3 and classic ESP32 already hold the TRM numbers for the registers
+    // the S3 got wrong. Pinned so this fix cannot be "applied" by dragging the
+    // correct files onto the broken one's values.
+    for rel in [C3_TIMG0, ESP32_TIMG0] {
+        assert_eq!(reset_of(rel, "T0CONFIG"), 0x6000_2000, "{rel}");
+        assert_eq!(reset_of(rel, "WDTCONFIG0"), 0x0004_C000, "{rel}");
+        assert_eq!(reset_of(rel, "WDTCONFIG2"), 0x018C_BA80, "{rel}");
+        assert_eq!(reset_of(rel, "RTCCALICFG"), 0x0001_3000, "{rel}");
+    }
+}

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -17,7 +17,7 @@ The models column is a content digest over everything that board's `models` list
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `c6edd440f7d52912` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `d17e310c125d5612` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `cba8077c91077c75` | ⚠ drift acked 2026-08-13 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `3c0fdf6ce23569b3` | ⚠ drift acked 2026-08-17 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `ce851b8dd4e6a6e0` | ⚠ drift acked 2026-08-17 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `1944e48e1e75ed3b` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a8c9baa90cb2a903` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `9637527458c15225` | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -2593,6 +2593,40 @@ boards:
     # attach path (DHT22, HC-SR04, rotary encoder, WS2812), and no silicon
     # capture covers any of those. No live re-capture owed for this change;
     # any re-capture already owed above still is.
+    # 2026-08-16: nine RESET VALUES corrected in configs/peripherals/esp32s3/
+    # {timg0,gpio}.yaml — T0CONFIG/T1CONFIG, WDTCONFIG0, WDTCONFIG2..5,
+    # RTCCALICFG and GPIO REG_DATE. Like the nRF52840 UARTE BAUDRATE ack above
+    # this is NOT digest-only churn: it changes numbers the model answers reads
+    # with. Unlike it, this one moves the model TOWARD what the 2026-08-09
+    # capture on this very board already read.
+    #
+    # Seven of the eight TIMG0 registers are in that capture
+    # (scripts/hw-oracle/captures/esp32s3/recapture-20260809T130700Z/
+    # reg_oracle.json) and the live ESP32-S3 reads exactly the new value:
+    # T0CONFIG 0x60002000, T1CONFIG 0x60002000, WDTCONFIG2 0x018CBA80,
+    # WDTCONFIG3 0x07FFFFFF, WDTCONFIG4 0x000FFFFF, WDTCONFIG5 0x000FFFFF,
+    # RTCCALICFG 0x00013000. Each was previously modelled 0x60013000 or 0x0.
+    # So a re-capture cannot move these against the change — it already did not.
+    #
+    # The eighth, WDTCONFIG0, reads 0x00000000 on that board and the model now
+    # says 0x0004C000. That is not a contradiction: the capture's own metadata
+    # records capture_state "reset halt (software core reset, post-ROM)", and
+    # WDTCONFIG0 is precisely the register the ROM + 2nd-stage bootloader clear
+    # when they disable the MWDT and drop flash-boot protection
+    # (TIMG_WDT_FLASHBOOT_MOD_EN, bit 14). WDTWPROTECT in the same capture is
+    # back at 0x50D83AA1, i.e. the write-key was re-armed after a write. The
+    # reset value itself is stated by the ESP32-S3 TRM v1.8 Register 12.10
+    # (p.665) and by the vendor SVD, which agree. Reading a cold WDTCONFIG0
+    # needs a power-on capture, not a `reset halt` — that is the one live read
+    # this change owes, and no S3 board is attached this session.
+    #
+    # GPIO REG_DATE (0x6FC) is NOT in the capture at all: the GPIO window stops
+    # at offset 0x0BC. It rests on TRM v1.8 Register 6.34 (p.512) alone, which
+    # states 0x1907040 and matches the vendor SVD; the old 0x02108190 is not
+    # this part's version stamp and is not any Espressif part's.
+    #
+    # The 9-register reset-state anchor is entirely I2C0
+    # (crates/hw-oracle/tests/esp32s3_reset_conformance.rs) and is untouched.
     # 2026-08-17 (#1008): octal PSRAM, dual-core startup and LCD_CAM i80 pixel
     # streaming, found by running real Doom on a physical ESP32-S3-N16R8 and
     # then in the twin. This is the LARGEST behavioural change to this board
@@ -2643,7 +2677,7 @@ boards:
     # 2026-08-12: chip yaml documents sar_adc_s3 + twai already registered by
     # configure_xtensa_esp32s3 (ESP32S3_PERIPHERALS). Address-map honesty only —
     # 9-reg reset-state silicon anchor unchanged. Arduino matrix L5/L8 green.
-    drift_ack_digest: 3c0fdf6ce23569b3158e409ff00a365a5be0e4bb7df684f5f50cb77bb78ec743
+    drift_ack_digest: ce851b8dd4e6a6e03c46521c4a0729321de66d29805e73b719b821da53edaf1d
     models:
       - crates/core/src/cpu/xtensa_lx7.rs
       - crates/core/src/decoder/xtensa.rs


### PR DESCRIPTION
fix(esp32s3): nine reset values the S3's own TRM contradicts

configs/peripherals/esp32s3/{timg0,gpio}.yaml say at the top that they are
"Based on ESP32-S3 Technical Reference Manual". Nine of their reset values
are not in that manual:

  register              modelled      ESP32-S3 TRM v1.8
  TIMG0.T0CONFIG        0x60013000    0x60002000   (Reg 12.1,  p.662)
  TIMG0.T1CONFIG        0x60013000    0x60002000   (Reg 12.1,  p.662)
  TIMG0.WDTCONFIG0      0x00048D00    0x0004C000   (Reg 12.10, p.665)
  TIMG0.WDTCONFIG2      0x00000000    0x018CBA80   (Reg 12.12, p.666)
  TIMG0.WDTCONFIG3      0x00000000    0x07FFFFFF   (Reg 12.13, p.666)
  TIMG0.WDTCONFIG4      0x00000000    0x000FFFFF   (Reg 12.14, p.666)
  TIMG0.WDTCONFIG5      0x00000000    0x000FFFFF   (Reg 12.15, p.667)
  TIMG0.RTCCALICFG      0x00000000    0x00013000   (Reg 12.18, p.668)
  GPIO.REG_DATE         0x02108190    0x01907040   (Reg 6.34,  p.512)

The TRM prints these per field, so they are reconstructed rather than quoted:
T0CONFIG is INCREASE=1 (b30), AUTORELOAD=1 (b29), DIVIDER=0x01 (b28:13) =
0x6000_2000. WDTCONFIG0 is CPU_RESET_LENGTH=0x1 (b20:18), SYS_RESET_LENGTH=0x1
(b17:15), FLASHBOOT_MOD_EN=1 (b14) = 0x0004_C000. RTCCALICFG is CALI_MAX=0x01
(b30:16), CALI_CLK_SEL=0x1 (b14:13), START_CYCLING=1 (b12) = 0x0001_3000. The
vendor SVD states the same numbers independently, and the gate asserts against
the SVD so the check re-runs.

These nine are the TIMG0/GPIO half of the 34 model/silicon conflicts that
0036_part_knowledge_svd_promotion.sql published as `conflicted` without
deciding a side. The TRM decides them, and it decides against the model.

SEVEN OF THE NINE ARE CONFIRMED BY A LIVE BOARD.

scripts/hw-oracle/captures/esp32s3/recapture-20260809T130700Z/reg_oracle.json
is a 2026-08-09 USB-JTAG capture of a physical ESP32-S3 (QFN56 rev v0.2) and
its TIMG0 window holds seven of these registers. Every one reads the NEW value:

  T0CONFIG   0x60002000    WDTCONFIG3  0x07FFFFFF    RTCCALICFG  0x00013000
  T1CONFIG   0x60002000    WDTCONFIG4  0x000FFFFF
  WDTCONFIG2 0x018CBA80    WDTCONFIG5  0x000FFFFF

so the model is being moved toward what silicon already read, not away from it.

The eighth, WDTCONFIG0, reads 0x00000000 on that board. That is not a
contradiction: the capture records its own capture_state as "reset halt
(software core reset, post-ROM)", and WDTCONFIG0 is exactly the register the
ROM and 2nd-stage bootloader clear when they disable the MWDT and drop
flash-boot protection. WDTWPROTECT in the same capture is back at 0x50D83AA1 —
the write-key was re-armed after a write. A cold WDTCONFIG0 needs a power-on
capture, and no S3 board is attached this session; the TRM and the SVD agree
on 0x0004C000.

GPIO.REG_DATE is not in the capture at all — that GPIO window stops at offset
0x0BC — so it rests on the TRM alone. 0x02108190 is not this part's version
stamp and is not any Espressif part's: the S2 reads 0x01905061, the C3
0x02006130, the C2 0x02106190. It was invented.

Blast radius

Every construction site was checked. Both descriptors are referenced only by
configs/chips/esp32s3.yaml (`path:`) and esp32s3-zero.yaml (`debug_schema:`),
plus the include_str! in bus/embedded_descriptors.rs. No other chip shares
either file. The ESP32-C3 and classic ESP32 model the same two peripherals
under character-identical register names and are correct today; both are
pinned by the new gate.

Prove it was broken: RED before, GREEN after

New gate: crates/core/tests/esp32s3_timg_gpio_reset_values.rs. Nothing
compared a peripheral descriptor's reset values to a vendor artifact before —
register_coverage counts responses, which a register holding the wrong reset
value still produces, and svd_conformance checks base addresses and IRQ
numbers only.

RED (models provably at HEAD: `git diff` empty for configs/peripherals/, and
grep confirmed 0x60013000 / 0x00048D00 / 0x02108190 still in the files):

    running 4 tests
    test esp32s3_timg0_answers_reads_with_the_trm_reset_values ... FAILED
    test esp32s3_gpio_version_stamp_matches_the_vendor_svd ... FAILED
    test esp32s3_timg0_reset_values_match_the_vendor_svd ... FAILED
    test esp32c3_and_esp32_timg_gpio_stay_on_their_own_silicon ... ok

    ---- esp32s3_timg0_reset_values_match_the_vendor_svd stdout ----
    configs/peripherals/esp32s3/timg0.yaml disagrees with
    tests/fixtures/svd/esp32s3.svd (8 findings over 28 shared registers):
      T0CONFIG: reset 0x60013000, silicon resets to 0x60002000
      T1CONFIG: reset 0x60013000, silicon resets to 0x60002000
      WDTCONFIG0: reset 0x00048D00, silicon resets to 0x0004C000
      WDTCONFIG2: reset 0x00000000, silicon resets to 0x018CBA80
      WDTCONFIG3: reset 0x00000000, silicon resets to 0x07FFFFFF
      WDTCONFIG4: reset 0x00000000, silicon resets to 0x000FFFFF
      WDTCONFIG5: reset 0x00000000, silicon resets to 0x000FFFFF
      RTCCALICFG: reset 0x00000000, silicon resets to 0x00013000

    test result: FAILED. 1 passed; 3 failed

GREEN (`git diff --stat` non-empty first: 2 files changed, 27 insertions(+),
9 deletions(-)):

    running 4 tests
    test esp32s3_gpio_version_stamp_matches_the_vendor_svd ... ok
    test esp32s3_timg0_answers_reads_with_the_trm_reset_values ... ok
    test esp32s3_timg0_reset_values_match_the_vendor_svd ... ok
    test esp32c3_and_esp32_timg_gpio_stay_on_their_own_silicon ... ok

    test result: ok. 4 passed; 0 failed

And the sibling-chip guard can say no. Sabotage: esp32c3/gpio.yaml REG_DATE
moved 33579312 -> 26243136, i.e. onto the S3's stamp. `git diff` non-empty
before the run (1 file changed, 1 insertion(+), 1 deletion(-), hunk shown):

    test esp32s3_gpio_version_stamp_matches_the_vendor_svd ... ok
    test esp32s3_timg0_answers_reads_with_the_trm_reset_values ... ok
    test esp32s3_timg0_reset_values_match_the_vendor_svd ... ok
    test esp32c3_and_esp32_timg_gpio_stay_on_their_own_silicon ... FAILED

    configs/peripherals/esp32c3/gpio.yaml disagrees with
    tests/fixtures/real_world/esp32c3.svd (1 findings over 199 shared registers):
      REG_DATE: reset 0x01907040, silicon resets to 0x02006130

Sabotage reverted; `git diff` for that file empty again, and this branch's own
edits survived it.

End-to-end, measured by the corpus's own pass

`npx tsx packages/api/scripts/generate-svd-promotion.ts --report` run against
this tree, which is what emitted the 34 conflicts in the first place:

    before this branch:  3 proven, 34 conflicts
    with this branch:   12 proven, 25 conflicts

The nine did not move to another bucket; they became `proven`. With the
esp32s3 interrupt-matrix fix (#995) also applied the S3 reaches 39 proven and
0 conflicts, leaving 3 corpus-wide (MKW41Z4 SIM.SDID, RP2040 SYSINFO x2), and
neither of those is a model defect.

Regeneration

scripts/regen-all.sh: exit 0, and the only artifact it moved is
docs/boards/VALIDATION_STATUS.md. A second run left the tree unchanged.
embedded_descriptors.rs did not change — it include_str!s these files by path.

generate_validation_status.py digests configs/peripherals/esp32s3, so the
esp32s3 row flipped to DRIFT and the required gate exited 1 (measured). The
ack is re-stamped in validation/manifest.yaml with a dated reason, and
--write-ack-digests stamped exactly 1 board. Gate now exits 0. The 9-register
reset-state anchor is entirely I2C0 (crates/hw-oracle/tests/
esp32s3_reset_conformance.rs) and none of these nine is in it.

Adjacent defect NOT fixed here

TIMG0.T0CONFIG/T1CONFIG also declare a DIVCNT_RST field at bit 12. The S3 TRM
has b12:11 reserved on this register; DIVCNT_RST at b12 is the ESP32-C3's
layout. That is a field-map defect, not a reset value, and no published
conflict covers it — left for its own change rather than widened into this one.

Verification (measured, by exit code)

  suite                                          pristine main    this branch
  cargo test -p labwired-core --lib              3093 passed, 0   3093 passed, 0
  chip_conformance, bus_visibility,
    unknown_peripheral_type, register_coverage,
    svd_conformance                              13 passed, 0     13 passed, 0
  esp32s3_timg_gpio_reset_values (new)           -                4 passed, 0
  esp32s3_walk_differential, intmatrix_alarm,
    debug_schema_is_not_fidelity
    (--features event-scheduler)                 -                4 passed, 0
  firmware_survival                              -                61 passed, 0

All exit 0. cargo fmt --all -- --check exit 0. cargo clippy -p labwired-core
--test esp32s3_timg_gpio_reset_values -- -D warnings clean.
