### PR TITLE
fix(wasm): boot the ESP32-S3 from a flash image, with no ELF

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -173,6 +173,11 @@ required-features = ["esp32s3-fixtures"]
 
 # #![cfg(feature = "esp32s3-fixtures")]
 [[test]]
+name = "e2e_esp32s3_flash_boot_no_elf"
+required-features = ["esp32s3-fixtures"]
+
+# #![cfg(feature = "esp32s3-fixtures")]
+[[test]]
 name = "e2e_hello_world"
 required-features = ["esp32s3-fixtures"]
 

--- a/crates/core/tests/e2e_esp32s3_flash_boot_no_elf.rs
+++ b/crates/core/tests/e2e_esp32s3_flash_boot_no_elf.rs
@@ -1,0 +1,90 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+//
+// The ESP32-S3 boots from a flash image with NO ELF.
+//
+// This is the assembly every HOSTED S3 run needs and the one that did not
+// exist: the hosted compiler ships `bootloader@0x0 + partition-table@0x8000 +
+// app@0x10000` and no ELF, while the only S3 constructor took an ELF and
+// `fast_boot`. A run with no ELF to load looked exactly like a hang — the mask
+// ROM printed
+//
+//     ESP-ROM:esp32s3-20210327 … entry 0x403c98d0
+//
+// and then nothing, at 20 M and at 200 M steps, with the fault PC in ROM space.
+// The C3 has had the ELF-less equivalent since its own rom-boot path landed.
+//
+// What this locks down is the assembly, not the wasm wrapper (which needs a JS
+// context): flash bytes in through `Esp32s3Opts::flash_image`, `real_reset_boot`
+// for the MMU XIP model, the real ROM, and the CPU left at the BROM reset
+// vector. If any one of those is dropped the boot dies before the app: identity
+// XIP in particular reads the wrong dcache page and returns zeros, which is a
+// silent wrong answer rather than an error.
+#![cfg(feature = "esp32s3-fixtures")]
+
+use labwired_core::bus::SystemBus;
+use labwired_core::system::xtensa::{configure_xtensa_esp32s3, Esp32s3BootMode, Esp32s3Opts};
+use labwired_core::Machine;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+fn flash_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/tier1/esp32s3-flash.bin")
+}
+
+#[test]
+fn flash_image_boots_the_app_without_an_elf() {
+    let Ok(flash) = std::fs::read(flash_path()) else {
+        eprintln!("skipping: tier1 esp32s3-flash.bin fixture not present");
+        return;
+    };
+
+    let mut bus = SystemBus::new();
+    let opts = Esp32s3Opts {
+        real_reset_boot: true,
+        flash_image: Some(flash.clone()),
+        flash_size: (flash.len() as u32).max(4 * 1024 * 1024),
+        ..Esp32s3Opts::default()
+    };
+    let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
+    assert_eq!(
+        wiring.boot_mode,
+        Esp32s3BootMode::Faithful,
+        "this path IS the ROM; without a real one there is nothing to boot"
+    );
+    let cpu = wiring.cpu;
+
+    // Both consoles: the mask ROM and the 2nd-stage bootloader talk on UART0,
+    // an Arduino sketch built CDC-on-boot talks on USB-Serial-JTAG. A tap on
+    // one of them is how a run that IS working reads as silent.
+    let sink = Arc::new(Mutex::new(Vec::new()));
+    bus.attach_uart_tx_sink(sink.clone(), false);
+    bus.attach_usb_serial_jtag_sink(sink.clone());
+    bus.refresh_peripheral_index();
+
+    let mut machine = Machine::new(cpu, bus);
+
+    // The banner arrives early; the fixture's own app output follows. 20 M
+    // steps is what the native `--rom-boot` CLI needs for both on this image.
+    for _ in 0..20_000_000u64 {
+        let _ = machine.step();
+    }
+
+    let out = String::from_utf8_lossy(&sink.lock().unwrap().clone()).to_string();
+    assert!(
+        out.contains("ESP-ROM:esp32s3"),
+        "no mask-ROM banner — the ROM never ran at all. Got: {out:?}"
+    );
+    // The distinguishing assertion. The broken path reached the banner too; it
+    // is the SECOND-stage bootloader, which only runs when the flash
+    // controller and the MMU serve real bytes, that it never reached.
+    assert!(
+        out.contains("boot:"),
+        "mask ROM ran but the 2nd-stage bootloader never printed — the app was never loaded. Got: {out:?}"
+    );
+    assert!(
+        out.contains("Loaded app from partition"),
+        "bootloader ran but never loaded the app image. Got: {out:?}"
+    );
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -432,7 +432,21 @@ impl WasmSimulator {
             }
             MachineFamily::Xtensa if chip.is_esp32s3() => {
                 let blob_map = parse_named_blobs(&blobs);
-                Self::new_from_config_xtensa_esp32s3(&manifest, firmware, &blob_map)
+                // Same trigger as the C3: the merged flash image
+                // (`bootloader@0x0 + partition-table@0x8000 + app@0x10000`)
+                // arriving as a named blob means boot the real mask ROM from
+                // the reset vector. Without it, `firmware` is a bare esp-hal
+                // ELF and the pre-existing fast-boot path runs.
+                //
+                // The hosted compiler ships flash images and NO ELF, so before
+                // this branch existed every hosted S3 run fell into fast_boot
+                // with nothing to load: the mask ROM printed its banner, jumped
+                // to the 2nd-stage bootloader, and the app never ran.
+                if blob_map.contains_key("esp32s3_flash") {
+                    Self::new_from_config_xtensa_esp32s3_flash(&manifest, &blob_map)
+                } else {
+                    Self::new_from_config_xtensa_esp32s3(&manifest, firmware, &blob_map)
+                }
             }
             MachineFamily::Xtensa => Self::new_from_config_xtensa_esp32(&manifest, firmware),
             // Classic Arduino Nano / ATmega328P — same shape as `build_avr_node`.
@@ -1014,6 +1028,114 @@ impl WasmSimulator {
     /// ELF's segments (identity XIP) and synthesises post-bootloader CPU state.
     /// Serial output on the S3 esp-hal apps goes through USB_SERIAL_JTAG, so we
     /// route that peripheral's sink into the `uart_sink` the widget reads.
+    /// Faithful ESP32-S3 boot from a merged flash image, with **no ELF**.
+    ///
+    /// The Xtensa counterpart of `new_from_config_riscv_flash_fastboot`, and
+    /// the path every hosted S3 run needs: the hosted compiler produces flash
+    /// images (bootloader + partition table + app) and no ELF, so a
+    /// constructor that can only `fast_boot(elf)` has nothing to boot. What
+    /// that produced looked exactly like a hang — the mask ROM printed its
+    /// banner, jumped to the 2nd-stage bootloader, and stopped.
+    ///
+    /// The assembly is the native `--rom-boot` sequence, already proven on this
+    /// chip: `real_reset_boot` selects the MMU XIP model (both cache windows
+    /// alias one physical flash backing and translate through the table the
+    /// bootloader programs — identity XIP reads the wrong page and returns
+    /// zeros), the flash image is passed as bytes rather than through
+    /// `LABWIRED_ESP32S3_FLASH` (there is no env on wasm), and the CPU is left
+    /// at the BROM reset vector so the chip's own ROM loads the app and jumps
+    /// to it. No `fast_boot`, no synthesised post-bootloader state, no thunks.
+    fn new_from_config_xtensa_esp32s3_flash(
+        manifest: &SystemManifest,
+        blobs: &std::collections::HashMap<String, Vec<u8>>,
+    ) -> Result<WasmSimulator, JsValue> {
+        use labwired_core::boot::esp32s3_rom::RomImages;
+        use labwired_core::system::xtensa::{
+            configure_xtensa_esp32s3, Esp32s3BootMode, Esp32s3Opts,
+        };
+
+        let flash = blobs.get("esp32s3_flash").ok_or_else(|| {
+            JsValue::from_str("ESP32-S3 flash boot needs the merged flash image blob esp32s3_flash")
+        })?;
+
+        // The real ROM is not optional here. Fast-boot may fall back to the
+        // thunk harness because it jumps straight into the app; this path IS
+        // the ROM, so a missing blob has to say so rather than boot nothing.
+        let (Some(irom), Some(drom)) = (blobs.get("esp32s3_irom"), blobs.get("esp32s3_drom"))
+        else {
+            return Err(JsValue::from_str(
+                "ESP32-S3 flash boot needs the boot ROM blobs: pass esp32s3_irom + esp32s3_drom",
+            ));
+        };
+
+        let mut bus = SystemBus::new();
+        let opts = Esp32s3Opts {
+            real_reset_boot: true,
+            rom_images: Some(RomImages {
+                irom: irom.clone(),
+                drom: drom.clone(),
+            }),
+            flash_image: Some(flash.clone()),
+            // A 16 MB N16R8 image must not be truncated into a 4 MB backing:
+            // the partition table addresses the app at its real offset, and a
+            // short backing reads 0xFF there.
+            flash_size: (flash.len() as u32).max(4 * 1024 * 1024),
+            ..Esp32s3Opts::default()
+        };
+        let wiring = configure_xtensa_esp32s3(&mut bus, &opts);
+        if wiring.boot_mode != Esp32s3BootMode::Faithful {
+            return Err(JsValue::from_str(
+                "ESP32-S3 flash boot needs the real boot ROM, but the injected images did not resolve",
+            ));
+        }
+        let cpu = wiring.cpu;
+
+        // Console selection is the rule every other ESP path uses: an
+        // undeclared manifest hears both consoles in one pane, a declared one
+        // is authoritative. Both taps matter here — the mask ROM prints on
+        // UART0 while an Arduino sketch built CDC-on-boot prints on
+        // USB-Serial-JTAG, so the boot banner and the sketch arrive on
+        // different peripherals of the same run.
+        let console = ConsoleCapture::for_manifest(manifest);
+        let uart_sink = console.heard_sink();
+        match console.tapped() {
+            HostConsole::Undeclared => {
+                bus.attach_usb_serial_jtag_sink(uart_sink.clone());
+                bus.attach_uart_tx_sink(uart_sink.clone(), false);
+            }
+            tapped => {
+                if !tapped.is_usb_serial_jtag() {
+                    bus.attach_usb_serial_jtag_sink(console.unheard_sink());
+                }
+                bus.attach_host_console(tapped, uart_sink.clone())
+                    .map_err(|e| JsValue::from_str(&e))?;
+                if tapped.is_usb_serial_jtag() {
+                    bus.attach_uart_tx_sink(console.unheard_sink(), false);
+                }
+            }
+        }
+        let uart_rx_bufs = bus.attach_uart_rx_source();
+
+        labwired_core::system::xtensa::attach_esp32_external_devices(&mut bus, manifest)
+            .map_err(|e| JsValue::from_str(&format!("ESP32-S3 external_devices: {:#}", e)))?;
+        bus.refresh_peripheral_index();
+
+        let boxed: Box<dyn Cpu> = Box::new(cpu);
+        let machine = Machine::new(boxed, bus);
+
+        Ok(WasmSimulator {
+            machine: Some(machine),
+            board_io: manifest.board_io.clone(),
+            uart_sink,
+            console,
+            uart_rx_bufs,
+            arch: MachineFamily::Xtensa,
+            esp32_ipi: None,
+            jit_browser_enabled: false,
+            jit_browser_cache: None,
+        })
+    }
+
     fn new_from_config_xtensa_esp32s3(
         manifest: &SystemManifest,
         firmware: &[u8],


### PR DESCRIPTION
**Every hosted ESP32-S3 run has been dead**, and it looks like a hang:

```
ESP-ROM:esp32s3-20210327
…
entry 0x403c98d0
```

…and nothing more. At 20 M steps and at 200 M, fault PC in ROM space. `ets_printf` — which writes through the same ROM UART that printed that banner — is silent too, so it is not a console-routing problem. The app was never loaded.

## Root cause

The hosted compiler ships a **merged flash image** (`bootloader@0x0 + partition-table@0x8000 + app@0x10000`) and **no ELF**.

The RISC-V side has had a constructor for exactly that since the C3 rom-boot path landed — `new_from_config_riscv_flash_fastboot`, selected by the presence of an `esp32c3_flash` blob. **Xtensa had no such branch.** `new_from_config` sent every S3 run to `new_from_config_xtensa_esp32s3`, which can only `fast_boot(elf)`. With no ELF there was nothing to boot, so the run sat in the mask ROM.

The engine itself was never broken: the native `--rom-boot` CLI boots this chip from flash today, which is why the tier1 S3 matrix is green while every hosted S3 run is dead.

## The fix

An `esp32s3_flash` blob now selects `new_from_config_xtensa_esp32s3_flash`, which assembles the machine the way the native CLI already does: `real_reset_boot` for the MMU XIP model, flash bytes passed in rather than read from `LABWIRED_ESP32S3_FLASH` (no env on wasm), the injected boot ROM, and the CPU left at the BROM reset vector so the chip's own ROM loads the app and jumps.

Three details that are load-bearing, not tidy:

| Detail | Why it is not optional |
| --- | --- |
| `real_reset_boot` (MMU XIP) | Identity XIP reads the wrong dcache page and returns **zeros**, so the bootloader walks a partition table of `0x00`. Not a smaller version of the right answer — a silent wrong one. |
| `flash_size` follows the image | A 16 MB **N16R8** image truncated into the default 4 MB backing reads `0xFF` where the partition table says the app is. |
| Both consoles tapped | The mask ROM talks on UART0; an Arduino sketch built CDC-on-boot talks on USB-Serial-JTAG. Tapping one is how a run that IS working reads as silent — the same trap the C3 hit. |

## Test

`e2e_esp32s3_flash_boot_no_elf` boots the tier1 flash fixture with **no ELF** and asserts it reaches the 2nd-stage bootloader and loads the app — the step the broken path never took, since it reached the banner too.

**Negative control run:** flipping `real_reset_boot` to `false` (what the hosted path effectively had) fails the test. The guard is not vacuous.

## After this merges

Monorepo needs a submodule bump, then **builder deploys before api**, before hosted S3 runs actually work in front of users.