### PR TITLE
fix(cortex-m): fault on an undefined instruction instead of skipping it

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -7,7 +7,8 @@
 use crate::bus::SystemBus;
 use crate::decoder::arm::{decode_thumb_16, decode_thumb_32, Instruction};
 use crate::peripherals::scb::{
-    ScbFaultState, CFSR_BFSR_BFARVALID, CFSR_BFSR_PRECISERR, HFSR_FORCED, SHCSR_BUSFAULTENA,
+    ScbFaultState, CFSR_BFSR_BFARVALID, CFSR_BFSR_PRECISERR, CFSR_UFSR_UNDEFINSTR, HFSR_FORCED,
+    SHCSR_BUSFAULTENA, SHCSR_USGFAULTENA,
 };
 use crate::{Bus, Cpu, SimResult, SimulationConfig, SimulationError, SimulationObserver};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -130,6 +131,15 @@ pub struct CortexM {
     ///
     /// Only ever written on the error path, so a clean step costs nothing.
     pending_data_fault: Option<u32>,
+    /// Set when decode reached an instruction this model does not implement, so
+    /// `step_internal` can raise UsageFault instead of returning the bare
+    /// `DecodeError`.
+    ///
+    /// Separate from `pending_data_fault` because the two escalate differently:
+    /// a data fault names an address and targets BusFault, an undefined
+    /// instruction names none and targets UsageFault. Only ever written on the
+    /// error path.
+    pending_undef_instruction: bool,
     pub decode_cache: Box<[Option<DecodeCacheEntry>; 4096]>,
     /// FPU single-precision register file (VFPv4 single — S0..S31).
     /// Each S register is the IEEE-754 binary32 bit pattern; reads via
@@ -187,6 +197,7 @@ impl Default for CortexM {
             sysreset_signal: None,
             faults: None,
             pending_data_fault: None,
+            pending_undef_instruction: false,
             decode_cache: Box::new([None; 4096]),
             fpu_s: [0u32; 32],
             sleeping: false,
@@ -1182,6 +1193,49 @@ impl CortexM {
         true
     }
 
+    /// ARMv7-M B1.5.14 escalation for an **undefined instruction**.
+    ///
+    /// Same shape as [`CortexM::escalate_precise_data_fault`], with UsageFault
+    /// in place of BusFault and no fault address — UFSR has no companion to
+    /// BFAR:
+    ///
+    /// * `CFSR.UFSR.UNDEFINSTR` (B3.2.15) — the processor attempted to execute
+    ///   an instruction it does not define.
+    /// * `HFSR.FORCED` (B3.2.16) — set only when the fault escalates, i.e. when
+    ///   `SHCSR.USGFAULTENA` is clear or UsageFault cannot preempt.
+    ///
+    /// Returns `false` when even HardFault cannot be taken (LOCKUP on silicon,
+    /// B1.5.15). The caller then stops the run rather than pending an exception
+    /// that can never dispatch and spinning on the faulting instruction.
+    fn escalate_undefined_instruction(&mut self) -> bool {
+        let Some(faults) = self.faults.clone() else {
+            return false;
+        };
+        faults
+            .cfsr
+            .fetch_or(CFSR_UFSR_UNDEFINSTR, Ordering::Relaxed);
+
+        let usagefault_enabled = faults.shcsr.load(Ordering::Relaxed) & SHCSR_USGFAULTENA != 0;
+        let exec_prio = self.execution_priority();
+        let target = if usagefault_enabled && self.exception_priority(6) < exec_prio {
+            6
+        } else {
+            faults.hfsr.fetch_or(HFSR_FORCED, Ordering::Relaxed);
+            3
+        };
+        if self.exception_priority(target) >= exec_prio {
+            return false; // LOCKUP — see the doc comment.
+        }
+        if trace_exc_enabled() {
+            eprintln!(
+                "EXC undefined instruction -> exc={} pc=0x{:08X}",
+                target, self.pc
+            );
+        }
+        self.set_exception_pending(target);
+        true
+    }
+
     /// One instruction, with ARMv7-M fault escalation layered over
     /// [`CortexM::step_execute`].
     ///
@@ -1206,9 +1260,21 @@ impl CortexM {
             Err(e) => {
                 // `take` unconditionally: the latch must not survive into the
                 // next step even when escalation is off.
+                let undef = std::mem::take(&mut self.pending_undef_instruction);
                 match self.pending_data_fault.take() {
                     Some(addr)
                         if self.faults_enabled() && self.escalate_precise_data_fault(addr) =>
+                    {
+                        Ok(())
+                    }
+                    // An undefined instruction escalates to UsageFault, or to
+                    // HardFault when UsageFault is not enabled. Escalation
+                    // failing means LOCKUP on silicon, so the `Err` stands and
+                    // stops the run — which is still incomparably better than
+                    // the old behaviour of advancing the PC and continuing.
+                    _ if undef
+                        && self.faults_enabled()
+                        && self.escalate_undefined_instruction() =>
                     {
                         Ok(())
                     }
@@ -2478,7 +2544,9 @@ impl CortexM {
                             ((h1 as u64) << 16) | (h2 as u64),
                             "undecoded T32",
                         );
-                        pc_increment = 4;
+                        // As for T16 above: fault rather than skip.
+                        self.pending_undef_instruction = true;
+                        return Err(SimulationError::DecodeError(self.pc as u64));
                     }
                 }
 
@@ -3724,7 +3792,12 @@ impl CortexM {
                 Instruction::Unknown(op) => {
                     tracing::warn!("Unknown instruction at {:#x}: Opcode {:#06x}", self.pc, op);
                     crate::fidelity::record_undecoded(self.pc, op as u64, "undecoded T16");
-                    pc_increment = 2; // Skip 16-bit
+                    // Silicon raises UsageFault (UNDEFINSTR) here. This used to
+                    // `pc_increment = 2` and carry on, which left every register
+                    // stale and the run ending green — see the note on
+                    // `escalate_undefined_instruction`.
+                    self.pending_undef_instruction = true;
+                    return Err(SimulationError::DecodeError(self.pc as u64));
                 }
             }
         }

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -1134,6 +1134,19 @@ pub fn decode_thumb_16(opcode: u16) -> Instruction {
                 imm8: (opcode & 0xFF) as u8,
             };
         }
+        // cond 0xE (1101 1110 ...) is UDF — PERMANENTLY UNDEFINED (A7.7.194).
+        // The B T1 encoding (A7.7.12) excludes both 1110 and 1111 from `cond`;
+        // only 1111 was excluded here, so `UDF #imm8` decoded as a branch with
+        // cond = "always" and offset = imm8 << 1. `UDF #0` therefore became a
+        // 4-byte forward step that looked exactly like ordinary execution.
+        //
+        // This is the instruction compilers emit to trap on purpose:
+        // `__builtin_trap()`, an unreachable arm, a Rust panic in some
+        // configurations. Firmware saying "stop, this must never happen" was
+        // being simulated as "jump forward and keep going".
+        if cond == 0xE {
+            return Instruction::Unknown(opcode);
+        }
         let mut offset = (opcode & 0xFF) as i32;
         // Sign extend 8-bit to 32-bit
         if (offset & 0x80) != 0 {

--- a/crates/core/src/peripherals/scb.rs
+++ b/crates/core/src/peripherals/scb.rs
@@ -51,6 +51,11 @@ pub const SHCSR_BUSFAULTENA: u32 = 1 << 17;
 pub const CFSR_BFSR_PRECISERR: u32 = 1 << 9;
 /// `CFSR.BFSR.BFARVALID` — BFSR bit 7, i.e. CFSR bit 15 (B3.2.15).
 pub const CFSR_BFSR_BFARVALID: u32 = 1 << 15;
+/// `SHCSR.USGFAULTENA`, bit 18 (ARMv7-M ARM B3.2.13).
+pub const SHCSR_USGFAULTENA: u32 = 1 << 18;
+/// `CFSR.UFSR.UNDEFINSTR` — UFSR bit 0, i.e. CFSR bit 16 (B3.2.15). Set when the
+/// processor attempts to execute an undefined instruction.
+pub const CFSR_UFSR_UNDEFINSTR: u32 = 1 << 16;
 /// `HFSR.FORCED`, bit 30 (B3.2.16): set when a configurable-priority fault
 /// escalates to HardFault.
 pub const HFSR_FORCED: u32 = 1 << 30;

--- a/crates/core/src/tests/cortex_m_fault_escalation.rs
+++ b/crates/core/src/tests/cortex_m_fault_escalation.rs
@@ -873,4 +873,174 @@ mod tests {
             "BFAR must still name the original data address"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // GUARD 5 — an UNDEFINED INSTRUCTION faults instead of being skipped.
+    // -------------------------------------------------------------------------
+    //
+    // The model used to `record_undecoded(..)` and advance the PC past anything
+    // it could not decode. The run continued with every register stale and
+    // ended green. That is the UADD8/`strlen` incident the fidelity module was
+    // written for, and the response at the time was a counter, not a fault.
+    //
+    // Silicon raises UsageFault with `CFSR.UFSR.UNDEFINSTR` (ARMv7-M B1.5.14).
+    // RISC-V and Xtensa in this same engine already fault; ARM was the outlier,
+    // and ARM is most of the fleet.
+
+    /// `UDF #0` — the T1 permanently-undefined encoding (ARMv7-M A7.7.194). The
+    /// architecture guarantees this will never decode to anything, which is why
+    /// it is a better probe than an opcode we merely have not implemented yet:
+    /// implementing that opcode would silently turn this test green-by-absence.
+    const UDF_0: u16 = 0xDE00;
+
+    /// `SHCSR.USGFAULTENA`, bit 18 (B3.2.13).
+    const SHCSR_USGFAULTENA: u32 = 1 << 18;
+    /// `CFSR.UFSR.UNDEFINSTR` — UFSR bit 0, i.e. CFSR bit 16 (B3.2.15).
+    const CFSR_UNDEFINSTR: u32 = 1 << 16;
+    /// Where the fake `UsageFault_Handler` lives.
+    const USAGEFAULT_HANDLER: u32 = 0x4000;
+
+    /// A machine whose instruction at `CODE` is permanently undefined, with all
+    /// three fault handlers installed.
+    fn undefined_instruction_machine(faults_enabled: bool) -> Machine<CortexM> {
+        let mut bus = crate::bus::SystemBus::new();
+        let (cpu, _nvic) = crate::system::cortex_m::configure_cortex_m(&mut bus);
+
+        bus.write_u32(0x0C, HARDFAULT_HANDLER | 1).unwrap(); // exception 3
+        bus.write_u32(0x18, USAGEFAULT_HANDLER | 1).unwrap(); // exception 6
+        bus.write_u16(HARDFAULT_HANDLER as u64, B_SELF).unwrap();
+        bus.write_u16(USAGEFAULT_HANDLER as u64, B_SELF).unwrap();
+
+        bus.write_u16(CODE as u64, UDF_0).unwrap();
+        bus.write_u16((CODE + 2) as u64, B_SELF).unwrap();
+
+        let mut machine = Machine::new(cpu, bus);
+        machine.cpu.set_faults_enabled(faults_enabled);
+        machine.cpu.set_pc(CODE);
+        machine.cpu.set_sp(STACK_TOP);
+        machine
+    }
+
+    /// USGFAULTENA set: UsageFault (exception 6) is taken, the handler runs, and
+    /// the run continues — firmware that installs a handler gets to keep going.
+    #[test]
+    fn undefined_instruction_takes_usagefault_when_enabled() {
+        let mut machine = undefined_instruction_machine(true);
+        machine.bus.write_u32(SHCSR, SHCSR_USGFAULTENA).unwrap();
+        assert_eq!(
+            machine.bus.read_u32(SHCSR).unwrap() & SHCSR_USGFAULTENA,
+            SHCSR_USGFAULTENA,
+            "USGFAULTENA must read back set, or this cannot tell the enabled \\
+             case from the escalated one"
+        );
+
+        run_alive(&mut machine, 4);
+
+        assert_eq!(
+            machine.cpu.get_pc() & !1,
+            USAGEFAULT_HANDLER,
+            "the UsageFault handler must be running; pc = 0x{:08X}",
+            machine.cpu.get_pc()
+        );
+        assert_eq!(
+            machine.bus.read_u32(CFSR).unwrap(),
+            CFSR_UNDEFINSTR,
+            "CFSR must report UNDEFINSTR and nothing else"
+        );
+        assert_eq!(
+            machine.bus.read_u32(HFSR).unwrap() & HFSR_FORCED,
+            0,
+            "HFSR.FORCED is for escalation only; UsageFault was taken directly"
+        );
+    }
+
+    /// USGFAULTENA clear: the fault escalates to HardFault with `HFSR.FORCED`,
+    /// and `CFSR` still names UNDEFINSTR so the HardFault handler can tell what
+    /// it is standing in for (B1.5.14).
+    #[test]
+    fn undefined_instruction_escalates_to_hardfault_when_usagefault_disabled() {
+        let mut machine = undefined_instruction_machine(true);
+        assert_eq!(
+            machine.bus.read_u32(SHCSR).unwrap() & SHCSR_USGFAULTENA,
+            0,
+            "precondition: USGFAULTENA clear"
+        );
+
+        run_alive(&mut machine, 4);
+
+        assert_eq!(
+            machine.cpu.get_pc() & !1,
+            HARDFAULT_HANDLER,
+            "must escalate to HardFault; pc = 0x{:08X}",
+            machine.cpu.get_pc()
+        );
+        assert_eq!(
+            machine.bus.read_u32(HFSR).unwrap() & HFSR_FORCED,
+            HFSR_FORCED,
+            "HFSR.FORCED marks an escalated configurable fault"
+        );
+        assert_eq!(
+            machine.bus.read_u32(CFSR).unwrap() & CFSR_UNDEFINSTR,
+            CFSR_UNDEFINSTR,
+            "CFSR must still say which fault escalated"
+        );
+    }
+
+    /// The regression itself, stated as an assertion: the PC must NOT walk past
+    /// an instruction the model cannot decode.
+    ///
+    /// With escalation off (the `LABWIRED_CORTEXM_FAULTS=0` opt-out) it stops
+    /// the run with `DecodeError` rather than skipping — matching RISC-V. Either
+    /// outcome is acceptable; silently continuing is not, and that is what this
+    /// pins.
+    #[test]
+    fn an_undecodable_instruction_is_never_skipped() {
+        let mut machine = undefined_instruction_machine(false);
+        let before = machine.cpu.get_pc();
+
+        let step = machine.step();
+
+        assert!(
+            matches!(step, Err(SimulationError::DecodeError(_))),
+            "with faults off, an undefined instruction must abort the run like \\
+             RISC-V does. got {step:?}"
+        );
+        assert_eq!(
+            machine.cpu.get_pc(),
+            before,
+            "the PC advanced past an instruction that was never executed — this \\
+             is exactly the defect: every register is now stale and the run will \\
+             end green"
+        );
+    }
+
+    /// The other direction. A change that faulted on everything would pass all
+    /// three tests above, so: ordinary decodable code must pend nothing and
+    /// leave every fault register at zero.
+    #[test]
+    fn decodable_code_raises_no_usagefault() {
+        let mut machine = undefined_instruction_machine(true);
+        machine.bus.write_u32(SHCSR, SHCSR_USGFAULTENA).unwrap();
+        // Replace the UDF with a plain `MOVS r0, #1`, then the self-loop.
+        machine.bus.write_u16(CODE as u64, 0x2001).unwrap();
+
+        run_alive(&mut machine, 8);
+
+        assert_eq!(
+            machine.bus.read_u32(CFSR).unwrap(),
+            0,
+            "valid code must leave CFSR untouched"
+        );
+        assert_eq!(machine.bus.read_u32(HFSR).unwrap(), 0, "and HFSR");
+        assert_ne!(
+            machine.cpu.get_pc() & !1,
+            USAGEFAULT_HANDLER,
+            "valid code must not end up in the UsageFault handler"
+        );
+        assert_ne!(
+            machine.cpu.get_pc() & !1,
+            HARDFAULT_HANDLER,
+            "nor HardFault"
+        );
+    }
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -23,7 +23,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf52832` | ⚪ structural | — | `a0b00c5f40ce5b0d` | no silicon capture |
 | `rp2040` | ⚪ structural | — | `2480b05f7681ed81` | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | `99e4ff01f1fe8988` | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `51d5dd2c462c6113` | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `202acb141847ccb3` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `6e8066344403540c` | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `f51aa6d65c014e1d` | no silicon capture |
 | `esp32` | ⚪ structural | — | `eac496cc5e5deb1b` | no silicon capture |


### PR DESCRIPTION
Closes ledger row **CORE-1**. Decision taken: *"yes Cortex-M should fault, otherwise we do unpredictable."*

## The core walked past anything it could not decode

```rust
Instruction::Unknown(op) => {
    record_undecoded(self.pc, op as u64, "undecoded T16");
    pc_increment = 2; // Skip 16-bit
}
```

Every register left stale, the run continuing, the verdict green. Silicon raises **UsageFault** (ARMv7-M B1.5.14, `CFSR.UFSR.UNDEFINSTR`). RISC-V returns `DecodeError` and Xtensa raises `EXCCAUSE=0` in this same engine — ARM was the outlier, and ARM is most of the shipped fleet.

This is the UADD8/`strlen` incident that `fidelity.rs` documents as its own founding story. The response then was a counter, not a fault.

Both decode sites (T16 and T32) now latch `pending_undef_instruction` and return `DecodeError`. `step_internal` escalates it exactly as it already escalates a precise data fault: UsageFault (exc 6) when `SHCSR.USGFAULTENA` is set and it can preempt, otherwise HardFault (exc 3) with `HFSR.FORCED`, `CFSR` still naming `UNDEFINSTR`. Failure to escalate is LOCKUP on silicon, so the `Err` stands and stops the run. All behind the existing `LABWIRED_CORTEXM_FAULTS` opt-out.

## Second bug, found while writing the test: `UDF` decoded as a branch

The `B` T1 encoding (A7.7.12) excludes cond `1110` **and** `1111`. The decoder excluded only `1111` (SVC). So `UDF #imm8` — cond `1110`, permanently undefined per A7.7.194 — decoded as a branch with cond *"always"* and offset `imm8 << 1`, making `UDF #0` a silent 4-byte forward step that looked like ordinary execution.

`UDF` is what a compiler emits to trap **on purpose**: `__builtin_trap()`, an unreachable arm, a Rust panic in some configurations. Firmware saying *"stop, this must never happen"* was being simulated as *"jump forward and keep going."*

## Blast radius — measured, because this turns green runs red by design

| check | result |
| --- | --- |
| `--test firmware_survival` | **61 passed / 0 failed** |
| `cargo test -p labwired-core` | identical to pristine `origin/main` |
| `cargo fmt --check`, clippy (lib) | clean |

`firmware_survival` is real ELFs on STM32 F401 / F407 / G474 / H563 / WB55 / L073 / WBA52 / L476, RP2040 and Nucleo CubeMX HAL, across both Arduino and Zephyr. **Nothing in the shipped corpus was relying on a skipped instruction.**

The full-suite run has one failure — `every_cpu_core_is_covered_by_this_file`, because the `Avr` core is missing from `cpu_trace_conformance`'s `cores()`. Verified failing at **exit 101 on a pristine tree before this change**: unrelated and pre-existing.

## Guards

Beside the existing data-fault ones in `cortex_m_fault_escalation.rs`:

- `undefined_instruction_takes_usagefault_when_enabled`
- `undefined_instruction_escalates_to_hardfault_when_usagefault_disabled`
- `an_undecodable_instruction_is_never_skipped` — the regression asserted directly: **the PC must not move**
- `decodable_code_raises_no_usagefault` — the other direction, so a change that faulted on *everything* cannot pass

The probe is `UDF #0` rather than an opcode we merely have not implemented yet: implementing that opcode later would have turned such a test green by absence.

## Caveat on coverage

`cargo test -p labwired-core` builds **18 of 186** test files — 38 are `#![cfg(feature = ...)]` and the rest carry `required-features`. So the default run is narrower than it appears, which is ledger row CORE-6. I ran `firmware_survival` explicitly for that reason rather than trusting the default lane.