### PR TITLE
fix(cli): a RISC-V run that ends on a fault exits 3, not 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`labwired run` exits 3 on a RISC-V simulation fault too.** v0.22.1 below
+  announces that "`labwired run` exits 3 when the run ends on a simulation
+  fault"; the change only landed on ARM. Both RISC-V loops kept
+  `tracing::debug!("… halt: {e}")` followed by `EXIT_PASS`, and `debug!` prints
+  nothing at the default log level — so a `MemoryViolation` or a `DecodeError`
+  on the ESP32-C3, the most-used board, produced **zero bytes of stderr and exit
+  0**. Both loops now name the fault and its PC on stderr and return
+  `EXIT_RUNTIME_ERROR`, the same as ARM and Xtensa. `--allow-sim-error` restores
+  exit 0 for callers that own the verdict and read it from the output.
+
 ## [0.22.1] - 2026-08-14
 
 A one-change release, because the change is one the last release made

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -330,6 +330,11 @@ pub(crate) fn run_firmware_riscv(
         eprintln!("[bridge] on; wifi_mac_idx={wifi_mac_idx:?}");
     }
 
+    // Set when the run ends because the simulation raised an error rather than
+    // because it ran out of steps. Read once, below the loop. See the policy
+    // note on `riscv_run_exit_code`.
+    let mut faulted = false;
+
     for i in 0..limit {
         // Periodic beacon so the STA's scan finds the AP (real APs beacon ~always).
         if bridge && i >= next_beacon_at {
@@ -440,14 +445,19 @@ pub(crate) fn run_firmware_riscv(
                 }
             }
             Err(e) => {
-                // Surface the halt (was a silent debug log): the fault PC + reason is
-                // the key signal when bringing real firmware up on the sim.
-                tracing::debug!("labwired-riscv: step {i} pc={pc:#010x} halt: {e}");
+                // A fault, reported as one. This used to be a `tracing::debug!`
+                // — invisible at the default log level, invisible with logging
+                // off — and the run then returned EXIT_PASS regardless, so a
+                // `MemoryViolation` or a `DecodeError` at instruction 12 of a
+                // hundred million produced no stderr and exit 0.
+                eprintln!(
+                    "labwired run (riscv): simulation error at pc={pc:#010x} (step {i}): {e}"
+                );
                 if !break_at.is_empty() {
-                    eprintln!("[halt] step {i} pc={pc:#010x} err={e}");
                     let trail: Vec<String> = recent.iter().map(|p| format!("{p:#010x}")).collect();
                     eprintln!("[trail] {}", trail.join(" -> "));
                 }
+                faulted = true;
                 break;
             }
         }
@@ -455,6 +465,50 @@ pub(crate) fn run_firmware_riscv(
 
     export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
     export_display_if_requested(&args.display_out, &machine.bus);
+    riscv_run_exit_code(faulted, args.allow_sim_error)
+}
+
+/// The one place a RISC-V `labwired run` turns "did the simulation fault?" into
+/// a process exit status. Both loops end here so they cannot drift apart again.
+///
+/// # Which errors are faults
+///
+/// All of them. `Machine::advance` returns `Ok` for every way a run ends
+/// normally — the fuel limit, `AdvanceStop::NoProgress`, a firmware-authored
+/// `FirmwareExit` — so an `Err` is never "the fixture finished". The comment
+/// this replaces ("a halt is the normal end of a fixture run") had it backwards:
+/// `SimulationError::Halt` is the firmware-reachable abort trap (a Cortex-M
+/// `bkpt`, which is what a Rust `panic!`/`abort` lowers to), and
+/// `crates/cli/tests/stop_conditions.rs::test_stop_when_assertions_pass_does_not_mask_crash`
+/// exists precisely to require that a run ending that way does NOT report
+/// `status: "pass"`. On RISC-V the question is moot in any case: the RV32IMC
+/// core constructs only `MemoryViolation`, `DecodeError` and `NotImplemented`,
+/// and nothing on its bus path constructs `Halt` or `BreakpointHit` at all.
+///
+/// So the policy here is the one `execute_test_loop` already applies for
+/// `labwired test` — every `SimulationError` sets `RunFacts`'
+/// `unrescued_runtime_error`, whose verdict is `Verdict::RuntimeError` and
+/// whose exit code is `EXIT_RUNTIME_ERROR` — and the one the ARM and Xtensa
+/// arms of this same file already apply for `labwired run`. Not a third one.
+///
+/// # What is deliberately NOT a fault here
+///
+/// `AdvanceStop::FirmwareExit` is the firmware stating its own result, not the
+/// simulator failing. It ends the run and is reported, and the exit status
+/// stays 0 — the same as the ARM loops. Translating a non-zero firmware code
+/// into a non-zero process status is `labwired test`'s job
+/// (`RunFacts::firmware_declared_failure` → `Verdict::AssertionFail` → exit 1);
+/// adopting that one fact of the verdict machinery here, on one architecture,
+/// would recreate exactly the per-architecture divergence this function exists
+/// to remove.
+///
+/// `--allow-sim-error` restores exit 0 for a caller that owns the verdict and
+/// reads it from the output rather than from `$?` — the TIER1 matrix takes the
+/// protocol lines on stdout as the result. The fault is still printed.
+fn riscv_run_exit_code(faulted: bool, allow_sim_error: bool) -> ExitCode {
+    if faulted && !allow_sim_error {
+        return ExitCode::from(EXIT_RUNTIME_ERROR);
+    }
     ExitCode::from(EXIT_PASS)
 }
 
@@ -468,8 +522,9 @@ pub(crate) fn run_firmware_riscv(
 /// The JIT is byte-identical to the single-step interpreter — proven on the
 /// real C3 OLED lab by tests/riscv_jit_c3_oled_differential.rs. It is default-ON
 /// here; set `LABWIRED_RISCV_JIT=0` to force the interpreter (the escape hatch).
-/// Preserves the single-step path's semantics: EXIT_PASS on completion, a halt
-/// ends the run, and the bus trace is exported if requested.
+/// Shares the single-step path's verdict: both end at
+/// [`riscv_run_exit_code`], so which loop a run took cannot change whether a
+/// fault is reported. The bus trace is exported either way.
 fn run_firmware_riscv_batched(
     mut machine: labwired_core::Machine<labwired_core::cpu::RiscV>,
     args: &RunArgs,
@@ -496,6 +551,7 @@ fn run_firmware_riscv_batched(
     // interval; we only cap the total instruction budget here.
     const CHUNK: u32 = 4_000_000;
     let mut ran: u64 = 0;
+    let mut faulted = false;
     while ran < limit {
         let n = if limit == u64::MAX {
             CHUNK
@@ -504,11 +560,27 @@ fn run_firmware_riscv_batched(
         };
         let before = machine.step_profile().cpu_instructions;
         match machine.run(Some(n)) {
+            // The firmware stated its own result. `DebugControl::run` is the
+            // only reader of that stop, and this loop used to drop it on the
+            // floor and keep issuing chunks — the single-step loop above breaks
+            // on it, so the two disagreed. Unreachable today (no RISC-V chip
+            // descriptor declares a `simctl` device, and this path synthesises
+            // its own manifest), which is why it is wired up rather than left
+            // to be discovered by the first board that does declare one.
+            Ok(labwired_core::StopReason::FirmwareExit(code)) => {
+                eprintln!("[firmware] {}", crate::firmware_exit_message(code));
+                break;
+            }
             Ok(_) => {}
             Err(e) => {
-                // A halt is the normal end of a fixture run; the fault PC/reason
-                // is only surfaced on the debug (--break-at) path.
-                tracing::debug!("labwired-riscv (batched): halt: {e}");
+                // Was `tracing::debug!("… halt: {e}")` under a comment claiming
+                // a halt is the normal end of a fixture run. It is not: a
+                // normal end arrives as `Ok`. See `riscv_run_exit_code`.
+                eprintln!(
+                    "labwired run (riscv, batched): simulation error at pc={:#010x}: {e}",
+                    machine.cpu.get_pc(),
+                );
+                faulted = true;
                 break;
             }
         }
@@ -548,7 +620,7 @@ fn run_firmware_riscv_batched(
 
     export_bus_trace_if_requested(&args.bus_trace_out, &machine.bus);
     export_display_if_requested(&args.display_out, &machine.bus);
-    ExitCode::from(EXIT_PASS)
+    riscv_run_exit_code(faulted, args.allow_sim_error)
 }
 
 /// Fast-boot an ESP32-classic (LX6) ELF and run the step loop.

--- a/crates/cli/tests/run_exit_code.rs
+++ b/crates/cli/tests/run_exit_code.rs
@@ -11,6 +11,13 @@
 //! a memory access violation as a pass. Xtensa already exited non-zero on the
 //! same class of failure; ARM did not.
 //!
+//! RISC-V did not either, and was worse: both of its loops logged the fault
+//! through `tracing::debug!`, which prints nothing at the default level, so an
+//! ESP32-C3 run that died on a `DecodeError` produced no stderr at all and exit
+//! 0. The RISC-V half of this file repeats the same cases, and covers each of
+//! its two run loops separately, because the two carried their own copies of
+//! the decision and had already drifted apart from ARM together.
+//!
 //! The escape hatch stays, because one caller genuinely owns the verdict: the
 //! TIER1 matrix reads protocol lines from stdout and a late fault is noise to
 //! it. That is what `--allow-sim-error` is for — an explicit opt-in, rather
@@ -111,5 +118,130 @@ fn a_clean_run_still_exits_zero() {
         Some(0),
         "a run with no fault must stay a pass; stderr: {}",
         String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ── RISC-V ──────────────────────────────────────────────────────────────────
+
+/// A RISC-V chip and an ELF built for something else: it loads, then the
+/// RV32IMC decoder meets Thumb bytes and raises `DecodeError` four
+/// instructions in.
+///
+/// `envs` selects the loop. With none set, `run_firmware_riscv` hands the run
+/// to `run_firmware_riscv_batched` — the default, and the only path a normal
+/// invocation takes. `LABWIRED_DHCP_TRACE=1` turns on per-instruction
+/// instrumentation, which pins the run to the single-step loop instead. Both
+/// had their own `Err` arm and both swallowed the fault, so both are covered.
+fn faulting_riscv_run(extra: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let root = workspace_root();
+    let mut cmd = Command::new(labwired_bin());
+    cmd.arg("run")
+        .arg("--chip")
+        .arg(root.join("configs/chips/esp32c3.yaml"))
+        .arg("--firmware")
+        .arg(root.join("tests/fixtures/nrf52832-demo.elf"))
+        .arg("--max-steps")
+        .arg("100000");
+    for arg in extra {
+        cmd.arg(arg);
+    }
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    cmd.output().expect("spawn labwired")
+}
+
+#[test]
+fn a_riscv_run_that_ends_on_a_fault_exits_non_zero() {
+    let out = faulting_riscv_run(&[], &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("simulation error"),
+        "expected the fault to be reported on stderr, got: {stderr}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_RUNTIME_ERROR),
+        "a fault must not report success; stderr was: {stderr}"
+    );
+}
+
+/// The regression this file exists for, in its RISC-V form: the fault used to
+/// be a `tracing::debug!`, which prints nothing at the default level and
+/// nothing at all with logging off. `RUST_LOG=off` is the honest test of
+/// whether the diagnostic is a log line or a report — before this fix the
+/// whole run produced zero bytes of stderr and exit 0.
+#[test]
+fn the_riscv_fault_is_reported_even_with_logging_off() {
+    let out = faulting_riscv_run(&[], &[("RUST_LOG", "off")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("simulation error"),
+        "the fault must be reported even with logging off, got {} byte(s): {stderr}",
+        out.stderr.len()
+    );
+    assert_eq!(out.status.code(), Some(EXIT_RUNTIME_ERROR));
+}
+
+/// The instrumented single-step loop is a second copy of the same decision.
+/// It kept its own `Err` arm, so it needs its own test.
+#[test]
+fn the_riscv_single_step_loop_reports_a_fault_the_same_way() {
+    let out = faulting_riscv_run(&[], &[("LABWIRED_DHCP_TRACE", "1"), ("RUST_LOG", "off")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(EXIT_RUNTIME_ERROR),
+        "the single-step loop must not have a different verdict from the \
+         batched one; stderr was: {stderr}"
+    );
+}
+
+/// `--batched` is an assertion about which loop ran. It must not change the
+/// verdict — on RISC-V it selects the same loop a default run already takes.
+#[test]
+fn the_riscv_batched_flag_reports_a_fault_the_same_way() {
+    let out = faulting_riscv_run(&["--batched"], &[("RUST_LOG", "off")]);
+    assert_eq!(out.status.code(), Some(EXIT_RUNTIME_ERROR));
+}
+
+#[test]
+fn allow_sim_error_restores_exit_zero_on_riscv_too() {
+    let out = faulting_riscv_run(&["--allow-sim-error"], &[("RUST_LOG", "off")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("simulation error"),
+        "the fault is still reported, only the exit status changes: {stderr}"
+    );
+    assert_eq!(out.status.code(), Some(0), "explicit opt-in must exit 0");
+}
+
+/// The other half of the blast radius: every RISC-V run that ends without a
+/// fault has to stay a pass. This one runs to `--max-steps` after its firmware
+/// has printed, which is the shape of every TIER1 C3 fixture.
+#[test]
+fn a_clean_riscv_run_still_exits_zero() {
+    let root = workspace_root();
+    let out = Command::new(labwired_bin())
+        .arg("run")
+        .arg("--chip")
+        .arg(root.join("configs/chips/esp32c3.yaml"))
+        .arg("--firmware")
+        .arg(root.join("tests/fixtures/esp32c3-demo.elf"))
+        .arg("--max-steps")
+        .arg("200000")
+        .env("RUST_LOG", "off")
+        .output()
+        .expect("spawn labwired");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a RISC-V run with no fault must stay a pass; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("ESP OK"),
+        "the fixture must actually have run: stdout was {:?}",
+        String::from_utf8_lossy(&out.stdout)
     );
 }

--- a/scripts/ci/docs-runnable-chips.sh
+++ b/scripts/ci/docs-runnable-chips.sh
@@ -12,8 +12,10 @@
 #   * every chip descriptor in configs/chips (minus CI fixtures) must appear in
 #     docs-runnable-chips.json — a new chip cannot arrive untested and silent;
 #   * `committed`, `asset` and `example` entries are RUN, and judged on what the
-#     firmware printed. Not on exit status: `labwired run` deliberately treats a
-#     simulation error as a non-fatal end of run and still exits 0;
+#     firmware printed, not on exit status. `labwired run` does now exit 3 on a
+#     simulation fault (on every architecture), but the interesting failures
+#     here are the ones that still exit 0 — firmware that boots, prints nothing
+#     and spins to the step limit — so the verdict is read out of the log;
 #   * `committed` is the preferred shape — the ELF is in this repo, so a clone
 #     plus an installed CLI is the whole prerequisite, and most of them are the
 #     TIER1 fixtures, whose transcript asserts real peripheral behaviour rather


### PR DESCRIPTION
## The defect

v0.22.1's release note says "`labwired run` exits 3 when the run ends on a simulation fault". That landed for ARM only (#965). Both RISC-V loops in `crates/cli/src/commands/run.rs` kept

```rust
Err(e) => {
    tracing::debug!("labwired-riscv: step {i} pc={pc:#010x} halt: {e}");
    … break;
}
```

and then `ExitCode::from(EXIT_PASS)`. `debug!` prints nothing at the default log level. The batched loop's comment even said so out loud: *"A halt is the normal end of a fixture run."*

Measured on `origin/main` (this branch's parent), an ESP32-C3 that dies on a `DecodeError` at instruction 7:

```
$ RUST_LOG=off labwired run --chip configs/chips/esp32c3.yaml \
    --firmware tests/fixtures/nrf52832-demo.elf --max-steps 100000
$ echo $?
0
$ # …and zero bytes of stderr
```

The Xtensa arms of the same file return `EXIT_RUNTIME_ERROR` with a register dump for the same class. Two verdict policies for one fault class, and the chip with the weaker one was the ESP32-C3.

## The policy, and why it is not a third one

Both loops now end at one function, `riscv_run_exit_code`, so they cannot drift apart again.

**Every `SimulationError` is a fault.** `Machine::advance` returns `Ok` for every way a run ends normally — the fuel limit, `AdvanceStop::NoProgress`, a firmware-authored `FirmwareExit` — so an `Err` is never "the fixture finished".

The old comment had `Halt` backwards. `SimulationError::Halt` is the *firmware-reachable abort trap* (a Cortex-M `bkpt`, which is what a Rust `panic!`/`abort` lowers to), and `crates/cli/tests/stop_conditions.rs::test_stop_when_assertions_pass_does_not_mask_crash` exists specifically to require that a run ending that way does **not** report `status: "pass"`. On RISC-V the question is moot in any case: `crates/core/src/cpu/riscv.rs` constructs only `MemoryViolation`, `DecodeError` and `NotImplemented`; nothing on its path constructs `Halt` or `BreakpointHit`.

So this agrees with the machinery already in the tree, on both sides:

| Path | Rule | Exit |
|---|---|---|
| `labwired test` (`execute_test_loop`) | any `SimulationError` → `RunFacts::unrescued_runtime_error` → `Verdict::RuntimeError` | 3 |
| `labwired run`, ARM (#965) | any `Err` → `faulted` | 3 |
| `labwired run`, Xtensa | `ExceptionRaised` / other → register dump | 3 |
| `labwired run`, RISC-V — **this PR** | any `Err` → `faulted` | 3 |

**`FirmwareExit` is deliberately not a fault.** It is the firmware stating its own result, not the simulator failing. It ends the run, is reported, and leaves the exit status 0 — exactly what the ARM loops do. Translating a non-zero firmware code into a non-zero process status is `labwired test`'s job (`RunFacts::firmware_declared_failure` → `Verdict::AssertionFail` → exit 1). Adopting *one* fact of the verdict machinery here, on *one* architecture, would recreate the per-architecture divergence this PR removes. Aligning all of `labwired run` with `RunFacts` is a separate change across three arches.

While there: the batched loop dropped `StopReason::FirmwareExit` on the floor and kept issuing chunks, while the single-step loop broke on it. It is now wired up to match. Latent today — no RISC-V chip descriptor declares a `simctl` device, and this path synthesises its own manifest — which is why it is wired rather than left for the first board that does.

`--allow-sim-error` restores exit 0 for callers that own the verdict and read it from the output. The fault is still printed.

## Before / after, on real fixtures

`RUST_LOG=off` throughout, so what you see is what the tool reports, not what the logger happens to be configured to show.

| Case | Before | After |
|---|---|---|
| C3 + foreign ELF, default (batched) loop | **exit 0**, 0 bytes stderr | **exit 3** + `labwired run (riscv, batched): simulation error at pc=0x0000040f: Instruction decoding error at 0x40f` |
| Same, instrumented single-step loop (`LABWIRED_DHCP_TRACE=1`) | **exit 0**, 0 bytes stderr | **exit 3** + `labwired run (riscv): simulation error at pc=0x0000040f (step 7): …` |
| Same, `--batched` | exit 0 | exit 3 |
| Same, `--allow-sim-error` | exit 0 | **exit 0**, fault still printed |
| `ci-fixture-riscv` chip + foreign ELF | exit 0 | exit 3 |
| **C3 + `esp32c3-demo.elf` (clean)**, both loops | exit 0, `ESP OK` | **exit 0**, `ESP OK` |
| **C3 TIER1 `tests/fixtures/tier1/esp32c3.elf`, 6M steps** (the run `docs-runnable-chips` documents) | exit 0, 8 TIER1 lines, `TIER1 done` | **exit 0**, 8 TIER1 lines, `TIER1 done` |
| ARM control (`nrf52832` + `esp32_brom.elf`) | exit 3 | exit 3 (unchanged) |

## Blast radius

By construction the diff can only reach `labwired run --chip <descriptor with arch: riscv>`, i.e. `esp32c3` and `ci-fixture-riscv`, and only when the run ends on an engine `Err`. Measured, not assumed:

- **Runs that previously exited 0 and now exit 3**: exactly the ones that end on a fault. That is the point of the change. No fixture in this repo is in that set — every RISC-V CLI run committed here ends on the step limit or on firmware output.
- **TIER1 matrix** (`crates/cli/src/tier1.rs`, the one in-repo caller of `labwired run` on a C3): unaffected. Its guard only errors when there is *no* TIER1 output **and** no `done` **and** a failed exit — which is exactly the crash it says must not become a row of `Blocked` cells. The documented C3 run still exits 0.
- **`scripts/ci/docs-runnable-chips.sh`**: judges on the log, never on `$?`. Its `esp32c3` entry still verdicts `OK`. Its comment claiming `labwired run` "deliberately treats a simulation error as a non-fatal end of run and still exits 0" was already stale for ARM after #965; corrected here.
- **Every other RISC-V consumer in the tree** (`esp32c3_*`, `riscv_jit_c3_oled_differential`, `firmware_survival`, the arduino/zephyr matrices) drives the library or `labwired test`, not `labwired run`. Unreachable from this diff.
- **Outside this repo**: any harness that calls `labwired run` on a C3 and reads `$?` will now see faults it was previously told were passes. That is the intended, breaking half of this change.

## Negative controls

- Reverted `crates/cli/src/commands/run.rs` to `origin/main` (104-line diff confirmed non-empty first), left the new tests in place, rebuilt: **5 of the 6 new tests fail**, with `left: Some(0), right: Some(3)` and `the fault must be reported even with logging off, got 0 byte(s)`. The sixth — `a_clean_riscv_run_still_exits_zero` — passes on both sides, which is what makes it the guard against breaking every passing run rather than a restatement of the fix. Then restored and re-verified byte-identical.
- ARM's four existing cases in the same file pass unchanged, and the ARM control run above still exits 3.

## Suites

Everything below was measured in the same worktree, judged by exit code.

| Suite | Before (pristine) | After |
|---|---|---|
| `cargo test -p labwired-cli --no-fail-fast` | 274 passed / 0 failed / 6 ignored, **exit 0** | 280 passed / 0 failed / 6 ignored, **exit 0** (+6 = the new cases) |
| `cargo test -p labwired-core --test firmware_survival` | 61 passed / 0 failed / 5 ignored, **exit 0** | 61 passed / 0 failed / 5 ignored, **exit 0** |
| `cargo test -p labwired-core --no-fail-fast` | 4010 passed / **3 failed** / 38 ignored, exit 101 | 4010 passed / **3 failed** / 38 ignored, exit 101 — identical, same three tests |
| `cargo fmt --all --check` | — | clean |
| `cargo clippy -p labwired-cli --all-targets -- -D warnings` | — | exit 0 |

The three `labwired-core` failures are **pre-existing on `origin/main` in this environment** and unrelated to this diff, which touches no code in `labwired-core`:

1. `cpu_trace_conformance::every_cpu_core_is_covered_by_this_file` — the `Avr` core is missing from `cores()`.
2. `e2e_nrf52840_obd2_scanner::real_scanner_and_ecu_firmware_complete_the_obd2_workflow` — `build the real scanner ELF: NotFound` (needs a cross toolchain).
3. `strict_onboarding::test_strict_board_onboarding` — `unexpected example gaps: ["atmega328p"]`.

`cargo test -p labwired-cli` also fails out of the box on `demo_blinky` until `cargo build -p demo-blinky --release --target thumbv7m-none-eabi` has been run; the numbers above are with that prerequisite built, on both sides.

## Not done here

- `run_interactive_riscv` (the legacy top-level `labwired`, no `run` subcommand) still returns `EXIT_PASS` unconditionally — but so do its ARM and Xtensa twins, so it is consistent, and fixing it is a separate three-arch change.
- The `[badjump]` guard in the instrumented loop ends the run and still exits 0. It is a hardcoded C3 address-window heuristic that only exists under `--break-at`, not an engine-reported fault; promoting a heuristic to a verdict would be a new policy rather than the engine's. It prints loudly either way.
