### PR TITLE
Give ci-runner-image the binary its Dockerfile copies

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1304,9 +1304,48 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+
+      # Dockerfile.ci does `COPY dist/${TARGETARCH}/labwired` — it ships a
+      # PREBUILT binary rather than compiling one, so that the image and the
+      # release archive of a tag are the same bytes and so arm64 needs no
+      # emulated Rust compile. core-release.yml satisfies that by extracting
+      # the published archives into dist/amd64 and dist/arm64.
+      #
+      # This job never did, and had no way to: it ran `docker build` on a bare
+      # checkout, so every run since the COPY landed failed with
+      #   failed to compute cache key: "/dist/amd64/labwired": not found
+      # As written it could not have passed once. Nothing noticed because the
+      # job is main-only and not a required check, so it is skipped on every PR
+      # and its red never blocked anyone — the runner image has simply been
+      # unsmoked. Build the binary this commit would ship and stage it where
+      # the COPY looks.
+      - name: Install Rust (pinned — must match pr-gate)
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-runner-image
+
+      - name: Stage dist/amd64/labwired for the COPY
+        run: |
+          set -euo pipefail
+          cargo build --release -p labwired-cli --bin labwired
+          mkdir -p dist/amd64
+          cp target/release/labwired dist/amd64/labwired
+          chmod +x dist/amd64/labwired
+          # Fail here, loudly, rather than inside a docker layer: a missing or
+          # non-executable binary is a staging bug, not a Dockerfile bug, and
+          # the two read identically in buildkit's output.
+          test -x dist/amd64/labwired
+
+      # Only linux/amd64 is smoked. The arm64 half of the manifest is built
+      # under emulation at release time from the arm64 archive; reproducing
+      # that here would cost a QEMU Rust build for no extra Dockerfile
+      # coverage, since both architectures run the identical COPY/ENTRYPOINT.
       - name: Smoke CI runner image
         run: |
           set -euo pipefail

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1322,25 +1322,52 @@ jobs:
       # and its red never blocked anyone — the runner image has simply been
       # unsmoked. Build the binary this commit would ship and stage it where
       # the COPY looks.
-      - name: Install Rust (pinned — must match pr-gate)
-        uses: dtolnay/rust-toolchain@1.95.0
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci-runner-image
-
+      #
+      # ⚠️ IN `rust:1.95-bullseye`, NOT ON THE RUNNER. core-release.yml builds
+      # both Linux targets in that container precisely so the shipped binaries
+      # keep a GLIBC_2.31 floor. Building on the runner instead produced a
+      # binary linked against the ubuntu-24.04 host glibc, and the image —
+      # `FROM debian:bookworm-slim`, glibc 2.36 — refused to run it:
+      #
+      #   labwired: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not
+      #   found (required by labwired)
+      #
+      # That is the second defect this job was hiding, and it is the one worth
+      # having: a smoke that compiles differently from the release proves
+      # nothing about the image that ships. Using the release's own container
+      # keeps one source of truth for how the shipped binary is linked.
       - name: Stage dist/amd64/labwired for the COPY
         run: |
           set -euo pipefail
-          cargo build --release -p labwired-cli --bin labwired
+          docker run --rm \
+            -v "$PWD":/src -w /src \
+            -e CARGO_TERM_COLOR=never \
+            -e CARGO_TARGET_DIR=/src/target-ci-runner-image \
+            rust:1.95-bullseye \
+            cargo build --release -p labwired-cli --bin labwired
           mkdir -p dist/amd64
-          cp target/release/labwired dist/amd64/labwired
+          cp target-ci-runner-image/release/labwired dist/amd64/labwired
           chmod +x dist/amd64/labwired
           # Fail here, loudly, rather than inside a docker layer: a missing or
           # non-executable binary is a staging bug, not a Dockerfile bug, and
           # the two read identically in buildkit's output.
           test -x dist/amd64/labwired
+
+      # Assert the floor rather than assume the container held it — the same
+      # check core-release.yml runs, for the same reason: without it the next
+      # base-image bump silently raises the floor again and the failure
+      # reappears at `RUN labwired --version` inside a buildkit layer.
+      - name: Assert glibc floor
+        run: |
+          set -euo pipefail
+          floor=GLIBC_2.31
+          max="$(readelf -V dist/amd64/labwired | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -V -u | tail -1)"
+          echo "dist/amd64/labwired requires $max (floor $floor)"
+          newest="$(printf '%s\n%s\n' "$max" "$floor" | sort -V | tail -1)"
+          if [ "$newest" != "$floor" ]; then
+            echo "::error::the staged binary requires $max, above the $floor floor — it cannot start in debian:bookworm-slim, which is what Dockerfile.ci is FROM."
+            exit 1
+          fi
 
       # Only linux/amd64 is smoked. The arm64 half of the manifest is built
       # under emulation at release time from the arm64 archive; reproducing

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -132,6 +132,23 @@ require_block_literal "$ci_runner_image_block" 'VERSION=ci-smoke' 'ci-runner-ima
 require_block_literal "$ci_runner_image_block" 'REVISION="$GITHUB_SHA"' 'ci-runner-image provides OCI revision metadata'
 require_block_literal "$ci_runner_image_block" 'docker run --rm labwired-ci-smoke:local --version' 'ci-runner-image executes the final image entrypoint'
 
+# Every assertion above describes what the job SAYS. None of them described
+# whether it could run, and that gap shipped: from the commit that made
+# Dockerfile.ci `COPY dist/${TARGETARCH}/labwired` until 2026-08-17 the job
+# built on a bare checkout and failed every single time with
+# `"/dist/amd64/labwired": not found`, while this contract stayed green because
+# the docker command still contained all the right words.
+#
+# So assert the input the COPY needs. A future edit that drops the staging step
+# fails here, on a PR, instead of on main where nobody is looking.
+# The literal is the COMMAND, not just the path: the path also appears in the
+# comment that explains why the step exists, so asserting the bare path would
+# be satisfied by deleting the step and keeping the prose — which is precisely
+# the failure mode this whole block is here to stop.
+require_block_literal "$ci_runner_image_block" 'cp target/release/labwired dist/amd64/labwired' 'ci-runner-image stages the binary Dockerfile.ci copies (the job cannot build without it)'
+require_block_literal "$ci_runner_image_block" 'cargo build --release -p labwired-cli' 'ci-runner-image builds the CLI it stages, from the commit under test'
+require_literal "$dockerfile" 'COPY dist/${TARGETARCH}/labwired' 'Dockerfile.ci copies the staged binary (the path the smoke job must provide)'
+
 require_literal "$workflow" 'tags:' 'release workflow declares a tag trigger'
 require_literal "$workflow" "'v[0-9]+.[0-9]+.[0-9]+'" 'release workflow triggers vMAJOR.MINOR.PATCH tags'
 for target in \

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -145,9 +145,21 @@ require_block_literal "$ci_runner_image_block" 'docker run --rm labwired-ci-smok
 # comment that explains why the step exists, so asserting the bare path would
 # be satisfied by deleting the step and keeping the prose — which is precisely
 # the failure mode this whole block is here to stop.
-require_block_literal "$ci_runner_image_block" 'cp target/release/labwired dist/amd64/labwired' 'ci-runner-image stages the binary Dockerfile.ci copies (the job cannot build without it)'
+require_block_literal "$ci_runner_image_block" 'cp target-ci-runner-image/release/labwired dist/amd64/labwired' 'ci-runner-image stages the binary Dockerfile.ci copies (the job cannot build without it)'
 require_block_literal "$ci_runner_image_block" 'cargo build --release -p labwired-cli' 'ci-runner-image builds the CLI it stages, from the commit under test'
 require_literal "$dockerfile" 'COPY dist/${TARGETARCH}/labwired' 'Dockerfile.ci copies the staged binary (the path the smoke job must provide)'
+
+# The smoke must link the binary the way the RELEASE links it, or it proves
+# nothing about the image that ships. Built on the runner instead, the binary
+# picked up ubuntu-24.04's glibc and debian:bookworm-slim refused to start it
+# ("version `GLIBC_2.39' not found"). Both halves are asserted: the container
+# that sets the floor, and the check that the floor actually held.
+release_container="$(grep -oE 'rust:1\.95-bullseye' "$workflow" | head -1)"
+if [[ -z "$release_container" ]]; then
+  fail 'release workflow pins a build container (expected: rust:1.95-bullseye)'
+fi
+require_block_literal "$ci_runner_image_block" 'rust:1.95-bullseye' 'ci-runner-image builds in the same container core-release.yml uses, so the glibc floor matches'
+require_block_literal "$ci_runner_image_block" 'GLIBC_' 'ci-runner-image asserts the glibc floor of what it staged'
 
 require_literal "$workflow" 'tags:' 'release workflow declares a tag trigger'
 require_literal "$workflow" "'v[0-9]+.[0-9]+.[0-9]+'" 'release workflow triggers vMAJOR.MINOR.PATCH tags'


### PR DESCRIPTION
`ci-runner-image` has failed on **every push to `main`** since `Dockerfile.ci`
started shipping a prebuilt binary. Checked across `9d855771`, `ccfc8163`,
`8dbb3b43`, `cba15eac` and every Rust Core CI run back to 2026-08-15.

```
Dockerfile.ci:39  COPY dist/${TARGETARCH}/labwired /usr/local/bin/labwired
ERROR: failed to compute cache key: "/dist/amd64/labwired": not found
```

The job runs `docker build` on a bare checkout. Nothing in it builds or
downloads that binary, so **as written it could not have passed once**.
`core-release.yml` satisfies the same COPY by extracting the published archives
into `dist/amd64` and `dist/arm64`; this job had no equivalent.

## Why nobody noticed

The job is main-only and explicitly *"NOT a PR required check"* — `skipped` on
every PR, so its red never blocked anyone. The cost is not the red square: the
**CI runner image has been unsmoked** for as long as this has been broken, so a
change that breaks it ships unnoticed.

## Why the contract did not catch it

`scripts/ci/verify-release-runner-contract.sh` already asserted six things about
this job: that it passes `--pull`, names `Dockerfile.ci`, tags the image, sets
`VERSION` and `REVISION`, and runs the entrypoint. **Every one of those
describes what the job says, not whether it can run** — so the contract stayed
green through a job that failed 100% of the time.

It now also requires the staging step, the release container, and the floor
check. Deliberately asserted by *command* (`cargo build --release -p
labwired-cli`, `cp target-ci-runner-image/release/labwired dist/amd64/labwired`)
rather than by path: the path also appears in the comment that explains the
step, so asserting the path alone would be satisfied by deleting the step and
keeping the prose — the same class of hole one level down.

## Two defects, not one

The first fix staged a binary built **on the runner**. That got past the missing
COPY and straight into the second defect the broken job had been concealing:

```
labwired: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

ubuntu-24.04 links against glibc 2.39; the image is `FROM debian:bookworm-slim`,
glibc 2.36. `core-release.yml` builds both Linux targets in `rust:1.95-bullseye`
precisely to hold a GLIBC_2.31 floor — a smoke that compiles differently from
the release proves nothing about the image that ships. The staging step now uses
the release's own container, and asserts the floor rather than assuming it, so
the next base-image bump fails on a readable error line instead of inside a
buildkit layer.

linux/amd64 only — the arm64 half of the manifest runs the identical
COPY/ENTRYPOINT and reproducing it would buy a QEMU Rust build for no extra
Dockerfile coverage. Timeout 20 → 40 min for the build.

## Verification

The job's `if:` restricts it to push-to-main / schedule / dispatch, so **it does
not run on this PR**. Proven instead by a `workflow_dispatch` of Rust Core CI
against this branch — run [`32043705258`](../actions/runs/32043705258),
`ci-runner-image: completed success`, every step green:

```
success  Run actions/checkout@v4
success  Stage dist/amd64/labwired for the COPY
success  Assert glibc floor
success  Smoke CI runner image
```

with the floor assertion doing real work, not passing vacuously:

```
floor=GLIBC_2.31
dist/amd64/labwired requires GLIBC_2.30 (floor GLIBC_2.31)
```

`docker build` then ran to completion and the entrypoint smoked.

- `verify-release-runner-contract.sh` passes.
- **Negative control**: deleting the staging step while keeping its comment
  turns the contract red on both new assertions.
