### PR TITLE
fix(core): preserve parked-secondary batching

### DIFF
--- a/crates/core/src/machine/boundary.rs
+++ b/crates/core/src/machine/boundary.rs
@@ -201,7 +201,7 @@ impl<C: Cpu> Machine<C> {
     ) -> SimResult<()> {
         let internally_committed_per_cycle_batch = mode == ExecutionMode::RunBatch
             && self.config.peripheral_tick_interval.max(1) == 1
-            && progress.primary_steps > 1
+            && progress.primary_steps > 0
             && progress.secondary_steps == progress.primary_steps;
         if mode == ExecutionMode::RunBatch && !internally_committed_per_cycle_batch {
             self.total_cycles += u64::from(progress.primary_steps);

--- a/crates/core/src/machine/boundary.rs
+++ b/crates/core/src/machine/boundary.rs
@@ -56,6 +56,40 @@ impl<C: Cpu> Machine<C> {
                     .cpu_secondary
                     .as_ref()
                     .is_some_and(|s| s.is_parked_idle());
+                // A tick interval of one is an interrupt-visibility contract,
+                // not a reason to throw away the CPU batch. Keep one planned
+                // window for accounting/dispatch, but retire it instruction by
+                // instruction so every peripheral tick can re-derive and
+                // deliver IRQ levels before the next instruction.
+                if parked_secondary && self.config.peripheral_tick_interval.max(1) == 1 {
+                    let mut primary_steps = 0u32;
+                    let mut secondary_steps = 0u32;
+                    for _ in 0..count {
+                        self.total_cycles += 1;
+                        self.bus.set_current_cycle(self.total_cycles);
+                        self.bus.bus_trace.set_cycle(self.total_cycles);
+                        if self.logic_capture.push_active() {
+                            self.bus.logic_tap.set_clock(self.total_cycles);
+                        }
+                        self.cpu
+                            .step(&mut self.bus, &self.observers, &self.config)?;
+                        primary_steps += 1;
+                        if let Some(sec) = self.cpu_secondary.as_mut() {
+                            if sec.is_parked_idle() {
+                                sec.step(&mut self.bus, &self.observers, &self.config)?;
+                                secondary_steps += 1;
+                            }
+                        }
+                        self.tick_peripherals_at_boundary();
+                        if self.rtc_cntl_reset_pending() {
+                            break;
+                        }
+                    }
+                    return Ok(CoreProgress {
+                        primary_steps,
+                        secondary_steps,
+                    });
+                }
                 let executed = if parked_secondary && self.rtc_cntl_index.is_some() {
                     let mut n = 0u32;
                     for _ in 0..count {
@@ -165,7 +199,11 @@ impl<C: Cpu> Machine<C> {
         _batch_start: u64,
         progress: CoreProgress,
     ) -> SimResult<()> {
-        if mode == ExecutionMode::RunBatch {
+        let internally_committed_per_cycle_batch = mode == ExecutionMode::RunBatch
+            && self.config.peripheral_tick_interval.max(1) == 1
+            && progress.primary_steps > 1
+            && progress.secondary_steps == progress.primary_steps;
+        if mode == ExecutionMode::RunBatch && !internally_committed_per_cycle_batch {
             self.total_cycles += u64::from(progress.primary_steps);
         }
         self.record_cpu_progress(progress.primary_steps);
@@ -191,7 +229,9 @@ impl<C: Cpu> Machine<C> {
         let coalesced_dual_idle = mode == ExecutionMode::RunBatch
             && progress.secondary_steps > 0
             && progress.primary_steps > 1;
-        let should_tick = if coalesced_dual_idle {
+        let should_tick = if internally_committed_per_cycle_batch {
+            false
+        } else if coalesced_dual_idle {
             true
         } else {
             self.total_cycles % tick_interval == 0
@@ -205,29 +245,7 @@ impl<C: Cpu> Machine<C> {
                 self.config.peripheral_tick_interval = n;
                 self.bus.config.peripheral_tick_interval = n;
             }
-            // Propagate peripherals. Reuse retained scratch buffers (swapped
-            // out via `mem::take` so the borrow checker sees them as owned
-            // locals) instead of letting the bus allocate a fresh Vec per tick.
-            let mut interrupts = std::mem::take(&mut self.tick_irq_scratch);
-            let mut costs = std::mem::take(&mut self.tick_cost_scratch);
-            self.bus
-                .tick_peripherals_fully_into(&mut interrupts, &mut costs);
-            self.record_peripheral_tick_profile(costs.len());
-            for c in costs.iter() {
-                self.total_cycles += c.cycles as u64;
-                if let Some(p) = self.bus.peripherals.get(c.index) {
-                    for observer in &self.observers {
-                        observer.on_peripheral_tick(&p.name, c.cycles);
-                    }
-                }
-            }
-            for &irq in interrupts.iter() {
-                self.cpu.set_exception_pending(irq);
-                tracing::debug!("Exception {} Pend", irq);
-            }
-            // Return the buffers (with their grown capacity) for reuse next tick.
-            self.tick_irq_scratch = interrupts;
-            self.tick_cost_scratch = costs;
+            self.tick_peripherals_at_boundary();
             if coalesced_dual_idle {
                 self.config.peripheral_tick_interval = saved_m;
                 self.bus.config.peripheral_tick_interval = saved_b;
@@ -350,5 +368,28 @@ impl<C: Cpu> Machine<C> {
         self.logic_observe(logic_boundary);
 
         Ok(())
+    }
+
+    fn tick_peripherals_at_boundary(&mut self) {
+        // Reuse retained scratch buffers instead of allocating per tick.
+        let mut interrupts = std::mem::take(&mut self.tick_irq_scratch);
+        let mut costs = std::mem::take(&mut self.tick_cost_scratch);
+        self.bus
+            .tick_peripherals_fully_into(&mut interrupts, &mut costs);
+        self.record_peripheral_tick_profile(costs.len());
+        for c in costs.iter() {
+            self.total_cycles += c.cycles as u64;
+            if let Some(p) = self.bus.peripherals.get(c.index) {
+                for observer in &self.observers {
+                    observer.on_peripheral_tick(&p.name, c.cycles);
+                }
+            }
+        }
+        for &irq in interrupts.iter() {
+            self.cpu.set_exception_pending(irq);
+            tracing::debug!("Exception {} Pend", irq);
+        }
+        self.tick_irq_scratch = interrupts;
+        self.tick_cost_scratch = costs;
     }
 }

--- a/crates/core/src/machine/plan.rs
+++ b/crates/core/src/machine/plan.rs
@@ -151,9 +151,7 @@ impl<C: Cpu> Machine<C> {
             // `tick_interval > 1` (the browser's `RECOMMENDED_TICK_INTERVAL`)
             // the window is still hundreds of instructions wide. At interval 1
             // the caller asked for per-cycle peripheral service and now gets it.
-            let until_tick = tick_interval - (self.total_cycles % tick_interval);
             clamp!(count, binder, clause::SECONDARY_PARKED, 1024);
-            clamp!(count, binder, clause::TICK_BOUNDARY, until_tick);
         } else {
             // Normal path: batch only up to the next peripheral tick boundary.
             let until_tick = tick_interval - (self.total_cycles % tick_interval);

--- a/crates/core/src/tests/machine_advance.rs
+++ b/crates/core/src/tests/machine_advance.rs
@@ -20,6 +20,7 @@ pub(crate) struct CountingCpu {
     sp: u32,
     steps: u32,
     pending: Vec<u64>,
+    first_pending_at_step: Option<u32>,
     halted: bool,
     // Non-architectural test injection; intentionally omitted from snapshots.
     fail_step: bool,
@@ -50,6 +51,9 @@ impl Cpu for CountingCpu {
         _observers: &[Arc<dyn SimulationObserver>],
         _config: &SimulationConfig,
     ) -> SimResult<()> {
+        if self.first_pending_at_step.is_none() && self.pending.iter().any(|word| *word != 0) {
+            self.first_pending_at_step = Some(self.steps);
+        }
         if self.fail_step {
             return Err(SimulationError::Other(
                 "CountingCpu injected step failure".to_string(),
@@ -289,6 +293,26 @@ fn counting_dual_core_machine() -> Machine<CountingCpu> {
         .with_secondary_cpu(CountingCpu::default())
 }
 
+#[derive(Debug)]
+struct EveryTickIrq;
+
+impl crate::Peripheral for EveryTickIrq {
+    fn read(&self, _offset: u64) -> SimResult<u8> {
+        Ok(0)
+    }
+
+    fn write(&mut self, _offset: u64, _value: u8) -> SimResult<()> {
+        Ok(())
+    }
+
+    fn tick(&mut self) -> crate::PeripheralTickResult {
+        crate::PeripheralTickResult {
+            irq: true,
+            ..Default::default()
+        }
+    }
+}
+
 #[test]
 fn step_adapter_advances_both_cores_once() {
     let mut machine = counting_dual_core_machine();
@@ -495,24 +519,18 @@ fn unified_run_advances_both_cores_one_quantum_at_a_time() {
     assert_eq!(machine.step_profile().cpu_batches, 4);
 }
 
-/// A WAITI-parked secondary lets the primary batch — but never past the next
-/// peripheral tick boundary.
-///
-/// At `peripheral_tick_interval == 1` the caller has asked for per-cycle
-/// peripheral service, so the coalesced dual-idle window collapses to one
-/// instruction per boundary: one CPU batch and one peripheral tick per retired
-/// instruction. `plan_cpu_window`'s `SECONDARY_PARKED` clause used to clamp at a
-/// flat 1024 and skip the tick clamp entirely, so this ran as a SINGLE batch of
-/// 64 with ONE peripheral boundary at the end — 63 instructions during which
-/// nothing re-derived an interrupt level. ESP-IDF SMP FreeRTOS deadlocks on
-/// exactly that (see `crates/core/tests/esp32s3_smp_yield_latency.rs`).
-///
-/// Negative control: change the clause back to a bare
-/// `clamp!(count, binder, clause::SECONDARY_PARKED, 1024)` and this fails with
-/// `cpu_batches = 1`.
+/// A WAITI-parked secondary keeps a wide primary batch while still servicing
+/// peripherals and re-deriving interrupts at every requested tick boundary.
 #[test]
-fn parked_secondary_batch_stays_inside_the_peripheral_tick_interval() {
+fn parked_secondary_batches_without_skipping_per_cycle_ticks() {
     let mut machine = counting_dual_core_machine();
+    machine.bus.add_peripheral(
+        "every-tick-irq",
+        0x5100_0000,
+        0x100,
+        Some(7),
+        Box::new(EveryTickIrq),
+    );
     machine.cpu_secondary.as_mut().unwrap().parked = true;
     machine.config.peripheral_tick_interval = 1;
     machine.bus.config.peripheral_tick_interval = 1;
@@ -521,15 +539,18 @@ fn parked_secondary_batch_stays_inside_the_peripheral_tick_interval() {
 
     assert_eq!(report.primary_steps, 64);
     assert_eq!(
-        report.cpu_batches, 64,
-        "at tick interval 1 a parked secondary must not buy the primary a \
-         multi-instruction window: peripherals are serviced every cycle or the \
-         interval is a lie"
+        report.cpu_batches, 1,
+        "per-cycle interrupt visibility must not collapse the parked-secondary batch"
     );
     assert_eq!(
         machine.step_profile().peripheral_ticks,
         64,
         "one peripheral boundary per retired instruction at interval 1"
+    );
+    assert_eq!(
+        machine.cpu.first_pending_at_step,
+        Some(1),
+        "the IRQ raised after instruction 1 must be visible before instruction 2"
     );
 }
 

--- a/crates/core/src/tests/machine_advance.rs
+++ b/crates/core/src/tests/machine_advance.rs
@@ -554,6 +554,20 @@ fn parked_secondary_batches_without_skipping_per_cycle_ticks() {
     );
 }
 
+#[test]
+fn one_step_parked_secondary_batch_commits_once() {
+    let mut machine = counting_dual_core_machine();
+    machine.cpu_secondary.as_mut().unwrap().parked = true;
+    machine.config.peripheral_tick_interval = 1;
+    machine.bus.config.peripheral_tick_interval = 1;
+
+    let report = machine.advance(AdvanceRequest::run(Some(1))).unwrap();
+
+    assert_eq!(report.elapsed_cycles, 1);
+    assert_eq!(machine.total_cycles, 1);
+    assert_eq!(machine.step_profile().peripheral_ticks, 1);
+}
+
 /// The coalescing win itself is preserved wherever it was ever sound: at a
 /// relaxed tick interval the parked-secondary window is still wide.
 #[test]


### PR DESCRIPTION
## Summary
- retain the 1024-wide primary CPU window while the secondary core is WAITI-parked
- at tick interval 1, retire that window instruction-by-instruction internally and drain peripherals/IRQs before the next instruction
- keep one CPU batch for dispatch/accounting without sacrificing SMP interrupt visibility

## Verification
- 44/44 machine boundary tests pass
- 3/3 ESP32-S3 SMP interrupt tests pass
- strict labwired-core Clippy passes
- regression proves an IRQ raised after instruction 1 is visible before instruction 2 while a 64-instruction window remains one batch

Closes #1013