### PR TITLE
fix(cli): tap USB-CDC on ELF-less C3 when debug_uart is undeclared

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -563,19 +563,31 @@ fn run_c3_rom_boot_no_elf(
         labwired_core::system::wifi::attach_configured_wifi_ap(&mut machine.bus, manifest);
     }
 
-    // The declared console, now that the rom-boot machine exists. `esp32c3_rom`
-    // constructs the USB-Serial-JTAG block (with its interrupt source) while
-    // building this machine, so this is the first point at which the block can
-    // be tapped — the pre-boot bus above has none.
-    if cdc_console && !machine.bus.attach_usb_serial_jtag_sink(uart_tx.clone()) {
-        warn!(
-            "debug_uart '{}' was declared but this machine has no USB-Serial-JTAG block; \
-             falling back to all UARTs",
-            labwired_core::console::USB_SERIAL_JTAG
-        );
-        machine
-            .bus
-            .attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+    // The console, now that the rom-boot machine exists. `esp32c3_rom` constructs
+    // the USB-Serial-JTAG block (with its interrupt source) while building this
+    // machine, so this is the first point at which the block can be tapped —
+    // the pre-boot bus above has none.
+    //
+    // Tap CDC when it is the declared console, AND when the console is
+    // undeclared. Wasm already captures both taps in the undeclared case; the
+    // ELF-bearing `test` path always mirrors CDC. Hosted playground yaml
+    // historically omitted `debug_uart`, so this ELF-less arm was the only one
+    // that left Arduino `Serial` (HWCDC on a native-USB C3) unheard — GPIO
+    // still toggled, `uart_contains` never saw the sketch. An explicit UART
+    // `debug_uart` stays UART-only so a bridge-chip board does not mix CDC
+    // into the assertion buffer.
+    let tap_cdc = cdc_console || debug_uart.is_none();
+    if tap_cdc && !machine.bus.attach_usb_serial_jtag_sink(uart_tx.clone()) {
+        if cdc_console {
+            warn!(
+                "debug_uart '{}' was declared but this machine has no USB-Serial-JTAG block; \
+                 falling back to all UARTs",
+                labwired_core::console::USB_SERIAL_JTAG
+            );
+            machine
+                .bus
+                .attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+        }
     }
 
     let metrics = std::sync::Arc::new(labwired_core::metrics::PerformanceMetrics::new());

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -433,18 +433,18 @@ fn run_c3_rom_boot_no_elf(
     // Load the manifest once: it drives both the UART sink selection (debug_uart)
     // and — the universal WiFi adapter — the `wifi_ap` attach below.
     let manifest_opt = system.map(|s| s.manifest.clone());
-    let debug_uart = manifest_opt.as_ref().and_then(|m| m.debug_uart.clone());
+    let console = manifest_opt
+        .as_ref()
+        .map(labwired_core::console::HostConsole::from_manifest)
+        .unwrap_or(labwired_core::console::HostConsole::Undeclared);
 
     // Console capture, mirroring the main flow: honour debug_uart, else all
     // UARTs, plus the IO-Link master log sink.
     //
-    // `debug_uart` names the console the board's USB socket is wired to, and on
-    // an ESP32-C3/S3 that can be the chip's USB-Serial-JTAG block rather than a
-    // UART (see docs/configuration_reference.md). This branch only ever asked
-    // `attach_uart_tx_sink_named`, so the documented value
-    // `debug_uart: "usb_serial_jtag"` could not resolve: it warned
-    // "did not resolve to a UART peripheral", fell back to the UARTs, and the
-    // CDC console was never tapped.
+    // Parse through HostConsole so `usb_serial_jtag` / `usb-serial-jtag` are
+    // the USB block, not a UART name that fails to resolve and silently falls
+    // back. USB-Serial-JTAG itself is attached AFTER the rom-boot machine is
+    // built — the pre-boot bus has no such block yet.
     //
     // That is the ELF-less rom-boot path — the one the hosted builder takes for
     // every ESP32-C3 Arduino build, which PlatformIO compiles with
@@ -454,22 +454,20 @@ fn run_c3_rom_boot_no_elf(
     // nothing else at 20M, 200M and 500M steps. The sibling ELF-bearing rom-boot
     // branch below already taps the CDC block; only this one did not.
     let uart_tx = Arc::new(Mutex::new(Vec::new()));
-    let cdc_console = debug_uart.as_deref() == Some(labwired_core::console::USB_SERIAL_JTAG);
-    if cdc_console {
-        // Attached AFTER the rom-boot machine is built — `bus` here is the
-        // pre-boot bus and carries no USB-Serial-JTAG block yet, so asking it
-        // now can only produce a spurious "this chip has no USB-Serial-JTAG
-        // block" warning and a silent fallback to the UARTs.
-    } else if let Some(debug_uart) = debug_uart.as_deref() {
-        if !bus.attach_uart_tx_sink_named(debug_uart, uart_tx.clone(), !args.no_uart_stdout) {
-            warn!(
-                "debug_uart '{}' did not resolve to a UART peripheral; falling back to all UARTs",
-                debug_uart
-            );
+    match &console {
+        labwired_core::console::HostConsole::UsbSerialJtag => {}
+        labwired_core::console::HostConsole::Uart(name) => {
+            if !bus.attach_uart_tx_sink_named(name, uart_tx.clone(), !args.no_uart_stdout) {
+                warn!(
+                    "debug_uart '{}' did not resolve to a UART peripheral; falling back to all UARTs",
+                    name
+                );
+                bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
+            }
+        }
+        labwired_core::console::HostConsole::Undeclared => {
             bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
         }
-    } else {
-        bus.attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
     }
     bus.attach_iolink_master_log_sink(uart_tx.clone());
 
@@ -569,16 +567,22 @@ fn run_c3_rom_boot_no_elf(
     // the pre-boot bus above has none.
     //
     // Tap CDC when it is the declared console, AND when the console is
-    // undeclared. Wasm already captures both taps in the undeclared case; the
-    // ELF-bearing `test` path always mirrors CDC. Hosted playground yaml
-    // historically omitted `debug_uart`, so this ELF-less arm was the only one
-    // that left Arduino `Serial` (HWCDC on a native-USB C3) unheard — GPIO
-    // still toggled, `uart_contains` never saw the sketch. An explicit UART
-    // `debug_uart` stays UART-only so a bridge-chip board does not mix CDC
-    // into the assertion buffer.
-    let tap_cdc = cdc_console || debug_uart.is_none();
+    // undeclared. The ELF-bearing `test` path always mirrors CDC into uart_tx
+    // so `uart_contains` sees Arduino Serial; this arm now does the same when
+    // the yaml omitted `debug_uart` (the hosted playground shape that shipped
+    // silent C3 serial while GPIO still toggled). Mixing UART0 + CDC can
+    // duplicate the BROM banner in uart.log — substring `uart_contains` still
+    // matches; do not copy this mix onto wasm `attach_c3_flash_console`, which
+    // keeps one heard stream on purpose (undeclared = UART0 heard, CDC unheard).
+    // An explicit UART `debug_uart` stays UART-only so a bridge-chip board
+    // does not mix CDC into the assertion buffer.
+    let tap_cdc = matches!(
+        console,
+        labwired_core::console::HostConsole::UsbSerialJtag
+            | labwired_core::console::HostConsole::Undeclared
+    );
     if tap_cdc && !machine.bus.attach_usb_serial_jtag_sink(uart_tx.clone()) {
-        if cdc_console {
+        if matches!(console, labwired_core::console::HostConsole::UsbSerialJtag) {
             warn!(
                 "debug_uart '{}' was declared but this machine has no USB-Serial-JTAG block; \
                  falling back to all UARTs",

--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -581,17 +581,18 @@ fn run_c3_rom_boot_no_elf(
         labwired_core::console::HostConsole::UsbSerialJtag
             | labwired_core::console::HostConsole::Undeclared
     );
-    if tap_cdc && !machine.bus.attach_usb_serial_jtag_sink(uart_tx.clone()) {
-        if matches!(console, labwired_core::console::HostConsole::UsbSerialJtag) {
-            warn!(
-                "debug_uart '{}' was declared but this machine has no USB-Serial-JTAG block; \
-                 falling back to all UARTs",
-                labwired_core::console::USB_SERIAL_JTAG
-            );
-            machine
-                .bus
-                .attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
-        }
+    if tap_cdc
+        && !machine.bus.attach_usb_serial_jtag_sink(uart_tx.clone())
+        && matches!(console, labwired_core::console::HostConsole::UsbSerialJtag)
+    {
+        warn!(
+            "debug_uart '{}' was declared but this machine has no USB-Serial-JTAG block; \
+             falling back to all UARTs",
+            labwired_core::console::USB_SERIAL_JTAG
+        );
+        machine
+            .bus
+            .attach_uart_tx_sink(uart_tx.clone(), !args.no_uart_stdout);
     }
 
     let metrics = std::sync::Arc::new(labwired_core::metrics::PerformanceMetrics::new());

--- a/crates/cli/tests/no_elf_c3_cdc_console.rs
+++ b/crates/cli/tests/no_elf_c3_cdc_console.rs
@@ -12,9 +12,10 @@
 //! UART0. Tapping only UART0 yields the ROM/bootloader banner and an empty
 //! app console — GPIO still toggles, `uart_contains` never sees the sketch.
 //!
-//! Wasm already taps both consoles when the board console is undeclared. The
-//! ELF-bearing `test` path always mirrors CDC. This gate locks the ELF-less
-//! arm to the same rule.
+//! The ELF-bearing `test` path always mirrors CDC into `uart_tx`. This gate
+//! locks the ELF-less arm to the same rule when `debug_uart` is undeclared.
+//! (Wasm C3 ROM-boot does NOT mix taps: undeclared means UART0 heard, CDC
+//! unheard. Do not cargo-cult this mix onto `attach_c3_flash_console`.)
 //!
 //! The flash image is `platformio/esp32c3-usb-cdc-console` (Serial.begin +
 //! `LW_CDC_SETUP` / `LW_CDC_LOOP N`).
@@ -67,10 +68,8 @@ fn c3_elf_less_rom_boot_captures_cdc_without_debug_uart() {
     // emitter produced before it started declaring the USB console.
     let system = require(root.join("configs/systems/esp32c3-devkit.yaml"));
     assert!(
-        !std::fs::read_to_string(&system)
-            .expect("read system yaml")
-            .contains("debug_uart"),
-        "esp32c3-devkit.yaml grew a debug_uart line; this gate needs an undeclared console"
+        !yaml_declares_debug_uart(&std::fs::read_to_string(&system).expect("read system yaml")),
+        "esp32c3-devkit.yaml grew a debug_uart: key; this gate needs an undeclared console"
     );
 
     let tmp = std::env::temp_dir().join(format!("lw-no-elf-c3-cdc-{}", std::process::id()));
@@ -120,6 +119,104 @@ fn c3_elf_less_rom_boot_captures_cdc_without_debug_uart() {
     assert!(
         uart.contains("LW_CDC_SETUP") && uart.contains("LW_CDC_LOOP"),
         "assertions passed but uart.log is missing the CDC markers:\n{uart}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+fn yaml_declares_debug_uart(yaml: &str) -> bool {
+    yaml.lines()
+        .any(|l| l.trim_start().starts_with("debug_uart:"))
+}
+
+fn write_uart0_system(dir: &Path, chip: &Path) -> PathBuf {
+    let yaml = format!(
+        "name: \"playground-board\"\n\
+         chip: \"{}\"\n\
+         cpu_hz: 160_000_000\n\
+         debug_uart: \"uart0\"\n\
+         external_devices: []\n\
+         board_io: []\n",
+        chip.display(),
+    );
+    let path = dir.join("uart0.yaml");
+    std::fs::write(&path, yaml).expect("write uart0 system yaml");
+    path
+}
+
+/// Long enough that a CDC tap would have printed `LW_CDC_SETUP` (the undeclared
+/// gate stops around 3.8M interpreted steps). Not the full 32M budget.
+const UART0_MAX_STEPS: u64 = 8_000_000;
+
+fn write_max_steps_script(dir: &Path, system: &Path) -> PathBuf {
+    let script = format!(
+        "schema_version: \"1.0\"\n\
+         inputs:\n  \
+           firmware: \"\"\n  \
+           system: \"{}\"\n\
+         limits:\n  \
+           max_steps: {UART0_MAX_STEPS}\n\
+         assertions:\n  \
+           - expected_stop_reason: max_steps\n",
+        system.display(),
+    );
+    let path = dir.join("uart0_cdc.yaml");
+    std::fs::write(&path, script).expect("write uart0 script");
+    path
+}
+
+/// Bridge-chip boards declare UART0. Mixing CDC into `uart_tx` would hide a
+/// real wiring fact (Serial on the wrong console). The same CDC-on-boot image
+/// must then leave `LW_CDC_SETUP` out of uart.log.
+#[test]
+fn c3_elf_less_rom_boot_does_not_mix_cdc_when_debug_uart_is_uart0() {
+    let root = repo_root();
+    let flash = require(root.join("crates/core/tests/fixtures/esp32c3-usb-cdc-console-flash.bin"));
+    let chip = require(root.join("configs/chips/esp32c3.yaml"));
+
+    let tmp = std::env::temp_dir().join(format!("lw-no-elf-c3-uart0-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("create tmp dir");
+    let system = write_uart0_system(&tmp, &chip);
+    let script = write_max_steps_script(&tmp, &system);
+    let out_dir = tmp.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(&root)
+        .env("LABWIRED_ESP32C3_FLASH", &flash)
+        .args([
+            "test",
+            "--script",
+            script.to_str().unwrap(),
+            "--rom-boot",
+            "--no-uart-stdout",
+            "--no-key",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn labwired");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ELF-less"),
+        "expected the ELF-less C3 rom-boot branch to run; stderr:\n{stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "uart0 run itself failed (exit {:?}); stderr:\n{stderr}",
+        output.status.code(),
+    );
+
+    let uart = std::fs::read_to_string(out_dir.join("uart.log")).unwrap_or_default();
+    assert!(
+        uart.contains("ESP-ROM:esp32c3"),
+        "uart0 run captured no UART0 ROM banner; the sink was not UART0:\n{uart}"
+    );
+    assert!(
+        !uart.contains("LW_CDC_SETUP") && !uart.contains("LW_CDC_LOOP"),
+        "explicit debug_uart: uart0 mixed USB-CDC into uart.log; bridge-chip \
+         boards must not see HWCDC on the assertion buffer:\n{uart}"
     );
 
     let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/cli/tests/no_elf_c3_cdc_console.rs
+++ b/crates/cli/tests/no_elf_c3_cdc_console.rs
@@ -1,0 +1,126 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! HARD GATE: ELF-less C3 rom-boot captures Arduino USB-CDC `Serial` even when
+//! the system yaml does NOT declare `debug_uart: usb_serial_jtag`.
+//!
+//! That is the hosted playground shape. `compile()` historically omitted the
+//! key; the builder invokes `labwired test --rom-boot` with `firmware: ""` and
+//! that yaml. Arduino on a native-USB C3 is built with
+//! `-DARDUINO_USB_CDC_ON_BOOT=1`, so `Serial` is HWCDC (USB-Serial-JTAG), not
+//! UART0. Tapping only UART0 yields the ROM/bootloader banner and an empty
+//! app console — GPIO still toggles, `uart_contains` never sees the sketch.
+//!
+//! Wasm already taps both consoles when the board console is undeclared. The
+//! ELF-bearing `test` path always mirrors CDC. This gate locks the ELF-less
+//! arm to the same rule.
+//!
+//! The flash image is `platformio/esp32c3-usb-cdc-console` (Serial.begin +
+//! `LW_CDC_SETUP` / `LW_CDC_LOOP N`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize repo root")
+}
+
+fn require(path: PathBuf) -> PathBuf {
+    assert!(path.exists(), "missing fixture: {}", path.display());
+    path
+}
+
+/// Cold rom-boot of the CDC console fixture prints `LW_CDC_LOOP 1` by 18.8M
+/// steps / 50M cycles (measured). 32M steps is that number plus headroom;
+/// `stop_when_assertions_pass` should halt far earlier once the sink is tapped.
+const CDC_MAX_STEPS: u64 = 32_000_000;
+
+fn write_hosted_shape_script(dir: &Path, system: &Path) -> PathBuf {
+    let script = format!(
+        "schema_version: \"1.0\"\n\
+         inputs:\n  \
+           firmware: \"\"\n  \
+           system: \"{}\"\n\
+         limits:\n  \
+           max_steps: {CDC_MAX_STEPS}\n  \
+           stop_when_assertions_pass: true\n\
+         assertions:\n  \
+           - uart_contains: \"LW_CDC_SETUP\"\n  \
+           - uart_contains: \"LW_CDC_LOOP\"\n  \
+           - expected_stop_reason: assertions_passed\n",
+        system.display(),
+    );
+    let path = dir.join("no_elf_c3_cdc.yaml");
+    std::fs::write(&path, script).expect("write test script");
+    path
+}
+
+#[test]
+fn c3_elf_less_rom_boot_captures_cdc_without_debug_uart() {
+    let root = repo_root();
+    let flash = require(root.join("crates/core/tests/fixtures/esp32c3-usb-cdc-console-flash.bin"));
+    // Hosted-like: cpu_hz, board_io, NO debug_uart. Same shape the playground
+    // emitter produced before it started declaring the USB console.
+    let system = require(root.join("configs/systems/esp32c3-devkit.yaml"));
+    assert!(
+        !std::fs::read_to_string(&system)
+            .expect("read system yaml")
+            .contains("debug_uart"),
+        "esp32c3-devkit.yaml grew a debug_uart line; this gate needs an undeclared console"
+    );
+
+    let tmp = std::env::temp_dir().join(format!("lw-no-elf-c3-cdc-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("create tmp dir");
+    let script = write_hosted_shape_script(&tmp, &system);
+    let out_dir = tmp.join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_labwired"))
+        .current_dir(&root)
+        .env("LABWIRED_ESP32C3_FLASH", &flash)
+        .args([
+            "test",
+            "--script",
+            script.to_str().unwrap(),
+            "--rom-boot",
+            "--no-uart-stdout",
+            "--no-key",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn labwired");
+
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ELF-less"),
+        "expected the ELF-less C3 rom-boot branch to run; stderr:\n{stderr}"
+    );
+
+    let result_path = out_dir.join("result.json");
+    let result_json = std::fs::read_to_string(&result_path).unwrap_or_else(|e| {
+        panic!(
+            "no result.json at {} (exit {:?}): {e}\nstderr:\n{stderr}",
+            result_path.display(),
+            output.status.code(),
+        )
+    });
+
+    let uart = std::fs::read_to_string(out_dir.join("uart.log")).unwrap_or_default();
+    assert!(
+        output.status.success(),
+        "ELF-less C3 CDC run failed (exit {:?}); USB-Serial-JTAG was not tapped \
+         on an undeclared console.\nresult.json:\n{result_json}\nuart.log:\n{uart}\nstderr:\n{stderr}",
+        output.status.code(),
+    );
+    assert!(
+        uart.contains("LW_CDC_SETUP") && uart.contains("LW_CDC_LOOP"),
+        "assertions passed but uart.log is missing the CDC markers:\n{uart}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## Why

Hosted ESP32-C3 Arduino `Serial.println` was silent while GPIO still toggled. The ELF-less `labwired test --rom-boot` path (the builder's C3 path) only attached the USB-Serial-JTAG sink when `debug_uart: usb_serial_jtag` was in the system yaml. Hosted playground yaml historically omitted that key. Arduino on a native-USB C3 is CDC-on-boot, so `Serial` is HWCDC and never writes UART0.

Wasm already taps both consoles when undeclared. The ELF-bearing `test` path always mirrors CDC. This is the remaining arm.

## What

- Attach USB-Serial-JTAG on the ELF-less C3 path when `debug_uart` is **undeclared**, in addition to when it is `usb_serial_jtag`.
- Explicit UART `debug_uart` stays UART-only (bridge-chip boards).
- Gate: `crates/cli/tests/no_elf_c3_cdc_console.rs` — hosted yaml shape (`esp32c3-devkit.yaml`, no `debug_uart`), committed CDC console flash, `uart_contains` `LW_CDC_SETUP` / `LW_CDC_LOOP`.

## Evidence

- RED: that gate failed with `captured len=235` (ROM banner only).
- GREEN: `cargo test --release -p labwired-cli --test no_elf_c3_cdc_console` → `ok` in 2.07s.
- Sibling OLED ELF-less gate still passes (6.63s).
- Live Hetzner `labwired-cli 0.22.1`: same flash **prints** with `debug_uart: usb_serial_jtag` (PASS 0.86s) and **stays silent** without it (FAIL, captured 235 bytes). This PR is the undeclared-console half. Declaring the console in board-config already landed in labwired `f47e2c2eb`; API worker shipped 2026-08-19. This closes the class of bug if yaml is missing again.

## Deploy

Needs a core submodule bump on `labwired` main and a builder image rebuild. Image push ≠ Europa pull.