### PR TITLE
fix(console): tap USB-Serial-JTAG from the generic UART sink

### DIFF
--- a/crates/core/src/bus/construct.rs
+++ b/crates/core/src/bus/construct.rs
@@ -486,6 +486,16 @@ impl SystemBus {
             // not UART0. Route it into the same capture sink.
             if let Some(usb) = any.downcast_mut::<crate::peripherals::rp2040::usb::Rp2040Usb>() {
                 usb.set_sink(Some(sink.clone()));
+                continue;
+            }
+            // ESP32-C3/S3 USB-Serial-JTAG: native-USB boards compile Arduino
+            // `Serial` to this block, not UART0. Same generic tap as RP2040 USB
+            // CDC — the twin finds the console, firmware does not special-case
+            // the board.
+            if let Some(jtag) = any.downcast_mut::<crate::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag>()
+            {
+                jtag.set_sink(Some(sink.clone()), echo_stdout);
+                continue;
             }
         }
     }
@@ -621,6 +631,11 @@ impl SystemBus {
             if let Some(uart) = any.downcast_mut::<crate::peripherals::esp_uart::EspUart>() {
                 uart.set_sink(Some(sink));
                 uart.silence_stdout_echo_if(echo_stdout);
+                return true;
+            }
+            if let Some(jtag) = any.downcast_mut::<crate::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag>()
+            {
+                jtag.set_sink(Some(sink), echo_stdout);
                 return true;
             }
             return false;

--- a/crates/core/src/bus/construct.rs
+++ b/crates/core/src/bus/construct.rs
@@ -492,7 +492,8 @@ impl SystemBus {
             // `Serial` to this block, not UART0. Same generic tap as RP2040 USB
             // CDC — the twin finds the console, firmware does not special-case
             // the board.
-            if let Some(jtag) = any.downcast_mut::<crate::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag>()
+            if let Some(jtag) =
+                any.downcast_mut::<crate::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag>()
             {
                 jtag.set_sink(Some(sink.clone()), echo_stdout);
                 continue;
@@ -633,7 +634,8 @@ impl SystemBus {
                 uart.silence_stdout_echo_if(echo_stdout);
                 return true;
             }
-            if let Some(jtag) = any.downcast_mut::<crate::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag>()
+            if let Some(jtag) =
+                any.downcast_mut::<crate::peripherals::esp32s3::usb_serial_jtag::UsbSerialJtag>()
             {
                 jtag.set_sink(Some(sink), echo_stdout);
                 return true;

--- a/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
+++ b/crates/core/src/peripherals/esp32s3/usb_serial_jtag.rs
@@ -690,6 +690,32 @@ mod tests {
         assert_eq!(sink.lock().unwrap().as_slice(), b"H");
     }
 
+    #[test]
+    fn attach_uart_tx_sink_captures_usb_serial_jtag() {
+        // Same rule as RP2040 USB CDC: if the bus has this console block, the
+        // generic UART tap must hear it. Architect prints `Serial.println` on
+        // every chip; the twin owns discovering where those bytes land.
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let mut bus = SystemBus::new();
+        const TEST_BASE: u64 = 0x1000_0000;
+        bus.add_peripheral(
+            "usb_serial_jtag",
+            TEST_BASE,
+            0x100,
+            None,
+            Box::new(UsbSerialJtag::new()),
+        );
+        bus.attach_uart_tx_sink(sink.clone(), false);
+        bus.write_u32(TEST_BASE + OFF_EP1, 0x0000_0048).unwrap();
+        bus.write_u32(TEST_BASE + OFF_EP1_CONF, EP1_CONF_WR_DONE)
+            .unwrap();
+        assert_eq!(
+            sink.lock().unwrap().as_slice(),
+            b"H",
+            "USB-Serial-JTAG must be on the generic console tap, not a per-board firmware fork"
+        );
+    }
+
     /// Back-pressure, as measured: `WR_DONE` drops DATA_FREE and
     /// SERIAL_IN_EMPTY together; host pickup returns both together; and a store
     /// while busy is ignored rather than silently buffered.

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -17,7 +17,7 @@ The models column is a content digest over everything that board's `models` list
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `6133dbb43b2146b1` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `231a8d9a589b5f73` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `26750bfeb2971fa2` | ⚠ drift acked 2026-08-13 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `88842114f716f85a` | ⚠ drift acked 2026-08-20 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `61660e987f8766e6` | ⚠ drift acked 2026-08-20 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `1944e48e1e75ed3b` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a8c9baa90cb2a903` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `9637527458c15225` | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -2689,6 +2689,11 @@ boards:
     # ETS source 0). The 9-reg reset-state capture never included the MAC
     # window. Owner-acked without a new live capture this session; recapture
     # of the MAC-ready bit at 0x60033D14 is owed on the board on the table.
+    # 2026-08-20: USB-Serial-JTAG is now on the generic UART-TX sink tap
+    # (SystemBus::attach_uart_tx_sink), same rule as RP2040 USB CDC. Arduino
+    # Serial on native-USB C3/S3 lands on this block, not UART0. Capture-path
+    # only: no register map, reset values, or 9-reg silicon windows change.
+    # Live re-capture still owed.
     drift_ack: 2026-08-20
     # 2026-08-10: GP-SPI2 CPU W-buffer transactions now deliver MOSI bytes to
     # attached devices and return their MISO bytes; display D/C observes the S3
@@ -2708,7 +2713,9 @@ boards:
     # now attached on the S3 bus so wifi-ap labs bind the virtual AP. Outside
     # the 9-reg reset-state windows (UART0/GPIO/I2C0/RMT/MCPWM0/TIMG0/
     # SYSTIMER/GDMA/SYSTEM/RTC_CNTL). Live re-capture still owed.
-    drift_ack_digest: 88842114f716f85a9421830d03851c3b8a2e0902667c5f678f2f1b1a00be7bbe
+    # 2026-08-20: USB-Serial-JTAG generic UART sink tap. Additive capture
+    # path; 9-reg reset-state windows untouched. Live re-capture still owed.
+    drift_ack_digest: 61660e987f8766e6e62395b62b2ab77ba2f9c3473cb91b3ef9ec1bf242f6f752
     models:
       - crates/core/src/cpu/xtensa_lx7.rs
       - crates/core/src/decoder/xtensa.rs


### PR DESCRIPTION
## Summary
- Generic `attach_uart_tx_sink` now captures USB-Serial-JTAG, same rule as RP2040 USB CDC.
- Architect keeps printing `Serial.println` on every chip; the twin finds the console.

## Test Plan
- [x] `cargo test -p labwired-core attach_uart_tx_sink_captures_usb_serial_jtag --lib` (failed empty sink, then passed)
- [ ] Hosted C3 button proof after builder image rebuild