### PR TITLE
fix(ci): unblock main — arch_chip_isolation red since #1019 (S3 Wi-Fi MAC aliases the C3's)

### DIFF
--- a/crates/core/tests/arch_chip_isolation.rs
+++ b/crates/core/tests/arch_chip_isolation.rs
@@ -29,6 +29,32 @@ const ALLOWED: &[(&str, &str, &str)] = &[
         "peripherals::esp32::spi::",
         "test-only: shared SPI register-bit constants",
     ),
+    // ⚠️ NOT a test helper and NOT generic infra — a PRODUCTION peripheral model
+    // shared across two CPU architectures. `esp32s3::wifi_mac` is a type alias
+    // of `Esp32c3WifiMac` (#1019), so an edit to `esp32c3/wifi_mac.rs` ALSO
+    // changes the ESP32-S3: one model, one register map, two chips.
+    //
+    // The "same WDEV IP" claim is NOT established in this repo. Every offset in
+    // that model — MAC-ready `0xD14`, RX ring `0x88`, event `0xC3C`/`0xC40`,
+    // PLCP0 `0xD08` — was reverse-engineered on live *C3* silicon (see
+    // docs/esp32c3_radio_reverse_engineering.md, scripts/hw-oracle/wifi-re,
+    // captures/esp32c3/wifi-radio-20260611T214340Z). There is no S3 radio
+    // capture, and the vendored S3 SVD (tests/fixtures/svd/esp32s3.svd) carries
+    // no Wi-Fi MAC peripheral at all. The one S3-corroborated claim is the
+    // interrupt source: INTERRUPT_CORE0 `PRO_MAC_INTR_MAP` @ 0x000 ⇒ source 0.
+    // validation/manifest.yaml already tracks the owed live capture of
+    // 0x60033D14. Precedent for caution: esp32s3/interrupt_core0.yaml carried
+    // the C3's map until 2026-08-20 and was wrong by 8/20/40 bytes.
+    //
+    // Drop this entry when the S3 gets its own model. That needs the virtual-
+    // WiFi medium relocated to a chip-neutral module first: the MAC struct
+    // holds an `esp32c3::virtual_wifi::VirtualWifiBus` by value, so a
+    // self-contained S3 model is not reachable by copying wifi_mac.rs alone.
+    (
+        "esp32s3/wifi_mac.rs",
+        "peripherals::esp32c3::wifi_mac::",
+        "UNVERIFIED on S3 silicon: the S3 MAC is an alias of the C3 model (#1019)",
+    ),
 ];
 
 /// Strip a `//`-comment tail (best-effort; ignores `//` inside string literals,


### PR DESCRIPTION
## Why

`crates/core/tests/arch_chip_isolation.rs` is **red on `main`** and is blocking
**#1021** and **#1022** on `pr-workspace-tests (shard 3)` through no fault of theirs.
(#1023, scripts-only, is clean — which corroborates the diagnosis.)

It is a deterministic source-text scan, so it fails identically everywhere. Exactly one
violation, introduced by `eb0edf108` (#1019):

```
src/peripherals/esp32s3/wifi_mac.rs:12: chip `esp32s3` references `esp32c3`:
  pub use crate::peripherals::esp32c3::wifi_mac::Esp32c3WifiMac as Esp32s3WifiMac;
```

The guard is **right** — this is a genuine cross-chip reference, not a false positive.

## What this does

Adds the share to the `ALLOWED` list so it is **explicit and tracked** rather than
silently red, and writes the reason honestly.

The one pre-existing `ALLOWED` entry is a *test-only constant* share. This one is a
**production peripheral model shared across two CPU architectures** (RISC-V C3, Xtensa
LX7 S3), so the entry says plainly: **an edit to `esp32c3/wifi_mac.rs` now also changes
the ESP32-S3.**

## The premise was checked, and it does not hold up in-repo

#1019 claims "the S3 uses the same MAC IP as the C3". Against what this repo carries:

| Claim | Status |
|---|---|
| Interrupt-matrix source 0 | ✅ **corroborated** — vendored `tests/fixtures/svd/esp32s3.svd`, `INTERRUPT_CORE0` `PRO_MAC_INTR_MAP` @ `0x000` |
| Base `0x6003_3000` | ❌ not in the repo for the S3 — the S3 SVD carries **no Wi-Fi MAC peripheral at all** |
| MAC-ready `0xD14`, RX ring `0x88`, event `0xC3C`/`0xC40`, PLCP0 `0xD08` | ❌ all RE'd on **live C3 silicon** only — `docs/esp32c3_radio_reverse_engineering.md`, `scripts/hw-oracle/wifi-re/`, `captures/esp32c3/wifi-radio-20260611T214340Z` |
| An S3 radio capture | ❌ none — `captures/esp32s3/` holds only the 9-reg reset-state recapture; there is no `hw-oracle/targets/esp32s3.json` MAC window |

Precedent for caution, from this repo, dated today: `configs/peripherals/esp32s3/interrupt_core0.yaml`
carried the **C3's** map until 2026-08-20 and was wrong by 8/20/40 bytes.

So the entry does **not** assert silicon equivalence. It records that the S3 model *is*
the C3 model, that this is unverified, and what must land to drop it.

## Why not give the S3 its own model in this PR

That is the right end state, but it is not a one-file change: `Esp32c3WifiMac` holds an
`esp32c3::virtual_wifi::VirtualWifiBus` **by value**, so a self-contained S3 model needs
the virtual-WiFi medium relocated to a chip-neutral module first (the relocation the
guard's own doc-comment anticipates). A thin S3 stub without the medium would silently
drop the `wifi-ap` binding #1019 just shipped. That belongs in its own reviewed PR, and
the `ALLOWED` entry names it as the exit condition.

The underlying fidelity debt is already owner-acked in `validation/manifest.yaml`
("recapture of the MAC-ready bit at 0x60033D14 is owed on the board on the table").

## Verification

Before — RED:
```
test chip_peripheral_modules_are_self_contained ... FAILED
src/peripherals/esp32s3/wifi_mac.rs:12: chip `esp32s3` references `esp32c3`: ...
test result: FAILED. 0 passed; 1 failed
```

After — green:
```
test chip_peripheral_modules_are_self_contained ... ok
test result: ok. 1 passed; 0 failed
```

Negative control (the entry is path-scoped, not a blanket whitelist of the file):
adding an unrelated `peripherals::esp32c3::gpio::` import to the *same file* still fails —
`src/peripherals/esp32s3/wifi_mac.rs:13: chip esp32s3 references esp32c3` — then reverted.

Drift gate: `python3 scripts/generate_validation_status.py --check --drift` → **exit 0**,
no output. Test-file only; no peripheral source moved, so nothing under `silicon.*`,
`tier:`, `result:`, `probe:` or the drift acks is touched.