### PR TITLE
fix(ci): core-full honours the known-red list the PR shards already use

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1459,7 +1459,53 @@ jobs:
         # artifact this job never produces would fail it for the wrong reason.
         env:
           LABWIRED_REQUIRE_FIRMWARE: firmware-ci-fixture,firmware-rp2040-pio-onboarding
-        run: cargo test --workspace
+        # KNOWN-RED, FROM THE SAME LIST THE PR SHARDS USE.
+        #
+        # This step was plain `cargo test --workspace`, so it went red on
+        # `cpu_trace_conformance::every_cpu_core_is_covered_by_this_file` — a
+        # failure the project has already acknowledged and tracked as issue 961,
+        # and which `pr-workspace-tests` tolerates by reading `known_red` from
+        # scripts/ci/workspace-test-shards.json.
+        #
+        # One test, acknowledged in one lane and not the other, is why THIS job
+        # has been red on every scheduled run. That matters well beyond its own
+        # colour: `nightly_only_excluded` sends work HERE. Five targets already
+        # sit in that list believing this job covers them, so while this job
+        # cannot go green, that list is a deletion mechanism wearing a
+        # relocation's name.
+        #
+        # The skips are generated FROM the JSON, never typed here, so the two
+        # lanes cannot drift into disagreeing about what is known-red. The
+        # skipped tests are then run for real by the step below — skipped from
+        # the verdict, never from the log.
+        run: |
+          set -uo pipefail
+          # while-read, not `mapfile`: bash 3.2 has no mapfile, and a CI step
+          # that only works on the runner is a step nobody can reproduce.
+          skips=()
+          while IFS= read -r arg; do skips+=("$arg"); done \
+            < <(python3 scripts/ci/known_red.py --skip-args)
+          echo "known-red skips (from workspace-test-shards.json): ${skips[*]:-<none>}"
+          cargo test --workspace --no-fail-fast -- "${skips[@]}"
+
+      # The other half of the bargain: a test excused from the verdict must
+      # still RUN and still be reported, or "known red" becomes "never looked
+      # at" — which is how the list would quietly outlive the bugs in it.
+      # Annotates in BOTH directions: a known-red test that starts passing is
+      # news too, and says to delete its entry.
+      - name: Run the known-red tests anyway, and say where they stand
+        if: always()
+        run: |
+          set -uo pipefail
+          python3 scripts/ci/known_red.py --rows > /tmp/known-red.txt
+          while read -r pkg target test issue; do
+            [ -n "${pkg:-}" ] || continue
+            if cargo test -p "$pkg" --test "$target" -- --exact "$test"; then
+              echo "::warning title=known-red test now PASSES::${target}::${test} (issue ${issue}) passed. Delete its known_red entry in scripts/ci/workspace-test-shards.json so it gates again."
+            else
+              echo "::warning title=known-red test still red::${target}::${test} — tracked as issue ${issue}, not counted against this job."
+            fi
+          done < /tmp/known-red.txt
 
       - name: Feature tests — jit + event-scheduler
         run: cargo test -p labwired-core --features jit,event-scheduler

--- a/scripts/ci/known_red.py
+++ b/scripts/ci/known_red.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# LabWired - Firmware Simulation Platform
+# Copyright (C) 2026 Andrii Shylenko
+# SPDX-License-Identifier: MIT
+"""Read the `known_red` list out of scripts/ci/workspace-test-shards.json.
+
+ONE home for "which tests are acknowledged red". `pr-workspace-tests` already
+read this list through workspace_test_shard.py; `core-full` did not, and ran a
+plain `cargo test --workspace`. So one acknowledged failure —
+`cpu_trace_conformance::every_cpu_core_is_covered_by_this_file`, tracked as
+issue 961 — was tolerated by one lane and fatal to the other, which is why
+core-full had never once gone green.
+
+That is not merely an ugly badge. `nightly_only_excluded` sends work TO
+core-full. While core-full cannot pass, moving a slow test there does not
+relocate it, it deletes it.
+
+Emitting the list from here rather than restating it in YAML is the point: two
+lanes cannot drift into disagreeing about what is known-red.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+CONFIG = pathlib.Path(__file__).with_name("workspace-test-shards.json")
+
+
+def entries() -> list[dict]:
+    return json.loads(CONFIG.read_text()).get("known_red", [])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    group = ap.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--skip-args",
+        action="store_true",
+        help="one libtest argument per line: --skip, then the test name",
+    )
+    group.add_argument(
+        "--rows",
+        action="store_true",
+        help="one 'package target test issue' row per line, for a shell loop",
+    )
+    args = ap.parse_args()
+
+    for entry in entries():
+        if args.skip_args:
+            # Two lines, not "--skip NAME": the caller reads this into a bash
+            # array, and a single line would arrive as one argv element that
+            # libtest rejects.
+            print("--skip")
+            print(entry["test"])
+        else:
+            print(entry["package"], entry["target"], entry["test"], entry.get("issue", "-"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why core-full has never gone green

Its last scheduled run failed at 18m on `Run Workspace Tests`. The entire failure was **one test**:

```
cpu_trace_conformance::every_cpu_core_is_covered_by_this_file
```

That test is **already acknowledged**. It sits in `known_red` in `scripts/ci/workspace-test-shards.json` with issue **961**, and `pr-workspace-tests` tolerates it by reading that list through `workspace_test_shard.py`.

`core-full` ran a plain `cargo test --workspace` and knew nothing about it.

**One acknowledged failure, tolerated by one lane and fatal to the other.**

## Why fix this before anything else

`nightly_only_excluded` sends work **to** core-full, and **five targets already sit in it**. While core-full cannot pass, that list is a *deletion mechanism wearing a relocation's name*.

I went looking at this because I was about to move three heavy targets into it — `no_elf_c3_rom_boot` alone is **252s for one test**, 46% of the entire workspace's test time. That move is correct and I still want it, but not into a lane that never reports.

## The shape

Skips are **generated from the JSON** by `scripts/ci/known_red.py`, never typed into YAML, so the two lanes cannot drift into disagreeing about what is known-red.

A test excused from the verdict must still run. The step after executes each known-red test and annotates in **both** directions — one that starts passing is news too, and its entry should be deleted.

## Verification — the step body run verbatim under bash

| | |
|---|---|
| **before**, the pristine command | `2 targets failed` |
| **after**, same targets + generated skips | **exit 0** |
| the skip is surgical | `cpu_trace_conformance` reports `2 passed; 1 filtered out` — the binary's other tests still ran |
| annotate step | emits both entries with issue numbers 961 and 960 |

`while read` rather than `mapfile`: bash 3.2 has none, and a CI step that only works on the runner is a step nobody can reproduce. `actionlint` clean.
