### PR TITLE
fix(esp32s3): model IO_MUX FUN_WPU so INPUT_PULLUP reads high

### DIFF
--- a/crates/core/src/bus/attach.rs
+++ b/crates/core/src/bus/attach.rs
@@ -841,6 +841,41 @@ impl SystemBus {
         }
     }
 
+    /// Wire S3 IO_MUX per-pad controls into S3 GPIO after both models have
+    /// been constructed — the S3 counterpart of
+    /// [`Self::wire_esp32c3_pad_controls`]. The IO_MUX owns the shared
+    /// `IO_MUX_GPIOn_REG` bank; GPIO reads `FUN_WPU` from it to model Arduino
+    /// `INPUT_PULLUP`. Without this the S3's per-pad words were write-only
+    /// storage and a released `INPUT_PULLUP` pin read 0. No-op on any bus
+    /// without both S3 peripherals.
+    pub(crate) fn wire_esp32s3_pad_controls(&mut self) {
+        use crate::peripherals::esp32s3::gpio::Esp32s3Gpio;
+        use crate::peripherals::esp32s3::io_mux::Esp32s3IoMux;
+
+        // Two type-scans rather than index-then-downcast: the concrete type
+        // decides identity either way, and this adds no new immutable-any call
+        // site (see `tests::downcast_ratchet` — remediation row 6.5). Scanning
+        // by type rather than by peripheral id keeps the wiring alive if the
+        // S3 tables ever rename `io_mux`/`gpio`; a silent no-op there would be
+        // invisible exactly the way the missing `wire_esp32s3_i2c_pads` call
+        // was.
+        let Some(controls) = self
+            .peripherals
+            .iter_mut()
+            .find_map(|p| p.dev.as_any_mut()?.downcast_mut::<Esp32s3IoMux>())
+            .map(|io_mux| io_mux.pad_controls())
+        else {
+            return;
+        };
+        if let Some(gpio) = self
+            .peripherals
+            .iter_mut()
+            .find_map(|p| p.dev.as_any_mut()?.downcast_mut::<Esp32s3Gpio>())
+        {
+            gpio.set_pad_controls(controls);
+        }
+    }
+
     /// Wire C3 IO_MUX per-pad controls into C3 GPIO after both models have
     /// been constructed. The IO_MUX owns the shared register bank; GPIO reads
     /// `FUN_WPU` from it to model Arduino `INPUT_PULLUP`. No-op on any bus

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -914,6 +914,11 @@ impl SystemBus {
         // `INPUT_PULLUP` changes the floating input level. No-op for every
         // other chip.
         bus.wire_esp32c3_pad_controls();
+        // Same for the ESP32-S3. (The S3's IO_MUX is registered by the coded
+        // `configure_xtensa_esp32s3` path rather than the chip yaml, which
+        // wires it there too; this keeps the declarative path honest if the
+        // peripheral is ever declared.)
+        bus.wire_esp32s3_pad_controls();
         // ESP32-C3: share the I²C0 bit engine's live SDA/SCL line levels with
         // the C3 GPIO model so matrix-routed pads carry the real waveform.
         // No-op for every other chip.

--- a/crates/core/src/peripherals/esp32s3/gpio.rs
+++ b/crates/core/src/peripherals/esp32s3/gpio.rs
@@ -12,7 +12,12 @@
 //! - Output direction (ENABLE/ENABLE_W1TS/ENABLE_W1TC @ 0x20/0x24/0x28)
 //! - Output value (OUT/OUT_W1TS/OUT_W1TC @ 0x04/0x08/0x0C) with synchronous
 //!   [`GpioObserver`] notification on every pin transition
-//! - Input value (IN @ 0x3C; settable via `set_pin_input` for tests/boards)
+//! - Input value (IN @ 0x3C / IN1 @ 0x40). A pad reads its external drive
+//!   (`set_pin_input` / board stimulus) when one is asserted, otherwise the
+//!   IO_MUX pad's weak pull-up (`FUN_WPU`) — this is what makes Arduino
+//!   `pinMode(pin, INPUT_PULLUP)` read 1 on a released pin. The IO_MUX bank is
+//!   shared in by `SystemBus::wire_esp32s3_pad_controls`; with no IO_MUX on the
+//!   bus every released pad reads 0, exactly as before.
 //! - Boot straps (STRAP @ 0x38, read-only): 0x8 = SPI_FAST_FLASH_BOOT
 //!   (GPIO0 high), captured from silicon over JTAG — the SVD reset value (0)
 //!   would send the boot ROM into download mode
@@ -205,7 +210,7 @@ const fn spec(word: usize) -> Option<(u32, u32)> {
         ENABLE..=ENABLE_W1TC => Some((0x0000_0000, 0xFFFF_FFFF)),
         ENABLE1..=ENABLE1_W1TC => Some((0x0000_0000, BANK1_MASK)),
         STRAP => Some((0x0000_0008, 0x0000_0000)), // RO, silicon-captured
-        IN => Some((0x0000_0000, 0xFFFF_FFFF)),    // behavioral (in_data)
+        IN => Some((0x0000_0000, 0xFFFF_FFFF)),    // behavioral (effective_input)
         IN1 => Some((0x0000_0000, BANK1_MASK)),
         STATUS..=STATUS_W1TC => Some((0x0000_0000, 0xFFFF_FFFF)),
         STATUS1..=STATUS1_W1TC => Some((0x0000_0000, BANK1_MASK)),
@@ -251,7 +256,17 @@ pub struct Esp32s3Gpio {
     /// [`BANK1_MASK`]. Served in place of `regs[OUT1/4]` so `apply_out1` can fire
     /// observers on bank-1 pad transitions (e.g. the onboard NeoPixel on GPIO48).
     out1: u32,
-    in_data: u32,
+    /// Host/board-driven pad levels, `[bank0 = GPIO0..31, bank1 = GPIO32..53]`.
+    /// A bit only has electrical authority when the matching
+    /// [`Self::external_drive_mask`] bit is set; otherwise the IO_MUX pull-up
+    /// (if any) supplies the released level.
+    external_levels: [u32; 2],
+    external_drive_mask: [u32; 2],
+    /// Shared IO_MUX per-pad register words (`IO_MUX_GPIOn_REG`). Installed by
+    /// `SystemBus::wire_esp32s3_pad_controls`. The pad's weak pull-up is an
+    /// electrical input condition, so it is kept separate from the output
+    /// matrix in `pad_routes`.
+    pad_controls: Option<super::io_mux::PadControls>,
     /// Live I²C0 wire levels shared with the I²C controller, installed at bus
     /// wiring time (`SystemBus::wire_esp32s3_i2c_pads`). Pads whose output
     /// matrix routes `I2CEXT0_SCL`/`SDA` read the wire here instead of the
@@ -292,7 +307,9 @@ impl Esp32s3Gpio {
             enable: 0,
             out: 0,
             out1: 0,
-            in_data: 0,
+            external_levels: [0; 2],
+            external_drive_mask: [0; 2],
+            pad_controls: None,
             pad_routes: crate::peripherals::pad_routing::PadRoutes::new(),
             tap: None,
             int_enable: 0,
@@ -508,15 +525,60 @@ impl Esp32s3Gpio {
             .collect()
     }
 
-    /// Set the input level on `pin` (0..=31). Used by tests / future
-    /// stimulus generators.
+    /// Set the input level on `pin` (0..=31). Used by tests, boards and
+    /// stimulus generators. This is an *external drive*: it takes electrical
+    /// priority over the pad's weak internal pull-up, so a button holding the
+    /// pin low still reads 0 with `INPUT_PULLUP` configured.
     pub fn set_pin_input(&mut self, pin: u8, level: bool) {
         assert!(pin < 32, "set_pin_input: pin {pin} >= 32");
         if level {
-            self.in_data |= 1u32 << pin;
+            self.external_levels[0] |= 1u32 << pin;
         } else {
-            self.in_data &= !(1u32 << pin);
+            self.external_levels[0] &= !(1u32 << pin);
         }
+        self.external_drive_mask[0] |= 1u32 << pin;
+    }
+
+    /// Wire the S3 IO_MUX's shared per-pad controls after both peripherals
+    /// exist on the system bus.
+    pub(crate) fn set_pad_controls(&mut self, controls: super::io_mux::PadControls) {
+        self.pad_controls = Some(controls);
+    }
+
+    /// `FUN_WPU` per pad, split into the two GPIO input banks. Pads 49..53 have
+    /// no `IO_MUX_GPIOn_REG` on the S3, so they never carry a pull-up here.
+    fn io_mux_pullup_mask(&self) -> [u32; 2] {
+        let Some(controls) = &self.pad_controls else {
+            return [0; 2];
+        };
+        controls
+            .read()
+            .expect("ESP32-S3 IO_MUX pad controls poisoned")
+            .iter()
+            .enumerate()
+            .fold([0u32; 2], |mut mask, (pin, word)| {
+                if word & super::io_mux::FUN_WPU != 0 {
+                    if pin < 32 {
+                        mask[0] |= 1u32 << pin;
+                    } else {
+                        mask[1] |= 1u32 << (pin - 32);
+                    }
+                }
+                mask
+            })
+    }
+
+    /// Firmware-visible input word for `bank` (0 = `IN`/GPIO0..31,
+    /// 1 = `IN1`/GPIO32..53). An explicit external drive always beats a weak
+    /// internal pull-up; otherwise the raw IO_MUX `FUN_WPU` bit supplies the
+    /// released level, including its SVD-defined cold reset. Without the
+    /// pull-up term a released `INPUT_PULLUP` pin reads 0 and every
+    /// button-to-GND lab reads permanently pressed.
+    fn effective_input(&self, bank: usize) -> u32 {
+        let valid = if bank == 0 { u32::MAX } else { BANK1_MASK };
+        ((self.external_levels[bank] & self.external_drive_mask[bank])
+            | (self.io_mux_pullup_mask()[bank] & !self.external_drive_mask[bank]))
+            & valid
     }
 
     /// Internal: apply a new `out` value, fire observers for each
@@ -594,7 +656,8 @@ impl Esp32s3Gpio {
             // W1TS/W1TC views read back the primary register's value.
             OUT | OUT_W1TS | OUT_W1TC => self.out,
             ENABLE | ENABLE_W1TS | ENABLE_W1TC => self.enable,
-            IN => self.in_data,
+            IN => self.effective_input(0),
+            IN1 => self.effective_input(1),
             // OUT1 and its W1TS/W1TC views read the behavioral bank-1 latch.
             OUT1 | OUT1_W1TS | OUT1_W1TC => self.out1,
             ENABLE1_W1TS | ENABLE1_W1TC => self.reg(ENABLE1),
@@ -615,10 +678,19 @@ impl Esp32s3Gpio {
             ENABLE => self.enable = value,
             ENABLE_W1TS => self.enable |= value,
             ENABLE_W1TC => self.enable &= !value,
-            // The SVD marks IN.DATA_NEXT read-write: a write stores into the
-            // same cell `set_pin_input` drives (the TRM documents the
-            // register as RO on silicon; firmware never writes it).
-            IN => self.in_data = value,
+            // The SVD marks IN/IN1.DATA_NEXT read-write: a write stores into
+            // the same cell `set_pin_input` drives (the TRM documents the
+            // registers as RO on silicon; firmware never writes them). It
+            // asserts the whole bank as an external drive so the written word
+            // reads back exactly, pull-ups included.
+            IN => {
+                self.external_levels[0] = value;
+                self.external_drive_mask[0] = u32::MAX;
+            }
+            IN1 => {
+                self.external_levels[1] = value & BANK1_MASK;
+                self.external_drive_mask[1] = BANK1_MASK;
+            }
             // OUT1 (bank-1 output latch) routes through apply_out1 so GPIO32..53
             // pad transitions fire observers, mirroring the bank-0 OUT path.
             OUT1 => self.apply_out1(value),
@@ -679,7 +751,7 @@ impl std::fmt::Debug for Esp32s3Gpio {
             "Esp32s3Gpio(enable=0x{:08x} out=0x{:08x} in=0x{:08x} cycle={} obs={})",
             self.enable,
             self.out,
-            self.in_data,
+            self.effective_input(0),
             self.cycle,
             self.observers.len(),
         )
@@ -750,7 +822,7 @@ impl Peripheral for Esp32s3Gpio {
         if pin >= 32 {
             return None;
         }
-        Some((self.in_data & (1u32 << pin)) != 0)
+        Some((self.effective_input(0) & (1u32 << pin)) != 0)
     }
 
     fn read_gpio_output(&self, pin: u8) -> Option<bool> {
@@ -778,7 +850,7 @@ impl Peripheral for Esp32s3Gpio {
         Some(if (self.enable & mask) != 0 {
             (self.out & mask) != 0
         } else {
-            (self.in_data & mask) != 0
+            (self.effective_input(0) & mask) != 0
         })
     }
 
@@ -1317,6 +1389,218 @@ mod tests {
         // Disabled pad → Input; out-of-range → None.
         assert_eq!(g.gpio_routing(6).unwrap().mode, GpioMode::Input);
         assert!(g.gpio_routing(54).is_none());
+    }
+
+    // ── IO_MUX pull-up (Arduino INPUT_PULLUP) ─────────────────────────────
+    //
+    // Mirrors the ESP32-C3's `input_pullup_*` tests. Measured defect before
+    // this landed: on an S3, `pinMode(p, INPUT_PULLUP); digitalRead(p)`
+    // returned 0 with nothing wired to the pin (real silicon reads 1), so
+    // every button-to-GND lab read permanently pressed.
+
+    /// Absolute addresses on the S3 memory map, so the test exercises the same
+    /// MMIO path firmware does.
+    const GPIO_BASE: u64 = 0x6000_4000;
+    const IO_MUX_BASE: u64 = 0x6000_9000;
+    /// `IO_MUX_GPIOn_REG` = base + 0x04 + n*4 (SVD `GPIO%s`, dim 49).
+    fn io_mux_gpio(pin: u64) -> u64 {
+        IO_MUX_BASE + 0x04 + pin * 4
+    }
+    /// Arduino-core pad words: `FUN_DRV=2 | FUN_IE | MCU_SEL=GPIO`, with and
+    /// without `FUN_WPU` (bit 8).
+    const PAD_INPUT: u32 = 0x0000_1A00;
+    const PAD_INPUT_PULLUP: u32 = 0x0000_1B00;
+
+    /// Build the S3 the way the firmware-execution path does — the coded
+    /// `configure_xtensa_esp32s3`, which is where the IO_MUX is registered.
+    fn s3_bus() -> crate::bus::SystemBus {
+        let mut bus = crate::bus::SystemBus::new();
+        crate::system::xtensa::configure_xtensa_esp32s3(
+            &mut bus,
+            &crate::system::xtensa::Esp32s3Opts::default(),
+        );
+        bus
+    }
+
+    fn with_gpio<R>(bus: &mut crate::bus::SystemBus, f: impl FnOnce(&mut Esp32s3Gpio) -> R) -> R {
+        let idx = bus
+            .find_peripheral_index_by_name("gpio")
+            .expect("S3 GPIO is present");
+        let gpio = bus.peripherals[idx]
+            .dev
+            .as_any_mut()
+            .and_then(|any| any.downcast_mut::<Esp32s3Gpio>())
+            .expect("S3 GPIO model");
+        f(gpio)
+    }
+
+    /// The headline behaviour: a pad with `FUN_WPU` set and nothing driving it
+    /// reads 1; an external drive (a button to GND) still wins.
+    #[test]
+    fn esp32s3_input_pullup_releases_a_floating_pin_but_external_drive_wins() {
+        use crate::Bus;
+        let mut bus = s3_bus();
+
+        // Cold reset already sets FUN_WPU (SVD GPIO%s reset = 0x0000_0B00).
+        assert_eq!(bus.read_u32(io_mux_gpio(5)).unwrap(), 0x0000_0B00);
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(
+                gpio.read_gpio_input(5),
+                Some(true),
+                "the cold IO_MUX FUN_WPU bit releases a floating GPIO5"
+            );
+            assert_eq!(gpio.read_gpio_pad(5), Some(true));
+        });
+
+        // pinMode(5, INPUT) clears FUN_WPU → the pad no longer reads high.
+        bus.write_u32(io_mux_gpio(5), PAD_INPUT)
+            .expect("emulate Arduino pinMode(GPIO5, INPUT)");
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(gpio.read_gpio_input(5), Some(false), "INPUT clears FUN_WPU");
+            assert_eq!(gpio.read_gpio_pad(5), Some(false));
+        });
+
+        // pinMode(5, INPUT_PULLUP) sets it again → released pin reads 1.
+        bus.write_u32(io_mux_gpio(5), PAD_INPUT_PULLUP)
+            .expect("emulate Arduino pinMode(GPIO5, INPUT_PULLUP)");
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(
+                gpio.read_gpio_input(5),
+                Some(true),
+                "pull-up releases GPIO5 high"
+            );
+            assert_eq!(gpio.read_gpio_pad(5), Some(true));
+        });
+
+        // A button pulling the pin to GND is an external drive and beats the
+        // weak pull-up; releasing it drives high again.
+        with_gpio(&mut bus, |gpio| {
+            assert!(gpio.set_gpio_input(5, false));
+            assert_eq!(
+                gpio.read_gpio_input(5),
+                Some(false),
+                "an external drive beats the weak internal pull-up"
+            );
+            assert!(gpio.set_gpio_input(5, true));
+            assert_eq!(gpio.read_gpio_input(5), Some(true));
+        });
+    }
+
+    /// What `digitalRead` actually executes: a load from `GPIO_IN`. This is the
+    /// register the measured sketch read as 0.
+    #[test]
+    fn esp32s3_input_pullup_is_visible_in_the_gpio_in_register() {
+        use crate::Bus;
+        let mut bus = s3_bus();
+
+        // GPIO6 unconnected + INPUT_PULLUP, GPIO7 unconnected + INPUT.
+        bus.write_u32(io_mux_gpio(6), PAD_INPUT_PULLUP).unwrap();
+        bus.write_u32(io_mux_gpio(7), PAD_INPUT).unwrap();
+
+        let in_word = bus.read_u32(GPIO_BASE + IN).unwrap();
+        assert_ne!(
+            in_word & (1 << 6),
+            0,
+            "NOWIRE-PU6 must read 1: FUN_WPU with nothing driving the pad"
+        );
+        assert_eq!(
+            in_word & (1 << 7),
+            0,
+            "FLOAT7 has no pull-up and nothing driving it"
+        );
+
+        // A button on GPIO5 to GND, held closed, with INPUT_PULLUP.
+        bus.write_u32(io_mux_gpio(5), PAD_INPUT_PULLUP).unwrap();
+        with_gpio(&mut bus, |gpio| assert!(gpio.set_gpio_input(5, false)));
+        assert_eq!(
+            bus.read_u32(GPIO_BASE + IN).unwrap() & (1 << 5),
+            0,
+            "a closed button to GND still reads 0 through GPIO_IN"
+        );
+    }
+
+    /// Bank 1 (`GPIO_IN1`, pads 32..48) goes through the same rule. Pads 49..53
+    /// have no `IO_MUX_GPIOn_REG` on the S3 and therefore never float high.
+    #[test]
+    fn esp32s3_input_pullup_reaches_bank_one_through_in1() {
+        use crate::Bus;
+        let mut bus = s3_bus();
+
+        let in1 = bus.read_u32(GPIO_BASE + IN1).unwrap();
+        assert_ne!(in1 & (1 << (47 - 32)), 0, "GPIO47 floats high at reset");
+        assert_ne!(in1 & (1 << (48 - 32)), 0, "GPIO48 floats high at reset");
+        assert_eq!(
+            in1 & !0x0001_FFFF,
+            0,
+            "GPIO49..53 have no IO_MUX pad word, so no pull-up"
+        );
+
+        bus.write_u32(io_mux_gpio(47), PAD_INPUT).unwrap();
+        let in1 = bus.read_u32(GPIO_BASE + IN1).unwrap();
+        assert_eq!(in1 & (1 << (47 - 32)), 0, "INPUT clears GPIO47's FUN_WPU");
+        assert_ne!(in1 & (1 << (48 - 32)), 0, "GPIO48 is untouched");
+    }
+
+    /// Direction-aware: an enabled output driver shows the value it drives, not
+    /// the pad's weak pull-up.
+    #[test]
+    fn esp32s3_enabled_output_driver_beats_the_pad_pullup() {
+        use crate::Bus;
+        let mut bus = s3_bus();
+        bus.write_u32(io_mux_gpio(8), PAD_INPUT_PULLUP).unwrap();
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(gpio.read_gpio_pad(8), Some(true), "released, pulled up");
+        });
+
+        // pinMode(8, OUTPUT); digitalWrite(8, LOW).
+        bus.write_u32(GPIO_BASE + ENABLE_W1TS, 1 << 8).unwrap();
+        bus.write_u32(GPIO_BASE + OUT_W1TC, 1 << 8).unwrap();
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(
+                gpio.read_gpio_pad(8),
+                Some(false),
+                "an enabled output driver shows the driven value"
+            );
+        });
+        bus.write_u32(GPIO_BASE + OUT_W1TS, 1 << 8).unwrap();
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(gpio.read_gpio_pad(8), Some(true))
+        });
+    }
+
+    /// No IO_MUX on the bus → no pull-ups, exactly as before this change. This
+    /// is the guard that the new term cannot invent a high level on a port that
+    /// was never wired to a pad-control bank.
+    #[test]
+    fn esp32s3_gpio_without_io_mux_wiring_reads_undriven_pads_low() {
+        let mut g = Esp32s3Gpio::new();
+        assert_eq!(g.read_gpio_input(5), Some(false));
+        assert_eq!(g.read_gpio_pad(5), Some(false));
+        assert_eq!(read_u32(&g, IN), 0);
+        assert_eq!(read_u32(&g, IN1), 0);
+        g.set_pin_input(5, true);
+        assert_eq!(g.read_gpio_input(5), Some(true));
+    }
+
+    /// A `FUN_WPU` write after an external drive was asserted must NOT undo the
+    /// drive — the released level only applies to pads nothing is driving.
+    #[test]
+    fn esp32s3_pullup_write_does_not_override_a_standing_external_drive() {
+        use crate::Bus;
+        let mut bus = s3_bus();
+        bus.write_u32(io_mux_gpio(9), PAD_INPUT).unwrap();
+        with_gpio(&mut bus, |gpio| {
+            assert!(gpio.set_gpio_input(9, false));
+            assert_eq!(gpio.read_gpio_input(9), Some(false));
+        });
+        bus.write_u32(io_mux_gpio(9), PAD_INPUT_PULLUP).unwrap();
+        with_gpio(&mut bus, |gpio| {
+            assert_eq!(
+                gpio.read_gpio_input(9),
+                Some(false),
+                "the wire still holds GPIO9 low"
+            );
+        });
     }
 
     #[test]

--- a/crates/core/src/peripherals/esp32s3/io_mux.rs
+++ b/crates/core/src/peripherals/esp32s3/io_mux.rs
@@ -2,52 +2,197 @@
 // Copyright (C) 2026 Andrii Shylenko
 // SPDX-License-Identifier: MIT
 
-//! IO_MUX peripheral for ESP32-S3.
+//! ESP32-S3 IO_MUX pad-control peripheral.
 //!
-//! Per ESP32-S3 TRM §6.5. Each of the 49 GPIOs (0..48) has a 32-bit
-//! function-select register at offset `pin * 4` from base 0x6000_9000.
+//! Mapped at `0x6000_9000`. `PIN_CTRL` sits at offset `0x00`; the 49 per-pad
+//! function words `IO_MUX_GPIO0..GPIO48` begin at `0x04` (stride 4, last at
+//! `0xC4`), and `DATE` is at `0xFC`. GPIO shares the per-pad bank so the
+//! pad-level `FUN_WPU` control behind Arduino `INPUT_PULLUP` is visible
+//! outside this MMIO model — see [`Esp32s3IoMux::pad_controls`].
 //!
-//! Plan 3 scope: round-trip storage only. The simulator does not enforce
-//! the matrix routing implied by FUN_MUX bits; the peripheral exists so
-//! esp-hal's pin-config sequence completes.
+//! ## Register map source
 //!
-//! Per-pin register bits (informational):
-//!   bits[6:4]  MCU_SEL (function 0 = matrix, function 1 = GPIO, ...)
-//!   bits[10:7] FUN_DRV (drive strength)
-//!   bit[8]     FUN_PU  (pull-up enable)
-//!   bit[7]     FUN_PD  (pull-down enable)
-//!   bit[12]    FUN_IE  (input enable)
+//! Offsets, reset values and bit positions are taken from the vendored
+//! ESP32-S3 SVD (`tests/fixtures/svd/esp32s3.svd`, `IO_MUX` peripheral), which
+//! is the in-repo oracle for this block and agrees with ESP32-S3 TRM §6.5
+//! (`IO_MUX_GPIOn_REG`). Per-pad field layout:
+//!
+//! ```text
+//!   bit[0]      MCU_OE     output enable in sleep mode
+//!   bit[1]      SLP_SEL    sleep-mode pad selection
+//!   bit[2]      MCU_WPD    pull-down enable in sleep mode
+//!   bit[3]      MCU_WPU    pull-up enable in sleep mode
+//!   bit[4]      MCU_IE     input enable in sleep mode
+//!   bit[7]      FUN_WPD    pull-down enable
+//!   bit[8]      FUN_WPU    pull-up enable
+//!   bit[9]      FUN_IE     input enable
+//!   bits[11:10] FUN_DRV    drive strength
+//!   bits[14:12] MCU_SEL    IO MUX function select
+//!   bit[15]     FILTER_EN  input filter enable
+//! ```
+//!
+//! This is the SAME layout as the ESP32-C3 (`esp32c3/io_mux.rs`) — both SVDs
+//! describe `GPIO%s` identically. The previous header comment in this file
+//! claimed `MCU_SEL` at bits[6:4] and `FUN_DRV` at bits[10:7], which overlaps
+//! its own `FUN_PU`/`FUN_PD` claim and matches no ESP part; it was never
+//! exercised because nothing read the stored word.
+//!
+//! ## Cold reset
+//!
+//! The SVD gives one `resetValue` for the whole `GPIO%s` array: `0x0000_0B00`
+//! = `FUN_WPU | FUN_IE | FUN_DRV=2`. So every pad comes out of reset with its
+//! weak pull-up and input buffer enabled; that is the value seeded here, not a
+//! simulator-chosen blanket. The SVD does not model the per-pad variation the
+//! S3 datasheet's pin summary documents (e.g. the SPI-flash and strapping pads
+//! whose ROM/eFuse configuration differs), and neither does this model — the
+//! C3 model has the same limitation for the same reason.
 
 use crate::{Peripheral, SimResult};
+use std::sync::{Arc, RwLock};
 
-const NUM_PINS: usize = 49;
+const PIN_CTRL: u64 = 0x00;
+const GPIO0: u64 = 0x04;
+const DATE: u64 = 0xFC;
+/// `IO_MUX_GPIO0_REG` .. `IO_MUX_GPIO48_REG` (SVD `GPIO%s`, dim = 49).
+pub(crate) const PAD_COUNT: usize = 49;
+const PIN_CTRL_RESET: u32 = 0x0000_07FF;
+/// `FUN_WPU | FUN_IE | FUN_DRV = 2` — the SVD's `GPIO%s` reset value.
+const PAD_RESET: u32 = 0x0000_0B00;
+const DATE_RESET: u32 = 0x0190_7160;
+/// `FUN_WPU` — the pad's weak pull-up, bit 8.
+pub(crate) const FUN_WPU: u32 = 1 << 8;
+
+/// The per-pad function words, shared with the GPIO model so a `FUN_WPU` write
+/// changes the electrical level an undriven pad reports.
+pub(crate) type PadControls = Arc<RwLock<[u32; PAD_COUNT]>>;
 
 #[derive(Debug)]
 pub struct Esp32s3IoMux {
-    pin_func: [u32; NUM_PINS],
+    pin_ctrl: u32,
+    pads: PadControls,
+    date: u32,
 }
 
 impl Esp32s3IoMux {
     pub fn new() -> Self {
         Self {
-            pin_func: [0; NUM_PINS],
+            pin_ctrl: PIN_CTRL_RESET,
+            pads: Arc::new(RwLock::new([PAD_RESET; PAD_COUNT])),
+            date: DATE_RESET,
         }
+    }
+
+    /// Hand out the shared pad-control cell. The GPIO model keeps this `Arc`
+    /// and reads `FUN_WPU` from it on every input read; `restore` writes
+    /// *through* the same cell rather than replacing it, so a resumed machine
+    /// keeps its wiring.
+    pub(crate) fn pad_controls(&self) -> PadControls {
+        Arc::clone(&self.pads)
     }
 
     /// Read the current function-select word for `pin` (0..=48).
     /// Returns 0 for out-of-range pins.
     pub fn pin_func(&self, pin: u8) -> u32 {
-        if (pin as usize) < NUM_PINS {
-            self.pin_func[pin as usize]
+        self.pads
+            .read()
+            .expect("ESP32-S3 IO_MUX pad controls poisoned")
+            .get(pin as usize)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Is `pin`'s weak pull-up (`FUN_WPU`) enabled?
+    pub fn fun_pull_up(&self, pin: u8) -> bool {
+        self.pin_func(pin) & FUN_WPU != 0
+    }
+
+    fn pad_index(word_off: u64) -> Option<usize> {
+        if (GPIO0..GPIO0 + (PAD_COUNT as u64) * 4).contains(&word_off) {
+            Some(((word_off - GPIO0) / 4) as usize)
+        } else {
+            None
+        }
+    }
+
+    fn read_word(&self, word_off: u64) -> u32 {
+        if word_off == PIN_CTRL {
+            self.pin_ctrl
+        } else if word_off == DATE {
+            self.date
+        } else if let Some(pin) = Self::pad_index(word_off) {
+            self.pads
+                .read()
+                .expect("ESP32-S3 IO_MUX pad controls poisoned")[pin]
         } else {
             0
         }
+    }
+
+    fn write_word(&mut self, word_off: u64, value: u32) {
+        if word_off == PIN_CTRL {
+            self.pin_ctrl = value;
+        } else if word_off == DATE {
+            self.date = value;
+        } else if let Some(pin) = Self::pad_index(word_off) {
+            self.pads
+                .write()
+                .expect("ESP32-S3 IO_MUX pad controls poisoned")[pin] = value;
+        }
+        // Offsets outside the architected map are silently dropped.
+    }
+
+    fn runtime_state(&self) -> IoMuxSnapshot {
+        IoMuxSnapshot {
+            pin_ctrl: self.pin_ctrl,
+            pads: *self
+                .pads
+                .read()
+                .expect("ESP32-S3 IO_MUX pad controls poisoned"),
+            date: self.date,
+        }
+    }
+
+    fn apply_runtime_state(&mut self, state: IoMuxSnapshot) {
+        self.pin_ctrl = state.pin_ctrl;
+        // Write THROUGH the shared cell — replacing the `Arc` would orphan the
+        // handle GPIO already holds and silently drop every pull-up on resume.
+        *self
+            .pads
+            .write()
+            .expect("ESP32-S3 IO_MUX pad controls poisoned") = state.pads;
+        self.date = state.date;
     }
 }
 
 impl Default for Esp32s3IoMux {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct IoMuxSnapshot {
+    pin_ctrl: u32,
+    #[serde(with = "serde_pads")]
+    pads: [u32; PAD_COUNT],
+    date: u32,
+}
+
+/// `[u32; 49]` is past serde's built-in array impls, so round-trip it as a
+/// slice and re-check the length on the way back in.
+mod serde_pads {
+    use super::PAD_COUNT;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(pads: &[u32; PAD_COUNT], s: S) -> Result<S::Ok, S::Error> {
+        s.collect_seq(pads.iter())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u32; PAD_COUNT], D::Error> {
+        let raw = Vec::<u32>::deserialize(d)?;
+        <[u32; PAD_COUNT]>::try_from(raw.as_slice()).map_err(|_| {
+            serde::de::Error::invalid_length(raw.len(), &"49 ESP32-S3 IO_MUX pad words")
+        })
     }
 }
 
@@ -63,28 +208,35 @@ impl Peripheral for Esp32s3IoMux {
     }
 
     fn read(&self, offset: u64) -> SimResult<u8> {
-        let word_off = offset & !3;
-        let byte_off = (offset & 3) * 8;
-        let pin = (word_off / 4) as usize;
-        let word = if pin < NUM_PINS {
-            self.pin_func[pin]
-        } else {
-            0
-        };
-        Ok(((word >> byte_off) & 0xFF) as u8)
+        let word = self.read_word(offset & !3);
+        Ok(((word >> ((offset & 3) * 8)) & 0xFF) as u8)
+    }
+
+    fn peek(&self, offset: u64) -> Option<u8> {
+        let word = self.read_word(offset & !3);
+        Some(((word >> ((offset & 3) * 8)) & 0xFF) as u8)
     }
 
     fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
         let word_off = offset & !3;
-        let byte_off = (offset & 3) * 8;
-        let pin = (word_off / 4) as usize;
-        if pin < NUM_PINS {
-            let word = &mut self.pin_func[pin];
-            *word &= !(0xFFu32 << byte_off);
-            *word |= (value as u32) << byte_off;
-        }
-        // Out-of-range writes silently dropped.
+        let shift = (offset & 3) * 8;
+        let mut word = self.read_word(word_off);
+        word &= !(0xFFu32 << shift);
+        word |= (value as u32) << shift;
+        self.write_word(word_off, word);
         Ok(())
+    }
+
+    fn write_u32(&mut self, offset: u64, value: u32) -> SimResult<()> {
+        if offset & 3 == 0 {
+            self.write_word(offset, value);
+            Ok(())
+        } else {
+            for byte in 0..4 {
+                self.write(offset + byte, ((value >> (byte * 8)) & 0xFF) as u8)?;
+            }
+            Ok(())
+        }
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -94,77 +246,176 @@ impl Peripheral for Esp32s3IoMux {
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
     }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::to_value(self.runtime_state()).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn restore(&mut self, state: serde_json::Value) -> SimResult<()> {
+        if let Ok(state) = serde_json::from_value::<IoMuxSnapshot>(state) {
+            self.apply_runtime_state(state);
+        }
+        Ok(())
+    }
+
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        bincode::serialize(&self.runtime_state()).expect("bincode serialize Esp32s3IoMux")
+    }
+
+    fn restore_runtime_snapshot(&mut self, bytes: &[u8]) -> SimResult<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let state: IoMuxSnapshot = bincode::deserialize(bytes).map_err(|error| {
+            crate::SimulationError::NotImplemented(format!("Esp32s3IoMux snapshot decode: {error}"))
+        })?;
+        self.apply_runtime_state(state);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn defaults_zero() {
-        let m = Esp32s3IoMux::new();
-        for pin in 0u8..49 {
-            assert_eq!(m.pin_func(pin), 0);
-        }
-    }
-
-    #[test]
-    fn pin0_round_trip() {
-        let mut m = Esp32s3IoMux::new();
-        // Pin 0 register at offset 0x00. Write FUN_DRV=2, MCU_SEL=1, FUN_IE=1.
-        // Word value: (1 << 4) | (2 << 7) | (1 << 12) = 0x10 | 0x100 | 0x1000 = 0x1110.
-        let val = 0x1110u32;
-        for byte in 0..4u64 {
-            m.write(byte, ((val >> (byte * 8)) & 0xFF) as u8).unwrap();
-        }
-        let mut read = 0u32;
-        for byte in 0..4u64 {
-            read |= (m.read(byte).unwrap() as u32) << (byte * 8);
-        }
-        assert_eq!(read, val);
-        assert_eq!(m.pin_func(0), val);
-    }
-
-    #[test]
-    fn pin2_round_trip_at_offset_8() {
-        let mut m = Esp32s3IoMux::new();
-        let val = 0xABCD_1234u32;
-        let off = 2 * 4u64;
+    fn write_u32(m: &mut Esp32s3IoMux, off: u64, val: u32) {
         for byte in 0..4u64 {
             m.write(off + byte, ((val >> (byte * 8)) & 0xFF) as u8)
                 .unwrap();
         }
-        assert_eq!(m.pin_func(2), val);
     }
 
-    #[test]
-    fn pin48_in_range() {
-        let mut m = Esp32s3IoMux::new();
-        let val = 0x42u32;
-        let off = 48 * 4u64;
-        m.write(off, val as u8).unwrap();
-        assert_eq!(m.pin_func(48) & 0xFF, val);
-    }
-
-    #[test]
-    fn out_of_range_pin_silently_dropped() {
-        let mut m = Esp32s3IoMux::new();
-        // Pin 49 would be at offset 49*4 = 196.
-        m.write(196, 0xAB).unwrap();
-        // Read returns 0 for out-of-range.
-        assert_eq!(m.read(196).unwrap(), 0);
-    }
-
-    #[test]
-    fn writes_isolated_per_pin() {
-        let mut m = Esp32s3IoMux::new();
+    fn read_u32(m: &Esp32s3IoMux, off: u64) -> u32 {
+        let mut read = 0u32;
         for byte in 0..4u64 {
-            m.write(byte, 0xAB).unwrap();
+            read |= (m.read(off + byte).unwrap() as u32) << (byte * 8);
         }
-        for byte in 0..4u64 {
-            m.write(4 + byte, 0xCD).unwrap();
+        read
+    }
+
+    /// The SVD's cold-reset state, register by register — including the pad
+    /// bank starting at 0x04, NOT at the peripheral base.
+    #[test]
+    fn cold_reset_matches_the_svd_pin_ctrl_pad_bank_and_date() {
+        let m = Esp32s3IoMux::new();
+
+        assert_eq!(read_u32(&m, PIN_CTRL), PIN_CTRL_RESET);
+        for pin in 0..PAD_COUNT as u64 {
+            assert_eq!(
+                read_u32(&m, GPIO0 + pin * 4),
+                0x0000_0B00,
+                "IO_MUX_GPIO{pin}_REG must hold the SVD cold reset"
+            );
         }
-        assert_eq!(m.pin_func(0), 0xABABABABu32);
-        assert_eq!(m.pin_func(1), 0xCDCDCDCDu32);
+        assert_eq!(read_u32(&m, DATE), 0x0190_7160);
+        // GPIO48 is the last pad word (0xC4); 0xC8 is outside the bank.
+        assert_eq!(read_u32(&m, GPIO0 + 48 * 4), 0x0000_0B00);
+        assert_eq!(read_u32(&m, GPIO0 + 49 * 4), 0);
+    }
+
+    /// `FUN_WPU` (bit 8) is what Arduino `INPUT_PULLUP` sets, and it is already
+    /// set at cold reset.
+    #[test]
+    fn fun_pull_up_reads_bit_eight_of_the_pad_word() {
+        let mut m = Esp32s3IoMux::new();
+        assert!(m.fun_pull_up(5), "FUN_WPU is set at cold reset");
+
+        // Clear FUN_WPU on GPIO5 only.
+        write_u32(&mut m, GPIO0 + 5 * 4, 0x0000_0A00);
+        assert!(!m.fun_pull_up(5));
+        assert!(m.fun_pull_up(6), "neighbouring pads are untouched");
+
+        // Set it again the way esp-hal does: FUN_WPU | FUN_IE | MCU_SEL=1.
+        write_u32(&mut m, GPIO0 + 5 * 4, FUN_WPU | (1 << 9) | (1 << 12));
+        assert!(m.fun_pull_up(5));
+        // Out-of-range pads have no pad word and therefore no pull-up.
+        assert!(!m.fun_pull_up(49));
+        assert!(!m.fun_pull_up(200));
+    }
+
+    #[test]
+    fn pad_words_round_trip_per_pin_without_a_write_mask() {
+        let mut m = Esp32s3IoMux::new();
+        write_u32(&mut m, GPIO0, 0xABCD_1234);
+        write_u32(&mut m, GPIO0 + 4, 0x0000_1B02);
+        assert_eq!(m.pin_func(0), 0xABCD_1234);
+        assert_eq!(m.pin_func(1), 0x0000_1B02);
+        assert_eq!(m.pin_func(2), PAD_RESET, "unwritten pads keep their reset");
+
+        write_u32(&mut m, PIN_CTRL, 0xA5A5_F123);
+        write_u32(&mut m, DATE, 0xDEAD_BEEF);
+        assert_eq!(read_u32(&m, PIN_CTRL), 0xA5A5_F123);
+        assert_eq!(read_u32(&m, DATE), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn out_of_range_offsets_ignore_writes_and_read_zero() {
+        let mut m = Esp32s3IoMux::new();
+        // 0xC8 is one word past IO_MUX_GPIO48_REG.
+        write_u32(&mut m, 0xC8, 0xFFFF_FFFF);
+        assert_eq!(read_u32(&m, 0xC8), 0);
+        write_u32(&mut m, 0xF0, 0xFFFF_FFFF);
+        assert_eq!(read_u32(&m, 0xF0), 0);
+    }
+
+    #[test]
+    fn word_write_and_byte_write_agree() {
+        let mut byte_wise = Esp32s3IoMux::new();
+        write_u32(&mut byte_wise, GPIO0 + 7 * 4, 0x1234_5678);
+
+        let mut word_wise = Esp32s3IoMux::new();
+        word_wise.write_u32(GPIO0 + 7 * 4, 0x1234_5678).unwrap();
+
+        assert_eq!(byte_wise.pin_func(7), word_wise.pin_func(7));
+        assert_eq!(word_wise.pin_func(7), 0x1234_5678);
+    }
+
+    #[test]
+    fn io_mux_is_inert_for_the_legacy_tick_walk() {
+        assert!(
+            !Esp32s3IoMux::new().needs_legacy_walk(),
+            "IO_MUX only changes at MMIO write time"
+        );
+    }
+
+    /// A resumed machine must keep its pull-ups: `restore` writes through the
+    /// SHARED cell, so the GPIO handle taken before the snapshot still sees the
+    /// restored words without any re-wiring step.
+    #[test]
+    fn runtime_snapshot_restores_pad_words_through_the_shared_cell() {
+        let mut original = Esp32s3IoMux::new();
+        original.write_u32(PIN_CTRL, 0x0000_0321).unwrap();
+        // GPIO6 keeps its pull-up; GPIO7 has it cleared.
+        original.write_u32(GPIO0 + 7 * 4, 0x0000_0A00).unwrap();
+        original.write_u32(DATE, 0x0BAD_C0DE).unwrap();
+        let blob = original.runtime_snapshot();
+
+        let mut resumed = Esp32s3IoMux::new();
+        // Take the handle BEFORE the restore, exactly as bus wiring does.
+        let mut gpio = crate::peripherals::esp32s3::gpio::Esp32s3Gpio::new();
+        gpio.set_pad_controls(resumed.pad_controls());
+        resumed.restore_runtime_snapshot(&blob).unwrap();
+
+        assert_eq!(resumed.read_u32(PIN_CTRL).unwrap(), 0x0000_0321);
+        assert_eq!(resumed.read_u32(DATE).unwrap(), 0x0BAD_C0DE);
+        assert!(resumed.fun_pull_up(6));
+        assert!(!resumed.fun_pull_up(7));
+        assert_eq!(
+            gpio.read_gpio_input(6),
+            Some(true),
+            "the pre-snapshot GPIO handle sees the restored pull-up"
+        );
+        assert_eq!(gpio.read_gpio_input(7), Some(false));
+    }
+
+    #[test]
+    fn json_snapshot_round_trips() {
+        let mut original = Esp32s3IoMux::new();
+        original.write_u32(GPIO0 + 9 * 4, 0x0000_1B02).unwrap();
+        let json = original.snapshot();
+
+        let mut resumed = Esp32s3IoMux::new();
+        resumed.restore(json).unwrap();
+        assert_eq!(resumed.pin_func(9), 0x0000_1B02);
     }
 }

--- a/crates/core/src/system/xtensa/esp32s3.rs
+++ b/crates/core/src/system/xtensa/esp32s3.rs
@@ -745,6 +745,12 @@ pub(crate) fn register_esp32s3_peripherals(bus: &mut SystemBus, opts: &Esp32s3Op
     // `from_config` alone would be green in test and dark in production.
     bus.wire_esp32s3_spi_pads();
     bus.wire_esp32s3_uart_pads();
+
+    // Share the IO_MUX per-pad register bank with GPIO now that both models
+    // exist, so a `FUN_WPU` write (Arduino `INPUT_PULLUP`) changes the level a
+    // released pad reports. Without this the pad words are write-only storage
+    // and every button-to-GND lab reads permanently pressed.
+    bus.wire_esp32s3_pad_controls();
 }
 
 /// Register the default thunk set for esp-hal hello-world boot.

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -17,7 +17,7 @@ The models column is a content digest over everything that board's `models` list
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `6133dbb43b2146b1` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `231a8d9a589b5f73` | ⚠ drift acked 2026-08-13 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `26750bfeb2971fa2` | ⚠ drift acked 2026-08-13 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `4d606be758f78b6f` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `768410642d3ff358` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `1944e48e1e75ed3b` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a8c9baa90cb2a903` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `9637527458c15225` | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -2724,7 +2724,25 @@ boards:
     # (UART0/GPIO/I2C0/RMT/MCPWM0/TIMG0/SYSTIMER/GDMA/SYSTEM/RTC_CNTL) moves.
     # Owner-acked without a live capture; the re-captures owed above are NOT
     # discharged by this line and remain owed.
-    drift_ack_digest: 4d606be758f78b6fb2900472b1a01aa5f5498ba0f25d43c4e01774da28323348
+    # 2026-08-21: IO_MUX FUN_WPU modelled, so INPUT_PULLUP reads high. Unlike
+    # most acks above this one DOES move reset values, and says so: the pad
+    # bank moves from offset 0 to 0x04 (SVD `GPIO%s`, dim 49 — the old model
+    # sat one register low across the whole bank, leaving IO_MUX_GPIO48_REG and
+    # DATE unreachable) and each pad's cold reset becomes 0x0000_0B00 instead
+    # of 0, per the SVD's resetValue for that array.
+    #
+    # IO_MUX is NOT one of the nine captured windows (UART0/GPIO/I2C0/RMT/
+    # MCPWM0/TIMG0/SYSTIMER/GDMA/SYSTEM/RTC_CNTL), so the 2026-08-09 live
+    # capture neither confirms nor contradicts these values — do not read this
+    # ack as silicon evidence. The authority is tests/fixtures/svd/esp32s3.svd,
+    # the same file svd_conformance and register_coverage already treat as the
+    # oracle for this block, and esp32s3_reset_conformance (the nine registers
+    # that ARE anchored to silicon) is unchanged and green.
+    #
+    # A live IO_MUX window read is now owed and is NOT covered by the
+    # re-captures listed above. Until someone runs it, the S3's pad reset state
+    # is SVD-verified, not silicon-verified.
+    drift_ack_digest: 768410642d3ff35844780fdc532dfe37651d6a676de52f86901dce117a83809d
     models:
       - crates/core/src/cpu/xtensa_lx7.rs
       - crates/core/src/decoder/xtensa.rs
@@ -2735,6 +2753,13 @@ boards:
       # UART register map lived outside its own watch list from that date.
       - crates/core/src/peripherals/esp_uart.rs
       - crates/core/src/cpu/xtensa_jit
+      # The S3's peripheral registration itself. The models above can be
+      # perfectly correct and still not be on the bus: this file decides which
+      # ones are constructed and how they are wired to each other, so an edit
+      # that deletes a wiring call un-models a peripheral without touching any
+      # file the list already watched. Added 2026-08-21 with the IO_MUX pad
+      # sharing, whose only wiring call lives here.
+      - crates/core/src/system/xtensa/esp32s3.rs
       - configs/chips/esp32s3.yaml
       # Declarative descriptors the chip yaml wires; the 9-reg reset-state
       # anchor is asserted against their reset_values.


### PR DESCRIPTION
## The defect

On the S3 twin, `pinMode(pin, INPUT_PULLUP); digitalRead(pin)` returns **0** with nothing wired to the pin. Real silicon reads 1.

Measured on the hosted twin, `esp32-s3-devkitc-1-n16r8`, GPIO5 wired to an open button, GPIO6 and GPIO7 unconnected:

```
NOWIRE-PU6=0
WIRED-PU5=0
FLOAT7=0
```

Every button-with-`INPUT_PULLUP` lab on the S3 therefore read **permanently pressed** — including the one embedded in the public getting-started lesson. It fails silently: `pinMode` and `digitalRead` both complete, nothing hangs, nothing faults. Only the value is wrong.

## Root cause

`peripherals/esp32s3/io_mux.rs` was, in its own header comment, *"round-trip storage only"* — it kept each pad's function word in a private `[u32; 49]` that nothing ever read, so the `FUN_WPU` bit Arduino sets had no electrical effect. GPIO built its input word purely from externally driven levels, so a released pin read 0.

## The fix — the C3's model, ported

The ESP32-C3 already gets this right; this is a port, not an invention.

- `Esp32s3IoMux` owns a shared `PadControls = Arc<RwLock<[u32; 49]>>`, hands it out via `pad_controls()`, exposes `fun_pull_up(pin)`.
- `Esp32s3Gpio` computes its input word as `(external_levels & external_drive_mask) | (io_mux_pullup_mask & !external_drive_mask)` — an explicit external drive always beats the weak internal pull-up. `IN` and `IN1` both route through it.
- `wire_esp32s3_pad_controls()` shares the bank after both models exist, from `register_esp32s3_peripherals` (the coded path that actually registers the S3 IO_MUX) and from `from_config`.
- Snapshot/resume writes **through** the shared cell instead of replacing the `Arc`, so a resumed machine keeps its pull-ups with no re-wiring step. A test proves it by taking the GPIO handle *before* the restore.

### Two map bugs the SVD also exposed

The old header claimed `MCU_SEL` [6:4], `FUN_DRV` [10:7], `FUN_PU` 8, `FUN_PD` 7 — self-contradictory (`FUN_DRV` would swallow both pull bits). It was never exercised because nothing read the word.

`tests/fixtures/svd/esp32s3.svd`, peripheral `IO_MUX`, is the in-repo oracle two existing gates already read. It gives `FUN_WPD` 7, `FUN_WPU` 8, `FUN_IE` 9, `FUN_DRV` [11:10], `MCU_SEL` [14:12] — identical to the C3. It also settles:

- **Pad bank was one register low.** `GPIO%s` is at `addressOffset 0x4` (dim 49, stride 4); the old model put pad *n* at `n*4`, i.e. in PIN_CTRL's slot. `IO_MUX_GPIO48_REG` and `DATE` were unreachable.
- **Cold reset is `0x0000_0B00`, not 0.** That is the SVD's single `resetValue` for the array — seeded per the oracle, not blanket-set. The SVD does not model the per-pad variation the S3 datasheet documents (SPI-flash pads, strapping pads) and neither does this; the C3 model carries the identical limitation.

## Verification

All measured on this branch, rebased onto `6bbe680ad`, exit codes read bare.

| Suite | pristine main | with this change |
|---|---|---|
| `cargo test -p labwired-core --lib` | 0 — 3122 passed | **0 — 3130 passed, 0 failed** |
| `--features event-scheduler --lib` | 0 — 3252 passed | 0 — 3260 passed, 0 failed |
| `svd_conformance` / `chip_conformance` / `register_compliance` / `register_coverage` | 0 | **0** |
| `cargo test -p labwired-hw-oracle` | — | 0 — 157 passed |
| `cargo fmt --all -- --check` | — | **0** |
| `cargo clippy -p labwired-core --all-targets -- -D warnings` | — | **0** |

`register_coverage` deltas: **esp32s3 modeled 3338 → 3340** (`IO_MUX_GPIO48_REG` and `DATE` now reachable), **reset_ok 3369 → 3418** (+49 pad words matching the SVD). **Every other chip is unchanged**, rp2040 included.

`tests::downcast_ratchet::the_downcast_count_only_shrinks` stays at its committed ceiling: the wiring helper uses two `iter_mut` type-scans rather than index-then-downcast, adding no new immutable-any call site. Scanning by type rather than by peripheral id also keeps the wiring alive across a rename — a silent no-op there would be invisible.

### Negative control

`effective_input` reverted alone, everything else untouched, edit confirmed present in the tree before running:

```
$ cargo test -p labwired-core --lib peripherals::esp32s3::
EXIT=101
test result: FAILED. 494 passed; 5 failed

esp32s3_input_pullup_releases_a_floating_pin_but_external_drive_wins  FAILED
esp32s3_input_pullup_is_visible_in_the_gpio_in_register               FAILED
esp32s3_input_pullup_reaches_bank_one_through_in1                     FAILED
esp32s3_enabled_output_driver_beats_the_pad_pullup                    FAILED
io_mux::runtime_snapshot_restores_pad_words_through_the_shared_cell   FAILED
esp32s3_gpio_without_io_mux_wiring_reads_undriven_pads_low            ok
esp32s3_pullup_write_does_not_override_a_standing_external_drive      ok
```

`Some(false)` / `0` is the measured defect, reproduced. The two that stay green are the two built to be pre-fix-compatible.

## Not covered

`esp32s3-fixtures` suites (`e2e_esp32s3_faithful_boot`, `openai_deck_s3_boot`) did not run — they need the `+esp` toolchain and report 0 tests / exit 0 without it, which is a green that proves nothing.

## Follow-up

The published lesson currently teaches an explicit 10 k pull-down as a workaround. Once this lands it can go back to the idiomatic `INPUT_PULLUP` form.