### PR TITLE
docs: drop two nav entries for pages that do not exist

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,8 +104,6 @@ nav:
     - ESP32-C3: boards/esp32c3.md
     - ESP32-S3: boards/esp32s3.md
     - nRF52840: boards/nrf52840.md
-    - Arduino Nano 33 BLE: boards/arduino-nano-33-ble.md
-    - Arduino Nano 33 BLE Sense: boards/arduino-nano-33-ble-sense.md
     - XIAO nRF52840 Sense: boards/seeed-xiao-nrf52840-sense.md
     - RP2040: boards/rp2040.md
     - RP2350: boards/rp2350.md


### PR DESCRIPTION
Two lines of config put a **404 in the left nav of every page on docs.labwired.com** — **212 of the 348 broken link instances** found crawling the live site.

```yaml
- Arduino Nano 33 BLE: boards/arduino-nano-33-ble.md
- Arduino Nano 33 BLE Sense: boards/arduino-nano-33-ble-sense.md
```

Neither file exists under `docs/boards/`. MkDocs emits the nav entry verbatim rather than failing, so all **106 published pages** carried two dead links. Both 404 as `.md` **and** as directories — checked live, not inferred.

## Why remove rather than write the pages

Neither board is in a state that documentation could describe honestly:

| board | state |
|---|---|
| `arduino_nano_33_ble` | exists **only** under `configs/**/onboarding/` — mid-onboarding, no validation entry, no docs |
| `arduino_nano_33_ble_sense` | appears **nowhere in this repo** except the `mkdocs.yml` line being removed |

The Sense entry isn't a board with missing docs; it's a nav entry for something that was never added. Writing pages for either would be inventing content. When the boards land, the nav entry comes back with the page it points at.

## Verified

| check | before | after |
|---|---|---|
| nav targets | 85 | 83 |
| nav targets with no file | **2** (exactly these) | **0** |

Control: the neighbouring board entries — `esp32c3`, `nrf52840`, `seeed-xiao-nrf52840-sense`, `rp2040` — all resolve, so the check distinguishes present from absent rather than reporting everything missing.

`mkdocs.yml` still parses (with a loader that tolerates the `pymdownx` Python tags; plain `safe_load` fails identically on unmodified `main`, so that is pre-existing and not introduced here).

## Not in this change

The other **121 broken docs links** are one systemic cause: doc sources use repo-relative paths (`../../configs`, `../../crates`, `../../examples`, `../../scripts`) that resolve on GitHub and nowhere else. Every `/boards/*` page links its own chip and system YAML that way. That wants either a link rewrite to `github.com/.../blob/main/…` or copying the referenced files into the docs tree — a bigger decision than this.