### PR TITLE
feat(efr32): the I²C and SPI buses are now MEASURABLE, not only decodable

### DIFF
--- a/configs/chips/efr32mg26.yaml
+++ b/configs/chips/efr32mg26.yaml
@@ -194,6 +194,24 @@ peripherals:
   # and the board_io pins take their levels from the port DOUTs. On silicon
   # the same writes are load-bearing (VCOM TX reach PB02 only through
   # USART1ROUTE). See the bench note in docs/boards/brd2709a.md.
+  #
+  # ⚠️ TIMERROUTE is NOT in this window, and that is the whole reason
+  # `analogWrite`'s waveform reaches no pad in the twin. Derived from
+  # GPIO_TypeDef the same way the USARTROUTE offsets above were, and
+  # cross-checked against them — the derivation puts USARTROUTE at exactly the
+  # +0x820 this entry already uses, which is what makes the rest believable:
+  #
+  #   GPIO_TIMERROUTE[10]  block +0x6E0, stride 0x20  (TIMER0 at 0x4003C6E0,
+  #                                                    TIMER1 at 0x4003C700)
+  #     ROUTEEN   +0x00   CC0ROUTE +0x04   CC1ROUTE +0x08   CC2ROUTE +0x0C
+  #     CDTI0ROUTE +0x10  CDTI1ROUTE +0x14  CDTI2ROUTE +0x18
+  #
+  # Modelling it is what would make `analogWrite` drive a pad and a PWM trace
+  # measurable. The duty IS already programmed into real TIMER1 CC registers
+  # and is correct on silicon once a route is set; what is missing is the
+  # route, not the timer. Deliberately not modelled here yet — the offsets are
+  # recorded so the next attempt does not re-derive them, and re-deriving is
+  # where a wrong number would come from.
   - id: "gpio_route"
     type: "stub"
     # Same GPIO clock as the port structs — the ROUTE registers live in the

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -1835,6 +1835,16 @@ pub struct Efr32s2I2c {
     /// ABORT. Once set it stays set; BUSY then follows the transfer.
     bus_idle_known: bool,
 
+    /// The routed pads' live SCL/SDA levels, when a GPIO model points at this
+    /// controller. `None` until something routes them, and the narration path
+    /// then costs one branch.
+    #[serde(skip)]
+    lines: Option<std::sync::Arc<PadLines>>,
+    /// Bytes this transaction has put on the wire, `(byte, acked)`, buffered
+    /// until STOP — see [`Efr32s2I2c::wire_flush`].
+    #[serde(skip)]
+    wire_frames: Vec<(u8, bool)>,
+
     #[serde(skip)]
     attached_devices: Vec<RefCell<Box<dyn I2cDevice>>>,
     #[serde(skip)]
@@ -1858,6 +1868,15 @@ impl Default for Efr32s2I2c {
             iflag: Cell::new(0),
             txc: false,
             bus_idle_known: false,
+            // ⚠️ EAGER, unlike the STM32 models' lazy `pad_lines_arc()`. Those
+            // create the cell when GPIO routing asks for it, which is fine for
+            // a PAD probe — there is nothing to see until a pad is muxed. The
+            // WIRE probe is the channel that exists precisely so a bus can be
+            // measured with no routing at all, and it can only resolve a cell
+            // that is already there. Lazy here means `resolve_wire_source`
+            // succeeds and `logic_watch` hands back `None`.
+            lines: Some(std::sync::Arc::new(PadLines::new(I2C_LINES, &[true, true]))),
+            wire_frames: Vec::new(),
             ien: 0,
             expect_address: false,
             is_reading: false,
@@ -1942,6 +1961,83 @@ impl Efr32s2I2c {
     }
 
     /// Resolve `addr` to an attached device index, through `claims_address`.
+    /// The narration cell for this controller's SCL/SDA, created on first use.
+    /// An I²C bus with pull-ups idles high on both lines. Mirrors
+    /// [`L4I2c::pad_lines_arc`].
+    pub(crate) fn pad_lines_arc(&mut self) -> std::sync::Arc<PadLines> {
+        self.lines
+            .get_or_insert_with(|| std::sync::Arc::new(PadLines::new(I2C_LINES, &[true, true])))
+            .clone()
+    }
+
+    pub(crate) fn wire_lines(&self) -> Option<&PadLines> {
+        self.lines.as_deref()
+    }
+
+    /// Record a byte this transaction put on the wire. Buffered, not published.
+    fn wire_push(&mut self, byte: u8, acked: bool) {
+        if self.lines.is_some() {
+            self.wire_frames.push((byte, acked));
+        }
+    }
+
+    /// Core cycles one SCL bit occupies, from `CLKDIV`.
+    ///
+    /// emlib's `I2C_BusFreqSet` inverts
+    /// `f_SCL = f_PCLK / ((N_low + N_high) * (DIV + 1) + 4)`, so one bit is
+    /// `(N_low + N_high) * (DIV + 1) + 4` peripheral clocks. `N_low`/`N_high`
+    /// come from `CTRL.CLHR`: 4:4 standard, 6:3 asymmetric, 11:6 fast.
+    ///
+    /// ⚠️ The core:PCLK ratio is a CONSTANT, exactly as the STM32L4 model does
+    /// it (`CORE_PER_KCLK`). On BRD2709A the descriptor declares `cpu_hz`
+    /// 78 MHz against a 19 MHz peripheral band, so 4. It governs how WIDE the
+    /// published waveform is, never what it decodes to.
+    fn bit_time_cycles(&self) -> u64 {
+        const CORE_PER_PCLK: u64 = 4;
+        // `CTRL.CLHR` is a 2-bit field at bit 4 (`_I2C_CTRL_CLHR_SHIFT`).
+        let (n_low, n_high) = match (self.ctrl >> 4) & 0x3 {
+            1 => (6u64, 3u64),  // ASYMMETRIC
+            2 => (11u64, 6u64), // FAST
+            _ => (4u64, 4u64),  // STANDARD, and the reset value
+        };
+        let div = u64::from(self.clkdiv & 0x1FF);
+        (((n_low + n_high) * (div + 1) + 4) * CORE_PER_PCLK).max(2)
+    }
+
+    /// Publish the completed transaction's waveform onto the routed pads.
+    ///
+    /// The phase model has already exchanged the bytes; this narrates the wire
+    /// activity they imply, so the bus can be MEASURED and not only decoded.
+    ///
+    /// Emitted as one contiguous run ending at the present cycle, for the same
+    /// reason [`L4I2c::wire_flush`] does it: this controller charges no wire
+    /// time at all — every byte crosses inside its register write — so there is
+    /// no room on the timeline to place each frame where it happened. One run
+    /// ending at completion has the right shape, bit rate and contents.
+    /// Narrating byte by byte would stamp later frames in the future, where the
+    /// capture layer collapses them onto a single cycle.
+    fn wire_flush(&mut self) {
+        let Some(lines) = self.lines.clone() else {
+            self.wire_frames.clear();
+            return;
+        };
+        if self.wire_frames.is_empty() {
+            return;
+        }
+        let mut wave = I2cNarrator::new(LINE_SCL, LINE_SDA, self.bit_time_cycles());
+        wave.start();
+        for &(byte, acked) in &self.wire_frames {
+            wave.frame(byte, acked);
+        }
+        wave.stop();
+        self.wire_frames.clear();
+        let now = lines.tap_clock().unwrap_or(0);
+        // A transfer this early in a run has less history behind it than the
+        // waveform needs; the narrator compresses to fit rather than emitting a
+        // spike. The bytes still decode; only the timebase gives.
+        let _fit = wave.emit_ending_at(&lines, now);
+    }
+
     fn resolve(&self, addr: u8) -> Option<usize> {
         self.attached_devices
             .iter()
@@ -1953,6 +2049,10 @@ impl Efr32s2I2c {
         if !self.enabled() {
             return;
         }
+        // A read transaction's first data byte is fetched inside the address
+        // phase, so it is captured here and narrated after the address frame —
+        // the order it goes onto the wire.
+        let mut read_back: Option<u8> = None;
         if self.expect_address {
             self.expect_address = false;
             let addr = byte >> 1;
@@ -1969,6 +2069,7 @@ impl Efr32s2I2c {
                         let b = self.attached_devices[idx].borrow_mut().read();
                         self.rx_byte.set(Some(b));
                         self.set_if(EFR_IF_RXDATAV);
+                        read_back = Some(b);
                     }
                 }
                 None => {
@@ -1980,10 +2081,17 @@ impl Efr32s2I2c {
                 }
             }
             self.txc = true;
-            self.txc = true;
             self.set_if(EFR_IF_TXC | EFR_IF_TXBL);
+            self.wire_push(byte, !self.nacked);
+            if let Some(b) = read_back {
+                // The CONTROLLER acks a byte it takes from the slave; the
+                // narrator draws SDA either way, and the ack bit is what a
+                // decoder reports.
+                self.wire_push(b, true);
+            }
             return;
         }
+        let acked = self.current_target.is_some();
         match self.current_target {
             Some(idx) => {
                 self.attached_devices[idx].borrow_mut().write(byte);
@@ -1993,6 +2101,7 @@ impl Efr32s2I2c {
         }
         self.txc = true;
         self.set_if(EFR_IF_TXC | EFR_IF_TXBL);
+        self.wire_push(byte, acked);
     }
 
     /// A `RXDATA` read: hand over the pending byte. Reading consumes it, so
@@ -2026,6 +2135,7 @@ impl Efr32s2I2c {
                     let b = self.attached_devices[idx].borrow_mut().read();
                     self.rx_byte.set(Some(b));
                     self.set_if(EFR_IF_RXDATAV);
+                    self.wire_push(b, true);
                 }
             }
         }
@@ -2052,6 +2162,9 @@ impl Efr32s2I2c {
             if value & EFR_CMD_STOP != 0 {
                 self.set_if(EFR_IF_MSTOP);
             }
+            // STOP or ABORT ends the transaction, which is when the whole
+            // waveform can be placed on the timeline at once.
+            self.wire_flush();
         }
     }
 
@@ -2208,10 +2321,8 @@ impl I2c {
         match self {
             Self::Stm32F1(i) => Some(i.pad_lines_arc()),
             Self::Stm32L4(i) => Some(i.pad_lines_arc()),
+            Self::Efr32s2(i) => Some(i.pad_lines_arc()),
             Self::Kinetis(_) => None,
-            // No wire model yet: a byte transfers instantly and no SCL edge is
-            // published, so this controller cannot be probed.
-            Self::Efr32s2(_) => None,
         }
     }
 
@@ -2335,13 +2446,10 @@ impl I2c {
 impl crate::Peripheral for I2c {
     fn line_names(&self) -> &'static [&'static str] {
         match self {
+            Self::Stm32F1(_) | Self::Stm32L4(_) | Self::Efr32s2(_) => I2C_LINES,
             // The Kinetis I2C model owns no narration cell, so it publishes no
             // wire — an honest empty answer, not a guess at SCL/SDA.
-            Self::Stm32F1(_) | Self::Stm32L4(_) => I2C_LINES,
-            // Neither the Kinetis nor the EFR32 model owns a narration cell,
-            // so neither publishes a wire — an honest empty answer, not a
-            // guess at SCL/SDA.
-            Self::Kinetis(_) | Self::Efr32s2(_) => &[],
+            Self::Kinetis(_) => &[],
         }
     }
 
@@ -2349,10 +2457,8 @@ impl crate::Peripheral for I2c {
         match self {
             Self::Stm32F1(i) => i.wire_lines(),
             Self::Stm32L4(i) => i.wire_lines(),
+            Self::Efr32s2(i) => i.wire_lines(),
             Self::Kinetis(_) => None,
-            // No wire model yet: a byte transfers instantly and no SCL edge is
-            // published, so this controller cannot be probed.
-            Self::Efr32s2(_) => None,
         }
     }
 

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -189,6 +189,10 @@ const SPI_NRF52_EASYDMA_TOKEN: u32 = 1;
 /// the sequence wraps.
 const SPI_H5_WIRE_TOKEN_FLAG: u32 = 0x8000_0000;
 
+/// Same idea for the EFR32 burst: a flag bit that cannot collide with the
+/// small tokens above.
+const SPI_EFR32_WIRE_TOKEN: u32 = 0x4000_0000;
+
 const fn h5_wire_token(seq: u32) -> u32 {
     SPI_H5_WIRE_TOKEN_FLAG | (seq & 0x7FFF_FFFF)
 }
@@ -1012,6 +1016,9 @@ pub struct Spi {
     efr32_wire_bytes: Vec<u8>,
     #[serde(skip)]
     efr32_wave_cursor: u64,
+    /// A publication wakeup is already armed for the held burst.
+    #[serde(skip)]
+    efr32_scheduled: bool,
 
     /// Classic/FIFO STM32 RXNE is **clear-on-DR-read** (RM0008 / RM0351).
     /// `Peripheral::read` is `&self`, so the flag lives in a `Cell` and SR
@@ -1364,6 +1371,28 @@ impl Spi {
     /// really does have its own moment, and the sketch's own delays between
     /// them are real wire idle. Emitting per byte puts each frame where it
     /// happened instead of collapsing a paced transfer into one block.
+    /// Cycles the held EFR32 burst still needs before the wire could have
+    /// carried it. 0 when it is due now or nothing is held.
+    fn efr32_wire_pending_cycles(&self) -> u64 {
+        if self.efr32_wire_bytes.is_empty() {
+            return 0;
+        }
+        let Some(lines) = self.lines.as_ref() else {
+            return 0;
+        };
+        let Some(framing) = self.efr32_framing() else {
+            return 0;
+        };
+        let Some(now) = lines.pad_lines().tap_clock() else {
+            return 0;
+        };
+        let duration =
+            self.efr32_wire_bytes.len() as u64 * framing.frame_bits() * self.efr32_sck_bit_cycles();
+        self.efr32_wave_cursor
+            .saturating_add(duration)
+            .saturating_sub(now)
+    }
+
     fn efr32_wire_push(&mut self, mosi: u8) {
         if self.lines.is_none() || self.efr32_framing().is_none() {
             return;
@@ -1418,6 +1447,7 @@ impl Spi {
             _ => {
                 self.efr32_wave_cursor = now;
                 self.efr32_wire_bytes.clear();
+                self.efr32_scheduled = false;
             }
         }
     }
@@ -2784,6 +2814,17 @@ impl crate::Peripheral for Spi {
             self.h5_scheduled = true;
             return vec![(self.h5_wire_ready_in(), h5_wire_token(self.h5_arm_seq))];
         }
+        // ⚠️ The EFR32 burst needs the SAME wakeup, and for a reason that only
+        // shows up under `event-scheduler`: with the feature on, the legacy
+        // walk skips this model, so the `tick_elapsed` retry never runs and a
+        // burst written back-to-back stays held forever. Measured — the
+        // `bus_visibility` ratchet decoded ONE byte of three (`[53]` of
+        // `[53, 1c, e1]`) with the feature on and all three with it off, which
+        // is a feature flag changing what a trace says.
+        if !self.efr32_wire_bytes.is_empty() && !self.efr32_scheduled {
+            self.efr32_scheduled = true;
+            return vec![(self.efr32_wire_pending_cycles(), SPI_EFR32_WIRE_TOKEN)];
+        }
         Vec::new()
     }
 
@@ -2798,6 +2839,17 @@ impl crate::Peripheral for Spi {
                 self.do_nrf52_easydma(bus);
             }
             return crate::sched::EventResult::default();
+        }
+        if event_token == SPI_EFR32_WIRE_TOKEN {
+            self.efr32_wire_flush();
+            let pending = !self.efr32_wire_bytes.is_empty();
+            self.efr32_scheduled = pending;
+            return crate::sched::EventResult {
+                // Ask for the wire time the burst still needs, floored at one
+                // cycle so a held burst always converges instead of spinning.
+                reschedule_delay: pending.then(|| self.efr32_wire_pending_cycles().max(1)),
+                ..Default::default()
+            };
         }
         if event_token & SPI_H5_WIRE_TOKEN_FLAG != 0 {
             if event_token != h5_wire_token(self.h5_arm_seq) {

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -880,6 +880,13 @@ const EFR_USART_IEN: u64 = 0x4C;
 
 const EFR_USART_EN_EN: u32 = 1 << 0;
 const EFR_USART_CTRL_SYNC: u32 = 1 << 0;
+/// `CTRL.CLKPOL` — the level SCK rests at between frames (SPI's CPOL).
+const EFR_USART_CTRL_CLKPOL: u32 = 1 << 8;
+/// `CTRL.CLKPHA` — which clock edge samples (SPI's CPHA).
+const EFR_USART_CTRL_CLKPHA: u32 = 1 << 9;
+/// `CTRL.MSBF` — MSB first. The narrator draws MSB-first only, so an LSB-first
+/// frame publishes no waveform rather than a wrong one.
+const EFR_USART_CTRL_MSBF: u32 = 1 << 10;
 const EFR_USART_CMD_RXEN: u32 = 1 << 0;
 const EFR_USART_CMD_RXDIS: u32 = 1 << 1;
 const EFR_USART_CMD_TXEN: u32 = 1 << 2;
@@ -988,6 +995,23 @@ pub struct Spi {
     rx_fifo: bool,
     /// Bytes sitting in the modelled RX FIFO (FIFO layout only).
     rx_fifo_level: u8,
+
+    /// MOSI bytes this EFR32 USART has shifted but not yet narrated, and the
+    /// cycle an earlier flush of this same wire already ran to.
+    ///
+    /// ⚠️ BUFFERED, not per byte. Narrating each `TXDATA` write on its own
+    /// looked right — firmware writes a Series-2 USART a byte at a time, so
+    /// each byte really does have its own moment — and it is wrong the moment
+    /// firmware writes two bytes without stepping the machine between them.
+    /// Every frame then lands on the same cycle and they stack: the
+    /// `bus_visibility` ratchet decoded three bytes as ONE (`[c1]` from
+    /// `[53, 1c, e1]`), which is a waveform describing a transfer that never
+    /// happened. Buffering and emitting the run between the cursor and now is
+    /// what the H5 path already does, for the same reason.
+    #[serde(skip)]
+    efr32_wire_bytes: Vec<u8>,
+    #[serde(skip)]
+    efr32_wave_cursor: u64,
 
     /// Classic/FIFO STM32 RXNE is **clear-on-DR-read** (RM0008 / RM0351).
     /// `Peripheral::read` is `&self`, so the flag lives in a `Cell` and SR
@@ -1160,13 +1184,25 @@ impl Spi {
             SpiRegisterLayout::KinetisDspi => SpiRegs::KinetisDspi(KinetisDspiRegs::default()),
             SpiRegisterLayout::Efr32s2Usart => SpiRegs::Efr32s2Usart(Efr32s2SpiRegs::default()),
         };
-        Self {
+        // ⚠️ The EFR32 line cell is created EAGERLY, unlike every other layout
+        // here. The others get theirs when GPIO routing calls
+        // `line_levels_arc()`, which is enough for a PAD probe — nothing is
+        // visible on a pad until one is muxed. The WIRE probe exists precisely
+        // so a bus can be measured with NO routing, and it can only resolve a
+        // cell that already exists: lazy here means `resolve_wire_source`
+        // succeeds and `logic_watch` hands back `None`.
+        let efr32 = matches!(regs, SpiRegs::Efr32s2Usart(_));
+        let mut spi = Self {
             regs,
             rx_fifo,
             rx_fifo_level: 0,
             cr2_mask,
             ..Default::default()
+        };
+        if efr32 {
+            let _ = spi.line_levels_arc();
         }
+        spi
     }
 
     pub fn set_loopback(&mut self, on: bool) {
@@ -1273,6 +1309,119 @@ impl Spi {
     /// bit-reversed byte — the single most damaging way to get a waveform
     /// wrong. A gap is honest; a reversed byte is not. LsbFirst joins the
     /// narrator when the narrator can draw it.
+    /// Frame shape for the EFR32 Series-2 USART in synchronous mode, read from
+    /// the live `CTRL`.
+    ///
+    /// Returns `None` when `MSBF` is clear: [`SpiNarrator`] draws MSB-first
+    /// only, and a bit order it cannot draw publishes nothing rather than a
+    /// waveform that decodes to a different byte than the one that moved.
+    fn efr32_framing(&self) -> Option<SpiFraming> {
+        let ctrl = match &self.regs {
+            SpiRegs::Efr32s2Usart(r) => r.ctrl,
+            _ => return None,
+        };
+        if ctrl & EFR_USART_CTRL_MSBF == 0 {
+            return None;
+        }
+        Some(SpiFraming {
+            cpol: ctrl & EFR_USART_CTRL_CLKPOL != 0,
+            cpha: ctrl & EFR_USART_CTRL_CLKPHA != 0,
+            // `FRAME.DATABITS` is modelled as the 8-bit reset value; this
+            // controller's transfer path is byte-wide, so a wider programmed
+            // frame would not have moved wider data either.
+            bits: 8,
+        })
+    }
+
+    /// Core cycles one SCK bit occupies, from `CLKDIV`.
+    ///
+    /// `f_SCK = f_PCLK / (2 * (1 + CLKDIV/256))` — the reference-manual form
+    /// emlib's `USART_BaudrateSyncSet` inverts. CLKDIV's fractional field lives
+    /// at bits 3..20, so the integer part of `CLKDIV/256` is `(clkdiv >> 8)`.
+    ///
+    /// ⚠️ The core:PCLK ratio is a CONSTANT here, exactly as the STM32L4 model
+    /// does it (`CORE_PER_KCLK`). On BRD2709A the descriptor declares
+    /// `cpu_hz` 78 MHz against a 19 MHz peripheral band, so 4. This governs
+    /// how WIDE the published waveform is on the timeline, never what it
+    /// decodes to — the bytes are the bytes the transfer moved.
+    fn efr32_sck_bit_cycles(&self) -> u64 {
+        let clkdiv = match &self.regs {
+            SpiRegs::Efr32s2Usart(r) => u64::from(r.clkdiv),
+            _ => return 2,
+        };
+        const CORE_PER_PCLK: u64 = 4;
+        let pclk_per_bit = 2 * (1 + (clkdiv >> 8));
+        (pclk_per_bit * CORE_PER_PCLK).max(2)
+    }
+
+    /// Publish one completed EFR32 byte onto the routed pads.
+    ///
+    /// ⚠️ Narrated PER BYTE, not per burst — the opposite of the nRF and H5
+    /// paths above, and for a reason that is a property of this controller.
+    /// Those move a whole DMA buffer inside one register write, so their frames
+    /// have no distinct moments to be placed at and are emitted as one run. A
+    /// Series-2 USART is written a byte at a time by firmware, so every byte
+    /// really does have its own moment, and the sketch's own delays between
+    /// them are real wire idle. Emitting per byte puts each frame where it
+    /// happened instead of collapsing a paced transfer into one block.
+    fn efr32_wire_push(&mut self, mosi: u8) {
+        if self.lines.is_none() || self.efr32_framing().is_none() {
+            return;
+        }
+        self.efr32_wire_bytes.push(mosi);
+        self.efr32_wire_flush();
+    }
+
+    /// Publish whatever is buffered, if the timeline has room for it.
+    ///
+    /// `emit_between` refuses to reach back past the cursor — the cycle the
+    /// last flush already drew to — so a burst written back-to-back stays
+    /// buffered until enough cycles have passed to draw it, and then goes out
+    /// as one contiguous run. That is the difference between a trace that
+    /// decodes to the bytes that moved and three frames stacked on one cycle.
+    fn efr32_wire_flush(&mut self) {
+        if self.efr32_wire_bytes.is_empty() {
+            return;
+        }
+        let Some(lines) = self.lines.clone() else {
+            self.efr32_wire_bytes.clear();
+            return;
+        };
+        let Some(framing) = self.efr32_framing() else {
+            return;
+        };
+        let pads = lines.pad_lines();
+        let now = pads.tap_clock().unwrap_or(0);
+        let mut wave = SpiNarrator::with_lines(
+            SpiSignal::Sck as usize,
+            SpiSignal::Mosi as usize,
+            // Series 2 can route a hardware CS, but the Arduino path drives it
+            // from a plain GPIO and no chip config maps the hardware one — so
+            // there is no CS wire to narrate rather than an assumed one.
+            None,
+            &[
+                pads.level(SpiSignal::Sck as usize),
+                pads.level(SpiSignal::Mosi as usize),
+                pads.level(SpiSignal::Miso as usize),
+            ],
+            self.efr32_sck_bit_cycles(),
+        );
+        for &byte in &self.efr32_wire_bytes {
+            wave.frame(u16::from(byte), framing);
+        }
+        match wave.emit_between(pads, self.efr32_wave_cursor, now) {
+            NarrationFit::LevelsOnly { .. } => {
+                // No room on the timeline yet: hold the bytes and try again
+                // once the machine has stepped. Drawing now would compress the
+                // run onto a single cycle.
+            }
+            _ => {
+                self.efr32_wave_cursor = now;
+                self.efr32_wire_bytes.clear();
+            }
+        }
+    }
+
     fn nrf52_framing(&self) -> Option<SpiFraming> {
         let config = match &self.regs {
             SpiRegs::Nrf52(r) => r.config,
@@ -1815,6 +1964,7 @@ impl Spi {
                     r.iflag |= EFR_USART_IF_TXC | EFR_USART_IF_TXBL | EFR_USART_IF_RXDATAV;
                     r.txc = true;
                 }
+                self.efr32_wire_push(mosi);
             }
             EFR_USART_IF => {
                 // Write-1-to-clear, the Series-2 convention.
@@ -2124,6 +2274,7 @@ impl Spi {
             let cpol = match &self.regs {
                 SpiRegs::Stm32(r) => r.cr1 & (1 << 1) != 0,
                 SpiRegs::Nrf52(r) => r.config & NRF52_CONFIG_CPOL != 0,
+                SpiRegs::Efr32s2Usart(r) => r.ctrl & EFR_USART_CTRL_CLKPOL != 0,
                 _ => false,
             };
             self.lines = Some(Arc::new(SpiLineLevels::new(cpol)));
@@ -2338,17 +2489,16 @@ impl Spi {
 }
 
 impl crate::Peripheral for Spi {
+    /// EVERY layout here publishes SCK/MOSI/MISO now.
+    ///
+    /// The EFR32 USART-as-SPI path was the last exception, and it did not
+    /// publish until 2026-08-22: a frame completed inside the `TXDATA` write
+    /// and no edge existed, so naming the lines would have been a pad-table row
+    /// promising a trace that stayed flat — which is what `bus_visibility`
+    /// exists to catch. `efr32_wire_flush` is what earns the names, and the
+    /// match this used to need went with it.
     fn line_names(&self) -> &'static [&'static str] {
-        match &self.regs {
-            // The EFR32 USART-as-SPI path owns no narration cell: a frame
-            // completes inside the TXDATA write and no SCK edge is published,
-            // so it publishes NO line names either. Naming lines it cannot
-            // drive is what `bus_visibility` exists to catch — a pad table row
-            // that answers "what could ever be seen here" while the trace stays
-            // flat. See the module header's idealisation list.
-            SpiRegs::Efr32s2Usart(_) => &[],
-            _ => SPI_LINES,
-        }
+        SPI_LINES
     }
 
     fn wire_lines(&self) -> Option<&PadLines> {
@@ -2776,6 +2926,15 @@ impl crate::Peripheral for Spi {
         // `h5_wire_pending_cycles`.
         if !self.h5_wire_words.is_empty() && self.h5_wire_pending_cycles() == 0 {
             self.h5_wire_flush(true);
+        }
+
+        // ── EFR32 Series-2 USART: publish any buffered SPI burst ─────────────
+        // The bytes are held until the timeline has room for them (see
+        // `efr32_wire_flush`), and firmware that writes a burst and then stops
+        // writing would otherwise never trigger a retry. Inert — one
+        // `is_empty` check — on every other layout.
+        if !self.efr32_wire_bytes.is_empty() {
+            self.efr32_wire_flush();
         }
 
         crate::PeripheralTickResult {

--- a/crates/core/tests/bus_visibility.rs
+++ b/crates/core/tests/bus_visibility.rs
@@ -362,7 +362,17 @@ fn enable_clock(machine: &mut Machine<CortexM>, peri_name: &str) {
     let Some(gate) = machine.bus.peripherals[idx].clock_gate.as_ref() else {
         return;
     };
-    let Some(rcc_idx) = machine.bus.find_peripheral_index_by_name("rcc") else {
+    // ⚠️ NOT just "rcc". The engine's own list is `CLOCK_CONTROLLER_IDS`
+    // (`bus/routing.rs`) — rcc / cmu / rcu — and a gate offset is relative to
+    // whichever of those a chip actually declares. Looking only for "rcc"
+    // silently returned here on a Silicon Labs part, so `enable_clock` was a
+    // no-op, the peripheral stayed gated and mute, and the ratchet reported
+    // "named line(s) produced no edges" — which reads as a broken narrator
+    // rather than a harness that never turned the clock on.
+    let Some(rcc_idx) = ["rcc", "cmu", "rcu"]
+        .iter()
+        .find_map(|id| machine.bus.find_peripheral_index_by_name(id))
+    else {
         return;
     };
     let rcc_base = machine.bus.peripherals[rcc_idx].base;
@@ -555,6 +565,10 @@ enum Family {
     Nrf52,
     Esp32c3,
     Esp32,
+    /// Silicon Labs EFR32 Series 2. ⚠️ "SPI" here is a USART with `CTRL.SYNC` —
+    /// the part has no separate SPI peripheral — so both kinds land in the same
+    /// arm and drive different register blocks of the same shape.
+    Efr32s2,
     Unknown,
 }
 
@@ -576,6 +590,8 @@ fn family_of(chip: &str) -> Family {
         Family::Esp32c3
     } else if chip == "esp32" {
         Family::Esp32
+    } else if chip.starts_with("efr32") {
+        Family::Efr32s2
     } else {
         Family::Unknown
     }
@@ -738,6 +754,20 @@ fn drive_uart(
                 .write_u32(inst.base, (1 << 0) | (1 << 3) | (1 << 2)); // CR1 if V2
             2082u64 // 694 * 240/80
         }
+        Family::Efr32s2 => {
+            // Not reached today: `efr32mg26`'s UART carries an EXCLUSIONS row,
+            // and `is_excluded` is consulted before this function. Kept, and
+            // saying the same thing that row says, so that deleting the row
+            // (the day the async path narrates) fails with the real reason
+            // rather than "no UART bring-up for family of chip".
+            return KindResult::Unsupported {
+                instance: inst.name.clone(),
+                reason: "EFR32 Series-2 USART in ASYNC mode narrates nothing — only the \
+                         SYNC (SPI) path publishes a wire, and no baud divisor is \
+                         captured, so there is no bit time to decode against"
+                    .into(),
+            };
+        }
         Family::Unknown => {
             return KindResult::Unsupported {
                 instance: inst.name.clone(),
@@ -885,6 +915,9 @@ fn transmit_uart_bytes(machine: &mut Machine<CortexM>, data_reg: u64) -> bool {
 /// into a no-op while still compiling (see DoD item 5).
 fn transmit_uart(family: Family, machine: &mut Machine<CortexM>, inst: &BusInstance) -> bool {
     match family {
+        // Never reached: `drive_uart` returns Unsupported for this family
+        // before the transmit step.
+        Family::Efr32s2 => false,
         Family::Stm32F1 | Family::Stm32V2 | Family::Stm32H5 => {
             // Covered by drive_uart_stm32 / transmit_uart_bytes.
             transmit_uart_bytes(machine, inst.base + 0x28)
@@ -1063,6 +1096,15 @@ fn drive_spi(
             let _ = machine.bus.write_u32(inst.base + 0x1C, 1 << 27); // USR_MOSI
             let _ = machine.bus.write_u32(inst.base + 0x34, 0); // PIN
         }
+        Family::Efr32s2 => {
+            // ⚠️ `CTRL.SYNC` is what makes this USART a SPI at all, and MSBF is
+            // the only bit order the narrator draws. CMD then enables master +
+            // TX. `GPIO_USARTROUTE` is deliberately NOT written.
+            let _ = machine.bus.write_u32(inst.base + 0x04, 1); // EN
+            let _ = machine.bus.write_u32(inst.base + 0x08, 1 | (1 << 10)); // CTRL SYNC|MSBF
+            let _ = machine.bus.write_u32(inst.base + 0x14, (1 << 4) | (1 << 2));
+            // CMD
+        }
         Family::Unknown => {
             return KindResult::Unsupported {
                 instance: inst.name.clone(),
@@ -1093,6 +1135,14 @@ fn drive_spi(
 
 fn transmit_spi(family: Family, machine: &mut Machine<CortexM>, inst: &BusInstance) -> bool {
     match family {
+        Family::Efr32s2 => {
+            // A frame completes inside the TXDATA write and is narrated there,
+            // so each byte is one write and no status poll is needed.
+            for &b in &PAYLOAD {
+                let _ = machine.bus.write_u32(inst.base + 0x3C, u32::from(b));
+            }
+            true
+        }
         Family::Stm32F1 | Family::Stm32V2 => {
             let dr = inst.base + 0x0C;
             let sr = inst.base + 0x08;
@@ -1295,6 +1345,13 @@ fn drive_i2c(
             let _ = machine.bus.write_u32(inst.base, 400); // SCL_LOW
             let _ = machine.bus.write_u32(inst.base + 0x38, 400); // SCL_HIGH
         }
+        Family::Efr32s2 => {
+            // CLKDIV at reset is 0, which the model reads as the slowest
+            // standard-mode bit time — enough edges to measure. EN is the only
+            // register a transfer needs; `GPIO_I2CROUTE` is deliberately NOT
+            // written, which is the difference between this and a pad probe.
+            let _ = machine.bus.write_u32(inst.base + 0x04, 1); // EN
+        }
         Family::Unknown => {
             return KindResult::Unsupported {
                 instance: inst.name.clone(),
@@ -1380,6 +1437,19 @@ fn transmit_i2c(family: Family, machine: &mut Machine<CortexM>, inst: &BusInstan
             for _ in 0..50_000 {
                 let _ = machine.step();
             }
+            true
+        }
+        Family::Efr32s2 => {
+            // START, address+W, the payload, STOP — the sequence emlib's
+            // `I2C_TransferInit` drives, byte at a time through TXDATA.
+            let _ = machine.bus.write_u32(inst.base + 0x0C, 1 << 0); // CMD.START
+            let _ = machine
+                .bus
+                .write_u32(inst.base + 0x34, u32::from(I2C_ADDR) << 1);
+            for &b in &PAYLOAD {
+                let _ = machine.bus.write_u32(inst.base + 0x34, u32::from(b));
+            }
+            let _ = machine.bus.write_u32(inst.base + 0x0C, 1 << 1); // CMD.STOP
             true
         }
         Family::Rp2040 => {

--- a/crates/core/tests/logic_wire_channels_cross_family.rs
+++ b/crates/core/tests/logic_wire_channels_cross_family.rs
@@ -308,6 +308,208 @@ fn a_wire_probe_reads_the_esp32c3_i2c_bus_with_no_gpio_matrix_routing() {
     );
 }
 
+// ── EFR32MG26 (Silicon Labs BRD2709A) ───────────────────────────────────────
+
+/// `CMU_CLKEN0` — the clock gate for every peripheral in group 0.
+const CMU_CLKEN0: u64 = 0x4000_8064;
+/// `_CMU_CLKEN0_I2C0_SHIFT`. ⚠️ I2C2/3 are on CLKEN2, so the bit does not
+/// follow the instance number.
+const CLKEN0_I2C0: u32 = 14;
+/// `_CMU_CLKEN0_USART0_SHIFT`.
+const CLKEN0_USART0: u32 = 9;
+
+/// An INDEPENDENT SPI decoder over SCK/MOSI: sample MOSI on the sampling edge
+/// implied by (CPOL, CPHA), MSB first, eight bits per frame. Imports nothing
+/// from `spi_waveform`.
+fn decode_spi(edges: &[LogicEdge], ch_sck: u32, ch_mosi: u32, cpol: bool, cpha: bool) -> Vec<u8> {
+    // CPHA=0 samples on the leading edge, CPHA=1 on the trailing one. The
+    // leading edge is a rise when the clock idles low.
+    let sample_on_rise = cpha == cpol;
+    let (mut sck, mut mosi) = (cpol, false);
+    let mut bits: Vec<bool> = Vec::new();
+    let mut bytes = Vec::new();
+    for edge in edges {
+        let prev_sck = sck;
+        if edge.ch == ch_sck {
+            sck = edge.value;
+        } else if edge.ch == ch_mosi {
+            mosi = edge.value;
+            continue;
+        } else {
+            continue;
+        }
+        let sampling = if sample_on_rise {
+            !prev_sck && sck
+        } else {
+            prev_sck && !sck
+        };
+        if !sampling {
+            continue;
+        }
+        bits.push(mosi);
+        if bits.len() == 8 {
+            bytes.push(bits.iter().fold(0u8, |acc, &b| (acc << 1) | u8::from(b)));
+            bits.clear();
+        }
+    }
+    bytes
+}
+
+/// A SPI device that answers with a known ramp, so a read carries bytes
+/// nothing else could have produced.
+struct SpiRamp {
+    next: u8,
+}
+impl labwired_core::peripherals::spi::SpiDevice for SpiRamp {
+    fn cs_pin(&self) -> &str {
+        // Single device on the bus; the EFR32 path broadcasts, so the label is
+        // only an identity here.
+        "PC00"
+    }
+    fn transfer(&mut self, _mosi: u8) -> u8 {
+        let byte = self.next;
+        self.next = self.next.wrapping_add(0x11);
+        byte
+    }
+}
+
+/// ACCEPTANCE — a Silicon Labs Series 2. `GPIO_I2CROUTE` is NEVER written, so
+/// no pad on this chip is claimed by I2C0 and a pad probe would be correct to
+/// show a flat line. The wire probe reads the bus regardless.
+///
+/// ⚠️ This controller published NOTHING until 2026-08-22: a byte crossed
+/// inside its `TXDATA` write, no SCL edge existed, and `line_names()` returned
+/// an empty slice — an honest answer to a real gap, and a bus a user could
+/// decode but not measure.
+#[test]
+fn a_wire_probe_reads_the_efr32mg26_i2c_bus_with_no_route_written() {
+    // I2C0_S_BASE — ⚠️ 0x4B00_0000, in the low-energy group, NOT with I2C1..3.
+    const I2C_BASE: u64 = 0x4B00_0000;
+    const REG_EN: u64 = 0x04;
+    const REG_CMD: u64 = 0x0C;
+    const REG_TXDATA: u64 = 0x34;
+    const CMD_START: u32 = 1 << 0;
+    const CMD_STOP: u32 = 1 << 1;
+
+    let mut machine = machine_for("efr32mg26");
+    machine
+        .bus
+        .attach_i2c_slave("i2c0", Box::new(Ramp { next: 0x60 }))
+        .expect("attach an I²C slave to the EFR32 controller");
+
+    let initial = watch_wire(&mut machine, "i2c0", &["SCL", "SDA"]);
+    assert_eq!(
+        initial,
+        vec![Some(true), Some(true)],
+        "an idle open-drain I²C wire rests high on both lines",
+    );
+
+    run(&mut machine, 40_000);
+
+    let bus = &mut machine.bus;
+    // ⚠️ The clock gate, and ONLY the clock gate. On Series 2 an ungated
+    // peripheral does not decode at all, so this is the one write a driver
+    // cannot skip — unlike `GPIO_I2CROUTE`, which is never written here and is
+    // what a pad probe would need.
+    bus.write_u32(CMU_CLKEN0, 1 << CLKEN0_I2C0).unwrap();
+    bus.write_u32(I2C_BASE + REG_EN, 1).unwrap();
+    bus.write_u32(I2C_BASE + REG_CMD, CMD_START).unwrap();
+    bus.write_u32(I2C_BASE + REG_TXDATA, u32::from(ADDR) << 1)
+        .unwrap();
+    for byte in ASYMMETRIC {
+        bus.write_u32(I2C_BASE + REG_TXDATA, u32::from(byte))
+            .unwrap();
+    }
+    bus.write_u32(I2C_BASE + REG_CMD, CMD_STOP).unwrap();
+    run(&mut machine, 20_000);
+
+    let edges = machine.logic_read_edges(0).edges;
+    assert!(
+        !edges.is_empty(),
+        "the EFR32 controller transacted a whole frame and a wire probe on \
+         i2c0.SCL/SDA saw nothing",
+    );
+    let frames = decode_i2c(&edges, 0, 1);
+    assert_eq!(
+        frames.first().map(|f| f.0),
+        Some(ADDR << 1),
+        "the first frame on the wire is the 7-bit address with R/W clear; got \
+         {frames:x?}",
+    );
+    let data: Vec<u8> = frames.iter().skip(1).map(|&(byte, _)| byte).collect();
+    assert_eq!(
+        data,
+        ASYMMETRIC.to_vec(),
+        "and then exactly the bytes the controller was given, in order; got \
+         {frames:x?}",
+    );
+}
+
+/// The same claim for the SPI side. ⚠️ On Series 2 "SPI" IS a USART with
+/// `CTRL.SYNC` — there is no separate SPI peripheral — so this exercises the
+/// same register block the console UART model drives, in its other mode.
+///
+/// `GPIO_USARTROUTE` is never written here either.
+#[test]
+fn a_wire_probe_reads_the_efr32mg26_spi_bus_with_no_route_written() {
+    // USART0_S_BASE, the instance the chip yaml declares as `spi0`.
+    const SPI_BASE: u64 = 0x400A_0000;
+    const REG_EN: u64 = 0x04;
+    const REG_CTRL: u64 = 0x08;
+    const REG_CMD: u64 = 0x14;
+    const REG_TXDATA: u64 = 0x3C;
+    const CTRL_SYNC: u32 = 1 << 0;
+    const CTRL_MSBF: u32 = 1 << 10;
+    const CMD_TXEN: u32 = 1 << 2;
+    const CMD_MASTEREN: u32 = 1 << 4;
+
+    let mut machine = machine_for("efr32mg26");
+    machine
+        .bus
+        .attach_spi_device("spi0", Box::new(SpiRamp { next: 0x60 }))
+        .expect("attach a SPI device to the EFR32 USART");
+
+    let initial = watch_wire(&mut machine, "spi0", &["SCK", "MOSI"]);
+    assert_eq!(
+        initial,
+        vec![Some(false), Some(false)],
+        "SCK idles at CPOL, which is low out of reset",
+    );
+
+    run(&mut machine, 40_000);
+
+    let bus = &mut machine.bus;
+    // The clock gate, as above; `GPIO_USARTROUTE` stays unwritten.
+    bus.write_u32(CMU_CLKEN0, 1 << CLKEN0_USART0).unwrap();
+    bus.write_u32(SPI_BASE + REG_EN, 1).unwrap();
+    // SYNC is what makes this block SPI rather than a UART; MSBF is the
+    // Arduino default bit order and the only one the narrator draws.
+    bus.write_u32(SPI_BASE + REG_CTRL, CTRL_SYNC | CTRL_MSBF)
+        .unwrap();
+    bus.write_u32(SPI_BASE + REG_CMD, CMD_MASTEREN | CMD_TXEN)
+        .unwrap();
+    for byte in ASYMMETRIC {
+        machine
+            .bus
+            .write_u32(SPI_BASE + REG_TXDATA, u32::from(byte))
+            .unwrap();
+        run(&mut machine, 4_000);
+    }
+
+    let edges = machine.logic_read_edges(0).edges;
+    assert!(
+        !edges.is_empty(),
+        "the EFR32 USART clocked three frames and a wire probe on \
+         spi0.SCK/MOSI saw nothing",
+    );
+    assert_eq!(
+        decode_spi(&edges, 0, 1, false, false),
+        ASYMMETRIC.to_vec(),
+        "the wire carries exactly the bytes the controller was given, MSB \
+         first, in order",
+    );
+}
+
 // ── nRF52840 ────────────────────────────────────────────────────────────────
 
 /// ACCEPTANCE 4b — an nRF52. `PSEL.TXD` is NEVER written, so no pad on either

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -11,12 +11,12 @@ The models column is a content digest over everything that board's `models` list
 |-------|------|----------------------|--------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `ba3c4a67fbe80199` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `ba3c4a67fbe80199` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `0cb0ba8ff1883581` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `c15842fb89f44fa3` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `4f22db3b82bcf418` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `c53bfb723d8132ad` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `23bad02f3a29021e` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `dcbab21d3b28969d` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `07889aa3ac482e37` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `47fe1e6359927e48` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `5a6d8034822a4abf` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `c80ebff5bd9b5e77` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `fb64424960222e1e` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `b0cce7fc436b9a1e` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `b6fef3a379137d96` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a28b3f47eb11df11` | no silicon capture |
@@ -24,11 +24,11 @@ The models column is a content digest over everything that board's `models` list
 | `rp2040` | ⚪ structural | — | `3c647e77c7572f2f` | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | `c04678006db2db1d` | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `23e65628bdf33cf1` | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `de4ba3a1b0a62400` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `91b07c07b174ed1a` | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `d3630909318c3816` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `49fadd52344a306a` | no silicon capture |
 | `brd2709a` | 🟡 smoke-manual | — | `4a1984fd9d8c2d8a` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
-| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `e3d0199807bd82c8` | no silicon capture |
+| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `32cbdfcebf57531b` | no silicon capture |
 | `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | `45f00f00bf020d1a` | no silicon capture |
 | `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | `b1628f57714f60f9` | no silicon capture |

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -11,12 +11,12 @@ The models column is a content digest over everything that board's `models` list
 |-------|------|----------------------|--------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `ba3c4a67fbe80199` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `ba3c4a67fbe80199` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `c15842fb89f44fa3` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `ecf3c94808a1c1c0` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `4f22db3b82bcf418` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `47fe1e6359927e48` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `5a6d8034822a4abf` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `c80ebff5bd9b5e77` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `fb64424960222e1e` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `9b7d5c1b978677c5` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `99e8a47c91fec9c2` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `ffa229051d49861a` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `6544fb6e994ae216` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `b0cce7fc436b9a1e` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `b6fef3a379137d96` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a28b3f47eb11df11` | no silicon capture |
@@ -24,8 +24,8 @@ The models column is a content digest over everything that board's `models` list
 | `rp2040` | ⚪ structural | — | `3c647e77c7572f2f` | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | `c04678006db2db1d` | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `23e65628bdf33cf1` | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `d3630909318c3816` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `49fadd52344a306a` | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `01e8f135a697a552` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `b2c3b4e4f95d92d2` | no silicon capture |
 | `brd2709a` | 🟡 smoke-manual | — | `4a1984fd9d8c2d8a` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -26,7 +26,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `23e65628bdf33cf1` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `01e8f135a697a552` | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `b2c3b4e4f95d92d2` | no silicon capture |
-| `brd2709a` | 🟡 smoke-manual | — | `4a1984fd9d8c2d8a` | no silicon capture |
+| `brd2709a` | 🟡 smoke-manual | — | `052d4a49ff8f968a` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `32cbdfcebf57531b` | no silicon capture |

--- a/docs/coverage/bus-visibility.json
+++ b/docs/coverage/bus-visibility.json
@@ -4,7 +4,10 @@
     "name": "atmega328p"
   },
   {
-    "buses": [],
+    "buses": [
+      "I2C",
+      "SPI"
+    ],
     "name": "efr32mg26"
   },
   {

--- a/docs/coverage/bus-visibility.md
+++ b/docs/coverage/bus-visibility.md
@@ -45,7 +45,7 @@ Chips that cannot yet produce edges for a bus are listed here with a reason — 
 | Chip | I2C | SPI | UART |
 |------|-----|-----|------|
 | atmega328p | — | — | — |
-| efr32mg26 | — | — | — |
+| efr32mg26 | ✓ | ✓ | — |
 | esp32 | ✓ | — | ✓ |
 | esp32c3 | ✓ | ✓ | ✓ |
 | esp32s3 | — | — | — |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -307,6 +307,13 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
+    #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
     # arms: the I2C IPVERSION constant, and in spi.rs a hand-written `Default`
@@ -500,6 +507,13 @@ boards:
     # a `!(x == 1)` simplification in the IT-block test itself, a feature-gated
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
+    #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
     #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
@@ -819,6 +833,13 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
+    #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
     # arms: the I2C IPVERSION constant, and in spi.rs a hand-written `Default`
@@ -828,7 +849,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 0cb0ba8ff18835815aff0e617d44d8654c713531033211aeee1fad8bb6ea230f
+    drift_ack_digest: c15842fb89f44fa342c10aafa93611f24c2d7b19f7dd319615f1cb894ba51ef6
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -1848,6 +1869,13 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
+    #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
     # arms: the I2C IPVERSION constant, and in spi.rs a hand-written `Default`
@@ -1857,7 +1885,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: c53bfb723d8132ad9f6bc3fc3e93c2e516ef63ccb6e5813503181c9932d2f3cc
+    drift_ack_digest: 47fe1e6359927e483783367e7622ada480e49e9e134b34ed8199331215c3eb58
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2109,6 +2137,13 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
+    #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
     # arms: the I2C IPVERSION constant, and in spi.rs a hand-written `Default`
@@ -2118,7 +2153,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 23bad02f3a29021e98c1a78e62b33b5260cea8cc0a314a539a36e2d975e0cdd9
+    drift_ack_digest: 5a6d8034822a4abfdd80f1de3438eeb33dfd86f1ce18615bd266098e3ffa784c
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2423,6 +2458,13 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
+    #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
     # arms: the I2C IPVERSION constant, and in spi.rs a hand-written `Default`
@@ -2432,7 +2474,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: dcbab21d3b28969d46322a4e740edc71aac521436e1dbf76605532b4a3168d3c
+    drift_ack_digest: c80ebff5bd9b5e7776c34894266ee2643d12b844f55e1fed1109db84679095e1
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2697,6 +2739,13 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
+    # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
+    # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
+    # untouched, these boards never construct the EFR32 variants, and the STM32
+    # waveform gates (`stm32h5_reset_values_match_silicon`, the L4 I²C
+    # narration tests, `bus_visibility` for every stm32 row) pass unchanged.
+    #
     # Re-stamped 2026-08-22 for the EFR32MG26 reset-value corrections. `i2c.rs`
     # and `spi.rs` both moved, and both edits are confined to their `Efr32s2*`
     # arms: the I2C IPVERSION constant, and in spi.rs a hand-written `Default`
@@ -2706,7 +2755,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 07889aa3ac482e376366f9f048c9d1134d5c597e87646e90b4c9728b3dbbb85e
+    drift_ack_digest: fb64424960222e1e05e2cb56bc451418787fc62b80d201315c9f6a409b45e8b7
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     # 2026-08-12: chip yaml adds bxcan1 (type bxcan @ 0x40006400, APB1ENR bit 25) for
     # Arduino matrix L8 loopback. Existing BxCan model; no register-map change to
@@ -3409,7 +3458,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: de4ba3a1b0a624005abbf36a9347e4060c72ba510024f4dabfe95d8122247b74
+    drift_ack_digest: d3630909318c38167fec550b91fff98bec1611a36e080e8ed8f49401fa60f983
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3480,7 +3529,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: 91b07c07b174ed1a10f85b51e6af3d5189cb552d900eb4dfdb393bb91422a2b4
+    drift_ack_digest: 49fadd52344a306a272f68865f7d62223991b452543afa78eff7f4abee333c52
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3556,7 +3605,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: e3d0199807bd82c8a634fd74d3ab987955ca67dc2cfab36ac9d557b571c35d90
+    drift_ack_digest: 3ab34d0f42e59464cff72293c291bc1af218bb8176e431d7638748772c1917d7
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -849,7 +849,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: c15842fb89f44fa342c10aafa93611f24c2d7b19f7dd319615f1cb894ba51ef6
+    drift_ack_digest: ecf3c94808a1c1c01478907261a8e9a796574edfb24872a8e3735c7299be123b
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -1885,7 +1885,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 47fe1e6359927e483783367e7622ada480e49e9e134b34ed8199331215c3eb58
+    drift_ack_digest: 9b7d5c1b978677c572ac6f0e7d3f0bb12bd7295d5333cb5787b8b7ae6f8f9c64
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2153,7 +2153,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 5a6d8034822a4abfdd80f1de3438eeb33dfd86f1ce18615bd266098e3ffa784c
+    drift_ack_digest: 99e8a47c91fec9c2d645815ae01065cd4dd0d713f026d2b456a3488482987f3f
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2474,7 +2474,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: c80ebff5bd9b5e7776c34894266ee2643d12b844f55e1fed1109db84679095e1
+    drift_ack_digest: ffa229051d49861a8356abf8b897191bab1acc4af5bd3aeb01b555c6b6df008e
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2755,7 +2755,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: fb64424960222e1e05e2cb56bc451418787fc62b80d201315c9f6a409b45e8b7
+    drift_ack_digest: 6544fb6e994ae2162df4d48ce5f7391dc3873d85bd6fbd60a767b1689a156716
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     # 2026-08-12: chip yaml adds bxcan1 (type bxcan @ 0x40006400, APB1ENR bit 25) for
     # Arduino matrix L8 loopback. Existing BxCan model; no register-map change to
@@ -3458,7 +3458,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: d3630909318c38167fec550b91fff98bec1611a36e080e8ed8f49401fa60f983
+    drift_ack_digest: 01e8f135a697a5529da1371b837f851a6792ce1211db2bd7583fed234bfd1dd4
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3529,7 +3529,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: 49fadd52344a306a272f68865f7d62223991b452543afa78eff7f4abee333c52
+    drift_ack_digest: b2c3b4e4f95d92d2d855f10988489e93a0c38970713fdec1cc5df37a6ad7135c
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs


### PR DESCRIPTION
Both controllers moved bytes correctly and published nothing. `line_names()`
returned an empty slice on each — an honest answer, and a real gap: a user
could read a transaction in a log and could not put a probe on the bus. This
is the last of the three gaps the BRD2709A onboarding note listed.

Neither narrator is new. `I2cNarrator` and `SpiNarrator` already exist and
already have independent protocol decoders gating them; this is wiring, and
each controller narrates the way its OWN timing model allows:

  * **I²C** buffers frames and flushes on STOP/ABORT, as the STM32L4 path does
    and for the same reason — this controller charges no wire time at all, so
    there is no room on the timeline to place each frame where it happened.
    One contiguous run ending at completion has the right shape, rate and
    contents. Bit time comes from `CLKDIV` and `CTRL.CLHR` through emlib's own
    formula, so a driver that programs 400 kHz gets a 400 kHz trace.
  * **SPI** buffers too, and ⚠️ that is a CORRECTION. Narrating each `TXDATA`
    write on its own looked right — firmware writes a Series-2 USART a byte at
    a time, so each byte has its own moment — and it breaks the instant
    firmware writes two bytes without stepping the machine. Every frame lands
    on the same cycle and they stack: `bus_visibility` decoded three bytes as
    ONE, `[c1]` out of `[53, 1c, e1]`. A waveform describing a transfer that
    never happened is worse than no waveform. It now emits between a cursor and
    now, holding the burst until the timeline has room, which is what the H5
    path already does.

## Two gates, both of which had to be taught something

`logic_wire_channels_cross_family.rs` gains an EFR32 case per bus, each with
its own protocol decoder, each asserting the wire carries the payload with NO
pad routing written — `GPIO_I2CROUTE` and `GPIO_USARTROUTE` are never touched,
so a pad probe would correctly be flat and the wire probe still reads the bus.
Proven able to fail: commenting out either flush reds both.

⚠️ The line cells are created EAGERLY for this family, unlike the lazy
`pad_lines_arc()` everywhere else. Lazy is fine for a PAD probe — nothing is
visible until a pad is muxed. The WIRE probe exists precisely so a bus can be
measured with no routing, and it can only resolve a cell that already exists;
lazily, `resolve_wire_source` succeeds and `logic_watch` hands back `None`.

`bus_visibility.rs` gains the family and its bring-up, and one fix that was
not about EFR32 at all: `enable_clock` looked up a peripheral named `"rcc"`.
The engine's own list is `CLOCK_CONTROLLER_IDS` — rcc / cmu / rcu — so on a
Silicon Labs part it silently returned, the peripheral stayed clock-gated and
mute, and the ratchet reported "named line(s) produced no edges". That reads
as a broken narrator rather than a harness that never turned the clock on.

  efr32mg26 | I2C ✓ | SPI ✓ | UART —

UART keeps its existing exclusion, with its existing reason: the async path
captures no baud divisor, so there is no bit time to decode against.