### PR TITLE
feat(efr32mg26): analogWrite reaches a PAD — GPIO_TIMERROUTE is modelled

### DIFF
--- a/configs/chips/efr32mg26.yaml
+++ b/configs/chips/efr32mg26.yaml
@@ -109,6 +109,15 @@ peripherals:
   # USART1_TX_IRQn = 17 (CMSIS header IRQn enum). The entry carries the TX
   # line; the smoke path is polled and the model's TXEIE/TCIE masks are 0 for
   # this layout, so no UART interrupt is ever pended either way.
+  # USART2, the third instance. CLKEN2 bit 8; `irq` names the TX vector, the
+  # same choice usart1 makes.
+  - id: "usart2"
+    type: "efr32s2_usart"
+    clock: { reg: "clken2", bit: 8 }
+    base_address: 0x400A8000
+    size: "4KB"
+    irq: 19
+
   - id: "usart1"
     type: "efr32s2_usart"
     # CMU_CLKEN2.USART1, bit 7 (`_CMU_CLKEN2_USART1_SHIFT`). USART1 is on
@@ -258,8 +267,15 @@ peripherals:
   # same firmware on the bench. Closing this properly means modelling the clock
   # tree so CLKSEL and the HFRCO band decide it.
   #
-  # TIMER2..9 are deliberately NOT declared: nothing uses them yet, and an
-  # undeclared window faults loudly where a stub would answer zero.
+  # TIMER2..9 ARE declared now, below. They were not, on the reasoning that an
+  # undeclared window faults loudly where a stub would answer zero — which is
+  # right for a peripheral with no model, and wrong for one whose model is
+  # already here. `GPIO_TIMERROUTE` routes all ten; leaving eight of them
+  # unmapped meant a sketch that reached for a second PWM timer hit a bus fault
+  # instead of the model sitting next to the two that worked.
+  #
+  # ⚠️ The clock bits do NOT follow the instance number. TIMER0..4 are CLKEN0
+  # bits 4..8; TIMER5..9 are CLKEN2 bits 0..4. Same trap as I2C0 vs I2C2/3.
   - id: "timer0"
     type: "efr32s2_timer"
     clock: { reg: "clken0", bit: 4 }
@@ -272,6 +288,54 @@ peripherals:
     clock: { reg: "clken0", bit: 5 }
     config: { counter_bits: 32, peripheral_hz: 19_000_000 }
     base_address: 0x4004C000
+    size: "4KB"
+  - id: "timer2"
+    type: "efr32s2_timer"
+    clock: { reg: "clken0", bit: 6 }
+    config: { counter_bits: 16, peripheral_hz: 19_000_000 }
+    base_address: 0x40050000
+    size: "4KB"
+  - id: "timer3"
+    type: "efr32s2_timer"
+    clock: { reg: "clken0", bit: 7 }
+    config: { counter_bits: 16, peripheral_hz: 19_000_000 }
+    base_address: 0x40054000
+    size: "4KB"
+  - id: "timer4"
+    type: "efr32s2_timer"
+    clock: { reg: "clken0", bit: 8 }
+    config: { counter_bits: 16, peripheral_hz: 19_000_000 }
+    base_address: 0x40058000
+    size: "4KB"
+  - id: "timer5"
+    type: "efr32s2_timer"
+    clock: { reg: "clken2", bit: 0 }
+    config: { counter_bits: 16, peripheral_hz: 19_000_000 }
+    base_address: 0x4005C000
+    size: "4KB"
+  - id: "timer6"
+    type: "efr32s2_timer"
+    clock: { reg: "clken2", bit: 1 }
+    config: { counter_bits: 16, peripheral_hz: 19_000_000 }
+    base_address: 0x40060000
+    size: "4KB"
+  - id: "timer7"
+    type: "efr32s2_timer"
+    clock: { reg: "clken2", bit: 2 }
+    config: { counter_bits: 16, peripheral_hz: 19_000_000 }
+    base_address: 0x40064000
+    size: "4KB"
+  - id: "timer8"
+    type: "efr32s2_timer"
+    clock: { reg: "clken2", bit: 3 }
+    config: { counter_bits: 32, peripheral_hz: 19_000_000 }
+    base_address: 0x40068000
+    size: "4KB"
+  - id: "timer9"
+    type: "efr32s2_timer"
+    clock: { reg: "clken2", bit: 4 }
+    config: { counter_bits: 32, peripheral_hz: 19_000_000 }
+    base_address: 0x4006C000
     size: "4KB"
     irq: 5
 
@@ -324,6 +388,23 @@ peripherals:
     base_address: 0x400B0000
     size: "4KB"
     irq: 42
+  # ⚠️ I2C2/3 are on CLKEN2 (bits 9, 10) while I2C0/1 are on CLKEN0 (14, 15).
+  # The clock bit does not follow the instance number on this family, and I2C0
+  # is not even in the same address group — see its entry above.
+  - id: "i2c2"
+    type: "i2c"
+    config: { profile: "efr32s2" }
+    clock: { reg: "clken2", bit: 9 }
+    base_address: 0x400B4000
+    size: "4KB"
+    irq: 43
+  - id: "i2c3"
+    type: "i2c"
+    config: { profile: "efr32s2" }
+    clock: { reg: "clken2", bit: 10 }
+    base_address: 0x400B8000
+    size: "4KB"
+    irq: 44
 
   # ── GPIO external interrupts ─────────────────────────────────────────────
   # The EXTI registers live in the GPIO block HEAD, not in the port structs:

--- a/configs/chips/efr32mg26.yaml
+++ b/configs/chips/efr32mg26.yaml
@@ -31,6 +31,9 @@
 #   mapped.
 #
 # Known divergences from silicon (honest list, L1 smoke target):
+#   - (FIXED) `analogWrite`'s waveform reaches a PAD. `GPIO_TIMERROUTE` is a
+#     real model, so a TIMER compare output is connected to the pin its route
+#     names — the last of the three gaps this board's onboarding note listed.
 #   - (FIXED) CMU and TIMER0 were `type: stub`. Both are real models now, and
 #     the clock gates gate. See `peripherals/efr32/{cmu,timer}.rs`.
 #   - Every register in the seven windows this part's silicon capture covers
@@ -206,12 +209,19 @@ peripherals:
   #     ROUTEEN   +0x00   CC0ROUTE +0x04   CC1ROUTE +0x08   CC2ROUTE +0x0C
   #     CDTI0ROUTE +0x10  CDTI1ROUTE +0x14  CDTI2ROUTE +0x18
   #
-  # Modelling it is what would make `analogWrite` drive a pad and a PWM trace
-  # measurable. The duty IS already programmed into real TIMER1 CC registers
-  # and is correct on silicon once a route is set; what is missing is the
-  # route, not the timer. Deliberately not modelled here yet — the offsets are
-  # recorded so the next attempt does not re-derive them, and re-deriving is
-  # where a wrong number would come from.
+  # (FIXED) That block is modelled now — `gpio_timerroute` above. `analogWrite`
+  # drives a pad, proven end to end in crates/core/tests/efr32mg26_pwm_pad.rs
+  # against this very yaml. What remains a stub here is USARTROUTE, whose
+  # writes still decode and read back zero.
+  # The TIMER route block: REAL, not a stub. This is what makes a timer's
+  # compare output reach a pin — `analogWrite` programmed the correct duty into
+  # real CC registers and lit nothing until this existed.
+  - id: "gpio_timerroute"
+    type: "efr32s2_timerroute"
+    clock: { reg: "clken0", bit: 26 }
+    base_address: 0x4003C6E0
+    size: "320B"
+
   - id: "gpio_route"
     type: "stub"
     # Same GPIO clock as the port structs — the ROUTE registers live in the

--- a/crates/core/src/bus/attach.rs
+++ b/crates/core/src/bus/attach.rs
@@ -1691,7 +1691,6 @@ impl SystemBus {
     /// [`Self::wire_rp2040_uart_pads`].
     pub(crate) fn wire_nrf52_pads(&mut self) {
         use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
-        use crate::peripherals::nrf52::pin_select::NrfPinClaims;
         use crate::peripherals::nrf52::serial_instance::Nrf52SerialInstance;
         use crate::peripherals::nrf52::twim::{LINE_SCL, LINE_SDA};
         use crate::peripherals::nrf52::uarte::{Nrf52Uarte, LINE_TXD};
@@ -1736,14 +1735,14 @@ impl SystemBus {
             return;
         }
 
-        let claims = Arc::new(NrfPinClaims::new());
+        let claims = Arc::new(crate::peripherals::nrf52::pin_select::nrf_pin_claims());
         for &(idx, port) in &ports {
             if let Some(gpio) = self.peripherals[idx]
                 .dev
                 .as_any_mut()
                 .and_then(|a| a.downcast_mut::<GpioPort>())
             {
-                gpio.set_nrf_pin_claims(claims.clone(), port);
+                gpio.set_pad_claims(claims.clone(), port);
             }
         }
 
@@ -1865,6 +1864,168 @@ impl SystemBus {
             for (lines, signals) in &wired {
                 for &(token, line, func) in signals {
                     for pin in 0..32u8 {
+                        gpio.add_pad_route_selector(lines, pin, Some(token), line, func);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Route EFR32 Series-2 TIMER compare outputs to the pads
+    /// `GPIO_TIMERROUTE` names.
+    ///
+    /// # Why a wiring pass at all
+    ///
+    /// `analogWrite` on BRD2709A programmed the right duty into real `CC_OC`
+    /// registers and lit nothing: on Series 2 an output reaches a pin only
+    /// through the GPIO block's ROUTE registers, and nothing modelled them. The
+    /// duty was never the problem.
+    ///
+    /// # Shape
+    ///
+    /// The same shape as [`Self::wire_nrf52_pads`], because the silicon has the
+    /// same shape: the PERIPHERAL names the pad, so a claim token minted here
+    /// is installed in the route block and bound into every port's routing
+    /// table, and that identity IS the routing.
+    ///
+    /// ⚠️ The token comes from
+    /// [`gpio_route::cc_token`](crate::peripherals::efr32::gpio_route::cc_token),
+    /// NOT from a counter of its own. The route block mints the same value when
+    /// firmware writes a route; deriving it twice is how the two halves would
+    /// disagree about which signal a pad carries.
+    pub(crate) fn wire_efr32_timer_pads(&mut self) {
+        use crate::peripherals::efr32::gpio_route::{cc_token, Efr32s2TimerRoute, CC_PER_TIMER};
+        use crate::peripherals::efr32::timer::Efr32s2Timer;
+        use crate::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+        use crate::peripherals::pad_claims::PadClaims;
+        use std::sync::Arc;
+
+        /// TIMER instances by base address — `TIMER0_S_BASE` + n * 0x4000
+        /// (efr32mg26b510f3200im48.h). The index is what `GPIO_TIMERROUTE[n]`
+        /// is indexed by, so it has to match the silicon's numbering and not
+        /// the order a chip yaml happens to declare them in.
+        const TIMER_BASE: u64 = 0x4004_8000;
+        const TIMER_STRIDE: u64 = 0x4000;
+        const TIMER_COUNT: u64 = 10;
+
+        /// ⚠️ FOUR ports of SIXTEEN pads (`GPIO_PORT_x_WIDTH` = 0x10 on the
+        /// IM48), which is not the Nordic 2 x 32. The claim index is computed
+        /// from these, so a wrong pair puts claims on real pads that are not
+        /// the ones firmware named.
+        const PORTS: usize = 4;
+        const PINS_PER_PORT: usize = 16;
+
+        // Port index in `CCnROUTE.PORT` order: A=0, B=1, C=2, D=3.
+        //
+        // Found and handed the table in ONE mutable pass rather than an
+        // immutable filter followed by a mutable loop. Not style:
+        // `downcast_ratchet` counts type-erasure call sites and refuses a rise,
+        // and the two-pass shape spends one for nothing.
+        //
+        // ⚠️ That ratchet counts literal SUBSTRINGS across every source file,
+        // so prose naming either method counts too and a comment alone can red
+        // it. It excludes only its own file, which is why this note talks
+        // around the names rather than quoting them.
+        let claims = Arc::new(PadClaims::new(PORTS, PINS_PER_PORT));
+        let mut ports: Vec<usize> = Vec::new();
+        for idx in 0..self.peripherals.len() {
+            let port = match self.peripherals[idx].name.as_str() {
+                "gpioa" => 0u8,
+                "gpiob" => 1,
+                "gpioc" => 2,
+                "gpiod" => 3,
+                _ => continue,
+            };
+            let Some(gpio) = self.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<GpioPort>())
+            else {
+                continue;
+            };
+            if gpio.register_layout() != GpioRegisterLayout::Efr32s2 {
+                continue;
+            }
+            gpio.set_pad_claims(claims.clone(), port);
+            ports.push(idx);
+        }
+        if ports.is_empty() {
+            return;
+        }
+
+        // The route block publishes claims; without it a route write stores and
+        // moves nothing, which is what this whole pass exists to change.
+        let mut route_installed = false;
+        for entry_idx in 0..self.peripherals.len() {
+            if let Some(route) = self.peripherals[entry_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Efr32s2TimerRoute>())
+            {
+                route.install_claims(claims.clone());
+                route_installed = true;
+            }
+        }
+        if !route_installed {
+            return;
+        }
+
+        type Bindings = (
+            std::sync::Arc<crate::peripherals::pad_lines::PadLines>,
+            Vec<(u32, usize, &'static str)>,
+        );
+        let mut wired: Vec<Bindings> = Vec::new();
+        // Signal names, one per (timer, channel), so a pad table reads
+        // "TIMER1_CC0" rather than a token.
+        const FUNCS: [[&str; CC_PER_TIMER]; 10] = [
+            ["TIMER0_CC0", "TIMER0_CC1", "TIMER0_CC2"],
+            ["TIMER1_CC0", "TIMER1_CC1", "TIMER1_CC2"],
+            ["TIMER2_CC0", "TIMER2_CC1", "TIMER2_CC2"],
+            ["TIMER3_CC0", "TIMER3_CC1", "TIMER3_CC2"],
+            ["TIMER4_CC0", "TIMER4_CC1", "TIMER4_CC2"],
+            ["TIMER5_CC0", "TIMER5_CC1", "TIMER5_CC2"],
+            ["TIMER6_CC0", "TIMER6_CC1", "TIMER6_CC2"],
+            ["TIMER7_CC0", "TIMER7_CC1", "TIMER7_CC2"],
+            ["TIMER8_CC0", "TIMER8_CC1", "TIMER8_CC2"],
+            ["TIMER9_CC0", "TIMER9_CC1", "TIMER9_CC2"],
+        ];
+
+        for entry_idx in 0..self.peripherals.len() {
+            let base = self.peripherals[entry_idx].base;
+            let in_block = (TIMER_BASE..TIMER_BASE + TIMER_STRIDE * TIMER_COUNT).contains(&base);
+            let Some(index) = (in_block && (base - TIMER_BASE) % TIMER_STRIDE == 0)
+                .then(|| ((base - TIMER_BASE) / TIMER_STRIDE) as usize)
+            else {
+                continue;
+            };
+            let Some(timer) = self.peripherals[entry_idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<Efr32s2Timer>())
+            else {
+                continue;
+            };
+            let lines = timer.pad_lines_arc();
+            let signals = (0..CC_PER_TIMER)
+                .map(|ch| (cc_token(index, ch), ch, FUNCS[index][ch]))
+                .collect();
+            wired.push((lines, signals));
+        }
+        if wired.is_empty() {
+            return;
+        }
+
+        for &idx in &ports {
+            let Some(gpio) = self.peripherals[idx]
+                .dev
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<GpioPort>())
+            else {
+                continue;
+            };
+            for (lines, signals) in &wired {
+                for &(token, line, func) in signals {
+                    for pin in 0..PINS_PER_PORT as u8 {
                         gpio.add_pad_route_selector(lines, pin, Some(token), line, func);
                     }
                 }

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -958,6 +958,11 @@ impl SystemBus {
         // publish which pin they claim and the port reads it. No-op for every
         // other chip.
         bus.wire_nrf52_pads();
+        // EFR32 Series 2: same shape as the Nordic pass above and for the same
+        // reason — the pad has no function register, so `GPIO_TIMERROUTE` names
+        // the pin and the port reads that claim. This is what makes
+        // `analogWrite` reach a pad. No-op for every other chip.
+        bus.wire_efr32_timer_pads();
         // Resolve declared per-peripheral RCC clock-gates now that every
         // peripheral (incl. the RCC, needed to map reg-name → offset) is on the
         // bus. Peripherals without a `clock:` field stay ungated.

--- a/crates/core/src/peripherals/efr32/gpio_route.rs
+++ b/crates/core/src/peripherals/efr32/gpio_route.rs
@@ -1,0 +1,313 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! `GPIO_TIMERROUTE[10]` — the pin-mux that decides which pad a TIMER's
+//! compare/capture output reaches.
+//!
+//! # Why this exists
+//!
+//! `analogWrite` on BRD2709A programmed the right duty into real TIMER1 `CC_OC`
+//! registers and lit nothing. The duty was correct, the timer was correct, and
+//! the waveform reached no pad — because on Series 2 a peripheral output is
+//! connected to a pin by the GPIO block's ROUTE registers, and this block was a
+//! read-as-zero stub. Every description of that gap said "unmodelled" and
+//! stopped there.
+//!
+//! # Where the numbers come from
+//!
+//! `GPIO_TypeDef` in `efr32mg26_gpio.h` (simplicity_sdk `sisdk-2025.6`), walked
+//! member by member: `TIMERROUTE[10]` at block `+0x6E0`, stride `0x20`.
+//!
+//! ⚠️ That offset is worth one sentence of provenance, because a first attempt
+//! at it was WRONG and looked fine — a parse that ran across several typedefs
+//! sized `GPIO_I2CROUTE_TypeDef` at 27 words instead of 4 and put this block at
+//! `+0x1018`. What makes `+0x6E0` believable is not the parser: the same walk
+//! puts `USARTROUTE` at exactly the `+0x820` that `configs/chips/efr32mg26.yaml`
+//! has used since onboarding, and sizes PORT/I2CROUTE/TIMERROUTE/USARTROUTE at
+//! 12/4/8/8 words, each countable by eye in the header.
+//!
+//! Field encodings, from the same header:
+//!   * `ROUTEEN.CCnPEN` — bit `n` (`_GPIO_TIMER_ROUTEEN_MASK` = 0x3F: three CC
+//!     plus three CDTI).
+//!   * `CCnROUTE.PORT` — bits [1:0] (`_GPIO_TIMER_CC0ROUTE_PORT_MASK` = 0x3).
+//!   * `CCnROUTE.PIN` — bits [19:16] (`_GPIO_TIMER_CC0ROUTE_PIN_MASK` =
+//!     0xF0000).
+//!
+//! # What is modelled
+//!
+//! The three CC channels per timer: enable bit, port, pin. Writes are stored
+//! and read back, and each one re-points the pad claim so a route programmed
+//! after the timer is already running takes effect immediately.
+//!
+//! NOT modelled: `CDTInROUTE` (dead-time insertion outputs — stored and read
+//! back, claimed by nothing, because no TIMER model here drives them).
+
+use std::sync::Arc;
+
+use crate::peripherals::pad_claims::PadClaims;
+use crate::SimResult;
+
+/// `GPIO_TIMERROUTE[10]`, stride 0x20.
+pub const TIMERROUTE_STRIDE: u64 = 0x20;
+/// Timer instances the block routes. ⚠️ TEN, not the four a reader expects
+/// from TIMER0..3 — this part has TIMER0..9.
+pub const TIMERROUTE_COUNT: usize = 10;
+/// CC channels per timer, the ones a TIMER model can drive.
+pub const CC_PER_TIMER: usize = 3;
+
+/// `ROUTEEN` is word 0 and `CC0..2ROUTE` are words 1..=3 of each timer's
+/// stanza. Named here for the tests, which drive this block the way firmware
+/// does — by offset.
+#[cfg(test)]
+const OFF_ROUTEEN: u64 = 0x00;
+#[cfg(test)]
+const OFF_CC0ROUTE: u64 = 0x04;
+
+/// `CCnROUTE.PORT`, bits [1:0].
+const ROUTE_PORT_MASK: u32 = 0x3;
+/// `CCnROUTE.PIN`, bits [19:16].
+const ROUTE_PIN_SHIFT: u32 = 16;
+const ROUTE_PIN_MASK: u32 = 0xF;
+
+/// The claim token for timer `t`, channel `ch`.
+///
+/// Stable and collision-free against the Nordic tokens, which are minted from
+/// a different table on a different chip — one bus never holds both.
+pub const fn cc_token(timer: usize, ch: usize) -> u32 {
+    (timer as u32) * (CC_PER_TIMER as u32) + ch as u32
+}
+
+/// The GPIO block's TIMER route registers.
+#[derive(Debug, serde::Serialize)]
+pub struct Efr32s2TimerRoute {
+    /// `[timer][0]` = ROUTEEN, `[timer][1..=3]` = CC0/1/2ROUTE, `[4..=6]` =
+    /// CDTI0/1/2ROUTE, `[7]` = the reserved word. Stored verbatim so a read
+    /// returns what firmware wrote.
+    regs: [[u32; 8]; TIMERROUTE_COUNT],
+    #[serde(skip)]
+    claims: Option<Arc<PadClaims>>,
+    /// The pad each (timer, channel) currently holds, so a re-pointed route
+    /// releases the old pad instead of leaking it.
+    #[serde(skip)]
+    held: [[Option<usize>; CC_PER_TIMER]; TIMERROUTE_COUNT],
+}
+
+impl Default for Efr32s2TimerRoute {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Efr32s2TimerRoute {
+    pub fn new() -> Self {
+        Self {
+            regs: [[0; 8]; TIMERROUTE_COUNT],
+            claims: None,
+            held: [[None; CC_PER_TIMER]; TIMERROUTE_COUNT],
+        }
+    }
+
+    /// Join the shared pad-claim table. Config-build time only; without it this
+    /// block still stores and reads back, and claims nothing.
+    pub fn install_claims(&mut self, claims: Arc<PadClaims>) {
+        self.claims = Some(claims);
+    }
+
+    fn index(offset: u64) -> Option<(usize, usize)> {
+        let timer = (offset / TIMERROUTE_STRIDE) as usize;
+        if timer >= TIMERROUTE_COUNT {
+            return None;
+        }
+        Some((timer, ((offset % TIMERROUTE_STRIDE) / 4) as usize))
+    }
+
+    /// Re-point every CC channel of `timer` at whatever its registers now name.
+    ///
+    /// Called after any write into that timer's block, because `ROUTEEN` and
+    /// `CCnROUTE` can move a pad independently and either one alone is enough
+    /// to change where the waveform goes.
+    fn resync(&mut self, timer: usize) {
+        let Some(claims) = self.claims.clone() else {
+            return;
+        };
+        let routeen = self.regs[timer][0];
+        for ch in 0..CC_PER_TIMER {
+            let enabled = routeen & (1 << ch) != 0;
+            let route = self.regs[timer][1 + ch];
+            let want = enabled.then(|| {
+                let port = (route & ROUTE_PORT_MASK) as u8;
+                let pin = ((route >> ROUTE_PIN_SHIFT) & ROUTE_PIN_MASK) as u8;
+                claims.pad_index(port, pin)
+            });
+            if want == self.held[timer][ch] {
+                continue;
+            }
+            let token = cc_token(timer, ch);
+            if let Some(previous) = self.held[timer][ch] {
+                claims.release(previous, token);
+            }
+            if let Some(pad) = want {
+                claims.take(pad, token);
+            }
+            self.held[timer][ch] = want;
+        }
+    }
+
+    fn read_word(&self, offset: u64) -> u32 {
+        Self::index(offset).map_or(0, |(t, w)| self.regs[t][w])
+    }
+
+    fn write_word(&mut self, offset: u64, value: u32) {
+        let Some((t, w)) = Self::index(offset) else {
+            return;
+        };
+        self.regs[t][w] = value;
+        // ROUTEEN (word 0) and CC0..2ROUTE (words 1..=3) move pads; the CDTI
+        // words and the reserved tail are stored and claim nothing.
+        if w <= CC_PER_TIMER {
+            self.resync(t);
+        }
+    }
+}
+
+impl crate::Peripheral for Efr32s2TimerRoute {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word = self.read_word(offset & !3);
+        Ok(((word >> ((offset % 4) * 8)) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let reg = offset & !3;
+        let shift = (offset % 4) * 8;
+        let merged = (self.read_word(reg) & !(0xFFu32 << shift)) | (u32::from(value) << shift);
+        self.write_word(reg, merged);
+        Ok(())
+    }
+
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+
+    /// ⚠️ `as_any_mut`, and NOT `as_any`.
+    ///
+    /// The wiring pass hands this block the claim table through
+    /// `downcast_mut`, and `Peripheral::as_any_mut` DEFAULTS TO `None`. The
+    /// first version of this file implemented `as_any` only: everything
+    /// compiled, every unit test passed, and `install_claims` was never called
+    /// — so routes stored, claimed nothing, and `analogWrite` still lit no pad.
+    /// The end-to-end gate in `efr32mg26_pwm_pad.rs` is what makes that
+    /// impossible to ship again.
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Peripheral;
+
+    fn routed() -> (Efr32s2TimerRoute, Arc<PadClaims>) {
+        let claims = Arc::new(PadClaims::new(4, 16));
+        let mut r = Efr32s2TimerRoute::new();
+        r.install_claims(claims.clone());
+        (r, claims)
+    }
+
+    /// TIMER1 CC0 to PC08 — the route `analogWrite(LED_BUILTIN, …)` needs on
+    /// BRD2709A, where LED0 is PC08.
+    #[test]
+    fn a_routed_channel_claims_the_pad_its_registers_name() {
+        let (mut r, claims) = routed();
+        let base = TIMERROUTE_STRIDE; // TIMER1
+        assert_eq!(claims.selector(2, 8), None, "nothing claims PC08 yet");
+        // CC0ROUTE: PORT=2 (C), PIN=8
+        r.write_u32(base + OFF_CC0ROUTE, 2 | (8 << ROUTE_PIN_SHIFT))
+            .unwrap();
+        assert_eq!(
+            claims.selector(2, 8),
+            None,
+            "a route with ROUTEEN clear drives nothing — the enable is not decorative",
+        );
+        r.write_u32(base + OFF_ROUTEEN, 1).unwrap();
+        assert_eq!(claims.selector(2, 8), Some(cc_token(1, 0)));
+    }
+
+    /// The release path: a re-pointed route must not leave the old pad claimed,
+    /// or a pad handed back to plain GPIO keeps reading the timer.
+    #[test]
+    fn re_pointing_a_route_releases_the_pad_it_held() {
+        let (mut r, claims) = routed();
+        let base = TIMERROUTE_STRIDE;
+        r.write_u32(base + OFF_ROUTEEN, 1).unwrap();
+        r.write_u32(base + OFF_CC0ROUTE, 2 | (8 << ROUTE_PIN_SHIFT))
+            .unwrap();
+        assert_eq!(claims.selector(2, 8), Some(cc_token(1, 0)));
+        r.write_u32(base + OFF_CC0ROUTE, 2 | (9 << ROUTE_PIN_SHIFT))
+            .unwrap();
+        assert_eq!(claims.selector(2, 8), None, "the old pad is given back");
+        assert_eq!(claims.selector(2, 9), Some(cc_token(1, 0)));
+    }
+
+    /// Clearing ROUTEEN gives the pad back too — firmware disabling a PWM
+    /// channel expects the pin to become an ordinary GPIO again.
+    #[test]
+    fn clearing_the_enable_gives_the_pad_back() {
+        let (mut r, claims) = routed();
+        r.write_u32(OFF_ROUTEEN, 1).unwrap();
+        r.write_u32(OFF_CC0ROUTE, 1 | (3 << ROUTE_PIN_SHIFT))
+            .unwrap();
+        assert_eq!(claims.selector(1, 3), Some(cc_token(0, 0)));
+        r.write_u32(OFF_ROUTEEN, 0).unwrap();
+        assert_eq!(claims.selector(1, 3), None);
+    }
+
+    /// Every timer gets its own token, or two timers routed to two pads would
+    /// look like one signal to the port.
+    #[test]
+    fn tokens_are_unique_per_timer_and_channel() {
+        let mut seen = std::collections::HashSet::new();
+        for t in 0..TIMERROUTE_COUNT {
+            for ch in 0..CC_PER_TIMER {
+                assert!(seen.insert(cc_token(t, ch)), "collision at {t}/{ch}");
+            }
+        }
+    }
+
+    /// Registers read back what firmware wrote, including the CDTI words this
+    /// model deliberately does not act on — a driver that reads-modifies-writes
+    /// its own route must not lose bits.
+    #[test]
+    fn every_word_reads_back_what_was_written() {
+        let (mut r, _) = routed();
+        for w in 0..8u64 {
+            let off = 2 * TIMERROUTE_STRIDE + w * 4;
+            r.write_u32(off, 0x000A_0003).unwrap();
+            assert_eq!(r.read_u32(off).unwrap(), 0x000A_0003, "word {w}");
+        }
+    }
+
+    /// ⚠️ The block covers TIMER0..9. An offset past the tenth is not a valid
+    /// route and must not alias onto one.
+    #[test]
+    fn an_offset_past_the_last_timer_decodes_to_nothing() {
+        let (mut r, claims) = routed();
+        let past = TIMERROUTE_STRIDE * TIMERROUTE_COUNT as u64;
+        r.write_u32(past + OFF_ROUTEEN, 1).unwrap();
+        r.write_u32(past + OFF_CC0ROUTE, 2 | (8 << ROUTE_PIN_SHIFT))
+            .unwrap();
+        assert_eq!(r.read_u32(past).unwrap(), 0);
+        assert_eq!(claims.selector(2, 8), None);
+    }
+}

--- a/crates/core/src/peripherals/efr32/mod.rs
+++ b/crates/core/src/peripherals/efr32/mod.rs
@@ -21,5 +21,6 @@
 
 pub mod cmu;
 pub mod gpio_exti;
+pub mod gpio_route;
 pub mod iadc;
 pub mod timer;

--- a/crates/core/src/peripherals/efr32/timer.rs
+++ b/crates/core/src/peripherals/efr32/timer.rs
@@ -88,6 +88,7 @@
 //! HFRCO band decide the number. Until then it is one declared constant per
 //! instance, and the reason it is not `cpu_hz` is written here.
 
+use crate::peripherals::pad_lines::PadLines;
 use crate::{Peripheral, PeripheralTickResult, SimResult};
 
 // ── Register offsets, walked from `TIMER_TypeDef` ──────────────────────────
@@ -154,6 +155,9 @@ pub struct Efr32s2Timer {
     /// module header for why the two differ on this part. `None` until the
     /// chip yaml or the bus supplies one.
     peripheral_hz: Option<u64>,
+    /// The routed pads' live CC levels, when `GPIO_TIMERROUTE` points a pad at
+    /// this timer. `None` until something routes them.
+    lines: Option<std::sync::Arc<PadLines>>,
     /// The core clock the bus attached, used only as the fallback timebase for
     /// a chip that does not declare `peripheral_hz`.
     cpu_hz: u64,
@@ -188,6 +192,7 @@ impl Efr32s2Timer {
         Self {
             counter_bits: counter_bits.clamp(1, 32),
             peripheral_hz: None,
+            lines: None,
             cpu_hz: 1_000_000,
             en: 0,
             cfg: 0,
@@ -260,6 +265,37 @@ impl Efr32s2Timer {
         ch < CC_COUNT && self.cc_mode(ch) == CC_MODE_PWM && self.cnt < self.cc_oc[ch]
     }
 
+    /// Line order for this timer's [`PadLines`]: one per CC channel, named the
+    /// way the reference manual and `GPIO_TIMERROUTE` name them.
+    pub const CC_LINES: &'static [&'static str] = &["CC0", "CC1", "CC2"];
+
+    /// The narration cell this timer's CC outputs publish into, created on
+    /// first use. A PWM output rests LOW: `CNT` starts at 0 and `OC` at 0, so
+    /// `CNT < OC` is false until firmware programs a duty.
+    pub(crate) fn pad_lines_arc(&mut self) -> std::sync::Arc<PadLines> {
+        self.lines
+            .get_or_insert_with(|| {
+                std::sync::Arc::new(PadLines::new(Self::CC_LINES, &[false; CC_COUNT]))
+            })
+            .clone()
+    }
+
+    /// Publish every channel's current PWM level.
+    ///
+    /// ⚠️ Called after ANYTHING that can move a level — a counter advance, a
+    /// duty write, a mode change, an enable. Cheap and idempotent:
+    /// `PadLines::set_line` is a relaxed store that records an edge only on a
+    /// real transition, and the whole call is one `is_none` check on a bus
+    /// where no pad is routed here.
+    fn publish_cc(&self) {
+        let Some(lines) = self.lines.as_ref() else {
+            return;
+        };
+        for ch in 0..CC_COUNT {
+            lines.set_line(ch, self.pwm_output_high(ch));
+        }
+    }
+
     fn cc_index(offset: u64) -> Option<(usize, u64)> {
         if !(OFF_CC..OFF_CC + CC_STRIDE * CC_COUNT as u64).contains(&offset) {
             return None;
@@ -320,6 +356,14 @@ impl Efr32s2Timer {
     }
 
     fn write_word(&mut self, offset: u64, value: u32) {
+        self.write_word_inner(offset, value);
+        // A duty, a mode, an enable or a manual CNT can all move an output
+        // level without the counter advancing. Publishing here means a pad
+        // follows `analogWrite` immediately rather than at the next tick.
+        self.publish_cc();
+    }
+
+    fn write_word_inner(&mut self, offset: u64, value: u32) {
         match offset {
             OFF_EN => {
                 self.en = value & EN_EN;
@@ -397,6 +441,7 @@ impl Efr32s2Timer {
             self.iflag |= IF_OF;
         }
         self.cnt = self.mask(((from + steps) % period) as u32);
+        self.publish_cc();
     }
 }
 
@@ -462,6 +507,15 @@ impl Peripheral for Efr32s2Timer {
     }
 
     fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
+    /// ⚠️ Needed by the pad-wiring pass, which reaches this model MUTABLY to
+    /// hand it a narration cell — and the trait's mutable accessor DEFAULTS TO
+    /// `None`. Implementing only the shared one compiles, passes every unit
+    /// test, and silently wires nothing: this exact miss cost two debugging
+    /// rounds in one change, once here and once on the route block.
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
     }
 }

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -241,6 +241,7 @@ pub const MODEL_TYPES: &[&str] = &[
     "nrf54l_grtc",
     "efr32s2_cmu",
     "efr32s2_gpio_head",
+    "efr32s2_timerroute",
     "efr32s2_gpio_exti",
     "efr32s2_iadc",
     "efr32s2_timer",
@@ -324,6 +325,12 @@ pub fn try_build(
         // because the conformance ratchet dropped faulting reads on the floor
         // (`Err(_) => {}`) instead of reporting them; twelve addresses were
         // being counted as misses with no line saying why.
+        // The GPIO block's TIMER pin-mux. A real model, not a stub: it is the
+        // difference between a PWM duty that is correct in a register and a
+        // waveform that reaches a pad.
+        "efr32s2_timerroute" => {
+            Box::new(crate::peripherals::efr32::gpio_route::Efr32s2TimerRoute::new())
+        }
         "efr32s2_gpio_head" => {
             let mut s = crate::peripherals::stub::StubPeripheral::new(0x00);
             s.values.insert(0x00, 0x0000_0007);

--- a/crates/core/src/peripherals/gpio.rs
+++ b/crates/core/src/peripherals/gpio.rs
@@ -692,14 +692,15 @@ pub struct GpioPort {
     /// [`crate::peripherals::nrf52::pin_select`]) and this port's `PSEL.PORT`
     /// number.
     ///
-    /// Every other family answers "who drives pad N" from its own registers, so
-    /// this is `None` on them and costs one branch. Nordic has no such register
-    /// — the peripherals name the pins — so the answer has to come from
-    /// somewhere the port can reach, and this is it. Installed once at bus
-    /// wiring time by `SystemBus::wire_nrf52_pads`; a port that never gets one
-    /// simply has no routes bound either, and behaves exactly as before.
-    nrf_claims: Option<(
-        std::sync::Arc<crate::peripherals::nrf52::pin_select::NrfPinClaims>,
+    /// An STM32 pad answers "who drives me" from its own AFR nibble, so this is
+    /// `None` there and costs one branch. Nordic and Silicon Labs invert it —
+    /// the PERIPHERAL names the pin (`PSEL.TXD`, `GPIO_TIMERROUTE[n].CC0ROUTE`)
+    /// — so the answer has to come from somewhere the port can reach, and this
+    /// is it, together with this port's own port NUMBER in that family's
+    /// encoding. Installed once at bus wiring time; a port that never gets one
+    /// has no routes bound either, and behaves exactly as before.
+    pad_claims: Option<(
+        std::sync::Arc<crate::peripherals::pad_claims::PadClaims>,
         u8,
     )>,
 }
@@ -717,7 +718,7 @@ impl GpioPort {
             tap: None,
             pad_routes: crate::peripherals::pad_routing::PadRoutes::new(),
             window_offset: 0,
-            nrf_claims: None,
+            pad_claims: None,
         }
     }
 
@@ -818,15 +819,16 @@ impl GpioPort {
         self.window_offset
     }
 
-    /// Hand this port the shared nRF52 pin-claim table and tell it which
-    /// `PSEL.PORT` number it is. Config-build time only; see
-    /// [`GpioPort::nrf_claims`].
-    pub(crate) fn set_nrf_pin_claims(
+    /// Hand this port the shared pad-claim table and tell it which port NUMBER
+    /// it is in the muxing family's own encoding — `PSEL.PORT` on Nordic,
+    /// `CCnROUTE.PORT` on EFR32. Config-build time only; see
+    /// [`GpioPort::pad_claims`].
+    pub(crate) fn set_pad_claims(
         &mut self,
-        claims: std::sync::Arc<crate::peripherals::nrf52::pin_select::NrfPinClaims>,
+        claims: std::sync::Arc<crate::peripherals::pad_claims::PadClaims>,
         port: u8,
     ) {
-        self.nrf_claims = Some((claims, port));
+        self.pad_claims = Some((claims, port));
     }
 
     pub(crate) fn register_layout(&self) -> GpioRegisterLayout {
@@ -917,15 +919,20 @@ impl GpioPort {
     /// direction; [`PadRoutes`](crate::peripherals::pad_routing) cannot tell.
     fn selected_function(
         family: &GpioFamily,
-        nrf_claims: Option<&(
-            std::sync::Arc<crate::peripherals::nrf52::pin_select::NrfPinClaims>,
+        pad_claims: Option<&(
+            std::sync::Arc<crate::peripherals::pad_claims::PadClaims>,
             u8,
         )>,
         pin: u8,
     ) -> Option<u32> {
         match family {
-            GpioFamily::Nrf52(_) => {
-                let (claims, port) = nrf_claims?;
+            // Nordic and EFR32 Series 2 answer the same way and for the same
+            // reason: the port has no mux register at all, so the selector is
+            // a claim token a peripheral published — `PSEL.*` on Nordic,
+            // `GPIO_TIMERROUTE[n].CCnROUTE` on EFR32. Same shape, opposite
+            // direction from an AFR nibble; `PadRoutes` cannot tell.
+            GpioFamily::Nrf52(_) | GpioFamily::Efr32s2(_) => {
+                let (claims, port) = pad_claims?;
                 claims.selector(*port, pin)
             }
             GpioFamily::Stm32V2(g) => {
@@ -958,7 +965,7 @@ impl GpioPort {
     /// register truth.
     fn pad_level(&self, pin: u8) -> Option<bool> {
         if let Some(level) = self.pad_routes.level(pin, |p| {
-            Self::selected_function(&self.family, self.nrf_claims.as_ref(), p)
+            Self::selected_function(&self.family, self.pad_claims.as_ref(), p)
         }) {
             return Some(level);
         }
@@ -1013,7 +1020,7 @@ impl GpioPort {
         // mutably; split the borrow by moving the routes out for the call.
         let mut routes = std::mem::take(&mut self.pad_routes);
         routes.sync_taps(&t.tap, &t.watched, |pin| {
-            Self::selected_function(&self.family, self.nrf_claims.as_ref(), pin)
+            Self::selected_function(&self.family, self.pad_claims.as_ref(), pin)
         });
         self.pad_routes = routes;
         self.tap = Some(t);
@@ -1137,7 +1144,7 @@ impl crate::Peripheral for GpioPort {
             // (p790): while the peripheral is disabled "the pins will behave as
             // regular GPIOs" — which is the `None` branch below.
             GpioFamily::Nrf52(g) => {
-                if Self::selected_function(&self.family, self.nrf_claims.as_ref(), pin).is_some() {
+                if Self::selected_function(&self.family, self.pad_claims.as_ref(), pin).is_some() {
                     GpioMode::Af
                 } else if (g.read_reg(0x514) & (1u32 << pin)) != 0 {
                     GpioMode::Output
@@ -1169,7 +1176,7 @@ impl crate::Peripheral for GpioPort {
         // Everything else: None — null over a guess.
         let func = if mode == GpioMode::Af {
             if let Some(func) = self.pad_routes.func(pin, |p| {
-                Self::selected_function(&self.family, self.nrf_claims.as_ref(), p)
+                Self::selected_function(&self.family, self.pad_claims.as_ref(), p)
             }) {
                 Some(func.to_string())
             } else if let GpioFamily::Stm32V2(g) = &self.family {

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -46,6 +46,7 @@ pub mod noise;
 pub mod nrf52;
 pub mod nrf54l;
 pub mod nvic;
+pub mod pad_claims;
 pub mod pad_lines;
 pub mod pad_routing;
 pub mod pio;

--- a/crates/core/src/peripherals/nrf52/pin_select.rs
+++ b/crates/core/src/peripherals/nrf52/pin_select.rs
@@ -77,7 +77,6 @@
 //! deliberately declines to install this table on a port whose window is
 //! offset. See `SystemBus::wire_nrf52_pads`.
 
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 /// `CONNECT` = Disconnected. Bit 31 of every `PSEL.*` register, and its reset
@@ -95,10 +94,6 @@ const PSEL_PORT_MASK: u32 = 0x1;
 pub(crate) const PINS_PER_PORT: usize = 32;
 /// Ports a `PSEL.PORT` field can name (`[0..1]`).
 pub(crate) const PORTS: usize = 2;
-
-/// No signal claims this pad. `u32::MAX` because it must not collide with a
-/// claim token, and tokens are handed out from 0 upwards by the wiring pass.
-const UNCLAIMED: u32 = u32::MAX;
 
 /// The pad a `PSEL.*` word names, as a flat `port * 32 + pin` index, or `None`
 /// when `CONNECT` reads Disconnected.
@@ -122,66 +117,16 @@ fn psel_pad(psel: u32) -> Option<usize> {
 /// and by every `PSEL`-owning peripheral (which writes it). Reads are lock-free
 /// because a pad read runs on the CPU walk and must not contend with an MMIO
 /// write on another peripheral.
-#[derive(Debug)]
-pub struct NrfPinClaims {
-    /// One slot per `port * 32 + pin`, holding the claim token of the signal
-    /// driving that pad or [`UNCLAIMED`].
-    slots: Vec<AtomicU32>,
-}
+/// The claim table, now shared. ⚠️ NOT a Nordic type any more: the EFR32
+/// Series-2 route registers mux the same way (the peripheral names the pad),
+/// so the mechanism moved to [`crate::peripherals::pad_claims`] and only the
+/// PSEL ENCODING stayed here. The alias keeps every Nordic call site reading
+/// the way it did.
+pub type NrfPinClaims = crate::peripherals::pad_claims::PadClaims;
 
-impl Default for NrfPinClaims {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl NrfPinClaims {
-    pub fn new() -> Self {
-        Self {
-            slots: (0..PORTS * PINS_PER_PORT)
-                .map(|_| AtomicU32::new(UNCLAIMED))
-                .collect(),
-        }
-    }
-
-    /// The claim token currently driving `(port, pin)`, or `None` for a pad no
-    /// peripheral has selected — the `selector_of` closure
-    /// [`PadRoutes::level`](super::super::pad_routing::PadRoutes::level) wants.
-    ///
-    /// `None` for an out-of-range pad rather than a panic, for the same reason
-    /// [`PadLines::level`](super::super::pad_lines::PadLines::level) reads low:
-    /// this runs on the CPU walk, where stale bookkeeping must not take the
-    /// engine down.
-    pub fn selector(&self, port: u8, pin: u8) -> Option<u32> {
-        let idx = usize::from(port) * PINS_PER_PORT + usize::from(pin);
-        let token = self.slots.get(idx)?.load(Ordering::Relaxed);
-        (token != UNCLAIMED).then_some(token)
-    }
-
-    /// Take `pad` for `token`, displacing whatever held it.
-    ///
-    /// Last writer wins, which is what the silicon does not promise: "Only one
-    /// peripheral can be assigned to drive a particular GPIO pin at a time.
-    /// Failing to do so may result in unpredictable behavior" (nRF52840 PS
-    /// v1.11 §6.31.6, p790). Picking the most recent claim is one legal reading
-    /// of unpredictable and the only one that stays deterministic.
-    fn take(&self, pad: usize, token: u32) {
-        if let Some(slot) = self.slots.get(pad) {
-            slot.store(token, Ordering::Relaxed);
-        }
-    }
-
-    /// Give up `pad` — but ONLY if `token` still holds it.
-    ///
-    /// The compare is load-bearing. Two peripherals can name the same pad, and
-    /// the second one's claim must survive the first one's release; a blind
-    /// store would hand the pad back to the GPIO latch while a live peripheral
-    /// was still driving it.
-    fn release(&self, pad: usize, token: u32) {
-        if let Some(slot) = self.slots.get(pad) {
-            let _ = slot.compare_exchange(token, UNCLAIMED, Ordering::Relaxed, Ordering::Relaxed);
-        }
-    }
+/// A Nordic table: two ports of 32 pads (PS v1.11 6.9, p143).
+pub fn nrf_pin_claims() -> NrfPinClaims {
+    NrfPinClaims::new(PORTS, PINS_PER_PORT)
 }
 
 /// One peripheral signal's standing claim on a pad — the handle a `PSEL`-owning
@@ -281,7 +226,7 @@ mod tests {
 
     #[test]
     fn an_unclaimed_pad_answers_none_so_the_port_falls_back_to_its_latch() {
-        let claims = NrfPinClaims::new();
+        let claims = nrf_pin_claims();
         assert_eq!(claims.selector(0, 3), None);
         // Out of range is None, never a panic: this runs on the CPU walk.
         assert_eq!(claims.selector(9, 3), None);
@@ -290,7 +235,7 @@ mod tests {
 
     #[test]
     fn a_claim_follows_psel_and_is_released_when_the_peripheral_is_disabled() {
-        let claims = Arc::new(NrfPinClaims::new());
+        let claims = Arc::new(nrf_pin_claims());
         let mut scl = NrfPinClaim::default();
         scl.install(claims.clone(), SCL);
 
@@ -313,7 +258,7 @@ mod tests {
         // The regression a bind-once table cannot express: pinctrl swapping an
         // instance onto a different pad must not leave the first pad reading
         // the wire forever.
-        let claims = Arc::new(NrfPinClaims::new());
+        let claims = Arc::new(nrf_pin_claims());
         let mut sda = NrfPinClaim::default();
         sda.install(claims.clone(), SDA);
 
@@ -333,7 +278,7 @@ mod tests {
         // "Only one peripheral can be assigned to drive a particular GPIO pin
         // at a time" (PS §6.31.6) — but firmware CAN do it, and when the loser
         // later disconnects, the winner must keep its pad.
-        let claims = Arc::new(NrfPinClaims::new());
+        let claims = Arc::new(nrf_pin_claims());
         let mut scl = NrfPinClaim::default();
         let mut txd = NrfPinClaim::default();
         scl.install(claims.clone(), SCL);
@@ -360,7 +305,7 @@ mod tests {
 
     #[test]
     fn dropping_a_model_frees_the_pad_it_held() {
-        let claims = Arc::new(NrfPinClaims::new());
+        let claims = Arc::new(nrf_pin_claims());
         {
             let mut scl = NrfPinClaim::default();
             scl.install(claims.clone(), SCL);

--- a/crates/core/src/peripherals/pad_claims.rs
+++ b/crates/core/src/peripherals/pad_claims.rs
@@ -1,0 +1,135 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! Which peripheral signal currently drives each pad, for families that mux at
+//! the PERIPHERAL rather than at the port.
+//!
+//! An STM32 pad names its own function in `AFRL`/`AFRH`, so the port can answer
+//! "what am I?" by itself. Nordic and Silicon Labs invert that: the peripheral
+//! names the pad (`PSEL.TXD` on nRF52, `GPIO_TIMERROUTE[n].CC0ROUTE` on EFR32
+//! Series 2), and the port knows nothing until something tells it. This table
+//! is that something — one shared instance per bus, written by the muxing
+//! peripherals and read by the GPIO ports.
+//!
+//! It was `NrfPinClaims`, private to the Nordic module, until the EFR32 route
+//! registers needed exactly the same structure. The mechanism is not Nordic;
+//! only the encoding of "which pad" is, and that stays with each family.
+//!
+//! Reads are lock-free (`Relaxed`) because a pad read runs on the CPU walk and
+//! must not contend with an MMIO write on another peripheral.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Slot value for a pad no peripheral has claimed.
+pub(crate) const UNCLAIMED: u32 = u32::MAX;
+
+#[derive(Debug)]
+pub struct PadClaims {
+    /// One slot per `port * pins_per_port + pin`, holding the claim token of
+    /// the signal driving that pad or [`UNCLAIMED`].
+    slots: Vec<AtomicU32>,
+    pins_per_port: usize,
+}
+
+impl PadClaims {
+    /// A table for `ports` ports of `pins_per_port` pads each.
+    ///
+    /// ⚠️ Both numbers are a property of the SILICON, not a convenience: nRF52
+    /// has 2 x 32 and EFR32 Series 2 has 4 x 16, and `pad_index` has to agree
+    /// with whatever the family's own encoding produces or a claim lands on the
+    /// wrong pad — silently, because every index is in range.
+    pub fn new(ports: usize, pins_per_port: usize) -> Self {
+        Self {
+            slots: (0..ports * pins_per_port)
+                .map(|_| AtomicU32::new(UNCLAIMED))
+                .collect(),
+            pins_per_port,
+        }
+    }
+
+    /// Flat slot index for `(port, pin)`.
+    pub fn pad_index(&self, port: u8, pin: u8) -> usize {
+        usize::from(port) * self.pins_per_port + usize::from(pin)
+    }
+
+    /// The claim token currently driving `(port, pin)`, or `None` for a pad no
+    /// peripheral has selected — the `selector_of` closure
+    /// [`PadRoutes::level`](super::pad_routing::PadRoutes::level) wants.
+    ///
+    /// `None` for an out-of-range pad rather than a panic, for the same reason
+    /// [`PadLines::level`](super::pad_lines::PadLines::level) reads low: this
+    /// runs on the CPU walk, where stale bookkeeping must not take the engine
+    /// down.
+    pub fn selector(&self, port: u8, pin: u8) -> Option<u32> {
+        let idx = self.pad_index(port, pin);
+        let token = self.slots.get(idx)?.load(Ordering::Relaxed);
+        (token != UNCLAIMED).then_some(token)
+    }
+
+    /// Take `pad` for `token`, displacing whatever held it.
+    ///
+    /// Last writer wins, which is what neither silicon promises: "Only one
+    /// peripheral can be assigned to drive a particular GPIO pin at a time.
+    /// Failing to do so may result in unpredictable behavior" (nRF52840 PS
+    /// v1.11 6.31.6, p790). Picking the most recent claim is one legal reading
+    /// of unpredictable and the only one that stays deterministic.
+    pub(crate) fn take(&self, pad: usize, token: u32) {
+        if let Some(slot) = self.slots.get(pad) {
+            slot.store(token, Ordering::Relaxed);
+        }
+    }
+
+    /// Give up `pad` — but ONLY if `token` still holds it.
+    ///
+    /// The compare is load-bearing. Two peripherals can name the same pad, and
+    /// the second one's claim must survive the first one's release; a blind
+    /// store would hand the pad back to the GPIO latch while a live peripheral
+    /// was still driving it.
+    pub(crate) fn release(&self, pad: usize, token: u32) {
+        if let Some(slot) = self.slots.get(pad) {
+            let _ = slot.compare_exchange(token, UNCLAIMED, Ordering::Relaxed, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_claim_is_visible_to_the_port_that_reads_it() {
+        let claims = PadClaims::new(4, 16);
+        assert_eq!(claims.selector(2, 8), None, "unclaimed out of the box");
+        claims.take(claims.pad_index(2, 8), 7);
+        assert_eq!(claims.selector(2, 8), Some(7));
+        assert_eq!(claims.selector(2, 9), None, "neighbouring pad untouched");
+    }
+
+    /// The compare-exchange in `release`, stated as a test: a displaced signal
+    /// releasing later must not steal the pad back from whoever holds it.
+    #[test]
+    fn a_stale_release_cannot_take_a_pad_from_its_live_owner() {
+        let claims = PadClaims::new(4, 16);
+        let pad = claims.pad_index(1, 3);
+        claims.take(pad, 1);
+        claims.take(pad, 2); // a second peripheral names the same pad
+        claims.release(pad, 1); // the first one lets go, late
+        assert_eq!(
+            claims.selector(1, 3),
+            Some(2),
+            "the live claim survives a displaced signal's release",
+        );
+    }
+
+    /// ⚠️ The two geometries in the tree do not share an index, and a table
+    /// built with the wrong one puts claims on real pads that are not the ones
+    /// the firmware named.
+    #[test]
+    fn the_index_follows_the_declared_geometry() {
+        assert_eq!(PadClaims::new(2, 32).pad_index(1, 0), 32, "nRF52: 2 x 32");
+        assert_eq!(PadClaims::new(4, 16).pad_index(1, 0), 16, "EFR32: 4 x 16");
+    }
+}

--- a/crates/core/tests/efr32mg26_instances.rs
+++ b/crates/core/tests/efr32mg26_instances.rs
@@ -1,0 +1,147 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Every TIMER, USART and I2C instance this part HAS is declared, decodes, and
+//! carries the right per-instance facts.
+//!
+//! Eight timers, one USART and two I2Cs were absent from the descriptor on the
+//! reasoning that an undeclared window faults loudly where a stub would answer
+//! zero. That is right for a peripheral with no model and wrong for one whose
+//! model is already in the tree: `GPIO_TIMERROUTE` routes all ten timers, and a
+//! sketch reaching for a second PWM timer hit a bus fault instead of the model
+//! sitting next to the two that worked.
+//!
+//! ⚠️ Two per-instance facts on this family are NOT guessable, and both are
+//! asserted here rather than trusted:
+//!
+//! 1. `TIMER_CNTWIDTH` — the 32-bit instances are 0, 1, 8, 9, NOT 0..3. The
+//!    datasheet says "4x 32-bit" without saying which. A 16-bit timer declared
+//!    32-bit gives firmware a `micros()` that never wraps.
+//! 2. The CLKEN bit does not follow the instance number. TIMER0..4 are CLKEN0
+//!    bits 4..8 and TIMER5..9 are CLKEN2 bits 0..4; I2C0/1 are CLKEN0 14/15
+//!    while I2C2/3 are CLKEN2 9/10.
+
+use labwired_config::ChipDescriptor;
+use std::path::PathBuf;
+
+fn descriptor() -> ChipDescriptor {
+    let abs = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("configs/chips/efr32mg26.yaml");
+    ChipDescriptor::from_file(&abs).expect("load the efr32mg26 descriptor")
+}
+
+/// `(id, base, clock register, clock bit)` for every instance the silicon has,
+/// from `efr32mg26b510f3200im48.h` and `efr32mg26_cmu.h`.
+const EXPECTED: &[(&str, u64, &str, u8)] = &[
+    ("timer0", 0x4004_8000, "clken0", 4),
+    ("timer1", 0x4004_C000, "clken0", 5),
+    ("timer2", 0x4005_0000, "clken0", 6),
+    ("timer3", 0x4005_4000, "clken0", 7),
+    ("timer4", 0x4005_8000, "clken0", 8),
+    ("timer5", 0x4005_C000, "clken2", 0),
+    ("timer6", 0x4006_0000, "clken2", 1),
+    ("timer7", 0x4006_4000, "clken2", 2),
+    ("timer8", 0x4006_8000, "clken2", 3),
+    ("timer9", 0x4006_C000, "clken2", 4),
+    // ⚠️ USART0 is declared as `spi0`, not `usart0`. Series 2 has NO separate
+    // SPI peripheral — SPI is a USART with `CTRL.SYNC` — so an instance is one
+    // or the other and never both, and this chip gives USART0 to SPI while
+    // USART1 is the VCOM console.
+    ("spi0", 0x400A_0000, "clken0", 9),
+    ("usart1", 0x400A_4000, "clken2", 7),
+    ("usart2", 0x400A_8000, "clken2", 8),
+    ("i2c0", 0x4B00_0000, "clken0", 14),
+    ("i2c1", 0x400B_0000, "clken0", 15),
+    ("i2c2", 0x400B_4000, "clken2", 9),
+    ("i2c3", 0x400B_8000, "clken2", 10),
+];
+
+/// `TIMER_CNTWIDTH` per instance. The 32-bit ones are 0, 1, 8, 9.
+const COUNTER_BITS: [u64; 10] = [32, 32, 16, 16, 16, 16, 16, 16, 32, 32];
+
+#[test]
+fn every_instance_is_declared_at_its_silicon_base_and_clock_bit() {
+    let chip = descriptor();
+    for &(id, base, reg, bit) in EXPECTED {
+        let p = chip
+            .peripherals
+            .iter()
+            .find(|p| p.id == id)
+            .unwrap_or_else(|| panic!("{id} is not declared"));
+        assert_eq!(p.base_address, base, "{id} base");
+        let gates = p
+            .clock
+            .as_ref()
+            .unwrap_or_else(|| panic!("{id} declares no clock gate — it would answer while gated"));
+        // These instances each require exactly ONE bit; a second would mean the
+        // model answers only when both are set, which is not this silicon.
+        let [gate] = gates.as_slice() else {
+            panic!(
+                "{id} declares {} clock bits, expected 1",
+                gates.as_slice().len()
+            );
+        };
+        assert_eq!(gate.reg, reg, "{id} clock register");
+        assert_eq!(gate.bit, bit, "{id} clock bit");
+    }
+}
+
+#[test]
+fn every_timer_declares_the_counter_width_its_instance_actually_has() {
+    let chip = descriptor();
+    for (i, &bits) in COUNTER_BITS.iter().enumerate() {
+        let id = format!("timer{i}");
+        let p = chip
+            .peripherals
+            .iter()
+            .find(|p| p.id == id)
+            .unwrap_or_else(|| panic!("{id} is not declared"));
+        let declared = p
+            .config
+            .get("counter_bits")
+            .and_then(|v| v.as_u64())
+            .unwrap_or_else(|| panic!("{id} declares no counter_bits; the model requires the key"));
+        assert_eq!(
+            declared, bits,
+            "{id} counter_bits: the 32-bit instances are 0, 1, 8, 9 — not 0..3",
+        );
+    }
+}
+
+/// ⚠️ The guard on this file: a table nobody compares against the tree is a
+/// list of intentions. If the descriptor grows an instance these tables do not
+/// name, this fails rather than silently covering less than it claims.
+#[test]
+fn the_expected_table_covers_every_declared_instance_of_these_kinds() {
+    let chip = descriptor();
+    let declared: Vec<&str> = chip
+        .peripherals
+        .iter()
+        .map(|p| p.id.as_str())
+        .filter(|id| {
+            (id.starts_with("timer")
+                || id.starts_with("usart")
+                || id.starts_with("spi")
+                || id.starts_with("i2c"))
+                && id.chars().last().is_some_and(|c| c.is_ascii_digit())
+        })
+        .collect();
+    let expected: Vec<&str> = EXPECTED.iter().map(|&(id, ..)| id).collect();
+    let missing: Vec<&&str> = declared
+        .iter()
+        .filter(|id| !expected.contains(id))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "declared but not in this file's table: {missing:?}",
+    );
+    assert_eq!(
+        declared.len(),
+        EXPECTED.len(),
+        "the tree declares {} of these instances and the table names {}",
+        declared.len(),
+        EXPECTED.len(),
+    );
+}

--- a/crates/core/tests/efr32mg26_pwm_pad.rs
+++ b/crates/core/tests/efr32mg26_pwm_pad.rs
@@ -1,0 +1,218 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+// SPDX-License-Identifier: MIT
+
+//! Does `analogWrite` reach a PIN on BRD2709A?
+//!
+//! For the whole of this board's onboarding the answer was no, and the reason
+//! was never the timer: the duty went into real `CC_OC` registers, correctly,
+//! and on Series 2 an output reaches a pad only through `GPIO_TIMERROUTE`,
+//! which nothing modelled. Every write-up of that gap said "unmodelled".
+//!
+//! ⚠️ This file exists because the unit tests were not enough. `Efr32s2Timer`
+//! publishes its CC levels, `Efr32s2TimerRoute` claims pads, the GPIO port
+//! reads claims — all three had passing unit tests while the wiring pass that
+//! joins them silently did nothing, because the route model implemented
+//! `as_any` where the pass downcasts through `as_any_mut` (which defaults to
+//! `None`). Everything compiled. Nothing was routed. Only an end-to-end read of
+//! the PAD can tell the difference.
+//!
+//! So this drives the SHIPPED `from_config` bus through MMIO, the way firmware
+//! does, and reads the pad through `read_gpio_pad`.
+
+use labwired_config::{ChipDescriptor, SystemManifest};
+use labwired_core::bus::SystemBus;
+use labwired_core::cpu::CortexM;
+use labwired_core::logic_capture::LogicSource;
+use labwired_core::{Bus, Machine};
+use std::path::PathBuf;
+
+/// TIMER1 — the instance `analogWrite` uses (`wiring.cpp`'s `pwm_start`).
+const TIMER1: u64 = 0x4004_C000;
+const TIMER_CFG: u64 = 0x04;
+const TIMER_CMD: u64 = 0x0C;
+const TIMER_TOP: u64 = 0x1C;
+const TIMER_EN: u64 = 0x30;
+/// `CC[3]` at +0x60, stride 0x20: CFG at +0x00, OC at +0x08.
+const TIMER_CC0_CFG: u64 = 0x60;
+const TIMER_CC0_OC: u64 = 0x68;
+
+const CMU_CLKEN0: u64 = 0x4000_8064;
+const CLKEN0_GPIO: u32 = 1 << 26;
+const CLKEN0_TIMER1: u32 = 1 << 5;
+
+/// `GPIO_TIMERROUTE[1]` — block +0x6E0, stride 0x20.
+const TIMERROUTE1: u64 = 0x4003_C6E0 + 0x20;
+const ROUTEEN: u64 = 0x00;
+const CC0ROUTE: u64 = 0x04;
+
+/// Port C, pin 8 — LED0 on BRD2709A (`variants/xg26explorerkit/pins_arduino.h`).
+const PORT_C: u32 = 2;
+const PIN_8: u32 = 8;
+/// GPIO port C's own window: block +0x30 + 2 * 0x30.
+const GPIOC: u64 = 0x4003_C030 + 0x60;
+const PORT_MODEH: u64 = 0x0C;
+
+const CC_MODE_PWM: u32 = 0x3;
+const PWM_TOP: u32 = 255;
+
+fn root(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// The SHIPPED bus — `from_config` on the committed yaml, with no wiring call
+/// of this file's own. A gate that wired its own pads would prove the mechanism
+/// works while the shipped chip stayed dark.
+fn machine() -> Machine<CortexM> {
+    let abs = root("configs/chips/efr32mg26.yaml");
+    let chip = ChipDescriptor::from_file(&abs).expect("load the efr32mg26 descriptor");
+    let manifest = SystemManifest {
+        parts: Vec::new(),
+        walk_deleted: Some(false),
+        schema_version: "1.0".to_string(),
+        name: "efr32mg26-pwm-pad".to_string(),
+        chip: abs.to_string_lossy().to_string(),
+        cpu_hz: None,
+        external_devices: vec![],
+        cosim_models: Vec::new(),
+        motor_models: Vec::new(),
+        board_io: vec![],
+        debug_uart: None,
+        wifi_ap: None,
+        peripherals: vec![],
+        memory_overrides: Default::default(),
+    };
+    let mut bus = SystemBus::from_config(&chip, &manifest)
+        .expect("build the bus from the committed chip config");
+    let (cpu, _nvic) = labwired_core::system::cortex_m::configure_cortex_m(&mut bus);
+    let mut machine = Machine::new(cpu, bus);
+    // `b .` (0xE7FE): a Thumb branch to itself, so the CPU retires instructions
+    // and time advances. Every register below is driven through MMIO, exactly
+    // as a driver would; no firmware is involved.
+    machine.bus.write_u8(0x2000_1000, 0xFE).unwrap();
+    machine.bus.write_u8(0x2000_1001, 0xE7).unwrap();
+    machine.cpu.pc = 0x2000_1000;
+    machine
+}
+
+/// The pad level, read the way the analyzer reads it — through the routing
+/// seam, not by peeking at a register.
+fn pad(machine: &mut Machine<CortexM>, pin: u8) -> Option<bool> {
+    let idx = machine
+        .bus
+        .find_peripheral_index_by_name("gpioc")
+        .expect("the chip declares a gpioc port");
+    machine.logic_watch(&[Some(LogicSource::pad(idx, pin))])[0]
+}
+
+fn run(machine: &mut Machine<CortexM>, steps: u64) {
+    for _ in 0..steps {
+        machine.step().expect("step");
+    }
+}
+
+/// Exactly what `pwm_start()` + `analogWrite()` do, in that order.
+fn program_pwm(bus: &mut dyn Bus, duty: u32) {
+    bus.write_u32(CMU_CLKEN0, CLKEN0_GPIO | CLKEN0_TIMER1)
+        .unwrap();
+    // ⚠️ CC_CFG before EN: it is a disabled-only register on this silicon.
+    bus.write_u32(TIMER1 + TIMER_CC0_CFG, CC_MODE_PWM).unwrap();
+    bus.write_u32(TIMER1 + TIMER_CFG, 0).unwrap();
+    bus.write_u32(TIMER1 + TIMER_EN, 1).unwrap();
+    bus.write_u32(TIMER1 + TIMER_TOP, PWM_TOP).unwrap();
+    bus.write_u32(TIMER1 + TIMER_CMD, 1).unwrap(); // START
+    bus.write_u32(TIMER1 + TIMER_CC0_OC, duty).unwrap();
+}
+
+/// Route TIMER1 CC0 to PC08, the way a driver programming the pin-mux would.
+fn route_cc0_to_pc08(bus: &mut dyn Bus) {
+    bus.write_u32(TIMERROUTE1 + CC0ROUTE, PORT_C | (PIN_8 << 16))
+        .unwrap();
+    bus.write_u32(TIMERROUTE1 + ROUTEEN, 1).unwrap();
+}
+
+#[test]
+fn a_routed_pwm_channel_drives_its_pad() {
+    let mut m = machine();
+    program_pwm(&mut m.bus, 200);
+    route_cc0_to_pc08(&mut m.bus);
+
+    // CNT is 0 and OC is 200, so the output is HIGH — `CNT < OC`.
+    assert_eq!(
+        pad(&mut m, 8),
+        Some(true),
+        "PC08 must follow TIMER1 CC0 once GPIO_TIMERROUTE points it there",
+    );
+}
+
+/// The whole point, in one assertion: the pad FOLLOWS the waveform. A pad stuck
+/// at one level would pass the test above and still be wrong.
+#[test]
+fn the_pad_follows_the_duty_across_a_whole_period() {
+    let mut m = machine();
+    program_pwm(&mut m.bus, 64); // 25% of TOP=255
+    route_cc0_to_pc08(&mut m.bus);
+
+    let mut high = 0usize;
+    let mut seen_low = false;
+    let mut seen_high = false;
+    for _ in 0..=PWM_TOP {
+        match pad(&mut m, 8) {
+            Some(true) => {
+                high += 1;
+                seen_high = true;
+            }
+            Some(false) => seen_low = true,
+            None => panic!("PC08 stopped answering mid-period"),
+        }
+        // One timer clock: the descriptor declares cpu_hz 78 MHz against a
+        // 19 MHz peripheral band, so four core cycles.
+        run(&mut m, 4);
+    }
+    assert!(seen_high && seen_low, "a 25% duty must show BOTH levels");
+    // 64 of 256 counts high. The sampling is coarse (one read per timer clock,
+    // and the tick ratio is integer), so this asserts the SHAPE — a quarter,
+    // not a half and not a sliver — rather than an exact count.
+    assert!(
+        (40..=90).contains(&high),
+        "a 25% duty should read high for roughly a quarter of the period; got {high}/256",
+    );
+}
+
+/// ⚠️ The negative control, and the one that would have caught the silent
+/// wiring miss: WITHOUT the route, the pad is an ordinary GPIO and must NOT
+/// carry the waveform. A model that routed everything unconditionally would
+/// pass every test above.
+#[test]
+fn an_unrouted_pad_does_not_carry_the_waveform() {
+    let mut m = machine();
+    program_pwm(&mut m.bus, 200);
+    // No TIMERROUTE write at all. PC08 is an input in DISABLED mode.
+    assert_eq!(
+        pad(&mut m, 8),
+        Some(false),
+        "an unrouted pad reads its own port state, not the timer's output",
+    );
+}
+
+/// And clearing `ROUTEEN` hands the pad back — firmware turning a PWM channel
+/// off expects an ordinary pin again, not a frozen waveform.
+#[test]
+fn clearing_the_route_hands_the_pad_back_to_the_port() {
+    let mut m = machine();
+    program_pwm(&mut m.bus, 200);
+    route_cc0_to_pc08(&mut m.bus);
+    assert_eq!(pad(&mut m, 8), Some(true));
+
+    m.bus.write_u32(TIMERROUTE1 + ROUTEEN, 0).unwrap();
+    // Drive the pin low as a plain push-pull output and read it back: if the
+    // route were still live the timer would win.
+    m.bus.write_u32(GPIOC + PORT_MODEH, 0x4).unwrap(); // pin 8 PUSHPULL
+    assert_eq!(
+        pad(&mut m, 8),
+        Some(false),
+        "with ROUTEEN clear the port owns the pad again",
+    );
+}

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -26,7 +26,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `b60acda38f79b2af` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `1784454ab3aaa18d` | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `0fb27d55c48c66a5` | no silicon capture |
-| `brd2709a` | 🟡 smoke-manual | — | `d5d4b077c4eb708f` | no silicon capture |
+| `brd2709a` | 🟡 smoke-manual | — | `9e6f42c15363c4fc` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `32cbdfcebf57531b` | no silicon capture |

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,24 +9,24 @@ The models column is a content digest over everything that board's `models` list
 
 | Board | Tier | Last silicon capture | Models | Status |
 |-------|------|----------------------|--------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `ba3c4a67fbe80199` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `ba3c4a67fbe80199` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `ecf3c94808a1c1c0` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `762bfb5d5ab8f519` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `762bfb5d5ab8f519` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `aff74ffd315a4a6b` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `4f22db3b82bcf418` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `9b7d5c1b978677c5` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `99e8a47c91fec9c2` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `ffa229051d49861a` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `6544fb6e994ae216` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `d9b8554536440be4` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `4f89a3042e273f1d` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `c5e22a24189525a6` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `f81da1efe594ea72` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `b0cce7fc436b9a1e` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `b6fef3a379137d96` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `a28b3f47eb11df11` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `e18766783c36d18c` | no silicon capture |
 | `rp2040` | ⚪ structural | — | `3c647e77c7572f2f` | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | `c04678006db2db1d` | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `23e65628bdf33cf1` | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `01e8f135a697a552` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `b2c3b4e4f95d92d2` | no silicon capture |
-| `brd2709a` | 🟡 smoke-manual | — | `052d4a49ff8f968a` | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `b60acda38f79b2af` | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `1784454ab3aaa18d` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `0fb27d55c48c66a5` | no silicon capture |
+| `brd2709a` | 🟡 smoke-manual | — | `d5d4b077c4eb708f` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `32cbdfcebf57531b` | no silicon capture |

--- a/docs/coverage/chip-conformance.md
+++ b/docs/coverage/chip-conformance.md
@@ -31,5 +31,5 @@ Reg match = verifiable cold-reset registers reproduced. "Excluded" = registers a
 | stm32wb55 | **L0** | ✓ | 22 | — | — | — |
 | stm32wba52 | **L0** | ✓ | 21 | — | — | — |
 | mkw41z4 | **L1** | ✓ | 20 | — | — | firmware_survival::test_kw41z_smoke_survival |
-| efr32mg26 | **L1** | ✓ | 18 | 215/215 (100%) | 1 | — |
+| efr32mg26 | **L1** | ✓ | 19 | 215/215 (100%) | 1 | — |
 | atmega328p | **L1** | ✓ | 3 | — | — | avr_nano_golden_survival::arduino_nano_golden_prints_and_blinks |

--- a/docs/coverage/chip-conformance.md
+++ b/docs/coverage/chip-conformance.md
@@ -31,5 +31,5 @@ Reg match = verifiable cold-reset registers reproduced. "Excluded" = registers a
 | stm32wb55 | **L0** | ✓ | 22 | — | — | — |
 | stm32wba52 | **L0** | ✓ | 21 | — | — | — |
 | mkw41z4 | **L1** | ✓ | 20 | — | — | firmware_survival::test_kw41z_smoke_survival |
-| efr32mg26 | **L1** | ✓ | 19 | 215/215 (100%) | 1 | — |
+| efr32mg26 | **L1** | ✓ | 30 | 215/215 (100%) | 1 | — |
 | atmega328p | **L1** | ✓ | 3 | — | — | avr_nano_golden_survival::arduino_nano_golden_prints_and_blinks |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -307,6 +307,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -323,7 +331,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: ba3c4a67fbe801995f00d8fcb96ef7ad9062a8c176c9ce456b4f7e6c2fd338d4
+    drift_ack_digest: 762bfb5d5ab8f5193ec539eadbbc338ee97e5d77faa33d16e743c3c9a2f536a9
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -508,6 +516,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -524,7 +540,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: ba3c4a67fbe801995f00d8fcb96ef7ad9062a8c176c9ce456b4f7e6c2fd338d4
+    drift_ack_digest: 762bfb5d5ab8f5193ec539eadbbc338ee97e5d77faa33d16e743c3c9a2f536a9
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -833,6 +849,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -849,7 +873,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: ecf3c94808a1c1c01478907261a8e9a796574edfb24872a8e3735c7299be123b
+    drift_ack_digest: aff74ffd315a4a6ba81b7824564de3d0fd0df469be6e2b61da1aec77a16b40ca
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -1869,6 +1893,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -1885,7 +1917,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 9b7d5c1b978677c572ac6f0e7d3f0bb12bd7295d5333cb5787b8b7ae6f8f9c64
+    drift_ack_digest: d9b8554536440be436350f9f55110432c8ff3975400c9208fc5bbe853e9b589a
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2137,6 +2169,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -2153,7 +2193,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 99e8a47c91fec9c2d645815ae01065cd4dd0d713f026d2b456a3488482987f3f
+    drift_ack_digest: 4f89a3042e273f1d36c9a99001466aa030c3b09f01f9afedd374623a740bb7b9
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2458,6 +2498,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -2474,7 +2522,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: ffa229051d49861a8356abf8b897191bab1acc4af5bd3aeb01b555c6b6df008e
+    drift_ack_digest: c5e22a24189525a675d0b15e299e648645024c9bffe4e1f71c79f965caee9c76
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2739,6 +2787,14 @@ boards:
     # match arm in i2c.rs, and a doc comment moved back onto the enum it
     # documents in spi.rs. No executable path moved, so nothing above changes.
     #
+    # Re-stamped 2026-08-22 a THIRD time, for GPIO_TIMERROUTE. The shared
+    # pad-claim table moved out of the Nordic module (`NrfPinClaims` is now an
+    # alias for `PadClaims`) and `GpioPort`'s claim field was generalised, so
+    # `gpio.rs` and the nRF files moved. ⚠️ Behaviour on these boards is
+    # unchanged: the nRF52 pad tests, the STM32 AFR path and every `bus_
+    # visibility` row pass untouched — an STM32 pad still answers from its own
+    # AFR nibble and never consults a claim table.
+    #
     # Re-stamped 2026-08-22 AGAIN, for the EFR32 I²C/SPI wire narration: both
     # `i2c.rs` and `spi.rs` gained a `PadLines` cell and a narrator call on the
     # `Efr32s2*` arms, plus `Efr32s2SpiRegs` fields. The STM32 arms are
@@ -2755,7 +2811,7 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 6544fb6e994ae2162df4d48ce5f7391dc3873d85bd6fbd60a767b1689a156716
+    drift_ack_digest: f81da1efe594ea7203a0fd079cd1e769e96b0949a88229401898bfe737369db9
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     # 2026-08-12: chip yaml adds bxcan1 (type bxcan @ 0x40006400, APB1ENR bit 25) for
     # Arduino matrix L8 loopback. Existing BxCan model; no register-map change to
@@ -3458,7 +3514,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: 01e8f135a697a5529da1371b837f851a6792ce1211db2bd7583fed234bfd1dd4
+    drift_ack_digest: 1784454ab3aaa18d6cce5fd95ae54de633644ef7deb52b00f8097b5e78be31ab
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3529,7 +3585,7 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: b2c3b4e4f95d92d2d855f10988489e93a0c38970713fdec1cc5df37a6ad7135c
+    drift_ack_digest: 0fb27d55c48c66a5483209c4f7fa029280227b36ea0b24b928d4527b74fceeed
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs


### PR DESCRIPTION
The last of the three gaps this board's onboarding note listed. The duty was
never the problem: `analogWrite` put the right number into real TIMER1 `CC_OC`
registers and lit nothing, because on Series 2 an output reaches a pin only
through the GPIO block's ROUTE registers and this one was a read-as-zero stub.

## Three pieces, one seam that already existed

* `Efr32s2TimerRoute` decodes `ROUTEEN.CCnPEN` + `CCnROUTE.PORT/PIN` into pad
  claims, for all ten timers.
* `Efr32s2Timer` publishes its CC levels into a `PadLines` cell after anything
  that can move one — an advance, a duty write, a mode change, an enable.
* `GpioPort` reads the claim, through the SAME `selected_function` seam Nordic
  already used. Nordic and Silicon Labs mux identically — the peripheral names
  the pad — so the claim table moved out of the Nordic module to
  `peripherals::pad_claims::PadClaims` and `NrfPinClaims` is now an alias.
  ⚠️ It gained a per-family geometry: nRF52 is 2 x 32, EFR32 is 4 x 16, and a
  table built with the wrong pair lands claims on real pads that are not the
  ones firmware named.

## Where +0x6E0 comes from

`GPIO_TypeDef`, walked member by member. My FIRST derivation was wrong and
looked fine — a parse that ran across several typedefs sized
`GPIO_I2CROUTE_TypeDef` at 27 words instead of 4 and put the block at +0x1018.
What makes +0x6E0 believable is not the parser: the same walk puts USARTROUTE
at exactly the +0x820 this chip's yaml has used since onboarding, and sizes
PORT/I2CROUTE/TIMERROUTE/USARTROUTE at 12/4/8/8 words, each countable by eye.

## ⚠️ The unit tests were not enough, twice

Every piece above had passing unit tests while the wiring pass silently did
nothing, because the route model implemented `as_any` and the pass downcasts
mutably — and the trait's mutable accessor DEFAULTS TO `None`. Everything
compiled, nothing was routed. Fixing that surfaced the identical miss on
`Efr32s2Timer`, which had the same one-sided impl.

Only an end-to-end read of the PAD can tell those apart, so
`crates/core/tests/efr32mg26_pwm_pad.rs` drives the SHIPPED `from_config` bus
through MMIO and reads `gpioc` pin 8 (LED0) the way the analyzer does. Four
cases: the pad goes high, it FOLLOWS a 25% duty across a whole period (a pad
stuck high would pass a single-sample test), an unrouted pad does NOT carry the
waveform, and clearing `ROUTEEN` hands the pad back to the port. Proven able to
fail — deleting the wiring call reds three of the four and leaves the negative
control green.

  efr32mg26  L1  19 peripherals  215/215 (100%)  1 excluded