### PR TITLE
fix(esp32s3): do not release APP_CPU to a reset vector fast boot has no ROM for

### DIFF
--- a/crates/cli/src/commands/test.rs
+++ b/crates/cli/src/commands/test.rs
@@ -1461,6 +1461,10 @@ pub(crate) fn run_test(
                     app_cpu.set_sp(0x3FCD_8000);
                     let mut machine =
                         labwired_core::Machine::new(pro_cpu, bus).with_secondary_cpu(app_cpu);
+                    // Fast boot: the mask ROM is a thunk harness, so core 1's
+                    // reset vector holds no startup code. Wait for
+                    // `ets_set_appcpu_boot_addr`.
+                    machine.secondary_awaits_boot_addr = true;
                     machine.observers.push(metrics.clone());
                     eprintln!(
                         "labwired-cli test: ESP32-S3 fast-boot entry=0x{:08x} (dual-core APP_CPU)",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1571,6 +1571,16 @@ pub struct Machine<C: Cpu> {
     /// `release_secondary_cpu_if_requested` so a core is never released
     /// without a stack.
     pub secondary_boot_sp: Option<u32>,
+    /// The secondary CPU has no ROM to boot: release it only on an explicit
+    /// entry point (`APPCPU_BOOT_ADDR`), never on the reset-release edge.
+    ///
+    /// A faithful ROM boot constructs core 1 sitting on its reset vector and
+    /// lets `SYSTEM_CORE_1_CONTROL_0.RESETING` 1->0 start it, exactly like
+    /// silicon. The fast-boot frontends do not: they replace the mask ROM with
+    /// a thunk harness, so that same vector holds no startup code and a core
+    /// released there executes the harness and collapses to PC 0. Those
+    /// frontends set this, and hand core 1 over at `call_start_cpu1` instead.
+    pub secondary_awaits_boot_addr: bool,
 
     // Debug state
     pub breakpoints: std::collections::HashSet<u32>,
@@ -2159,6 +2169,7 @@ impl<C: Cpu> Machine<C> {
             bus,
             observers: Vec::new(),
             secondary_boot_sp: None,
+            secondary_awaits_boot_addr: false,
             breakpoints: HashSet::new(),
             last_breakpoint: None,
             total_cycles: 0,

--- a/crates/core/src/machine/advance.rs
+++ b/crates/core/src/machine/advance.rs
@@ -70,8 +70,18 @@ impl<C: Cpu> Machine<C> {
             // flag here is harmless for a frontend that also checks it (the
             // first taker wins and both unhalt the same core) and a no-op on
             // every chip that never sets it.
+            //
+            // Not, however, when the secondary has no ROM to boot. A fast-boot
+            // frontend swaps the mask ROM for a thunk harness, so the reset
+            // vector core 1 is constructed on holds no startup code: releasing
+            // it there runs the harness and faults as `cause=0 at pc=0x0` a few
+            // hundred steps in. Such frontends set `secondary_awaits_boot_addr`
+            // and hand core 1 over at `call_start_cpu1` (`APPCPU_BOOT_ADDR`)
+            // instead, which is what `release_secondary_cpu_if_requested` acts
+            // on. Drain the flag either way so it cannot fire later.
             if crate::peripherals::esp_xtensa_common::rom_thunks::APPCPU_RESET_RELEASED
                 .with(|s| s.take())
+                && !self.secondary_awaits_boot_addr
             {
                 if let Some(cpu1) = self.cpu_secondary.as_mut() {
                     cpu1.unhalt();


### PR DESCRIPTION
Fixes the `Core Arduino Matrix Smoke` lane, red on main since 2026-08-17.

## Symptom

All 9 ESP32-S3 cells fail — `compile: ok (firmware.elf)` then `run: unmodeled`, each dying identically:

```
labwired-cli test: ESP32-S3 fast-boot entry=0x403767c4 (dual-core APP_CPU)
ERROR Simulation error at step 602: Exception raised: cause=0 at pc=0x0
FAIL  0/1 checks · 602 steps · 0.05s
```

15 of 16 boards pass; `arduino-matrix-gate` fails only as a consequence. Bisected to a single commit in the last green → first red window: #1008.

## Cause

#1008 moved the APP_CPU release onto the real hardware edge (PRO_CPU clearing `SYSTEM_CORE_1_CONTROL_0.RESETING`) and placed it in `Machine::advance` so every consumer gets it — fixing a browser hang where core 1 was constructed but never let out of reset.

That release is sound only when core 1 has a ROM to boot. `XtensaLx7::new()` constructs it on the reset vector `0x4000_0400`, and a faithful ROM boot starts there exactly like silicon. The **fast-boot** frontend replaces the mask ROM with a thunk harness (`ESP32-S3 ROM harness (thunk code + 131072 B DROM)`), so that vector holds no startup code — released there, core 1 runs the harness and collapses to PC 0.

Fast boot hands core 1 over at `call_start_cpu1` instead: `ets_set_appcpu_boot_addr` → `APPCPU_BOOT_ADDR` → `release_secondary_cpu_if_requested`, which is also the path that gives it a stack.

## Fix

Add `Machine::secondary_awaits_boot_addr`; the fast-boot frontend sets it, and the edge release skips a machine that has it. **Defaults false**, so the ROM-boot and browser paths keep the behaviour #1008 gave them.

## Evidence

The nine real ELFs from failing run `32540476230`, replayed against a clean `main` worktree:

| | result |
|---|---|
| before | **0 pass / 9 fail** — every cell FAIL at 602 steps |
| after | **9 pass / 0 fail** — L0 PASS at 925086 steps |

Negative control: stashing the patch on that same tree returns it to `FAIL 602 steps`; restoring it returns `PASS`. 925k steps matches the board entry’s own `Dual-core S3 boot ~1.1M` budget note, so core 1 is genuinely booting rather than being skipped.

```
L0_serial_boot   PASS  925086 steps      L5_adc      PASS  1050006 steps
L1_serial_loop   PASS  1165086 steps     L6_pwm      PASS  8125087 steps
L2_blink_serial  PASS  1405086 steps     L7_timer    PASS  1645136 steps
L3_i2c_sensor    PASS  1650002 steps     L8_can      PASS  1050006 steps
L4_spi_sensor    PASS  1168867 steps
```

Regression: `labwired-core --lib` 3232 passed / 0 failed; `esp32s3_smp_yield_latency` (#1008’s own dual-core test) 3/3; `e2e_esp32s3_faithful_boot` 1/1; `esp32s3_lcd_i80_pixels` 5/5; `labwired-cli` all green except `test_demo_blinky_gpio_toggle`, which needs a prebuilt `thumbv7m-none-eabi/demo-blinky` fixture absent from my scratch target dir (environmental, unrelated to S3).