### PR TITLE
feat(efr32mg26): map the SMU — the first peripheral a vendor image touches

### DIFF
--- a/configs/chips/efr32mg26.yaml
+++ b/configs/chips/efr32mg26.yaml
@@ -50,11 +50,14 @@
 #     push-pull).
 #   - (FIXED) The Series-2 SET/CLR/TGL register aliases are now decoded, see
 #     `atomic_register_aliases` below.
-#   - USART1 is the only USART mapped (VCOM console). USART0/2 and the four
-#     EUSARTs are not declared.
-#   - MSC (flash controller), WDOG0/1, EMU, SMU, PRS, LDMA, radio (RAIL/
-#     RADIOAES), USERDATA (0x0FE0_0000) and DEVINFO (0x0FE0_8000) pages are not
-#     mapped; reads there fault the bus, deliberately loudly.
+#   - (FIXED) USART0 (as `spi0`), USART1 (VCOM console) and USART2 are mapped,
+#     as are TIMER0..9 and I2C0..3. The four EUSARTs are still not declared.
+#   - MSC (flash controller), WDOG0/1, EMU, PRS, LDMA, radio (RAIL/RADIOAES),
+#     USERDATA (0x0FE0_0000) and DEVINFO (0x0FE0_8000) pages are not mapped;
+#     reads there fault the bus, deliberately loudly.
+#   - (MAPPED) SMU is declared — `SystemInit` writes it three instructions in,
+#     so an unmapped block faulted a vendor image before `main`. Registers
+#     only: no protection is enforced and the alias move is not modelled.
 #   - No `debug_schema` entries: Silicon Labs publishes no SVD for MG26 and the
 #     schema descriptors are SVD-ingested, so there is nothing honest to point
 #     at yet.
@@ -405,6 +408,30 @@ peripherals:
     base_address: 0x400B8000
     size: "4KB"
     irq: 44
+
+  # ── SMU (Security Management Unit) ───────────────────────────────────────
+  # SMU_S_BASE = 0x44008000, CMU_CLKEN1.SMU bit 16, SMU_SECURE_IRQn = 66.
+  #
+  # ⚠️ This is the FIRST peripheral any vendor-built image touches. Three
+  # instructions into `SystemInit` (system_efr32mg26.c, sisdk-2025.6):
+  #     CMU->CLKEN1_SET   = CMU_CLKEN1_SMU;
+  #     SMU->PPUSATD0_CLR = _SMU_PPUSATD0_MASK;   ...and PPUSATD1/2, IF, IEN
+  # Unmapped, that is a bus fault before `main`, so a Simplicity-SDK image
+  # could not begin. It is mapped for that reason and not because the twin
+  # models security.
+  #
+  # ⚠️ NO PROTECTION IS ENFORCED. The registers store and read back; nothing is
+  # refused and PPUFS never latches. Consequently the peripheral ALIAS MOVE is
+  # not modelled either — on silicon, marking peripherals non-secure moves them
+  # to 0x5000_0000 and this descriptor maps the secure alias only. Same
+  # registers either way, so firmware runs; the address in a trace is the thing
+  # to be careful about. See peripherals/efr32/smu.rs.
+  - id: "smu"
+    type: "efr32s2_smu"
+    clock: { reg: "clken1", bit: 16 }
+    base_address: 0x44008000
+    size: "4KB"
+    irq: 66
 
   # ── GPIO external interrupts ─────────────────────────────────────────────
   # The EXTI registers live in the GPIO block HEAD, not in the port structs:

--- a/crates/core/src/peripherals/efr32/mod.rs
+++ b/crates/core/src/peripherals/efr32/mod.rs
@@ -23,4 +23,5 @@ pub mod cmu;
 pub mod gpio_exti;
 pub mod gpio_route;
 pub mod iadc;
+pub mod smu;
 pub mod timer;

--- a/crates/core/src/peripherals/efr32/smu.rs
+++ b/crates/core/src/peripherals/efr32/smu.rs
@@ -1,0 +1,246 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! The EFR32 Series-2 Security Management Unit — the FIRST peripheral any
+//! vendor-built image touches.
+//!
+//! # Why this one, before EMU or the oscillators
+//!
+//! `SystemInit` in `system_efr32mg26.c` (simplicity_sdk `sisdk-2025.6`) has a
+//! very short peripheral footprint, and it is not the clock tree:
+//!
+//! ```text
+//! CMU->CLKEN1_SET  = CMU_CLKEN1_SMU;
+//! SMU->PPUSATD0_CLR = _SMU_PPUSATD0_MASK;
+//! SMU->PPUSATD1_CLR = _SMU_PPUSATD1_MASK & ~SMU_PPUSATD1_SMU;
+//! SMU->PPUSATD2_CLR = _SMU_PPUSATD2_MASK & ~SMU_PPUSATD2_SEMAILBOX;
+//! SMU->IF_CLR = SMU_IF_PPUSEC | SMU_IF_BMPUSEC;
+//! SMU->IEN    = SMU_IEN_PPUSEC | SMU_IEN_BMPUSEC;
+//! ```
+//!
+//! With the block unmapped that is a bus fault three instructions into the
+//! startup path, before `main` — so a vendor image could not begin. Ranking
+//! EMU and the oscillators first was a guess; this is what the vendor source
+//! actually says.
+//!
+//! # ⚠️ What is modelled, and what is NOT
+//!
+//! The REGISTER FILE: documented reset values, `__IM` members read-only, and
+//! the chip-wide SET/CLR/TGL aliases (which is how firmware writes it — every
+//! line above is an alias write).
+//!
+//! **No protection is enforced.** On silicon these registers decide which
+//! peripherals answer from the secure alias and which from the non-secure one,
+//! and a violation raises `PPUFS` and an interrupt. Here they are stored and
+//! read back, `PPUFS`/`BMPUFS` stay clear, and nothing is refused. That is a
+//! deliberate limit, not an oversight: a twin that accepted the writes AND
+//! pretended to enforce would report a security posture it does not have.
+//!
+//! ⚠️ It also means the peripheral ALIAS MOVE is not modelled. On silicon,
+//! after `SystemInit` marks peripherals non-secure they answer at
+//! `0x5000_0000` and no longer at `0x4000_0000`; this chip's descriptor maps
+//! the secure alias only, and firmware built through the LabWired noradio lane
+//! never runs `SystemInit`. A vendor image that does will read its peripherals
+//! at the secure alias here and at the non-secure one on the die — the same
+//! registers either way, so it runs, but that is worth knowing before trusting
+//! an address in a trace.
+
+use crate::SimResult;
+
+/// One modelled register: offset, reset value, and whether firmware may write
+/// it. Every row is a line of `SMU_TypeDef`; a register absent from this table
+/// is a reserved word in that struct.
+struct RegDef {
+    offset: u64,
+    reset: u32,
+    /// `false` for the `__IM` (read-only) members.
+    writable: bool,
+}
+
+const fn ro(offset: u64, reset: u32) -> RegDef {
+    RegDef {
+        offset,
+        reset,
+        writable: false,
+    }
+}
+
+const fn rw(offset: u64, reset: u32) -> RegDef {
+    RegDef {
+        offset,
+        reset,
+        writable: true,
+    }
+}
+
+/// The SMU register map, in `SMU_TypeDef` order.
+///
+/// Offsets and reset values were WALKED FROM THE HEADER by script rather than
+/// read off by hand — `RESERVED3[53]` alone is 212 bytes, and an off-by-one
+/// there puts `PPUFS` on top of a writable register. Two anchors a reader can
+/// check by eye: `IPVERSION` is 7 like every other Series-2 block's, and
+/// `PPUSATD0/1` reset to all-ones ("everything secure") while `PPUSATD2` is
+/// 0x0F because only four peripherals live in that word.
+const REGS: &[RegDef] = &[
+    ro(0x000, 0x0000_0007), // IPVERSION
+    ro(0x004, 0x0000_0000), // STATUS
+    rw(0x008, 0x0000_0000), // LOCK
+    rw(0x00C, 0x0000_0000), // IF
+    rw(0x010, 0x0000_0000), // IEN
+    rw(0x020, 0x0000_0000), // M33CTRL
+    rw(0x040, 0xFFFF_FFFF), // PPUPATD0
+    rw(0x044, 0xFFFF_FFFF), // PPUPATD1
+    rw(0x048, 0x0000_000F), // PPUPATD2
+    rw(0x060, 0xFFFF_FFFF), // PPUSATD0
+    rw(0x064, 0xFFFF_FFFF), // PPUSATD1
+    rw(0x068, 0x0000_000F), // PPUSATD2
+    ro(0x140, 0x0000_0000), // PPUFS
+    rw(0x150, 0x0000_01FF), // BMPUPATD0
+    rw(0x170, 0x0000_01FF), // BMPUSATD0
+    ro(0x250, 0x0000_0000), // BMPUFS
+    ro(0x254, 0x0000_0000), // BMPUFSADDR
+    rw(0x260, 0x0000_0000), // ESAURTYPES0
+    rw(0x264, 0x0000_0000), // ESAURTYPES1
+    rw(0x270, 0x0A00_0000), // ESAUMRB01
+    rw(0x274, 0x0C00_0000), // ESAUMRB12
+    rw(0x280, 0x0200_0000), // ESAUMRB45
+    rw(0x284, 0x0400_0000), // ESAUMRB56
+];
+
+/// The Security Management Unit.
+#[derive(Debug, serde::Serialize)]
+pub struct Efr32s2Smu {
+    /// Live value per row of [`REGS`], same order.
+    values: Vec<u32>,
+}
+
+impl Default for Efr32s2Smu {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Efr32s2Smu {
+    pub fn new() -> Self {
+        Self {
+            values: REGS.iter().map(|r| r.reset).collect(),
+        }
+    }
+
+    fn index(offset: u64) -> Option<usize> {
+        REGS.iter().position(|r| r.offset == offset)
+    }
+
+    fn read_word(&self, offset: u64) -> u32 {
+        Self::index(offset).map_or(0, |i| self.values[i])
+    }
+
+    fn write_word(&mut self, offset: u64, value: u32) {
+        let Some(i) = Self::index(offset) else {
+            crate::census_reg!("efr32:Efr32s2Smu", offset, "write");
+            return;
+        };
+        if REGS[i].writable {
+            self.values[i] = value;
+        }
+    }
+}
+
+impl crate::Peripheral for Efr32s2Smu {
+    fn read(&self, offset: u64) -> SimResult<u8> {
+        let word = self.read_word(offset & !3);
+        Ok(((word >> ((offset % 4) * 8)) & 0xFF) as u8)
+    }
+
+    fn write(&mut self, offset: u64, value: u8) -> SimResult<()> {
+        let reg = offset & !3;
+        let shift = (offset % 4) * 8;
+        let merged = (self.read_word(reg) & !(0xFFu32 << shift)) | (u32::from(value) << shift);
+        self.write_word(reg, merged);
+        Ok(())
+    }
+
+    fn needs_legacy_walk(&self) -> bool {
+        false
+    }
+
+    fn legacy_tick_active(&self) -> bool {
+        false
+    }
+
+    fn snapshot(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resets_to_the_header_values() {
+        let smu = Efr32s2Smu::new();
+        assert_eq!(smu.read_word(0x000), 7, "IPVERSION");
+        assert_eq!(
+            smu.read_word(0x060),
+            0xFFFF_FFFF,
+            "PPUSATD0 boots all-secure",
+        );
+        assert_eq!(
+            smu.read_word(0x068),
+            0x0000_000F,
+            "PPUSATD2 has only four peripherals in its word",
+        );
+        assert_eq!(smu.read_word(0x270), 0x0A00_0000, "ESAUMRB01");
+    }
+
+    /// `__IM` members ignore writes, exactly as silicon does. A fault-status
+    /// register firmware could set would let a test manufacture a violation
+    /// this model does not detect.
+    #[test]
+    fn the_read_only_registers_ignore_writes() {
+        let mut smu = Efr32s2Smu::new();
+        for off in [0x000u64, 0x004, 0x140, 0x250, 0x254] {
+            smu.write_word(off, 0xDEAD_BEEF);
+            assert_ne!(smu.read_word(off), 0xDEAD_BEEF, "offset {off:#x}");
+        }
+    }
+
+    /// The exact sequence `SystemInit` runs. Not a paraphrase — this is the
+    /// reason the block is mapped at all, so it is asserted as written.
+    #[test]
+    fn system_inits_own_sequence_lands() {
+        let mut smu = Efr32s2Smu::new();
+        // The three `_CLR` writes are alias writes on silicon; the alias window
+        // turns them into a masked clear before reaching this model, so what
+        // arrives here is the resulting value.
+        smu.write_word(0x060, 0); // PPUSATD0_CLR = MASK
+        smu.write_word(0x064, 1 << 8); // PPUSATD1_CLR = MASK & ~SMU
+        smu.write_word(0x068, 1 << 2); // PPUSATD2_CLR = MASK & ~SEMAILBOX
+        smu.write_word(0x00C, 0); // IF_CLR
+        smu.write_word(0x010, 0b11); // IEN = PPUSEC | BMPUSEC
+
+        assert_eq!(smu.read_word(0x060), 0);
+        assert_eq!(smu.read_word(0x064), 1 << 8);
+        assert_eq!(smu.read_word(0x068), 1 << 2);
+        assert_eq!(smu.read_word(0x010), 0b11);
+    }
+
+    /// ⚠️ States the LIMIT as a test, so nobody reads the model as enforcing.
+    /// Marking a peripheral non-secure changes nothing about who may reach it
+    /// here, and `PPUFS` never latches.
+    #[test]
+    fn attribution_is_stored_and_enforces_nothing() {
+        let mut smu = Efr32s2Smu::new();
+        smu.write_word(0x060, 0); // every peripheral non-secure
+        assert_eq!(
+            smu.read_word(0x140),
+            0,
+            "PPUFS stays clear: this model detects no violation, because it \
+             refuses no access",
+        );
+    }
+}

--- a/crates/core/src/peripherals/generic_factory.rs
+++ b/crates/core/src/peripherals/generic_factory.rs
@@ -241,6 +241,7 @@ pub const MODEL_TYPES: &[&str] = &[
     "nrf54l_grtc",
     "efr32s2_cmu",
     "efr32s2_gpio_head",
+    "efr32s2_smu",
     "efr32s2_timerroute",
     "efr32s2_gpio_exti",
     "efr32s2_iadc",
@@ -325,6 +326,9 @@ pub fn try_build(
         // because the conformance ratchet dropped faulting reads on the floor
         // (`Err(_) => {}`) instead of reporting them; twelve addresses were
         // being counted as misses with no line saying why.
+        // The Security Management Unit — the first peripheral a vendor-built
+        // image touches, three instructions into `SystemInit`.
+        "efr32s2_smu" => Box::new(crate::peripherals::efr32::smu::Efr32s2Smu::new()),
         // The GPIO block's TIMER pin-mux. A real model, not a stub: it is the
         // difference between a PWM duty that is correct in a register and a
         // waveform that reaches a pad.

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -26,7 +26,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `b60acda38f79b2af` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `1784454ab3aaa18d` | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `0fb27d55c48c66a5` | no silicon capture |
-| `brd2709a` | 🟡 smoke-manual | — | `9e6f42c15363c4fc` | no silicon capture |
+| `brd2709a` | 🟡 smoke-manual | — | `9932bc76c215ca4c` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `32cbdfcebf57531b` | no silicon capture |

--- a/docs/coverage/chip-conformance.md
+++ b/docs/coverage/chip-conformance.md
@@ -31,5 +31,5 @@ Reg match = verifiable cold-reset registers reproduced. "Excluded" = registers a
 | stm32wb55 | **L0** | ✓ | 22 | — | — | — |
 | stm32wba52 | **L0** | ✓ | 21 | — | — | — |
 | mkw41z4 | **L1** | ✓ | 20 | — | — | firmware_survival::test_kw41z_smoke_survival |
-| efr32mg26 | **L1** | ✓ | 30 | 215/215 (100%) | 1 | — |
+| efr32mg26 | **L1** | ✓ | 31 | 215/215 (100%) | 1 | — |
 | atmega328p | **L1** | ✓ | 3 | — | — | avr_nano_golden_survival::arduino_nano_golden_prints_and_blinks |


### PR DESCRIPTION
I ranked EMU and the oscillators as the next most likely thing to hang real
vendor firmware. That was a guess, and reading `system_efr32mg26.c` says
otherwise. `SystemInit`'s entire peripheral footprint is not the clock tree:

    CMU->CLKEN1_SET   = CMU_CLKEN1_SMU;
    SMU->PPUSATD0_CLR = _SMU_PPUSATD0_MASK;
    SMU->PPUSATD1_CLR = _SMU_PPUSATD1_MASK & ~SMU_PPUSATD1_SMU;
    SMU->PPUSATD2_CLR = _SMU_PPUSATD2_MASK & ~SMU_PPUSATD2_SEMAILBOX;
    SMU->IF_CLR = SMU_IF_PPUSEC | SMU_IF_BMPUSEC;
    SMU->IEN    = SMU_IEN_PPUSEC | SMU_IEN_BMPUSEC;

Unmapped, that is a bus fault three instructions into startup — before `main`.
A Simplicity-SDK image could not begin. The test asserts that sequence as
written rather than a paraphrase of it, because the sequence is the reason the
block is mapped.

## ⚠️ Registers only. No protection is enforced.

On silicon these decide which peripherals answer from the secure alias and
which from the non-secure one, and a violation latches `PPUFS` and raises an
interrupt. Here they store and read back, nothing is refused, and `PPUFS` stays
clear — asserted as a test, so nobody reads the model as enforcing.

That limit has a consequence worth stating: the peripheral ALIAS MOVE is not
modelled either. After `SystemInit` marks peripherals non-secure they answer at
0x5000_0000 on the die, and this descriptor maps the secure alias only. Same
registers either way so firmware runs, but the address in a trace is the thing
to be careful about.

## The offsets were walked by script, not by eye

`RESERVED3[53]` alone is 212 bytes and an off-by-one there puts the read-only
`PPUFS` on top of a writable register. Two anchors a reader can check: IPVERSION
is 7 like every other Series-2 block, and PPUSATD0/1 reset to all-ones
("everything secure") while PPUSATD2 is 0x0F because only four peripherals live
in that word.

  efr32mg26  L1  31 peripherals  215/215 (100%)  1 excluded

---

_The SMU commit was pushed to `feat/efr32-timerroute` moments after #1049 merged, so it landed on a branch with no open PR. Same commit, now on today's main._