### PR TITLE
fix(cortex-m): decode SMLABB — blink did not blink on EFR32MG26

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -3583,6 +3583,38 @@ impl CortexM {
                     self.write_reg(rd, res);
                     pc_increment = 4;
                 }
+                Instruction::SmlaXy {
+                    rd,
+                    rn,
+                    rm,
+                    ra,
+                    n_top,
+                    m_top,
+                    accumulate,
+                } => {
+                    // ⚠️ SIGNED halves, sign-extended before the multiply. Taking
+                    // them as u16 would agree with the hardware on every small
+                    // positive operand and disagree on every negative one — the
+                    // shape of bug that passes a smoke test and fails a sensor.
+                    let half = |value: u32, top: bool| -> i32 {
+                        (if top {
+                            (value >> 16) as u16
+                        } else {
+                            value as u16
+                        }) as i16 as i32
+                    };
+                    let product =
+                        half(self.read_reg(rn), n_top).wrapping_mul(half(self.read_reg(rm), m_top));
+                    // The SMUL forms have no addend; `ra` there is the 0b1111
+                    // encoding marker, not a register.
+                    let res = if accumulate {
+                        (self.read_reg(ra) as i32).wrapping_add(product)
+                    } else {
+                        product
+                    };
+                    self.write_reg(rd, res as u32);
+                    pc_increment = 4;
+                }
 
                 // -------- VFPv4 single-precision (FPU) --------
                 Instruction::Vldr { sd, rn, imm, add } => {
@@ -4987,6 +5019,73 @@ mod tests {
         run_test_instr(&mut cpu, &mut bus, 0xFBA2_0103, true);
         assert_eq!(cpu.r0, 0xFFFF_FFFE, "UMULL low half");
         assert_eq!(cpu.r1, 0x0000_0001, "UMULL high half");
+    }
+
+    /// SMLABB/BT/TB/TT and SMULBB — the DSP halfword multiplies.
+    ///
+    /// ⚠️ THIS IS A BLINK TEST WEARING A DECODER TEST'S CLOTHES. `smlabb r3,
+    /// r3, r4, r2` is what GCC emits at -Os for the port-base arithmetic in
+    /// Arduino's `digitalWrite` on EFR32MG26 — `0x4003C000 + 0x30 * (pin >> 4)`
+    /// — and while it was undecoded it was a silent no-op, so `digitalWrite`
+    /// wrote to a garbage address. The BRD2709A Arduino column read 6 pass /
+    /// 2 fail, and the two failures were blink and SPI: the two sketches that
+    /// drive a pin.
+    ///
+    /// The negative cases matter as much as the positive one. Taking the halves
+    /// as UNSIGNED agrees with the hardware on every small positive operand —
+    /// which is every pin number — and disagrees on every negative one.
+    ///
+    /// ⚠️ Every encoding below is `arm-none-eabi-as -mcpu=cortex-m33` output,
+    /// not hand-derived. Two of them were hand-derived first and both put Rm at
+    /// r0: the product came out zero and the assertion still read like a
+    /// sign-extension bug rather than a typo in the test.
+    #[test]
+    fn test_thumb2_halfword_multiplies() {
+        let mut cpu = CortexM::new();
+        let mut bus = MockBus::new();
+
+        // The exact instruction from a compiled digitalWrite:
+        //   smlabb r3, r3, r4, r2   =  FB13 2304
+        // r3 = SInt(r3[15:0]) * SInt(r4[15:0]) + r2
+        cpu.r3 = 0x30; // 48 bytes per GPIO port
+        cpu.r4 = 2; // port index for a PC pin
+        cpu.r2 = 0x4003_C000; // GPIO block base
+        run_test_instr(&mut cpu, &mut bus, 0xFB13_2304, true);
+        assert_eq!(
+            cpu.r3, 0x4003_C060,
+            "SMLABB: PORTC base = 0x4003C000 + 48*2"
+        );
+
+        // ⚠️ SIGNED, and the halves are sign-extended BEFORE the multiply.
+        // -2 * 3 = -6, not 65534 * 3.
+        cpu.r3 = 0x0000_FFFE; // bottom half = -2
+        cpu.r4 = 0x0000_0003;
+        cpu.r2 = 0;
+        run_test_instr(&mut cpu, &mut bus, 0xFB13_2304, true);
+        assert_eq!(cpu.r3 as i32, -6, "SMLABB sign-extends both halves");
+
+        // The TOP-half selectors are separate bits and must not be swapped.
+        //   smlatb r0, r1, r2, r3  = FB11 3022  (N=1 -> Rn top, M=0 -> Rm bottom)
+        cpu.r1 = 0x0005_0000; // top half = 5, bottom = 0
+        cpu.r2 = 0x0000_0007; // bottom half = 7
+        cpu.r3 = 1;
+        run_test_instr(&mut cpu, &mut bus, 0xFB11_3022, true);
+        assert_eq!(cpu.r0, 36, "SMLATB: 5*7 + 1, Rn top and Rm bottom");
+
+        //   smlabt r0, r1, r2, r3  = FB11 3012  (N=0 -> Rn bottom, M=1 -> Rm top)
+        cpu.r1 = 0x0000_0005;
+        cpu.r2 = 0x0007_0000;
+        cpu.r3 = 1;
+        run_test_instr(&mut cpu, &mut bus, 0xFB11_3012, true);
+        assert_eq!(cpu.r0, 36, "SMLABT: Rn bottom and Rm top");
+
+        // Ra == 0b1111 is SMULBB — the product alone, with NO addend. Reading
+        // r15 as an accumulator instead would add the PC.
+        //   smulbb r0, r1, r2  = FB11 F002
+        cpu.r1 = 6;
+        cpu.r2 = 7;
+        run_test_instr(&mut cpu, &mut bus, 0xFB11_F002, true);
+        assert_eq!(cpu.r0, 42, "SMULBB does not accumulate");
     }
 
     #[test]

--- a/crates/core/src/decoder/arm.rs
+++ b/crates/core/src/decoder/arm.rs
@@ -653,6 +653,27 @@ pub enum Instruction {
         rm: u8,
         ra: u8,
     },
+    /// SMLABB/BT/TB/TT and SMULBB/BT/TB/TT — ARMv7-M A7.7.166/A7.7.171.
+    ///
+    /// A 16x16 signed multiply picking a HALF of each operand register, with an
+    /// optional 32-bit accumulate. Part of the DSP extension, which the
+    /// Cortex-M33 in EFR32MG26 has and which GCC reaches for on ordinary code:
+    /// it compiles `base + 48 * index` in Arduino's `digitalWrite` to SMLABB
+    /// because it can prove both operands fit in 16 bits.
+    ///
+    /// `accumulate` is false for the SMUL forms (Ra == 0b1111), where there is
+    /// no addend and Ra is not a register at all.
+    SmlaXy {
+        rd: u8,
+        rn: u8,
+        rm: u8,
+        ra: u8,
+        /// Take Rn's TOP half rather than its bottom.
+        n_top: bool,
+        /// Take Rm's TOP half rather than its bottom.
+        m_top: bool,
+        accumulate: bool,
+    },
 
     // -------- VFPv4 single-precision (FPU) --------
     //
@@ -1456,6 +1477,39 @@ pub fn decode_thumb_32(h1: u16, h2: u16) -> Instruction {
             0x1 => return Instruction::Mls { rd, rn, rm, ra },
             _ => {}
         }
+    }
+
+    // SMLABB/BT/TB/TT, SMULBB/BT/TB/TT — ARMv7-M A7.7.166 / A7.7.171.
+    //
+    //   1111 1011 0001 nnnn | aaaa dddd 00 N M mmmm
+    //
+    // ⚠️ NOT an exotic DSP intrinsic nobody's code reaches. This is what GCC
+    // emits at -Os for `base + K * index` when it can prove both halves fit in
+    // 16 bits, and Arduino's `digitalWrite` is exactly that shape — the GPIO
+    // port base is `0x4003C000 + 0x30 * (pin >> 4)`. Undecoded, it was a silent
+    // no-op (see `record_undecoded`), so `digitalWrite` computed a garbage port
+    // address and BLINK DID NOT BLINK on EFR32MG26 while every other cell of
+    // that board's Arduino column passed.
+    //
+    // h2[7:6] must be 00: 01/10/11 in that field are SMLAD/SMLAWx/SMLSD, which
+    // are different instructions and are still undecoded rather than
+    // approximated by this one.
+    if (h1 & 0xFFF0) == 0xFB10 && (h2 & 0x00C0) == 0 {
+        let ra = ((h2 >> 12) & 0xF) as u8;
+        let rd = ((h2 >> 8) & 0xF) as u8;
+        let rn = (h1 & 0xF) as u8;
+        let rm = (h2 & 0xF) as u8;
+        return Instruction::SmlaXy {
+            rd,
+            rn,
+            rm,
+            ra,
+            n_top: (h2 & 0x0020) != 0,
+            m_top: (h2 & 0x0010) != 0,
+            // Ra == 0b1111 is the SMUL form: no addend, and Ra is an encoding
+            // marker rather than a register to read.
+            accumulate: ra != 0xF,
+        };
     }
 
     // -------------------------------------------------------------

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,29 +9,29 @@ The models column is a content digest over everything that board's `models` list
 
 | Board | Tier | Last silicon capture | Models | Status |
 |-------|------|----------------------|--------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `762bfb5d5ab8f519` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `762bfb5d5ab8f519` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `aff74ffd315a4a6b` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `4ed1cf55f5ca29eb` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `4ed1cf55f5ca29eb` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `fe15dea91457eac5` | ⚠ drift acked 2026-08-21 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `f1e2477dfe90c111` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `028d2a8a44b6f7a8` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `4f89a3042e273f1d` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `f5554f202059a1ce` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `5ee5241dca313ed4` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `e511c7e725d61034` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `f25b4203a3f32c92` | ⚠ drift acked 2026-08-21 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `8f491ed0bee517b5` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `b6850f7e5ffa2a08` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `5de4805fa1b110ee` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `stm32f401` | 🟡 smoke-manual | — | `b6fef3a379137d96` | no silicon capture |
-| `stm32wba52` | 🟡 smoke-manual | — | `a28b3f47eb11df11` | no silicon capture |
-| `nrf52832` | ⚪ structural | — | `e18766783c36d18c` | no silicon capture |
-| `rp2040` | ⚪ structural | — | `7862c68a44c27a50` | no silicon capture |
-| `rp2350` | 🟡 smoke-manual | — | `f7a97402f01fc605` | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `b60acda38f79b2af` | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `1784454ab3aaa18d` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `0fb27d55c48c66a5` | no silicon capture |
+| `stm32f401` | 🟡 smoke-manual | — | `8e26de97053f91af` | no silicon capture |
+| `stm32wba52` | 🟡 smoke-manual | — | `25e6d324074dce80` | no silicon capture |
+| `nrf52832` | ⚪ structural | — | `913a32bf4a37cb81` | no silicon capture |
+| `rp2040` | ⚪ structural | — | `79ff1ba649399fc6` | no silicon capture |
+| `rp2350` | 🟡 smoke-manual | — | `62d0835a612f241f` | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `abcdac5cc123d3c0` | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `b3de20ac20320b1e` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `8d7c7f22e537baef` | no silicon capture |
 | `brd2709a` | 🟡 smoke-manual | — | `9932bc76c215ca4c` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
-| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `3ab34d0f42e59464` | no silicon capture |
-| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `32cbdfcebf57531b` | no silicon capture |
-| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | `45f00f00bf020d1a` | no silicon capture |
-| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | `b1628f57714f60f9` | no silicon capture |
+| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `9c339cd43758ed97` | no silicon capture |
+| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `493aad26a23404e1` | no silicon capture |
+| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | `c28cf19a14404118` | no silicon capture |
+| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | `04c5be0e36f25d58` | no silicon capture |
 | `ci-fixture-riscv` | ⚪ structural | — | `9fd2074c862cfb3d` | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -331,7 +331,23 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 762bfb5d5ab8f5193ec539eadbbc338ee97e5d77faa33d16e743c3c9a2f536a9
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: 4ed1cf55f5ca29eb38d3db073a84f283ea389b624259166352c9fe132b284fe1
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -540,7 +556,23 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 762bfb5d5ab8f5193ec539eadbbc338ee97e5d77faa33d16e743c3c9a2f536a9
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: 4ed1cf55f5ca29eb38d3db073a84f283ea389b624259166352c9fe132b284fe1
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -873,7 +905,23 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: aff74ffd315a4a6ba81b7824564de3d0fd0df469be6e2b61da1aec77a16b40ca
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: fe15dea91457eac5c4c7ca31ce88dc547ca703b920179eccab21e530e7f253dc
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -1935,7 +1983,23 @@ boards:
       # real one. No register layout, reset value or peripheral behaviour is
       # touched, which is what the silicon capture asserts, so the capture stands.
     drift_ack: 2026-08-22
-    drift_ack_digest: 028d2a8a44b6f7a837f361181d2f5dcbd990c3502049aa245d20dcd148204da8
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: e511c7e725d610348ce5b57c71167d508958045ec7cc46d157de12c7d03b323a
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2211,7 +2275,23 @@ boards:
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
     drift_ack: 2026-08-21
-    drift_ack_digest: 4f89a3042e273f1d36c9a99001466aa030c3b09f01f9afedd374623a740bb7b9
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: f25b4203a3f32c92d9272521e140db27d2a799d778dc7c2818f49545af1f7687
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2546,7 +2626,23 @@ boards:
       # real one. No register layout, reset value or peripheral behaviour is
       # touched, which is what the silicon capture asserts, so the capture stands.
     drift_ack: 2026-08-22
-    drift_ack_digest: f5554f202059a1ceacf23ec1014c9ceb2e2f7a07e55c9b5758169af15bd331de
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: 8f491ed0bee517b51dd9e4f406b623f7f5d8a3e89d5257f637e7adbf85832ee8
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2841,7 +2937,23 @@ boards:
       # real one. No register layout, reset value or peripheral behaviour is
       # touched, which is what the silicon capture asserts, so the capture stands.
     drift_ack: 2026-08-22
-    drift_ack_digest: 5ee5241dca313ed484b6a2ca01255eb828208f68c6544d8e68ec16a72f730b8f
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: b6850f7e5ffa2a08631eb5f5c410237bb5e1d36d4d8c4f8e60a06f6577035a37
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     # 2026-08-12: chip yaml adds bxcan1 (type bxcan @ 0x40006400, APB1ENR bit 25) for
     # Arduino matrix L8 loopback. Existing BxCan model; no register-map change to
@@ -3471,7 +3583,23 @@ boards:
       # real one. No register layout, reset value or peripheral behaviour is
       # touched, which is what the silicon capture asserts, so the capture stands.
     drift_ack: 2026-08-22
-    drift_ack_digest: 7862c68a44c27a503d02baad5a8ec795474c0a8c9c691e0e940be7c3fd5af062
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: 79ff1ba649399fc628090cbea5aeeb0ce59ed36b99d17117c72ef9fdd989ce31
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3556,7 +3684,23 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: 1784454ab3aaa18d6cce5fd95ae54de633644ef7deb52b00f8097b5e78be31ab
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: b3de20ac20320b1e82f10fd72f848a7defe066eb2d475bc8122af01bb3b25795
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3627,7 +3771,23 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: 0fb27d55c48c66a5483209c4f7fa029280227b36ea0b24b928d4527b74fceeed
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: 8d7c7f22e537baef2daa2aa2ecfbcc60a531417289477cfb23da554beced010d
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -3703,7 +3863,23 @@ boards:
     # this ack names content a human actually read; no live re-capture owed for
     # this change, and any already owed above still is.
     drift_ack: 2026-08-13
-    drift_ack_digest: 3ab34d0f42e59464cff72293c291bc1af218bb8176e431d7638748772c1917d7
+    # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
+    # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
+    # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
+    # SMLABB and was writing to a garbage address, so blink did not blink.
+    # Purely additive: one new `else if` in decoder/arm.rs and one new match arm
+    # in cortex_m.rs; `git diff` removes no existing line, so every encoding that
+    # decoded before decodes identically now.
+    # ⚠ MEASURED, NOT ASSUMED, because a newly-decoded instruction genuinely does
+    # change behaviour for firmware that executes it — this is the one drift note
+    # in this file where "additive" is not by itself an argument. All 96 committed
+    # ELF fixtures were disassembled: exactly ONE contains the family, the
+    # `smulbb r0, r1, r0` divide-by-3 in
+    # crates/wasm/tests/fixtures/firmware-l476-bldc-six-step.elf, and its committed
+    # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
+    # matches. No other pinned firmware on any board reaches the encoding, so
+    # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
+    drift_ack_digest: 9c339cd43758ed9795889960668582a8f27a562b558411116395955894983887
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs


### PR DESCRIPTION
The BRD2709A Arduino column read 6 pass / 2 fail, and the two failures were
L2_blink_serial and L4_spi_sensor: the only two sketches that drive a pin.
Both stopped at the same warning, at the same address, in the same function:

    WARN Unknown 32-bit instruction at 0x80082b4: 0xfb13 0x2304
    080082ac <digitalWrite>:
      80082b4:  fb13 2304   smlabb r3, r3, r4, r2

`digitalWrite` computes its GPIO port base as 0x4003C000 + 0x30 * (pin >> 4),
and GCC at -Os proves both operands fit in 16 bits and emits the DSP halfword
multiply. Undecoded, it is a SILENT NO-OP — `record_undecoded` files it and
execution continues — so the port base stayed 0x30 and every write went
somewhere that is not a GPIO. Both sketches printed their BOOT marker and then
never their OK marker, which reads like a hang in the sketch and is a wrong
address in the core.

⚠️ NOT AN EXOTIC INTRINSIC. This is the plainest possible Arduino call on the
plainest possible board. The Cortex-M33 in EFR32MG26 has the DSP extension and
GCC uses it without being asked; nothing about this is specific to Silicon
Labs, and any M33 or M4 part reaching this pattern was in the same state.

SMLABB/BT/TB/TT and SMULBB/BT/TB/TT, ARMv7-M A7.7.166 / A7.7.171:

    1111 1011 0001 nnnn | aaaa dddd 00 N M mmmm

h2[7:6] must be 00 — 01/10/11 in that field are SMLAD, SMLAWx and SMLSD, which
are different instructions and are left undecoded rather than approximated by
this one. Ra == 0b1111 is the SMUL form, where there is no addend and Ra is an
encoding marker rather than a register to read.

⚠️ SIGNED halves, sign-extended BEFORE the multiply. Taking them as u16 agrees
with the hardware on every small positive operand — which is every pin number,
so the whole Arduino matrix would still pass — and disagrees on every negative
one.

Cases cover both half-selectors independently, the sign extension, and the
non-accumulating SMUL form. ⚠️ Every encoding in them is
`arm-none-eabi-as -mcpu=cortex-m33` output, not hand-derived: two were
hand-derived first and both put Rm at r0, so the product came out zero and the
assertion read like a sign-extension bug rather than a typo in the test.

Measured on the BRD2709A Arduino matrix, through the hand-written
silabs-arduino core and the shipped twin:

    before   6 pass / 1 skip / 2 fail
    after    8 pass / 1 skip / 0 fail        (L8 skipped: no CAN controller)

labwired-core lib: 3256 passed, 0 failed. fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MeY1h5Uvfn9kPiQTSnWKHb