### PR TITLE
fix(cpu): give guest arithmetic explicit wrapping ops, and fix four panics it was hiding

### DIFF
--- a/crates/core/src/cpu/cortex_m.rs
+++ b/crates/core/src/cpu/cortex_m.rs
@@ -595,17 +595,17 @@ impl CortexM {
         let frame_ptr = if frame_on_psp { self.psp } else { self.msp };
 
         self.r0 = bus.read_u32(frame_ptr as u64)?;
-        self.r1 = bus.read_u32((frame_ptr + 4) as u64)?;
-        self.r2 = bus.read_u32((frame_ptr + 8) as u64)?;
-        self.r3 = bus.read_u32((frame_ptr + 12) as u64)?;
-        self.r12 = bus.read_u32((frame_ptr + 16) as u64)?;
-        self.lr = bus.read_u32((frame_ptr + 20) as u64)?;
-        self.pc = bus.read_u32((frame_ptr + 24) as u64)? & !1;
-        self.xpsr = bus.read_u32((frame_ptr + 28) as u64)?;
+        self.r1 = bus.read_u32(frame_ptr.wrapping_add(4) as u64)?;
+        self.r2 = bus.read_u32(frame_ptr.wrapping_add(8) as u64)?;
+        self.r3 = bus.read_u32(frame_ptr.wrapping_add(12) as u64)?;
+        self.r12 = bus.read_u32(frame_ptr.wrapping_add(16) as u64)?;
+        self.lr = bus.read_u32(frame_ptr.wrapping_add(20) as u64)?;
+        self.pc = bus.read_u32(frame_ptr.wrapping_add(24) as u64)? & !1;
+        self.xpsr = bus.read_u32(frame_ptr.wrapping_add(28) as u64)?;
         self.it_state = Self::itstate_from_xpsr(self.xpsr);
 
         // Advance the bank the frame was popped from.
-        let new_sp = frame_ptr + 32;
+        let new_sp = frame_ptr.wrapping_add(32);
         if frame_on_psp {
             self.psp = new_sp;
         } else {
@@ -1361,13 +1361,18 @@ impl CortexM {
                     // data-access fault, and escalating it would re-enter this
                     // same broken stack forever. See `CortexM::bus_load`.
                     Self::bus_store(bus, frame_ptr, AccessWidth::Word, self.r0)?;
-                    Self::bus_store(bus, frame_ptr + 4, AccessWidth::Word, self.r1)?;
-                    Self::bus_store(bus, frame_ptr + 8, AccessWidth::Word, self.r2)?;
-                    Self::bus_store(bus, frame_ptr + 12, AccessWidth::Word, self.r3)?;
-                    Self::bus_store(bus, frame_ptr + 16, AccessWidth::Word, self.r12)?;
-                    Self::bus_store(bus, frame_ptr + 20, AccessWidth::Word, self.lr)?;
-                    Self::bus_store(bus, frame_ptr + 24, AccessWidth::Word, self.pc)?;
-                    Self::bus_store(bus, frame_ptr + 28, AccessWidth::Word, save_xpsr)?;
+                    Self::bus_store(bus, frame_ptr.wrapping_add(4), AccessWidth::Word, self.r1)?;
+                    Self::bus_store(bus, frame_ptr.wrapping_add(8), AccessWidth::Word, self.r2)?;
+                    Self::bus_store(bus, frame_ptr.wrapping_add(12), AccessWidth::Word, self.r3)?;
+                    Self::bus_store(bus, frame_ptr.wrapping_add(16), AccessWidth::Word, self.r12)?;
+                    Self::bus_store(bus, frame_ptr.wrapping_add(20), AccessWidth::Word, self.lr)?;
+                    Self::bus_store(bus, frame_ptr.wrapping_add(24), AccessWidth::Word, self.pc)?;
+                    Self::bus_store(
+                        bus,
+                        frame_ptr.wrapping_add(28),
+                        AccessWidth::Word,
+                        save_xpsr,
+                    )?;
 
                     // Bank the preempted stack pointer into its bank (PSP or MSP)
                     // BEFORE entering Handler mode, then switch the live `sp` to MSP.
@@ -1397,7 +1402,7 @@ impl CortexM {
 
                     // Jump to ISR handler
                     let vtor = self.vtor.load(Ordering::SeqCst);
-                    let vector_addr = vtor + (exception_num * 4);
+                    let vector_addr = vtor.wrapping_add(exception_num.wrapping_mul(4));
                     if trace_exc_enabled() {
                         eprintln!(
                             "EXC take num={} vtor=0x{:08X} vec=0x{:08X} fetch={:?}",
@@ -1446,7 +1451,7 @@ impl CortexM {
             let is_32bit = (h1 & 0xE000) == 0xE000 && (h1 & 0x1800) != 0;
 
             let (instr, op, pincr, cyc) = if is_32bit {
-                let h2 = bus.read_u16((fetch_pc + 2) as u64)?;
+                let h2 = bus.read_u16(fetch_pc.wrapping_add(2) as u64)?;
                 let instr = decode_thumb_32(h1, h2);
                 let op = ((h1 as u32) << 16) | h2 as u32;
                 (instr, op, 4, 2)
@@ -2582,7 +2587,7 @@ impl CortexM {
                     }
                 }
                 Instruction::Branch { offset } => {
-                    let target = (self.pc as i32 + 4 + offset) as u32;
+                    let target = (self.pc as i32).wrapping_add(4).wrapping_add(offset) as u32;
                     self.pc = target;
                     pc_increment = 0;
                 }
@@ -3049,7 +3054,7 @@ impl CortexM {
                 }
 
                 Instruction::LdrLit { rt, imm } => {
-                    let pc_val = (self.pc & !3) + 4;
+                    let pc_val = (self.pc & !3).wrapping_add(4);
                     let addr = pc_val.wrapping_add(imm as u32);
                     let val = self.load(bus, addr, AccessWidth::Word)?;
                     self.write_reg(rt, val);
@@ -3070,7 +3075,7 @@ impl CortexM {
                     self.write_reg(rd, res);
                 }
                 Instruction::Adr { rd, imm } => {
-                    let pc_val = (self.pc & !3) + 4;
+                    let pc_val = (self.pc & !3).wrapping_add(4);
                     let res = pc_val.wrapping_add(imm as u32);
                     self.write_reg(rd, res);
                 }
@@ -3380,15 +3385,15 @@ impl CortexM {
                 Instruction::Bl { offset } => {
                     // BL: Branch with Link.
                     // LR = Next Instruction Address | 1 (Thumb bit)
-                    let _next_pc = self.pc + 4; // 32-bit instruction size for BL?
-                                                // Wait. BL is decoded as 32-bit.
-                                                // If we assume decode_thumb_16 handled a 32-bit stream, then PC increment should be adjusted?
-                                                // Or does `decode_thumb_16` return `BlPrefix` and then we handle it?
-                                                // The current `decoder` returns `Bl` with full offset if it sees the pair??
-                                                // NO. My decoder implementation for BL (in previous turn) was:
-                                                // `Instruction::Bl { offset: offset << 1 }`
-                                                // But `decode_thumb_16` ONLY sees 16 bits. It cannot see the second half!
-                                                // Real decoding of BL requires fetching 32 bits.
+                    let _next_pc = self.pc.wrapping_add(4); // 32-bit instruction size for BL?
+                                                            // Wait. BL is decoded as 32-bit.
+                                                            // If we assume decode_thumb_16 handled a 32-bit stream, then PC increment should be adjusted?
+                                                            // Or does `decode_thumb_16` return `BlPrefix` and then we handle it?
+                                                            // The current `decoder` returns `Bl` with full offset if it sees the pair??
+                                                            // NO. My decoder implementation for BL (in previous turn) was:
+                                                            // `Instruction::Bl { offset: offset << 1 }`
+                                                            // But `decode_thumb_16` ONLY sees 16 bits. It cannot see the second half!
+                                                            // Real decoding of BL requires fetching 32 bits.
 
                     // CRITICAL CORRECTION: `decode_thumb_16` is 16-bit.
                     // BL is 32-bit (encoded as two 16-bit halves).
@@ -3402,14 +3407,14 @@ impl CortexM {
                     // For now, let's just implement the execution stub assuming the decoder *somehow* gave us the full BL.
                     // But since the decoder only sees 16 bits, we need to handle the prefix state in the CPU loop!
 
-                    self.lr = (self.pc + 4) | 1;
-                    let target = (self.pc as i32 + 4 + offset) as u32;
+                    self.lr = self.pc.wrapping_add(4) | 1;
+                    let target = (self.pc as i32).wrapping_add(4).wrapping_add(offset) as u32;
                     self.pc = target;
                     pc_increment = 0;
                 }
                 Instruction::BranchCond { cond, offset } => {
                     if self.check_condition(cond) {
-                        let target = (self.pc as i32 + 4 + offset) as u32;
+                        let target = (self.pc as i32).wrapping_add(4).wrapping_add(offset) as u32;
                         self.pc = target;
                         pc_increment = 0;
                     }
@@ -6109,6 +6114,98 @@ mod tests {
                 machine.step_profile().cpu_instructions < 10,
                 "boxed CPU path should still leave the batch loop at WFI"
             );
+        }
+    }
+
+    /// Exception entry with a stack pointer near zero must WRAP the frame, not
+    /// panic.
+    ///
+    /// `frame_ptr = sp.wrapping_sub(32)` already wraps — it always has. The
+    /// eight stacking stores then computed `frame_ptr + 4 .. + 28` with plain
+    /// `+`, so a frame pointer that has wrapped past 0 overflowed `u32` on the
+    /// fifth store. Under `[profile.release] overflow-checks = true` that is a
+    /// PANIC inside the simulator on perfectly legal guest input: any firmware
+    /// whose SP has run down past the bottom of its stack (0x10 here) and then
+    /// takes an exception. Real hardware wraps the address and faults on the
+    /// access, or writes wherever the wrapped address lands; it does not stop
+    /// the machine.
+    #[test]
+    fn armv7m_exception_entry_wraps_the_stack_frame_instead_of_overflowing() {
+        let mut bus = MockBus::new();
+        let mut cpu = CortexM::new();
+        cpu.pc = 0x1000;
+        // A stack pointer 0x10 above zero: the 32-byte frame does not fit
+        // below it, so `frame_ptr` wraps to 0xFFFF_FFF0.
+        cpu.sp = 0x10;
+        cpu.r0 = 0xA0A0_A0A0;
+        cpu.r12 = 0xCCCC_CCCC;
+        // PendSV (exception 14): priority 0 from SHPR3, no NVIC ISPR to consult.
+        cpu.pending_exceptions[0] = 1 << 14;
+        // Vector table entry for PendSV.
+        bus.write_u32(0x38, 0x2001).unwrap();
+
+        let config = bus.config.clone();
+        cpu.step_internal(&mut bus, &[], &config).unwrap();
+
+        assert_eq!(
+            cpu.msp, 0xFFFF_FFF0,
+            "frame pointer must wrap, not saturate"
+        );
+        // R0 lands below the wrap, R12 lands above it: 0xFFFF_FFF0 + 16 == 0.
+        assert_eq!(bus.read_u32(0xFFFF_FFF0).unwrap(), 0xA0A0_A0A0);
+        assert_eq!(bus.read_u32(0x0000_0000).unwrap(), 0xCCCC_CCCC);
+        assert_eq!(cpu.pc, 0x2000, "PendSV handler must be entered");
+    }
+
+    /// The matching unstacking path: exception return from a frame whose
+    /// pointer is near the top of the address space.
+    ///
+    /// `frame_ptr + 4 .. + 32` had the same plain `+`. The stack pointer being
+    /// restored is whatever the guest put in MSP/PSP, so this is reachable
+    /// from a single `MSR MSP, Rn` — or from the wrapped frame the entry path
+    /// above leaves behind.
+    #[test]
+    fn armv7m_exception_return_wraps_the_stack_frame_instead_of_overflowing() {
+        let mut bus = MockBus::new();
+        let mut cpu = CortexM::new();
+        cpu.active_exception = 14;
+        cpu.sp = 0xFFFF_FFF0;
+        bus.write_u32(0xFFFF_FFF0, 0x1111_1111).unwrap(); // r0
+        bus.write_u32(0x0000_0000, 0x2222_2222).unwrap(); // r12, after the wrap
+        bus.write_u32(0x0000_0008, 0x0000_3001).unwrap(); // stacked PC
+
+        // 0xFFFF_FFF9 = return to Thread mode on MSP.
+        cpu.exception_return(0xFFFF_FFF9, &mut bus).unwrap();
+
+        assert_eq!(cpu.r0, 0x1111_1111);
+        assert_eq!(cpu.r12, 0x2222_2222);
+        assert_eq!(cpu.pc, 0x0000_3000);
+        assert_eq!(cpu.msp, 0x0000_0010, "SP must advance by 32 with a wrap");
+    }
+
+    /// A branch executed from the top of the low half of the address space.
+    ///
+    /// The target was computed as `(self.pc as i32 + 4 + offset) as u32`. At
+    /// PC 0x7FFF_FFFC the `+ 4` alone overflows `i32`, so the instruction
+    /// panicked before the offset was even applied. 0x6000_0000-0x9FFF_FFFF is
+    /// ordinary executable external RAM in the ARMv7-M memory map, so this is
+    /// legal guest code, and the ARM result is the wrapped 32-bit address.
+    #[test]
+    fn armv7m_branch_wraps_at_the_signed_pc_boundary() {
+        for (name, encoding, pc, expected) in [
+            // B #0 at the i32 boundary: 0x7FFF_FFFC + 4 + 0.
+            ("b", 0xE000u16, 0x7FFF_FFFCu32, 0x8000_0000u32),
+            // BEQ #0 with Z set, same boundary.
+            ("beq", 0xD000u16, 0x7FFF_FFFCu32, 0x8000_0000u32),
+        ] {
+            let mut bus = MockBus::new();
+            let mut cpu = CortexM::new();
+            cpu.pc = pc;
+            cpu.xpsr |= 1 << 30; // Z = 1, so the conditional branch is taken.
+            bus.write_u16(pc as u64, encoding).unwrap();
+            let config = bus.config.clone();
+            cpu.step_internal(&mut bus, &[], &config).unwrap();
+            assert_eq!(cpu.pc, expected, "{name} must wrap to {expected:#010x}");
         }
     }
 }

--- a/crates/core/src/cpu/riscv.rs
+++ b/crates/core/src/cpu/riscv.rs
@@ -408,7 +408,7 @@ impl RiscV {
         if mode == 1 && (cause & 0x80000000) != 0 {
             // Vectored interrupt
             let irq = cause & 0x7FFFFFFF;
-            self.pc = base + irq * 4;
+            self.pc = base.wrapping_add(irq.wrapping_mul(4));
         } else {
             self.pc = base;
         }
@@ -823,15 +823,15 @@ impl Cpu for RiscV {
                 self.write_reg(rd, res);
             }
             Instruction::Slli { rd, rs1, shamt } => {
-                let res = self.read_reg(rs1) << shamt;
+                let res = self.read_reg(rs1).wrapping_shl(shamt as u32);
                 self.write_reg(rd, res);
             }
             Instruction::Srli { rd, rs1, shamt } => {
-                let res = self.read_reg(rs1) >> shamt;
+                let res = self.read_reg(rs1).wrapping_shr(shamt as u32);
                 self.write_reg(rd, res);
             }
             Instruction::Srai { rd, rs1, shamt } => {
-                let res = (self.read_reg(rs1) as i32) >> shamt;
+                let res = (self.read_reg(rs1) as i32).wrapping_shr(shamt as u32);
                 self.write_reg(rd, res as u32);
             }
             Instruction::Add { rd, rs1, rs2 } => {
@@ -1124,7 +1124,7 @@ impl Cpu for RiscV {
             }
             Instruction::CSli { rd, shamt } => {
                 if rd != 0 {
-                    let res = self.read_reg(rd) << shamt;
+                    let res = self.read_reg(rd).wrapping_shl(shamt as u32);
                     self.write_reg(rd, res);
                 }
             }
@@ -2530,6 +2530,27 @@ mod tests {
             machine.cpu.read_reg(7),
             1,
             "self-modifying store into the IRAM fetch window must be visible"
+        );
+    }
+
+    /// A vectored trap whose `mtvec` base sits at the top of the address space
+    /// must WRAP to the vector, not panic.
+    ///
+    /// `self.pc = base + irq * 4` used plain `+` on `u32`. `mtvec` is written
+    /// by the guest with `csrw mtvec, rN` and RISC-V only requires the base to
+    /// be 4-byte aligned, so a base near 0xFFFF_FFFF plus a vectored interrupt
+    /// overflowed `u32` — a simulator panic on legal guest input. The hardware
+    /// wraps the address like every other address computation.
+    #[test]
+    fn riscv_vectored_trap_wraps_at_the_top_of_the_address_space() {
+        let mut cpu = RiscV::new();
+        // Vectored mode (mode == 1) with base 0xFFFF_FFF0.
+        cpu.mtvec = 0xFFFF_FFF1;
+        // Machine timer interrupt: cause = 0x8000_0007, so irq == 7.
+        cpu.handle_trap(0x8000_0007, 0x0000_0100);
+        assert_eq!(
+            cpu.pc, 0x0000_000C,
+            "0xFFFF_FFF0 + 7*4 must wrap to 0x0000_000C"
         );
     }
 }

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,30 +9,30 @@ The models column is a content digest over everything that board's `models` list
 
 | Board | Tier | Last silicon capture | Models | Status |
 |-------|------|----------------------|--------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `4ed1cf55f5ca29eb` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `4ed1cf55f5ca29eb` | ⚠ drift acked 2026-08-21 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `7ec3b6b08e01804a` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `f1e2477dfe90c111` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `223bd47e640a63f1` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `4ea15df2185a50fc` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `4dedf6a08c8ce021` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `90973fe04efe024b` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `38977d62ae07157d` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `38977d62ae07157d` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `bf17c75035af9f39` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `c973ed6df35e75c5` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `43e40c14337f3567` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `b72b145c9a17f443` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `be87a841db2f192f` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `4492f70d355dd855` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `5de4805fa1b110ee` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `stm32f401` | 🟡 smoke-manual | — | `8e26de97053f91af` | no silicon capture |
-| `stm32wba52` | 🟡 smoke-manual | — | `25e6d324074dce80` | no silicon capture |
-| `nrf52832` | ⚪ structural | — | `913a32bf4a37cb81` | no silicon capture |
-| `rp2040` | ⚪ structural | — | `79ff1ba649399fc6` | no silicon capture |
-| `rp2350` | 🟡 smoke-manual | — | `62d0835a612f241f` | no silicon capture |
-| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `abcdac5cc123d3c0` | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `e964259b59d88f13` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `87ee4e974c24ddec` | no silicon capture |
+| `stm32f401` | 🟡 smoke-manual | — | `70dc5cdb821b4fd1` | no silicon capture |
+| `stm32wba52` | 🟡 smoke-manual | — | `54357ab00d5380ea` | no silicon capture |
+| `nrf52832` | ⚪ structural | — | `4868d947c79c522f` | no silicon capture |
+| `rp2040` | ⚪ structural | — | `6ed07913f151b582` | no silicon capture |
+| `rp2350` | 🟡 smoke-manual | — | `5f078da8df1f94c5` | no silicon capture |
+| `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `2093b56e967fff91` | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `c8ea2adf5ae07e5c` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `925e4134387cde10` | no silicon capture |
 | `brd2709a` | 🟡 smoke-manual | — | `9932bc76c215ca4c` | no silicon capture |
 | `esp32` | ⚪ structural | — | `1ffa6e4e6a27dd31` | no silicon capture |
-| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `9c339cd43758ed97` | no silicon capture |
-| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `493aad26a23404e1` | no silicon capture |
-| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | `c28cf19a14404118` | no silicon capture |
-| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | `04c5be0e36f25d58` | no silicon capture |
-| `ci-fixture-riscv` | ⚪ structural | — | `9fd2074c862cfb3d` | no silicon capture |
+| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `5346225310de0b3e` | no silicon capture |
+| `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `2474872ffcd181ac` | no silicon capture |
+| `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | `dd70d18ad77eea65` | no silicon capture |
+| `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | `969b7346ea411c7b` | no silicon capture |
+| `ci-fixture-riscv` | ⚪ structural | — | `75ba36b451a49fa7` | no silicon capture |
 
 ## `nrf52840` — 🟢 silicon-verified
 
@@ -40,7 +40,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on ST-LINK V2 (V2J37S7, serial 48FF6B064884534929321087), openocd 0.12.0 hla_swd; nRF52840 FICR INFO.PART=0x00052840, DEVICEID 707dc298 — re-captured live 2026-08-09 with NRF52_STRICT=1: ALL 11 hw-oracle suites pass — conformance, cpu_conformance, mmio 16/16, gpio, onboarding, power, spis_twis, timer_rtc, spim_easydma, full_register, ccm. NOT a second board: DEVICEID 707dc298 matches the 2026-06-09 baseline, so this is a re-read of the SAME part (unlike the C3/S3 re-captures, which were cross-board). The run was NOT clean on arrival and found three real defects, all fixed in this commit: (1) seven nrf52_* hw-oracle tests had not COMPILED since the 2026-07-18 bus consolidation removed the inherent SystemBus read_u32/write_u32 shadows — they build only under --features hw-oracle-nrf52, which CI never enables, so the 're-capture pending' ack pointed at a path that could not build; (2) mmio was 15/16, SPIM0 PSEL_MISO sim=0x0 vs hw=0x2E, because the serial-instance broadcast PSEL WRITES to both halves but dispatched READS to TWIM, which models only 0x508/0x50C; (3) SPIM PSEL.CSN (0x514) was missing from Nrf52SpiRegs entirely — corroborated present on silicon (wrote 0x2B, read 0x2B). Guarded going forward by a hardware-free unit test, serial_instance::psel_block_reads_back_while_disabled.
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-08-21 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-22 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -48,7 +48,7 @@ The models column is a content digest over everything that board's `models` list
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-08-09** on ST-LINK V2 (V2J37S7, serial 48FF6B064884534929321087) — the same physical XIAO the nrf52840 entry describes — rides the nrf52840 re-capture of 2026-08-09: all 11 hw-oracle suites pass under NRF52_STRICT=1, mmio 16/16. This is not an independent run — it is the SAME board and the SAME suites, which is exactly what `note` says this entry means. See the nrf52840 result for the three defects that run uncovered and fixed.
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-08-21 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-22 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -330,7 +330,28 @@ boards:
     # layouts are not touched — these boards never construct the EFR32 variant,
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
-    drift_ack: 2026-08-21
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
+    drift_ack: 2026-08-22
     # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
     # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
     # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
@@ -347,7 +368,7 @@ boards:
     # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
     # matches. No other pinned firmware on any board reaches the encoding, so
     # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
-    drift_ack_digest: 4ed1cf55f5ca29eb38d3db073a84f283ea389b624259166352c9fe132b284fe1
+    drift_ack_digest: 38977d62ae07157d9312bc6767a3a608e91dcae2521dd092369ec2bf95b2ad5c
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -555,7 +576,28 @@ boards:
     # layouts are not touched — these boards never construct the EFR32 variant,
     # and the STM32 reset-value tests (`stm32h5_reset_values_match_silicon`,
     # `test_i2c_reset_values`) pass unchanged.
-    drift_ack: 2026-08-21
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
+    drift_ack: 2026-08-22
     # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
     # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
     # silent no-op — `digitalWrite` on EFR32MG26 computes its port base with
@@ -572,7 +614,7 @@ boards:
     # golden trace (crates/wasm/tests/fixtures/motor-parity-native.json) still
     # matches. No other pinned firmware on any board reaches the encoding, so
     # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
-    drift_ack_digest: 4ed1cf55f5ca29eb38d3db073a84f283ea389b624259166352c9fe132b284fe1
+    drift_ack_digest: 38977d62ae07157d9312bc6767a3a608e91dcae2521dd092369ec2bf95b2ad5c
     models:
       - crates/core/src/cpu/cortex_m.rs
       - crates/core/src/decoder/arm.rs
@@ -933,8 +975,29 @@ boards:
     # from this change. Ran: `labwired-core --lib` 3255 pass / 0 fail, and the 126
     # GPIO tests, all unchanged. This is an ack, not a capture — no live re-capture
     # was made this session.
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
     drift_ack: 2026-08-22
-    drift_ack_digest: 7ec3b6b08e01804a74fec0f5414bb6226c9d541243bfd298434ae1b2e213280c
+    drift_ack_digest: bf17c75035af9f39852c7758c55c1a3bdf94beac1a3e41dbc11c2fa42179ea8b
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -1052,6 +1115,27 @@ boards:
       # `parse_size` reads MB as 10^6 — the modelled part grows to the size of the
       # real one. No register layout, reset value or peripheral behaviour is
       # touched, which is what the silicon capture asserts, so the capture stands.
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
     drift_ack: 2026-08-22
       #
       # Re-stamped 2026-08-22 for the EspI2cCore extraction in this branch: the ESP
@@ -1059,7 +1143,7 @@ boards:
       # changes. Behaviour-preserving extraction, not a model correction —
       # `pr-workspace-tests` green on all shards is what exercises this peripheral,
       # so nothing the silicon capture asserts changed and the capture stands.
-    drift_ack_digest: f1e2477dfe90c1110a6c7bb7e9ffbd75eae35cbd145be807d3080d27376c380b
+    drift_ack_digest: c973ed6df35e75c599d163f114cbe648d73606d710f82858692050e1f9e9f15b
     models:
       - crates/core/src/cpu/riscv.rs
       - crates/core/src/decoder/riscv.rs
@@ -2008,6 +2092,27 @@ boards:
     # from this change. Ran: `labwired-core --lib` 3255 pass / 0 fail, and the 126
     # GPIO tests, all unchanged. This is an ack, not a capture — no live re-capture
     # was made this session.
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
     drift_ack: 2026-08-22
     # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
     # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
@@ -2026,7 +2131,7 @@ boards:
     # matches. No other pinned firmware on any board reaches the encoding, so
     # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
     drift_ack: 2026-08-22
-    drift_ack_digest: 223bd47e640a63f1c8bd6f75b31246af518c6319408a542f2b7c174376c5dda4
+    drift_ack_digest: 43e40c14337f3567f33c0676403d6d8d4143da00e7c8bbd96510793229837d99
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2330,8 +2435,29 @@ boards:
     # from this change. Ran: `labwired-core --lib` 3255 pass / 0 fail, and the 126
     # GPIO tests, all unchanged. This is an ack, not a capture — no live re-capture
     # was made this session.
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
     drift_ack: 2026-08-22
-    drift_ack_digest: 4ea15df2185a50fc6b31db7945f4a43775984f3b0c912c1d22649483e64a856f
+    drift_ack_digest: b72b145c9a17f4437dc04b684a055b0ec4d09e76f985efd9d9ca138b9eb9a1b1
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2678,6 +2804,27 @@ boards:
     # from this change. Ran: `labwired-core --lib` 3255 pass / 0 fail, and the 126
     # GPIO tests, all unchanged. This is an ack, not a capture — no live re-capture
     # was made this session.
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
     drift_ack: 2026-08-22
     # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
     # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
@@ -2696,7 +2843,7 @@ boards:
     # matches. No other pinned firmware on any board reaches the encoding, so
     # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
     drift_ack: 2026-08-22
-    drift_ack_digest: 4dedf6a08c8ce02125db67aaa0f3feefd38a65d61680a836bdcb4f0e7db92d9e
+    drift_ack_digest: be87a841db2f192f8e3b93e2a4477658f892d89ce329214633f54cb66c183735
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -3003,6 +3150,27 @@ boards:
     # from this change. Ran: `labwired-core --lib` 3255 pass / 0 fail, and the 126
     # GPIO tests, all unchanged. This is an ack, not a capture — no live re-capture
     # was made this session.
+    #
+    # Re-stamped 2026-08-22 for explicit wrapping ops on GUEST arithmetic.
+    # `cortex_m.rs` and `riscv.rs` replace `+`/`<<` with `wrapping_add`/`wrapping_shl`
+    # at sites where the guest ISA specifies modulo-2^32 behaviour: exception entry
+    # and return stacking (`frame_ptr + 4..32`), branch target `pc + 4 + offset`,
+    # `vtor + n*4`, the BL link address, and the RISC-V vectored trap base and
+    # SLLI/SRLI/SRAI shifts (shamt is masked to 5 bits at decode).
+    #
+    # `a + b` and `a.wrapping_add(b)` differ ONLY when the op overflows, which under
+    # `overflow-checks = true` was a PANIC, never a wrong value. So no silicon-anchored
+    # register can have moved: every input that used to produce a number still produces
+    # the same number. Four inputs that used to CRASH the simulator now wrap the way the
+    # part does — see the four new tests (`armv7m_exception_entry/return_wraps_the_stack
+    # _frame`, `armv7m_branch_wraps_at_the_signed_pc_boundary`,
+    # `riscv_vectored_trap_wraps_at_the_top_of_the_address_space`). Confirmed by
+    # restoring one site to `+`: it panics at cortex_m.rs:1367 `attempt to add with
+    # overflow`.
+    #
+    # Ran: labwired-core --lib 3260 pass / 0 fail, and nrf52_timer_walk_differential,
+    # stm32f401/stm32l476_walk_differential, kw41z_walk_free_differential. This is an
+    # ack, not a capture — no live re-capture was made.
     drift_ack: 2026-08-22
     # 2026-08-22: the Thumb-2 decoder gained SMLABB/BT/TB/TT and SMULBB/BT/TB/TT
     # (ARMv7-M A7.7.166/171). They were UNDECODED, which in this core means a
@@ -3021,7 +3189,7 @@ boards:
     # matches. No other pinned firmware on any board reaches the encoding, so
     # nothing a silicon capture asserts moved. No live re-capture is evidenced here.
     drift_ack: 2026-08-22
-    drift_ack_digest: 90973fe04efe024b4ac47fa82929e63b3069e89d60ad31ca0b8d3d9c86e7ff04
+    drift_ack_digest: 4492f70d355dd855b22e667d1cbbe89ab26016f588fa747b9a12844f868e7a73
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     # 2026-08-12: chip yaml adds bxcan1 (type bxcan @ 0x40006400, APB1ENR bit 25) for
     # Arduino matrix L8 loopback. Existing BxCan model; no register-map change to


### PR DESCRIPTION
Started as a perf task and turned into a correctness one. Both results are reported honestly below, including the part that did not work.

## Four reachable panics — the actual find

Each of these is **legal guest code that crashes the simulator** while real silicon runs it fine. `overflow-checks = true` (#918) turned them from silent wraps into panics; they had simply never been reached by a test.

| site | guest input that reaches it |
|---|---|
| exception **entry** stacking, `frame_ptr + 4..28` | `SP = 0x10`, then any interrupt — `frame_ptr` has already wrapped to `0xFFFF_FFF0`, so `+16` overflows |
| exception **return** unstacking, `frame_ptr + 4..32` | MSP/PSP near the top of the map; both are guest-written via `MSR MSP, Rn` |
| `Branch`/`BranchCond`/`BL` target `(pc as i32 + 4 + offset)` | `PC = 0x7FFF_FFFC` — the `+4` alone overflows i32, and `0x6000_0000–0x9FFF_FFFF` is ordinary executable external RAM in the ARMv7-M map |
| RISC-V vectored trap `base + irq * 4` | `csrw mtvec, 0xFFFF_FFF1` (vectored, 4-byte aligned, legal) plus a machine timer interrupt |

Four new tests cover them. Verified non-vacuous by restoring one site to `+`: it panics at `cortex_m.rs:1367:42`, `attempt to add with overflow`.

The conversions are **guest-semantics only** — ARM address arithmetic is modulo 2^32 and the RISC-V shifts have their shamt masked to 5 bits at decode, so `wrapping_*` is what the ISA specifies, not an approximation. Host bookkeeping (cycle counters, loop counters, indices) is deliberately left checked; that is what the flag is for.

## Perf: mostly not recoverable, and here is why

The premise was that #918's `overflow-checks` costs 8.3% on the batched loop. It does. But after resolving the `R_X86_64_RELATIVE` GOT slots to `panic_const_*_overflow`, taking the basic block each call starts, finding every conditional jump targeting one, and weighting by executed counts from `callgrind --dump-instr=yes`, the **entire** check budget on stm32f103 batch is:

```
1,200,000  cortex_m.rs:918   sysbus.current_cycle += live_step   (host)
1,200,000  cortex_m.rs:920   executed += 1                       (host)
  299,995  cortex_m.rs:2585  branch target                       (guest)
   16,408  advance.rs/boundary.rs                                (per batch)
```

**2.3 Ir/step of a 16.4 Ir/step cost.** The other ~14 is codegen the flag perturbs while emitting no check at all — `highest_priority_pending` moves +9 Ir/step (46.8% of the delta) and contains **zero** check sites in either build; the empty-word scan loop is 9 instructions per word with the flag and 8 without, a spilled-pointer reload versus a folded addressing mode.

Result: **−1.6%**, not −7.7%.

| board-mode | baseline | after |
|---|---|---|
| stm32f103 batch | 232.8 | 229.2 |
| rp2040 batch | 231.0 | 227.1 |
| stm32l476 batch | 232.8 | 229.1 |
| nrf52840 batch | 233.3 | 230.2 |
| mkw41z4 batch | 231.2 | 227.5 |

All `step` modes and `esp32c3 batch` unchanged. `baselines.json` is **not** touched — these are improvements inside the ±3% tolerance and the recorded numbers stay honest.

## Measured but deliberately not taken

- The two host counters at `cortex_m.rs:918/920` are worth **5.4 Ir/step (−2.3%)** on their own. They are host bookkeeping, so they stay checked. (`executed += 1` sits one line under `while executed < max_count`, so its overflow is unreachable by the loop guard — arguably free to convert, but that is a policy call, not mine.)
- `[profile.release.package.labwired-core] codegen-units = 1` returns a further 3.3 Ir/step batch and 11 Ir/step step, at +3.5 min compile time.
- Unrelated and larger than everything above: `highest_priority_pending` costs **64 Ir/step, 28% of the whole batch loop**, because `step_internal` calls it unconditionally *before* the `pending_exceptions.iter().any(...)` guard on the next line.

## Gates

`labwired-core --lib` 3260 pass / 0 fail (3256 + 4 new). Walk differentials green: `nrf52_timer` 14/14, `stm32f401` 1/1, `stm32l476` 1/1, `kw41z_walk_free` 6/6. `cargo fmt --check` and `clippy -D warnings` clean. The two pre-existing failures (`cpu_trace_conformance`, `e2e_nrf52840_obd2_scanner`) were confirmed to fail identically on pristine sources.