### PR TITLE
fix(perf-budget): the e-reader's walk ceiling was made unreachable on purpose

### DIFF
--- a/docs/coverage/lab-perf-budget.json
+++ b/docs/coverage/lab-perf-budget.json
@@ -85,7 +85,7 @@
       "min_mean_batch": 40.0,
       "min_lit_px": 0,
       "min_serial_bytes": 200,
-      "max_legacy_ticks_per_cycle": 0.3,
+      "max_legacy_ticks_per_cycle": 15.5,
       "min_idle_ff_ratio": 0.0
     }
   ]


### PR DESCRIPTION
`shipped-lab-perf` has failed on the monorepo's main since 2026-08-18. It is not a slow peripheral — the walk moved from once per **batch** to once per **cycle**, and 109x is just `mean_batch`:

|  | legacy_tick_entries | total_cycles | walk/cycle |
|---|---|---|---|
| before | 4,116,885 | 30,000,000 | 0.137 |
| after | 450,001,860 | 30,126,976 | 14.937 |

4,116,885 / 15 legacy peripherals = 274,459 — exactly that run's `batches`. 450,001,860 = 15 x 30M cycles.

The move was deliberate: #1008 clamped the coalesced dual-core idle window so it cannot run past the next peripheral tick boundary, because the old window hid a timed IRQ for up to 1024 instructions and deadlocked ESP-IDF SMP FreeRTOS. Its comment says it outright: *"At interval 1 the caller asked for per-cycle peripheral service and now gets it."*

This lab runs at interval 1 because its walk is not deletable — probing the `esp32-wroom-epaper` bus shows seven forcers (`timg0`, `spi0/1/3`, `i2c0`, `uart1/2`), each `needs_legacy_walk() && !uses_scheduler()`. **That set is identical either side of the regression window**, so deletability never changed. With interval 1 and 15 legacy peripherals, ~15/cycle is the floor.

So 0.3 stopped being a budget and became an assertion that a deadlock fix had not shipped. 15.5 is floor + headroom, and still fails if per-cycle walk work exceeds the peripheral count.

The real win is making those seven scheduler-driven — that would delete the walk and restore interval 512. Separate change.