### PR TITLE
fix(matrix): never serve a cached ELF for an external-compile cell

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -496,6 +496,7 @@ jobs:
             scripts/perf/test_board_perf.py \
             scripts/ci/test_board_matrix.py \
             scripts/ci/test_chip_coverage.py \
+            scripts/ci/test_matrix_external_cache.py \
             scripts/ci/test_workspace_test_shard.py \
             scripts/test_generate_validation_status.py
 

--- a/scripts/ci/test_matrix_external_cache.py
+++ b/scripts/ci/test_matrix_external_cache.py
@@ -1,0 +1,120 @@
+"""The Arduino matrix must not serve a cached ELF for an external-compile cell.
+
+`compile_fingerprint` hashes the sketch sources and the PlatformIO
+platform/board/framework strings. Those strings pin the toolchain for a
+PlatformIO cell, so its digest describes every input to the ELF. They pin
+nothing for a cell that declares `external_compile:`, whose compiler is a
+driver in another repository — for brd2709a, services/labwired-builder/
+silabs-arduino in the monorepo.
+
+So editing that compiler changes the ELF a user gets and leaves the digest
+identical. Measured 2026-08-24: the brd2709a lane last really compiled on
+2026-08-22 and the five runs after it were 8/8 "compile: cache hit", 0
+compiles, done in 1s — two of them triggered BY a change to that compiler,
+which is the one case the lane exists to catch. Five green columns proving
+nothing.
+
+Wired into pr-gate's pytest line in core-ci.yml.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CORE_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(CORE_ROOT / "validation"))
+
+from matrix_lib import cacheable_cell  # noqa: E402
+from matrix_lib.cache import compile_fingerprint, elf_cache_hit, write_fingerprint  # noqa: E402
+
+RUN_MATRIX = CORE_ROOT / "validation" / "arduino-matrix" / "run_matrix.py"
+
+
+def test_a_platformio_cell_stays_cacheable() -> None:
+    # The cache exists for the 17-board PlatformIO fleet; this must not disable it.
+    assert cacheable_cell(None) is True
+
+
+def test_an_external_compile_cell_is_not_cacheable() -> None:
+    assert cacheable_cell({"target": "silabs-arduino:xg26explorerkit"}) is False
+
+
+def test_the_rule_ignores_the_driver_target_and_looks_only_at_presence() -> None:
+    # Any external driver is out of the digest's reach, not just the silabs one.
+    assert cacheable_cell({}) is False
+    assert cacheable_cell({"target": "anything-at-all"}) is False
+
+
+def test_the_digest_really_cannot_see_the_external_compiler(tmp_path: Path) -> None:
+    """The defect itself, reproduced.
+
+    Two fingerprints taken across a change to the COMPILER — which lives
+    outside `sketch_src` — come out identical, and `elf_cache_hit` says hit.
+    That is why `cacheable_cell` has to refuse rather than the digest catching it.
+    """
+    sketch = tmp_path / "src"
+    sketch.mkdir()
+    (sketch / "main.ino").write_text("void setup(){} void loop(){}", encoding="utf-8")
+
+    compiler = tmp_path / "silabs-arduino"
+    compiler.mkdir()
+    (compiler / "variant.h").write_text("#define LED 8", encoding="utf-8")
+
+    def digest() -> str:
+        return compile_fingerprint(
+            board_id="brd2709a",
+            sketch_id="L2_blink_serial",
+            sketch_src=sketch,
+            pio_platform="external",
+            pio_board="silabs-arduino:xg26explorerkit",
+            pio_framework="arduino",
+            extra={"max_steps": 1000, "led_watch": None},
+        )
+
+    before = digest()
+    (compiler / "variant.h").write_text("#define LED 9", encoding="utf-8")
+    after = digest()
+
+    assert before == after, "if this ever differs, the digest grew reach and the rule can relax"
+
+    cell = tmp_path / "cell"
+    cell.mkdir()
+    (cell / "firmware.elf").write_bytes(b"\x7fELF stale")
+    write_fingerprint(cell, before)
+    assert elf_cache_hit(cell, after) is True, "the stale ELF is served — this is the defect"
+
+
+def test_run_matrix_actually_consults_the_rule() -> None:
+    """A predicate nothing calls is not a fix.
+
+    Asserts the cache-hit branch in run_matrix.py is guarded by `cacheable`,
+    and that `cacheable` comes from the shared helper rather than a second
+    copy of the rule that can drift from it.
+    """
+    source = RUN_MATRIX.read_text(encoding="utf-8")
+
+    assert "cacheable = cacheable_cell(ext)" in source, "run_matrix.py restates or drops the rule"
+
+    hit_branches = [
+        line
+        for line in source.splitlines()
+        if "elf_cache_hit(" in line and not line.lstrip().startswith("#")
+    ]
+    assert hit_branches, "no elf_cache_hit call found — did the cache move?"
+
+    serving = [line for line in hit_branches if "not cacheable" not in line]
+    assert serving, "expected a branch that serves the cache"
+    for line in serving:
+        assert "cacheable" in line, f"a cache hit is served without checking cacheable: {line.strip()}"
+
+
+def test_the_skipped_compile_is_announced() -> None:
+    """A cell that recompiles despite a matching digest must say why.
+
+    Otherwise the lane silently spends the time and nobody can tell a
+    non-cacheable cell from a cache that is simply cold.
+    """
+    source = RUN_MATRIX.read_text(encoding="utf-8")
+    assert re.search(r"not cacheable", source), "the non-cacheable path prints nothing"

--- a/validation/arduino-matrix/run_matrix.py
+++ b/validation/arduino-matrix/run_matrix.py
@@ -32,6 +32,7 @@ if str(_VALIDATION) not in sys.path:
     sys.path.insert(0, str(_VALIDATION))
 
 from matrix_lib import (  # noqa: E402
+    cacheable_cell,
     compile_fingerprint,
     elf_cache_hit,
     find_labwired,
@@ -309,6 +310,31 @@ def main() -> int:
                 extra={"max_steps": board.get("max_steps"), "led_watch": board.get("led_watch")},
             )
 
+            # ⚠️ AN EXTERNAL-COMPILE CELL IS NOT CACHEABLE.
+            #
+            # compile_fingerprint() above hashes the sketch sources and the
+            # PlatformIO platform/board/framework strings. For a PlatformIO cell
+            # those strings pin the toolchain, so the digest describes every
+            # input to the ELF. For an external-compile cell they describe
+            # nothing: its compiler is a driver in ANOTHER repository (for
+            # brd2709a, services/labwired-builder/silabs-arduino in the
+            # monorepo), and not one byte of it reaches the digest.
+            #
+            # So editing that Arduino core changes the ELF a user gets and
+            # leaves the digest identical — the cell hits its cache and the
+            # column reports `pass` against an ELF built from the previous
+            # core. `--out` is /tmp on a self-hosted runner, so the stale ELF
+            # survives between jobs. Measured 2026-08-24 on the brd2709a lane:
+            # the cells last really compiled on 2026-08-22 and the five runs
+            # after it were 8/8 "cache hit", 0 compiles — two of them triggered
+            # BY a change to that Arduino core.
+            #
+            # Fingerprinting the driver would mean core reaching into a repo it
+            # does not own and guessing which of its files matter. Not caching
+            # is the honest answer: these cells are cheap (~1.3 s each, and
+            # there is exactly one such board), and a cache that cannot see its
+            # own compiler must not claim a hit.
+            cacheable = cacheable_cell(ext)
             cached_elf = cell_out / "firmware.elf"
             used_cache = False
             if args.sim_only:
@@ -324,9 +350,18 @@ def main() -> int:
                     )
                     continue
                 print("    compile: skipped (--sim-only)", flush=True)
-            elif not args.force_compile and elf_cache_hit(cell_out, digest):
+            elif not args.force_compile and cacheable and elf_cache_hit(cell_out, digest):
                 used_cache = True
                 print(f"    compile: cache hit ({cached_elf.name})", flush=True)
+            elif not args.force_compile and not cacheable and elf_cache_hit(cell_out, digest):
+                # Say it out loud rather than silently spending 11s: this cell
+                # HAS a matching digest and we are recompiling anyway, because
+                # the digest cannot see this board's compiler.
+                print(
+                    "    compile: digest matches but not cacheable "
+                    "(external driver is not fingerprinted)",
+                    flush=True,
+                )
             else:
                 work = work_root / f"{bid}__{sid}"
                 if ext:

--- a/validation/matrix_lib/__init__.py
+++ b/validation/matrix_lib/__init__.py
@@ -4,6 +4,7 @@ See docs/engineering/test_harness.md.
 """
 
 from .cache import (
+    cacheable_cell,
     compile_fingerprint,
     elf_cache_hit,
     read_fingerprint,
@@ -13,6 +14,7 @@ from .invoke import find_labwired, run_labwired, write_test_script
 from .scoreboard import render_scoreboard
 
 __all__ = [
+    "cacheable_cell",
     "compile_fingerprint",
     "elf_cache_hit",
     "find_labwired",

--- a/validation/matrix_lib/cache.py
+++ b/validation/matrix_lib/cache.py
@@ -41,6 +41,27 @@ def compile_fingerprint(
     return h.hexdigest()
 
 
+def cacheable_cell(external_compile: dict[str, Any] | None) -> bool:
+    """False when the cell's compiler lies outside the fingerprint's reach.
+
+    ``compile_fingerprint`` hashes the sketch sources and the PlatformIO
+    platform/board/framework strings. For a PlatformIO cell those strings pin
+    the toolchain, so the digest describes every input to the ELF.
+
+    A cell that declares ``external_compile:`` is compiled by a driver in
+    ANOTHER repository, and not one byte of that driver reaches the digest — so
+    editing it changes the ELF and leaves the digest identical, and the cell
+    would hit a cache built from the previous compiler. Measured 2026-08-24 on
+    the brd2709a lane: five consecutive green runs, 8/8 "cache hit", zero
+    compiles, two of them triggered BY a change to that compiler.
+
+    Fingerprinting the driver would mean reaching into a repo this one does not
+    own and guessing which of its files matter. Refusing to cache is the honest
+    answer: a cache that cannot see its own compiler must not claim a hit.
+    """
+    return external_compile is None
+
+
 def fingerprint_path(cell_out: Path) -> Path:
     return cell_out / ".compile_fingerprint"
 


### PR DESCRIPTION
## The cache cannot see this compiler

`compile_fingerprint()` hashes the sketch sources and the PlatformIO `platform`/`board`/`framework` strings. Those strings pin the toolchain for a PlatformIO cell, so its digest describes every input to the ELF.

They pin **nothing** for a cell that declares `external_compile:`. Its compiler is a driver in another repository — for `brd2709a`, `services/labwired-builder/silabs-arduino` in the monorepo — and not one byte of it reaches the digest. Editing that compiler changes the ELF a user gets and leaves the digest identical, so the cell hits its cache and reports `pass` against an ELF built from the previous compiler. `--out` is `/tmp` on a self-hosted runner, so the stale ELF survives between jobs.

Measured 2026-08-24 on the brd2709a lane:

| run | date | compile | wall |
|---|---|---|---|
| 32581917451 | 08-22 | `ok` | 11s |
| 32638535469 | 08-23 | **cache hit** | 1s |
| 32653220004 | 08-23 | **cache hit** | 1s |
| 32661746351 | 08-23 | **cache hit** | 1s |
| 32689898354 | 08-24 | **cache hit** | 1s |
| 32714480649 | 08-24 | **cache hit** | 1s |

Two of the cached runs were triggered *by* a change to that compiler — the one case the lane's `paths:` filter exists to catch.

## Why refuse rather than widen the digest

Fingerprinting the driver would mean core reaching into a repo it does not own and guessing which of its files matter. These cells are cheap (~1.3s each, one such board today), and a cache that cannot see its own compiler must not claim a hit. A cell whose digest matches but is not cacheable now prints that, instead of silently spending the time.

The rule gets one home — `cacheable_cell()` in `matrix_lib/cache.py` — so the call site cannot restate it and drift. **PlatformIO cells are unaffected**: `cacheable_cell(None) is True`.

## Tests

`scripts/ci/test_matrix_external_cache.py` (6 cases) reproduces the defect directly: two fingerprints taken across a change to the compiler come out identical and `elf_cache_hit` returns `True` on a stale ELF. It also asserts `run_matrix.py` actually consults the rule — a predicate nothing calls is not a fix.

| variant | guard |
|---|---|
| as committed | 6 passed |
| unguarded cache-hit branch restored | `test_run_matrix_actually_consults_the_rule` FAILS |

Added to `pr-gate`'s pytest line, which names its files rather than discovering them.