### PR TITLE
fix(onboarding): pass the linker script once, not twice

### DIFF
--- a/scripts/onboarding_smoke.sh
+++ b/scripts/onboarding_smoke.sh
@@ -165,21 +165,26 @@ infer_failure_hint() {
 run_smoke_output_dir="${OUT_DIR}/simulation-output"
 mkdir -p "${run_smoke_output_dir}"
 
-firmware_build_env=()
-if [[ "${TARGET}" == "thumbv6m-none-eabi" ]]; then
-  firmware_build_env=(env RUSTFLAGS="-C link-arg=-Tlink.x")
-fi
+# No RUSTFLAGS here. A firmware crate passes its own linker script from its
+# build.rs, so `cargo build -p <crate> --target <t>` links on its own.
+#
+# ⚠️ Exactly one place may pass `-Tlink.x`. This block used to add it for every
+# thumbv6m target; when firmware-rp2040-pio-onboarding's build.rs started
+# passing its own (labwired-core#1064), the script included link.x — and the
+# memory.x it consumes — twice, and the build died with "region 'FLASH'
+# already defined". This gate does not run on pull requests, so that break
+# only appeared on main.
 
 if ! run_stage build_cli cargo build -p labwired-cli; then
   :
 elif [[ "${PROFILE}" == "release" ]]; then
-  if ! run_stage build_firmware "${firmware_build_env[@]}" cargo build -p "${CRATE}" --release --target "${TARGET}"; then
+  if ! run_stage build_firmware cargo build -p "${CRATE}" --release --target "${TARGET}"; then
     :
   elif ! run_stage run_smoke cargo run -q -p labwired-cli -- test --script "${SCRIPT}" --output-dir "${run_smoke_output_dir}" --no-uart-stdout; then
     :
   fi
 else
-  if ! run_stage build_firmware "${firmware_build_env[@]}" cargo build -p "${CRATE}" --target "${TARGET}"; then
+  if ! run_stage build_firmware cargo build -p "${CRATE}" --target "${TARGET}"; then
     :
   elif ! run_stage run_smoke cargo run -q -p labwired-cli -- test --script "${SCRIPT}" --output-dir "${run_smoke_output_dir}" --no-uart-stdout; then
     :


### PR DESCRIPTION
## What broke

`Core Onboarding Smoke` went red on `main` at 69b428a2 (the #1064 merge). The
`onboarding-rp2040-pio` job failed at `build_firmware`:

```
rust-lld: error: .../firmware-rp2040-pio-onboarding-*/out/memory.x:10: region 'FLASH' already defined
  >>>   FLASH : ORIGIN = 0x10000000, LENGTH = 2048K
```

The linker line ends `--gc-sections -Tlink.x -Tlink.x`. `link.x` includes
`memory.x`, so including it twice defines every MEMORY region twice.

Two places were passing the flag:

| place | added by |
|---|---|
| `crates/firmware-rp2040-pio-onboarding/build.rs` | #1064 |
| `scripts/onboarding_smoke.sh`, for any thumbv6m target | pre-existing |

#1064 moved the flag into build.rs so that
`cargo build -p firmware-rp2040-pio-onboarding --target thumbv6m-none-eabi`
links on its own — before that it produced an ELF with entry point 0x0 unless
one specific gate happened to build it. That is the right home for it, so this
PR drops the script's copy.

## Why #1064 was green

`Core Onboarding Smoke` runs on `main`, nightly and `workflow_dispatch` — the
workflow says so plainly: *"Slow gates: nightly + main tip + manual. Not on
PRs."* No pull request can exercise it. This is deliberate and I am not
changing it; the comment left in the script names the one-place constraint so
the next person does not re-add the flag.

The other two matrix entries are `thumbv7em`/`thumbv7m` and never took the
thumbv6m branch — both passed in the same red run.

## Verification on this tree

- **Negative control** — re-adding the removed flag reproduces the CI error
  exactly, same `memory.x:10: region 'FLASH' already defined`.
- **Positive** — `scripts/onboarding_smoke.sh --target-id rp2040-pio ...`
  reports `status: pass`, `failure_stage: n/a`, with `build_cli`,
  `build_firmware` and `run_smoke` all green, and writes a fresh 84 KB ELF.
- `shellcheck scripts/onboarding_smoke.sh` clean.

## Notes, not fixed here

- The empty-array `firmware_build_env` is gone rather than left empty: under
  `set -u`, bash 3.2 (macOS) errors on `"${arr[@]}"` for an empty array.
- The script calls `date +%s%3N`, which is GNU-only — it cannot run on macOS
  as-is. I ran it behind a shim. Worth fixing separately.
- `crates/firmware-uart-echo-fixture/build.rs` and
  `crates/firmware-ci-fixture/build.rs` still carry a comment claiming the
  workspace `.cargo/config.toml` passes `-Tlink.x` for thumbv6m. It does not,
  and that file now says so explicitly. Stale comment only — both crates link
  from their own `minimal.ld` — but it points the wrong way on exactly this
  trap.
