### PR TITLE
fix: release v0.22.2 install canary

### DIFF
--- a/.github/actions/labwired-test/README.md
+++ b/.github/actions/labwired-test/README.md
@@ -10,13 +10,13 @@ intentionally documents the action beside its implementation rather than
 choosing its own source SHA: every immutable revision therefore carries its own
 matching input and report contract.
 
-The `version` input defaults to `v0.22.1` and independently selects the
+The `version` input defaults to `v0.22.2` and independently selects the
 immutable Core CLI release archive named
-`labwired-v0.22.1-<platform>.tar.gz`. The action downloads that public archive
+`labwired-v0.22.2-<platform>.tar.gz`. The action downloads that public archive
 from the `w1ne/labwired-core` GitHub release with `curl`; it does not build Core
 on the consumer runner.
 
-Its inputs are exactly `script` (required), `version` (default `v0.22.1`),
+Its inputs are exactly `script` (required), `version` (default `v0.22.2`),
 `output-dir`, and `args`. `args` is whitespace-separated extra CLI flags; shell
 quoting inside this input is not interpreted.
 

--- a/.github/actions/labwired-test/action.yml
+++ b/.github/actions/labwired-test/action.yml
@@ -11,7 +11,7 @@ inputs:
   version:
     description: "Immutable LabWired Core release tag to install."
     required: false
-    default: "v0.22.1"
+    default: "v0.22.2"
   output-dir:
     description: "Directory for run artifacts (result.json, uart.log, junit.xml, and reports)."
     required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-08-26
+
 ### Changed
 - **The EFR32 TIMER compare is a level match on `CNT == OC`, measured on a
   BRD2709A die.** A counter *written* onto its compare value and then started

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmware"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-ci-fixture"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1116,56 +1116,56 @@ version = "0.1.0"
 
 [[package]]
 name = "firmware-f103-i2c-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f401cdu6-blackpill-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-f407-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-fullchip-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-h563-io-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-hil-showcase"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
@@ -1197,46 +1197,46 @@ dependencies = [
 
 [[package]]
 name = "firmware-l476-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-mg26-adc"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-mg26-ble"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-mg26-bootloader"
-version = "0.22.1"
+version = "0.22.2"
 
 [[package]]
 name = "firmware-mg26-demo"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-mg26-i2c"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
 
 [[package]]
 name = "firmware-mg26-spi"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
 ]
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-nrf52840-obd2-scanner"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-perf-spin"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "cortex-m-rt",
  "panic-halt",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-perf-spin-riscv"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
  "riscv-rt",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "firmware-uart-echo-fixture"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "cortex-m",
  "panic-halt",
@@ -1949,7 +1949,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "labwired-cli"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-codegen"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "labwired-ir",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-config"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "human-size",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-core"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-dap"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-egress-relay"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "labwired-core",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-fuzz"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-gdbstub"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "gdbstub",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-oracle-macros"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "labwired-hw-oracle",
  "proc-macro2",
@@ -2118,11 +2118,11 @@ dependencies = [
 
 [[package]]
 name = "labwired-hw-runner"
-version = "0.22.1"
+version = "0.22.2"
 
 [[package]]
 name = "labwired-hw-trace"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-ir"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-loader"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-python"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "labwired-config",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "labwired-wasm"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "cortex-m",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "riscv-ci-fixture"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "panic-halt",
  "riscv 0.10.1",
@@ -3682,7 +3682,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svd-ingestor"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = [
 default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
 
 [workspace.package]
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 authors = ["Andrii Shylenko"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Clone the repository, install the CLI, run a firmware. No cross-toolchain needed
 
 ```sh
 git clone https://github.com/w1ne/labwired-core && cd labwired-core
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.1 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.2 sh
 labwired test --script examples/nrf54l15-dk/io-smoke.yaml
 ```
 
@@ -110,7 +110,7 @@ UART output and `--json` stay on stdout, so pipes keep working.
 The install script covers Linux, macOS, and Windows via WSL2.
 
 ```sh
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.1 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.2 sh
 ```
 
 | Variable | Effect |
@@ -133,7 +133,7 @@ no install script for it; the archive is unpacked by hand. PowerShell 5.1 and
 later have `tar` built in.
 
 ```powershell
-$v = "v0.22.1"
+$v = "v0.22.2"
 Invoke-WebRequest "https://github.com/w1ne/labwired-core/releases/download/$v/labwired-$v-windows-x86_64.tar.gz" -OutFile labwired.tar.gz
 mkdir $env:LOCALAPPDATA\LabWired -Force
 tar -xzf labwired.tar.gz -C $env:LOCALAPPDATA\LabWired

--- a/docs/ci_integration.md
+++ b/docs/ci_integration.md
@@ -2,14 +2,14 @@
 
 Run the **same** `labwired test` command on your laptop and in GitHub Actions or GitLab. Pin a CLI release so firmware changes are judged by a fixed simulator version.
 
-Default pin used in examples: **v0.22.1**.
+Default pin used in examples: **v0.22.2**.
 
 ---
 
 ## Local first
 
 ```bash
-curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.1 sh
+curl -fsSL https://labwired.com/install.sh | LABWIRED_VERSION=v0.22.2 sh
 
 labwired test \
   --script tests/firmware-test.yaml \
@@ -43,10 +43,10 @@ jobs:
 
       - id: labwired
         name: Run LabWired
-        uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
+        uses: w1ne/labwired-core/.github/actions/labwired-test@75a3d9e906bab90fc0281d1dd786fe479a910d48
         with:
           script: tests/firmware-test.yaml
-          version: v0.22.1
+          version: v0.22.2
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -56,8 +56,8 @@ jobs:
 ```
 
 The public action reference is an **immutable action-source pin** to
-`cfc26b5df0218cceedcd832bc689c89d00a13e2d`. Inputs: `script` (required), `version`
-(default `v0.22.1`), `output-dir`, and `args`. The action downloads that CLI
+`75a3d9e906bab90fc0281d1dd786fe479a910d48`. Inputs: `script` (required), `version`
+(default `v0.22.2`), `output-dir`, and `args`. The action downloads that CLI
 release, writes JUnit to `output-dir/junit.xml`, appends `summary.md` to the job
 summary, and always uploads the output directory (including on failure).
 
@@ -76,7 +76,7 @@ docker run --rm \
   --user "$(id -u):$(id -g)" \
   --volume "$PWD:/workspace" \
   --workdir /workspace \
-  ghcr.io/w1ne/labwired:v0.22.1 \
+  ghcr.io/w1ne/labwired:v0.22.2 \
   test --script tests/firmware-test.yaml \
        --output-dir out/labwired \
        --no-uart-stdout
@@ -95,7 +95,7 @@ Clear the image entrypoint so GitLab can start its job shell. See
 ```yaml
 test:firmware:
   image:
-    name: ghcr.io/w1ne/labwired:v0.22.1
+    name: ghcr.io/w1ne/labwired:v0.22.2
     entrypoint: [""]
   script:
     - labwired test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout

--- a/docs/ci_test_runner.md
+++ b/docs/ci_test_runner.md
@@ -415,21 +415,21 @@ configuration; these produce `status: "error"` with `stop_reason:
 
 ## CI release runners
 
-Use the pinned v0.22.1 release runner in CI. It runs the same `labwired test`
+Use the pinned v0.22.2 release runner in CI. It runs the same `labwired test`
 command described above and writes the same artifact contract.
 
 ### GitHub Actions
 
 Use the public Core action and pin the Core CLI with its version input. Its
 only inputs are required `script`, optional `version` (default
-`v0.22.1`), `output-dir`, and `args`:
+`v0.22.2`), `output-dir`, and `args`:
 
 ~~~yaml
 - id: labwired
   name: Run LabWired tests
-  uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
+  uses: w1ne/labwired-core/.github/actions/labwired-test@75a3d9e906bab90fc0281d1dd786fe479a910d48
   with:
-    version: v0.22.1
+    version: v0.22.2
     script: examples/ci/dummy-max-steps.yaml
     output-dir: out/artifacts
     args: --no-uart-stdout
@@ -440,7 +440,7 @@ only inputs are required `script`, optional `version` (default
 ~~~
 
 The Core action is an immutable action-source pin to
-`cfc26b5df0218cceedcd832bc689c89d00a13e2d`; `version: v0.22.1` independently
+`75a3d9e906bab90fc0281d1dd786fe479a910d48`; `version: v0.22.2` independently
 pins the immutable Core CLI release. It downloads that public release archive
 with `curl`, creates `output-dir/junit.xml` plus Markdown and HTML reports,
 appends the Markdown report to the job summary, and always uploads the entire
@@ -456,7 +456,7 @@ use either a single-machine script or an `inputs.env` world script.
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.22.1 \
+  ghcr.io/w1ne/labwired:v0.22.2 \
   test --script examples/ci/dummy-max-steps.yaml \
        --output-dir out/artifacts \
        --no-uart-stdout
@@ -466,7 +466,7 @@ GitLab should clear that entrypoint and invoke labwired from its job shell:
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.22.1
+  name: ghcr.io/w1ne/labwired:v0.22.2
   entrypoint: [""]
 script:
   - labwired test --script examples/ci/dummy-max-steps.yaml --output-dir out/artifacts --no-uart-stdout

--- a/docs/integration-templates/README.md
+++ b/docs/integration-templates/README.md
@@ -1,14 +1,14 @@
 # CI workflow templates
 
-These templates run a pinned LabWired Core v0.22.1 release and preserve the
+These templates run a pinned LabWired Core v0.22.2 release and preserve the
 result.json, uart.log, snapshot.json, and junit.xml artifacts.
 
 ## GitHub Actions
 
 [github-actions.yml](github-actions.yml) is the primary GitHub template. It
 uses the public Core action at
-w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
-as an immutable action-source pin, while `version: v0.22.1` independently pins
+w1ne/labwired-core/.github/actions/labwired-test@75a3d9e906bab90fc0281d1dd786fe479a910d48
+as an immutable action-source pin, while `version: v0.22.2` independently pins
 the Core CLI. Its only inputs are `script` (required), `version`, `output-dir`,
 and whitespace-separated `args`. The action downloads the public release archive
 with `curl`, writes JUnit at `output-dir/junit.xml`, renders the GitHub report,
@@ -27,7 +27,7 @@ cp docs/integration-templates/github-actions.yml .github/workflows/firmware-test
 
 ~~~yaml
 image:
-  name: ghcr.io/w1ne/labwired:v0.22.1
+  name: ghcr.io/w1ne/labwired:v0.22.2
   entrypoint: [""]
 ~~~
 
@@ -42,7 +42,7 @@ entrypoint:
 
 ~~~bash
 docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/workspace" -w /workspace \
-  ghcr.io/w1ne/labwired:v0.22.1 \
+  ghcr.io/w1ne/labwired:v0.22.2 \
   test --script tests/firmware-test.yaml --output-dir out/labwired --no-uart-stdout
 ~~~
 

--- a/docs/integration-templates/github-actions.yml
+++ b/docs/integration-templates/github-actions.yml
@@ -23,10 +23,10 @@ jobs:
       - id: labwired
         name: Run LabWired test
         # This immutable action-source pin is separate from the CLI version below.
-        uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
+        uses: w1ne/labwired-core/.github/actions/labwired-test@75a3d9e906bab90fc0281d1dd786fe479a910d48
         with:
           script: tests/firmware-test.yaml
-          version: v0.22.1
+          version: v0.22.2
           output-dir: out/labwired
           args: --no-uart-stdout
 
@@ -36,4 +36,4 @@ jobs:
 
 # Advanced alternative: build LabWired from a source checkout only when testing
 # an unreleased LabWired change. For normal firmware CI, keep the pinned release
-# selected by version: v0.22.1 above.
+# selected by version: v0.22.2 above.

--- a/docs/integration-templates/gitlab-ci.yml
+++ b/docs/integration-templates/gitlab-ci.yml
@@ -17,7 +17,7 @@ build:firmware:
 test:labwired:
   stage: test
   image:
-    name: ghcr.io/w1ne/labwired:v0.22.1
+    name: ghcr.io/w1ne/labwired:v0.22.2
     entrypoint: [""]
   dependencies:
     - build:firmware

--- a/docs/reference_client_flows.md
+++ b/docs/reference_client_flows.md
@@ -37,16 +37,16 @@ jobs:
       # Step 2: Run the public immutable Core action
       - id: labwired
         name: Run LabWired CLI
-        uses: w1ne/labwired-core/.github/actions/labwired-test@cfc26b5df0218cceedcd832bc689c89d00a13e2d
+        uses: w1ne/labwired-core/.github/actions/labwired-test@75a3d9e906bab90fc0281d1dd786fe479a910d48
         with:
           script: tests/hardware_validation.yaml
-          version: v0.22.1
+          version: v0.22.2
           output-dir: out/labwired
           args: --no-uart-stdout
 ```
 
 The action source is an immutable action-source pin. It has exactly four inputs:
-`script` (required), `version` (default `v0.22.1`), `output-dir`, and
+`script` (required), `version` (default `v0.22.2`), `output-dir`, and
 `args`. It downloads the selected public release
 with `curl`; callers do not need to add a token, repository, JUnit, or artifact
 upload setting. It automatically uploads `out/labwired/`, including

--- a/scripts/ci/docs-runnable-chips.json
+++ b/scripts/ci/docs-runnable-chips.json
@@ -44,8 +44,8 @@
     "nrf54lm20a": {
       "how": "example",
       "script": "examples/nrf54lm20a-snake/io-smoke.yaml",
-      "expect": "core=cortex-m33 rram=2036K ram=511K",
-      "note": "Snake on an RM67162 AMOLED over SPIM22. Firmware is committed (tests/fixtures/nrf54lm20a-snake.elf), so a clone plus the CLI is the whole prerequisite. The expected line is the chip's own geometry rather than the banner on purpose: nRF54L15 is 1524K/256K, so a firmware linked against the sibling's map cannot print it."
+      "expect": "map rram=ffffffff ram=54120000 p3cnf=00000003",
+      "note": "Snake on an RM67162 AMOLED over SPIM22. Firmware is committed (tests/fixtures/nrf54lm20a-snake.elf), so a clone plus the CLI is the whole prerequisite. The expected map is read back from the model: each value reaches memory or GPIO3 outside the nRF54L15 sibling's map."
     },
     "rp2040": {
       "how": "committed",

--- a/scripts/ci/test-docs-runnable-chips.sh
+++ b/scripts/ci/test-docs-runnable-chips.sh
@@ -69,6 +69,11 @@ json.dump(m, open(work / "wrong-marker.json", "w"), indent=2)
 
 # 4. The positive control.
 json.dump(trimmed({"stm32f103"}), open(work / "good.json", "w"), indent=2)
+
+# 5. The nRF54LM20A smoke changed its measured map transcript in #1064. Keep
+# this real-map entry as a regression control so its marker cannot remain on a
+# retired banner while the example itself still passes.
+json.dump(trimmed({"nrf54lm20a"}), open(work / "nrf54lm20a.json", "w"), indent=2)
 PY
 
 expect_gate_to_fail() {
@@ -92,6 +97,14 @@ if LABWIRED_CHIPS_MAP="$work/good.json" bash "$GATE" "$CLI" > "$work/real" 2>&1;
 else
   printf 'FAIL  a correct map does not pass\n' >&2
   tail -n 12 "$work/real" >&2
+  failures=$((failures + 1))
+fi
+
+if LABWIRED_CHIPS_MAP="$work/nrf54lm20a.json" bash "$GATE" "$CLI" > "$work/nrf54lm20a" 2>&1; then
+  printf 'ok    the nRF54LM20A map marker matches its smoke transcript\n'
+else
+  printf 'FAIL  the nRF54LM20A map marker does not match its smoke transcript\n' >&2
+  tail -n 12 "$work/nrf54lm20a" >&2
   failures=$((failures + 1))
 fi
 

--- a/scripts/ci/test-docs-runnable-chips.sh
+++ b/scripts/ci/test-docs-runnable-chips.sh
@@ -70,10 +70,6 @@ json.dump(m, open(work / "wrong-marker.json", "w"), indent=2)
 # 4. The positive control.
 json.dump(trimmed({"stm32f103"}), open(work / "good.json", "w"), indent=2)
 
-# 5. The nRF54LM20A smoke changed its measured map transcript in #1064. Keep
-# this real-map entry as a regression control so its marker cannot remain on a
-# retired banner while the example itself still passes.
-json.dump(trimmed({"nrf54lm20a"}), open(work / "nrf54lm20a.json", "w"), indent=2)
 PY
 
 expect_gate_to_fail() {
@@ -100,11 +96,19 @@ else
   failures=$((failures + 1))
 fi
 
-if LABWIRED_CHIPS_MAP="$work/nrf54lm20a.json" bash "$GATE" "$CLI" > "$work/nrf54lm20a" 2>&1; then
+if python3 - "$MAP" <<'PY'
+import json, pathlib, sys
+
+entry = json.load(open(sys.argv[1]))["chips"]["nrf54lm20a"]
+smoke = pathlib.Path(entry["script"]).read_text()
+marker = entry["expect"]
+if f'- uart_contains: "{marker}"' not in smoke:
+    raise SystemExit(f"nrf54lm20a map marker is stale: {marker!r}")
+PY
+then
   printf 'ok    the nRF54LM20A map marker matches its smoke transcript\n'
 else
   printf 'FAIL  the nRF54LM20A map marker does not match its smoke transcript\n' >&2
-  tail -n 12 "$work/nrf54lm20a" >&2
   failures=$((failures + 1))
 fi
 

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -434,8 +434,8 @@ require_literal "$backfill_workflow" 'examples/ci/dummy-max-steps.yaml' 'runner 
 require_literal RELEASE_PROCESS.md 'core-backfill-runner-image.yml' 'release process documents the one-time runner image backfill workflow'
 require_literal RELEASE_PROCESS.md 'v0.18.0' 'release process documents the initial v0.18.0 runner image backfill'
 
-safe_action_sha=cfc26b5df0218cceedcd832bc689c89d00a13e2d
-safe_action_version=v0.22.1
+safe_action_sha=75a3d9e906bab90fc0281d1dd786fe479a910d48
+safe_action_version=v0.22.2
 safe_action_ref="w1ne/labwired-core/.github/actions/labwired-test@${safe_action_sha}"
 for doc in docs/ci_integration.md docs/ci_test_runner.md docs/integration-templates/github-actions.yml docs/integration-templates/gitlab-ci.yml docs/integration-templates/README.md docs/reference_client_flows.md .github/actions/labwired-test/README.md; do
   require_absent_literal "$doc" 'ghcr.io/w1ne/labwired:latest' "$doc does not recommend a mutable runner image tag"
@@ -487,7 +487,7 @@ else
     fail "immutable action-source commit $safe_action_sha contains its action README"
   fi
   if [[ -n "$pinned_action" ]]; then
-    require_block_literal "$pinned_action" 'default: "v0.22.1"' 'pinned action defaults to the supported public release'
+    require_block_literal "$pinned_action" 'default: "v0.22.2"' 'pinned action defaults to the supported public release'
     require_block_literal "$pinned_action" 'https://github.com/w1ne/labwired-core/releases/download/${version}/${asset}' 'pinned action downloads the public release archive'
     pinned_action_inputs=$(awk '
       /^inputs:$/ { inside = 1; next }
@@ -508,7 +508,7 @@ else
     require_block_literal "$pinned_action" 'name: labwired-${{ github.job }}-${{ github.run_id }}-${{ github.action }}' 'pinned action gives each invocation a unique artifact name'
   fi
   if [[ -n "$pinned_action_readme" ]]; then
-    require_block_literal "$pinned_action_readme" 'defaults to `v0.22.1`' 'pinned action README states the supported public release'
+    require_block_literal "$pinned_action_readme" 'defaults to `v0.22.2`' 'pinned action README states the supported public release'
     require_block_literal "$pinned_action_readme" '[CI integration guide](../../../docs/ci_integration.md)' 'pinned action README links the canonical consumer guide'
     require_block_literal "$pinned_action_readme" 'intentionally documents the action beside its implementation' 'pinned action README explains its source-local contract'
     require_block_absent_literal "$pinned_action_readme" 'uses: w1ne/labwired-core/.github/actions/labwired-test@' 'pinned action README does not recursively choose its own SHA'

--- a/scripts/ci/verify-release-runner-contract.sh
+++ b/scripts/ci/verify-release-runner-contract.sh
@@ -305,7 +305,7 @@ if [[ -f "$dockerignore" ]]; then
   done
 fi
 
-require_literal "$action" 'default: "v0.22.1"' 'core action defaults to the supported public release'
+require_literal "$action" 'default: "v0.22.2"' 'core action defaults to the supported public release'
 action_inputs=$(awk '
   /^inputs:$/ { inside = 1; next }
   inside && /^[^[:space:]]/ { exit }
@@ -554,9 +554,9 @@ require_literal docs/configuration_reference.md 'including `{}` and `null`' 'con
 require_literal docs/configuration_reference.md 'stop_when_assertions_pass' 'configuration reference documents world assertion completion'
 require_literal examples/egress-demo/README.md 'config` is a closed mapping' 'egress example documents its closed config mapping'
 require_literal examples/egress-demo/README.md 'positive integer' 'egress example documents buffer_max type validation'
-require_literal Cargo.toml 'version = "0.22.1"' 'workspace metadata uses the current release version'
-require_literal CHANGELOG.md '## [0.21.0] - 2026-07-27' 'changelog records the current release version'
-require_literal README.md 'LABWIRED_VERSION=v0.22.1' 'public README pins the current release version'
+require_literal Cargo.toml 'version = "0.22.2"' 'workspace metadata uses the current release version'
+require_literal CHANGELOG.md '## [0.22.2] - 2026-08-26' 'changelog records the current release version'
+require_literal README.md 'LABWIRED_VERSION=v0.22.2' 'public README pins the current release version'
 require_absent_literal README.md 'LABWIRED_VERSION=v0.20.0' 'public README does not retain the superseded release version'
 
 if (( failures > 0 )); then


### PR DESCRIPTION
## Summary
- release v0.22.2 with the nRF54LM20A documented-chip marker corrected to its measured map transcript
- add a focused regression control for that marker
- update the public installer, action, and consumer release pins to v0.22.2

## Root cause
The installer downloaded v0.22.1, which lacked the nRF54L/EF32 support. Once the candidate carried that support, the canary exposed a second stale expected transcript: the smoke output changed from a literal geometry banner to a measured map line in #1064.

## Verification
- `cargo check -p labwired-cli`
- `bash scripts/ci/verify-release-runner-contract.sh`
- `bash scripts/ci/test-docs-runnable-chips.sh target/release/labwired`
- `bash scripts/ci/docs-runnable-chips.sh target/release/labwired` (28/28)

The issue stays open until the merged tag publishes and the external install canary passes.