### PR TITLE
ci: keep extension registry checks out of core canary

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Verify installer contract
         run: bash scripts/ci/test-install-script.sh
 
+      - name: Keep extension distribution checks outside core
+        run: bash scripts/ci/test-install-canary-boundaries.sh
+
       # Docs are checked against the RELEASED CLI, not the workspace build:
       # what a reader can run is whatever they were able to install. The README
       # told people to pass `--system` to `labwired run` for months; that flag

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -356,7 +356,7 @@ jobs:
 
   # ── Two claims that are not commands, but are still promises ────────────────
   promises:
-    name: Release freshness and extension availability
+    name: Release freshness and telemetry contract
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -379,23 +379,6 @@ jobs:
       # break or fix the other side.
       - name: install.sh and the CLI speak the schema the endpoint serves
         run: bash scripts/ci/telemetry-schema-conformance.sh
-
-      # The extension is a product with a distribution channel, and until it is
-      # on a registry the only way to install it is downloading a .vsix by
-      # hand. That is worth a red light rather than a note in a backlog.
-      - name: The extension is installable from a registry
-        run: |
-          set -uo pipefail
-          fail=0
-          mk=$(curl -s -o /dev/null -w '%{http_code}' -L \
-            'https://marketplace.visualstudio.com/items?itemName=w1ne.labwired-vscode')
-          ovsx=$(curl -s -o /dev/null -w '%{http_code}' -L \
-            'https://open-vsx.org/api/w1ne/labwired-vscode')
-          echo "VS Code Marketplace: $mk"
-          echo "Open VSX:            $ovsx"
-          [ "$mk" = "200" ] || { echo "::error::Not on the VS Code Marketplace. Create the w1ne publisher and add VSCE_PAT to labwired-vscode."; fail=1; }
-          [ "$ovsx" = "200" ] || { echo "::error::Not on Open VSX — VSCodium, Cursor and Windsurf users cannot install it. Create the namespace and add OVSX_PAT."; fail=1; }
-          exit "$fail"
 
   # ── One issue, kept current, when any of the above goes red ─────────────────
   report:

--- a/scripts/ci/test-install-canary-boundaries.sh
+++ b/scripts/ci/test-install-canary-boundaries.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Keep labwired-core's canary focused on surfaces this repository owns.
+set -euo pipefail
+
+workflow=${1:-.github/workflows/install-canary.yml}
+
+test -f "$workflow"
+! rg -q 'marketplace\.visualstudio\.com|open-vsx\.org|labwired-vscode|extension is installable' "$workflow"


### PR DESCRIPTION
Removes VS Code Marketplace and Open VSX availability checks from `labwired-core`’s install canary.

Those registries and publisher credentials belong to `w1ne/labwired-vscode`; core retains its release-freshness and telemetry-contract checks. A small CI guard prevents extension registry URLs from returning to the core canary.

Verification:
- `bash scripts/ci/test-install-canary-boundaries.sh`
- YAML parse for both edited workflows
- `actionlint .github/workflows/install-canary.yml .github/workflows/core-ci.yml`