### PR TITLE
ci: stop scheduled workflows from running (and mailing) on forks

### DIFF
--- a/.github/workflows/core-arduino-matrix-smoke.yml
+++ b/.github/workflows/core-arduino-matrix-smoke.yml
@@ -4,6 +4,12 @@ name: Core Arduino Matrix Smoke
 # Required status: `arduino-matrix-gate` (branch protection).
 # See validation/FRAMEWORK_FLEET.md.
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Pushes and manual dispatch are
+# untouched — a fork still gets this workflow on its own changes.
 on:
   # Slow fleet: nightly + main tip + manual. Not on PRs (PR merge target <1 min).
   schedule:
@@ -28,6 +34,7 @@ concurrency:
 jobs:
   arduino-matrix:
     name: arduino-${{ matrix.board }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -154,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: arduino-matrix
-    if: always()
+    if: ${{ always() && (github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-board-ci.yml
+++ b/.github/workflows/core-board-ci.yml
@@ -1,5 +1,11 @@
 name: Core Board CI
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Pushes, PRs and manual dispatch
+# are untouched — a fork still gets full CI on its own changes.
 on:
   push:
     branches: [main]
@@ -33,6 +39,7 @@ concurrency:
 
 jobs:
   setup:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -51,6 +58,7 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   board:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -122,6 +130,7 @@ jobs:
   # auto-committing to protected main: regenerate here and fail if it drifted, so
   # whoever changed the matrix must commit the regenerated scoreboard.
   coverage-staleness:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1,5 +1,12 @@
 name: Rust Core CI
 
+# Scheduled runs are gated to this repository. GitHub attributes a cron run to
+# whoever last edited the schedule, so a fork with Actions enabled mails this
+# workflow's nightly failures to a maintainer here, about a run they can
+# neither see nor stop. The schedule-reachable jobs below say
+# `github.event_name == 'schedule' && github.repository == 'w1ne/labwired-core'`
+# in place of a bare schedule arm; the PR lanes never run on a schedule and are
+# untouched, so a fork still gets full CI on its own changes.
 on:
   push:
     branches:
@@ -41,6 +48,7 @@ jobs:
   # ── Static contract (always on PR; seconds) ────────────────────────────────
   release-runner-contract:
     name: release-runner-contract
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1133,7 +1141,7 @@ jobs:
     name: core-integrity
     if: >
       github.event_name == 'push' ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'w1ne/labwired-core') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # 30, not 20: the release-gated step now boots two ESP32-C3 mask ROMs and
@@ -1389,7 +1397,7 @@ jobs:
     name: ci-runner-image
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'w1ne/labwired-core') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -1477,7 +1485,7 @@ jobs:
     name: core-full
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' ||
+      (github.event_name == 'schedule' && github.repository == 'w1ne/labwired-core') ||
       (github.event_name == 'push' && contains(github.event.head_commit.message, '[full-ci]'))
     runs-on: ubuntu-latest
     # 45 was the budget for a job that never finished: `Run Workspace Tests`

--- a/.github/workflows/core-coverage-matrix-smoke.yml
+++ b/.github/workflows/core-coverage-matrix-smoke.yml
@@ -1,5 +1,11 @@
 name: Core Coverage Matrix Smoke
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Pushes and manual dispatch are
+# untouched — a fork still gets this workflow on its own changes.
 on:
   # Slow gates: nightly + main tip + manual. Not on PRs (PR merge target <1 min).
   schedule:
@@ -24,6 +30,7 @@ concurrency:
 jobs:
   coverage-matrix-smoke:
     name: coverage-matrix-${{ matrix.id }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -344,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: coverage-matrix-smoke
-    if: always()
+    if: ${{ always() && (github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-coverage-weekly.yml
+++ b/.github/workflows/core-coverage-weekly.yml
@@ -1,5 +1,11 @@
 name: Core Coverage Gate
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Only the cron is gated: a manual
+# dispatch in a fork still runs every job here.
 on:
   schedule:
     - cron: "20 2 * * 0"
@@ -11,6 +17,7 @@ concurrency:
 
 jobs:
   coverage:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/core-nightly.yml
+++ b/.github/workflows/core-nightly.yml
@@ -1,5 +1,11 @@
 name: Rust Core Nightly
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Only the cron is gated: a manual
+# dispatch in a fork still runs every job here.
 on:
   schedule:
     # Nightly 02:00 UTC (was Sunday-only). Slow coverage / validation lives here.
@@ -24,6 +30,7 @@ concurrency:
 jobs:
   validation:
     name: Advanced Validation
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -82,6 +89,7 @@ jobs:
 
   example-smokes:
     name: Example Smokes (real-output autochecks)
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -126,6 +134,7 @@ jobs:
 
   esp32s3-fixtures-e2e:
     name: ESP32-S3 Fixtures E2E (espup)
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -224,6 +233,7 @@ jobs:
   # on demand with `workflow_dispatch` when touching the BT model.
   esp32c3-ble-e2e:
     name: ESP32-C3 BLE Baseband E2E
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     # 45 covered the first two gates. The re-publication gate below adds ~500 M
     # steps for each of two twins — the sketch's own 700 ms `delay()` is 112 M
@@ -327,6 +337,7 @@ jobs:
   # must not take the three pinned-image BLE gates down with it.
   esp32c3-ble-pong-soak:
     name: ESP32-C3 BLE Pong Cadence Soak
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     # The run is ~6 min; the release build of labwired-core on a cold cache is
     # the rest. Generous so a slow runner reports the SOAK's verdict rather
@@ -388,6 +399,7 @@ jobs:
 
   tier1-fixture-drift:
     name: Tier-1 Fixture Drift Check
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -507,6 +519,7 @@ jobs:
   # it ever catches something a PR should have caught.
   never-run-features:
     name: never-run-feature-lanes
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -666,6 +679,7 @@ jobs:
   # wrapper now counts that case and goes red.
   tick-interval-licence:
     name: C3 OLED tick-interval licence (#[ignore]d, --release)
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/.github/workflows/core-onboarding-smoke.yml
+++ b/.github/workflows/core-onboarding-smoke.yml
@@ -1,5 +1,11 @@
 name: Core Onboarding Smoke
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Pushes and manual dispatch are
+# untouched — a fork still gets this workflow on its own changes.
 on:
   # Slow gates: nightly + main tip + manual. Not on PRs (PR merge target <1 min).
   schedule:
@@ -24,6 +30,7 @@ concurrency:
 jobs:
   onboarding-smoke:
     name: onboarding-${{ matrix.id }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -91,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: onboarding-smoke
-    if: always()
+    if: ${{ always() && (github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/core-perf.yml
+++ b/.github/workflows/core-perf.yml
@@ -18,6 +18,12 @@ name: Core Perf (simulator throughput)
 # Run it on a PR by hand with workflow_dispatch when touching the CPU step
 # path, the machine-advance loop, or the peripheral tick walk.
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Pushes and manual dispatch are
+# untouched — a fork still gets this workflow on its own changes.
 on:
   push:
     branches:
@@ -54,6 +60,7 @@ permissions:
 jobs:
   board-throughput:
     name: board-throughput
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/core-unsupported-audit.yml
+++ b/.github/workflows/core-unsupported-audit.yml
@@ -1,5 +1,11 @@
 name: Core Unsupported Audit
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Only the cron is gated: a manual
+# dispatch in a fork still runs every job here.
 on:
   schedule:
     - cron: "40 2 * * *"
@@ -7,6 +13,7 @@ on:
 
 jobs:
   unsupported-audit:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/core-validate-hw-targets.yml
+++ b/.github/workflows/core-validate-hw-targets.yml
@@ -1,5 +1,11 @@
 name: Core Validate HW Targets
 
+# Scheduled runs are gated to this repository: every job below carries
+# `if: github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core'`.
+# GitHub attributes a cron run to whoever last edited the schedule, so a fork
+# with Actions enabled mails this workflow's failures to a maintainer here,
+# about a run they can neither see nor stop. Pushes and manual dispatch are
+# untouched — a fork still gets this workflow on its own changes.
 on:
   schedule:
     - cron: '0 0 * * 0'
@@ -20,6 +26,7 @@ concurrency:
 
 jobs:
   validate-targets:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/install-canary.yml
+++ b/.github/workflows/install-canary.yml
@@ -12,6 +12,15 @@
 #      drifted before.
 #   2. Assert on output, not exit codes alone. An installer that prints
 #      "Installation complete!" and exits 0 is exactly how the last outage hid.
+#
+# Every job carries `if: github.repository == 'w1ne/labwired-core'`, because
+# nothing here is a fork's business. The legs fetch labwired.com and this
+# repo's releases — on a fork they test our infrastructure, not the fork's
+# change, and `report` would try to file an issue about our outage there.
+# Worse, GitHub attributes a scheduled run to whoever last edited the cron,
+# so a fork with Actions enabled mails every failure to a maintainer here,
+# about a run they cannot see, fix, or turn off. A fork that wants the canary
+# can point the guard at itself.
 name: Install canary
 
 on:
@@ -38,6 +47,7 @@ jobs:
   # ── The CLI, installed the way the README says ───────────────────────────────
   cli:
     name: CLI on ${{ matrix.label }}
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -94,6 +104,7 @@ jobs:
   # runs. The steps below are the README's Windows section, verbatim.
   cli-windows:
     name: CLI on Windows x86_64
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -164,6 +175,7 @@ jobs:
   # ── The distributions people actually run, not the one CI runs ───────────────
   cli-old-distros:
     name: CLI on ${{ matrix.image }} (${{ matrix.arch }})
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.image }}
     strategy:
@@ -199,6 +211,7 @@ jobs:
   # ── Every chip we document, run with the CLI a user can install ─────────────
   chips:
     name: Documented chips on ${{ matrix.label }}
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -234,6 +247,7 @@ jobs:
   # ── The agent one-liner, in every shell the docs' `| sh` can land in ─────────
   mcp-oneliner:
     name: mcp.sh under ${{ matrix.shell }}
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -276,6 +290,7 @@ jobs:
   # ── Windows: both PowerShells, and the user's other MCP servers survive ──────
   mcp-windows:
     name: mcp.ps1 on ${{ matrix.ps }}
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -321,6 +336,7 @@ jobs:
   # ── The npm and container channels ──────────────────────────────────────────
   packages:
     name: npm and container channels
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v4
@@ -357,6 +373,7 @@ jobs:
   # ── Two claims that are not commands, but are still promises ────────────────
   promises:
     name: Release freshness and telemetry contract
+    if: ${{ github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -384,7 +401,7 @@ jobs:
   report:
     name: Raise the alarm
     needs: [cli, cli-old-distros, chips, mcp-oneliner, mcp-windows, packages, promises]
-    if: failure()
+    if: ${{ failure() && github.repository == 'w1ne/labwired-core' }}
     runs-on: ubuntu-latest
     steps:
       # ⚠️ `-R` ON EVERY CALL, AND NO `actions/checkout`.


### PR DESCRIPTION
## Why

`CrispStrobe/labwired-core` is a fork with Actions enabled. Its copy of `Install canary` runs every 6 hours, and GitHub attributes a **scheduled** run to whoever last edited the cron — a maintainer here. So every failing canary leg in that fork mails a maintainer about a run in a repository they can neither see, fix, nor turn off.

The runs are also meaningless there: every canary leg curls `labwired.com` and this repo's releases, so a fork tests our infrastructure rather than its own change, and `report` would file an issue about our outage in the fork's tracker.

Eleven other workflows carry a `schedule:` trigger with no fork guard at all — same defect, just quieter today.

## What changed

**`install-canary.yml`** — gated wholesale. Every job carries `if: github.repository == 'w1ne/labwired-core'`; the `report` job's existing `failure()` gate has it ANDed in. Nothing in this workflow is a fork's business under any trigger.

**The other eleven** — gated on the *schedule only*, not the workflow:

```yaml
if: ${{ github.event_name != 'schedule' || github.repository == 'w1ne/labwired-core' }}
```

`core-ci`, `core-board-ci`, `core-perf` and others also fire on push and PR, and a blanket repository guard would have killed CI for anyone working in a fork. This way pushes, pull requests and manual dispatch behave exactly as before — a fork keeps full CI on its own changes — and only the misattributed cron mail stops.

- 25 jobs across `core-nightly` (8), `core-board-ci` (3), `core-arduino-matrix-smoke`, `core-coverage-matrix-smoke`, `core-onboarding-smoke` (2 each), `core-coverage-weekly`, `core-perf`, `core-unsupported-audit`, `core-validate-hw-targets`, plus `release-runner-contract` in `core-ci`.
- The three `if: always()` scoreboard/gate jobs get the guard ANDed in — `always()` would otherwise run them with every dependency skipped.
- `core-ci`'s `integrity`, `ci-runner-image` and `full` already enumerate their events, so the schedule arm is narrowed in place to `(github.event_name == 'schedule' && github.repository == 'w1ne/labwired-core')` rather than given a second condition. The PR lanes there cannot reach a schedule and are untouched.
- `core-hil.yml` is left alone: its cron is commented out, so there is nothing to gate until someone enables it.

Each file carries a short note above `on:` explaining the guard, worded to its own trigger set.

## Validation

`actionlint 1.7.12 -shellcheck=shellcheck 0.11.0 -pyflakes= .github/workflows/*.yml` — the exact command `core-workflows-lint` runs, on the repo's pinned versions. Clean, exit 0.

## Note

This protects against future forks. `CrispStrobe/labwired-core` runs *its* copy of these files, so the 6-hourly mail continues until that fork syncs or disables Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsQTTgsv5HqSf7xyA9N6me

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsQTTgsv5HqSf7xyA9N6me)_