### PR TITLE
fix(ci): Arduino fleet gate could report "full fleet pass" with zero compiles

### DIFF
--- a/.github/workflows/core-arduino-matrix-smoke.yml
+++ b/.github/workflows/core-arduino-matrix-smoke.yml
@@ -172,38 +172,27 @@ jobs:
           pattern: arduino-matrix-*
           merge-multiple: false
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Fleet verdict inputs
+        run: python -m pip install --quiet pyyaml
+
+      # The verdict lives in scripts/ci/matrix_verdict.py with a pytest suite
+      # (scripts/ci/test_matrix_verdict.py, run by core-ci.yml) because the
+      # inline version it replaces reported success while proving nothing:
+      # `skipped` counted as a pass with no check that the skip was WAIVED, and
+      # there was no minimum-pass floor, so a run whose 144 cells were all
+      # skipped printed "full fleet pass". Measured on this fixture before the
+      # change: old block exit 0, new gate exit 1.
+      #
+      # `EXPECTED` was also the literal `16 * 9`. It is now derived from
+      # boards.yaml (boards without `external_compile:` x sketches), so a fleet
+      # that shrinks cannot quietly lower its own floor.
       - name: Require full fleet cells pass
         run: |
-          python3 - <<'PY'
-          import json
-          import sys
-          from pathlib import Path
-
-          # 16 boards × 9 sketches (L0–L8); skips count as cells
-          EXPECTED = 16 * 9
-          root = Path("validation/arduino-matrix/out-ci")
-          results = list(root.rglob("results.json"))
-          if not results:
-              print("::error::no results.json from arduino matrix jobs", file=sys.stderr)
-              sys.exit(1)
-
-          bad = []
-          total = 0
-          for path in results:
-              data = json.loads(path.read_text())
-              for row in data.get("rows") or []:
-                  total += 1
-                  st = row.get("status")
-                  # skipped = explicit boards.yaml sketches_skip (e.g. STM32 L3 Wire)
-                  if st not in ("pass", "skipped"):
-                      bad.append(f"{row.get('board')}/{row.get('sketch')}: {st}")
-          print(f"cells={total} expected>={EXPECTED} fails={len(bad)}")
-          for b in bad:
-              print("FAIL", b)
-          if total < EXPECTED:
-              print(f"::error::expected ≥{EXPECTED} cells, got {total}", file=sys.stderr)
-              sys.exit(1)
-          if bad:
-              sys.exit(1)
-          print("arduino matrix gate: full fleet pass (pass|skipped ok)")
-          PY
+          python3 scripts/ci/matrix_verdict.py \
+            --results-dir validation/arduino-matrix/out-ci \
+            --fleet validation/arduino-matrix/boards.yaml

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -508,6 +508,7 @@ jobs:
             scripts/ci/test_board_matrix.py \
             scripts/ci/test_chip_coverage.py \
             scripts/ci/test_matrix_external_cache.py \
+            scripts/ci/test_matrix_verdict.py \
             scripts/ci/test_workspace_test_shard.py \
             scripts/test_generate_validation_status.py
 

--- a/scripts/ci/matrix_verdict.py
+++ b/scripts/ci/matrix_verdict.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Grade an Arduino-matrix fleet run against the fleet definition.
+
+WHY THIS IS A SCRIPT AND NOT A `run:` BLOCK.
+
+The verdict it replaces lived inline in core-arduino-matrix-smoke.yml and could
+report success while proving nothing:
+
+  * `skipped` counted as a pass and NOTHING checked that the skip was declared,
+    so any cell that reports `skipped` without a waiver bought a green column.
+  * There was no minimum-pass floor at all. A run in which every cell reported
+    `skipped` printed "arduino matrix gate: full fleet pass".
+  * `EXPECTED` was the literal `16 * 9`, so the fleet could shrink in
+    boards.yaml and the floor would follow it down with nobody editing a floor.
+
+The monorepo's sibling gate (brd2709a-arduino-matrix.yml) already carried the
+`passes == 0` floor this one lacked — two copies of one rule, one incomplete.
+This is that rule, once, with a test.
+
+Every threshold is DERIVED from the fleet definition. Nothing here is a literal
+that a shrinking fleet can satisfy.
+
+Usage:
+    matrix_verdict.py --results-dir validation/arduino-matrix/out-ci \
+                      --fleet validation/arduino-matrix/boards.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+# Statuses that are not a failure of the board under test. Everything else --
+# sim_error, toolchain_missing, elf_missing, a build stage name -- is a failure.
+OK_STATUSES = {"pass", "skipped"}
+
+
+def load_fleet(path: Path) -> tuple[dict[str, set[str]], list[str]]:
+    """Return (declared skips by board, sketch ids) for the SIMULATED fleet.
+
+    Boards carrying `external_compile:` are excluded: they are graded by their
+    own lane in the monorepo, not by this workflow, and counting them here would
+    make the expected-cell floor unsatisfiable.
+    """
+    cfg = yaml.safe_load(path.read_text()) or {}
+    sketch_ids = [s["id"] for s in cfg.get("sketches") or []]
+    skips: dict[str, set[str]] = {}
+    for board in cfg.get("boards") or []:
+        if board.get("external_compile"):
+            continue
+        skips[board["id"]] = set(board.get("sketches_skip") or [])
+    return skips, sketch_ids
+
+
+def read_rows(results_dir: Path) -> tuple[list[dict], int]:
+    """Collect every row from every results.json under results_dir."""
+    files = sorted(results_dir.rglob("results.json"))
+    rows: list[dict] = []
+    for path in files:
+        data = json.loads(path.read_text())
+        rows.extend(data.get("rows") or [])
+    return rows, len(files)
+
+
+def grade(rows: list[dict], skips: dict[str, set[str]], sketch_ids: list[str]) -> list[str]:
+    """Return failure messages. Empty means the fleet result is honest."""
+    errors: list[str] = []
+    board_ids = set(skips)
+
+    if not board_ids or not sketch_ids:
+        return ["fleet definition names no boards or no sketches"]
+
+    expected = len(board_ids) * len(sketch_ids)
+    sketch_set = set(sketch_ids)
+
+    seen: dict[tuple[str, str], str] = {}
+    for row in rows:
+        cell = (row.get("board"), row.get("sketch"))
+        status = row.get("status")
+        if cell in seen:
+            errors.append(
+                f"duplicate cell {cell[0]}/{cell[1]} (statuses {seen[cell]}, {status})"
+            )
+            continue
+        seen[cell] = status
+        if cell[0] not in board_ids:
+            errors.append(f"result for board {cell[0]!r}, which is not in the simulated fleet")
+        elif cell[1] not in sketch_set:
+            errors.append(f"result for sketch {cell[1]!r}, which is not in the fleet definition")
+
+    ordered = sorted(seen.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or ""))
+
+    # 1. Nothing may report a status other than pass or a declared skip.
+    for cell, status in ordered:
+        if status not in OK_STATUSES:
+            errors.append(f"{cell[0]}/{cell[1]}: {status}")
+
+    # 2. A skip must be WAIVED in boards.yaml. An undeclared skip is a hole --
+    #    a cell nobody decided to stop testing.
+    for cell, status in ordered:
+        if status == "skipped" and cell[1] not in skips.get(cell[0], set()):
+            errors.append(
+                f"{cell[0]}/{cell[1]}: skipped but not in that board's sketches_skip -- "
+                "waive it in boards.yaml with a reason, or fix the cell"
+            )
+
+    # 3. The fleet must be whole, against a count derived from boards.yaml.
+    if len(seen) < expected:
+        missing = sorted(f"{b}/{s}" for b in board_ids for s in sketch_ids if (b, s) not in seen)
+        errors.append(
+            f"expected {expected} cells ({len(board_ids)} boards x {len(sketch_ids)} sketches), "
+            f"got {len(seen)}; missing: {', '.join(missing[:12])}"
+            + (" ..." if len(missing) > 12 else "")
+        )
+
+    passes = sum(1 for st in seen.values() if st == "pass")
+
+    # 4. The sibling gate's floor: a column of pure skips proves nothing.
+    if passes == 0:
+        errors.append("no cell passed -- the column proves nothing")
+
+    # 5. Per board, which the global floor cannot see: one board going entirely
+    #    dark is invisible while fifteen others still pass.
+    for board in sorted(board_ids):
+        reported = [st for c, st in seen.items() if c[0] == board]
+        if reported and not any(st == "pass" for st in reported):
+            errors.append(f"{board}: no sketch passed -- this board proves nothing")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Grade an Arduino-matrix fleet run.")
+    ap.add_argument("--results-dir", required=True)
+    ap.add_argument("--fleet", required=True)
+    args = ap.parse_args(argv)
+
+    results_dir = Path(args.results_dir)
+    skips, sketch_ids = load_fleet(Path(args.fleet))
+    rows, files = read_rows(results_dir)
+
+    if files == 0:
+        print(f"::error::no results.json under {results_dir}", file=sys.stderr)
+        return 1
+
+    errors = grade(rows, skips, sketch_ids)
+
+    expected = len(skips) * len(sketch_ids)
+    n_pass = sum(1 for r in rows if r.get("status") == "pass")
+    n_skip = sum(1 for r in rows if r.get("status") == "skipped")
+    print(
+        f"artifacts={files} cells={len(rows)} expected={expected} "
+        f"pass={n_pass} skip={n_skip} fail={len(rows) - n_pass - n_skip}"
+    )
+
+    if errors:
+        for e in errors:
+            print(f"::error::{e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"arduino matrix gate: {n_pass} pass / {n_skip} declared skip / 0 fail "
+        f"across {len(skips)} boards"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_matrix_verdict.py
+++ b/scripts/ci/test_matrix_verdict.py
@@ -1,0 +1,184 @@
+"""Unit cover for the Arduino-matrix fleet verdict.
+
+Every case but the last builds a SYNTHETIC fleet and a synthetic results tree.
+Grading the real out-ci here is impossible (it exists only on a runner), and
+grading the real boards.yaml for a *verdict* would make these tests a mirror of
+today's fleet: they would go green for the wrong reason the moment someone
+waived a cell, and they could never express "a column of pure skips must fail",
+because the committed fleet is by design not in that state.
+
+The last case does read the real boards.yaml, and it asserts the gate's own
+claim about it -- that the committed fleet is gradeable and that an honest run
+over it comes back clean -- rather than restating the fleet's contents.
+
+Each negative case is a real exploit of the verdict this replaced: the inline
+block in core-arduino-matrix-smoke.yml passed every one of them.
+"""
+
+import json
+from pathlib import Path
+
+import matrix_verdict as mv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REAL_FLEET = REPO_ROOT / "validation/arduino-matrix/boards.yaml"
+
+SKETCHES = ["L0", "L1", "L2"]
+FLEET = {"alpha": set(), "beta": {"L2"}}
+
+
+def write_fleet(root: Path, *, boards, sketches=SKETCHES):
+    """boards: list of (id, [skips], external_compile?)."""
+    lines = ["boards:"]
+    for entry in boards:
+        bid, skips = entry[0], entry[1]
+        external = entry[2] if len(entry) > 2 else False
+        lines.append(f"  - id: {bid}")
+        lines.append(f"    chip: {bid}")
+        if skips:
+            lines.append(f"    sketches_skip: [{', '.join(skips)}]")
+        if external:
+            lines.append("    external_compile: { lane: elsewhere }")
+    lines.append("sketches:")
+    for sid in sketches:
+        lines.append(f"  - id: {sid}")
+        lines.append(f"    dir: sketches/{sid}")
+    path = root / "boards.yaml"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def write_results(root: Path, rows_by_artifact):
+    """rows_by_artifact: list of lists of (board, sketch, status)."""
+    out = root / "out-ci"
+    for i, rows in enumerate(rows_by_artifact):
+        d = out / f"artifact-{i}"
+        d.mkdir(parents=True)
+        (d / "results.json").write_text(
+            json.dumps({"rows": [{"board": b, "sketch": s, "status": st} for b, s, st in rows]})
+        )
+    return out
+
+
+def to_rows(triples):
+    """grade() consumes results.json rows; the cases author them as triples."""
+    return [{"board": b, "sketch": s, "status": st} for b, s, st in triples]
+
+
+def honest_rows():
+    rows = []
+    for board, skips in FLEET.items():
+        for sid in SKETCHES:
+            rows.append((board, sid, "skipped" if sid in skips else "pass"))
+    return rows
+
+
+def test_honest_full_fleet_passes():
+    assert mv.grade(to_rows(honest_rows()), FLEET, SKETCHES) == []
+
+
+def test_all_skipped_fails_even_though_nothing_failed(tmp_path):
+    """THE hole this gate was written for.
+
+    Every cell reports `skipped`. Nothing is a failure, the cell count is
+    complete, and the verdict this replaced printed "full fleet pass".
+    """
+    rows = [(b, s, "skipped") for b in FLEET for s in SKETCHES]
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any("no cell passed" in e for e in errors), errors
+
+
+def test_one_board_going_entirely_dark_fails():
+    """A per-board floor the global `passes == 0` rule cannot see."""
+    rows = [(b, s, "skipped" if b == "alpha" else "pass") for b in FLEET for s in SKETCHES]
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any(e.startswith("alpha: no sketch passed") for e in errors), errors
+
+
+def test_undeclared_skip_fails():
+    rows = [r for r in honest_rows() if r[:2] != ("alpha", "L1")]
+    rows.append(("alpha", "L1", "skipped"))
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any("not in that board's sketches_skip" in e for e in errors), errors
+
+
+def test_declared_skip_is_accepted():
+    """beta/L2 is waived in the fleet, so it must not trip the skip rule."""
+    errors = mv.grade(to_rows(honest_rows()), FLEET, SKETCHES)
+    assert errors == []
+
+
+def test_missing_board_fails_against_a_derived_count():
+    rows = [r for r in honest_rows() if r[0] != "beta"]
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any("expected 6 cells" in e and "beta/L0" in e for e in errors), errors
+
+
+def test_toolchain_missing_fails():
+    rows = [r for r in honest_rows() if r[:2] != ("alpha", "L0")]
+    rows.append(("alpha", "L0", "toolchain_missing"))
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any(e == "alpha/L0: toolchain_missing" for e in errors), errors
+
+
+def test_duplicate_cell_fails():
+    rows = honest_rows() + [("alpha", "L0", "pass")]
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any("duplicate cell alpha/L0" in e for e in errors), errors
+
+
+def test_result_for_a_board_outside_the_fleet_fails():
+    rows = honest_rows() + [("gamma", "L0", "pass")]
+    errors = mv.grade(to_rows(rows), FLEET, SKETCHES)
+    assert any("not in the simulated fleet" in e for e in errors), errors
+
+
+def test_external_compile_boards_are_not_counted(tmp_path):
+    """They are graded by their own lane; counting them makes the floor unmeetable."""
+    fleet_path = write_fleet(
+        tmp_path, boards=[("alpha", []), ("beta", ["L2"]), ("elsewhere", [], True)]
+    )
+    skips, sketch_ids = mv.load_fleet(fleet_path)
+    assert set(skips) == {"alpha", "beta"}
+    assert skips["beta"] == {"L2"}
+    assert sketch_ids == SKETCHES
+
+
+def test_main_reports_no_results_as_an_error(tmp_path, capsys):
+    fleet_path = write_fleet(tmp_path, boards=[("alpha", [])])
+    (tmp_path / "out-ci").mkdir()
+    rc = mv.main(["--results-dir", str(tmp_path / "out-ci"), "--fleet", str(fleet_path)])
+    assert rc == 1
+    assert "no results.json" in capsys.readouterr().err
+
+
+def test_main_end_to_end_over_a_synthetic_tree(tmp_path):
+    fleet_path = write_fleet(tmp_path, boards=[("alpha", []), ("beta", ["L2"])])
+    # One artifact per board, the way download-artifact lays them out.
+    out = write_results(
+        tmp_path,
+        [
+            [("alpha", s, "pass") for s in SKETCHES],
+            [("beta", s, "skipped" if s == "L2" else "pass") for s in SKETCHES],
+        ],
+    )
+    assert mv.main(["--results-dir", str(out), "--fleet", str(fleet_path)]) == 0
+
+
+def test_the_committed_fleet_is_gradeable_and_an_honest_run_is_clean():
+    """Reads the real boards.yaml -- the gate's claim about it, not its contents.
+
+    Asserts the fleet parses into a non-trivial simulated set, and that a run in
+    which every non-waived cell passes grades clean. If someone adds a board or
+    a sketch, this keeps working; if the fleet stops being gradeable, it fails.
+    """
+    skips, sketch_ids = mv.load_fleet(REAL_FLEET)
+    assert len(skips) >= 10, f"simulated fleet collapsed to {len(skips)} boards"
+    assert len(sketch_ids) >= 3, sketch_ids
+
+    rows = [
+        (board, sid, "skipped" if sid in waived else "pass")
+        for board, waived in skips.items()
+        for sid in sketch_ids
+    ]
+    assert mv.grade(to_rows(rows), skips, sketch_ids) == []


### PR DESCRIPTION
The fleet verdict in `core-arduino-matrix-smoke.yml` counted `skipped` as a pass, never checked that the skip was **waived** in `boards.yaml`, and had **no minimum-pass floor at all**.

Measured against a fixture of the real 16×9 fleet with every cell reporting `skipped`:

```
old inline block -> exit 0, "arduino matrix gate: full fleet pass"
new gate         -> exit 1
```

`EXPECTED` was also the literal `16 * 9`, so a fleet that shrank in `boards.yaml` would quietly lower its own floor with nobody editing a floor.

The monorepo sibling `brd2709a-arduino-matrix.yml` already carried the `passes == 0` floor this one lacked — two copies of one rule, one of them incomplete.

## What this does

`scripts/ci/matrix_verdict.py` grades the run. Every threshold is derived from `boards.yaml`, not written down twice:

1. no status outside `{pass, skipped}`
2. a `skipped` cell must appear in that board’s `sketches_skip` — an undeclared skip is a cell nobody decided to stop testing
3. cell count ≥ (boards without `external_compile:`) × sketches
4. `passes > 0` across the fleet — the sibling’s rule
5. `passes > 0` per board — which rule 4 cannot see; one board going dark is invisible while fifteen others pass
6. duplicate cells, and results for boards outside the fleet

## Tests

`scripts/ci/test_matrix_verdict.py` — 13 cases. Each negative case is a real exploit of the block being replaced; the old block passed every one. Synthetic fleets throughout, plus one case that asserts the committed fleet is gradeable and that an honest run over it comes back clean, without restating its contents.

Added to the **explicit** pytest list in `core-ci.yml`, which warns that a suite not named there never runs.

## Also

The gate job gains `setup-python` + `pyyaml`; it previously ran bare `python3`.

Verified locally: `actionlint` clean on both workflows; the full pytest lane as CI invokes it is 110 passed.