### PR TITLE
fix(validation): a drift_ack now lapses — it was permanent

### DIFF
--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -9,15 +9,15 @@ The models column is a content digest over everything that board's `models` list
 
 | Board | Tier | Last silicon capture | Models | Status |
 |-------|------|----------------------|--------|--------|
-| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `f74e787229a42a69` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `c973ed6df35e75c5` | ⚠ drift acked 2026-08-22 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `7228fac77c86d817` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `78eca237f59b067f` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `5780ce19be964586` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `fd5c841eb1ab9f1a` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `821161b38b485986` | ⚠ drift acked 2026-08-23 (re-capture pending) |
+| `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending) |
+| `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `f74e787229a42a69` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `c973ed6df35e75c5` | ⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `7228fac77c86d817` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `78eca237f59b067f` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `5780ce19be964586` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `fd5c841eb1ab9f1a` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `821161b38b485986` | ⚠ drift acked 2026-08-23, expires 2026-09-22 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `70dc5cdb821b4fd1` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `54357ab00d5380ea` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `4868d947c79c522f` | no silicon capture |
@@ -40,7 +40,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on ST-LINK V2 (V2J37S7, serial 48FF6B064884534929321087), openocd 0.12.0 hla_swd; nRF52840 FICR INFO.PART=0x00052840, DEVICEID 707dc298 — re-captured live 2026-08-09 with NRF52_STRICT=1: ALL 11 hw-oracle suites pass — conformance, cpu_conformance, mmio 16/16, gpio, onboarding, power, spis_twis, timer_rtc, spim_easydma, full_register, ccm. NOT a second board: DEVICEID 707dc298 matches the 2026-06-09 baseline, so this is a re-read of the SAME part (unlike the C3/S3 re-captures, which were cross-board). The run was NOT clean on arrival and found three real defects, all fixed in this commit: (1) seven nrf52_* hw-oracle tests had not COMPILED since the 2026-07-18 bus consolidation removed the inherent SystemBus read_u32/write_u32 shadows — they build only under --features hw-oracle-nrf52, which CI never enables, so the 're-capture pending' ack pointed at a path that could not build; (2) mmio was 15/16, SPIM0 PSEL_MISO sim=0x0 vs hw=0x2E, because the serial-instance broadcast PSEL WRITES to both halves but dispatched READS to TWIM, which models only 0x508/0x50C; (3) SPIM PSEL.CSN (0x514) was missing from Nrf52SpiRegs entirely — corroborated present on silicon (wrote 0x2B, read 0x2B). Guarded going forward by a hardware-free unit test, serial_instance::psel_block_reads_back_while_disabled.
   - offline (CI): nrf52_conformance::conformance_sim (digest vs frozen 2026-06-09 capture)
   - offline (CI): nrf52_mmio_diff / nrf52_gpio_conformance (sim halves)
-- Drift status: **⚠ drift acked 2026-08-22 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending)**
 
 ## `seeed-xiao-nrf52840-sense` — 🟢 silicon-verified
 
@@ -48,7 +48,7 @@ The models column is a content digest over everything that board's `models` list
 - Note: Same silicon as nrf52840 (the bench board IS a Seeed XIAO nRF52840 Sense).
 - Silicon: **2026-08-09** on ST-LINK V2 (V2J37S7, serial 48FF6B064884534929321087) — the same physical XIAO the nrf52840 entry describes — rides the nrf52840 re-capture of 2026-08-09: all 11 hw-oracle suites pass under NRF52_STRICT=1, mmio 16/16. This is not an independent run — it is the SAME board and the SAME suites, which is exactly what `note` says this entry means. See the nrf52840 result for the three defects that run uncovered and fixed.
   - offline (CI): nrf52.rs xiao_* (manifest build, GPIO task regs, SPIM0 EasyDMA)
-- Drift status: **⚠ drift acked 2026-08-22 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending)**
 
 ## `stm32h563` — 🟢 silicon-verified
 
@@ -56,7 +56,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-10** on STLINK-V3 (V3J13, serial 002100174741500220383733, USB 0483:374e, NUCLEO-H563ZI on-board CN1/STLK, dapdirect AP1 recipe) — Re-captured live 2026-08-10 with H563_STRICT=1 on merge commit e1851d80 (a clean tree — see the caveat below): h563_mmio_diff 8/8, h563_parity_diff 48/48, h563_class_diff 65/65, 121 cases total, 0 divergence / 0 both_disagree / 0 sim_err. Clean on arrival; nothing to fix. Target answered SWD DPIDR 0x6ba02477, Cortex-M33 r0p4, target voltage 3.289 V. Probe serial is recorded from this run on — the 2026-06-22 entry named the USB PID but no serial, so whether this is the same physical NUCLEO as that capture cannot be established either way. SCOPE CAVEAT, read before treating this as a full re-validation: this run re-executed the MMIO/parity/class register diff ONLY. The FLASH program-behaviour live-diff described below (real program/erase driven over SWD) was NOT re-run on 2026-08-10; its findings are carried forward from 2026-06-22 and are older than this date stamp implies. TREE CAVEAT: an initial run of the same 121 cases also passed, but was executed while another session had an uncommitted merge of origin/main staged in this worktree, so it was not attributable to any commit; it was discarded and the run recorded here was repeated against a 0-dirty checkout of e1851d80. FLASH program-behaviour live-diff run on the board 2026-06-22 (drives real program/erase over SWD): write buffer (NSSR.WBNE) accumulates a 16-byte quad-word, commits + sets EOP only on completion; a misaligned quad-word raises INCERR alone and commits nothing; program-over-not-erased is permitted and ANDs the bits (no PGSERR); flags clear via NSCCR (0x30), not by writing NSSR. The sim H5 flash error-flag + read-while-write fidelity gates were CORRECTED to match this capture (earlier datasheet model was wrong on all four points). Prior MMIO/reset diff (h563_mmio_diff + h563_parity_diff + h563_class_diff, 0 divergence) still holds.
   - offline (CI): h563_conformance (6 tests vs frozen 2026-06-10..12 captures)
   - offline (CI): h563_mmio_diff::{h563_mmio_sim_only,h563_parity_sim_only,h563_class_sim_only}
-- Drift status: **⚠ drift acked 2026-08-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending)**
 
 ## `esp32c3` — 🟢 silicon-verified
 
@@ -65,7 +65,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on USB-JTAG (built-in) + openocd-esp32 v0.12.0-esp32-20260703, board MAC 9c:cc:01:d0:98:e0 (QFN32 rev v0.4) — re-captured live 2026-08-09 on a SECOND physical C3 (MAC 9c:cc:01:d0:98:e0; the 2026-06-11 baseline came from 38:44:be:42:f5:58, same QFN32 rev v0.4) — cross-board corroboration, not a re-read of the same part. 1207 registers read in ONE state (21 estate windows + 43 control registers + the radio windows): 84/84 RESET_VALUES matched, 0 mismatched, and both FREE_RUNNING_COUNTERS windows mapped. Radio note: a JTAG `reset halt` on the C3 is a software CORE reset that does not cold-reset peripherals, so RADIO_FE/WIFI_MAC only read their cold baseline when no resident firmware has brought the PHY up — the board was temporarily flashed with crates/wasm/tests/fixtures/esp32c3-hello-world-flash.bin for the capture, then its original 4 MB image was restored and verified byte-identical (sha256 844abc88…8a910). Do NOT try to reach cold radio via RTC_CNTL SW_SYS_RST: it resets the USB-Serial-JTAG bridge too and drops the debug link mid-write (verified, LIBUSB_ERROR_IO). Artifacts: scripts/hw-oracle/captures/esp32c3/recapture-20260809T121824Z/.
   - offline (CI): esp32c3_reset_conformance::esp32c3_reset_values_match_silicon (87 regs; 366/423 overlap matched silicon)
   - offline (CI): esp32c3_reset_conformance::esp32c3_free_running_counters_are_mapped (2 WiFi MAC counter windows; mapping only, no equality claim)
-- Drift status: **⚠ drift acked 2026-08-22 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending)**
 
 ## `nucleo-l476rg` — 🟢 silicon-verified
 
@@ -74,7 +74,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on STLINK-V2.1 (USB 0483:374b serial 0670FF…1747, NUCLEO-L476RG onboard) — re-captured live 2026-08-09 with L476_STRICT=1: l476_mmio_diff 15/15 and l476_parity_diff 104/104, 0 divergence — identical to the 2026-06-20 figures. Clean on arrival; nothing to fix. SAME physical board as that baseline, established by probe serial 0670FF535155878281121747 being recorded in both (the L073 entry could not make that claim, having no serial on file before today). Scope unchanged and still partial: the mmio+parity set, not a full-chip sweep.
   - offline (CI): l476_mmio_diff::{l476_mmio_sim_only,l476_parity_sim_only}
   - offline (CI): firmware_survival L476 cases (UART byte stream)
-- Drift status: **⚠ drift acked 2026-08-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending)**
 
 ## `nucleo-l073rz` — 🟢 silicon-verified
 
@@ -83,7 +83,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on ST-LINK V2.1 (NUCLEO-L073RZ on-board, V2J28S17, serial 066CFF555054877567065340) over SWD; DBGMCU IDCODE read back 0x20086447 — re-captured live 2026-08-09 with L073_STRICT=1: l0_mmio_diff 20/20, 0 divergence (RCC IOPENR/APB1ENR/APB2ENR/AHBENR/CFGR clock switch, GPIOA BSRR/BRR, SPI1 CR1/CR2, TIM2 ARR/PSC/CR1, TIM21 ARR, DBGMCU IDCODE). Clean on arrival — unlike the nRF re-capture the same day, this one found nothing to fix. Scope is UNCHANGED and still partial: RCC/GPIO/SPI1/TIM2/TIM21 only, not a full-chip sweep (see `note`); I2C/UART/ADC on this part remain outside the asserted set. Probe serial is recorded from this run on — the earlier entries named no serial, so whether this is the same physical NUCLEO as the 2026-06-20 capture cannot be established either way.
   - offline (CI): stm32l0_mmio_diff::{l0_mmio_sim_only,l0_parity_sim_only}
   - offline (CI): firmware_survival L073 smoke case
-- Drift status: **⚠ drift acked 2026-08-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending)**
 
 ## `stm32f103` — 🟢 silicon-verified
 
@@ -92,7 +92,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on ST-LINK V2.1 (V2J43S28, serial 066CFF534951775087071123, USB 0483:374b), genuine STM32F103 — chipid 0x410 STM32F1xx_MD, 128K flash / 20K SRAM — re-captured live 2026-08-09 with F103_STRICT=1: stm32f1_mmio_diff 102/102 (24 reset + 26 R/W + 52 sweep), 0 divergence, and f103_conformance reports no sim-vs-silicon gaps — identical to the 2026-06-20 figures. Clean on arrival; nothing to fix. f103_conformance needed firmware-f103-conformance built for thumbv7m-none-eabi first; without it the test panics in 0.00s, which reads like a failure but is a missing prerequisite. Probe serial recorded from this run on, so a future capture can tell whether it is the same physical board (the earlier entry named none). (Earlier capture caught + fixed a classic SPI CR1 bug masking CRCNEXT bit 12 — 0xEFFF vs silicon 0xFFFF.)
   - offline (CI): stm32f1_mmio_diff::{f1_reset_sim_only,f1_mmio_sim_only,f1_parity_sim_only,f1_sweep_sim_only}
   - offline (CI): f103_conformance::conformance_sim (digest)
-- Drift status: **⚠ drift acked 2026-08-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending)**
 
 ## `stm32f407` — 🟢 silicon-smoke
 
@@ -101,7 +101,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-06-20** on ST-LINK/V2 (USB 0483:3748, IDCODE 0x10016413) — connect-under-reset (firmware was holding SWD), adapter 480 kHz — Live re-capture after the v0.17.0 merge: stm32f4_mmio_diff 37/37 (2 reset + 31 sweep + 4 behaviour), 0 divergence. Caught + fixed a real model bug: F407 silicon does NOT latch SPI1 CR1 bit 12 (CRCNEXT) — writes 0xFFFF, reads 0xEFFF — vs F103 which keeps it writable; spi.rs now applies a per-part cr1_mask (F4 0xEFFF). Supersedes the 2026-06-19 drift_ack. (I²C/UART models still smoke-tier — not in the mmio diff.)
   - offline (CI): stm32f4_mmio_diff::{f4_reset_sim_only,f4_sweep_sim_only,f4_behavior_sim_only}
   - offline (CI): firmware_survival F407 smoke + i2c cases (sim-self-pinned)
-- Drift status: **⚠ drift acked 2026-08-24 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending)**
 
 ## `esp32s3` — 🟢 silicon-verified
 
@@ -110,7 +110,7 @@ The models column is a content digest over everything that board's `models` list
 - Silicon: **2026-08-09** on USB-JTAG built-in (USB 303a:1001, openocd-esp32 v0.12.0-esp32-20260703, both Tensilica taps 0x120034e5), board MAC 3c:0f:02:df:f3:c8 (QFN56 rev v0.2) — re-captured live 2026-08-09 on a SECOND physical S3 (MAC 3c:0f:02:df:f3:c8, QFN56 rev v0.2; the 2026-07-15 baseline came from an ESP32-S3-Zero, MAC 9c:13:9e:f4:40:c0, same rev) — cross-board corroboration, not a re-read of the same part. Both Xtensa taps (tap0+tap1) examined. 384 registers read across 10 windows (UART0, GPIO, I2C0, RMT, MCPWM0, TIMG0, SYSTIMER, GDMA, SYSTEM, RTC_CNTL): 9/9 RESET_VALUES matched, 0 mismatched. Scope is unchanged and still thin — this is a 9-register reset-state anchor, NOT a broad register or behavioural diff; see the KNOWN GAPS in `note`. Artifacts: scripts/hw-oracle/captures/esp32s3/recapture-20260809T130700Z/.
   - offline (CI): esp32s3_reset_conformance (9 reset regs vs live silicon, firmware-path bus)
   - offline (CI): e2e_i2c_tmp102 / e2e_hello_world / xtensa_exec / e2e_esp32_epaper (sim)
-- Drift status: **⚠ drift acked 2026-08-23 (re-capture pending)**
+- Drift status: **⚠ drift acked 2026-08-23, expires 2026-09-22 (re-capture pending)**
 
 ## `stm32f401` — 🟡 smoke-manual
 

--- a/scripts/generate_validation_status.py
+++ b/scripts/generate_validation_status.py
@@ -23,7 +23,10 @@ Drift
 For each board with `silicon.last_capture`, the newest git commit date across
 `models` is compared to the capture date. If newer, the board has drifted. A
 dated `drift_ack` (>= the newest model date) is an explicit human acknowledgement
-that keeps it green; any later model change re-breaks the gate.
+that keeps it green; any later model change re-breaks the gate. An ack also
+LAPSES: it covers the board for ACK_TTL_DAYS (30), or until an explicit
+`drift_ack_expires`, after which --drift fails again. An ack is a promise to
+re-capture, and a promise with no date is a waiver.
 
 Drift-watch coverage
 --------------------
@@ -56,7 +59,7 @@ import posixpath
 import re
 import subprocess
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 try:
@@ -347,8 +350,41 @@ def as_date(v) -> date | None:
     return parse_iso(str(v)).date()
 
 
-def evaluate(board: dict) -> dict:
-    """Compute drift status for one board."""
+# How long a `drift_ack` covers a drifted board before it must be renewed.
+#
+# WHY AN ACK NEEDS A CLOCK. The digest rule makes an ack precise -- it covers
+# exactly the tree a human looked at -- but it made it PERMANENT: while the
+# models hold still, an ack from any date keeps the board green forever. Every
+# acked board on this manifest reads "re-capture pending", and nothing ever
+# made the pending part come due. An ack is a promise to re-capture, and a
+# promise with no date is a waiver.
+#
+# 30 days. Override per board with `drift_ack_expires:` when a re-capture is
+# genuinely blocked (no probe, board on order) -- an explicit later date in the
+# manifest is reviewable; a silent forever is not.
+ACK_TTL_DAYS = 30
+
+
+def ack_expiry(board: dict) -> date | None:
+    """When this board's ack stops covering it. None if it carries no ack.
+
+    A manifest may name `drift_ack_expires:` explicitly; otherwise the ack runs
+    for ACK_TTL_DAYS from the day it was written.
+    """
+    explicit = as_date(board.get("drift_ack_expires"))
+    if explicit:
+        return explicit
+    ack = as_date(board.get("drift_ack"))
+    return ack + timedelta(days=ACK_TTL_DAYS) if ack else None
+
+
+def evaluate(board: dict, today: date | None = None) -> dict:
+    """Compute drift status for one board.
+
+    `today` is injectable so the expiry rule is testable; it affects the
+    GATE only, never the rendered document (see the note on `status`).
+    """
+    today = today or date.today()
     silicon = board.get("silicon")
     models = board.get("models", [])
     newest = newest_commit_date(models)
@@ -377,18 +413,37 @@ def evaluate(board: dict) -> dict:
     # "any model change PAST the ack date re-fails the gate. No silent decay."
     recorded = board.get("drift_ack_digest")
     if ack and recorded:
-        acked = recorded == model_digest(models)
+        covers_content = recorded == model_digest(models)
     else:
-        acked = bool(ack and newest and ack >= newest)
+        covers_content = bool(ack and newest and ack >= newest)
+
+    # An ack also has to still be in date. See ACK_TTL_DAYS: the digest rule
+    # made acks precise and permanent, and permanent is the failure mode --
+    # every acked board here reads "re-capture pending" and nothing made it come
+    # due.
+    expires = ack_expiry(board)
+    expired = bool(expires and today > expires)
+    acked = covers_content and not expired
+
     # A board with no silicon capture cannot "drift" — it never claimed silicon.
     failing = drifted and not acked
 
+    # WHY `status` DOES NOT MENTION EXPIRY.
+    #
+    # It is rendered into a COMMITTED document that `--check` diffs. Anything
+    # here that moves with the calendar would make the doc go stale on a day
+    # nobody committed, and every PR after that would demand a regen commit
+    # carrying no information — precisely the #834 / #798 defect the digest rule
+    # was introduced to end. So the row states the two dates a reader needs (the
+    # ack, and when it lapses), both of which come from the manifest and hold
+    # still. The GATE is what notices the day it lapses: `--drift` reads
+    # `failing`, which does depend on today.
     if not silicon:
         status = "no silicon capture"
     elif not drifted:
         status = "✅ fresh"
-    elif acked:
-        status = f"⚠ drift acked {ack:%Y-%m-%d} (re-capture pending)"
+    elif covers_content:
+        status = f"⚠ drift acked {ack:%Y-%m-%d}, expires {expires:%Y-%m-%d} (re-capture pending)"
     else:
         status = f"✖ DRIFT — model {newest:%Y-%m-%d} > capture; RE-CAPTURE"
 
@@ -397,12 +452,21 @@ def evaluate(board: dict) -> dict:
         "digest": model_digest(models),
         "capture": capture,
         "drifted": drifted,
+        "expires": expires,
+        "expired": expired,
         "failing": failing,
         "status": status,
     }
 
 
-def render(manifest: dict) -> str:
+def render(manifest: dict, today: date | None = None) -> str:
+    """Render the committed doc.
+
+    `today` exists so a test can PROVE the output does not move with the
+    calendar. It is threaded into evaluate() and must change nothing here:
+    an expiry that leaked into this document would make it go stale on a day
+    nobody committed. See the note on `status` in evaluate().
+    """
     boards = manifest["boards"]
     lines: list[str] = []
     lines.append("<!-- GENERATED by scripts/generate_validation_status.py — DO NOT EDIT BY HAND.")
@@ -429,7 +493,7 @@ def render(manifest: dict) -> str:
     lines.append("| Board | Tier | Last silicon capture | Models | Status |")
     lines.append("|-------|------|----------------------|--------|--------|")
     for b in boards:
-        ev = evaluate(b)
+        ev = evaluate(b, today=today)
         tier = TIER_BADGE.get(b["tier"], b["tier"])
         cap = f"{ev['capture']:%Y-%m-%d}" if ev["capture"] else "—"
         dg = f"`{ev['digest'][:16]}`" if ev["digest"] else "—"
@@ -438,7 +502,7 @@ def render(manifest: dict) -> str:
 
     # Per-board detail
     for b in boards:
-        ev = evaluate(b)
+        ev = evaluate(b, today=today)
         lines.append(f"## `{b['id']}` — {TIER_BADGE.get(b['tier'], b['tier'])}")
         lines.append("")
         lines.append(f"- Doc: [`{b['doc']}`]({Path(b['doc']).name})  ·  Chip: `{b['chip']}`")
@@ -625,11 +689,32 @@ def main() -> int:
         print(f"wrote {OUT_DOC.relative_to(CORE_ROOT)}")
 
     if args.drift:
-        failing = [b["id"] for b in manifest["boards"] if evaluate(b)["failing"]]
-        if failing:
+        verdicts = {b["id"]: evaluate(b) for b in manifest["boards"]}
+        # Two different asks, so two different messages. An EXPIRED ack means a
+        # human already looked at this drift and promised a re-capture; the
+        # promise has come due. An unacked drift has never been looked at.
+        expired = [i for i, v in verdicts.items() if v["failing"] and v["expired"]]
+        unacked = [i for i, v in verdicts.items() if v["failing"] and not v["expired"]]
+        if expired:
+            print(
+                "ERROR: drift_ack EXPIRED — the promised re-capture is now due:\n  "
+                + "\n  ".join(
+                    f"{i} (acked {as_date(next(b for b in manifest['boards'] if b['id'] == i).get('drift_ack')):%Y-%m-%d}, "
+                    f"expired {verdicts[i]['expires']:%Y-%m-%d})"
+                    for i in expired
+                )
+                + "\n"
+                "       Re-run the live diff and bump silicon.last_capture + models_digest,\n"
+                "       or renew the ack (new drift_ack date, re-stamp with --write-ack-digests).\n"
+                "       If a re-capture is genuinely blocked, set an explicit drift_ack_expires\n"
+                "       with the reason in a note — a later date is reviewable, forever is not.",
+                file=sys.stderr,
+            )
+            rc = 1
+        if unacked:
             print(
                 "ERROR: silicon validation has DRIFTED (model changed after last capture, "
-                "no covering drift_ack):\n  " + "\n  ".join(failing) + "\n"
+                "no covering drift_ack):\n  " + "\n  ".join(unacked) + "\n"
                 "       Re-run the live diff and bump silicon.last_capture, or set a dated "
                 "drift_ack in validation/manifest.yaml.",
                 file=sys.stderr,

--- a/scripts/test_generate_validation_status.py
+++ b/scripts/test_generate_validation_status.py
@@ -18,6 +18,8 @@ belief about it — a stub would have happily agreed with the broken version too
 import datetime
 import subprocess
 import sys
+
+import yaml
 from pathlib import Path
 
 import pytest
@@ -152,6 +154,13 @@ def test_require_full_history_exits_with_the_fix(tmp_path, monkeypatch, capsys):
 # four cases are the whole contract.
 
 
+# Inside the fixture ack's window (2026-06-01 + ACK_TTL_DAYS). The cases below
+# assert the CONTENT rule, so they pin the clock rather than drift into the
+# expiry rule as the wall clock moves past the fixture's ack. Expiry has its own
+# cases further down.
+IN_WINDOW = datetime.date(2026, 6, 15)
+
+
 def _board_with_digest(tmp_path, monkeypatch, model_body: bytes):
     """A one-board manifest whose ack is pinned to `model_body`'s digest."""
     root = tmp_path / "repo"
@@ -183,7 +192,7 @@ def test_digest_ack_tracks_content_not_dates(tmp_path, monkeypatch, redated, mut
         lambda paths: datetime.date(2099, 1, 1) if redated else datetime.date(2026, 5, 1),
     )
 
-    failing = gvs.evaluate(board)["failing"]
+    failing = gvs.evaluate(board, today=IN_WINDOW)["failing"]
     assert failing is mutated, (
         f"redated={redated} mutated={mutated}: a digest-pinned ack must fail iff the "
         "model CONTENT moved — a re-date alone must not fail, and a same-day edit "
@@ -197,10 +206,10 @@ def test_ack_without_a_digest_keeps_the_legacy_date_rule(tmp_path, monkeypatch):
     assert "drift_ack_digest" not in board
 
     monkeypatch.setattr(gvs, "newest_commit_date", lambda paths: datetime.date(2026, 5, 1))
-    assert gvs.evaluate(board)["failing"] is False, "ack (06-01) >= newest (05-01) still covers"
+    assert gvs.evaluate(board, today=IN_WINDOW)["failing"] is False, "ack (06-01) >= newest (05-01) still covers"
 
     monkeypatch.setattr(gvs, "newest_commit_date", lambda paths: datetime.date(2026, 7, 1))
-    assert gvs.evaluate(board)["failing"] is True, "model newer than the ack still fails"
+    assert gvs.evaluate(board, today=IN_WINDOW)["failing"] is True, "model newer than the ack still fails"
 
 
 def test_write_ack_digests_never_acks_an_unacked_board(tmp_path, monkeypatch):
@@ -231,8 +240,8 @@ def test_digests_reports_the_same_verdict_as_the_gate(tmp_path, monkeypatch, cap
     assert gvs.print_digests({"boards": [board]}) == 0
     printed = capsys.readouterr().out
     assert gvs.model_digest(board["models"]) in printed
-    assert gvs.evaluate(board)["status"] in printed
-    assert not gvs.evaluate(board)["failing"]
+    assert gvs.evaluate(board, today=IN_WINDOW)["status"] in printed
+    assert not gvs.evaluate(board, today=IN_WINDOW)["failing"]
 
     # The negative control. Move a byte of the model: the printed digest must
     # change, the recorded ack must be shown as the thing that no longer
@@ -242,7 +251,7 @@ def test_digests_reports_the_same_verdict_as_the_gate(tmp_path, monkeypatch, cap
     printed = capsys.readouterr().out
     assert gvs.model_digest(board["models"]) in printed
     assert f"ack recorded {board['drift_ack_digest']}" in printed
-    assert gvs.evaluate(board)["failing"]
+    assert gvs.evaluate(board, today=IN_WINDOW)["failing"]
 
 
 def test_digests_never_writes(tmp_path, monkeypatch, capsys):
@@ -257,3 +266,116 @@ def test_digests_never_writes(tmp_path, monkeypatch, capsys):
     gvs.print_digests({"boards": [board]})
     capsys.readouterr()
     assert manifest_path.read_text() == original
+
+
+# ── An ack lapses ────────────────────────────────────────────────────────────
+#
+# The digest rule made acks precise and, in doing so, PERMANENT: while the
+# models hold still, an ack from any date keeps a drifted board green forever.
+# Every acked board on the manifest reads "re-capture pending" and nothing ever
+# made the pending part come due. An ack is a promise to re-capture; a promise
+# with no date is a waiver.
+#
+# Two properties, and the second matters as much as the first: the GATE must
+# move with the calendar, and the DOCUMENT must not.
+
+
+def _acked_drifted_board(tmp_path, monkeypatch):
+    """A board that has genuinely drifted and carries a content-covering ack."""
+    board, model = _board_with_digest(tmp_path, monkeypatch, b"fn model() {}\n")
+    board["drift_ack_digest"] = gvs.model_digest(board["models"])
+    # Newer than the 2026-01-01 capture, so `drifted` is true and the ack is
+    # the only thing keeping this board green.
+    monkeypatch.setattr(gvs, "newest_commit_date", lambda paths: datetime.date(2026, 5, 1))
+    return board
+
+
+def test_a_fresh_ack_covers_the_board(tmp_path, monkeypatch):
+    board = _acked_drifted_board(tmp_path, monkeypatch)
+    v = gvs.evaluate(board, today=datetime.date(2026, 6, 2))
+    assert v["drifted"] is True, "the fixture must actually be drifted or this proves nothing"
+    assert v["expired"] is False
+    assert v["failing"] is False
+
+
+def test_the_ack_lapses_on_the_day_after_its_expiry(tmp_path, monkeypatch):
+    """The whole point: unchanged content, unchanged manifest, red anyway."""
+    board = _acked_drifted_board(tmp_path, monkeypatch)
+    expires = board["drift_ack"] + datetime.timedelta(days=gvs.ACK_TTL_DAYS)
+
+    assert gvs.evaluate(board, today=expires)["failing"] is False, "valid through its last day"
+    lapsed = gvs.evaluate(board, today=expires + datetime.timedelta(days=1))
+    assert lapsed["expired"] is True
+    assert lapsed["failing"] is True, "an expired ack must stop covering the board"
+
+
+def test_an_explicit_expiry_overrides_the_default_window(tmp_path, monkeypatch):
+    """For a re-capture that is genuinely blocked — reviewable, unlike forever."""
+    board = _acked_drifted_board(tmp_path, monkeypatch)
+    board["drift_ack_expires"] = datetime.date(2027, 1, 1)
+
+    assert gvs.evaluate(board, today=datetime.date(2026, 12, 31))["failing"] is False
+    assert gvs.evaluate(board, today=datetime.date(2027, 1, 2))["failing"] is True
+
+
+def test_expiry_cannot_fail_a_board_that_never_drifted(tmp_path, monkeypatch):
+    """A stale ack on a board whose models never moved is not a finding."""
+    board = _acked_drifted_board(tmp_path, monkeypatch)
+    # Model older than the capture: nothing drifted, so nothing to acknowledge.
+    monkeypatch.setattr(gvs, "newest_commit_date", lambda paths: datetime.date(2025, 6, 1))
+    v = gvs.evaluate(board, today=datetime.date(2099, 1, 1))
+    assert v["drifted"] is False
+    assert v["failing"] is False
+
+
+def test_a_board_with_no_ack_is_unchanged_by_expiry(tmp_path, monkeypatch):
+    board = _acked_drifted_board(tmp_path, monkeypatch)
+    del board["drift_ack"]
+    del board["drift_ack_digest"]
+    v = gvs.evaluate(board, today=datetime.date(2026, 6, 2))
+    assert v["expires"] is None
+    assert v["expired"] is False
+    assert v["failing"] is True, "still failing for the original reason — unacked drift"
+
+
+def test_the_generated_document_does_not_move_with_the_calendar(tmp_path, monkeypatch):
+    """The other half of the contract, and the easy half to get wrong.
+
+    `--check` diffs a COMMITTED document. If an expiry verdict leaked into a row,
+    the doc would go stale on a day nobody committed and every later PR would
+    demand a regen commit carrying no information — exactly the #834 / #798
+    defect the digest rule was introduced to end. The row states the two dates
+    (both from the manifest, both still); only the gate reads the clock.
+    """
+    board = _acked_drifted_board(tmp_path, monkeypatch)
+    board.update({"tier": "silicon-verified", "doc": "boards/demo.md", "chip": "demo"})
+    manifest = {"boards": [board]}
+
+    baseline = gvs.render(manifest, today=datetime.date(2026, 6, 2))
+    for far in (datetime.date(2026, 7, 5), datetime.date(2027, 1, 1), datetime.date(2099, 1, 1)):
+        assert gvs.render(manifest, today=far) == baseline, (
+            f"the document changed at {far} — an expiry verdict leaked into a row, "
+            "which makes the committed doc rot on a day nobody committed"
+        )
+
+    # And the row must still SHOW the expiry, or a reader cannot see it coming.
+    assert "expires 2026-07-01" in baseline
+
+
+def test_the_committed_manifest_is_not_already_expired():
+    """Reads the real manifest: this change must cost nothing on the day it lands.
+
+    Not a restatement of the manifest — it asserts the property that made this
+    safe to merge, and it will fail loudly the day a real ack comes due, which
+    is the entire intent.
+    """
+    manifest = yaml.safe_load(gvs.MANIFEST.read_text())
+    stale = [
+        b["id"]
+        for b in manifest["boards"]
+        if gvs.evaluate(b, today=datetime.date.today())["expired"]
+    ]
+    assert not stale, (
+        "drift acks have come due: " + ", ".join(stale) + ". Re-capture and bump "
+        "silicon.last_capture, or renew the ack — do not widen ACK_TTL_DAYS to clear this."
+    )

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -26,6 +26,26 @@
 #   recording when; that keeps CI green. Any later model change moves the digest
 #   and re-fails the gate. No silent decay.
 #
+#   AN ACK LAPSES. `drift_ack` covers a drifted board for 30 days
+#   (ACK_TTL_DAYS in the generator), after which `--drift` fails again. The
+#   digest rule made acks precise and, in doing so, permanent: while the models
+#   held still, an ack from any date kept a board green forever, and every acked
+#   board here read "re-capture pending" with nothing making the pending part
+#   come due. An ack is a promise to re-capture; a promise with no date is a
+#   waiver.
+#
+#   When it lapses you have three honest moves, in order of preference:
+#     1. re-capture (bump silicon.last_capture + silicon.models_digest),
+#     2. renew the ack (new drift_ack date, then --write-ack-digests),
+#     3. set `drift_ack_expires: YYYY-MM-DD` with a note saying why a
+#        re-capture is blocked (no probe, board on order). An explicit later
+#        date is reviewable. Widening ACK_TTL_DAYS to clear a red gate is not —
+#        it silences every board at once.
+#
+#   The expiry never appears in a VERDICT in the generated doc, only as the
+#   `expires` date in the status column. A doc that changed with the calendar
+#   would go stale on a day nobody committed, which is the #834 defect.
+#
 #   Print the current digests with:
 #     python3 scripts/generate_validation_status.py --digests
 #


### PR DESCRIPTION
The digest rule (#834) made acks precise and, in doing so, **permanent**: while the models hold still, an ack from any date keeps a drifted board green forever. Today every acked board on the manifest reads `⚠ drift acked … (re-capture pending)` and nothing has ever made the pending part come due.

An ack is a promise to re-capture. A promise with no date is a waiver.

## What changes

`drift_ack` covers a board for `ACK_TTL_DAYS` (30), or until an explicit `drift_ack_expires:` for a re-capture that is genuinely blocked. After that `--drift` fails again — with its own message, because an expired ack (a human looked at this and the promise came due) is a different ask from a drift nobody has looked at.

## It costs nothing today

The oldest ack on the manifest is 18 days old. Measured against the committed manifest:

| date | boards failing |
|---|---|
| 2026-08-31 | 0 |
| 2026-09-12 | 0 |
| 2026-09-22 | 3 — nrf52840, seeed-xiao-nrf52840-sense, esp32c3 |
| 2026-09-24 | 9 |
| 2026-10-01 | 9 |

## The document does not move with the calendar

This is the half that is easy to get wrong. `status` states the ack date and the expiry date — both from the manifest, both still — and **never** an expired/not-expired verdict. A verdict there would make the committed doc go stale on a day nobody committed, and every later PR would demand a regen commit carrying no information: exactly the #834 / #798 defect the digest rule exists to end.

`render()` now takes `today` purely so a test can prove it. `test_the_generated_document_does_not_move_with_the_calendar` renders at 2026-07-05, 2027-01-01 and 2099-01-01 and asserts byte equality.

## Tests

7 new cases: fresh ack covers · lapses the day after expiry (and is valid through its last day) · explicit `drift_ack_expires` override · expiry cannot fail a board that never drifted · no-ack boards unchanged · doc stability · and one reading the committed manifest that fails the day a real ack comes due.

Negative control: sabotaging `expired` to `False` fails 2 of them.

The four existing cases now pin `today` inside the fixture ack’s window. They assert the **content** rule and would otherwise drift into the expiry rule as the wall clock passed their fixed `2026-06-01` ack.

## When it goes red

Three honest moves, documented in the manifest header, in order of preference: re-capture · renew the ack · set `drift_ack_expires` with a note saying why a re-capture is blocked. Widening `ACK_TTL_DAYS` to clear a red gate is not one of them — it silences every board at once.

Verified locally: `--check --drift` exit 0, 25 passed.