### PR TITLE
feat(fidelity): ratchet the CHEAT surface, and reconcile the three ledgers

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -482,6 +482,14 @@ jobs:
           python3 scripts/generate_validation_status.py --check --drift
           python3 scripts/generate_firmware_exercise_matrix.py --check
 
+      # The CHEAT(...) surface FIDELITY.md defines had no gate at all: the doc
+      # said "grep for it", and a convention nothing counts is a comment. This
+      # asserts the schema, the marker format, that FIDELITY.md's own references
+      # still resolve (two had rotted onto paths that no longer exist), and that
+      # the count only falls. Pure Python over comments — under a second.
+      - name: Fidelity debt — the CHEAT surface only falls
+        run: python3 scripts/ci/cheat_ratchet.py --check
+
       # The perf gate measures whatever chip descriptors it can link a fixture
       # against. Adding a chip on an unhandled memory map used to drop it out of
       # the gate silently — this asserts, on the PR that adds it, that it is
@@ -509,6 +517,7 @@ jobs:
             scripts/ci/test_chip_coverage.py \
             scripts/ci/test_matrix_external_cache.py \
             scripts/ci/test_matrix_verdict.py \
+            scripts/ci/test_cheat_ratchet.py \
             scripts/ci/test_workspace_test_shard.py \
             scripts/test_generate_validation_status.py
 

--- a/FIDELITY.md
+++ b/FIDELITY.md
@@ -194,6 +194,16 @@ Every cheat in the code carries a grep-able marker on the line or block:
 
 ```
 // CHEAT(<CATEGORY>): <what is faked> — real: <what silicon/real execution does>
+
+A `//!` marker may declare that it covers the WHOLE file:
+
+//! CHEAT(<CATEGORY>, module): <what every fn here fakes> — real: <what silicon does>
+
+The `, module` is not decoration. Without it a blanket marker is
+indistinguishable from a single-site one, and `scripts/ci/cheat_ratchet.py`
+cannot tell a file that discloses 88 thunks in one line from a file with one
+cheat in it. Every marker needs a `real:` clause, blanket ones included —
+that clause is the only place the cost of the cheat is written down.
 ```
 
 Find them all:
@@ -206,6 +216,7 @@ grep -rn "CHEAT(" crates/ --include="*.rs"
 
 | Category | Meaning | How to tighten |
 |----------|---------|----------------|
+| `CHEAT(THUNK)` | An umbrella for a whole module of thunks whose members are of BOTH kinds below, used only with `, module` scope. Individual fns inside still carry their own marker. | Reduce it to the specific kinds, then to none. |
 | `CHEAT(THUNK-ROM)` | A **boot-ROM** function is emulated in Rust because we have no ROM binary to execute (math helpers, memcpy, cache ops, ets_printf). | Map a real ESP32 ROM image and execute it. |
 | `CHEAT(THUNK-LIB)` | A **firmware library** function (compiled into the ELF — FreeRTOS, heap_caps, Arduino SPI) is intercepted and faked instead of letting the real code run. The real code IS in the binary; we skip it. | Complete the peripheral models the real code needs, then drop the thunk. |
 | `CHEAT(BYPASS)` | Device/peripheral state is mutated **directly**, bypassing the register/FIFO/bus decode path. | Route through the real register write → peripheral → device path. |
@@ -223,7 +234,7 @@ RAM/flash regions correctly modeled as backing store. Real register models
 
 ## Inventory (audit 2026-06-11)
 
-### A. ESP32 ROM/library thunks — `crates/core/src/peripherals/esp32s3/rom_thunks.rs`
+### A. ESP32 ROM/library thunks — `crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs`
 60 thunk fns total. Split:
 
 - **THUNK-ROM (legit-but-gap, ~30):** `rom_memcpy/memset/memmove/memcmp`,
@@ -294,7 +305,7 @@ pre-seed paints ANY symbol-bearing Arduino-ESP32 build byte-exact — this is th
 generic path proto.cat should use (NOT `agentdeck`, whose hardcoded addresses
 fit one firmware).
 
-### D. Peripheral-as-RAM stubs — `crates/core/src/system/xtensa.rs`
+### D. Peripheral-as-RAM stubs — `crates/core/src/system/xtensa/esp32.rs`
 Of 16 `RamPeripheral` installs, the **cheats** are the ones standing in for a
 real peripheral: `slc` (SDIO host), `sdmmc_host`. The rest (`iram`, `dram`,
 `flash_icache`, `flash_dcache`, `psram`, `rtc_slow`, `rtc_fast`,

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -667,7 +667,8 @@ pub(crate) fn run_firmware_esp32(args: &RunArgs) -> ExitCode {
 
     // Set PC to ELF entry and seed SP at top of SRAM1 (post-BROM default on
     // real silicon; see e2e_external_arduino_esp32_in_sim for the rationale).
-    // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC/SP. See FIDELITY.md §C.
+    // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC/SP — real: the boot
+// ROM executes and leaves PC/SP where it puts them. See FIDELITY.md §C.
     cpu.set_pc(image.entry_point as u32);
     cpu.set_sp(0x3FFE_0000);
     // Post-bootloader PS state: WOE=1 (windowed ABI), INTLEVEL=0, EXCM=0.

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -668,7 +668,7 @@ pub(crate) fn run_firmware_esp32(args: &RunArgs) -> ExitCode {
     // Set PC to ELF entry and seed SP at top of SRAM1 (post-BROM default on
     // real silicon; see e2e_external_arduino_esp32_in_sim for the rationale).
     // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC/SP — real: the boot
-// ROM executes and leaves PC/SP where it puts them. See FIDELITY.md §C.
+    // ROM executes and leaves PC/SP where it puts them. See FIDELITY.md §C.
     cpu.set_pc(image.entry_point as u32);
     cpu.set_sp(0x3FFE_0000);
     // Post-bootloader PS state: WOE=1 (windowed ABI), INTLEVEL=0, EXCM=0.

--- a/crates/cli/src/commands/snapshot.rs
+++ b/crates/cli/src/commands/snapshot.rs
@@ -151,7 +151,8 @@ pub(crate) fn run_snapshot_capture(
     }
     // XtensaLx7::reset() leaves PC at the 0x40000400 BROM reset vector.
     // Skip BROM and jump straight to the ELF's app entry — same as WASM.
-    // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC (SP seeded below).
+    // CHEAT(SKIP): bypasses the boot ROM and hand-seeds PC (SP seeded below)
+    // — real: the boot ROM executes and hands over at its own entry.
     // See FIDELITY.md §C.
     machine.cpu.set_pc(program_image.entry_point as u32);
 

--- a/crates/core/src/peripherals/esp32s3/wifi_thunks.rs
+++ b/crates/core/src/peripherals/esp32s3/wifi_thunks.rs
@@ -5,8 +5,9 @@
 //! WiFi + lwIP socket thunks — the firmware-reachability layer of the ESP32
 //! WiFi functional model (simulated endpoints).
 //!
-//! CHEAT(THUNK-LIB): every fn here short-circuits the WiFi/lwIP stack to a
-//! canned functional outcome (WL_CONNECTED, fake sockets) instead of running it.
+//! CHEAT(THUNK-LIB, module): every fn here short-circuits the WiFi/lwIP stack
+//! to a canned functional outcome (WL_CONNECTED, fake sockets) instead of
+//! running it — real: the lwIP/socket code compiled into the ELF executes.
 //! Unlike most cheats this is partly unavoidable — the WiFi MAC/PHY is a closed
 //! RF-coprocessor blob with no executable image — but the lwIP/socket layer
 //! above it is real compiled code we skip. See FIDELITY.md §A.

--- a/crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs
+++ b/crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs
@@ -10,8 +10,9 @@
 //! these.  Rather than emulate the whole BROM, we register Rust thunks at
 //! the addresses the firmware calls.
 //!
-//! CHEAT(THUNK): every fn in this module fakes a function instead of executing
-//! real code. Two kinds (see FIDELITY.md §A): THUNK-ROM (boot-ROM helpers we
+//! CHEAT(THUNK, module): every fn in this module fakes a function instead of
+//! executing it — real: the CPU executes the ROM routine or the library code
+//! that is already present in the image. Two kinds (see FIDELITY.md §A): THUNK-ROM (boot-ROM helpers we
 //! have no binary to run — math, memcpy, cache, printf — reasonable to emulate)
 //! and THUNK-LIB / BYPASS / NOP (firmware library code that IS in the ELF but we
 //! skip — heap_caps, FreeRTOS, the SPI/GxEPD path — genuine fidelity debt).
@@ -773,7 +774,8 @@ pub fn xthal_window_spill_thunk(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimRe
 /// operator sees what blew up.  The caller never re-runs, so the loop
 /// breaks.  The OTHER CPU (if dual-core) keeps running.
 // CHEAT(NOP): halts the sim on abort() instead of running the real abort path
-// (which would print a backtrace via the panic handler). See FIDELITY.md §A.
+// — real: the firmware's abort() runs the panic handler and prints a
+// backtrace, then resets. See FIDELITY.md §A.
 pub fn abort_halt(cpu: &mut XtensaLx7, bus: &mut dyn Bus) -> SimResult<()> {
     use core::sync::atomic::{AtomicU32, Ordering};
     static FIRST_PRINT: AtomicU32 = AtomicU32::new(0);

--- a/crates/core/src/system/xtensa/arduino_esp32_profile.rs
+++ b/crates/core/src/system/xtensa/arduino_esp32_profile.rs
@@ -363,7 +363,9 @@ pub fn install_arduino_esp32_profile<C: Cpu>(
     // `g_ticks_per_us_pro` / `_app` — CPU MHz, written by
     // `ets_update_cpu_frequency()`. On silicon the ROM bootloader calls that
     // before it hands control to the app image; we start at the app entry
-    // (see the CHEAT(SKIP) above that seeds PC), so nothing ever writes them
+    // (the boot-ROM skip lives in the CLI entry points — `commands/run.rs`
+    // and `commands/snapshot.rs`, both marked there), so nothing ever writes
+    // them
     // and they stay 0.
     //
     // That is not cosmetic. `esp_clk_apb_freq()` on ESP32-classic is

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -12,12 +12,12 @@ The models column is a content digest over everything that board's `models` list
 | `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `f74e787229a42a69` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `c973ed6df35e75c5` | ⚠ drift acked 2026-08-22 (re-capture pending) |
+| `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `5c35a6f778b2787a` | ⚠ drift acked 2026-08-22 (re-capture pending) |
 | `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `7228fac77c86d817` | ⚠ drift acked 2026-08-24 (re-capture pending) |
 | `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `78eca237f59b067f` | ⚠ drift acked 2026-08-24 (re-capture pending) |
 | `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `5780ce19be964586` | ⚠ drift acked 2026-08-24 (re-capture pending) |
 | `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `fd5c841eb1ab9f1a` | ⚠ drift acked 2026-08-24 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `821161b38b485986` | ⚠ drift acked 2026-08-23 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `7601f41b277b41da` | ⚠ drift acked 2026-08-23 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `70dc5cdb821b4fd1` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `54357ab00d5380ea` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `4868d947c79c522f` | no silicon capture |

--- a/scripts/ci/cheat_ratchet.py
+++ b/scripts/ci/cheat_ratchet.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Gate the deliberately-faked surface: FIDELITY.md's `CHEAT(...)` markers.
+
+WHY THIS EXISTS
+
+FIDELITY.md defines a seven-category taxonomy for behaviour the twin fakes and
+tells the reader to find it with `grep -rn "CHEAT("`. A convention nothing
+counts is a comment. This counts it.
+
+WHAT IT IS NOT. It is not the only ledger of this debt, and pretending otherwise
+was the actual defect. Three exist and none knew about the others:
+
+  FIDELITY.md `CHEAT(...)` markers          the prose taxonomy
+  `declared_thunk_symbols()`                 ratcheted at a hard ceiling in
+                                             arduino_esp32_profile.rs
+  `extract_arduino_esp32_thunks()`           the loader's symbol table
+
+A reader could not reconcile 25 markers against a ceiling of 56 against a table
+of ~187 names. `--reconcile` prints all three side by side so the numbers stop
+disagreeing silently. Closing the gap between them is separate, sequenced work
+(FIDELITY.md, Batches A-D); this makes the gap VISIBLE and COUNTED.
+
+WHAT IT ASSERTS
+
+  1. schema     every marker's category is one FIDELITY.md documents
+  2. format     `CHEAT(CAT): <what is faked> - real: <what silicon does>`,
+                with `, module` for a `//!` blanket over a whole file
+  3. references every repo path FIDELITY.md names exists; every "see the
+                CHEAT(X)" citation resolves to a real marker in its own file;
+                every `file.rs:NN (CHEAT(...))` citation in validation/ lands on
+                a marker line
+  4. ratchet    the count per category only falls, against a baseline keyed on
+                CONTENT, never on file:line
+
+WHY THE BASELINE IS CONTENT-KEYED. A `file:line` key rots on the first move or
+reflow -- which is exactly how FIDELITY.md came to name a path that no longer
+exists and how a marker came to cite a `CHEAT(SKIP)` that is not in its file.
+The key is a digest of the category plus the normalised "what is faked" clause,
+so a rename or a move changes nothing and editing what is faked changes the key,
+which should require review. `file` and `symbol` are stored alongside as
+informational fields the tool rewrites on every run, so they self-heal.
+
+Usage:
+    cheat_ratchet.py --check        # the gate
+    cheat_ratchet.py --write        # accept the current surface as the baseline
+    cheat_ratchet.py --reconcile    # print the three ledgers side by side
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+CORE_ROOT = Path(__file__).resolve().parents[2]
+FIDELITY = CORE_ROOT / "FIDELITY.md"
+BASELINE = CORE_ROOT / "validation" / "cheat_baseline.json"
+VALIDATION_DIR = CORE_ROOT / "validation"
+
+# A MARKER declares a cheat and is followed by a colon. A CITATION refers to one
+# and is not. Conflating them is why "25 markers" was never a reproducible
+# number: prose mentions and cross-references counted as cheats.
+MARKER_RE = re.compile(r"CHEAT\(([A-Z][A-Z0-9-]*)(,\s*module)?\):")
+CITATION_RE = re.compile(r"CHEAT\(([A-Z][A-Z0-9-]*)\)(?!\s*[,:])")
+COMMENT_RE = re.compile(r"^\s*(//!|///|//)")
+# The taxonomy table in FIDELITY.md: | `CHEAT(X)` | ... |
+TAXONOMY_RE = re.compile(r"^\|\s*`CHEAT\(([A-Z][A-Z0-9-]*)\)`\s*\|")
+
+
+def documented_categories() -> set[str]:
+    """Parse the taxonomy out of FIDELITY.md. Never hardcode it here."""
+    return {m.group(1) for line in FIDELITY.read_text().splitlines() if (m := TAXONOMY_RE.match(line))}
+
+
+def rust_files() -> list[Path]:
+    return sorted(
+        p
+        for p in (CORE_ROOT / "crates").rglob("*.rs")
+        if "/target/" not in str(p)
+    )
+
+
+def normalise(text: str) -> str:
+    """The clause, with whitespace and comment leaders removed.
+
+    Keyed on this so a reflow or a rename does not invalidate a baseline entry,
+    and so editing WHAT IS FAKED does.
+    """
+    return re.sub(r"\s+", " ", re.sub(r"^\s*(//!|///|//)\s*", "", text)).strip().rstrip(".")
+
+
+def enclosing_symbol(lines: list[str], idx: int) -> str:
+    """Best-effort name of the item the marker sits on. Informational only."""
+    for j in range(idx, min(idx + 12, len(lines))):
+        m = re.match(r"\s*(pub\s+)?(unsafe\s+)?(extern\s+\"[^\"]*\"\s+)?fn\s+([A-Za-z0-9_]+)", lines[j])
+        if m:
+            return m.group(4)
+    return "<module>"
+
+
+def collect_markers() -> tuple[list[dict], list[str]]:
+    """Return (markers, format errors)."""
+    markers: list[dict] = []
+    errors: list[str] = []
+    for path in rust_files():
+        rel = path.relative_to(CORE_ROOT).as_posix()
+        lines = path.read_text(errors="ignore").splitlines()
+        for i, line in enumerate(lines):
+            m = MARKER_RE.search(line)
+            if not m:
+                continue
+            if not COMMENT_RE.match(line):
+                # A marker inside a string literal is documentation ABOUT the
+                # convention, not a declaration of a cheat.
+                continue
+            # The clause may wrap onto continuation comment lines.
+            clause_lines = [line[m.end():]]
+            for j in range(i + 1, len(lines)):
+                nxt = lines[j]
+                if not COMMENT_RE.match(nxt) or MARKER_RE.search(nxt):
+                    break
+                stripped = normalise(nxt)
+                if not stripped:
+                    break
+                clause_lines.append(nxt)
+            # Strip the comment leader from EACH line before joining, or the
+            # `//` of a continuation line lands in the middle of the clause and
+            # becomes part of the content key.
+            clause = normalise(" ".join(normalise(c) for c in clause_lines))
+            entry = {
+                "category": m.group(1),
+                "module_scope": bool(m.group(2)),
+                "file": rel,
+                "line": i + 1,
+                "symbol": enclosing_symbol(lines, i),
+                "clause": clause,
+            }
+            if "real:" not in clause.lower():
+                errors.append(
+                    f"{rel}:{i + 1}: CHEAT({m.group(1)}) has no `real:` clause — "
+                    "state what silicon or real execution does instead"
+                )
+            markers.append(entry)
+    return markers, errors
+
+
+def key_of(entry: dict) -> str:
+    return hashlib.sha256(f"{entry['category']}\n{entry['clause']}".encode()).hexdigest()[:16]
+
+
+def check_schema(markers: list[dict]) -> list[str]:
+    documented = documented_categories()
+    if not documented:
+        return ["FIDELITY.md taxonomy table did not parse — the schema is unknown, so nothing can be graded"]
+    return [
+        f"{e['file']}:{e['line']}: CHEAT({e['category']}) is not a category FIDELITY.md documents "
+        f"({', '.join(sorted(documented))})"
+        for e in markers
+        if e["category"] not in documented
+    ]
+
+
+def check_references(markers: list[dict]) -> list[str]:
+    """The rot check. All three of these were broken when this landed."""
+    errors: list[str] = []
+    text = FIDELITY.read_text()
+
+    # (a) every repo path FIDELITY.md names must exist
+    for m in re.finditer(r"`?((?:crates|scripts|configs|validation|docs|examples)/[A-Za-z0-9_./-]+\.[a-z]+)`?", text):
+        rel = m.group(1)
+        if not (CORE_ROOT / rel).exists():
+            line = text[: m.start()].count("\n") + 1
+            errors.append(f"FIDELITY.md:{line}: names {rel}, which does not exist")
+
+    # (b) a "see the CHEAT(X)" citation must resolve inside its own file
+    by_file: dict[str, set[str]] = {}
+    for e in markers:
+        by_file.setdefault(e["file"], set()).add(e["category"])
+    for path in rust_files():
+        rel = path.relative_to(CORE_ROOT).as_posix()
+        for i, line in enumerate(path.read_text(errors="ignore").splitlines()):
+            if not COMMENT_RE.match(line):
+                continue
+            for c in CITATION_RE.finditer(line):
+                if c.group(1) not in by_file.get(rel, set()):
+                    errors.append(
+                        f"{rel}:{i + 1}: cites CHEAT({c.group(1)}), which is not declared in this file"
+                    )
+
+    # (c) `file.rs:NN (CHEAT(...))` citations in validation/ must land on a marker
+    marker_lines = {(e["file"], e["line"]) for e in markers}
+    for yml in sorted(VALIDATION_DIR.glob("*.yaml")):
+        for i, line in enumerate(yml.read_text(errors="ignore").splitlines()):
+            for c in re.finditer(r'"?([A-Za-z0-9_/]+\.rs):(\d+)[^"]*CHEAT\(', line):
+                suffix, num = c.group(1), int(c.group(2))
+                hits = [f for f, ln in marker_lines if f.endswith(suffix) and ln == num]
+                if not hits:
+                    errors.append(
+                        f"{yml.name}:{i + 1}: cites {suffix}:{num} as a CHEAT marker; "
+                        "no marker is on that line (line-number citations rot — cite the symbol)"
+                    )
+    return errors
+
+
+def load_baseline() -> dict:
+    if not BASELINE.exists():
+        return {"entries": {}, "waived": []}
+    return json.loads(BASELINE.read_text())
+
+
+def check_ratchet(markers: list[dict], today: date) -> list[str]:
+    base = load_baseline()
+    errors: list[str] = []
+
+    for w in base.get("waived", []):
+        expires = date.fromisoformat(w["expires"])
+        if today > expires:
+            errors.append(
+                f"waiver for {w['key']} expired {w['expires']} ({w.get('reason', 'no reason recorded')})"
+            )
+
+    waived = {w["key"] for w in base.get("waived", [])}
+    known = set(base.get("entries", {})) | waived
+    for e in markers:
+        k = key_of(e)
+        if k not in known:
+            errors.append(
+                f"{e['file']}:{e['line']}: NEW cheat CHEAT({e['category']}) — {e['clause'][:90]}\n"
+                f"       If this is deliberate, run `scripts/ci/cheat_ratchet.py --write` and say why in "
+                f"the commit message. The count is allowed to fall, never to rise unreviewed."
+            )
+    return errors
+
+
+def write_baseline(markers: list[dict]) -> None:
+    base = load_baseline()
+    entries = {}
+    for e in sorted(markers, key=lambda x: (x["file"], x["line"])):
+        entries[key_of(e)] = {
+            "category": e["category"],
+            "clause": e["clause"],
+            # Informational. Rewritten every run, so a move or rename self-heals
+            # instead of rotting the way FIDELITY.md's paths did.
+            "file": e["file"],
+            "symbol": e["symbol"],
+        }
+    BASELINE.write_text(
+        json.dumps({"entries": entries, "waived": base.get("waived", [])}, indent=2, sort_keys=True) + "\n"
+    )
+    print(f"wrote {BASELINE.relative_to(CORE_ROOT)} — {len(entries)} cheats")
+
+
+def reconcile(markers: list[dict]) -> None:
+    """Print the three ledgers side by side. A report, not a gate."""
+    profile = CORE_ROOT / "crates/core/src/system/xtensa/arduino_esp32_profile.rs"
+    loader = CORE_ROOT / "crates/loader/src/lib.rs"
+
+    ceiling = "?"
+    if profile.exists():
+        m = re.search(r"CEILING:\s*usize\s*=\s*(\d+)", profile.read_text())
+        if m:
+            ceiling = m.group(1)
+    loader_syms = "?"
+    if loader.exists():
+        body = loader.read_text()
+        m = re.search(r"fn extract_arduino_esp32_thunks.*?\n}", body, re.S)
+        if m:
+            loader_syms = str(len(set(re.findall(r'"([a-z_][A-Za-z0-9_]*)"', m.group(0)))))
+
+    print("three ledgers of the same debt:")
+    print(f"  FIDELITY.md CHEAT markers            {len(markers)}")
+    print(f"  declared_thunk_symbols() ceiling     {ceiling}")
+    print(f"  extract_arduino_esp32_thunks symbols {loader_syms}")
+    print()
+    counts: dict[str, int] = {}
+    for e in markers:
+        counts[e["category"]] = counts.get(e["category"], 0) + 1
+    for cat in sorted(counts):
+        print(f"  CHEAT({cat}){'':<{max(0, 12 - len(cat))}} {counts[cat]}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Gate the CHEAT(...) fidelity-debt surface.")
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--write", action="store_true")
+    ap.add_argument("--reconcile", action="store_true")
+    args = ap.parse_args(argv)
+
+    markers, format_errors = collect_markers()
+
+    if args.reconcile:
+        reconcile(markers)
+        return 0
+    if args.write:
+        write_baseline(markers)
+        return 0
+
+    errors = format_errors + check_schema(markers) + check_references(markers)
+    errors += check_ratchet(markers, date.today())
+
+    print(f"{len(markers)} CHEAT markers across {len({e['file'] for e in markers})} files")
+    if errors:
+        for e in errors:
+            print(f"::error::{e}", file=sys.stderr)
+        print(f"\n{len(errors)} problem(s). See FIDELITY.md.", file=sys.stderr)
+        return 1
+    print("cheat ratchet: schema, references and count are honest")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_cheat_ratchet.py
+++ b/scripts/ci/test_cheat_ratchet.py
@@ -1,0 +1,198 @@
+"""Unit cover for the CHEAT ratchet.
+
+Every case builds a SYNTHETIC tree and points the gate at it. Grading the real
+crates/ for a VERDICT would make these tests a mirror of today's surface: they
+would go green for the wrong reason the moment someone marked a cheat, and they
+could never express "a marker with no `real:` clause must fail", because the
+tree is (by design) not in that state.
+
+Two cases do read the real repo, and they assert the gate's own claims about it
+— that the committed baseline covers the committed markers, and that the
+taxonomy parses — rather than restating either.
+
+Each negative case is a defect this gate found on its first run against main.
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+
+import cheat_ratchet as cr
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+TAXONOMY = """
+## Marking
+
+// CHEAT(<CATEGORY>): <what is faked> — real: <what silicon does>
+
+//! CHEAT(<CATEGORY>, module): <what every fn here fakes> — real: <what silicon does>
+
+| Marker | Meaning | Exit |
+|---|---|---|
+| `CHEAT(NOP)` | A function is replaced by a constant return. | Model it. |
+| `CHEAT(STUB)` | A peripheral is faked as plain RAM. | Implement the registers. |
+| `CHEAT(THUNK)` | Umbrella for a module of thunks of both kinds. | Reduce it. |
+"""
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """A minimal core checkout the gate can grade."""
+    (tmp_path / "crates/demo/src").mkdir(parents=True)
+    (tmp_path / "validation").mkdir()
+    (tmp_path / "FIDELITY.md").write_text(TAXONOMY)
+    monkeypatch.setattr(cr, "CORE_ROOT", tmp_path)
+    monkeypatch.setattr(cr, "FIDELITY", tmp_path / "FIDELITY.md")
+    monkeypatch.setattr(cr, "BASELINE", tmp_path / "validation/cheat_baseline.json")
+    monkeypatch.setattr(cr, "VALIDATION_DIR", tmp_path / "validation")
+    return tmp_path
+
+
+def rs(tree, body: str, name: str = "lib.rs"):
+    (tree / "crates/demo/src" / name).write_text(body)
+
+
+def seed(tree):
+    """Accept whatever is currently marked, so later cases test one thing."""
+    markers, _ = cr.collect_markers()
+    cr.write_baseline(markers)
+
+
+HONEST = """
+// CHEAT(NOP): returns 0 for the call — real: the function's actual effect runs.
+pub fn thing() {}
+"""
+
+
+def test_the_taxonomy_is_parsed_not_hardcoded(tree):
+    assert cr.documented_categories() == {"NOP", "STUB", "THUNK"}
+
+
+def test_an_honest_marked_tree_passes(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    assert cr.main(["--check"]) == 0
+
+
+def test_an_undocumented_category_fails(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    rs(tree, HONEST.replace("CHEAT(NOP)", "CHEAT(GUESS)"))
+    assert cr.main(["--check"]) == 1
+    assert "is not a category FIDELITY.md documents" in capsys.readouterr().err
+
+
+def test_a_marker_without_a_real_clause_fails(tree, capsys):
+    rs(tree, "// CHEAT(NOP): returns 0 for the call.\npub fn thing() {}\n")
+    seed(tree)
+    assert cr.main(["--check"]) == 1
+    assert "has no `real:` clause" in capsys.readouterr().err
+
+
+def test_a_new_cheat_fails_but_a_removed_one_does_not(tree, capsys):
+    """The ratchet, both directions. It must fall freely and rise only on review."""
+    rs(tree, HONEST)
+    seed(tree)
+
+    rs(tree, HONEST + "\n// CHEAT(STUB): faked as RAM — real: model the registers.\npub fn two() {}\n")
+    assert cr.main(["--check"]) == 1, "a new cheat must fail"
+    assert "NEW cheat" in capsys.readouterr().err
+
+    rs(tree, "")
+    assert cr.main(["--check"]) == 0, "removing every cheat must PASS — the count may always fall"
+
+
+def test_the_key_survives_a_move_and_a_rename(tree):
+    """Content-keyed, because file:line rots — which is how this repo got here."""
+    rs(tree, HONEST)
+    seed(tree)
+    (tree / "crates/demo/src/lib.rs").unlink()
+    rs(tree, "\n\n\n" + HONEST.replace("pub fn thing", "pub fn renamed"), name="moved.rs")
+    assert cr.main(["--check"]) == 0, "a move + rename must not read as a new cheat"
+
+
+def test_editing_what_is_faked_does_read_as_new(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    rs(tree, HONEST.replace("returns 0 for the call", "returns a fabricated pointer"))
+    assert cr.main(["--check"]) == 1
+    assert "NEW cheat" in capsys.readouterr().err
+
+
+def test_fidelity_naming_a_path_that_does_not_exist_fails(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    (tree / "FIDELITY.md").write_text(TAXONOMY + "\nSee `crates/demo/src/gone.rs` for the list.\n")
+    assert cr.main(["--check"]) == 1
+    assert "which does not exist" in capsys.readouterr().err
+
+
+def test_a_citation_to_a_marker_not_in_this_file_fails(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    rs(tree, "// see the CHEAT(STUB) above that fakes it\npub fn other() {}\n", name="other.rs")
+    assert cr.main(["--check"]) == 1
+    assert "cites CHEAT(STUB), which is not declared in this file" in capsys.readouterr().err
+
+
+def test_a_validation_citation_landing_off_a_marker_line_fails(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    (tree / "validation/exercise.yaml").write_text('- {ev: "demo/src/lib.rs:99 (CHEAT(NOP))"}\n')
+    assert cr.main(["--check"]) == 1
+    assert "no marker is on that line" in capsys.readouterr().err
+
+
+def test_a_prose_mention_is_not_a_cheat(tree):
+    """`CHEAT(...)` without a colon is a citation. Counting those is why "25
+    markers" was never reproducible: three of the 25 on main were prose."""
+    rs(tree, HONEST + '\nconst DOC: &str = "write CHEAT(NOP): like this";\n')
+    seed(tree)
+    markers, _ = cr.collect_markers()
+    assert len(markers) == 1, [m["clause"] for m in markers]
+
+
+def test_an_expired_waiver_fails(tree, capsys):
+    rs(tree, HONEST)
+    seed(tree)
+    base = json.loads((tree / "validation/cheat_baseline.json").read_text())
+    base["waived"] = [{"key": "abc", "reason": "probe on order", "expires": "2020-01-01"}]
+    (tree / "validation/cheat_baseline.json").write_text(json.dumps(base))
+    assert cr.main(["--check"]) == 1
+    assert "expired 2020-01-01" in capsys.readouterr().err
+
+
+def test_a_live_waiver_covers_a_cheat_that_is_not_in_the_baseline(tree):
+    rs(tree, HONEST)
+    seed(tree)
+    markers, _ = cr.collect_markers()
+    key = cr.key_of(markers[0])
+    (tree / "validation/cheat_baseline.json").write_text(
+        json.dumps({"entries": {}, "waived": [{"key": key, "reason": "tracked", "expires": "2999-01-01"}]})
+    )
+    assert cr.main(["--check"]) == 0
+
+
+def test_module_scope_is_recorded(tree):
+    rs(tree, "//! CHEAT(THUNK, module): every fn fakes it — real: the code runs.\n")
+    markers, errors = cr.collect_markers()
+    assert errors == []
+    assert markers[0]["module_scope"] is True
+
+
+# ── The real tree: the gate's own claims about it, not a restatement ─────────
+
+
+def test_the_committed_baseline_covers_the_committed_markers():
+    """This is the gate. If it fails, main is red and that is the intent."""
+    assert cr.main(["--check"]) == 0
+
+
+def test_the_real_taxonomy_parses_and_covers_every_marker_in_use():
+    documented = cr.documented_categories()
+    assert len(documented) >= 7, documented
+    markers, _ = cr.collect_markers()
+    assert markers, "no markers found — the parser stopped seeing the surface it grades"
+    assert {m["category"] for m in markers} <= documented

--- a/validation/cheat_baseline.json
+++ b/validation/cheat_baseline.json
@@ -1,0 +1,137 @@
+{
+  "entries": {
+    "0b1b04d003843679": {
+      "category": "NOP",
+      "clause": "returns pdTRUE unconditionally \u2014 real: the wrapped FreeRTOS call computes its result. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "return_pd_true"
+    },
+    "134b9017d1526231": {
+      "category": "THUNK-LIB",
+      "clause": "echoes the static buffer back as the queue handle instead of running xQueueCreateMutexStatic \u2014 real: FreeRTOS initializes the queue structure. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "x_queue_create_mutex_static_echo"
+    },
+    "2e22344b56e475e5": {
+      "category": "SKIP",
+      "clause": "bypasses the boot ROM and hand-seeds PC (SP seeded below) \u2014 real: the boot ROM executes and hands over at its own entry See FIDELITY.md \u00a7C",
+      "file": "crates/cli/src/commands/snapshot.rs",
+      "symbol": "<module>"
+    },
+    "317b5787723c9369": {
+      "category": "STUB",
+      "clause": "SDIO SLC peripheral faked as plain RAM \u2014 real: model the SLC registers/DMA. (host_slc below is a smarter FSM stub.) See FIDELITY.md \u00a7D",
+      "file": "crates/core/src/system/xtensa/esp32.rs",
+      "symbol": "<module>"
+    },
+    "46de94e639ba65de": {
+      "category": "THUNK-LIB",
+      "clause": "fakes SPIClass::beginTransaction (populates _spi->dev so transfer finds SPI3) \u2014 real: the compiled Arduino code configures clock/mode on the SPI peripheral. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "spi_class_begin_transaction"
+    },
+    "4969b34f12af8a4f": {
+      "category": "THUNK-LIB",
+      "clause": "writes a canned esp_chip_info_t \u2014 real: reads eFuse/DPORT to report cores/features/revision. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "esp_chip_info_stub"
+    },
+    "572d1aa17659971e": {
+      "category": "STUB",
+      "clause": "SDMMC host peripheral faked as plain RAM \u2014 real: model the SDMMC controller registers. See FIDELITY.md \u00a7D",
+      "file": "crates/core/src/system/xtensa/esp32.rs",
+      "symbol": "<module>"
+    },
+    "5b325c5b3006c04d": {
+      "category": "THUNK-LIB",
+      "clause": "fakes the Arduino spiStartBus() so later transfers find a \"bus up\" \u2014 real: the compiled IDF/Arduino SPI bus-init code runs against the SPI peripheral + GPIO matrix. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "spi_start_bus_fake"
+    },
+    "60255674f3030bed": {
+      "category": "THUNK-LIB",
+      "clause": "bump-allocates from a Rust-side arena instead of running the compiled heap_caps allocator \u2014 real: the IDF allocator manages the heap regions. (Sibling thunks: init/calloc/free/realloc.) See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "esp_idf_heap_caps_malloc"
+    },
+    "73ac3f1a28fd5497": {
+      "category": "THUNK",
+      "clause": "every fn in this module fakes a function instead of executing it \u2014 real: the CPU executes the ROM routine or the library code that is already present in the image. Two kinds (see FIDELITY.md \u00a7A): THUNK-ROM (boot-ROM helpers we have no binary to run \u2014 math, memcpy, cache, printf \u2014 reasonable to emulate) and THUNK-LIB / BYPASS / NOP (firmware library code that IS in the ELF but we skip \u2014 heap_caps, FreeRTOS, the SPI/GxEPD path \u2014 genuine fidelity debt) Individual cheats below carry their own CHEAT(...) marker",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "<module>"
+    },
+    "760b1187ade0d38f": {
+      "category": "SKIP",
+      "clause": "bypasses the boot ROM and hand-seeds PC/SP \u2014 real: the boot ROM executes and leaves PC/SP where it puts them. See FIDELITY.md \u00a7C",
+      "file": "crates/cli/src/commands/run.rs",
+      "symbol": "<module>"
+    },
+    "774915942f0cd48a": {
+      "category": "INFER",
+      "clause": "no D/C line wired \u2014 guess command vs data from protocol state \u2014 real: sample the D/C GPIO. See FIDELITY.md \u00a7E",
+      "file": "crates/core/src/peripherals/components/ssd1680_tricolor_290.rs",
+      "symbol": "<module>"
+    },
+    "84bd3d25acaf0a7c": {
+      "category": "NOP",
+      "clause": "halts the sim on abort() instead of running the real abort path \u2014 real: the firmware's abort() runs the panic handler and prints a backtrace, then resets. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "abort_halt"
+    },
+    "8591fdbe22da2cc4": {
+      "category": "THUNK-ROM",
+      "clause": "emulates xthal_window_spill (flush windowed regs to stack) in Rust \u2014 real: the ROM routine spills via ROTW + S32I and ends with WINDOWSTART = 1<<WB (only the current frame live). See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "xthal_window_spill_thunk"
+    },
+    "96f0ac1a4858216e": {
+      "category": "THUNK-LIB",
+      "clause": "returns an incrementing counter as a fake timestamp \u2014 real: the IDF reads a hardware timer (systimer/CCOUNT). See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "monotonic_counter_32"
+    },
+    "ab23fa4c41d1b614": {
+      "category": "THUNK-LIB",
+      "clause": "returns a fabricated current-task handle \u2014 real: the compiled FreeRTOS scheduler tracks pxCurrentTCB. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "x_task_get_current_task_handle"
+    },
+    "b28fbfe81dc6aaf6": {
+      "category": "STUB",
+      "clause": "SYSTEM/RTC_CNTL/EFUSE are register stubs \u2014 read-as-zero / write-accept with a few round-tripped or canned fields, no real behavior Real: model the register semantics (clock tree, RTC, eFuse). FIDELITY.md \u00a7D",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/system_stub.rs",
+      "symbol": "<module>"
+    },
+    "bb2d84e5020a064a": {
+      "category": "NOP",
+      "clause": "returns a fixed DRAM address as the per-task reent struct \u2014 real: __getreent returns the running task's _reent. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "getreent_dram_fake_ptr"
+    },
+    "c86435d61543e04f": {
+      "category": "INFER",
+      "clause": "no D/C line wired \u2014 can't tell command from data, so treat every byte as data \u2014 real: sample the D/C GPIO. FIDELITY.md \u00a7E",
+      "file": "crates/core/src/peripherals/components/uc8151d_tricolor_290.rs",
+      "symbol": "dc_pin"
+    },
+    "e66fabdce77a2c75": {
+      "category": "NOP",
+      "clause": "swallows the call and returns 0 \u2014 real: execute the function's actual effect. Installed at ~25 ROM/IDF addresses. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "nop_return_zero"
+    },
+    "f76588d19464e2c0": {
+      "category": "NOP",
+      "clause": "returns a fabricated non-null pointer so the caller proceeds \u2014 real: the function allocates/returns a genuine structure. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs",
+      "symbol": "nop_return_fake_ptr"
+    },
+    "fb58c803779eb03f": {
+      "category": "THUNK-LIB",
+      "clause": "every fn here short-circuits the WiFi/lwIP stack to a canned functional outcome (WL_CONNECTED, fake sockets) instead of running it \u2014 real: the lwIP/socket code compiled into the ELF executes Unlike most cheats this is partly unavoidable \u2014 the WiFi MAC/PHY is a closed RF-coprocessor blob with no executable image \u2014 but the lwIP/socket layer above it is real compiled code we skip. See FIDELITY.md \u00a7A",
+      "file": "crates/core/src/peripherals/esp32s3/wifi_thunks.rs",
+      "symbol": "<module>"
+    }
+  },
+  "waived": []
+}

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -1223,7 +1223,7 @@ boards:
       # changes. Behaviour-preserving extraction, not a model correction —
       # `pr-workspace-tests` green on all shards is what exercises this peripheral,
       # so nothing the silicon capture asserts changed and the capture stands.
-    drift_ack_digest: c973ed6df35e75c599d163f114cbe648d73606d710f82858692050e1f9e9f15b
+    drift_ack_digest: 5c35a6f778b2787af06537d52b04e3e25df34ab15a87c9e577f19a7a10c66da4
     models:
       - crates/core/src/cpu/riscv.rs
       - crates/core/src/decoder/riscv.rs
@@ -3976,7 +3976,7 @@ boards:
       # changes. Behaviour-preserving extraction, not a model correction —
       # `pr-workspace-tests` green on all shards is what exercises this peripheral,
       # so nothing the silicon capture asserts changed and the capture stands.
-    drift_ack_digest: 821161b38b4859863e513233a8da9edeb9ce71cfc4f8796a71ba6302c0550f3a
+    drift_ack_digest: 7601f41b277b41da8799dd7554689c238e44da88b4ab95012499cff98be979cd
     models:
       - crates/core/src/cpu/xtensa_lx7.rs
       - crates/core/src/decoder/xtensa.rs


### PR DESCRIPTION
FIDELITY.md defines a seven-category taxonomy for behaviour the twin fakes and tells the reader to find it with `grep -rn "CHEAT("`. No script, test or workflow referenced CHEAT. **A convention nothing counts is a comment.**

## What the gate found on its first run against main — all fixed here

| where | defect |
|---|---|
| `FIDELITY.md:226` | names `peripherals/esp32s3/rom_thunks.rs` — the file moved to `esp_xtensa_common/` and the doc did not follow |
| `FIDELITY.md:297` | names `system/xtensa.rs` — now a directory |
| `arduino_esp32_profile.rs:366` | cites *“the CHEAT(SKIP) above that seeds PC”*. There is no `CHEAT(SKIP)` in that file — the boot-ROM skip lives in the CLI entry points |
| `rom_thunks.rs:13` | uses `CHEAT(THUNK)`, a category the taxonomy does not define |
| ×5 markers | no `real:` clause — the only place the **cost** of a cheat is written down |

The real count is **22, not the 25 a grep reports**: three of those are prose, a cross-reference, and a string literal in a test. That is why “25 markers” was never reproducible, and why the parser separates a **marker** (`CHEAT(CAT):`, with a colon) from a **citation** (`CHEAT(CAT)`, without one).

## Three ledgers, none aware of the others

```
FIDELITY.md CHEAT markers             22
declared_thunk_symbols() ceiling      56   ← and it is AT its ceiling
extract_arduino_esp32_thunks symbols 176
```

`--reconcile` prints all three side by side. Closing the gap is separate, already-sequenced work (FIDELITY.md Batches A–D); this makes it **visible and counted** instead of three numbers that quietly disagree.

## What it asserts

1. **schema** — every category is one FIDELITY.md documents, *parsed from the doc*, never hardcoded
2. **format** — `CHEAT(CAT): <what is faked> — real: <what silicon does>`, with `, module` for a `//!` blanket. The scope is not decoration: without it, a marker covering 88 thunks is indistinguishable from one covering a single line
3. **references** — FIDELITY.md’s own paths resolve; a “see the CHEAT(X)” citation resolves inside its own file; a `file.rs:NN (CHEAT(...))` citation in `validation/` lands on a marker line
4. **ratchet** — the count only falls

The baseline is keyed on a digest of the category plus the normalised clause, **never on `file:line`** — a `file:line` key rots on the first move, which is exactly how two of the defects above came to exist. `file` and `symbol` are stored alongside as informational fields the tool rewrites every run, so they self-heal. Waivers carry an expiry and an expired one is red — the one thing the neighbouring validation-status gate lacks.

## Negative controls

Each is a defect class this found. All five fail the gate; the tree restores to green.

- undocumented category · a FIDELITY.md path that does not exist · a new unreviewed cheat · a marker with no `real:` clause · an expired waiver

16 pytest cases, wired into the **explicit** list in `core-ci.yml`.

## ⚠️ Re-stamped digests — please read

Every `.rs` edit here is comment-only (verified: **zero** non-comment ± lines), but `esp32c3` and `esp32s3` both watch the *directory* containing `rom_thunks.rs`, so their models digest moved and their acks stopped covering them. Their `drift_ack_digest` is re-stamped. **The ack dates are unchanged** (2026-08-22 / 2026-08-23), so no promise is extended.

Noted while doing it: `--write-ack-digests` re-stamped **six** boards, not two. `rp2040`, `stm32h735`, `stm32f411ceu6` and `mkw41z4` carried digests that were already stale on main — harmless, because none of them is `drifted`, so the digest is never consulted. Those four are **reverted to their committed values** here rather than swept along. The tool is a blunt instrument: it re-stamps every acked board, including ones the change never touched.