### PR TITLE
refactor(peripherals): one home for the device traits; unify the duplicated GpioObserver

### DIFF
--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -1087,9 +1087,7 @@ impl SystemBus {
     /// point — the same path `AttachCtx::install_gpio_observer` uses.
     pub fn install_gpio_observer<T>(bus: &mut SystemBus, observer: std::sync::Arc<T>)
     where
-        T: crate::peripherals::esp32s3::gpio::GpioObserver
-            + crate::peripherals::esp32::gpio::GpioObserver
-            + 'static,
+        T: crate::peripherals::device::GpioObserver + 'static,
     {
         if let Some(idx) = bus.find_peripheral_index_by_name("gpio") {
             let any = bus.peripherals[idx].dev.as_any_mut();

--- a/crates/core/src/peripherals/components/h_bridge_motor.rs
+++ b/crates/core/src/peripherals/components/h_bridge_motor.rs
@@ -97,13 +97,7 @@ impl HBridgeMotor {
     }
 }
 
-impl crate::peripherals::esp32s3::gpio::GpioObserver for HBridgeMotor {
-    fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
-        self.on_gpio_edge(pin, to, sim_cycle);
-    }
-}
-
-impl crate::peripherals::esp32::gpio::GpioObserver for HBridgeMotor {
+impl crate::peripherals::device::GpioObserver for HBridgeMotor {
     fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
         self.on_gpio_edge(pin, to, sim_cycle);
     }

--- a/crates/core/src/peripherals/components/ili9341_parallel.rs
+++ b/crates/core/src/peripherals/components/ili9341_parallel.rs
@@ -6,7 +6,7 @@
 //!
 //! Phase-2 v1 targets ESP32 / ESP32-S3 GPIO bit-bang of the classic 16-bit
 //! Intel 8080 bus (CS, RS/D-C, WR, RD, RST, DB[15:0]). Edges arrive through
-//! [`GpioObserver`](crate::peripherals::esp32s3::gpio::GpioObserver); unit tests
+//! [`GpioObserver`](crate::peripherals::device::GpioObserver); unit tests
 //! inject them directly.
 //!
 //! ## Bus protocol (write path)
@@ -420,13 +420,7 @@ impl Ili9341Parallel {
     }
 }
 
-impl crate::peripherals::esp32s3::gpio::GpioObserver for Ili9341Parallel {
-    fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
-        self.on_gpio_edge(pin, to, sim_cycle);
-    }
-}
-
-impl crate::peripherals::esp32::gpio::GpioObserver for Ili9341Parallel {
+impl crate::peripherals::device::GpioObserver for Ili9341Parallel {
     fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
         self.on_gpio_edge(pin, to, sim_cycle);
     }

--- a/crates/core/src/peripherals/components/servo.rs
+++ b/crates/core/src/peripherals/components/servo.rs
@@ -17,7 +17,7 @@
 //! is therefore driven by a duty fraction, obtained two ways:
 //!
 //!   * [`Servo::on_gpio_edge`] — fed from real pin transitions (the
-//!     [`GpioObserver`](crate::peripherals::esp32s3::gpio::GpioObserver)
+//!     [`GpioObserver`](crate::peripherals::device::GpioObserver)
 //!     path). It measures `high_cycles / period_cycles` across frames, so
 //!     it is robust to the simulator's instruction-paced (non-wall-clock)
 //!     cycle counter: only the *ratio* matters, not absolute cycle timing.
@@ -212,7 +212,7 @@ impl Servo {
     }
 
     /// Feed a single GPIO pin transition (the
-    /// [`GpioObserver`](crate::peripherals::esp32s3::gpio::GpioObserver)
+    /// [`GpioObserver`](crate::peripherals::device::GpioObserver)
     /// hook). Measures the duty ratio across frames and updates the angle
     /// on each falling edge once a frame period is known. No-op for edges
     /// on other pins.
@@ -254,13 +254,7 @@ impl Servo {
 // Bridge the servo into each chip's GPIO observer protocol. Both traits
 // share the same `(pin, from, to, sim_cycle)` signature; the servo only
 // needs the `to` level and the cycle.
-impl crate::peripherals::esp32s3::gpio::GpioObserver for Servo {
-    fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
-        self.on_gpio_edge(pin, to, sim_cycle);
-    }
-}
-
-impl crate::peripherals::esp32::gpio::GpioObserver for Servo {
+impl crate::peripherals::device::GpioObserver for Servo {
     fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
         self.on_gpio_edge(pin, to, sim_cycle);
     }

--- a/crates/core/src/peripherals/components/step_dir_motor.rs
+++ b/crates/core/src/peripherals/components/step_dir_motor.rs
@@ -116,13 +116,7 @@ impl StepDirMotor {
     }
 }
 
-impl crate::peripherals::esp32s3::gpio::GpioObserver for StepDirMotor {
-    fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
-        self.on_gpio_edge(pin, to, sim_cycle);
-    }
-}
-
-impl crate::peripherals::esp32::gpio::GpioObserver for StepDirMotor {
+impl crate::peripherals::device::GpioObserver for StepDirMotor {
     fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
         self.on_gpio_edge(pin, to, sim_cycle);
     }

--- a/crates/core/src/peripherals/components/unipolar_stepper.rs
+++ b/crates/core/src/peripherals/components/unipolar_stepper.rs
@@ -100,13 +100,7 @@ impl UnipolarStepper {
     }
 }
 
-impl crate::peripherals::esp32s3::gpio::GpioObserver for UnipolarStepper {
-    fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
-        self.on_gpio_edge(pin, to, sim_cycle);
-    }
-}
-
-impl crate::peripherals::esp32::gpio::GpioObserver for UnipolarStepper {
+impl crate::peripherals::device::GpioObserver for UnipolarStepper {
     fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
         self.on_gpio_edge(pin, to, sim_cycle);
     }

--- a/crates/core/src/peripherals/components/ws2812.rs
+++ b/crates/core/src/peripherals/components/ws2812.rs
@@ -29,7 +29,7 @@
 //! (see [`crate::peripherals::esp32s3::rmt`]), which flips the routed GPIO pad
 //! through [`Esp32s3Gpio::drive_pad_output`](crate::peripherals::esp32s3::gpio::Esp32s3Gpio::drive_pad_output).
 //! This component registers as an S3
-//! [`GpioObserver`](crate::peripherals::esp32s3::gpio::GpioObserver) and decodes
+//! [`GpioObserver`](crate::peripherals::device::GpioObserver) and decodes
 //! purely from the `(pin, from, to, sim_cycle)` callbacks — accumulating each
 //! bit's HIGH duration, shifting it into a 24-bit register, and pushing a pixel
 //! every 24 bits.
@@ -201,13 +201,7 @@ impl Ws2812 {
 
 // Bridge into the ESP32-S3 GPIO observer protocol (the chip whose RMT drives the
 // pad today). `from` is unused — only the new level and the sim cycle matter.
-impl crate::peripherals::esp32s3::gpio::GpioObserver for Ws2812 {
-    fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
-        self.on_edge(pin, to, sim_cycle);
-    }
-}
-
-impl crate::peripherals::esp32::gpio::GpioObserver for Ws2812 {
+impl crate::peripherals::device::GpioObserver for Ws2812 {
     fn on_pin_change(&self, pin: u8, _from: bool, to: bool, sim_cycle: u64) {
         self.on_edge(pin, to, sim_cycle);
     }
@@ -431,7 +425,8 @@ mod tests {
 
     #[test]
     fn registers_as_s3_gpio_observer() {
-        use crate::peripherals::esp32s3::gpio::{Esp32s3Gpio, GpioObserver};
+        use crate::peripherals::device::GpioObserver;
+        use crate::peripherals::esp32s3::gpio::Esp32s3Gpio;
         let strip = Arc::new(Ws2812::new(PIN, 1, CPU_HZ));
         let mut g = Esp32s3Gpio::new();
         g.add_observer(strip.clone() as Arc<dyn GpioObserver>);

--- a/crates/core/src/peripherals/device.rs
+++ b/crates/core/src/peripherals/device.rs
@@ -1,0 +1,331 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! ONE HOME FOR THE OFF-CHIP DEVICE VOCABULARY.
+//!
+//! Why this module exists
+//! ======================
+//! An *off-chip device* — a sensor on an I²C bus, a panel on SPI, a GPS on a
+//! UART, a WS2812 strip watching a pad — is not part of any MCU. It is the
+//! other side of a wire. The traits that say what such a thing can do are
+//! therefore the engine's stable public vocabulary, and they were living
+//! inside the four MCU-peripheral files that happened to call them first:
+//! `I2cDevice` in `peripherals::i2c` next to the STM32 CR1/CR2 register file,
+//! `SpiDevice` in `peripherals::spi`, `UartStreamDevice`/`UartStreamHost` in
+//! `peripherals::uart`, and `GpioObserver` declared TWICE — once in
+//! `peripherals::esp32::gpio` and once, byte for byte, in
+//! `peripherals::esp32s3::gpio`.
+//!
+//! That placement is what makes a device change an engine change. It also
+//! produced the duplication directly: a component that wanted to watch pad
+//! edges on both ESP32 families had to write the same `impl` twice, because
+//! the two families each owned a private copy of the same three-line contract.
+//! Six components did (`servo`, `ws2812`, `step_dir_motor`, `h_bridge_motor`,
+//! `unipolar_stepper`, `ili9341_parallel`) and every call site that accepted
+//! an observer carried a two-trait bound (`SystemBus::install_gpio_observer`,
+//! `AttachCtx::install_gpio_observer`) that no third family could satisfy
+//! without a third declaration and a third `impl` on all six.
+//!
+//! What is here
+//! ============
+//! The traits themselves, moved verbatim. **Nothing else changed**: the old
+//! paths keep `pub use` re-exports, so every `impl`, bound, and intra-doc link
+//! outside this module still resolves, and the behaviour is bit-identical.
+//!
+//! This is the cheap half of the split the remediation ledger's C-1 row is
+//! about. Whether or not a `labwired-peripheral-api` crate is ever created,
+//! the vocabulary now has one home to read and one place to change; if it is
+//! created, this file is a `git mv` rather than surgery on four register
+//! models.
+//!
+//! What is deliberately NOT here
+//! =============================
+//! The MCU-side controllers (`Uart`, `Spi`, `I2c`, `Esp32Gpio`,
+//! `Esp32s3Gpio`). Those are register models of silicon and belong with their
+//! families. The line this module draws is the wire, not the bus protocol.
+
+use std::any::Any;
+use std::sync::mpsc::{Receiver, Sender};
+
+// ── I²C ─────────────────────────────────────────────────────────────────────
+pub trait I2cDevice: Send {
+    fn address(&self) -> u8;
+    fn read(&mut self) -> u8;
+    fn write(&mut self, data: u8);
+    fn start(&mut self) {}
+    fn stop(&mut self) {}
+
+    /// What this device can show of itself — its own inspect evidence.
+    ///
+    /// The ONE place a an I²C device's artifacts are decided is the model
+    /// itself, next to the buffers it owns. Default: nothing, which is correct
+    /// for a sensor with no display surface and honest for anything else —
+    /// absent means "this engine has nothing to show", never "the screen was
+    /// blank". See [`crate::inspect::DeviceEvidence`] for why this is not a
+    /// central match on concrete types.
+    ///
+    /// Implementations must read the model's REAL buffer and synthesize
+    /// nothing; a panel that was never painted reports zero.
+    fn artifacts(
+        &self,
+        _id: &str,
+        _opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        Vec::new()
+    }
+
+    /// Does this device answer to `addr` on the wire *right now*?
+    ///
+    /// A plain slave owns exactly one address, so the default is the obvious
+    /// `self.address() == addr` — every existing model keeps its behaviour with
+    /// no edit. The hook exists for devices whose answered-address set is not a
+    /// singleton and is not static: an I²C **bus switch** (TCA9548A) answers to
+    /// its own control address *and*, while a channel is enabled, to every
+    /// address reachable behind that channel. That set changes whenever
+    /// firmware rewrites the switch's control register, so it cannot be
+    /// flattened into one `address()` at attach time.
+    ///
+    /// Controllers MUST resolve a slave with this, never by comparing
+    /// `address()` — a flat `position(|d| d.address() == addr)` is first-match
+    /// and makes four identical sensors behind a mux collapse into one.
+    fn claims_address(&self, addr: u8) -> bool {
+        self.address() == addr
+    }
+
+    /// Tell the device which address the master just selected, immediately
+    /// after [`claims_address`](Self::claims_address) returned `true` for it and
+    /// before any `start`/`write`/`read`/`stop` of that transaction.
+    ///
+    /// Default no-op: a single-address slave already knows who it is. A bus
+    /// switch uses it to decide whether this transaction targets its own
+    /// control register or is to be forwarded to the downstream device(s) that
+    /// claim `addr` on the currently enabled channel(s).
+    fn select_address(&mut self, addr: u8) {
+        let _ = addr;
+    }
+
+    /// Walk every [`SimInput`](crate::sim_input::SimInput) surface this device
+    /// exposes, including devices nested *behind* it. Returns `true` if `f`
+    /// asked to stop early.
+    ///
+    /// The default is exactly the old behaviour — a device offers at most its
+    /// own [`as_sim_input_mut`](Self::as_sim_input_mut). It is overridden by
+    /// containers (the TCA9548A mux) so their children stay reachable from the
+    /// ONE stimulus walk in [`crate::bus::SystemBus::for_each_sim_input`].
+    /// Without it, putting a sensor behind a mux would silently subtract it
+    /// from `list_inputs` / `set_input` — the same class of invisible-device
+    /// bug the controller-level seam was introduced to kill.
+    fn for_each_sim_input(
+        &mut self,
+        f: &mut dyn FnMut(&mut dyn crate::sim_input::SimInput) -> bool,
+    ) -> bool {
+        match self.as_sim_input_mut() {
+            Some(si) => f(si),
+            None => false,
+        }
+    }
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        None
+    }
+    /// Runtime-drivable view of this device, if it accepts simulated input.
+    /// Overridden by input devices (accelerometers, …) so the generic
+    /// [`crate::Machine::set_input`] resolver can reach them without a
+    /// downcast. Default `None` = not an input device.
+    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
+        None
+    }
+
+    /// Advance this device's free-running sample/measurement clock by `us`
+    /// microseconds of wall-clock time.
+    ///
+    /// Real sensors sample on their own oscillator, independent of when the CPU
+    /// gets around to reading them: a PPG FIFO keeps filling at its configured
+    /// rate whether or not firmware is draining it. A bus master that knows the
+    /// elapsed wall-clock calls this on a slave immediately before servicing it,
+    /// so a *late* poll observes exactly the samples that accrued while the CPU
+    /// was busy elsewhere — and a FIFO that was allowed to overrun reports the
+    /// overflow it really would have. Without this hook a model only advances on
+    /// the very transactions that would have prevented the overflow, which hides
+    /// precisely the CPU-starvation failures worth simulating.
+    ///
+    /// Default no-op: a purely register-mapped device has no clock to advance.
+    fn advance_time_us(&mut self, _us: u64) {}
+}
+
+// ── SPI ─────────────────────────────────────────────────────────────────────
+/// Trait implemented by simulated SPI devices (peripherals attached to an SPI bus).
+///
+/// For v1, CS-pin-aware routing is not implemented: all transfers are broadcast
+/// to every attached device and the first non-zero MISO byte wins.  This is
+/// correct for single-device labs (MAX31855 alone).  CS-aware routing is noted
+/// as a Phase 2 follow-up.
+pub trait SpiDevice: Send {
+    fn needs_external_bus_poll(&self) -> bool {
+        false
+    }
+    fn component_id(&self) -> Option<&str> {
+        None
+    }
+    fn attach_can_bus(
+        &mut self,
+        _tx: Sender<crate::network::CanFrame>,
+        _rx: Receiver<crate::network::CanFrame>,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("SPI device is not a CAN controller")
+    }
+    fn poll_external_bus(&mut self) {}
+    /// Called when the CS line goes low (chip is selected).
+    fn cs_select(&mut self) {}
+    /// Called when the CS line goes high (chip is released — flush state).
+    fn cs_release(&mut self) {}
+    /// SPI is full-duplex: master sends `mosi_byte`, device returns its current MISO byte.
+    /// On read-only devices like MAX31855, `mosi_byte` is ignored.
+    fn transfer(&mut self, mosi_byte: u8) -> u8;
+    /// CS pin label this device is wired to (e.g. "PA4" or numeric pin ID). Used by the bus
+    /// dispatcher to pick which device responds when the firmware drives a particular CS line.
+    fn cs_pin(&self) -> &str;
+
+    /// What this device can show of itself — its own inspect evidence.
+    ///
+    /// The ONE place a a SPI device's artifacts are decided is the model
+    /// itself, next to the buffers it owns. Default: nothing, which is correct
+    /// for a sensor with no display surface and honest for anything else —
+    /// absent means "this engine has nothing to show", never "the screen was
+    /// blank". See [`crate::inspect::DeviceEvidence`] for why this is not a
+    /// central match on concrete types.
+    ///
+    /// Implementations must read the model's REAL buffer and synthesize
+    /// nothing; a panel that was never painted reports zero.
+    fn artifacts(
+        &self,
+        _id: &str,
+        _opts: &crate::inspect::InspectOpts,
+    ) -> Vec<crate::inspect::Artifact> {
+        Vec::new()
+    }
+    /// Data/Command (D/C) pin label this device observes, if any (e.g. "PB6").
+    ///
+    /// Displays like the Nokia 5110 (PCD8544) distinguish command bytes from
+    /// pixel-data bytes by the level of a dedicated GPIO line rather than by
+    /// byte semantics. When this returns `Some(pin)`, the bus latches that
+    /// pin's current output level into the device via [`set_dc_level`] after
+    /// each MMIO write, so the value is current by the time the firmware
+    /// writes the SPI data register. Default `None` → the bus does no latching
+    /// and the device infers framing from the protocol (ILI9341 / SSD1680).
+    ///
+    /// [`set_dc_level`]: SpiDevice::set_dc_level
+    fn dc_pin(&self) -> Option<&str> {
+        None
+    }
+    /// Latched level of the [`dc_pin`](SpiDevice::dc_pin) at transfer time,
+    /// pushed by the bus. No-op for devices that do not observe a D/C line.
+    fn set_dc_level(&mut self, _level: bool) {}
+    /// Resolved `(ODR address, bit)` of the D/C line. The bus computes this
+    /// once at install time (from [`dc_pin`](SpiDevice::dc_pin)) and records it
+    /// via [`set_dc_source`]; thereafter the bus reads that GPIO output bit
+    /// just before each transfer and pushes the level via [`set_dc_level`].
+    /// Default `None` → no D/C latching.
+    ///
+    /// [`set_dc_source`]: SpiDevice::set_dc_source
+    fn dc_source(&self) -> Option<(u64, u8)> {
+        None
+    }
+    /// Bus-side setter recording the resolved D/C `(ODR address, bit)`.
+    fn set_dc_source(&mut self, _odr_addr: u64, _bit: u8) {}
+    fn as_any(&self) -> Option<&dyn Any> {
+        None
+    }
+    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
+        None
+    }
+    /// Runtime-drivable view of this device, if it accepts simulated input.
+    /// Same contract as the hook on `I2cDevice`: input devices override it so
+    /// the generic [`crate::Machine::set_input`] resolver can reach them
+    /// without a downcast. Default `None` = not an input device.
+    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
+        None
+    }
+    /// Binary mid-flight snapshot for runtime resume. Default empty;
+    /// override for stateful devices (e-paper panels with framebuffers,
+    /// thermocouples with cached temperatures, etc.).
+    fn runtime_snapshot(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn restore_runtime_snapshot(&mut self, _bytes: &[u8]) -> crate::SimResult<()> {
+        Ok(())
+    }
+}
+
+// ── UART stream ─────────────────────────────────────────────────────────────
+/// A UART model that can host a [`UartStreamDevice`] — the contract an
+/// inter-chip cross-link binds to.
+///
+/// This exists so the cross-link seam names a CAPABILITY rather than one
+/// concrete struct. It used to downcast to [`Uart`], which silently excluded
+/// every chip family with its own UART model: an ESP32-C3's `uart1` reported
+/// "is not a UART" and two C3s could not be wired together at all. A new UART
+/// model now joins by implementing this trait, not by editing the seam.
+pub trait UartStreamHost {
+    /// Bind a peer to this UART's RX/TX paths.
+    fn attach_stream_device(&mut self, dev: Box<dyn UartStreamDevice>);
+
+    /// Stop mirroring TX to the console/capture sink. A cross-linked UART
+    /// carries raw protocol octets, not console text, and letting those into
+    /// the serial monitor floods it with binary that looks identical on both
+    /// peers.
+    fn detach_console_sink(&mut self);
+
+    /// True when any attached peer carries protocol octets — the test
+    /// `attach_uart_tx_sink` uses to leave a linked UART off the console sink.
+    fn hosts_protocol_peer(&self) -> bool;
+}
+
+/// A device that emits bytes through the UART's RX path (e.g. a GPS module).
+pub trait UartStreamDevice: Send {
+    /// Called periodically by the bus tick. Returns the next byte to push into UART RX,
+    /// or None if no byte is pending. Implementations should respect `elapsed_us` to
+    /// pace output (e.g. 9600 baud → ~1 ms/byte → emit one byte per ~1000 us tick).
+    fn poll(&mut self, elapsed_us: u32) -> Option<u8>;
+    /// Observe a byte transmitted by firmware on the TX path. Default: ignore.
+    /// Bidirectional peers (e.g. an IO-Link master) override this to receive the
+    /// device's responses, complementing `poll` which drives the RX path.
+    fn on_tx_byte(&mut self, _byte: u8) {}
+
+    /// True when this peer's traffic is raw protocol octets rather than console
+    /// text, so the UART hosting it must be kept OFF the console capture sink.
+    ///
+    /// Without this, a node's link UART and its console UART push into the same
+    /// buffer and the two byte streams splice together — a two-chip run prints
+    /// `pPiInNgGer up` and no serial assertion can be trusted. Default `false`:
+    /// an ordinary stream device (a GPS emitting NMEA) is console-safe.
+    fn carries_protocol_octets(&self) -> bool {
+        false
+    }
+    fn as_any(&self) -> Option<&dyn Any> {
+        None
+    }
+    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
+        None
+    }
+    /// Runtime-drivable view of this device, if it accepts simulated input.
+    /// Same contract as the hook on `I2cDevice`: input devices override it so
+    /// the generic [`crate::Machine::set_input`] resolver can reach them
+    /// without a downcast. Default `None` = not an input device.
+    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
+        None
+    }
+}
+
+// ── GPIO edge observation ───────────────────────────────────────────────────
+/// Notified synchronously inside the bus write path on every GPIO pin
+/// transition. Observers must not panic — a panic propagates out of
+/// `bus.write_u8` and crashes the simulator.
+pub trait GpioObserver: Send + Sync + std::fmt::Debug {
+    fn on_pin_change(&self, pin: u8, from: bool, to: bool, sim_cycle: u64);
+}

--- a/crates/core/src/peripherals/esp32/gpio.rs
+++ b/crates/core/src/peripherals/esp32/gpio.rs
@@ -15,7 +15,7 @@
 //! pin map (CS=5, SCK=18, MOSI=23, DC=17, RST=16, BUSY=4) is all in 0..31.
 //! Writes to those offsets are no-ops; reads return 0.
 //!
-//! Observer protocol matches `peripherals::esp32s3::gpio::GpioObserver` —
+//! Observer protocol is the shared `peripherals::device::GpioObserver` —
 //! a single trait makes observer code work on both chip variants.
 
 use crate::peripherals::pad_routing::PadRoutes;
@@ -188,12 +188,17 @@ struct Esp32PortTap {
     scratch: Vec<Option<bool>>,
 }
 
-/// Notified synchronously inside the bus write path on every GPIO pin
-/// transition. Observers must not panic — a panic propagates out of
-/// `bus.write_u8` and crashes the simulator.
-pub trait GpioObserver: Send + Sync + std::fmt::Debug {
-    fn on_pin_change(&self, pin: u8, from: bool, to: bool, sim_cycle: u64);
-}
+/// Edge-observation contract for anything watching this port's pads.
+/// Declared in [`peripherals::device`](crate::peripherals::device) — ONE
+/// declaration shared by every GPIO family — and re-exported here so every
+/// existing `impl`, bound and intra-doc link at this path keeps resolving.
+///
+/// It used to be declared separately, byte for byte, in the classic-ESP32
+/// and S3 GPIO models. Two identical traits are two types: a component that
+/// wanted edges on both families wrote the same `impl` twice, and every
+/// call site accepting an observer carried a two-trait bound that no third
+/// family could satisfy without a third copy of all of it.
+pub use crate::peripherals::device::GpioObserver;
 
 /// ESP32-classic GPIO peripheral.
 pub struct Esp32Gpio {

--- a/crates/core/src/peripherals/esp32s3/gpio.rs
+++ b/crates/core/src/peripherals/esp32s3/gpio.rs
@@ -226,12 +226,17 @@ const fn spec(word: usize) -> Option<(u32, u32)> {
     }
 }
 
-/// Notified synchronously inside the bus write path on every GPIO pin
-/// transition. Observers must not panic — a panic propagates out of
-/// `bus.write_u8` and crashes the simulator.
-pub trait GpioObserver: Send + Sync + std::fmt::Debug {
-    fn on_pin_change(&self, pin: u8, from: bool, to: bool, sim_cycle: u64);
-}
+/// Edge-observation contract for anything watching this port's pads.
+/// Declared in [`peripherals::device`](crate::peripherals::device) — ONE
+/// declaration shared by every GPIO family — and re-exported here so every
+/// existing `impl`, bound and intra-doc link at this path keeps resolving.
+///
+/// It used to be declared separately, byte for byte, in the classic-ESP32
+/// and S3 GPIO models. Two identical traits are two types: a component that
+/// wanted edges on both families wrote the same `impl` twice, and every
+/// call site accepting an observer carried a two-trait bound that no third
+/// family could satisfy without a third copy of all of it.
+pub use crate::peripherals::device::GpioObserver;
 
 /// ESP32-S3 GPIO peripheral. Mapped at 0x6000_4000.
 /// Push-capture state for one S3 GPIO port. `scratch` caches each watched

--- a/crates/core/src/peripherals/i2c.rs
+++ b/crates/core/src/peripherals/i2c.rs
@@ -22,112 +22,11 @@ use crate::{CycleClock, SimResult};
 use std::cell::{Cell, RefCell};
 use std::str::FromStr;
 
-pub trait I2cDevice: Send {
-    fn address(&self) -> u8;
-    fn read(&mut self) -> u8;
-    fn write(&mut self, data: u8);
-    fn start(&mut self) {}
-    fn stop(&mut self) {}
-
-    /// What this device can show of itself — its own inspect evidence.
-    ///
-    /// The ONE place a an I²C device's artifacts are decided is the model
-    /// itself, next to the buffers it owns. Default: nothing, which is correct
-    /// for a sensor with no display surface and honest for anything else —
-    /// absent means "this engine has nothing to show", never "the screen was
-    /// blank". See [`crate::inspect::DeviceEvidence`] for why this is not a
-    /// central match on concrete types.
-    ///
-    /// Implementations must read the model's REAL buffer and synthesize
-    /// nothing; a panel that was never painted reports zero.
-    fn artifacts(
-        &self,
-        _id: &str,
-        _opts: &crate::inspect::InspectOpts,
-    ) -> Vec<crate::inspect::Artifact> {
-        Vec::new()
-    }
-
-    /// Does this device answer to `addr` on the wire *right now*?
-    ///
-    /// A plain slave owns exactly one address, so the default is the obvious
-    /// `self.address() == addr` — every existing model keeps its behaviour with
-    /// no edit. The hook exists for devices whose answered-address set is not a
-    /// singleton and is not static: an I²C **bus switch** (TCA9548A) answers to
-    /// its own control address *and*, while a channel is enabled, to every
-    /// address reachable behind that channel. That set changes whenever
-    /// firmware rewrites the switch's control register, so it cannot be
-    /// flattened into one `address()` at attach time.
-    ///
-    /// Controllers MUST resolve a slave with this, never by comparing
-    /// `address()` — a flat `position(|d| d.address() == addr)` is first-match
-    /// and makes four identical sensors behind a mux collapse into one.
-    fn claims_address(&self, addr: u8) -> bool {
-        self.address() == addr
-    }
-
-    /// Tell the device which address the master just selected, immediately
-    /// after [`claims_address`](Self::claims_address) returned `true` for it and
-    /// before any `start`/`write`/`read`/`stop` of that transaction.
-    ///
-    /// Default no-op: a single-address slave already knows who it is. A bus
-    /// switch uses it to decide whether this transaction targets its own
-    /// control register or is to be forwarded to the downstream device(s) that
-    /// claim `addr` on the currently enabled channel(s).
-    fn select_address(&mut self, addr: u8) {
-        let _ = addr;
-    }
-
-    /// Walk every [`SimInput`](crate::sim_input::SimInput) surface this device
-    /// exposes, including devices nested *behind* it. Returns `true` if `f`
-    /// asked to stop early.
-    ///
-    /// The default is exactly the old behaviour — a device offers at most its
-    /// own [`as_sim_input_mut`](Self::as_sim_input_mut). It is overridden by
-    /// containers (the TCA9548A mux) so their children stay reachable from the
-    /// ONE stimulus walk in [`crate::bus::SystemBus::for_each_sim_input`].
-    /// Without it, putting a sensor behind a mux would silently subtract it
-    /// from `list_inputs` / `set_input` — the same class of invisible-device
-    /// bug the controller-level seam was introduced to kill.
-    fn for_each_sim_input(
-        &mut self,
-        f: &mut dyn FnMut(&mut dyn crate::sim_input::SimInput) -> bool,
-    ) -> bool {
-        match self.as_sim_input_mut() {
-            Some(si) => f(si),
-            None => false,
-        }
-    }
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        None
-    }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        None
-    }
-    /// Runtime-drivable view of this device, if it accepts simulated input.
-    /// Overridden by input devices (accelerometers, …) so the generic
-    /// [`crate::Machine::set_input`] resolver can reach them without a
-    /// downcast. Default `None` = not an input device.
-    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
-        None
-    }
-
-    /// Advance this device's free-running sample/measurement clock by `us`
-    /// microseconds of wall-clock time.
-    ///
-    /// Real sensors sample on their own oscillator, independent of when the CPU
-    /// gets around to reading them: a PPG FIFO keeps filling at its configured
-    /// rate whether or not firmware is draining it. A bus master that knows the
-    /// elapsed wall-clock calls this on a slave immediately before servicing it,
-    /// so a *late* poll observes exactly the samples that accrued while the CPU
-    /// was busy elsewhere — and a FIFO that was allowed to overrun reports the
-    /// overflow it really would have. Without this hook a model only advances on
-    /// the very transactions that would have prevented the overflow, which hides
-    /// precisely the CPU-starvation failures worth simulating.
-    ///
-    /// Default no-op: a purely register-mapped device has no clock to advance.
-    fn advance_time_us(&mut self, _us: u64) {}
-}
+/// The off-chip I²C slave contract. Declared in
+/// [`peripherals::device`](crate::peripherals::device) — the ONE home for the
+/// vocabulary of things that hang off a wire — and re-exported here so every
+/// existing `impl`, bound and intra-doc link at this path keeps resolving.
+pub use crate::peripherals::device::I2cDevice;
 
 /// I2C register layout selector. STM32F1/F2/F4 share the legacy I2C
 /// peripheral; STM32L4/F7/H5/G0 share the modern peripheral. The config-facing

--- a/crates/core/src/peripherals/kit/ctx.rs
+++ b/crates/core/src/peripherals/kit/ctx.rs
@@ -225,9 +225,7 @@ impl<'a> AttachCtx<'a> {
     /// in `from_config` so bit-bang devices share one attach path.
     pub fn install_gpio_observer<T>(&mut self, observer: std::sync::Arc<T>)
     where
-        T: crate::peripherals::esp32s3::gpio::GpioObserver
-            + crate::peripherals::esp32::gpio::GpioObserver
-            + 'static,
+        T: crate::peripherals::device::GpioObserver + 'static,
     {
         SystemBus::install_gpio_observer(self.bus, observer);
     }

--- a/crates/core/src/peripherals/mod.rs
+++ b/crates/core/src/peripherals/mod.rs
@@ -17,6 +17,7 @@ pub mod crc;
 pub mod dac;
 pub mod dbgmcu;
 pub mod declarative;
+pub mod device;
 pub mod dma;
 pub mod dwt;
 pub mod efr32;

--- a/crates/core/src/peripherals/spi.rs
+++ b/crates/core/src/peripherals/spi.rs
@@ -13,117 +13,18 @@
 // `as_any`) is unchanged. The chip-yaml `profile` selects the variant.
 
 use crate::{Bus, SimResult};
-use std::any::Any;
 use std::cell::Cell;
 use std::str::FromStr;
-use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 
 use crate::peripherals::pad_lines::PadLines;
 use crate::peripherals::spi_waveform::{NarrationFit, SpiFraming, SpiNarrator};
 
-/// Trait implemented by simulated SPI devices (peripherals attached to an SPI bus).
-///
-/// For v1, CS-pin-aware routing is not implemented: all transfers are broadcast
-/// to every attached device and the first non-zero MISO byte wins.  This is
-/// correct for single-device labs (MAX31855 alone).  CS-aware routing is noted
-/// as a Phase 2 follow-up.
-pub trait SpiDevice: Send {
-    fn needs_external_bus_poll(&self) -> bool {
-        false
-    }
-    fn component_id(&self) -> Option<&str> {
-        None
-    }
-    fn attach_can_bus(
-        &mut self,
-        _tx: Sender<crate::network::CanFrame>,
-        _rx: Receiver<crate::network::CanFrame>,
-    ) -> anyhow::Result<()> {
-        anyhow::bail!("SPI device is not a CAN controller")
-    }
-    fn poll_external_bus(&mut self) {}
-    /// Called when the CS line goes low (chip is selected).
-    fn cs_select(&mut self) {}
-    /// Called when the CS line goes high (chip is released — flush state).
-    fn cs_release(&mut self) {}
-    /// SPI is full-duplex: master sends `mosi_byte`, device returns its current MISO byte.
-    /// On read-only devices like MAX31855, `mosi_byte` is ignored.
-    fn transfer(&mut self, mosi_byte: u8) -> u8;
-    /// CS pin label this device is wired to (e.g. "PA4" or numeric pin ID). Used by the bus
-    /// dispatcher to pick which device responds when the firmware drives a particular CS line.
-    fn cs_pin(&self) -> &str;
-
-    /// What this device can show of itself — its own inspect evidence.
-    ///
-    /// The ONE place a a SPI device's artifacts are decided is the model
-    /// itself, next to the buffers it owns. Default: nothing, which is correct
-    /// for a sensor with no display surface and honest for anything else —
-    /// absent means "this engine has nothing to show", never "the screen was
-    /// blank". See [`crate::inspect::DeviceEvidence`] for why this is not a
-    /// central match on concrete types.
-    ///
-    /// Implementations must read the model's REAL buffer and synthesize
-    /// nothing; a panel that was never painted reports zero.
-    fn artifacts(
-        &self,
-        _id: &str,
-        _opts: &crate::inspect::InspectOpts,
-    ) -> Vec<crate::inspect::Artifact> {
-        Vec::new()
-    }
-    /// Data/Command (D/C) pin label this device observes, if any (e.g. "PB6").
-    ///
-    /// Displays like the Nokia 5110 (PCD8544) distinguish command bytes from
-    /// pixel-data bytes by the level of a dedicated GPIO line rather than by
-    /// byte semantics. When this returns `Some(pin)`, the bus latches that
-    /// pin's current output level into the device via [`set_dc_level`] after
-    /// each MMIO write, so the value is current by the time the firmware
-    /// writes the SPI data register. Default `None` → the bus does no latching
-    /// and the device infers framing from the protocol (ILI9341 / SSD1680).
-    ///
-    /// [`set_dc_level`]: SpiDevice::set_dc_level
-    fn dc_pin(&self) -> Option<&str> {
-        None
-    }
-    /// Latched level of the [`dc_pin`](SpiDevice::dc_pin) at transfer time,
-    /// pushed by the bus. No-op for devices that do not observe a D/C line.
-    fn set_dc_level(&mut self, _level: bool) {}
-    /// Resolved `(ODR address, bit)` of the D/C line. The bus computes this
-    /// once at install time (from [`dc_pin`](SpiDevice::dc_pin)) and records it
-    /// via [`set_dc_source`]; thereafter the bus reads that GPIO output bit
-    /// just before each transfer and pushes the level via [`set_dc_level`].
-    /// Default `None` → no D/C latching.
-    ///
-    /// [`set_dc_source`]: SpiDevice::set_dc_source
-    fn dc_source(&self) -> Option<(u64, u8)> {
-        None
-    }
-    /// Bus-side setter recording the resolved D/C `(ODR address, bit)`.
-    fn set_dc_source(&mut self, _odr_addr: u64, _bit: u8) {}
-    fn as_any(&self) -> Option<&dyn Any> {
-        None
-    }
-    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
-        None
-    }
-    /// Runtime-drivable view of this device, if it accepts simulated input.
-    /// Same contract as the hook on `I2cDevice`: input devices override it so
-    /// the generic [`crate::Machine::set_input`] resolver can reach them
-    /// without a downcast. Default `None` = not an input device.
-    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
-        None
-    }
-    /// Binary mid-flight snapshot for runtime resume. Default empty;
-    /// override for stateful devices (e-paper panels with framebuffers,
-    /// thermocouples with cached temperatures, etc.).
-    fn runtime_snapshot(&self) -> Vec<u8> {
-        Vec::new()
-    }
-    fn restore_runtime_snapshot(&mut self, _bytes: &[u8]) -> crate::SimResult<()> {
-        Ok(())
-    }
-}
+/// The off-chip SPI device contract. Declared in
+/// [`peripherals::device`](crate::peripherals::device) — the ONE home for the
+/// vocabulary of things that hang off a wire — and re-exported here so every
+/// existing `impl`, bound and intra-doc link at this path keeps resolving.
+pub use crate::peripherals::device::SpiDevice;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/core/src/peripherals/uart.rs
+++ b/crates/core/src/peripherals/uart.rs
@@ -8,7 +8,6 @@ use super::pad_lines::PadLines;
 use super::uart_waveform::{UartFraming, UartNarrator};
 use super::wave_plan::NarrationFit;
 use crate::SimResult;
-use std::any::Any;
 use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::str::FromStr;
@@ -52,64 +51,13 @@ pub struct UartTraceEvent {
     pub byte: u8,
 }
 
-/// A UART model that can host a [`UartStreamDevice`] — the contract an
-/// inter-chip cross-link binds to.
-///
-/// This exists so the cross-link seam names a CAPABILITY rather than one
-/// concrete struct. It used to downcast to [`Uart`], which silently excluded
-/// every chip family with its own UART model: an ESP32-C3's `uart1` reported
-/// "is not a UART" and two C3s could not be wired together at all. A new UART
-/// model now joins by implementing this trait, not by editing the seam.
-pub trait UartStreamHost {
-    /// Bind a peer to this UART's RX/TX paths.
-    fn attach_stream_device(&mut self, dev: Box<dyn UartStreamDevice>);
-
-    /// Stop mirroring TX to the console/capture sink. A cross-linked UART
-    /// carries raw protocol octets, not console text, and letting those into
-    /// the serial monitor floods it with binary that looks identical on both
-    /// peers.
-    fn detach_console_sink(&mut self);
-
-    /// True when any attached peer carries protocol octets — the test
-    /// `attach_uart_tx_sink` uses to leave a linked UART off the console sink.
-    fn hosts_protocol_peer(&self) -> bool;
-}
-
-/// A device that emits bytes through the UART's RX path (e.g. a GPS module).
-pub trait UartStreamDevice: Send {
-    /// Called periodically by the bus tick. Returns the next byte to push into UART RX,
-    /// or None if no byte is pending. Implementations should respect `elapsed_us` to
-    /// pace output (e.g. 9600 baud → ~1 ms/byte → emit one byte per ~1000 us tick).
-    fn poll(&mut self, elapsed_us: u32) -> Option<u8>;
-    /// Observe a byte transmitted by firmware on the TX path. Default: ignore.
-    /// Bidirectional peers (e.g. an IO-Link master) override this to receive the
-    /// device's responses, complementing `poll` which drives the RX path.
-    fn on_tx_byte(&mut self, _byte: u8) {}
-
-    /// True when this peer's traffic is raw protocol octets rather than console
-    /// text, so the UART hosting it must be kept OFF the console capture sink.
-    ///
-    /// Without this, a node's link UART and its console UART push into the same
-    /// buffer and the two byte streams splice together — a two-chip run prints
-    /// `pPiInNgGer up` and no serial assertion can be trusted. Default `false`:
-    /// an ordinary stream device (a GPS emitting NMEA) is console-safe.
-    fn carries_protocol_octets(&self) -> bool {
-        false
-    }
-    fn as_any(&self) -> Option<&dyn Any> {
-        None
-    }
-    fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
-        None
-    }
-    /// Runtime-drivable view of this device, if it accepts simulated input.
-    /// Same contract as the hook on `I2cDevice`: input devices override it so
-    /// the generic [`crate::Machine::set_input`] resolver can reach them
-    /// without a downcast. Default `None` = not an input device.
-    fn as_sim_input_mut(&mut self) -> Option<&mut dyn crate::sim_input::SimInput> {
-        None
-    }
-}
+/// The UART cross-link contracts — a model that can HOST a stream peer
+/// ([`UartStreamHost`]) and the peer itself ([`UartStreamDevice`]). Declared
+/// in [`peripherals::device`](crate::peripherals::device) — the ONE home for
+/// the vocabulary of things that hang off a wire — and re-exported here so
+/// every existing `impl`, bound and intra-doc link at this path keeps
+/// resolving.
+pub use crate::peripherals::device::{UartStreamDevice, UartStreamHost};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -11,24 +11,24 @@ The models column is a content digest over everything that board's `models` list
 |-------|------|----------------------|--------|--------|
 | `nrf52840` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending) |
 | `seeed-xiao-nrf52840-sense` | 🟢 silicon-verified | 2026-08-09 | `04d349f125b91bd6` | ⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending) |
-| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `f74e787229a42a69` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `stm32h563` | 🟢 silicon-verified | 2026-08-10 | `e6a7c0479a962ada` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
 | `esp32c3` | 🟢 silicon-verified | 2026-08-09 | `5c35a6f778b2787a` | ⚠ drift acked 2026-08-22, expires 2026-09-21 (re-capture pending) |
-| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `7228fac77c86d817` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
-| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `78eca237f59b067f` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
-| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `5780ce19be964586` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
-| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `fd5c841eb1ab9f1a` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
-| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `7601f41b277b41da` | ⚠ drift acked 2026-08-23, expires 2026-09-22 (re-capture pending) |
+| `nucleo-l476rg` | 🟢 silicon-verified | 2026-08-09 | `70afb05b26f0a9ee` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `nucleo-l073rz` | 🟢 silicon-verified | 2026-08-09 | `b18bb27d064db6a9` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `stm32f103` | 🟢 silicon-verified | 2026-08-09 | `8cf71b344af92780` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `stm32f407` | 🟢 silicon-smoke | 2026-06-20 | `9b9e0c07d8492921` | ⚠ drift acked 2026-08-24, expires 2026-09-23 (re-capture pending) |
+| `esp32s3` | 🟢 silicon-verified | 2026-08-09 | `89d498518d56833d` | ⚠ drift acked 2026-08-23, expires 2026-09-22 (re-capture pending) |
 | `stm32f401` | 🟡 smoke-manual | — | `70dc5cdb821b4fd1` | no silicon capture |
 | `stm32wba52` | 🟡 smoke-manual | — | `54357ab00d5380ea` | no silicon capture |
 | `nrf52832` | ⚪ structural | — | `4868d947c79c522f` | no silicon capture |
 | `rp2040` | ⚪ structural | — | `6ed07913f151b582` | no silicon capture |
 | `rp2350` | 🟡 smoke-manual | — | `5f078da8df1f94c5` | no silicon capture |
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `303234a1ddb9e5ad` | no silicon capture |
-| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `4bc42a793d29aa15` | no silicon capture |
-| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `0dca4a83963083ce` | no silicon capture |
+| `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `e0b9f7806fb8f867` | no silicon capture |
+| `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `83818f98402d4de9` | no silicon capture |
 | `brd2709a` | 🟡 smoke-manual | — | `9932bc76c215ca4c` | no silicon capture |
 | `esp32` | ⚪ structural | — | `f2264e3d66957844` | no silicon capture |
-| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `b2a67ec6a44dffaf` | no silicon capture |
+| `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `f6645581571bd944` | no silicon capture |
 | `nrf54l15` | 🔵 sim-validated (deep model, no HW diff) | — | `2474872ffcd181ac` | no silicon capture |
 | `stm32g474re` | 🔵 sim-validated (deep model, no HW diff) | — | `dd70d18ad77eea65` | no silicon capture |
 | `stm32wb55` | 🔵 sim-validated (deep model, no HW diff) | — | `969b7346ea411c7b` | no silicon capture |

--- a/validation/manifest.yaml
+++ b/validation/manifest.yaml
@@ -1097,7 +1097,7 @@ boards:
     # idr_pin_level_tests (3), all green. This is an ACK, NOT A CAPTURE — a live
     # re-capture on this board is still owed.
     drift_ack: 2026-08-24
-    drift_ack_digest: f74e787229a42a69ed7716a1fba32c3703f8016a3521634de9c6eb416b1512ce
+    drift_ack_digest: e6a7c0479a962ada8585851c8735e065090b676ad211e8bb78fa776dc60e2490
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2273,7 +2273,7 @@ boards:
     # idr_pin_level_tests (3), all green. This is an ACK, NOT A CAPTURE — a live
     # re-capture on this board is still owed.
     drift_ack: 2026-08-24
-    drift_ack_digest: 7228fac77c86d817206be8e37fbbee9d5088aa3caf607cf226de11dab6e917ca
+    drift_ack_digest: 70afb05b26f0a9ee97b6c6c9680c5e8e3c85dd2eca3b5e30633befa831a6c9c9
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -2641,7 +2641,7 @@ boards:
     # idr_pin_level_tests (3), all green. This is an ACK, NOT A CAPTURE — a live
     # re-capture on this board is still owed.
     drift_ack: 2026-08-24
-    drift_ack_digest: 78eca237f59b067fd738fa96058869da10b82f65dce4dd54b6a3537d569f4a56
+    drift_ack_digest: b18bb27d064db6a933712f6e290a9154f2dcede8d1981bc342be9ddb829b7858
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -3069,7 +3069,7 @@ boards:
     # idr_pin_level_tests (3), all green. This is an ACK, NOT A CAPTURE — a live
     # re-capture on this board is still owed.
     drift_ack: 2026-08-24
-    drift_ack_digest: 5780ce19be9645869b4185584962e1373cb66852a9f671175cd8a90132ede452
+    drift_ack_digest: 8cf71b344af92780991f0b079991fca197b531fd7dc60c15e5c3ac726871a7b0
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     models:
       - crates/core/src/cpu/cortex_m.rs
@@ -3457,7 +3457,7 @@ boards:
     # idr_pin_level_tests (3), all green. This is an ACK, NOT A CAPTURE — a live
     # re-capture on this board is still owed.
     drift_ack: 2026-08-24
-    drift_ack_digest: fd5c841eb1ab9f1a5c4fa6fcecfff0788c0b34fb2aea6d4726ad57083f71e564
+    drift_ack_digest: 9b9e0c07d849292195854123981cd6099f1346198e9baea13d58d1a762018bb7
     # 2026-08-05: deterministic motor plants (DC/BLDC physics + bus service) land; shared timer/bus paths may be watched for this board. Additive plant models; no live re-capture this session — tracked.
     # 2026-08-12: chip yaml adds bxcan1 (type bxcan @ 0x40006400, APB1ENR bit 25) for
     # Arduino matrix L8 loopback. Existing BxCan model; no register-map change to
@@ -3996,7 +3996,7 @@ boards:
       # changes. Behaviour-preserving extraction, not a model correction —
       # `pr-workspace-tests` green on all shards is what exercises this peripheral,
       # so nothing the silicon capture asserts changed and the capture stands.
-    drift_ack_digest: 7601f41b277b41da8799dd7554689c238e44da88b4ab95012499cff98be979cd
+    drift_ack_digest: 89d498518d56833dc22d93ad933fcbda26da0dca280d7d5729fe441726081a58
     models:
       - crates/core/src/cpu/xtensa_lx7.rs
       - crates/core/src/decoder/xtensa.rs


### PR DESCRIPTION
Steps 1 and 2 of ledger row **C-1**. No crate move — these are the two steps that pay for themselves whether or not the crate is ever split.

## Why, in one measurement

`crates/core` is 349,982 of the 440,419-line workspace. The blocker is not size, it is coupling: over the last 400 commits, **14 touched `src/peripherals/components/` and only 3 touched nothing else — 25 also edited `crates/core/src/bus/`**. A device change is an engine change. Fix that and the crate boundary becomes cheap; skip it and the boundary is cosmetic.

## Step 1 — one home for the device traits

New `peripherals/device.rs` holds all five off-chip device traits, with `pub use` left at every old path so **no call site changes**:

| Trait | Was |
|---|---|
| `I2cDevice` | `peripherals/i2c.rs` |
| `SpiDevice` | `peripherals/spi.rs` |
| `UartStreamHost` / `UartStreamDevice` | `peripherals/uart.rs` |
| `GpioObserver` | `esp32/gpio.rs` **and** `esp32s3/gpio.rs` |

Verified byte-identical by extracting each trait block by name from the base commit and diffing against the new file — all six **VERBATIM**, doc comments included. 7 files still import through the old paths, unedited, and compile.

## Step 2 — unify `GpioObserver`

Two byte-identical declarations, and six component files implemented **both**: `servo`, `ws2812`, `step_dir_motor`, `h_bridge_motor`, `unipolar_stepper`, `ili9341_parallel`. 12 impls → **6**, zero family-path impls left.

The two-trait bound `T: esp32s3::GpioObserver + esp32::GpioObserver` existed in **two** places, not one — `kit/ctx.rs:228` and also `bus/from_config.rs:1090` (`SystemBus::install_gpio_observer`, the choke point `AttachCtx` delegates to). Both now take the single trait.

**The concrete win**, in `ws2812.rs`’s own test:

```diff
-use crate::peripherals::esp32s3::gpio::{Esp32s3Gpio, GpioObserver};
+use crate::peripherals::device::GpioObserver;
+use crate::peripherals::esp32s3::gpio::Esp32s3Gpio;
```

The contract under test stops naming a silicon family. A third family now needs one `impl` on `Ws2812`, not one per family on all six components.

## Ratchet — unchanged, and that is correct

`downcast_ratchet.rs`: `as_any=193 downcast_ref=207` before and after (files scanned 993 → 994, the new `device.rs`). Traits were **relocated, not rewritten**, so no ceiling moved and none should have. `peripheral_kit_gate` 8/8, `device_identity_one_home` 5/5, `no_vacuous_test_targets` pass.

## Verified

Every command run at both the base and the branch:

| | base | branch |
|---|---|---|
| `cargo +1.95.0 fmt --all -- --check` | clean | clean |
| `cargo check -p labwired-core` | exit 0 | exit 0 |
| `cargo check -p labwired-core --features event-scheduler` | exit 0 | exit 0 |
| `cargo check -p labwired-core --all-targets` | exit 0 | **exit 0 (re-run independently)** |
| targeted `cargo test` (device_identity_one_home, ws2812, servo, stepper, h_bridge, ili9341_parallel, gpio, downcast_ratchet, peripheral_kit_gate, esp32s3_ws2812_rmt, intmatrix_alarm) | 163 + 10 passed | 163 + 10 passed |

`--all-targets` is the one that matters: it proves the `crates/core/tests/` integration targets still compile through the re-exports.

## Not verified

`--all-features` fails at base **and** on the branch — `iolink-native` builds C against the uninitialized `third_party/iolinki` submodule. Pre-existing and environmental. No wasm/CLI build; `grep` finds no reference to the five traits outside `crates/core`, and the re-exports keep every old path valid regardless.