### PR TITLE
fix(ci): one source for -Tlink.x — main's cold build was broken

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -476,6 +476,18 @@ jobs:
       - name: Every `#[ignore]` says why
         run: python3 scripts/ci/ignore_reasons.py --check
 
+      # A doubled `-Tlink.x` duplicates memory.x's MEMORY block and the link
+      # dies with "region 'FLASH' already defined". It is invisible on a warm
+      # `target/` — cargo does not relink a cached artifact — so the build step
+      # further down carried the flag for a week after the crate's build.rs
+      # started passing its own, stayed green on the self-hosted runners, and
+      # failed the first time it ran on a clean one. The rule is derived, not
+      # listed: a crate whose build.rs emits the flag owns it, and no caller may
+      # repeat it. Pure Python, no toolchain, so it sits before the Rust
+      # install with the two checks above.
+      - name: One source for `-Tlink.x`
+        run: python3 scripts/ci/linker_script_single_source.py --check
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.95.0
         with:
@@ -537,6 +549,7 @@ jobs:
             scripts/ci/test_matrix_verdict.py \
             scripts/ci/test_cheat_ratchet.py \
             scripts/ci/test_ignore_reasons.py \
+            scripts/ci/test_linker_script_single_source.py \
             scripts/ci/test_workspace_test_shard.py \
             scripts/test_generate_validation_status.py
 
@@ -1572,7 +1585,18 @@ jobs:
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi
           cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
           cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
-          RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
+          # No RUSTFLAGS here. firmware-rp2040-pio-onboarding passes its own
+          # `-Tlink.x` from build.rs, so a plain `cargo build -p <crate>` links
+          # on its own.
+          #
+          # ⚠️ Exactly one place may pass `-Tlink.x`. This line used to add it
+          # too; once the crate's build.rs started passing its own
+          # (labwired-core#1064) the script was included twice, along with the
+          # memory.x it consumes, and the link died with "region 'FLASH'
+          # already defined". A warm target/ hides it — cargo does not relink a
+          # cached artifact — so this stayed green on the self-hosted runners
+          # and only fell over the first time the job ran on a clean one.
+          cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
           cargo build -p firmware-ci-fixture --target thumbv7m-none-eabi
 
       - name: Run Workspace Tests

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1591,6 +1591,28 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-arm-none-eabi
 
+      # ubuntu-latest ships ~14 GB free, and this job builds the workspace test
+      # binaries twice — once on default features, once on `jit,event-scheduler`
+      # — with debug info. `Feature tests` died on:
+      #
+      #     rustc-LLVM ERROR: IO failure on output stream: No space left on device
+      #     collect2: fatal error: ld terminated with signal 7 [Bus error]
+      #
+      # The bus error is the same exhaustion wearing a different hat, which is
+      # why this looked like an LLVM crash and says "PLEASE submit a bug report".
+      #
+      # The images carry ~25 GB of preinstalled SDKs this job never touches.
+      # Measured, not assumed: the df either side is printed, so if a future
+      # image stops shipping them the log says so instead of the step quietly
+      # freeing nothing.
+      - name: Reclaim runner disk
+        run: |
+          df -h / | tail -1
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+                      /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
+          docker image prune -af >/dev/null 2>&1 || true
+          df -h / | tail -1
+
       - name: Build test firmware fixture
         run: |
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -1580,6 +1580,17 @@ jobs:
           rustup target add thumbv7em-none-eabihf
           rustup target add thumbv8m.main-none-eabi
 
+      # `pr-workspace-tests` installs this and this job did not, so the same
+      # OBD2 end-to-end passed on every PR and failed here — the ECU half is C,
+      # built with arm-none-eabi-gcc, and the test builds it itself. It asserts
+      # rather than skips (a gate that cannot build its inputs is not a gate),
+      # so the absent compiler is a hard failure, and it was invisible for as
+      # long as the firmware build above failed first and skipped this step.
+      - name: Add the C cross-compiler (OBD2 ECU firmware)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi
+
       - name: Build test firmware fixture
         run: |
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi

--- a/.github/workflows/core-coverage-weekly.yml
+++ b/.github/workflows/core-coverage-weekly.yml
@@ -76,7 +76,18 @@ jobs:
           cargo build -p demo-blinky --release --target thumbv7m-none-eabi
           cargo build -p firmware-h563-io-demo --release --target thumbv7m-none-eabi
           cargo build -p firmware-f401-demo --release --target thumbv7em-none-eabi
-          RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
+          # No RUSTFLAGS here. firmware-rp2040-pio-onboarding passes its own
+          # `-Tlink.x` from build.rs, so a plain `cargo build -p <crate>` links
+          # on its own.
+          #
+          # ⚠️ Exactly one place may pass `-Tlink.x`. This line used to add it
+          # too; once the crate's build.rs started passing its own
+          # (labwired-core#1064) the script was included twice, along with the
+          # memory.x it consumes, and the link died with "region 'FLASH'
+          # already defined". A warm target/ hides it — cargo does not relink a
+          # cached artifact — so this stayed green on the self-hosted runners
+          # and only fell over the first time the job ran on a clean one.
+          cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
 
       - name: Run coverage
         run: |

--- a/crates/core/tests/rp2040_pio_onboarding.rs
+++ b/crates/core/tests/rp2040_pio_onboarding.rs
@@ -30,9 +30,12 @@
 //!
 //! The fixture is built by the core-ci "Build test firmware fixture" step:
 //! ```text
-//! RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2040-pio-onboarding \
-//!     --release --target thumbv6m-none-eabi
+//! cargo build -p firmware-rp2040-pio-onboarding --release --target thumbv6m-none-eabi
 //! ```
+//! No RUSTFLAGS: the crate passes its own `-Tlink.x` from build.rs, and
+//! passing it a second time fails the link with "region 'FLASH' already
+//! defined".
+//!
 //! When it is absent (a plain `cargo test` without that pre-build) the test
 //! skips with a notice rather than failing spuriously.
 
@@ -83,7 +86,7 @@ fn rp2040_pio_onboarding_reaches_pio_ok() {
         labwired_core::test_support::skip_or_fail_missing_firmware(
             "firmware-rp2040-pio-onboarding",
             &format!("RP2040 PIO onboarding fixture ({})", firmware.display()),
-            "RUSTFLAGS=\"-C link-arg=-Tlink.x\" cargo build -p firmware-rp2040-pio-onboarding \
+            "cargo build -p firmware-rp2040-pio-onboarding \
              --release --target thumbv6m-none-eabi",
         );
         return;

--- a/scripts/ci/linker_script_single_source.py
+++ b/scripts/ci/linker_script_single_source.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Exactly one place may pass `-Tlink.x` for a firmware crate.
+
+`cortex-m-rt`'s `link.x` pulls in the `memory.x` a firmware crate's build.rs
+writes. Include it twice and the MEMORY block is defined twice, and the link
+dies with:
+
+    rust-lld: error: .../out/memory.x:10: region 'FLASH' already defined
+
+This has now happened twice, both times the same way: a crate's build.rs
+started passing its own `-Tlink.x` (so that a plain
+`cargo build -p <crate> --target <t>` links on its own, instead of producing an
+ELF with entry point 0x0 that the simulator rejects at step 0) while some
+caller kept its `RUSTFLAGS="-C link-arg=-Tlink.x"` prefix.
+
+It hides well. Cargo does not relink a cached artifact, so on a warm `target/`
+the doubled flag costs nothing; the break appears only on a cold build. In
+2026-08 that meant core-ci was green on the self-hosted runners for a week and
+went red the first time the job landed on a clean hosted one.
+
+So this derives the rule instead of restating it: any crate whose build.rs
+emits `cargo:rustc-link-arg=-Tlink.x` owns that flag, and no workflow or script
+may pass it again for that crate. Nothing here is a hardcoded list — add a
+build.rs line and the callers are checked from the next run on.
+
+    python3 scripts/ci/linker_script_single_source.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+BUILD_RS_EMIT = re.compile(r'cargo:rustc-link-arg=-Tlink\.x')
+PASSES_LINK_X = re.compile(r'-Tlink\.x')
+# `-p crate`, `-p=crate` and `--package crate`, quoted or not.
+PACKAGE_ARG = re.compile(r'(?:-p|--package)[=\s]+"?\'?([A-Za-z0-9_.-]+)')
+
+
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _is_comment(line: str) -> bool:
+    stripped = line.lstrip()
+    return stripped.startswith("#") or stripped.startswith("//")
+
+
+def _without_block_comments(text: str) -> str:
+    """Blank out `/* ... */` spans, keeping line numbers intact.
+
+    A build.rs that carries its emit inside a block comment is not an owner.
+    Getting this wrong points the gate at a crate that passes nothing, and the
+    message it prints would then be false in both halves.
+    """
+    return BLOCK_COMMENT.sub(lambda m: re.sub(r"[^\n]", " ", m.group(0)), text)
+
+
+def self_linking_crates(root: Path) -> dict[str, Path]:
+    """Crates whose own build.rs passes `-Tlink.x`."""
+    found: dict[str, Path] = {}
+    for build_rs in sorted(root.glob("crates/*/build.rs")):
+        text = _without_block_comments(
+            build_rs.read_text(encoding="utf-8", errors="replace")
+        )
+        for line in text.splitlines():
+            if _is_comment(line):
+                continue
+            if BUILD_RS_EMIT.search(line):
+                found[build_rs.parent.name] = build_rs.relative_to(root)
+                break
+    return found
+
+
+def _scanned_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    workflows = root / ".github" / "workflows"
+    if workflows.is_dir():
+        files.extend(sorted(workflows.glob("*.yml")))
+        files.extend(sorted(workflows.glob("*.yaml")))
+    scripts = root / "scripts"
+    if scripts.is_dir():
+        files.extend(sorted(scripts.rglob("*.sh")))
+    return files
+
+
+def violations(root: Path) -> list[str]:
+    owners = self_linking_crates(root)
+    if not owners:
+        return []
+
+    out: list[str] = []
+    for path in _scanned_files(root):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for number, line in enumerate(text.splitlines(), start=1):
+            if _is_comment(line) or not PASSES_LINK_X.search(line):
+                continue
+            for crate in PACKAGE_ARG.findall(line):
+                if crate in owners:
+                    rel = path.relative_to(root)
+                    out.append(
+                        f"{rel}:{number}: passes -Tlink.x for `{crate}`, which "
+                        f"already passes its own from {owners[crate]}. Two "
+                        f"copies of link.x duplicate memory.x's MEMORY block "
+                        f'("region \'FLASH\' already defined") on any cold '
+                        f"build. Drop the flag here: `cargo build -p {crate} "
+                        f"--release --target <target>` links on its own."
+                    )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero when a caller re-passes a crate's own -Tlink.x",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repository root to scan (default: this checkout)",
+    )
+    args = parser.parse_args(argv)
+
+    owners = self_linking_crates(args.root)
+    found = violations(args.root)
+
+    if found:
+        print("-Tlink.x is passed twice:\n", file=sys.stderr)
+        for line in found:
+            print(f"  {line}\n", file=sys.stderr)
+        return 1
+
+    print(
+        f"-Tlink.x single source: OK "
+        f"({len(owners)} crate(s) pass their own, no caller repeats it)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_linker_script_single_source.py
+++ b/scripts/ci/test_linker_script_single_source.py
@@ -1,0 +1,142 @@
+"""Unit tests for the `-Tlink.x` single-source gate.
+
+The gate exists because a doubled linker script is invisible on a warm
+`target/`. These tests build synthetic trees, so they assert the rule itself —
+including the shapes that must NOT trip it, which is where a grep-shaped check
+would produce noise nobody reads.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import linker_script_single_source as gate  # noqa: E402
+
+
+def make_repo(tmp_path: Path, *, build_rs: str = "", workflow: str = "", script: str = "") -> Path:
+    crate = tmp_path / "crates" / "firmware-demo"
+    crate.mkdir(parents=True)
+    (crate / "build.rs").write_text(build_rs, encoding="utf-8")
+    if workflow:
+        wf = tmp_path / ".github" / "workflows"
+        wf.mkdir(parents=True)
+        (wf / "ci.yml").write_text(workflow, encoding="utf-8")
+    if script:
+        sc = tmp_path / "scripts"
+        sc.mkdir(parents=True, exist_ok=True)
+        (sc / "smoke.sh").write_text(script, encoding="utf-8")
+    return tmp_path
+
+
+OWNS = 'fn main() { println!("cargo:rustc-link-arg=-Tlink.x"); }\n'
+PLAIN = 'fn main() { println!("cargo:rustc-link-search=out"); }\n'
+
+
+def test_owner_plus_workflow_flag_is_a_violation(tmp_path):
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        workflow='        run: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo --release\n',
+    )
+    found = gate.violations(root)
+    assert len(found) == 1
+    assert "ci.yml:1" in found[0]
+    assert "firmware-demo" in found[0]
+
+
+def test_shell_script_is_scanned_too(tmp_path):
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        script='RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo\n',
+    )
+    assert len(gate.violations(root)) == 1
+
+
+def test_no_violation_once_the_caller_drops_the_flag(tmp_path):
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        workflow="        run: cargo build -p firmware-demo --release\n",
+    )
+    assert gate.violations(root) == []
+
+
+def test_caller_may_pass_it_for_a_crate_that_does_not(tmp_path):
+    """The flag is not banned — it is required for crates without their own.
+
+    `firmware-rp2040-demo` is the live example: its build.rs writes memory.x but
+    never emits the link arg, so the RUSTFLAGS form is the correct invocation
+    and a gate that flagged it would be telling the truth backwards.
+    """
+    root = make_repo(
+        tmp_path,
+        build_rs=PLAIN,
+        workflow='        run: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo\n',
+    )
+    assert gate.violations(root) == []
+
+
+def test_comments_are_not_commands(tmp_path):
+    """Every one of these lines exists in-tree, explaining the rule."""
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        workflow='        # do not add RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo\n',
+        script='# was: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo\n',
+    )
+    assert gate.violations(root) == []
+
+
+def test_a_commented_out_build_rs_line_does_not_make_an_owner(tmp_path):
+    root = make_repo(
+        tmp_path,
+        build_rs='fn main() { /* println!("cargo:rustc-link-arg=-Tlink.x"); */ }\n',
+        workflow='        run: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo\n',
+    )
+    assert gate.self_linking_crates(root) == {}
+    assert gate.violations(root) == []
+
+
+@pytest.mark.parametrize("form", ["-p firmware-demo", "-p=firmware-demo", "--package firmware-demo"])
+def test_every_package_spelling_is_caught(tmp_path, form):
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        workflow=f'        run: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build {form} --release\n',
+    )
+    assert len(gate.violations(root)) == 1
+
+
+def test_a_different_crate_on_the_same_line_is_not_flagged(tmp_path):
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        workflow='        run: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-other\n',
+    )
+    assert gate.violations(root) == []
+
+
+def test_main_returns_nonzero_and_names_the_file(tmp_path, capsys):
+    root = make_repo(
+        tmp_path,
+        build_rs=OWNS,
+        workflow='        run: RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-demo\n',
+    )
+    assert gate.main(["--check", "--root", str(root)]) == 1
+    assert "ci.yml" in capsys.readouterr().err
+
+
+def test_this_repository_passes():
+    """The live tree. This is the assertion that would have caught the break."""
+    assert gate.violations(gate.REPO_ROOT) == []
+
+
+def test_the_live_tree_has_owners_to_check():
+    """A gate over an empty owner set would pass by finding nothing to check."""
+    assert gate.self_linking_crates(gate.REPO_ROOT)


### PR DESCRIPTION
`Rust Core CI` is red on `main`. `Build test firmware fixture` dies at:

```
rust-lld: error: .../out/memory.x:10: region 'FLASH' already defined
```

## Cause

`core-ci.yml` and `core-coverage-weekly.yml` still prefixed the
`firmware-rp2040-pio-onboarding` build with `RUSTFLAGS="-C link-arg=-Tlink.x"`.
Since #1064 the crate's `build.rs` passes its own, so `link.x` — and the
`memory.x` it consumes — was included twice.

Reproduced both directions on a cold target dir:

| invocation | result |
|---|---|
| `RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p …` | exit 101, `region 'FLASH' already defined` |
| `cargo build -p …` | exit 0, ELF entry `0x100000c1` |

`cargo test -p labwired-core --test rp2040_pio_onboarding` then passes against
that ELF — so the fixture links *and* boots to `PIO_OK`, not merely compiles.

## Why it hid for a week

Cargo does not relink a cached artifact, so on the self-hosted runners' warm
`target/` the doubled flag cost nothing. **The same commit passed at 04:17 and
failed at 08:48** — the second run landed on a clean hosted runner.
`scripts/onboarding_smoke.sh` was fixed when this was first diagnosed; these
two callers were missed, and nothing was looking.

## The gate

`scripts/ci/linker_script_single_source.py` derives the rule instead of
restating it: it reads which crates emit `cargo:rustc-link-arg=-Tlink.x` from
their `build.rs`, and fails any workflow or shell script that passes the flag
again for one of them. No hardcoded list — a new `build.rs` line puts its
callers under the check from the next run on.

The flag is **not** banned. `firmware-rp2040-demo` does not pass its own, so
the `RUSTFLAGS` form is correct there and stays; a gate that flagged it would
state the rule backwards. That case is a test.

**Negative control:** against `main`'s `core-ci.yml` the gate exits 1 and names
line 1575; against this tree it exits 0, having found 21 owning crates. 13 unit
tests, one of which asserts the owner set is non-empty — a gate over nothing
passes by having nothing to check.