### PR TITLE
fix(validation): --write-ack-digests swept boards whose digest nothing reads

### DIFF
--- a/scripts/generate_validation_status.py
+++ b/scripts/generate_validation_status.py
@@ -562,7 +562,7 @@ def print_digests(manifest: dict) -> int:
     return 0
 
 
-def write_ack_digests(manifest: dict) -> int:
+def write_ack_digests(manifest: dict, stamp_all: bool = False) -> int:
     """Stamp `drift_ack_digest` next to every existing `drift_ack`.
 
     Deliberately only touches boards that ALREADY carry a human-written
@@ -574,10 +574,29 @@ def write_ack_digests(manifest: dict) -> int:
     Edits the YAML as text rather than round-tripping through the loader: the
     manifest is a hand-maintained document whose comments carry the reasoning
     for every ack, and PyYAML would drop all of them.
+
+    ⚠️ ONLY DRIFTED BOARDS ARE STAMPED, and that restriction is the point.
+
+    `evaluate()` consults a `drift_ack_digest` for exactly one purpose: deciding
+    whether an ack still covers a DRIFTED board. For a board that is not
+    drifted, the field is dead weight — no gate reads it, and re-stamping it
+    rewrites a line nothing consults.
+
+    That was not a theoretical cost. Stamping every acked board whose digest had
+    gone stale swept four unrelated boards into every model-sized change
+    (mkw41z4, rp2040, stm32f411ceu6, stm32h735 — the SAME four, four separate
+    times on 2026-08-31), and each time they had to be reverted by hand so that
+    every moved digest could be attributed to a file the change actually
+    touched. A tool that reliably produces work its user must undo is a defect,
+    not a convenience.
+
+    `--write-ack-digests-all` restores the old sweep for when a stale field
+    genuinely wants tidying — deliberately, and on its own.
     """
     text = MANIFEST.read_text()
     lines = text.split("\n")
     stamped = 0
+    skipped_not_drifted: list[str] = []
 
     for board in manifest.get("boards", []):
         if not board.get("drift_ack"):
@@ -586,6 +605,11 @@ def write_ack_digests(manifest: dict) -> int:
         if not digest:
             continue
         if board.get("drift_ack_digest") == digest:
+            continue
+        # `evaluate()` is the same function `--drift` and the rendered doc use,
+        # so this can never disagree with the gate about which boards are in play.
+        if not stamp_all and not evaluate(board)["drifted"]:
+            skipped_not_drifted.append(board["id"])
             continue
 
         # Find this board's `drift_ack:` line: scan from its `- id:` header to
@@ -621,6 +645,14 @@ def write_ack_digests(manifest: dict) -> int:
 
     MANIFEST.write_text("\n".join(lines))
     print(f"stamped {stamped} drift_ack_digest value(s)")
+    # Name what was left alone and why. The old sweep's cost stayed invisible
+    # until someone diffed the manifest and found boards they never touched.
+    if skipped_not_drifted:
+        print(
+            f"left {len(skipped_not_drifted)} stale digest(s) alone — not drifted, so "
+            f"nothing reads them: {', '.join(sorted(skipped_not_drifted))}"
+        )
+        print("  (use --write-ack-digests-all to tidy those deliberately)")
     return 0
 
 
@@ -632,6 +664,15 @@ def main() -> int:
         "--digests",
         action="store_true",
         help="print each board's current model digest against what it recorded",
+    )
+    ap.add_argument(
+        "--write-ack-digests-all",
+        action="store_true",
+        help=(
+            "stamp EVERY acked board whose digest moved, including boards that are "
+            "not drifted. The plain flag stamps only drifted boards, whose digest is "
+            "the only one any gate reads."
+        ),
     )
     ap.add_argument(
         "--write-ack-digests",
@@ -650,8 +691,8 @@ def main() -> int:
     if args.digests:
         return print_digests(manifest)
 
-    if args.write_ack_digests:
-        return write_ack_digests(manifest)
+    if args.write_ack_digests or args.write_ack_digests_all:
+        return write_ack_digests(manifest, stamp_all=args.write_ack_digests_all)
 
     rendered = render(manifest)
 

--- a/scripts/test_generate_validation_status.py
+++ b/scripts/test_generate_validation_status.py
@@ -379,3 +379,56 @@ def test_the_committed_manifest_is_not_already_expired():
         "drift acks have come due: " + ", ".join(stale) + ". Re-capture and bump "
         "silicon.last_capture, or renew the ack — do not widen ACK_TTL_DAYS to clear this."
     )
+
+def test_write_ack_digests_leaves_undrifted_boards_alone(tmp_path, monkeypatch):
+    """The stamper must not sweep boards whose digest nothing reads.
+
+    A `drift_ack_digest` is consulted by `evaluate()` for exactly one purpose:
+    deciding whether an ack still covers a DRIFTED board. Stamping a board that
+    is not drifted rewrites a line no gate consults, and on 2026-08-31 that put
+    the SAME four unrelated boards into four separate pull requests, each time
+    to be reverted by hand.
+    """
+    boards = [
+        {"id": "drifted-one", "drift_ack": "2026-08-31", "drift_ack_digest": "stale",
+         "models": ["m.rs"], "silicon": {"last_capture": "2020-01-01"}},
+        {"id": "fresh-one", "drift_ack": "2026-08-31", "drift_ack_digest": "stale",
+         "models": ["m.rs"], "silicon": {"last_capture": "2099-01-01"}},
+    ]
+    seen = {"drifted": False, "fresh": False}
+
+    def fake_evaluate(board, today=None):
+        return {"drifted": board["id"] == "drifted-one"}
+
+    def fake_digest(models):
+        return "newdigest"
+
+    monkeypatch.setattr(gvs, "evaluate", fake_evaluate)
+    monkeypatch.setattr(gvs, "model_digest", fake_digest)
+
+    manifest_text = (
+        "boards:\n"
+        "  - id: drifted-one\n"
+        "    drift_ack: 2026-08-31\n"
+        "    drift_ack_digest: stale\n"
+        "  - id: fresh-one\n"
+        "    drift_ack: 2026-08-31\n"
+        "    drift_ack_digest: stale\n"
+    )
+    manifest_file = tmp_path / "manifest.yaml"
+    manifest_file.write_text(manifest_text)
+    monkeypatch.setattr(gvs, "MANIFEST", manifest_file)
+
+    gvs.write_ack_digests({"boards": boards})
+    after = manifest_file.read_text()
+
+    drifted_line = [ln for ln in after.splitlines() if "drift_ack_digest" in ln][0]
+    fresh_line = [ln for ln in after.splitlines() if "drift_ack_digest" in ln][1]
+    assert "newdigest" in drifted_line, "a drifted board must be stamped"
+    assert "stale" in fresh_line, "an undrifted board must be left alone"
+
+    # And the escape hatch still does the old thing, deliberately.
+    manifest_file.write_text(manifest_text)
+    gvs.write_ack_digests({"boards": boards}, stamp_all=True)
+    lines = [ln for ln in manifest_file.read_text().splitlines() if "drift_ack_digest" in ln]
+    assert all("newdigest" in ln for ln in lines), "--all must stamp both"


### PR DESCRIPTION
Four times on 2026-08-31, across four separate pull requests, this tool re-stamped **seven** boards when three had moved — and **the same four strays every time**: `mkw41z4`, `rp2040`, `stm32f411ceu6`, `stm32h735`. Each time they were reverted by hand so every moved digest could be attributed to a file the change actually touched.

A tool that reliably produces work its user must undo is a defect, not a convenience.

## The rule

`evaluate()` consults a `drift_ack_digest` for exactly **one** purpose: whether an ack still covers a **drifted** board. For a board that is not drifted the field is dead weight — no gate reads it, and re-stamping it rewrites a line nothing consults while putting boards the author never touched into their diff.

The default now stamps drifted boards only, and names what it left:

```
stamped 0 drift_ack_digest value(s)
left 4 stale digest(s) alone — not drifted, so nothing reads them:
  mkw41z4, rp2040, stm32f411ceu6, stm32h735
  (use --write-ack-digests-all to tidy those deliberately)
```

`--write-ack-digests-all` keeps the old sweep for when a stale field genuinely wants tidying — on its own, not folded into unrelated work.

The drifted check goes through `evaluate()`, the same function `--drift` and the rendered doc use, so it can never disagree with the gate about which boards are in play.

## Verified three ways on the live manifest

| scenario | result |
|---|---|
| nothing drifted | `stamped 0`, names the four strays |
| `adc.rs` touched | `stamped 3` — exactly the boards the gate names |
| `--write-ack-digests-all` | `stamped 4` — old behaviour, deliberately |

Plus a unit test pinning both halves: a drifted board **is** stamped, an undrifted board is **not**, and `stamp_all=True` stamps both. **26 tests pass.**

## One note worth recording

Proving the drifted case by `git add -A && commit` then `git reset --hard HEAD~1` swept the uncommitted source changes into that commit and deleted them with it. The control passed, and the code that produced it was gone. The unit test is what caught the absence — it failed with `stamped 2` where the guard should have made it 1.