### PR TITLE
ci: derive the clippy scope from the workspace instead of default-members

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -550,6 +550,7 @@ jobs:
             scripts/ci/test_cheat_ratchet.py \
             scripts/ci/test_ignore_reasons.py \
             scripts/ci/test_linker_script_single_source.py \
+            scripts/ci/test_host_clippy_scope.py \
             scripts/ci/test_workspace_test_shard.py \
             scripts/test_generate_validation_status.py
 
@@ -604,8 +605,22 @@ jobs:
       # `pull_request` CI builds the merge commit, not the branch tip, so
       # linting the default-members here catches that class of semantic
       # conflict against the tree the merge will actually produce — before it
-      # lands rather than after. Keep this scope in step with the `Run Clippy`
-      # step in core-integrity; if they drift apart the hole reopens.
+      # lands rather than after.
+      #
+      # ⚠️ THIS IS FIVE PACKAGES OF EIGHTY-FOUR, AND THAT IS NOW DELIBERATE
+      # RATHER THAN ACCIDENTAL. `cargo clippy --all-targets` resolves to
+      # `default-members`; it never linted the workspace. The remaining host
+      # crates are covered by the `Clippy (host crates outside default-members)`
+      # step in `browser-layer`, whose scope `host_clippy_scope.py` derives as
+      # the COMPLEMENT of this command. So: keep this step bare. Narrowing it to
+      # a `-p` list would leave default-members linted by nothing, and
+      # `--check` fails the moment no bare `cargo clippy` remains in this file.
+      #
+      # This is also what the old note here — "keep this scope in step with the
+      # `Run Clippy` step in core-integrity; if they drift apart the hole
+      # reopens" — was asking a human to do by hand. The two steps are still
+      # identical, but drift between them can no longer open a hole silently:
+      # the union of the three clippy scopes is asserted against the tree.
       - name: Clippy (default-members)
         run: cargo clippy --all-targets -- -D warnings
 
@@ -822,8 +837,79 @@ jobs:
       # signature that no longer lines up with core) all surface here without
       # needing the wasm32 toolchain on the runner. A wasm32 link is a heavier,
       # separate concern and stays in the deploy path.
+      #
+      # ⚠️ KEEP THE `-p labwired-wasm` HERE. `host_clippy_scope.py` subtracts
+      # this package from the scope of the step below on the strength of this
+      # step existing, and its `--check` reads this file to prove it still
+      # does. Delete or rename the flag and that check goes red rather than
+      # letting the browser layer go quietly unlinted again.
       - name: Clippy + build the browser layer (crates/wasm)
         run: cargo clippy -p labwired-wasm --all-targets -- -D warnings
+
+      # THE REST OF THE HOST WORKSPACE — the step above's argument, generalized.
+      #
+      # It was never only crates/wasm. `cargo clippy --all-targets` in `pr-gate`
+      # and in `core-integrity` is not a workspace command: it resolves to
+      # `default-members`, FIVE packages of eighty-four. crates/wasm was lifted
+      # out of that hole one crate at a time by the step above; twelve more host
+      # crates were still in it when this landed. What reached them, measured:
+      #
+      #   * cargo applies `RUSTC_WORKSPACE_WRAPPER=clippy-driver` to every
+      #     workspace member it builds, dependencies included, so SIX of the
+      #     twelve already had their lib linted incidentally as path-deps of a
+      #     default-member (codegen, config, gdbstub, hw-trace, ir,
+      #     svd-ingestor);
+      #   * SIX were reached by no clippy lane at all — egress-relay, hw-oracle
+      #     (the silicon ground-truth comparator), hw-oracle-macros, hw-runner,
+      #     validation-report, python;
+      #   * and for all twelve, everything that is NOT the lib — tests/,
+      #     benches/, [[bin]] targets, `#[cfg(test)]` modules — was linted by
+      #     nothing, because a dependency is only ever built as a lib. That is
+      #     the exact class the note on pr-gate's clippy step already records:
+      #     `channel: Option<String>` on `BoardIoBinding` stranded four literals
+      #     in the DAP adapter's tests and "was invisible to anything short of
+      #     `--all-targets`".
+      #
+      # None of that is a testing gap. `pr-workspace-tests` shards
+      # `cargo test --workspace --no-run`, which compiles and runs every member.
+      # It is clippy, and only clippy, that stopped short.
+      #
+      # DERIVED, NOT LISTED. A longer `-p` list in this file would be the same
+      # defect one level up — the hole reopens the next time somebody adds a
+      # crate, exactly as it did after crates/wasm was handled by name.
+      # `host_clippy_scope.py` classifies every workspace member from the tree
+      # (a per-crate `.cargo/config.toml` pinning a bare-metal triple, or a
+      # `#![no_std]` crate root, means firmware) and emits the host crates the
+      # other two clippy scopes do not cover. Its `--check` asserts those other
+      # two still exist — a bare `cargo clippy` somewhere for default-members,
+      # and the `-p labwired-wasm` step above — so the three scopes PARTITION
+      # the host set instead of leaving a gap between them, and it fails when
+      # this scope comes out empty, because a `cargo clippy` with no packages
+      # left to name silently falls back to linting default-members again.
+      #
+      # HERE AND NOT IN `pr-gate`, AND THAT IS MEASURED, NOT A MOVE TO SAFETY.
+      # This job is a REQUIRED context on main and runs on every PR, so the gate
+      # stays pre-merge. Run 33458359629: `pr-gate` 7m03s against a 12-minute
+      # wall whose own note says do not bump it a third time, `browser-layer`
+      # 2m14s against 20. Locally the step costs 25s on top of the wasm clippy
+      # above (26s), and folding the same crates into pr-gate's `--all-targets`
+      # default-members build measured 50s instead — the test targets of core
+      # and cli are most of that, and this scope does not rebuild them.
+      #
+      # PYO3_USE_ABI3_FORWARD_COMPATIBILITY: `crates/python` builds pyo3 0.20,
+      # whose build script refuses any interpreter newer than 3.12. CI's ubuntu
+      # image ships 3.12 so this is a no-op here, but it keeps the same command
+      # working on a developer machine with a newer python3 — the identical
+      # escape `scripts/ci/rust-suite-baseline.py` sets for the same crate, and
+      # documented in docs/testing/RUST_SUITE_BASELINE.md.
+      - name: Clippy (host crates outside default-members)
+        run: |
+          python3 scripts/ci/host_clippy_scope.py --check
+          scope="$(python3 scripts/ci/host_clippy_scope.py --cargo-args | tr '\n' ' ')"
+          echo "derived scope: $scope"
+          # shellcheck disable=SC2086  # deliberate word split: one --package= per field
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+            cargo clippy $scope --all-targets -- -D warnings
 
       # playground_repro drives the secure-boot lab through the same entry
       # points simulator-bridge.ts uses, so it needs that lab's firmware. It
@@ -1243,8 +1329,26 @@ jobs:
       - name: Check Formatting
         run: cargo fmt --all -- --check
 
+      # Bare on purpose — see the long note on `Clippy (default-members)` in
+      # `pr-gate`. This resolves to `default-members`, and the step below covers
+      # the host crates it leaves out.
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
+
+      # The main-side twin of `browser-layer`'s host-scope step. `browser-layer`
+      # runs on pull_request/dispatch only, so without this the twelve crates
+      # outside `default-members` would be linted on PRs and not on main — and
+      # this job is where the note on `Clippy (default-members)` says the hole
+      # used to live, main noticing a break only after the merge. Scope derived
+      # by the same script; nothing here to keep in step by hand.
+      - name: Clippy (host crates outside default-members)
+        run: |
+          python3 scripts/ci/host_clippy_scope.py --check
+          scope="$(python3 scripts/ci/host_clippy_scope.py --cargo-args | tr '\n' ' ')"
+          echo "derived scope: $scope"
+          # shellcheck disable=SC2086  # deliberate word split: one --package= per field
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+            cargo clippy $scope --all-targets -- -D warnings
 
       # Before the --lib run, not just before the fixture suites below. The
       # playground secure-boot repro in crates/wasm builds

--- a/scripts/ci/host_clippy_scope.py
+++ b/scripts/ci/host_clippy_scope.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""The host crates clippy never linted — derived from the tree, not listed.
+
+`cargo clippy --all-targets` at the workspace root does NOT lint the workspace.
+It resolves to `default-members`, which is five packages of eighty-four:
+
+    ["crates/cli", "crates/core", "crates/dap", "crates/loader",
+     "crates/labwired-fuzz"]
+
+Most of the other seventy-nine are firmware: `no_std` crates that only build for
+thumbv*/riscv32*/xtensa*, and pointing a host clippy at them is meaningless. But
+not all of them are. Twelve are ordinary host crates, and what reaches them is
+partial in a way that is easy to mis-state, so — measured on this tree:
+
+  * cargo applies `RUSTC_WORKSPACE_WRAPPER=clippy-driver` to every WORKSPACE
+    member it builds, dependencies included. So six of the twelve already get
+    their **lib** linted incidentally, as path-dependencies of a default-member:
+    labwired-codegen, labwired-config, labwired-gdbstub, labwired-hw-trace,
+    labwired-ir, svd-ingestor.
+  * The other six are reached by no clippy lane at all, in any target:
+    labwired-egress-relay, labwired-hw-oracle, labwired-hw-oracle-macros,
+    labwired-hw-runner, validation-report, labwired-python. That includes
+    `labwired-hw-oracle`, the silicon ground-truth comparator.
+  * And for ALL twelve, everything that is not the lib — `tests/`, `benches/`,
+    `[[bin]]` targets, `#[cfg(test)]` modules — is linted by nothing, because a
+    dependency is only ever built as a lib. That is precisely the class the note
+    on pr-gate's own clippy step already records: `channel: Option<String>` on
+    `BoardIoBinding` stranded four literals in the DAP adapter's tests and "was
+    invisible to anything short of `--all-targets`".
+
+None of this is a testing gap. `pr-workspace-tests` shards
+`cargo test --workspace --no-run`, which compiles and runs every member. It is
+clippy, and only clippy, that stopped short.
+
+`crates/wasm` was in exactly this state and was rescued one crate at a time: it
+got its own `-p labwired-wasm` clippy step in `browser-layer` after a
+browser-only fork shipped behind a fully green board, and the note on that step
+ends "Before this step, NO pre-merge lane in this repo compiled the code the
+browser actually runs." That argument was right and it was never generalized —
+it applies verbatim to every host crate outside `default-members`.
+
+A longer `-p` list in the workflow would be the same defect one level up: the
+hole reopens the moment somebody adds a crate. So the scope is DERIVED. A member
+is cross-target-only when it says so itself, in one of the two ways this
+repository already uses:
+
+  1. a per-crate `.cargo/config.toml` pinning `[build] target` to a bare-metal
+     triple (22 members do), or
+  2. a crate root carrying `#![no_std]` (65 members do).
+
+Everything else is host-lintable. Of those, `default-members` are already
+covered by the bare `cargo clippy --all-targets` and `labwired-wasm` by its own
+step, so what this script emits is the remainder: the crates nothing lints. Add
+a host crate to `members` and it is linted from the next run on, with nobody
+editing a list.
+
+⚠️ The `.cargo/config.toml` target is read as a DECLARATION, not as the
+mechanism. Cargo reads config from the invocation's cwd and its ancestors, so
+`cargo clippy -p firmware-rp2040-demo` run from the workspace root never sees
+`crates/firmware-rp2040-demo/.cargo/config.toml` at all and would try to build
+that crate for the host. The file is still the crate's own statement of which
+target it is for, which is exactly what needs classifying here.
+
+USAGE
+
+    python3 scripts/ci/host_clippy_scope.py --check       # assert the rule holds
+    python3 scripts/ci/host_clippy_scope.py --cargo-args  # one --package= per line
+    python3 scripts/ci/host_clippy_scope.py --json
+
+The clippy step builds its invocation from `--cargo-args`, so it cannot fall
+behind the tree: it holds no list to fall behind with. `--check` closes the
+other half — it asserts that the three scopes TOGETHER (the bare
+default-members command, the `-p labwired-wasm` step, and this one) still cover
+every host-lintable member, so no crate can fall between them either.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# `#![no_std]`, and the conditional spelling in
+# crates/firmware-nrf52840-obd2-scanner: `#![cfg_attr(not(test), no_std)]`.
+# A crate that is no_std under ANY configuration is firmware, not a host crate.
+NO_STD = re.compile(r"^\s*#!\[[^]]*\bno_std\b[^]]*\]", re.M)
+
+# Bare-metal / non-host triples: thumbv7em-none-eabi, riscv32imac-unknown-none-elf,
+# xtensa-esp32s3-none-elf, wasm32-unknown-unknown.
+OFF_HOST_TRIPLE = re.compile(r"-none(?:-|$)|^wasm\d*-")
+
+CLIPPY_LINE = re.compile(r"\bcargo\s+clippy\b")
+PACKAGE_ARG = re.compile(r"(?:-p|--package)[=\s]+\"?'?([A-Za-z0-9_.-]+)")
+
+# ── The one explicit exception ────────────────────────────────────────────────
+#
+# `labwired-wasm` IS host-lintable — this script classifies it as such — and it
+# IS linted pre-merge. It is simply linted somewhere else, by the dedicated
+# `-p labwired-wasm` step in `browser-layer`, and it stays there for a reason
+# that is not tidiness:
+#
+#   FEATURE UNIFICATION. `crates/wasm` turns `event-scheduler` on, and one cargo
+#   invocation unifies features across every package in it. Naming wasm
+#   alongside `labwired-core` therefore lints a DIFFERENT core from the one the
+#   browser builds. Measured on this tree: folding wasm into this scope turns
+#   the step red on `crates/core/tests/esp32_classic_walk_differential.rs:89`
+#   (clippy::type_complexity) — real debt in the event-scheduler arm that no
+#   lane lints, and not debt this scope should be paying by accident. Its own
+#   invocation keeps the browser's exact feature set, which is the point of
+#   that job.
+#
+# `--check` asserts a `cargo clippy` step in .github/workflows/ still names this
+# package. An exception whose justification has quietly evaporated is the same
+# hole with better paperwork, so it fails closed instead of trusting this
+# comment.
+BROWSER_LAYER_PACKAGE = "labwired-wasm"
+
+
+class Unclassified(RuntimeError):
+    """A member neither signal can place. Fails the gate rather than guessing."""
+
+
+def workspace(root: Path) -> dict:
+    return tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))["workspace"]
+
+
+def _crate_roots(crate_dir: Path, manifest: dict) -> list[Path]:
+    """Every source file cargo would compile as a crate root for this package.
+
+    Read from the manifest, not guessed: `firmware-f407-demo` declares two
+    `[[bin]]` targets at `src/smoke.rs` and `src/i2c.rs` and has no
+    `src/main.rs`, so a scan that only looked at the default paths would find no
+    `#![no_std]` and call a Cortex-M4 firmware crate a host crate.
+    """
+    candidates: list[Path] = [
+        crate_dir / manifest.get("lib", {}).get("path", "src/lib.rs"),
+        crate_dir / "src" / "main.rs",
+    ]
+    for entry in manifest.get("bin") or []:
+        candidates.append(
+            crate_dir / entry.get("path", f"src/bin/{entry.get('name', '')}.rs")
+        )
+    candidates.extend(sorted(crate_dir.glob("src/bin/*.rs")))
+    roots: list[Path] = []
+    for path in candidates:
+        if path.is_file() and path not in roots:
+            roots.append(path)
+    return roots
+
+
+def _pinned_target(crate_dir: Path) -> str | None:
+    """`[build] target` from the crate's own .cargo/config.toml, if any."""
+    config = crate_dir / ".cargo" / "config.toml"
+    if not config.is_file():
+        return None
+    target = tomllib.loads(config.read_text(encoding="utf-8")).get("build", {}).get("target")
+    if isinstance(target, list):  # cargo allows a list of triples
+        return target[0] if target else None
+    return target
+
+
+def classify(root: Path) -> tuple[list[dict], list[dict]]:
+    """Split `workspace.members` into (host-lintable, cross-target-only).
+
+    Each entry carries the REASON it landed where it did, so a surprise shows up
+    as a wrong reason rather than as a silent membership change.
+    """
+    host: list[dict] = []
+    cross: list[dict] = []
+
+    for member in workspace(root)["members"]:
+        crate_dir = root / member
+        manifest = tomllib.loads((crate_dir / "Cargo.toml").read_text(encoding="utf-8"))
+        name = manifest["package"]["name"]
+
+        target = _pinned_target(crate_dir)
+        if target is not None:
+            if not OFF_HOST_TRIPLE.search(target):
+                raise Unclassified(
+                    f'{member}: .cargo/config.toml pins `target = "{target}"`, '
+                    f"which does not look like a bare-metal triple. Decide "
+                    f"explicitly whether `{name}` is host-lintable and either "
+                    f"widen OFF_HOST_TRIPLE or name it as an exception here — "
+                    f"guessing is how a crate falls out of clippy silently."
+                )
+            cross.append({"member": member, "package": name, "reason": f"builds for {target}"})
+            continue
+
+        roots = _crate_roots(crate_dir, manifest)
+        if not roots:
+            raise Unclassified(
+                f"{member}: no crate root found for `{name}`. Neither signal can "
+                f"be read, so this member cannot be classified."
+            )
+        no_std = [
+            p
+            for p in roots
+            if NO_STD.search(p.read_text(encoding="utf-8", errors="replace"))
+        ]
+        if no_std:
+            cross.append(
+                {
+                    "member": member,
+                    "package": name,
+                    "reason": f"#![no_std] in {no_std[0].relative_to(root)}",
+                }
+            )
+            continue
+
+        host.append({"member": member, "package": name, "reason": "host crate"})
+
+    return host, cross
+
+
+def clippy_packages(root: Path) -> list[str]:
+    """The host crates nothing else lints — this scope's `-p` set.
+
+    Host-lintable, MINUS the ones already covered:
+      * `default-members`, linted by the bare `cargo clippy --all-targets`;
+      * `labwired-wasm`, linted by its own step (see BROWSER_LAYER_PACKAGE).
+
+    Both subtractions are derived — the first from the root Cargo.toml, the
+    second asserted against the workflows by `--check` — so the three scopes
+    partition the host set without a list anywhere.
+    """
+    host, _ = classify(root)
+    default = set(workspace(root).get("default-members") or [])
+    return [
+        e["package"]
+        for e in host
+        if e["member"] not in default and e["package"] != BROWSER_LAYER_PACKAGE
+    ]
+
+
+def _clippy_invocations(root: Path) -> list[list[str]]:
+    """Package lists of every `cargo clippy` line in .github/workflows/.
+
+    An empty list means an invocation that passed no `-p` at all, i.e. the bare
+    default-members form.
+    """
+    found: list[list[str]] = []
+    workflows = root / ".github" / "workflows"
+    if not workflows.is_dir():
+        return found
+    for path in sorted(workflows.glob("*.yml")) + sorted(workflows.glob("*.yaml")):
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.lstrip().startswith("#") or not CLIPPY_LINE.search(line):
+                continue
+            found.append(PACKAGE_ARG.findall(line))
+    return found
+
+
+def problems(root: Path) -> list[str]:
+    """Everything wrong with the derived scope. Empty means the rule holds."""
+    out: list[str] = []
+    host, cross = classify(root)
+    host_names = {e["package"] for e in host}
+    invocations = _clippy_invocations(root)
+    named = {pkg for inv in invocations for pkg in inv}
+
+    if not host:
+        out.append("no member classified as host-lintable — the scope is empty")
+    if not cross:
+        out.append(
+            "no member classified as cross-target-only — with nothing in the "
+            "other class the classifier is not discriminating and would pass "
+            "over any tree"
+        )
+    if not clippy_packages(root):
+        out.append(
+            "this scope emits no package: every host-lintable member is either "
+            "a default-member or the excused one, so the step built from it "
+            "lints nothing and would report green for doing no work"
+        )
+
+    # A default-member is linted for the HOST by the bare workspace clippy that
+    # has always run. If one classified as cross-target-only, the classifier is
+    # wrong about the tree, not the tree about itself.
+    for member in workspace(root).get("default-members") or []:
+        entry = next((e for e in cross if e["member"] == member), None)
+        if entry is not None:
+            out.append(
+                f"default-member `{member}` classified cross-target-only "
+                f"({entry['reason']}), but the workspace's own "
+                f"`cargo clippy --all-targets` builds it for the host"
+            )
+
+    # The half of the partition this script does NOT emit: default-members are
+    # covered only for as long as a bare `cargo clippy` (no -p) still runs. If
+    # somebody narrows those steps to a package list, this scope silently stops
+    # being the complement it claims to be.
+    if not any(inv == [] for inv in invocations):
+        out.append(
+            "no `cargo clippy` step in .github/workflows/ runs without `-p`, so "
+            "nothing covers `default-members` any more. This scope is the "
+            "COMPLEMENT of that command and does not include them."
+        )
+
+    if BROWSER_LAYER_PACKAGE not in host_names:
+        out.append(
+            f"`{BROWSER_LAYER_PACKAGE}` is excused from this scope on the "
+            f"grounds that it is host-lintable and linted elsewhere, but it no "
+            f"longer classifies as host-lintable. Drop the exception."
+        )
+    elif BROWSER_LAYER_PACKAGE not in named:
+        out.append(
+            f"`{BROWSER_LAYER_PACKAGE}` is excluded from this scope because a "
+            f"dedicated `cargo clippy -p {BROWSER_LAYER_PACKAGE}` step lints it, "
+            f"and no such step exists in .github/workflows/ any more. It is now "
+            f"linted by nothing. Either restore that step or delete "
+            f"BROWSER_LAYER_PACKAGE so this scope picks it up."
+        )
+
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero when the derived scope is empty, vacuous or stale",
+    )
+    parser.add_argument(
+        "--cargo-args",
+        action="store_true",
+        help="print one `--package=<name>` per line for a cargo clippy invocation",
+    )
+    parser.add_argument("--json", action="store_true", help="print the full classification")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repository root to scan (default: this checkout)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        _, cross = classify(args.root)
+        scope = clippy_packages(args.root)
+    except Unclassified as exc:
+        print(
+            f"host clippy scope: cannot classify a workspace member:\n  {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.cargo_args:
+        for name in scope:
+            print(f"--package={name}")
+        return 0
+
+    if args.json:
+        host, _ = classify(args.root)
+        print(
+            json.dumps(
+                {
+                    "host": host,
+                    "cross_target_only": cross,
+                    "clippy_packages": scope,
+                    "excused": BROWSER_LAYER_PACKAGE,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    found = problems(args.root)
+    if found:
+        print("host clippy scope is not sound:\n", file=sys.stderr)
+        for line in found:
+            print(f"  {line}\n", file=sys.stderr)
+        return 1
+
+    print(
+        f"host clippy scope: OK ({len(scope)} host member(s) linted by this "
+        f"scope, default-members by the bare `cargo clippy`, "
+        f"`{BROWSER_LAYER_PACKAGE}` by its own step, "
+        f"{len(cross)} cross-target-only member(s) skipped)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_host_clippy_scope.py
+++ b/scripts/ci/test_host_clippy_scope.py
@@ -1,0 +1,385 @@
+"""Unit tests for the derived host-clippy scope.
+
+The defect this scope closes is a gate that looks like it lints a workspace and
+lints five packages of eighty-four. A test suite for it therefore has to assert
+two different things: that the classifier puts each SHAPE of crate where it
+belongs (synthetic trees, below), and that on the LIVE tree it is not passing
+vacuously — a classifier that called everything host-lintable, or everything
+firmware, would satisfy every synthetic case here and gate nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import host_clippy_scope as scope  # noqa: E402
+
+
+def make_repo(tmp_path: Path, crates: dict[str, dict], *, default_members: list[str] | None = None,
+              workflow: str | None = None) -> Path:
+    """Build a synthetic workspace.
+
+    `crates` maps a member path to a dict of: `name`, optional `manifest_extra`
+    (raw TOML appended to Cargo.toml), optional `files` (relative path -> text),
+    optional `cargo_target` (written to the crate's .cargo/config.toml).
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    members = list(crates)
+    default = default_members if default_members is not None else members
+    root_toml = [
+        "[workspace]",
+        "resolver = \"2\"",
+        "members = [" + ", ".join(f'"{m}"' for m in members) + "]",
+        "default-members = [" + ", ".join(f'"{m}"' for m in default) + "]",
+    ]
+    (tmp_path / "Cargo.toml").write_text("\n".join(root_toml) + "\n", encoding="utf-8")
+
+    for member, spec in crates.items():
+        crate = tmp_path / member
+        (crate / "src").mkdir(parents=True, exist_ok=True)
+        manifest = f'[package]\nname = "{spec["name"]}"\nversion = "0.0.0"\nedition = "2021"\n'
+        manifest += spec.get("manifest_extra", "")
+        (crate / "Cargo.toml").write_text(manifest, encoding="utf-8")
+        for rel, text in (spec.get("files") or {"src/lib.rs": "pub fn f() {}\n"}).items():
+            path = crate / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+        if spec.get("cargo_target"):
+            cfg = crate / ".cargo"
+            cfg.mkdir(parents=True, exist_ok=True)
+            (cfg / "config.toml").write_text(
+                f'[build]\ntarget = "{spec["cargo_target"]}"\n', encoding="utf-8"
+            )
+
+    if workflow is not None:
+        wf = tmp_path / ".github" / "workflows"
+        wf.mkdir(parents=True)
+        (wf / "ci.yml").write_text(workflow, encoding="utf-8")
+    return tmp_path
+
+
+HOST = {"name": "host-crate"}
+NOSTD = {"name": "fw-crate", "files": {"src/main.rs": "#![no_std]\n#![no_main]\nfn main() {}\n"}}
+
+
+def names(entries: list[dict]) -> set[str]:
+    return {e["package"] for e in entries}
+
+
+# ── the two signals ───────────────────────────────────────────────────────────
+
+
+def test_a_plain_host_crate_is_lintable(tmp_path):
+    host, cross = scope.classify(make_repo(tmp_path, {"crates/a": HOST}))
+    assert names(host) == {"host-crate"}
+    assert cross == []
+
+
+def test_no_std_marks_a_crate_cross_target(tmp_path):
+    host, cross = scope.classify(make_repo(tmp_path, {"crates/a": NOSTD}))
+    assert host == []
+    assert names(cross) == {"fw-crate"}
+    assert "no_std" in cross[0]["reason"]
+
+
+def test_conditional_no_std_counts_too(tmp_path):
+    """`#![cfg_attr(not(test), no_std)]` — the live spelling in obd2-scanner.
+
+    A crate that is no_std under any configuration is firmware. Reading only
+    the bare attribute would call that one a host crate.
+    """
+    crate = {"name": "fw", "files": {"src/lib.rs": "#![cfg_attr(not(test), no_std)]\n"}}
+    host, cross = scope.classify(make_repo(tmp_path, {"crates/a": crate}))
+    assert host == []
+    assert names(cross) == {"fw"}
+
+
+@pytest.mark.parametrize(
+    "triple",
+    [
+        "thumbv6m-none-eabi",
+        "thumbv7em-none-eabi",
+        "thumbv8m.main-none-eabi",
+        "riscv32imac-unknown-none-elf",
+        "xtensa-esp32s3-none-elf",
+        "wasm32-unknown-unknown",
+    ],
+)
+def test_a_pinned_bare_metal_target_marks_a_crate_cross_target(tmp_path, triple):
+    crate = {"name": "fw", "cargo_target": triple}
+    host, cross = scope.classify(make_repo(tmp_path, {"crates/a": crate}))
+    assert host == []
+    assert triple in cross[0]["reason"]
+
+
+def test_a_cross_target_crate_that_is_not_no_std_is_still_caught(tmp_path):
+    """firmware-f407-demo is exactly this: pinned target, no `#![no_std]` root.
+
+    Its two `[[bin]]` targets live at src/smoke.rs and src/i2c.rs, so the
+    default-path scan finds nothing to read. The pinned target is what saves it.
+    """
+    crate = {
+        "name": "fw",
+        "cargo_target": "thumbv7em-none-eabi",
+        "manifest_extra": '\n[[bin]]\nname = "smoke"\npath = "src/smoke.rs"\n',
+        "files": {"src/smoke.rs": "#![no_std]\n#![no_main]\n"},
+    }
+    host, cross = scope.classify(make_repo(tmp_path, {"crates/a": crate}))
+    assert host == []
+
+
+def test_declared_bin_paths_are_read_for_no_std(tmp_path):
+    """The same crate WITHOUT the pinned target still classifies correctly.
+
+    Two independent signals, and either one alone is enough — which is what
+    makes a crate that drops its .cargo/config.toml not silently become a host
+    crate.
+    """
+    crate = {
+        "name": "fw",
+        "manifest_extra": '\n[[bin]]\nname = "smoke"\npath = "src/smoke.rs"\n',
+        "files": {"src/smoke.rs": "#![no_std]\n#![no_main]\n"},
+    }
+    host, cross = scope.classify(make_repo(tmp_path, {"crates/a": crate}))
+    assert host == []
+    assert "src/smoke.rs" in cross[0]["reason"]
+
+
+def test_a_custom_lib_path_is_read(tmp_path):
+    crate = {
+        "name": "fw",
+        "manifest_extra": '\n[lib]\npath = "src/other.rs"\n',
+        "files": {"src/other.rs": "#![no_std]\n"},
+    }
+    _, cross = scope.classify(make_repo(tmp_path, {"crates/a": crate}))
+    assert names(cross) == {"fw"}
+
+
+# ── failing closed ────────────────────────────────────────────────────────────
+
+
+def test_an_unrecognised_pinned_target_is_an_error_not_a_guess(tmp_path):
+    """A pinned host-looking triple must stop the gate, not fall through.
+
+    Either answer would be a guess, and the wrong guess drops a crate out of
+    clippy with nothing to show for it — the defect this file exists to prevent.
+    """
+    crate = {"name": "odd", "cargo_target": "x86_64-unknown-linux-musl"}
+    root = make_repo(tmp_path, {"crates/a": crate})
+    with pytest.raises(scope.Unclassified) as err:
+        scope.classify(root)
+    assert "x86_64-unknown-linux-musl" in str(err.value)
+    assert scope.main(["--check", "--root", str(root)]) == 1
+
+
+def test_a_member_with_no_crate_root_is_an_error(tmp_path):
+    crate = {"name": "empty", "files": {"README.md": "nothing here\n"}}
+    with pytest.raises(scope.Unclassified):
+        scope.classify(make_repo(tmp_path, {"crates/a": crate}))
+
+
+# ── the soundness checks --check runs ─────────────────────────────────────────
+
+
+# A workflow that covers the other two thirds of the partition: the bare
+# default-members command, and the dedicated browser-layer step.
+WASM_STEP = (
+    "        run: cargo clippy --all-targets -- -D warnings\n"
+    "        run: cargo clippy -p labwired-wasm --all-targets -- -D warnings\n"
+)
+
+# A three-crate workspace shaped like the real one: one default-member that the
+# bare command covers, one host crate outside it that this scope must emit, one
+# firmware crate, and the excused browser package.
+TRIO = {
+    "crates/d": {"name": "default-member"},
+    "crates/a": HOST,
+    "crates/b": NOSTD,
+    "crates/w": {"name": "labwired-wasm"},
+}
+DEFAULTS = ["crates/d"]
+
+
+def test_a_tree_with_only_host_crates_fails_the_check(tmp_path):
+    """No cross-target class means the classifier discriminated nothing."""
+    root = make_repo(tmp_path, {"crates/a": HOST}, workflow=WASM_STEP)
+    assert any("cross-target-only" in p for p in scope.problems(root))
+
+
+def test_a_tree_with_only_firmware_fails_the_check(tmp_path):
+    root = make_repo(tmp_path, {"crates/a": NOSTD}, workflow=WASM_STEP)
+    assert any("empty" in p for p in scope.problems(root))
+
+
+def test_a_scope_that_emits_nothing_fails_the_check(tmp_path):
+    """A step that lints no package reports green for doing no work.
+
+    Exactly the shape of the bug being fixed: a command that looks like it
+    covers a workspace and covers a subset — here, the empty one.
+    """
+    crates = {"crates/d": {"name": "default-member"}, "crates/b": NOSTD,
+              "crates/w": {"name": "labwired-wasm"}}
+    root = make_repo(tmp_path, crates, default_members=DEFAULTS, workflow=WASM_STEP)
+    assert scope.clippy_packages(root) == []
+    assert any("lints nothing" in p for p in scope.problems(root))
+
+
+def test_a_default_member_that_classifies_as_firmware_is_a_contradiction(tmp_path):
+    """`cargo clippy --all-targets` builds every default-member for the host.
+
+    So a default-member the classifier calls cross-target-only means the
+    classifier is wrong, and saying so beats silently shrinking the scope.
+    """
+    root = make_repo(
+        tmp_path, TRIO, default_members=["crates/d", "crates/b"], workflow=WASM_STEP
+    )
+    assert any("default-member `crates/b`" in p for p in scope.problems(root))
+
+
+def test_the_reference_tree_is_sound(tmp_path):
+    """The positive control for every negative one below it."""
+    root = make_repo(tmp_path, TRIO, default_members=DEFAULTS, workflow=WASM_STEP)
+    assert scope.problems(root) == []
+
+
+def test_default_members_are_left_to_the_bare_command(tmp_path):
+    """This scope is the COMPLEMENT, not a second copy.
+
+    Re-linting them here would double the step's cost for no coverage — the
+    measured reason the crates/wasm steps were split out of pr-gate in the
+    first place.
+    """
+    root = make_repo(tmp_path, TRIO, default_members=DEFAULTS, workflow=WASM_STEP)
+    assert scope.clippy_packages(root) == ["host-crate"]
+
+
+def test_a_bare_clippy_step_must_still_exist_somewhere(tmp_path):
+    """Narrow every `cargo clippy` to a `-p` list and default-members go dark.
+
+    This scope subtracts them on the strength of that command existing. If it
+    stops existing, the subtraction stops being safe, and saying so is the
+    difference between a partition and a hole.
+    """
+    root = make_repo(
+        tmp_path,
+        TRIO,
+        default_members=DEFAULTS,
+        workflow="        run: cargo clippy -p labwired-wasm --all-targets -- -D warnings\n",
+    )
+    assert any("runs without `-p`" in p for p in scope.problems(root))
+
+
+def test_the_excused_package_must_still_be_linted_somewhere(tmp_path):
+    """Delete the browser-layer clippy step and this scope must notice.
+
+    An exception whose justification has quietly evaporated is the same hole
+    with better paperwork.
+    """
+    root = make_repo(
+        tmp_path,
+        TRIO,
+        default_members=DEFAULTS,
+        workflow="        run: cargo clippy --all-targets -- -D warnings\n",
+    )
+    assert any("linted by nothing" in p for p in scope.problems(root))
+
+
+def test_a_commented_out_clippy_step_does_not_cover_the_exception(tmp_path):
+    root = make_repo(
+        tmp_path,
+        TRIO,
+        default_members=DEFAULTS,
+        workflow=(
+            "        run: cargo clippy --all-targets -- -D warnings\n"
+            "        # run: cargo clippy -p labwired-wasm --all-targets\n"
+        ),
+    )
+    assert any("linted by nothing" in p for p in scope.problems(root))
+
+
+def test_cargo_args_are_one_package_per_line(tmp_path, capsys):
+    root = make_repo(tmp_path, TRIO, default_members=DEFAULTS, workflow=WASM_STEP)
+    assert scope.main(["--cargo-args", "--root", str(root)]) == 0
+    assert capsys.readouterr().out.splitlines() == ["--package=host-crate"]
+
+
+# ── the live tree ─────────────────────────────────────────────────────────────
+
+
+def test_this_repository_passes():
+    assert scope.problems(scope.REPO_ROOT) == []
+
+
+def test_the_live_tree_has_crates_in_BOTH_classes():
+    """The non-vacuity assertion.
+
+    A classifier that answered "host" for everything, or "firmware" for
+    everything, passes every synthetic case above. This is the one that fails.
+    """
+    host, cross = scope.classify(scope.REPO_ROOT)
+    assert len(host) > 1
+    assert len(cross) > 1
+    assert len(host) + len(cross) == len(scope.workspace(scope.REPO_ROOT)["members"])
+
+
+def test_the_scope_is_strictly_wider_than_the_default_members():
+    """The whole point: `cargo clippy --all-targets` lints default-members only.
+
+    If this ever stops holding, the new step has stopped adding coverage and the
+    hole is back with a script in front of it.
+    """
+    default = set(scope.workspace(scope.REPO_ROOT)["default-members"])
+    host, _ = scope.classify(scope.REPO_ROOT)
+    host_members = {e["member"] for e in host}
+    assert default < host_members
+
+
+def test_the_crates_this_change_was_written_for_are_in_scope():
+    """Named on purpose, and NOT as the source of the scope.
+
+    The script derives its scope from the tree; this test asserts the derivation
+    actually reaches the crates that motivated it, which a rule that quietly
+    narrowed would not.
+
+    The two groups are different defects and both are real. NO_CLIPPY_AT_ALL is
+    reached by no lane in any target. VIA_DEPENDENCY_ONLY had its *lib* linted
+    incidentally — cargo runs clippy-driver over workspace members it builds as
+    dependencies too — but never its tests, benches, bins or `#[cfg(test)]`
+    modules, which is the half `--all-targets` exists for.
+    """
+    NO_CLIPPY_AT_ALL = {
+        "labwired-egress-relay",
+        "labwired-hw-oracle",
+        "labwired-hw-oracle-macros",
+        "labwired-hw-runner",
+        "validation-report",
+        "labwired-python",
+    }
+    VIA_DEPENDENCY_ONLY = {
+        "labwired-codegen",
+        "labwired-config",
+        "labwired-gdbstub",
+        "labwired-hw-trace",
+        "labwired-ir",
+        "svd-ingestor",
+    }
+    linted = set(scope.clippy_packages(scope.REPO_ROOT))
+    assert NO_CLIPPY_AT_ALL <= linted
+    assert VIA_DEPENDENCY_ONLY <= linted
+
+
+def test_no_firmware_crate_leaks_into_the_scope():
+    """Firmware in the scope would fail the step for the wrong reason.
+
+    `cargo clippy -p firmware-rp2040-demo` from the workspace root builds it for
+    the HOST — its own .cargo/config.toml is out of cargo's config search path
+    from there — and a `#![no_std]` Cortex-M crate does not link on x86.
+    """
+    linted = scope.clippy_packages(scope.REPO_ROOT)
+    assert [n for n in linted if n.startswith("firmware-")] == []
+    assert [n for n in linted if n.endswith("-lab")] == []


### PR DESCRIPTION
## The defect

`cargo clippy --all-targets` at the workspace root is **not a workspace command**. It resolves to `default-members`:

```toml
default-members = ["crates/cli", "crates/core", "crates/dap", "crates/loader", "crates/labwired-fuzz"]
```

Five packages of eighty-four. Both clippy steps in `core-ci.yml` are that bare command — `Clippy (default-members)` in `pr-gate` and `Run Clippy` in `integrity` — so the pre-merge lane and the main lane have the same five-package scope, which is why the existing "keep these two in step" note never closed anything.

`crates/wasm` was rescued from this gap **one crate at a time, by name**, after a browser-only fork shipped behind a fully green board. The note on that step ends: *"Before this step, NO pre-merge lane in this repo compiled the code the browser actually runs."* That argument was right and it was never generalized. Twelve more host crates sit outside `default-members`.

## What actually reached those twelve — measured, and narrower than it first looks

The first pass at this assumed the twelve were linted by nothing. That is only half true, and the half that is false matters:

* Cargo applies `RUSTC_WORKSPACE_WRAPPER=clippy-driver` to **every workspace member it builds, dependencies included**. So six of the twelve already had their **lib** linted incidentally, as path-deps of a default-member: `labwired-codegen`, `labwired-config`, `labwired-gdbstub`, `labwired-hw-trace`, `labwired-ir`, `svd-ingestor`.
* Six were reached by **no clippy lane at all, in any target**: `labwired-egress-relay`, `labwired-hw-oracle` (the silicon ground-truth comparator), `labwired-hw-oracle-macros`, `labwired-hw-runner`, `validation-report`, `labwired-python`.
* And for **all twelve**, everything that is not the lib — `tests/`, `benches/`, `[[bin]]` targets, `#[cfg(test)]` modules — was linted by nothing, because a dependency is only ever built as a lib. That is exactly the class the `pr-gate` note already records: `channel: Option<String>` on `BoardIoBinding` stranded four literals in the DAP adapter's tests and *"was invisible to anything short of `--all-targets`"*.

**None of this is a testing gap.** `pr-workspace-tests` shards `cargo test --workspace --no-run`, which compiles and runs every member. It is clippy, and only clippy, that stopped short.

## The fix: a derived scope, not a longer list

A hand-maintained `-p` list in the workflow would be the same defect one level up — the hole reopens the next time somebody adds a crate, exactly as it did after `crates/wasm` was handled by name.

`scripts/ci/host_clippy_scope.py` classifies every workspace member from the tree. A member is cross-target-only when it says so itself, in one of the two ways this repo already uses:

1. a per-crate `.cargo/config.toml` pinning `[build] target` to a bare-metal triple (22 members), or
2. a crate root carrying `#![no_std]` (65 members).

Crate roots are read from the manifest, not guessed — `firmware-f407-demo` declares `[[bin]]` targets at `src/smoke.rs` and `src/i2c.rs` and has no `src/main.rs`, so a default-path scan would find no `#![no_std]` and call a Cortex-M4 crate a host crate. A pinned target that does **not** look bare-metal raises rather than guessing.

The script emits the host crates the other two clippy scopes do not cover, and `--check` asserts those two still exist — a bare `cargo clippy` somewhere for `default-members`, and the `-p labwired-wasm` step in `browser-layer`. The three scopes therefore **partition** the host set with no list anywhere and no gap between them. `--check` also fails when the emitted scope comes out empty, because a `cargo clippy` with no packages left to name silently falls back to linting `default-members` and reports green.

### Before / after, in member counts

| | linted by a clippy step | |
|---|---|---|
| **before** | 5 (`default-members`) + 1 (`labwired-wasm`, its own step) | = **6** of 18 host-lintable members |
| **after** | 5 + 1 + **12** derived | = **18** of 18 |

The other 66 members are firmware and are correctly skipped. 18 + 66 = 84, asserted by a test.

### The one exception, and it is mechanically checked

`labwired-wasm` stays in its own invocation. Folding it into this scope turns the step **red** on `crates/core/tests/esp32_classic_walk_differential.rs:89` (`clippy::type_complexity`) — `crates/wasm` turns `event-scheduler` on and one cargo invocation unifies features, so a shared invocation lints a *different* core from the one the browser builds. That is genuine pre-existing debt in the `event-scheduler` arm that no lane lints; it is left for its own change rather than paid by accident here. `--check` asserts the `-p labwired-wasm` step still exists, so the exception cannot quietly become a hole.

## Negative control

Sabotage appended to two files, `git diff --stat` confirming each landed before any conclusion was drawn, restored afterwards by copying the saved original back (SHA-256 verified equal, `git diff` empty) — never `git checkout`.

The **first** control was in `crates/ir/src/lib.rs` and **failed to prove anything**: the default-members clippy caught it, which is what exposed the transitive-dependency mechanism above. The corrected controls target the two real gaps:

| command | `crates/hw-oracle/src/lib.rs` (no lane reaches it) + `crates/config/tests/config_tests.rs` (test target of a transitively-linted lib) |
|---|---|
| `cargo clippy --all-targets -- -D warnings` (today's `pr-gate` / `integrity`) | **exit 0 — misses both** |
| `cargo clippy -p labwired-wasm --all-targets -- -D warnings` (today's `browser-layer`) | **exit 0 — misses both** |
| the derived scope (this PR) | **exit 101** — `clippy::ptr_arg`, `clippy::len_zero`, `clippy::map_clone` in both files |

On the clean tree the derived scope exits 0. All twelve crates are clippy-clean today, so **this change pays no debt**.

## Runtime

Wired into `browser-layer` and `integrity`, not `pr-gate`.

`pr-gate` is time-budgeted and its own note forbids a third timeout bump. Measured from run `33458359629`: `pr-gate` **7m03s** against a 12-minute wall (`Clippy (default-members)` 59s, `Unit tests` 164s, `Generated artifacts` 88s); `browser-layer` **2m14s** against a 20-minute wall (wasm clippy 22s, wasm lib tests 91s).

Locally, cold: the new step is **25s** on top of the existing wasm clippy (26s). Folding the same twelve into `pr-gate`'s `--all-targets` default-members build measured **50s** instead — the test targets of `core` and `cli` are most of that, and this scope does not rebuild them.

**Measured on this PR's own run** (`33498580667`, cold cache — `browser-layer` has its own cache key and this branch had none): the new `Clippy (host crates outside default-members)` step cost **62s**, taking `browser-layer` from 2m14s to **3m25s** of its 20-minute wall. `pr-gate` was **5m48s**, unchanged by this PR. The step logged the derived scope it built:

```
host clippy scope: OK (12 host member(s) linted by this scope, default-members by the bare `cargo clippy`, `labwired-wasm` by its own step, 66 cross-target-only member(s) skipped)
derived scope: --package=labwired-codegen --package=labwired-config --package=labwired-egress-relay --package=labwired-gdbstub --package=labwired-hw-oracle --package=labwired-hw-oracle-macros --package=labwired-hw-runner --package=labwired-hw-trace --package=labwired-ir --package=validation-report --package=labwired-python --package=svd-ingestor
```

`browser-layer` is a **required context on main and runs on every PR**, so this is not a move to a main-only lane. `integrity` gets the same step because it is push-on-main only and would otherwise lint the twelve on PRs and not on main — the exact asymmetry the `pr-gate` note says the hole used to live in.

## Verification run locally

* `python3 -m pytest scripts/ci/test_host_clippy_scope.py scripts/ci/test_linker_script_single_source.py -q` → **42 passed**
* `python3 scripts/ci/host_clippy_scope.py --check` → OK, 12 linted here, 66 skipped
* the derived `cargo clippy` command on the clean tree → exit 0
* `actionlint .github/workflows/core-ci.yml` → exit 0 (it shellchecks `run:` blocks too)
* `yaml.safe_load` on the workflow, and `bash -n` over every edited `run:` block → OK

`scripts/ci/test_host_clippy_scope.py` is added to the explicit pytest list in `pr-gate` — a suite not named there never runs. Its live-tree tests assert the classifier is non-vacuous (crates in **both** classes, counts summing to `members`), that the scope is strictly wider than `default-members`, and that no `firmware-*` or `*-lab` crate leaks in (those would fail the step for the wrong reason: from the workspace root their own `.cargo/config.toml` is outside cargo's config search path, so they would be built for x86).
