### PR TITLE
fix: support analog-source AI part packs

### DIFF
--- a/crates/core/src/bus/declarative_device.rs
+++ b/crates/core/src/bus/declarative_device.rs
@@ -40,6 +40,47 @@ pub(crate) fn lookup(device_type: &str) -> Result<Option<DeviceDescriptor>> {
     DeviceDescriptor::embedded(device_type)
 }
 
+/// Validate the static portion of a GPIO / pin-timing descriptor.
+///
+/// Pin labels themselves belong to a placed `external_devices` entry and need
+/// a concrete MCU to resolve, but every primitive's role-to-config-key mapping
+/// is part of the pack. Checking it here lets manifest preflight reject an
+/// incomplete private GPIO leaf even when no current canvas references it.
+pub(crate) fn validate_descriptor(desc: &DeviceDescriptor) -> Result<()> {
+    let required_roles: &[&str] = match desc.behavior.primitive.as_str() {
+        "quadrature" => &["a", "b"],
+        "matrix" => &["rows", "cols"],
+        "one_wire" => &["data"],
+        "pulse_echo" => &["trig", "echo"],
+        other => {
+            return Err(anyhow!(
+                "declarative device '{}' names unknown primitive '{}'",
+                desc.r#type,
+                other
+            ));
+        }
+    };
+    for role in required_roles {
+        let Some(config_key) = desc.behavior.pins.get(*role) else {
+            return Err(anyhow!(
+                "declarative device '{}' primitive '{}' is missing required pin role '{}'",
+                desc.r#type,
+                desc.behavior.primitive,
+                role
+            ));
+        };
+        if config_key.trim().is_empty() {
+            return Err(anyhow!(
+                "declarative device '{}' primitive '{}' has a blank config key for pin role '{}'",
+                desc.r#type,
+                desc.behavior.primitive,
+                role
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl SystemBus {
     /// Attach a declarative GPIO device described by `desc` for the placed
     /// `ext`. Dispatches on the descriptor's primitive; each primitive arm
@@ -50,6 +91,7 @@ impl SystemBus {
         ext: &ExternalDevice,
         desc: &DeviceDescriptor,
     ) -> Result<()> {
+        validate_descriptor(desc)?;
         match desc.behavior.primitive.as_str() {
             "quadrature" => self.attach_quadrature(ext, desc),
             "matrix" => self.attach_matrix(ext, desc),

--- a/crates/core/src/bus/from_config.rs
+++ b/crates/core/src/bus/from_config.rs
@@ -136,7 +136,7 @@ impl SystemBus {
         // `from_file` is the CLI's path, and the browser and hosted runners
         // parse with `from_yaml`. Validating at load time only would mean two
         // of our three runtimes silently accept documents the third rejects.
-        manifest.validate_parts()?;
+        super::part_pack::validate_manifest(manifest)?;
         let flash_size = chip.flash.size;
         let ram_size = chip.ram.size;
 

--- a/crates/core/src/bus/part_pack.rs
+++ b/crates/core/src/bus/part_pack.rs
@@ -16,8 +16,8 @@
 //! is the one we exercise every day rather than a side door that rots.
 //!
 //! What is NOT here is any new modelling. A pack names one of the irreducible
-//! primitives (`i2c_device`, `spi_device`, `quadrature`, `matrix`, `one_wire`,
-//! `pulse_echo`) and this module routes it to the same construction the built-in
+//! primitives (`i2c_device`, `spi_device`, `analog_source`, `quadrature`,
+//! `matrix`, `one_wire`, `pulse_echo`) and this module routes it to the same construction the built-in
 //! parts use. A part with a genuinely new wire protocol needs a new primitive,
 //! which is a change to this crate — that boundary is real and worth being
 //! straight about.
@@ -34,6 +34,8 @@
 //! - **SPI** — SPI devices only ever attach through the `PeripheralKit`
 //!   registry, so [`kit_for`] interns the pack as a kit and `from_config`
 //!   attaches it exactly as it attaches a built-in.
+//! - **Analog source** — a source owns both its ADC connection and simulator
+//!   input channel, so it also attaches through its `PeripheralKit`.
 //! - **GPIO / pin-timing** — no factory at all; `from_config` hands the
 //!   descriptor to `attach_declarative_device`, the same call the embedded
 //!   `configs/devices/*.yaml` descriptors take.
@@ -44,6 +46,7 @@ use std::sync::{LazyLock, Mutex};
 use anyhow::{Context, Result};
 use labwired_config::{DeviceDescriptor, SystemManifest};
 
+use crate::peripherals::components::declarative_analog::DeclarativeAnalogKit;
 use crate::peripherals::components::{DeclarativeI2cKit, DeclarativeSpiKit};
 use crate::peripherals::kit::PeripheralKit;
 use crate::sim_input::SimInput;
@@ -66,6 +69,28 @@ fn builtin_owns(device_type: &str) -> bool {
         || labwired_config::embedded_device_yaml(device_type).is_some()
 }
 
+/// Reject an implicit replacement of an engine-owned device type.
+///
+/// This belongs to manifest preflight as well as lookup: a manifest carries a
+/// complete portable catalog, so an unused collision is already invalid rather
+/// than a deferred surprise when a later canvas places that part.
+fn validate_shadowing(pack: &DeviceDescriptor) -> Result<()> {
+    if builtin_owns(&pack.r#type) && pack.overrides.as_deref() != Some(pack.r#type.as_str()) {
+        anyhow::bail!(
+            "part pack '{}' ({}) shadows a built-in part. \
+             Set `overrides: {}` to replace it deliberately, or rename the pack. \
+             Which model ran is not something a bug report should have to guess at.",
+            pack.r#type,
+            pack.source
+                .as_deref()
+                .map(|s| format!("source: {s}"))
+                .unwrap_or_else(|| "no declared source".to_string()),
+            pack.r#type,
+        );
+    }
+    Ok(())
+}
+
 /// Resolve `device_type` against the manifest's `parts:`, enforcing the
 /// shadowing rule.
 ///
@@ -78,21 +103,61 @@ pub(crate) fn lookup<'m>(
     let Some(pack) = manifest.resolve_part(device_type) else {
         return Ok(None);
     };
-    if builtin_owns(device_type) && pack.overrides.as_deref() != Some(device_type) {
-        anyhow::bail!(
-            "part pack '{device_type}' ({}) shadows a built-in part. \
-             Set `overrides: {device_type}` to replace it deliberately, or rename the pack. \
-             Which model ran is not something a bug report should have to guess at.",
-            pack.source
-                .as_deref()
-                .map(|s| format!("source: {s}"))
-                .unwrap_or_else(|| "no declared source".to_string()),
-        );
-    }
+    validate_shadowing(pack)?;
     Ok(Some(pack))
 }
 
-/// Intern a pack as a `PeripheralKit` for the bus-resident (I²C / SPI)
+/// Validate every part pack a manifest carries before any simulator path
+/// starts attaching devices.
+///
+/// `SystemManifest::validate_parts` owns the portable envelope (schema,
+/// duplicate names, and path entries). This adds the engine-owned semantic
+/// check for each supported primitive, including packs that are not referenced
+/// by the current canvas. A saved manifest is a complete portable catalog: a
+/// malformed leaf must not wait for a later diagram to happen to use it.
+pub(crate) fn validate_manifest(manifest: &SystemManifest) -> Result<()> {
+    manifest.validate_parts()?;
+    for entry in &manifest.parts {
+        let pack = entry.descriptor().ok_or_else(|| {
+            anyhow::anyhow!(
+                "part pack path entry reached runtime validation after manifest validation"
+            )
+        })?;
+        validate_shadowing(pack)?;
+        validate_runtime_descriptor(pack)?;
+    }
+    Ok(())
+}
+
+/// Validate one pack against the primitive that will eventually interpret it,
+/// without constructing/interning a runtime kit. The same seven primitive
+/// names are the public `labwired.part/v1` contract.
+fn validate_runtime_descriptor(pack: &DeviceDescriptor) -> Result<()> {
+    let result = match pack.behavior.primitive.as_str() {
+        "i2c_device" => crate::peripherals::components::declarative_i2c::validate_descriptor(pack),
+        "spi_device" => crate::peripherals::components::declarative_spi::validate_descriptor(pack),
+        "analog_source" => {
+            crate::peripherals::components::declarative_analog::validate_descriptor(pack)
+        }
+        "quadrature" | "matrix" | "one_wire" | "pulse_echo" => {
+            super::declarative_device::validate_descriptor(pack)
+        }
+        primitive => anyhow::bail!(
+            "part pack '{}' names unsupported primitive '{}'. Supported primitives are \
+             i2c_device, spi_device, analog_source, quadrature, matrix, one_wire, pulse_echo",
+            pack.r#type,
+            primitive
+        ),
+    };
+    result.with_context(|| {
+        format!(
+            "part pack '{}' is not a valid {}",
+            pack.r#type, pack.behavior.primitive
+        )
+    })
+}
+
+/// Intern a pack as a `PeripheralKit` for bus-resident (I²C / SPI / analog)
 /// primitives. Returns `Ok(None)` for a primitive that is not bus-resident —
 /// the GPIO / pin-timing family, which attaches through
 /// [`super::declarative_device`] instead.
@@ -100,6 +165,7 @@ pub(crate) fn kit_for(pack: &DeviceDescriptor) -> Result<Option<&'static dyn Per
     let transport = match pack.behavior.primitive.as_str() {
         "i2c_device" => Transport::I2c,
         "spi_device" => Transport::Spi,
+        "analog_source" => Transport::Analog,
         _ => return Ok(None),
     };
 
@@ -120,6 +186,11 @@ pub(crate) fn kit_for(pack: &DeviceDescriptor) -> Result<Option<&'static dyn Per
         Transport::Spi => Box::leak(Box::new(DeclarativeSpiKit::from_yaml(&key).with_context(
             || format!("part pack '{}' is not a valid spi_device", pack.r#type),
         )?)),
+        Transport::Analog => Box::leak(Box::new(
+            DeclarativeAnalogKit::from_yaml(&key).with_context(|| {
+                format!("part pack '{}' is not a valid analog_source", pack.r#type)
+            })?,
+        )),
     };
     interned.insert(key, kit);
     Ok(Some(kit))
@@ -128,6 +199,7 @@ pub(crate) fn kit_for(pack: &DeviceDescriptor) -> Result<Option<&'static dyn Per
 enum Transport {
     I2c,
     Spi,
+    Analog,
 }
 
 /// Build the I²C model for `ext` from a manifest-carried pack, if one claims

--- a/crates/core/src/peripherals/components/declarative_analog.rs
+++ b/crates/core/src/peripherals/components/declarative_analog.rs
@@ -62,12 +62,23 @@ impl DeclarativeAnalogDevice {
             .context("analog_source kit is missing behavior.analog")?;
         validate_spec(spec)?;
         let below_clamp_mv = spec.curve[0].1;
+        let input_value = descriptor
+            .metadata
+            .as_ref()
+            .and_then(|metadata| {
+                metadata
+                    .inputs
+                    .iter()
+                    .find(|candidate| candidate.key == input.key)
+            })
+            .and_then(|input| input.default)
+            .unwrap_or(0.0);
         Ok(Self {
             channel,
             curve: spec.curve.clone(),
             below_clamp_mv,
             above: spec.above_last,
-            input_value: 0.0,
+            input_value,
             input,
             v_ref_mv: 3300.0,
             component_id: None,
@@ -191,26 +202,9 @@ pub struct DeclarativeAnalogKit {
 impl DeclarativeAnalogKit {
     pub fn from_yaml(yaml: &str) -> Result<Self> {
         let descriptor = DeviceDescriptor::from_yaml(yaml)?;
-        if descriptor.behavior.primitive != "analog_source" {
-            bail!(
-                "declarative analog kit requires behavior.primitive: analog_source, got '{}'",
-                descriptor.behavior.primitive
-            );
-        }
-        let spec = descriptor
-            .behavior
-            .analog
-            .as_ref()
-            .context("analog_source kit is missing behavior.analog")?;
-        validate_spec(spec)?;
+        validate_descriptor(&descriptor)?;
 
         let channels = leak_channels(&descriptor);
-        if channels.len() != 1 {
-            bail!(
-                "analog_source drives exactly one input channel, got {}",
-                channels.len()
-            );
-        }
         let metadata = leak_metadata(&descriptor, channels);
         Ok(Self {
             descriptor,
@@ -218,6 +212,33 @@ impl DeclarativeAnalogKit {
             metadata,
         })
     }
+}
+
+/// Validate the static descriptor contract for the `analog_source` primitive
+/// without constructing a long-lived kit. Part-pack preflight calls this for
+/// every carried pack, including leaves that no current canvas references.
+pub(crate) fn validate_descriptor(descriptor: &DeviceDescriptor) -> Result<()> {
+    if descriptor.behavior.primitive != "analog_source" {
+        bail!(
+            "declarative analog kit requires behavior.primitive: analog_source, got '{}'",
+            descriptor.behavior.primitive
+        );
+    }
+    let spec = descriptor
+        .behavior
+        .analog
+        .as_ref()
+        .context("analog_source kit is missing behavior.analog")?;
+    validate_spec(spec)?;
+    let input_count = descriptor
+        .metadata
+        .as_ref()
+        .map(|metadata| metadata.inputs.len())
+        .unwrap_or(0);
+    if input_count != 1 {
+        bail!("analog_source drives exactly one input channel, got {input_count}");
+    }
+    Ok(())
 }
 
 /// Leak the descriptor's `metadata.inputs` into a static channel table — the

--- a/crates/core/src/peripherals/components/declarative_i2c.rs
+++ b/crates/core/src/peripherals/components/declarative_i2c.rs
@@ -193,12 +193,12 @@ impl GenericI2cDevice {
         address: u8,
         channels: &'static [InputChannel],
     ) -> Result<Self> {
+        validate_descriptor(descriptor)?;
         let spec = descriptor
             .behavior
             .i2c
             .as_ref()
             .context("declarative i2c device is missing behavior.i2c")?;
-        validate_spec(spec)?;
 
         let address = if address == 0 {
             spec.default_address
@@ -990,6 +990,25 @@ impl SimInput for GenericI2cDevice {
     }
 }
 
+/// Validate the static descriptor contract for the `i2c_device` primitive.
+///
+/// Kept separate from construction so a manifest can preflight every carried
+/// pack without leaking runtime channel tables for leaves it does not attach.
+pub(crate) fn validate_descriptor(descriptor: &DeviceDescriptor) -> Result<()> {
+    if descriptor.behavior.primitive != "i2c_device" {
+        bail!(
+            "declarative i2c kit requires behavior.primitive: i2c_device, got '{}'",
+            descriptor.behavior.primitive
+        );
+    }
+    let spec = descriptor
+        .behavior
+        .i2c
+        .as_ref()
+        .context("declarative i2c kit is missing behavior.i2c")?;
+    validate_spec(spec)
+}
+
 /// A descriptor is exactly one shape (registers XOR commands XOR register_file),
 /// and command devices with CRC framing must use even-width words (CRC is
 /// computed per 16-bit word).
@@ -1338,18 +1357,12 @@ pub struct DeclarativeI2cKit {
 impl DeclarativeI2cKit {
     pub fn from_yaml(yaml: &str) -> Result<Self> {
         let descriptor = DeviceDescriptor::from_yaml(yaml)?;
-        if descriptor.behavior.primitive != "i2c_device" {
-            bail!(
-                "declarative i2c kit requires behavior.primitive: i2c_device, got '{}'",
-                descriptor.behavior.primitive
-            );
-        }
+        validate_descriptor(&descriptor)?;
         let spec = descriptor
             .behavior
             .i2c
             .as_ref()
             .context("declarative i2c kit is missing behavior.i2c")?;
-        validate_spec(spec)?;
         let default_address = spec.default_address;
 
         let channels = leak_channels(&descriptor);

--- a/crates/core/src/peripherals/components/declarative_spi.rs
+++ b/crates/core/src/peripherals/components/declarative_spi.rs
@@ -49,47 +49,67 @@ pub struct GenericSpiDevice {
     component_id: Option<String>,
 }
 
+/// Validate the static descriptor contract for the `spi_device` primitive.
+///
+/// This stays separate from construction so manifest preflight can reject
+/// malformed unused packs without allocating runtime input tables.
+pub(crate) fn validate_descriptor(descriptor: &DeviceDescriptor) -> Result<()> {
+    if descriptor.behavior.primitive != "spi_device" {
+        bail!(
+            "declarative spi kit requires behavior.primitive: spi_device, got '{}'",
+            descriptor.behavior.primitive
+        );
+    }
+    let spec = descriptor
+        .behavior
+        .spi
+        .as_ref()
+        .context("declarative spi device is missing behavior.spi")?;
+    if spec.registers.is_empty() {
+        bail!("behavior.spi declares no registers");
+    }
+    if spec.framing.command_bytes > 1 {
+        bail!(
+            "behavior.spi command_bytes {} unsupported (0 or 1)",
+            spec.framing.command_bytes
+        );
+    }
+    // `zero_when` power-gates work here too (the read math is shared with
+    // the I²C engine), so a dangling reference must not silently no-op into
+    // "gate never fires". No shipping SPI descriptor uses one yet; this is
+    // the guard that keeps the first one from being wrong in silence.
+    for reg in &spec.registers {
+        if let Some(z) = &reg.zero_when {
+            if !spec.registers.iter().any(|r| r.name == z.register) {
+                bail!(
+                    "register '{}' zero_when register '{}' is not a declared register",
+                    reg.name,
+                    z.register
+                );
+            }
+            if z.mask == 0 {
+                bail!(
+                    "register '{}' zero_when mask is 0 — the gate could never fire",
+                    reg.name
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl GenericSpiDevice {
     pub fn from_descriptor(
         descriptor: &DeviceDescriptor,
         cs_pin: String,
         channels: &'static [InputChannel],
     ) -> Result<Self> {
+        validate_descriptor(descriptor)?;
         let spec = descriptor
             .behavior
             .spi
             .as_ref()
             .context("declarative spi device is missing behavior.spi")?;
-        if spec.registers.is_empty() {
-            bail!("behavior.spi declares no registers");
-        }
-        if spec.framing.command_bytes > 1 {
-            bail!(
-                "behavior.spi command_bytes {} unsupported (0 or 1)",
-                spec.framing.command_bytes
-            );
-        }
-        // `zero_when` power-gates work here too (the read math is shared with
-        // the I²C engine), so a dangling reference must not silently no-op into
-        // "gate never fires". No shipping SPI descriptor uses one yet; this is
-        // the guard that keeps the first one from being wrong in silence.
-        for reg in &spec.registers {
-            if let Some(z) = &reg.zero_when {
-                if !spec.registers.iter().any(|r| r.name == z.register) {
-                    bail!(
-                        "register '{}' zero_when register '{}' is not a declared register",
-                        reg.name,
-                        z.register
-                    );
-                }
-                if z.mask == 0 {
-                    bail!(
-                        "register '{}' zero_when mask is 0 — the gate could never fire",
-                        reg.name
-                    );
-                }
-            }
-        }
         let mut slots = HashMap::new();
         if let Some(meta) = &descriptor.metadata {
             for input in &meta.inputs {
@@ -341,17 +361,7 @@ pub struct DeclarativeSpiKit {
 impl DeclarativeSpiKit {
     pub fn from_yaml(yaml: &str) -> Result<Self> {
         let descriptor = DeviceDescriptor::from_yaml(yaml)?;
-        if descriptor.behavior.primitive != "spi_device" {
-            bail!(
-                "declarative spi kit requires behavior.primitive: spi_device, got '{}'",
-                descriptor.behavior.primitive
-            );
-        }
-        descriptor
-            .behavior
-            .spi
-            .as_ref()
-            .context("declarative spi kit is missing behavior.spi")?;
+        validate_descriptor(&descriptor)?;
         let channels = super::declarative_i2c::leak_channels(&descriptor);
         let metadata = leak_metadata(&descriptor, channels);
         Ok(Self {

--- a/crates/core/src/system/xtensa/esp32.rs
+++ b/crates/core/src/system/xtensa/esp32.rs
@@ -49,6 +49,10 @@ pub fn attach_esp32_external_devices(
     bus: &mut SystemBus,
     manifest: &labwired_config::SystemManifest,
 ) -> anyhow::Result<()> {
+    // Xtensa machines build their peripheral bank directly instead of through
+    // `SystemBus::from_config`, so this is the runtime contract boundary for
+    // browser/WASM manifests as well as native callers.
+    crate::bus::part_pack::validate_manifest(manifest)?;
     // Classic ESP32 builds its peripheral bank in Rust and never runs
     // `SystemBus::from_config`'s peripheral loop, so it must record the
     // manifest's external-device declarations itself. Without this the devices

--- a/crates/core/tests/part_pack_contract.rs
+++ b/crates/core/tests/part_pack_contract.rs
@@ -19,6 +19,7 @@ use labwired_config::{ChipDescriptor, SystemManifest};
 use labwired_core::bus::SystemBus;
 use labwired_core::peripherals::esp32c3::i2c::Esp32c3I2c;
 use labwired_core::peripherals::i2c::I2cDevice;
+use labwired_core::system::xtensa::{attach_esp32_external_devices, configure_xtensa_esp32};
 use std::path::PathBuf;
 
 /// A private I²C temperature sensor that exists nowhere in this repository.
@@ -230,6 +231,231 @@ fn an_unresolved_path_entry_reaching_the_engine_is_refused() {
     );
 }
 
+/// The classic ESP32/S3 browser path constructs its bank in Rust and calls the
+/// exported attacher directly, so its contract cannot depend on `from_config`
+/// having run first. A browser-style parsed manifest missing the pack schema
+/// must fail before that direct path records or attaches anything.
+#[test]
+fn direct_xtensa_attach_validates_manifest_part_contracts() {
+    let manifest = SystemManifest::from_yaml(
+        r#"
+schema_version: "1.0"
+name: "direct-xtensa-part-pack-contract"
+chip: "esp32"
+external_devices: []
+parts:
+  - type: "acme:missing-schema"
+    behavior:
+      primitive: analog_source
+"#,
+    )
+    .expect("raw browser-style manifest must deserialize before the engine validates it");
+    let mut bus = SystemBus::new();
+    let _cpu = configure_xtensa_esp32(&mut bus);
+
+    let err = attach_esp32_external_devices(&mut bus, &manifest)
+        .expect_err("direct Xtensa attachment must enforce the part-pack contract");
+    assert!(
+        format!("{err:#}").contains("missing `schema: labwired.part/v1`"),
+        "the direct attach error must name the missing contract declaration: {err:#}"
+    );
+}
+
+#[test]
+fn direct_xtensa_attach_preflights_unused_pack_semantics() {
+    let manifest = SystemManifest::from_yaml(
+        r#"
+schema_version: "1.0"
+name: "direct-xtensa-invalid-pack"
+chip: "esp32"
+external_devices: []
+parts:
+  - schema: labwired.part/v1
+    type: "acme:invalid-analog"
+    source: acme-private
+    behavior:
+      primitive: analog_source
+"#,
+    )
+    .expect("raw browser-style manifest must deserialize before the engine validates it");
+    let mut bus = SystemBus::new();
+    let _cpu = configure_xtensa_esp32(&mut bus);
+
+    let err = attach_esp32_external_devices(&mut bus, &manifest)
+        .expect_err("direct Xtensa attachment must preflight every carried part pack");
+    assert!(
+        format!("{err:#}").contains("behavior.analog"),
+        "the direct attach error must identify the invalid runtime descriptor: {err:#}"
+    );
+}
+
+/// A manifest is a complete portable catalog, not just a bag of descriptors
+/// that happen to be referenced today. Otherwise a bad private leaf is saved
+/// successfully and fails only when a future canvas happens to use it.
+#[test]
+fn every_manifest_pack_is_runtime_validated_even_when_unused() {
+    let src = r#"
+schema_version: "1.0"
+name: "unused-invalid-pack"
+chip: "esp32c3"
+external_devices: []
+parts:
+  - schema: labwired.part/v1
+    type: "acme:invalid-analog"
+    source: acme-private
+    behavior:
+      primitive: analog_source
+"#;
+
+    let msg = build_error(
+        src,
+        "an unused malformed part pack must not silently enter a runnable manifest",
+    );
+    assert!(
+        msg.contains("behavior.analog"),
+        "the runtime error must identify the missing analog model, got: {msg}"
+    );
+}
+
+#[test]
+fn unused_analog_part_packs_require_exactly_one_input_channel() {
+    let src = r#"
+schema_version: "1.0"
+name: "unused-invalid-analog-inputs"
+chip: "esp32c3"
+external_devices: []
+parts:
+  - schema: labwired.part/v1
+    type: "acme:two-input-analog"
+    source: acme-private
+    behavior:
+      primitive: analog_source
+      analog:
+        curve: [[0, 0], [100, 3300]]
+    metadata:
+      inputs:
+        - { key: first, label: First, unit: "%", min: 0, max: 100 }
+        - { key: second, label: Second, unit: "%", min: 0, max: 100 }
+"#;
+
+    let msg = build_error(
+        src,
+        "an analog source with multiple drive channels is ambiguous and must be rejected",
+    );
+    assert!(
+        msg.contains("exactly one input channel") && msg.contains("2"),
+        "the runtime error must identify the invalid analog input count, got: {msg}"
+    );
+}
+
+#[test]
+fn unused_spi_part_packs_run_the_same_semantic_validation_as_attached_ones() {
+    let src = r#"
+schema_version: "1.0"
+name: "unused-invalid-spi-pack"
+chip: "esp32c3"
+external_devices: []
+parts:
+  - schema: labwired.part/v1
+    type: "acme:bad-spi"
+    source: acme-private
+    behavior:
+      primitive: spi_device
+      spi:
+        framing: { command_bytes: 2 }
+        registers: []
+"#;
+
+    let msg = build_error(
+        src,
+        "an unused SPI pack must receive the device-level semantic checks",
+    );
+    assert!(
+        msg.contains("behavior.spi declares no registers"),
+        "the runtime error must come from the SPI primitive validator, got: {msg}"
+    );
+}
+
+#[test]
+fn unsupported_part_pack_primitives_are_rejected_even_when_unused() {
+    let src = r#"
+schema_version: "1.0"
+name: "unused-unknown-primitive"
+chip: "esp32c3"
+external_devices: []
+parts:
+  - schema: labwired.part/v1
+    type: "acme:novel-sensor"
+    source: acme-private
+    behavior:
+      primitive: quantum_bus
+"#;
+
+    let msg = build_error(
+        src,
+        "a pack may use an engine primitive, but not invent a silent runtime protocol",
+    );
+    assert!(
+        msg.contains("quantum_bus") && msg.contains("acme:novel-sensor"),
+        "the runtime error must identify the unsupported pack primitive, got: {msg}"
+    );
+}
+
+#[test]
+fn unused_gpio_part_packs_validate_their_required_pin_roles() {
+    let src = r#"
+schema_version: "1.0"
+name: "unused-invalid-gpio-pack"
+chip: "esp32c3"
+external_devices: []
+parts:
+  - schema: labwired.part/v1
+    type: "acme:incomplete-encoder"
+    source: acme-private
+    behavior:
+      primitive: quadrature
+      pins:
+        a: clk_pin
+"#;
+
+    let msg = build_error(
+        src,
+        "a GPIO primitive missing a required role must fail before a future canvas uses it",
+    );
+    assert!(
+        msg.contains("quadrature") && msg.contains("b"),
+        "the runtime error must name the missing quadrature role, got: {msg}"
+    );
+}
+
+#[test]
+fn unused_part_packs_cannot_implicitly_shadow_a_builtin() {
+    let pack = ACME_PACK.replace("\"acme:tmp999\"", "tmp102");
+    let mut root: serde_yaml::Mapping = serde_yaml::from_str(
+        r#"
+schema_version: "1.0"
+name: "unused-builtin-shadow"
+chip: "esp32c3"
+external_devices: []
+"#,
+    )
+    .expect("harness manifest is valid YAML");
+    root.insert(
+        "parts".into(),
+        serde_yaml::Value::Sequence(vec![serde_yaml::from_str(&pack).unwrap()]),
+    );
+    let src = serde_yaml::to_string(&root).unwrap();
+
+    let msg = build_error(
+        &src,
+        "a private pack cannot defer its built-in collision until a later canvas uses it",
+    );
+    assert!(
+        msg.contains("shadows a built-in") && msg.contains("overrides: tmp102"),
+        "the preflight error must name the explicit override requirement, got: {msg}"
+    );
+}
+
 // ─── the two halves actually meet ──────────────────────────────────────────
 
 /// The manifest the APP emits, parsed by the ENGINE.
@@ -322,5 +548,67 @@ external_devices:
     assert_eq!(
         devid, 0xE5,
         "the pack's declared reset value must clock out"
+    );
+}
+
+/// Analog packs take the same runtime-owned-kit route as SPI packs.  They are
+/// not GPIO timing primitives: their kit owns both the ADC source and the
+/// `SimInput` channel the browser drives.  A manifest that carries an unknown
+/// analogue leaf therefore has to expose that channel after the bus builds.
+#[test]
+fn an_analog_source_pack_attaches_through_the_kit_door() {
+    const ANALOG_PACK: &str = r#"
+schema: labwired.part/v1
+type: "acme:soil-proxy"
+source: acme-private
+behavior:
+  primitive: analog_source
+  analog:
+    curve:
+      - [0, 3300]
+      - [100, 0]
+metadata:
+  inputs:
+    - { key: moisture, label: Moisture, unit: "%", min: 0, max: 100, default: 50 }
+"#;
+    let mut root: serde_yaml::Mapping = serde_yaml::from_str(
+        r#"
+schema_version: "1.0"
+name: "part-pack-analog"
+chip: "esp32c3"
+external_devices:
+  - id: soil
+    type: "acme:soil-proxy"
+    connection: apb_saradc
+    config: { channel: 3 }
+"#,
+    )
+    .unwrap();
+    root.insert(
+        "parts".into(),
+        serde_yaml::Value::Sequence(vec![serde_yaml::from_str(ANALOG_PACK).unwrap()]),
+    );
+    let src = serde_yaml::to_string(&root).unwrap();
+
+    let mut bus = build_bus(&src).expect("an analog-source pack must build");
+    assert!(
+        bus.list_inputs()
+            .iter()
+            .any(|(owner, channel)| owner == "soil" && channel.key == "moisture"),
+        "the pack must expose its declared simulator input"
+    );
+    let idx = bus
+        .find_peripheral_index_by_name("apb_saradc")
+        .expect("the C3 declares its SAR ADC");
+    let adc = bus.peripherals[idx]
+        .dev
+        .as_any_mut()
+        .expect("the SAR ADC is downcastable")
+        .downcast_mut::<labwired_core::peripherals::esp32c3::apb_saradc::Esp32c3ApbSarAdc>()
+        .expect("the C3 SAR ADC has its production model");
+    assert_eq!(
+        adc.channel_input_count(3),
+        ((1650u32 * 4095) / 3300) as u16,
+        "the descriptor default must seed the midpoint of its analog curve, not 0%"
     );
 }


### PR DESCRIPTION
Adds generic analog-source transport support to declarative AI part packs and covers the real kit attachment contract.\n\nVerified: 
running 10 tests
test an_unresolved_path_entry_reaching_the_engine_is_refused ... ok
test a_pack_without_a_schema_declaration_is_refused ... ok
test two_packs_for_one_type_is_an_error_not_a_race ... ok
test an_analog_source_pack_attaches_through_the_kit_door ... ok
test declaring_the_override_replaces_the_builtin_model ... ok
test an_spi_pack_attaches_through_the_kit_door ... ok
test shadowing_a_builtin_without_declaring_it_is_refused ... ok
test a_part_the_engine_has_never_seen_attaches_and_answers ... ok
test the_same_part_without_its_pack_is_rejected ... ok
test the_manifest_the_app_emits_is_one_the_engine_can_run ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s (10 passed); .