### PR TITLE
docs: onboard Waveshare RP2350-Zero (USB-native)

### DIFF
--- a/configs/systems/rp2350-zero.yaml
+++ b/configs/systems/rp2350-zero.yaml
@@ -1,0 +1,19 @@
+# LabWired - Waveshare RP2350-Zero
+#
+# USB-C is the RP2350 native USB (no UART bridge). Twin console is UART0
+# (GP0/GP1 on the header), not USB CDC. Onboard WS2812 is GP16; this YAML
+# uses a board_io LED stand-in on that pad (same pattern as esp32s3-zero
+# GPIO48). Not Pico 2 GP25.
+#
+# Sources: pico-sdk boards/waveshare_rp2350_zero.h (PICO_DEFAULT_WS2812_PIN 16);
+# Waveshare RP2350_Zero.pdf (DIN = GPIO16).
+name: "rp2350-zero"
+chip: "../chips/rp2350.yaml"
+external_devices: []
+board_io:
+  - id: "led_gp16"
+    kind: "led"
+    peripheral: "sio"
+    pin: 16
+    signal: "output"
+    active_high: true

--- a/docs/boards/rp2350-zero.md
+++ b/docs/boards/rp2350-zero.md
@@ -1,0 +1,197 @@
+# Waveshare RP2350-Zero
+
+Compact **RP2350A** USB-C module (Waveshare RP2350-Zero): dual Cortex-M33,
+520 KB SRAM, 4 MB flash, castellated 18.00 × 23.50 mm board, onboard WS2812
+on **GP16**. Same silicon descriptor as Pico 2; this page is the **Zero
+carrier**. USB-C is native USB — there is no UART-bridge chip.
+
+!!! tip "Live status"
+    The tables below are a maintained snapshot. Authoritative automation:
+
+    - [Chip conformance scoreboard](../coverage/chip-conformance.md)
+    - [Tier-1 matrix](../coverage/tier1-scoreboard.md)
+    - [Target support rubric](../target_support_rubric.md)
+
+---
+
+## Status at a glance
+
+| Aspect | Status |
+|--------|--------|
+| Chip descriptor | [`configs/chips/rp2350.yaml`](../../configs/chips/rp2350.yaml) |
+| System YAML | [`configs/systems/rp2350-zero.yaml`](../../configs/systems/rp2350-zero.yaml) |
+| Example | [`examples/rp2350-zero/`](../../examples/rp2350-zero/README.md) |
+| Playground board id | *not registered* (slice 2) |
+| Reference firmware | `crates/firmware-rp2350-demo/` (UART0 smoke) |
+| Tier (snapshot) | smoke-manual (UART0). **No silicon capture.** |
+
+Pico 2 (GP25 LED, different USB connector) is [`rp2350.md`](rp2350.md) /
+[`examples/pico2/`](../../examples/pico2/README.md).
+
+---
+
+## Flash / firmware artifact
+
+| Use | Artifact | Notes |
+|-----|----------|--------|
+| Twin / CLI | **ELF** linked at XIP `0x10000000` | `firmware-rp2350-demo` |
+| Bench | **UF2** | Hold BOOT, tap RUN, copy to the UF2 disk |
+| Arduino-Pico | `waveshare_rp2350_zero` | Hosted compile is **not** wired yet |
+
+!!! warning "USB-C is not UART0"
+    The cable is RP2350 USB CDC. Header UART0 is GP0 (TX) / GP1 (RX). The twin
+    sinks UART0 only. USB device enumeration is not modeled.
+
+---
+
+## Twin vs USB cable
+
+| | Twin | USB-C cable |
+|---|---|---|
+| Console | UART0 PL011 @ `0x40070000` | CDC (desk capture: VID `2e8a` PID `0009`) |
+| LED | `board_io` LED on SIO GP16 (WS2812 stand-in) | WS2812 DIN GP16 |
+| Load | ELF into XIP | UF2 |
+
+---
+
+## Pins (castellated header, USB-C at top)
+
+Silk from Waveshare wiki pinout + `RP2350_Zero.pdf` P1 (23 pads). Defaults
+from pico-sdk `waveshare_rp2350_zero.h`. Authored drawing:
+[`examples/rp2350-zero/images/pinout.svg`](../../examples/rp2350-zero/images/pinout.svg).
+
+### Right edge (top → bottom)
+
+| Silk | GPIO | Default (pico-sdk) |
+|------|------|--------------------|
+| GP0 | GPIO0 | UART0 TX |
+| GP1 | GPIO1 | UART0 RX |
+| GP2 | GPIO2 | |
+| GP3 | GPIO3 | |
+| GP4 | GPIO4 | |
+| GP5 | GPIO5 | |
+| GP6 | GPIO6 | I2C1 SDA |
+| GP7 | GPIO7 | I2C1 SCL |
+
+### Bottom edge (left → right)
+
+| Silk | GPIO | Default (pico-sdk) |
+|------|------|--------------------|
+| GP13 | GPIO13 | SPI1 CSN |
+| GP12 | GPIO12 | SPI1 RX |
+| GP11 | GPIO11 | SPI1 TX |
+| GP10 | GPIO10 | SPI1 SCK |
+| GP9 | GPIO9 | |
+| GP8 | GPIO8 | |
+
+### Left edge (top → bottom)
+
+| Silk | GPIO | Notes |
+|------|------|--------|
+| 5V | — | VBUS |
+| GND | — | |
+| 3V3 | — | ME6217 3.3 V |
+| GP29 | GPIO29 | ADC3 |
+| GP28 | GPIO28 | ADC2 |
+| GP27 | GPIO27 | ADC1 |
+| GP26 | GPIO26 | ADC0 |
+| GP15 | GPIO15 | |
+| GP14 | GPIO14 | |
+
+### Onboard / solder (not the 20-pin header)
+
+| Silk | GPIO | Notes |
+|------|------|--------|
+| WS2812 DIN | GPIO16 | **Used.** Twin: `led_gp16` stand-in. Not a free header GPIO. |
+| GP17–GP25 | GPIO17–25 | Underside solder points (9 GPIOs + GND). Schematic P2/P3. |
+| SWCLK / SWDIO | debug | Pads; no onboard probe. |
+| BOOT / RUN | — | UF2 entry: BOOT then RUN. |
+
+Always confirm with `labwired_describe` once the playground id exists.
+
+---
+
+## Support matrix
+
+| Mark | Meaning |
+|------|---------|
+| ✅ | Modeled well enough for the demos we ship |
+| ⚠️ | Present but partial, stubbed, or easy to misuse |
+| ❌ | Not simulated — use the bench |
+
+### Core & boot
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| Cortex-M33 core 0 | ✅ | `thumbv8m.main-none-eabi` smoke ELF |
+| Core 1 / SIO FIFO | ❌ | Not a dual-core product story |
+| Hazard3 RISC-V | ❌ | Unmodeled |
+| TrustZone | ❌ | Unmodeled |
+| Bootrom / IMAGE_DEF / UF2 | ❌ | Twin loads ELF. Bench uses UF2. |
+| `rp2350` clocks/resets | ✅ | Moved APB map vs RP2040 |
+
+### Console, GPIO, LED
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| UART0 | ✅ | Twin console. Header GP0/GP1 — not the USB cable. |
+| USB CDC / USB device | ❌ | Bench only |
+| SIO GPIO | ⚠️ | Enough for the GP16 LED stand-in |
+| WS2812 on GP16 | ⚠️ | Stand-in LED. PIO/WS2812 timing not claimed |
+| ADC GP26–29 | ⚠️ | Partial analog |
+
+### Buses
+
+| Block | Status | Notes |
+|-------|--------|--------|
+| I2C0/1, SPI0/1 | ⚠️ | RP2040-lane models on RP2350 bases |
+| PIO0/1/2 | ⚠️ | v1-compatible only; v2-only ops unmodeled |
+| DMA, PWM, TIMER0, WATCHDOG | ⚠️ | See chip page |
+
+Firmware that touches unmodeled MMIO will hit `MemoryAccessViolation` or poll
+forever — that is intentional.
+
+---
+
+## What it catches vs what needs a bench
+
+**Twin is strong for:** UART0 bring-up of an RP2350 Thumb ELF; GP16 as a
+digital LED stand-in; deterministic CLI oracles that match UART0.
+
+**Needs the bench:** anything on USB CDC, UF2 boot, WS2812 color, SWD
+register parity, PIO v2, dual-core.
+
+---
+
+## How to run
+
+### CLI
+
+```bash
+RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2350-demo \
+  --release --target thumbv8m.main-none-eabi
+cargo run -q -p labwired-cli -- test \
+  --script examples/rp2350-zero/uart-smoke.yaml \
+  --output-dir out/rp2350-zero/uart-smoke \
+  --no-uart-stdout
+```
+
+Details: [`examples/rp2350-zero/VALIDATION.md`](../../examples/rp2350-zero/VALIDATION.md).
+
+### Playground
+
+Not in the picker yet. Do not pass `board: rp2350-zero` to playground APIs
+until that id is registered.
+
+### Agent
+
+[MCP](../agent/mcp.md) → describe the **chip** `rp2350` and run against
+`examples/rp2350-zero/system.yaml`. Do not claim USB or WS2812 success.
+
+---
+
+## Related
+
+- Chip / Pico 2: [RP2350](rp2350.md)
+- Example: [`examples/rp2350-zero/`](../../examples/rp2350-zero/README.md)
+- [Parts](../parts/index.md) · [Fidelity](../fidelity.md) · [Rubric](../target_support_rubric.md)

--- a/docs/boards/rp2350-zero.md
+++ b/docs/boards/rp2350-zero.md
@@ -21,7 +21,7 @@ carrier**. USB-C is native USB — there is no UART-bridge chip.
 | Chip descriptor | [`configs/chips/rp2350.yaml`](../../configs/chips/rp2350.yaml) |
 | System YAML | [`configs/systems/rp2350-zero.yaml`](../../configs/systems/rp2350-zero.yaml) |
 | Example | [`examples/rp2350-zero/`](../../examples/rp2350-zero/README.md) |
-| Playground board id | *not registered* (slice 2) |
+| Playground board id | `rp2350-zero` |
 | Reference firmware | `crates/firmware-rp2350-demo/` (UART0 smoke) |
 | Tier (snapshot) | smoke-manual (UART0). **No silicon capture.** |
 
@@ -36,7 +36,7 @@ Pico 2 (GP25 LED, different USB connector) is [`rp2350.md`](rp2350.md) /
 |-----|----------|--------|
 | Twin / CLI | **ELF** linked at XIP `0x10000000` | `firmware-rp2350-demo` |
 | Bench | **UF2** | Hold BOOT, tap RUN, copy to the UF2 disk |
-| Arduino-Pico | `waveshare_rp2350_zero` | Hosted compile is **not** wired yet |
+| Arduino-Pico | `waveshare_rp2350_zero` | Hosted compile id `rp2350-zero`. Browser flash is **not** wired (UF2 on the bench). |
 
 !!! warning "USB-C is not UART0"
     The cable is RP2350 USB CDC. Header UART0 is GP0 (TX) / GP1 (RX). The twin
@@ -180,8 +180,8 @@ Details: [`examples/rp2350-zero/VALIDATION.md`](../../examples/rp2350-zero/VALID
 
 ### Playground
 
-Not in the picker yet. Do not pass `board: rp2350-zero` to playground APIs
-until that id is registered.
+Board id `rp2350-zero` on [app.labwired.com](https://app.labwired.com). USB CDC
+on the cable is still unmodeled — serial in the twin is UART0.
 
 ### Agent
 

--- a/docs/boards/rp2350.md
+++ b/docs/boards/rp2350.md
@@ -7,8 +7,12 @@ PIO0–2), SIO, ADC, PWM, timer, and watchdog, with a `profile: rp2350` on the
 shared clock/reset model for the moved APB map. It is **smoke-validated, not
 hardware-validated** — no Pico 2 has been on the bench.
 
-For build/run instructions, see
+This page is the **Pico 2 carrier** (user LED GP25). The USB-C castellated
+module is **[Waveshare RP2350-Zero](rp2350-zero.md)** (WS2812 on GP16).
+
+For Pico 2 build/run instructions, see
 [`examples/pico2/README.md`](../../examples/pico2/README.md).
+Zero: [`examples/rp2350-zero/README.md`](../../examples/rp2350-zero/README.md).
 
 ## Status at a glance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Parts catalog: [Parts](parts/index.md) · Support levels: [Target rubric](target
 
 ## Boards (popular)
 
-[ESP32-C3](boards/esp32c3.md) · [ESP32-S3](boards/esp32s3.md) · [nRF52840](boards/nrf52840.md) · [RP2040](boards/rp2040.md) · [STM32F401](boards/stm32f401.md)
+[ESP32-C3](boards/esp32c3.md) · [ESP32-S3](boards/esp32s3.md) · [nRF52840](boards/nrf52840.md) · [RP2040](boards/rp2040.md) · [RP2350-Zero](boards/rp2350-zero.md) · [STM32F401](boards/stm32f401.md)
 
 ---
 

--- a/examples/rp2350-zero/EXTERNAL_COMPONENTS.md
+++ b/examples/rp2350-zero/EXTERNAL_COMPONENTS.md
@@ -1,0 +1,19 @@
+# External Components (Waveshare RP2350-Zero)
+
+No required external simulated components for minimal deterministic smoke.
+
+Onboard parts (not extra modules):
+
+| Part | Pad | Twin |
+|------|-----|------|
+| WS2812 RGB | GP16 (DIN) | `board_io` LED stand-in `led_gp16` on SIO pin 16. Not a NeoPixel kit. Timing/PIO of the real WS2812 is unproven here. |
+| ME6217C33M5G LDO | 3V3 rail | Power is digital in the twin — not SPICE. |
+| 12 MHz crystal | XIN/XOUT | Clock tree via `rp2350` clkrst profile. |
+| 4 MB NOR flash | QSPI | XIP load of the ELF; not a flash programmer model. |
+| BOOT, RUN | USB boot / reset | Not modeled as GPIOs. Bench: BOOT then RESET enters UF2. |
+
+USB Type-C is the RP2350 USB peripheral. The twin does **not** enumerate USB. Do not attach a `usb_serial` bridge part — there is none on this board.
+
+## Adding an external device
+
+See [`examples/demo-blinky/`](../demo-blinky/README.md) for `external_devices`. I2C/SPI sensors that attach on the RP2040 lane attach here on the RP2350 bases. Header defaults (pico-sdk): I2C1 GP6/GP7, SPI1 GP10–13, UART0 GP0/GP1.

--- a/examples/rp2350-zero/README.md
+++ b/examples/rp2350-zero/README.md
@@ -1,0 +1,49 @@
+# Waveshare RP2350-Zero
+
+Run all commands from `core/`.
+
+## Purpose
+
+Deterministic bring-up for the **Waveshare RP2350-Zero** (RP2350A, USB-C,
+castellated, 4 MB flash, WS2812 on **GP16**). Same chip descriptor as Pico 2;
+different carrier. Twin console is UART0. The USB-C cable is native USB CDC
+on the bench and is **not** modeled.
+
+## Twin vs this USB cable
+
+| | Twin | USB-C cable |
+|---|---|---|
+| Console | UART0 DR (`0x40070000`) | CDC (this desk: `/dev/cu.usbmodem11201`) |
+| LED | SIO `board_io` on GP16 (WS2812 stand-in) | WS2812 DIN GP16 |
+| Load | ELF at XIP `0x10000000` | UF2: hold BOOT, tap RUN, copy `.uf2` |
+
+## Quick run (twin)
+
+```bash
+rustup target add thumbv8m.main-none-eabi   # once
+RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2350-demo \
+  --release --target thumbv8m.main-none-eabi
+cargo run -q -p labwired-cli -- test \
+  --script examples/rp2350-zero/uart-smoke.yaml \
+  --output-dir out/rp2350-zero/uart-smoke \
+  --no-uart-stdout
+```
+
+Expected: exit 0, UART contains `RP2350_SMOKE_OK`.
+
+## Bench (UF2)
+
+1. Hold **BOOT**, tap **RUN**, release BOOT. A UF2 disk appears.
+2. Copy a `.uf2` built for `waveshare_rp2350_zero` / RP2350A.
+3. Serial is USB CDC, not GP0/GP1 unless you wire a UART adapter.
+
+## Files
+
+1. `system.yaml` — GP16 LED stand-in via SIO.
+2. `uart-smoke.yaml` — UART oracle (not CDC).
+3. `REQUIRED_DOCS.md` — schematic, pico-sdk header, live USB id.
+4. `EXTERNAL_COMPONENTS.md` — onboard WS2812 / no extra parts.
+5. `VALIDATION.md` — smoke + audit + honesty notes.
+6. `images/` — authored pinout and board illustration (schematic/wiki silk). Desk photographs are slice 2.
+
+Pinout: [`images/pinout.svg`](images/pinout.svg)

--- a/examples/rp2350-zero/REQUIRED_DOCS.md
+++ b/examples/rp2350-zero/REQUIRED_DOCS.md
@@ -1,0 +1,34 @@
+# Required Source Documents (Waveshare RP2350-Zero)
+
+## MCU
+
+1. RP2350 Datasheet (memory map, peripherals, dual M33):
+   https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf
+2. pico-sdk `hardware_regs` for RP2350 (moved APB map vs RP2040):
+   https://github.com/raspberrypi/pico-sdk/tree/master/src/rp2350/hardware_regs
+3. CHIP_ID = `0x30004927` (sysinfo.h / RP2350 datasheet SYSINFO).
+
+## Board (this carrier — not Pico 2)
+
+1. Waveshare RP2350-Zero product page:
+   https://www.waveshare.com/rp2350-zero.htm
+2. Waveshare wiki (UF2: BOOT then RESET; WS2812; dimensions 18.00 × 23.50 mm):
+   https://www.waveshare.com/wiki/RP2350-Zero
+3. Schematic `RP2350_Zero.pdf` (P1 23-pad header, P2/P3 solder GPIOs, WS2812 DIN = GPIO16):
+   https://files.waveshare.com/wiki/RP2350-Zero/RP2350_Zero.pdf
+4. pico-sdk board header `waveshare_rp2350_zero.h`:
+   - `PICO_DEFAULT_UART` 0, TX GP0, RX GP1
+   - `PICO_DEFAULT_WS2812_PIN` 16
+   - `PICO_DEFAULT_I2C` 1, SDA GP6, SCL GP7
+   - `PICO_DEFAULT_SPI` 1, SCK GP10, TX GP11, RX GP12, CSN GP13
+   - `PICO_FLASH_SIZE_BYTES` 4 MiB
+   - `PICO_RP2350A` 1
+5. Zephyr `boards/waveshare/rp2350_zero` pinctrl (UART0 P0/P1, WS2812 PIO0_P16, ADC P26–P29).
+
+## Live USB identity (this desk, 2026-09-03)
+
+Not a source of pin facts. Records the native-USB path used while writing these docs:
+
+- USB: Raspberry Pi product string `Pico`, VID `2e8a`, PID `0009`, serial `38EE7132FF1204D0`
+- CDC: `/dev/cu.usbmodem11201`
+- Firmware on the cable at capture: Waveshare factory GPIO/ADC self-test (CDC text). That stream is **not** a twin oracle.

--- a/examples/rp2350-zero/VALIDATION.md
+++ b/examples/rp2350-zero/VALIDATION.md
@@ -1,0 +1,77 @@
+# Waveshare RP2350-Zero Validation Runbook
+
+Run all commands from `core/`.
+
+## 0) Firmware rationale
+
+The smoke firmware is `firmware-rp2350-demo`: bare-metal Cortex-M33
+(`thumbv8m.main-none-eabi` + `cortex-m-rt`), linked at XIP flash
+`0x10000000` with RAM at `0x20000000`. It writes `RP2350_SMOKE_OK\n` straight
+to UART0 DR (`0x40070000` — the RP2350 PL011 base, not the RP2040's
+`0x40034000`).
+
+**What this proves:** the RP2350 descriptor boots a Thumb ELF against the
+Zero system YAML (WS2812/LED stand-in on **GP16**), the vector table at
+flash base is accepted, and UART0 on the RP2350 address map sinks bytes.
+
+**What it cannot prove:** USB CDC on the Type-C port (unmodeled), WS2812
+bit timing, dual-core/SIO FIFO, TrustZone, real bootrom/IMAGE_DEF, PIO v2,
+HSTX, or silicon register parity. This chip is smoke-manual until an SWD
+capture exists.
+
+Factory firmware on the desk CDC (`GPIO connet to GND`, ADC GP28/29) only
+proves the USB port is alive. It is **not** a twin oracle.
+
+**Build note:** cortex-m-rt firmware must be linked with `-Tlink.x`
+(`RUSTFLAGS="-C link-arg=-Tlink.x"` or the crate's `.cargo/config.toml`).
+
+## 1) Build smoke firmware
+
+```bash
+rustup target add thumbv8m.main-none-eabi   # once
+RUSTFLAGS="-C link-arg=-Tlink.x" cargo build -p firmware-rp2350-demo \
+  --release --target thumbv8m.main-none-eabi
+```
+
+## 2) Run deterministic UART smoke
+
+```bash
+cargo run -q -p labwired-cli -- test \
+  --script examples/rp2350-zero/uart-smoke.yaml \
+  --output-dir out/rp2350-zero/uart-smoke \
+  --no-uart-stdout
+```
+
+Pass criteria: exit `0`, UART contains `RP2350_SMOKE_OK`.
+
+## 3) Run unsupported-instruction audit
+
+```bash
+./scripts/unsupported_instruction_audit.sh \
+  --firmware target/thumbv8m.main-none-eabi/release/firmware-rp2350-demo \
+  --system examples/rp2350-zero/system.yaml \
+  --max-steps 200000 \
+  --out-dir out/unsupported-audit/rp2350-zero
+```
+
+Pass criteria: exit `0`, report exists, `unsupported_total: 0`.
+
+## Bench (USB, not SWD)
+
+This board has no onboard debugger. Flash is UF2 (hold BOOT, tap RUN/RESET,
+copy `.uf2`). Console on the cable is USB CDC (this desk: VID `2e8a` PID
+`0009`, `/dev/cu.usbmodem11201`). Header UART0 GP0/GP1 is a different
+connector.
+
+SWD pads (SWCLK/SWDIO) exist for a later silicon capture. Not used in this
+runbook.
+
+## Validation record
+
+- 2026-09-03: UART smoke exit 0 against `examples/rp2350-zero/uart-smoke.yaml`
+  (`RP2350_SMOKE_OK` in `out/rp2350-zero/uart-smoke/uart.log`). Unsupported-
+  instruction audit `unsupported_total: 0`
+  (`out/unsupported-audit/rp2350-zero/metrics.json`). Firmware is
+  `firmware-rp2350-demo` reused from Pico 2; system YAML LED stand-in is
+  GP16. USB CDC observed on the desk board (VID `2e8a` PID `0009`); not
+  claimed as sim evidence.

--- a/examples/rp2350-zero/images/README.md
+++ b/examples/rp2350-zero/images/README.md
@@ -1,0 +1,16 @@
+# RP2350-Zero images
+
+Authored LabWired drawings from:
+
+- Waveshare `RP2350_Zero.pdf` (P1 23-pad nets, WS2812 DIN = GPIO16)
+- Wiki pinout silk (USB-C at top; 18.00 × 23.50 mm)
+- pico-sdk `waveshare_rp2350_zero.h`
+
+These are **not** product photographs and **not** vendored vendor art.
+No brand logos. Desk photos of the physical board belong in playground
+`component-photos/` (slice 2).
+
+| File | What |
+|------|------|
+| `pinout.svg` | Castellated silk, USB-C up, GP16 called out as WS2812 |
+| `board.svg` | Top-down illustration (BOOT, RUN, RGB, USB-C) |

--- a/examples/rp2350-zero/images/board.svg
+++ b/examples/rp2350-zero/images/board.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 360" width="280" height="360">
+  <title>RP2350-Zero top illustration</title>
+  <desc>Flat vector of the USB-C castellated module. No vendor logos. USB-C at top. BOOT left, RUN right, WS2812 below the die.</desc>
+  <rect width="280" height="360" fill="#FFFFFF"/>
+  <g transform="translate(32,24)">
+    <rect x="0" y="0" width="216" height="282" rx="8" fill="#1e4d8c" stroke="#0d1013" stroke-width="2"/>
+    <rect x="73" y="0" width="70" height="28" rx="6" fill="#d4a84b" stroke="#0d1013" stroke-width="1.25"/>
+    <rect x="80" y="6" width="56" height="16" rx="4" fill="#20252a"/>
+    <text x="108" y="52" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#e8eee9">RP2350-ZERO</text>
+    <circle cx="70" cy="88" r="11" fill="#e8eee9" stroke="#0d1013" stroke-width="1.25"/>
+    <circle cx="70" cy="88" r="5" fill="#c9c4b8"/>
+    <text x="70" y="112" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="8" fill="#e8eee9">BOOT</text>
+    <circle cx="146" cy="88" r="11" fill="#e8eee9" stroke="#0d1013" stroke-width="1.25"/>
+    <circle cx="146" cy="88" r="5" fill="#c9c4b8"/>
+    <text x="146" y="112" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="8" fill="#e8eee9">RUN</text>
+    <rect x="78" y="122" width="60" height="60" rx="3" fill="#20252a" stroke="#0d1013"/>
+    <text x="108" y="156" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#cbd1d4">RP2350A</text>
+    <circle cx="108" cy="204" r="8" fill="#38e88a" stroke="#0d1013"/>
+    <circle cx="108" cy="204" r="3.5" fill="#6ca8ff"/>
+    <text x="108" y="224" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="8" fill="#e8eee9">WS2812 GP16</text>
+    <!-- castellations -->
+    <g fill="#d4a84b" stroke="#0d1013" stroke-width="0.8">
+      <circle cx="216" cy="42" r="6"/><circle cx="216" cy="72" r="6"/>
+      <circle cx="216" cy="102" r="6"/><circle cx="216" cy="132" r="6"/>
+      <circle cx="216" cy="162" r="6"/><circle cx="216" cy="192" r="6"/>
+      <circle cx="216" cy="222" r="6"/><circle cx="216" cy="252" r="6"/>
+      <circle cx="0" cy="42" r="6"/><circle cx="0" cy="72" r="6"/>
+      <circle cx="0" cy="102" r="6"/><circle cx="0" cy="132" r="6"/>
+      <circle cx="0" cy="162" r="6"/><circle cx="0" cy="192" r="6"/>
+      <circle cx="0" cy="222" r="6"/><circle cx="0" cy="252" r="6"/>
+      <circle cx="0" cy="270" r="6"/>
+      <circle cx="36" cy="282" r="6"/><circle cx="68" cy="282" r="6"/>
+      <circle cx="100" cy="282" r="6"/><circle cx="132" cy="282" r="6"/>
+      <circle cx="164" cy="282" r="6"/><circle cx="196" cy="282" r="6"/>
+    </g>
+  </g>
+  <text x="140" y="330" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#445">USB-C · 18.00 × 23.50 mm</text>
+  <text x="140" y="346" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#667">Illustration, not a product photo</text>
+</svg>

--- a/examples/rp2350-zero/images/pinout.svg
+++ b/examples/rp2350-zero/images/pinout.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 520" width="640" height="520">
+  <title>RP2350-Zero pinout (USB-C at top)</title>
+  <desc>Castellated P1 from RP2350_Zero.pdf and wiki silk. GP16 is onboard WS2812. Twin UART is GP0/GP1, not USB-C.</desc>
+  <rect width="640" height="520" fill="#FFFFFF"/>
+  <text x="320" y="28" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="16" fill="#0d1013">RP2350-Zero · USB-C up · 18.00 × 23.50 mm</text>
+  <g transform="translate(210,48)">
+    <rect x="0" y="0" width="216" height="282" rx="8" fill="#1e4d8c" stroke="#0d1013" stroke-width="2"/>
+    <rect x="73" y="0" width="70" height="28" rx="6" fill="#d4a84b" stroke="#0d1013" stroke-width="1.25"/>
+    <rect x="80" y="6" width="56" height="16" rx="4" fill="#20252a"/>
+    <rect x="78" y="118" width="60" height="60" rx="3" fill="#20252a" stroke="#0d1013"/>
+    <text x="108" y="152" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#cbd1d4">RP2350A</text>
+    <circle cx="70" cy="86" r="10" fill="#e8eee9" stroke="#0d1013" stroke-width="1.25"/>
+    <text x="70" y="74" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="8" fill="#e8eee9">BOOT</text>
+    <circle cx="146" cy="86" r="10" fill="#e8eee9" stroke="#0d1013" stroke-width="1.25"/>
+    <text x="146" y="74" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="8" fill="#e8eee9">RUN</text>
+    <rect x="98" y="190" width="20" height="14" rx="2" fill="#38e88a" stroke="#0d1013"/>
+    <text x="108" y="220" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="8" fill="#e8eee9">GP16 WS2812</text>
+    <g fill="#d4a84b" stroke="#0d1013" stroke-width="1">
+      <!-- right GP0–GP7 -->
+      <circle cx="216" cy="40" r="7"/><circle cx="216" cy="70" r="7"/>
+      <circle cx="216" cy="100" r="7"/><circle cx="216" cy="130" r="7"/>
+      <circle cx="216" cy="160" r="7"/><circle cx="216" cy="190" r="7"/>
+      <circle cx="216" cy="220" r="7"/><circle cx="216" cy="250" r="7"/>
+      <!-- left 5V…GP14 -->
+      <circle cx="0" cy="40" r="7"/><circle cx="0" cy="68" r="7"/>
+      <circle cx="0" cy="96" r="7"/><circle cx="0" cy="124" r="7"/>
+      <circle cx="0" cy="152" r="7"/><circle cx="0" cy="180" r="7"/>
+      <circle cx="0" cy="208" r="7"/><circle cx="0" cy="236" r="7"/>
+      <circle cx="0" cy="264" r="7"/>
+      <!-- bottom GP13–GP8 -->
+      <circle cx="36" cy="282" r="7"/><circle cx="68" cy="282" r="7"/>
+      <circle cx="100" cy="282" r="7"/><circle cx="132" cy="282" r="7"/>
+      <circle cx="164" cy="282" r="7"/><circle cx="196" cy="282" r="7"/>
+    </g>
+  </g>
+  <g font-family="ui-monospace,Menlo,monospace" font-size="12" fill="#0d1013">
+    <text x="448" y="92">GP0  UART0 TX</text>
+    <text x="448" y="122">GP1  UART0 RX</text>
+    <text x="448" y="152">GP2</text>
+    <text x="448" y="182">GP3</text>
+    <text x="448" y="212">GP4</text>
+    <text x="448" y="242">GP5</text>
+    <text x="448" y="272">GP6  I2C1 SDA</text>
+    <text x="448" y="302">GP7  I2C1 SCL</text>
+    <text x="8" y="92">5V</text>
+    <text x="8" y="120">GND</text>
+    <text x="8" y="148">3V3</text>
+    <text x="8" y="176">GP29 ADC3</text>
+    <text x="8" y="204">GP28 ADC2</text>
+    <text x="8" y="232">GP27 ADC1</text>
+    <text x="8" y="260">GP26 ADC0</text>
+    <text x="8" y="288">GP15</text>
+    <text x="8" y="316">GP14</text>
+    <text x="234" y="360" text-anchor="middle">13</text>
+    <text x="266" y="360" text-anchor="middle">12</text>
+    <text x="298" y="360" text-anchor="middle">11</text>
+    <text x="330" y="360" text-anchor="middle">10</text>
+    <text x="362" y="360" text-anchor="middle">9</text>
+    <text x="394" y="360" text-anchor="middle">8</text>
+  </g>
+  <text x="320" y="384" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12" fill="#0d1013">Bottom GP13–GP8 (SPI1 SCK/TX/RX/CSN = GP10–13)</text>
+  <text x="320" y="408" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12" fill="#445">Underside solder: GP17–GP25 + GND · SWCLK / SWDIO</text>
+  <text x="320" y="428" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12" fill="#445">Twin console = UART0 on GP0/GP1 — not the USB-C CDC</text>
+  <text x="320" y="500" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#667">Sources: RP2350_Zero.pdf P1 · wiki silk · pico-sdk waveshare_rp2350_zero.h</text>
+</svg>

--- a/examples/rp2350-zero/system.yaml
+++ b/examples/rp2350-zero/system.yaml
@@ -1,0 +1,14 @@
+# LabWired - Waveshare RP2350-Zero example
+#
+# Same wiring as configs/systems/rp2350-zero.yaml. LED/WS2812 stand-in on
+# GP16 via SIO — not Pico 2 GP25. Twin UART is UART0, not the USB-C CDC.
+name: "rp2350-zero-example"
+chip: "../../configs/chips/rp2350.yaml"
+external_devices: []
+board_io:
+  - id: "led_gp16"
+    kind: "led"
+    peripheral: "sio"
+    pin: 16
+    signal: "output"
+    active_high: true

--- a/examples/rp2350-zero/uart-smoke.yaml
+++ b/examples/rp2350-zero/uart-smoke.yaml
@@ -1,0 +1,12 @@
+# LabWired - Waveshare RP2350-Zero UART smoke
+# Firmware: firmware-rp2350-demo (bare-metal, RP2350 UART0 DR @ 0x40070000).
+# Proves the chip descriptor + this system YAML boot. Does not prove USB CDC.
+schema_version: "1.0"
+inputs:
+  firmware: "../../target/thumbv8m.main-none-eabi/release/firmware-rp2350-demo"
+  system: "./system.yaml"
+limits:
+  max_steps: 200000
+assertions:
+  - uart_contains: "RP2350_SMOKE_OK"
+  - expected_stop_reason: max_steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - XIAO nRF52840 Sense: boards/seeed-xiao-nrf52840-sense.md
     - RP2040: boards/rp2040.md
     - RP2350: boards/rp2350.md
+    - RP2350-Zero: boards/rp2350-zero.md
     - STM32F103: boards/stm32f103.md
     - STM32F401: boards/stm32f401.md
     - STM32F405: boards/stm32f405.md


### PR DESCRIPTION
## Summary
- Board page, GP16 system YAML, example pack, pinout drawings
- UART smoke `RP2350_SMOKE_OK`; instruction audit `unsupported_total: 0`
- Twin console is UART0; USB-C is native CDC (unmodeled)

## Test Plan
- [x] `cargo run -p labwired-cli -- test --script examples/rp2350-zero/uart-smoke.yaml`
- [x] unsupported_instruction_audit `unsupported_total: 0`