### PR TITLE
test(sched): ratchet the event-scheduler conditional-compilation surface (M-1)

### DIFF
--- a/crates/core/src/tests/event_scheduler_cfg_ratchet.rs
+++ b/crates/core/src/tests/event_scheduler_cfg_ratchet.rs
@@ -1,0 +1,670 @@
+// LabWired - Firmware Simulation Platform
+// Copyright (C) 2026 Andrii Shylenko
+//
+// This software is released under the MIT License.
+// See the LICENSE file in the project root for full license information.
+
+//! The `event-scheduler` conditional-compilation surface may not grow.
+//!
+//! `crates/core/Cargo.toml` declares the feature with its own end condition:
+//! *"Off through 2B.N-1; flipped unconditional after every peripheral migrates
+//! and the legacy walk is deleted."* That is a promise with no clock on it, and
+//! the surface has only ever gone one way. Re-derived from this repo's history
+//! (`git rev-list -1 --before=<date> origin/main`, counted with the same
+//! comment-stripping counter this file uses):
+//!
+//! ```text
+//!   date        sha         cfg attrs   cfg!()   TOTAL   files
+//!   2026-05-01  0348a53cc           0        0       0       0
+//!   2026-05-30  aa016d8ec           0        0       0       0   feature lands (#143)
+//!   2026-06-01  0efb362f0          19        0      19       2
+//!   2026-07-01  ff0300d8a          19        0      19       4
+//!   2026-07-15  fbc155386          78       19      97      26
+//!   2026-08-01  013a4c4d4         100       58     158      65
+//!   2026-08-15  22574f888         134       62     196      72
+//!   2026-09-01  d7b9cb010         140       68     208      77
+//! ```
+//!
+//! Flat for six weeks, then 19 → 208 in eight. Every peripheral author now has
+//! to be correct in two worlds and a given build only ever compiles one of
+//! them; the wire gates already run under three feature sets to see both paths,
+//! and the `e-reader` walk regression was `legacy_walk_disabled` flipping.
+//!
+//! This gate does NOT decide the feature's fate, and deliberately so — that
+//! decision needs a walk-differential measurement nobody has. It is the move
+//! that is right under both outcomes: if the migration finishes the count falls
+//! to zero and this file is deleted with it; if the feature becomes permanent
+//! the surface still stops spreading unwatched.
+//!
+//! # What is counted, and why
+//!
+//! A **site** is one place the compiler is asked to pick a world:
+//!
+//! * `#[cfg(...)]` / `#![cfg(...)]` / `#[cfg_attr(...)]` whose predicate names
+//!   the feature — the item exists in one world and not the other.
+//! * `cfg!(...)` whose predicate names the feature — both arms compile, but
+//!   only one is ever live, and the dead one is never type-checked *against
+//!   reality*. 68 of the 208 sites are this form. Counting attributes alone
+//!   would let the whole surface keep growing through `cfg!` without ever
+//!   moving the number, which is a gate that governs nothing.
+//!
+//! `not(feature = "event-scheduler")` **counts**. It is not a third world, it
+//! is the second one written from the other side, and it costs an author
+//! exactly the same double-correctness. 9 of the 140 attributes are negated.
+//!
+//! Two ceilings, not one, because the two surfaces move for unrelated reasons
+//! and a single number would let one hide the other — and because a single
+//! number scoped to `crates/core/src` could be reduced by *moving* a gated
+//! block into a test file rather than deleting it:
+//!
+//! * [`MAX_MODEL_SITES`] governs `crates/core/src/**` — the engine itself.
+//! * [`MAX_HARNESS_SITES`] governs the rest of `crates/**` — chiefly
+//!   `crates/core/tests/**`, plus 5 sites that have already spread into
+//!   `crates/cli`.
+//!
+//! # What it does NOT do
+//!
+//! It does not say any individual site is wrong. Some are load-bearing (the
+//! per-chip walk-differential gates exist *because* the two paths are not known
+//! to agree). It does not migrate anything, flip the feature, or touch
+//! `legacy_walk_disabled`. A count cannot tell a justified gate from debt, and
+//! pretending otherwise would make this an excuse rather than a floor.
+//!
+//! # Why a rise fails but a fall does not
+//!
+//! [`crate::tests::downcast_ratchet`] additionally asserts *equality*, so a
+//! shrink cannot be banked as headroom. That is right for a number expected to
+//! hover. This one is expected to be driven to **zero**, in large steps, by
+//! migration PRs that have no other reason to touch this file — so here a fall
+//! is the goal and is allowed to land unattended. Only a rise is a fact
+//! somebody has to defend, in the commit that causes it.
+//!
+//! # The counter ignores prose
+//!
+//! Naive `grep` over this tree counts 217 model sites where the truth is 208:
+//! nine of the matches are doc comments *about* the feature (`scheduler_lane_
+//! coverage.rs` quotes `#![cfg(feature = "event-scheduler")]` five times to
+//! explain the vacuous-target hazard) and assertion strings. Miscounts of
+//! exactly that kind have reached this repo's ledger before, so
+//! [`count_in_source`] blanks comments and string literals *before* it looks
+//! for anything, and [`prose_about_the_feature_is_not_a_site`] pins that
+//! behaviour to fixtures. The same property means this file needs no
+//! self-exclusion: its own doc comment above is invisible to it, which
+//! [`this_file_contributes_no_sites`] proves rather than assumes.
+
+use std::path::{Path, PathBuf};
+
+/// The literal the predicates are matched against. Not `env!` — the point is
+/// to notice when a *new* place starts naming this feature, including a place
+/// that spells the name by hand.
+const FEATURE: &str = "event-scheduler";
+
+/// `crates/core/src/**` — the engine's own conditional-compilation surface.
+///
+/// Measured at 208 on `c8172b917` (2026-09-03): 140 `cfg`/`cfg_attr`
+/// attributes (9 of them negated) plus 68 `cfg!` expressions, across 77 files.
+///
+/// LOWER this when peripherals migrate and gated blocks are deleted. RAISING it
+/// requires the commit to say which of the two futures the new site serves: a
+/// step in the migration that ends the feature, or another permanent fork the
+/// migration will have to unpick later.
+const MAX_MODEL_SITES: usize = 208;
+
+/// The rest of `crates/**` — test harnesses and downstream crates.
+///
+/// Measured at 75 on `c8172b917`: 70 in `crates/core/tests/**` (67 attributes,
+/// 3 `cfg!`) and 5 in `crates/cli` (2 `cfg!` in `commands/test.rs` and
+/// `lib.rs`, 3 `#[cfg]` attributes in `crates/cli/tests/`).
+///
+/// Split from [`MAX_MODEL_SITES`] on purpose. `crates/core/tests/**` holds
+/// files whose *whole body* sits behind `#![cfg(feature = "event-scheduler")]`
+/// — the vacuous-target hazard `no_vacuous_test_targets` and
+/// `scheduler_lane_coverage` already govern — so those move for lane reasons,
+/// not model reasons. Counting them together would let a lane change mask an
+/// engine regression, or vice versa.
+const MAX_HARNESS_SITES: usize = 75;
+
+// ---------------------------------------------------------------------------
+// The counter. A pure function over source text, so its definition is testable
+// against fixtures rather than only against the tree it happens to be run on.
+// ---------------------------------------------------------------------------
+
+/// Blank every comment and string/char literal body, preserving byte offsets.
+///
+/// Everything downstream runs on the result, so a mention of the feature in a
+/// doc comment, an `assert!` message or a test fixture cannot be a site. Raw
+/// strings (`r"..."`, `r#"..."#`) and nested block comments are handled because
+/// this file's own fixtures use both.
+fn strip_comments_and_strings(src: &str) -> String {
+    let b = src.as_bytes();
+    let mut out = b.to_vec();
+    let mut i = 0usize;
+    let blank = |out: &mut Vec<u8>, from: usize, to: usize| {
+        for p in from..to.min(out.len()) {
+            if out[p] != b'\n' {
+                out[p] = b' ';
+            }
+        }
+    };
+    while i < b.len() {
+        // Raw string: r"..." or r#"..."# (any number of hashes).
+        if b[i] == b'r' && i + 1 < b.len() && (b[i + 1] == b'"' || b[i + 1] == b'#') {
+            let mut j = i + 1;
+            let mut hashes = 0usize;
+            while j < b.len() && b[j] == b'#' {
+                hashes += 1;
+                j += 1;
+            }
+            if j < b.len() && b[j] == b'"' {
+                j += 1;
+                let mut term = String::from("\"");
+                term.push_str(&"#".repeat(hashes));
+                let end = src[j..]
+                    .find(&term)
+                    .map(|k| j + k + term.len())
+                    .unwrap_or(b.len());
+                blank(&mut out, i, end);
+                i = end;
+                continue;
+            }
+        }
+        // Ordinary string literal (covers char literals closely enough: a
+        // `'"'` would be a lone quote, which we terminate at the next quote —
+        // and no `cfg` predicate hides inside a char literal).
+        if b[i] == b'"' {
+            let mut j = i + 1;
+            while j < b.len() {
+                if b[j] == b'\\' {
+                    j += 2;
+                    continue;
+                }
+                if b[j] == b'"' {
+                    break;
+                }
+                j += 1;
+            }
+            let end = (j + 1).min(b.len());
+            blank(&mut out, i, end);
+            i = end;
+            continue;
+        }
+        // Line comment (`//`, `///`, `//!`).
+        if b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'/' {
+            let end = src[i..].find('\n').map(|k| i + k).unwrap_or(b.len());
+            blank(&mut out, i, end);
+            i = end;
+            continue;
+        }
+        // Block comment, nesting as Rust does.
+        if b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'*' {
+            let mut depth = 1usize;
+            let mut j = i + 2;
+            while j < b.len() && depth > 0 {
+                if b[j] == b'/' && j + 1 < b.len() && b[j + 1] == b'*' {
+                    depth += 1;
+                    j += 2;
+                } else if b[j] == b'*' && j + 1 < b.len() && b[j + 1] == b'/' {
+                    depth -= 1;
+                    j += 2;
+                } else {
+                    j += 1;
+                }
+            }
+            blank(&mut out, i, j.min(b.len()));
+            i = j;
+            continue;
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Byte index of the delimiter that closes the group opened at `open`.
+fn matching_close(b: &[u8], open: usize, opens: &[u8], closes: &[u8]) -> usize {
+    let mut depth = 0usize;
+    let mut j = open;
+    while j < b.len() {
+        if opens.contains(&b[j]) {
+            depth += 1;
+        } else if closes.contains(&b[j]) {
+            depth -= 1;
+            if depth == 0 {
+                return j;
+            }
+        }
+        j += 1;
+    }
+    b.len().saturating_sub(1)
+}
+
+/// Does `haystack` contain `needle`? Byte-wise on purpose — see
+/// [`count_in_source`] on why nothing here may slice a `&str`.
+fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// The identifier immediately after an attribute's `[`, with whitespace
+/// skipped, up to (and including) its opening `(`. `None` if the next
+/// non-whitespace run is not an `ident(`.
+fn attr_head(sb: &[u8], open_bracket: usize) -> Option<&[u8]> {
+    let mut j = open_bracket + 1;
+    while j < sb.len() && sb[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    let start = j;
+    while j < sb.len() && (sb[j].is_ascii_alphanumeric() || sb[j] == b'_') {
+        j += 1;
+    }
+    let name = &sb[start..j];
+    while j < sb.len() && sb[j].is_ascii_whitespace() {
+        j += 1;
+    }
+    if j < sb.len() && sb[j] == b'(' {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+/// `(cfg attributes, cfg! expressions)` naming [`FEATURE`] in one source file.
+///
+/// The predicate is read from the ORIGINAL text between the matched delimiters
+/// (the stripped copy has blanked the feature name, which lives in a string
+/// literal), while the *structure* — where an attribute starts and ends — comes
+/// from the stripped copy, so nothing inside a comment can open one.
+///
+/// Everything below indexes BYTES, never `&str`. The engine's sources are full
+/// of em-dashes and arrows in comments, and an offset landing mid-codepoint
+/// panics `&str` slicing — which is how the first draft of this file went red
+/// on the real tree while every fixture passed. `strip_comments_and_strings`
+/// blanks byte-for-byte, so the two buffers share one offset space and every
+/// offset used here is at an ASCII delimiter.
+fn count_in_source(src: &str) -> (usize, usize) {
+    let stripped = strip_comments_and_strings(src);
+    let sb = stripped.as_bytes();
+    let ob = src.as_bytes();
+    let feat = FEATURE.as_bytes();
+    let (mut attrs, mut macros) = (0usize, 0usize);
+
+    let mut i = 0usize;
+    while i < sb.len() {
+        if sb[i] == b'#' {
+            // `#[` or `#![`
+            let mut j = i + 1;
+            if j < sb.len() && sb[j] == b'!' {
+                j += 1;
+            }
+            if j < sb.len()
+                && sb[j] == b'['
+                && matches!(attr_head(sb, j), Some(b"cfg") | Some(b"cfg_attr"))
+            {
+                let close = matching_close(sb, j, b"[(", b"])");
+                if bytes_contain(&ob[j..=close.min(ob.len() - 1)], feat) {
+                    attrs += 1;
+                }
+                i = close + 1;
+                continue;
+            }
+        }
+        // `cfg!(` — must not be preceded by an identifier character, so
+        // `some_cfg!(...)` is not a match.
+        if sb[i..].starts_with(b"cfg!")
+            && (i == 0 || !(sb[i - 1].is_ascii_alphanumeric() || sb[i - 1] == b'_'))
+        {
+            let mut j = i + 4;
+            while j < sb.len() && sb[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < sb.len() && sb[j] == b'(' {
+                let close = matching_close(sb, j, b"(", b")");
+                if bytes_contain(&ob[j..=close.min(ob.len() - 1)], feat) {
+                    macros += 1;
+                }
+                i = close + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    (attrs, macros)
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+struct Counts {
+    attrs: usize,
+    macros: usize,
+    files: usize,
+}
+
+impl Counts {
+    fn total(&self) -> usize {
+        self.attrs + self.macros
+    }
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root")
+}
+
+/// Every `.rs` under `dir`, sorted. `target/` is skipped: it is build output,
+/// and counting generated code would swamp the figure this governs.
+fn rust_sources(dir: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "target") {
+                    continue;
+                }
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(dir, &mut out);
+    out.sort();
+    out
+}
+
+/// Count every `.rs` under `dir` for which `keep` returns true.
+fn scan(dir: &Path, keep: &dyn Fn(&Path) -> bool) -> Counts {
+    let mut c = Counts::default();
+    for path in rust_sources(dir) {
+        if !keep(&path) {
+            continue;
+        }
+        let Ok(src) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        c.files += 1;
+        let (a, m) = count_in_source(&src);
+        c.attrs += a;
+        c.macros += m;
+    }
+    c
+}
+
+fn model_counts() -> Counts {
+    scan(&repo_root().join("crates/core/src"), &|_| true)
+}
+
+fn harness_counts() -> Counts {
+    let root = repo_root();
+    let model = root.join("crates/core/src");
+    scan(&root.join("crates"), &|p| !p.starts_with(&model))
+}
+
+// ---------------------------------------------------------------------------
+// The gate.
+// ---------------------------------------------------------------------------
+
+/// THE ratchet predicate — one definition, used by the gate below and by the
+/// negative control. Deliberately a named function rather than an inline
+/// comparison in each `assert!`: a negative control that re-types the
+/// comparison proves only that `<=` works, not that the gate's own rule
+/// rejects anything.
+fn within_ceiling(total: usize, ceiling: usize) -> bool {
+    total <= ceiling
+}
+
+#[test]
+fn the_event_scheduler_cfg_surface_only_falls() {
+    let model = model_counts();
+    let harness = harness_counts();
+
+    assert!(
+        within_ceiling(model.total(), MAX_MODEL_SITES),
+        "event-scheduler conditional-compilation sites in crates/core/src rose to {} \
+         (ceiling {MAX_MODEL_SITES}): {} cfg/cfg_attr attributes + {} cfg!() expressions over \
+         {} scanned files. Every site is a place a peripheral author has to be correct in two worlds \
+         while the build compiles one — the surface went 19 -> 208 in eight weeks while \
+         Cargo.toml still promised the feature would be flipped unconditional and deleted. \
+         If the new site is a step that ENDS the feature, say so in this commit and raise \
+         MAX_MODEL_SITES. If it is another permanent fork, say that instead — it is the same \
+         edit, and the difference is the whole decision.",
+        model.total(),
+        model.attrs,
+        model.macros,
+        model.files
+    );
+
+    assert!(
+        within_ceiling(harness.total(), MAX_HARNESS_SITES),
+        "event-scheduler conditional-compilation sites outside crates/core/src rose to {} \
+         (ceiling {MAX_HARNESS_SITES}): {} attributes + {} cfg!() over {} scanned files. A whole test \
+         file behind `#![cfg(feature = \"event-scheduler\")]` compiles to nothing and reports \
+         `0 passed` as a pass — see `no_vacuous_test_targets`. Raise this only with the reason \
+         in the commit.",
+        harness.total(),
+        harness.attrs,
+        harness.macros,
+        harness.files
+    );
+}
+
+/// The scan must be able to see the code it governs. Without this the assertions
+/// above pass on an empty walk — the failure this repo keeps finding, where a
+/// gate reports success having read nothing.
+#[test]
+fn the_scan_is_not_vacuous() {
+    let model = model_counts();
+    let harness = harness_counts();
+    assert!(
+        model.files > 400,
+        "only {} .rs files scanned under crates/core/src; the walk is not reaching the engine",
+        model.files
+    );
+    assert!(
+        harness.files > 100,
+        "only {} .rs files scanned outside crates/core/src; the walk is not reaching crates/",
+        harness.files
+    );
+    assert!(
+        model.attrs > 0 && model.macros > 0,
+        "found {} attributes and {} cfg!() naming `{FEATURE}` across {} files — both forms \
+         exist in this tree, so a zero means the matcher stopped matching and both ceilings \
+         above are meaningless",
+        model.attrs,
+        model.macros,
+        model.files
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The counter's definition, pinned. These are what make the number above mean
+// something specific rather than "whatever a regex happened to hit".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_counted_form_is_counted_once() {
+    // Positive control: one of each shape this file claims to count.
+    let src = r####"
+#![cfg(feature = "event-scheduler")]
+#[cfg(feature = "event-scheduler")]
+fn a() {}
+#[cfg(not(feature = "event-scheduler"))]
+fn b() {}
+#[cfg(all(feature = "event-scheduler", not(debug_assertions)))]
+fn c() {}
+#[cfg_attr(feature = "event-scheduler", allow(dead_code))]
+fn d() {}
+#[cfg(
+    any(
+        feature = "event-scheduler",
+        feature = "jit"
+    )
+)]
+fn e() {}
+fn f() -> bool { cfg!(feature = "event-scheduler") }
+fn g() -> bool { cfg!(all(feature = "event-scheduler", feature = "jit")) }
+"####;
+    assert_eq!(
+        count_in_source(src),
+        (6, 2),
+        "the six attribute forms (inner, plain, negated, all(), cfg_attr, multi-line) and both \
+         cfg!() forms must each count exactly once"
+    );
+}
+
+#[test]
+fn unrelated_cfgs_are_not_counted() {
+    // Negative control on the predicate: a cfg that does not name the feature
+    // is not this feature's surface, however scheduler-ish it reads.
+    let src = r####"
+#[cfg(feature = "jit")]
+fn a() {}
+#[cfg(test)]
+fn b() {}
+#[cfg(target_arch = "wasm32")]
+fn c() {}
+fn d() -> bool { cfg!(feature = "scheduler") }
+fn e() -> bool { cfg!(debug_assertions) }
+"####;
+    assert_eq!(count_in_source(src), (0, 0));
+}
+
+#[test]
+fn prose_about_the_feature_is_not_a_site() {
+    // THE MISCOUNT THIS GATE EXISTS NOT TO REPEAT. Naive grep reports 217 model
+    // sites against a true 208; the nine extras are all of these shapes.
+    let src = r####"
+//! `crates/core/tests/board_batch_width.rs` opens with
+//! `#![cfg(feature = "event-scheduler")]`, so without the feature the whole
+//! file compiles to nothing.
+
+// Gated on `event-scheduler`: `uses_scheduler()` is
+// `cfg!(feature = "event-scheduler") && clock.is_some()`.
+
+/* #[cfg(feature = "event-scheduler")] left here during a bisect
+   /* with a nested comment inside it */ */
+
+fn msg() {
+    assert!(false, "found no #![cfg(feature = \"event-scheduler\")] tests");
+    let _ = r#"#[cfg(feature = "event-scheduler")]"#;
+}
+"####;
+    assert_eq!(
+        count_in_source(src),
+        (0, 0),
+        "doc comments, line comments, nested block comments, escaped assertion strings and raw \
+         string fixtures all merely MENTION the feature; none of them asks the compiler for a \
+         world"
+    );
+}
+
+#[test]
+fn non_ascii_prose_does_not_derail_the_scan() {
+    // THE BUG THIS FILE SHIPPED FIRST. The engine's comments are full of
+    // em-dashes, arrows and ⚠️; the original draft sliced `&str` at byte
+    // offsets computed over the stripped copy and panicked mid-codepoint on the
+    // real tree while every ASCII fixture passed. A counter that panics is not
+    // a green gate, but it is not a red one for the reason it claims either.
+    let src = "//! ⚠️ the walk — see `#[cfg(feature = \"event-scheduler\")]` → below\n\
+               #[cfg(feature = \"event-scheduler\")] // ← counted\n\
+               fn a() {}\n\
+               /// Δt — cadence\n\
+               fn b() -> bool { cfg!(feature = \"event-scheduler\") }\n";
+    assert_eq!(count_in_source(src), (1, 1));
+}
+
+/// This file names the feature dozens of times, all of it in prose and
+/// fixtures. If [`strip_comments_and_strings`] ever regressed, this file would
+/// start counting itself and the ceilings would drift by its own edits — the
+/// reason `downcast_ratchet` has to exclude itself by path. Proving the
+/// property is better than excluding by path, because the property also covers
+/// every other file that merely discusses the feature.
+#[test]
+fn this_file_contributes_no_sites() {
+    let me = repo_root().join("crates/core/src/tests/event_scheduler_cfg_ratchet.rs");
+    let src = std::fs::read_to_string(&me).expect("read this file");
+    assert!(
+        src.contains(FEATURE),
+        "fixture check is vacuous: this file no longer mentions `{FEATURE}`"
+    );
+    assert_eq!(
+        count_in_source(&src),
+        (0, 0),
+        "this ratchet counted ITSELF; its ceilings now move when its own comments are edited"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE CONTROL
+//
+// A gate nobody has watched fail is the defect one level up. This writes a
+// scratch fixture into a temp directory and runs the REAL directory walk over
+// it — not the pure counter — so the file discovery, the read and the ceiling
+// comparison are all exercised on a surface that is one site too large.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_new_site_makes_the_gate_go_red() {
+    let dir = std::env::temp_dir().join(format!(
+        "labwired-es-cfg-ratchet-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("nested")).expect("scratch dir");
+
+    // A file that merely talks about the feature: the walk must find it and
+    // count nothing, or the "rise" below would not be attributable.
+    std::fs::write(
+        dir.join("prose.rs"),
+        "//! mentions #[cfg(feature = \"event-scheduler\")] in prose only\nfn a() {}\n",
+    )
+    .expect("write prose fixture");
+    let baseline = scan(&dir, &|_| true);
+    assert_eq!(
+        (baseline.attrs, baseline.macros, baseline.files),
+        (0, 0, 1),
+        "scratch baseline must be one file with zero sites, got {baseline:?}"
+    );
+
+    // Now add one real site, of each counted form, in a nested directory.
+    std::fs::write(
+        dir.join("nested/regression.rs"),
+        "#[cfg(feature = \"event-scheduler\")]\nfn a() {}\nfn b() -> bool { cfg!(feature = \"event-scheduler\") }\n",
+    )
+    .expect("write regression fixture");
+    let risen = scan(&dir, &|_| true);
+
+    assert_eq!(
+        (risen.attrs, risen.macros, risen.files),
+        (1, 1, 2),
+        "the walk did not pick up the added sites, so the ceilings above cannot go red for a \
+         real one either; got {risen:?}"
+    );
+    assert!(
+        risen.total() > baseline.total(),
+        "adding a gated item did not raise the count"
+    );
+
+    // And the gate's OWN predicate — the same `within_ceiling` the two
+    // assertions above call, not a re-typed comparison — must reject a surface
+    // that is over by exactly the sites this fixture added, while still
+    // accepting the ceiling itself.
+    assert!(
+        within_ceiling(MAX_MODEL_SITES, MAX_MODEL_SITES),
+        "the ratchet predicate rejected a count exactly AT its ceiling; today's tree would be \
+         red for no change at all"
+    );
+    assert!(
+        !within_ceiling(MAX_MODEL_SITES + risen.total(), MAX_MODEL_SITES),
+        "the ratchet predicate accepted a count above its own ceiling — the gate cannot go red"
+    );
+    assert!(
+        !within_ceiling(MAX_HARNESS_SITES + risen.total(), MAX_HARNESS_SITES),
+        "the harness ratchet predicate accepted a count above its own ceiling"
+    );
+
+    std::fs::remove_dir_all(&dir).expect("clean up scratch dir");
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -24,6 +24,10 @@ pub mod esp32;
 pub mod esp32c3_i2c_waveform;
 #[cfg(test)]
 pub mod esp32c3_rtc_delay_loop;
+
+/// The `event-scheduler` conditional-compilation surface may not grow.
+#[cfg(test)]
+pub mod event_scheduler_cfg_ratchet;
 #[cfg(test)]
 pub mod hcsr04_event_tick_differential;
 #[cfg(test)]


### PR DESCRIPTION
Ledger row **M-1**. Measures the `event-scheduler` conditional-compilation surface, ratchets it, and reports what a decision on the feature's future would need. It does **not** take that decision.

**No behaviour changes.** No peripheral migrates, the feature is not flipped, `legacy_walk_disabled` is not touched. The per-chip walk-differential gates exist precisely because the two paths are not yet known to agree everywhere, and that measurement does not exist.

---

## Why now

`crates/core/Cargo.toml:103` declares the feature with its own end condition:

> *"Off through 2B.N-1; flipped unconditional after every peripheral migrates and the legacy walk is deleted."*

Three months on, the surface has only ever grown. This is the right move under **both** futures, which is why it is not waiting on the decision:

* if the migration finishes, the count falls to zero and the ratchet is deleted with it;
* if the feature becomes permanent, the ratchet still stops unbounded spread.

---

## 1. The site-count series, re-derived

Sampled with `git rev-list -1 --before=<date> origin/main` on a full clone, counting each snapshot with the same comment-stripping counter this PR adds, cross-checked against an independent Python implementation over the same file set. Scope is `crates/core/src/**`.

| sample date | sha | commit date | `#[cfg]`/`#[cfg_attr]` | `cfg!()` | **total** | files |
|---|---|---|---|---|---|---|
| 2026-05-01 | `0348a53cc` | 2026-05-01 | 0 | 0 | **0** | 0 |
| 2026-05-30 | `aa016d8ec` | 2026-05-29 | 0 | 0 | **0** | 0 |
| 2026-06-01 | `0efb362f0` | 2026-06-01 | 19 | 0 | **19** | 2 |
| 2026-06-15 | `b5b06444c` | 2026-06-14 | 19 | 0 | **19** | 4 |
| 2026-07-01 | `ff0300d8a` | 2026-07-01 | 19 | 0 | **19** | 4 |
| 2026-07-15 | `fbc155386` | 2026-07-15 | 78 | 19 | **97** | 26 |
| 2026-08-01 | `013a4c4d4` | 2026-08-01 | 100 | 58 | **158** | 65 |
| 2026-08-15 | `22574f888` | 2026-08-15 | 134 | 62 | **196** | 72 |
| 2026-09-01 | `d7b9cb010` | 2026-09-01 | 140 | 68 | **208** | 77 |
| tip | `c8172b917` | 2026-09-03 | 140 | 68 | **208** | 77 |

Flat for six weeks, then **19 → 208 in eight**. Adjacent measurements on `c8172b917`:

* `crates/core/src/sched/` is **1108** lines (`event_scheduler.rs` 973, `clock.rs` 79, `result.rs` 35, `mod.rs` 21).
* the legacy walk is referenced **364** times in `crates/core/src` code and **488** across `crates/` (identifier occurrences with comments stripped: `needs_legacy_walk` 210, `legacy_walk_disabled` 86, `force_legacy_walk` 70, `tick_peripherals_fully` 35, `legacy_tick_dynamic` 26, `legacy_tick_indices` 24, `recompute_walk_deletable` 21, `derive_walk_deletable` 13, `tick_peripherals_phase1` 3). Counting comment text too gives 537 / 762.
* the surface has already spread past `core`: **5 sites in `crates/cli`** (`commands/test.rs:69`, `lib.rs:2255`, and three `#[cfg]` in `crates/cli/tests/`).

### A correction to the brief's numbers

The brief's series (0 / 19 / 19 / 159 / 214) is close but high at the recent end. A naive grep over the tip counts **217** model sites against a true **208**. The nine extras are prose: `scheduler_lane_coverage.rs` quotes `#![cfg(feature = "event-scheduler")]` five times to *explain* the vacuous-target hazard, `no_vacuous_test_targets.rs` once, three peripheral files discuss `cfg!(feature = "event-scheduler")` in doc comments, and one is inside an `assert!` message. That is exactly the miscount this repo's ledger has produced before, so the counter here blanks comments and string literals before it looks for anything.

---

## 2. The seam: `Peripheral::uses_scheduler()`

Migration is detectable, and by a real predicate rather than a convention.

* **`Peripheral::uses_scheduler()`** (`crates/core/src/lib.rs:1116`) — default `false`. When `true`, `Machine::advance` skips this peripheral's legacy `tick()` walk and the scheduler drives it.
* **`SystemBus::derive_walk_deletable()`** (`crates/core/src/bus/tick.rs:76`) is the derived predicate the brief asked about, and it is exactly two clauses:

  ```rust
  self.peripherals.iter()
      .all(|p| p.dev.uses_scheduler() || !p.dev.needs_legacy_walk())
  ```

  So a model stops blocking walk deletion either by migrating (`uses_scheduler`) **or** by proving its tick is a structural no-op (`!needs_legacy_walk`). `recompute_walk_deletable()` latches it into `legacy_walk_disabled`.
* Supporting methods that only a migrated model implements: `on_event`, `on_clock_change`, `sync_to`, `take_scheduled_events`, `attach_cycle_clock`, `attach_irq_line`.

**A one-source-of-truth problem at the seam.** `scheduler_mode()` — the per-model predicate `uses_scheduler()` delegates to — is defined **34 times**, once per model, with **30 byte-identical copies** of

```rust
cfg!(feature = "event-scheduler") && self.clock.is_some()
```

and 4 variants (`exti.rs:313`, `fdcan.rs:291`, `i2c.rs:2344`, `nrf52/timer.rs:164`). It is a private inherent method, so there is no trait default and no single place to change the rule. Whatever is decided about the feature, collapsing these 34 into one default would remove 30 of the 208 sites on its own.

---

## 3. Migrated vs not

164 distinct `impl Peripheral for T`; 8 are test/inspect-only helpers, leaving **156 production models**.

| | count |
|---|---|
| **migrated** — override `uses_scheduler()` | **71** |
| **walk-free** — `needs_legacy_walk() { false }`, never needed migrating | **64** |
| **blockers** — neither; still force the walk on | **21** |

The 64 walk-free models are register banks, eFuse/ROM stubs and IO-mux blocks whose `tick()` is a structural no-op. They are already invisible to `derive_walk_deletable` and are not migration work.

### The 21 blockers — the actual remaining list

| model | file |
|---|---|
| `AvrGpioPort` | `crates/core/src/peripherals/avr_gpio.rs:42` |
| `BxCan` | `crates/core/src/peripherals/bxcan.rs:523` — conditional: `needs_legacy_walk = self.bus_rx.is_some()` |
| `CanController` | `crates/core/src/peripherals/can.rs:37` |
| `CosimPeripheral` | `crates/core/src/cosim/mod.rs:81` |
| `Esp32I2c` | `crates/core/src/peripherals/esp32/i2c.rs:367` |
| `Esp32I2cAhbFifo` | `crates/core/src/peripherals/esp32/i2c.rs:319` |
| `Esp32Uart` | `crates/core/src/peripherals/esp32/uart.rs:453` |
| `FlashSpiMemStub` | `crates/core/src/peripherals/esp_xtensa_common/system_stub.rs:148` |
| `GenericPeripheral` | `crates/core/src/peripherals/declarative.rs:414` — conditional: `has_read_trigger() \|\| has_write_trigger() \|\| !inflight_events.is_empty()` |
| `LevelSource` | `crates/core/src/bus/tick.rs:2875` |
| `Nrf52Ccm` | `crates/core/src/peripherals/nrf52/ccm.rs:401` |
| `Nrf54lUarte` | `crates/core/src/peripherals/nrf54l/uarte.rs:310` |
| `OneShotDynamic` | `crates/core/src/bus/tick.rs:1482` |
| `OneShotRam` | `crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs:2358` |
| `RadioController` | `crates/core/src/peripherals/radio.rs:45` |
| `RamPeripheral` | `crates/core/src/boot/esp32s3.rs:282` |
| `RomThunkBank` | `crates/core/src/peripherals/esp_xtensa_common/rom_thunks.rs:219` |
| `SamSercomUsart` | `crates/core/src/peripherals/sam/sercom_usart.rs:316` |
| `SimCtl` | `crates/core/src/peripherals/simctl.rs:142` |
| `TimgStub` | `crates/core/src/peripherals/esp_xtensa_common/system_stub.rs:388` |
| `Tmp102` | `crates/core/src/peripherals/i2c_temp_sensor.rs:67` |

### The half of "migrated" that is only migrated in one world

Of the 71 that override `uses_scheduler()`, **48 resolve through `cfg!(feature = "event-scheduler")`** and are therefore back on the legacy walk in the default build. **23 do not** and report `uses_scheduler() == true` regardless of the feature — 15 return a bare `true` (`Esp32Gpio`, `Esp32c3Gpio`, `Esp32c3Rmt`, `Nrf52Clock/Ecb/Egu/Gpiote/Pwm/Radio/Saadc/SerialInstance/Twim/Uarte`, `Rp2040I2c/Spi/Usb`, `RtcCntl`, `Timg`), the rest gate on a clock or a flag (`Nrf52Rng`, `Nrf52Wdt`, `Nrf52Timer`, `Systimer`, `OrderedTick`).

That split is the two-worlds cost made concrete: **the same bus derives a different `legacy_walk_disabled` depending on which feature set compiled it**, and which of the 71 count as migrated changes with it. The consumers of `legacy_walk_disabled` I checked (`bus/policy.rs:116`, `hcsr04_event_scheduled`, `tick_profile_entry_counts`, the walk-skip at `bus/tick.rs:396`) are each themselves behind `cfg!`/`#[cfg]`, so I found no observable defect — but I did not prove the asymmetry is inert everywhere, and 208 sites is what makes that expensive to establish.

---

## 4. My read: bounded, and smaller than it looks

**Bounded.** 21 named models, not an open-ended sweep. Six are stubs, RAM windows or test scaffolding (`RamPeripheral`, `RomThunkBank`, `OneShotRam`, `OneShotDynamic`, `LevelSource`, `FlashSpiMemStub`, `TimgStub`) that plausibly need `needs_legacy_walk() -> false` rather than a scheduler migration. Three ESP32-classic models (`Esp32Uart`, `Esp32I2c`, `Esp32I2cAhbFifo`) already have migrated siblings on C3 and S3 to copy from.

**Two are not like the others**, and they are where the estimate lives:

* **`GenericPeripheral`** (`declarative.rs`) is the declarative yaml model — it backs a large share of every chip's peripheral set, and it blocks *conditionally*, on triggers and in-flight events. Migrating it is not one model, it is the declarative DSL's event semantics.
* **`CosimPeripheral`** bridges to an external co-simulator whose pacing this repo does not own.

**And the 208 is not 208 pieces of work.** 30 of the sites are the copy-pasted `scheduler_mode()` body; 68 are `cfg!` expressions, most of them that same predicate or a guard on it. A trait-default `scheduler_mode()` plus finishing the 19 straightforward blockers looks like it retires most of the surface without resolving the two hard ones.

So: **finishable, but not by a sweep, and `GenericPeripheral` should be scoped before anyone commits to a date.** I am not recommending which future to take — the walk-differential evidence that would settle it does not exist yet.

---

## 5. The gate

`crates/core/src/tests/event_scheduler_cfg_ratchet.rs`, in the shape of `thunk_debt_only_falls()` and its sibling `downcast_ratchet`.

**What a site is.** An attribute (`#[cfg]` / `#![cfg]` / `#[cfg_attr]`) or a `cfg!()` whose predicate names the feature.

* **`cfg!()` counts.** 68 of the 208 are that form. A gate blind to it would let the whole surface keep growing without moving the number.
* **`not(feature = ...)` counts.** It is the second world written from the other side, at the same cost to an author. 9 of the 140 attributes are negated.
* **Tests are counted separately**, under their own ceiling.

**Two ceilings**, measured on `c8172b917`:

```rust
const MAX_MODEL_SITES:   usize = 208;  // crates/core/src/**   140 attrs + 68 cfg!
const MAX_HARNESS_SITES: usize =  75;  // rest of crates/**     70 attrs +  5 cfg!
```

Split so a test-lane change cannot mask an engine regression, and so the model number cannot be reduced by *moving* a gated block into a test file. `crates/core/tests/**` also has its own hazard already governed elsewhere (`no_vacuous_test_targets`, `scheduler_lane_coverage`): a file entirely behind `#![cfg(feature = "event-scheduler")]` reports `0 passed` as a pass.

**Falls are free; only a rise fails.** This deviates from `downcast_ratchet`, which also asserts equality so a shrink cannot be banked. That is right for a number expected to hover; this one is meant to be driven to zero in large steps by migration PRs with no other reason to touch this file. Stated in the header.

**The counter's definition is testable** — `count_in_source` is a pure function over source text, pinned by four fixture tests: `every_counted_form_is_counted_once` (six attribute shapes incl. multi-line and `cfg_attr`, both `cfg!` shapes), `unrelated_cfgs_are_not_counted`, `prose_about_the_feature_is_not_a_site` (doc comments, nested block comments, escaped assert strings, raw-string fixtures), and `non_ascii_prose_does_not_derail_the_scan`. The last one is a bug this file actually shipped: the first draft sliced `&str` at byte offsets and panicked mid-codepoint on the em-dashes in the engine's comments while every ASCII fixture passed. `this_file_contributes_no_sites` proves the file does not count itself, so no exclusion-by-path is needed.

### It is provably able to go red

Both controls, not one:

1. **In-test scratch fixture** — `a_new_site_makes_the_gate_go_red` writes files to a temp dir, runs the **real** directory walk over them (not the pure counter), asserts a prose-only file contributes `(0, 0)`, then adds one `#[cfg]` and one `cfg!` in a nested directory and asserts the walk reports `(1, 1, 2)`. It then calls the gate's **own** `within_ceiling` predicate — shared with the assertions above, not re-typed — and asserts it accepts a count exactly at the ceiling and rejects one above it. Cleans up after itself.
2. **Against the production tree** — I temporarily set both ceilings to `0` and ran it. It failed with:

   > `event-scheduler conditional-compilation sites in crates/core/src rose to 208 (ceiling 0): 140 cfg/cfg_attr attributes + 68 cfg!() expressions over 502 scanned files.`

   and, with the model ceiling restored, with `rose to 75 ... 70 attributes + 5 cfg!() over 504 scanned files`. Both match the independent Python counter exactly. Ceilings restored before commit.

`the_scan_is_not_vacuous` guards the other direction: >400 files under `crates/core/src`, >100 outside, and both forms non-zero — so the gate cannot pass having read nothing.

### Where it runs

`.github/workflows/core-ci.yml` has **no `paths:` filter**; its trigger is

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

The test is an in-crate `#[cfg(test)]` module of `crates/core`, which is a workspace **default member** (`Cargo.toml:116`). It therefore runs in the **`pr-gate`** job's step

```yaml
      - name: Unit tests (default-members lib)
        run: cargo test --lib
```

`pr-gate` is one of only two required contexts on `main` (with `release-runner-contract`), so this blocks merges. Same step `thunk_debt_only_falls` and `downcast_ratchet` already run in — no new job, no new required context.

### Verification

Run in the worktree, foreground:

* `cargo test --lib` — the exact `pr-gate` invocation. **3485 passed, 0 failed** across 5 binaries; the 8 new tests all ran. (Parsed from a captured log with Python: `grep` returned empty on this log while `tail` showed content — the known non-UTF8 grep hazard.)
* `cargo test -p labwired-core --lib event_scheduler_cfg_ratchet` — 8/8 green under **default features** and under **`--features event-scheduler`**. The count is source-text based, so it is the same number in both worlds; the point of running both is that the file compiles and passes in each.
* `cargo clippy --all-targets -- -D warnings` — clean (the `pr-gate` invocation).
* `cargo fmt --all -- --check` — clean.

### Things in the brief that turned out otherwise

* **The 214 / 159 figures are naive-grep numbers.** True values are 208 and 158; the difference is doc-comment prose and assertion strings.
* **"56 of 151 `Peripheral` implementors touch the scheduler seam"** — I measure **164** distinct implementors (156 production), of which **74** touch any seam method and **71** override `uses_scheduler()`.
* **"~481 references to the legacy walk"** — not reproducible as stated without a definition. Identifier occurrences with comments stripped are **364** in `crates/core/src` and **488** across `crates/`; including comment text, 537 / 762.
* **`derive_walk_deletable()` exists** and is exactly the predicate the brief guessed at.
* The brief's `origin/main` tip `5c2a11b65` had moved on; measurements here are against `c8172b917`, which carries the same 208.
