### PR TITLE
feat(efr32mg26): onboard MSC — firmware can write its own flash (243/243 vs silicon)

### DIFF
--- a/configs/chips/efr32mg26.yaml
+++ b/configs/chips/efr32mg26.yaml
@@ -45,9 +45,16 @@
 #     4-bit mode nibble gates input vs output (open-drain WIREDOR pins only
 #     pull LOW). NOT modelled: the ROUTE pin-mux registers are a stub window
 #     (`gpio_route` below — a deliberate sim no-op, load-bearing on silicon),
-#     the EXTI/EM4WU interrupt path, drive-strength/slew fields (stored, no
-#     behaviour), and the WIREDAND open-source analog niceties (treated as
-#     push-pull).
+#     EM4WU wake, drive-strength/slew fields (stored, no behaviour), and the
+#     WIREDAND open-source analog niceties (treated as push-pull).
+#   - (FIXED) The EXTI interrupt path IS modelled — this list said it was not,
+#     for long enough that "can I do an interrupt-driven button on this board?"
+#     had a wrong answer written down. `peripherals/efr32/gpio_exti.rs` is a
+#     real model: EXTIPSEL/EXTIPINSEL group selection, rising and falling arms
+#     independently, write-1-to-clear flags that latch without IEN, and even
+#     and odd lines raising GPIO_EVEN_IRQn 40 / GPIO_ODD_IRQn 39 separately.
+#     Ten unit tests cover it, including that a line armed for neither edge
+#     never fires and that a pad's first transition is an edge, not a baseline.
 #   - (FIXED) The Series-2 SET/CLR/TGL register aliases are now decoded, see
 #     `atomic_register_aliases` below.
 #   - (FIXED) USART0 (as `spi0`), USART1 (VCOM console) and USART2 are mapped,

--- a/docs/boards/VALIDATION_STATUS.md
+++ b/docs/boards/VALIDATION_STATUS.md
@@ -26,7 +26,7 @@ The models column is a content digest over everything that board's `models` list
 | `nrf5340` | 🔵 sim-validated (deep model, no HW diff) | — | `303234a1ddb9e5ad` | no silicon capture |
 | `stm32h735` | 🔵 sim-validated (deep model, no HW diff) | — | `cfb5b3966d884843` | no silicon capture |
 | `stm32f411ceu6` | 🔵 sim-validated (deep model, no HW diff) | — | `8d1317c4aee8f2dc` | no silicon capture |
-| `brd2709a` | 🟡 smoke-manual | — | `a17c8f2e9acf8931` | no silicon capture |
+| `brd2709a` | 🟡 smoke-manual | — | `35c258ec41dbf031` | no silicon capture |
 | `esp32` | ⚪ structural | — | `f2264e3d66957844` | no silicon capture |
 | `mkw41z4` | 🔵 sim-validated (deep model, no HW diff) | — | `f6645581571bd944` | no silicon capture |
 | `atsamd21g18a` | 🔵 sim-validated (deep model, no HW diff) | — | `e45ed514e86b58b7` | no silicon capture |


### PR DESCRIPTION
Measured on the board, not argued from the manual.

## What this closes

MSC was unmapped, so a store to a flash address FAULTED the bus and **nothing on this part could persist across a reset**. It is mapped now at 0x40030000 (RM §4.2.4.1 p.48), registers from RM §6.7 p.134, semantics from §6.8.

## Three things only the silicon could tell me

⚠️ **The reset values are the die's, not the manual's.** RM p.143 gives `MSC_STATUS` reset as WREADY|WDATAREADY = `0x0800_0008`. A connected BRD2709A reads **`0x0B00_0008`** — PWRON0 and PWRON1 are set too, because both flash banks finish powering up before anything can look. Model the paper reset and a driver waiting on PWRON hangs in the twin while working on the bench.

⚠️ **MSC does not answer the bus unclocked.** A cold `reset halt` read of 0x40030000 fails outright over SWD — as do PRS, LDMA, ICACHE0, SYSCFG, EUSART1. Only CMU replies. Series-2 clock gating, not TrustZone. The twin gates it identically.

⚠️ **A flash region is not a RAM hole.** `memory_regions` install as zeros; an erased flash byte is 0xFF, and this board's blank user-data page reads `ffffffff…`. `NamedMemoryRange` gains `erased`, and the 1 kB UD page (RM Table 6.1 p.60) is mapped with it.

## Two defects in my own work, caught before they shipped

⚠️ `take_scheduled_events` **would have been dead code** — the bus harvests it only under `event-scheduler` AND `uses_scheduler()`. The controller would have armed an op, set BUSY, and never completed it. It uses `tick_with_bus` now, with a test that asserts the hook is *requested*.

⚠️ **One test was silently vacuous.** An unclocked MSC reads 0 everywhere, and 0 satisfies every absence-shaped assertion in the file. One test was left on the unclocked bus and went green against a silent peripheral. `clocked_bus()` now asserts the clock took.

## Evidence

- Silicon reg match **219/219 → 243/243 (100%)**, peripherals 31 → 32; all 24 new MSC words match exactly. Capture committed.
- Negative controls, one failing assertion each: programming that REPLACES instead of ANDing (flash can only clear bits), ignoring WREN, and the manual's paper reset.
- 3351 lib tests, clippy `--all-targets -D warnings` clean, fmt clean, both validation gates exit 0.

Also carries the EXTI divergence-list correction this branch opened with.