### PR TITLE
fix(gpio): the encoder and keypad drove nothing on read-only input words

### DIFF
--- a/crates/core/src/peripherals/components/keypad.rs
+++ b/crates/core/src/peripherals/components/keypad.rs
@@ -200,6 +200,11 @@ impl crate::bus::BusResidentDevice for Keypad {
         for (c, &(high, changed)) in cols.iter().enumerate().take(COLS) {
             if changed {
                 let (addr, bit) = self.col_idr[c];
+                // Both seams — see the note in `rotary_encoder.rs`. A bare
+                // `drive_idr_bit` is an MMIO store, so this matrix was inert on
+                // every part whose input word is read-only (EFR32 DIN, SAM IN,
+                // ESP32-C3): a key could be held down and no column ever fell.
+                let _ = pins.drive_input_bit(addr, bit, high);
                 pins.drive_idr_bit(addr, bit, high);
             }
         }

--- a/crates/core/src/peripherals/components/rotary_encoder.rs
+++ b/crates/core/src/peripherals/components/rotary_encoder.rs
@@ -238,10 +238,27 @@ impl crate::bus::BusResidentDevice for RotaryEncoder {
         // Inherent `RotaryEncoder::service` (chosen over the trait method here —
         // inherent methods win resolution) does the phase advance + change flags.
         let ((clk_high, dt_high), (clk_changed, dt_changed)) = self.service(now);
+        // ⚠️ BOTH SEAMS, THE SAME PAIR THE DHT22 DRIVES — and driving only the
+        // second made this knob inert on half the catalog. `drive_idr_bit` is an
+        // ordinary MMIO store to the input register, which works only where the
+        // model lets a store to IDR land (STM32). On silicon whose input word is
+        // READ-ONLY the store is correctly ignored and the pin never moves:
+        // EFR32 Series 2 (DIN @0x14, `gpio.rs` write_reg drops it by design),
+        // SAM PORT (IN @0x20) and ESP32-C3. `drive_input_bit` is the external-
+        // world seam (`set_external_input`) those models actually sample.
+        //
+        // Measured 2026-09-05: on brd2709a the encoder read CLK=0 DT=0 forever,
+        // at rest and after a 3-detent stimulus, while nucleo-f401re walked the
+        // Gray code correctly from the identical diagram. The stimulus reported
+        // `outcome: applied` both times — the exact "attach succeeds, set_input
+        // returns Ok, and the pin never moves" failure `gpio_devices_walk_free`
+        // was written about, arriving through a different door.
         if clk_changed {
+            let _ = pins.drive_input_bit(self.clk_idr_addr, self.clk_bit, clk_high);
             pins.drive_idr_bit(self.clk_idr_addr, self.clk_bit, clk_high);
         }
         if dt_changed {
+            let _ = pins.drive_input_bit(self.dt_idr_addr, self.dt_bit, dt_high);
             pins.drive_idr_bit(self.dt_idr_addr, self.dt_bit, dt_high);
         }
     }

--- a/crates/core/tests/bus_resident_device_port.rs
+++ b/crates/core/tests/bus_resident_device_port.rs
@@ -147,12 +147,36 @@ fn a_keypad_scans_with_no_bus_in_sight() {
         pins.idr_writes
     );
 
-    // A keypad drives its columns through the input register, never through
-    // the external-level seam — the other half of the port stayed untouched.
-    assert!(
-        pins.input_writes.is_empty(),
-        "a keypad has no business on the external-level seam: {:?}",
-        pins.input_writes
+    // ⚠️ THIS USED TO ASSERT THE OPPOSITE, and the opposite was the bug.
+    //
+    // It read: "a keypad has no business on the external-level seam", requiring
+    // `input_writes` to stay EMPTY. That held only because every part in view at
+    // the time let a store to the input register land. On silicon whose input
+    // word is READ-ONLY the store is correctly ignored and the column never
+    // moves — EFR32 Series 2 (DIN @0x14), SAM PORT (IN @0x20), ESP32-C3. The
+    // matrix was inert on all three, silently: attach succeeded, the stimulus
+    // reported applied, no pin moved.
+    //
+    // So a keypad has exactly the same business on that seam as the DHT22,
+    // which has always driven both. `gpio_devices_drive_read_only_inputs.rs`
+    // gates the behaviour on a real EFR32 port; this asserts the port CONTRACT:
+    // both halves are used, and each column change appears on each seam once.
+    // `idr_writes` is cleared as the scan progresses, so the seam is checked
+    // against the full drive history the scan above performed: four columns
+    // settled high, then column 1 low for the press, then back high.
+    assert_eq!(
+        pins.input_writes,
+        vec![
+            (COL_ADDR, 0, true),
+            (COL_ADDR, 1, true),
+            (COL_ADDR, 2, true),
+            (COL_ADDR, 3, true),
+            (COL_ADDR, 1, false),
+            (COL_ADDR, 1, true),
+        ],
+        "every column change must reach BOTH seams — the MMIO store for ports \
+         that accept it, the external-level seam for ports whose input word is \
+         read-only — and a settled keypad must still add nothing"
     );
 }
 

--- a/crates/core/tests/gpio_devices_drive_read_only_inputs.rs
+++ b/crates/core/tests/gpio_devices_drive_read_only_inputs.rs
@@ -173,9 +173,5 @@ fn a_keypad_column_falls_on_a_read_only_input_word() {
          having been driven at all, which a low-only assertion cannot tell apart \
          from a correct press"
     );
-    assert_eq!(
-        din_bit(&bus, 9),
-        0,
-        "the pressed key's column must fall"
-    );
+    assert_eq!(din_bit(&bus, 9), 0, "the pressed key's column must fall");
 }

--- a/crates/core/tests/gpio_devices_drive_read_only_inputs.rs
+++ b/crates/core/tests/gpio_devices_drive_read_only_inputs.rs
@@ -1,0 +1,181 @@
+// A bus-resident GPIO device must drive pins on parts whose input word is
+// READ-ONLY to firmware — not only on the STM32-style ports where a store to
+// IDR happens to land.
+//
+// `DevicePins` exposes two seams. `drive_idr_bit` is an ordinary MMIO store to
+// the input register; `drive_input_bit` is the external-world seam
+// (`set_external_input`). They are NOT interchangeable:
+//
+//   STM32V2   IDR @0x10 — write_reg accepts the store, so either seam works.
+//   EFR32s2   DIN @0x14 — write_reg drops it by design ("DIN is read-only for
+//                         firmware — like silicon, a store to it is ignored;
+//                         external input arrives via set_external_input").
+//   SAM PORT  IN  @0x20 — same, read-only.
+//
+// A device that drives only `drive_idr_bit` is therefore silently inert on the
+// second and third families. That is the costliest possible failure: attach
+// succeeds, `list_inputs` advertises the channel, the stimulus reports applied,
+// and the pin never moves — a stimulus that proves nothing.
+//
+// Measured 2026-09-05 on brd2709a (EFR32MG26): a rotary encoder read
+// CLK=0 DT=0 at rest and after a 3-detent stimulus, while nucleo-f401re walked
+// the Gray code correctly from the identical diagram. `gpio_devices_walk_free`
+// gates the same failure reached through the TICK; this file gates it reached
+// through the REGISTER LAYOUT.
+
+use labwired_core::bus::SystemBus;
+use labwired_core::peripherals::components::keypad::Keypad;
+use labwired_core::peripherals::components::rotary_encoder::RotaryEncoder;
+use labwired_core::peripherals::gpio::{GpioPort, GpioRegisterLayout};
+use labwired_core::Bus;
+
+/// A real BRD2709A port base (GPIOC) and its DIN, from `efr32mg26.yaml`.
+const GPIOC: u64 = 0x4003_C090;
+const DIN: u64 = GPIOC + 0x14;
+const CPU_HZ: u64 = 78_000_000;
+
+fn efr32_bus() -> SystemBus {
+    let mut bus = SystemBus::empty();
+    bus.add_peripheral(
+        "gpioc",
+        GPIOC,
+        0x30,
+        None,
+        Box::new(GpioPort::new_with_layout(GpioRegisterLayout::Efr32s2)),
+    );
+    bus
+}
+
+fn din_bit(bus: &SystemBus, bit: u8) -> u32 {
+    (bus.read_u32(DIN).unwrap() >> bit) & 1
+}
+
+/// Advance the bus through the real per-cycle tick, as `Machine::advance` does.
+fn tick(bus: &mut SystemBus, cycles: u64) {
+    for c in 0..cycles {
+        bus.set_current_cycle(c);
+        let _ = bus.tick_peripherals_fully();
+    }
+}
+
+/// A store to DIN is ignored — the premise the rest of this file rests on. If
+/// this ever fails, EFR32 stopped modelling its input word as read-only and the
+/// gates below would pass for the wrong reason.
+#[test]
+fn a_store_to_efr32_din_is_ignored() {
+    let mut bus = efr32_bus();
+    let _ = bus.write_u32(DIN, 0xFFFF);
+    assert_eq!(
+        bus.read_u32(DIN).unwrap(),
+        0,
+        "EFR32 DIN must stay read-only to firmware; if a store lands, these gates prove nothing"
+    );
+}
+
+/// The encoder's documented rest state is (A,B) = (1,1) — both contacts
+/// released. On a read-only input word that level can only arrive through
+/// `drive_input_bit`.
+#[test]
+fn a_rotary_encoder_reaches_its_rest_state_on_a_read_only_input_word() {
+    let mut bus = efr32_bus();
+    bus.gpio_devices.push(Box::new(RotaryEncoder::new(
+        "enc".into(),
+        DIN,
+        5, // PC05, the deck's encoder A
+        DIN,
+        7, // PC07, the deck's encoder B
+        CPU_HZ,
+    )));
+
+    tick(&mut bus, 64);
+
+    assert_eq!(
+        (din_bit(&bus, 5), din_bit(&bus, 7)),
+        (1, 1),
+        "encoder must settle at its documented rest value (both released/high); \
+         reading 0,0 is the pin never having been driven at all"
+    );
+}
+
+/// Rest is not enough: a knob that is stuck high proves as little as one stuck
+/// low. Turning it must actually move a contact.
+#[test]
+fn a_turned_rotary_encoder_moves_a_contact_on_a_read_only_input_word() {
+    use labwired_core::sim_input::SimInput;
+
+    let mut bus = efr32_bus();
+    bus.gpio_devices.push(Box::new(RotaryEncoder::new(
+        "enc".into(),
+        DIN,
+        5,
+        DIN,
+        7,
+        CPU_HZ,
+    )));
+    tick(&mut bus, 64);
+    assert_eq!((din_bit(&bus, 5), din_bit(&bus, 7)), (1, 1), "precondition");
+
+    bus.gpio_devices_of_mut::<RotaryEncoder>()
+        .next()
+        .unwrap()
+        .set_input("position", 3.0)
+        .expect("position is a declared channel");
+
+    // One detent is ~8 ms of contact bounce at this clock; walk well past it
+    // and record whether either contact ever left its rest level.
+    let mut moved = false;
+    for c in 64..(CPU_HZ / 20) {
+        bus.set_current_cycle(c);
+        let _ = bus.tick_peripherals_fully();
+        if (din_bit(&bus, 5), din_bit(&bus, 7)) != (1, 1) {
+            moved = true;
+            break;
+        }
+    }
+
+    assert!(
+        moved,
+        "turning the shaft must move a contact; a stimulus that reports applied \
+         while both pins hold rest is the failure this file exists for"
+    );
+}
+
+/// The keypad drives its columns through the same seam and had the same defect.
+#[test]
+fn a_keypad_column_falls_on_a_read_only_input_word() {
+    let mut bus = efr32_bus();
+    // Rows on DOUT (an output the firmware drives), columns on DIN.
+    let row_odr: [(u64, u8); 4] = std::array::from_fn(|r| (GPIOC + 0x10, r as u8));
+    let col_idr: [(u64, u8); 4] = std::array::from_fn(|c| (DIN, (c + 8) as u8));
+    bus.gpio_devices
+        .push(Box::new(Keypad::new("kp".into(), row_odr, col_idr)));
+    bus.gpio_devices_of_mut::<Keypad>()
+        .next()
+        .unwrap()
+        .set_pressed(Some((2, 1)));
+
+    // Select row 2 (active low), then let the tick service the matrix.
+    bus.write_u32(GPIOC + 0x10, 0b1111u32 & !(1 << 2)).unwrap();
+    tick(&mut bus, 8);
+
+    // ⚠️ ASSERT THE HIGH COLUMN FIRST, AND ASSERT IT AT ALL. An undriven DIN
+    // reads 0, and "pressed" also expects 0 — so a bare `column == 0` passes
+    // just as happily when the keypad was never wired to anything. Caught by
+    // negative control: with the fix reverted, the low-only assertion still
+    // went green while both encoder gates went red.
+    //
+    // The idle columns are the real evidence here: they can only read 1 if
+    // something drove them.
+    assert_eq!(
+        din_bit(&bus, 8),
+        1,
+        "an unpressed column must be driven HIGH; reading 0 is the matrix never \
+         having been driven at all, which a low-only assertion cannot tell apart \
+         from a correct press"
+    );
+    assert_eq!(
+        din_bit(&bus, 9),
+        0,
+        "the pressed key's column must fall"
+    );
+}


### PR DESCRIPTION
## What

`DevicePins` has two seams, and they are not interchangeable:

- `drive_idr_bit` — an ordinary MMIO **store** to the input register
- `drive_input_bit` — the external-world seam (`set_external_input`)

| Family | Input word | A store to it |
|---|---|---|
| STM32V2 | IDR @0x10 | accepted — either seam works |
| **EFR32s2** | DIN @0x14 | **dropped by design** |
| **SAM PORT** | IN @0x20 | **read-only** |
| **ESP32-C3** | — | read-only |

EFR32's `write_reg` says it outright: *"DIN is read-only for firmware — like silicon, a store to it is ignored; external input arrives via set_external_input."*

`RotaryEncoder` and `Keypad` drove **only the first seam**, so on the other three families they were silently inert — attach succeeds, `list_inputs` advertises the channel, the stimulus reports `applied`, and the pin never moves.

`Button` already used the right seam, which is why buttons worked on the same board and hid how narrow the gap was. `DHT22` has always driven **both** — that's the precedent followed here.

## Evidence

Measured 2026-09-05 through `labwired_verify`, identical diagram both times:

- `brd2709a`: `CLK=0 DT=0` at rest **and** after a 3-detent stimulus — never moves
- `nucleo-f401re`: `CLK=1 DT=1` at rest (documented `rest=11`), walks the Gray code

Both runs reported `outcome: applied`.

## Tests

`gpio_devices_walk_free` gates this failure reached through the **tick**. This is the same failure reached through the **register layout**, so the new file gates that axis on a real EFR32 port — including a premise test that DIN really does ignore a store, without which the behaviour gates would pass for the wrong reason.

⚠️ **One existing assertion was inverted, because it encoded the bug.** `a_keypad_scans_with_no_bus_in_sight` required `input_writes` to stay empty — *"a keypad has no business on the external-level seam"*. That held only while every part in view accepted an IDR store.

## Negative control

Reverting the two `drive_input_bit` calls turns all three behaviour gates red and leaves the premise test green.

Worth recording: the **first draft of the keypad gate was vacuous** — it asserted only that the pressed column reads `0`, which an *undriven* pin also reads, so it passed with the fix reverted. It now asserts the idle columns are driven **high**, which nothing but a real drive can produce.

```
before fix:  1 passed; 3 failed
after fix:   4 passed; 0 failed
core --lib:  3366 passed; 0 failed
efr32_deck_behavior: ok
```